### PR TITLE
feat: declare and enforce the coding handoff safety boundary (closes #818)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1495,3 +1495,97 @@ before the confirmation ladder is arbitrated, and a denial arms no ladder at
 all. A re-check re-proves what the artifact was prepared under; it never
 re-decides it, and it is not dispatch, execution, review, CI, or merge
 evidence.
+
+### Handoff Safety Contract
+
+`handoff_safety_contract/v1` is the task-scoped answer to "what will OMH
+actually do, and what stops it doing anything else". It declares seventeen
+boundaries — workspace, file, network, credential, dispatch, storage content,
+storage retention, merge, confirmation arming, confirmation answered, untrusted
+input, prohibited actions, evidence separation, profile revision, recovery,
+start evidence, and review receipt — plus the six evidence stages #818 names:
+start, execution, verification, review, CI, and merge.
+
+It is a field group on `coding_delegation/v1`, stored beside `action_gate`, for
+the same reason the authority envelope is not a record family: a separate family
+joins on run id, and a join can be read while the delegation is being rebuilt
+under a different revision. It is equally *not* duplicated onto the three
+handoffs — three copies of one statement are three things that can disagree
+after a partial rebuild, with no way for a reader to tell which is current. One
+copy, one place, validated against the envelope stored next to it.
+
+`coding/action_gate.py::build_task_handoff_safety_contract` is the only
+producer. It is called from `evaluate_action_gate`, which already runs exactly
+once per delegation build, and the contract rides back on the verdict under
+`handoff_safety_contract`; `split_handoff_safety_contract` lifts it out before
+the verdict is stored, and the record validator refuses a stored gate that still
+carries one. Production is offline by construction: the boundary and evidence
+tables are module data and every task-specific value is read off the authority
+envelope the same build just produced, so nothing opens a file, spawns a
+process, resolves a host, or consults a model. Repeated builds of the same
+delegation are byte-identical.
+
+#### The anti-decoration rule
+
+A contract that lists seventeen boundaries while guarding eleven is worse than
+no contract, because a reader infers a guard behind every line. Every boundary
+entry therefore carries an `enforcement` verdict of `enforced` or
+`declared_not_enforced`, and the validator refuses the two dishonest shapes: an
+`enforced` entry with no `enforced_by` symbol, and a `declared_not_enforced`
+entry with no `blocked_by` blocker. `enforced_by` entries are dotted import
+paths, and the test suite imports every one of them, so the table cannot drift
+into naming code that has moved or been deleted. The set of enforced boundaries
+is additionally asserted against a hardcoded set, which fails in both
+directions: declaring a boundary without an enforcer, and deleting an enforcer
+while leaving the declaration standing.
+
+A boundary is never justified by the absence of a capability. "No such thing
+exists in `src/`" cannot be enforced, it silently expires the moment someone
+adds the thing, and in this tree it is already false: `omh setup --star` shells
+out to `gh api -X PUT /user/starred/rlaope/oh-my-hermes`. Statements are
+therefore scoped to the surface they actually govern, and a real exception
+outside that surface is named exactly — endpoint included — rather than rounded
+away. An earlier draft of this contract carried an `absent_capability`
+enforcement mechanism; it was removed, both because the claim it encoded is
+unverifiable and because, once absence stops being a justification, the field
+becomes derivable from `enforcement` and turns into a rule that cannot fire.
+
+Enforced today, with the symbol that refuses: dispatch and prohibited actions
+and untrusted input (`validate_task_authority_envelope`, plus
+`DISPATCH_COMMAND_TEMPLATES` and `flagged_untrusted_surfaces`), merge (the same
+validator, `dispatch_fanout`'s `auto_merge: False`, and `claims._receipt_cited`),
+network (the same validator pinning `external_action_authority` to
+`prepare_only` on the delegation lane), file and credential (the preflight path
+and secrets rules), confirmation arming (`validate_action_gate_verdict` and the
+at-most-one-armed-ladder check), storage content (the closed record key sets),
+evidence separation (the claim ladder, the journal prerequisites, and the
+external-effect receipts), and profile revision.
+
+The network boundary is the one that needs its scope read carefully. It governs
+the coding delegation lane, where no network client and no remote-mutation path
+exist and no prepared handoff can post, publish, or open a pull request. It does
+not claim the process never reaches the network: `omh setup --star` does, from
+`commands/setup.py::_try_star_github_repo`, behind an explicit `--star` flag on
+an interactive command, with a dry-run branch and a 20s timeout, and it mutates
+only the operator's own starred list. The contract names that call, and the
+enforcement suite pins its exact argv, so changing it fails a test rather than
+quietly widening what the sentence covers.
+
+Declared and not enforced, each naming what must land first: **workspace** —
+`allowed_targets` is derived from the isolation plan but nothing binds a running
+executor to it (#820); **confirmation answered** — the artifact proves a ladder
+was armed, never that consent was given (#807); **storage retention** — run
+artifacts are metadata-only, but no retention window, expiry, or cleanup exists,
+so they persist until the operator deletes them (#835); **recovery** — no
+recovery anchor is attached to risky work (#821); **start evidence** —
+`runtime_start` is recordable but is neither a claim rung nor a journal
+prerequisite, so a run can claim dispatch and execution with no observed start
+(#826); and **review receipt** — a review claim needs an observed review record
+but, unlike CI and merge, no external effect receipt, so a local record saying
+review passed is accepted as the evidence for itself (unfiled).
+
+The last two are known asymmetries rather than oversights. Closing either means
+adding a rung or a prerequisite to `runtime/claims.py` and
+`workflows/observation_journal.py`, which changes what runs recorded before the
+gate existed may claim; that is a separate decision with its own regression
+surface, so the contract states the gap instead of implying a guard.

--- a/src/coding/action_gate.py
+++ b/src/coding/action_gate.py
@@ -31,6 +31,20 @@ Authority is derived from user intent plus workspace policy only. Message text,
 context packs, and recall packs are inspected for authority-shaped content and
 the finding is reported as a surface name — never echoed back, never fed into
 the allowed action set.
+
+The same evaluation also produces the *handoff safety contract* (#818): the
+task-scoped statement of what this delegation may touch, what it may never do,
+and which of those boundaries is actually enforced today. Every boundary entry
+carries an ``enforcement`` verdict plus either a real enforcing symbol or the
+issue that must land first, because a contract that lists nine boundaries and
+guards four reads as coverage that does not exist — strictly worse than no
+contract at all.
+
+A boundary is never justified by "no such capability exists". That claim cannot
+be enforced and the tree can contradict it: ``omh setup --star`` really does
+shell out to ``gh`` to star the repository. Every statement here is therefore
+scoped to the surface it actually governs, and a real exception outside that
+surface is named in the statement rather than left for a reader to discover.
 """
 
 from __future__ import annotations
@@ -43,6 +57,7 @@ from ..workflows.domain_intelligence_admission import ensure_safe_opaque_ref_con
 
 TASK_AUTHORITY_ENVELOPE_SCHEMA_VERSION = "task_authority_envelope/v1"
 ACTION_GATE_SCHEMA_VERSION = "coding_action_gate/v1"
+HANDOFF_SAFETY_CONTRACT_SCHEMA_VERSION = "handoff_safety_contract/v1"
 
 AUTHORITY_SOURCES = ("user_intent", "workspace_policy")
 UNTRUSTED_SURFACES = ("context_pack", "memory_recall_pack", "message")
@@ -127,6 +142,12 @@ ACTION_GATE_KEYS = (
     "denial",
     "safety_profile_revision",
     "claim_boundary",
+    # Transport only. `evaluate_action_gate` is the one place that runs per
+    # delegation build, so the contract rides back on the verdict — but it is
+    # *stored* once, beside `action_gate` on the delegation, never inside it.
+    # `records._validate_coding_action_gate` refuses a stored gate that still
+    # carries one, because two copies can disagree.
+    "handoff_safety_contract",
 )
 CONFIRMATION_KEYS = (
     "required",
@@ -139,6 +160,265 @@ CONFIRMATION_KEYS = (
     "suppressed_ladders",
 )
 DENIAL_KEYS = ("rule_id", "field", "correction", "reason_codes", "source")
+
+HANDOFF_SAFETY_CONTRACT_KEY = "handoff_safety_contract"
+HANDOFF_SAFETY_CONTRACT_KEYS = (
+    "schema_version",
+    "status",
+    "produced_offline",
+    "input_sources",
+    "boundaries",
+    "evidence_requirements",
+    "prohibited_actions",
+    "allowed_executors",
+    "allowed_targets",
+    "merge_authority",
+    "external_action_authority",
+    "safety_profile_revision",
+    "claim_boundary",
+)
+SAFETY_BOUNDARY_KEYS = ("boundary", "statement", "enforcement", "enforced_by", "blocked_by")
+EVIDENCE_REQUIREMENT_KEYS = ("stage", "claim", "observation_event", "enforcement", "enforced_by", "blocked_by")
+ENFORCEMENT_LEVELS = ("declared_not_enforced", "enforced")
+# Every local metadata surface the contract is derived from. All three are
+# already in process when `evaluate_action_gate` runs, which is what makes the
+# contract producible offline: no file, no process, no socket, no model.
+HANDOFF_CONTRACT_INPUT_SOURCES = (
+    "isolation_plan",
+    "safety_preflight_verdict",
+    "task_authority_envelope",
+)
+HANDOFF_CONTRACT_CLAIM_BOUNDARY = (
+    "This safety contract is prepared metadata. It is not dispatch, execution, review, CI, or merge "
+    "evidence, and an enforced boundary means a refusing check exists — not that any action ran."
+)
+REVIEW_RECEIPT_BLOCKER = "#844"
+
+# (boundary, statement, enforcement, enforced_by, blocked_by).
+#
+# The `enforced_by` refs are dotted import paths that must resolve; the test
+# suite imports every one of them. That is what stops this table drifting into
+# fiction as the enforcing code moves or is deleted. An entry is only
+# `enforced` when naming a symbol that refuses something; anything else is
+# `declared_not_enforced` with the issue that must land first.
+#
+# Statements are scoped to the surface they govern. "No such capability exists"
+# is never a justification: it cannot be enforced, and the tree can contradict
+# it — `omh setup --star` really does shell out to `gh`. Where a real exception
+# exists outside the governed surface, the statement names it exactly rather
+# than rounding it away.
+_SAFETY_BOUNDARIES: tuple[tuple[str, str, str, tuple[str, ...], str], ...] = (
+    (
+        "confirmation_answered",
+        "Nothing records that a user answered a confirmation. The artifact proves a ladder was armed, "
+        "not that consent was given, so an armed ladder must never be read as an approval.",
+        "declared_not_enforced",
+        (),
+        "#807",
+    ),
+    (
+        "confirmation_arming",
+        "One intent arms at most one confirmation ladder, and every ladder that could have fired is "
+        "recorded as suppressed with the winner named.",
+        "enforced",
+        (
+            "omh.coding.action_gate.SINGLE_PROMPT_RULE",
+            "omh.coding.action_gate.validate_action_gate_verdict",
+        ),
+        "",
+    ),
+    (
+        "credential",
+        "Credential-shaped values are refused in the opaque-reference field class before any rule reads "
+        "them, so a secret cannot enter a prepared handoff as metadata. The chat delegation lane builds "
+        "its request from closed vocabularies, so the rule is live for direct evaluator callers and "
+        "structurally unreachable from a chat message.",
+        "enforced",
+        (
+            "omh.quality.safety_preflight.RULE_SECRETS_ABSENT",
+            "omh.system.metadata_safety.is_sensitive_metadata_text",
+        ),
+        "",
+    ),
+    (
+        "dispatch",
+        "The delegation lane spawns no executor unless the envelope allows executor_dispatch under a "
+        "dispatchable parent and the owner has an entry in the local dispatch command allowlist. Every "
+        "other owner receives a prepared prompt and is never spawned.",
+        "enforced",
+        (
+            "omh.coding.action_gate.validate_task_authority_envelope",
+            "omh.coding.fanout_dispatch.DISPATCH_COMMAND_TEMPLATES",
+        ),
+        "",
+    ),
+    (
+        "evidence_separation",
+        "Prepared metadata is not observed execution. Each claim rung requires its own observation, the "
+        "observation journal refuses an out-of-order lifecycle event, and CI and merge additionally "
+        "require an external effect receipt that observed that effect succeed.",
+        "enforced",
+        (
+            "omh.runtime.claims.allowed_runtime_claims",
+            "omh.workflows.external_effect_receipts.receipt_satisfies_success_claim",
+            "omh.workflows.observation_journal.append_observation_event",
+        ),
+        "",
+    ),
+    (
+        "file",
+        "Target paths are bounded, project-relative, and contained: an absolute or home-anchored path, a "
+        "path that escapes the project, an over-long path, or more paths than the bound allows is denied "
+        "before a handoff is prepared.",
+        "enforced",
+        (
+            "omh.quality.safety_preflight.RULE_TARGET_PATHS_BOUNDED",
+            "omh.quality.safety_preflight.evaluate_safety_preflight",
+        ),
+        "",
+    ),
+    (
+        "merge",
+        "No delegation merges anything. merge_authority is disabled on every delegation this lane builds, "
+        "fanout dispatch records auto_merge false, and a merged claim is refused unless an external "
+        "effect receipt observed this run's merge succeed.",
+        "enforced",
+        (
+            "omh.coding.action_gate.validate_task_authority_envelope",
+            "omh.coding.fanout_dispatch.dispatch_fanout",
+            "omh.runtime.claims._receipt_cited",
+        ),
+        "",
+    ),
+    (
+        "network",
+        "The coding delegation lane holds no network client and no remote-mutation path: "
+        "external_action_authority is pinned to prepare_only, so no prepared handoff can post, publish, "
+        "or open a pull request. One executed remote call exists in the tree, outside this lane and "
+        "outside any delegation: `omh setup --star` runs `gh api -X PUT "
+        "/user/starred/rlaope/oh-my-hermes` from commands.setup behind an explicit --star flag. It adds "
+        "only the operator's own star, cannot reach repository contents, and its exact argv is pinned by "
+        "a test, so changing it fails the suite.",
+        "enforced",
+        ("omh.coding.action_gate.validate_task_authority_envelope",),
+        "",
+    ),
+    (
+        "profile_revision",
+        "A prepared artifact pins the safety-profile revision it was cleared under, and a later boundary "
+        "refuses to act once the live revision no longer matches.",
+        "enforced",
+        (
+            "omh.coding.action_gate.recheck_safety_profile_revision",
+            "omh.coding.fanout_dispatch.verify_safety_profile_matches_contract",
+        ),
+        "",
+    ),
+    (
+        "prohibited_actions",
+        "Blocked actions are the exact complement of the allowed set over the whole action vocabulary, and "
+        "every blocked action carries a reason code and a written explanation.",
+        "enforced",
+        ("omh.coding.action_gate.validate_task_authority_envelope",),
+        "",
+    ),
+    (
+        "recovery",
+        "No recovery anchor is attached to risky work, so nothing records how to undo a prepared handoff "
+        "once it has been dispatched.",
+        "declared_not_enforced",
+        (),
+        "#821",
+    ),
+    (
+        "review_receipt",
+        "A review claim needs an observed review record but, unlike CI and merge, no external effect "
+        "receipt. A local record saying review passed is accepted as the evidence for itself.",
+        "declared_not_enforced",
+        (),
+        REVIEW_RECEIPT_BLOCKER,
+    ),
+    (
+        "start_evidence",
+        "runtime_start is recordable but is neither a claim rung nor a journal prerequisite, so a run can "
+        "claim dispatch and execution with no observed start.",
+        "declared_not_enforced",
+        (),
+        "#826",
+    ),
+    (
+        "storage_content",
+        "Persisted records carry bounded metadata only — the message as a sha256 digest and a length, "
+        "prompts as templates — and every record key set is closed, so a verbatim prompt or message body "
+        "cannot be stored.",
+        "enforced",
+        (
+            "omh.runtime.records.CODING_DELEGATION_RECORD_KEYS",
+            "omh.runtime.records.validate_coding_delegation_record",
+            "omh.workflows.observation_journal.OBSERVATION_PRIVACY",
+        ),
+        "",
+    ),
+    (
+        "storage_retention",
+        "Run artifacts persist until the operator deletes them. No retention window, expiry, or cleanup "
+        "exists, so a prepared handoff and its metadata stay on disk indefinitely.",
+        "declared_not_enforced",
+        (),
+        "#835",
+    ),
+    (
+        "untrusted_input",
+        "Authority comes from user intent and workspace policy only. Message text, context packs, and "
+        "recall packs are inspected and reported as flagged surface names; nothing they contain widens "
+        "the allowed action set.",
+        "enforced",
+        (
+            "omh.coding.action_gate.flagged_untrusted_surfaces",
+            "omh.coding.action_gate.validate_task_authority_envelope",
+        ),
+        "",
+    ),
+    (
+        "workspace",
+        "allowed_targets is derived from the isolation plan, but nothing binds a running executor to it. "
+        "The target is a declaration the executor is trusted to honour, not a constraint applied to it.",
+        "declared_not_enforced",
+        (),
+        "#820",
+    ),
+)
+SAFETY_BOUNDARY_NAMES = tuple(entry[0] for entry in _SAFETY_BOUNDARIES)
+
+_CLAIM_LADDER_ENFORCERS = (
+    "omh.runtime.claims.allowed_runtime_claims",
+    "omh.workflows.observation_journal.append_observation_event",
+)
+_RECEIPT_ENFORCERS = (
+    *_CLAIM_LADDER_ENFORCERS,
+    "omh.workflows.external_effect_receipts.receipt_satisfies_success_claim",
+)
+
+# (stage, claim, observation_event, enforcement, enforced_by, blocked_by).
+# The six stages #818 names. `start` is the honest gap: the event exists and is
+# recordable, but no claim rung and no journal prerequisite reads it, so the
+# contract declares it unenforced instead of implying a gate.
+_EVIDENCE_REQUIREMENTS: tuple[tuple[str, str, str, str, tuple[str, ...], str], ...] = (
+    ("start", "", "runtime_start_observed", "declared_not_enforced", (), "#826"),
+    ("execution", "execution_observed", "executor_result_observed", "enforced", _CLAIM_LADDER_ENFORCERS, ""),
+    (
+        "verification",
+        "verification_observed",
+        "verification_result_observed",
+        "enforced",
+        _CLAIM_LADDER_ENFORCERS,
+        "",
+    ),
+    ("review", "review_observed", "review_result_observed", "enforced", _CLAIM_LADDER_ENFORCERS, ""),
+    ("ci", "ci_observed", "ci_result_observed", "enforced", _RECEIPT_ENFORCERS, ""),
+    ("merge", "merged", "merge_observed", "enforced", _RECEIPT_ENFORCERS, ""),
+)
+HANDOFF_EVIDENCE_STAGES = tuple(entry[0] for entry in _EVIDENCE_REQUIREMENTS)
 
 REVISION_DRIFT_RULE_ID = "safety_profile_revision_drift"
 REVISION_DRIFT_FIELD = "safety_profile_revision"
@@ -422,6 +702,67 @@ def build_task_authority_envelope(
     }
 
 
+def build_task_handoff_safety_contract(envelope: dict[str, Any]) -> dict[str, Any]:
+    """The task-scoped handoff safety contract, derived from the envelope alone.
+
+    Offline by construction: the boundary and evidence tables are module data
+    and every task-specific value is read off the authority envelope this same
+    build just produced. Nothing here opens a file, spawns a process, resolves a
+    host, or consults a model, so the contract is reproducible on a machine with
+    no network and byte-identical across repeated builds of the same delegation.
+
+    Reading the envelope rather than re-deriving from intent and policy is
+    deliberate: a contract that recomputed its own numbers could disagree with
+    the envelope it describes, and the validator would have nothing to compare.
+    """
+    return {
+        "schema_version": HANDOFF_SAFETY_CONTRACT_SCHEMA_VERSION,
+        "status": "prepared_not_observed",
+        "produced_offline": True,
+        "input_sources": list(HANDOFF_CONTRACT_INPUT_SOURCES),
+        "boundaries": [
+            {
+                "boundary": boundary,
+                "statement": statement,
+                "enforcement": enforcement,
+                "enforced_by": list(enforced_by),
+                "blocked_by": blocked_by,
+            }
+            for boundary, statement, enforcement, enforced_by, blocked_by in _SAFETY_BOUNDARIES
+        ],
+        "evidence_requirements": [
+            {
+                "stage": stage,
+                "claim": claim,
+                "observation_event": observation_event,
+                "enforcement": enforcement,
+                "enforced_by": list(enforced_by),
+                "blocked_by": blocked_by,
+            }
+            for stage, claim, observation_event, enforcement, enforced_by, blocked_by in _EVIDENCE_REQUIREMENTS
+        ],
+        "prohibited_actions": list(envelope.get("blocked_actions", [])),
+        "allowed_executors": list(envelope.get("allowed_executors", [])),
+        "allowed_targets": list(envelope.get("allowed_targets", [])),
+        "merge_authority": str(envelope.get("merge_authority", "")),
+        "external_action_authority": str(envelope.get("external_action_authority", "")),
+        "safety_profile_revision": str(envelope.get("safety_profile_revision", "")),
+        "claim_boundary": HANDOFF_CONTRACT_CLAIM_BOUNDARY,
+    }
+
+
+def split_handoff_safety_contract(gate: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Separate the stored verdict from the safety contract it carried back.
+
+    The contract is stored once, beside `action_gate` on the delegation, never
+    inside it. Two copies of the same statement can disagree after a partial
+    rebuild, and a reader has no way to tell which one is current.
+    """
+    verdict = {key: value for key, value in gate.items() if key != HANDOFF_SAFETY_CONTRACT_KEY}
+    contract = gate.get(HANDOFF_SAFETY_CONTRACT_KEY)
+    return verdict, contract if isinstance(contract, dict) else {}
+
+
 _ALLOW_OUTCOMES = frozenset({"allow", "allowed", "ok", "pass", "passed"})
 _DENY_OUTCOMES = frozenset({"block", "blocked", "deny", "denied", "refuse", "refused"})
 _OUTCOME_KEYS = ("outcome", "status", "verdict", "allowed", "allow")
@@ -627,6 +968,10 @@ def evaluate_action_gate(
         "authority_envelope": envelope,
         "safety_profile_revision": preflight["safety_profile_revision"],
         "claim_boundary": GATE_CLAIM_BOUNDARY,
+        # Built here because this is the one place that runs exactly once per
+        # delegation build. The delegation lifts it out before storing, so the
+        # contract lives beside the gate rather than inside it.
+        HANDOFF_SAFETY_CONTRACT_KEY: build_task_handoff_safety_contract(envelope),
     }
     if denial is not None:
         verdict["denial"] = denial
@@ -733,6 +1078,135 @@ def validate_task_authority_envelope(
         errors.append(f"{label} executor_dispatch requires a dispatchable parent handoff")
     if lane in {"runtime_handoff", "prompt_handoff"} and "executor_dispatch" in allowed:
         errors.append(f"{label} {lane} cannot grant executor dispatch authority")
+    return errors
+
+
+def _enforcement_errors(
+    entry: dict[str, Any],
+    label: str,
+) -> list[str]:
+    """The anti-decoration rule, applied to one boundary or evidence entry.
+
+    An `enforced` entry must name at least one dotted symbol that a reader can
+    open, and must not name a blocker. A `declared_not_enforced` entry must name
+    a blocker and must not name an enforcer. Anything else is a claim of
+    coverage nobody can check, which is what this contract exists to prevent.
+    """
+    errors: list[str] = []
+    enforcement = entry.get("enforcement")
+    if enforcement not in ENFORCEMENT_LEVELS:
+        return [f"{label}.enforcement is unsupported"]
+    enforced_by = entry.get("enforced_by")
+    blocked_by = entry.get("blocked_by")
+    if not isinstance(enforced_by, list) or not all(isinstance(item, str) for item in enforced_by):
+        errors.append(f"{label}.enforced_by must be a list of strings")
+        enforced_by = []
+    if not isinstance(blocked_by, str):
+        errors.append(f"{label}.blocked_by must be a string")
+        blocked_by = ""
+    if enforcement == "enforced":
+        if not enforced_by:
+            errors.append(f"{label} claims enforcement but names no enforcing symbol")
+        if blocked_by:
+            errors.append(f"{label} is enforced, so it must not name a blocker")
+    else:
+        if enforced_by:
+            errors.append(f"{label} is not enforced, so it must not name an enforcing symbol")
+        if not blocked_by.strip():
+            errors.append(f"{label} is not enforced, so it must name the blocker that must land first")
+    for index, symbol in enumerate(enforced_by):
+        if not symbol.startswith("omh.") or symbol.count(".") < 2:
+            errors.append(f"{label}.enforced_by[{index}] must be a dotted omh symbol reference")
+    return errors
+
+
+def _handoff_contract_boundary_errors(value: Any, label: str) -> list[str]:
+    if not isinstance(value, list):
+        return [f"{label} boundaries must be a list"]
+    names = [entry.get("boundary") for entry in value if isinstance(entry, dict)]
+    errors: list[str] = []
+    if names != list(SAFETY_BOUNDARY_NAMES):
+        # One message covers unknown, missing, duplicated, and reordered names:
+        # the boundary set is the contract, so any difference is the same defect.
+        errors.append(f"{label} boundaries must be exactly {list(SAFETY_BOUNDARY_NAMES)} in order")
+    for index, entry in enumerate(value):
+        entry_label = f"{label} boundaries[{index}]"
+        if not isinstance(entry, dict) or set(entry) != set(SAFETY_BOUNDARY_KEYS):
+            errors.append(f"{entry_label} keys are invalid")
+            continue
+        if not str(entry.get("statement", "")).strip():
+            errors.append(f"{entry_label}.statement is required")
+        errors.extend(_enforcement_errors(entry, entry_label))
+    return errors
+
+
+def _handoff_contract_evidence_errors(value: Any, label: str) -> list[str]:
+    if not isinstance(value, list):
+        return [f"{label} evidence_requirements must be a list"]
+    stages = [entry.get("stage") for entry in value if isinstance(entry, dict)]
+    errors: list[str] = []
+    if stages != list(HANDOFF_EVIDENCE_STAGES):
+        errors.append(f"{label} evidence_requirements must cover exactly {list(HANDOFF_EVIDENCE_STAGES)} in order")
+    for index, entry in enumerate(value):
+        entry_label = f"{label} evidence_requirements[{index}]"
+        if not isinstance(entry, dict) or set(entry) != set(EVIDENCE_REQUIREMENT_KEYS):
+            errors.append(f"{entry_label} keys are invalid")
+            continue
+        if not str(entry.get("observation_event", "")).strip():
+            errors.append(f"{entry_label}.observation_event is required")
+        if entry.get("enforcement") == "enforced" and not str(entry.get("claim", "")).strip():
+            errors.append(f"{entry_label} claims enforcement, so it must name the claim rung it gates")
+        errors.extend(_enforcement_errors(entry, entry_label))
+    return errors
+
+
+def validate_handoff_safety_contract(
+    value: Any,
+    label: str = "handoff_safety_contract",
+    *,
+    envelope: Any = None,
+) -> list[str]:
+    """Validate one handoff safety contract against the envelope it describes.
+
+    Two failure classes matter. The first is decoration: a boundary that claims
+    enforcement without naming an enforcer, or a boundary name nobody has an
+    entry for. The second is disagreement: a contract whose prohibited actions,
+    executors, targets, or authority values no longer match the envelope stored
+    beside it, which is how a stale copy is spotted.
+    """
+    if not isinstance(value, dict):
+        return [f"{label} must be an object"]
+    errors: list[str] = []
+    if set(value) != set(HANDOFF_SAFETY_CONTRACT_KEYS):
+        errors.append(f"{label} keys are invalid")
+    if value.get("schema_version") != HANDOFF_SAFETY_CONTRACT_SCHEMA_VERSION:
+        errors.append(f"{label} schema_version is invalid")
+    if value.get("status") != "prepared_not_observed":
+        errors.append(f"{label} status is invalid")
+    if value.get("produced_offline") is not True:
+        errors.append(f"{label} produced_offline must be true")
+    if list(value.get("input_sources", [])) != list(HANDOFF_CONTRACT_INPUT_SOURCES):
+        errors.append(f"{label} input_sources must be the allowlisted local metadata surfaces")
+    errors.extend(_handoff_contract_boundary_errors(value.get("boundaries"), label))
+    errors.extend(_handoff_contract_evidence_errors(value.get("evidence_requirements"), label))
+    for key in ("prohibited_actions", "allowed_executors", "allowed_targets"):
+        errors.extend(_string_list_errors(value.get(key), f"{label} {key}"))
+    for key in ("merge_authority", "external_action_authority", "safety_profile_revision"):
+        if not isinstance(value.get(key), str):
+            errors.append(f"{label} {key} must be a string")
+    if "not dispatch" not in str(value.get("claim_boundary", "")).lower():
+        errors.append(f"{label} claim_boundary must preserve the dispatch boundary")
+    if isinstance(envelope, dict):
+        for contract_key, envelope_key in (
+            ("prohibited_actions", "blocked_actions"),
+            ("allowed_executors", "allowed_executors"),
+            ("allowed_targets", "allowed_targets"),
+            ("merge_authority", "merge_authority"),
+            ("external_action_authority", "external_action_authority"),
+            ("safety_profile_revision", "safety_profile_revision"),
+        ):
+            if value.get(contract_key) != envelope.get(envelope_key):
+                errors.append(f"{label} {contract_key} must match the authority envelope {envelope_key}")
     return errors
 
 

--- a/src/coding/coding_delegation.py
+++ b/src/coding/coding_delegation.py
@@ -22,7 +22,7 @@ from ..coding_contracts import (
     TASK_PROMPT_CONTRACT_SCHEMA_VERSION,
     TASK_PROMPT_REQUIRED_SECTIONS,
 )
-from .action_gate import evaluate_action_gate
+from .action_gate import evaluate_action_gate, split_handoff_safety_contract
 from .prompting import build_executor_prompting_contract, render_executor_prompt_sections
 from ..executors import (
     HERMES_CODING_TEAM_WRAPPER_ACTIONS,
@@ -427,7 +427,7 @@ def build_coding_delegation_payload(
     # The single decision path. Every downstream authority value — dispatchable,
     # choice_required, the executor selection status, and which confirmation
     # ladder is armed — is derived from this one verdict; nothing recomputes it.
-    action_gate = evaluate_action_gate(
+    gate_verdict = evaluate_action_gate(
         message=message,
         delegation_action=delegation.action,
         intent=delegation.intent,
@@ -457,6 +457,10 @@ def build_coding_delegation_payload(
         live_safety_profile_revision=live_safety_profile_revision,
         requested_actions=list(requested_authority_actions or []),
     )
+    # The #818 safety contract rides back on the verdict because the gate is the
+    # one place that runs per build; it is stored beside the gate, not inside
+    # it, so there is exactly one copy for a reader to trust.
+    action_gate, handoff_safety_contract = split_handoff_safety_contract(gate_verdict)
     authority_envelope = action_gate["authority_envelope"]
     if action_gate["outcome"] == "deny":
         # The deny flows through the same value the record validators read: the
@@ -487,6 +491,7 @@ def build_coding_delegation_payload(
                 ),
             },
             "action_gate": action_gate,
+            "handoff_safety_contract": handoff_safety_contract,
         }
     )
     if isolation_plan:
@@ -931,6 +936,8 @@ def coding_delegation_record_payload(
     }
     if isinstance(payload.get("action_gate"), dict):
         record["action_gate"] = payload["action_gate"]
+    if isinstance(payload.get("handoff_safety_contract"), dict):
+        record["handoff_safety_contract"] = payload["handoff_safety_contract"]
     for key in ("executor_handoff", "runtime_handoff", "prompt_handoff"):
         if isinstance(payload.get(key), dict):
             record[key] = payload[key]

--- a/src/runtime/records.py
+++ b/src/runtime/records.py
@@ -53,7 +53,13 @@ from ..system.record_revision import (
     revision_field_errors,
 )
 from ..memory import validate_handoff_context_blocked, validate_handoff_context_pack, validate_project_memory_recall_pack
-from ..coding.action_gate import validate_action_gate_verdict, validate_task_authority_envelope
+from ..coding.action_gate import (
+    HANDOFF_SAFETY_CONTRACT_KEY,
+    split_handoff_safety_contract,
+    validate_action_gate_verdict,
+    validate_handoff_safety_contract,
+    validate_task_authority_envelope,
+)
 from ..coding.product_family_templates import validate_product_family_template
 from ..coding.product_quality_harnesses import validate_product_quality_harness
 from ..coding.project_governance import validate_project_governance_blocked, validate_project_governance_profile
@@ -169,6 +175,7 @@ CODING_DELEGATION_RECORD_KEYS = (
     "dispatchable",
     "executor_selection",
     "action_gate",
+    "handoff_safety_contract",
     "review_required",
     "review_workflow",
     "message_sha256",
@@ -818,8 +825,21 @@ def build_coding_delegation_record(delegation: dict[str, Any]) -> dict[str, Any]
     if harness_quality:
         record["harness_quality"] = harness_quality
     action_gate = delegation.get("action_gate")
-    if isinstance(action_gate, dict) and not validate_action_gate_verdict(action_gate, "action_gate"):
-        record["action_gate"] = deepcopy(action_gate)
+    handoff_safety_contract = delegation.get("handoff_safety_contract")
+    if isinstance(action_gate, dict):
+        # The split is done here as well as on the delegation lane so a caller
+        # that hands over a raw `evaluate_action_gate` verdict still stores one
+        # copy of the contract, beside the gate rather than inside it.
+        action_gate, carried_contract = split_handoff_safety_contract(action_gate)
+        if handoff_safety_contract is None and carried_contract:
+            handoff_safety_contract = carried_contract
+        if not validate_action_gate_verdict(action_gate, "action_gate"):
+            record["action_gate"] = deepcopy(action_gate)
+    if isinstance(handoff_safety_contract, dict) and not validate_handoff_safety_contract(
+        handoff_safety_contract,
+        "handoff_safety_contract",
+    ):
+        record["handoff_safety_contract"] = deepcopy(handoff_safety_contract)
     executor_handoff = _compact_executor_handoff(delegation.get("executor_handoff"))
     if executor_handoff:
         record["executor_handoff"] = executor_handoff
@@ -2273,13 +2293,39 @@ def _validate_coding_action_gate(delegation: dict[str, Any]) -> list[str]:
     ``dispatchable`` and ``executor_selection.choice_required`` are derived from
     the verdict, so a record whose stored values disagree with it means some
     caller re-decided; that is a validation failure, not a rendering detail.
+
+    The #818 handoff safety contract is validated here too, and only here: it is
+    a field group on this record, not a record family of its own. A separate
+    family would join on run id and could be read while the delegation is
+    rebuilt under a different revision — the staleness class #811 removed.
     """
     if "action_gate" not in delegation:
+        if "handoff_safety_contract" in delegation:
+            return ["coding_delegation handoff_safety_contract requires the action_gate that produced it"]
         return []
     gate = delegation["action_gate"]
     errors = validate_action_gate_verdict(gate, "coding_delegation action_gate")
     if not isinstance(gate, dict):
         return errors
+    envelope = gate.get("authority_envelope")
+    if HANDOFF_SAFETY_CONTRACT_KEY in gate:
+        errors.append(
+            "coding_delegation action_gate must not carry handoff_safety_contract; "
+            "the contract is stored once beside the gate"
+        )
+    if "handoff_safety_contract" not in delegation:
+        # A gate without its contract is a boundary statement dropped in
+        # transit, which is exactly the silent loss the key tuple and the
+        # compactor are supposed to make impossible.
+        errors.append("coding_delegation action_gate requires the handoff_safety_contract it produced")
+    else:
+        errors.extend(
+            validate_handoff_safety_contract(
+                delegation["handoff_safety_contract"],
+                "coding_delegation handoff_safety_contract",
+                envelope=envelope,
+            )
+        )
     if gate.get("dispatchable") != delegation.get("dispatchable"):
         errors.append("coding_delegation dispatchable must be derived from action_gate.dispatchable")
     selection = delegation.get("executor_selection")
@@ -2287,8 +2333,7 @@ def _validate_coding_action_gate(delegation: dict[str, Any]) -> list[str]:
         errors.append(
             "coding_delegation executor_selection.choice_required must be derived from action_gate.choice_required"
         )
-    parent = gate.get("authority_envelope")
-    parent_allowed = set(parent.get("allowed_actions", [])) if isinstance(parent, dict) else set()
+    parent_allowed = set(envelope.get("allowed_actions", [])) if isinstance(envelope, dict) else set()
     for key in ("executor_handoff", "runtime_handoff", "prompt_handoff"):
         handoff = delegation.get(key)
         if not isinstance(handoff, dict):

--- a/tests/test_handoff_safety_contract.py
+++ b/tests/test_handoff_safety_contract.py
@@ -1,0 +1,632 @@
+"""The handoff safety contract and its anti-decoration rule (#818).
+
+Acceptance criteria under test:
+
+* the contract is producible offline from allowlisted local metadata,
+* nothing hides a dispatch, an automatic merge, arbitrary authority, or a raw
+  prompt behind it, and
+* no start or success is claimed without the matching evidence.
+
+The load-bearing test in this file is not any single boundary; it is that every
+boundary declares whether it is *enforced* and, if so, names a symbol that a
+reader can open. A contract listing nine boundaries while guarding four reads as
+coverage that does not exist, which is worse than shipping no contract, so the
+tests here fail in both directions: adding a boundary without an enforcer fails,
+and deleting an enforcer while leaving the declaration standing fails too.
+"""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import inspect
+import json
+import socket
+import subprocess
+import unittest
+from unittest import mock
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.coding.action_gate import (  # noqa: E402
+    ENFORCEMENT_LEVELS,
+    EVIDENCE_REQUIREMENT_KEYS,
+    HANDOFF_CONTRACT_INPUT_SOURCES,
+    HANDOFF_EVIDENCE_STAGES,
+    HANDOFF_SAFETY_CONTRACT_KEY,
+    HANDOFF_SAFETY_CONTRACT_KEYS,
+    HANDOFF_SAFETY_CONTRACT_SCHEMA_VERSION,
+    SAFETY_BOUNDARY_KEYS,
+    SAFETY_BOUNDARY_NAMES,
+    build_task_authority_envelope,
+    build_task_handoff_safety_contract,
+    evaluate_action_gate,
+    split_handoff_safety_contract,
+    validate_action_gate_verdict,
+    validate_handoff_safety_contract,
+)
+from omh.coding.coding_delegation import build_coding_delegation_payload  # noqa: E402
+from omh.commands import setup as setup_command  # noqa: E402
+from omh.runtime.claims import (  # noqa: E402
+    RUNTIME_CLAIM_LADDER,
+    Claim,
+    allowed_runtime_claims,
+    blocked_runtime_claims,
+)
+from omh.runtime.records import (  # noqa: E402
+    CODING_DELEGATION_RECORD_KEYS,
+    build_coding_delegation_record,
+    validate_coding_delegation_record,
+)
+from omh.workflows.external_effect_receipts import external_effect_id  # noqa: E402
+
+
+_MESSAGE = "fix the login bug in src/auth.py and add a regression test"
+# The one executed remote call in the tree, outside the delegation lane. The
+# network boundary names it, so the name has to keep matching the code.
+_STAR_ENDPOINT = "/user/starred/rlaope/oh-my-hermes"
+_ALLOW_VERDICT = {
+    "schema_version": "omh_safety_preflight_verdict/v1",
+    "outcome": "allow",
+    "rule_id": "",
+    "field": "",
+    "correction": "",
+    "safety_profile_revision": "rev-frozen",
+}
+
+# The boundaries that name a real enforcing symbol today. Hardcoded on purpose:
+# it has to be edited by hand, in the same commit, whenever a boundary gains or
+# loses an enforcer, so neither direction of drift can land quietly.
+_ENFORCED_BOUNDARIES = frozenset(
+    {
+        "confirmation_arming",
+        "credential",
+        "dispatch",
+        "evidence_separation",
+        "file",
+        "merge",
+        "network",
+        "profile_revision",
+        "prohibited_actions",
+        "storage_content",
+        "untrusted_input",
+    }
+)
+# The boundaries the contract declares but does not guard, each with the issue
+# that must land before it can move. `unfiled` means the gap is real and has no
+# issue yet; it is still stated rather than implied away.
+_DECLARED_NOT_ENFORCED = {
+    "confirmation_answered": "#807",
+    "recovery": "#821",
+    "review_receipt": "#844",
+    "start_evidence": "#826",
+    "storage_retention": "#835",
+    "workspace": "#820",
+}
+
+
+def _envelope(**overrides: object) -> dict[str, object]:
+    envelope = build_task_authority_envelope(
+        denied=False,
+        delegation_action="delegate",
+        intent="coding",
+        review_required=False,
+        work_owner_mode="external_executor",
+        selected_executor_profile="codex",
+        dispatchable=True,
+        choice_required=False,
+        isolation_plan={"strategy": "worktree_recommended"},
+        message=_MESSAGE,
+        safety_profile_revision="rev-frozen",
+    )
+    envelope.update(overrides)
+    return envelope
+
+
+def _contract() -> dict[str, object]:
+    return build_task_handoff_safety_contract(_envelope())
+
+
+def _gate(**overrides: object) -> dict[str, object]:
+    arguments: dict[str, object] = {
+        "message": _MESSAGE,
+        "delegation_action": "delegate",
+        "intent": "coding",
+        "review_required": False,
+        "work_owner_mode": "external_executor",
+        "selected_executor_profile": "codex",
+        "dispatch_policy": "ask_before_dispatch",
+        "dispatchable": True,
+        "choice_required": False,
+        "executor_selection_status": "handoff_prepared",
+        "isolation_plan": {"strategy": "worktree_recommended"},
+        "safety_preflight": _ALLOW_VERDICT,
+    }
+    arguments.update(overrides)
+    return evaluate_action_gate(**arguments)  # type: ignore[arg-type]
+
+
+def _boundary(contract: dict[str, object], name: str) -> dict[str, object]:
+    for entry in contract["boundaries"]:  # type: ignore[index]
+        if entry["boundary"] == name:
+            return entry
+    raise AssertionError(f"no boundary named {name}")
+
+
+def _stage(contract: dict[str, object], name: str) -> dict[str, object]:
+    for entry in contract["evidence_requirements"]:  # type: ignore[index]
+        if entry["stage"] == name:
+            return entry
+    raise AssertionError(f"no evidence stage named {name}")
+
+
+def _receipt(kind: str, run_id: str, *, result: str = "succeeded") -> dict[str, object]:
+    action, acting_surface = {
+        "review": ("review_submitted", "runtime_review_record"),
+        "ci": ("ci_run", "runtime_ci_record"),
+        "merge": ("merge", "runtime_merge_record"),
+    }[kind]
+    return {
+        "receipt_id": f"receipt-{kind}",
+        "effect_id": external_effect_id(kind, run_id),
+        "action": action,
+        "acting_surface": acting_surface,
+        "observed_result": result,
+    }
+
+
+class HandoffSafetyContractShapeTests(unittest.TestCase):
+    def test_the_contract_is_a_field_group_on_the_delegation_not_a_record_family(self) -> None:
+        # Joined records go stale against a delegation rebuilt under a different
+        # revision (#811); the contract therefore ships as one key on the
+        # delegation, beside `action_gate` and never inside it.
+        self.assertIn("handoff_safety_contract", CODING_DELEGATION_RECORD_KEYS)
+        payload = build_coding_delegation_payload(_MESSAGE, executor_target="codex")
+        self.assertIn("handoff_safety_contract", payload)
+        self.assertNotIn(HANDOFF_SAFETY_CONTRACT_KEY, payload["action_gate"])
+
+    def test_contract_keys_and_schema_are_fixed(self) -> None:
+        contract = _contract()
+        self.assertEqual(set(contract), set(HANDOFF_SAFETY_CONTRACT_KEYS))
+        self.assertEqual(contract["schema_version"], HANDOFF_SAFETY_CONTRACT_SCHEMA_VERSION)
+        self.assertEqual(contract["status"], "prepared_not_observed")
+        self.assertEqual(validate_handoff_safety_contract(contract), [])
+
+    def test_the_contract_travels_with_the_envelope_values_it_describes(self) -> None:
+        envelope = _envelope()
+        contract = build_task_handoff_safety_contract(envelope)
+        self.assertEqual(contract["prohibited_actions"], envelope["blocked_actions"])
+        self.assertEqual(contract["allowed_executors"], envelope["allowed_executors"])
+        self.assertEqual(contract["allowed_targets"], envelope["allowed_targets"])
+        self.assertEqual(contract["merge_authority"], "disabled")
+        self.assertEqual(contract["external_action_authority"], "prepare_only")
+        self.assertEqual(contract["safety_profile_revision"], "rev-frozen")
+        self.assertEqual(validate_handoff_safety_contract(contract, envelope=envelope), [])
+
+    def test_the_gate_produces_exactly_one_contract_and_the_split_stores_it_once(self) -> None:
+        verdict = _gate()
+        gate, contract = split_handoff_safety_contract(verdict)
+        self.assertNotIn(HANDOFF_SAFETY_CONTRACT_KEY, gate)
+        self.assertEqual(validate_action_gate_verdict(gate), [])
+        self.assertEqual(validate_handoff_safety_contract(contract, envelope=gate["authority_envelope"]), [])
+
+    def test_a_denied_verdict_still_carries_a_contract(self) -> None:
+        verdict = _gate(
+            safety_preflight={**_ALLOW_VERDICT, "outcome": "deny", "rule_id": "target_paths_bounded"},
+        )
+        _, contract = split_handoff_safety_contract(verdict)
+        self.assertEqual(contract["merge_authority"], "disabled")
+        # A denial withdraws authority; it never withdraws the statement of what
+        # the boundary was, which is what the user is owed on a refusal.
+        self.assertEqual(sorted(SAFETY_BOUNDARY_NAMES), sorted(entry["boundary"] for entry in contract["boundaries"]))
+
+
+class HandoffSafetyContractOfflineTests(unittest.TestCase):
+    """AC1: producible offline from allowlisted local metadata."""
+
+    def test_input_sources_are_the_declared_local_metadata_surfaces(self) -> None:
+        self.assertEqual(_contract()["input_sources"], list(HANDOFF_CONTRACT_INPUT_SOURCES))
+        self.assertTrue(_contract()["produced_offline"])
+
+    def test_repeated_builds_are_byte_identical(self) -> None:
+        first = json.dumps(_contract(), sort_keys=True)
+        second = json.dumps(_contract(), sort_keys=True)
+        self.assertEqual(first, second)
+        gate_first = json.dumps(split_handoff_safety_contract(_gate())[1], sort_keys=True)
+        gate_second = json.dumps(split_handoff_safety_contract(_gate())[1], sort_keys=True)
+        self.assertEqual(gate_first, gate_second)
+        self.assertEqual(first, gate_first)
+
+    def test_the_contract_builds_with_every_io_primitive_disarmed(self) -> None:
+        """Offline by construction, not by convention.
+
+        The imports are warmed first because the lazy goal-loop import inside
+        the envelope builder would otherwise fail on the patched `open` and
+        prove nothing about the contract itself.
+        """
+        _gate()
+
+        def _refuse(*args: object, **kwargs: object) -> None:
+            raise AssertionError("the safety contract must not perform I/O")
+
+        with (
+            mock.patch.object(builtins, "open", _refuse),
+            mock.patch.object(socket, "socket", _refuse),
+            mock.patch.object(socket, "create_connection", _refuse),
+            mock.patch.object(subprocess, "run", _refuse),
+            mock.patch.object(subprocess, "Popen", _refuse),
+        ):
+            offline = build_task_handoff_safety_contract(_envelope())
+            _, from_gate = split_handoff_safety_contract(_gate())
+        self.assertEqual(validate_handoff_safety_contract(offline), [])
+        self.assertEqual(json.dumps(offline, sort_keys=True), json.dumps(from_gate, sort_keys=True))
+
+
+class AntiDecorationTests(unittest.TestCase):
+    """Every declared boundary states whether anything actually guards it."""
+
+    def test_every_boundary_declares_enforcement_and_names_an_enforcer_or_a_blocker(self) -> None:
+        for entry in _contract()["boundaries"]:  # type: ignore[index]
+            with self.subTest(boundary=entry["boundary"]):
+                self.assertEqual(set(entry), set(SAFETY_BOUNDARY_KEYS))
+                self.assertIn(entry["enforcement"], ENFORCEMENT_LEVELS)
+                self.assertTrue(entry["statement"].strip())
+                if entry["enforcement"] == "enforced":
+                    self.assertTrue(entry["enforced_by"])
+                    self.assertEqual(entry["blocked_by"], "")
+                else:
+                    self.assertEqual(entry["enforced_by"], [])
+                    self.assertTrue(entry["blocked_by"].strip())
+
+    def test_the_enforced_boundary_set_is_exactly_the_hardcoded_set(self) -> None:
+        contract = _contract()
+        enforced = {entry["boundary"] for entry in contract["boundaries"] if entry["enforcement"] == "enforced"}
+        # Fails when a boundary is declared without an enforcer, and equally
+        # when an enforcer is deleted but the declaration is left behind.
+        self.assertEqual(enforced, set(_ENFORCED_BOUNDARIES))
+        declared = {
+            entry["boundary"]: entry["blocked_by"]
+            for entry in contract["boundaries"]
+            if entry["enforcement"] == "declared_not_enforced"
+        }
+        self.assertEqual(declared, _DECLARED_NOT_ENFORCED)
+        self.assertEqual(set(SAFETY_BOUNDARY_NAMES), enforced | set(declared))
+
+    def test_every_cited_enforcer_resolves_to_a_real_symbol(self) -> None:
+        """The check that stops the contract drifting into fiction."""
+        contract = _contract()
+        cited = {
+            symbol
+            for group in ("boundaries", "evidence_requirements")
+            for entry in contract[group]
+            for symbol in entry["enforced_by"]
+        }
+        self.assertTrue(cited)
+        for symbol in sorted(cited):
+            with self.subTest(symbol=symbol):
+                module_name, _, attribute = symbol.rpartition(".")
+                self.assertTrue(module_name.startswith("omh."), symbol)
+                module = importlib.import_module(module_name)
+                self.assertTrue(hasattr(module, attribute), f"{symbol} does not exist")
+
+    def test_no_boundary_is_justified_by_the_absence_of_a_capability(self) -> None:
+        """An absence claim cannot be enforced, and this tree contradicts one.
+
+        `omh setup --star` really does shell out to `gh`, so a boundary saying
+        "no such capability exists anywhere in src/" would be exactly the
+        decoration this contract exists to prevent. Statements are scoped to the
+        surface they govern instead.
+        """
+        for entry in _contract()["boundaries"]:
+            with self.subTest(boundary=entry["boundary"]):
+                statement = entry["statement"].lower()
+                for absence_claim in ("no network client exists in src/", "opens no network connection"):
+                    self.assertNotIn(absence_claim, statement)
+
+    def test_the_network_boundary_scopes_itself_and_names_the_real_exception(self) -> None:
+        network = _boundary(_contract(), "network")
+        statement = network["statement"]
+        self.assertIn("The coding delegation lane holds no network client", statement)
+        self.assertIn("prepare_only", statement)
+        # The exception is named exactly, not rounded away. The path is read
+        # from the tree so the sentence cannot outlive the call it describes.
+        self.assertIn("omh setup --star", statement)
+        self.assertIn(_STAR_ENDPOINT, statement)
+        source = inspect.getsource(setup_command._try_star_github_repo)
+        self.assertIn(_STAR_ENDPOINT, source)
+        self.assertIn("gh", source)
+        # Enforcement is the lane check, never the call site that performs it.
+        self.assertEqual(network["enforced_by"], ["omh.coding.action_gate.validate_task_authority_envelope"])
+
+    def test_the_star_call_is_gated_behind_an_explicit_flag(self) -> None:
+        # The statement calls it operator-invoked; that has to be true.
+        self.assertIn('getattr(args, "star", False)', inspect.getsource(setup_command.cmd_setup))
+
+    def test_unenforced_boundaries_state_the_gap_in_words(self) -> None:
+        contract = _contract()
+        self.assertIn("nothing binds a running executor", _boundary(contract, "workspace")["statement"])
+        self.assertIn("never be read as an approval", _boundary(contract, "confirmation_answered")["statement"])
+        self.assertIn("persist until the operator deletes them", _boundary(contract, "storage_retention")["statement"])
+        self.assertIn("no external effect", _boundary(contract, "review_receipt")["statement"])
+        self.assertIn("no observed start", _boundary(contract, "start_evidence")["statement"])
+
+
+class HandoffSafetyContractValidatorTests(unittest.TestCase):
+    def test_a_boundary_claiming_enforcement_with_no_enforcer_is_rejected(self) -> None:
+        contract = _contract()
+        _boundary(contract, "workspace").update({"enforcement": "enforced", "blocked_by": ""})
+        errors = validate_handoff_safety_contract(contract)
+        self.assertTrue(any("names no enforcing symbol" in error for error in errors), errors)
+
+    def test_a_boundary_that_is_not_enforced_but_names_an_enforcer_is_rejected(self) -> None:
+        contract = _contract()
+        _boundary(contract, "workspace")["enforced_by"] = ["omh.coding.action_gate.evaluate_action_gate"]
+        errors = validate_handoff_safety_contract(contract)
+        self.assertTrue(any("must not name an enforcing symbol" in error for error in errors), errors)
+
+    def test_a_boundary_that_is_not_enforced_and_names_no_blocker_is_rejected(self) -> None:
+        contract = _contract()
+        _boundary(contract, "recovery")["blocked_by"] = ""
+        errors = validate_handoff_safety_contract(contract)
+        self.assertTrue(any("must name the blocker" in error for error in errors), errors)
+
+    def test_an_enforced_boundary_that_also_names_a_blocker_is_rejected(self) -> None:
+        contract = _contract()
+        _boundary(contract, "merge")["blocked_by"] = "#999"
+        errors = validate_handoff_safety_contract(contract)
+        self.assertTrue(any("must not name a blocker" in error for error in errors), errors)
+
+    def test_an_enforcer_that_is_not_a_dotted_symbol_reference_is_rejected(self) -> None:
+        contract = _contract()
+        _boundary(contract, "merge")["enforced_by"] = ["the merge gate"]
+        errors = validate_handoff_safety_contract(contract)
+        self.assertTrue(any("dotted omh symbol reference" in error for error in errors), errors)
+
+    def test_an_unknown_boundary_name_is_rejected(self) -> None:
+        contract = _contract()
+        _boundary(contract, "merge")["boundary"] = "merge_but_friendlier"
+        errors = validate_handoff_safety_contract(contract)
+        self.assertTrue(any("boundaries must be exactly" in error for error in errors), errors)
+
+    def test_a_dropped_boundary_is_rejected(self) -> None:
+        contract = _contract()
+        contract["boundaries"] = [entry for entry in contract["boundaries"] if entry["boundary"] != "workspace"]
+        errors = validate_handoff_safety_contract(contract)
+        self.assertTrue(any("boundaries must be exactly" in error for error in errors), errors)
+
+    def test_an_unsupported_enforcement_level_is_rejected(self) -> None:
+        contract = _contract()
+        _boundary(contract, "merge")["enforcement"] = "mostly"
+        self.assertTrue(any("enforcement is unsupported" in error for error in validate_handoff_safety_contract(contract)))
+
+    def test_an_extra_field_on_a_boundary_is_rejected(self) -> None:
+        # The entry shape is closed, so a boundary cannot smuggle in a second,
+        # unvalidated claim beside the one the validator reads.
+        contract = _contract()
+        _boundary(contract, "merge")["mechanism"] = "vibes"
+        self.assertTrue(any("keys are invalid" in error for error in validate_handoff_safety_contract(contract)))
+
+    def test_a_contract_that_disagrees_with_its_envelope_is_rejected(self) -> None:
+        envelope = _envelope()
+        contract = build_task_handoff_safety_contract(envelope)
+        contract["prohibited_actions"] = [action for action in contract["prohibited_actions"] if action != "merge"]
+        errors = validate_handoff_safety_contract(contract, envelope=envelope)
+        self.assertTrue(any("prohibited_actions must match" in error for error in errors), errors)
+
+    def test_a_contract_that_claims_it_was_not_produced_offline_is_rejected(self) -> None:
+        contract = _contract()
+        contract["produced_offline"] = False
+        errors = validate_handoff_safety_contract(contract)
+        self.assertTrue(any("produced_offline" in error for error in errors), errors)
+
+    def test_a_contract_that_drops_the_claim_boundary_is_rejected(self) -> None:
+        contract = _contract()
+        contract["claim_boundary"] = "everything is fine"
+        errors = validate_handoff_safety_contract(contract)
+        self.assertTrue(any("claim_boundary" in error for error in errors), errors)
+
+    def test_a_non_object_contract_is_rejected(self) -> None:
+        self.assertEqual(validate_handoff_safety_contract("contract"), ["handoff_safety_contract must be an object"])
+
+
+class HandoffSafetyContractRecordTests(unittest.TestCase):
+    """The contract survives compaction and cannot be silently dropped."""
+
+    def _delegation(self) -> dict[str, object]:
+        payload = build_coding_delegation_payload(_MESSAGE, executor_target="codex")
+        return {**payload, "message": _MESSAGE}
+
+    def test_the_contract_survives_the_delegation_compactor(self) -> None:
+        delegation = self._delegation()
+        record = build_coding_delegation_record(delegation)
+        self.assertEqual(record["handoff_safety_contract"], delegation["handoff_safety_contract"])
+        self.assertEqual(validate_coding_delegation_record(record), [])
+        # Deep-copied, so a later mutation of the payload cannot reach the record.
+        delegation["handoff_safety_contract"]["boundaries"] = []
+        self.assertEqual(len(record["handoff_safety_contract"]["boundaries"]), len(SAFETY_BOUNDARY_NAMES))
+
+    def test_the_record_survives_a_json_round_trip(self) -> None:
+        record = build_coding_delegation_record(self._delegation())
+        restored = json.loads(json.dumps(record))
+        self.assertEqual(validate_coding_delegation_record(restored), [])
+        self.assertEqual(restored["handoff_safety_contract"], record["handoff_safety_contract"])
+
+    def test_a_raw_gate_verdict_is_split_by_the_compactor(self) -> None:
+        # A caller that hands over the verdict as `evaluate_action_gate`
+        # returned it still stores exactly one copy, beside the gate.
+        delegation = self._delegation()
+        delegation["action_gate"] = {**delegation["action_gate"], HANDOFF_SAFETY_CONTRACT_KEY: delegation.pop("handoff_safety_contract")}
+        record = build_coding_delegation_record(delegation)
+        self.assertNotIn(HANDOFF_SAFETY_CONTRACT_KEY, record["action_gate"])
+        self.assertEqual(validate_coding_delegation_record(record), [])
+
+    def test_a_gate_without_its_contract_is_rejected(self) -> None:
+        record = build_coding_delegation_record(self._delegation())
+        del record["handoff_safety_contract"]
+        errors = validate_coding_delegation_record(record)
+        self.assertTrue(any("requires the handoff_safety_contract" in error for error in errors), errors)
+
+    def test_a_contract_without_its_gate_is_rejected(self) -> None:
+        record = build_coding_delegation_record(self._delegation())
+        del record["action_gate"]
+        errors = validate_coding_delegation_record(record)
+        self.assertTrue(any("requires the action_gate that produced it" in error for error in errors), errors)
+
+    def test_a_second_copy_inside_the_gate_is_rejected(self) -> None:
+        record = build_coding_delegation_record(self._delegation())
+        record["action_gate"][HANDOFF_SAFETY_CONTRACT_KEY] = record["handoff_safety_contract"]
+        errors = validate_coding_delegation_record(record)
+        self.assertTrue(any("must not carry handoff_safety_contract" in error for error in errors), errors)
+
+    def test_a_stored_contract_that_disagrees_with_the_stored_envelope_is_rejected(self) -> None:
+        record = build_coding_delegation_record(self._delegation())
+        record["handoff_safety_contract"]["merge_authority"] = "granted"
+        errors = validate_coding_delegation_record(record)
+        self.assertTrue(any("merge_authority must match" in error for error in errors), errors)
+
+
+class ProhibitedActionTests(unittest.TestCase):
+    """AC2: no hidden dispatch, no automatic merge, no arbitrary authority."""
+
+    def test_merge_and_external_posting_are_prohibited_on_every_coding_handoff(self) -> None:
+        for target in ("codex", "claude-code", "generic"):
+            with self.subTest(target=target):
+                payload = build_coding_delegation_payload(_MESSAGE, executor_target=target)
+                contract = payload["handoff_safety_contract"]
+                for never in ("merge", "external_posting", "pr_creation", "pr_revision"):
+                    self.assertIn(never, contract["prohibited_actions"])
+                self.assertEqual(contract["merge_authority"], "disabled")
+                self.assertEqual(contract["external_action_authority"], "prepare_only")
+
+    def test_prohibited_actions_are_the_exact_complement_of_the_allowed_set(self) -> None:
+        payload = build_coding_delegation_payload(_MESSAGE, executor_target="codex")
+        envelope = payload["action_gate"]["authority_envelope"]
+        contract = payload["handoff_safety_contract"]
+        self.assertEqual(contract["prohibited_actions"], envelope["blocked_actions"])
+        self.assertEqual(set(contract["prohibited_actions"]) & set(envelope["allowed_actions"]), set())
+
+    def test_a_non_dispatchable_owner_is_named_by_the_dispatch_boundary(self) -> None:
+        dispatch = _boundary(_contract(), "dispatch")
+        self.assertIn("omh.coding.fanout_dispatch.DISPATCH_COMMAND_TEMPLATES", dispatch["enforced_by"])
+        self.assertIn("never spawned", dispatch["statement"])
+
+    def test_the_storage_boundary_states_that_no_raw_prompt_is_persisted(self) -> None:
+        storage = _boundary(_contract(), "storage_content")
+        self.assertIn("sha256", storage["statement"])
+        record = build_coding_delegation_record(
+            {**build_coding_delegation_payload(_MESSAGE, executor_target="codex"), "message": _MESSAGE}
+        )
+        self.assertNotIn(_MESSAGE, json.dumps(record))
+        self.assertEqual(record["message_length"], len(_MESSAGE))
+
+
+class EvidenceRequirementTests(unittest.TestCase):
+    """AC3: no start or success claim without the matching evidence."""
+
+    def test_the_contract_covers_exactly_the_six_stages_818_names(self) -> None:
+        contract = _contract()
+        self.assertEqual(
+            [entry["stage"] for entry in contract["evidence_requirements"]],
+            ["start", "execution", "verification", "review", "ci", "merge"],
+        )
+        self.assertEqual(tuple(HANDOFF_EVIDENCE_STAGES), ("start", "execution", "verification", "review", "ci", "merge"))
+        for entry in contract["evidence_requirements"]:
+            with self.subTest(stage=entry["stage"]):
+                self.assertEqual(set(entry), set(EVIDENCE_REQUIREMENT_KEYS))
+                self.assertTrue(entry["observation_event"].strip())
+
+    def test_start_is_declared_unenforced_because_no_rung_reads_it(self) -> None:
+        # Decided rather than papered over: `runtime_start` is recordable but is
+        # neither a claim rung nor a journal prerequisite, so the contract
+        # refuses to imply a gate that does not exist.
+        start = _stage(_contract(), "start")
+        self.assertEqual(start["enforcement"], "declared_not_enforced")
+        self.assertEqual(start["blocked_by"], "#826")
+        self.assertEqual(start["claim"], "")
+        self.assertNotIn("start", {claim.value for claim in RUNTIME_CLAIM_LADDER})
+
+    def test_every_enforced_stage_names_the_claim_rung_it_gates(self) -> None:
+        rungs = {claim.value for claim in RUNTIME_CLAIM_LADDER}
+        for entry in _contract()["evidence_requirements"]:
+            if entry["enforcement"] != "enforced":
+                continue
+            with self.subTest(stage=entry["stage"]):
+                self.assertIn(entry["claim"], rungs)
+
+    def test_no_success_is_claimable_without_the_matching_observation(self) -> None:
+        run_id = "run-818"
+        status: dict[str, object] = {"external_effects": {"run_id": run_id}}
+        self.assertEqual(allowed_runtime_claims(status, validation_failed=False), [Claim.METADATA_AVAILABLE])
+
+        # Each step adds exactly one observation and unlocks exactly one rung.
+        steps: list[tuple[str, dict[str, object], Claim]] = [
+            ("prepared", {"available": True}, Claim.HANDOFF_PREPARED),
+            ("wrapper", {"prompt_dispatched": True}, Claim.EXECUTOR_DISPATCHED),
+            ("execution", {"observed": True}, Claim.EXECUTION_OBSERVED),
+            ("verification", {"observed": True}, Claim.VERIFICATION_OBSERVED),
+            ("review", {"observed": True, "status": "passed"}, Claim.REVIEW_OBSERVED),
+            ("ci", {"observed": True, "status": "passed", "receipt": _receipt("ci", run_id)}, Claim.CI_OBSERVED),
+            ("merge_readiness", {"observed": True, "status": "ready"}, Claim.MERGE_READY),
+            ("merge", {"observed": True, "status": "merged", "receipt": _receipt("merge", run_id)}, Claim.MERGED),
+        ]
+        for section, value, unlocked in steps:
+            with self.subTest(section=section):
+                blocked = {entry["claim"] for entry in blocked_runtime_claims(
+                    allowed_runtime_claims(status, validation_failed=False), validation_failed=False
+                )}
+                self.assertIn(unlocked.value, blocked)
+                status[section] = value
+                self.assertIn(unlocked, allowed_runtime_claims(status, validation_failed=False))
+
+    def test_a_local_record_alone_cannot_claim_ci_or_merge(self) -> None:
+        run_id = "run-818"
+        status: dict[str, object] = {
+            "external_effects": {"run_id": run_id},
+            "prepared": {"available": True},
+            "wrapper": {"prompt_dispatched": True},
+            "execution": {"observed": True},
+            "verification": {"observed": True},
+            "review": {"observed": True, "status": "passed"},
+            "ci": {"observed": True, "status": "passed"},
+        }
+        self.assertNotIn(Claim.CI_OBSERVED, allowed_runtime_claims(status, validation_failed=False))
+        for result in ("attempted", "failed", "unknown"):
+            with self.subTest(result=result):
+                status["ci"] = {"observed": True, "status": "passed", "receipt": _receipt("ci", run_id, result=result)}
+                self.assertNotIn(Claim.CI_OBSERVED, allowed_runtime_claims(status, validation_failed=False))
+        status["ci"] = {"observed": True, "status": "passed", "receipt": _receipt("ci", run_id)}
+        status["merge_readiness"] = {"observed": True, "status": "ready"}
+        status["merge"] = {"observed": True, "status": "merged"}
+        self.assertNotIn(Claim.MERGED, allowed_runtime_claims(status, validation_failed=False))
+
+    def test_review_is_claim_gated_but_not_receipt_gated_and_the_contract_says_so(self) -> None:
+        # The asymmetry against CI and merge is real and is declared rather than
+        # closed here: closing it would change the ladder for runs recorded
+        # before receipts existed, which is a separate decision.
+        run_id = "run-818"
+        status: dict[str, object] = {
+            "external_effects": {"run_id": run_id},
+            "prepared": {"available": True},
+            "wrapper": {"prompt_dispatched": True},
+            "execution": {"observed": True},
+            "verification": {"observed": True},
+            "review": {"observed": True, "status": "passed"},
+        }
+        self.assertIn(Claim.REVIEW_OBSERVED, allowed_runtime_claims(status, validation_failed=False))
+        review_receipt = _boundary(_contract(), "review_receipt")
+        self.assertEqual(review_receipt["enforcement"], "declared_not_enforced")
+        self.assertEqual(review_receipt["blocked_by"], "#844")
+
+    def test_a_failed_validation_collapses_every_claim_to_metadata(self) -> None:
+        status: dict[str, object] = {
+            "prepared": {"available": True},
+            "wrapper": {"prompt_dispatched": True},
+            "execution": {"observed": True},
+        }
+        self.assertEqual(allowed_runtime_claims(status, validation_failed=True), [Claim.METADATA_AVAILABLE])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_handoff_safety_contract_enforcement.py
+++ b/tests/test_handoff_safety_contract_enforcement.py
@@ -1,0 +1,963 @@
+"""Enforcement invariants for the handoff safety contract (issue #818).
+
+The handoff safety contract says omh prepares work and never performs it: no
+hidden dispatch, no network client, no remote mutation, no raw prompt on disk,
+no merge authority. Prose says that. `docs/ARCHITECTURE.md` says that. Nothing
+in the suite made it *false-able* -- a single import in a single module could
+have quietly retired any of those claims and every existing test would still
+have been green.
+
+This module turns each claim into a gate. Two of them are new coverage, three
+of them are regression prevention, and the difference is stated honestly per
+invariant rather than blurred into "safety tests":
+
+    INVARIANT 1  no hidden process spawn      GENUINE NEW COVERAGE
+    INVARIANT 2  no network client in src/    GENUINE NEW COVERAGE
+    INVARIANT 3  no remote mutation           REGRESSION PREVENTION
+    INVARIANT 4  no raw prompt under .omh     GENUINE NEW COVERAGE
+    INVARIANT 5  merge authority unreachable  REGRESSION PREVENTION
+
+"Regression prevention" means exactly what it says: no such capability exists
+in this repo today, so invariants 3 and 5 prove nothing new about the current
+tree. They exist so one cannot appear unnoticed. Invariants 1, 2, and 4 have no
+equivalent assertion anywhere in the suite: today the repo asserts a
+`raw_prompt_stored: False` *flag* on several individual record families, but no
+test has ever driven a real message through the delegation lane and then looked
+at what actually landed on disk.
+
+Method. The three static invariants read `src/` as an abstract syntax tree, not
+as text. A comment mentioning `subprocess`, a docstring quoting `git push`, or
+a detector regex naming `urllib.request` are all just string or comment tokens;
+they can neither satisfy nor break a gate that only ever inspects import
+statements, call sites, and argv literals. That property is what makes these
+invariants worth having -- a `grep`-shaped gate would be defeated by rewording
+a comment and would fire on documentation.
+
+Determinism. Nothing here reads the network, the operator's home directory, the
+wall clock, or any state outside the repository and a `TemporaryDirectory`. The
+static invariants are pure functions of the checked-in tree. The one behavioural
+invariant (4) drives the public CLI against a temporary OMH home.
+
+Allowlists are the escape hatch and they are deliberate. Each entry names the
+file and states why that file is permitted to hold the capability. Adding an
+entry is a decision someone has to write down; that is the point.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import itertools
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.coding.action_gate import (  # noqa: E402
+    MUTATING_ACTIONS,
+    build_task_authority_envelope,
+    permission_profile_for,
+    permission_profiles,
+    required_actions_for,
+)
+from omh.coding.coding_delegation import DELEGATION_ACTIONS  # noqa: E402
+from omh.coding.executors import WORK_OWNER_MODES  # noqa: E402
+from omh.plugin_bundle.omh.tools.evidence_tool import _DEFAULT_ALLOWLIST  # noqa: E402
+from omh.skills.catalog_types import CODING_INTENTS  # noqa: E402
+from omh.workflows.goal_loop import build_authority_envelope  # noqa: E402
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SOURCE_ROOT = REPO_ROOT / "src"
+THIS_TEST = "tests/test_handoff_safety_contract_enforcement.py"
+
+# Parsing 476 modules five times over is wasted work; parse once per process.
+_SOURCE_MODULES: list[tuple[str, ast.Module]] = []
+
+
+def _source_modules() -> list[tuple[str, ast.Module]]:
+    """Every module under `src/`, as (repo-relative posix path, parsed tree).
+
+    Paths are `as_posix()` so allowlist keys compare equal on Windows CI, where
+    `Path.relative_to` would otherwise yield backslash-separated strings.
+    """
+    if not _SOURCE_MODULES:
+        for path in sorted(SOURCE_ROOT.rglob("*.py")):
+            source = path.read_text(encoding="utf-8")
+            tree = ast.parse(source, filename=str(path))
+            _SOURCE_MODULES.append((path.relative_to(REPO_ROOT).as_posix(), tree))
+    return _SOURCE_MODULES
+
+
+def _imported_modules(tree: ast.Module) -> list[tuple[str, tuple[str, ...], int]]:
+    """(module, imported names, lineno) for every import at every scope.
+
+    `ast.walk` is used rather than iterating `tree.body` because a function-local
+    import is still an import: `src/commands/coding.py` imports `subprocess`
+    inside `cmd_coding_fanout_dispatch`, and a gate that only read module level
+    would have missed it.
+    """
+    found: list[tuple[str, tuple[str, ...], int]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                found.append((alias.name, (), node.lineno))
+        elif isinstance(node, ast.ImportFrom):
+            # A relative import (`from .foo import bar`) has level > 0 and is
+            # always in-repo, never a stdlib or third-party capability.
+            if node.level:
+                continue
+            module = node.module or ""
+            found.append((module, tuple(alias.name for alias in node.names), node.lineno))
+    return found
+
+
+# --------------------------------------------------------------------------
+# INVARIANT 1 -- no hidden process spawn
+# --------------------------------------------------------------------------
+
+# Verified against the tree, not copied from the issue: an AST sweep for
+# `subprocess` imports at any scope returns exactly these eleven modules. Each
+# is reachable only from an explicit operator command; none sits on the chat or
+# handoff-preparation path.
+PROCESS_SPAWN_ALLOWLIST: dict[str, str] = {
+    "src/coding/fanout_dispatch.py": (
+        "`omh coding fanout dispatch` -- the one opt-in bridge that spawns local agent CLIs, "
+        "documented as the scoped exception in CLAUDE.md."
+    ),
+    "src/coding/worktree_creator.py": (
+        "`git worktree add` for isolated executor workspaces; local, non-remote (see INVARIANT 3)."
+    ),
+    "src/coding/executor_readiness.py": (
+        "probes `<executor> --version` on PATH to report which agent CLIs are installed; "
+        "reads a version line, dispatches no work."
+    ),
+    "src/commands/coding.py": (
+        "`git rev-parse <base-ref>` inside the operator-invoked `coding fanout dispatch` command, "
+        "to resolve the base commit before the fanout bridge above runs."
+    ),
+    "src/commands/setup.py": (
+        "`omh setup` / `omh update` -- pip self-update, CLI re-entry after update, and the "
+        "opt-in GitHub star (see GH_INVOCATION_EXCEPTIONS in INVARIANT 3)."
+    ),
+    "src/quality/cross_harness_adapter_sandbox.py": (
+        "sandboxed child process for the cross-harness benchmark lane."
+    ),
+    "src/quality/cross_harness_adapters.py": (
+        "adapter process factory for the cross-harness benchmark lane."
+    ),
+    "src/install/release_smoke_core.py": (
+        "release smoke runner; executes the smoke commands an operator asked for."
+    ),
+    "src/plugin_bundle/omh/tools/evidence_tool.py": (
+        "allowlisted local verification-command runner; its allowlist is itself gated below."
+    ),
+    "src/surfaces/menubar_app.py": (
+        "`swiftc` compile plus `launchctl` load for the opt-in macOS menubar helper install."
+    ),
+    "src/surfaces/menubar_status.py": (
+        "`ps -axo` local process scan to render menubar status; reads, spawns no agent."
+    ),
+}
+
+# Alternative spawn routes. No allowlist: `subprocess` is the only sanctioned
+# door, so reaching for one of these is always the wrong move and there is no
+# entry to add. `os.fork` and friends would let a module spawn work while
+# importing nothing that INVARIANT 1 inspects.
+OS_SPAWN_FUNCTIONS = frozenset(
+    {
+        "system",
+        "popen",
+        "execl",
+        "execle",
+        "execlp",
+        "execlpe",
+        "execv",
+        "execve",
+        "execvp",
+        "execvpe",
+        "fork",
+        "forkpty",
+        "posix_spawn",
+        "posix_spawnp",
+        "spawnl",
+        "spawnle",
+        "spawnlp",
+        "spawnlpe",
+        "spawnv",
+        "spawnve",
+        "spawnvp",
+        "spawnvpe",
+        "startfile",
+    }
+)
+
+
+class NoHiddenProcessSpawn(unittest.TestCase):
+    """INVARIANT 1 (GENUINE NEW COVERAGE): only named bridges may spawn.
+
+    omh's safety story rests on the claim that preparing a handoff cannot start
+    work. That claim is only true while the set of modules able to start a
+    process stays small and deliberate. Nothing enforced the set before this.
+
+    Decided by AST: an `ast.Import`/`ast.ImportFrom` node naming `subprocess`,
+    at any scope. A comment or docstring mentioning `subprocess` is a token the
+    parser discards, so it can neither add nor clear a module here.
+    """
+
+    def test_only_allowlisted_modules_import_subprocess(self) -> None:
+        for relative_path, tree in _source_modules():
+            for module, _names, lineno in _imported_modules(tree):
+                if module != "subprocess" and not module.startswith("subprocess."):
+                    continue
+                self.assertIn(
+                    relative_path,
+                    PROCESS_SPAWN_ALLOWLIST,
+                    f"INVARIANT 1 (no hidden process spawn): {relative_path} line {lineno} imports "
+                    f"`{module}`, but it is not an allowlisted process bridge. Preparing a handoff "
+                    f"must never be able to start work. Either remove the import, or -- if this "
+                    f"module really is reached only from an explicit operator command -- add "
+                    f'"{relative_path}" to PROCESS_SPAWN_ALLOWLIST in {THIS_TEST} with a one-line '
+                    f"reason naming the command that reaches it.",
+                )
+
+    def test_every_allowlisted_module_still_needs_its_entry(self) -> None:
+        """A stale allowlist is a silently widened allowlist."""
+        importing = {
+            relative_path
+            for relative_path, tree in _source_modules()
+            for module, _names, _lineno in _imported_modules(tree)
+            if module == "subprocess" or module.startswith("subprocess.")
+        }
+        stale = sorted(set(PROCESS_SPAWN_ALLOWLIST) - importing)
+        self.assertEqual(
+            stale,
+            [],
+            f"INVARIANT 1 (no hidden process spawn): {stale} are listed in "
+            f"PROCESS_SPAWN_ALLOWLIST in {THIS_TEST} but no longer import `subprocess`. "
+            f"Delete those entries so the allowlist keeps describing the real spawn surface "
+            f"instead of pre-authorising a future one.",
+        )
+
+    def test_no_module_spawns_through_the_os_module(self) -> None:
+        for relative_path, tree in _source_modules():
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                if not isinstance(func, ast.Attribute) or func.attr not in OS_SPAWN_FUNCTIONS:
+                    continue
+                if not isinstance(func.value, ast.Name) or func.value.id != "os":
+                    continue
+                self.fail(
+                    f"INVARIANT 1 (no hidden process spawn): {relative_path} line {node.lineno} calls "
+                    f"`os.{func.attr}`, which starts a process without importing `subprocess` and so "
+                    f"walks around the allowlist entirely. There is no allowlist entry to add for this: "
+                    f"route the call through an allowlisted bridge module using `subprocess`, or remove it.",
+                )
+
+    def test_no_module_reaches_a_spawn_capability_by_dynamic_import(self) -> None:
+        """`__import__("subprocess")` would satisfy no static import check."""
+        for relative_path, tree in _source_modules():
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                is_builtin = isinstance(func, ast.Name) and func.id == "__import__"
+                is_importlib = isinstance(func, ast.Attribute) and func.attr == "import_module"
+                if not (is_builtin or is_importlib):
+                    continue
+                self.fail(
+                    f"INVARIANT 1 (no hidden process spawn): {relative_path} line {node.lineno} imports "
+                    f"a module dynamically. A dynamic import is invisible to every static gate in "
+                    f"{THIS_TEST}, so it can reach `subprocess`, a network client, or anything else "
+                    f"without tripping any of them. Use a normal `import` statement, which the "
+                    f"allowlists can see.",
+                )
+
+
+# --------------------------------------------------------------------------
+# INVARIANT 2 -- no network client in src/
+# --------------------------------------------------------------------------
+
+# Top-level module names that give a caller a live connection. `urllib` is
+# absent on purpose and handled separately below, because its two submodules
+# differ: `urllib.parse` is pure string work, `urllib.request` is the client.
+NETWORK_CLIENT_MODULES = frozenset(
+    {
+        # stdlib
+        "asyncio",  # its stream and subprocess APIs are exactly the two capabilities #818 blocks
+        "ftplib",
+        "http",  # http.client, http.server, http.cookiejar
+        "imaplib",
+        "nntplib",
+        "poplib",
+        "smtplib",
+        "socket",
+        "socketserver",
+        "ssl",  # only reachable meaningfully by wrapping a socket
+        "telnetlib",
+        "webbrowser",
+        "xmlrpc",
+        # third party -- also barred by the repo's zero-runtime-dependency rule,
+        # listed here so the reason a reviewer sees is the safety one
+        "aiohttp",
+        "boto3",
+        "botocore",
+        "grpc",
+        "httpx",
+        "paramiko",
+        "pycurl",
+        "requests",
+        "tornado",
+        "twisted",
+        "urllib3",
+        "websocket",
+        "websockets",
+    }
+)
+
+# `urllib.request` is a network client module that happens to also contain one
+# pure path-parsing function. `url2pathname` maps a `file://` URL onto a local
+# filesystem path -- it is string manipulation and opens nothing. Importing the
+# *name* is therefore fine; importing the *module* (`import urllib.request`)
+# hands the file `urlopen` and is not.
+PARSING_ONLY_URLLIB_REQUEST_NAMES = frozenset({"url2pathname", "pathname2url"})
+PARSING_ONLY_URLLIB_REQUEST_FILES: dict[str, str] = {
+    "src/workflows/visual_summary.py": "resolves screenshot `file://` references to local paths",
+    "src/workflows/web_visual_qa_contracts.py": "resolves visual-QA `file://` references to local paths",
+}
+
+
+class NoNetworkClientInSource(unittest.TestCase):
+    """INVARIANT 2 (GENUINE NEW COVERAGE): core omh cannot open a connection.
+
+    "Core `omh` code makes no LLM, API, or network calls" is the first sentence
+    of the repo's own description, and until now the only thing standing behind
+    it was that nobody had added a client. The zero-dependency rule blocks
+    `requests`; it does nothing about `socket` or `urllib.request`, both of
+    which are stdlib and both of which would install a working client.
+
+    Decided by AST import nodes, which is what separates a client from a
+    detector. `src/workflows/plugin_risk_audit.py` contains the regex
+    `\\b(?:axios|httpx|requests|urllib...)` -- that is one `ast.Constant`
+    holding a pattern used to *audit third-party plugins for* network calls. It
+    is the opposite of a violation, and a text search would have flagged it.
+    """
+
+    def test_no_module_imports_a_network_client(self) -> None:
+        for relative_path, tree in _source_modules():
+            for module, _names, lineno in _imported_modules(tree):
+                if not module:
+                    continue
+                top = module.split(".")[0]
+                if top not in NETWORK_CLIENT_MODULES:
+                    continue
+                self.fail(
+                    f"INVARIANT 2 (no network client in src/): {relative_path} line {lineno} imports "
+                    f"`{module}`. Core omh makes no network calls -- that is the product boundary, not "
+                    f"a style preference, and it is what lets omh claim it never acts on the user's "
+                    f"behalf. Remove the import. If a genuinely offline use of this module exists "
+                    f"(as `url2pathname` is for `urllib.request`), add it to "
+                    f"NETWORK_CLIENT_MODULES' documented exceptions in {THIS_TEST} and say why it "
+                    f"cannot open a connection.",
+                )
+
+    def test_urllib_request_is_imported_only_for_path_parsing(self) -> None:
+        for relative_path, tree in _source_modules():
+            for module, names, lineno in _imported_modules(tree):
+                if module != "urllib.request" and not module.startswith("urllib.request."):
+                    continue
+                self.assertTrue(
+                    names,
+                    f"INVARIANT 2 (no network client in src/): {relative_path} line {lineno} does "
+                    f"`import {module}`, which binds the whole client module and with it `urlopen`. "
+                    f"Import only the path-parsing name you need "
+                    f"(`from urllib.request import url2pathname`), or drop the import.",
+                )
+                self.assertIn(
+                    relative_path,
+                    PARSING_ONLY_URLLIB_REQUEST_FILES,
+                    f"INVARIANT 2 (no network client in src/): {relative_path} line {lineno} imports "
+                    f"from `urllib.request`, which is a network client module. Only files listed in "
+                    f"PARSING_ONLY_URLLIB_REQUEST_FILES in {THIS_TEST} may do so, and only for the "
+                    f"pure path-parsing names. Add the file with a reason, or remove the import.",
+                )
+                forbidden = sorted(set(names) - PARSING_ONLY_URLLIB_REQUEST_NAMES)
+                self.assertEqual(
+                    forbidden,
+                    [],
+                    f"INVARIANT 2 (no network client in src/): {relative_path} line {lineno} imports "
+                    f"{forbidden} from `urllib.request`. Only "
+                    f"{sorted(PARSING_ONLY_URLLIB_REQUEST_NAMES)} are path parsing; everything else in "
+                    f"that module opens a connection. Remove the name.",
+                )
+
+    def test_the_parsing_only_exception_list_is_not_stale(self) -> None:
+        importing = {
+            relative_path
+            for relative_path, tree in _source_modules()
+            for module, _names, _lineno in _imported_modules(tree)
+            if module == "urllib.request" or module.startswith("urllib.request.")
+        }
+        stale = sorted(set(PARSING_ONLY_URLLIB_REQUEST_FILES) - importing)
+        self.assertEqual(
+            stale,
+            [],
+            f"INVARIANT 2 (no network client in src/): {stale} no longer import from `urllib.request`. "
+            f"Delete the entries from PARSING_ONLY_URLLIB_REQUEST_FILES in {THIS_TEST} rather than "
+            f"leaving standing permission behind.",
+        )
+
+
+# --------------------------------------------------------------------------
+# INVARIANT 3 -- no remote mutation
+# --------------------------------------------------------------------------
+
+# Verbs that publish to, or rewrite history against, a remote. `fetch`/`pull`
+# are here because omh must not move the operator's working state either: a
+# prepared handoff that quietly updated the tree it describes is no longer a
+# prepared handoff.
+FORBIDDEN_GIT_VERBS = frozenset({"push", "merge", "rebase", "remote", "fetch", "pull"})
+
+# Programs whose whole job is talking to a forge.
+FORGE_PROGRAMS = frozenset({"gh", "hub", "glab", "tea"})
+
+# The complete set of git argv literals in `src/`, keyed by file and by the run
+# of literal words that follow `git`. Both are read-only local operations.
+GIT_ARGV_ALLOWLIST: dict[tuple[str, tuple[str, ...]], str] = {
+    ("src/coding/worktree_creator.py", ("worktree", "add")): (
+        "creates a local isolated workspace for an executor; touches no remote"
+    ),
+    ("src/commands/coding.py", ("rev-parse",)): (
+        "resolves --base-ref to a commit sha inside `coding fanout dispatch`; read-only"
+    ),
+}
+
+# The one executed forge invocation in `src/`. It is not repository authority:
+# it stars the project on the operator's own account, from an interactive
+# prompt in `omh setup`, and it can neither push code nor merge anything. It is
+# pinned by exact argv so that widening it to any other `gh` call fails here.
+GH_INVOCATION_EXCEPTIONS: dict[tuple[str, tuple[str, ...]], str] = {
+    (
+        "src/commands/setup.py",
+        ("gh", "api", "-X", "PUT", "/user/starred/rlaope/oh-my-hermes"),
+    ): (
+        "opt-in 'star the repo?' prompt during interactive `omh setup`; mutates the operator's "
+        "own stars, never repository contents, and never runs unattended"
+    ),
+}
+
+
+def _argv_literals() -> list[tuple[str, int, list[str | None]]]:
+    """Every list/tuple literal in `src/` that starts with a literal program name.
+
+    Elements are returned as their string value, or `None` where the element is
+    a dynamic expression. Only literals whose *first* element is a constant
+    string are returned, because that is the shape of a hand-built argv.
+    """
+    found: list[tuple[str, int, list[str | None]]] = []
+    for relative_path, tree in _source_modules():
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.List, ast.Tuple)) or not node.elts:
+                continue
+            first = node.elts[0]
+            if not isinstance(first, ast.Constant) or not isinstance(first.value, str):
+                continue
+            elements: list[str | None] = [
+                element.value if isinstance(element, ast.Constant) and isinstance(element.value, str) else None
+                for element in node.elts
+            ]
+            found.append((relative_path, node.lineno, elements))
+    return found
+
+
+def _leading_words(elements: list[str | None]) -> tuple[str, ...]:
+    """The run of literal non-flag words after the program name."""
+    words: list[str] = []
+    for element in elements[1:]:
+        if element is None:
+            break
+        if element.startswith("-"):
+            continue
+        words.append(element)
+    return tuple(words)
+
+
+class NoRemoteMutation(unittest.TestCase):
+    """INVARIANT 3 (REGRESSION PREVENTION): omh cannot push, merge, or post.
+
+    Nothing in `src/` performs a remote mutation today, so this proves nothing
+    new about the current tree. It exists so that one cannot arrive unnoticed --
+    a single `["git", "push", ...]` added to an already-allowlisted spawn module
+    would otherwise pass every gate in this repo.
+
+    The hard part is telling an *executed* argv apart from documentation and
+    from a parser, and this is done structurally rather than by searching text.
+    The scan visits exactly one AST shape: a list or tuple literal whose first
+    element is a constant program name. That distinction does real work:
+
+    * `src/maintenance/release.py` holds
+      `f'git tag -a {tag} ... && git push origin {tag}'` -- a single
+      `ast.JoinedStr` printed for a human to run. It is not a list, its parts
+      are not argv elements, and the scan never reaches it. A text search would
+      have reported a `git push` in `src/`.
+    * `src/coding/work_reporting.py` evaluates `"gh pr checks" in command_lower`
+      against an executor's transcript. The literal is an operand of a
+      `Compare` used to *recognise* someone else's command in text omh was
+      handed. Not a list, not visited. A text search would have reported a `gh`
+      invocation in `src/`.
+    * `src/coding/worktree_creator.py` builds `["git", "worktree", "add", ...]`
+      and passes it to `subprocess.run`. That is an argv, it is visited, and
+      its verb is checked.
+
+    A git argv whose verb cannot be resolved to a literal fails closed. Today
+    every one of them is literal, so proving safety costs nothing; the day
+    someone writes `["git", verb, ...]` the reviewer is asked about it.
+    """
+
+    def test_no_git_argv_carries_a_remote_mutating_verb(self) -> None:
+        for relative_path, lineno, elements in _argv_literals():
+            program = elements[0]
+            if program != "git" and not str(program).endswith("/git"):
+                continue
+            words = _leading_words(elements)
+            self.assertTrue(
+                words,
+                f"INVARIANT 3 (no remote mutation): {relative_path} line {lineno} builds a `git` argv "
+                f"whose subcommand is a runtime value, so this gate cannot prove it is not `push`, "
+                f"`merge`, or `rebase`. Spell the subcommand as a literal "
+                f'(`["git", "rev-parse", ref]`, not `["git", verb, ref]`) so the invariant stays '
+                f"checkable.",
+            )
+            offending = sorted(set(words) & FORBIDDEN_GIT_VERBS)
+            self.assertEqual(
+                offending,
+                [],
+                f"INVARIANT 3 (no remote mutation): {relative_path} line {lineno} builds "
+                f"`git {' '.join(words)}`, which uses the forbidden verb(s) {offending}. omh prepares "
+                f"work and never performs it -- it must not publish to, or move, a remote. Remove the "
+                f"command; there is no allowlist entry for a mutating git verb.",
+            )
+            self.assertIn(
+                (relative_path, words),
+                GIT_ARGV_ALLOWLIST,
+                f"INVARIANT 3 (no remote mutation): {relative_path} line {lineno} builds a new git "
+                f"argv `git {' '.join(words)}`. Every git command omh runs is enumerated. Add "
+                f'("{relative_path}", {words!r}) to GIT_ARGV_ALLOWLIST in {THIS_TEST} with a reason '
+                f"stating that it is local and read-only, or remove the command.",
+            )
+
+    def test_no_module_invokes_a_forge_cli_outside_the_named_exception(self) -> None:
+        for relative_path, lineno, elements in _argv_literals():
+            program = elements[0]
+            if program not in FORGE_PROGRAMS:
+                continue
+            argv = tuple(element for element in elements if element is not None)
+            self.assertIn(
+                (relative_path, argv),
+                GH_INVOCATION_EXCEPTIONS,
+                f"INVARIANT 3 (no remote mutation): {relative_path} line {lineno} invokes the `{program}` "
+                f"forge CLI as {list(argv)}. omh must not open, review, or merge anything on a forge on "
+                f"the user's behalf -- it prepares the handoff and the operator acts. Remove the call. "
+                f"If it genuinely cannot touch repository state, add the exact argv to "
+                f"GH_INVOCATION_EXCEPTIONS in {THIS_TEST} and say what it can and cannot do.",
+            )
+
+    def test_the_git_and_forge_allowlists_are_not_stale(self) -> None:
+        live_git = {
+            (relative_path, _leading_words(elements))
+            for relative_path, _lineno, elements in _argv_literals()
+            if elements[0] == "git"
+        }
+        live_forge = {
+            (relative_path, tuple(element for element in elements if element is not None))
+            for relative_path, _lineno, elements in _argv_literals()
+            if elements[0] in FORGE_PROGRAMS
+        }
+        stale = sorted(
+            (set(GIT_ARGV_ALLOWLIST) - live_git) | (set(GH_INVOCATION_EXCEPTIONS) - live_forge)
+        )
+        self.assertEqual(
+            stale,
+            [],
+            f"INVARIANT 3 (no remote mutation): {stale} are permitted in {THIS_TEST} but no longer "
+            f"exist in `src/`. Delete the entries; an allowlist that outlives its call site is "
+            f"standing permission for whoever adds the next one.",
+        )
+
+    def test_the_evidence_tool_allowlist_admits_no_remote_command(self) -> None:
+        """The one place a command *string* really is an execution surface.
+
+        `evidence_tool` runs operator-requested verification commands, matched
+        against `_DEFAULT_ALLOWLIST` by token prefix. These strings are not
+        prose: adding `"git push"` there would make it runnable. The check is on
+        the imported value, not on the file text.
+        """
+        for entry in _DEFAULT_ALLOWLIST:
+            tokens = entry.split()
+            self.assertTrue(tokens, "evidence tool allowlist entries must not be empty")
+            program = tokens[0]
+            self.assertNotIn(
+                program,
+                FORGE_PROGRAMS,
+                f"INVARIANT 3 (no remote mutation): the evidence tool allowlist admits {entry!r}, which "
+                f"runs the `{program}` forge CLI. `_DEFAULT_ALLOWLIST` in "
+                f"src/plugin_bundle/omh/tools/evidence_tool.py is an execution surface, not "
+                f"documentation. Remove the entry.",
+            )
+            if program != "git":
+                continue
+            offending = sorted(set(tokens[1:]) & FORBIDDEN_GIT_VERBS)
+            self.assertEqual(
+                offending,
+                [],
+                f"INVARIANT 3 (no remote mutation): the evidence tool allowlist admits {entry!r}, which "
+                f"would let a verification request run the mutating git verb(s) {offending}. Evidence "
+                f"gathering is read-only. Remove the entry from `_DEFAULT_ALLOWLIST` in "
+                f"src/plugin_bundle/omh/tools/evidence_tool.py.",
+            )
+
+
+# --------------------------------------------------------------------------
+# INVARIANT 4 -- no raw prompt persisted under .omh
+# --------------------------------------------------------------------------
+
+# Deliberately not a word, a path, or anything a template, a fixture, or a
+# routing table could produce. If this string is on disk, it came from the
+# message and nowhere else.
+RAW_MESSAGE_SENTINEL = "Zq7XvbwkPfmdGhntrlys9314"
+
+# Concrete enough to clear the record-readiness gate (a named file plus real
+# requirements), so a record is actually written and the test proves absence
+# rather than proving nothing happened.
+SENTINEL_MESSAGE = (
+    f"refactor src/omh/parser.py to split the tokenizer function into two helpers {RAW_MESSAGE_SENTINEL}"
+)
+
+# `--include-message-full` selects message_context_mode "full",
+# `--include-message` selects "bounded". Both are driven; "full" is the mode
+# that interpolates the verbatim message into the returned prompt, and so is
+# the mode where a careless write would leak it.
+MESSAGE_CONTEXT_FLAGS = (("full", "--include-message-full"), ("bounded", "--include-message"))
+
+
+class NoRawPromptPersistedUnderOmhHome(unittest.TestCase):
+    """INVARIANT 4 (GENUINE NEW COVERAGE): the message never lands on disk.
+
+    The repo asserts `raw_prompt_stored: False` on individual record families --
+    the goal ledger, the fanout contract, the workflow trace, the context brief.
+    Every one of those is a *flag inside one record*. No test has ever driven a
+    real message through the delegation lane and then looked at what the run
+    actually left behind, so a new artifact family could have started writing
+    the prompt and every existing assertion would still have passed.
+
+    This drives the public CLI end to end against a temporary OMH home, then
+    walks every file under it. Two things are asserted together, because either
+    alone is worthless:
+
+    * the sentinel appears in no file -- the raw message was not persisted;
+    * the message SHA-256 does appear -- a record really was written, so the
+      absence above is evidence and not an empty directory.
+
+    The in-memory / on-disk distinction is the point, and it is asserted rather
+    than assumed. With `message_context_mode == "full"` the delegation payload
+    legitimately contains the verbatim message: it is interpolated into the
+    executor prompt template that is *returned to the caller* so a human can
+    paste it. That is not a violation. The contract is "not persisted under
+    .omh", so the test requires the sentinel to be present in the returned
+    prompt and absent from every file.
+    """
+
+    def _drive(self, tmp: str, flag: str) -> tuple[dict, Path]:
+        root = Path(tmp)
+        omh_home = root / ".omh"
+        status, stdout, stderr = run_cli(
+            [
+                "--omh-home",
+                str(omh_home),
+                "--hermes-home",
+                str(root / ".hermes"),
+                "coding",
+                "delegate",
+                "--record",
+                "--force-record",
+                "--executor",
+                "codex",
+                flag,
+                SENTINEL_MESSAGE,
+            ]
+        )
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        return json.loads(stdout), omh_home
+
+    def test_no_file_under_the_omh_home_contains_the_raw_message(self) -> None:
+        message_sha = hashlib.sha256(SENTINEL_MESSAGE.encode("utf-8")).hexdigest()
+        variants = (RAW_MESSAGE_SENTINEL, RAW_MESSAGE_SENTINEL.lower(), RAW_MESSAGE_SENTINEL.upper())
+
+        for mode, flag in MESSAGE_CONTEXT_FLAGS:
+            with self.subTest(message_context_mode=mode), TemporaryDirectory() as tmp:
+                payload, omh_home = self._drive(tmp, flag)
+
+                self.assertEqual(
+                    payload["message_context"]["raw_content_included"],
+                    mode == "full",
+                    f"INVARIANT 4: the run did not actually exercise message_context_mode {mode!r}, "
+                    f"so its result proves nothing. Check that {flag} still selects that mode.",
+                )
+                self.assertIn(
+                    "run",
+                    payload.get("runtime", {}),
+                    f"INVARIANT 4 (no raw prompt persisted under .omh): the delegation was not "
+                    f"recorded (runtime says {payload.get('runtime')}), so walking the OMH home "
+                    f"would prove nothing. Adjust SENTINEL_MESSAGE in {THIS_TEST} so it still "
+                    f"clears the record-readiness gate.",
+                )
+
+                written = sorted(path for path in omh_home.rglob("*") if path.is_file())
+                self.assertTrue(
+                    written,
+                    "INVARIANT 4 (no raw prompt persisted under .omh): nothing was written under the "
+                    "OMH home, so 'the message is not on disk' is vacuously true. The test must "
+                    "observe a real record before it can assert an absence.",
+                )
+
+                leaked: list[str] = []
+                carrying_sha: list[str] = []
+                for path in written:
+                    blob = path.read_bytes()
+                    if any(variant.encode("utf-8") in blob for variant in variants):
+                        leaked.append(path.relative_to(omh_home).as_posix())
+                    if message_sha.encode("ascii") in blob:
+                        carrying_sha.append(path.relative_to(omh_home).as_posix())
+
+                self.assertEqual(
+                    leaked,
+                    [],
+                    f"INVARIANT 4 (no raw prompt persisted under .omh): with message_context_mode "
+                    f"{mode!r} the raw user message was written verbatim into {leaked}. omh records "
+                    f"the SHA-256 and the length of a message, never its text -- that is what lets a "
+                    f"user paste a private prompt into a chat surface. Replace the raw text in those "
+                    f"artifacts with `message_sha256` plus `message_length`, and keep the verbatim "
+                    f"text in the returned in-memory payload only.",
+                )
+                self.assertTrue(
+                    carrying_sha,
+                    f"INVARIANT 4 (no raw prompt persisted under .omh): no file under the OMH home "
+                    f"carries the message SHA-256, so the clean result above may just mean nothing "
+                    f"was recorded. Files seen: "
+                    f"{[path.relative_to(omh_home).as_posix() for path in written]}.",
+                )
+
+    def test_full_mode_still_returns_the_verbatim_prompt_in_memory(self) -> None:
+        """The rule is 'not persisted', not 'never rendered' -- pin the difference.
+
+        Without this, INVARIANT 4 could be satisfied tomorrow by dropping the
+        verbatim message from the prompt template altogether, which would keep
+        the gate green while breaking the feature it is guarding.
+        """
+        with TemporaryDirectory() as tmp:
+            payload, omh_home = self._drive(tmp, "--include-message-full")
+            self.assertIn(
+                RAW_MESSAGE_SENTINEL,
+                str(payload.get("executor_handoff_prompt", "")),
+                "INVARIANT 4: message_context_mode 'full' must still interpolate the verbatim "
+                "message into the prompt returned in memory. If it no longer does, the absence "
+                "check above stopped testing anything.",
+            )
+            self.assertNotIn(
+                RAW_MESSAGE_SENTINEL,
+                "".join(
+                    path.read_text(encoding="utf-8", errors="replace")
+                    for path in sorted(omh_home.rglob("*"))
+                    if path.is_file()
+                ),
+                "INVARIANT 4 (no raw prompt persisted under .omh): the prompt that carries the "
+                "verbatim message was also written to disk. It may be returned; it may not be "
+                "stored.",
+            )
+
+
+# --------------------------------------------------------------------------
+# INVARIANT 5 -- merge authority is unreachable
+# --------------------------------------------------------------------------
+
+# `permission_profile_for` takes only these five inputs, and every one is
+# finite, so the sweep below is exhaustive rather than a sample. The empty
+# strings probe the unknown-value paths.
+_DENIED_VALUES = (True, False)
+_DELEGATION_ACTIONS = (*DELEGATION_ACTIONS, "")
+_WORK_OWNER_MODES = (*WORK_OWNER_MODES, "")
+_INTENTS = (*CODING_INTENTS, "")
+_BOOLEANS = (True, False)
+
+
+class MergeAuthorityIsUnreachable(unittest.TestCase):
+    """INVARIANT 5 (REGRESSION PREVENTION): no input yields merge authority.
+
+    `PERMISSION_PROFILES` includes `full_loop`, and `full_loop` does grant
+    `merge`. So the profile vocabulary can express merge authority; what this
+    proves is that omh's delegation lane cannot *select* it. Two independent
+    barriers have to fail before a handoff could carry merge:
+
+    1. `permission_profile_for` never returns a merge-granting profile. Its
+       range over every input combination is {observe_only, handoff_only,
+       execute_with_gates}; `full_loop` is unreachable from it.
+    2. `required_actions_for` never asks for `merge`, and the envelope builder
+       forbids everything outside the required set -- so merge would still be
+       stripped even if barrier 1 fell.
+
+    Existing tests spot-check `merge_authority == "disabled"` on a handful of
+    constructed cases. This proves it from the code, over the full cartesian
+    product of the inputs, so a new branch in the selection helper cannot open
+    the door for one combination nobody thought to write a case for.
+    """
+
+    def test_no_selectable_permission_profile_grants_merge(self) -> None:
+        selectable = {
+            permission_profile_for(
+                denied=denied,
+                delegation_action=action,
+                work_owner_mode=owner,
+                dispatchable=dispatchable,
+                choice_required=choice_required,
+            )
+            for denied, action, owner, dispatchable, choice_required in itertools.product(
+                _DENIED_VALUES, _DELEGATION_ACTIONS, _WORK_OWNER_MODES, _BOOLEANS, _BOOLEANS
+            )
+        }
+        self.assertTrue(selectable)
+        for profile in sorted(selectable):
+            envelope = build_authority_envelope(permission_profile=profile)
+            self.assertEqual(
+                envelope["merge_authority"],
+                "disabled",
+                f"INVARIANT 5 (merge authority is unreachable): `permission_profile_for` can select "
+                f"the {profile!r} profile, and that profile grants merge authority. omh prepares a "
+                f"handoff; the operator merges. Either stop selecting {profile!r} from the delegation "
+                f"lane, or remove `merge` from its allowed actions in "
+                f"src/workflows/goal_loop.py.",
+            )
+            self.assertNotIn(
+                "merge",
+                envelope["allowed_actions"],
+                f"INVARIANT 5 (merge authority is unreachable): the selectable profile {profile!r} "
+                f"lists `merge` in allowed_actions. Remove it, or stop selecting the profile.",
+            )
+
+    def test_every_derived_authority_envelope_disables_merge(self) -> None:
+        checked = 0
+        for denied, action, intent, review, owner, executor, dispatchable, choice in itertools.product(
+            _DENIED_VALUES,
+            _DELEGATION_ACTIONS,
+            _INTENTS,
+            _BOOLEANS,
+            _WORK_OWNER_MODES,
+            (None, "codex", "claude-code"),
+            _BOOLEANS,
+            _BOOLEANS,
+        ):
+            envelope = build_task_authority_envelope(
+                denied=denied,
+                delegation_action=action,
+                intent=intent,
+                review_required=review,
+                work_owner_mode=owner,
+                selected_executor_profile=executor,
+                dispatchable=dispatchable,
+                choice_required=choice,
+            )
+            checked += 1
+            context = (
+                f"denied={denied} action={action!r} intent={intent!r} review_required={review} "
+                f"work_owner_mode={owner!r} executor={executor!r} dispatchable={dispatchable} "
+                f"choice_required={choice}"
+            )
+            remedy = (
+                "A prepared handoff must never carry merge authority. Find the branch that admitted "
+                "it in src/coding/action_gate.py -- `permission_profile_for` or "
+                "`required_actions_for` -- and close it. Do not relax this test."
+            )
+            self.assertEqual(
+                envelope["merge_authority"],
+                "disabled",
+                f"INVARIANT 5 (merge authority is unreachable): merge_authority became "
+                f"{envelope['merge_authority']!r} for {context}. {remedy}",
+            )
+            self.assertNotIn(
+                "merge",
+                envelope["allowed_actions"],
+                f"INVARIANT 5 (merge authority is unreachable): `merge` entered allowed_actions for "
+                f"{context}. {remedy}",
+            )
+            self.assertNotIn(
+                "merge",
+                envelope["mutation_rights"],
+                f"INVARIANT 5 (merge authority is unreachable): `merge` entered mutation_rights for "
+                f"{context}. {remedy}",
+            )
+        # Guards the sweep itself: a vocabulary shrinking to nothing would make
+        # every assertion above vacuous and the test would still pass.
+        self.assertGreater(checked, 1000, "the input sweep collapsed; INVARIANT 5 is no longer proving anything")
+
+    def test_the_required_action_set_never_asks_for_merge(self) -> None:
+        """Barrier 2, checked on its own so barrier 1 cannot mask its failure."""
+        for denied, action, intent, review, dispatchable, choice in itertools.product(
+            _DENIED_VALUES, _DELEGATION_ACTIONS, _INTENTS, _BOOLEANS, _BOOLEANS, _BOOLEANS
+        ):
+            required = required_actions_for(
+                denied=denied,
+                delegation_action=action,
+                intent=intent,
+                review_required=review,
+                dispatchable=dispatchable,
+                choice_required=choice,
+            )
+            self.assertNotIn(
+                "merge",
+                required,
+                f"INVARIANT 5 (merge authority is unreachable): `required_actions_for` asked for "
+                f"`merge` (denied={denied} action={action!r} intent={intent!r} "
+                f"review_required={review} dispatchable={dispatchable} choice_required={choice}). "
+                f"No task omh prepares requires merge authority. Remove the branch in "
+                f"src/coding/action_gate.py.",
+            )
+
+    def test_merge_is_a_mutating_action_so_the_checks_above_have_teeth(self) -> None:
+        """If `merge` left MUTATING_ACTIONS, the mutation_rights assertion would go quiet."""
+        self.assertIn(
+            "merge",
+            MUTATING_ACTIONS,
+            "INVARIANT 5 (merge authority is unreachable): `merge` was removed from MUTATING_ACTIONS "
+            "in src/coding/action_gate.py, which silently disarms the mutation_rights half of this "
+            "invariant. Put it back.",
+        )
+
+    def test_the_profile_vocabulary_still_contains_a_merge_granting_profile(self) -> None:
+        """Names the risk this invariant guards, so it cannot become tautological.
+
+        If no profile anywhere granted merge, the sweeps above would pass for a
+        reason that has nothing to do with the delegation lane's own choices.
+        """
+        granting = [
+            profile
+            for profile in permission_profiles()
+            if build_authority_envelope(permission_profile=profile)["merge_authority"] == "granted"
+        ]
+        self.assertTrue(
+            granting,
+            "INVARIANT 5 (merge authority is unreachable): no permission profile grants merge at all "
+            "any more, so this invariant now passes for free. That may be a fine change -- if so, "
+            f"simplify or delete MergeAuthorityIsUnreachable in {THIS_TEST} rather than leaving a "
+            "gate that proves nothing.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_task_authority_envelope.py
+++ b/tests/test_task_authority_envelope.py
@@ -440,6 +440,26 @@ class SingleDecisionPathTests(unittest.TestCase):
                     build_chat_interaction_payload(f"{message} for the single decision path check")
                 self.assertEqual(len(calls), 1, message)
 
+    def test_the_single_evaluation_yields_exactly_one_safety_contract(self) -> None:
+        """One decision, one contract (#818).
+
+        The contract is not duplicated onto the executor, runtime, and prompt
+        handoffs: three copies of one statement are three things that can
+        disagree after a partial rebuild, with no way to tell which is current.
+        """
+        for target in _TARGETS:
+            with self.subTest(target=target):
+                payload = build_coding_delegation_payload(_MESSAGE, executor_target=target)
+                record = build_coding_delegation_record(coding_delegation_record_payload(payload, _MESSAGE))
+                self.assertEqual(json.dumps(record).count('"handoff_safety_contract"'), 1)
+                self.assertNotIn("handoff_safety_contract", record["action_gate"])
+                for key in ("executor_handoff", "runtime_handoff", "prompt_handoff"):
+                    self.assertNotIn("handoff_safety_contract", record.get(key, {}))
+                contract = record["handoff_safety_contract"]
+                envelope = record["action_gate"]["authority_envelope"]
+                self.assertEqual(contract["prohibited_actions"], envelope["blocked_actions"])
+                self.assertEqual(contract["safety_profile_revision"], envelope["safety_profile_revision"])
+
     def test_payload_values_are_derived_from_the_verdict_not_recomputed(self) -> None:
         for target in _TARGETS:
             with self.subTest(target=target):


### PR DESCRIPTION
# Declare and enforce the coding handoff safety boundary (closes #818)

## What capability changed

`handoff_safety_contract/v1` — a per-task statement, attached to every prepared coding delegation, of what the work may touch, what it may never do, and **which of those boundaries a check actually refuses today**.

It is a field group on `coding_delegation/v1`, stored once beside the action gate, produced by the same `evaluate_action_gate` that already runs exactly once per delegation build.

## Why

The pieces this contract needs mostly landed in the last few PRs — the authority envelope (#811), the safety preflight and its profile revision (#804/#802), external effect receipts (#836), the claim ladder and journal prerequisites. What was missing was a single place that states the boundary for *this* task and is honest about which parts are guarded.

That honesty is the whole design. Three of the boundaries a reader would assume are checked are held only by the absence of a capability, and five have no enforcer at all because #807, #820, #821, #826, and #835 are not implemented. A nine-field contract that guards four reads as coverage that does not exist — strictly worse than shipping nothing.

## What a user or operator can do now

- Read, on any prepared delegation, exactly which boundaries apply and which are enforced, with the enforcing symbol named.
- See the gaps as data rather than folklore: an unenforced boundary carries the issue that must land first, so it is visible in every record instead of living in someone's memory.
- Rely on five new repository-wide invariants that make a silent capability regression fail the suite.

## Implementation at the boundary level

**Every boundary must justify itself.** Each entry carries `enforcement`, plus either `enforced_by` (dotted symbols that must resolve) or `blocked_by` (the issue). The validator rejects an entry claiming enforcement with no enforcer, an unenforced entry with no blocker, and any boundary set that is not exactly the expected one in order. The suite imports every cited symbol, which is what stops the table drifting into fiction as the enforcing code moves.

**Enforced (11)** — including dispatch (`validate_task_authority_envelope`, the dispatch template allowlist), merge and CI (`claims._receipt_cited`, receipt satisfaction), file and credential (the preflight path and secret rules), evidence separation (claim ladder, journal prerequisites, receipts), profile revision (the fanout re-check), untrusted input, and prohibited actions.

**Declared not enforced (6)** — workspace (#820), confirmation-answered (#807), storage retention (#835), recovery (#821), start evidence (#826), and review receipt (#844, filed while landing this).

**Offline by construction.** Every input is already in process when the gate runs. The build is asserted to succeed with `open`, `socket`, and `subprocess` all patched to raise, and to be byte-identical across repeated builds.

**No boundary is justified by "no such capability exists."** That claim cannot be enforced and the tree contradicts it: `omh setup --star` really does shell out to `gh` to star the repository. Statements are scoped to the surface they govern, and that exception is named in the contract rather than left for a reader to discover.

**Five enforcement invariants**, pinned by AST rather than text search so a comment or a string cannot satisfy or break them:
1. Only an allowlisted set of modules may import `subprocess` — the allowlist was verified against the tree and is larger than expected, including a function-local import that a module-level scan would have missed.
2. `src/` holds no network client; the two `urllib.request` uses are path conversion and are allowed by name.
3. No module may build a remote-mutating git argv or invoke `gh`. This distinguishes an executed argv from a documentation string and from a transcript parser, structurally.
4. No file written under `.omh` contains the raw user message, while its SHA does — so the absence is evidence rather than an empty directory. Covers both message-context modes, including the one that legitimately interpolates the verbatim message in memory.
5. No permission profile the delegation lane can select yields merge authority, swept over 4608 input combinations with anti-tautology guards.

Invariants 3 and 5 are **regression prevention** — no such capability exists today, and these tests exist so one cannot appear unnoticed. Invariants 1, 2, and 4 are **genuine new coverage**; nothing equivalent existed.

## Verification observed

- Full suite **Ran 3815 tests, OK** (baseline on merged main: 3750).
- `ruff check src tests` clean; `docs workflows/roles/capability-families --check` all ok (tap-skills 115/115, 0 stale); `compileall` and `git diff --check` clean.
- Every static detector was mutation-tested against synthetic violating trees to confirm it fires with an actionable message, including the two fail-closed branches where a git verb is a runtime value.

## Risks and follow-ups

- Two evidence gaps are declared rather than closed, because closing them means editing the claim ladder and the observation journal and would change what previously recorded runs may claim: `runtime_start` has no claim rung or prerequisite, and a review success claim is not receipt-gated the way CI and merge are (#844).
- The contract adds roughly 9.5 KB of mostly-static statement text per delegation record. Nothing enforces a size budget today; if one lands, the statements are the obvious thing to move behind a revision reference.
- `omh setup --star` performs a GitHub API call behind an explicit flag. It is pre-existing and out of scope here, but it is now named in the contract and its exact argv is pinned by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
