### PR TITLE
feat: reject stale updates to shared OMH records (closes #828)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -942,6 +942,235 @@ Initial transition policy is intentionally conservative: clarification can hand
 off to planning, and planning can hand off to execution or QA. Other active
 workflow conflicts must be finished or cleared explicitly.
 
+## Record Revisions and Idempotent Mutations
+
+Wrapper sessions, goal ledgers, loop cycles, executor sessions, and workflow
+state are shared local records: a chat wrapper, a CLI call, and an automation
+tick can all reach the same JSON file. `src/system/record_revision.py` gives
+those records one optimistic-concurrency contract.
+
+Every guarded record carries up to three bookkeeping fields:
+
+- `record_revision` — an integer that starts at `1` on the first write and
+  increases by exactly one per applied mutation.
+- `applied_mutations` — a bounded map of `"<operation>:<mutation_id>"` to
+  `{"record_revision", "operation", "result_digest"}`, keeping at most
+  `APPLIED_MUTATIONS_LIMIT` (128) of the most recent entries so records cannot
+  grow without limit.
+- `applied_mutations_floor_revision` — written only once eviction has actually
+  dropped entries, and equal to the highest `record_revision` whose mutation id
+  is no longer retained.
+
+`guarded_record_update()` runs the whole read-modify-write inside one advisory
+file lock: it reads the record inside the lock, replays an already-applied
+mutation, compares `expected_revision`, applies the mutation, bumps
+`record_revision`, validates, and only then writes atomically. Status
+preconditions — a queue item still being `prepared_not_observed`, a session
+still being in a decidable status — run inside that same transaction, so two
+concurrent callers cannot both pass the same check.
+
+Callers name the mutation and may guard it two ways:
+
+- `operation` (**required**) — a short stable name for the logical mutation,
+  such as `record_goal_checkpoint` or `record_plan_decision`. It scopes
+  `mutation_id`, so it must not contain `:`.
+- `expected_revision` — the `record_revision` the caller last rendered. When it
+  no longer matches, the mutation raises `StaleRecordMutation` and **nothing is
+  written**: the rejection is total, never partial.
+- `mutation_id` — a client-chosen id for one logical intent. Retrying the same
+  `(operation, mutation_id)` pair replays the original outcome instead of
+  applying it twice, so a retried call creates no duplicate checkpoint,
+  blocker, quality gate, queue observation, or session event, and does not bump
+  the revision again.
+- `mutation_digest` — optional; a digest the caller computes from its own
+  arguments so a retry can be proven to mean the same thing.
+
+Terminal records refuse new child work. `require_not_terminal()` backs the
+refusal for cancelled wrapper sessions (executor selection, handoff
+preparation, and every executor-session entrypoint) and for terminal goals —
+`complete` and `cancelled` refuse checkpoints, blockers, and quality gates. The
+refusal message names the terminal state so a wrapper can explain it.
+
+### What the lock actually guarantees
+
+The guarantees below hold **only while an OS file lock is held**:
+
+- The read, every precondition check, the mutation, and the write happen as one
+  transaction, so no concurrent writer can interleave between the
+  `expected_revision` compare and the write it authorizes.
+- No update is lost: each applied mutation bumps `record_revision` by exactly
+  one.
+- A `(operation, mutation_id)` pair applies at most once, even under concurrent
+  retries of the same id.
+
+The lock is taken on a `.<name>.lock` sidecar, never on the record itself:
+
+- **POSIX** — `fcntl.flock` with `LOCK_EX | LOCK_NB`, polled until the timeout.
+- **Windows** — `msvcrt.locking` with `LK_NBLCK` on one byte of the sidecar,
+  released with `LK_UNLCK`, polled the same way. This is a real OS lock, so
+  Windows gets the same guarantees as POSIX.
+- **Neither module importable** — no OS lock exists. The transaction still
+  runs, protected only by the `expected_revision` compare and the atomic
+  replace, so concurrent writers can interleave and the "applies at most once"
+  and "no lost update" properties **do not hold**. This is surfaced, not
+  assumed away: `file_lock()` yields `{"locked": False, "enforced": False,
+  "reason": "no_os_file_lock"}`, and `guarded_record_update()` returns a
+  `GuardedRecord` whose `lock_enforced` attribute is `False` so a caller can
+  say the guarantee was downgraded to best-effort instead of claiming it held.
+  `lock_enforced` is an attribute of the returned dict and is never persisted
+  into the record.
+
+### Operation-scoped mutation ids
+
+`mutation_id` is scoped by `operation`, and the pair is the replay key:
+
+- **Same `operation`, same `mutation_id`** — replay. No write, no revision
+  bump, no duplicate child item. The result is a `DuplicateMutationReplay`
+  carrying the unchanged record and `replayed=True`.
+- **Same `mutation_id`, different `operation`** — **not** a replay. A client
+  turn id reused by a different operation is different logical intent and
+  applies normally. Without this scoping a `goal cancel` that reused the id of
+  an earlier `goal blocker` would be swallowed and exit successfully while the
+  goal stayed active.
+- **Same `(operation, mutation_id)`, divergent payload** — refused. When the
+  caller supplies `mutation_digest` and it does not match the digest stored
+  with the applied entry, the retry is different work sharing one id, and
+  `ConflictingMutationReplay` is raised naming the operation and the id.
+  `mutation_digest` must be used consistently within one operation: a retry
+  that supplies a digest where the original call did not is treated as
+  divergent rather than replayed, because silently dropping work is the worse
+  failure.
+
+### Eviction floor
+
+`applied_mutations` is bounded at 128 entries, so a long-lived record does
+eventually forget an old id. Forgetting is not silent. When entries are
+evicted, `applied_mutations_floor_revision` moves up to the highest evicted
+`record_revision`, and the retry rule becomes:
+
+- id present in the map → replay, as above.
+- id absent, `expected_revision` supplied and **at or below** the floor → the
+  record cannot prove whether that mutation already applied. Applying it risks
+  a duplicate and replaying it risks losing it, so `MutationHistoryEvicted` is
+  raised, telling the caller to re-render the current record and retry against
+  its current revision.
+- id absent, no `expected_revision` or one above the floor → applies normally.
+
+The consequence for callers: a retry is only guaranteed to be recognized while
+its mutation is still within the most recent 128 applied mutations of that
+record. Beyond that a retry carrying a stale `expected_revision` is refused,
+never duplicated.
+
+### Materialized mutation ids
+
+The eviction floor only fires when the caller supplied an `expected_revision`,
+and that asymmetry is deliberate: without one there is nothing to compare
+against the floor, and refusing every id absent from the map would refuse every
+legitimately new `mutation_id` once any eviction had happened. So a retry that
+carries **only** a `mutation_id` gets no eviction protection from the map — and
+the CLI accepts `--mutation-id` independently of `--expected-revision`.
+
+The rule that closes that gap: **a surface that materializes a `mutation_id`
+into a persisted item id must dedupe on that derived id inside its own locked
+`mutate`, before appending.** The goal ledger does exactly this. It derives
+`checkpoint_id`, `blocker_id`, and `quality_gate_id` from the `mutation_id`
+(verbatim when the id is filesystem-safe, otherwise a stable hash), so the
+record itself is the proof a retry needs: if an item with that id is already in
+the target list, the mutation already applied. The mutator returns "no change",
+the caller reports `replayed=true`, and `applied` stays re-derived from the
+persisted record. This is exact, survives eviction, and costs one list scan.
+The dedupe check runs before the mutator's other preconditions, matching the
+`applied_mutations` replay path it backstops — that path never runs them
+either, so a retry must not start failing preconditions once its id is evicted.
+
+Two things this rule is not:
+
+- It is **not** a widening of the floor rule. Refusing every id absent from the
+  map after eviction would break normal operation on any long-lived record.
+- It is **not** a substitute for the bounded map. The map still short-circuits
+  the common retry before `mutate` runs; the id scan is the backstop for the
+  window the map has forgotten.
+
+`validate_goal_ledger()` enforces the invariant from the other side: two items
+in one list sharing an id is a validation error, and the validator runs inside
+the guarded write, so a duplicate is refused before it is persisted.
+
+One consequence is worth naming. `record_goal_quality_gate` and
+`complete_goal_ledger` are different operations that write into the *same*
+`quality_gates` list, so one `mutation_id` reused across the two is a genuine
+id collision, not two independent intents. The second call is refused as a
+replay — visibly: `completed` stays `false`, `replayed` is `true`, and the CLI
+exits non-zero. That is the conservative direction; the alternative was a
+duplicate id the validator now rejects anyway. A distinct `mutation_id`
+applies normally.
+
+Surfaces that do **not** materialize the id need nothing extra, but the reason
+has to be checked rather than assumed. Loop cycles
+(`src/workflows/goal_loop.py`) mint `cycle_id` and `queue_id` from
+`_new_item_id()`, never from the `mutation_id`; their queue mutators are
+additionally guarded by status preconditions — `observe` and `dispatch` require
+`prepared_not_observed`, `block` refuses an already-observed item — so a
+replayed queue mutation is refused rather than applied twice. Wrapper sessions
+(`src/wrapper/sessions.py`) mutate in place — status transitions and a single
+`current_run_id` — instead of appending id-bearing items, so a repeat write is
+idempotent by shape.
+
+### Bounded mutation ids
+
+`mutation_id` is caller-supplied text that is persisted into the bounded map,
+so an unbounded id multiplies straight into the record: 128 retained entries of
+a 100k-character id is a multi-megabyte record written by one buggy connector.
+`mutation_id` is therefore bounded at 200 characters and `operation` at 64,
+both validated in `guarded_record_update()` *before* the lock is taken, so an
+oversized id is refused with a readable message and no file — record, lock
+sidecar, or temp file — is touched. 200 is sized against the ids connectors
+actually send (UUID 36, ULID 26, Discord snowflake 20, git sha 40, composite
+Slack reference ~36), leaving roughly five times the widest observed id.
+Validating in the one shared helper is the point: goal, wrapper-session, and
+loop writes reject identically instead of each inventing a limit.
+
+### Stale-rejection UX
+
+A stale rejection is a conversation, not a crash. On `StaleRecordMutation` the
+wrapper should tell the user the work changed under them, summarize the record
+at its current `record_revision`, and offer to retry against that revision. The
+exception carries `expected_revision` and `current_revision` for exactly this
+message. `MutationHistoryEvicted` and `ConflictingMutationReplay` deserve the
+same treatment: both name what could not be proven and both leave the record
+untouched. Auto-resolving two conflicting decisions is deliberately out of
+scope: the user picks.
+
+### CLI surfaces that can arm the guard
+
+A guarantee a wrapper cannot reach is not a guarantee. `--expected-revision`
+and `--mutation-id` are therefore defined once, in
+`add_revision_guard_arguments()` (`src/commands/common.py`), and attached to
+every CLI subcommand that reaches a guarded write:
+
+- `omh goal checkpoint | blocker | complete | cancel`
+- `omh chat session accept-plan | revise-plan | cancel | select-executor |
+  prepare-handoff`
+
+Both flags stay optional, and absent means "no guard requested" — `None` and
+`""`, never revision `0`. A rejection reaches the user as a plain
+`omh: <message>` line on stderr with a non-zero exit and nothing on stdout.
+
+Chat session subcommands that write the *executor* session record
+(`open-executor`, `attach-executor`, `record-executor`,
+`request-verification`) do not take the flags: those writes go through
+`executor_sessions.py`, which does not yet accept a `mutation_id`. That is a
+known boundary, not an oversight.
+
+### Adoption boundary
+
+This contract covers record-level staleness only. Cross-record binding — such as
+a session pinned to a workspace — is tracked separately as issue #820 and is not
+enforced here. Distributed locks across machines are also out of scope: the
+guard is a single-host advisory lock plus a revision compare. Records written
+before operation scoping keep un-prefixed `applied_mutations` keys; those keys
+are never matched again, so one legacy id can apply a second time and then
+behaves normally.
+
 ## Safety Model
 
 - Managed files are tracked by manifest hashes.

--- a/docs/MULTI_AGENT_OPERATIONS.md
+++ b/docs/MULTI_AGENT_OPERATIONS.md
@@ -30,12 +30,21 @@ contract every read-modify-write caller under `~/.omh` should use, not an
 implementation walkthrough — see `src/system/local_store.py` for the actual
 lock and atomic-write primitives.
 
-One capability boundary inside the contract itself: the advisory lock is
-POSIX `flock`-based. On platforms without `fcntl` the locked update path
-degrades to plain atomic writes — torn files are still prevented, but mutual
-exclusion between concurrent processes is not, so multi-agent lost-update
-protection only holds on POSIX hosts. The degradation is signaled by the
-lock primitive rather than silent, and single-agent behavior is unaffected.
+One capability boundary inside the contract itself: the advisory lock is a
+real OS file lock on the platforms OMH supports, taken on a `.<name>.lock`
+sidecar rather than on the record. POSIX locks through `fcntl.flock`, Windows
+through `msvcrt.locking` on one byte of the sidecar, and both are polled
+until the caller's timeout, so mutual exclusion between concurrent processes
+holds on both. Only when *neither* module is importable does the locked
+update path degrade to best-effort: torn files are still prevented by the
+atomic replace, but concurrent writers can interleave, so multi-agent
+lost-update protection does not hold. That degradation is signaled rather
+than silent — the lock primitive reports `enforced: False` with reason
+`no_os_file_lock`, and `guarded_record_update()` surfaces it as
+`lock_enforced=False` so a caller can say the guarantee was downgraded
+instead of claiming it held. Single-agent behavior is unaffected either way.
+See "What the lock actually guarantees" in
+[Architecture](ARCHITECTURE.md) for the per-platform detail.
 
 Practical implications for a wrapper or operator running more than one agent
 against the same OMH home:

--- a/src/commands/chat.py
+++ b/src/commands/chat.py
@@ -50,6 +50,7 @@ from .common import (
     _print_json,
     _resolved_executor,
     _wants_json,
+    add_revision_guard_arguments,
 )
 from .runtime import _validate_runtime_names
 
@@ -208,12 +209,28 @@ def cmd_chat_session_start(args: argparse.Namespace) -> int:
     return 0
 
 
+def _revision_guard(args: argparse.Namespace) -> dict[str, object]:
+    """The guard arguments a chat session mutation forwards to the record write.
+
+    Read through getattr so subcommands that do not reach a guarded write stay
+    unaffected, and normalized the same way the goal CLI does: an absent
+    --mutation-id is None ("no id supplied"), never the empty string.
+    """
+    return {
+        "expected_revision": getattr(args, "expected_revision", None),
+        "mutation_id": getattr(args, "mutation_id", "") or None,
+    }
+
+
 def cmd_chat_session_decision(args: argparse.Namespace) -> int:
     try:
-        _print_json(record_plan_decision(_paths(args), args.session_id, args.decision))
+        _print_json(record_plan_decision(_paths(args), args.session_id, args.decision, **_revision_guard(args)))
     except FileNotFoundError as exc:
         raise OmhError(f"wrapper session not found: {args.session_id}") from exc
-    except WrapperSessionError as exc:
+    # StaleRecordMutation / MutationHistoryEvicted / ConflictingMutationReplay
+    # are ValueErrors raised by the guarded write, and reach the user as
+    # "omh: <message>" rather than a traceback.
+    except (ValueError, WrapperSessionError) as exc:
         raise OmhError(str(exc)) from exc
     return 0
 
@@ -230,6 +247,7 @@ def cmd_chat_session_prepare_handoff(args: argparse.Namespace) -> int:
             source_metadata=source_metadata,
             executor_target=args.executor,
             context_pack=_context_pack(args),
+            **_revision_guard(args),
         )
     except FileNotFoundError as exc:
         raise OmhError(f"wrapper session not found: {args.session_id}") from exc
@@ -673,10 +691,12 @@ def _add_codex_observation_options(parser: argparse.ArgumentParser) -> None:
 
 def cmd_chat_session_select_executor(args: argparse.Namespace) -> int:
     try:
-        _print_json(select_wrapper_session_executor(_paths(args), args.session_id, args.executor))
+        _print_json(
+            select_wrapper_session_executor(_paths(args), args.session_id, args.executor, **_revision_guard(args))
+        )
     except FileNotFoundError as exc:
         raise OmhError(f"wrapper session not found: {args.session_id}") from exc
-    except WrapperSessionError as exc:
+    except (ValueError, WrapperSessionError) as exc:
         raise OmhError(str(exc)) from exc
     return 0
 
@@ -1170,21 +1190,29 @@ def _add_chat_commands(sub) -> None:
     _add_target_metadata_options(session_start)
     session_start.set_defaults(func=cmd_chat_session_start)
 
+    # Every chat session subcommand below reaches a guarded session.json write,
+    # so each carries the same two guard flags: the guarantee is "the wrapper
+    # submits the revision it rendered", and it is unreachable from a surface
+    # that cannot pass one.
     session_accept = session_sub.add_parser("accept-plan")
     session_accept.add_argument("session_id")
+    add_revision_guard_arguments(session_accept)
     session_accept.set_defaults(func=cmd_chat_session_decision, decision="accept")
 
     session_revise = session_sub.add_parser("revise-plan")
     session_revise.add_argument("session_id")
+    add_revision_guard_arguments(session_revise)
     session_revise.set_defaults(func=cmd_chat_session_decision, decision="revise")
 
     session_cancel = session_sub.add_parser("cancel")
     session_cancel.add_argument("session_id")
+    add_revision_guard_arguments(session_cancel)
     session_cancel.set_defaults(func=cmd_chat_session_decision, decision="cancel")
 
     session_select = session_sub.add_parser("select-executor")
     session_select.add_argument("session_id")
     session_select.add_argument("executor", choices=tuple(value for value in CODING_EXECUTOR_TARGETS if value != "choose"))
+    add_revision_guard_arguments(session_select)
     session_select.set_defaults(func=cmd_chat_session_select_executor)
 
     session_prepare = session_sub.add_parser("prepare-handoff")
@@ -1203,6 +1231,7 @@ def _add_chat_commands(sub) -> None:
         default=None,
         help="Optional handoff_context_pack/v1 JSON to attach to the prepared executor prompt when conflict-free.",
     )
+    add_revision_guard_arguments(session_prepare)
     session_prepare.set_defaults(func=cmd_chat_session_prepare_handoff)
 
     session_status = session_sub.add_parser("status")

--- a/src/commands/common.py
+++ b/src/commands/common.py
@@ -18,6 +18,29 @@ def _paths(args: argparse.Namespace):
     return resolve_paths(args.omh_home, args.hermes_home, scope=getattr(args, "scope", None))
 
 
+def add_revision_guard_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add the two optional stale-mutation guard flags to one mutation parser.
+
+    Shared by every CLI surface that reaches a guarded record write, so the
+    flags are spelled and defaulted identically: the guarantee the guard
+    offers is "the wrapper submits the revision it rendered", and a surface
+    that reaches a guarded write without these flags cannot arm it at all.
+    Absent flags stay None / "" so they mean "no guard requested" rather than
+    revision 0 or an empty mutation id.
+    """
+    parser.add_argument(
+        "--expected-revision",
+        type=int,
+        default=None,
+        help="Reject this mutation when the record_revision no longer matches the rendered state.",
+    )
+    parser.add_argument(
+        "--mutation-id",
+        default="",
+        help="Client-chosen id that makes a retried mutation replay the original result instead of duplicating it.",
+    )
+
+
 JSON_PRETTY_ENV = "OMH_JSON_PRETTY"
 _JSON_PRETTY_TRUE = {"1", "true", "yes", "on"}
 _json_pretty_requested = False

--- a/src/commands/goal.py
+++ b/src/commands/goal.py
@@ -7,6 +7,7 @@ from ..goal_ledger import (
     build_goal_completion_gate,
     build_goal_continuation,
     build_goal_status_card,
+    cancel_goal_ledger,
     complete_goal_ledger,
     create_goal_ledger,
     list_goal_ledgers,
@@ -15,7 +16,7 @@ from ..goal_ledger import (
     record_goal_checkpoint,
 )
 from ..installer import OmhError
-from .common import _paths, _print_json
+from .common import _paths, _print_json, add_revision_guard_arguments
 
 
 def cmd_goal_create(args: argparse.Namespace) -> int:
@@ -36,8 +37,25 @@ def cmd_goal_create(args: argparse.Namespace) -> int:
     return 0
 
 
+def _mutation_payload(paths, goal_id: str, goal: dict, outcome: dict) -> dict:
+    """CLI payload that reports what the persisted record actually says.
+
+    `applied` is re-derived from the stored goal, not from "the call
+    returned": a mutation replayed away by a reused mutation_id leaves the
+    goal untouched, and printing it as success is how a discarded change
+    looks like a successful one.
+    """
+    return {
+        "goal": goal,
+        "completion_gate": build_goal_completion_gate(paths, goal_id),
+        "applied": bool(outcome.get("applied")),
+        "replayed": bool(outcome.get("replayed")),
+    }
+
+
 def cmd_goal_checkpoint(args: argparse.Namespace) -> int:
     paths = _paths(args)
+    outcome: dict = {}
     try:
         goal = record_goal_checkpoint(
             paths,
@@ -48,15 +66,19 @@ def cmd_goal_checkpoint(args: argparse.Namespace) -> int:
             evidence_refs=args.evidence_ref or [],
             notes_summary=args.notes_summary or "",
             linked_runtime_run_id=args.linked_runtime_run or "",
+            expected_revision=args.expected_revision,
+            mutation_id=args.mutation_id or None,
+            outcome=outcome,
         )
     except (FileNotFoundError, ValueError) as exc:
         raise OmhError(str(exc)) from exc
-    _print_json({"goal": goal, "completion_gate": build_goal_completion_gate(paths, args.goal_id)})
-    return 0
+    _print_json(_mutation_payload(paths, args.goal_id, goal, outcome))
+    return 0 if outcome.get("applied") else 1
 
 
 def cmd_goal_blocker(args: argparse.Namespace) -> int:
     paths = _paths(args)
+    outcome: dict = {}
     try:
         goal = record_goal_blocker(
             paths,
@@ -66,20 +88,49 @@ def cmd_goal_blocker(args: argparse.Namespace) -> int:
             missing_authority=args.missing_authority or "",
             evidence_refs=args.evidence_ref or [],
             mark_goal_blocked=args.mark_goal_blocked,
+            expected_revision=args.expected_revision,
+            mutation_id=args.mutation_id or None,
+            outcome=outcome,
         )
     except (FileNotFoundError, ValueError) as exc:
         raise OmhError(str(exc)) from exc
-    _print_json({"goal": goal, "completion_gate": build_goal_completion_gate(paths, args.goal_id)})
-    return 0
+    _print_json(_mutation_payload(paths, args.goal_id, goal, outcome))
+    return 0 if outcome.get("applied") else 1
 
 
 def cmd_goal_complete(args: argparse.Namespace) -> int:
     try:
-        result = complete_goal_ledger(_paths(args), args.goal_id, evidence_refs=args.evidence_ref or [])
+        result = complete_goal_ledger(
+            _paths(args),
+            args.goal_id,
+            evidence_refs=args.evidence_ref or [],
+            expected_revision=args.expected_revision,
+            mutation_id=args.mutation_id or None,
+        )
     except (FileNotFoundError, ValueError) as exc:
         raise OmhError(str(exc)) from exc
     _print_json(result)
     return 0 if result["completed"] else 1
+
+
+def cmd_goal_cancel(args: argparse.Namespace) -> int:
+    paths = _paths(args)
+    outcome: dict = {}
+    try:
+        goal = cancel_goal_ledger(
+            paths,
+            args.goal_id,
+            reason=args.reason or "",
+            expected_revision=args.expected_revision,
+            mutation_id=args.mutation_id or None,
+            outcome=outcome,
+        )
+    except (FileNotFoundError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    payload = _mutation_payload(paths, args.goal_id, goal, outcome)
+    payload["cancelled"] = bool(outcome.get("applied"))
+    _print_json(payload)
+    return 0 if outcome.get("applied") else 1
 
 
 def cmd_goal_status(args: argparse.Namespace) -> int:
@@ -143,6 +194,7 @@ def _add_goal_commands(sub) -> None:
     goal_checkpoint.add_argument("--evidence-ref", action="append")
     goal_checkpoint.add_argument("--notes-summary", default="")
     goal_checkpoint.add_argument("--linked-runtime-run", default="")
+    add_revision_guard_arguments(goal_checkpoint)
     goal_checkpoint.set_defaults(func=cmd_goal_checkpoint)
 
     goal_blocker = goal_sub.add_parser("blocker")
@@ -152,12 +204,20 @@ def _add_goal_commands(sub) -> None:
     goal_blocker.add_argument("--missing-authority", default="")
     goal_blocker.add_argument("--evidence-ref", action="append")
     goal_blocker.add_argument("--mark-goal-blocked", action="store_true")
+    add_revision_guard_arguments(goal_blocker)
     goal_blocker.set_defaults(func=cmd_goal_blocker)
 
     goal_complete = goal_sub.add_parser("complete")
     goal_complete.add_argument("--goal", dest="goal_id", required=True)
     goal_complete.add_argument("--evidence-ref", action="append")
+    add_revision_guard_arguments(goal_complete)
     goal_complete.set_defaults(func=cmd_goal_complete)
+
+    goal_cancel = goal_sub.add_parser("cancel")
+    goal_cancel.add_argument("--goal", dest="goal_id", required=True)
+    goal_cancel.add_argument("--reason", default="")
+    add_revision_guard_arguments(goal_cancel)
+    goal_cancel.set_defaults(func=cmd_goal_cancel)
 
     goal_status = goal_sub.add_parser("status")
     goal_status.add_argument("--goal", dest="goal_id", default="")

--- a/src/omh/record_revision.py
+++ b/src/omh/record_revision.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+from .system.record_revision import *  # noqa: F401,F403

--- a/src/runtime/records.py
+++ b/src/runtime/records.py
@@ -45,6 +45,13 @@ from ..harness_quality import HARNESS_QUALITY_KEYS, HARNESS_QUALITY_SCHEMA_VERSI
 from ..quality.specialist_work_validation import validate_prepared_specialist_work_quality
 from ..isolation import ISOLATION_SCHEMA_VERSION
 from ..local_store import utc_now
+from ..system.record_revision import (
+    APPLIED_MUTATIONS_FLOOR_KEY,
+    applied_mutations_floor_of,
+    bounded_applied_mutations,
+    record_revision_of,
+    revision_field_errors,
+)
 from ..memory import validate_handoff_context_blocked, validate_handoff_context_pack, validate_project_memory_recall_pack
 from ..coding.product_family_templates import validate_product_family_template
 from ..coding.product_quality_harnesses import validate_product_quality_harness
@@ -528,6 +535,9 @@ WRAPPER_SESSION_RECORD_KEYS = (
     "record_provenance",
     "redaction_policy",
     "authority",
+    "record_revision",
+    "applied_mutations",
+    "applied_mutations_floor_revision",
 )
 
 
@@ -856,7 +866,14 @@ def build_wrapper_session_record(session: dict[str, Any]) -> dict[str, Any]:
             "session_owns": list(WRAPPER_SESSION_AUTHORITY_SESSION_OWNS),
             "run_ledger_owns": list(WRAPPER_SESSION_AUTHORITY_RUN_LEDGER_OWNS),
         },
+        "record_revision": record_revision_of(session),
+        "applied_mutations": _compact_applied_mutations(session.get("applied_mutations")),
     }
+    # Only present once applied_mutations eviction has moved the floor; keeping
+    # it out otherwise leaves untouched sessions byte-identical.
+    floor_revision = applied_mutations_floor_of(session)
+    if floor_revision >= 1:
+        record[APPLIED_MUTATIONS_FLOOR_KEY] = floor_revision
     errors = validate_wrapper_session_record(record)
     if errors:
         raise ValueError(errors[0])
@@ -907,6 +924,27 @@ def _compact_source_metadata(metadata: Any) -> dict[str, str]:
     if not isinstance(metadata, dict):
         return {}
     return {key: str(metadata[key]) for key in CODING_SOURCE_METADATA_KEYS if key in metadata and str(metadata[key])}
+
+
+def _compact_applied_mutations(applied: Any) -> dict[str, Any]:
+    if not isinstance(applied, dict):
+        return {}
+    compact: dict[str, Any] = {}
+    for mutation_id, entry in applied.items():
+        if not isinstance(entry, dict) or not str(mutation_id).strip():
+            continue
+        revision = entry.get("record_revision")
+        if isinstance(revision, bool) or not isinstance(revision, int):
+            continue
+        compact_entry: dict[str, Any] = {
+            "record_revision": revision,
+            "result_digest": str(entry.get("result_digest", "")),
+        }
+        operation = entry.get("operation")
+        if isinstance(operation, str) and operation.strip():
+            compact_entry["operation"] = operation
+        compact[str(mutation_id)] = compact_entry
+    return bounded_applied_mutations(compact)
 
 
 def _compact_wrapper_session_source_metadata(metadata: Any) -> dict[str, str]:
@@ -2357,6 +2395,7 @@ def validate_wrapper_session_record(session: dict[str, Any]) -> list[str]:
             errors,
             "wrapper_session authority.run_ledger_owns must match the run ledger authority contract",
         )
+    errors.extend(revision_field_errors(session, "wrapper_session"))
     return errors
 
 

--- a/src/system/local_store.py
+++ b/src/system/local_store.py
@@ -17,6 +17,20 @@ try:
 except ImportError:
     fcntl = None
 
+try:
+    import msvcrt
+except ImportError:
+    msvcrt = None
+
+LOCK_MECHANISM_FCNTL = "fcntl"
+LOCK_MECHANISM_MSVCRT = "msvcrt"
+LOCK_MECHANISM_NONE = "none"
+LOCK_UNENFORCED_REASON = "no_os_file_lock"
+# Both backends report "the region is already held" through errno rather than a
+# dedicated exception: fcntl.flock uses EACCES/EAGAIN, msvcrt.locking uses
+# EACCES for LK_NBLCK and EDEADLK when a blocking attempt gives up.
+_LOCK_BUSY_ERRNOS = frozenset({errno.EACCES, errno.EAGAIN, errno.EDEADLK, getattr(errno, "EDEADLOCK", errno.EDEADLK)})
+
 
 def utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
@@ -131,6 +145,46 @@ class FileLockTimeout(TimeoutError):
     """Raised when an advisory file lock cannot be acquired within the timeout."""
 
 
+def _acquire_os_file_lock(
+    handle: Any,
+    path: Path,
+    *,
+    deadline: float,
+    poll_interval: float,
+    timeout_seconds: float,
+) -> str:
+    """Take an exclusive OS lock on the already-open sidecar handle.
+
+    Returns the mechanism that granted it. Both backends are polled through
+    their non-blocking flag so one shared timeout covers either platform.
+    """
+    while True:
+        try:
+            if fcntl is not None:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                return LOCK_MECHANISM_FCNTL
+            # msvcrt.locking locks a byte range starting at the current file
+            # position, so the region has to be pinned to byte 0 on both the
+            # acquire and the release for the two calls to describe one region.
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+            return LOCK_MECHANISM_MSVCRT
+        except OSError as exc:
+            if exc.errno not in _LOCK_BUSY_ERRNOS:
+                raise
+            if time.monotonic() >= deadline:
+                raise FileLockTimeout(f"could not acquire lock on {path} within {timeout_seconds}s") from exc
+            time.sleep(poll_interval)
+
+
+def _release_os_file_lock(handle: Any, mechanism: str) -> None:
+    if mechanism == LOCK_MECHANISM_FCNTL:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        return
+    handle.seek(0)
+    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+
+
 @contextmanager
 def file_lock(
     path: Path,
@@ -139,29 +193,44 @@ def file_lock(
     poll_interval: float = 0.05,
     private: bool = False,
 ) -> Iterator[dict[str, Any]]:
+    """Hold an exclusive advisory lock on the ``.<name>.lock`` sidecar of path.
+
+    ``path`` itself is never opened, created, or written here; only the sidecar
+    is. POSIX locks through ``fcntl.flock`` and Windows through
+    ``msvcrt.locking``, so mutual exclusion is a real OS lock on both and the
+    yielded mapping reports ``enforced: True``.
+
+    On a platform with neither module the lock cannot be taken at all. The
+    block still runs - refusing to run would break every caller - but the
+    yielded mapping reports ``locked: False``, ``enforced: False`` and a
+    ``reason``, so a caller can surface that the mutual-exclusion guarantee did
+    not hold instead of assuming it did.
+    """
     lock_path = path.with_name(f".{path.name}.lock")
     ensure_dir(lock_path.parent, private=private)
-    if fcntl is None:
-        yield {"locked": False, "reason": "fcntl_unavailable"}
+    if fcntl is None and msvcrt is None:
+        yield {
+            "locked": False,
+            "enforced": False,
+            "mechanism": LOCK_MECHANISM_NONE,
+            "reason": LOCK_UNENFORCED_REASON,
+        }
         return
     ensure_file(lock_path, private=private)
     deadline = time.monotonic() + max(timeout_seconds, 0.0)
     handle = lock_path.open("a+")
     try:
-        while True:
-            try:
-                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-                break
-            except OSError as exc:
-                if exc.errno not in (errno.EACCES, errno.EAGAIN):
-                    raise
-                if time.monotonic() >= deadline:
-                    raise FileLockTimeout(f"could not acquire lock on {path} within {timeout_seconds}s") from exc
-                time.sleep(poll_interval)
+        mechanism = _acquire_os_file_lock(
+            handle,
+            path,
+            deadline=deadline,
+            poll_interval=poll_interval,
+            timeout_seconds=timeout_seconds,
+        )
         try:
-            yield {"locked": True, "reason": ""}
+            yield {"locked": True, "enforced": True, "mechanism": mechanism, "reason": ""}
         finally:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            _release_os_file_lock(handle, mechanism)
     finally:
         handle.close()
 

--- a/src/system/record_revision.py
+++ b/src/system/record_revision.py
@@ -1,0 +1,515 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+from .hashutil import sha256_text
+from .local_store import atomic_write_json, file_lock, read_json_object_result
+
+RECORD_REVISION_KEY = "record_revision"
+APPLIED_MUTATIONS_KEY = "applied_mutations"
+APPLIED_MUTATIONS_FLOOR_KEY = "applied_mutations_floor_revision"
+# The three bookkeeping keys a guarded record carries. Record validators that
+# reject unsupported top-level keys splat this into their allowed key set.
+REVISION_RECORD_KEYS = (RECORD_REVISION_KEY, APPLIED_MUTATIONS_KEY, APPLIED_MUTATIONS_FLOOR_KEY)
+# Bounded so records cannot grow forever; only the most recent entries by
+# record_revision are kept. 128 is sized against the observed worst case: one
+# autonomous loop turn writes a handful of guarded mutations, so 128 covers a
+# long session's retry window while capping the map at roughly 20KB of JSON
+# (~150 bytes per entry). Eviction below the bound is not silent - it raises
+# the persisted APPLIED_MUTATIONS_FLOOR_KEY so a retry that lands after its id
+# was dropped is refused instead of applied twice.
+APPLIED_MUTATIONS_LIMIT = 128
+APPLIED_MUTATION_ENTRY_KEYS = ("operation", "record_revision", "result_digest")
+# applied_mutations keys are "<operation>:<mutation_id>", so an operation name
+# may not contain the separator.
+OPERATION_SEPARATOR = ":"
+# mutation_id is caller-supplied text that is persisted into the bounded map,
+# so an unbounded id multiplies straight into the record: 128 retained entries
+# of a 100k-character id is a ~13MB goal.json written by one buggy connector.
+# 200 characters is sized against the ids real connectors actually send - a
+# UUID is 36, a ULID 26, a Discord snowflake 20, a git sha 40, and a composite
+# Slack reference like "slack:C0123456789/p1700000000.000100" is 36 - so the
+# bound leaves roughly five times the widest observed id while capping the map
+# at tens of kilobytes instead of megabytes.
+MAX_MUTATION_ID_CHARS = 200
+# operation is a code-chosen constant, never user text; the longest one in this
+# repo is 31 characters. The bound exists so the same "one caller cannot
+# inflate the key" property holds for both halves of the composite key.
+MAX_OPERATION_CHARS = 64
+
+
+class StaleRecordMutation(ValueError):
+    """A mutation carried an expected_revision that no longer matches the record.
+
+    The mutation is rejected without any partial write; the caller should
+    re-read the record, show the user what changed, and retry against the
+    current record_revision.
+    """
+
+    def __init__(self, *, expected_revision: int, current_revision: int, record_name: str = "record", action: str = "") -> None:
+        self.expected_revision = int(expected_revision)
+        self.current_revision = int(current_revision)
+        refused = action or "mutation"
+        super().__init__(
+            f"stale {refused} rejected for {record_name}: expected record_revision "
+            f"{self.expected_revision} but the record is now at record_revision "
+            f"{self.current_revision}; the record changed since it was read - "
+            "re-read it and retry against the current revision"
+        )
+
+
+class ConflictingMutationReplay(ValueError):
+    """One (operation, mutation_id) pair was retried with a different intent.
+
+    A replay is only safe when the retry means the same thing as the call that
+    already applied. When the caller's mutation_digest does not match the
+    digest stored with the applied entry the two calls are different work
+    sharing one id, so replaying would silently swallow the second one.
+    """
+
+    def __init__(
+        self,
+        *,
+        operation: str,
+        mutation_id: str,
+        stored_digest: str,
+        incoming_digest: str,
+        record_name: str = "record",
+    ) -> None:
+        self.operation = str(operation)
+        self.mutation_id = str(mutation_id)
+        self.stored_digest = str(stored_digest)
+        self.incoming_digest = str(incoming_digest)
+        super().__init__(
+            f"conflicting replay rejected for {record_name}: operation "
+            f"{self.operation!r} already applied mutation_id {self.mutation_id!r} "
+            "with a different payload; a mutation_id may only be retried with "
+            "the same arguments - re-read the record and retry with a new "
+            "mutation_id for the new payload"
+        )
+
+
+class MutationHistoryEvicted(ValueError):
+    """A retry arrived after its mutation_id was evicted from the bounded map.
+
+    The record can no longer prove whether this mutation already applied, so
+    applying it would risk a duplicate and replaying it would risk losing it.
+    The caller has to re-render the current record and decide.
+
+    This only fires when the caller supplied an expected_revision, and that is
+    deliberate: without one there is nothing to compare against the floor, and
+    refusing every id absent from the map would refuse every legitimately new
+    mutation once any eviction has happened. A surface that materializes the
+    mutation id into a persisted item id must therefore dedupe on that derived
+    id itself - see ``guarded_record_update``.
+    """
+
+    def __init__(
+        self,
+        *,
+        operation: str,
+        mutation_id: str,
+        expected_revision: int,
+        floor_revision: int,
+        current_revision: int,
+        record_name: str = "record",
+    ) -> None:
+        self.operation = str(operation)
+        self.mutation_id = str(mutation_id)
+        self.expected_revision = int(expected_revision)
+        self.floor_revision = int(floor_revision)
+        self.current_revision = int(current_revision)
+        super().__init__(
+            f"unprovable retry rejected for {record_name}: operation "
+            f"{self.operation!r} mutation_id {self.mutation_id!r} is not in the "
+            f"applied history, and expected_revision {self.expected_revision} is "
+            f"at or below applied_mutations_floor_revision {self.floor_revision}, "
+            f"so ids from that revision are no longer retained (the record is at "
+            f"record_revision {self.current_revision}); whether this mutation "
+            "already applied cannot be proven - re-read the record and retry "
+            "against the current revision"
+        )
+
+
+class GuardedRecord(dict):
+    """The record a guarded update settled on, plus how strong the guard was.
+
+    It is an ordinary dict for consumers, validators, and json serialization.
+    The two attributes describe the advisory lock the transaction ran under and
+    are deliberately never persisted into the record: a caller that needs to
+    know the mutual-exclusion guarantee did not hold reads lock_enforced, and
+    nothing about the lock leaks into the stored JSON.
+    """
+
+    __slots__ = ("lock_enforced", "lock_mechanism")
+
+    def __init__(self, record: dict[str, Any], *, lock_enforced: bool, lock_mechanism: str) -> None:
+        super().__init__(record)
+        self.lock_enforced = bool(lock_enforced)
+        self.lock_mechanism = str(lock_mechanism)
+
+
+@dataclass(frozen=True)
+class DuplicateMutationReplay:
+    """Result of retrying an already-applied (operation, mutation_id) pair.
+
+    This is a result path, not an error: the record is returned unchanged,
+    no revision bump happens, and no duplicate event or item is created.
+    ``replayed`` is always True so a consumer can surface "this was a retry"
+    without re-deriving it from the type.
+    """
+
+    mutation_id: str
+    record: dict[str, Any]
+    record_revision: int
+    result_digest: str
+    outcome: Any = field(default=None)
+    operation: str = ""
+    replayed: bool = True
+    lock_enforced: bool = True
+    lock_mechanism: str = ""
+
+
+def record_revision_of(record: dict[str, Any] | None) -> int:
+    if not isinstance(record, dict):
+        return 0
+    value = record.get(RECORD_REVISION_KEY, 0)
+    if isinstance(value, bool) or not isinstance(value, int):
+        return 0
+    return max(value, 0)
+
+
+def applied_mutations_floor_of(record: dict[str, Any] | None) -> int:
+    """The revision at or below which mutation ids are no longer retained."""
+    if not isinstance(record, dict):
+        return 0
+    value = record.get(APPLIED_MUTATIONS_FLOOR_KEY, 0)
+    if isinstance(value, bool) or not isinstance(value, int):
+        return 0
+    return max(value, 0)
+
+
+def applied_mutation_key(operation: str, mutation_id: str) -> str:
+    """The applied_mutations key for one mutation id under one operation.
+
+    Scoping the key by operation is the point: the same client-side turn id
+    reused by a different operation is different logical intent and must apply,
+    not replay.
+    """
+    return f"{validated_operation(operation)}{OPERATION_SEPARATOR}{mutation_id}"
+
+
+def validated_operation(operation: str) -> str:
+    text = str(operation or "").strip()
+    if not text:
+        raise ValueError(
+            "operation is required: it scopes mutation_id so one client id "
+            "reused by a different operation is not swallowed as a replay"
+        )
+    if OPERATION_SEPARATOR in text:
+        raise ValueError(f"operation must not contain {OPERATION_SEPARATOR!r}: {operation!r}")
+    if len(text) > MAX_OPERATION_CHARS:
+        raise ValueError(
+            f"operation must be at most {MAX_OPERATION_CHARS} characters, got {len(text)}"
+        )
+    return text
+
+
+def validated_mutation_id(mutation_id: str) -> str:
+    """Bound one caller-supplied retry token before it is persisted.
+
+    Called by every guarded update before the lock is taken, so an oversized
+    id is refused with a readable message and no file - record, lock sidecar,
+    or temp file - is touched. Every surface that accepts a mutation_id
+    therefore rejects identically, which is the point: goal, wrapper-session,
+    and loop writes must not each invent their own limit.
+    """
+    text = str(mutation_id)
+    if len(text) > MAX_MUTATION_ID_CHARS:
+        raise ValueError(
+            f"mutation_id must be at most {MAX_MUTATION_ID_CHARS} characters, got {len(text)}; "
+            "a mutation_id is a short retry token (a message id, uuid, or turn id), "
+            "not a payload - it is persisted into the bounded applied_mutations map"
+        )
+    return text
+
+
+def revision_field_errors(record: dict[str, Any], label: str = "record") -> list[str]:
+    """Validation for the optional revision fields, shared by record validators."""
+    errors: list[str] = []
+    if RECORD_REVISION_KEY in record:
+        value = record[RECORD_REVISION_KEY]
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            errors.append(f"{label} {RECORD_REVISION_KEY} must be a non-negative integer")
+    if APPLIED_MUTATIONS_FLOOR_KEY in record:
+        floor = record[APPLIED_MUTATIONS_FLOOR_KEY]
+        if isinstance(floor, bool) or not isinstance(floor, int) or floor < 0:
+            errors.append(f"{label} {APPLIED_MUTATIONS_FLOOR_KEY} must be a non-negative integer")
+    if APPLIED_MUTATIONS_KEY in record:
+        applied = record[APPLIED_MUTATIONS_KEY]
+        if not isinstance(applied, dict):
+            errors.append(f"{label} {APPLIED_MUTATIONS_KEY} must be an object")
+            return errors
+        if len(applied) > APPLIED_MUTATIONS_LIMIT:
+            errors.append(f"{label} {APPLIED_MUTATIONS_KEY} must keep at most {APPLIED_MUTATIONS_LIMIT} entries")
+        for mutation_key, entry in applied.items():
+            if not str(mutation_key).strip():
+                errors.append(f"{label} {APPLIED_MUTATIONS_KEY} keys must be non-empty mutation ids")
+                continue
+            if not isinstance(entry, dict):
+                errors.append(f"{label} {APPLIED_MUTATIONS_KEY}[{mutation_key}] must be an object")
+                continue
+            extra = sorted(set(entry) - set(APPLIED_MUTATION_ENTRY_KEYS))
+            if extra:
+                errors.append(f"{label} {APPLIED_MUTATIONS_KEY}[{mutation_key}] has unsupported keys: {extra}")
+            revision = entry.get("record_revision")
+            if isinstance(revision, bool) or not isinstance(revision, int) or revision < 1:
+                errors.append(f"{label} {APPLIED_MUTATIONS_KEY}[{mutation_key}].record_revision must be a positive integer")
+            if not isinstance(entry.get("result_digest"), str):
+                errors.append(f"{label} {APPLIED_MUTATIONS_KEY}[{mutation_key}].result_digest must be a string")
+            # operation is optional so records written before operation
+            # scoping - and projections that drop it, since the key already
+            # carries it - stay valid instead of failing every later write.
+            if "operation" in entry:
+                operation = entry["operation"]
+                if not isinstance(operation, str) or not operation.strip():
+                    errors.append(f"{label} {APPLIED_MUTATIONS_KEY}[{mutation_key}].operation must be a non-empty string")
+    return errors
+
+
+def bounded_applied_mutations_with_floor(
+    applied: dict[str, Any],
+    floor_revision: int = 0,
+) -> tuple[dict[str, Any], int]:
+    """Bound the applied map and report the revision the eviction floor moved to.
+
+    The floor is the highest record_revision whose mutation id was dropped, so
+    "id absent and expected_revision <= floor" means the retry cannot be proven
+    new. It only ever moves forward.
+    """
+    entries = [(key, entry) for key, entry in applied.items() if isinstance(entry, dict)]
+    floor = max(int(floor_revision), 0)
+    if len(entries) <= APPLIED_MUTATIONS_LIMIT:
+        return dict(entries), floor
+    entries.sort(key=lambda pair: (_entry_revision(pair[1]), str(pair[0])), reverse=True)
+    kept = entries[:APPLIED_MUTATIONS_LIMIT]
+    for _, entry in entries[APPLIED_MUTATIONS_LIMIT:]:
+        floor = max(floor, _entry_revision(entry))
+    return dict(sorted(kept, key=lambda pair: (_entry_revision(pair[1]), str(pair[0])))), floor
+
+
+def bounded_applied_mutations(applied: dict[str, Any]) -> dict[str, Any]:
+    """Keep only the most recent APPLIED_MUTATIONS_LIMIT entries by revision."""
+    bounded, _ = bounded_applied_mutations_with_floor(applied)
+    return bounded
+
+
+def _entry_revision(entry: dict[str, Any]) -> int:
+    value = entry.get("record_revision", 0)
+    if isinstance(value, bool) or not isinstance(value, int):
+        return 0
+    return value
+
+
+def _result_digest(record: dict[str, Any]) -> str:
+    projected = {key: value for key, value in record.items() if key not in (APPLIED_MUTATIONS_KEY, APPLIED_MUTATIONS_FLOOR_KEY)}
+    return sha256_text(json.dumps(projected, sort_keys=True, separators=(",", ":"), default=str))
+
+
+def _reject_divergent_replay(
+    *,
+    entry: dict[str, Any],
+    operation: str,
+    mutation_id: str,
+    mutation_digest: str | None,
+    record_name: str,
+) -> None:
+    if mutation_digest is None:
+        return
+    stored = str(entry.get("result_digest", ""))
+    if stored == str(mutation_digest):
+        return
+    raise ConflictingMutationReplay(
+        operation=operation,
+        mutation_id=mutation_id,
+        stored_digest=stored,
+        incoming_digest=str(mutation_digest),
+        record_name=record_name,
+    )
+
+
+def guarded_record_update(
+    path: Path,
+    *,
+    mutate: Callable[[dict[str, Any]], dict[str, Any] | None],
+    operation: str,
+    expected_revision: int | None = None,
+    mutation_id: str | None = None,
+    mutation_digest: str | None = None,
+    lock_name: str,
+    validate: Callable[[dict[str, Any]], None] | None = None,
+    on_replay: Callable[[dict[str, Any], dict[str, Any]], Any] | None = None,
+    default: dict[str, Any] | None = None,
+    private: bool = True,
+    timeout_seconds: float = 10.0,
+) -> GuardedRecord | DuplicateMutationReplay:
+    """One locked read-modify-write transaction for a shared JSON record.
+
+    ``operation`` is a required short stable name for the logical mutation
+    ("record_goal_checkpoint", "record_plan_decision"). It scopes mutation_id:
+    applied entries are keyed ``"<operation>:<mutation_id>"``, so one client
+    turn id reused by a different operation is different intent and applies
+    normally instead of being swallowed as a replay.
+
+    Inside a single advisory file lock (derived from lock_name, so several
+    record files in one directory can share a lock when needed) this:
+
+    1. reads the current record (default, when given, seeds a missing file;
+       otherwise a missing file raises FileNotFoundError),
+    2. returns a DuplicateMutationReplay - without any write or revision
+       bump - when this (operation, mutation_id) already applied. When the
+       caller supplies mutation_digest and it does not match the digest stored
+       with that entry the retry is a different payload under one id and
+       raises ConflictingMutationReplay instead of replaying,
+    3. raises MutationHistoryEvicted - without any write - when the id is
+       absent, an expected_revision was supplied, and that revision is at or
+       below applied_mutations_floor_revision, because the record can no
+       longer prove the retry is new,
+    4. raises StaleRecordMutation - without any write - when
+       expected_revision is given and does not match the current
+       record_revision,
+    5. applies mutate(current); a None result means "no change" and skips
+       the write and the revision bump entirely,
+    6. bumps record_revision (first write initializes it to 1), records the
+       applied mutation with a bounded history, carries the eviction floor,
+       runs validate on the final record, and atomically writes it while
+       still holding the lock.
+
+    The replay check runs before the staleness check on purpose: a retry that
+    carries both its original expected_revision and its mutation_id has to
+    replay, not be reported as stale, or every retry after any other write
+    would look like a conflict.
+
+    ``mutation_digest`` must be used consistently within one operation. It is
+    stored as the entry's result_digest when supplied (otherwise the digest of
+    the written record is stored), so a retry that supplies a digest where the
+    original call did not is treated as divergent rather than replayed - the
+    conservative direction, since the alternative silently drops work.
+
+    ``mutation_id`` is bounded at MAX_MUTATION_ID_CHARS and ``operation`` at
+    MAX_OPERATION_CHARS. Both are checked before the lock is taken, so an
+    oversized id is refused without creating the record, the lock sidecar, or
+    a temp file.
+
+    A surface that MATERIALIZES mutation_id into a persisted item id - the way
+    the goal ledger derives checkpoint_id / blocker_id / quality_gate_id from
+    it - MUST additionally dedupe on that derived id inside its own ``mutate``
+    before appending. The bounded map alone cannot prove a retry after
+    eviction: once the id has been dropped, step 2 finds nothing and step 3
+    only fires when an expected_revision was supplied, so a retry carrying a
+    mutation_id and nothing else applies a second time and appends a duplicate
+    item. Widening the floor rule is not the fix - it would refuse every
+    legitimately new mutation_id once any eviction has happened. Scanning the
+    target list for the derived id is exact, survives eviction, and costs one
+    pass. See "Materialized mutation ids" in docs/ARCHITECTURE.md.
+
+    The returned GuardedRecord is a plain dict carrying ``lock_enforced``: on a
+    platform with neither fcntl nor msvcrt no OS lock exists, the transaction
+    is protected only by the revision compare and the atomic replace, and
+    lock_enforced is False so callers can say so rather than claim a guarantee
+    that did not hold.
+    """
+    operation = validated_operation(operation)
+    if mutation_id is not None:
+        mutation_id = validated_mutation_id(mutation_id)
+    lock_path = path.with_name(lock_name)
+    with file_lock(lock_path, timeout_seconds=timeout_seconds, private=private) as lock:
+        lock_enforced = bool(lock.get("enforced", False))
+        lock_mechanism = str(lock.get("mechanism", ""))
+        current, read_error = read_json_object_result(path)
+        if current is None:
+            if read_error is not None and path.exists():
+                raise ValueError(f"{path}: {read_error}")
+            if default is None:
+                raise FileNotFoundError(path)
+            current = dict(default)
+        current_revision = record_revision_of(current)
+        floor_revision = applied_mutations_floor_of(current)
+        applied_raw = current.get(APPLIED_MUTATIONS_KEY)
+        applied = dict(applied_raw) if isinstance(applied_raw, dict) else {}
+        entry_key = applied_mutation_key(operation, mutation_id) if mutation_id else ""
+        entry = applied.get(entry_key) if entry_key else None
+        if isinstance(entry, dict):
+            _reject_divergent_replay(
+                entry=entry,
+                operation=operation,
+                mutation_id=str(mutation_id),
+                mutation_digest=mutation_digest,
+                record_name=path.name,
+            )
+            outcome = on_replay(current, entry) if on_replay is not None else None
+            return DuplicateMutationReplay(
+                mutation_id=str(mutation_id),
+                record=current,
+                record_revision=_entry_revision(entry),
+                result_digest=str(entry.get("result_digest", "")),
+                outcome=outcome,
+                operation=operation,
+                lock_enforced=lock_enforced,
+                lock_mechanism=lock_mechanism,
+            )
+        if mutation_id and expected_revision is not None and floor_revision >= 1 and int(expected_revision) <= floor_revision:
+            raise MutationHistoryEvicted(
+                operation=operation,
+                mutation_id=str(mutation_id),
+                expected_revision=int(expected_revision),
+                floor_revision=floor_revision,
+                current_revision=current_revision,
+                record_name=path.name,
+            )
+        if expected_revision is not None and int(expected_revision) != current_revision:
+            raise StaleRecordMutation(
+                expected_revision=int(expected_revision),
+                current_revision=current_revision,
+                record_name=path.name,
+            )
+        updated = mutate(current)
+        if updated is None:
+            return GuardedRecord(current, lock_enforced=lock_enforced, lock_mechanism=lock_mechanism)
+        updated[RECORD_REVISION_KEY] = current_revision + 1
+        if mutation_id:
+            applied[entry_key] = {
+                "operation": operation,
+                "record_revision": current_revision + 1,
+                "result_digest": str(mutation_digest) if mutation_digest is not None else _result_digest(updated),
+            }
+            applied, floor_revision = bounded_applied_mutations_with_floor(applied, floor_revision)
+        updated[APPLIED_MUTATIONS_KEY] = applied
+        # Written only once eviction has actually happened, so records that
+        # never reach the bound keep their existing shape.
+        if floor_revision >= 1:
+            updated[APPLIED_MUTATIONS_FLOOR_KEY] = floor_revision
+        if validate is not None:
+            validate(updated)
+        atomic_write_json(path, updated, private=private)
+        return GuardedRecord(updated, lock_enforced=lock_enforced, lock_mechanism=lock_mechanism)
+
+
+def require_not_terminal(
+    record: dict[str, Any],
+    status_key: str,
+    terminal_statuses: tuple[str, ...],
+    action: str,
+    *,
+    error_type: type[ValueError] = ValueError,
+) -> None:
+    """Refuse preparing child work or mutations on a terminally closed record."""
+    status = str(record.get(status_key, ""))
+    if status in terminal_statuses:
+        raise error_type(
+            f"cannot {action}: {status_key} is {status}, a terminal state; "
+            "terminal records refuse new child work and further mutations"
+        )

--- a/src/system/workflow_state.py
+++ b/src/system/workflow_state.py
@@ -4,9 +4,10 @@ from json import JSONDecodeError
 from pathlib import Path
 from typing import Any
 
-from ..local_store import atomic_write_json, read_json_object, utc_now
+from ..local_store import file_lock, read_json_object, utc_now
 from ..paths import OmhPaths
 from ..skill_pack import routable_skill_names
+from .record_revision import DuplicateMutationReplay, guarded_record_update
 
 SCHEMA_VERSION = 1
 LIFECYCLE_OUTCOMES = ("finished", "blocked", "failed", "user_interlude", "question_pending")
@@ -94,11 +95,37 @@ def _terminal_state(workflow: str, state: dict[str, Any] | None, outcome: str, n
     return result
 
 
+def _workflow_state_lock_anchor(paths: OmhPaths) -> Path:
+    """Anchor for the one lock that serializes all workflow-state transitions.
+
+    The active-workflow invariant spans every ``*-state.json`` in the
+    directory, so a per-file lock is not enough: the transition check and all
+    of the writes it authorizes have to run under this single directory-level
+    lock. ``file_lock`` derives ``.workflow-state.lock`` beside this anchor,
+    so the anchor path itself is never created or written.
+    """
+    return paths.workflow_state_dir / "workflow-state"
+
+
+def _write_workflow_state(paths: OmhPaths, workflow: str, record: dict[str, Any]) -> dict[str, Any]:
+    """Write one state file, bumping its record_revision, under its own lock."""
+    result = guarded_record_update(
+        workflow_state_path(paths, workflow),
+        mutate=lambda current: dict(record),
+        operation="write_workflow_state",
+        lock_name=f"{workflow}-state.json",
+        default={},
+        private=True,
+    )
+    return result.record if isinstance(result, DuplicateMutationReplay) else result
+
+
 def finish_workflow_state(paths: OmhPaths, workflow: str, outcome: str = "finished", note: str = "") -> dict[str, Any]:
-    state = read_workflow_state(paths, workflow)
-    result = _terminal_state(workflow, state, outcome, note)
-    atomic_write_json(workflow_state_path(paths, workflow), result, private=True)
-    return result
+    validate_workflow_name(workflow)
+    with file_lock(_workflow_state_lock_anchor(paths), private=True):
+        state = read_workflow_state(paths, workflow)
+        result = _terminal_state(workflow, state, outcome, note)
+        return _write_workflow_state(paths, workflow, result)
 
 
 def _transition_allowed(source: str, destination: str) -> bool:
@@ -107,37 +134,40 @@ def _transition_allowed(source: str, destination: str) -> bool:
 
 def start_workflow_state(paths: OmhPaths, workflow: str, note: str = "") -> dict[str, Any]:
     validate_workflow_name(workflow)
-    active, errors = active_workflow_states(paths)
-    if errors:
-        first = errors[0]
-        raise WorkflowStateError(f"cannot start workflow while state is unreadable: {first['path']}: {first['error']}")
-    now = utc_now()
-    for current in active:
-        source = str(current.get("workflow", ""))
-        if source == workflow:
-            updated = {**current, "schema_version": SCHEMA_VERSION, "active": True, "updated_at": now}
-            if note:
-                updated["note"] = note
-            atomic_write_json(workflow_state_path(paths, workflow), updated, private=True)
-            return updated
-        if not _transition_allowed(source, workflow):
-            raise WorkflowStateError(f"cannot start {workflow}; active workflow {source} must finish or be cleared first")
-    for current in active:
-        source = str(current["workflow"])
-        completed = _terminal_state(source, current, "finished", f"auto-completed before starting {workflow}", workflow)
-        atomic_write_json(workflow_state_path(paths, source), completed, private=True)
-    state = {
-        "schema_version": SCHEMA_VERSION,
-        "workflow": workflow,
-        "active": True,
-        "lifecycle_outcome": None,
-        "started_at": now,
-        "updated_at": now,
-    }
-    if note:
-        state["note"] = note
-    atomic_write_json(workflow_state_path(paths, workflow), state, private=True)
-    return state
+    # Read the active set and write every state file it authorizes inside one
+    # lock. Reading outside the lock let two concurrent starts each observe an
+    # empty active set and both become active, or let one overwrite the
+    # auto-completion the other had just written.
+    with file_lock(_workflow_state_lock_anchor(paths), private=True):
+        active, errors = active_workflow_states(paths)
+        if errors:
+            first = errors[0]
+            raise WorkflowStateError(f"cannot start workflow while state is unreadable: {first['path']}: {first['error']}")
+        now = utc_now()
+        for current in active:
+            source = str(current.get("workflow", ""))
+            if source == workflow:
+                updated = {**current, "schema_version": SCHEMA_VERSION, "active": True, "updated_at": now}
+                if note:
+                    updated["note"] = note
+                return _write_workflow_state(paths, workflow, updated)
+            if not _transition_allowed(source, workflow):
+                raise WorkflowStateError(f"cannot start {workflow}; active workflow {source} must finish or be cleared first")
+        for current in active:
+            source = str(current["workflow"])
+            completed = _terminal_state(source, current, "finished", f"auto-completed before starting {workflow}", workflow)
+            _write_workflow_state(paths, source, completed)
+        state = {
+            "schema_version": SCHEMA_VERSION,
+            "workflow": workflow,
+            "active": True,
+            "lifecycle_outcome": None,
+            "started_at": now,
+            "updated_at": now,
+        }
+        if note:
+            state["note"] = note
+        return _write_workflow_state(paths, workflow, state)
 
 
 def clear_workflow_state(paths: OmhPaths, workflow: str) -> bool:

--- a/src/workflows/goal_ledger.py
+++ b/src/workflows/goal_ledger.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 import secrets
 from datetime import datetime, timezone
@@ -7,7 +8,13 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from ..hashutil import sha256_text
-from ..local_store import atomic_write_json, ensure_dir, read_json_object, utc_now
+from ..local_store import ensure_dir, read_json_object, utc_now
+from ..system.record_revision import (
+    DuplicateMutationReplay,
+    guarded_record_update,
+    require_not_terminal,
+    revision_field_errors,
+)
 from ..paths import OmhPaths
 from ..runtime.artifacts import summarize_delegated_coding_status
 
@@ -17,7 +24,8 @@ GOAL_COMPLETION_GATE_SCHEMA = "goal_completion_gate/v1"
 GOAL_CONTINUATION_SCHEMA = "goal_continuation/v1"
 GOAL_STATUS_CARD_SCHEMA = "goal_status_card/v1"
 
-GOAL_STATUSES = {"active", "blocked", "failed", "complete"}
+GOAL_STATUSES = {"active", "blocked", "failed", "complete", "cancelled"}
+GOAL_TERMINAL_STATUSES = ("complete", "cancelled")
 CRITERION_STATUSES = {"pending", "satisfied"}
 CHECKPOINT_STATUSES = {"pending", "in_progress", "done", "blocked", "failed"}
 BLOCKER_STATUSES = {"active", "resolved"}
@@ -170,10 +178,126 @@ def _read_goal(paths: OmhPaths, goal_id: str) -> dict[str, Any]:
     return data
 
 
-def _write_goal(paths: OmhPaths, goal: dict[str, Any]) -> dict[str, Any]:
-    goal["updated_at"] = utc_now()
-    atomic_write_json(goal_ledger_path(paths, str(goal["goal_id"])), goal, private=True)
-    return goal
+def _guarded_goal_update(
+    paths: OmhPaths,
+    goal_id: str,
+    mutate,
+    *,
+    operation: str,
+    expected_revision: int | None = None,
+    mutation_id: str | None = None,
+    mutation_digest: str | None = None,
+    default: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], bool]:
+    """One locked read-check-write transaction on goal.json.
+
+    Returns (goal_record, replayed). A replayed mutation_id returns the
+    current goal without a write or revision bump, so a retried CLI call
+    cannot append a duplicate item; replay is keyed on
+    (operation, mutation_id), so the same client id reused for a different
+    logical operation still applies.
+    """
+    path = goal_ledger_path(paths, goal_id)
+
+    def _mutate(current: dict[str, Any]) -> dict[str, Any] | None:
+        if default is None:
+            _raise_goal_validation_errors(current)
+        updated = mutate(current)
+        if updated is None:
+            return None
+        updated["updated_at"] = utc_now()
+        return updated
+
+    result = guarded_record_update(
+        path,
+        mutate=_mutate,
+        operation=operation,
+        expected_revision=expected_revision,
+        mutation_id=mutation_id,
+        mutation_digest=mutation_digest,
+        lock_name="goal.json",
+        validate=_raise_goal_validation_errors,
+        default=default,
+    )
+    if isinstance(result, DuplicateMutationReplay):
+        return result.record, True
+    return result, False
+
+
+def _mutation_digest(*parts: object) -> str:
+    """Digest of one operation's own arguments, for replay-conflict detection.
+
+    The core helper compares this against the digest stored for the same
+    (operation, mutation_id); a retry that carries different content is then
+    refused instead of silently replaying somebody else's result.
+    """
+    return sha256_text(json.dumps(list(parts), sort_keys=True, separators=(",", ":"), default=str))
+
+
+def _record_goal_outcome(
+    outcome: dict[str, Any] | None,
+    goal: dict[str, Any],
+    *,
+    replayed: bool,
+    applied: bool,
+) -> None:
+    """Re-derive what actually landed in the persisted record for the caller.
+
+    A replayed or refused mutation still returns a goal, so surfaces that
+    report success must read `applied` here instead of assuming the call did
+    what it asked for.
+    """
+    if outcome is None:
+        return
+    outcome.update({"replayed": replayed, "applied": applied, "goal_status": str(goal.get("status", ""))})
+
+
+def _raise_goal_validation_errors(goal: dict[str, Any]) -> None:
+    validation = validate_goal_ledger(goal)
+    if not validation["ok"]:
+        raise ValueError("; ".join(validation["errors"]))
+
+
+def _mutation_item_id(mutation_id: str | None, prefix: str) -> str:
+    """Derive the ledger item id a mutation_id owns, for any mutation_id.
+
+    A mutation_id is a client-chosen retry token, not a storage id: wrapper
+    sessions and loop cycles accept arbitrary strings, so connectors that
+    derive ids from upstream message ids (snowflakes carrying ':' or '/')
+    must not fail on goals alone. Filesystem-safe ids stay verbatim so the
+    item id remains readable; anything else is hashed, which keeps the
+    derivation deterministic - the same mutation_id always maps to the same
+    item id - without ever putting caller text in a path segment.
+    """
+    item = str(mutation_id or "").strip()
+    if not item:
+        return _new_item_id(prefix)
+    if _is_storage_id(item):
+        return item
+    return f"{prefix}-{sha256_text(item)[:24]}"
+
+
+def _item_id_already_present(items: Any, id_key: str, item_id: str) -> bool:
+    """True when the list already holds the item this mutation would append.
+
+    The bounded applied_mutations map forgets an id after 128 later mutations,
+    and the eviction floor only refuses a retry that also carried an
+    expected_revision. A retry carrying nothing but --mutation-id therefore
+    reached mutate() with no replay proof and appended a second item under the
+    same derived id (issue #828). Because the id here is *materialized* from
+    the mutation_id, the record itself is the proof: if the item is already
+    there, the mutation already applied. This scan runs inside the lock, so it
+    cannot race a concurrent append.
+    """
+    if not item_id or not isinstance(items, list):
+        return False
+    return any(isinstance(item, dict) and str(item.get(id_key, "")) == item_id for item in items)
+
+
+def _is_storage_id(value: str) -> bool:
+    if not STORAGE_ID_RE.fullmatch(value):
+        return False
+    return value not in {".", ".."} and ".." not in value and "/" not in value and "\\" not in value
 
 
 def create_goal_ledger(
@@ -212,8 +336,9 @@ def create_goal_ledger(
         raise ValueError("; ".join(validation["errors"]))
     ensure_dir(_goal_dir(paths, goal_id), private=True)
     ensure_dir(_goal_dir(paths, goal_id) / "evidence", private=True)
-    atomic_write_json(goal_ledger_path(paths, goal_id), goal, private=True)
-    return goal
+    return _guarded_goal_update(
+        paths, goal_id, lambda current: dict(goal), operation="create_goal_ledger", default={}
+    )[0]
 
 
 def read_goal_ledger(paths: OmhPaths, goal_id: str) -> dict[str, Any]:
@@ -245,45 +370,82 @@ def record_goal_checkpoint(
     evidence_refs: Iterable[str] | None = None,
     notes_summary: str = "",
     linked_runtime_run_id: str = "",
+    expected_revision: int | None = None,
+    mutation_id: str | None = None,
+    outcome: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     if status not in CHECKPOINT_STATUSES:
         raise ValueError(f"unsupported checkpoint status: {status}")
     if not summary.strip():
         raise ValueError("checkpoint summary is required")
-    goal = read_goal_ledger(paths, goal_id)
-    criterion_ids = {str(criterion["id"]) for criterion in goal["acceptance_criteria"]}
+    checkpoint_id = _mutation_item_id(mutation_id, "checkpoint")
     refs = [str(ref).strip() for ref in criteria_refs or [] if str(ref).strip()]
-    unknown_refs = [ref for ref in refs if ref not in criterion_ids]
-    if unknown_refs:
-        raise ValueError(f"unknown acceptance criteria: {', '.join(unknown_refs)}")
     evidence = _evidence_refs(evidence_refs)
     linked_runtime_ref = (
         _storage_id(linked_runtime_run_id, "linked_runtime_run_id") if linked_runtime_run_id.strip() else ""
     )
-    checkpoint = {
-        "checkpoint_id": _new_item_id("checkpoint"),
-        "created_at": utc_now(),
-        "status": status,
-        "summary": _safe_summary(summary),
-        "criteria_refs": refs,
-        "evidence_refs": evidence,
-        "notes_summary": _safe_summary(notes_summary) if notes_summary.strip() else "",
-        "linked_runtime_run_id": linked_runtime_ref,
-    }
-    goal["checkpoints"].append(checkpoint)
-    goal["current_checkpoint"] = checkpoint["checkpoint_id"]
-    if status == "done":
-        if refs and not evidence:
+
+    replay = {"deduped": False}
+
+    def mutate(goal: dict[str, Any]) -> dict[str, Any] | None:
+        # The materialized-id dedupe runs before every other check, exactly
+        # like the applied_mutations replay path it backstops: that path
+        # returns the record without running preconditions either, so a retry
+        # must not start failing them once its id has been evicted.
+        if _item_id_already_present(goal.get("checkpoints"), "checkpoint_id", checkpoint_id):
+            replay["deduped"] = True
+            return None
+        # Every precondition runs inside the locked transaction and in the
+        # original order: an unknown criterion ref is reported before the
+        # missing-evidence rule, and a raise here leaves the record untouched.
+        require_not_terminal(goal, "status", GOAL_TERMINAL_STATUSES, "record a checkpoint on this goal")
+        criterion_ids = {str(criterion["id"]) for criterion in goal["acceptance_criteria"]}
+        unknown_refs = [ref for ref in refs if ref not in criterion_ids]
+        if unknown_refs:
+            raise ValueError(f"unknown acceptance criteria: {', '.join(unknown_refs)}")
+        if status == "done" and refs and not evidence:
             raise ValueError("done checkpoints that satisfy criteria require evidence_refs")
-        for criterion in goal["acceptance_criteria"]:
-            if criterion["id"] in refs:
-                criterion["status"] = "satisfied"
-                criterion["evidence_refs"] = sorted(set(criterion["evidence_refs"] + evidence))
-    if linked_runtime_ref:
-        runs = set(goal.get("linked_runtime_runs", []))
-        runs.add(linked_runtime_ref)
-        goal["linked_runtime_runs"] = sorted(runs)
-    return _write_goal(paths, goal)
+        checkpoint = {
+            "checkpoint_id": checkpoint_id,
+            "created_at": utc_now(),
+            "status": status,
+            "summary": _safe_summary(summary),
+            "criteria_refs": refs,
+            "evidence_refs": evidence,
+            "notes_summary": _safe_summary(notes_summary) if notes_summary.strip() else "",
+            "linked_runtime_run_id": linked_runtime_ref,
+        }
+        goal["checkpoints"].append(checkpoint)
+        goal["current_checkpoint"] = checkpoint["checkpoint_id"]
+        if status == "done":
+            for criterion in goal["acceptance_criteria"]:
+                if criterion["id"] in refs:
+                    criterion["status"] = "satisfied"
+                    criterion["evidence_refs"] = sorted(set(criterion["evidence_refs"] + evidence))
+        if linked_runtime_ref:
+            runs = set(goal.get("linked_runtime_runs", []))
+            runs.add(linked_runtime_ref)
+            goal["linked_runtime_runs"] = sorted(runs)
+        return goal
+
+    goal, replayed = _guarded_goal_update(
+        paths,
+        goal_id,
+        mutate,
+        operation="record_goal_checkpoint",
+        expected_revision=expected_revision,
+        mutation_id=mutation_id,
+        mutation_digest=_mutation_digest(
+            "record_goal_checkpoint", summary, status, refs, evidence, notes_summary, linked_runtime_ref
+        ),
+    )
+    _record_goal_outcome(
+        outcome,
+        goal,
+        replayed=replayed or replay["deduped"],
+        applied=_item_id_already_present(goal.get("checkpoints"), "checkpoint_id", checkpoint_id),
+    )
+    return goal
 
 
 def record_goal_blocker(
@@ -295,24 +457,60 @@ def record_goal_blocker(
     missing_authority: str = "",
     evidence_refs: Iterable[str] | None = None,
     mark_goal_blocked: bool = False,
+    expected_revision: int | None = None,
+    mutation_id: str | None = None,
+    outcome: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     if not summary.strip():
         raise ValueError("blocker summary is required")
-    goal = read_goal_ledger(paths, goal_id)
-    goal["blockers"].append(
-        {
-            "blocker_id": _new_item_id("blocker"),
-            "created_at": utc_now(),
-            "status": "active",
-            "summary": _safe_summary(summary),
-            "attempted_recovery": _safe_summary(attempted_recovery) if attempted_recovery.strip() else "",
-            "missing_authority": _safe_summary(missing_authority) if missing_authority.strip() else "",
-            "evidence_refs": _evidence_refs(evidence_refs),
-        }
+    blocker_id = _mutation_item_id(mutation_id, "blocker")
+    replay = {"deduped": False}
+
+    def mutate(goal: dict[str, Any]) -> dict[str, Any] | None:
+        # See _item_id_already_present: this is the retry proof the bounded
+        # applied_mutations map can no longer give once the id was evicted.
+        if _item_id_already_present(goal.get("blockers"), "blocker_id", blocker_id):
+            replay["deduped"] = True
+            return None
+        require_not_terminal(goal, "status", GOAL_TERMINAL_STATUSES, "record a blocker on this goal")
+        goal["blockers"].append(
+            {
+                "blocker_id": blocker_id,
+                "created_at": utc_now(),
+                "status": "active",
+                "summary": _safe_summary(summary),
+                "attempted_recovery": _safe_summary(attempted_recovery) if attempted_recovery.strip() else "",
+                "missing_authority": _safe_summary(missing_authority) if missing_authority.strip() else "",
+                "evidence_refs": _evidence_refs(evidence_refs),
+            }
+        )
+        if mark_goal_blocked:
+            goal["status"] = "blocked"
+        return goal
+
+    goal, replayed = _guarded_goal_update(
+        paths,
+        goal_id,
+        mutate,
+        operation="record_goal_blocker",
+        expected_revision=expected_revision,
+        mutation_id=mutation_id,
+        mutation_digest=_mutation_digest(
+            "record_goal_blocker",
+            summary,
+            attempted_recovery,
+            missing_authority,
+            _evidence_refs(evidence_refs),
+            mark_goal_blocked,
+        ),
     )
-    if mark_goal_blocked:
-        goal["status"] = "blocked"
-    return _write_goal(paths, goal)
+    _record_goal_outcome(
+        outcome,
+        goal,
+        replayed=replayed or replay["deduped"],
+        applied=_item_id_already_present(goal.get("blockers"), "blocker_id", blocker_id),
+    )
+    return goal
 
 
 def record_goal_quality_gate(
@@ -322,22 +520,87 @@ def record_goal_quality_gate(
     *,
     status: str = "passed",
     evidence_refs: Iterable[str] | None = None,
+    expected_revision: int | None = None,
+    mutation_id: str | None = None,
+    outcome: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     if status not in QUALITY_GATE_STATUSES:
         raise ValueError(f"unsupported quality gate status: {status}")
     if not summary.strip():
         raise ValueError("quality gate summary is required")
-    goal = read_goal_ledger(paths, goal_id)
-    goal["quality_gates"].append(
-        {
-            "quality_gate_id": _new_item_id("quality-gate"),
-            "created_at": utc_now(),
-            "status": status,
-            "summary": _safe_summary(summary),
-            "evidence_refs": _evidence_refs(evidence_refs),
-        }
+    quality_gate_id = _mutation_item_id(mutation_id, "quality-gate")
+    replay = {"deduped": False}
+
+    def mutate(goal: dict[str, Any]) -> dict[str, Any] | None:
+        # See _item_id_already_present: this is the retry proof the bounded
+        # applied_mutations map can no longer give once the id was evicted.
+        if _item_id_already_present(goal.get("quality_gates"), "quality_gate_id", quality_gate_id):
+            replay["deduped"] = True
+            return None
+        require_not_terminal(goal, "status", GOAL_TERMINAL_STATUSES, "record a quality gate on this goal")
+        goal["quality_gates"].append(
+            {
+                "quality_gate_id": quality_gate_id,
+                "created_at": utc_now(),
+                "status": status,
+                "summary": _safe_summary(summary),
+                "evidence_refs": _evidence_refs(evidence_refs),
+            }
+        )
+        return goal
+
+    goal, replayed = _guarded_goal_update(
+        paths,
+        goal_id,
+        mutate,
+        operation="record_goal_quality_gate",
+        expected_revision=expected_revision,
+        mutation_id=mutation_id,
+        mutation_digest=_mutation_digest(
+            "record_goal_quality_gate", summary, status, _evidence_refs(evidence_refs)
+        ),
     )
-    return _write_goal(paths, goal)
+    _record_goal_outcome(
+        outcome,
+        goal,
+        replayed=replayed or replay["deduped"],
+        applied=_item_id_already_present(goal.get("quality_gates"), "quality_gate_id", quality_gate_id),
+    )
+    return goal
+
+
+def cancel_goal_ledger(
+    paths: OmhPaths,
+    goal_id: str,
+    *,
+    reason: str = "",
+    expected_revision: int | None = None,
+    mutation_id: str | None = None,
+    outcome: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Terminally cancel a goal; later checkpoints, blockers, and gates refuse."""
+
+    def mutate(goal: dict[str, Any]) -> dict[str, Any]:
+        require_not_terminal(goal, "status", GOAL_TERMINAL_STATUSES, "cancel this goal")
+        goal["status"] = "cancelled"
+        if reason.strip():
+            goal["cancel_reason"] = _safe_summary(reason)
+        return goal
+
+    goal, replayed = _guarded_goal_update(
+        paths,
+        goal_id,
+        mutate,
+        operation="cancel_goal_ledger",
+        expected_revision=expected_revision,
+        mutation_id=mutation_id,
+        mutation_digest=_mutation_digest("cancel_goal_ledger", reason),
+    )
+    # Re-derived from the persisted status, never from "the call returned":
+    # a mutation replayed away leaves an uncancelled goal, and reporting that
+    # as success is how a discarded cancel looks like a cancelled goal.
+    _record_goal_outcome(outcome, goal, replayed=replayed, applied=goal.get("status") == "cancelled")
+    return goal
 
 
 def validate_goal_ledger(goal: dict[str, Any]) -> dict[str, Any]:
@@ -354,7 +617,9 @@ def validate_goal_ledger(goal: dict[str, Any]) -> dict[str, Any]:
         except ValueError as exc:
             errors.append(str(exc))
     if goal.get("status") not in GOAL_STATUSES:
-        errors.append("status must be active, blocked, failed, or complete")
+        errors.append("status must be active, blocked, failed, complete, or cancelled")
+    if "cancel_reason" in goal and not isinstance(goal.get("cancel_reason"), str):
+        errors.append("cancel_reason must be a string")
     objective_hash = str(goal.get("objective_hash", ""))
     if len(objective_hash) != 64 or not re.fullmatch(r"[0-9a-f]+", objective_hash):
         errors.append("objective_hash must be a sha256 hex digest")
@@ -372,6 +637,7 @@ def validate_goal_ledger(goal: dict[str, Any]) -> dict[str, Any]:
                 _storage_id(str(run_id), "linked_runtime_run_id")
             except ValueError as exc:
                 errors.append(f"linked_runtime_runs[{index}]: {exc}")
+    errors.extend(revision_field_errors(goal, "goal_ledger"))
     return {"ok": not errors, "errors": errors}
 
 
@@ -400,7 +666,19 @@ def build_goal_completion_gate(paths: OmhPaths, goal_id: str) -> dict[str, Any]:
         status_gaps.append("goal status is blocked")
     if goal["status"] == "failed":
         status_gaps.append("goal status is failed")
+    if goal["status"] == "cancelled":
+        status_gaps.append("goal status is cancelled")
     ready = not missing_required and not active_blockers and not runtime_gaps and not status_gaps
+    next_action = _completion_next_action(
+        missing_required=missing_required,
+        active_blockers=active_blockers,
+        runtime_gaps=runtime_gaps,
+        status_gaps=status_gaps,
+    )
+    if goal["status"] == "cancelled":
+        # A cancelled goal is terminal: recording blockers or checkpoints is
+        # refused, so the only safe next action is showing status.
+        next_action = "show_status"
     return {
         "schema_version": GOAL_COMPLETION_GATE_SCHEMA,
         "goal_id": goal_id,
@@ -415,12 +693,7 @@ def build_goal_completion_gate(paths: OmhPaths, goal_id: str) -> dict[str, Any]:
         "missing_required_criteria": missing_required,
         "active_blockers": active_blockers,
         "linked_runtime_checks": runtime_checks,
-        "next_action": _completion_next_action(
-            missing_required=missing_required,
-            active_blockers=active_blockers,
-            runtime_gaps=runtime_gaps,
-            status_gaps=status_gaps,
-        ),
+        "next_action": next_action,
     }
 
 
@@ -429,33 +702,82 @@ def complete_goal_ledger(
     goal_id: str,
     *,
     evidence_refs: Iterable[str] | None = None,
+    expected_revision: int | None = None,
+    mutation_id: str | None = None,
 ) -> dict[str, Any]:
-    gate = build_goal_completion_gate(paths, goal_id)
-    goal = read_goal_ledger(paths, goal_id)
-    if not gate["ready"]:
-        return {"completed": False, "goal": goal, "completion_gate": gate}
     evidence = _evidence_refs(evidence_refs)
-    if not evidence:
-        gate = {
-            **gate,
-            "ready": False,
-            "summary": "Completion requires final evidence_refs.",
-            "next_action": "record_completion",
-        }
-        return {"completed": False, "goal": goal, "completion_gate": gate}
-    if goal["status"] != "complete":
+    quality_gate_id = _mutation_item_id(mutation_id, "quality-gate")
+    outcome: dict[str, Any] = {}
+    replay = {"deduped": False}
+
+    def mutate(goal: dict[str, Any]) -> dict[str, Any] | None:
+        # See _item_id_already_present: the completion quality gate is
+        # materialized from the mutation_id too, so the gate itself proves the
+        # retry even after the applied_mutations entry was evicted.
+        if _item_id_already_present(goal.get("quality_gates"), "quality_gate_id", quality_gate_id):
+            replay["deduped"] = True
+            return None
+        # The gate is evaluated inside the locked transaction so a concurrent
+        # blocker or cancellation cannot slip in between the check and the
+        # completion write.
+        gate = build_goal_completion_gate(paths, goal_id)
+        if not gate["ready"]:
+            outcome.update({"completed": False, "goal": goal, "completion_gate": gate})
+            return None
+        if not evidence:
+            adjusted = {
+                **gate,
+                "ready": False,
+                "summary": "Completion requires final evidence_refs.",
+                "next_action": "record_completion",
+            }
+            outcome.update({"completed": False, "goal": goal, "completion_gate": adjusted})
+            return None
+        outcome["completed"] = True
+        if goal["status"] == "complete":
+            outcome["goal"] = goal
+            return None
         goal["status"] = "complete"
         goal["quality_gates"].append(
             {
-                "quality_gate_id": _new_item_id("quality-gate"),
+                "quality_gate_id": quality_gate_id,
                 "created_at": utc_now(),
                 "status": "passed",
                 "summary": "Completion gate passed.",
                 "evidence_refs": evidence,
             }
         )
-        goal = _write_goal(paths, goal)
-    return {"completed": True, "goal": goal, "completion_gate": build_goal_completion_gate(paths, goal_id)}
+        outcome["goal"] = goal
+        return goal
+
+    goal, replayed = _guarded_goal_update(
+        paths,
+        goal_id,
+        mutate,
+        operation="complete_goal_ledger",
+        expected_revision=expected_revision,
+        mutation_id=mutation_id,
+        mutation_digest=_mutation_digest("complete_goal_ledger", evidence),
+    )
+    replayed = replayed or replay["deduped"]
+    if not outcome:
+        # Replayed mutation_id: the completion already applied.
+        return {
+            "completed": goal.get("status") == "complete",
+            "replayed": replayed,
+            "goal": goal,
+            "completion_gate": build_goal_completion_gate(paths, goal_id),
+        }
+    if outcome["completed"]:
+        # Re-derived from the persisted status, not from the gate verdict the
+        # mutate callable computed before the write.
+        return {
+            "completed": goal.get("status") == "complete",
+            "replayed": replayed,
+            "goal": goal,
+            "completion_gate": build_goal_completion_gate(paths, goal_id),
+        }
+    return {**outcome, "replayed": replayed}
 
 
 def build_goal_continuation(paths: OmhPaths, goal_id: str) -> dict[str, Any]:
@@ -609,6 +931,9 @@ def _goal_progress(goal: dict[str, Any]) -> dict[str, Any]:
 
 
 def _allowed_goal_actions(gate: dict[str, Any]) -> list[str]:
+    if gate.get("goal_status") == "cancelled":
+        # Terminal cancellation: checkpoints, blockers, and completion refuse.
+        return ["show_status"]
     actions = ["continue_goal", "show_status"]
     if gate["missing_required_criteria"]:
         actions.append("record_checkpoint")
@@ -683,10 +1008,32 @@ def _validate_criteria(criteria: Any, errors: list[str]) -> None:
             errors.append(f"acceptance_criteria[{index}].evidence_refs must be a list")
 
 
+def _validate_unique_item_ids(items: list[Any], id_key: str, label: str, errors: list[str]) -> None:
+    """Reject two items in one list sharing an id.
+
+    Item ids are materialized from mutation_id, so a duplicate is the exact
+    shape of a retry that applied twice after its applied_mutations entry was
+    evicted (issue #828). The validator runs inside the guarded write, so this
+    refuses the duplicate before it is persisted rather than reporting a
+    ledger that already lost the invariant as ok.
+    """
+    seen: set[str] = set()
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        item_id = str(item.get(id_key, "")).strip()
+        if not item_id:
+            continue
+        if item_id in seen:
+            errors.append(f"duplicate {label} {id_key}: {item_id}")
+        seen.add(item_id)
+
+
 def _validate_checkpoints(checkpoints: Any, errors: list[str]) -> None:
     if not isinstance(checkpoints, list):
         errors.append("checkpoints must be a list")
         return
+    _validate_unique_item_ids(checkpoints, "checkpoint_id", "checkpoint", errors)
     for index, checkpoint in enumerate(checkpoints, start=1):
         if not isinstance(checkpoint, dict):
             errors.append(f"checkpoints[{index}] must be an object")
@@ -705,6 +1052,7 @@ def _validate_blockers(blockers: Any, errors: list[str]) -> None:
     if not isinstance(blockers, list):
         errors.append("blockers must be a list")
         return
+    _validate_unique_item_ids(blockers, "blocker_id", "blocker", errors)
     for index, blocker in enumerate(blockers, start=1):
         if not isinstance(blocker, dict):
             errors.append(f"blockers[{index}] must be an object")
@@ -721,6 +1069,7 @@ def _validate_quality_gates(quality_gates: Any, errors: list[str]) -> None:
     if not isinstance(quality_gates, list):
         errors.append("quality_gates must be a list")
         return
+    _validate_unique_item_ids(quality_gates, "quality_gate_id", "quality gate", errors)
     for index, gate in enumerate(quality_gates, start=1):
         if not isinstance(gate, dict):
             errors.append(f"quality_gates[{index}] must be an object")

--- a/src/workflows/goal_loop.py
+++ b/src/workflows/goal_loop.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 import secrets
 from datetime import datetime, timezone
@@ -9,7 +10,8 @@ from typing import Any, Iterable
 from ..codex_progress import summarize_codex_jsonl_text
 from ..goal_ledger import build_goal_completion_gate, read_goal_ledger
 from ..hashutil import sha256_text
-from ..local_store import atomic_write_json, ensure_dir, read_json_object, utc_now
+from ..local_store import ensure_dir, read_json_object, utc_now
+from ..system.record_revision import DuplicateMutationReplay, guarded_record_update, revision_field_errors
 from ..loopability import LOOPABILITY_ASSESSMENT_SCHEMA, assess_loopability, validate_loopability_assessment
 from ..paths import OmhPaths
 
@@ -260,8 +262,9 @@ def create_loop_cycle(
     if not validation["ok"]:
         raise ValueError("; ".join(validation["errors"]))
     ensure_dir(_loop_dir(paths, loop_id), private=True)
-    atomic_write_json(loop_cycle_path(paths, loop_id), cycle, private=True)
-    return cycle
+    return _guarded_cycle_update(
+        paths, loop_id, lambda current: dict(cycle), operation="create_loop_cycle", default={}
+    )
 
 
 def loop_executor_capability(executor: str) -> dict[str, Any]:
@@ -562,8 +565,9 @@ def record_loop_feedback(
     external_wait: str = "",
     context_exhausted: bool = False,
     budget_exhausted: bool = False,
+    expected_revision: int | None = None,
+    mutation_id: str | None = None,
 ) -> dict[str, Any]:
-    cycle = read_loop_cycle(paths, loop_id)
     artifacts = [_safe_summary(value, limit=320) for value in observed_artifacts or [] if str(value).strip()]
     feedback_gate = _feedback_gate(
         observed_artifacts=artifacts,
@@ -590,22 +594,37 @@ def record_loop_feedback(
         phase = "feedback"
         wait_reason = "none"
         next_action = "record_feedback"
-    cycle["phase"] = phase
-    cycle["wait_reason"] = wait_reason
-    cycle["feedback_gate"] = feedback_gate
-    cycle["next_action"] = next_action
-    cycle["cycles"].append(
-        {
-            "cycle_id": _new_item_id("cycle"),
-            "created_at": utc_now(),
-            "phase": phase,
-            "wait_reason": wait_reason,
-            "observed_artifacts": artifacts,
-            "internal_actionable_gap": _safe_summary(internal_gap) if internal_gap.strip() else "",
-            "external_wait": _safe_summary(external_wait) if external_wait.strip() else "",
-        }
+
+    def mutate(cycle: dict[str, Any]) -> dict[str, Any]:
+        cycle["phase"] = phase
+        cycle["wait_reason"] = wait_reason
+        cycle["feedback_gate"] = feedback_gate
+        cycle["next_action"] = next_action
+        cycle["cycles"].append(
+            {
+                "cycle_id": _new_item_id("cycle"),
+                "created_at": utc_now(),
+                "phase": phase,
+                "wait_reason": wait_reason,
+                "observed_artifacts": artifacts,
+                "internal_actionable_gap": _safe_summary(internal_gap) if internal_gap.strip() else "",
+                "external_wait": _safe_summary(external_wait) if external_wait.strip() else "",
+            }
+        )
+        cycle["updated_at"] = utc_now()
+        return cycle
+
+    return _guarded_cycle_update(
+        paths,
+        loop_id,
+        mutate,
+        operation="record_loop_feedback",
+        expected_revision=expected_revision,
+        mutation_id=mutation_id,
+        mutation_digest=_mutation_digest(
+            "record_loop_feedback", artifacts, internal_gap, external_wait, context_exhausted, budget_exhausted
+        ),
     )
-    return _write_loop(paths, cycle)
 
 
 def update_loop_permission(
@@ -615,25 +634,43 @@ def update_loop_permission(
     allow_actions: Iterable[str] | None = None,
     forbid_actions: Iterable[str] | None = None,
     allowed_executors: Iterable[str] | None = None,
+    expected_revision: int | None = None,
+    mutation_id: str | None = None,
 ) -> dict[str, Any]:
-    cycle = read_loop_cycle(paths, loop_id)
-    current = _dict_value(cycle, "authority_envelope")
-    existing_allowed = _string_set(current.get("allowed_actions", []))
-    existing_forbidden = _string_set(current.get("forbidden_actions", []))
     requested_allow = _valid_actions(allow_actions or [])
     requested_forbid = _valid_actions(forbid_actions or [])
-    forbidden = sorted(existing_forbidden | requested_forbid)
-    allowed = sorted((existing_allowed | requested_allow) - set(forbidden))
-    existing_executors = _string_set(current.get("allowed_executors", []))
     requested_executors = _safe_list(allowed_executors or [], limit=120)
-    cycle["authority_envelope"] = build_authority_envelope(
-        permission_profile="custom",
-        allowed_executors=sorted(existing_executors | set(requested_executors)),
-        allow_actions=allowed,
-        forbid_actions=forbidden,
+
+    def mutate(cycle: dict[str, Any]) -> dict[str, Any]:
+        # The merge reads the envelope that is current inside the lock, so a
+        # concurrent grant is extended rather than reverted.
+        current = _dict_value(cycle, "authority_envelope")
+        existing_allowed = _string_set(current.get("allowed_actions", []))
+        existing_forbidden = _string_set(current.get("forbidden_actions", []))
+        forbidden = sorted(existing_forbidden | requested_forbid)
+        allowed = sorted((existing_allowed | requested_allow) - set(forbidden))
+        existing_executors = _string_set(current.get("allowed_executors", []))
+        cycle["authority_envelope"] = build_authority_envelope(
+            permission_profile="custom",
+            allowed_executors=sorted(existing_executors | set(requested_executors)),
+            allow_actions=allowed,
+            forbid_actions=forbidden,
+        )
+        _normalize_permission_state(cycle)
+        cycle["updated_at"] = utc_now()
+        return cycle
+
+    return _guarded_cycle_update(
+        paths,
+        loop_id,
+        mutate,
+        operation="update_loop_permission",
+        expected_revision=expected_revision,
+        mutation_id=mutation_id,
+        mutation_digest=_mutation_digest(
+            "update_loop_permission", sorted(requested_allow), sorted(requested_forbid), requested_executors
+        ),
     )
-    _normalize_permission_state(cycle)
-    return _write_loop(paths, cycle)
 
 
 def tick_loop_runtime(
@@ -649,53 +686,90 @@ def tick_loop_runtime(
     connector_action: str = "",
     workflow_pattern: str = "single_step",
     note: str = "",
+    expected_revision: int | None = None,
+    mutation_id: str | None = None,
 ) -> dict[str, Any]:
-    cycle = read_loop_cycle(paths, loop_id)
-    envelope = _dict_value(cycle, "authority_envelope")
-    plan = _next_runtime_plan(cycle, envelope)
-    queue_item = _runtime_queue_item(
-        cycle,
-        envelope,
-        plan,
-        trigger=trigger,
-        cadence=cadence,
-        worktree_base=worktree_base,
-        worktree_branch=worktree_branch,
-        subagent_role=subagent_role,
-        connector=connector,
-        connector_action=connector_action,
-        workflow_pattern=workflow_pattern,
-        note=note,
+    def mutate(cycle: dict[str, Any]) -> dict[str, Any]:
+        # The plan and the queue item are derived from the cycle read inside
+        # the lock: deriving them from an unlocked read appended a queue item
+        # computed against permissions or a queue that had already moved on.
+        envelope = _dict_value(cycle, "authority_envelope")
+        plan = _next_runtime_plan(cycle, envelope)
+        queue_item = _runtime_queue_item(
+            cycle,
+            envelope,
+            plan,
+            trigger=trigger,
+            cadence=cadence,
+            worktree_base=worktree_base,
+            worktree_branch=worktree_branch,
+            subagent_role=subagent_role,
+            connector=connector,
+            connector_action=connector_action,
+            workflow_pattern=workflow_pattern,
+            note=note,
+        )
+        runtime = _runtime_state(cycle.get("runtime"))
+        runtime["heartbeat_count"] = int(runtime.get("heartbeat_count", 0)) + 1
+        runtime["last_tick_at"] = queue_item["created_at"]
+        runtime["last_trigger"] = queue_item["trigger"]
+        runtime["last_planned_action"] = queue_item["planned_action"]
+        runtime["last_queue_id"] = queue_item["queue_id"]
+        runtime.setdefault("queue", []).append(queue_item)
+        cycle["runtime"] = runtime
+        if queue_item["status"] == "prepared_not_observed":
+            cycle["phase"] = str(plan["phase"])
+            cycle["wait_reason"] = "none"
+            cycle["next_action"] = "observe_runtime_queue"
+        else:
+            cycle["next_action"] = str(plan["next_action"])
+        cycle["updated_at"] = utc_now()
+        return cycle
+
+    return _guarded_cycle_update(
+        paths,
+        loop_id,
+        mutate,
+        operation="tick_loop_runtime",
+        expected_revision=expected_revision,
+        mutation_id=mutation_id,
+        mutation_digest=_mutation_digest(
+            "tick_loop_runtime",
+            trigger,
+            cadence,
+            worktree_base,
+            worktree_branch,
+            subagent_role,
+            connector,
+            connector_action,
+            workflow_pattern,
+            note,
+        ),
     )
-    runtime = _runtime_state(cycle.get("runtime"))
-    runtime["heartbeat_count"] = int(runtime.get("heartbeat_count", 0)) + 1
-    runtime["last_tick_at"] = queue_item["created_at"]
-    runtime["last_trigger"] = queue_item["trigger"]
-    runtime["last_planned_action"] = queue_item["planned_action"]
-    runtime["last_queue_id"] = queue_item["queue_id"]
-    runtime.setdefault("queue", []).append(queue_item)
-    cycle["runtime"] = runtime
-    if queue_item["status"] == "prepared_not_observed":
-        cycle["phase"] = str(plan["phase"])
-        cycle["wait_reason"] = "none"
-        cycle["next_action"] = "observe_runtime_queue"
-    else:
-        cycle["next_action"] = str(plan["next_action"])
-    return _write_loop(paths, cycle)
 
 
 def run_loop_once(paths: OmhPaths, loop_id: str) -> dict[str, Any]:
-    cycle = read_loop_cycle(paths, loop_id)
-    runtime = _runtime_state(cycle.get("runtime"))
-    pending = [
-        item
-        for item in runtime.get("queue", [])
-        if isinstance(item, dict) and item.get("status") == "prepared_not_observed"
-    ]
-    if pending:
+    needs_tick: dict[str, bool] = {}
+
+    def mutate(cycle: dict[str, Any]) -> dict[str, Any] | None:
+        runtime = _runtime_state(cycle.get("runtime"))
+        pending = [
+            item
+            for item in runtime.get("queue", [])
+            if isinstance(item, dict) and item.get("status") == "prepared_not_observed"
+        ]
+        if not pending:
+            # No write here: the tick below takes the lock again on its own.
+            needs_tick["tick"] = True
+            return None
         cycle["phase"] = str(pending[-1].get("phase", cycle.get("phase", "handoff")))
         cycle["next_action"] = "observe_runtime_queue"
-        return _write_loop(paths, cycle)
+        cycle["updated_at"] = utc_now()
+        return cycle
+
+    cycle = _guarded_cycle_update(paths, loop_id, mutate, operation="run_loop_once")
+    if not needs_tick:
+        return cycle
     return tick_loop_runtime(
         paths,
         loop_id,
@@ -808,30 +882,46 @@ def dispatch_loop_queue_item(
     thread_ref: str = "",
     evidence_refs: Iterable[str] | None = None,
     summary: str = "",
+    expected_revision: int | None = None,
+    mutation_id: str | None = None,
 ) -> dict[str, Any]:
     refs = _safe_list(evidence_refs or [], limit=320)
-    cycle = read_loop_cycle(paths, loop_id)
-    runtime, item = _queue_item_ref(cycle, queue_id)
-    if item.get("status") != "prepared_not_observed":
-        raise ValueError("only prepared_not_observed loop queue items can record executor dispatch")
     capability = loop_executor_capability(executor)
-    item["executor_session"] = {
-        **_empty_executor_session(str(capability["executor"])),
-        "executor": capability["executor"],
-        "loop_mode": capability["loop_mode"],
-        "dispatch_owner": capability["dispatch_owner"],
-        "dispatch_status": "dispatched" if refs or session_ref.strip() or thread_ref.strip() else "prepared",
-        "session_ref": _safe_summary(session_ref, limit=220) if session_ref.strip() else "",
-        "thread_ref": _safe_summary(thread_ref, limit=220) if thread_ref.strip() else "",
-        "dispatch_evidence_refs": refs,
-        "summary": _safe_summary(summary, limit=320) if summary.strip() else "Executor dispatch metadata recorded for this loop queue item.",
-        "capability": capability,
-    }
-    runtime["last_queue_id"] = str(item["queue_id"])
-    runtime["last_queue_status"] = str(item["status"])
-    cycle["runtime"] = runtime
-    cycle["next_action"] = "observe_runtime_queue"
-    return _write_loop(paths, cycle)
+
+    def mutate(cycle: dict[str, Any]) -> dict[str, Any]:
+        runtime, item = _queue_item_ref(cycle, queue_id)
+        if item.get("status") != "prepared_not_observed":
+            raise ValueError("only prepared_not_observed loop queue items can record executor dispatch")
+        item["executor_session"] = {
+            **_empty_executor_session(str(capability["executor"])),
+            "executor": capability["executor"],
+            "loop_mode": capability["loop_mode"],
+            "dispatch_owner": capability["dispatch_owner"],
+            "dispatch_status": "dispatched" if refs or session_ref.strip() or thread_ref.strip() else "prepared",
+            "session_ref": _safe_summary(session_ref, limit=220) if session_ref.strip() else "",
+            "thread_ref": _safe_summary(thread_ref, limit=220) if thread_ref.strip() else "",
+            "dispatch_evidence_refs": refs,
+            "summary": _safe_summary(summary, limit=320) if summary.strip() else "Executor dispatch metadata recorded for this loop queue item.",
+            "capability": capability,
+        }
+        runtime["last_queue_id"] = str(item["queue_id"])
+        runtime["last_queue_status"] = str(item["status"])
+        cycle["runtime"] = runtime
+        cycle["next_action"] = "observe_runtime_queue"
+        cycle["updated_at"] = utc_now()
+        return cycle
+
+    return _guarded_cycle_update(
+        paths,
+        loop_id,
+        mutate,
+        operation="dispatch_loop_queue_item",
+        expected_revision=expected_revision,
+        mutation_id=mutation_id,
+        mutation_digest=_mutation_digest(
+            "dispatch_loop_queue_item", queue_id, executor, session_ref, thread_ref, refs, summary
+        ),
+    )
 
 
 def observe_codex_loop_queue_item(
@@ -843,47 +933,61 @@ def observe_codex_loop_queue_item(
     evidence_refs: Iterable[str] | None = None,
     codex_log_ref: str = "",
     summary: str = "",
+    expected_revision: int | None = None,
+    mutation_id: str | None = None,
 ) -> dict[str, Any]:
     refs = _safe_list(evidence_refs or [], limit=320)
     log_ref = _safe_summary(codex_log_ref, limit=320) if codex_log_ref.strip() else ""
     all_refs = _safe_list([*refs, *([log_ref] if log_ref else [])], limit=320)
     if not all_refs:
         raise ValueError("Codex loop queue observation requires at least one evidence ref")
-    cycle = read_loop_cycle(paths, loop_id)
-    runtime, item = _queue_item_ref(cycle, queue_id)
-    if item.get("status") != "prepared_not_observed":
-        raise ValueError("only prepared_not_observed loop queue items can observe Codex progress")
     progress = summarize_codex_jsonl_text(
         codex_log_text,
         evidence_refs=all_refs,
         source=log_ref or "codex-loop-observation",
     )
-    existing = _dict_value(item, "executor_session")
-    executor_session = {
-        **_empty_executor_session("codex"),
-        **existing,
-        "executor": "codex",
-        "loop_mode": "omh_managed",
-        "dispatch_owner": "omh_wrapper",
-        "dispatch_status": "progress_observed",
-        "progress_summary": progress,
-        "summary": _safe_summary(summary, limit=320) if summary.strip() else str(progress.get("chat_summary", "")),
-        "progress_evidence_refs": all_refs,
-        "capability": loop_executor_capability("codex"),
-    }
-    item["executor_session"] = executor_session
-    item["status"] = "observed"
-    item["observed"] = True
-    item["observed_at"] = utc_now()
-    item["observed_evidence_refs"] = _safe_list([*_string_list(item.get("observed_evidence_refs", [])), *all_refs], limit=320)
-    item["observation_summary"] = executor_session["summary"] or "Codex progress observed for this loop queue item."
-    runtime["last_queue_id"] = str(item["queue_id"])
-    runtime["last_queue_status"] = "observed"
-    cycle["runtime"] = runtime
-    cycle["phase"] = "feedback"
-    cycle["wait_reason"] = "none"
-    cycle["next_action"] = "record_feedback"
-    return _write_loop(paths, cycle)
+
+    def mutate(cycle: dict[str, Any]) -> dict[str, Any]:
+        runtime, item = _queue_item_ref(cycle, queue_id)
+        if item.get("status") != "prepared_not_observed":
+            raise ValueError("only prepared_not_observed loop queue items can observe Codex progress")
+        existing = _dict_value(item, "executor_session")
+        executor_session = {
+            **_empty_executor_session("codex"),
+            **existing,
+            "executor": "codex",
+            "loop_mode": "omh_managed",
+            "dispatch_owner": "omh_wrapper",
+            "dispatch_status": "progress_observed",
+            "progress_summary": progress,
+            "summary": _safe_summary(summary, limit=320) if summary.strip() else str(progress.get("chat_summary", "")),
+            "progress_evidence_refs": all_refs,
+            "capability": loop_executor_capability("codex"),
+        }
+        item["executor_session"] = executor_session
+        item["status"] = "observed"
+        item["observed"] = True
+        item["observed_at"] = utc_now()
+        item["observed_evidence_refs"] = _safe_list([*_string_list(item.get("observed_evidence_refs", [])), *all_refs], limit=320)
+        item["observation_summary"] = executor_session["summary"] or "Codex progress observed for this loop queue item."
+        runtime["last_queue_id"] = str(item["queue_id"])
+        runtime["last_queue_status"] = "observed"
+        cycle["runtime"] = runtime
+        cycle["phase"] = "feedback"
+        cycle["wait_reason"] = "none"
+        cycle["next_action"] = "record_feedback"
+        cycle["updated_at"] = utc_now()
+        return cycle
+
+    return _guarded_cycle_update(
+        paths,
+        loop_id,
+        mutate,
+        operation="observe_codex_loop_queue_item",
+        expected_revision=expected_revision,
+        mutation_id=mutation_id,
+        mutation_digest=_mutation_digest("observe_codex_loop_queue_item", queue_id, all_refs, summary),
+    )
 
 
 def build_loop_cycle_narration(paths: OmhPaths, loop_id: str, queue_id: str = "") -> dict[str, Any]:
@@ -929,6 +1033,8 @@ def observe_loop_queue_item(
     subagent_evidence_refs: Iterable[str] | None = None,
     connector_evidence_refs: Iterable[str] | None = None,
     summary: str = "",
+    expected_revision: int | None = None,
+    mutation_id: str | None = None,
 ) -> dict[str, Any]:
     refs = _safe_list(evidence_refs, limit=320)
     worktree_refs = _safe_list(worktree_evidence_refs or [], limit=320)
@@ -937,28 +1043,40 @@ def observe_loop_queue_item(
     aggregate_refs = _safe_list([*refs, *worktree_refs, *subagent_refs, *connector_refs], limit=320)
     if not aggregate_refs:
         raise ValueError("loop queue observation requires at least one evidence ref")
-    cycle = read_loop_cycle(paths, loop_id)
-    runtime, item = _queue_item_ref(cycle, queue_id)
-    if item.get("status") != "prepared_not_observed":
-        raise ValueError("only prepared_not_observed loop queue items can be observed")
-    item["status"] = "observed"
-    item["observed"] = True
-    item["observed_at"] = utc_now()
-    item["observed_evidence_refs"] = aggregate_refs
-    item["observation_summary"] = _safe_summary(summary, limit=320) if summary.strip() else "Queue item observed by wrapper or operator evidence."
-    _mark_queue_plans_observed(
-        item,
-        worktree_evidence_refs=worktree_refs,
-        subagent_evidence_refs=subagent_refs,
-        connector_evidence_refs=connector_refs,
+
+    def mutate(cycle: dict[str, Any]) -> dict[str, Any]:
+        runtime, item = _queue_item_ref(cycle, queue_id)
+        if item.get("status") != "prepared_not_observed":
+            raise ValueError("only prepared_not_observed loop queue items can be observed")
+        item["status"] = "observed"
+        item["observed"] = True
+        item["observed_at"] = utc_now()
+        item["observed_evidence_refs"] = aggregate_refs
+        item["observation_summary"] = _safe_summary(summary, limit=320) if summary.strip() else "Queue item observed by wrapper or operator evidence."
+        _mark_queue_plans_observed(
+            item,
+            worktree_evidence_refs=worktree_refs,
+            subagent_evidence_refs=subagent_refs,
+            connector_evidence_refs=connector_refs,
+        )
+        runtime["last_queue_id"] = str(item["queue_id"])
+        runtime["last_queue_status"] = "observed"
+        cycle["runtime"] = runtime
+        cycle["phase"] = "feedback"
+        cycle["wait_reason"] = "none"
+        cycle["next_action"] = "record_feedback"
+        cycle["updated_at"] = utc_now()
+        return cycle
+
+    return _guarded_cycle_update(
+        paths,
+        loop_id,
+        mutate,
+        operation="observe_loop_queue_item",
+        expected_revision=expected_revision,
+        mutation_id=mutation_id,
+        mutation_digest=_mutation_digest("observe_loop_queue_item", queue_id, aggregate_refs, summary),
     )
-    runtime["last_queue_id"] = str(item["queue_id"])
-    runtime["last_queue_status"] = "observed"
-    cycle["runtime"] = runtime
-    cycle["phase"] = "feedback"
-    cycle["wait_reason"] = "none"
-    cycle["next_action"] = "record_feedback"
-    return _write_loop(paths, cycle)
 
 
 def block_loop_queue_item(
@@ -967,25 +1085,39 @@ def block_loop_queue_item(
     queue_id: str,
     *,
     reason: str,
+    expected_revision: int | None = None,
+    mutation_id: str | None = None,
 ) -> dict[str, Any]:
     blocker = _safe_summary(reason, limit=320)
     if not blocker:
         raise ValueError("loop queue blocker reason is required")
-    cycle = read_loop_cycle(paths, loop_id)
-    runtime, item = _queue_item_ref(cycle, queue_id)
-    if item.get("status") == "observed" or item.get("observed") is True:
-        raise ValueError("observed loop queue items cannot be blocked")
-    item["status"] = "blocked"
-    item["observed"] = False
-    item["blocked_at"] = utc_now()
-    item["blocker_reason"] = blocker
-    runtime["last_queue_id"] = str(item["queue_id"])
-    runtime["last_queue_status"] = "blocked"
-    cycle["runtime"] = runtime
-    cycle["phase"] = "blocked"
-    cycle["wait_reason"] = "none"
-    cycle["next_action"] = "resolve_runtime_queue_blocker"
-    return _write_loop(paths, cycle)
+
+    def mutate(cycle: dict[str, Any]) -> dict[str, Any]:
+        runtime, item = _queue_item_ref(cycle, queue_id)
+        if item.get("status") == "observed" or item.get("observed") is True:
+            raise ValueError("observed loop queue items cannot be blocked")
+        item["status"] = "blocked"
+        item["observed"] = False
+        item["blocked_at"] = utc_now()
+        item["blocker_reason"] = blocker
+        runtime["last_queue_id"] = str(item["queue_id"])
+        runtime["last_queue_status"] = "blocked"
+        cycle["runtime"] = runtime
+        cycle["phase"] = "blocked"
+        cycle["wait_reason"] = "none"
+        cycle["next_action"] = "resolve_runtime_queue_blocker"
+        cycle["updated_at"] = utc_now()
+        return cycle
+
+    return _guarded_cycle_update(
+        paths,
+        loop_id,
+        mutate,
+        operation="block_loop_queue_item",
+        expected_revision=expected_revision,
+        mutation_id=mutation_id,
+        mutation_digest=_mutation_digest("block_loop_queue_item", queue_id, blocker),
+    )
 
 
 def build_loop_status_card(paths: OmhPaths, loop_id: str) -> dict[str, Any]:
@@ -1105,6 +1237,7 @@ def validate_loop_cycle(cycle: dict[str, Any]) -> dict[str, Any]:
     assessment = cycle.get("loopability_assessment")
     if assessment is not None:
         errors.extend(validate_loopability_assessment(assessment))
+    errors.extend(revision_field_errors(cycle, "loop_cycle"))
     return {"ok": not errors, "errors": errors}
 
 
@@ -1116,13 +1249,56 @@ def loop_cycle_path(paths: OmhPaths, loop_id: str) -> Path:
     return _loop_dir(paths, loop_id) / "cycle.json"
 
 
-def _write_loop(paths: OmhPaths, cycle: dict[str, Any]) -> dict[str, Any]:
-    cycle["updated_at"] = utc_now()
+def _raise_loop_validation_errors(cycle: dict[str, Any]) -> None:
     validation = validate_loop_cycle(cycle)
     if not validation["ok"]:
         raise ValueError("; ".join(validation["errors"]))
-    atomic_write_json(loop_cycle_path(paths, str(cycle["loop_id"])), cycle, private=True)
-    return cycle
+
+
+def _mutation_digest(*parts: object) -> str:
+    """Digest of one operation's own arguments, for replay-conflict detection."""
+    return sha256_text(json.dumps(list(parts), sort_keys=True, separators=(",", ":"), default=str))
+
+
+def _guarded_cycle_update(
+    paths: OmhPaths,
+    loop_id: str,
+    mutate,
+    *,
+    operation: str,
+    expected_revision: int | None = None,
+    mutation_id: str | None = None,
+    mutation_digest: str | None = None,
+    default: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """One locked read-check-write transaction on cycle.json.
+
+    Every cycle mutator goes through here: reading the cycle outside the lock
+    and writing the whole record back blind-overwrote whatever a concurrent
+    writer had already committed, including guarded queue observations.
+    Queue-item and permission preconditions therefore run inside this
+    transaction, and a replayed mutation_id returns the current cycle without
+    a write or revision bump. Replay is keyed on (operation, mutation_id).
+    """
+    path = loop_cycle_path(paths, loop_id)
+
+    def _mutate(current: dict[str, Any]) -> dict[str, Any] | None:
+        if default is None:
+            _raise_loop_validation_errors(current)
+        return mutate(current)
+
+    result = guarded_record_update(
+        path,
+        mutate=_mutate,
+        operation=operation,
+        expected_revision=expected_revision,
+        mutation_id=mutation_id,
+        mutation_digest=mutation_digest,
+        lock_name="cycle.json",
+        validate=_raise_loop_validation_errors,
+        default=default,
+    )
+    return result.record if isinstance(result, DuplicateMutationReplay) else result
 
 
 def _loop_dir(paths: OmhPaths, loop_id: str) -> Path:

--- a/src/wrapper/executor_sessions.py
+++ b/src/wrapper/executor_sessions.py
@@ -20,7 +20,13 @@ from ..executor_progress import (
 from ..executors import CODING_EXECUTOR_TARGETS, executor_label
 from ..coding.hermes_harness import build_hermes_coding_harness
 from ..coding.executor_capability_snapshots import validate_executor_capability_snapshot
-from ..local_store import atomic_write_json, ensure_dir, ensure_file, read_json_object, utc_now
+from ..local_store import ensure_dir, ensure_file, read_json_object, utc_now
+from ..system.record_revision import (
+    DuplicateMutationReplay,
+    guarded_record_update,
+    require_not_terminal,
+    revision_field_errors,
+)
 from ..paths import OmhPaths
 from ..runtime.artifacts import (
     read_runtime_observations_result,
@@ -352,6 +358,13 @@ def open_executor_session(
     if external_session_ref.strip() and not observed:
         raise ExecutorSessionError("open-executor --external-session-ref requires --observed")
     session = _existing_session(paths, session_id)
+    require_not_terminal(
+        session,
+        "status",
+        ("cancelled",),
+        "open an executor session for this wrapper session",
+        error_type=ExecutorSessionError,
+    )
     _require_prepared_handoff(session)
     _require_no_observed_result(paths, session)
     patch = {
@@ -407,6 +420,13 @@ def attach_executor_session(
     if not external_session_ref.strip():
         raise ExecutorSessionError("attach-executor requires --external-session-ref")
     session = _existing_session(paths, session_id)
+    require_not_terminal(
+        session,
+        "status",
+        ("cancelled",),
+        "attach an executor session to this wrapper session",
+        error_type=ExecutorSessionError,
+    )
     _require_prepared_handoff(session)
     _require_no_observed_result(paths, session)
     patch = {
@@ -462,6 +482,13 @@ def record_executor_session_result(
     if result not in {"completed", "blocked", "failed"}:
         raise ExecutorSessionError("executor result must be completed, blocked, or failed")
     session = _existing_session(paths, session_id)
+    require_not_terminal(
+        session,
+        "status",
+        ("cancelled",),
+        "record an executor result for this wrapper session",
+        error_type=ExecutorSessionError,
+    )
     _require_prepared_handoff(session)
     current = read_executor_session(paths, session_id) or _default_executor_session(session)
     linked_status, linked_status_error = _linked_status_result(paths, session)
@@ -797,8 +824,31 @@ def _codex_observation_patch(
 
 
 def _write_executor_session(paths: OmhPaths, record: dict[str, Any]) -> dict[str, Any]:
-    atomic_write_json(_executor_session_path(paths, str(record["session_id"])), record, private=True)
-    return record
+    path = _executor_session_path(paths, str(record["session_id"]))
+
+    def _validate(final: dict[str, Any]) -> None:
+        errors = validate_executor_session_record(final)
+        if errors:
+            raise ExecutorSessionError(errors[0])
+
+    result = guarded_record_update(
+        path,
+        mutate=lambda current: {
+            **record,
+            "record_revision": current.get("record_revision", 0),
+            "applied_mutations": current.get("applied_mutations", {}),
+            **(
+                {"applied_mutations_floor_revision": current["applied_mutations_floor_revision"]}
+                if "applied_mutations_floor_revision" in current
+                else {}
+            ),
+        },
+        operation="write_executor_session",
+        lock_name="executor_session.json",
+        validate=_validate,
+        default={},
+    )
+    return result.record if isinstance(result, DuplicateMutationReplay) else result
 
 
 def validate_executor_session_record(record: dict[str, Any]) -> list[str]:
@@ -824,6 +874,10 @@ def validate_executor_session_record(record: dict[str, Any]) -> list[str]:
         "codex_session",
         "codex_progress",
         "claim_boundary",
+        "record_revision",
+        "applied_mutations",
+        # Present only once applied_mutations eviction has moved the floor.
+        "applied_mutations_floor_revision",
     }
     extra = sorted(set(record) - allowed)
     if extra:
@@ -873,6 +927,7 @@ def validate_executor_session_record(record: dict[str, Any]) -> list[str]:
         errors.append("executor_session observed result requires result_observed=true")
     if record.get("verification") == "requested" and record.get("verification_requested") is not True:
         errors.append("executor_session requested verification requires verification_requested=true")
+    errors.extend(revision_field_errors(record, "executor_session"))
     return errors
 
 

--- a/src/wrapper/sessions.py
+++ b/src/wrapper/sessions.py
@@ -4,14 +4,20 @@ import hashlib
 import json
 from json import JSONDecodeError
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from ..ingress import CHAT_SOURCES, compact_source_metadata, extract_message_text, extract_source_metadata
 from ..routing.chat import CONFIDENCE_LEVELS
 from ..executors import CODING_EXECUTOR_TARGETS, executor_label, executor_selection_for_target
 from .lifecycle import report_codex_delegation_lifecycle, start_codex_delegation_lifecycle
 from .session_handoff_projection import project_valid_session_handoffs
-from ..local_store import atomic_write_json, ensure_dir, ensure_file, file_lock, read_json_object, read_jsonl_objects, utc_now
+from ..local_store import ensure_dir, ensure_file, read_json_object, read_jsonl_objects, utc_now
+from ..system.record_revision import (
+    DuplicateMutationReplay,
+    guarded_record_update,
+    record_revision_of,
+    require_not_terminal,
+)
 from ..memory import memory_recall_pack_for_handoff, record_attached_recall_usage
 from ..paths import OmhPaths
 from ..runtime.records import (
@@ -79,6 +85,17 @@ class WrapperSessionError(ValueError):
     pass
 
 
+def _mutation_digest(*parts: object) -> str:
+    """Digest of one operation's own arguments, for replay-conflict detection.
+
+    The core helper compares this against the digest stored for the same
+    (operation, mutation_id); a retry that carries different content is then
+    refused instead of silently replaying somebody else's result.
+    """
+    payload = json.dumps(list(parts), sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
 def session_id_for_thread_key(thread_key: str) -> str:
     if not thread_key:
         raise WrapperSessionError("wrapper session requires a thread_key")
@@ -137,7 +154,10 @@ def create_or_resume_wrapper_session(
         resumed = True
     else:
         session = _session_from_interaction(session_id, interaction, record_provenance=record_provenance)
-        write_wrapper_session(paths, session)
+        # Keep the persisted record, not the pre-write draft: the wrapper echoes
+        # session["record_revision"] back on the next mutation, so returning the
+        # unbumped draft would make every first mutation look stale.
+        session = write_wrapper_session(paths, session)
         append_wrapper_session_event(
             session_dir,
             {
@@ -156,34 +176,53 @@ def create_or_resume_wrapper_session(
     }
 
 
-def record_plan_decision(paths: OmhPaths, session_id: str, decision: str) -> dict[str, object]:
+def record_plan_decision(
+    paths: OmhPaths,
+    session_id: str,
+    decision: str,
+    *,
+    expected_revision: int | None = None,
+    mutation_id: str | None = None,
+) -> dict[str, object]:
     if decision not in {"accept", "revise", "cancel"}:
         raise WrapperSessionError("plan decision must be accept, revise, or cancel")
-    session = _existing_session(paths, session_id)
-    current_status = str(session["status"])
-    allowed = PLAN_DECISION_TRANSITIONS.get(current_status, set())
-    if decision not in allowed:
-        raise WrapperSessionError(f"cannot {decision.replace('_', ' ')} a wrapper session while status is {current_status}")
-    accept_status = _accepted_status_for_session(session)
-    updates = {
-        "accept": {"status": accept_status, "decision": "plan_accepted"},
-        "revise": {"status": "revision_requested", "decision": "plan_revision_requested"},
-        "cancel": {"status": "cancelled", "decision": "plan_cancelled"},
-    }[decision]
-    session = {**session, **updates, "updated_at": utc_now()}
-    write_wrapper_session(paths, session)
-    append_wrapper_session_event(
-        _session_dir(paths, session_id),
-        {
-            "event": f"plan_{updates['decision']}",
-            "message": f"wrapper recorded {updates['decision']}",
-            "data": {"status": session["status"], "decision": session["decision"]},
-        },
+
+    def mutate(current: dict[str, Any]) -> dict[str, Any]:
+        current_status = str(current.get("status", ""))
+        allowed = PLAN_DECISION_TRANSITIONS.get(current_status, set())
+        if decision not in allowed:
+            raise WrapperSessionError(f"cannot {decision.replace('_', ' ')} a wrapper session while status is {current_status}")
+        accept_status = _accepted_status_for_session(current)
+        updates = {
+            "accept": {"status": accept_status, "decision": "plan_accepted"},
+            "revise": {"status": "revision_requested", "decision": "plan_revision_requested"},
+            "cancel": {"status": "cancelled", "decision": "plan_cancelled"},
+        }[decision]
+        return build_wrapper_session_record({**current, **updates, "updated_at": utc_now()})
+
+    session, replayed = _guarded_session_update(
+        paths,
+        session_id,
+        mutate,
+        operation="record_plan_decision",
+        expected_revision=expected_revision,
+        mutation_id=mutation_id,
+        mutation_digest=_mutation_digest("record_plan_decision", decision),
     )
+    if not replayed:
+        append_wrapper_session_event(
+            _session_dir(paths, session_id),
+            {
+                "event": f"plan_{session['decision']}",
+                "message": f"wrapper recorded {session['decision']}",
+                "data": {"status": session["status"], "decision": session["decision"]},
+            },
+        )
     return {
         "schema_version": WRAPPER_SESSION_RESULT_SCHEMA_VERSION,
         "session": session,
         "status": build_wrapper_session_status(paths, session_id),
+        "replayed": replayed,
     }
 
 
@@ -193,42 +232,65 @@ def select_wrapper_session_executor(
     executor_target: str,
     *,
     dispatch_policy: str | None = None,
+    expected_revision: int | None = None,
+    mutation_id: str | None = None,
 ) -> dict[str, object]:
     if executor_target not in CODING_EXECUTOR_TARGETS:
         raise WrapperSessionError(f"unsupported wrapper session executor: {executor_target}")
-    session = _existing_session(paths, session_id)
-    if session["status"] not in {"plan_accepted", "executor_choice_required", "executor_selected"}:
-        raise WrapperSessionError(f"cannot select executor while status is {session['status']}")
     selection = executor_selection_for_target(executor_target, action="delegate")
     if selection.choice_required:
         raise WrapperSessionError("select-executor requires a concrete executor profile, not choose")
     policy = dispatch_policy or selection.dispatch_policy
-    session = {
-        **session,
-        "status": "executor_selected",
-        "work_owner_mode": selection.work_owner_mode,
-        "selected_executor_profile": selection.selected_executor_profile,
-        "dispatch_policy": policy,
-        "updated_at": utc_now(),
-    }
-    write_wrapper_session(paths, session)
-    append_wrapper_session_event(
-        _session_dir(paths, session_id),
-        {
-            "event": "executor_selected",
-            "message": "wrapper session selected executor/runtime profile",
-            "data": {
+
+    def mutate(current: dict[str, Any]) -> dict[str, Any]:
+        require_not_terminal(
+            current,
+            "status",
+            ("cancelled",),
+            "select an executor for this wrapper session",
+            error_type=WrapperSessionError,
+        )
+        if current.get("status") not in {"plan_accepted", "executor_choice_required", "executor_selected"}:
+            raise WrapperSessionError(f"cannot select executor while status is {current.get('status')}")
+        return build_wrapper_session_record(
+            {
+                **current,
+                "status": "executor_selected",
                 "work_owner_mode": selection.work_owner_mode,
                 "selected_executor_profile": selection.selected_executor_profile,
                 "dispatch_policy": policy,
-                "dispatchable": selection.dispatchable,
-            },
-        },
+                "updated_at": utc_now(),
+            }
+        )
+
+    session, replayed = _guarded_session_update(
+        paths,
+        session_id,
+        mutate,
+        operation="select_wrapper_session_executor",
+        expected_revision=expected_revision,
+        mutation_id=mutation_id,
+        mutation_digest=_mutation_digest("select_wrapper_session_executor", executor_target, policy),
     )
+    if not replayed:
+        append_wrapper_session_event(
+            _session_dir(paths, session_id),
+            {
+                "event": "executor_selected",
+                "message": "wrapper session selected executor/runtime profile",
+                "data": {
+                    "work_owner_mode": selection.work_owner_mode,
+                    "selected_executor_profile": selection.selected_executor_profile,
+                    "dispatch_policy": policy,
+                    "dispatchable": selection.dispatchable,
+                },
+            },
+        )
     return {
         "schema_version": WRAPPER_SESSION_RESULT_SCHEMA_VERSION,
         "session": session,
         "status": build_wrapper_session_status(paths, session_id),
+        "replayed": replayed,
     }
 
 
@@ -242,10 +304,24 @@ def prepare_wrapper_session_handoff(
     source_metadata: dict[str, str] | None = None,
     executor_target: str | None = None,
     context_pack: dict[str, object] | None = None,
+    expected_revision: int | None = None,
+    mutation_id: str | None = None,
 ) -> dict[str, object]:
     session = _existing_session(paths, session_id)
-    if session["status"] == "cancelled":
-        raise WrapperSessionError("cannot prepare a handoff for a cancelled wrapper session")
+    # expected_revision is threaded into every write this call authorizes
+    # instead of being compared once against this unlocked read: the in-lock
+    # compare is the guard, and it runs after the replay check, so a client
+    # that timed out and retried with the ORIGINAL revision and the SAME
+    # mutation_id replays idempotently rather than being refused as stale.
+    # `guard_revision` advances when a write here moves the record on.
+    guard_revision = expected_revision
+    require_not_terminal(
+        session,
+        "status",
+        ("cancelled",),
+        "prepare a handoff for this wrapper session",
+        error_type=WrapperSessionError,
+    )
     # A prepared session re-serves its handoff only for a retry of the SAME
     # message (or an empty show call). A different non-empty message is a
     # follow-up instruction; silently re-serving the old handoff dropped it
@@ -266,6 +342,7 @@ def prepare_wrapper_session_handoff(
                 "session": session,
                 "status": build_wrapper_session_status(paths, session_id),
                 "handoff": report_codex_delegation_lifecycle(paths, run_id),
+                "replayed": False,
             }
         follow_up = True
     elif session["status"] == "prompt_handoff_prepared":
@@ -275,6 +352,7 @@ def prepare_wrapper_session_handoff(
                 "session": session,
                 "status": build_wrapper_session_status(paths, session_id),
                 "handoff": {"prompt_handoff": session.get("prompt_handoff", {})},
+                "replayed": False,
             }
         follow_up = True
     elif session["status"] == "runtime_handoff_prepared":
@@ -284,6 +362,7 @@ def prepare_wrapper_session_handoff(
                 "session": session,
                 "status": build_wrapper_session_status(paths, session_id),
                 "handoff": _runtime_session_handoff_envelope(session.get("runtime_handoff", {})),
+                "replayed": False,
             }
         follow_up = True
     if session["status"] == "executor_choice_required" and not executor_target:
@@ -292,8 +371,19 @@ def prepare_wrapper_session_handoff(
         if executor_target != str(session.get("selected_executor_profile") or ""):
             raise WrapperSessionError("a follow-up handoff keeps the selected executor; start a new session to switch executors")
     elif executor_target:
-        select_wrapper_session_executor(paths, session_id, executor_target)
-        session = _existing_session(paths, session_id)
+        selected = select_wrapper_session_executor(
+            paths,
+            session_id,
+            executor_target,
+            expected_revision=guard_revision,
+            mutation_id=mutation_id,
+        )
+        session = dict(selected["session"])
+        if guard_revision is not None:
+            # This call authorized the selection write, so the handoff write
+            # that follows must compare against the revision that write
+            # produced, not the one the wrapper originally rendered.
+            guard_revision = record_revision_of(session)
     if not follow_up and session["status"] not in {"plan_accepted", "executor_selected"}:
         raise WrapperSessionError("wrapper session plan must be accepted before preparing a handoff")
     selected_executor = str(session.get("selected_executor_profile") or "codex")
@@ -308,6 +398,8 @@ def prepare_wrapper_session_handoff(
             executor_target=selected_executor,
             context_pack=context_pack,
             follow_up=follow_up,
+            expected_revision=guard_revision,
+            mutation_id=mutation_id,
         )
     if selected_executor and selected_executor != "codex":
         return _prepare_prompt_only_session_handoff(
@@ -320,6 +412,8 @@ def prepare_wrapper_session_handoff(
             executor_target=selected_executor,
             context_pack=context_pack,
             follow_up=follow_up,
+            expected_revision=guard_revision,
+            mutation_id=mutation_id,
         )
     message = extract_message_text(event_or_message)
     metadata = _source_metadata(event_or_message)
@@ -327,34 +421,64 @@ def prepare_wrapper_session_handoff(
     metadata.update({str(key): str(value) for key, value in session.get("source_metadata", {}).items() if str(value)})
     metadata = _compact_coding_source_metadata(metadata)
     message_sha256 = hashlib.sha256(message.encode("utf-8")).hexdigest()
+    digest = _mutation_digest("link_prepared_handoff_run", message_sha256, "codex", metadata)
     recovered_run_id = _find_recoverable_prepared_handoff_run(paths, session, message_sha256, metadata)
     if recovered_run_id:
-        return _link_prepared_handoff_run(paths, session, recovered_run_id, recovered=True)
-    append_wrapper_session_event(
-        _session_dir(paths, session_id),
-        {
-            "event": "handoff_prepare_started",
-            "message": "wrapper session started preparing coding handoff",
-            "data": {"message_sha256": message_sha256, "message_length": len(message)},
-        },
-    )
+        return _link_prepared_handoff_run(
+            paths,
+            session,
+            recovered_run_id,
+            recovered=True,
+            expected_revision=guard_revision,
+            mutation_id=mutation_id,
+            mutation_digest=digest,
+        )
     follow_up_workflow, follow_up_score = _session_route_preference(session) if follow_up else (None, None)
-    lifecycle = start_codex_delegation_lifecycle(
+    lifecycle: dict[str, object] = {}
+
+    def prepare_run() -> str:
+        # Runs inside the session lock, after the terminal, replay, and
+        # revision guards have passed: a rejected prepare must leave no
+        # prepare-started event, no runtime run directory, and no run ledger
+        # entry behind (issue #828 AC1).
+        append_wrapper_session_event(
+            _session_dir(paths, session_id),
+            {
+                "event": "handoff_prepare_started",
+                "message": "wrapper session started preparing coding handoff",
+                "data": {"message_sha256": message_sha256, "message_length": len(message)},
+            },
+        )
+        lifecycle.update(
+            start_codex_delegation_lifecycle(
+                paths,
+                message,
+                source=str(session["source"]),
+                source_metadata=metadata,
+                limit=limit,
+                include_message=include_message,
+                context_pack=context_pack,
+                preferred_workflow=follow_up_workflow,
+                preferred_workflow_score=follow_up_score,
+                force_coding_handoff=follow_up,
+            )
+        )
+        run = lifecycle["run"]
+        return str(run["run_id"]) if isinstance(run, dict) else ""
+
+    linked = _link_prepared_handoff_run(
         paths,
-        message,
-        source=str(session["source"]),
-        source_metadata=metadata,
-        limit=limit,
-        include_message=include_message,
-        context_pack=context_pack,
-        preferred_workflow=follow_up_workflow,
-        preferred_workflow_score=follow_up_score,
-        force_coding_handoff=follow_up,
+        session,
+        recovered=False,
+        expected_revision=guard_revision,
+        mutation_id=mutation_id,
+        mutation_digest=digest,
+        prepare_run=prepare_run,
     )
-    run_id = str(lifecycle["run"]["run_id"])
-    linked = _link_prepared_handoff_run(paths, session, run_id, recovered=False)
-    lifecycle["status"] = report_codex_delegation_lifecycle(paths, run_id)
-    linked["handoff"] = lifecycle
+    if lifecycle:
+        run = lifecycle["run"]
+        lifecycle["status"] = report_codex_delegation_lifecycle(paths, str(run["run_id"]) if isinstance(run, dict) else "")
+        linked["handoff"] = lifecycle
     return linked
 
 
@@ -388,6 +512,8 @@ def _prepare_prompt_only_session_handoff(
     executor_target: str,
     context_pack: dict[str, object] | None,
     follow_up: bool = False,
+    expected_revision: int | None = None,
+    mutation_id: str | None = None,
 ) -> dict[str, object]:
     message = extract_message_text(event_or_message)
     metadata = _source_metadata(event_or_message)
@@ -416,32 +542,60 @@ def _prepare_prompt_only_session_handoff(
     prompt_handoff = payload.get("prompt_handoff")
     if not isinstance(prompt_handoff, dict):
         raise WrapperSessionError("selected executor produced no prompt handoff")
-    record_attached_recall_usage(paths, payload)
     session_id = str(session["session_id"])
-    session = {
-        **session,
-        "status": "prompt_handoff_prepared",
-        "work_owner_mode": "prompt_only_handoff",
-        "selected_executor_profile": executor_target,
-        "dispatch_policy": "prepare_only",
-        "prompt_handoff": prompt_handoff,
-        "current_run_id": "",
-        "updated_at": utc_now(),
-    }
-    write_wrapper_session(paths, session)
-    append_wrapper_session_event(
-        _session_dir(paths, session_id),
-        {
-            "event": "prompt_handoff_prepared",
-            "message": "wrapper session prepared prompt-only coding handoff",
-            "data": {
+
+    def mutate(current: dict[str, Any]) -> dict[str, Any]:
+        require_not_terminal(
+            current,
+            "status",
+            ("cancelled",),
+            "prepare a handoff for this wrapper session",
+            error_type=WrapperSessionError,
+        )
+        # Recall-usage counters are a persisted side effect, so they are
+        # recorded only after the guards that can reject have passed.
+        record_attached_recall_usage(paths, payload)
+        return build_wrapper_session_record(
+            {
+                **current,
+                "status": "prompt_handoff_prepared",
+                "work_owner_mode": "prompt_only_handoff",
                 "selected_executor_profile": executor_target,
-                "dispatchable": False,
-                "message_sha256": hashlib.sha256(message.encode("utf-8")).hexdigest(),
-                "message_length": len(message),
-            },
-        },
+                "dispatch_policy": "prepare_only",
+                "prompt_handoff": prompt_handoff,
+                "current_run_id": "",
+                "updated_at": utc_now(),
+            }
+        )
+
+    session, replayed = _guarded_session_update(
+        paths,
+        session_id,
+        mutate,
+        operation="prepare_prompt_only_session_handoff",
+        expected_revision=expected_revision,
+        mutation_id=mutation_id,
+        mutation_digest=_mutation_digest(
+            "prepare_prompt_only_session_handoff",
+            hashlib.sha256(message.encode("utf-8")).hexdigest(),
+            executor_target,
+            metadata,
+        ),
     )
+    if not replayed:
+        append_wrapper_session_event(
+            _session_dir(paths, session_id),
+            {
+                "event": "prompt_handoff_prepared",
+                "message": "wrapper session prepared prompt-only coding handoff",
+                "data": {
+                    "selected_executor_profile": executor_target,
+                    "dispatchable": False,
+                    "message_sha256": hashlib.sha256(message.encode("utf-8")).hexdigest(),
+                    "message_length": len(message),
+                },
+            },
+        )
     result: dict[str, object] = {
         "schema_version": WRAPPER_SESSION_RESULT_SCHEMA_VERSION,
         "session": session,
@@ -454,6 +608,7 @@ def _prepare_prompt_only_session_handoff(
                 "reason": "prompt_only_handoff_is_not_lifecycle_backed",
             },
         },
+        "replayed": replayed,
     }
     if include_message and "prompt_handoff_prompt" in payload:
         result["prompt_handoff_prompt"] = payload["prompt_handoff_prompt"]
@@ -471,6 +626,8 @@ def _prepare_runtime_session_handoff(
     executor_target: str,
     context_pack: dict[str, object] | None,
     follow_up: bool = False,
+    expected_revision: int | None = None,
+    mutation_id: str | None = None,
 ) -> dict[str, object]:
     message = extract_message_text(event_or_message)
     metadata = _source_metadata(event_or_message)
@@ -499,40 +656,69 @@ def _prepare_runtime_session_handoff(
     runtime_handoff = payload.get("runtime_handoff")
     if not isinstance(runtime_handoff, dict):
         raise WrapperSessionError("selected runtime produced no runtime handoff")
-    record_attached_recall_usage(paths, payload)
     session_id = str(session["session_id"])
-    session = {
-        **session,
-        "status": "runtime_handoff_prepared",
-        "work_owner_mode": "runtime_handoff",
-        "selected_executor_profile": executor_target,
-        "dispatch_policy": "prepare_only",
-        "prompt_handoff": {},
-        "runtime_handoff": runtime_handoff,
-        "current_run_id": "",
-        "updated_at": utc_now(),
-    }
-    write_wrapper_session(paths, session)
-    append_wrapper_session_event(
-        _session_dir(paths, session_id),
-        {
-            "event": "runtime_handoff_prepared",
-            "message": "wrapper session prepared runtime coding handoff",
-            "data": {
+
+    def mutate(current: dict[str, Any]) -> dict[str, Any]:
+        require_not_terminal(
+            current,
+            "status",
+            ("cancelled",),
+            "prepare a handoff for this wrapper session",
+            error_type=WrapperSessionError,
+        )
+        # Recall-usage counters are a persisted side effect, so they are
+        # recorded only after the guards that can reject have passed.
+        record_attached_recall_usage(paths, payload)
+        return build_wrapper_session_record(
+            {
+                **current,
+                "status": "runtime_handoff_prepared",
+                "work_owner_mode": "runtime_handoff",
                 "selected_executor_profile": executor_target,
-                "dispatchable": False,
-                "message_sha256": hashlib.sha256(message.encode("utf-8")).hexdigest(),
-                "message_length": len(message),
-                "team_swarm_guidance": True,
-                "worktree_guidance": True,
-            },
-        },
+                "dispatch_policy": "prepare_only",
+                "prompt_handoff": {},
+                "runtime_handoff": runtime_handoff,
+                "current_run_id": "",
+                "updated_at": utc_now(),
+            }
+        )
+
+    session, replayed = _guarded_session_update(
+        paths,
+        session_id,
+        mutate,
+        operation="prepare_runtime_session_handoff",
+        expected_revision=expected_revision,
+        mutation_id=mutation_id,
+        mutation_digest=_mutation_digest(
+            "prepare_runtime_session_handoff",
+            hashlib.sha256(message.encode("utf-8")).hexdigest(),
+            executor_target,
+            metadata,
+        ),
     )
+    if not replayed:
+        append_wrapper_session_event(
+            _session_dir(paths, session_id),
+            {
+                "event": "runtime_handoff_prepared",
+                "message": "wrapper session prepared runtime coding handoff",
+                "data": {
+                    "selected_executor_profile": executor_target,
+                    "dispatchable": False,
+                    "message_sha256": hashlib.sha256(message.encode("utf-8")).hexdigest(),
+                    "message_length": len(message),
+                    "team_swarm_guidance": True,
+                    "worktree_guidance": True,
+                },
+            },
+        )
     result: dict[str, object] = {
         "schema_version": WRAPPER_SESSION_RESULT_SCHEMA_VERSION,
         "session": session,
         "status": build_wrapper_session_status(paths, session_id),
         "handoff": _runtime_session_handoff_envelope(runtime_handoff),
+        "replayed": replayed,
     }
     if include_message and "runtime_handoff_prompt" in payload:
         result["runtime_handoff_prompt"] = payload["runtime_handoff_prompt"]
@@ -581,6 +767,7 @@ def build_wrapper_session_status(paths: OmhPaths, session_id: str) -> dict[str, 
             "thread_key": session["thread_key"],
             "current_run_id": run_id,
             "session_status": session["status"],
+            "record_revision": record_revision_of(session),
             "runtime_status": runtime_status,
             "executor_session_status": executor_status,
             "coding_briefing": coding_briefing,
@@ -620,6 +807,7 @@ def build_wrapper_session_status(paths: OmhPaths, session_id: str) -> dict[str, 
         "thread_key": session["thread_key"],
         "current_run_id": "",
         "session_status": session["status"],
+        "record_revision": record_revision_of(session),
         "work_owner_mode": session.get("work_owner_mode", "external_executor"),
         "selected_executor_profile": session.get("selected_executor_profile"),
         "dispatch_policy": session.get("dispatch_policy", "ask_before_dispatch"),
@@ -678,9 +866,54 @@ def read_wrapper_session(paths: OmhPaths, session_id: str) -> dict[str, Any] | N
 def write_wrapper_session(paths: OmhPaths, session: dict[str, Any]) -> dict[str, Any]:
     record = build_wrapper_session_record(session)
     session_path = _session_dir(paths, str(record["session_id"])) / "session.json"
-    with file_lock(session_path, private=True):
-        atomic_write_json(session_path, record, private=True)
-    return record
+    result = guarded_record_update(
+        session_path,
+        mutate=lambda current: build_wrapper_session_record({**record, "record_revision": current.get("record_revision", 0), "applied_mutations": current.get("applied_mutations", {})}),
+        operation="write_wrapper_session",
+        lock_name="session.json",
+        validate=_validated_session_record,
+        default={},
+    )
+    return result.record if isinstance(result, DuplicateMutationReplay) else result
+
+
+def _validated_session_record(record: dict[str, Any]) -> None:
+    errors = validate_wrapper_session_record(record)
+    if errors:
+        raise WrapperSessionError(errors[0])
+
+
+def _guarded_session_update(
+    paths: OmhPaths,
+    session_id: str,
+    mutate,
+    *,
+    operation: str,
+    expected_revision: int | None = None,
+    mutation_id: str | None = None,
+    mutation_digest: str | None = None,
+) -> tuple[dict[str, Any], bool]:
+    """Run one locked read-check-write transaction on session.json.
+
+    Returns (session_record, replayed). A replayed mutation_id returns the
+    current record without a write, revision bump, or session event. Replay is
+    keyed on (operation, mutation_id), so the same client id reused for a
+    different logical operation still applies.
+    """
+    session_path = _session_dir(paths, session_id) / "session.json"
+    result = guarded_record_update(
+        session_path,
+        mutate=mutate,
+        operation=operation,
+        expected_revision=expected_revision,
+        mutation_id=mutation_id,
+        mutation_digest=mutation_digest,
+        lock_name="session.json",
+        validate=_validated_session_record,
+    )
+    if isinstance(result, DuplicateMutationReplay):
+        return result.record, True
+    return result, False
 
 
 def append_wrapper_session_event(session_dir: Path, event: dict[str, Any]) -> dict[str, Any]:
@@ -717,25 +950,71 @@ def validate_wrapper_sessions(paths: OmhPaths, session_id: str | None = None) ->
     return {"ok": all(result["ok"] for result in results), "sessions": results}
 
 
-def _link_prepared_handoff_run(paths: OmhPaths, session: dict[str, Any], run_id: str, *, recovered: bool) -> dict[str, object]:
-    session = {
-        **session,
-        "status": "handoff_prepared",
-        "work_owner_mode": "external_executor",
-        "selected_executor_profile": "codex",
-        "dispatch_policy": "ask_before_dispatch",
-        "prompt_handoff": {},
-        "runtime_handoff": {},
-        "current_run_id": run_id,
-        "updated_at": utc_now(),
-    }
-    _ensure_handoff_prepared_event(paths, session, run_id, recovered=recovered)
-    write_wrapper_session(paths, session)
+def _link_prepared_handoff_run(
+    paths: OmhPaths,
+    session: dict[str, Any],
+    run_id: str = "",
+    *,
+    recovered: bool,
+    expected_revision: int | None = None,
+    mutation_id: str | None = None,
+    mutation_digest: str | None = None,
+    prepare_run: Callable[[], str] | None = None,
+) -> dict[str, object]:
+    """Link a prepared coding run to the session inside one locked transaction.
+
+    ``prepare_run`` is invoked only after the guards that can reject have
+    passed, so the run it creates is never an orphan left behind by a refused
+    prepare; ``run_id`` is passed directly instead when an existing run is
+    being recovered.
+    """
+    session_id = str(session["session_id"])
+    prepared: dict[str, str] = {"run_id": run_id}
+
+    def mutate(current: dict[str, Any]) -> dict[str, Any]:
+        require_not_terminal(
+            current,
+            "status",
+            ("cancelled",),
+            "link a prepared handoff run to this wrapper session",
+            error_type=WrapperSessionError,
+        )
+        if not prepared["run_id"] and prepare_run is not None:
+            prepared["run_id"] = prepare_run()
+        if not prepared["run_id"]:
+            raise WrapperSessionError("wrapper session handoff preparation produced no runtime run")
+        return build_wrapper_session_record(
+            {
+                **current,
+                "status": "handoff_prepared",
+                "work_owner_mode": "external_executor",
+                "selected_executor_profile": "codex",
+                "dispatch_policy": "ask_before_dispatch",
+                "prompt_handoff": {},
+                "runtime_handoff": {},
+                "current_run_id": prepared["run_id"],
+                "updated_at": utc_now(),
+            }
+        )
+
+    session, replayed = _guarded_session_update(
+        paths,
+        session_id,
+        mutate,
+        operation="link_prepared_handoff_run",
+        expected_revision=expected_revision,
+        mutation_id=mutation_id,
+        mutation_digest=mutation_digest,
+    )
+    linked_run_id = prepared["run_id"] or str(session.get("current_run_id", ""))
+    if not replayed and linked_run_id:
+        _ensure_handoff_prepared_event(paths, session, linked_run_id, recovered=recovered)
     return {
         "schema_version": WRAPPER_SESSION_RESULT_SCHEMA_VERSION,
         "session": session,
-        "status": build_wrapper_session_status(paths, str(session["session_id"])),
-        "handoff": _existing_lifecycle_payload(paths, run_id),
+        "status": build_wrapper_session_status(paths, session_id),
+        "handoff": _existing_lifecycle_payload(paths, linked_run_id) if linked_run_id else {},
+        "replayed": replayed,
     }
 
 

--- a/tests/test_architecture_layout.py
+++ b/tests/test_architecture_layout.py
@@ -181,6 +181,7 @@ class ArchitectureLayoutTests(unittest.TestCase):
             "src/omh/local_store.py": "from .system.local_store import *  # noqa: F401,F403",
             "src/omh/hashutil.py": "from .system.hashutil import *  # noqa: F401,F403",
             "src/omh/workflow_state.py": "from .system.workflow_state import *  # noqa: F401,F403",
+            "src/omh/record_revision.py": "from .system.record_revision import *  # noqa: F401,F403",
             "src/omh/targets.py": "from .system.targets import *  # noqa: F401,F403",
             "src/omh/ingress.py": "from .system.ingress import *  # noqa: F401,F403",
             "src/omh/capability_roadmap.py": "from .quality.capability_roadmap import *  # noqa: F401,F403",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,6 +22,7 @@ from omh.config_adapter import ensure_external_dir, external_dirs
 from omh.maintenance.doctor import _skill_shadowing_check
 from omh.paths import resolve_paths
 from omh.plugin_bundle.omh.memory_governance import canonical_payload_digest
+from omh.record_revision import MAX_MUTATION_ID_CHARS
 from omh.routing.intent import classify_omh_quality_intent
 from omh.skill_pack import CORE_PROFILE_SKILLS, builtin_skill_reference_templates, builtin_skill_templates
 from omh.skills.catalog import builtin_harnesses, installable_skill_names
@@ -29,6 +30,7 @@ from omh.wrapper.localized_copy import detect_copy_locale
 from omh.wrapper_sessions import (
     create_or_resume_wrapper_session,
     prepare_wrapper_session_handoff,
+    read_wrapper_session,
     record_plan_decision,
     select_wrapper_session_executor,
 )
@@ -12197,6 +12199,164 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             self.assertEqual(status, 1)
             checks = {check["name"]: check for check in json.loads(stdout)["checks"]}
             self.assertFalse(checks["runtime_state"]["ok"])
+
+
+class ChatSessionRevisionGuardCliTests(unittest.TestCase):
+    """The stale-mutation guard has to be reachable from the wrapper surface.
+
+    `omh chat session` is where a wrapper submits the revision it rendered, so
+    every session subcommand that reaches a guarded session.json write carries
+    --expected-revision and --mutation-id. Before issue #828 the flags existed
+    only on `omh goal`, which left the guarantee unreachable from the surface
+    the contract is actually about.
+    """
+
+    GUARDED_SUBCOMMANDS = (
+        ("accept-plan", ["ws-1"]),
+        ("revise-plan", ["ws-1"]),
+        ("cancel", ["ws-1"]),
+        ("select-executor", ["ws-1", "codex"]),
+        ("prepare-handoff", ["ws-1"]),
+    )
+
+    def _base(self, root: Path) -> list[str]:
+        return ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+    def _started(self, base: list[str]) -> dict:
+        status, stdout, stderr = run_cli(
+            base
+            + [
+                "chat",
+                "session",
+                "start",
+                "--source",
+                "discord",
+                "--source-event-id",
+                "m1",
+                "--channel-ref",
+                "c1",
+                "risky refactor with private-token-123",
+            ]
+        )
+        self.assertEqual(status, 0, stderr)
+        return json.loads(stdout)["session"]
+
+    def test_revision_guard_flag_names_are_pinned_on_every_session_mutation(self) -> None:
+        parser = build_parser()
+
+        for subcommand, positional in self.GUARDED_SUBCOMMANDS:
+            with self.subTest(subcommand=subcommand):
+                args = parser.parse_args(
+                    ["chat", "session", subcommand, *positional, "--expected-revision", "4", "--mutation-id", "m-1"]
+                )
+                self.assertEqual(args.expected_revision, 4)
+                self.assertEqual(args.mutation_id, "m-1")
+                # Absent flags must stay "no guard requested", not 0 / "0".
+                defaults = parser.parse_args(["chat", "session", subcommand, *positional])
+                self.assertIsNone(defaults.expected_revision)
+                self.assertEqual(defaults.mutation_id, "")
+
+    def test_a_stale_revision_through_the_chat_cli_exits_non_zero_and_writes_nothing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+            session_id = str(self._started(base)["session_id"])
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            before = read_wrapper_session(paths, session_id)
+
+            status, stdout, stderr = run_cli(
+                base + ["chat", "session", "accept-plan", session_id, "--expected-revision", "99"]
+            )
+
+            self.assertEqual(status, 2)
+            self.assertEqual(stdout, "")
+            self.assertTrue(stderr.startswith("omh: "), stderr)
+            self.assertIn("record_revision", stderr)
+            self.assertNotIn("Traceback", stderr)
+            self.assertEqual(read_wrapper_session(paths, session_id), before)
+
+    def test_the_rendered_revision_is_accepted_and_moves_the_record_on(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+            session = self._started(base)
+            session_id = str(session["session_id"])
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "chat",
+                    "session",
+                    "accept-plan",
+                    session_id,
+                    "--expected-revision",
+                    str(session["record_revision"]),
+                ]
+            )
+
+            self.assertEqual(status, 0, stderr)
+            accepted = json.loads(stdout)["session"]
+            self.assertEqual(accepted["status"], "executor_choice_required")
+            self.assertEqual(int(accepted["record_revision"]), int(session["record_revision"]) + 1)
+
+    def test_a_retried_mutation_id_replays_instead_of_transitioning_twice(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+            session_id = str(self._started(base)["session_id"])
+            command = base + ["chat", "session", "accept-plan", session_id, "--mutation-id", "accept-retry"]
+
+            first_status, first_stdout, first_stderr = run_cli(command)
+            second_status, second_stdout, second_stderr = run_cli(command)
+
+            self.assertEqual(first_status, 0, first_stderr)
+            self.assertEqual(second_status, 0, second_stderr)
+            first = json.loads(first_stdout)
+            second = json.loads(second_stdout)
+            self.assertFalse(first["replayed"])
+            self.assertTrue(second["replayed"])
+            self.assertEqual(first["session"]["record_revision"], second["session"]["record_revision"])
+
+    def test_a_stale_revision_on_prepare_handoff_is_refused_readably(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+            message = "risky refactor with private-token-123"
+            session_id = str(self._started(base)["session_id"])
+            self.assertEqual(run_cli(base + ["chat", "session", "accept-plan", session_id])[0], 0)
+            self.assertEqual(run_cli(base + ["chat", "session", "select-executor", session_id, "codex"])[0], 0)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            before = read_wrapper_session(paths, session_id)
+
+            status, stdout, stderr = run_cli(
+                base + ["chat", "session", "prepare-handoff", session_id, message, "--expected-revision", "1"]
+            )
+
+            self.assertEqual(status, 2)
+            self.assertEqual(stdout, "")
+            self.assertTrue(stderr.startswith("omh: "), stderr)
+            self.assertIn("record_revision", stderr)
+            self.assertNotIn("Traceback", stderr)
+            self.assertEqual(read_wrapper_session(paths, session_id), before)
+
+    def test_an_over_long_mutation_id_is_rejected_with_nothing_written(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+            session_id = str(self._started(base)["session_id"])
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            before = read_wrapper_session(paths, session_id)
+
+            status, stdout, stderr = run_cli(
+                base + ["chat", "session", "accept-plan", session_id, "--mutation-id", "x" * 100_000]
+            )
+
+            self.assertEqual(status, 2)
+            self.assertEqual(stdout, "")
+            self.assertTrue(stderr.startswith("omh: "), stderr)
+            self.assertIn(f"at most {MAX_MUTATION_ID_CHARS} characters", stderr)
+            self.assertNotIn("Traceback", stderr)
+            self.assertEqual(read_wrapper_session(paths, session_id), before)
 
 
 if __name__ == "__main__":

--- a/tests/test_domain_context_persistence_privacy.py
+++ b/tests/test_domain_context_persistence_privacy.py
@@ -87,7 +87,15 @@ class DomainContextPersistencePrivacyMixin:
         self.assertTrue(second["resumed"])
         self.assertNotIn("domain_routing_context", second["interaction"])
         self.assertEqual(calls, 2)
-        self.assertEqual(set(second["session"]), set(WRAPPER_SESSION_RECORD_KEYS))
+        # The privacy property is that the record carries no key outside the
+        # canonical set. `applied_mutations_floor_revision` is written only once
+        # mutation history has actually been evicted, so it is the one key the
+        # canonical set allows and a fresh session legitimately omits.
+        self.assertLessEqual(set(second["session"]), set(WRAPPER_SESSION_RECORD_KEYS))
+        self.assertEqual(
+            set(WRAPPER_SESSION_RECORD_KEYS) - set(second["session"]),
+            {"applied_mutations_floor_revision"},
+        )
         self.assertEqual(validate_wrapper_session_record(second["session"]), [])
         _assert_no_private_material(
             self,

--- a/tests/test_goal_cli.py
+++ b/tests/test_goal_cli.py
@@ -1,0 +1,432 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+from omh.commands.main import build_parser
+from omh.goal_ledger import goal_ledger_path, read_goal_ledger
+from omh.paths import resolve_paths
+from omh.record_revision import APPLIED_MUTATIONS_LIMIT, MAX_MUTATION_ID_CHARS, applied_mutation_key
+
+# The digest helper is deliberately private; the deep module is imported here
+# so the planted replay entry below matches what the real cancel computes
+# instead of re-implementing the recipe in the test.
+from omh.workflows.goal_ledger import _mutation_digest
+
+
+def _base(root: Path) -> list[str]:
+    return ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+
+def _create(base: list[str], goal_id: str = "goal-cli-guard") -> None:
+    status, _stdout, stderr = run_cli(
+        base
+        + [
+            "goal",
+            "create",
+            "--goal-id",
+            goal_id,
+            "--objective",
+            "Ship the stale mutation guard",
+            "--criterion",
+            "Guard is verified",
+        ]
+    )
+    if status != 0:  # pragma: no cover - only trips when the fixture itself breaks
+        raise AssertionError(f"goal create failed: {stderr}")
+
+
+class GoalCliRevisionGuardTests(unittest.TestCase):
+    def test_revision_guard_flag_names_are_pinned_on_every_mutation_subcommand(self) -> None:
+        parser = build_parser()
+
+        for subcommand, extra in (
+            ("checkpoint", ["--summary", "s"]),
+            ("blocker", ["--summary", "s"]),
+            ("complete", []),
+            ("cancel", []),
+        ):
+            with self.subTest(subcommand=subcommand):
+                args = parser.parse_args(
+                    ["goal", subcommand, "--goal", "g", *extra, "--expected-revision", "4", "--mutation-id", "m-1"]
+                )
+                self.assertEqual(args.expected_revision, 4)
+                self.assertEqual(args.mutation_id, "m-1")
+                # Absent flags must stay "no guard requested", not 0 / "0".
+                defaults = parser.parse_args(["goal", subcommand, "--goal", "g", *extra])
+                self.assertIsNone(defaults.expected_revision)
+                self.assertEqual(defaults.mutation_id, "")
+
+    def test_cancel_reports_the_terminal_state_and_refuses_later_checkpoints(self) -> None:
+        with TemporaryDirectory() as tmp:
+            base = _base(Path(tmp))
+            _create(base)
+
+            status, stdout, stderr = run_cli(base + ["goal", "cancel", "--goal", "goal-cli-guard", "--reason", "Superseded"])
+
+            self.assertEqual(status, 0, stderr)
+            payload = json.loads(stdout)
+            self.assertTrue(payload["cancelled"])
+            self.assertTrue(payload["applied"])
+            self.assertFalse(payload["replayed"])
+            self.assertEqual(payload["goal"]["status"], "cancelled")
+            self.assertEqual(payload["completion_gate"]["next_action"], "show_status")
+
+            status, stdout, stderr = run_cli(
+                base + ["goal", "checkpoint", "--goal", "goal-cli-guard", "--summary", "After cancel"]
+            )
+
+            self.assertEqual(status, 2)
+            self.assertEqual(stdout, "")
+            self.assertTrue(stderr.startswith("omh: "), stderr)
+            self.assertIn("cancelled", stderr)
+            self.assertIn("terminal", stderr)
+            self.assertNotIn("Traceback", stderr)
+
+    def test_stale_expected_revision_exits_non_zero_with_a_readable_message(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = _base(root)
+            _create(base)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            stale_revision = read_goal_ledger(paths, "goal-cli-guard")["record_revision"]
+            # Another writer moves the record on while the stale call is in flight.
+            run_cli(base + ["goal", "checkpoint", "--goal", "goal-cli-guard", "--summary", "First", "--status", "in_progress"])
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "goal",
+                    "checkpoint",
+                    "--goal",
+                    "goal-cli-guard",
+                    "--summary",
+                    "Racing",
+                    "--status",
+                    "in_progress",
+                    "--expected-revision",
+                    str(stale_revision),
+                ]
+            )
+
+            self.assertEqual(status, 2)
+            self.assertEqual(stdout, "")
+            self.assertTrue(stderr.startswith("omh: "), stderr)
+            self.assertIn("record_revision", stderr)
+            self.assertNotIn("Traceback", stderr)
+            self.assertEqual(len(read_goal_ledger(paths, "goal-cli-guard")["checkpoints"]), 1)
+
+    def test_repeated_mutation_id_leaves_one_item_and_reports_replayed(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = _base(root)
+            _create(base)
+            command = base + [
+                "goal",
+                "checkpoint",
+                "--goal",
+                "goal-cli-guard",
+                "--summary",
+                "Only once",
+                "--status",
+                "in_progress",
+                "--mutation-id",
+                "cp-retry",
+            ]
+
+            first_status, first_stdout, first_stderr = run_cli(command)
+            second_status, second_stdout, second_stderr = run_cli(command)
+
+            self.assertEqual(first_status, 0, first_stderr)
+            self.assertEqual(second_status, 0, second_stderr)
+            first = json.loads(first_stdout)
+            second = json.loads(second_stdout)
+            self.assertFalse(first["replayed"])
+            self.assertTrue(second["replayed"])
+            # A replay still reports applied=true: the checkpoint the caller
+            # asked for is in the record, it was just written by the first try.
+            self.assertTrue(second["applied"])
+            self.assertEqual(first["goal"]["record_revision"], second["goal"]["record_revision"])
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            self.assertEqual(len(read_goal_ledger(paths, "goal-cli-guard")["checkpoints"]), 1)
+
+    def test_repeated_cancel_mutation_id_replays_without_a_second_transition(self) -> None:
+        with TemporaryDirectory() as tmp:
+            base = _base(Path(tmp))
+            _create(base)
+            command = base + ["goal", "cancel", "--goal", "goal-cli-guard", "--mutation-id", "cancel-retry"]
+
+            first_status, first_stdout, _first_stderr = run_cli(command)
+            second_status, second_stdout, _second_stderr = run_cli(command)
+
+            first = json.loads(first_stdout)
+            second = json.loads(second_stdout)
+            self.assertEqual((first_status, second_status), (0, 0))
+            self.assertFalse(first["replayed"])
+            self.assertTrue(second["replayed"])
+            self.assertTrue(second["cancelled"])
+            self.assertEqual(first["goal"]["record_revision"], second["goal"]["record_revision"])
+
+    def test_mutation_id_reused_across_operations_is_not_swallowed_as_a_replay(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = _base(root)
+            _create(base)
+            # A connector deriving mutation ids from one upstream message id
+            # sends both a checkpoint and a blocker under that id; the blocker
+            # is different intent and must still apply.
+            run_cli(
+                base
+                + [
+                    "goal",
+                    "checkpoint",
+                    "--goal",
+                    "goal-cli-guard",
+                    "--summary",
+                    "Checkpoint under the shared id",
+                    "--status",
+                    "in_progress",
+                    "--mutation-id",
+                    "shared-turn-1",
+                ]
+            )
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "goal",
+                    "blocker",
+                    "--goal",
+                    "goal-cli-guard",
+                    "--summary",
+                    "Blocker under the shared id",
+                    "--mutation-id",
+                    "shared-turn-1",
+                ]
+            )
+
+            self.assertEqual(status, 0, stderr)
+            payload = json.loads(stdout)
+            self.assertFalse(payload["replayed"])
+            self.assertTrue(payload["applied"])
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            stored = read_goal_ledger(paths, "goal-cli-guard")
+            self.assertEqual(len(stored["checkpoints"]), 1)
+            self.assertEqual(len(stored["blockers"]), 1)
+
+    def test_connector_style_mutation_ids_are_accepted_by_the_goal_cli(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = _base(root)
+            _create(base)
+            # Upstream message ids carry ':' and '/'; goals must not be the one
+            # surface that rejects them (wrapper sessions and loop cycles do not).
+            command = base + [
+                "goal",
+                "checkpoint",
+                "--goal",
+                "goal-cli-guard",
+                "--summary",
+                "Snowflake id",
+                "--status",
+                "in_progress",
+                "--mutation-id",
+                "slack:C123/p1700000000.000100",
+            ]
+
+            first_status, first_stdout, first_stderr = run_cli(command)
+            second_status, second_stdout, _second_stderr = run_cli(command)
+
+            self.assertEqual(first_status, 0, first_stderr)
+            self.assertEqual(second_status, 0)
+            self.assertFalse(json.loads(first_stdout)["replayed"])
+            self.assertTrue(json.loads(second_stdout)["replayed"])
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            checkpoints = read_goal_ledger(paths, "goal-cli-guard")["checkpoints"]
+            self.assertEqual(len(checkpoints), 1)
+            checkpoint_id = checkpoints[0]["checkpoint_id"]
+            self.assertNotIn("/", checkpoint_id)
+            self.assertNotIn(":", checkpoint_id)
+
+    def test_same_mutation_id_with_different_content_is_refused_not_replayed(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = _base(root)
+            _create(base)
+            run_cli(
+                base
+                + [
+                    "goal",
+                    "blocker",
+                    "--goal",
+                    "goal-cli-guard",
+                    "--summary",
+                    "Original blocker",
+                    "--mutation-id",
+                    "blocker-1",
+                ]
+            )
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "goal",
+                    "blocker",
+                    "--goal",
+                    "goal-cli-guard",
+                    "--summary",
+                    "A completely different blocker",
+                    "--mutation-id",
+                    "blocker-1",
+                ]
+            )
+
+            self.assertEqual(status, 2)
+            self.assertEqual(stdout, "")
+            self.assertTrue(stderr.startswith("omh: "), stderr)
+            self.assertNotIn("Traceback", stderr)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            blockers = read_goal_ledger(paths, "goal-cli-guard")["blockers"]
+            self.assertEqual(len(blockers), 1)
+            self.assertEqual(blockers[0]["summary"], "Original blocker")
+
+    def test_a_cancel_replayed_away_is_reported_as_not_cancelled_and_exits_non_zero(self) -> None:
+        # The defect this pins: cmd_goal_cancel printed the goal and returned 0
+        # whenever the call did not raise, so a cancel whose mutation replayed
+        # away left an active goal that read as successfully cancelled. The
+        # applied_mutations entry below is planted directly to force exactly
+        # that state, which operation scoping otherwise makes hard to reach.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = _base(root)
+            _create(base)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            path = goal_ledger_path(paths, "goal-cli-guard")
+            goal = json.loads(path.read_text(encoding="utf-8"))
+            goal["applied_mutations"] = {
+                applied_mutation_key("cancel_goal_ledger", "cancel-1"): {
+                    "operation": "cancel_goal_ledger",
+                    "record_revision": int(goal["record_revision"]),
+                    "result_digest": _mutation_digest("cancel_goal_ledger", ""),
+                }
+            }
+            path.write_text(json.dumps(goal, sort_keys=True), encoding="utf-8")
+
+            status, stdout, stderr = run_cli(
+                base + ["goal", "cancel", "--goal", "goal-cli-guard", "--mutation-id", "cancel-1"]
+            )
+
+            self.assertEqual(status, 1, stderr)
+            payload = json.loads(stdout)
+            self.assertTrue(payload["replayed"])
+            self.assertFalse(payload["cancelled"])
+            self.assertFalse(payload["applied"])
+            self.assertEqual(payload["goal"]["status"], "active")
+
+    def test_a_retry_after_eviction_with_only_a_mutation_id_leaves_one_blocker(self) -> None:
+        # The exact issue #828 repro, end to end through the CLI: the goal CLI
+        # accepts --mutation-id independently of --expected-revision, so the
+        # eviction floor never fires for this call. Before the fix the retry
+        # exited 0 with applied=true/replayed=false and produced TWO blockers
+        # sharing one blocker_id, which validate_goal_ledger still called ok.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = _base(root)
+            _create(base)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            retry = base + [
+                "goal",
+                "blocker",
+                "--goal",
+                "goal-cli-guard",
+                "--summary",
+                "the original blocker",
+                "--mutation-id",
+                "turn-EVICT-ME",
+            ]
+            self.assertEqual(run_cli(retry)[0], 0)
+            for index in range(APPLIED_MUTATIONS_LIMIT + 10):
+                status, _stdout, stderr = run_cli(
+                    base
+                    + [
+                        "goal",
+                        "checkpoint",
+                        "--goal",
+                        "goal-cli-guard",
+                        "--summary",
+                        f"filler {index}",
+                        "--status",
+                        "in_progress",
+                        "--mutation-id",
+                        f"filler-{index:04d}",
+                    ]
+                )
+                self.assertEqual(status, 0, stderr)
+            evicted = json.loads(goal_ledger_path(paths, "goal-cli-guard").read_text(encoding="utf-8"))
+            self.assertGreaterEqual(int(evicted["applied_mutations_floor_revision"]), 1)
+            self.assertNotIn(
+                applied_mutation_key("record_goal_blocker", "turn-EVICT-ME"), evicted["applied_mutations"]
+            )
+
+            status, stdout, stderr = run_cli(retry)
+
+            self.assertEqual(status, 0, stderr)
+            payload = json.loads(stdout)
+            self.assertTrue(payload["applied"])
+            self.assertTrue(payload["replayed"])
+            stored = read_goal_ledger(paths, "goal-cli-guard")
+            self.assertEqual([item["blocker_id"] for item in stored["blockers"]], ["turn-EVICT-ME"])
+            self.assertEqual(int(stored["record_revision"]), int(evicted["record_revision"]))
+
+    def test_an_over_long_mutation_id_is_rejected_with_nothing_written(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = _base(root)
+            _create(base)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            path = goal_ledger_path(paths, "goal-cli-guard")
+            before = path.read_bytes()
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "goal",
+                    "checkpoint",
+                    "--goal",
+                    "goal-cli-guard",
+                    "--summary",
+                    "Oversized retry token",
+                    "--status",
+                    "in_progress",
+                    "--mutation-id",
+                    "x" * 100_000,
+                ]
+            )
+
+            self.assertEqual(status, 2)
+            self.assertEqual(stdout, "")
+            self.assertTrue(stderr.startswith("omh: "), stderr)
+            self.assertIn(f"at most {MAX_MUTATION_ID_CHARS} characters", stderr)
+            self.assertNotIn("Traceback", stderr)
+            self.assertEqual(path.read_bytes(), before)
+
+    def test_missing_goal_reports_a_readable_error_not_a_traceback(self) -> None:
+        with TemporaryDirectory() as tmp:
+            base = _base(Path(tmp))
+
+            status, stdout, stderr = run_cli(base + ["goal", "cancel", "--goal", "no-such-goal"])
+
+            self.assertEqual(status, 2)
+            self.assertEqual(stdout, "")
+            self.assertTrue(stderr.startswith("omh: "), stderr)
+            self.assertNotIn("Traceback", stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_goal_ledger.py
+++ b/tests/test_goal_ledger.py
@@ -16,6 +16,7 @@ from omh.goal_ledger import (
     build_goal_completion_gate,
     build_goal_continuation,
     build_goal_status_card,
+    cancel_goal_ledger,
     complete_goal_ledger,
     create_goal_ledger,
     goal_ledger_path,
@@ -26,6 +27,7 @@ from omh.goal_ledger import (
     validate_goal_ledger,
 )
 from omh.paths import resolve_paths
+from omh.record_revision import APPLIED_MUTATIONS_LIMIT, applied_mutation_key
 
 
 class GoalLedgerTests(unittest.TestCase):
@@ -321,6 +323,340 @@ class GoalStatusCardCheckpointRenderingTests(unittest.TestCase):
                 status_card["safe_copy"]["checkpoint_format"],
                 "- cpN: summary — status, evidence",
             )
+
+
+class GoalLedgerMutationIdTests(unittest.TestCase):
+    def _goal(self, paths, goal_id: str = "goal-mutation-id") -> dict:
+        return create_goal_ledger(
+            paths,
+            "Finish the durable goal",
+            [{"id": "AC-guard", "summary": "Guard is verified"}],
+            goal_id=goal_id,
+        )
+
+    def test_connector_style_mutation_ids_are_accepted_and_replay_once(self) -> None:
+        # Goals used to be the one surface that restricted mutation_id to the
+        # storage-id charset, so a connector deriving ids from upstream
+        # message ids (snowflakes carrying ':' or '/') failed only here.
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            self._goal(paths)
+            mutation_id = "slack:C123/p1700000000.000100"
+
+            first = record_goal_checkpoint(
+                paths, "goal-mutation-id", "Snowflake", status="in_progress", mutation_id=mutation_id
+            )
+            second = record_goal_checkpoint(
+                paths, "goal-mutation-id", "Snowflake", status="in_progress", mutation_id=mutation_id
+            )
+
+            stored = read_goal_ledger(paths, "goal-mutation-id")
+            self.assertEqual(len(stored["checkpoints"]), 1)
+            self.assertEqual(first["record_revision"], second["record_revision"])
+            # The item id is derived from the mutation id, never taken from it
+            # verbatim when it is not filesystem-safe.
+            checkpoint_id = stored["checkpoints"][0]["checkpoint_id"]
+            self.assertTrue(checkpoint_id.startswith("checkpoint-"))
+            self.assertNotIn("/", checkpoint_id)
+            self.assertNotIn(":", checkpoint_id)
+
+    def test_item_id_derivation_from_a_mutation_id_is_deterministic(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            self._goal(paths, "goal-a")
+            self._goal(paths, "goal-b")
+
+            first = record_goal_blocker(paths, "goal-a", "Needs approval", mutation_id="slack:C1/p1.2")
+            second = record_goal_blocker(paths, "goal-b", "Needs approval", mutation_id="slack:C1/p1.2")
+
+            self.assertEqual(first["blockers"][0]["blocker_id"], second["blockers"][0]["blocker_id"])
+
+    def test_filesystem_safe_mutation_ids_stay_verbatim_in_the_item_id(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            self._goal(paths)
+
+            goal = record_goal_checkpoint(
+                paths, "goal-mutation-id", "Readable", status="in_progress", mutation_id="cp-retry-1"
+            )
+
+            self.assertEqual(goal["checkpoints"][0]["checkpoint_id"], "cp-retry-1")
+
+    def test_mutation_outcome_reports_replay_and_what_the_record_actually_says(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            self._goal(paths)
+            first_outcome: dict = {}
+            replay_outcome: dict = {}
+
+            cancel_goal_ledger(paths, "goal-mutation-id", mutation_id="cancel-1", outcome=first_outcome)
+            cancel_goal_ledger(paths, "goal-mutation-id", mutation_id="cancel-1", outcome=replay_outcome)
+
+            self.assertEqual(first_outcome, {"replayed": False, "applied": True, "goal_status": "cancelled"})
+            self.assertEqual(replay_outcome, {"replayed": True, "applied": True, "goal_status": "cancelled"})
+
+    def test_goal_ledger_validator_rejects_bad_revision_fields(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            goal = self._goal(paths)
+
+            revision_errors = validate_goal_ledger({**goal, "record_revision": -1})["errors"]
+            applied_errors = validate_goal_ledger({**goal, "applied_mutations": []})["errors"]
+
+            self.assertIn("goal_ledger record_revision must be a non-negative integer", revision_errors)
+            self.assertIn("goal_ledger applied_mutations must be an object", applied_errors)
+
+
+class GoalLedgerEvictedRetryTests(unittest.TestCase):
+    """The retry proof left after the bounded applied_mutations map forgot an id.
+
+    The eviction floor only refuses a retry that also carried an
+    expected_revision, and every CLI accepts --mutation-id on its own. Before
+    issue #828 such a retry applied a second time and appended a duplicate item
+    under the same derived id. The item id is materialized from the mutation
+    id, so the record itself is the proof the map can no longer give.
+    """
+
+    def _goal(self, paths, goal_id: str = "goal-evicted") -> dict:
+        return create_goal_ledger(
+            paths,
+            "Survive applied_mutations eviction",
+            [{"id": "AC-evict", "summary": "Retries survive eviction"}],
+            goal_id=goal_id,
+        )
+
+    def _evict(self, paths, goal_id: str = "goal-evicted") -> dict:
+        """Push the goal past the bound so the seeded id is no longer retained."""
+        for index in range(APPLIED_MUTATIONS_LIMIT + 10):
+            record_goal_checkpoint(
+                paths,
+                goal_id,
+                f"filler {index}",
+                status="in_progress",
+                mutation_id=f"filler-{index:04d}",
+            )
+        stored = read_goal_ledger(paths, goal_id)
+        self.assertGreaterEqual(int(stored["applied_mutations_floor_revision"]), 1)
+        return stored
+
+    def test_a_retry_carrying_only_a_mutation_id_leaves_one_blocker_after_eviction(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            self._goal(paths)
+            record_goal_blocker(paths, "goal-evicted", "the original blocker", mutation_id="turn-EVICT-ME")
+            stored = self._evict(paths)
+            self.assertNotIn(
+                applied_mutation_key("record_goal_blocker", "turn-EVICT-ME"), stored["applied_mutations"]
+            )
+            outcome: dict = {}
+
+            goal = record_goal_blocker(
+                paths, "goal-evicted", "the original blocker", mutation_id="turn-EVICT-ME", outcome=outcome
+            )
+
+            self.assertEqual(outcome, {"replayed": True, "applied": True, "goal_status": "active"})
+            blockers = read_goal_ledger(paths, "goal-evicted")["blockers"]
+            self.assertEqual([item["blocker_id"] for item in blockers], ["turn-EVICT-ME"])
+            self.assertEqual(blockers[0]["summary"], "the original blocker")
+            # A replay is not a write: the revision did not move.
+            self.assertEqual(goal["record_revision"], int(stored["record_revision"]))
+
+    def test_a_retried_checkpoint_after_eviction_neither_duplicates_nor_bumps(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            self._goal(paths)
+            record_goal_checkpoint(
+                paths, "goal-evicted", "the original checkpoint", status="in_progress", mutation_id="cp-EVICT-ME"
+            )
+            stored = self._evict(paths)
+            before = len(stored["checkpoints"])
+            outcome: dict = {}
+
+            record_goal_checkpoint(
+                paths,
+                "goal-evicted",
+                "the original checkpoint",
+                status="in_progress",
+                mutation_id="cp-EVICT-ME",
+                outcome=outcome,
+            )
+
+            after = read_goal_ledger(paths, "goal-evicted")
+            self.assertEqual(len(after["checkpoints"]), before)
+            self.assertEqual(int(after["record_revision"]), int(stored["record_revision"]))
+            self.assertTrue(outcome["replayed"])
+            self.assertTrue(outcome["applied"])
+
+    def test_a_retried_quality_gate_after_eviction_leaves_one_gate(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            self._goal(paths)
+            record_goal_quality_gate(paths, "goal-evicted", "suite green", mutation_id="qg-EVICT-ME")
+            self._evict(paths)
+            outcome: dict = {}
+
+            record_goal_quality_gate(
+                paths, "goal-evicted", "suite green", mutation_id="qg-EVICT-ME", outcome=outcome
+            )
+
+            gates = read_goal_ledger(paths, "goal-evicted")["quality_gates"]
+            self.assertEqual([item["quality_gate_id"] for item in gates], ["qg-EVICT-ME"])
+            self.assertTrue(outcome["replayed"])
+            self.assertTrue(outcome["applied"])
+
+    def test_a_new_mutation_id_still_applies_after_eviction_has_happened(self) -> None:
+        # The dedupe must not be a disguised widening of the floor rule: once
+        # any eviction has happened, an id the record has never seen still has
+        # to apply normally.
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            self._goal(paths)
+            stored = self._evict(paths)
+            outcome: dict = {}
+
+            goal = record_goal_blocker(
+                paths, "goal-evicted", "brand new blocker", mutation_id="turn-BRAND-NEW", outcome=outcome
+            )
+
+            self.assertEqual(outcome, {"replayed": False, "applied": True, "goal_status": "active"})
+            self.assertEqual(int(goal["record_revision"]), int(stored["record_revision"]) + 1)
+            self.assertEqual(
+                [item["blocker_id"] for item in read_goal_ledger(paths, "goal-evicted")["blockers"]],
+                ["turn-BRAND-NEW"],
+            )
+
+    def test_a_retried_completion_after_eviction_reports_a_replay(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            self._goal(paths)
+            record_goal_checkpoint(
+                paths,
+                "goal-evicted",
+                "Criterion satisfied",
+                criteria_refs=["AC-evict"],
+                evidence_refs=["observed:suite-green"],
+            )
+            first = complete_goal_ledger(
+                paths, "goal-evicted", evidence_refs=["observed:suite-green"], mutation_id="done-EVICT-ME"
+            )
+            self.assertTrue(first["completed"])
+            # A complete goal refuses further checkpoints, so eviction is
+            # forced by clearing the map directly rather than by more writes.
+            path = goal_ledger_path(paths, "goal-evicted")
+            stored = json.loads(path.read_text(encoding="utf-8"))
+            stored["applied_mutations"] = {}
+            stored["applied_mutations_floor_revision"] = int(stored["record_revision"])
+            path.write_text(json.dumps(stored, sort_keys=True), encoding="utf-8")
+
+            second = complete_goal_ledger(
+                paths, "goal-evicted", evidence_refs=["observed:suite-green"], mutation_id="done-EVICT-ME"
+            )
+
+            self.assertTrue(second["completed"])
+            self.assertTrue(second["replayed"])
+            gates = read_goal_ledger(paths, "goal-evicted")["quality_gates"]
+            self.assertEqual([item["quality_gate_id"] for item in gates], ["done-EVICT-ME"])
+
+
+class GoalLedgerDuplicateItemIdValidationTests(unittest.TestCase):
+    def _goal(self, paths) -> dict:
+        return create_goal_ledger(
+            paths,
+            "Reject duplicate item ids",
+            [{"id": "AC-dup", "summary": "Duplicates are rejected"}],
+            goal_id="goal-duplicate",
+        )
+
+    def test_duplicate_item_ids_in_one_list_are_a_validation_error(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            goal = self._goal(paths)
+            for id_key, label, list_key, item in (
+                (
+                    "checkpoint_id",
+                    "checkpoint",
+                    "checkpoints",
+                    {"status": "done", "summary": "s", "criteria_refs": [], "evidence_refs": []},
+                ),
+                ("blocker_id", "blocker", "blockers", {"status": "active", "summary": "s", "evidence_refs": []}),
+                (
+                    "quality_gate_id",
+                    "quality gate",
+                    "quality_gates",
+                    {"status": "passed", "summary": "s", "evidence_refs": []},
+                ),
+            ):
+                with self.subTest(list_key=list_key):
+                    duplicated = {
+                        **goal,
+                        list_key: [{**item, id_key: "shared-id"}, {**item, id_key: "shared-id"}],
+                    }
+
+                    validation = validate_goal_ledger(duplicated)
+
+                    self.assertFalse(validation["ok"])
+                    self.assertIn(f"duplicate {label} {id_key}: shared-id", validation["errors"])
+
+    def test_distinct_item_ids_in_one_list_stay_valid(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            self._goal(paths)
+            record_goal_blocker(paths, "goal-duplicate", "First", mutation_id="b-1")
+            record_goal_blocker(paths, "goal-duplicate", "Second", mutation_id="b-2")
+
+            stored = read_goal_ledger(paths, "goal-duplicate")
+
+            self.assertEqual([item["blocker_id"] for item in stored["blockers"]], ["b-1", "b-2"])
+            self.assertEqual(validate_goal_ledger(stored), {"ok": True, "errors": []})
+
+    def test_a_duplicate_planted_by_hand_is_refused_by_the_guarded_write(self) -> None:
+        # The validator runs inside guarded_record_update, so a record that
+        # already lost the invariant cannot be extended by a further mutation.
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            self._goal(paths)
+            record_goal_blocker(paths, "goal-duplicate", "First", mutation_id="b-1")
+            path = goal_ledger_path(paths, "goal-duplicate")
+            stored = json.loads(path.read_text(encoding="utf-8"))
+            stored["blockers"] = stored["blockers"] + [dict(stored["blockers"][0])]
+            path.write_text(json.dumps(stored, sort_keys=True), encoding="utf-8")
+
+            with self.assertRaises(ValueError) as caught:
+                record_goal_blocker(paths, "goal-duplicate", "Second", mutation_id="b-2")
+
+            self.assertIn("duplicate blocker blocker_id: b-1", str(caught.exception))
+
+    def test_one_mutation_id_shared_across_both_quality_gate_writers_is_refused(self) -> None:
+        # record_goal_quality_gate and complete_goal_ledger are different
+        # operations writing into the SAME list, so one id reused across them
+        # is a genuine collision. It is refused visibly - completed stays
+        # false and replayed is true - rather than persisting a duplicate id.
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            self._goal(paths)
+            record_goal_checkpoint(
+                paths,
+                "goal-duplicate",
+                "Criterion satisfied",
+                criteria_refs=["AC-dup"],
+                evidence_refs=["observed:suite-green"],
+            )
+            record_goal_quality_gate(paths, "goal-duplicate", "suite green", mutation_id="turn-1")
+
+            collided = complete_goal_ledger(
+                paths, "goal-duplicate", evidence_refs=["observed:suite-green"], mutation_id="turn-1"
+            )
+            distinct = complete_goal_ledger(
+                paths, "goal-duplicate", evidence_refs=["observed:suite-green"], mutation_id="turn-2"
+            )
+
+            self.assertFalse(collided["completed"])
+            self.assertTrue(collided["replayed"])
+            self.assertTrue(distinct["completed"])
+            self.assertFalse(distinct["replayed"])
+            stored = read_goal_ledger(paths, "goal-duplicate")
+            self.assertEqual([item["quality_gate_id"] for item in stored["quality_gates"]], ["turn-1", "turn-2"])
+            self.assertEqual(validate_goal_ledger(stored), {"ok": True, "errors": []})
 
 
 if __name__ == "__main__":

--- a/tests/test_local_store_locking.py
+++ b/tests/test_local_store_locking.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import errno
+import os
 import threading
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest import mock
 
 from _local_package import load_local_package
 
@@ -22,6 +25,42 @@ try:
     HAS_FCNTL = True
 except ImportError:
     HAS_FCNTL = False
+
+
+class FakeMsvcrt:
+    """Stand-in for the Windows locking API, exercised on every platform.
+
+    Real ``msvcrt.locking`` locks a byte region per open handle, so a second
+    handle on the same file - even inside the same process - fails with
+    ``EACCES``. The fake keys its registry by (device, inode) so two handles on
+    one file collide exactly that way, which is the property ``file_lock``
+    relies on for mutual exclusion.
+    """
+
+    LK_NBLCK = 2
+    LK_UNLCK = 0
+
+    def __init__(self) -> None:
+        self._guard = threading.Lock()
+        self._held: dict[tuple[int, int], int] = {}
+        self.modes: list[str] = []
+
+    def locking(self, fd: int, mode: int, nbytes: int) -> None:
+        info = os.fstat(fd)
+        key = (info.st_dev, info.st_ino)
+        with self._guard:
+            if mode == self.LK_NBLCK:
+                if key in self._held:
+                    raise OSError(errno.EACCES, "region already locked")
+                self._held[key] = fd
+                self.modes.append("lock")
+                return
+            if mode == self.LK_UNLCK:
+                if self._held.get(key) == fd:
+                    del self._held[key]
+                self.modes.append("unlock")
+                return
+            raise ValueError(f"unsupported msvcrt mode: {mode}")
 
 
 class LocalStoreLockingTests(unittest.TestCase):
@@ -83,13 +122,100 @@ class LocalStoreLockingTests(unittest.TestCase):
                     with file_lock(path, timeout_seconds=0.2, poll_interval=0.01):
                         pass
 
-    @unittest.skipIf(HAS_FCNTL, "degraded no-op path only applies without fcntl")
-    def test_file_lock_degrades_gracefully_without_fcntl(self) -> None:
+    @unittest.skipUnless(HAS_FCNTL, "fcntl advisory locking is POSIX-only")
+    def test_fcntl_lock_reports_itself_as_enforced(self) -> None:
         with TemporaryDirectory() as tmp:
             path = Path(tmp) / "state.json"
-            with file_lock(path, timeout_seconds=0.2) as acquired:
-                self.assertFalse(acquired["locked"])
-                self.assertEqual(acquired["reason"], "fcntl_unavailable")
+            with file_lock(path) as acquired:
+                self.assertTrue(acquired["locked"])
+                self.assertTrue(acquired["enforced"])
+                self.assertEqual(acquired["mechanism"], "fcntl")
+
+
+class WindowsFileLockTests(unittest.TestCase):
+    """The Windows lock path, exercised through a fake on every platform.
+
+    windows-latest is an enforcing CI target, so the msvcrt branch cannot be
+    left to run only there.
+    """
+
+    def test_msvcrt_takes_the_lock_when_fcntl_is_unavailable(self) -> None:
+        fake = FakeMsvcrt()
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "state.json"
+            with (
+                mock.patch("omh.system.local_store.fcntl", None),
+                mock.patch("omh.system.local_store.msvcrt", fake),
+            ):
+                with file_lock(path) as acquired:
+                    self.assertTrue(acquired["locked"])
+                    self.assertTrue(acquired["enforced"])
+                    self.assertEqual(acquired["mechanism"], "msvcrt")
+                    self.assertEqual(fake.modes, ["lock"])
+
+            self.assertEqual(fake.modes, ["lock", "unlock"])
+            self.assertTrue((Path(tmp) / ".state.json.lock").exists())
+
+    def test_msvcrt_lock_is_exclusive_and_times_out(self) -> None:
+        fake = FakeMsvcrt()
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "contended.json"
+            with (
+                mock.patch("omh.system.local_store.fcntl", None),
+                mock.patch("omh.system.local_store.msvcrt", fake),
+            ):
+                with file_lock(path, timeout_seconds=5.0) as acquired:
+                    self.assertTrue(acquired["enforced"])
+                    with self.assertRaises(FileLockTimeout):
+                        with file_lock(path, timeout_seconds=0.2, poll_interval=0.01):
+                            pass
+
+    def test_msvcrt_lock_serializes_concurrent_updates(self) -> None:
+        fake = FakeMsvcrt()
+        worker_count = 16
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "state.json"
+            barrier = threading.Barrier(worker_count)
+
+            def worker(index: int) -> None:
+                barrier.wait()
+                locked_json_update(
+                    path,
+                    lambda current: {**current, f"key-{index}": index},
+                    default={},
+                    timeout_seconds=30.0,
+                )
+
+            with (
+                mock.patch("omh.system.local_store.fcntl", None),
+                mock.patch("omh.system.local_store.msvcrt", fake),
+            ):
+                threads = [threading.Thread(target=worker, args=(index,)) for index in range(worker_count)]
+                for thread in threads:
+                    thread.start()
+                for thread in threads:
+                    thread.join()
+
+            final = read_json_object(path)
+            assert final is not None
+            for index in range(worker_count):
+                self.assertEqual(final.get(f"key-{index}"), index)
+
+    def test_lock_reports_not_enforced_without_fcntl_or_msvcrt(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "state.json"
+            with (
+                mock.patch("omh.system.local_store.fcntl", None),
+                mock.patch("omh.system.local_store.msvcrt", None),
+            ):
+                with file_lock(path, timeout_seconds=0.2) as acquired:
+                    self.assertFalse(acquired["locked"])
+                    self.assertFalse(acquired["enforced"])
+                    self.assertEqual(acquired["mechanism"], "none")
+                    self.assertEqual(acquired["reason"], "no_os_file_lock")
+
+            # A lock that was never taken leaves no sidecar behind either.
+            self.assertFalse((Path(tmp) / ".state.json.lock").exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_loop_cycle.py
+++ b/tests/test_loop_cycle.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import threading
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from _local_package import load_local_package
+from _platform_support import requires_fcntl_locks
 
 load_local_package()
 from omh.goal_loop import (
@@ -21,9 +23,11 @@ from omh.goal_loop import (
     dispatch_loop_queue_item,
     inspect_loop_queue_item,
     list_loop_queue,
+    loop_cycle_path,
     loop_executor_capability,
     observe_codex_loop_queue_item,
     observe_loop_queue_item,
+    read_loop_cycle,
     record_loop_feedback,
     run_loop_once_result,
     tick_loop_runtime,
@@ -31,6 +35,7 @@ from omh.goal_loop import (
     validate_loop_cycle,
 )
 from omh.paths import resolve_paths
+from omh.record_revision import StaleRecordMutation
 
 
 class GoalLoopTests(unittest.TestCase):
@@ -701,6 +706,120 @@ class GoalLoopTests(unittest.TestCase):
 
         self.assertFalse(validation["ok"])
         self.assertIn("runtime.queue[0].subagent_plan.result_contract must be an object", validation["errors"])
+
+
+class LoopCycleMutationGuardTests(unittest.TestCase):
+    def _cycle(self, paths) -> dict:
+        return create_loop_cycle(
+            paths,
+            goal_summary="Ship the stale mutation guard",
+            goal_reframe="Implement the guard, verify it, and prepare the handoff material.",
+            success_criteria=["Guard is verified by tests"],
+            permission_profile="handoff_only",
+        )
+
+    def test_every_cycle_mutator_rejects_a_stale_expected_revision_without_writing(self) -> None:
+        # Only the queue mutators were guarded first; feedback, permission,
+        # and tick still read outside the lock and wrote the whole cycle back,
+        # so a stale caller silently reverted whatever landed in between.
+        mutators = {
+            "record_loop_feedback": lambda paths, loop_id, revision: record_loop_feedback(
+                paths, loop_id, observed_artifacts=["artifact:1"], expected_revision=revision
+            ),
+            "update_loop_permission": lambda paths, loop_id, revision: update_loop_permission(
+                paths, loop_id, allow_actions=["merge"], expected_revision=revision
+            ),
+            "tick_loop_runtime": lambda paths, loop_id, revision: tick_loop_runtime(
+                paths, loop_id, expected_revision=revision
+            ),
+        }
+        for name, call in mutators.items():
+            with self.subTest(mutator=name), TemporaryDirectory() as tmp:
+                paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+                cycle = self._cycle(paths)
+                loop_id = str(cycle["loop_id"])
+                stale_revision = int(cycle["record_revision"])
+                # Another writer moves the cycle on while the call is in flight.
+                tick_loop_runtime(paths, loop_id)
+                path = loop_cycle_path(paths, loop_id)
+                before = path.read_bytes()
+
+                with self.assertRaises(StaleRecordMutation):
+                    call(paths, loop_id, stale_revision)
+
+                self.assertEqual(path.read_bytes(), before)
+
+    def test_loop_mutation_ids_accept_connector_style_ids_and_replay(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = self._cycle(paths)
+            loop_id = str(cycle["loop_id"])
+            mutation_id = "slack:C123/p1700000000.000100"
+
+            first = record_loop_feedback(
+                paths, loop_id, observed_artifacts=["artifact:1"], mutation_id=mutation_id
+            )
+            second = record_loop_feedback(
+                paths, loop_id, observed_artifacts=["artifact:1"], mutation_id=mutation_id
+            )
+
+            self.assertEqual(first["record_revision"], second["record_revision"])
+            self.assertEqual(len(read_loop_cycle(paths, loop_id)["cycles"]), 1)
+
+    def test_loop_cycle_validator_rejects_bad_revision_fields(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = self._cycle(paths)
+
+            revision_errors = validate_loop_cycle({**cycle, "record_revision": -1})["errors"]
+            applied_errors = validate_loop_cycle({**cycle, "applied_mutations": []})["errors"]
+
+            self.assertIn("loop_cycle record_revision must be a non-negative integer", revision_errors)
+            self.assertIn("loop_cycle applied_mutations must be an object", applied_errors)
+
+    @requires_fcntl_locks
+    def test_concurrent_feedback_does_not_revert_a_guarded_queue_observation(self) -> None:
+        # The confirmed probe: a guarded observation was reverted by a stale
+        # record_loop_feedback write, after which the observation's own
+        # mutation_id replayed it away and the queue item stayed unobserved.
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = self._cycle(paths)
+            loop_id = str(cycle["loop_id"])
+            ticked = tick_loop_runtime(paths, loop_id)
+            queue_id = str(ticked["runtime"]["queue"][0]["queue_id"])
+            barrier = threading.Barrier(2)
+            failures: list[BaseException] = []
+
+            def observe() -> None:
+                barrier.wait()
+                try:
+                    observe_loop_queue_item(
+                        paths, loop_id, queue_id, evidence_refs=["wrapper:queue-observation:1"]
+                    )
+                except BaseException as exc:  # noqa: BLE001
+                    failures.append(exc)
+
+            def feedback() -> None:
+                barrier.wait()
+                try:
+                    record_loop_feedback(paths, loop_id, observed_artifacts=["artifact:1"])
+                except BaseException as exc:  # noqa: BLE001
+                    failures.append(exc)
+
+            threads = [threading.Thread(target=observe), threading.Thread(target=feedback)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+            self.assertEqual(failures, [])
+            stored = read_loop_cycle(paths, loop_id)
+            # Both writes survived: the observation is not reverted and the
+            # feedback cycle entry is not lost.
+            self.assertEqual(stored["runtime"]["queue"][0]["status"], "observed")
+            self.assertEqual(len(stored["cycles"]), 1)
+            self.assertEqual(stored["record_revision"], int(ticked["record_revision"]) + 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_record_revision.py
+++ b/tests/test_record_revision.py
@@ -1,0 +1,1531 @@
+from __future__ import annotations
+
+import json
+import re
+import threading
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.goal_ledger import (
+    GOAL_STATUSES,
+    cancel_goal_ledger,
+    complete_goal_ledger,
+    create_goal_ledger,
+    goal_ledger_path,
+    read_goal_ledger,
+    record_goal_blocker,
+    record_goal_checkpoint,
+    record_goal_quality_gate,
+    validate_goal_ledger,
+)
+from omh.goal_loop import (
+    block_loop_queue_item,
+    create_loop_cycle,
+    loop_cycle_path,
+    observe_loop_queue_item,
+    read_loop_cycle,
+    tick_loop_runtime,
+    validate_loop_cycle,
+)
+from omh.local_store import read_json_object
+from omh.paths import resolve_paths
+from omh.record_revision import (
+    APPLIED_MUTATIONS_FLOOR_KEY,
+    APPLIED_MUTATIONS_KEY,
+    APPLIED_MUTATIONS_LIMIT,
+    MAX_MUTATION_ID_CHARS,
+    MAX_OPERATION_CHARS,
+    RECORD_REVISION_KEY,
+    ConflictingMutationReplay,
+    DuplicateMutationReplay,
+    MutationHistoryEvicted,
+    StaleRecordMutation,
+    applied_mutation_key,
+    applied_mutations_floor_of,
+    guarded_record_update,
+    record_revision_of,
+    require_not_terminal,
+    revision_field_errors,
+    validated_mutation_id,
+    validated_operation,
+)
+from omh.runtime_records import WRAPPER_SESSION_RECORD_KEYS
+from test_local_store_locking import FakeMsvcrt
+from omh.wrapper.executor_sessions import (
+    ExecutorSessionError,
+    attach_executor_session,
+    open_executor_session,
+    record_executor_session_result,
+)
+from omh.wrapper_sessions import (
+    WrapperSessionError,
+    create_or_resume_wrapper_session,
+    prepare_wrapper_session_handoff,
+    read_wrapper_session,
+    record_plan_decision,
+    select_wrapper_session_executor,
+)
+
+try:
+    import fcntl as _fcntl  # noqa: F401 - import used only to probe platform availability
+
+    HAS_FCNTL = True
+except ImportError:
+    HAS_FCNTL = False
+
+
+def _bump(current: dict[str, object]) -> dict[str, object]:
+    return {**current, "value": int(current.get("value", 0)) + 1}
+
+
+class RecordRevisionHelperTests(unittest.TestCase):
+    def test_revision_starts_at_one_and_increments_once_per_mutation(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+
+            first = guarded_record_update(path, mutate=_bump, operation="probe", lock_name="record.json", default={})
+            second = guarded_record_update(path, mutate=_bump, operation="probe", lock_name="record.json")
+            third = guarded_record_update(path, mutate=_bump, operation="probe", lock_name="record.json")
+
+            self.assertEqual(first[RECORD_REVISION_KEY], 1)
+            self.assertEqual(second[RECORD_REVISION_KEY], 2)
+            self.assertEqual(third[RECORD_REVISION_KEY], 3)
+            self.assertEqual(third["value"], 3)
+            self.assertEqual(record_revision_of(read_json_object(path)), 3)
+
+    def test_record_revision_of_rejects_bools_and_missing_values(self) -> None:
+        self.assertEqual(record_revision_of(None), 0)
+        self.assertEqual(record_revision_of({}), 0)
+        self.assertEqual(record_revision_of({RECORD_REVISION_KEY: True}), 0)
+        self.assertEqual(record_revision_of({RECORD_REVISION_KEY: "3"}), 0)
+        self.assertEqual(record_revision_of({RECORD_REVISION_KEY: -2}), 0)
+        self.assertEqual(record_revision_of({RECORD_REVISION_KEY: 7}), 7)
+
+    def test_stale_mutation_is_rejected_and_leaves_the_file_byte_identical(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+            guarded_record_update(path, mutate=_bump, operation="probe", lock_name="record.json", default={})
+            guarded_record_update(path, mutate=_bump, operation="probe", lock_name="record.json")
+            before = path.read_bytes()
+
+            with self.assertRaises(StaleRecordMutation) as caught:
+                guarded_record_update(
+                    path,
+                    mutate=_bump,
+                    operation="probe",
+                    lock_name="record.json",
+                    expected_revision=1,
+                )
+
+            self.assertEqual(path.read_bytes(), before)
+            self.assertEqual(caught.exception.expected_revision, 1)
+            self.assertEqual(caught.exception.current_revision, 2)
+            self.assertIn("record_revision 2", str(caught.exception))
+
+    def test_stale_rejection_never_runs_the_mutate_callable(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+            guarded_record_update(path, mutate=_bump, operation="probe", lock_name="record.json", default={})
+            calls: list[int] = []
+
+            def mutate(current: dict[str, object]) -> dict[str, object]:
+                calls.append(1)
+                return _bump(current)
+
+            with self.assertRaises(StaleRecordMutation):
+                guarded_record_update(path, mutate=mutate, operation="probe", lock_name="record.json", expected_revision=99)
+
+            self.assertEqual(calls, [])
+
+    def test_matching_expected_revision_applies_the_mutation(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+            first = guarded_record_update(path, mutate=_bump, operation="probe", lock_name="record.json", default={})
+
+            second = guarded_record_update(
+                path,
+                mutate=_bump,
+                operation="probe",
+                lock_name="record.json",
+                expected_revision=first[RECORD_REVISION_KEY],
+            )
+
+            self.assertEqual(second[RECORD_REVISION_KEY], 2)
+            self.assertEqual(second["value"], 2)
+
+    def test_replayed_mutation_id_returns_the_original_outcome_without_a_write(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+            applied = guarded_record_update(
+                path,
+                mutate=_bump,
+                operation="probe",
+                lock_name="record.json",
+                mutation_id="mutation-1",
+                default={},
+            )
+            after_first = path.read_bytes()
+
+            replay = guarded_record_update(
+                path,
+                mutate=_bump,
+                operation="probe",
+                lock_name="record.json",
+                mutation_id="mutation-1",
+                on_replay=lambda record, entry: {"digest": entry["result_digest"]},
+            )
+
+            self.assertIsInstance(replay, DuplicateMutationReplay)
+            assert isinstance(replay, DuplicateMutationReplay)
+            self.assertEqual(path.read_bytes(), after_first)
+            self.assertEqual(replay.record_revision, applied[RECORD_REVISION_KEY])
+            self.assertEqual(replay.record["value"], 1)
+            self.assertEqual(
+                replay.outcome,
+                {"digest": applied[APPLIED_MUTATIONS_KEY]["probe:mutation-1"]["result_digest"]},
+            )
+
+    def test_distinct_mutation_ids_each_apply_once(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+            guarded_record_update(path, mutate=_bump, operation="probe", lock_name="record.json", mutation_id="a", default={})
+            final = guarded_record_update(path, mutate=_bump, operation="probe", lock_name="record.json", mutation_id="b")
+
+            self.assertEqual(final["value"], 2)
+            self.assertEqual(final[RECORD_REVISION_KEY], 2)
+            self.assertEqual(sorted(final[APPLIED_MUTATIONS_KEY]), ["probe:a", "probe:b"])
+
+    def test_applied_mutations_stay_bounded_and_keep_the_most_recent(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+            total = APPLIED_MUTATIONS_LIMIT + 12
+            record: dict[str, object] = {}
+            for index in range(total):
+                record = guarded_record_update(
+                    path,
+                    mutate=_bump,
+                    operation="probe",
+                    lock_name="record.json",
+                    mutation_id=f"mutation-{index:03d}",
+                    default={},
+                )
+
+            applied = record[APPLIED_MUTATIONS_KEY]
+            self.assertEqual(len(applied), APPLIED_MUTATIONS_LIMIT)
+            self.assertEqual(record[RECORD_REVISION_KEY], total)
+            self.assertIn(f"probe:mutation-{total - 1:03d}", applied)
+            self.assertNotIn("probe:mutation-000", applied)
+            for entry in applied.values():
+                self.assertEqual(sorted(entry), ["operation", "record_revision", "result_digest"])
+                self.assertIsInstance(entry["record_revision"], int)
+                self.assertIsInstance(entry["result_digest"], str)
+
+    def test_applied_mutation_entries_hold_only_scalar_values(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+            record = guarded_record_update(
+                path,
+                mutate=lambda current: {**current, "nested": {"deep": [1, 2, 3]}},
+                operation="probe",
+                lock_name="record.json",
+                mutation_id="scalars",
+                default={},
+            )
+
+            for entry in record[APPLIED_MUTATIONS_KEY].values():
+                for value in entry.values():
+                    self.assertIsInstance(value, (int, str))
+                self.assertEqual(entry["operation"], "probe")
+
+    def test_mutate_returning_none_skips_the_write_and_the_revision_bump(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+            guarded_record_update(path, mutate=_bump, operation="probe", lock_name="record.json", default={})
+            before = path.read_bytes()
+
+            unchanged = guarded_record_update(path, mutate=lambda current: None, operation="probe", lock_name="record.json")
+
+            self.assertEqual(path.read_bytes(), before)
+            self.assertEqual(unchanged[RECORD_REVISION_KEY], 1)
+
+    def test_validate_failure_leaves_the_record_untouched(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+            guarded_record_update(path, mutate=_bump, operation="probe", lock_name="record.json", default={})
+            before = path.read_bytes()
+
+            def reject(record: dict[str, object]) -> None:
+                raise ValueError("record failed validation")
+
+            with self.assertRaisesRegex(ValueError, "record failed validation"):
+                guarded_record_update(path, mutate=_bump, operation="probe", lock_name="record.json", validate=reject)
+
+            self.assertEqual(path.read_bytes(), before)
+
+    def test_missing_record_without_default_raises_file_not_found(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "absent.json"
+
+            with self.assertRaises(FileNotFoundError):
+                guarded_record_update(path, mutate=_bump, operation="probe", lock_name="absent.json")
+
+    def test_lock_file_is_a_sibling_dotfile_and_never_the_record(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+            guarded_record_update(path, mutate=_bump, operation="probe", lock_name="record.json", default={})
+
+            self.assertEqual(read_json_object(path), {**{"value": 1}, RECORD_REVISION_KEY: 1, APPLIED_MUTATIONS_KEY: {}})
+            self.assertTrue((Path(tmp) / ".record.json.lock").exists())
+
+    def test_revision_compare_is_enforced_without_fcntl(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+            with mock.patch("omh.system.local_store.fcntl", None):
+                guarded_record_update(path, mutate=_bump, operation="probe", lock_name="record.json", default={})
+                before = path.read_bytes()
+
+                with self.assertRaises(StaleRecordMutation):
+                    guarded_record_update(path, mutate=_bump, operation="probe", lock_name="record.json", expected_revision=99)
+
+                self.assertEqual(path.read_bytes(), before)
+                replay = guarded_record_update(
+                    path,
+                    mutate=_bump,
+                    operation="probe",
+                    lock_name="record.json",
+                    mutation_id="only-once",
+                )
+                self.assertEqual(replay[RECORD_REVISION_KEY], 2)
+                second = guarded_record_update(
+                    path,
+                    mutate=_bump,
+                    operation="probe",
+                    lock_name="record.json",
+                    mutation_id="only-once",
+                )
+                self.assertIsInstance(second, DuplicateMutationReplay)
+
+    def test_stale_rejection_fires_against_a_record_that_does_not_exist_yet(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+
+            with self.assertRaises(StaleRecordMutation) as caught:
+                guarded_record_update(
+                    path,
+                    mutate=_bump,
+                    operation="probe",
+                    lock_name="record.json",
+                    default={},
+                    expected_revision=1,
+                )
+
+            self.assertEqual(caught.exception.current_revision, 0)
+            self.assertFalse(path.exists())
+
+    def test_expected_revision_zero_creates_the_missing_record(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+
+            created = guarded_record_update(
+                path,
+                mutate=_bump,
+                operation="probe",
+                lock_name="record.json",
+                default={},
+                expected_revision=0,
+            )
+
+            self.assertEqual(created[RECORD_REVISION_KEY], 1)
+
+    def test_the_same_mutation_id_on_two_records_is_independent(self) -> None:
+        with TemporaryDirectory() as tmp:
+            first_path = Path(tmp) / "first.json"
+            second_path = Path(tmp) / "second.json"
+
+            first = guarded_record_update(
+                first_path,
+                mutate=_bump,
+                operation="probe",
+                lock_name="first.json",
+                mutation_id="turn-1",
+                default={},
+            )
+            second = guarded_record_update(
+                second_path,
+                mutate=_bump,
+                operation="probe",
+                lock_name="second.json",
+                mutation_id="turn-1",
+                default={},
+            )
+
+            self.assertNotIsInstance(second, DuplicateMutationReplay)
+            self.assertEqual(first["value"], 1)
+            self.assertEqual(second["value"], 1)
+            self.assertEqual(second[RECORD_REVISION_KEY], 1)
+
+    def test_mutate_raising_mid_transaction_leaves_the_record_byte_identical(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+            guarded_record_update(path, mutate=_bump, operation="probe", lock_name="record.json", default={})
+            before = path.read_bytes()
+
+            def explode(current: dict[str, object]) -> dict[str, object]:
+                current["value"] = 999
+                raise RuntimeError("mutation exploded")
+
+            with self.assertRaisesRegex(RuntimeError, "mutation exploded"):
+                guarded_record_update(path, mutate=explode, operation="probe", lock_name="record.json")
+
+            self.assertEqual(path.read_bytes(), before)
+            stored = read_json_object(path)
+            assert stored is not None
+            self.assertEqual(stored["value"], 1)
+
+    def test_a_retry_carrying_both_its_mutation_id_and_a_stale_revision_replays(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+            first = guarded_record_update(
+                path,
+                mutate=_bump,
+                operation="probe",
+                lock_name="record.json",
+                mutation_id="turn-1",
+                default={},
+            )
+            # Another writer moves the record on, so the retry's rendered
+            # revision is now stale as well as already applied.
+            guarded_record_update(path, mutate=_bump, operation="probe", lock_name="record.json")
+            after_second_write = path.read_bytes()
+
+            retry = guarded_record_update(
+                path,
+                mutate=_bump,
+                operation="probe",
+                lock_name="record.json",
+                mutation_id="turn-1",
+                expected_revision=int(first[RECORD_REVISION_KEY]),
+            )
+
+            # Replay wins over staleness: a retry of applied work is not a
+            # conflict, and reporting it as one would make every retry after
+            # any other write look like a lost race.
+            self.assertIsInstance(retry, DuplicateMutationReplay)
+            assert isinstance(retry, DuplicateMutationReplay)
+            self.assertTrue(retry.replayed)
+            self.assertEqual(retry.record_revision, 1)
+            self.assertEqual(path.read_bytes(), after_second_write)
+
+
+class OperationScopedMutationTests(unittest.TestCase):
+    def test_the_same_mutation_id_under_two_operations_both_apply(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+
+            blocked = guarded_record_update(
+                path,
+                mutate=_bump,
+                operation="record_goal_blocker",
+                lock_name="record.json",
+                mutation_id="turn-4711",
+                default={},
+            )
+            cancelled = guarded_record_update(
+                path,
+                mutate=_bump,
+                operation="cancel_goal_ledger",
+                lock_name="record.json",
+                mutation_id="turn-4711",
+            )
+
+            # One client turn id reused by a different operation is different
+            # logical intent: swallowing it silently drops the cancel.
+            self.assertNotIsInstance(cancelled, DuplicateMutationReplay)
+            self.assertEqual(blocked["value"], 1)
+            self.assertEqual(cancelled["value"], 2)
+            self.assertEqual(cancelled[RECORD_REVISION_KEY], 2)
+            self.assertEqual(
+                sorted(cancelled[APPLIED_MUTATIONS_KEY]),
+                ["cancel_goal_ledger:turn-4711", "record_goal_blocker:turn-4711"],
+            )
+
+    def test_the_same_operation_and_id_replays_and_reports_it(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+            guarded_record_update(
+                path,
+                mutate=_bump,
+                operation="record_goal_blocker",
+                lock_name="record.json",
+                mutation_id="turn-4711",
+                default={},
+            )
+            before = path.read_bytes()
+
+            replay = guarded_record_update(
+                path,
+                mutate=_bump,
+                operation="record_goal_blocker",
+                lock_name="record.json",
+                mutation_id="turn-4711",
+            )
+
+            self.assertIsInstance(replay, DuplicateMutationReplay)
+            assert isinstance(replay, DuplicateMutationReplay)
+            self.assertTrue(replay.replayed)
+            self.assertEqual(replay.operation, "record_goal_blocker")
+            self.assertEqual(replay.mutation_id, "turn-4711")
+            self.assertEqual(replay.record["value"], 1)
+            self.assertEqual(path.read_bytes(), before)
+
+    def test_a_divergent_payload_under_one_operation_is_refused(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+            guarded_record_update(
+                path,
+                mutate=_bump,
+                operation="record_goal_checkpoint",
+                lock_name="record.json",
+                mutation_id="turn-1",
+                mutation_digest="digest-of-first-checkpoint",
+                default={},
+            )
+            before = path.read_bytes()
+
+            with self.assertRaises(ConflictingMutationReplay) as caught:
+                guarded_record_update(
+                    path,
+                    mutate=_bump,
+                    operation="record_goal_checkpoint",
+                    lock_name="record.json",
+                    mutation_id="turn-1",
+                    mutation_digest="digest-of-a-different-checkpoint",
+                )
+
+            self.assertEqual(path.read_bytes(), before)
+            self.assertEqual(caught.exception.operation, "record_goal_checkpoint")
+            self.assertEqual(caught.exception.mutation_id, "turn-1")
+            self.assertIn("record_goal_checkpoint", str(caught.exception))
+            self.assertIn("turn-1", str(caught.exception))
+
+    def test_a_matching_mutation_digest_still_replays(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+            guarded_record_update(
+                path,
+                mutate=_bump,
+                operation="record_goal_checkpoint",
+                lock_name="record.json",
+                mutation_id="turn-1",
+                mutation_digest="same-digest",
+                default={},
+            )
+
+            replay = guarded_record_update(
+                path,
+                mutate=_bump,
+                operation="record_goal_checkpoint",
+                lock_name="record.json",
+                mutation_id="turn-1",
+                mutation_digest="same-digest",
+            )
+
+            self.assertIsInstance(replay, DuplicateMutationReplay)
+            assert isinstance(replay, DuplicateMutationReplay)
+            self.assertEqual(replay.result_digest, "same-digest")
+
+    def test_operation_is_required_and_may_not_contain_the_separator(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+
+            with self.assertRaisesRegex(ValueError, "operation is required"):
+                guarded_record_update(path, mutate=_bump, operation="", lock_name="record.json", default={})
+            with self.assertRaisesRegex(ValueError, "must not contain"):
+                guarded_record_update(path, mutate=_bump, operation="a:b", lock_name="record.json", default={})
+
+            self.assertFalse(path.exists())
+
+    def test_applied_mutation_key_is_operation_scoped(self) -> None:
+        self.assertEqual(applied_mutation_key("record_plan_decision", "turn-9"), "record_plan_decision:turn-9")
+
+
+class MutationHistoryFloorTests(unittest.TestCase):
+    def _fill(self, path: Path, count: int) -> dict[str, object]:
+        record: dict[str, object] = {}
+        for index in range(count):
+            record = guarded_record_update(
+                path,
+                mutate=_bump,
+                operation="probe",
+                lock_name="record.json",
+                mutation_id=f"mutation-{index:03d}",
+                default={},
+            )
+        return record
+
+    def test_the_floor_is_absent_until_eviction_happens(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+
+            record = self._fill(path, APPLIED_MUTATIONS_LIMIT)
+
+            self.assertNotIn(APPLIED_MUTATIONS_FLOOR_KEY, record)
+            self.assertEqual(applied_mutations_floor_of(record), 0)
+            self.assertEqual(len(record[APPLIED_MUTATIONS_KEY]), APPLIED_MUTATIONS_LIMIT)
+
+    def test_eviction_persists_the_floor_it_moved_to(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+
+            record = self._fill(path, APPLIED_MUTATIONS_LIMIT + 5)
+
+            stored = read_json_object(path)
+            assert stored is not None
+            # Revisions 1..5 were evicted, so ids from those revisions are gone.
+            self.assertEqual(record[APPLIED_MUTATIONS_FLOOR_KEY], 5)
+            self.assertEqual(applied_mutations_floor_of(stored), 5)
+            self.assertNotIn("probe:mutation-000", record[APPLIED_MUTATIONS_KEY])
+
+    def test_a_retry_at_or_below_the_floor_is_refused_instead_of_duplicated(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+            record = self._fill(path, APPLIED_MUTATIONS_LIMIT + 5)
+            before = path.read_bytes()
+
+            with self.assertRaises(MutationHistoryEvicted) as caught:
+                guarded_record_update(
+                    path,
+                    mutate=_bump,
+                    operation="probe",
+                    lock_name="record.json",
+                    mutation_id="mutation-000",
+                    expected_revision=1,
+                )
+
+            self.assertEqual(path.read_bytes(), before)
+            self.assertEqual(caught.exception.floor_revision, 5)
+            self.assertEqual(caught.exception.expected_revision, 1)
+            self.assertEqual(caught.exception.current_revision, int(record[RECORD_REVISION_KEY]))
+            self.assertIn("re-read the record", str(caught.exception))
+
+    def test_a_retry_above_the_floor_still_applies(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+            record = self._fill(path, APPLIED_MUTATIONS_LIMIT + 5)
+
+            applied = guarded_record_update(
+                path,
+                mutate=_bump,
+                operation="probe",
+                lock_name="record.json",
+                mutation_id="fresh",
+                expected_revision=int(record[RECORD_REVISION_KEY]),
+            )
+
+            self.assertNotIsInstance(applied, DuplicateMutationReplay)
+            self.assertEqual(applied[RECORD_REVISION_KEY], int(record[RECORD_REVISION_KEY]) + 1)
+
+    def test_the_floor_only_refuses_retries_that_carry_an_expected_revision(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+            record = self._fill(path, APPLIED_MUTATIONS_LIMIT + 5)
+
+            # Documented boundary: without a rendered revision there is nothing
+            # to compare against the floor, so the call applies normally.
+            applied = guarded_record_update(
+                path,
+                mutate=_bump,
+                operation="probe",
+                lock_name="record.json",
+                mutation_id="mutation-000",
+            )
+
+            self.assertNotIsInstance(applied, DuplicateMutationReplay)
+            self.assertEqual(applied[RECORD_REVISION_KEY], int(record[RECORD_REVISION_KEY]) + 1)
+
+
+class BoundedMutationIdTests(unittest.TestCase):
+    def test_an_over_long_mutation_id_is_refused_before_any_file_is_touched(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = root / "record.json"
+
+            with self.assertRaises(ValueError) as caught:
+                guarded_record_update(
+                    path,
+                    mutate=_bump,
+                    operation="probe",
+                    lock_name="record.json",
+                    mutation_id="x" * (MAX_MUTATION_ID_CHARS + 1),
+                    default={},
+                )
+
+            self.assertIn("mutation_id", str(caught.exception))
+            self.assertIn(str(MAX_MUTATION_ID_CHARS), str(caught.exception))
+            # Nothing was created: not the record, not the lock sidecar, not a
+            # temp file. The refusal happens before the lock is taken.
+            self.assertEqual(sorted(item.name for item in root.iterdir()), [])
+
+    def test_a_mutation_id_at_the_bound_still_applies(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+
+            record = guarded_record_update(
+                path,
+                mutate=_bump,
+                operation="probe",
+                lock_name="record.json",
+                mutation_id="x" * MAX_MUTATION_ID_CHARS,
+                default={},
+            )
+
+            self.assertEqual(record[RECORD_REVISION_KEY], 1)
+
+    def test_the_bound_leaves_room_for_the_ids_connectors_actually_send(self) -> None:
+        # The limit is only defensible if it never rejects an id a real
+        # connector sends, so the widest observed shapes are pinned here.
+        for label, mutation_id in (
+            ("uuid4", "123e4567-e89b-12d3-a456-426614174000"),
+            ("ulid", "01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+            ("discord-snowflake", "1234567890123456789"),
+            ("git-sha", "0" * 40),
+            ("slack-composite", "slack:C0123456789/p1700000000.000100"),
+        ):
+            with self.subTest(label=label):
+                self.assertEqual(validated_mutation_id(mutation_id), mutation_id)
+                self.assertLess(len(mutation_id) * 2, MAX_MUTATION_ID_CHARS)
+
+    def test_an_over_long_operation_is_refused_the_same_way(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = root / "record.json"
+
+            with self.assertRaises(ValueError) as caught:
+                guarded_record_update(
+                    path,
+                    mutate=_bump,
+                    operation="o" * (MAX_OPERATION_CHARS + 1),
+                    lock_name="record.json",
+                    default={},
+                )
+
+            self.assertIn("operation", str(caught.exception))
+            self.assertIn(str(MAX_OPERATION_CHARS), str(caught.exception))
+            self.assertEqual(sorted(item.name for item in root.iterdir()), [])
+
+    def test_every_shipped_operation_name_fits_the_bound(self) -> None:
+        # A bound any real operation trips would be a latent outage, so the
+        # names actually passed to guarded_record_update are re-derived from
+        # source instead of listed by hand.
+        source_root = Path(__file__).resolve().parents[1] / "src"
+        names: set[str] = set()
+        for module in sorted(source_root.rglob("*.py")):
+            names.update(re.findall(r"operation=[\"']([^\"']+)[\"']", module.read_text(encoding="utf-8")))
+
+        self.assertTrue(names)
+        for name in sorted(names):
+            with self.subTest(operation=name):
+                self.assertEqual(validated_operation(name), name)
+
+    def test_an_over_long_mutation_id_is_refused_identically_on_every_surface(self) -> None:
+        oversized = "x" * (MAX_MUTATION_ID_CHARS + 1)
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            create_goal_ledger(
+                paths,
+                "Bound the retry token",
+                [{"id": "AC-bound", "summary": "Ids are bounded"}],
+                goal_id="goal-bound",
+            )
+            cycle = create_loop_cycle(
+                paths,
+                goal_summary="Bound the retry token",
+                goal_reframe="Reject an oversized mutation id on every guarded surface.",
+                success_criteria=["Ids are bounded"],
+                permission_profile="handoff_only",
+            )
+            loop_id = str(cycle["loop_id"])
+            started = create_or_resume_wrapper_session(
+                paths,
+                "risky refactor with private-token-123",
+                source="discord",
+                source_metadata={"source_event_id": "bound-1", "channel_ref": "c1"},
+            )
+            session_id = str(started["session"]["session_id"])
+            goal_path = goal_ledger_path(paths, "goal-bound")
+            cycle_path = loop_cycle_path(paths, loop_id)
+            before_goal = goal_path.read_bytes()
+            before_cycle = cycle_path.read_bytes()
+            before_session = read_wrapper_session(paths, session_id)
+
+            for surface, call in (
+                (
+                    "goal",
+                    lambda: record_goal_checkpoint(
+                        paths, "goal-bound", "Bounded", status="in_progress", mutation_id=oversized
+                    ),
+                ),
+                ("session", lambda: record_plan_decision(paths, session_id, "accept", mutation_id=oversized)),
+                ("loop", lambda: tick_loop_runtime(paths, loop_id, mutation_id=oversized)),
+            ):
+                with self.subTest(surface=surface):
+                    with self.assertRaises(ValueError) as caught:
+                        call()
+                    self.assertIn(f"at most {MAX_MUTATION_ID_CHARS} characters", str(caught.exception))
+
+            # Identical rejection means identical consequences: nothing written.
+            self.assertEqual(goal_path.read_bytes(), before_goal)
+            self.assertEqual(cycle_path.read_bytes(), before_cycle)
+            self.assertEqual(read_wrapper_session(paths, session_id), before_session)
+
+
+class GuardedLockReportingTests(unittest.TestCase):
+    def test_a_guarded_record_reports_the_lock_that_protected_it(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+
+            record = guarded_record_update(path, mutate=_bump, operation="probe", lock_name="record.json", default={})
+
+            self.assertTrue(record.lock_enforced)
+            self.assertIn(record.lock_mechanism, ("fcntl", "msvcrt"))
+
+    def test_a_fully_degraded_lock_reports_enforced_false_without_persisting_it(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+            with (
+                mock.patch("omh.system.local_store.fcntl", None),
+                mock.patch("omh.system.local_store.msvcrt", None),
+            ):
+                record = guarded_record_update(
+                    path,
+                    mutate=_bump,
+                    operation="probe",
+                    lock_name="record.json",
+                    mutation_id="turn-1",
+                    default={},
+                )
+                replay = guarded_record_update(
+                    path,
+                    mutate=_bump,
+                    operation="probe",
+                    lock_name="record.json",
+                    mutation_id="turn-1",
+                )
+
+            self.assertFalse(record.lock_enforced)
+            self.assertEqual(record.lock_mechanism, "none")
+            assert isinstance(replay, DuplicateMutationReplay)
+            self.assertFalse(replay.lock_enforced)
+            # The degraded flag is a property of the call, never of the record.
+            stored = read_json_object(path)
+            assert stored is not None
+            self.assertEqual(sorted(stored), [APPLIED_MUTATIONS_KEY, RECORD_REVISION_KEY, "value"])
+
+    def test_the_msvcrt_path_serializes_racing_updates_when_fcntl_is_absent(self) -> None:
+        fake = FakeMsvcrt()
+        worker_count = 16
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+            guarded_record_update(path, mutate=_bump, operation="probe", lock_name="record.json", default={})
+            barrier = threading.Barrier(worker_count)
+            applied: list[object] = []
+            stale: list[BaseException] = []
+            unexpected: list[BaseException] = []
+            guard = threading.Lock()
+
+            def worker() -> None:
+                barrier.wait()
+                try:
+                    result = guarded_record_update(
+                        path,
+                        mutate=_bump,
+                        operation="probe",
+                        lock_name="record.json",
+                        expected_revision=1,
+                        timeout_seconds=30.0,
+                    )
+                except StaleRecordMutation as exc:
+                    with guard:
+                        stale.append(exc)
+                except BaseException as exc:  # noqa: BLE001
+                    with guard:
+                        unexpected.append(exc)
+                else:
+                    with guard:
+                        applied.append(result)
+
+            with (
+                mock.patch("omh.system.local_store.fcntl", None),
+                mock.patch("omh.system.local_store.msvcrt", fake),
+            ):
+                threads = [threading.Thread(target=worker) for _ in range(worker_count)]
+                for thread in threads:
+                    thread.start()
+                for thread in threads:
+                    thread.join()
+
+            # Without a real Windows lock every writer read revision 1, passed
+            # the compare, and clobbered the others. Under msvcrt exactly one
+            # wins and the rest are told the record moved.
+            self.assertEqual(unexpected, [])
+            self.assertEqual(len(applied), 1)
+            self.assertEqual(len(stale), worker_count - 1)
+            final = read_json_object(path)
+            assert final is not None
+            self.assertEqual(final[RECORD_REVISION_KEY], 2)
+            self.assertEqual(final["value"], 2)
+
+
+class RevisionFieldValidationTests(unittest.TestCase):
+    def test_absent_revision_fields_are_accepted(self) -> None:
+        self.assertEqual(revision_field_errors({}, "record"), [])
+
+    def test_bad_revision_and_applied_mutations_are_reported(self) -> None:
+        errors = revision_field_errors({RECORD_REVISION_KEY: -1, APPLIED_MUTATIONS_KEY: []}, "record")
+
+        self.assertIn("record record_revision must be a non-negative integer", errors)
+        self.assertIn("record applied_mutations must be an object", errors)
+
+    def test_applied_mutation_entry_shape_is_enforced(self) -> None:
+        errors = revision_field_errors(
+            {APPLIED_MUTATIONS_KEY: {"m1": {"record_revision": 0, "result_digest": 3, "extra": "x"}}},
+            "record",
+        )
+
+        self.assertTrue(any("unsupported keys" in error for error in errors))
+        self.assertTrue(any("record_revision must be a positive integer" in error for error in errors))
+        self.assertTrue(any("result_digest must be a string" in error for error in errors))
+
+    def test_oversized_applied_mutations_are_reported(self) -> None:
+        applied = {
+            f"m{index}": {"record_revision": index + 1, "result_digest": "d"}
+            for index in range(APPLIED_MUTATIONS_LIMIT + 1)
+        }
+
+        errors = revision_field_errors({APPLIED_MUTATIONS_KEY: applied}, "record")
+
+        self.assertTrue(any("at most" in error for error in errors))
+
+    def test_a_negative_record_revision_is_the_only_reported_error(self) -> None:
+        self.assertEqual(
+            revision_field_errors({RECORD_REVISION_KEY: -1}, "goal_ledger"),
+            ["goal_ledger record_revision must be a non-negative integer"],
+        )
+
+    def test_a_list_applied_mutations_is_the_only_reported_error(self) -> None:
+        self.assertEqual(
+            revision_field_errors({APPLIED_MUTATIONS_KEY: []}, "loop_cycle"),
+            ["loop_cycle applied_mutations must be an object"],
+        )
+
+    def test_the_eviction_floor_must_be_a_non_negative_integer(self) -> None:
+        self.assertEqual(revision_field_errors({APPLIED_MUTATIONS_FLOOR_KEY: 5}, "record"), [])
+        for bad in (-1, True, "5", 1.5):
+            with self.subTest(value=bad):
+                self.assertEqual(
+                    revision_field_errors({APPLIED_MUTATIONS_FLOOR_KEY: bad}, "record"),
+                    ["record applied_mutations_floor_revision must be a non-negative integer"],
+                )
+
+    def test_entry_operation_is_optional_but_typed_when_present(self) -> None:
+        legacy = {APPLIED_MUTATIONS_KEY: {"m1": {"record_revision": 1, "result_digest": "d"}}}
+        scoped = {APPLIED_MUTATIONS_KEY: {"probe:m1": {"record_revision": 1, "operation": "probe", "result_digest": "d"}}}
+        blank = {APPLIED_MUTATIONS_KEY: {"probe:m1": {"record_revision": 1, "operation": "  ", "result_digest": "d"}}}
+
+        self.assertEqual(revision_field_errors(legacy, "record"), [])
+        self.assertEqual(revision_field_errors(scoped, "record"), [])
+        self.assertEqual(
+            revision_field_errors(blank, "record"),
+            ["record applied_mutations[probe:m1].operation must be a non-empty string"],
+        )
+
+
+class RequireNotTerminalTests(unittest.TestCase):
+    def test_terminal_status_is_named_in_the_refusal(self) -> None:
+        with self.assertRaises(ValueError) as caught:
+            require_not_terminal({"status": "cancelled"}, "status", ("complete", "cancelled"), "prepare child work")
+
+        self.assertIn("cancelled", str(caught.exception))
+        self.assertIn("prepare child work", str(caught.exception))
+        self.assertIn("terminal", str(caught.exception))
+
+    def test_non_terminal_status_passes(self) -> None:
+        require_not_terminal({"status": "active"}, "status", ("complete", "cancelled"), "prepare child work")
+
+    def test_custom_error_type_is_raised(self) -> None:
+        with self.assertRaises(WrapperSessionError):
+            require_not_terminal(
+                {"status": "cancelled"},
+                "status",
+                ("cancelled",),
+                "prepare child work",
+                error_type=WrapperSessionError,
+            )
+
+
+class GuardedUpdateConcurrencyTests(unittest.TestCase):
+    @unittest.skipUnless(HAS_FCNTL, "fcntl advisory locking is POSIX-only")
+    def test_concurrent_guarded_updates_do_not_lose_writes(self) -> None:
+        worker_count = 24
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+            guarded_record_update(path, mutate=lambda current: dict(current), operation="probe", lock_name="record.json", default={})
+            barrier = threading.Barrier(worker_count)
+            failures: list[BaseException] = []
+
+            def worker(index: int) -> None:
+                barrier.wait()
+                try:
+                    guarded_record_update(
+                        path,
+                        mutate=lambda current: {**current, f"key-{index}": index},
+                        operation="probe",
+                        lock_name="record.json",
+                        timeout_seconds=30.0,
+                    )
+                except BaseException as exc:  # noqa: BLE001
+                    failures.append(exc)
+
+            threads = [threading.Thread(target=worker, args=(index,)) for index in range(worker_count)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+            self.assertEqual(failures, [])
+            final = read_json_object(path)
+            assert final is not None
+            # One seeding write plus one write per worker, and every worker's
+            # key survived: no read-modify-write lost an update.
+            self.assertEqual(final[RECORD_REVISION_KEY], worker_count + 1)
+            for index in range(worker_count):
+                self.assertEqual(final.get(f"key-{index}"), index)
+
+    @unittest.skipUnless(HAS_FCNTL, "fcntl advisory locking is POSIX-only")
+    def test_concurrent_same_mutation_id_retries_apply_exactly_once(self) -> None:
+        worker_count = 16
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "record.json"
+            guarded_record_update(path, mutate=lambda current: {"value": 0}, operation="probe", lock_name="record.json", default={})
+            barrier = threading.Barrier(worker_count)
+            failures: list[BaseException] = []
+
+            def worker() -> None:
+                barrier.wait()
+                try:
+                    guarded_record_update(
+                        path,
+                        mutate=_bump,
+                        operation="probe",
+                        lock_name="record.json",
+                        mutation_id="retried-once",
+                        timeout_seconds=30.0,
+                    )
+                except BaseException as exc:  # noqa: BLE001
+                    failures.append(exc)
+
+            threads = [threading.Thread(target=worker) for _ in range(worker_count)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+            self.assertEqual(failures, [])
+            final = read_json_object(path)
+            assert final is not None
+            self.assertEqual(final["value"], 1)
+            self.assertEqual(final[RECORD_REVISION_KEY], 2)
+
+
+class WrapperSessionRevisionGuardTests(unittest.TestCase):
+    def test_wrapper_session_record_keys_expose_the_revision_fields(self) -> None:
+        self.assertIn(RECORD_REVISION_KEY, WRAPPER_SESSION_RECORD_KEYS)
+        self.assertIn(APPLIED_MUTATIONS_KEY, WRAPPER_SESSION_RECORD_KEYS)
+
+    def test_created_session_echoes_the_persisted_revision(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+
+            started = create_or_resume_wrapper_session(paths, "risky refactor", source="discord")
+            session_id = str(started["session"]["session_id"])
+            stored = read_wrapper_session(paths, session_id)
+
+            assert stored is not None
+            self.assertEqual(started["session"][RECORD_REVISION_KEY], 1)
+            self.assertEqual(started["status"]["record_revision"], 1)
+            self.assertEqual(record_revision_of(stored), 1)
+
+    def test_plan_decision_bumps_the_revision_and_accepts_the_echoed_value(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            started = create_or_resume_wrapper_session(paths, "risky refactor", source="discord")
+            session_id = str(started["session"]["session_id"])
+
+            accepted = record_plan_decision(
+                paths,
+                session_id,
+                "accept",
+                expected_revision=started["session"][RECORD_REVISION_KEY],
+            )
+
+            self.assertEqual(accepted["session"][RECORD_REVISION_KEY], 2)
+            self.assertEqual(accepted["status"]["record_revision"], 2)
+            self.assertFalse(accepted["replayed"])
+
+    def test_stale_plan_decision_is_rejected_without_a_partial_write(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            started = create_or_resume_wrapper_session(paths, "risky refactor", source="discord")
+            session_id = str(started["session"]["session_id"])
+            rendered_revision = int(started["session"][RECORD_REVISION_KEY])
+            # Another writer moves the session on while the first decision is
+            # still in flight against the revision it rendered.
+            record_plan_decision(paths, session_id, "revise")
+            session_path = paths.runtime_wrapper_sessions_dir / session_id / "session.json"
+            before = session_path.read_bytes()
+
+            with self.assertRaises(StaleRecordMutation) as caught:
+                record_plan_decision(paths, session_id, "accept", expected_revision=rendered_revision)
+
+            self.assertEqual(session_path.read_bytes(), before)
+            self.assertEqual(caught.exception.expected_revision, rendered_revision)
+            self.assertEqual(caught.exception.current_revision, 2)
+            stored = read_wrapper_session(paths, session_id)
+            assert stored is not None
+            self.assertEqual(stored["status"], "revision_requested")
+
+    def test_replayed_plan_decision_writes_no_duplicate_event_or_revision(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            started = create_or_resume_wrapper_session(paths, "risky refactor", source="discord")
+            session_id = str(started["session"]["session_id"])
+            events_path = paths.runtime_wrapper_sessions_dir / session_id / "events.jsonl"
+
+            first = record_plan_decision(paths, session_id, "accept", mutation_id="decide-1")
+            events_after_first = events_path.read_text(encoding="utf-8")
+
+            second = record_plan_decision(paths, session_id, "accept", mutation_id="decide-1")
+
+            self.assertFalse(first["replayed"])
+            self.assertTrue(second["replayed"])
+            self.assertEqual(second["session"][RECORD_REVISION_KEY], first["session"][RECORD_REVISION_KEY])
+            self.assertEqual(events_path.read_text(encoding="utf-8"), events_after_first)
+
+    def test_cancelled_session_refuses_executor_selection(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            started = create_or_resume_wrapper_session(paths, "risky refactor", source="discord")
+            session_id = str(started["session"]["session_id"])
+            record_plan_decision(paths, session_id, "cancel")
+
+            with self.assertRaises(WrapperSessionError) as caught:
+                select_wrapper_session_executor(paths, session_id, "codex")
+
+            self.assertIn("cancelled", str(caught.exception))
+            self.assertIn("terminal", str(caught.exception))
+
+    def test_cancelled_session_refuses_handoff_preparation(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            started = create_or_resume_wrapper_session(paths, "risky refactor", source="discord")
+            session_id = str(started["session"]["session_id"])
+            record_plan_decision(paths, session_id, "cancel")
+
+            with self.assertRaises(WrapperSessionError) as caught:
+                prepare_wrapper_session_handoff(paths, session_id, "risky refactor")
+
+            self.assertIn("cancelled", str(caught.exception))
+
+    def test_cancelled_session_refuses_every_executor_session_entrypoint(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            started = create_or_resume_wrapper_session(paths, "risky refactor", source="discord")
+            session_id = str(started["session"]["session_id"])
+            # A handoff_prepared session refuses plan decisions outright, so a
+            # cancelled session is always cancelled before the handoff exists.
+            # The terminal guard must still fire ahead of the
+            # "no prepared handoff" complaint, naming the terminal state.
+            record_plan_decision(paths, session_id, "cancel")
+
+            for call in (
+                lambda: open_executor_session(paths, session_id),
+                lambda: attach_executor_session(paths, session_id, external_session_ref="codex-thread-1"),
+                lambda: record_executor_session_result(paths, session_id, result="completed"),
+            ):
+                with self.assertRaises(ExecutorSessionError) as caught:
+                    call()
+                self.assertIn("cancelled", str(caught.exception))
+                self.assertIn("terminal", str(caught.exception))
+
+    def test_stale_handoff_preparation_starts_no_child_work(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            started = create_or_resume_wrapper_session(paths, "risky refactor", source="discord")
+            session_id = str(started["session"]["session_id"])
+            accepted = record_plan_decision(paths, session_id, "accept")
+            stale_revision = int(accepted["session"][RECORD_REVISION_KEY])
+            select_wrapper_session_executor(paths, session_id, "codex")
+            session_path = paths.runtime_wrapper_sessions_dir / session_id / "session.json"
+            before = session_path.read_bytes()
+            runs_before = sorted(paths.runtime_runs_dir.glob("*")) if paths.runtime_runs_dir.exists() else []
+
+            with self.assertRaises(StaleRecordMutation):
+                prepare_wrapper_session_handoff(
+                    paths,
+                    session_id,
+                    "risky refactor",
+                    expected_revision=stale_revision,
+                )
+
+            self.assertEqual(session_path.read_bytes(), before)
+            runs_after = sorted(paths.runtime_runs_dir.glob("*")) if paths.runtime_runs_dir.exists() else []
+            self.assertEqual(runs_after, runs_before)
+
+
+class GoalLedgerRevisionGuardTests(unittest.TestCase):
+    def _goal(self, paths) -> dict[str, object]:
+        return create_goal_ledger(
+            paths,
+            "Finish the durable goal",
+            [{"id": "AC-guard", "summary": "Guard is verified"}],
+            goal_id="goal-guard",
+        )
+
+    def test_cancelled_is_a_supported_goal_status(self) -> None:
+        self.assertIn("cancelled", GOAL_STATUSES)
+
+    def test_goal_revision_starts_at_one_and_survives_validation(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+
+            goal = self._goal(paths)
+
+            self.assertEqual(goal[RECORD_REVISION_KEY], 1)
+            self.assertEqual(validate_goal_ledger(goal), {"ok": True, "errors": []})
+
+    def test_stale_checkpoint_is_rejected_without_a_partial_write(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            goal = self._goal(paths)
+            stale_revision = int(goal[RECORD_REVISION_KEY])
+            record_goal_checkpoint(paths, "goal-guard", "First checkpoint", status="in_progress")
+            path = goal_ledger_path(paths, "goal-guard")
+            before = path.read_bytes()
+
+            with self.assertRaises(StaleRecordMutation) as caught:
+                record_goal_checkpoint(
+                    paths,
+                    "goal-guard",
+                    "Racing checkpoint",
+                    status="in_progress",
+                    expected_revision=stale_revision,
+                )
+
+            self.assertEqual(path.read_bytes(), before)
+            self.assertEqual(caught.exception.current_revision, 2)
+            self.assertEqual(len(read_goal_ledger(paths, "goal-guard")["checkpoints"]), 1)
+
+    def test_retried_checkpoint_mutation_id_creates_exactly_one_checkpoint(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            self._goal(paths)
+
+            first = record_goal_checkpoint(
+                paths, "goal-guard", "Only once", status="in_progress", mutation_id="cp-retry"
+            )
+            second = record_goal_checkpoint(
+                paths, "goal-guard", "Only once", status="in_progress", mutation_id="cp-retry"
+            )
+            third = record_goal_checkpoint(
+                paths, "goal-guard", "Only once", status="in_progress", mutation_id="cp-retry"
+            )
+
+            stored = read_goal_ledger(paths, "goal-guard")
+            self.assertEqual(len(stored["checkpoints"]), 1)
+            self.assertEqual(first[RECORD_REVISION_KEY], 2)
+            self.assertEqual(second[RECORD_REVISION_KEY], 2)
+            self.assertEqual(third[RECORD_REVISION_KEY], 2)
+
+    def test_retried_blocker_and_quality_gate_mutation_ids_do_not_duplicate(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            self._goal(paths)
+
+            record_goal_blocker(paths, "goal-guard", "Needs approval", mutation_id="blocker-retry")
+            record_goal_blocker(paths, "goal-guard", "Needs approval", mutation_id="blocker-retry")
+            record_goal_quality_gate(paths, "goal-guard", "Suite green", mutation_id="gate-retry")
+            record_goal_quality_gate(paths, "goal-guard", "Suite green", mutation_id="gate-retry")
+
+            stored = read_goal_ledger(paths, "goal-guard")
+            self.assertEqual(len(stored["blockers"]), 1)
+            self.assertEqual(len(stored["quality_gates"]), 1)
+
+    def test_cancelled_goal_refuses_further_child_work(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            self._goal(paths)
+
+            cancelled = cancel_goal_ledger(paths, "goal-guard", reason="Superseded by another goal")
+
+            self.assertEqual(cancelled["status"], "cancelled")
+            self.assertEqual(validate_goal_ledger(cancelled), {"ok": True, "errors": []})
+            for call in (
+                lambda: record_goal_checkpoint(paths, "goal-guard", "After cancel", status="in_progress"),
+                lambda: record_goal_blocker(paths, "goal-guard", "After cancel"),
+                lambda: record_goal_quality_gate(paths, "goal-guard", "After cancel"),
+                lambda: cancel_goal_ledger(paths, "goal-guard"),
+            ):
+                with self.assertRaises(ValueError) as caught:
+                    call()
+                self.assertIn("cancelled", str(caught.exception))
+                self.assertIn("terminal", str(caught.exception))
+
+    def test_completed_goal_refuses_further_child_work(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            self._goal(paths)
+            record_goal_checkpoint(
+                paths,
+                "goal-guard",
+                "Guard verified",
+                criteria_refs=["AC-guard"],
+                evidence_refs=["tests:green"],
+            )
+            completed = complete_goal_ledger(paths, "goal-guard", evidence_refs=["tests:green"])
+            self.assertTrue(completed["completed"])
+
+            with self.assertRaises(ValueError) as caught:
+                record_goal_checkpoint(paths, "goal-guard", "After completion", status="in_progress")
+
+            self.assertIn("complete", str(caught.exception))
+            self.assertIn("terminal", str(caught.exception))
+
+    def test_cancelled_goal_completion_gate_reports_the_terminal_state(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            self._goal(paths)
+            cancel_goal_ledger(paths, "goal-guard")
+
+            from omh.goal_ledger import build_goal_completion_gate
+
+            gate = build_goal_completion_gate(paths, "goal-guard")
+
+            self.assertFalse(gate["ready"])
+            self.assertEqual(gate["goal_status"], "cancelled")
+            self.assertIn("goal status is cancelled", gate["summary"])
+            self.assertEqual(gate["next_action"], "show_status")
+
+
+class LoopCycleRevisionGuardTests(unittest.TestCase):
+    def _cycle(self, paths) -> dict[str, object]:
+        return create_loop_cycle(
+            paths,
+            goal_summary="Ship the stale mutation guard",
+            goal_reframe="Implement the guard, verify it, and prepare the handoff material.",
+            success_criteria=["Guard is verified by tests"],
+            permission_profile="handoff_only",
+        )
+
+    def test_loop_cycle_revision_starts_at_one_and_validates(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+
+            cycle = self._cycle(paths)
+
+            self.assertEqual(cycle[RECORD_REVISION_KEY], 1)
+            self.assertEqual(validate_loop_cycle(cycle), {"ok": True, "errors": []})
+
+    def test_stale_queue_observation_is_rejected_without_a_partial_write(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = self._cycle(paths)
+            loop_id = str(cycle["loop_id"])
+            ticked = tick_loop_runtime(paths, loop_id)
+            queue_id = str(ticked["runtime"]["queue"][0]["queue_id"])
+            stale_revision = int(cycle[RECORD_REVISION_KEY])
+            path = loop_cycle_path(paths, loop_id)
+            before = path.read_bytes()
+
+            with self.assertRaises(StaleRecordMutation) as caught:
+                observe_loop_queue_item(
+                    paths,
+                    loop_id,
+                    queue_id,
+                    evidence_refs=["wrapper:queue-observation:1"],
+                    expected_revision=stale_revision,
+                )
+
+            self.assertEqual(path.read_bytes(), before)
+            self.assertEqual(caught.exception.current_revision, int(ticked[RECORD_REVISION_KEY]))
+            stored = read_loop_cycle(paths, loop_id)
+            self.assertEqual(stored["runtime"]["queue"][0]["status"], "prepared_not_observed")
+
+    def test_retried_queue_observation_records_exactly_one_observation(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = self._cycle(paths)
+            loop_id = str(cycle["loop_id"])
+            ticked = tick_loop_runtime(paths, loop_id)
+            queue_id = str(ticked["runtime"]["queue"][0]["queue_id"])
+
+            first = observe_loop_queue_item(
+                paths,
+                loop_id,
+                queue_id,
+                evidence_refs=["wrapper:queue-observation:1"],
+                mutation_id="observe-retry",
+            )
+            second = observe_loop_queue_item(
+                paths,
+                loop_id,
+                queue_id,
+                evidence_refs=["wrapper:queue-observation:1"],
+                mutation_id="observe-retry",
+            )
+
+            self.assertEqual(first[RECORD_REVISION_KEY], second[RECORD_REVISION_KEY])
+            item = second["runtime"]["queue"][0]
+            self.assertEqual(item["status"], "observed")
+            # The retry replayed instead of appending the evidence ref twice.
+            self.assertEqual(item["observed_evidence_refs"], ["wrapper:queue-observation:1"])
+
+    def test_a_queue_observation_retry_with_different_evidence_is_refused(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = self._cycle(paths)
+            loop_id = str(cycle["loop_id"])
+            ticked = tick_loop_runtime(paths, loop_id)
+            queue_id = str(ticked["runtime"]["queue"][0]["queue_id"])
+            observe_loop_queue_item(
+                paths,
+                loop_id,
+                queue_id,
+                evidence_refs=["wrapper:queue-observation:1"],
+                mutation_id="observe-retry",
+            )
+            path = loop_cycle_path(paths, loop_id)
+            before = path.read_bytes()
+
+            # Same id, different evidence: two different observations sharing
+            # one id, so replaying would silently drop the second one.
+            with self.assertRaises(ConflictingMutationReplay) as caught:
+                observe_loop_queue_item(
+                    paths,
+                    loop_id,
+                    queue_id,
+                    evidence_refs=["wrapper:queue-observation:2"],
+                    mutation_id="observe-retry",
+                )
+
+            self.assertEqual(path.read_bytes(), before)
+            self.assertEqual(caught.exception.mutation_id, "observe-retry")
+            self.assertIn("observe_loop_queue_item", str(caught.exception))
+
+    def test_second_observation_without_mutation_id_still_refuses(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = self._cycle(paths)
+            loop_id = str(cycle["loop_id"])
+            ticked = tick_loop_runtime(paths, loop_id)
+            queue_id = str(ticked["runtime"]["queue"][0]["queue_id"])
+            observe_loop_queue_item(paths, loop_id, queue_id, evidence_refs=["wrapper:queue-observation:1"])
+            path = loop_cycle_path(paths, loop_id)
+            before = path.read_bytes()
+
+            with self.assertRaisesRegex(ValueError, "only prepared_not_observed"):
+                observe_loop_queue_item(paths, loop_id, queue_id, evidence_refs=["wrapper:queue-observation:2"])
+
+            self.assertEqual(path.read_bytes(), before)
+
+    def test_queue_mutators_are_protected_by_status_after_the_id_is_evicted(self) -> None:
+        # Loop cycles never materialize a mutation_id into a persisted id -
+        # queue_id and cycle_id come from _new_item_id - so the goal ledger's
+        # id dedupe does not apply here. The claim that the queue mutators are
+        # protected anyway is pinned rather than assumed: with the applied
+        # entry gone, the status precondition refuses the retry.
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            loop_id = str(self._cycle(paths)["loop_id"])
+            ticked = tick_loop_runtime(paths, loop_id)
+            queue_id = str(ticked["runtime"]["queue"][0]["queue_id"])
+            observe_loop_queue_item(
+                paths, loop_id, queue_id, evidence_refs=["wrapper:queue-observation:1"], mutation_id="observe-evict"
+            )
+            path = loop_cycle_path(paths, loop_id)
+            stored = read_loop_cycle(paths, loop_id)
+            self.assertNotEqual(str(stored["runtime"]["queue"][0]["queue_id"]), "observe-evict")
+            # Force the eviction the bounded map would eventually cause.
+            stored[APPLIED_MUTATIONS_KEY] = {}
+            stored[APPLIED_MUTATIONS_FLOOR_KEY] = int(stored[RECORD_REVISION_KEY])
+            path.write_text(json.dumps(stored, sort_keys=True), encoding="utf-8")
+            before = path.read_bytes()
+
+            with self.assertRaisesRegex(ValueError, "only prepared_not_observed"):
+                observe_loop_queue_item(
+                    paths,
+                    loop_id,
+                    queue_id,
+                    evidence_refs=["wrapper:queue-observation:1"],
+                    mutation_id="observe-evict",
+                )
+            with self.assertRaisesRegex(ValueError, "observed loop queue items cannot be blocked"):
+                block_loop_queue_item(paths, loop_id, queue_id, reason="late", mutation_id="block-evict")
+
+            self.assertEqual(path.read_bytes(), before)
+
+
+class WorkflowStateRevisionTests(unittest.TestCase):
+    def test_started_state_carries_a_record_revision(self) -> None:
+        from omh.workflow_state import finish_workflow_state, start_workflow_state
+
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+
+            started = start_workflow_state(paths, "plan", note="clarify")
+            finished = finish_workflow_state(paths, "plan")
+
+            self.assertEqual(started[RECORD_REVISION_KEY], 1)
+            self.assertEqual(finished[RECORD_REVISION_KEY], 2)
+            self.assertFalse(finished["active"])
+
+    @unittest.skipUnless(HAS_FCNTL, "fcntl advisory locking is POSIX-only")
+    def test_concurrent_starts_do_not_both_become_active(self) -> None:
+        from omh.workflow_state import WorkflowStateError, active_workflow_states, start_workflow_state
+
+        worker_count = 8
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            barrier = threading.Barrier(worker_count)
+            unexpected: list[BaseException] = []
+
+            def worker(index: int) -> None:
+                workflow = "plan" if index % 2 == 0 else "ralph"
+                barrier.wait()
+                try:
+                    start_workflow_state(paths, workflow)
+                except WorkflowStateError:
+                    pass
+                except BaseException as exc:  # noqa: BLE001
+                    unexpected.append(exc)
+
+            threads = [threading.Thread(target=worker, args=(index,)) for index in range(worker_count)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+            self.assertEqual(unexpected, [])
+            active, errors = active_workflow_states(paths)
+            self.assertEqual(errors, [])
+            # The transition check and the writes it authorizes run under one
+            # lock, so the "one active workflow" invariant survives the race.
+            self.assertEqual(len(active), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wrapper_sessions.py
+++ b/tests/test_wrapper_sessions.py
@@ -33,6 +33,7 @@ from omh.runtime_artifacts import (
     write_review_record,
     write_runtime_observation,
 )
+from omh.record_revision import StaleRecordMutation
 from omh.runtime_records import validate_wrapper_session_record
 from omh.wrapper.executor_sessions import (
     ExecutorSessionError,
@@ -42,6 +43,7 @@ from omh.wrapper.executor_sessions import (
     open_executor_session,
     record_executor_session_result,
     request_executor_session_verification,
+    validate_executor_session_record,
 )
 from omh.wrapper_sessions import (
     WrapperSessionError,
@@ -2041,6 +2043,186 @@ class WrapperSessionTests(unittest.TestCase):
             errors = validate_wrapper_session_record(session)
 
             self.assertIn("wrapper_session authority.session_owns must match the wrapper session authority contract", errors)
+
+    def test_prepare_handoff_threads_expected_revision_into_the_writes_it_authorizes(self) -> None:
+        # Two prepares rendered at the same revision both used to commit,
+        # leaving two run directories: the pre-flight compare never reached
+        # the write that actually linked the run.
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            started = create_or_resume_wrapper_session(paths, "risky refactor", source="discord")
+            session_id = str(started["session"]["session_id"])
+            record_plan_decision(paths, session_id, "accept")
+            selected = select_wrapper_session_executor(paths, session_id, "codex")
+            rendered_revision = int(selected["session"]["record_revision"])
+
+            first = prepare_wrapper_session_handoff(
+                paths, session_id, "risky refactor one", expected_revision=rendered_revision
+            )
+
+            with self.assertRaises(StaleRecordMutation) as caught:
+                prepare_wrapper_session_handoff(
+                    paths, session_id, "risky refactor two", expected_revision=rendered_revision
+                )
+
+            self.assertEqual(caught.exception.expected_revision, rendered_revision)
+            runs = sorted(path for path in paths.runtime_runs_dir.glob("*") if path.is_dir())
+            self.assertEqual(len(runs), 1)
+            self.assertEqual(str(first["session"]["current_run_id"]), runs[0].name)
+
+    def test_prepare_handoff_threads_the_revision_through_the_executor_selection_it_makes(self) -> None:
+        # prepare --executor writes twice: the selection and the handoff. The
+        # second write must compare against the revision the first produced,
+        # not against the one the wrapper rendered, or the guard is dropped
+        # exactly where the multi-write path needs it.
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            started = create_or_resume_wrapper_session(paths, "risky refactor", source="discord")
+            session_id = str(started["session"]["session_id"])
+            accepted = record_plan_decision(paths, session_id, "accept")
+            rendered_revision = int(accepted["session"]["record_revision"])
+
+            prepared = prepare_wrapper_session_handoff(
+                paths,
+                session_id,
+                "risky refactor",
+                executor_target="codex",
+                expected_revision=rendered_revision,
+            )
+
+            self.assertEqual(prepared["session"]["status"], "handoff_prepared")
+            self.assertEqual(int(prepared["session"]["record_revision"]), rendered_revision + 2)
+
+    @staticmethod
+    def _file_digests(root: Path) -> dict[str, str]:
+        return {
+            str(path.relative_to(root)): hashlib.sha256(path.read_bytes()).hexdigest()
+            for path in sorted(root.rglob("*"))
+            if path.is_file()
+        }
+
+    def test_prepare_refused_by_a_concurrent_cancel_writes_nothing_at_all(self) -> None:
+        # AC1: a rejected prepare used to leave two new session events and a
+        # runtime run directory behind, because the artifacts were created
+        # before the guard that refuses ran. Every prepare path is covered:
+        # the codex lifecycle path, the runtime-handoff path, and the
+        # prompt-only path each create their own side effects.
+        for executor_target in ("codex", "hermes", "claude-code"):
+            with self.subTest(executor_target=executor_target), TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                paths = resolve_paths(root / ".omh", root / ".hermes")
+                started = create_or_resume_wrapper_session(paths, "risky refactor", source="discord")
+                session_id = str(started["session"]["session_id"])
+                record_plan_decision(paths, session_id, "accept")
+                selected = select_wrapper_session_executor(paths, session_id, executor_target)
+                stale_revision = int(selected["session"]["record_revision"])
+                record_plan_decision(paths, session_id, "cancel")
+                before = self._file_digests(root)
+
+                with self.assertRaises(WrapperSessionError):
+                    prepare_wrapper_session_handoff(
+                        paths, session_id, "risky refactor", expected_revision=stale_revision
+                    )
+
+                self.assertEqual(self._file_digests(root), before)
+
+    def test_prepare_refused_by_the_in_lock_revision_compare_writes_nothing_at_all(self) -> None:
+        # The same guarantee when the guard that refuses is the revision
+        # compare rather than the terminal-status pre-check.
+        for executor_target in ("codex", "hermes", "claude-code"):
+            with self.subTest(executor_target=executor_target), TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                paths = resolve_paths(root / ".omh", root / ".hermes")
+                started = create_or_resume_wrapper_session(paths, "risky refactor", source="discord")
+                session_id = str(started["session"]["session_id"])
+                record_plan_decision(paths, session_id, "accept")
+                selected = select_wrapper_session_executor(paths, session_id, executor_target)
+                stale_revision = int(selected["session"]["record_revision"])
+                select_wrapper_session_executor(paths, session_id, executor_target)
+                before = self._file_digests(root)
+
+                with self.assertRaises(StaleRecordMutation):
+                    prepare_wrapper_session_handoff(
+                        paths, session_id, "risky refactor", expected_revision=stale_revision
+                    )
+
+                self.assertEqual(self._file_digests(root), before)
+
+    def test_retry_with_the_original_revision_and_mutation_id_replays_instead_of_going_stale(self) -> None:
+        # The canonical retry: the client timed out, never saw the result, and
+        # resends the request it built - original expected_revision, same
+        # mutation_id. Checking staleness before replay turned that into a
+        # StaleRecordMutation the client could never recover from.
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            started = create_or_resume_wrapper_session(paths, "risky refactor", source="discord")
+            session_id = str(started["session"]["session_id"])
+            record_plan_decision(paths, session_id, "accept")
+            selected = select_wrapper_session_executor(paths, session_id, "codex")
+            rendered_revision = int(selected["session"]["record_revision"])
+
+            first = prepare_wrapper_session_handoff(
+                paths,
+                session_id,
+                "risky refactor",
+                expected_revision=rendered_revision,
+                mutation_id="prepare-turn-1",
+            )
+            retry = prepare_wrapper_session_handoff(
+                paths,
+                session_id,
+                "risky refactor",
+                expected_revision=rendered_revision,
+                mutation_id="prepare-turn-1",
+            )
+
+            self.assertFalse(first["replayed"])
+            self.assertEqual(
+                int(first["session"]["record_revision"]), int(retry["session"]["record_revision"])
+            )
+            runs = sorted(path for path in paths.runtime_runs_dir.glob("*") if path.is_dir())
+            self.assertEqual(len(runs), 1)
+
+    def test_wrapper_session_mutation_ids_accept_connector_style_ids(self) -> None:
+        # Same charset rule as goal ledgers and loop cycles: an id derived from
+        # an upstream message id must work on every surface, not just this one.
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            started = create_or_resume_wrapper_session(paths, "risky refactor", source="discord")
+            session_id = str(started["session"]["session_id"])
+
+            first = record_plan_decision(paths, session_id, "accept", mutation_id="slack:C123/p1700000000.000100")
+            second = record_plan_decision(paths, session_id, "accept", mutation_id="slack:C123/p1700000000.000100")
+
+            self.assertFalse(first["replayed"])
+            self.assertTrue(second["replayed"])
+            self.assertEqual(first["session"]["record_revision"], second["session"]["record_revision"])
+
+    def test_wrapper_session_validator_rejects_bad_revision_fields(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            started = create_or_resume_wrapper_session(paths, "risky refactor", source="discord")
+
+            errors = validate_wrapper_session_record({**started["session"], "record_revision": -1})
+            applied_errors = validate_wrapper_session_record({**started["session"], "applied_mutations": []})
+
+            self.assertIn("wrapper_session record_revision must be a non-negative integer", errors)
+            self.assertIn("wrapper_session applied_mutations must be an object", applied_errors)
+
+    def test_executor_session_validator_rejects_bad_revision_fields(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            started = create_or_resume_wrapper_session(paths, "risky refactor", source="discord")
+            session_id = str(started["session"]["session_id"])
+            record_plan_decision(paths, session_id, "accept")
+            prepare_wrapper_session_handoff(paths, session_id, "risky refactor", executor_target="codex")
+            record = open_executor_session(paths, session_id)["executor_session"]
+
+            errors = validate_executor_session_record({**record, "record_revision": -1})
+            applied_errors = validate_executor_session_record({**record, "applied_mutations": []})
+
+            self.assertIn("executor_session record_revision must be a non-negative integer", errors)
+            self.assertIn("executor_session applied_mutations must be an object", applied_errors)
 
     def test_src_does_not_add_network_or_platform_sdk_imports(self) -> None:
         banned = (


### PR DESCRIPTION
# Reject stale updates to shared OMH records (closes #828)

## What capability changed

OMH gains a shared optimistic-concurrency vocabulary for its mutable local records — wrapper sessions, executor sessions, goal ledgers, loop cycles and their queues, and workflow lifecycle state. Every guarded mutation now runs as one locked read-modify-write transaction that carries a `record_revision`, honors a caller-supplied `expected_revision`, and replays a caller-supplied `mutation_id` instead of duplicating work. Terminal records refuse child work.

## Why

Multiple wrappers, CLI invocations, and agent sessions act on the same records concurrently. Before this change the primary records had no revision at all, and the read that fed a write happened *outside* the lock (or, for goal ledgers and loop cycles, with no lock whatsoever), so a wrapper acting on a snapshot it rendered seconds earlier could silently overwrite newer state. Retried CLI calls appended duplicate checkpoints because item ids were server-generated. Only one of roughly eight child-work entrypoints refused to act on a cancelled session.

## What a user or operator can do now

- Submit the revision they rendered and get a clear rejection ("the work changed, here is the latest revision, retry against current state") instead of clobbering a newer decision.
- Retry a timed-out mutation with the same `mutation_id` and get the original outcome back rather than a second checkpoint, blocker, quality gate, or queue observation.
- Cancel a goal (`omh goal cancel`) and have every later checkpoint/blocker/quality-gate refuse, naming the terminal state.
- See explicitly when a mutation was replayed rather than applied, with a non-zero exit when a requested transition did not actually happen.

## Implementation at the boundary level

**New `src/system/record_revision.py`** — `guarded_record_update(path, *, mutate, operation, expected_revision=None, mutation_id=None, mutation_digest=None, lock_name, validate=None, ...)`: take the lock, read inside it, then check in order — replay → payload divergence → eviction floor → staleness → mutate → bump revision → record the applied mutation → validate → atomic write, all still inside the lock. Companions: `StaleRecordMutation`, `ConflictingMutationReplay`, `MutationHistoryEvicted`, `DuplicateMutationReplay`, `require_not_terminal()`, `revision_field_errors()`.

**Idempotency is operation-scoped.** Entries are keyed `f"{operation}:{mutation_id}"`, so reusing one id across two different intents applies both instead of swallowing the second — an earlier iteration of this change let `goal blocker --mutation-id X` followed by `goal cancel --mutation-id X` return exit 0 with the goal still active. Within one operation a `mutation_digest` mismatch raises rather than replaying someone else's result.

**Locking is real on Windows.** `src/system/local_store.py` gained an `msvcrt` path beside `fcntl`; `file_lock` now reports `enforced` and `mechanism`, and `guarded_record_update` propagates both so a platform with neither mechanism cannot quietly appear to provide a guarantee. This mattered: with `fcntl` absent, 16 threads passing the same `expected_revision` were all accepted and 15 mutations were lost.

**Bounded history with a floor.** `applied_mutations` keeps the most recent 128 entries and persists `applied_mutations_floor_revision`; a retry whose id was already evicted raises instead of silently duplicating.

**Consumers.** Wrapper session mutations, executor-session writes, all goal-ledger mutations (plus a new `cancelled` status and `cancel_goal_ledger`), every `_write_loop` caller including the queue mutators (preconditions moved inside the lock), and `workflow_state` (whose start/finish transition check and writes were TOCTOU) now run through the guard. `omh goal` gained `--expected-revision` / `--mutation-id` / `cancel`.

## Verification observed

- Full suite: **Ran 3444 tests, OK** (baseline on origin/main: 3319; +125 new tests).
- `uv run --group lint ruff check src tests` clean; `docs workflows --check`, `docs roles --check`, `docs capability-families --check` all ok (tap-skills 115/115, 0 stale); `git diff --check` clean; `compileall` clean.
- Adversarial multi-agent review over the diff confirmed 18 findings (9 high) against the first implementation. Every confirmed defect was fixed, then re-verified by re-running each original reproduction against the fixed tree. Repros that now fail closed: `goal blocker --mutation-id X` followed by `goal cancel --mutation-id X` leaving the goal active on exit 0; 16 threads sharing one `expected_revision` all being accepted with `fcntl` absent; two prepares rendered at the same revision both committing; a rejected prepare leaving a run directory and two events behind; a stale `record_loop_feedback` reverting a guarded observation; an evicted `mutation_id` retry duplicating a blocker.
- The eviction-retry duplicate is closed by deduping on the materialized item id inside the locked transaction (verified end-to-end: seed past the 128-entry bound, evict the id, retry with only `--mutation-id` → one blocker, `replayed: true`, revision unmoved), and `validate_goal_ledger` now rejects duplicate item ids outright.

## Risks and follow-ups

- The guarantee is only as strong as the OS lock. Platforms providing neither `fcntl` nor `msvcrt` degrade to best-effort and now say so through `lock_enforced`; this is documented rather than hidden.
- `expected_revision` and `mutation_id` are optional everywhere, so existing callers keep working unchanged and gain only the locking; wrappers adopt the guarantee by echoing the revision back.
- Workspace-binding records (#820) do not exist yet; `docs/ARCHITECTURE.md` records that they must adopt this vocabulary when they land.
- Records written before this change have no revision fields and are read normally; the first guarded write initializes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
