### PR TITLE
feat: data boundaries, run-bound approval receipts, and risky-action classification (closes #801, #807, #799)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -758,6 +758,8 @@ Runtime artifacts are local JSON/JSONL files under `.omh/runtime/`.
       events.jsonl
       external_effect_receipts.jsonl
       external_effect_mint_failures.jsonl
+      approval_receipts.jsonl
+      approval_mint_failures.jsonl
     wrapper_sessions/
       <session-id>/
         session.json
@@ -914,6 +916,131 @@ status means a handoff was prepared; the companion run envelope is also marked
 `prepared_coding_delegation`, not proof that Hermes executed the task.
 Executor-choice, runtime-handoff, clarify, fallback, and prompt-only handoffs
 return `runtime.recorded=false` and should stay in wrapper/session state.
+
+### Approval Receipts
+
+`runtime/journal/approval_receipts.jsonl` is an append-only store of
+`approval_receipt/v1` records: one per answer an operator gave to a confirmation
+ladder. It is the second store in the journal directory and follows the same
+mechanics as the first — JSONL appended under `local_store.file_lock`, an append
+that terminates a torn tail first, closed vocabularies everywhere including at
+render, idempotent minting, and supersession by link rather than by rewrite.
+
+**Why this is a record family and not a field group.** This repo refused a new
+family twice (#811, #818) because a family joins on run id and a join is where an
+artifact and its metadata desynchronize. Consent is the case that argument does
+not cover: it is created at a different time from the delegation (when the
+operator answers, not when the handoff is built), by a different actor, it has
+its own lifetime — it goes stale on a clock the delegation knows nothing about,
+and it can be revoked while the delegation is untouched — and it must survive a
+rebuild of the delegation it approves. Rebuilding a prepared handoff must
+neither silently re-grant consent nor silently destroy it. A field group is
+written by whoever writes the record, so it cannot express "written by someone
+else, before this record existed, and still true after this record is replaced".
+
+**What a receipt binds.** Exactly five things, and each is a separate refusal
+with its own code:
+
+| Dimension | Refusal code |
+| --- | --- |
+| `run_id` | `run_not_approved` |
+| `owner` | `owner_not_approved` |
+| `approved_action` | `action_not_approved` |
+| `scope_class` + `scope_ref` | `scope_not_approved` |
+| `safety_profile_revision` | `safety_revision_not_approved` |
+
+Matching is equality on every dimension, including the scope pair. There is no
+containment, prefix, or subsumption rule anywhere in the module, which is what
+makes widening structurally impossible rather than merely unimplemented: an
+approval for `src/omh/paths.py` satisfies a request for `src/omh/paths.py` and
+nothing else — not `src/omh`, not a sibling file, not the same path for another
+owner. `scope_class` is one of `filesystem_path`, `network_endpoint`, `tool`,
+`executor_profile`, `permission_profile`, and `scope_ref` stores the exact path,
+endpoint, or tool verbatim rather than a summary, because an approval nobody can
+read the target of is not a citable one.
+
+The lifecycle refusals are `approval_absent`, `approval_expired`,
+`approval_revoked`, `approval_superseded`, and `approval_denied`. Every refusal
+code carries a constant explanation line; nothing is interpolated into it, so a
+refusal rendered to an operator can never carry caller-controlled text.
+
+**Time bounding.** Freshness is derived at read time from `decided_at` against
+`APPROVAL_TTL_SECONDS` (one hour), the idiom `coding/executor_auth_signals.py`
+uses for limit signals, rather than stored as an `expires_at` the reader must
+trust. A stored deadline is a second independently writable field: a hand-edited
+store widens the window by editing one number, while a window that lives in code
+cannot be widened by anything on disk. The honest reason matters more — the
+`storage_retention` boundary of `handoff_safety_contract/v1` is
+`declared_not_enforced` (blocked by #835) because no retention or cleanup exists
+for run artifacts. Nothing deletes an approval receipt, so claiming one
+"expires" on disk would be a lie about a file that outlives every window it
+names. Expiry is a property every reader recomputes and never a property the
+artifact has. A decision stamped in the future returns `age_seconds = -1` and
+refuses rather than clamping to zero, which is the other half of "the window
+cannot be widened from disk".
+
+**Three separate things.** #800 requires approval, attempt, and observed outcome
+to be reported separately, which is exactly why this is not folded into the
+external effect receipt store. An approval receipt proves consent was given. It
+never proves the host applied the permission and it never proves anything ran.
+`CLAIM_BOUNDARY` says so on every record, and `validate_approval_receipt`
+refuses a record shaped to assert execution — `applied`, `executed`,
+`exit_code`, `observed_result`, `result` and their siblings are rejected by key
+name, before the closed key set would reject them as merely unsupported.
+
+**Revocation and supersession.** A revocation is a new record with
+`decision = "revoked"` linked to the grant through `supersedes_receipt_ref`; the
+grant's line on disk is untouched. Re-answering the same confirmation — after
+the safety profile moved, say — appends a new receipt that supersedes the
+earlier answer, and the earlier answer stops satisfying anything from that
+moment. `approval_id` is the identity of the *question* (run, owner, action,
+scope) and deliberately excludes the revision, so re-answering supersedes rather
+than opening a second chain that both claim to be current. The chain validator
+rejects the shapes a consent chain must never take: a self-cycle, a link to a
+receipt that does not exist, a duplicate receipt id, and a fork — two answers
+that both believe they replaced the same predecessor, which would make "the
+current answer" ambiguous.
+
+**Minting.** The confirmation flow calls `mint_approval_receipt`, which never
+raises into it: an unwritable store must not make an answer that *was* given
+look like one that was not. Refusals and write failures come back as an
+`approval_mint_result/v1` mapping and are appended to
+`runtime/journal/approval_mint_failures.jsonl`. Minting is idempotent by
+decision fingerprint while the answer is live, so one answer reported three
+times has one receipt; once a grant is past its window the identical answer
+mints again, because consent re-given after expiry is new consent rather than a
+duplicate report of the old.
+
+**Consumers.** `omh runtime approvals` is a read-only view with the usual
+plain-text default and `--json` opt-in. There is deliberately no command that
+mints an approval from operator input: whoever typed the flag would be granting
+themselves the permission the confirmation was supposed to ask about. A test
+asserts both halves — that today's parser refuses the obvious flags, and that no
+module under `src/commands/` references a writer at all.
+
+`omh runtime validate` is the store's third consumer, and the one that reaches
+the chain validator. `runtime/artifacts.py::validate_runtime` reports the store
+under an `approval_receipts` key beside `external_effect_receipts`, and
+`_validate_run_approval_receipts` applies the per-record validator
+`records.OPTIONAL_APPROVAL_STORE_VALIDATORS` names to the receipts belonging to
+each run. Without those two callers the registry validated nothing: an
+unparseable line, a duplicate receipt id, and a forked supersede chain — two
+answers that both believe they replaced the same predecessor, which makes "the
+current answer" ambiguous — all went unreported. Why each registry needs its own
+reader rather than one shared tuple is the design problem #846 tracks.
+
+The gate is the store's other consumer. `coding/action_gate.py::classify_action_risk`
+calls `approval_satisfies_request_in` with receipts the caller already read — the
+pure form, so the gate performs no I/O — and withholds the escalated authority
+when no live approval names exactly this action, scope, owner, run, and
+safety-profile revision. That refusal is real, and it is reachable only by a
+caller that supplies a run id: an approval binds to a run,
+`build_approval_receipt` refuses an empty one, and the delegation lane builds
+its payload before any runtime run exists. So the `confirmation_answered`
+boundary of `handoff_safety_contract/v1` is `declared_not_enforced`, blocked by
+`no_confirmation_answer_intake_mints_a_run_bound_approval`. "Consent is
+classified; on the shipped lane it is not enforced" below says why arming there
+would have been worse than not arming.
 
 ### Prepared Runtime Run Executor Matrix
 
@@ -1461,18 +1588,216 @@ handoff end up side by side in one record. The child-cannot-exceed-parent
 lattice is checked in the same pass: a handoff envelope may not allow an action
 its parent verdict's envelope does not.
 
-Three "ask the user" ladders used to live side by side without knowing about
-each other: executor selection (`choose_executor`), permission profile
-(`choose_permission_profile`), and the operator confirmation family
+Four "ask the user" ladders used to live side by side without knowing about each
+other: executor selection (`choose_executor`), permission profile
+(`choose_permission_profile`), the risky-action confirmation
+(`confirm_risky_action`), and the operator confirmation family
 (`send_to_executor`). Arbitration is now explicit and ordered — a denial asks
-nothing, because a denied request is corrected rather than confirmed; otherwise
-executor selection wins, because nothing downstream can be confirmed before the
-agent that owns the work is chosen; then permission profile, because widening
-authority routes through one profile choice; then operator confirmation, when
-the envelope already allows dispatch and only the act itself needs a go-ahead.
-At most one ladder is armed. Every ladder that could have fired is recorded in
-`confirmation.suppressed_ladders` with the winner named, so a surface that
-renders one prompt can still explain which questions were not asked and why.
+nothing, because a denied request is corrected rather than confirmed; a refused
+or revoked approval asks nothing either, because the operator already answered
+and asking again is asking until the answer changes; otherwise executor
+selection wins, because nothing downstream can be confirmed before the agent
+that owns the work is chosen; then permission profile, because widening
+authority routes through one profile choice; then risky action, because
+confirming one risky act inside the envelope is a smaller question than widening
+the envelope and a bigger one than confirming the dispatch that carries it; then
+operator confirmation, when the envelope already allows dispatch and only the act
+itself needs a go-ahead. At most one ladder is armed. Every ladder that could
+have fired is recorded in `confirmation.suppressed_ladders` with the winner
+named, so a surface that renders one prompt can still explain which questions
+were not asked and why.
+
+The risky-action rung carries one further precondition: it arms only when the
+confirmation can be answered, which means the gate was given a `run_id`. See
+"Consent is classified; on the shipped lane it is not enforced" below — arming a
+ladder whose answer nothing can record does not gate a request, it ends it.
+
+Registering the risky-action confirmation *as a ladder* is the point of #800,
+not an implementation convenience. `validate_action_gate_verdict` already
+asserts that at most one ladder is armed and that armed plus suppressed accounts
+for every candidate; a risky-action prompt built outside the arbitration would
+have satisfied that check while producing a second prompt on one intent, which
+is the failure mode. `wrapper/contract.py::_apply_action_gate_arbitration`
+renders the armed ladder and disables the rest, and its action-id list is now
+*derived* from `coding/action_gate.py::LADDER_ACTION_IDS` rather than retyped —
+the two hand-maintained copies had already drifted (`send_to_codex` was in one
+and not the other) without anything failing. The wrapper adds only what it
+genuinely owns: `send_to_codex`, the codex lane's rendering alias for
+`send_to_executor`, and the four operator-card `confirm_*` ids, which belong to
+the same confirmation family and must be disabled when another ladder wins.
+
+#### What action risk reads, and what that does not promise
+
+`coding/action_gate.py::classify_action_risk` answers "may this act proceed
+without asking". It reads the isolation plan's *strategy*, the authority
+envelope's granted actions, and the declared safety-preflight request's access
+intents and target paths. It has no parameter through which message text, a
+context pack, or a recall pack could arrive, so the same envelope and the same
+declared request always produce an identical verdict whatever the message said.
+
+**That bounds the classifier, not the pipeline, and the record says so.**
+`external_mutation` and `publication` are `policy_derived`: the envelope alone
+decides them and no phrasing can move them. `broad_write` is `request_declared`,
+and on the coding-delegation lane the `target_paths` it counts are regex-scraped
+out of the user's message by
+`coding_delegation.py::_safety_preflight_target_paths`. End to end that class is
+therefore message-sensitive: two phrasings of one intent classify differently, a
+pasted traceback naming files raises the count, and "rewrite everything under
+`src/`" declares zero targets and classifies as no risk at all.
+`action_risk.text_policy` states each of those in those words rather than
+claiming the classifier is not message-derived, because the earlier claim was
+true only at a boundary no user ever sees.
+
+Reusing `coding/isolation.py::_risk_level` is still refused. It computes from
+`message.lower()` against term tables, and `quality/safety_preflight.py`'s own
+docstring forbids making a safety decision depend on user text — which is why
+that module contains no `*_guard_applies` helper. The two levels carry different
+names on one record: `isolation_plan.risk_level` is advisory routing that
+answers "how much should this work be isolated"; `action_risk.level` answers the
+authority question. They can disagree without either being wrong,
+`action_risk.isolation_risk_relationship` says so on every verdict, and nothing
+reads one to compute the other.
+
+#800 names five risky kinds and the contract accounts for all five rather than
+shipping the three it can derive and dropping the rest. `broad_write` is a repo
+edit whose declared target set is larger than an operator can read from the
+request (`MAX_UNCONFIRMED_TARGET_PATHS`, well inside the bound at which the
+preflight denies outright); `external_mutation` is granted merge or
+pull-request authority; `publication` is granted `external_posting`. Every rule
+is anchored on the envelope's own `mutation_rights`, so a class is present only
+when the envelope grants an action that could perform it — a request that merely
+declares a destination or a share intent raises no class, because the handoff
+cannot reach one and the preflight's destination and access-intent rules are
+what refuse an undeclared reach. `deletion` and `identity_change` are
+`subsumed`, each naming the class that carries it and why: `ACCESS_INTENTS` is
+read, write, and share, so nothing declares a delete and a deletion is the write
+that performs it; and no request field names an account, an identity, or a
+credential rotation, so an identity change is the external mutation that
+performs it. The validator enforces that split in both directions — a subsumed
+class with no carrier and a derivable class claiming a carrier are both rejected
+— which is the anti-decoration rule applied to a vocabulary instead of to a
+boundary table.
+
+#### Consent is per risky class
+
+An armed ladder proves a question was asked. `workflows/approval_receipts.py`
+proves an operator answered it. There is deliberately **no single "the
+approvable action"**: for every class present, every action the envelope really
+grants that carries it becomes one `action_risk.consent` entry with its own
+five-dimension approval request and its own verdict. The aggregate is `deny` if
+any entry is refused, `ask` if any is unanswered, and `allow` only when every
+class present is approved on every action that carries it;
+`action_risk.withheld_actions` is exactly the set of actions whose entry is not
+allowed.
+
+Collapsing those into one question was a real defect and not a simplification.
+One receipt naming `merge` released `broad_write`, `external_mutation`, and
+`publication` together, `merge` was an action `required_actions_for` never
+yields and the envelope never grants — so the stored receipt read "operator
+approved merge" while a broad repo write proceeded — and a receipt for
+`repo_edit`, the action that actually performs the write, was refused as a
+sibling. Two validators now make each of those unconstructible.
+`validate_action_risk` rejects an `allow` while any present class is unapproved,
+and rejects a verdict that reports a present class no consent entry asks about.
+`validate_action_gate_verdict` rejects a consent entry naming an action the
+authority envelope neither allows nor withheld — an approval request for
+authority nobody was ever given, which no receipt could ever satisfy.
+
+The scope an approval binds to is the permission profile, uniformly. It is the
+only scope stable across a rebuild of the same delegation — target paths and
+destinations are re-derived from the request on every build, so an approval
+bound to them would either stop matching or silently cover a changed set. The
+other four dimensions are the run, the owner, the action, and the revision, and
+matching is equality on all five inside the receipt module, which is what makes
+widening structurally impossible rather than merely unimplemented. One
+consequence is deliberate and stated rather than papered over: inside one run,
+one hour, and one revision, a second delegation for the same owner and profile
+is covered by the first answer *for the same class and action*. That is what a
+run-bound approval means; it is not a per-delegation consent and is not claimed
+to be.
+
+#### Consent is classified; on the shipped lane it is not enforced
+
+The refusal above fires only when the confirmation can be answered, and on the
+coding-delegation lane it cannot. An approval binds to a run,
+`build_approval_receipt` refuses an empty `run_id`, and
+`evaluate_action_gate`'s only production caller —
+`coding_delegation.py::build_coding_delegation_payload` — runs before any
+runtime run exists (`wrapper/lifecycle.py` creates the run from the payload).
+Nothing anywhere in `src/` receives an operator's answer to a card action back
+as data, and there is deliberately no CLI verb that mints an approval. So on
+that lane no receipt that could release the work is constructible at all.
+
+Withholding there would not gate a request, it would end it: a user naming nine
+files would get a permanently non-dispatchable delegation with no route forward,
+and an armed `confirm_risky_action` button whose answer could never be recorded.
+`evaluate_action_gate` therefore withholds and arms **only when `run_id` is
+set**. Everywhere else the classification rides as a report:
+`action_risk.enforcement` is `declared_not_enforced`,
+`action_risk.blocked_by` is `no_confirmation_answer_intake_mints_a_run_bound_approval`,
+the envelope is untouched, and no ladder is armed. Given a run id — a caller
+holding a receipt store — the same block reports `enforced`, names its two
+enforcing symbols, and the refusal is real.
+
+A refusal is still honoured wherever it can exist.
+`wrapper/contract.py::_apply_refused_risky_action` disables every ladder action
+on the card when the verdict is an *enforced* `deny`, because an operator who
+answered no must not be offered "Open coding agent" as the enabled primary
+action; a report-only classification disables nothing.
+
+A "narrow" answer is a smaller requested action set fed back through
+`requested_authority_actions`. That parameter already existed as a seam with no
+production caller; #800 is its first one. One seam carries both directions and
+they are told apart by one question: anything asked for *outside* what the task
+required widens the envelope and routes through the permission-profile ladder,
+while a subset narrows it and is excluded with the `narrowed_by_request` reason
+code. `action_risk.narrowing_route` names the parameter and the exact action set
+that removes the question — *every* action carrying an unapproved class, not one
+of them, because a set that dropped one carrier and kept a sibling would ask the
+same question again and the explanation promises it will not.
+
+#### Account authorization (#799)
+
+`account_authorization/v1` rides on the same verdict and is honest about being
+roughly three quarters a projection over what already exists. Derived now: that
+a task needs account-backed access at all (the envelope allows — *or withheld
+pending approval* — `executor_dispatch`, `external_posting`, `merge`,
+`pr_creation`, or `pr_revision`; withholding an action because nobody approved
+it does not stop the task needing the account behind it, and reading
+`allowed_actions` alone made `required` report false exactly when a risky action
+was held back), the account and its minimum scopes, safe references only — an
+environment variable *name* matching the `provider_profile_posture` shape and
+screened through the credential boundary's own value detectors, or an opaque
+handle screened by the same admission check every other caller-supplied
+reference passes — and one of four states: `missing` (the readiness probe found
+no marker), `authorized-unverified` (a login marker is present, which is exactly
+what a marker means and what `executor_auth_signals`' claim boundary already
+says), `observed-ready` (a probe reported ready *and* exited 0), and `expired`
+(derived at read time from the signal's own timestamp against the same six-hour
+horizon `executor_auth_signals` uses for limit signals). Signals are handed in
+already read; the gate never probes.
+
+Declared and not enforced, with the gap written out rather than implied.
+`consent-required` is not an observable state: completing a provider's consent
+flow happens on that provider's site and nothing local reports it. The approval
+receipt closes the *adjacent* gap and is cited saying so — it proves the operator
+consented to this wrapper's own escalation, which is a different question from
+whether a provider granted a scope. And guiding an operator through a host-owned
+consent flow can only ever be rendered instructions, because launching a browser
+or running an auth CLI is something the enforcement tests make a test failure
+rather than a choice. The blocker is therefore
+`host_owned_consent_flow_is_not_observable_by_omh` rather than an issue number:
+nothing that could be filed would close it, and
+`safety_preflight.data_boundary_enforcement_facts` already set the precedent of
+a `blocked_by` that names the reason. No credential value is ever read, stored,
+or echoed; the credential boundary is cited, not restated. The name shape alone
+is not the whole screen — plenty of issued credentials are upper-case
+alphanumerics, and an AWS key id satisfies every character rule — so a reference
+is also run through `metadata_safety.is_secret_value_shaped`, the value half of
+the existing credential predicate. The *name* half is deliberately not used:
+`GITHUB_TOKEN` is a legitimate environment variable name. That bounds the guard
+to the detectors the tree already owns; a credential value none of them
+recognises still matches the shape.
 
 #### Dispatch-boundary revision re-check
 
@@ -1499,11 +1824,12 @@ evidence.
 ### Handoff Safety Contract
 
 `handoff_safety_contract/v1` is the task-scoped answer to "what will OMH
-actually do, and what stops it doing anything else". It declares seventeen
+actually do, and what stops it doing anything else". It declares twenty-four
 boundaries — workspace, file, network, credential, dispatch, storage content,
 storage retention, merge, confirmation arming, confirmation answered, untrusted
 input, prohibited actions, evidence separation, profile revision, recovery,
-start evidence, and review receipt — plus the six evidence stages #818 names:
+start evidence, review receipt, account authorization, and the six `data_*` rows
+the #801 data boundary contributes — plus the six evidence stages #818 names:
 start, execution, verification, review, CI, and merge.
 
 It is a field group on `coding_delegation/v1`, stored beside `action_gate`, for
@@ -1527,8 +1853,8 @@ delegation are byte-identical.
 
 #### The anti-decoration rule
 
-A contract that lists seventeen boundaries while guarding eleven is worse than
-no contract, because a reader infers a guard behind every line. Every boundary
+A contract that lists twenty-four boundaries while guarding fourteen is worse
+than no contract, because a reader infers a guard behind every line. Every boundary
 entry therefore carries an `enforcement` verdict of `enforced` or
 `declared_not_enforced`, and the validator refuses the two dishonest shapes: an
 `enforced` entry with no `enforced_by` symbol, and a `declared_not_enforced`
@@ -1559,7 +1885,39 @@ network (the same validator pinning `external_action_authority` to
 and secrets rules), confirmation arming (`validate_action_gate_verdict` and the
 at-most-one-armed-ladder check), storage content (the closed record key sets),
 evidence separation (the claim ladder, the journal prerequisites, and the
-external-effect receipts), and profile revision.
+external-effect receipts), profile revision, and the three
+`refused_before_handoff` data-boundary rows (`data_workspace_root_claim`,
+`data_prohibited_data_class`, `data_declared_destination`).
+
+`confirmation answered` is the one this contract most wanted to move and did
+not. #807's receipt store gained a reader, and the refusal behind it is real:
+an unapproved risky action loses every action carrying it and `executor_dispatch`
+from the envelope, and the verdict stops being dispatchable. But that refusal
+needs a run an approval can bind to, and the shipped delegation lane has none —
+`build_approval_receipt` refuses an empty `run_id`, and the payload is built
+before the runtime run exists. A boundary that refuses nothing on the path users
+travel is a declaration, so it is declared, blocked by
+`no_confirmation_answer_intake_mints_a_run_bound_approval`. Labelling it
+`enforced` because the code *could* refuse for some other caller is exactly the
+decoration this contract exists to prevent, and shipping an armed
+`confirm_risky_action` button whose answer nothing can record would have been
+worse than either: the request would have had no route forward at all.
+
+The six `data_*` rows are fed by
+`quality/safety_preflight.py::data_boundary_enforcement_facts` and mapped onto
+the existing `ENFORCEMENT_LEVELS` / `enforced_by` / `blocked_by` triple rather
+than onto a second label set. The facts function's `enforcement_kind` survives
+only inside the statement, where it explains *why* a limit is or is not enforced
+here; `enforced_here` is the whole mapping to `enforced` versus
+`declared_not_enforced`. Three of the rows are host-dependent by nature: a host
+with an OS confinement backend is blocked on #820, and a host without one is
+blocked on not having one, which is why the test compares those three against
+the same facts the contract read instead of pinning a string that would pass on
+macOS and fail on Windows. The facts are declared in
+`HANDOFF_CONTRACT_INPUT_SOURCES` and probed once per process behind
+`data_boundary_facts`, so `produced_offline` still means what it says — local
+stats, no socket, no process, no model — and a delegation build does not
+re-probe the host.
 
 The network boundary is the one that needs its scope read carefully. It governs
 the coding delegation lane, where no network client and no remote-mutation path
@@ -1573,16 +1931,24 @@ quietly widening what the sentence covers.
 
 Declared and not enforced, each naming what must land first: **workspace** —
 `allowed_targets` is derived from the isolation plan but nothing binds a running
-executor to it (#820); **confirmation answered** — the artifact proves a ladder
-was armed, never that consent was given (#807); **storage retention** — run
-artifacts are metadata-only, but no retention window, expiry, or cleanup exists,
-so they persist until the operator deletes them (#835); **recovery** — no
-recovery anchor is attached to risky work (#821); **start evidence** —
-`runtime_start` is recordable but is neither a claim rung nor a journal
-prerequisite, so a run can claim dispatch and execution with no observed start
-(#826); and **review receipt** — a review claim needs an observed review record
-but, unlike CI and merge, no external effect receipt, so a local record saying
-review passed is accepted as the evidence for itself (unfiled).
+executor to it (#820); **confirmation answered** — the gate classifies every
+risky class and names the approval each granted carrier action would need, but
+nothing on the shipped lane can record an answer, so nothing is withheld
+(`no_confirmation_answer_intake_mints_a_run_bound_approval`); **storage retention** — run artifacts are metadata-only,
+but no retention window, expiry, or cleanup exists, so they persist until the
+operator deletes them (#835); **recovery** — no recovery anchor is attached to
+risky work (#821); **start evidence** — `runtime_start` is recordable but is
+neither a claim rung nor a journal prerequisite, so a run can claim dispatch and
+execution with no observed start (#826); **review receipt** — a review claim
+needs an observed review record but, unlike CI and merge, no external effect
+receipt, so a local record saying review passed is accepted as the evidence for
+itself (#844); **account authorization** — the projection names the account,
+the minimum scopes, and a readiness state, but grants, verifies, and refuses
+nothing, because a consent flow owned by a provider's website is not observable
+from here (`host_owned_consent_flow_is_not_observable_by_omh`); and the three
+runtime `data_*` rows — the cross-harness adapter lane builds an OS confinement
+sandbox that no delegation or fanout lane places an executor under (#820 on a
+capable host, and the host's own missing backend elsewhere).
 
 The last two are known asymmetries rather than oversights. Closing either means
 adding a rung or a prerequisite to `runtime/claims.py` and

--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -218,6 +218,23 @@ goal to Hermes in chat; these commands are the backend surface.
   first without ever removing an option. A later successful dispatch to
   the same executor clears its signal. Only the boolean and label persist
   — never the matched text, and stderr is matched in memory only.
+- **Data boundary.** The #801 limits split three ways and this lane sits on
+  the honest side of the split. `workspace_root_claim`,
+  `prohibited_data_class`, and `declared_destination` are
+  `refused_before_handoff`: omh declines to prepare the artifact at all, so
+  they hold identically on every host and a dispatched unit can never be handed
+  a target, a data class, or a destination that was refused upstream.
+  `runtime_filesystem_confinement` and `runtime_network_confinement` are
+  `host_confinement`, and dispatch does **not** provide them — the
+  cross-harness adapter lane builds an OS confinement sandbox (`sandbox-exec`
+  on macOS, a trusted `bwrap` on Linux) and no dispatched unit runs under it
+  (#820). `executor_honours_declared_targets` is advisory everywhere: a unit's
+  file boundary is frozen in the contract and checked for overlaps at prepare
+  time, but nothing constrains the spawned CLI to it at runtime.
+  `quality/safety_preflight.py::data_boundary_enforcement_facts` reports which
+  of these the current host *could* enforce, and the six rows ride on
+  `handoff_safety_contract/v1` as `data_*` boundaries so the answer is a fact
+  about this machine rather than a promise.
 - **Resume.** Re-running dispatch skips units whose runs already carry an
   observed successful result. `--unit <id>` selects subsets.
 - **Never**: auto-merge, default-on execution, network calls by omh itself,

--- a/src/coding/action_gate.py
+++ b/src/coding/action_gate.py
@@ -1,18 +1,22 @@
 """One decision path for task-scoped authority on the coding delegation lane.
 
-Three independent "ask the user" ladders used to live side by side and none of
+Four independent "ask the user" ladders used to live side by side and none of
 them knew about the others:
 
 1. ``executor_selection.choice_required`` -> ``choose_executor``
 2. ``permission_profile_required`` -> ``choose_permission_profile``
-3. the operator-card ``confirm_*`` family (and, on the delegation lane, the
+3. the risky-action confirmation (#800) -> ``confirm_risky_action``
+4. the operator-card ``confirm_*`` family (and, on the delegation lane, the
    ``send_to_executor`` go-ahead that ``ask_before_dispatch`` implies)
 
 ``evaluate_action_gate`` is the only place that decides. It runs exactly once
 per delegation build and returns one verdict carrying:
 
 * the safety preflight outcome (allow/deny plus rule id, field, correction),
-* the derived task-scoped authority envelope (#811), and
+* the derived task-scoped authority envelope (#811),
+* the action-risk verdict and, per risky class, the approval that does or does
+  not cover it (#800),
+* the account-authorization projection (#799), and
 * which single confirmation ladder — at most one — is armed, and why the
   others are suppressed.
 
@@ -45,13 +49,69 @@ be enforced and the tree can contradict it: ``omh setup --star`` really does
 shell out to ``gh`` to star the repository. Every statement here is therefore
 scoped to the surface it actually governs, and a real exception outside that
 surface is named in the statement rather than left for a reader to discover.
+
+What action risk reads, and what that does not promise (#800)
+-------------------------------------------------------------
+
+``classify_action_risk`` answers "may this act proceed without asking". It
+reads the isolation plan's *strategy*, the authority envelope's granted actions,
+and the declared safety-preflight request's access intents and target paths. It
+never reads message text, a context pack, or a recall pack, and there is no
+parameter through which one could arrive — ``safety_preflight``'s own docstring
+forbids making a safety decision depend on user text, and
+``isolation._risk_level`` is exactly such a decision because it matches
+``message.lower()`` against term tables.
+
+That bounds this function and says nothing about how a caller built the request
+it hands in. ``external_mutation`` and ``publication`` are decided by the
+envelope alone, so no phrasing moves them. ``broad_write`` is decided by
+declared request fields, and on the coding-delegation lane those fields are
+scraped out of the user's message — so end to end that class *is*
+message-sensitive. ``ACTION_RISK_TEXT_POLICY`` names the scraper and the evasion
+in those words rather than claiming a property the pipeline does not have.
+
+The two risk levels are named apart and never compared; see
+``ACTION_RISK_VS_ISOLATION_RISK``.
+
+Consent is per risky class, and on the shipped lane it is reported (#800/#807)
+------------------------------------------------------------------------------
+
+An armed ladder proves a question was asked. ``omh.workflows.approval_receipts``
+proves an operator answered it. The gate consults
+``approval_satisfies_request_in`` — the pure, already-read-receipts form, so the
+gate stays free of I/O — once per (present class, granted action that carries
+it), and withholds every action whose approval is missing. There is deliberately
+no single collapsed "the approvable action": one answer covering several classes
+is several approvals wearing one answer. Matching is equality on all five
+dimensions inside that module; there is no containment rule here either, because
+there is none to call.
+
+That refusal fires only when the confirmation can be answered. An approval binds
+to a run, ``build_approval_receipt`` refuses an empty one, and this module's only
+production caller builds its payload before any runtime run exists — so on that
+lane no receipt that could release the work is constructible, and withholding
+would end the request rather than gate it. ``evaluate_action_gate`` therefore
+withholds and arms only when ``run_id`` is set; everywhere else the
+classification rides as a report and ``action_risk.enforcement`` /
+``action_risk.blocked_by`` say so on the record, and the
+``confirmation_answered`` boundary stays ``declared_not_enforced``.
 """
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+from functools import lru_cache
 from typing import Any
 
 from ..plugin_bundle.omh._governance_safety import classify_memory_admission
+from ..system.metadata_safety import is_secret_value_shaped
+from ..workflows.approval_receipts import (
+    APPROVABLE_ACTIONS,
+    REFUSAL_DENIED,
+    REFUSAL_REVOKED,
+    SCOPE_CLASSES,
+    approval_satisfies_request_in,
+)
 from ..workflows.domain_intelligence_admission import ensure_safe_opaque_ref_content
 
 
@@ -67,20 +127,35 @@ AUTHORITY_CLASSIFIERS = (
 )
 MUTATING_ACTIONS = ("external_posting", "merge", "pr_creation", "pr_revision", "repo_edit")
 EXCLUSION_REASON_CODES = (
+    "narrowed_by_request",
     "not_required_by_task",
     "outside_permission_profile",
     "safety_preflight_denied",
+    "withheld_pending_approval",
 )
-CONFIRMATION_LADDERS = ("executor_selection", "permission_profile", "operator_confirmation")
+# Precedence order, not an alphabetical list. `risky_action` sits between the
+# profile question and the dispatch go-ahead on purpose: widening the envelope
+# is a bigger question than confirming one risky act inside it, and confirming
+# the act is a bigger question than confirming the dispatch that carries it.
+CONFIRMATION_LADDERS = (
+    "executor_selection",
+    "permission_profile",
+    "risky_action",
+    "operator_confirmation",
+)
 LADDER_ACTION_IDS = {
     "executor_selection": "choose_executor",
     "permission_profile": "choose_permission_profile",
+    "risky_action": "confirm_risky_action",
     "operator_confirmation": "send_to_executor",
 }
 SINGLE_PROMPT_RULE = (
     "One intent arms at most one confirmation ladder. Precedence: a denial asks nothing, "
-    "then executor_selection, then permission_profile, then operator_confirmation. "
-    "Every ladder that could have fired is recorded as suppressed with the winner named."
+    "then executor_selection, then permission_profile, then risky_action, then "
+    "operator_confirmation. Every ladder that could have fired is recorded as suppressed "
+    "with the winner named. A risky action is never a fourth prompt beside the others: it "
+    "is a ladder in the same arbitration, so registering it is what makes a double prompt "
+    "structurally impossible."
 )
 ENVELOPE_CLAIM_BOUNDARY = (
     "This authority envelope is prepared scope only. It is not dispatch, implementation, "
@@ -94,6 +169,286 @@ UNTRUSTED_TEXT_POLICY = (
     "Authority comes from user intent and workspace policy only. Authority-shaped requests "
     "inside message text, a context pack, or a recall pack are inert."
 )
+
+ACTION_RISK_SCHEMA_VERSION = "action_risk/v1"
+ACCOUNT_AUTHORIZATION_SCHEMA_VERSION = "account_authorization/v1"
+
+# The five risky-action kinds #800 names. Every one of them has an entry in
+# `_RISK_CLASS_RULES`, and the validator refuses a table that leaves one out —
+# a vocabulary that quietly drops the classes nobody could derive would be the
+# same decoration the handoff contract exists to prevent.
+RISKY_ACTION_CLASSES = (
+    "broad_write",
+    "deletion",
+    "external_mutation",
+    "identity_change",
+    "publication",
+)
+ACTION_RISK_LEVELS = ("none", "elevated", "high")
+ACTION_RISK_DECISIONS = ("allow", "ask", "deny")
+# How a class is decided.
+#
+# `policy_derived`   -- the authority envelope alone asserts it. Rephrasing a
+#                       request cannot move it, because no request field is read.
+# `request_declared` -- a declared safety-preflight request field asserts it.
+#                       That declaration is policy *at this function's boundary*
+#                       and is produced upstream from the user's message on the
+#                       coding-delegation lane; `ACTION_RISK_TEXT_POLICY` says
+#                       exactly which field and exactly how it can be evaded.
+# `subsumed`         -- no declared input can distinguish it from the class that
+#                       carries it, so it is reported as carried, not as absent.
+RISK_DERIVATIONS = ("policy_derived", "request_declared", "subsumed")
+
+# Every input the classifier reads. Message text, context packs, and recall
+# packs are absent from this list and the classifier has no parameter for them —
+# which bounds this function and, deliberately, claims nothing about how a
+# caller produced the request it hands in.
+ACTION_RISK_INPUTS = (
+    "isolation_plan.strategy",
+    "safety_preflight_request.access_intents",
+    "safety_preflight_request.target_paths",
+    "task_authority_envelope.allowed_actions",
+    "task_authority_envelope.mutation_rights",
+)
+ACTION_RISK_TEXT_POLICY = (
+    "This classifier reads the isolation strategy, the authority envelope, and the declared "
+    "safety-preflight request. No message, context pack, or recall pack reaches it and there is no "
+    "parameter through which one could, so the same envelope and the same declared request always "
+    "yield an identical verdict whatever the message said. That bounds the classifier, not the "
+    "pipeline. `external_mutation` and `publication` are decided by the envelope alone and no "
+    "phrasing can move them. `broad_write` is decided by the declared `target_paths` and "
+    "`access_intents`, and on the coding-delegation lane those paths are scraped out of the user's "
+    "message by `coding_delegation._safety_preflight_target_paths` — so end to end that class is "
+    "message-sensitive: two phrasings of one intent classify differently, a pasted traceback naming "
+    "files raises the count, and a request that names no path at all (\"rewrite everything under "
+    "src/\") declares zero targets and classifies as no risk."
+)
+ACTION_RISK_VS_ISOLATION_RISK = (
+    "action_risk.level and isolation_plan.risk_level are different measurements and are never "
+    "compared. isolation.risk_level is matched from message.lower() against term tables and answers "
+    "'how much should this work be isolated'; it is advisory routing and may not decide authority. "
+    "action_risk.level is derived from the authority envelope and the declared safety-preflight "
+    "request and answers 'may this act proceed without asking'; text_policy states what that "
+    "declared half does and does not promise. The two can disagree without either being wrong, "
+    "which is why they carry different names on one record and why nothing reads one to compute "
+    "the other."
+)
+
+# A write is broad once the operator can no longer read what it will change.
+# The bound is a count of *declared* target paths. That declaration is policy at
+# this module's boundary and is produced upstream from the user's message on the
+# coding-delegation lane, so rephrasing a request really can move this class;
+# `ACTION_RISK_TEXT_POLICY` names the scraper and the evasion. Well inside
+# `safety_preflight.MAX_TARGET_PATHS` (32), which is the point at which the
+# preflight denies outright rather than asking.
+MAX_UNCONFIRMED_TARGET_PATHS = 8
+
+# (class, derivation, approvable actions, carrier, statement).
+#
+# `approvable actions` are the `approval_receipts.APPROVABLE_ACTIONS` members
+# that *carry* that class's risk — every envelope action whose grant is what
+# makes the class present. A class is only ever present when the envelope grants
+# at least one of them, which is what stops a confirmation naming an action
+# nobody could have granted and nobody can approve. `carrier` is the class that
+# carries a subsumed one and is empty otherwise.
+_RISK_CLASS_RULES: tuple[tuple[str, str, tuple[str, ...], str, str], ...] = (
+    (
+        "broad_write",
+        "request_declared",
+        ("repo_edit",),
+        "",
+        "The envelope grants repo_edit, the request declares a write intent, and it names more "
+        f"than {MAX_UNCONFIRMED_TARGET_PATHS} target paths, so the operator can no longer read "
+        "what the write will change from the request itself. The path count is a declared request "
+        "field; on the coding-delegation lane it is scraped from the user's message, so this class "
+        "is the one that moves when a request is rephrased.",
+    ),
+    (
+        "deletion",
+        "subsumed",
+        ("repo_edit",),
+        "broad_write",
+        "safety_preflight.ACCESS_INTENTS is read, write, and share. Nothing declares a delete, so a "
+        "deletion cannot be distinguished from the write that performs it and is classified as that "
+        "write rather than as a class nothing can assert.",
+    ),
+    (
+        "external_mutation",
+        "policy_derived",
+        ("merge", "pr_creation", "pr_revision"),
+        "",
+        "The envelope grants merge or a pull-request action, so the act changes state outside the "
+        "workspace. A request that merely declares a destination does not raise this class: with "
+        "none of these actions granted the handoff cannot reach one, and the preflight's own "
+        "destination rule is what refuses an undeclared reach.",
+    ),
+    (
+        "identity_change",
+        "subsumed",
+        ("merge", "pr_creation", "pr_revision"),
+        "external_mutation",
+        "No request field names an account, an identity, or a credential rotation, so an identity "
+        "change cannot be distinguished from the external mutation that performs it. The "
+        "account_authorization projection is what would make it derivable, and that projection is "
+        "declared and not enforced.",
+    ),
+    (
+        "publication",
+        "policy_derived",
+        ("external_posting",),
+        "",
+        "The envelope grants external_posting, so the act makes something visible outside the "
+        "workspace. A declared share intent alone does not raise this class: without the grant "
+        "nothing can publish, and the preflight refuses a share intent no approved destination "
+        "covers.",
+    ),
+)
+RISK_CLASS_NAMES = tuple(entry[0] for entry in _RISK_CLASS_RULES)
+# Classes something can actually assert. A subsumed class must name one of these
+# as its carrier; a derivable class must not name a carrier at all.
+_DERIVABLE_CLASSES = tuple(entry[0] for entry in _RISK_CLASS_RULES if entry[1] != "subsumed")
+_RISK_CLASS_ACTIONS = {name: actions for name, _d, actions, _c, _s in _RISK_CLASS_RULES}
+# Classes that leave the workspace. Their presence is what separates `high` from
+# `elevated`: a broad write is recoverable inside the repository, a publication
+# or an external mutation is not.
+_ESCAPING_CLASSES = frozenset({"external_mutation", "publication"})
+
+# Why an unanswered risky action is reported and not refused on the shipped
+# lane. Not an issue number, for the reason `ACCOUNT_AUTHORIZATION_BLOCKER` is
+# not one: nothing that could be filed closes it on its own. `build_approval_
+# receipt` requires a non-empty run id, and `evaluate_action_gate`'s only
+# production caller — `coding_delegation.build_coding_delegation_payload` —
+# runs before any runtime run exists, so on that lane no receipt that could
+# satisfy the request is constructible at all. Arming a ladder whose answer
+# cannot be recorded would leave a user permanently blocked with no route
+# forward, so the classification rides as a report there and the gate withholds
+# nothing.
+RISK_CONSENT_BLOCKER = "no_confirmation_answer_intake_mints_a_run_bound_approval"
+RISK_CONSENT_ENFORCERS = (
+    "omh.coding.action_gate.classify_action_risk",
+    "omh.workflows.approval_receipts.approval_satisfies_request_in",
+)
+
+ACTION_RISK_KEYS = (
+    "schema_version",
+    "status",
+    "level",
+    "decision",
+    "reason",
+    "classes",
+    "subsumed_classes",
+    "consent",
+    "withheld_actions",
+    "narrowing_route",
+    "inputs",
+    "text_policy",
+    "isolation_risk_relationship",
+    "enforcement",
+    "enforced_by",
+    "blocked_by",
+    "claim_boundary",
+)
+RISK_CLASS_ENTRY_KEYS = ("class", "derivation", "approvable_actions", "carrier", "statement")
+APPROVAL_REQUEST_KEYS = (
+    "approved_action",
+    "scope_class",
+    "scope_ref",
+    "owner",
+    "run_id",
+    "safety_profile_revision",
+)
+# One entry per (present class, action that carries it). There is deliberately
+# no collapsed "the approvable action" field: one answer covering several
+# classes is several approvals wearing one answer, which is the shape that let a
+# receipt naming one action release the rest.
+CONSENT_ENTRY_KEYS = ("class", "approved_action", "decision", "approval_request", "approval")
+NARROWING_ROUTE_KEYS = ("parameter", "narrowed_actions", "explanation")
+ACTION_RISK_CLAIM_BOUNDARY = (
+    "This action-risk verdict is a prepared decision. It is not dispatch, execution, review, CI, or "
+    "merge evidence, and an approval it cites proves consent was given, never that anything ran."
+)
+# One scope for every class on purpose. The permission profile is the only scope
+# that is stable across a rebuild of the same delegation: target paths and
+# destinations are re-derived from the request every build, so an approval bound
+# to them would either stop matching or silently cover a changed set.
+RISK_APPROVAL_SCOPE_CLASS = "permission_profile"
+
+ACCOUNT_ACCESS_STATES = ("missing", "authorized-unverified", "observed-ready", "expired")
+ACCOUNT_REFERENCE_KINDS = ("env_var_name", "opaque_handle")
+# The actions that cannot run without an account the operator owns: spawning a
+# vendor CLI that authenticates as them, or reaching a git host.
+ACCOUNT_BACKED_ACTIONS = ("executor_dispatch", "external_posting", "merge", "pr_creation", "pr_revision")
+# Same horizon `executor_auth_signals.LIMIT_SIGNAL_STALE_AFTER_SECONDS` uses,
+# and for the same reason: past it a locally observed provider signal is history
+# rather than current state. Mirrored rather than imported because that module
+# reads files and this one must not.
+ACCOUNT_SIGNAL_STALE_AFTER_SECONDS = 6 * 60 * 60
+ACCOUNT_AUTHORIZATION_KEYS = (
+    "schema_version",
+    "status",
+    "required",
+    "reason",
+    "accounts",
+    "enforcement",
+    "enforced_by",
+    "blocked_by",
+    "blockers",
+    "credential_boundary",
+    "claim_boundary",
+)
+ACCOUNT_ENTRY_KEYS = (
+    "account_ref",
+    "reference_kind",
+    "minimum_scopes",
+    "state",
+    "state_source",
+)
+ACCOUNT_BLOCKER_KEYS = ("blocker", "statement", "cites")
+# Not an issue number. Nothing that can be filed would close it: OMH cannot
+# observe that a person completed a flow owned by someone else's website, and
+# `data_boundary_enforcement_facts` already sets the precedent of a `blocked_by`
+# that names the reason rather than a ticket.
+ACCOUNT_AUTHORIZATION_BLOCKER = "host_owned_consent_flow_is_not_observable_by_omh"
+ACCOUNT_AUTHORIZATION_CLAIM_BOUNDARY = (
+    "This account-authorization projection is prepared metadata. It is not dispatch, execution, or "
+    "evidence that any account is usable: a login marker means a local file exists, never that a "
+    "provider would accept the credential behind it."
+)
+# Cited, never restated. The credential boundary already refuses credential
+# material in the field class every one of these references travels in; writing
+# a second rule here would give the tree two answers to one question.
+ACCOUNT_CREDENTIAL_BOUNDARY = (
+    "No credential value is read, stored, or echoed. Only a reference is carried — an environment "
+    "variable *name* matching the provider-posture shape, or an opaque handle — and the credential "
+    "boundary of handoff_safety_contract/v1 is what refuses anything else."
+)
+_ACCOUNT_CREDENTIAL_ENFORCERS = (
+    "omh.quality.safety_preflight.RULE_SECRETS_ABSENT",
+    "omh.system.metadata_safety.is_sensitive_metadata_text",
+)
+# Rendered onto chat cards, so the statements never carry a bare `omh ` token:
+# the card tests assert that no internal command-shaped string reaches a user,
+# and "OMH cannot..." reads as one. The wrapper is named as "this wrapper"
+# here and as OMH only in the handoff contract, which is not rendered.
+_ACCOUNT_BLOCKERS: tuple[tuple[str, str, tuple[str, ...]], ...] = (
+    (
+        "consent_required_is_not_observable",
+        "`consent-required` is not a state this wrapper can observe. Completing a provider's consent "
+        "flow happens on that provider's site, and nothing local reports it. The approval receipt "
+        "closes the adjacent gap and not this one: it proves the operator consented to this "
+        "wrapper's own escalation, which is a different question from whether a provider granted a "
+        "scope.",
+        ("omh.workflows.approval_receipts.approval_satisfies_request_in",),
+    ),
+    (
+        "guided_consent_flow_is_rendered_only",
+        "Guiding an operator through the host-owned consent flow can only ever be rendered "
+        "instructions. This wrapper may not launch a browser or run an auth CLI, and the "
+        "enforcement tests make that a test failure rather than a choice.",
+        (),
+    ),
+)
+ACCOUNT_BLOCKER_NAMES = tuple(entry[0] for entry in _ACCOUNT_BLOCKERS)
 
 TASK_AUTHORITY_ENVELOPE_KEYS = (
     "schema_version",
@@ -139,6 +494,8 @@ ACTION_GATE_KEYS = (
     "dispatch_policy",
     "confirmation",
     "authority_envelope",
+    "action_risk",
+    "account_authorization",
     "denial",
     "safety_profile_revision",
     "claim_boundary",
@@ -180,10 +537,16 @@ HANDOFF_SAFETY_CONTRACT_KEYS = (
 SAFETY_BOUNDARY_KEYS = ("boundary", "statement", "enforcement", "enforced_by", "blocked_by")
 EVIDENCE_REQUIREMENT_KEYS = ("stage", "claim", "observation_event", "enforcement", "enforced_by", "blocked_by")
 ENFORCEMENT_LEVELS = ("declared_not_enforced", "enforced")
-# Every local metadata surface the contract is derived from. All three are
-# already in process when `evaluate_action_gate` runs, which is what makes the
-# contract producible offline: no file, no process, no socket, no model.
+# Every local metadata surface the contract is derived from. Three of the four
+# are already in process when `evaluate_action_gate` runs. The fourth,
+# `data_boundary_enforcement_facts`, is a host-capability probe taken once per
+# process and memoized by `data_boundary_facts` below; it stats local paths and
+# never opens a socket, spawns a process, or consults a model, which is what
+# `produced_offline` claims. It is declared here rather than left implicit
+# because a surface a contract reads and does not name is exactly the kind of
+# hidden input this table exists to remove.
 HANDOFF_CONTRACT_INPUT_SOURCES = (
+    "data_boundary_enforcement_facts",
     "isolation_plan",
     "safety_preflight_verdict",
     "task_authority_envelope",
@@ -207,14 +570,30 @@ REVIEW_RECEIPT_BLOCKER = "#844"
 # it — `omh setup --star` really does shell out to `gh`. Where a real exception
 # exists outside the governed surface, the statement names it exactly rather
 # than rounding it away.
-_SAFETY_BOUNDARIES: tuple[tuple[str, str, str, tuple[str, ...], str], ...] = (
+_STATIC_SAFETY_BOUNDARIES: tuple[tuple[str, str, str, tuple[str, ...], str], ...] = (
     (
-        "confirmation_answered",
-        "Nothing records that a user answered a confirmation. The artifact proves a ladder was armed, "
-        "not that consent was given, so an armed ladder must never be read as an approval.",
+        "account_authorization",
+        "A task that needs account-backed access names the account and the minimum scopes by safe "
+        "reference only, and reports one of missing, authorized-unverified, observed-ready, or "
+        "expired. Nothing here grants, verifies, or refuses account access: `consent-required` is not "
+        "a state OMH can observe, and guiding an operator through a host-owned consent flow can only "
+        "ever be rendered instructions.",
         "declared_not_enforced",
         (),
-        "#807",
+        ACCOUNT_AUTHORIZATION_BLOCKER,
+    ),
+    (
+        "confirmation_answered",
+        "A risky action is classified, and every class present names the granted actions that carry "
+        "it and the approval each one would need. Nothing is withheld on the shipped lane: an "
+        "approval binds to a run, no surface records a confirmation answer, and the delegation is "
+        "built before any run exists — so no receipt that could answer the question is "
+        "constructible, and arming a ladder nobody can answer would block the work permanently "
+        "instead of gating it. A caller that does hold a run and a receipt store gets the refusal; "
+        "the shipped lane gets the report.",
+        "declared_not_enforced",
+        (),
+        RISK_CONSENT_BLOCKER,
     ),
     (
         "confirmation_arming",
@@ -388,7 +767,156 @@ _SAFETY_BOUNDARIES: tuple[tuple[str, str, str, tuple[str, ...], str], ...] = (
         "#820",
     ),
 )
-SAFETY_BOUNDARY_NAMES = tuple(entry[0] for entry in _SAFETY_BOUNDARIES)
+
+# The #801 data-boundary limits, by name. Mirrored rather than imported for the
+# reason `approval_receipts` mirrors this module's vocabularies: the import is
+# taken lazily inside `data_boundary_facts` so a probe never runs at import
+# time, and `tests/test_risky_action_confirmation.py` pins the two tuples equal
+# instead of letting them drift.
+DATA_BOUNDARY_LIMIT_NAMES = (
+    "workspace_root_claim",
+    "prohibited_data_class",
+    "declared_destination",
+    "runtime_filesystem_confinement",
+    "runtime_network_confinement",
+    "executor_honours_declared_targets",
+)
+# One prefix so the data-boundary rows read as one family in a contract that
+# already has seventeen other lines.
+DATA_BOUNDARY_PREFIX = "data_"
+DATA_BOUNDARY_NAMES = tuple(f"{DATA_BOUNDARY_PREFIX}{name}" for name in DATA_BOUNDARY_LIMIT_NAMES)
+
+# What each limit governs, in the contract's own voice. The *statement* is
+# host-independent; only the enforcement verdict moves per host, and that comes
+# from `data_boundary_enforcement_facts()` rather than from anything written
+# here.
+_DATA_BOUNDARY_STATEMENTS = {
+    "workspace_root_claim": (
+        "A target path outside the declared workspace roots is denied before a handoff is prepared, "
+        "on the same rule that already bounds absolute, escaping, and over-long paths."
+    ),
+    "prohibited_data_class": (
+        "A request declaring credential material, personal data, or a conversation transcript — or "
+        "carrying content shaped like one — is denied before any other rule reads it."
+    ),
+    "declared_destination": (
+        "A remote target that no approved destination names is denied, and so is an access intent "
+        "the approval does not cover, so a prepared handoff cannot reach somewhere nobody approved."
+    ),
+    "runtime_filesystem_confinement": (
+        "Confining a running executor's filesystem access needs an OS-level confinement backend. The "
+        "cross-harness adapter lane builds one; no delegation or fanout lane places an executor under "
+        "it, so the limit is declared rather than applied."
+    ),
+    "runtime_network_confinement": (
+        "Confining a running executor's network access needs the same OS-level backend and the same "
+        "unused sandbox, so the limit is declared rather than applied."
+    ),
+    "executor_honours_declared_targets": (
+        "The declared targets are a statement the executor is trusted to honour. Nothing measures "
+        "whether it did, on any host."
+    ),
+}
+
+# The enforcement kind each limit reports, mapped onto the contract's existing
+# ENFORCEMENT_LEVELS. There is deliberately no second label set: `enforced_here`
+# is the whole mapping, and `enforcement_kind` survives only inside the
+# statement, where it explains *why* a limit is or is not enforced here.
+_DATA_BOUNDARY_KIND_NOTES = {
+    "refused_before_handoff": (
+        "Refused before the handoff is prepared, so the limit holds identically on every host."
+    ),
+    "host_confinement": (
+        "Enforceable only through an OS-level confinement backend, so whether this host can enforce "
+        "it at all is a host fact and not a policy choice."
+    ),
+    "advisory": "Advisory on every host: nothing checks it anywhere.",
+}
+
+
+@lru_cache(maxsize=1)
+def data_boundary_facts() -> dict[str, Any]:
+    """The #801 host-capability answer, probed once per process and memoized.
+
+    Lazily imported for the reason `loop_actions` is: the evaluator lane owns
+    the probe, and importing it at module import time would run a filesystem
+    probe every time anything imports the action gate — including
+    `runtime.records`, which imports this module purely to validate a stored
+    verdict.
+
+    Memoized because it is called on every delegation build and the answer
+    cannot change inside one process without the host changing underneath it.
+    An install without the evaluator lane returns an empty mapping and the
+    contract then carries no data-boundary rows, which is the same
+    fail-without-bricking rule `normalize_safety_preflight` applies to a missing
+    verdict.
+    """
+    try:
+        from ..quality.safety_preflight import data_boundary_enforcement_facts
+    except ImportError:
+        return {}
+    facts = data_boundary_enforcement_facts()
+    return facts if isinstance(facts, dict) else {}
+
+
+def _data_boundary_entries() -> tuple[tuple[str, str, str, tuple[str, ...], str], ...]:
+    """The data-boundary rows, mapped onto the contract's own enforcement triple.
+
+    `enforcement_kind` is not a second label set living beside
+    ENFORCEMENT_LEVELS: it selects the note appended to the statement and
+    nothing else. The verdict itself is `enforced_here`, and `enforced_by` /
+    `blocked_by` are taken verbatim from the facts, which already emit them in
+    the exact shape `_enforcement_errors` requires.
+    """
+    facts = data_boundary_facts()
+    limits = facts.get("limits")
+    if not isinstance(limits, list):
+        return ()
+    entries: list[tuple[str, str, str, tuple[str, ...], str]] = []
+    for limit in limits:
+        if not isinstance(limit, dict):
+            continue
+        name = str(limit.get("limit", ""))
+        statement = _DATA_BOUNDARY_STATEMENTS.get(name, "")
+        if not statement:
+            continue
+        note = _DATA_BOUNDARY_KIND_NOTES.get(str(limit.get("enforcement_kind", "")), "")
+        enforced_here = limit.get("enforced_here") is True
+        entries.append(
+            (
+                f"{DATA_BOUNDARY_PREFIX}{name}",
+                f"{statement} {note}".strip(),
+                "enforced" if enforced_here else "declared_not_enforced",
+                tuple(str(symbol) for symbol in limit.get("enforced_by", []) or ()) if enforced_here else (),
+                "" if enforced_here else str(limit.get("blocked_by", "")),
+            )
+        )
+    return tuple(entries)
+
+
+def safety_boundaries() -> tuple[tuple[str, str, str, tuple[str, ...], str], ...]:
+    """The full boundary table, static rows and data-boundary rows, in one order.
+
+    Sorted by name so the table stays readable as it grows and so a reader
+    cannot infer precedence from position; the validator compares the whole
+    ordered name list, which is what makes a dropped, duplicated, or reordered
+    row the same defect.
+    """
+    return tuple(sorted((*_STATIC_SAFETY_BOUNDARIES, *_data_boundary_entries()), key=lambda entry: entry[0]))
+
+
+def safety_boundary_names() -> tuple[str, ...]:
+    """The boundary names this install really produces, in table order."""
+    return tuple(entry[0] for entry in safety_boundaries())
+
+
+# The boundary set a complete install declares. The validator compares against
+# `safety_boundary_names()` instead, so an install missing the #801 evaluator
+# lane still validates its own smaller contract rather than failing on rows it
+# could never have built; a test pins the two equal for a complete install.
+SAFETY_BOUNDARY_NAMES = tuple(
+    sorted((*(entry[0] for entry in _STATIC_SAFETY_BOUNDARIES), *DATA_BOUNDARY_NAMES))
+)
 
 _CLAIM_LADDER_ENFORCERS = (
     "omh.runtime.claims.allowed_runtime_claims",
@@ -500,6 +1028,12 @@ def permission_profile_for(
     return "handoff_only"
 
 
+# Never narrowed away. Reading and thinking about a request is what makes an
+# answer possible at all, so a narrowing answer that removed them would leave a
+# handoff that cannot even be described.
+BASELINE_ACTIONS = frozenset({"planning", "research"})
+
+
 def required_actions_for(
     *,
     denied: bool,
@@ -524,6 +1058,13 @@ def required_actions_for(
 
 
 def _explanation(action: str, reason_code: str, profile: str) -> str:
+    if reason_code == "withheld_pending_approval":
+        return (
+            f"`{action}` is held back until an approval on record covers it for this owner, run, "
+            "scope, and safety profile revision."
+        )
+    if reason_code == "narrowed_by_request":
+        return f"`{action}` was removed because the request narrowed the authority it asked for."
     if reason_code == "safety_preflight_denied":
         return f"`{action}` was withdrawn because the safety preflight denied this request."
     if reason_code == "outside_permission_profile":
@@ -618,8 +1159,22 @@ def build_task_authority_envelope(
     context_pack: dict[str, Any] | None = None,
     memory_recall_pack: dict[str, Any] | None = None,
     safety_profile_revision: str = "",
+    narrow_to: set[str] | frozenset[str] | None = None,
+    withheld: set[str] | frozenset[str] | None = None,
 ) -> dict[str, Any]:
-    """Derive the task-scoped authority envelope from intent and policy only."""
+    """Derive the task-scoped authority envelope from intent and policy only.
+
+    `narrow_to` is the "narrow" answer to a risky-action confirmation: a smaller
+    requested action set, fed back through the same `requested_actions` seam a
+    widening request travels on. It can only ever remove authority — the result
+    is the intersection with what the task already required — so a narrowing
+    answer can never become a widening one by accident.
+
+    `withheld` is authority the task really does require and that no recorded
+    approval covers. It is separated from `narrow_to` because the two mean
+    opposite things to a reader: a narrowed action was not asked for, while a
+    withheld one was asked for and is waiting on an answer.
+    """
     profile = permission_profile_for(
         denied=denied,
         delegation_action=delegation_action,
@@ -646,6 +1201,13 @@ def build_task_authority_envelope(
         choice_required=choice_required,
     )
     vocabulary = set(loop_actions())
+    narrowed_away: set[str] = set()
+    if narrow_to is not None:
+        kept = required & (set(narrow_to) | BASELINE_ACTIONS)
+        narrowed_away = required - kept
+        required = kept
+    withheld_away = (required & set(withheld)) - BASELINE_ACTIONS if withheld else set()
+    required = required - withheld_away
     executors = [selected_executor_profile] if selected_executor_profile else []
     base = _loop_envelope(profile, executors=executors, forbid=sorted(vocabulary - required))
     allowed = set(base["allowed_actions"])
@@ -653,7 +1215,11 @@ def build_task_authority_envelope(
 
     exclusions: list[dict[str, str]] = []
     for action in blocked:
-        if denied and action in undenied:
+        if action in withheld_away:
+            reason_code = "withheld_pending_approval"
+        elif action in narrowed_away:
+            reason_code = "narrowed_by_request"
+        elif denied and action in undenied:
             reason_code = "safety_preflight_denied"
         elif action in required:
             reason_code = "outside_permission_profile"
@@ -702,14 +1268,499 @@ def build_task_authority_envelope(
     }
 
 
-def build_task_handoff_safety_contract(envelope: dict[str, Any]) -> dict[str, Any]:
-    """The task-scoped handoff safety contract, derived from the envelope alone.
+def _declared_strings(request: dict[str, Any] | None, key: str) -> list[str]:
+    value = (request or {}).get(key)
+    if not isinstance(value, (list, tuple)):
+        return []
+    return [str(item) for item in value if isinstance(item, str)]
 
-    Offline by construction: the boundary and evidence tables are module data
-    and every task-specific value is read off the authority envelope this same
-    build just produced. Nothing here opens a file, spawns a process, resolves a
-    host, or consults a model, so the contract is reproducible on a machine with
-    no network and byte-identical across repeated builds of the same delegation.
+
+def granted_risk_actions(envelope: dict[str, Any], risk_class: str) -> list[str]:
+    """The actions this envelope really grants that carry one class's risk.
+
+    The whole anti-collapse rule in one function. A confirmation may only ever
+    name an action the envelope granted: an approval for an action nobody was
+    ever given is unmatchable, and a class whose granted carriers are empty is
+    a class the handoff cannot perform.
+    """
+    granted = set(_declared_strings(envelope, "allowed_actions"))
+    return sorted(action for action in _RISK_CLASS_ACTIONS.get(risk_class, ()) if action in granted)
+
+
+def risk_classes_present(
+    *,
+    envelope: dict[str, Any],
+    safety_preflight_request: dict[str, Any] | None = None,
+) -> list[str]:
+    """The risky classes this delegation carries, sorted.
+
+    Two inputs and no others: what the envelope granted, and what the request
+    declared. Nothing here reads the message, and there is no parameter through
+    which it could — see `ACTION_RISK_TEXT_POLICY` for what that does and does
+    not promise about the request a caller hands in.
+
+    Every rule is anchored on `mutation_rights`, which is the envelope's own
+    grant set, so a class is present only when the envelope really grants an
+    action that could perform it. `merge_authority` and
+    `external_action_authority` are not read separately: on any envelope the
+    validator accepts they are restatements of `merge` and `external_posting`
+    being allowed, and reading them as independent triggers is what let a class
+    appear with no grantable action behind it.
+    """
+    mutation_rights = set(_declared_strings(envelope, "mutation_rights"))
+    intents = set(_declared_strings(safety_preflight_request, "access_intents"))
+    target_paths = _declared_strings(safety_preflight_request, "target_paths")
+
+    present: set[str] = set()
+    if (
+        "repo_edit" in mutation_rights
+        and "write" in intents
+        and len(target_paths) > MAX_UNCONFIRMED_TARGET_PATHS
+    ):
+        present.add("broad_write")
+    if mutation_rights & set(_RISK_CLASS_ACTIONS["external_mutation"]):
+        present.add("external_mutation")
+    if "external_posting" in mutation_rights:
+        present.add("publication")
+    return sorted(present)
+
+
+def _risk_level_for(classes: list[str]) -> str:
+    if not classes:
+        return "none"
+    if set(classes) & _ESCAPING_CLASSES:
+        return "high"
+    return "elevated"
+
+
+def _narrowing_route(envelope: dict[str, Any], withheld_actions: list[str]) -> dict[str, Any]:
+    """The smaller action set that answers "narrow" instead of "approve".
+
+    Fed back through `requested_authority_actions`, which is the same seam a
+    widening request travels on. That seam existed with no production caller;
+    this is its first one.
+
+    Every action that still carries an unapproved class is removed, not just one
+    of them: the promise in the explanation is that re-running with this set
+    leaves nothing to confirm, and a set that dropped one carrier while keeping
+    a sibling would ask the same question again.
+    """
+    allowed = set(_declared_strings(envelope, "allowed_actions"))
+    narrowed = sorted((allowed - set(withheld_actions)) | BASELINE_ACTIONS)
+    return {
+        "parameter": "requested_authority_actions",
+        "narrowed_actions": narrowed,
+        "explanation": (
+            "Answering narrow means asking for a smaller action set. Re-run the same request with "
+            "these actions and no action carrying an unapproved risky class is granted, so nothing "
+            "is left to confirm."
+        ),
+    }
+
+
+def classify_action_risk(
+    *,
+    envelope: dict[str, Any],
+    isolation_plan: dict[str, Any] | None = None,
+    safety_preflight_request: dict[str, Any] | None = None,
+    approval_receipts: Any = None,
+    owner: str = "",
+    run_id: str = "",
+    now: str = "",
+) -> dict[str, Any]:
+    """Allow, ask, or deny every risky class present, each on its own consent.
+
+    Consent is per risky class, and within a class per granted action. There is
+    no single "the approvable action": one answer covering three classes is
+    three approvals wearing one answer, and it was that collapse which let a
+    receipt naming `merge` release a broad repo write and a publication at once.
+
+    For every class present, every action the envelope really grants that
+    carries it becomes one `consent` entry with its own five-dimension approval
+    request and its own verdict:
+
+    * a live approval naming exactly that action, scope, owner, run, and
+      safety-profile revision -> **allow** for that entry.
+    * an approval that was revoked or answered with a denial -> **deny**. The
+      operator already said no; asking again is asking until the answer changes.
+    * anything else — absent, expired, superseded, or an approval covering a
+      sibling action, a different scope, another owner, another run, or another
+      revision -> **ask**.
+
+    The verdict is the aggregate: **deny** if any entry is refused, **ask** if
+    any entry is unanswered, and **allow** only when every class present is
+    approved on every action that carries it. `withheld_actions` is exactly the
+    set of actions whose entry is not allowed.
+
+    `enforcement` is the honest half. A receipt binds to a run, and
+    `build_approval_receipt` refuses an empty one, so with no run id no receipt
+    that could satisfy any of these requests is constructible and the whole
+    classification is a report: `declared_not_enforced`, blocked by
+    `RISK_CONSENT_BLOCKER`, and the gate withholds nothing. Given a run id the
+    same refusal is real and the block reports `enforced`.
+
+    `approval_receipts` is a sequence of receipts the caller already read, and
+    the pure `approval_satisfies_request_in` form is what judges them, so this
+    function opens nothing. A caller with no store passes nothing and every
+    risky action is unapproved, which is the safe direction.
+
+    One scope stays run-wide by design: the approval binds to the permission
+    profile, so inside one run, one hour, and one revision, a second delegation
+    for the same owner and profile is covered by the first answer for the same
+    class and action. That is what a run-bound approval means; it is not a
+    per-delegation consent and never claimed to be.
+
+    `isolation_plan` is read for its *strategy* only. `isolation_plan.risk_level`
+    is deliberately never touched; see `ACTION_RISK_VS_ISOLATION_RISK`.
+    """
+    classes = risk_classes_present(envelope=envelope, safety_preflight_request=safety_preflight_request)
+    subsumed = [
+        {
+            "class": name,
+            "derivation": derivation,
+            "approvable_actions": list(actions),
+            "carrier": carrier,
+            "statement": statement,
+        }
+        for name, derivation, actions, carrier, statement in _RISK_CLASS_RULES
+        if derivation == "subsumed"
+    ]
+    profile = str(envelope.get("permission_profile", ""))
+    revision = str(envelope.get("safety_profile_revision", ""))
+    strategy = str((isolation_plan or {}).get("strategy", ""))
+    enforceable = bool(str(run_id).strip())
+    enforcement = {
+        "enforcement": "enforced" if enforceable else "declared_not_enforced",
+        "enforced_by": list(RISK_CONSENT_ENFORCERS) if enforceable else [],
+        "blocked_by": "" if enforceable else RISK_CONSENT_BLOCKER,
+    }
+
+    if not classes:
+        return {
+            "schema_version": ACTION_RISK_SCHEMA_VERSION,
+            "status": "prepared_not_observed",
+            "level": "none",
+            "decision": "allow",
+            "reason": (
+                "Nothing in this handoff escalates past prepare-only, so no risky action needs "
+                f"confirming under the `{strategy or 'unstated'}` isolation strategy."
+            ),
+            "classes": [],
+            "subsumed_classes": subsumed,
+            "consent": [],
+            "withheld_actions": [],
+            "narrowing_route": {},
+            "inputs": list(ACTION_RISK_INPUTS),
+            "text_policy": ACTION_RISK_TEXT_POLICY,
+            "isolation_risk_relationship": ACTION_RISK_VS_ISOLATION_RISK,
+            **enforcement,
+            "claim_boundary": ACTION_RISK_CLAIM_BOUNDARY,
+        }
+
+    receipts = list(approval_receipts or [])
+    consent: list[dict[str, Any]] = []
+    for name, _derivation, _actions, _carrier, _statement in _RISK_CLASS_RULES:
+        if name not in classes:
+            continue
+        for action in granted_risk_actions(envelope, name):
+            request = {
+                "approved_action": action,
+                "scope_class": RISK_APPROVAL_SCOPE_CLASS,
+                "scope_ref": profile,
+                "owner": str(owner),
+                "run_id": str(run_id),
+                "safety_profile_revision": revision,
+            }
+            approval = approval_satisfies_request_in(
+                receipts,
+                approved_action=action,
+                scope_class=RISK_APPROVAL_SCOPE_CLASS,
+                scope_ref=profile,
+                owner=str(owner),
+                run_id=str(run_id),
+                safety_profile_revision=revision,
+                now=now,
+            )
+            reason_code = str(approval.get("reason_code", ""))
+            if approval.get("satisfied") is True:
+                entry_decision = "allow"
+            elif reason_code in {REFUSAL_REVOKED, REFUSAL_DENIED}:
+                entry_decision = "deny"
+            else:
+                entry_decision = "ask"
+            consent.append(
+                {
+                    "class": name,
+                    "approved_action": action,
+                    "decision": entry_decision,
+                    "approval_request": request,
+                    "approval": approval,
+                }
+            )
+
+    refused = [entry for entry in consent if entry["decision"] == "deny"]
+    unanswered = [entry for entry in consent if entry["decision"] == "ask"]
+    withheld = sorted({str(entry["approved_action"]) for entry in consent if entry["decision"] != "allow"})
+    if refused:
+        decision = "deny"
+        reason = (
+            "The operator refused or revoked the approval for "
+            + _quoted_actions(refused)
+            + ", so "
+            + _quoted_classes(refused)
+            + " stays refused. Asking again would be asking until the answer changes."
+        )
+    elif unanswered:
+        decision = "ask"
+        reason = (
+            "No recorded approval covers "
+            + _quoted_actions(unanswered)
+            + " for this owner, run, scope, and safety profile revision, so "
+            + _quoted_classes(unanswered)
+            + " needs an explicit answer on every action that carries it."
+        )
+    elif consent:
+        decision = "allow"
+        reason = (
+            "A recorded approval covers "
+            + _quoted_actions(consent)
+            + " for this owner, run, scope, and safety profile revision, so every risky class "
+            "present proceeds on consent that was given rather than on a ladder that was armed."
+        )
+    else:
+        # A class is present and the envelope grants nothing that carries it.
+        # `risk_classes_present` cannot produce this today because every rule is
+        # anchored on `mutation_rights`; a future rule that could would have no
+        # answerable question, so it refuses rather than silently allowing.
+        decision = "deny"
+        reason = (
+            "This handoff carries a risky class the envelope grants no action for, so there is no "
+            "approval that could release it and nothing may proceed on it."
+        )
+    return {
+        "schema_version": ACTION_RISK_SCHEMA_VERSION,
+        "status": "prepared_not_observed",
+        "level": _risk_level_for(classes),
+        "decision": decision,
+        "reason": reason.strip(),
+        "classes": [
+            {
+                "class": name,
+                "derivation": derivation,
+                "approvable_actions": granted_risk_actions(envelope, name),
+                "carrier": carrier,
+                "statement": statement,
+            }
+            for name, derivation, _actions, carrier, statement in _RISK_CLASS_RULES
+            if name in classes
+        ],
+        "subsumed_classes": subsumed,
+        "consent": consent,
+        "withheld_actions": withheld,
+        "narrowing_route": _narrowing_route(envelope, withheld),
+        "inputs": list(ACTION_RISK_INPUTS),
+        "text_policy": ACTION_RISK_TEXT_POLICY,
+        "isolation_risk_relationship": ACTION_RISK_VS_ISOLATION_RISK,
+        **enforcement,
+        "claim_boundary": ACTION_RISK_CLAIM_BOUNDARY,
+    }
+
+
+def _quoted_actions(entries: list[dict[str, Any]]) -> str:
+    return ", ".join(f"`{action}`" for action in sorted({str(entry["approved_action"]) for entry in entries}))
+
+
+def _quoted_classes(entries: list[dict[str, Any]]) -> str:
+    return ", ".join(f"`{name}`" for name in sorted({str(entry["class"]) for entry in entries}))
+
+
+def _account_state(signal: Any, now: str = "") -> tuple[str, str]:
+    """(state, what said so) for one account, from a signal the caller already read.
+
+    Four states and the one thing each of them means:
+
+    * `missing` — the readiness probe found no marker at all.
+    * `authorized-unverified` — a login marker is present. That is exactly what
+      a marker means and `executor_auth_signals`' own claim boundary already
+      says so: a local file exists, not that the provider would accept it.
+    * `observed-ready` — a readiness probe reported ready *and* the process it
+      ran exited 0. Either half alone is not readiness.
+    * `expired` — the signal's own timestamp is older than the staleness
+      horizon, derived here at read time rather than stored as a deadline.
+    """
+    if not isinstance(signal, dict):
+        return "missing", "readiness_probe"
+    observed_at = str(signal.get("observed_at", "") or "")
+    if observed_at and _stamp_age_seconds(observed_at, now) > ACCOUNT_SIGNAL_STALE_AFTER_SECONDS:
+        return "expired", "stored_timestamp"
+    if str(signal.get("probe_status", "")) == "ready" and signal.get("exit_code") == 0:
+        return "observed-ready", "probe_exit_code"
+    if str(signal.get("login_marker", "")) == "present":
+        return "authorized-unverified", "login_marker"
+    return "missing", "readiness_probe"
+
+
+def _stamp_age_seconds(observed_at: str, now: str = "") -> int:
+    """Age of an ISO-8601 stamp in seconds, or a value past every horizon.
+
+    Unreadable and future stamps both return a value larger than any horizon,
+    for the reason `approval_age_seconds` returns `UNKNOWN_AGE_SECONDS`: neither
+    can be shown to be fresh, and clamping would make editing a timestamp a way
+    to widen a window from disk.
+    """
+
+    def _parse(value: str) -> datetime | None:
+        text = value.strip().replace("Z", "+00:00")
+        try:
+            parsed = datetime.fromisoformat(text)
+        except ValueError:
+            return None
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+    observed = _parse(observed_at)
+    if observed is None:
+        return ACCOUNT_SIGNAL_STALE_AFTER_SECONDS + 1
+    reference = _parse(now) or datetime.now(timezone.utc)
+    age = int((reference - observed).total_seconds())
+    return ACCOUNT_SIGNAL_STALE_AFTER_SECONDS + 1 if age < 0 else age
+
+
+def build_account_authorization(
+    *,
+    envelope: dict[str, Any],
+    auth_signals: dict[str, Any] | None = None,
+    account_references: dict[str, str] | None = None,
+    withheld_actions: list[str] | tuple[str, ...] | None = None,
+    now: str = "",
+) -> dict[str, Any]:
+    """The #799 projection: which accounts this task needs, and what is known.
+
+    Honest about what it is. Roughly three quarters of #799 is a projection over
+    things this tree already derives — that a task needs account-backed access,
+    which account, the minimum scopes, and a readiness state — and that part is
+    implemented here. The remaining quarter is not implementable: OMH cannot
+    observe that a person completed a consent flow on a provider's site, and it
+    may not launch a browser or run an auth CLI to move them through one. Those
+    two are declared as blockers with the reason written out, and the whole
+    projection reports `declared_not_enforced`.
+
+    Never probes. `auth_signals` is an `executor_auth_signals/v1`-shaped mapping
+    the caller already read, so this stays as I/O-free as the rest of the gate.
+    A caller that read nothing gets `missing`, which is the safe direction.
+
+    Never carries credential material. A reference is either an environment
+    variable *name* matching the provider-posture shape or an opaque handle;
+    the credential boundary is cited rather than reimplemented.
+
+    `withheld_actions` is read for the same reason the envelope is: withholding
+    an action because nobody approved it does not stop the task needing the
+    account behind it. Reading `allowed_actions` alone made `required` report
+    false exactly when a risky action was held back, which is the inverse of
+    what a reader takes it to mean.
+    """
+    allowed = set(_declared_strings(envelope, "allowed_actions")) | {
+        str(action) for action in (withheld_actions or [])
+    }
+    account_backed = sorted(allowed & set(ACCOUNT_BACKED_ACTIONS))
+    executors = _declared_strings(envelope, "allowed_executors")
+    profiles = (auth_signals or {}).get("profiles")
+    signals = profiles if isinstance(profiles, dict) else {}
+    accounts: list[dict[str, Any]] = []
+    for executor in executors:
+        state, source = _account_state(signals.get(executor), now)
+        reference = str((account_references or {}).get(executor, "") or "")
+        kind = "env_var_name" if _is_env_var_name(reference) else "opaque_handle"
+        accounts.append(
+            {
+                "account_ref": reference if kind == "env_var_name" else _safe_account_handle(executor),
+                "reference_kind": kind,
+                "minimum_scopes": list(account_backed),
+                "state": state,
+                "state_source": source,
+            }
+        )
+    required = bool(account_backed)
+    return {
+        "schema_version": ACCOUNT_AUTHORIZATION_SCHEMA_VERSION,
+        "status": "prepared_not_observed",
+        "required": required,
+        "reason": (
+            "This task needs account-backed access: the envelope allows "
+            f"{', '.join(f'`{action}`' for action in account_backed)}, and none of those can run "
+            "without an account the operator owns."
+            if required
+            else "Nothing this envelope allows reaches an account, so no account-backed access is needed."
+        ),
+        "accounts": accounts,
+        "enforcement": "declared_not_enforced",
+        "enforced_by": [],
+        "blocked_by": ACCOUNT_AUTHORIZATION_BLOCKER,
+        "blockers": [
+            {"blocker": blocker, "statement": statement, "cites": list(cites)}
+            for blocker, statement, cites in _ACCOUNT_BLOCKERS
+        ],
+        "credential_boundary": ACCOUNT_CREDENTIAL_BOUNDARY,
+        "claim_boundary": ACCOUNT_AUTHORIZATION_CLAIM_BOUNDARY,
+    }
+
+
+def _is_env_var_name(value: str) -> bool:
+    """The `provider_profile_posture` secret-name shape, applied to a reference.
+
+    Same shape and the same reason: an environment variable *name* is safe to
+    carry because it is not the value. The shape alone is not enough — plenty of
+    issued credentials are upper-case alphanumerics too, and
+    `AKIAIOSFODNN7EXAMPLE` satisfies every character rule below — so the value
+    is also screened through the credential boundary's own value detectors
+    before it is accepted as a name.
+
+    `is_secret_value_shaped` rather than `is_sensitive_metadata_text`: the wider
+    predicate flags anything *named* like a secret, and an environment variable
+    name legitimately is (`GITHUB_TOKEN`, `CODEX_API_KEY`). The narrow one flags
+    issued material only, which is exactly the confusion this guard exists for.
+    Its reach is the reach of those detectors and no further; a credential value
+    none of them recognise still passes the shape.
+    """
+    if not 2 <= len(value) <= 96 or not value[0].isascii() or not value[0].isupper():
+        return False
+    if is_secret_value_shaped(value):
+        return False
+    return all(character.isascii() and (character.isupper() or character.isdigit() or character == "_") for character in value)
+
+
+def _safe_account_handle(value: str) -> str:
+    """An opaque handle for an account, or an empty string when it is not safe.
+
+    Routed through the same admission check the envelope uses on every other
+    caller-supplied reference, so an account name cannot become the one string
+    on this record nobody screened.
+    """
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    try:
+        ensure_safe_opaque_ref_content(text, "account_ref")
+    except ValueError:
+        return ""
+    return text
+
+
+def build_task_handoff_safety_contract(envelope: dict[str, Any]) -> dict[str, Any]:
+    """The task-scoped handoff safety contract, derived from the envelope and the host.
+
+    Offline by construction: the boundary and evidence tables are module data,
+    every task-specific value is read off the authority envelope this same build
+    just produced, and the one host-dependent surface — whether this machine can
+    enforce a #801 runtime limit — is a memoized local stat taken once per
+    process through `data_boundary_facts`. Nothing here spawns a process,
+    resolves a host, opens a socket, or consults a model, so the contract is
+    reproducible on a machine with no network and byte-identical across repeated
+    builds of the same delegation on the same host.
+
+    That host dependence is named in `input_sources` rather than left implicit.
+    It stays out of `safety_rule_profile()` for the reason that function's own
+    comment gives: a host-dependent digest would read as profile drift on every
+    second machine.
 
     Reading the envelope rather than re-deriving from intent and policy is
     deliberate: a contract that recomputed its own numbers could disagree with
@@ -728,7 +1779,7 @@ def build_task_handoff_safety_contract(envelope: dict[str, Any]) -> dict[str, An
                 "enforced_by": list(enforced_by),
                 "blocked_by": blocked_by,
             }
-            for boundary, statement, enforcement, enforced_by, blocked_by in _SAFETY_BOUNDARIES
+            for boundary, statement, enforcement, enforced_by, blocked_by in safety_boundaries()
         ],
         "evidence_requirements": [
             {
@@ -850,18 +1901,41 @@ def _arbitrate_confirmation(
     denied: bool,
     choice_required: bool,
     expansion_requested: bool,
+    risky_action_ask: bool,
+    risky_action_refused: bool,
     dispatchable: bool,
 ) -> dict[str, Any]:
-    """Pick at most one ladder and record why every other one stayed silent."""
+    """Pick at most one ladder and record why every other one stayed silent.
+
+    `risky_action_ask` and `risky_action_refused` are already gated on the risk
+    verdict being enforced. A ladder whose answer cannot be recorded is not
+    armed here at all: asking a question nothing can answer is how a request
+    ends with no route forward.
+    """
     if denied:
         winner = ""
         reason = "A denied request is corrected, not confirmed; no ladder is armed."
+    elif risky_action_refused:
+        # A revoked or refused approval is an answer. Re-arming the ladder would
+        # be asking again until the answer changes, so the refusal stands and the
+        # authority it covered stays withheld.
+        winner = ""
+        reason = (
+            "The operator already refused or revoked the approval this risky action needs, so the "
+            "authority stays withheld and no ladder asks again."
+        )
     elif choice_required:
         winner = "executor_selection"
         reason = "The coding agent that owns this work is not chosen yet, so nothing downstream can be confirmed."
     elif expansion_requested:
         winner = "permission_profile"
         reason = "The request asks for authority outside the derived envelope, so widening routes through one profile choice."
+    elif risky_action_ask:
+        winner = "risky_action"
+        reason = (
+            "A risky action inside the envelope has no recorded approval covering this action, scope, "
+            "owner, run, and safety profile revision, so the act itself needs one answer."
+        )
     elif dispatchable:
         winner = "operator_confirmation"
         reason = "The envelope already allows dispatch, so only the act itself needs a go-ahead."
@@ -875,6 +1949,8 @@ def _arbitrate_confirmation(
             continue
         if denied:
             suppressed.append({"ladder": ladder, "reason": "suppressed_by:denial"})
+        elif risky_action_refused:
+            suppressed.append({"ladder": ladder, "reason": "suppressed_by:refused_approval"})
         elif winner:
             suppressed.append({"ladder": ladder, "reason": f"superseded_by:{winner}"})
         else:
@@ -907,14 +1983,39 @@ def evaluate_action_gate(
     context_pack: dict[str, Any] | None = None,
     memory_recall_pack: dict[str, Any] | None = None,
     safety_preflight: dict[str, Any] | None = None,
+    safety_preflight_request: dict[str, Any] | None = None,
     live_safety_profile_revision: str | None = None,
     requested_actions: list[str] | tuple[str, ...] | None = None,
+    approval_receipts: Any = None,
+    executor_auth_signals: dict[str, Any] | None = None,
+    account_references: dict[str, str] | None = None,
+    run_id: str = "",
+    now: str = "",
 ) -> dict[str, Any]:
-    """The single decision path: preflight, envelope, and one confirmation ladder.
+    """The single decision path: preflight, envelope, risk, and one ladder.
 
     The safety-profile revision re-check runs *before* the confirmation is
     arbitrated, so a user never pays a prompt for work that then hard-fails on
-    drift.
+    drift. The risk classification runs after the envelope and before the
+    arbitration, for the same reason in the other direction: the ladder that is
+    armed has to be the ladder the classified risk asks for.
+
+    `requested_actions` is one seam with two directions. Actions outside the
+    envelope widen it and route through the permission-profile ladder; actions
+    inside it narrow it, which is the "narrow" answer to a risky-action
+    confirmation and is #800's first real caller of that parameter.
+
+    The risky-action ladder only arms, and authority is only withheld, when the
+    confirmation can actually be answered — which means `run_id` is set, because
+    an approval binds to a run and `build_approval_receipt` refuses an empty
+    one. Without it no receipt that could release the work is constructible, so
+    arming would leave a user permanently blocked with no route forward; the
+    classification rides as a report instead and
+    `action_risk.enforcement` says so on the record.
+
+    Every new input is something the caller already holds. `approval_receipts`
+    and `executor_auth_signals` are read elsewhere and handed in, so this
+    function still opens nothing.
     """
     preflight = normalize_safety_preflight(safety_preflight)
     denial: dict[str, Any] | None = None
@@ -928,7 +2029,11 @@ def evaluate_action_gate(
 
     effective_dispatchable = bool(dispatchable) and not denied
     effective_choice_required = bool(choice_required) and not denied
-    envelope = build_task_authority_envelope(
+    requested = {str(action) for action in (requested_actions or [])}
+    # Widening and narrowing travel the same seam and are told apart by one
+    # question: is anything asked for outside what the task already required?
+    # An empty request narrows nothing, so the default path is untouched.
+    unnarrowed = build_task_authority_envelope(
         denied=denied,
         delegation_action=delegation_action,
         intent=intent,
@@ -946,12 +2051,77 @@ def evaluate_action_gate(
         memory_recall_pack=memory_recall_pack,
         safety_profile_revision=preflight["safety_profile_revision"],
     )
-    requested = {str(action) for action in (requested_actions or [])}
-    expansion_requested = bool(requested - set(envelope["allowed_actions"]))
+    expansion_requested = bool(requested - set(unnarrowed["allowed_actions"]))
+    narrow_to = None if expansion_requested or not requested else set(requested)
+
+    def _envelope(withheld: set[str] | None = None) -> dict[str, Any]:
+        return build_task_authority_envelope(
+            denied=denied,
+            delegation_action=delegation_action,
+            intent=intent,
+            review_required=review_required,
+            work_owner_mode="retained_hermes" if denied else work_owner_mode,
+            selected_executor_profile=None if denied else selected_executor_profile,
+            dispatchable=bool(dispatchable),
+            choice_required=bool(choice_required),
+            isolation_plan={} if denied else isolation_plan,
+            message=message,
+            context_pack=context_pack,
+            memory_recall_pack=memory_recall_pack,
+            safety_profile_revision=preflight["safety_profile_revision"],
+            narrow_to=narrow_to,
+            withheld=withheld,
+        )
+
+    envelope = unnarrowed if narrow_to is None else _envelope()
+    owner = "" if denied else str(selected_executor_profile or "")
+    action_risk = classify_action_risk(
+        envelope=envelope,
+        isolation_plan={} if denied else isolation_plan,
+        safety_preflight_request=safety_preflight_request,
+        approval_receipts=approval_receipts,
+        owner=owner,
+        run_id=run_id,
+        now=now,
+    )
+    # The refusal, and the one condition under which it is a refusal at all.
+    # Every action carrying an unapproved class — not one collapsed stand-in for
+    # all of them — plus the dispatch that would carry them, is withheld from the
+    # envelope, and the verdict stops being dispatchable, so a caller cannot read
+    # an armed ladder as the consent that was never given.
+    #
+    # `enforced` is what gates that. When the confirmation cannot be answered,
+    # withholding would not gate the work, it would end it: nothing could ever
+    # release the authority again. There the classification is reported, the
+    # ladder stays silent, and `action_risk.blocked_by` names why.
+    risk_enforced = action_risk["enforcement"] == "enforced"
+    risk_allows = action_risk["decision"] == "allow"
+    withheld_actions = [str(action) for action in action_risk["withheld_actions"]]
+    if risk_enforced and not risk_allows:
+        withheld = {*withheld_actions, "executor_dispatch"}
+        envelope = _envelope(withheld={action for action in withheld if action})
+        action_risk["narrowing_route"] = _narrowing_route(unnarrowed, withheld_actions)
+        effective_dispatchable = False
+    account_authorization = build_account_authorization(
+        envelope=envelope,
+        auth_signals=executor_auth_signals,
+        account_references=account_references,
+        # Withheld authority is authority the task still needs; see the note in
+        # `build_account_authorization`. Read back off the envelope's own
+        # exclusions rather than recomputed, so it is exactly what was withheld.
+        withheld_actions=[
+            str(entry["action"])
+            for entry in envelope["exclusions"]
+            if entry.get("reason_code") == "withheld_pending_approval"
+        ],
+        now=now,
+    )
     confirmation = _arbitrate_confirmation(
         denied=denied,
         choice_required=effective_choice_required,
         expansion_requested=expansion_requested,
+        risky_action_ask=risk_enforced and action_risk["decision"] == "ask",
+        risky_action_refused=risk_enforced and action_risk["decision"] == "deny",
         dispatchable=effective_dispatchable,
     )
     verdict: dict[str, Any] = {
@@ -963,9 +2133,11 @@ def evaluate_action_gate(
         "executor_selection_status": "retained_hermes" if denied else executor_selection_status,
         "work_owner_mode": "retained_hermes" if denied else work_owner_mode,
         "selected_executor_profile": None if denied else selected_executor_profile,
-        "dispatch_policy": "prepare_only" if denied else dispatch_policy,
+        "dispatch_policy": "prepare_only" if denied or (risk_enforced and not risk_allows) else dispatch_policy,
         "confirmation": confirmation,
         "authority_envelope": envelope,
+        "action_risk": action_risk,
+        "account_authorization": account_authorization,
         "safety_profile_revision": preflight["safety_profile_revision"],
         "claim_boundary": GATE_CLAIM_BOUNDARY,
         # Built here because this is the one place that runs exactly once per
@@ -1081,6 +2253,217 @@ def validate_task_authority_envelope(
     return errors
 
 
+def _risk_class_entry_errors(value: Any, label: str, *, expected: tuple[str, ...]) -> list[str]:
+    if not isinstance(value, list):
+        return [f"{label} must be a list"]
+    errors: list[str] = []
+    if [entry.get("class") for entry in value if isinstance(entry, dict)] != list(expected):
+        errors.append(f"{label} must be exactly {list(expected)} in order")
+    for index, entry in enumerate(value):
+        entry_label = f"{label}[{index}]"
+        if not isinstance(entry, dict) or set(entry) != set(RISK_CLASS_ENTRY_KEYS):
+            errors.append(f"{entry_label} keys are invalid")
+            continue
+        if entry.get("derivation") not in RISK_DERIVATIONS:
+            errors.append(f"{entry_label}.derivation is unsupported")
+        actions = entry.get("approvable_actions")
+        if not isinstance(actions, list) or not actions or not set(actions) <= set(APPROVABLE_ACTIONS):
+            errors.append(f"{entry_label}.approvable_actions must be a non-empty list of approvable actions")
+        if not str(entry.get("statement", "")).strip():
+            errors.append(f"{entry_label}.statement is required")
+        # The anti-decoration rule, applied to the risk vocabulary: a subsumed
+        # class must name the class that carries it, and a class something can
+        # assert must not pretend to be carried by something else.
+        carrier = str(entry.get("carrier", ""))
+        if entry.get("derivation") == "subsumed":
+            if carrier not in _DERIVABLE_CLASSES:
+                errors.append(f"{entry_label} is subsumed, so it must name a derivable carrier")
+        elif carrier:
+            errors.append(f"{entry_label} is derived directly, so it must not name a carrier")
+    return errors
+
+
+def _consent_entry_errors(value: Any, label: str, *, present: list[Any]) -> list[str]:
+    """Every present class is asked about, on every action that carries it.
+
+    The anti-collapse rule as a check. A verdict may not name one action and
+    call three classes answered, and it may not quietly drop a class from the
+    consent list: a class in `classes` with no consent entry is a risk nobody
+    was asked about.
+    """
+    if not isinstance(value, list):
+        return [f"{label} must be a list"]
+    errors: list[str] = []
+    covered: set[str] = set()
+    for index, entry in enumerate(value):
+        entry_label = f"{label}[{index}]"
+        if not isinstance(entry, dict) or set(entry) != set(CONSENT_ENTRY_KEYS):
+            errors.append(f"{entry_label} keys are invalid")
+            continue
+        risk_class = str(entry.get("class", ""))
+        covered.add(risk_class)
+        if risk_class not in present:
+            errors.append(f"{entry_label}.class must be a class this verdict reports as present")
+        action = entry.get("approved_action")
+        if action not in APPROVABLE_ACTIONS:
+            errors.append(f"{entry_label}.approved_action must be an approvable action")
+        elif action not in _RISK_CLASS_ACTIONS.get(risk_class, ()):
+            errors.append(f"{entry_label}.approved_action must be an action that carries its own class")
+        if entry.get("decision") not in ACTION_RISK_DECISIONS:
+            errors.append(f"{entry_label}.decision is unsupported")
+        request = entry.get("approval_request")
+        if not isinstance(request, dict) or set(request) != set(APPROVAL_REQUEST_KEYS):
+            errors.append(f"{entry_label}.approval_request keys are invalid")
+        else:
+            if request.get("approved_action") != action:
+                errors.append(f"{entry_label}.approval_request must ask about the action it names")
+            if request.get("scope_class") not in SCOPE_CLASSES:
+                errors.append(f"{entry_label}.approval_request.scope_class is unsupported")
+        approval = entry.get("approval")
+        if not isinstance(approval, dict) or approval.get("satisfied") is None:
+            errors.append(f"{entry_label} must name the approval decision it acted on")
+        elif (entry.get("decision") == "allow") is not (approval.get("satisfied") is True):
+            errors.append(f"{entry_label} may only allow on a satisfying approval")
+    missing = sorted(name for name in present if isinstance(name, str) and name not in covered)
+    if missing:
+        errors.append(f"{label} must ask about every present class; {missing} has no consent entry")
+    return errors
+
+
+def validate_action_risk(value: Any, label: str = "action_risk") -> list[str]:
+    """Validate one action-risk verdict, including that it stayed explainable.
+
+    Three failure classes, mirroring the handoff contract's. The first is an
+    unexplained verdict: a decision with no reason, a present class with no
+    statement, or a subsumed class with no carrier. The second is a verdict that
+    asks or refuses without naming the approval it wanted, which is how "we
+    checked" becomes unfalsifiable. The third is the collapse: an `allow` while
+    any class present is unapproved, or a class present that no consent entry
+    asks about — either one lets one answer speak for several questions.
+    """
+    if not isinstance(value, dict):
+        return [f"{label} must be an object"]
+    errors: list[str] = []
+    if set(value) != set(ACTION_RISK_KEYS):
+        errors.append(f"{label} keys are invalid")
+    if value.get("schema_version") != ACTION_RISK_SCHEMA_VERSION:
+        errors.append(f"{label} schema_version is invalid")
+    if value.get("status") != "prepared_not_observed":
+        errors.append(f"{label} status is invalid")
+    if value.get("level") not in ACTION_RISK_LEVELS:
+        errors.append(f"{label} level is unsupported")
+    decision = value.get("decision")
+    if decision not in ACTION_RISK_DECISIONS:
+        errors.append(f"{label} decision is unsupported")
+    if not str(value.get("reason", "")).strip():
+        errors.append(f"{label} decision must be explained")
+    classes = value.get("classes")
+    present = [entry.get("class") for entry in classes if isinstance(entry, dict)] if isinstance(classes, list) else []
+    errors.extend(
+        _risk_class_entry_errors(
+            classes,
+            f"{label} classes",
+            expected=tuple(name for name in RISK_CLASS_NAMES if name in present),
+        )
+    )
+    errors.extend(
+        _risk_class_entry_errors(
+            value.get("subsumed_classes"),
+            f"{label} subsumed_classes",
+            expected=tuple(name for name, derivation, _a, _c, _s in _RISK_CLASS_RULES if derivation == "subsumed"),
+        )
+    )
+    if (value.get("level") == "none") is not (not present):
+        errors.append(f"{label} level must be none exactly when no risky class is present")
+    consent = value.get("consent")
+    if present:
+        errors.extend(_consent_entry_errors(consent, f"{label} consent", present=present))
+    elif consent:
+        errors.append(f"{label} consent is only allowed when a risky class is present")
+    entries = [entry for entry in consent if isinstance(entry, dict)] if isinstance(consent, list) else []
+    unapproved = [entry for entry in entries if entry.get("decision") != "allow"]
+    if decision == "allow" and unapproved:
+        errors.append(
+            f"{label} cannot allow while a present class is unapproved: "
+            f"{sorted({str(entry.get('class', '')) for entry in unapproved})}"
+        )
+    if decision == "allow" and present and not entries:
+        errors.append(f"{label} cannot allow a risky action without a satisfying approval")
+    withheld = value.get("withheld_actions")
+    expected_withheld = sorted({str(entry.get("approved_action", "")) for entry in unapproved})
+    if not isinstance(withheld, list) or withheld != expected_withheld:
+        errors.append(f"{label} withheld_actions must be exactly the unapproved actions, sorted")
+    errors.extend(_enforcement_errors(value, label))
+    narrowing = value.get("narrowing_route")
+    if not isinstance(narrowing, dict):
+        errors.append(f"{label} narrowing_route must be an object")
+    elif present:
+        if set(narrowing) != set(NARROWING_ROUTE_KEYS):
+            errors.append(f"{label} narrowing_route keys are invalid")
+        elif narrowing.get("parameter") != "requested_authority_actions":
+            errors.append(f"{label} narrowing_route must route through requested_authority_actions")
+    if list(value.get("inputs", [])) != list(ACTION_RISK_INPUTS):
+        errors.append(f"{label} inputs must be the declared policy inputs")
+    for key in ("text_policy", "isolation_risk_relationship"):
+        if not str(value.get(key, "")).strip():
+            errors.append(f"{label} {key} is required")
+    if "not dispatch" not in str(value.get("claim_boundary", "")).lower():
+        errors.append(f"{label} claim_boundary must preserve the dispatch boundary")
+    return errors
+
+
+def validate_account_authorization(value: Any, label: str = "account_authorization") -> list[str]:
+    """Validate the #799 projection, including that it stays declared not enforced."""
+    if not isinstance(value, dict):
+        return [f"{label} must be an object"]
+    errors: list[str] = []
+    if set(value) != set(ACCOUNT_AUTHORIZATION_KEYS):
+        errors.append(f"{label} keys are invalid")
+    if value.get("schema_version") != ACCOUNT_AUTHORIZATION_SCHEMA_VERSION:
+        errors.append(f"{label} schema_version is invalid")
+    if value.get("status") != "prepared_not_observed":
+        errors.append(f"{label} status is invalid")
+    if not isinstance(value.get("required"), bool):
+        errors.append(f"{label} required must be boolean")
+    if not str(value.get("reason", "")).strip():
+        errors.append(f"{label} reason is required")
+    accounts = value.get("accounts")
+    if not isinstance(accounts, list):
+        errors.append(f"{label} accounts must be a list")
+    else:
+        for index, entry in enumerate(accounts):
+            entry_label = f"{label} accounts[{index}]"
+            if not isinstance(entry, dict) or set(entry) != set(ACCOUNT_ENTRY_KEYS):
+                errors.append(f"{entry_label} keys are invalid")
+                continue
+            if entry.get("state") not in ACCOUNT_ACCESS_STATES:
+                errors.append(f"{entry_label}.state is unsupported")
+            if entry.get("reference_kind") not in ACCOUNT_REFERENCE_KINDS:
+                errors.append(f"{entry_label}.reference_kind is unsupported")
+            if entry.get("reference_kind") == "env_var_name" and not _is_env_var_name(str(entry.get("account_ref", ""))):
+                errors.append(f"{entry_label}.account_ref must be an environment variable name, never a value")
+            errors.extend(_string_list_errors(entry.get("minimum_scopes"), f"{entry_label}.minimum_scopes"))
+            if not set(entry.get("minimum_scopes", []) or []) <= set(ACCOUNT_BACKED_ACTIONS):
+                errors.append(f"{entry_label}.minimum_scopes must be account-backed actions")
+    # The whole point of this block is that it does not enforce. A future edit
+    # that flips it has to move the enforcement verdict deliberately.
+    errors.extend(_enforcement_errors(value, label))
+    if value.get("enforcement") != "declared_not_enforced":
+        errors.append(f"{label} must stay declared_not_enforced while no host consent flow is observable")
+    blockers = value.get("blockers")
+    if not isinstance(blockers, list) or [
+        entry.get("blocker") for entry in blockers if isinstance(entry, dict)
+    ] != list(ACCOUNT_BLOCKER_NAMES):
+        errors.append(f"{label} blockers must be exactly {list(ACCOUNT_BLOCKER_NAMES)} in order")
+    elif any(not str(entry.get("statement", "")).strip() for entry in blockers):
+        errors.append(f"{label} every blocker must state the gap in words")
+    if "credential" not in str(value.get("credential_boundary", "")).lower():
+        errors.append(f"{label} credential_boundary must cite the credential boundary")
+    if "not dispatch" not in str(value.get("claim_boundary", "")).lower():
+        errors.append(f"{label} claim_boundary must preserve the dispatch boundary")
+    return errors
+
+
 def _enforcement_errors(
     entry: dict[str, Any],
     label: str,
@@ -1125,10 +2508,11 @@ def _handoff_contract_boundary_errors(value: Any, label: str) -> list[str]:
         return [f"{label} boundaries must be a list"]
     names = [entry.get("boundary") for entry in value if isinstance(entry, dict)]
     errors: list[str] = []
-    if names != list(SAFETY_BOUNDARY_NAMES):
+    expected = list(safety_boundary_names())
+    if names != expected:
         # One message covers unknown, missing, duplicated, and reordered names:
         # the boundary set is the contract, so any difference is the same defect.
-        errors.append(f"{label} boundaries must be exactly {list(SAFETY_BOUNDARY_NAMES)} in order")
+        errors.append(f"{label} boundaries must be exactly {expected} in order")
     for index, entry in enumerate(value):
         entry_label = f"{label} boundaries[{index}]"
         if not isinstance(entry, dict) or set(entry) != set(SAFETY_BOUNDARY_KEYS):
@@ -1210,6 +2594,53 @@ def validate_handoff_safety_contract(
     return errors
 
 
+def _verdict_risk_consistency_errors(value: dict[str, Any], action_risk: Any, label: str) -> list[str]:
+    """The two rules that tie a risk verdict to the envelope beside it.
+
+    The first is the anti-phantom rule: every action a confirmation asks about
+    must be one the envelope granted. A withheld action is checked against the
+    envelope's own `withheld_pending_approval` exclusions, because withholding
+    it is exactly what removed it from `allowed_actions`; anything else is an
+    approval request for authority nobody was ever given, which no receipt can
+    ever satisfy.
+
+    The second is the refusal rule: an *enforced* unapproved risky action may
+    not leave the verdict dispatchable. A verdict that reports
+    `declared_not_enforced` is a report and is allowed to stay dispatchable —
+    that is what the label means, and `blocked_by` has to say why.
+    """
+    if not isinstance(action_risk, dict):
+        return []
+    errors: list[str] = []
+    envelope = value.get("authority_envelope")
+    envelope = envelope if isinstance(envelope, dict) else {}
+    allowed = set(_declared_strings(envelope, "allowed_actions"))
+    exclusions = envelope.get("exclusions")
+    withheld = {
+        str(entry.get("action", ""))
+        for entry in (exclusions if isinstance(exclusions, list) else [])
+        if isinstance(entry, dict) and entry.get("reason_code") == "withheld_pending_approval"
+    }
+    grantable = allowed | withheld
+    consent = action_risk.get("consent")
+    for index, entry in enumerate(consent if isinstance(consent, list) else []):
+        if not isinstance(entry, dict):
+            continue
+        action = str(entry.get("approved_action", ""))
+        if action and action not in grantable:
+            errors.append(
+                f"{label} action_risk consent[{index}] asks to approve `{action}`, which the authority "
+                "envelope neither allows nor withheld, so no approval could ever release it"
+            )
+    if (
+        action_risk.get("enforcement") == "enforced"
+        and action_risk.get("decision") != "allow"
+        and value.get("dispatchable") is True
+    ):
+        errors.append(f"{label} cannot stay dispatchable while a risky action has no approval covering it")
+    return errors
+
+
 def validate_action_gate_verdict(value: Any, label: str = "action_gate") -> list[str]:
     if not isinstance(value, dict):
         return [f"{label} must be an object"]
@@ -1235,6 +2666,16 @@ def validate_action_gate_verdict(value: Any, label: str = "action_gate") -> list
             parent_dispatchable=value.get("dispatchable"),
         )
     )
+    # Optional on purpose: a verdict recorded before these blocks existed is
+    # still a valid verdict, and the record validators re-read stored gates.
+    action_risk = value.get("action_risk")
+    if action_risk is not None:
+        errors.extend(validate_action_risk(action_risk, f"{label} action_risk"))
+        errors.extend(_verdict_risk_consistency_errors(value, action_risk, label))
+    if value.get("account_authorization") is not None:
+        errors.extend(
+            validate_account_authorization(value.get("account_authorization"), f"{label} account_authorization")
+        )
     confirmation = value.get("confirmation")
     if not isinstance(confirmation, dict) or set(confirmation) != set(CONFIRMATION_KEYS):
         errors.append(f"{label} confirmation keys are invalid")

--- a/src/coding/coding_delegation.py
+++ b/src/coding/coding_delegation.py
@@ -424,6 +424,21 @@ def build_coding_delegation_payload(
         if delegation.action == "delegate"
         else {}
     )
+    # Built once and handed to both the preflight and the gate. The gate's
+    # risk classifier reads the *declared* request — destinations, access
+    # intents, target paths — and rebuilding it there would scan the message a
+    # second time to produce a value this build already has.
+    preflight_request = _safety_preflight_request(
+        message,
+        owner=proposed_selection.selected_executor_profile or "hermes",
+        workflow=delegation.recommended_workflow,
+        message_context_mode=message_context_mode,
+        # The same condition `_attach_visible_message` is called under below, so
+        # the flag states what the artifact will carry.
+        raw_content_included=include_message and message_context_mode == "full",
+        intent=delegation.intent,
+        action=delegation.action,
+    )
     # The single decision path. Every downstream authority value — dispatchable,
     # choice_required, the executor selection status, and which confirmation
     # ladder is armed — is derived from this one verdict; nothing recomputes it.
@@ -442,18 +457,11 @@ def build_coding_delegation_payload(
         context_pack=context_pack,
         memory_recall_pack=memory_recall_pack,
         safety_preflight=(
-            safety_preflight
-            if safety_preflight is not None
-            else _safety_preflight_verdict(
-                message,
-                owner=proposed_selection.selected_executor_profile or "hermes",
-                workflow=delegation.recommended_workflow,
-                message_context_mode=message_context_mode,
-                # The same condition `_attach_visible_message` is called under
-                # below, so the flag states what the artifact will carry.
-                raw_content_included=include_message and message_context_mode == "full",
-            )
+            safety_preflight if safety_preflight is not None else _safety_preflight_verdict(preflight_request)
         ),
+        # What this build declared it would touch. The gate classifies risk from
+        # these declarations and never from the message.
+        safety_preflight_request=preflight_request,
         live_safety_profile_revision=live_safety_profile_revision,
         requested_actions=list(requested_authority_actions or []),
     )
@@ -763,6 +771,43 @@ def _safety_preflight_target_paths(message: str) -> list[str]:
     return paths
 
 
+def _safety_preflight_access_intents(intent: str, action: str) -> list[str]:
+    """Read, write, and share, declared for what this build will actually prepare.
+
+    Read is unconditional: preparing coding work means reading the workspace
+    the request names. Write is claimed only when the routed action would carry
+    `repo_edit`, on the same intent set `action_gate.required_actions_for` uses
+    for that action -- this is a declaration made before the gate runs, and the
+    gate's own answer stays the authority on what the envelope grants. Share is
+    never claimed, because the lane names no remote target and
+    `external_action_authority` is pinned to prepare_only, so there is nothing
+    to share with.
+    """
+    intents = ["read"]
+    if action == "delegate" and intent in {"coding", "cleanup", "docs"}:
+        intents.append("write")
+    return intents
+
+
+def _safety_preflight_data_classes(target_paths: list[str], raw_content_included: bool) -> list[str]:
+    """The data classes this build will actually touch, and no others.
+
+    Bounded metadata is always present: a prepared artifact stores digests,
+    paths, and references rather than content. Workspace source appears once
+    the user names a file. The user's own request text appears only when the
+    build will carry it verbatim, which is the same flag the raw-context rule
+    reads. No prohibited class is ever derivable here, which is the point: the
+    rule that refuses one is live for any caller, and this lane can never
+    produce a request that trips it.
+    """
+    classes = ["workspace_metadata"]
+    if target_paths:
+        classes.append("workspace_source")
+    if raw_content_included:
+        classes.append("user_request_text")
+    return classes
+
+
 def _safety_preflight_request(
     message: str,
     *,
@@ -770,6 +815,8 @@ def _safety_preflight_request(
     workflow: str,
     message_context_mode: str,
     raw_content_included: bool,
+    intent: str = "",
+    action: str = "",
 ) -> dict[str, object]:
     """The closed, bounded metadata request the preflight evaluates.
 
@@ -777,7 +824,17 @@ def _safety_preflight_request(
     packs are deliberately excluded: a path pasted into retrieved content is
     not the user asking for that target, and letting it through would be the
     exact widening #811 forbids.
+
+    The #801 boundary halves are declared here too. `workspace_roots` stays
+    empty on purpose: nothing in a chat request narrows the project, and the
+    evaluator reads an undeclared boundary as "the project itself", which the
+    absolute-path and escape rules already enforce. Declaring a synthetic root
+    derived from the very paths it would bound would be a boundary that can
+    never refuse anything. `approved_destinations` stays empty for the same
+    reason the lane names no remote target: nothing here reaches one, and an
+    empty approval approves nothing rather than everything.
     """
+    target_paths = _safety_preflight_target_paths(message)
     return {
         "owner": owner,
         "approved_scope": f"coding/{workflow}",
@@ -789,20 +846,21 @@ def _safety_preflight_request(
         # even under full mode. Re-deriving it from the mode would make the
         # rule unable to disagree with its own input.
         "raw_content_included": raw_content_included,
-        "target_paths": _safety_preflight_target_paths(message),
+        "data_classes": _safety_preflight_data_classes(target_paths, raw_content_included),
+        "workspace_roots": [],
+        "target_paths": target_paths,
+        "approved_destinations": [],
+        "access_intents": _safety_preflight_access_intents(intent, action),
         "evidence_claims": ["prepared_not_observed"],
     }
 
 
-def _safety_preflight_verdict(
-    message: str,
-    *,
-    owner: str,
-    workflow: str,
-    message_context_mode: str,
-    raw_content_included: bool,
-) -> dict[str, object] | None:
-    """The preflight verdict, or None when no evaluator is installed.
+def _safety_preflight_verdict(request: dict[str, object]) -> dict[str, object] | None:
+    """The preflight verdict for an already-built request, or None when no evaluator is installed.
+
+    Takes the request rather than rebuilding it: the gate reads the same
+    declarations to classify action risk, and building it twice would scan the
+    message twice to produce one value.
 
     The two absences stay distinct, which is the distinction the action gate
     then acts on. `None` means the lane is not present and delegation must keep
@@ -815,15 +873,7 @@ def _safety_preflight_verdict(
     evaluator = _safety_preflight_evaluator()
     if evaluator is None:
         return None
-    verdict = evaluator(
-        _safety_preflight_request(
-            message,
-            owner=owner,
-            workflow=workflow,
-            message_context_mode=message_context_mode,
-            raw_content_included=raw_content_included,
-        )
-    )
+    verdict = evaluator(request)
     if isinstance(verdict, dict) and verdict.get("status"):
         return verdict
     return {"status": "unreadable"}

--- a/src/commands/runtime.py
+++ b/src/commands/runtime.py
@@ -23,6 +23,14 @@ from ..external_effect_receipts import (
     read_external_effect_receipts,
     validate_external_effect_receipt_store,
 )
+from ..workflows.approval_receipts import (
+    APPROVAL_TTL_SECONDS,
+    CLAIM_BOUNDARY as APPROVAL_CLAIM_BOUNDARY,
+    compact_approval_receipt,
+    read_approval_mint_failures,
+    read_approval_receipts,
+    validate_approval_receipt_store,
+)
 from ..goal_ledger import RUNTIME_COMPLETION_ACTIONS
 from ..installer import OmhError
 from ..runtime.artifacts import (
@@ -930,6 +938,90 @@ def _render_receipts_text(payload: dict) -> str:
     return "\n".join(line for line in lines if line)
 
 
+def cmd_runtime_approvals(args: argparse.Namespace) -> int:
+    """Read recorded approval receipts. There is deliberately no grant command.
+
+    An approval exists because an operator answered a confirmation. A CLI flag
+    that minted one would make this store exactly the kind of self-asserted
+    evidence it exists to replace -- whoever typed the flag would be granting
+    themselves the permission the confirmation was supposed to ask about.
+
+    Freshness is computed here, at read time, and never read off the record: the
+    store has no retention or cleanup, so an expired approval stays on disk
+    forever and only the reader can say whether it still means anything.
+    """
+    paths = _paths(args)
+    run_id = getattr(args, "run_id", None)
+    limit = _bounded_limit(args)
+    store_path = paths.runtime_approval_receipts_path
+    receipts = [
+        compact_approval_receipt(receipt)
+        for receipt in read_approval_receipts(paths, run_id=run_id, limit=limit)
+    ]
+    # Unscoped on purpose: this is the one surface that reports on the whole
+    # store, so a fault on a receipt belonging to another run is still visible
+    # here rather than nowhere.
+    store = validate_approval_receipt_store(store_path)
+    mint_failures = read_approval_mint_failures(store_path)
+    payload: dict[str, object] = {
+        "schema_version": "runtime_approval_receipts_view/v1",
+        "run_id": run_id or "",
+        "store_path": str(store_path),
+        "receipts": receipts,
+        "store_ok": store["ok"],
+        "store_errors": store["errors"],
+        "receipt_count": store["receipt_count"],
+        # An answered confirmation whose mint failed has no receipt at all,
+        # which is exactly what this view exists to make visible, so failures
+        # are never scoped away by --run.
+        "mint_failures": _bounded_tail(mint_failures, limit),
+        "mint_failure_count": len(mint_failures),
+        "expires_after_seconds": APPROVAL_TTL_SECONDS,
+        "claim_boundary": APPROVAL_CLAIM_BOUNDARY,
+    }
+    if _wants_json(args):
+        _print_json(payload)
+    else:
+        print(_render_approvals_text(payload))
+    return 0
+
+
+def _approval_row_line(row: dict) -> str:
+    # `or "unknown"` rather than a `.get` default: a closed-vocabulary field
+    # renders empty when the stored value is not in its vocabulary, and an empty
+    # cell would read as a dangling em-dash rather than as an unreadable record.
+    freshness = "expired" if row.get("expired") else "live"
+    return (
+        f"  {row.get('decision') or 'unknown'} — {row.get('approved_action') or 'unknown'} — "
+        f"{row.get('scope_class') or 'unknown'} {row.get('scope_ref') or 'unnamed'} — "
+        f"owner {row.get('owner') or 'unknown'} — {freshness} — {row.get('receipt_id', '')}"
+    )
+
+
+def _render_approvals_text(payload: dict) -> str:
+    receipts = [row for row in payload.get("receipts", []) or [] if isinstance(row, dict)]
+    lines = [f"Approval receipts ({len(receipts)} shown)"]
+    if not receipts:
+        lines.append("  No recorded approvals.")
+    lines.extend(_approval_row_line(row) for row in receipts)
+    lines.append(f"  Approval window: {payload.get('expires_after_seconds', 0)}s, evaluated at read time.")
+    failures = [row for row in payload.get("mint_failures", []) or [] if isinstance(row, dict)]
+    if payload.get("mint_failure_count"):
+        lines.append(f"  Unrecorded answers: {payload.get('mint_failure_count', 0)}")
+        for row in failures:
+            lines.append(
+                f"    {row.get('decision', 'unknown')} — {row.get('outcome', 'unknown')} — "
+                f"{row.get('approved_action', 'unknown')} — approval {row.get('approval_id', '')}"
+            )
+        lines.append("    These confirmations were answered and have no receipt.")
+    if not payload.get("store_ok", True):
+        errors = [str(error) for error in payload.get("store_errors", []) or []]
+        lines.append(f"  Store errors: {len(errors)}")
+        lines.extend(f"    {error}" for error in errors[:10])
+    lines.append(str(payload.get("claim_boundary", "")))
+    return "\n".join(line for line in lines if line)
+
+
 def cmd_runtime_validate(args: argparse.Namespace) -> int:
     result = validate_runtime(_paths(args), args.run_id)
     _print_json(result)
@@ -1135,6 +1227,26 @@ def _add_runtime_commands(sub) -> None:
     runtime_receipts.add_argument("--all", action="store_true", help="Return all receipts.")
     runtime_receipts.add_argument("--json", action="store_true", help="Emit the machine payload instead of plain text.")
     runtime_receipts.set_defaults(func=cmd_runtime_receipts)
+
+    runtime_approvals = runtime_sub.add_parser(
+        "approvals",
+        help="Read recorded approval receipts. Read-only: approvals come only from the confirmation flow.",
+    )
+    runtime_approvals.add_argument(
+        "--run",
+        dest="run_id",
+        default=None,
+        help="Limit to one runtime run. Unrecorded answers are never scoped away.",
+    )
+    runtime_approvals.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Maximum recent approvals to return. Use --all for every approval.",
+    )
+    runtime_approvals.add_argument("--all", action="store_true", help="Return all approvals.")
+    runtime_approvals.add_argument("--json", action="store_true", help="Emit the machine payload instead of plain text.")
+    runtime_approvals.set_defaults(func=cmd_runtime_approvals)
 
     runtime_validate = runtime_sub.add_parser("validate")
     runtime_validate.add_argument("--run", dest="run_id", default=None)

--- a/src/quality/safety_preflight.py
+++ b/src/quality/safety_preflight.py
@@ -29,15 +29,30 @@ the user named, so `token_store.py` is a filename and not a credential; a
 closed vocabulary already denies every value outside it. Only the body-shape
 bound is universal, because a body is a body in any field.
 
+The data boundary (issue #801) lives here rather than in a module of its own.
+`REQUEST_FIELDS` already carried the owner, the approved scope, the target
+paths, the remote targets, the persisted content refs, and the raw-content
+admission -- most of "which roots, which intent, which destinations, which
+prohibited content" was already a pre-expansion field on this request. A
+parallel data-boundary evaluator would have given the tree two answers to "what
+may this work touch" and only one of them would sit inside
+`safety_profile_revision`, so the boundary is expressed as four more closed
+fields and four more rules on the evaluator that already pins itself.
+
 No model, no network, no new dependency: the whole evaluator is stdlib
-`hashlib` plus `re` over caller-supplied metadata.
+`hashlib` plus `re` over caller-supplied metadata, plus the prohibited-content
+detectors this tree already owns. `data_boundary_enforcement_facts()` is the
+one host-dependent surface, it is not part of the profile, and no rule reads
+it.
 """
 
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 import hashlib
+import os
 import re
+import sys
 from typing import Final
 
 from ..coding.project_governance import ORG_SAFETY_RULE_SOURCE_REASON_CODES
@@ -46,10 +61,12 @@ from ..system.metadata_safety import (
     is_sensitive_metadata_text,
     require_opaque_metadata_ref,
 )
+from ..workflows.domain_intelligence_admission import ensure_safe_opaque_ref_content
 
 SAFETY_PROFILE_SCHEMA_VERSION: Final = "omh_safety_profile/v1"
 SAFETY_PREFLIGHT_VERDICT_SCHEMA_VERSION: Final = "omh_safety_preflight_verdict/v1"
 SAFETY_PREFLIGHT_RECHECK_SCHEMA_VERSION: Final = "omh_safety_preflight_recheck/v1"
+DATA_BOUNDARY_ENFORCEMENT_SCHEMA_VERSION: Final = "omh_data_boundary_enforcement/v1"
 
 SAFETY_PREFLIGHT_CLAIM_BOUNDARY: Final = (
     "Passing safety preflight is permission to prepare this work; it is not compliance, "
@@ -68,9 +85,36 @@ MAX_REMOTE_TARGETS: Final = 8
 MAX_PERSISTED_CONTENT_REFS: Final = 8
 MAX_EVIDENCE_CLAIMS: Final = 8
 MAX_OBSERVED_RECORD_REFS: Final = 8
+MAX_WORKSPACE_ROOTS: Final = 8
+MAX_APPROVED_DESTINATIONS: Final = 8
+MAX_DATA_CLASSES: Final = 8
 
 MESSAGE_CONTEXT_MODES: Final = ("bounded", "full")
 REMOTE_TARGET_KINDS: Final = ("git_remote", "issue_tracker", "package_registry", "public_internet")
+
+# Read, write, and share, the three intents issue #801 names. Kept to three on
+# purpose: an intent nothing can distinguish is a label, not a boundary.
+ACCESS_INTENTS: Final = ("read", "write", "share")
+MAX_ACCESS_INTENTS: Final = len(ACCESS_INTENTS)
+
+# The data classes a prepared coding handoff can actually name today, split by
+# whether the class may cross the handoff boundary at all.
+#
+# Each permitted class is something this lane really produces: the workspace
+# files the request names, the bounded references and digests a prepared
+# artifact stores instead of content, and -- only under the full message
+# context mode -- the user's own request text.
+#
+# Each prohibited class is something the tree already has a detector for, so
+# the vocabulary is a name for an existing refusal rather than a new taxonomy:
+# `metadata_safety.is_sensitive_metadata_text` for credential material, and
+# `domain_intelligence_admission.ensure_safe_opaque_ref_content` for the
+# personal-data (SSN, email) and transcript (role marker, sensitive
+# assignment, bidi/control unicode) shapes. Nothing here invents a regex.
+PERMITTED_DATA_CLASSES: Final = ("workspace_source", "workspace_metadata", "user_request_text")
+PROHIBITED_DATA_CLASSES: Final = ("credential_material", "personal_data", "conversation_transcript")
+DATA_CLASSES: Final = (*PERMITTED_DATA_CLASSES, *PROHIBITED_DATA_CLASSES)
+
 EVIDENCE_CLAIMS: Final = (
     "prepared_not_observed",
     "dispatch_observed",
@@ -88,12 +132,24 @@ REQUEST_FIELDS: Final = (
     "approved_scope",
     "message_context_mode",
     "raw_content_included",
+    "data_classes",
+    "workspace_roots",
     "target_paths",
     "remote_targets",
+    "approved_destinations",
+    "access_intents",
     "persisted_content_refs",
     "evidence_claims",
     "observed_record_refs",
 )
+
+# The boundary half of the request against the claim half. `workspace_roots`
+# and `approved_destinations` are what the approval covers; `target_paths`,
+# `remote_targets`, and `access_intents` are what the prepared action says it
+# will do. Every #801 rule is one comparison between the two halves, which is
+# why they are fields on this request and not a second artifact.
+BOUNDARY_FIELDS: Final = ("workspace_roots", "approved_destinations", "data_classes")
+CLAIM_FIELDS: Final = ("target_paths", "remote_targets", "access_intents")
 
 # The field classes. `opaque_ref` is free-form caller text carrying an
 # identifier, `path` is a source location the caller named, `vocabulary` is a
@@ -109,15 +165,32 @@ FIELD_CLASSES: Final = {
     "approved_scope": FIELD_CLASS_OPAQUE_REF,
     "message_context_mode": FIELD_CLASS_VOCABULARY,
     "raw_content_included": FIELD_CLASS_OPAQUE_REF,
+    # A declared data class and a declared access intent are closed value sets
+    # whose own rules deny every non-member, exactly like `evidence_claims`.
+    # Classing them as opaque refs would run credential shape over the literal
+    # word `credential_material` and deny the request that correctly declares
+    # what it must not carry.
+    "data_classes": FIELD_CLASS_VOCABULARY,
+    "access_intents": FIELD_CLASS_VOCABULARY,
+    # A workspace root is a source location the caller named, same as a target
+    # path: it takes the longer path bound and is exempt from credential shape,
+    # because `src/auth/` is a directory and not a secret.
+    "workspace_roots": FIELD_CLASS_PATH,
     "target_paths": FIELD_CLASS_PATH,
+    # Both destination lists are objects whose nested keys carry their own
+    # classes; the field-level class covers any other string in them.
     "remote_targets": FIELD_CLASS_OPAQUE_REF,
+    "approved_destinations": FIELD_CLASS_OPAQUE_REF,
     "persisted_content_refs": FIELD_CLASS_OPAQUE_REF,
     "evidence_claims": FIELD_CLASS_VOCABULARY,
     "observed_record_refs": FIELD_CLASS_OPAQUE_REF,
 }
-# `remote_targets` entries are objects: the kind is a closed vocabulary, the
-# ref is an opaque metadata ref. Any other key inherits the field's own class.
-REMOTE_TARGET_FIELD_CLASSES: Final = {
+# Destination entries are objects: the kind is a closed vocabulary, the ref is
+# an opaque metadata ref. Any other key inherits the field's own class. The two
+# destination fields share one shape so a declared destination and a claimed
+# one are compared like against like.
+DESTINATION_FIELDS: Final = ("remote_targets", "approved_destinations")
+DESTINATION_FIELD_CLASSES: Final = {
     "kind": FIELD_CLASS_VOCABULARY,
     "ref": FIELD_CLASS_OPAQUE_REF,
 }
@@ -127,6 +200,11 @@ REMOTE_TARGET_FIELD_CLASSES: Final = {
 # membership, so reading either as a possible credential denies ordinary work
 # without adding any protection.
 SECRET_SHAPE_FIELD_CLASSES: Final = (FIELD_CLASS_OPAQUE_REF,)
+# The wider prohibited-content scan reads the same class, and for the same
+# reason. SSN and email shapes over a user-named path would deny
+# `src/api/credentials_loader.py`-class work all over again; over a closed
+# vocabulary they can never fire. Only free-form caller text can carry them.
+PROHIBITED_CONTENT_FIELD_CLASSES: Final = (FIELD_CLASS_OPAQUE_REF,)
 
 RULE_INPUT_METADATA_BOUNDED: Final = "input_metadata_bounded"
 RULE_OWNER_DECLARED: Final = "owner_declared"
@@ -138,6 +216,10 @@ RULE_REMOTE_TARGETS_DECLARED: Final = "remote_targets_declared"
 RULE_PERSISTED_CONTENT_REFERENCED: Final = "persisted_content_referenced"
 RULE_EVIDENCE_CLAIM_BOUNDED: Final = "evidence_claim_bounded"
 RULE_ORG_RULE_SOURCE: Final = "org_rule_source"
+RULE_DATA_CLASSES_PERMITTED: Final = "data_classes_permitted"
+RULE_WORKSPACE_ROOTS_DECLARED: Final = "workspace_roots_declared"
+RULE_DESTINATIONS_APPROVED: Final = "destinations_approved"
+RULE_ACCESS_INTENT_DECLARED: Final = "access_intent_declared"
 
 # (rule id, axis, level, reason codes). Rule ids are stable strings and the
 # order is the denial precedence: the first rule that denies is the
@@ -150,6 +232,18 @@ _RULES: Final = (
         ("request_not_an_object", "unknown_request_field", "body_shaped_request_value"),
     ),
     (RULE_SECRETS_ABSENT, "secrets", "builtin_omh", ("secret_shaped_value",)),
+    (
+        RULE_DATA_CLASSES_PERMITTED,
+        "data_classes",
+        "builtin_omh",
+        (
+            "data_class_not_bounded",
+            "data_class_count_exceeded",
+            "data_class_unknown",
+            "data_class_prohibited",
+            "prohibited_data_class_content",
+        ),
+    ),
     (RULE_OWNER_DECLARED, "owner", "builtin_omh", ("owner_missing", "owner_not_opaque_ref")),
     (
         RULE_APPROVED_SCOPE_DECLARED,
@@ -164,6 +258,17 @@ _RULES: Final = (
         ("raw_context_mode_unknown", "raw_context_undeclared"),
     ),
     (
+        RULE_WORKSPACE_ROOTS_DECLARED,
+        "workspace_roots",
+        "builtin_omh",
+        (
+            "workspace_root_not_bounded",
+            "workspace_root_count_exceeded",
+            "workspace_root_absolute",
+            "workspace_root_escapes_project",
+        ),
+    ),
+    (
         RULE_TARGET_PATHS_BOUNDED,
         "paths",
         "builtin_omh",
@@ -172,6 +277,10 @@ _RULES: Final = (
             "target_path_count_exceeded",
             "target_path_absolute",
             "target_path_escapes_project",
+            # #801 extends this rule rather than adding a second path rule: an
+            # out-of-workspace path is one more way a target leaves the
+            # approved boundary, and one rule id keeps the answer single.
+            "target_path_outside_workspace_roots",
         ),
     ),
     (
@@ -183,6 +292,30 @@ _RULES: Final = (
             "remote_target_count_exceeded",
             "remote_target_kind_unknown",
             "remote_target_ref_missing",
+        ),
+    ),
+    (
+        RULE_DESTINATIONS_APPROVED,
+        "destinations",
+        "builtin_omh",
+        (
+            "approved_destination_not_bounded",
+            "approved_destination_count_exceeded",
+            "approved_destination_kind_unknown",
+            "approved_destination_ref_missing",
+            "destination_not_declared",
+        ),
+    ),
+    (
+        RULE_ACCESS_INTENT_DECLARED,
+        "access_intent",
+        "builtin_omh",
+        (
+            "access_intent_not_bounded",
+            "access_intent_count_exceeded",
+            "access_intent_unknown",
+            "access_intent_undeclared",
+            "access_intent_unapproved",
         ),
     ),
     (
@@ -227,10 +360,30 @@ _CORRECTIONS: Final = {
     "approved_scope_not_opaque_ref": "Use a short opaque approved-scope reference.",
     "raw_context_mode_unknown": f"Set message_context_mode to one of {', '.join(MESSAGE_CONTEXT_MODES)}.",
     "raw_context_undeclared": "Declare raw_content_included as a boolean, and declare it true only under the full message context mode.",
+    "data_class_not_bounded": "Pass data_classes as a list of declared data class names.",
+    "data_class_count_exceeded": f"Reduce data_classes to at most {MAX_DATA_CLASSES} entries.",
+    "data_class_unknown": f"Declare a data class from {', '.join(DATA_CLASSES)}.",
+    "data_class_prohibited": f"Remove the prohibited data class; {', '.join(PROHIBITED_DATA_CLASSES)} may not cross a prepared handoff.",
+    "prohibited_data_class_content": "Remove the prohibited-class content from the metadata value and pass an opaque reference instead.",
+    "workspace_root_not_bounded": f"Pass workspace roots as bounded strings of at most {MAX_PATH_CHARS} characters.",
+    "workspace_root_count_exceeded": f"Reduce workspace_roots to at most {MAX_WORKSPACE_ROOTS} entries.",
+    "workspace_root_absolute": "Use a project-relative workspace root instead of an absolute or home-anchored path.",
+    "workspace_root_escapes_project": "Remove the parent-directory segment so the workspace root stays inside the project.",
     "target_path_not_bounded": f"Pass target paths as bounded strings of at most {MAX_PATH_CHARS} characters.",
     "target_path_count_exceeded": f"Reduce target_paths to at most {MAX_TARGET_PATHS} entries.",
     "target_path_absolute": "Use a project-relative target path instead of an absolute or home-anchored path.",
     "target_path_escapes_project": "Remove the parent-directory segment so the path stays inside the project.",
+    "target_path_outside_workspace_roots": "Move the target inside a declared workspace root, or widen workspace_roots and get that approved.",
+    "approved_destination_not_bounded": "Pass each approved destination as an object with exactly a kind and a ref.",
+    "approved_destination_count_exceeded": f"Reduce approved_destinations to at most {MAX_APPROVED_DESTINATIONS} entries.",
+    "approved_destination_kind_unknown": f"Declare an approved destination kind from {', '.join(REMOTE_TARGET_KINDS)}.",
+    "approved_destination_ref_missing": "Give the approved destination a short opaque reference.",
+    "destination_not_declared": "Declare this destination in approved_destinations before the work may reach it.",
+    "access_intent_not_bounded": "Pass access_intents as a list of declared access intent names.",
+    "access_intent_count_exceeded": f"Reduce access_intents to at most {MAX_ACCESS_INTENTS} entries.",
+    "access_intent_unknown": f"Declare an access intent from {', '.join(ACCESS_INTENTS)}.",
+    "access_intent_undeclared": "Declare the share intent before naming a remote target, or drop the remote target.",
+    "access_intent_unapproved": "Declare the approved destination the share intent covers, or drop the share intent.",
     "remote_target_not_bounded": "Pass each remote target as an object with exactly a kind and a ref.",
     "remote_target_count_exceeded": f"Reduce remote_targets to at most {MAX_REMOTE_TARGETS} entries.",
     "remote_target_kind_unknown": f"Declare a remote target kind from {', '.join(REMOTE_TARGET_KINDS)}.",
@@ -257,6 +410,86 @@ _CORRECTIONS: Final = {
 }
 
 
+# How a data-boundary limit can be enforced at all.
+#
+# `refused_before_handoff` is omh refusing to prepare the artifact, so it holds
+# on every host and needs nothing from the executor. `host_confinement` is an
+# OS-level confinement the host either can or cannot provide. `advisory` is a
+# declaration the executor is trusted to honour and nothing checks. The three
+# are deliberately not interchangeable: only the middle one is host-dependent,
+# and that is the distinction issue #801 asks OMH to surface.
+DATA_BOUNDARY_ENFORCEMENT_KINDS: Final = ("refused_before_handoff", "host_confinement", "advisory")
+
+# (limit id, enforcement kind, enforcer symbols, blocker).
+#
+# The symbols are dotted import paths in `omh.coding.action_gate`'s
+# `enforced_by` format, so a boundary table can consume them directly instead
+# of restating them. A limit is only ever reported as enforced on a host where
+# something really refuses; see `data_boundary_enforcement_facts`.
+DATA_BOUNDARY_LIMITS: Final = (
+    (
+        "workspace_root_claim",
+        "refused_before_handoff",
+        (
+            "omh.quality.safety_preflight.RULE_TARGET_PATHS_BOUNDED",
+            "omh.quality.safety_preflight.evaluate_safety_preflight",
+        ),
+        "",
+    ),
+    (
+        "prohibited_data_class",
+        "refused_before_handoff",
+        (
+            "omh.quality.safety_preflight.RULE_DATA_CLASSES_PERMITTED",
+            "omh.system.metadata_safety.is_sensitive_metadata_text",
+            "omh.workflows.domain_intelligence_admission.ensure_safe_opaque_ref_content",
+        ),
+        "",
+    ),
+    (
+        "declared_destination",
+        "refused_before_handoff",
+        (
+            "omh.quality.safety_preflight.RULE_DESTINATIONS_APPROVED",
+            "omh.quality.safety_preflight.RULE_ACCESS_INTENT_DECLARED",
+        ),
+        "",
+    ),
+    (
+        "runtime_filesystem_confinement",
+        "host_confinement",
+        (
+            "omh.quality.cross_harness_adapter_sandbox.sandbox_command",
+            "omh.quality.cross_harness_adapter_sandbox.read_roots_are_safe",
+        ),
+        "#820",
+    ),
+    (
+        "runtime_network_confinement",
+        "host_confinement",
+        ("omh.quality.cross_harness_adapter_sandbox.sandbox_command",),
+        "#820",
+    ),
+    (
+        "executor_honours_declared_targets",
+        "advisory",
+        (),
+        "#820",
+    ),
+)
+DATA_BOUNDARY_LIMIT_NAMES: Final = tuple(entry[0] for entry in DATA_BOUNDARY_LIMITS)
+
+# The confinement tool each platform would use, and the reason a platform with
+# neither can never enforce a runtime limit no matter which issue lands.
+_MACOS_CONFINEMENT_TOOL: Final = "/usr/bin/sandbox-exec"
+_NO_HOST_BACKEND_REASON: Final = "no_os_confinement_backend_on_this_platform"
+# Every host_confinement limit is blocked on the same issue today, because no
+# delegation or fanout lane places an executor under the sandbox the adapter
+# lane already builds. A host that *could* confine still reports the limit as
+# unenforced; it reports a different blocker from a host that could not.
+_HOST_CONFINEMENT_BLOCKER: Final = "#820"
+
+
 def safety_rule_profile() -> dict[str, object]:
     """The full rule profile: the content the safety-profile revision pins."""
     return {
@@ -275,19 +508,41 @@ def safety_rule_profile() -> dict[str, object]:
             "max_persisted_content_refs": MAX_PERSISTED_CONTENT_REFS,
             "max_evidence_claims": MAX_EVIDENCE_CLAIMS,
             "max_observed_record_refs": MAX_OBSERVED_RECORD_REFS,
+            "max_workspace_roots": MAX_WORKSPACE_ROOTS,
+            "max_approved_destinations": MAX_APPROVED_DESTINATIONS,
+            "max_access_intents": MAX_ACCESS_INTENTS,
+            "max_data_classes": MAX_DATA_CLASSES,
         },
         "vocabularies": {
             "request_fields": list(REQUEST_FIELDS),
             "message_context_modes": list(MESSAGE_CONTEXT_MODES),
             "remote_target_kinds": list(REMOTE_TARGET_KINDS),
             "evidence_claims": list(EVIDENCE_CLAIMS),
+            "access_intents": list(ACCESS_INTENTS),
+            "data_classes": list(DATA_CLASSES),
+            "permitted_data_classes": list(PERMITTED_DATA_CLASSES),
+            "prohibited_data_classes": list(PROHIBITED_DATA_CLASSES),
+            "data_boundary_enforcement_kinds": list(DATA_BOUNDARY_ENFORCEMENT_KINDS),
         },
         # Pinned by the digest on purpose: which rule reads which field is part
         # of the profile a prepared artifact was cleared under, not an
         # implementation detail a later revision can change silently.
         "field_classes": dict(FIELD_CLASSES),
-        "remote_target_field_classes": dict(REMOTE_TARGET_FIELD_CLASSES),
+        "destination_fields": list(DESTINATION_FIELDS),
+        "destination_field_classes": dict(DESTINATION_FIELD_CLASSES),
         "secret_shape_field_classes": list(SECRET_SHAPE_FIELD_CLASSES),
+        "prohibited_content_field_classes": list(PROHIBITED_CONTENT_FIELD_CLASSES),
+        "boundary_fields": list(BOUNDARY_FIELDS),
+        "claim_fields": list(CLAIM_FIELDS),
+        # Which limits exist and how each one *can* be enforced is profile
+        # content. Whether a given host actually enforces one is not: a
+        # host-dependent digest would read as drift on every second machine and
+        # make `recheck_safety_preflight_revision` useless. The per-host answer
+        # lives in `data_boundary_enforcement_facts()` and never reaches here.
+        "data_boundary_limits": [
+            {"limit": limit, "enforcement_kind": kind, "enforced_by": list(symbols), "blocked_by": blocker}
+            for limit, kind, symbols, blocker in DATA_BOUNDARY_LIMITS
+        ],
         "claim_boundary": SAFETY_PREFLIGHT_CLAIM_BOUNDARY,
     }
 
@@ -367,6 +622,105 @@ def recheck_safety_preflight_revision(carried: object) -> dict[str, object]:
     }
 
 
+def data_boundary_enforcement_facts() -> dict[str, object]:
+    """Which data-boundary limits *this host* can enforce, as facts not prose.
+
+    Issue #801 asks OMH to label which limits the selected host can enforce.
+    This is the fact surface that labelling reads: for every limit in
+    `DATA_BOUNDARY_LIMITS` it reports whether the host is capable of enforcing
+    it at all, whether anything refuses today, the enforcing symbols when
+    something does, and the blocker when nothing does. `enforced_by` is empty
+    exactly when `enforced_here` is false, and `blocked_by` is non-empty
+    exactly then, which is the shape `action_gate`'s boundary validator already
+    requires -- a caller cannot build a decorated entry out of this.
+
+    Three genuine differences, and no others:
+
+    * `refused_before_handoff` limits hold identically on every host, because
+      the refusal is OMH declining to prepare the artifact. No executor and no
+      OS feature is involved, so there is nothing for a host to lack.
+    * `host_confinement` limits need an OS-level confinement backend. macOS has
+      `sandbox-exec` in the base system; Linux needs a root-owned, non
+      group/other-writable `bwrap` actually present on disk; every other
+      platform has neither. That probe is real: the Linux half asks the same
+      trust snapshot the sandbox lane spawns under, so a host that would be
+      refused there is not reported as capable here.
+    * `advisory` limits are enforced nowhere, on any host, and report the same
+      blocker on every host: no host fact bears on them, so a missing
+      confinement backend is not an explanation for one.
+
+    Today every `host_confinement` limit is still unenforced even where the
+    host is capable, because no delegation or fanout lane places an executor
+    under the sandbox the cross-harness adapter lane builds (#820). The
+    capability flag is what separates "the host could, once #820 lands" from
+    "this host never could", and that separation is the deliverable.
+
+    Deliberately not part of `safety_rule_profile()`: the answer differs per
+    machine, and a host-dependent digest would read as profile drift on every
+    second host. No rule reads this, and no verdict changes because of it.
+    """
+    backend, capable, unavailable_reason = _host_confinement_backend()
+    limits: list[dict[str, object]] = []
+    for limit, kind, symbols, blocker in DATA_BOUNDARY_LIMITS:
+        host_can_enforce = kind == "refused_before_handoff" or (kind == "host_confinement" and capable)
+        enforced_here = kind == "refused_before_handoff"
+        # A missing confinement backend explains a `host_confinement` limit and
+        # nothing else. Substituting it wherever `host_can_enforce` was false
+        # made the `advisory` row report an OS-confinement blocker for a limit
+        # no OS feature could ever enforce, and turned a host-independent answer
+        # into a host-dependent one.
+        if enforced_here:
+            blocked_by = ""
+        elif kind == "host_confinement" and not capable:
+            blocked_by = unavailable_reason or blocker
+        else:
+            blocked_by = blocker
+        limits.append(
+            {
+                "limit": limit,
+                "enforcement_kind": kind,
+                "host_can_enforce": host_can_enforce,
+                "enforced_here": enforced_here,
+                "enforced_by": list(symbols) if enforced_here else [],
+                "blocked_by": blocked_by,
+            }
+        )
+    return {
+        "schema_version": DATA_BOUNDARY_ENFORCEMENT_SCHEMA_VERSION,
+        "host_confinement_backend": backend,
+        "host_confinement_available": capable,
+        "host_confinement_unavailable_reason": unavailable_reason,
+        "limits": limits,
+        "claim_boundary": SAFETY_PREFLIGHT_CLAIM_BOUNDARY,
+    }
+
+
+def _host_confinement_backend() -> tuple[str, bool, str]:
+    """(backend name, usable here, reason it is not) -- probed, never assumed."""
+    if sys.platform == "darwin":
+        present = os.path.exists(_MACOS_CONFINEMENT_TOOL)
+        return "sandbox-exec", present, "" if present else "sandbox_exec_absent"
+    if sys.platform.startswith("linux"):
+        present = _trusted_bwrap_present()
+        return "bwrap", present, "" if present else "bwrap_absent_or_untrusted"
+    return "unsupported", False, _NO_HOST_BACKEND_REASON
+
+
+def _trusted_bwrap_present() -> bool:
+    """The sandbox lane's own trust snapshot, or False when that lane is absent.
+
+    Bound lazily and by relative import for the reason `coding_delegation`
+    binds the evaluator lazily: an install without the cross-harness lane must
+    still answer this question, and the honest answer there is "no confinement
+    backend I can vouch for". Nothing here spawns a process.
+    """
+    try:
+        from .cross_harness_adapter_backend import trusted_bwrap
+    except ImportError:
+        return False
+    return trusted_bwrap() is not None
+
+
 # (rule id, field, reason code, level)
 _Denial = tuple[str, str, str, str]
 
@@ -411,11 +765,15 @@ def _builtin_denial(request: object) -> _Denial | None:
     if admission is not None:
         return admission
     for check in (
+        _data_classes_denial,
         _owner_denial,
         _approved_scope_denial,
         _raw_context_denial,
+        _workspace_roots_denial,
         _target_paths_denial,
         _remote_targets_denial,
+        _destinations_denial,
+        _access_intents_denial,
         _persisted_content_denial,
         _evidence_claims_denial,
     ):
@@ -429,7 +787,13 @@ def _admission_denial(request: Mapping[str, object]) -> _Denial | None:
     """Refuse credentials and body-shaped values before any rule reads them.
 
     Credential shape is read on the opaque-ref class only. The body-shape bound
-    is read on every string, with the path class carrying the longer bound.
+    is read on every string, with the path class carrying the longer bound. The
+    prohibited-class scan is last of the three so the two older reason codes
+    keep naming the same values they always did, and it reuses the detectors
+    `domain_intelligence_admission` already owns rather than adding a pattern:
+    an SSN, an email address, a role marker, a `password=`-shaped assignment,
+    or a bidi/control character in an opaque ref is prohibited-class content
+    riding in as metadata.
     """
     for field, text, field_class in _bounded_strings(request):
         if field_class in SECRET_SHAPE_FIELD_CLASSES and is_sensitive_metadata_text(text):
@@ -437,7 +801,17 @@ def _admission_denial(request: Mapping[str, object]) -> _Denial | None:
         limit = MAX_PATH_CHARS if field_class == FIELD_CLASS_PATH else MAX_FIELD_CHARS
         if is_body_shaped_metadata_text(text, limit=limit):
             return (RULE_INPUT_METADATA_BOUNDED, field, "body_shaped_request_value", "builtin_omh")
+        if field_class in PROHIBITED_CONTENT_FIELD_CLASSES and _carries_prohibited_class_content(text):
+            return (RULE_DATA_CLASSES_PERMITTED, field, "prohibited_data_class_content", "builtin_omh")
     return None
+
+
+def _carries_prohibited_class_content(text: str) -> bool:
+    try:
+        ensure_safe_opaque_ref_content(text, "request_field")
+    except ValueError:
+        return True
+    return False
 
 
 def _bounded_strings(request: Mapping[str, object]) -> list[tuple[str, str, str]]:
@@ -457,8 +831,8 @@ def _bounded_strings(request: Mapping[str, object]) -> list[tuple[str, str, str]
                         (
                             f"{field}[{index}].{key}",
                             entry,
-                            REMOTE_TARGET_FIELD_CLASSES.get(str(key), field_class)
-                            if field == "remote_targets"
+                            DESTINATION_FIELD_CLASSES.get(str(key), field_class)
+                            if field in DESTINATION_FIELDS
                             else field_class,
                         )
                         for key, entry in sorted(item.items())
@@ -509,37 +883,177 @@ def _raw_context_denial(request: Mapping[str, object]) -> _Denial | None:
     return None
 
 
+def _data_classes_denial(request: Mapping[str, object]) -> _Denial | None:
+    """The declared half of the #801 prohibited-content rule.
+
+    A request states which data classes the work will touch. Naming a
+    prohibited class is refused here, before a handoff exists; carrying the
+    content of one is refused in the admission pass above. The two halves share
+    a rule id because they are one boundary: what may cross a prepared handoff.
+    """
+    classes = request.get("data_classes", ())
+    if not _is_str_sequence(classes):
+        return (RULE_DATA_CLASSES_PERMITTED, "data_classes", "data_class_not_bounded", "builtin_omh")
+    if len(classes) > MAX_DATA_CLASSES:
+        return (RULE_DATA_CLASSES_PERMITTED, "data_classes", "data_class_count_exceeded", "builtin_omh")
+    for index, item in enumerate(classes):
+        field = f"data_classes[{index}]"
+        if item not in DATA_CLASSES:
+            return (RULE_DATA_CLASSES_PERMITTED, field, "data_class_unknown", "builtin_omh")
+        if item in PROHIBITED_DATA_CLASSES:
+            return (RULE_DATA_CLASSES_PERMITTED, field, "data_class_prohibited", "builtin_omh")
+    return None
+
+
+def _workspace_roots_denial(request: Mapping[str, object]) -> _Denial | None:
+    """The declared boundary must itself be inside the project before it bounds anything."""
+    roots = request.get("workspace_roots", ())
+    if not _is_str_sequence(roots):
+        return (RULE_WORKSPACE_ROOTS_DECLARED, "workspace_roots", "workspace_root_not_bounded", "builtin_omh")
+    if len(roots) > MAX_WORKSPACE_ROOTS:
+        return (RULE_WORKSPACE_ROOTS_DECLARED, "workspace_roots", "workspace_root_count_exceeded", "builtin_omh")
+    for index, item in enumerate(roots):
+        field = f"workspace_roots[{index}]"
+        if not item.strip():
+            return (RULE_WORKSPACE_ROOTS_DECLARED, field, "workspace_root_not_bounded", "builtin_omh")
+        if _ABSOLUTE_PATH_RE.match(item):
+            return (RULE_WORKSPACE_ROOTS_DECLARED, field, "workspace_root_absolute", "builtin_omh")
+        if ".." in _path_parts(item):
+            return (RULE_WORKSPACE_ROOTS_DECLARED, field, "workspace_root_escapes_project", "builtin_omh")
+    return None
+
+
 def _target_paths_denial(request: Mapping[str, object]) -> _Denial | None:
+    """Every target is bounded, project-relative, contained -- and inside the approved roots.
+
+    The containment check runs last so an absolute or escaping path keeps
+    naming the reason code it always named; only a path that is already
+    project-relative can be outside a declared root. Declaring no root leaves
+    the project itself as the boundary, which is what the absolute and escape
+    checks above already enforce, so an undeclared boundary narrows nothing and
+    widens nothing.
+    """
     paths = request.get("target_paths", ())
     if not _is_str_sequence(paths):
         return (RULE_TARGET_PATHS_BOUNDED, "target_paths", "target_path_not_bounded", "builtin_omh")
     if len(paths) > MAX_TARGET_PATHS:
         return (RULE_TARGET_PATHS_BOUNDED, "target_paths", "target_path_count_exceeded", "builtin_omh")
+    roots = request.get("workspace_roots", ())
+    root_parts = [_path_parts(root) for root in roots] if _is_str_sequence(roots) else []
     for index, item in enumerate(paths):
         field = f"target_paths[{index}]"
         if not item.strip():
             return (RULE_TARGET_PATHS_BOUNDED, field, "target_path_not_bounded", "builtin_omh")
         if _ABSOLUTE_PATH_RE.match(item):
             return (RULE_TARGET_PATHS_BOUNDED, field, "target_path_absolute", "builtin_omh")
-        if ".." in item.replace("\\", "/").split("/"):
+        if ".." in _path_parts(item):
             return (RULE_TARGET_PATHS_BOUNDED, field, "target_path_escapes_project", "builtin_omh")
+        if root_parts and not _within_roots(item, root_parts):
+            return (RULE_TARGET_PATHS_BOUNDED, field, "target_path_outside_workspace_roots", "builtin_omh")
     return None
 
 
 def _remote_targets_denial(request: Mapping[str, object]) -> _Denial | None:
-    remotes = request.get("remote_targets", ())
-    if not _is_sequence(remotes):
-        return (RULE_REMOTE_TARGETS_DECLARED, "remote_targets", "remote_target_not_bounded", "builtin_omh")
-    if len(remotes) > MAX_REMOTE_TARGETS:
-        return (RULE_REMOTE_TARGETS_DECLARED, "remote_targets", "remote_target_count_exceeded", "builtin_omh")
-    for index, item in enumerate(remotes):
-        field = f"remote_targets[{index}]"
+    return _destination_shape_denial(
+        request,
+        field="remote_targets",
+        rule_id=RULE_REMOTE_TARGETS_DECLARED,
+        limit=MAX_REMOTE_TARGETS,
+        not_bounded="remote_target_not_bounded",
+        count_exceeded="remote_target_count_exceeded",
+        kind_unknown="remote_target_kind_unknown",
+        ref_missing="remote_target_ref_missing",
+    )
+
+
+def _destinations_denial(request: Mapping[str, object]) -> _Denial | None:
+    """A prepared action may only reach a destination the boundary declared.
+
+    Fail-closed by construction: an empty `approved_destinations` approves
+    nothing, so naming any remote target without declaring it is a denial
+    rather than a default-allow. The comparison is on the whole (kind, ref)
+    pair -- approving `git_remote` in the abstract would approve every git
+    remote, which is not a boundary.
+    """
+    shape = _destination_shape_denial(
+        request,
+        field="approved_destinations",
+        rule_id=RULE_DESTINATIONS_APPROVED,
+        limit=MAX_APPROVED_DESTINATIONS,
+        not_bounded="approved_destination_not_bounded",
+        count_exceeded="approved_destination_count_exceeded",
+        kind_unknown="approved_destination_kind_unknown",
+        ref_missing="approved_destination_ref_missing",
+    )
+    if shape is not None:
+        return shape
+    approved = {
+        (str(item["kind"]), str(item["ref"]))
+        for item in request.get("approved_destinations", ())
+        if isinstance(item, Mapping) and "kind" in item and "ref" in item
+    }
+    for index, item in enumerate(request.get("remote_targets", ())):
+        if not isinstance(item, Mapping):
+            continue
+        if (str(item.get("kind")), str(item.get("ref"))) not in approved:
+            return (RULE_DESTINATIONS_APPROVED, f"remote_targets[{index}]", "destination_not_declared", "builtin_omh")
+    return None
+
+
+def _destination_shape_denial(
+    request: Mapping[str, object],
+    *,
+    field: str,
+    rule_id: str,
+    limit: int,
+    not_bounded: str,
+    count_exceeded: str,
+    kind_unknown: str,
+    ref_missing: str,
+) -> _Denial | None:
+    """One shape check for both destination lists, so they cannot drift apart."""
+    entries = request.get(field, ())
+    if not _is_sequence(entries):
+        return (rule_id, field, not_bounded, "builtin_omh")
+    if len(entries) > limit:
+        return (rule_id, field, count_exceeded, "builtin_omh")
+    for index, item in enumerate(entries):
+        entry_field = f"{field}[{index}]"
         if not isinstance(item, Mapping) or set(item) != {"kind", "ref"}:
-            return (RULE_REMOTE_TARGETS_DECLARED, field, "remote_target_not_bounded", "builtin_omh")
+            return (rule_id, entry_field, not_bounded, "builtin_omh")
         if item["kind"] not in REMOTE_TARGET_KINDS:
-            return (RULE_REMOTE_TARGETS_DECLARED, f"{field}.kind", "remote_target_kind_unknown", "builtin_omh")
-        if not _is_opaque_ref(item["ref"], field=f"{field}.ref"):
-            return (RULE_REMOTE_TARGETS_DECLARED, f"{field}.ref", "remote_target_ref_missing", "builtin_omh")
+            return (rule_id, f"{entry_field}.kind", kind_unknown, "builtin_omh")
+        if not _is_opaque_ref(item["ref"], field=f"{entry_field}.ref"):
+            return (rule_id, f"{entry_field}.ref", ref_missing, "builtin_omh")
+    return None
+
+
+def _access_intents_denial(request: Mapping[str, object]) -> _Denial | None:
+    """Read, write, and share, checked against what the boundary actually approves.
+
+    Only the share axis carries a denial, and that is deliberate. `read` and
+    `write` stay inside the workspace, where `workspace_roots` and the path
+    rules above are the whole boundary, so a separate intent check there would
+    refuse nothing the path rules do not already refuse. Sharing is the axis
+    that leaves the workspace, so it is checked in both directions: reaching a
+    destination without declaring the intent, and declaring the intent with no
+    destination the boundary approved.
+    """
+    intents = request.get("access_intents", ())
+    if not _is_str_sequence(intents):
+        return (RULE_ACCESS_INTENT_DECLARED, "access_intents", "access_intent_not_bounded", "builtin_omh")
+    if len(intents) > MAX_ACCESS_INTENTS:
+        return (RULE_ACCESS_INTENT_DECLARED, "access_intents", "access_intent_count_exceeded", "builtin_omh")
+    for index, item in enumerate(intents):
+        if item not in ACCESS_INTENTS:
+            return (RULE_ACCESS_INTENT_DECLARED, f"access_intents[{index}]", "access_intent_unknown", "builtin_omh")
+    # Both destination lists are already shape-valid here: `_remote_targets_denial`
+    # and `_destinations_denial` run before this check.
+    shares = "share" in intents
+    if request.get("remote_targets", ()) and not shares:
+        return (RULE_ACCESS_INTENT_DECLARED, "access_intents", "access_intent_undeclared", "builtin_omh")
+    if shares and not request.get("approved_destinations", ()):
+        return (RULE_ACCESS_INTENT_DECLARED, "access_intents", "access_intent_unapproved", "builtin_omh")
     return None
 
 
@@ -651,6 +1165,26 @@ def _is_opaque_ref(value: object, *, field: str) -> bool:
     except ValueError:
         return False
     return True
+
+
+def _path_parts(value: str) -> tuple[str, ...]:
+    """A declared path as comparable segments, on every host.
+
+    Both separators are folded and empty and `.` segments dropped, so
+    `src/quality`, `src\\quality`, and `./src/quality/` are the same boundary.
+    The comparison stays case-sensitive on purpose: a case-insensitive answer
+    would depend on which machine evaluated the request, and a verdict that
+    differs by host is not a verdict.
+    """
+    return tuple(part for part in value.replace("\\", "/").split("/") if part not in ("", "."))
+
+
+def _within_roots(path: str, root_parts: Sequence[tuple[str, ...]]) -> bool:
+    # A root that normalises to no segments is the project root, and an empty
+    # prefix matches every path, so declaring `.` is the same boundary as
+    # declaring none rather than a boundary nothing can satisfy.
+    parts = _path_parts(path)
+    return any(parts[: len(root)] == root for root in root_parts)
 
 
 def _is_sequence(value: object) -> bool:

--- a/src/routing/action_copy.py
+++ b/src/routing/action_copy.py
@@ -18,6 +18,7 @@ NEXT_ACTION_LABELS: dict[str, str] = {
     "choose_skill": "opening the workflow picker",
     "clarify_or_route": "checking the best workflow or clarification",
     "classify_signal_and_prepare_investigation": "classifying the signal and preparing investigation steps",
+    "confirm_risky_action": "asking for one answer on the risky action",
     "dispatch_to_workflow": "opening the selected workflow",
     "dispatch_to_executor": "dispatching to the selected coding agent",
     "gather_source_backed_evidence": "gathering source-backed evidence",

--- a/src/runtime/artifacts.py
+++ b/src/runtime/artifacts.py
@@ -45,6 +45,7 @@ from ..external_effect_receipts import (
     success_claim_citation,
     validate_external_effect_receipt_store,
 )
+from ..workflows.approval_receipts import validate_approval_receipt_store
 from ..observation_journal import (
     append_observation_event,
     merge_lifecycle_projection,
@@ -57,6 +58,7 @@ from .records import (
     DELEGATION_RESULTS,
     EVENT_LEVELS,
     OBSERVED_RESULTS,
+    OPTIONAL_APPROVAL_STORE_VALIDATORS,
     OPTIONAL_RECORD_VALIDATORS,
     OPTIONAL_RUNTIME_STORE_VALIDATORS,
     PRIVACY_MODES,
@@ -1924,6 +1926,7 @@ def validate_run_dir(
         if record:
             errors.extend(f"{path}: {error}" for error in validator(record))
     errors.extend(_validate_run_external_effect_receipts(run_dir, receipts))
+    errors.extend(_validate_run_approval_receipts(run_dir))
     errors.extend(_validate_run_status_gate_consistency(run_dir, receipts))
     return {"run_id": run_dir.name, "ok": not errors, "errors": errors}
 
@@ -1960,6 +1963,32 @@ def _validate_run_external_effect_receipts(run_dir: Path, receipts: list[dict[st
         if store_path is None:
             continue
         for record in receipts:
+            errors.extend(
+                f"{store_path}[{record.get('receipt_id', '')}]: {error}" for error in validator(record)
+            )
+    return errors
+
+
+def _validate_run_approval_receipts(run_dir: Path) -> list[str]:
+    """Schema-validate this run's approval receipts, through the registry that names them.
+
+    The same shape `_validate_run_external_effect_receipts` has, and the reader
+    `OPTIONAL_APPROVAL_STORE_VALIDATORS` was registered for: without a consumer
+    the registry validated nothing and the approval store was the one runtime
+    store `omh runtime validate` never opened. Parse errors are dropped here for
+    the reason they are dropped there -- a line that does not parse belongs to
+    no run, and `validate_runtime` reports it once at store level.
+    """
+    errors: list[str] = []
+    run_id = _safe_run_id_for_dir(run_dir)
+    for name, validator in OPTIONAL_APPROVAL_STORE_VALIDATORS:
+        store_path = runtime_store_path_for_run_dir(run_dir, name)
+        if store_path is None:
+            continue
+        records, _ = read_jsonl_objects(store_path)
+        for record in records:
+            if str(record.get("run_id", "")) != run_id:
+                continue
             errors.extend(
                 f"{store_path}[{record.get('receipt_id', '')}]: {error}" for error in validator(record)
             )
@@ -2107,16 +2136,27 @@ def validate_runtime(paths: OmhPaths, run_id: str | None = None) -> dict[str, An
         paths.runtime_external_effect_receipts_path,
         run_id=run_id,
     )
+    # The approval store is validated here for the same reason the effect store
+    # is: unparseable lines and a forked or self-referencing supersede chain
+    # belong to the store, not to a run, and an ambiguous consent chain is the
+    # one thing an approval record must never be. Without this call nothing in
+    # production ever ran the chain validator.
+    approval_store_result = validate_approval_receipt_store(
+        paths.runtime_approval_receipts_path,
+        run_id=run_id,
+    )
     _add_duplicate_wrapper_run_link_errors(session_results, session_dirs)
     return {
         "ok": all(result["ok"] for result in results)
         and all(result["ok"] for result in session_results)
         and bool(journal_result["ok"])
-        and bool(receipt_store_result["ok"]),
+        and bool(receipt_store_result["ok"])
+        and bool(approval_store_result["ok"]),
         "runs": results,
         "wrapper_sessions": session_results,
         "journal": journal_result,
         "external_effect_receipts": receipt_store_result,
+        "approval_receipts": approval_store_result,
     }
 
 

--- a/src/runtime/records.py
+++ b/src/runtime/records.py
@@ -65,6 +65,10 @@ from ..coding.product_quality_harnesses import validate_product_quality_harness
 from ..coding.project_governance import validate_project_governance_blocked, validate_project_governance_profile
 from ..routing.route_plan import compact_workflow_route_plan
 from ..skills.catalog_types import REASONING_DEMAND_VALUES
+from ..workflows.approval_receipts import (
+    APPROVAL_RECEIPT_KEYS,
+    validate_approval_receipt,
+)
 from ..workflows.external_effect_receipts import (
     EXTERNAL_EFFECT_RECEIPT_KEYS,
     validate_external_effect_receipt,
@@ -3910,7 +3914,23 @@ OPTIONAL_RECORD_VALIDATORS = (
 # than inside one. The exact-key tuple is re-exported here so a store record's
 # contract is discoverable next to every other runtime record contract.
 EXTERNAL_EFFECT_RECEIPT_RECORD_KEYS = EXTERNAL_EFFECT_RECEIPT_KEYS
+APPROVAL_RECEIPT_RECORD_KEYS = APPROVAL_RECEIPT_KEYS
 
 OPTIONAL_RUNTIME_STORE_VALIDATORS = (
     ("external_effect_receipts.jsonl", validate_external_effect_receipt),
+)
+
+# The approval store registers in its own tuple following the same precedent,
+# rather than joining the one above. The tuple above has one consumer --
+# `runtime.artifacts._validate_run_external_effect_receipts` -- and that consumer
+# applies *every* entry in it to the external effect receipts it just read, so a
+# second family in the same tuple would validate external effect receipts
+# against the approval schema and fault every run that has one. Each registry
+# therefore names the single store its validators are for, and each has its own
+# reader: this one is read by `runtime.artifacts._validate_run_approval_receipts`,
+# which together with the store-level `validate_approval_receipt_store` call in
+# `validate_runtime` is what makes `omh runtime validate` open the approval store
+# at all. The registry design that forces one reader per registry is #846.
+OPTIONAL_APPROVAL_STORE_VALIDATORS = (
+    ("approval_receipts.jsonl", validate_approval_receipt),
 )

--- a/src/system/metadata_safety.py
+++ b/src/system/metadata_safety.py
@@ -31,15 +31,34 @@ _GOOGLE_API_KEY = re.compile(r"\bAIza[A-Za-z0-9_-]{20,}\b", re.IGNORECASE)
 _BODY_SHAPED = re.compile(r"[\r\n\t\f\v\x00]|```")
 
 
-def is_sensitive_metadata_text(value: str) -> bool:
-    lowered = value.lower()
+def is_secret_value_shaped(value: str) -> bool:
+    """True when the text looks like a credential *value* rather than a name.
+
+    The value half of `is_sensitive_metadata_text`, split out because the two
+    halves answer different questions. The marker words below flag anything
+    *named* like a secret -- `GITHUB_TOKEN`, `token_store.py` -- which is right
+    for a free-form opaque reference and wrong for a field whose whole content
+    is an environment variable *name*, since such a name legitimately contains
+    them. These four patterns flag the issued material itself, and a name can
+    never match one, so a field that must accept `GITHUB_TOKEN` while refusing
+    `AKIAIOSFODNN7EXAMPLE` reads this predicate instead of the wider one.
+
+    No new pattern is introduced here: these are exactly the detectors this
+    module already owned, which also bounds what the screen can catch. A
+    credential value that none of them recognises and that also matches the
+    caller's own name shape is not caught by either predicate.
+    """
     return (
-        any(marker in lowered for marker in _SENSITIVE_MARKERS)
-        or bool(_COMMON_SECRET_PREFIX.search(value))
+        bool(_COMMON_SECRET_PREFIX.search(value))
         or bool(_PLATFORM_SECRET_PREFIX.search(value))
         or bool(_AWS_ACCESS_KEY.search(value))
         or bool(_GOOGLE_API_KEY.search(value))
     )
+
+
+def is_sensitive_metadata_text(value: str) -> bool:
+    lowered = value.lower()
+    return any(marker in lowered for marker in _SENSITIVE_MARKERS) or is_secret_value_shaped(value)
 
 
 def redact_metadata_text(value: str, *, limit: int) -> str:

--- a/src/system/paths.py
+++ b/src/system/paths.py
@@ -71,6 +71,14 @@ class OmhPaths:
         return self.runtime_journal_dir / "external_effect_receipts.jsonl"
 
     @property
+    def runtime_approval_receipts_path(self) -> Path:
+        # Runtime-wide, beside the external effect receipts, never inside a run
+        # directory: an approval is answered by a different actor at a different
+        # time from the delegation it approves, and it has to survive that
+        # delegation being rebuilt.
+        return self.runtime_journal_dir / "approval_receipts.jsonl"
+
+    @property
     def runtime_plan_context_dir(self) -> Path:
         return self.runtime_dir / "plan-context"
 

--- a/src/workflows/approval_receipts.py
+++ b/src/workflows/approval_receipts.py
@@ -1,0 +1,1403 @@
+"""Append-only receipts for consent an operator actually gave (issue #807).
+
+An approval receipt records that a human answered a confirmation ladder and
+said yes to one escalation: one action, on one named scope, for one owner, in
+one run, under one safety-profile revision. Nothing else.
+
+Why this is its own record family and not a field group on the delegation
+--------------------------------------------------------------------------
+
+This repo has twice refused a new record family (#811, #818) for a good reason:
+a family joins on run id, and a join is where an artifact and its metadata
+desynchronize. A field group on the record that already exists cannot go stale
+against itself.
+
+Consent is the case that reasoning does not cover. It is created at a different
+time from the delegation (when the operator answers, not when the handoff is
+built), by a different actor (the operator, not the router), it has its own
+lifetime (it goes stale on a clock the delegation knows nothing about, and it
+can be revoked while the delegation is untouched), and it must survive a rebuild
+of the delegation it approves -- rebuilding a prepared handoff must not silently
+re-grant consent, and it must not silently destroy consent either. A field group
+is written by whoever writes the record; it cannot express "written by someone
+else, before this record existed, and still true after this record is replaced".
+That is what makes a separate append-only family right here and wrong there.
+
+What a receipt binds
+--------------------
+
+An approval is scoped to exactly five things, and each of them is a separate
+refusal with its own code:
+
+    run_id                    -> run_not_approved
+    owner                     -> owner_not_approved
+    approved_action           -> action_not_approved
+    (scope_class, scope_ref)  -> scope_not_approved
+    safety_profile_revision   -> safety_revision_not_approved
+
+Matching is equality on every dimension, including the scope pair. There is no
+containment, prefix, or subsumption rule anywhere in this module, which is what
+makes widening structurally impossible rather than merely unimplemented: an
+approval for `src/a.py` satisfies a request for `src/a.py` and nothing else --
+not `src/`, not `src/b.py`, not the same path for another owner.
+
+Time bounding
+-------------
+
+Freshness is derived at read time from the stored decision stamp, the idiom
+`coding/executor_auth_signals.py` uses for limit signals, rather than stored as
+a deadline the reader must trust (the `_governance_overrides` shape). Two
+reasons. A stored `expires_at` is a second independently writable field: a
+hand-edited store widens the window by editing one number, while a window that
+lives in `APPROVAL_TTL_SECONDS` here cannot be widened by anything on disk. And
+the honest reason -- the `storage_retention` boundary of
+`handoff_safety_contract/v1` is `declared_not_enforced` (blocked by #835)
+because no retention or cleanup exists for run artifacts. Nothing deletes an
+approval receipt. Claiming an approval "expires" on disk would be a lie about a
+file that outlives every window it names, so expiry is a property every reader
+recomputes and never a property the artifact has.
+
+A decision stamped in the future is not fresh either. It cannot be shown to be
+older than zero seconds, so it is refused rather than clamped, which is the
+other half of "the window cannot be widened from disk".
+
+Three separate things
+---------------------
+
+`external_effect_receipts` separates requested / attempted / succeeded / failed
+/ unknown so a request can never be read as an outcome. The same discipline is
+why this family exists separately from that one: approval, attempt, and observed
+outcome are three different claims (#800). An approval receipt proves consent
+was given. It never proves the host applied the permission, and it never proves
+anything ran -- `CLAIM_BOUNDARY` says so on every record, and
+`validate_approval_receipt` refuses a record shaped to assert execution, by key
+name as well as by the closed key set.
+
+Store mechanics
+---------------
+
+Everything else follows `workflows/external_effect_receipts.py`, which is this
+repo's proven append-only receipt store: a JSONL appended under
+`local_store.file_lock` (a real OS lock on POSIX and on Windows), sorted-keys
+lines, an append that terminates an unterminated tail before writing so a short
+write cannot swallow the next record, closed vocabularies everywhere including
+at render, minting that is idempotent by decision fingerprint, supersession and
+revocation as new linked records rather than edits, and a mint entry point that
+returns its failures instead of raising into the producer.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import secrets
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Final
+
+from ..system.local_store import ensure_dir, ensure_file, file_lock, read_jsonl_objects, utc_now
+from ..system.metadata_safety import is_sensitive_metadata_text, require_opaque_metadata_ref
+from ..system.paths import OmhPaths
+
+
+APPROVAL_RECEIPT_SCHEMA_VERSION: Final[str] = "approval_receipt/v1"
+APPROVAL_DECISION_SCHEMA_VERSION: Final[str] = "approval_decision/v1"
+APPROVAL_RECEIPT_STORE_VALIDATION_SCHEMA_VERSION: Final[str] = "approval_receipt_store_validation/v1"
+APPROVAL_MINT_RESULT_SCHEMA_VERSION: Final[str] = "approval_mint_result/v1"
+APPROVAL_MINT_FAILURE_SCHEMA_VERSION: Final[str] = "approval_mint_failure/v1"
+
+APPROVAL_RECEIPT_STORE_NAME: Final[str] = "approval_receipts.jsonl"
+APPROVAL_MINT_FAILURE_STORE_NAME: Final[str] = "approval_mint_failures.jsonl"
+
+RECEIPT_PRIVACY: Final[str] = "metadata_only"
+
+# Stated on every record and echoed on every decision. The three claims #800
+# keeps apart are approval, attempt, and observed outcome; this family carries
+# the first one and is forbidden from carrying either of the others.
+CLAIM_BOUNDARY: Final[str] = (
+    "An approval receipt is one recorded answer to one confirmation, scoped to one action on one named "
+    "scope for one owner in one run under one safety profile revision. It proves consent was given. It is "
+    "not dispatch, execution, or evidence that the host applied the permission, and it approves nothing "
+    "else."
+)
+
+# What an operator can be asked to approve. Every entry is an action that
+# escalates past prepare-only, which is the only kind of answer worth storing:
+# approving `research` would put a state in the store that nothing ever reads.
+# Mirrors `coding.action_gate.MUTATING_ACTIONS` plus `executor_dispatch` and is
+# held here rather than imported because the gate will call into this module --
+# `tests/test_approval_receipts.py` pins the relationship instead.
+APPROVABLE_ACTIONS: Final[tuple[str, ...]] = (
+    "executor_dispatch",
+    "external_posting",
+    "merge",
+    "pr_creation",
+    "pr_revision",
+    "repo_edit",
+)
+
+# What kind of thing `scope_ref` names. AC3 of #807 requires the exact added
+# path, endpoint, or tool to be named, so the class says how to read the name
+# and the name itself is stored verbatim rather than summarized.
+SCOPE_CLASSES: Final[tuple[str, ...]] = (
+    "executor_profile",
+    "filesystem_path",
+    "network_endpoint",
+    "permission_profile",
+    "tool",
+)
+
+# The ladders a confirmation can be answered through. Mirrors
+# `coding.action_gate.CONFIRMATION_LADDERS`; a receipt names the ladder it came
+# from, so there is no shape in which an approval arrived from somewhere that is
+# not the confirmation flow.
+CONFIRMATION_LADDERS: Final[tuple[str, ...]] = (
+    "executor_selection",
+    "permission_profile",
+    # #800's risky-action confirmation. Registered here because it is registered
+    # there: a ladder the gate can arm and this module cannot name would be a
+    # confirmation whose answer is unmintable, so the two tuples move together
+    # and the pin in `tests/test_approval_receipts.py` is what forces it.
+    "risky_action",
+    "operator_confirmation",
+)
+
+# `granted` -- the operator said yes.
+# `denied`  -- the operator said no. Recorded because a refusal is an answer,
+#              and an unanswered confirmation must not look like a refused one.
+# `revoked` -- consent already given is withdrawn. Appended as its own record
+#              linked to the grant; the grant itself is never rewritten.
+APPROVAL_DECISIONS: Final[tuple[str, ...]] = ("granted", "denied", "revoked")
+
+# One hour. Chosen against the two bounded-approval precedents in the tree: it
+# is well inside the six-hour horizon `executor_auth_signals` gives an *advisory*
+# limit signal (consent is stronger than advice, so it must not outlive it), and
+# two orders of magnitude below the seven-day cap `_governance_overrides` allows
+# a stale-read override (that override tolerates a stale read; this one
+# authorises a mutating action on a live run). A run that lets an hour pass
+# between the answer and the action has changed enough that the question is
+# worth asking again.
+APPROVAL_TTL_SECONDS: Final[int] = 60 * 60
+
+# `age_seconds` when the decision stamp cannot be read, or is stamped in the
+# future. Both mean the same thing: the receipt cannot be shown to be fresh.
+UNKNOWN_AGE_SECONDS: Final[int] = -1
+
+APPROVAL_RECEIPT_KEYS: Final[tuple[str, ...]] = (
+    "approval_id",
+    "approved_action",
+    "claim_boundary",
+    "confirmation_ladder",
+    "decided_at",
+    "decision",
+    "owner",
+    "privacy",
+    "receipt_id",
+    "run_id",
+    "safety_profile_revision",
+    "schema_version",
+    "scope_class",
+    "scope_ref",
+    "supersedes_receipt_ref",
+)
+
+# The three keys whose value is a module constant rather than data. Everything
+# else on a receipt is rendered, and `compact_approval_receipt` must cover all
+# of it -- a key in the tuple and missing from the compactor is a field that is
+# stored and never seen, which has cost this repo twice.
+APPROVAL_RECEIPT_CONSTANT_KEYS: Final[tuple[str, ...]] = ("claim_boundary", "privacy", "schema_version")
+
+# Identifiers that must be present, through `require_opaque_metadata_ref`.
+_REQUIRED_APPROVAL_REFS: Final[tuple[str, ...]] = (
+    "approval_id",
+    "decided_at",
+    "owner",
+    "receipt_id",
+    "run_id",
+    "safety_profile_revision",
+)
+# The link is empty on the first answer to a confirmation and only then.
+_OPTIONAL_APPROVAL_REFS: Final[tuple[str, ...]] = ("supersedes_receipt_ref",)
+_APPROVAL_VOCABULARIES: Final[tuple[tuple[str, tuple[str, ...]], ...]] = (
+    ("approved_action", APPROVABLE_ACTIONS),
+    ("confirmation_ladder", CONFIRMATION_LADDERS),
+    ("decision", APPROVAL_DECISIONS),
+    ("scope_class", SCOPE_CLASSES),
+)
+# Every string field, which on this record is every field: there is no list, no
+# nested object, and deliberately no free text. A summary line would be one more
+# place for a prompt to arrive, and consent needs no prose to be citable.
+_APPROVAL_STRING_FIELDS: Final[tuple[str, ...]] = APPROVAL_RECEIPT_KEYS
+
+# What identifies *which answer* a receipt records. The stamp, the receipt id,
+# and the supersede link are excluded: reporting the same answer twice must not
+# mint a second receipt just because the clock moved.
+_DECISION_IDENTITY_KEYS: Final[tuple[str, ...]] = (
+    "approval_id",
+    "approved_action",
+    "confirmation_ladder",
+    "decision",
+    "owner",
+    "run_id",
+    "safety_profile_revision",
+    "scope_class",
+    "scope_ref",
+)
+
+# Refusal codes. The first five are the five dimensions an approval binds; no
+# two of them can collapse into one answer, because "this approval does not
+# cover you" is useless to a caller that has to decide what to ask for next.
+REFUSAL_RUN: Final[str] = "run_not_approved"
+REFUSAL_OWNER: Final[str] = "owner_not_approved"
+REFUSAL_ACTION: Final[str] = "action_not_approved"
+REFUSAL_SCOPE: Final[str] = "scope_not_approved"
+REFUSAL_REVISION: Final[str] = "safety_revision_not_approved"
+# Lifecycle refusals: an approval that names exactly this request but cannot
+# speak for it any more.
+REFUSAL_ABSENT: Final[str] = "approval_absent"
+REFUSAL_EXPIRED: Final[str] = "approval_expired"
+REFUSAL_REVOKED: Final[str] = "approval_revoked"
+REFUSAL_SUPERSEDED: Final[str] = "approval_superseded"
+REFUSAL_DENIED: Final[str] = "approval_denied"
+
+# The five scope refusals, in the order `approval_satisfies_request_in` reports
+# them when a candidate differs on more than one dimension. Run first because a
+# receipt borrowed from another run is the failure #807 is named after; owner
+# next because it is the other identity dimension; then what was approved, then
+# what it was approved over, then the profile it was cleared under.
+SCOPE_REFUSAL_CODES: Final[tuple[str, ...]] = (
+    REFUSAL_RUN,
+    REFUSAL_OWNER,
+    REFUSAL_ACTION,
+    REFUSAL_SCOPE,
+    REFUSAL_REVISION,
+)
+LIFECYCLE_REFUSAL_CODES: Final[tuple[str, ...]] = (
+    REFUSAL_ABSENT,
+    REFUSAL_EXPIRED,
+    REFUSAL_REVOKED,
+    REFUSAL_SUPERSEDED,
+    REFUSAL_DENIED,
+)
+REFUSAL_CODES: Final[tuple[str, ...]] = SCOPE_REFUSAL_CODES + LIFECYCLE_REFUSAL_CODES
+
+# Constant strings, keyed by code. Nothing is interpolated into a reason: a
+# refusal line is rendered to operators, and a line built from request values
+# would be one more path for caller-controlled text to reach a terminal.
+REFUSAL_REASONS: Final[dict[str, str]] = {
+    REFUSAL_RUN: "The approval on record belongs to another run; consent is run-bound and never carries over.",
+    REFUSAL_OWNER: "The approval on record was given to another owner.",
+    REFUSAL_ACTION: "The approval on record names another action; consent never extends to a sibling action.",
+    REFUSAL_SCOPE: (
+        "The approval on record names another scope; consent covers exactly the scope it named and never a "
+        "broader one."
+    ),
+    REFUSAL_REVISION: "The approval on record was given under another safety profile revision.",
+    REFUSAL_ABSENT: "No approval on record names this action, scope, owner, run, and safety profile revision.",
+    REFUSAL_EXPIRED: "The approval on record is outside the approval window, measured now from its decision stamp.",
+    REFUSAL_REVOKED: "The approval on record was revoked.",
+    REFUSAL_SUPERSEDED: "The approval on record was superseded by a later answer to the same confirmation.",
+    REFUSAL_DENIED: "The confirmation on record was answered with a denial.",
+}
+
+# Key names an execution claim arrives under. The closed key set already refuses
+# every one of them, but it refuses them as "unsupported keys", and the whole
+# point of this family is that an approval is not an outcome -- so the shape is
+# named and refused by name first. Enforcing E of #800: a record asserting that
+# something ran is not constructible here.
+_EXECUTION_CLAIM_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "applied",
+        "attempted",
+        "completed",
+        "dispatched",
+        "effect_applied",
+        "enforced",
+        "executed",
+        "execution",
+        "execution_result",
+        "exit_code",
+        "external_ref",
+        "host_applied",
+        "observed",
+        "observed_at",
+        "observed_result",
+        "outcome",
+        "performed",
+        "ran",
+        "result",
+        "status",
+        "succeeded",
+        "success",
+    }
+)
+
+# Mirrors the guard in `external_effect_receipts`: these are how raw model
+# output and private payloads arrive, so they are refused by name as well as by
+# the closed key set.
+_RAW_OR_HIDDEN_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "analysis",
+        "body",
+        "body_text",
+        "chain_of_thought",
+        "conversation",
+        "cot",
+        "hidden",
+        "hidden_reasoning",
+        "message",
+        "payload",
+        "prompt",
+        "raw",
+        "raw_log",
+        "raw_logs",
+        "raw_message",
+        "raw_output",
+        "raw_payload",
+        "raw_prompt",
+        "reasoning",
+        "stderr",
+        "stdout",
+        "think",
+        "thinking",
+        "transcript",
+        "url",
+    }
+)
+
+# A reference that navigates somewhere is not an opaque identifier. Same three
+# markers `external_effect_receipts` draws the line at.
+_URL_SHAPED: Final[tuple[str, ...]] = ("://", "?", "#")
+# A scope must name something inside the workspace. `require_opaque_metadata_ref`
+# already refuses a leading `/` or `~` (the first character must be alphanumeric)
+# and every backslash, so what is left is the parent traversal and the Windows
+# drive prefix, which are the two ways an in-bounds-looking scope reaches out.
+_SCOPE_TRAVERSAL: Final[re.Pattern[str]] = re.compile(r"(?:^|/)\.\.(?:/|$)")
+_WINDOWS_DRIVE: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z]:")
+
+
+class ApprovalReceiptError(ValueError):
+    """Raised when a receipt cannot be minted from what an operator answered."""
+
+
+def approval_id(
+    *,
+    run_id: str,
+    owner: str,
+    approved_action: str,
+    scope_class: str,
+    scope_ref: str,
+) -> str:
+    """Stable identity of one confirmation question.
+
+    The safety-profile revision is deliberately not in it. The revision is part
+    of the *answer's* validity, not part of the question: re-answering the same
+    question after the profile moved must supersede the earlier answer rather
+    than open a second, parallel chain that both claim to be current.
+    """
+    base = json.dumps(
+        {
+            "approved_action": str(approved_action),
+            "owner": str(owner),
+            "run_id": str(run_id),
+            "scope_class": str(scope_class),
+            "scope_ref": str(scope_ref),
+        },
+        sort_keys=True,
+    )
+    return f"approval-{hashlib.sha256(base.encode('utf-8')).hexdigest()[:16]}"
+
+
+def build_approval_receipt(
+    *,
+    approved_action: str,
+    scope_class: str,
+    scope_ref: str,
+    owner: str,
+    run_id: str,
+    safety_profile_revision: str,
+    confirmation_ladder: str,
+    decision: str = "granted",
+    decided_at: str = "",
+    supersedes_receipt_ref: str = "",
+) -> dict[str, Any]:
+    """Mint one receipt, or refuse.
+
+    Every refusal here is the invariant this module exists for: a receipt can
+    only describe an answer a human gave to a confirmation about a named scope.
+    """
+    if decision not in APPROVAL_DECISIONS:
+        raise ApprovalReceiptError(f"approval_receipt decision is unsupported: {decision!r}")
+    if approved_action not in APPROVABLE_ACTIONS:
+        raise ApprovalReceiptError(f"approval_receipt approved_action is unsupported: {approved_action!r}")
+    if scope_class not in SCOPE_CLASSES:
+        raise ApprovalReceiptError(f"approval_receipt scope_class is unsupported: {scope_class!r}")
+    if confirmation_ladder not in CONFIRMATION_LADDERS:
+        raise ApprovalReceiptError(
+            f"approval_receipt confirmation_ladder is unsupported: {confirmation_ladder!r}"
+        )
+    safe_scope_ref = _scope_ref(scope_ref)
+    safe_owner = _opaque(owner, field="approval_receipt owner")
+    safe_run_id = _opaque(run_id, field="approval_receipt run_id")
+    safe_revision = _opaque(safety_profile_revision, field="approval_receipt safety_profile_revision")
+    safe_supersedes = (
+        _opaque(supersedes_receipt_ref, field="approval_receipt supersedes_receipt_ref")
+        if supersedes_receipt_ref
+        else ""
+    )
+    stamp = _opaque(str(decided_at or utc_now()), field="approval_receipt decided_at")
+    identity = approval_id(
+        run_id=safe_run_id,
+        owner=safe_owner,
+        approved_action=approved_action,
+        scope_class=scope_class,
+        scope_ref=safe_scope_ref,
+    )
+    record = {
+        "schema_version": APPROVAL_RECEIPT_SCHEMA_VERSION,
+        "receipt_id": _receipt_id(stamp, identity, decision),
+        "approval_id": identity,
+        "run_id": safe_run_id,
+        "owner": safe_owner,
+        "approved_action": approved_action,
+        "scope_class": scope_class,
+        "scope_ref": safe_scope_ref,
+        "safety_profile_revision": safe_revision,
+        "confirmation_ladder": confirmation_ladder,
+        "decision": decision,
+        "decided_at": stamp,
+        "supersedes_receipt_ref": safe_supersedes,
+        "privacy": RECEIPT_PRIVACY,
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+    errors = validate_approval_receipt(record)
+    if errors:
+        raise ApprovalReceiptError(errors[0])
+    return record
+
+
+def validate_approval_receipt(record: dict[str, Any]) -> list[str]:
+    """Every reason one record is not an approval receipt."""
+    errors: list[str] = []
+    if not isinstance(record, dict):
+        return ["approval_receipt must be an object"]
+    claims_execution = sorted(key for key in record if str(key).lower() in _EXECUTION_CLAIM_KEYS)
+    if claims_execution:
+        errors.append(
+            "approval_receipt must not carry execution-claim keys: "
+            f"{claims_execution}; consent is not an attempt and not an outcome"
+        )
+    forbidden = sorted(key for key in record if str(key).lower() in _RAW_OR_HIDDEN_KEYS)
+    if forbidden:
+        errors.append(f"approval_receipt must not carry raw or hidden keys: {forbidden}")
+    extra_keys = sorted(set(record) - set(APPROVAL_RECEIPT_KEYS) - set(claims_execution) - set(forbidden))
+    if extra_keys:
+        errors.append(f"approval_receipt has unsupported keys: {extra_keys}")
+    missing = sorted(set(APPROVAL_RECEIPT_KEYS) - set(record))
+    if missing:
+        errors.append(f"approval_receipt is missing keys: {missing}")
+    if record.get("schema_version") != APPROVAL_RECEIPT_SCHEMA_VERSION:
+        errors.append(f"approval_receipt schema_version must be {APPROVAL_RECEIPT_SCHEMA_VERSION}")
+    for key in _APPROVAL_STRING_FIELDS:
+        if not isinstance(record.get(key), str):
+            errors.append(f"approval_receipt {key} must be a string")
+    for key, vocabulary in _APPROVAL_VOCABULARIES:
+        if record.get(key) not in vocabulary:
+            errors.append(f"approval_receipt {key} is unsupported: {record.get(key)!r}")
+    if record.get("privacy") != RECEIPT_PRIVACY:
+        errors.append("approval_receipt privacy must be metadata_only")
+    if record.get("claim_boundary") != CLAIM_BOUNDARY:
+        errors.append("approval_receipt claim_boundary must state the approval boundary")
+    for field in _REQUIRED_APPROVAL_REFS:
+        errors.extend(_reference_errors(record.get(field), field=field, required=True))
+    for field in _OPTIONAL_APPROVAL_REFS:
+        errors.extend(_reference_errors(record.get(field), field=field, required=False))
+    errors.extend(_scope_ref_errors(record.get("scope_ref")))
+    if str(record.get("receipt_id", "")) and str(record.get("receipt_id", "")) == str(
+        record.get("supersedes_receipt_ref", "")
+    ):
+        errors.append("approval_receipt supersedes_receipt_ref must not name itself")
+    expected_identity = approval_id(
+        run_id=str(record.get("run_id", "")),
+        owner=str(record.get("owner", "")),
+        approved_action=str(record.get("approved_action", "")),
+        scope_class=str(record.get("scope_class", "")),
+        scope_ref=str(record.get("scope_ref", "")),
+    )
+    if str(record.get("approval_id", "")) != expected_identity:
+        # Without this a hand-edited store could move one grant onto another
+        # question's chain and have it supersede an approval it never answered.
+        errors.append("approval_receipt approval_id does not identify its own action, scope, owner, and run")
+    return errors
+
+
+def append_approval_receipt(paths: OmhPaths, record: dict[str, Any]) -> dict[str, Any]:
+    """Append one validated receipt. Never rewrites, never reorders."""
+    errors = validate_approval_receipt(record)
+    if errors:
+        raise ApprovalReceiptError(errors[0])
+    path = paths.runtime_approval_receipts_path
+    # `file_lock` rather than a bare `fcntl.flock`: it holds a real OS lock on
+    # both POSIX and Windows, and this store's mutual exclusion has to be a
+    # property CI can assert on either platform.
+    with file_lock(path, private=True):
+        _append_store_line(path, record)
+    return record
+
+
+def record_approval_receipt(
+    paths: OmhPaths,
+    *,
+    approved_action: str,
+    scope_class: str,
+    scope_ref: str,
+    owner: str,
+    run_id: str,
+    safety_profile_revision: str,
+    confirmation_ladder: str,
+    decision: str = "granted",
+    now: str = "",
+) -> dict[str, Any]:
+    """Mint and append one receipt, or return the receipt that already records it.
+
+    The strict entry point: it raises when the answer cannot become a receipt
+    and when the store cannot be written. The confirmation flow calls
+    `mint_approval_receipt` instead, because a receipt store outage must not
+    fail the flow that already collected the answer.
+
+    Re-answering a confirmation appends a new receipt linked through
+    `supersedes_receipt_ref`; nothing on disk is changed. Reporting the same
+    answer again while it is still live appends nothing and returns the receipt
+    already on record, so one answer reported three times has one receipt. Once
+    a grant is outside its window the identical answer mints again -- consent
+    re-given after expiry is new consent, not a duplicate report of the old.
+
+    The read of the prior receipt and the append happen under one lock, so two
+    concurrent answers to one confirmation cannot both link to the same
+    predecessor and fork the chain.
+    """
+    record, _ = _record_approval(
+        paths.runtime_approval_receipts_path,
+        approved_action=approved_action,
+        scope_class=scope_class,
+        scope_ref=scope_ref,
+        owner=owner,
+        run_id=run_id,
+        safety_profile_revision=safety_profile_revision,
+        confirmation_ladder=confirmation_ladder,
+        decision=decision,
+        now=now,
+    )
+    return record
+
+
+def mint_approval_receipt(
+    paths: OmhPaths,
+    *,
+    approved_action: str,
+    scope_class: str,
+    scope_ref: str,
+    owner: str,
+    run_id: str,
+    safety_profile_revision: str,
+    confirmation_ladder: str,
+    decision: str = "granted",
+    now: str = "",
+) -> dict[str, Any]:
+    """Record one answered confirmation without ever raising into the flow.
+
+    The confirmation flow records a receipt *after* the operator has already
+    answered. Letting the receipt store fail that flow would make an unwritable
+    store look like an answer that was never given, so every refusal and every
+    write failure is returned instead of raised.
+
+    Returns an `approval_mint_result/v1` mapping:
+
+        schema_version -- APPROVAL_MINT_RESULT_SCHEMA_VERSION
+        minted         -- True only when a new receipt reached the store
+        outcome        -- "recorded" | "already_recorded" | "refused" | "not_written"
+        approval_id    -- the confirmation this call was about
+        receipt_id     -- the receipt now on record, "" when there is none
+        decision       -- the decision now on record, "" when there is none
+        error          -- the refusal or write failure, "" otherwise
+
+    Failures are also appended to `approval_mint_failures.jsonl` beside the
+    store, best effort, so an answer that went unrecorded is visible without the
+    flow having to invent a channel for it.
+    """
+    return mint_approval_receipt_at(
+        paths.runtime_approval_receipts_path,
+        approved_action=approved_action,
+        scope_class=scope_class,
+        scope_ref=scope_ref,
+        owner=owner,
+        run_id=run_id,
+        safety_profile_revision=safety_profile_revision,
+        confirmation_ladder=confirmation_ladder,
+        decision=decision,
+        now=now,
+    )
+
+
+def mint_approval_receipt_at(
+    store_path: Path,
+    *,
+    approved_action: str,
+    scope_class: str,
+    scope_ref: str,
+    owner: str,
+    run_id: str,
+    safety_profile_revision: str,
+    confirmation_ladder: str,
+    decision: str = "granted",
+    now: str = "",
+) -> dict[str, Any]:
+    """`mint_approval_receipt` against an already-resolved store path.
+
+    Callers that hold a runtime directory rather than an `OmhPaths` use this, so
+    every path they touch is derived from the directory they were given and none
+    is reconstructed from an environment they are not running in.
+    """
+    identity = approval_id(
+        run_id=str(run_id),
+        owner=str(owner),
+        approved_action=str(approved_action),
+        scope_class=str(scope_class),
+        scope_ref=str(scope_ref),
+    )
+    try:
+        record, minted = _record_approval(
+            store_path,
+            approved_action=approved_action,
+            scope_class=scope_class,
+            scope_ref=scope_ref,
+            owner=owner,
+            run_id=run_id,
+            safety_profile_revision=safety_profile_revision,
+            confirmation_ladder=confirmation_ladder,
+            decision=decision,
+            now=now,
+        )
+    except ApprovalReceiptError as exc:
+        return _mint_failure(
+            store_path,
+            outcome="refused",
+            error=str(exc),
+            approval_id=identity,
+            approved_action=approved_action,
+            decision=decision,
+            run_id=run_id,
+        )
+    except OSError as exc:
+        # Covers FileLockTimeout, which is a TimeoutError and therefore an
+        # OSError: an unavailable lock is a store that could not be written.
+        return _mint_failure(
+            store_path,
+            outcome="not_written",
+            error=str(exc),
+            approval_id=identity,
+            approved_action=approved_action,
+            decision=decision,
+            run_id=run_id,
+        )
+    return {
+        "schema_version": APPROVAL_MINT_RESULT_SCHEMA_VERSION,
+        "minted": minted,
+        "outcome": "recorded" if minted else "already_recorded",
+        "approval_id": str(record.get("approval_id", "")),
+        "receipt_id": str(record.get("receipt_id", "")),
+        "decision": str(record.get("decision", "")),
+        "error": "",
+    }
+
+
+def read_approval_receipts_result(paths: OmhPaths) -> tuple[list[dict[str, Any]], list[str]]:
+    return read_jsonl_objects(paths.runtime_approval_receipts_path)
+
+
+def read_approval_receipts(
+    paths: OmhPaths,
+    *,
+    run_id: str | None = None,
+    approval_id: str | None = None,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """The store, in append order, optionally scoped to one run or one question."""
+    receipts, _ = read_approval_receipts_result(paths)
+    if run_id is not None:
+        receipts = [receipt for receipt in receipts if str(receipt.get("run_id", "")) == run_id]
+    if approval_id is not None:
+        receipts = [receipt for receipt in receipts if str(receipt.get("approval_id", "")) == approval_id]
+    if limit is None:
+        return receipts
+    if limit < 1:
+        return []
+    return receipts[-limit:]
+
+
+def latest_receipt_in(
+    receipts: Sequence[Mapping[str, Any]],
+    approval_id_value: str,
+) -> dict[str, Any]:
+    """The receipt that speaks for one confirmation: the one selection rule.
+
+    The store is append-only, so store order is arrival order and the last
+    record for a question is its current answer. Every surface that judges an
+    approval selects through this function, which is what stops the store
+    validator and the satisfaction predicate from picking different receipts for
+    one question and reaching opposite conclusions about it.
+    """
+    matches = [
+        dict(receipt) for receipt in receipts if str(receipt.get("approval_id", "")) == str(approval_id_value)
+    ]
+    return matches[-1] if matches else {}
+
+
+def approval_age_seconds(decided_at: str, now: str = "") -> int:
+    """How old a decision is, computed now, or `UNKNOWN_AGE_SECONDS`.
+
+    A stamp that does not parse and a stamp in the future both return
+    `UNKNOWN_AGE_SECONDS`: neither can be shown to be inside the window, and
+    clamping a future stamp to zero would make "edit the timestamp forward" a
+    way to widen the window from disk.
+    """
+    decided = _parse_stamp(decided_at)
+    if decided is None:
+        return UNKNOWN_AGE_SECONDS
+    reference = _parse_stamp(now) or datetime.now(timezone.utc)
+    age = int((reference - decided).total_seconds())
+    if age < 0:
+        return UNKNOWN_AGE_SECONDS
+    return age
+
+
+def approval_is_expired(receipt: Mapping[str, Any], now: str = "") -> bool:
+    """Whether this receipt is outside the approval window, evaluated now."""
+    age = approval_age_seconds(str(receipt.get("decided_at", "")), now)
+    return age == UNKNOWN_AGE_SECONDS or age > APPROVAL_TTL_SECONDS
+
+
+def approval_satisfies_request(
+    paths: OmhPaths,
+    *,
+    approved_action: str,
+    scope_class: str,
+    scope_ref: str,
+    owner: str,
+    run_id: str,
+    safety_profile_revision: str,
+    now: str = "",
+) -> dict[str, Any]:
+    """Does an unrevoked, unexpired approval cover exactly this request?
+
+    The entry point a gate calls. Returns an `approval_decision/v1` mapping; see
+    `approval_satisfies_request_in` for the shape and for how the refusal code
+    is chosen.
+    """
+    return approval_satisfies_request_in(
+        read_approval_receipts(paths),
+        approved_action=approved_action,
+        scope_class=scope_class,
+        scope_ref=scope_ref,
+        owner=owner,
+        run_id=run_id,
+        safety_profile_revision=safety_profile_revision,
+        now=now,
+    )
+
+
+def approval_satisfies_request_in(
+    receipts: Sequence[Mapping[str, Any]],
+    *,
+    approved_action: str,
+    scope_class: str,
+    scope_ref: str,
+    owner: str,
+    run_id: str,
+    safety_profile_revision: str,
+    now: str = "",
+) -> dict[str, Any]:
+    """`approval_satisfies_request` over receipts already in hand.
+
+    An `approval_decision/v1` mapping:
+
+        satisfied              -- True only when a live approval names exactly
+                                  this action, scope, owner, run, and revision
+        reason_code            -- "" when satisfied, otherwise one of REFUSAL_CODES
+        reason                 -- the constant line for that code
+        receipt_id             -- the approval this verdict is about, "" when none
+        approval_id            -- identity of the confirmation this request asks about
+        age_seconds            -- age of that approval, computed now
+        expires_after_seconds  -- APPROVAL_TTL_SECONDS, so a caller can cite the window
+
+    An approval that names this request exactly is judged on its lifecycle:
+    superseded, then revoked, then denied, then expired. Otherwise the nearest
+    live grant explains what it does cover, reporting its first differing
+    dimension in `SCOPE_REFUSAL_CODES` order. There is no containment rule
+    anywhere in that walk, so nothing widens.
+    """
+    identity = approval_id(
+        run_id=str(run_id),
+        owner=str(owner),
+        approved_action=str(approved_action),
+        scope_class=str(scope_class),
+        scope_ref=str(scope_ref),
+    )
+    request = (
+        str(run_id),
+        str(owner),
+        str(approved_action),
+        (str(scope_class), str(scope_ref)),
+        str(safety_profile_revision),
+    )
+    known = [receipt for receipt in receipts if isinstance(receipt, Mapping)]
+    exact = [receipt for receipt in known if not _dimension_mismatches(receipt, request)]
+    if exact:
+        return _lifecycle_verdict(known, exact[-1], identity, request, now)
+    candidate, mismatches = _nearest_live_grant(known, request, now)
+    if candidate is None:
+        return _decision_payload(
+            satisfied=False,
+            reason_code=REFUSAL_ABSENT,
+            receipt={},
+            approval_id_value=identity,
+            request=request,
+            now=now,
+        )
+    return _decision_payload(
+        satisfied=False,
+        reason_code=mismatches[0],
+        receipt=candidate,
+        approval_id_value=identity,
+        request=request,
+        now=now,
+    )
+
+
+def validate_approval_receipt_store(path: Path, *, run_id: str | None = None) -> dict[str, Any]:
+    """Validate the approval store, optionally scoped to one run's records.
+
+    Unscoped (`run_id=None`) this is the store's own report: unparseable lines,
+    every record's schema, and the integrity of the supersede chain. A line that
+    does not parse belongs to no run -- it has no `run_id` to read -- so it is
+    the store's fault and is reported here, once, never against a run that
+    happened to be validated while it sat there.
+    """
+    receipts, read_errors = read_jsonl_objects(path)
+    indexed = [
+        (index, receipt)
+        for index, receipt in enumerate(receipts, start=1)
+        if run_id is None or str(receipt.get("run_id", "")) == run_id
+    ]
+    errors: list[str] = list(read_errors) if run_id is None else []
+    for index, receipt in indexed:
+        errors.extend(f"{path}:{index}: {error}" for error in validate_approval_receipt(receipt))
+    errors.extend(_supersede_chain_errors(path, receipts, run_id=run_id))
+    return {
+        "schema_version": APPROVAL_RECEIPT_STORE_VALIDATION_SCHEMA_VERSION,
+        "path": str(path),
+        "run_id": run_id or "",
+        "ok": not errors,
+        "receipt_count": len(indexed),
+        "mint_failure_count": len(read_approval_mint_failures(path)),
+        "errors": errors,
+    }
+
+
+def approval_mint_failures_path(store_path: Path) -> Path:
+    """Where unrecorded answers are logged, beside the store they failed to reach."""
+    return store_path.with_name(APPROVAL_MINT_FAILURE_STORE_NAME)
+
+
+def read_approval_mint_failures(store_path: Path) -> list[dict[str, Any]]:
+    failures, _ = read_jsonl_objects(approval_mint_failures_path(store_path))
+    return failures
+
+
+def compact_approval_receipt(receipt: Mapping[str, Any], *, now: str = "") -> dict[str, Any]:
+    """The user-facing shape, with every field through its class's guard.
+
+    Rendering is the last point at which a hand-edited store reaches a human, so
+    nothing is copied through verbatim: identifiers fold to a stable
+    non-navigable handle when they are not opaque, and closed vocabularies
+    render empty outside their vocabulary. `age_seconds` and `expired` are
+    derived here rather than stored, which is the whole point -- nothing on disk
+    says an approval is still good.
+    """
+    age = approval_age_seconds(str(receipt.get("decided_at", "")), now)
+    return {
+        "receipt_id": redacted_approval_ref(str(receipt.get("receipt_id", ""))),
+        "approval_id": redacted_approval_ref(str(receipt.get("approval_id", ""))),
+        "run_id": redacted_approval_ref(str(receipt.get("run_id", ""))),
+        "owner": redacted_approval_ref(str(receipt.get("owner", ""))),
+        "approved_action": closed_approval_value(receipt.get("approved_action"), APPROVABLE_ACTIONS),
+        "scope_class": closed_approval_value(receipt.get("scope_class"), SCOPE_CLASSES),
+        "scope_ref": redacted_approval_ref(str(receipt.get("scope_ref", ""))),
+        "safety_profile_revision": redacted_approval_ref(str(receipt.get("safety_profile_revision", ""))),
+        "confirmation_ladder": closed_approval_value(receipt.get("confirmation_ladder"), CONFIRMATION_LADDERS),
+        "decision": closed_approval_value(receipt.get("decision"), APPROVAL_DECISIONS),
+        "decided_at": redacted_approval_ref(str(receipt.get("decided_at", ""))),
+        "supersedes_receipt_ref": redacted_approval_ref(str(receipt.get("supersedes_receipt_ref", ""))),
+        "age_seconds": age,
+        "expired": approval_is_expired(receipt, now),
+    }
+
+
+def redacted_approval_ref(value: str) -> str:
+    """Fold any handle into a bounded, non-navigable receipt reference."""
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    if _is_url_shaped(text) or is_sensitive_metadata_text(text):
+        return _digest_ref(text)
+    try:
+        require_opaque_metadata_ref(text, field="approval_ref")
+    except ValueError:
+        return _digest_ref(text)
+    return text
+
+
+def closed_approval_value(value: Any, allowed: tuple[str, ...]) -> str:
+    """A closed-vocabulary field renders only what its vocabulary contains.
+
+    Rendering reads whatever is on disk, and a store can be hand-edited. A value
+    outside the vocabulary is not a new state, it is a value with no meaning, so
+    it renders empty rather than as itself.
+    """
+    text = str(value or "")
+    return text if text in allowed else ""
+
+
+def _record_approval(
+    path: Path,
+    *,
+    approved_action: str,
+    scope_class: str,
+    scope_ref: str,
+    owner: str,
+    run_id: str,
+    safety_profile_revision: str,
+    confirmation_ladder: str,
+    decision: str,
+    now: str,
+) -> tuple[dict[str, Any], bool]:
+    """The receipt now on record, and whether this call is what put it there."""
+    with file_lock(path, private=True):
+        identity = approval_id(
+            run_id=str(run_id),
+            owner=str(owner),
+            approved_action=str(approved_action),
+            scope_class=str(scope_class),
+            scope_ref=str(scope_ref),
+        )
+        receipts, _ = read_jsonl_objects(path)
+        prior = latest_receipt_in(receipts, identity)
+        record = build_approval_receipt(
+            approved_action=approved_action,
+            scope_class=scope_class,
+            scope_ref=scope_ref,
+            owner=owner,
+            run_id=run_id,
+            safety_profile_revision=safety_profile_revision,
+            confirmation_ladder=confirmation_ladder,
+            decision=decision,
+            # `now` is the clock for this call: it stamps the new receipt and it
+            # is the instant the prior receipt's freshness is judged against.
+            # Two clocks here -- a real stamp and an injected comparison -- is
+            # how a fresh receipt ends up looking expired the moment it is
+            # written.
+            decided_at=now,
+            supersedes_receipt_ref=str(prior.get("receipt_id", "")) if prior else "",
+        )
+        if prior and _decision_fingerprint(prior) == _decision_fingerprint(record):
+            # Identical re-report of an answer that is still live. A grant past
+            # its window is *not* still live: consent re-given after expiry is
+            # new consent, and returning the stale receipt would hand the caller
+            # an approval that refuses one line later.
+            if str(prior.get("decision", "")) != "granted" or not approval_is_expired(prior, now):
+                return prior, False
+        _append_store_line(path, record)
+    return record, True
+
+
+def _append_store_line(path: Path, record: dict[str, Any]) -> None:
+    """Append one line, terminating a torn tail first.
+
+    A short write leaves a partial line with no trailing newline. Appending
+    straight onto it concatenates two records into one unparseable line and
+    loses both, so the tail byte is checked and a newline is written first when
+    it is missing. The torn line stays on disk as one corrupt line the store
+    validator reports; the new record survives as its own.
+
+    Binary mode on purpose: Windows text mode would rewrite ``\\n`` as ``\\r\\n``
+    and make the tail check platform-dependent.
+    """
+    ensure_dir(path.parent, private=True)
+    ensure_file(path, private=True)
+    payload = json.dumps(record, sort_keys=True).encode("utf-8") + b"\n"
+    with path.open("r+b") as handle:
+        handle.seek(0, os.SEEK_END)
+        if handle.tell():
+            handle.seek(-1, os.SEEK_END)
+            if handle.read(1) != b"\n":
+                payload = b"\n" + payload
+        handle.seek(0, os.SEEK_END)
+        handle.write(payload)
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def _mint_failure(
+    store_path: Path,
+    *,
+    outcome: str,
+    error: str,
+    approval_id: str,
+    approved_action: str,
+    decision: str,
+    run_id: str,
+) -> dict[str, Any]:
+    failure = {
+        "schema_version": APPROVAL_MINT_FAILURE_SCHEMA_VERSION,
+        "recorded_at": utc_now(),
+        "outcome": outcome,
+        "approval_id": str(approval_id),
+        "approved_action": str(approved_action),
+        "decision": str(decision),
+        "run_id": str(run_id),
+        "error": _bounded_error(error),
+    }
+    _append_mint_failure(store_path, failure)
+    return {
+        "schema_version": APPROVAL_MINT_RESULT_SCHEMA_VERSION,
+        "minted": False,
+        "outcome": outcome,
+        "approval_id": str(approval_id),
+        "receipt_id": "",
+        "decision": "",
+        "error": str(error),
+    }
+
+
+def _append_mint_failure(store_path: Path, failure: dict[str, Any]) -> None:
+    path = approval_mint_failures_path(store_path)
+    try:
+        # The same lock the receipt appends take, on this log's own sidecar. It
+        # is the record that has to survive when things are already going wrong,
+        # so two flows failing at once must not interleave and lose a line. The
+        # lock is never held while the receipt store's lock is: a mint failure
+        # is raised out of that block before this runs.
+        with file_lock(path, private=True):
+            _append_store_line(path, failure)
+    except OSError:
+        # The failure log lives next to the store, so the same outage that lost
+        # the receipt can lose this line too. The mint result the caller already
+        # holds is the record of last resort; there is nothing further to try.
+        return
+
+
+def _lifecycle_verdict(
+    receipts: Sequence[Mapping[str, Any]],
+    exact: Mapping[str, Any],
+    identity: str,
+    request: tuple[Any, ...],
+    now: str,
+) -> dict[str, Any]:
+    """Judge an approval that names this request exactly.
+
+    Order matters. Superseded first: a later answer to the same confirmation is
+    the current one whatever the earlier record said, so an operator who
+    re-answered must not still be bound by what they replaced. Then the terminal
+    decisions, then the window.
+    """
+    head = latest_receipt_in(receipts, str(exact.get("approval_id", "")))
+    if str(head.get("receipt_id", "")) != str(exact.get("receipt_id", "")):
+        return _decision_payload(
+            satisfied=False,
+            reason_code=REFUSAL_SUPERSEDED,
+            receipt=exact,
+            approval_id_value=identity,
+            request=request,
+            now=now,
+        )
+    decision = str(exact.get("decision", ""))
+    if decision == "revoked":
+        return _decision_payload(
+            satisfied=False,
+            reason_code=REFUSAL_REVOKED,
+            receipt=exact,
+            approval_id_value=identity,
+            request=request,
+            now=now,
+        )
+    if decision != "granted":
+        return _decision_payload(
+            satisfied=False,
+            reason_code=REFUSAL_DENIED,
+            receipt=exact,
+            approval_id_value=identity,
+            request=request,
+            now=now,
+        )
+    if approval_is_expired(exact, now):
+        return _decision_payload(
+            satisfied=False,
+            reason_code=REFUSAL_EXPIRED,
+            receipt=exact,
+            approval_id_value=identity,
+            request=request,
+            now=now,
+        )
+    return _decision_payload(
+        satisfied=True,
+        reason_code="",
+        receipt=exact,
+        approval_id_value=identity,
+        request=request,
+        now=now,
+    )
+
+
+def _nearest_live_grant(
+    receipts: Sequence[Mapping[str, Any]],
+    request: tuple[Any, ...],
+    now: str,
+) -> tuple[Mapping[str, Any] | None, tuple[str, ...]]:
+    """The live grant closest to this request, and how it differs.
+
+    Only grants that are still the current answer to their own confirmation are
+    considered: a revoked, denied, or superseded record explains nothing about
+    what is allowed now. An expired grant stays a candidate on purpose -- "there
+    is an approval for another run" is a more useful refusal than "there is no
+    approval", and it refuses either way.
+    """
+    heads = _chain_heads(receipts)
+    best: Mapping[str, Any] | None = None
+    best_mismatches: tuple[str, ...] = ()
+    for receipt in receipts:
+        if str(receipt.get("decision", "")) != "granted":
+            continue
+        if heads.get(str(receipt.get("approval_id", ""))) != str(receipt.get("receipt_id", "")):
+            continue
+        mismatches = _dimension_mismatches(receipt, request)
+        if not mismatches:
+            continue
+        if best is None or len(mismatches) <= len(best_mismatches):
+            best = receipt
+            best_mismatches = mismatches
+    return best, best_mismatches
+
+
+def _chain_heads(receipts: Sequence[Mapping[str, Any]]) -> dict[str, str]:
+    """The current answer to every confirmation in one pass over the store.
+
+    The same selection rule as `latest_receipt_in` -- last record wins -- built
+    once so judging a store of n receipts does not walk it n times.
+    """
+    heads: dict[str, str] = {}
+    for receipt in receipts:
+        heads[str(receipt.get("approval_id", ""))] = str(receipt.get("receipt_id", ""))
+    return heads
+
+
+def _dimension_mismatches(receipt: Mapping[str, Any], request: tuple[Any, ...]) -> tuple[str, ...]:
+    """Which of the five bound dimensions this receipt does not match.
+
+    Append order is `SCOPE_REFUSAL_CODES` order, which is the reporting
+    precedence. Every comparison is equality, including the scope pair: there is
+    no containment rule here, and that absence is what makes widening
+    structurally impossible rather than merely unimplemented.
+    """
+    run_id, owner, action, scope, revision = request
+    mismatches: list[str] = []
+    if str(receipt.get("run_id", "")) != run_id:
+        mismatches.append(REFUSAL_RUN)
+    if str(receipt.get("owner", "")) != owner:
+        mismatches.append(REFUSAL_OWNER)
+    if str(receipt.get("approved_action", "")) != action:
+        mismatches.append(REFUSAL_ACTION)
+    if (str(receipt.get("scope_class", "")), str(receipt.get("scope_ref", ""))) != scope:
+        mismatches.append(REFUSAL_SCOPE)
+    if str(receipt.get("safety_profile_revision", "")) != revision:
+        mismatches.append(REFUSAL_REVISION)
+    return tuple(mismatches)
+
+
+def _decision_payload(
+    *,
+    satisfied: bool,
+    reason_code: str,
+    receipt: Mapping[str, Any],
+    approval_id_value: str,
+    request: tuple[Any, ...],
+    now: str,
+) -> dict[str, Any]:
+    run_id, owner, action, scope, revision = request
+    scope_class, scope_ref = scope
+    return {
+        "schema_version": APPROVAL_DECISION_SCHEMA_VERSION,
+        "satisfied": satisfied,
+        "reason_code": reason_code,
+        "reason": REFUSAL_REASONS.get(reason_code, ""),
+        "receipt_id": redacted_approval_ref(str(receipt.get("receipt_id", ""))),
+        "approval_id": redacted_approval_ref(approval_id_value),
+        "requested_action": redacted_approval_ref(str(action)),
+        "requested_scope_class": redacted_approval_ref(str(scope_class)),
+        "requested_scope_ref": redacted_approval_ref(str(scope_ref)),
+        "requested_owner": redacted_approval_ref(str(owner)),
+        "requested_run_id": redacted_approval_ref(str(run_id)),
+        "requested_safety_profile_revision": redacted_approval_ref(str(revision)),
+        "decided_at": redacted_approval_ref(str(receipt.get("decided_at", ""))),
+        "age_seconds": approval_age_seconds(str(receipt.get("decided_at", "")), now) if receipt else UNKNOWN_AGE_SECONDS,
+        "expires_after_seconds": APPROVAL_TTL_SECONDS,
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+
+
+def _supersede_chain_errors(
+    path: Path,
+    receipts: list[dict[str, Any]],
+    *,
+    run_id: str | None,
+) -> list[str]:
+    """Reject every shape a supersede chain must not take.
+
+    A chain is a line, not a graph: a receipt cannot supersede itself, cannot
+    supersede a receipt that does not already exist, and cannot supersede a
+    receipt something else already superseded. A fork means two answers to one
+    confirmation both believe they replaced the same predecessor, which makes
+    "the current answer" ambiguous -- and an ambiguous approval is the one thing
+    a consent record must never be.
+
+    Every receipt in the store is walked even when the report is scoped to one
+    run, so a link into a receipt outside the scope is still a link into a
+    receipt that exists. Only faults on in-scope receipts are reported: scoping
+    a report must never invent a broken chain.
+    """
+    seen: set[str] = set()
+    successors: dict[str, str] = {}
+    errors: list[str] = []
+    for index, receipt in enumerate(receipts, start=1):
+        in_scope = run_id is None or str(receipt.get("run_id", "")) == run_id
+        receipt_id = str(receipt.get("receipt_id", ""))
+        if receipt_id and receipt_id in seen and in_scope:
+            errors.append(f"{path}:{index}: approval_receipt receipt_id is not unique: {receipt_id}")
+        superseded = str(receipt.get("supersedes_receipt_ref", ""))
+        if superseded:
+            if superseded == receipt_id:
+                if in_scope:
+                    errors.append(
+                        f"{path}:{index}: approval_receipt supersedes_receipt_ref must not name itself: {receipt_id}"
+                    )
+            elif superseded not in seen:
+                if in_scope:
+                    errors.append(
+                        f"{path}:{index}: approval_receipt supersedes_receipt_ref does not name an earlier "
+                        f"receipt: {superseded}"
+                    )
+            elif superseded in successors:
+                if in_scope:
+                    errors.append(
+                        f"{path}:{index}: approval_receipt supersedes_receipt_ref forks the chain: "
+                        f"{superseded} is already superseded by {successors[superseded]}"
+                    )
+            else:
+                successors[superseded] = receipt_id
+        seen.add(receipt_id)
+    return errors
+
+
+def _decision_fingerprint(receipt: Mapping[str, Any]) -> str:
+    """Which answer a receipt records, ignoring when it was recorded."""
+    identity = {key: receipt.get(key) for key in _DECISION_IDENTITY_KEYS}
+    return hashlib.sha256(json.dumps(identity, sort_keys=True, default=str).encode("utf-8")).hexdigest()
+
+
+def _parse_stamp(value: str) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
+
+
+def _reference_errors(value: Any, *, field: str, required: bool) -> list[str]:
+    if not isinstance(value, str):
+        return [f"approval_receipt {field} must be a string"]
+    if not value:
+        return [f"approval_receipt {field} is required"] if required else []
+    if _is_url_shaped(value):
+        return [f"approval_receipt {field} must be an opaque identifier, not a URL"]
+    try:
+        require_opaque_metadata_ref(value, field=f"approval_receipt {field}")
+    except ValueError as exc:
+        return [str(exc)]
+    return []
+
+
+def _scope_ref_errors(value: Any) -> list[str]:
+    errors = _reference_errors(value, field="scope_ref", required=True)
+    if errors or not isinstance(value, str):
+        return errors
+    if _SCOPE_TRAVERSAL.search(value):
+        return ["approval_receipt scope_ref must not escape the workspace"]
+    if _WINDOWS_DRIVE.match(value):
+        return ["approval_receipt scope_ref must be workspace-relative, not drive-anchored"]
+    return []
+
+
+def _scope_ref(value: str) -> str:
+    text = _opaque(value, field="approval_receipt scope_ref")
+    errors = _scope_ref_errors(text)
+    if errors:
+        raise ApprovalReceiptError(errors[0])
+    return text
+
+
+def _opaque(value: str, *, field: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ApprovalReceiptError(f"{field} is required")
+    if _is_url_shaped(text):
+        raise ApprovalReceiptError(f"{field} must be an opaque identifier, not a URL")
+    try:
+        return require_opaque_metadata_ref(text, field=field)
+    except ValueError as exc:
+        raise ApprovalReceiptError(str(exc)) from exc
+
+
+def _is_url_shaped(value: str) -> bool:
+    return any(marker in value for marker in _URL_SHAPED)
+
+
+def _digest_ref(value: str) -> str:
+    return f"ref-{hashlib.sha256(value.encode('utf-8')).hexdigest()[:12]}"
+
+
+def _bounded_error(value: str) -> str:
+    """One bounded, secret-free line for the failure log."""
+    raw = " ".join(str(value or "").split())
+    if not raw:
+        return ""
+    if is_sensitive_metadata_text(raw):
+        return "[redacted]"
+    return raw[:200]
+
+
+def _receipt_id(decided_at: str, approval_id_value: str, decision: str) -> str:
+    # Random tail for the same reason `external_effect_receipts._receipt_id`
+    # carries one: `utc_now()` has second resolution, so two answers to one
+    # confirmation in the same second would otherwise share an id and break the
+    # supersede chain.
+    base = json.dumps(
+        {"approval_id": approval_id_value, "decided_at": decided_at, "decision": decision},
+        sort_keys=True,
+    )
+    digest = hashlib.sha256(base.encode("utf-8")).hexdigest()[:16]
+    return f"approval-receipt-{digest}-{secrets.token_hex(3)}"

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from ..context_safety import MAX_SUMMARY_CHARS, bounded_prompt_preview, compact_progress_events
+from ..coding.action_gate import LADDER_ACTION_IDS
 from ..coding.agentic_playbook import maybe_build_agentic_playbook
 from ..coding.agentic_playbook_contract import chat_response_with_agentic_playbook
 from ..coding.executor_local_workflow import validate_executor_local_workflow
@@ -129,6 +130,7 @@ VISIBLE_ACTIONS = (
     "show_target_status",
     "apply_target_change",
     "choose_permission_profile",
+    "confirm_risky_action",
     "assess_loopability",
     "convert_to_loop_goal",
     "route_direct_task",
@@ -5631,12 +5633,79 @@ def build_chat_response_from_plan(plan_payload: dict[str, object], *, thread_key
     )
 
 
-_LADDER_ACTION_IDS = ("choose_executor", "choose_permission_profile", "send_to_codex", "send_to_executor")
+# The four operator-card confirmations. They ship `enabled: False` with no
+# arming path today, and they are named here so the arbitration disables them
+# for the same reason it disables every other confirmation action: they belong
+# to the same family, and a card that leaves one live beside an armed ladder is
+# a second authority question on one intent.
+_OPERATOR_CARD_CONFIRM_ACTION_IDS = (
+    "confirm_browser_action",
+    "confirm_command_execution",
+    "confirm_connector_action",
+    "confirm_file_operation",
+)
+# `send_to_codex` is the codex lane's rendering alias for the
+# `operator_confirmation` ladder's `send_to_executor`; it is a label on the same
+# question, not a ladder of its own, which is why it never appears in
+# `action_gate.LADDER_ACTION_IDS`.
+_LADDER_ACTION_ALIASES = {"send_to_codex": "send_to_executor"}
+# Derived, not retyped. This tuple and `action_gate.LADDER_ACTION_IDS` were two
+# hand-maintained copies of one list and they had already drifted apart —
+# `send_to_codex` was in this one and not in that one — so the gate's map is now
+# the source and the two additions this lane really owns are named beside it.
+_LADDER_ACTION_IDS = tuple(
+    sorted({*LADDER_ACTION_IDS.values(), *_LADDER_ACTION_ALIASES, *_OPERATOR_CARD_CONFIRM_ACTION_IDS})
+)
 _LADDER_ACTION_LABELS = {
     "choose_executor": "Choose coding agent",
     "choose_permission_profile": "Choose permission profile",
+    "confirm_risky_action": "Confirm risky action",
     "send_to_executor": "Open coding agent",
 }
+
+
+_RISKY_ACTION_REFUSED_REASON = (
+    "The operator refused or revoked the approval this risky action needs, so the authority it "
+    "carried stays withheld and this action is not offered."
+)
+
+
+def _apply_refused_risky_action(
+    actions: list[dict[str, object]],
+    next_action: str,
+    gate: dict[str, object],
+) -> tuple[list[dict[str, object]], str]:
+    """Take the refused action off the table when the gate refused a risky class.
+
+    Only on a real refusal: an enforced `deny` verdict. A report-only
+    classification withheld nothing and must not disable anything, and an
+    unarmed ladder with no refusal behind it is the ordinary quiet case.
+    """
+    risk = gate.get("action_risk")
+    if not isinstance(risk, dict):
+        return actions, next_action
+    if risk.get("decision") != "deny" or risk.get("enforcement") != "enforced":
+        return actions, next_action
+    adjusted = [
+        {
+            **entry,
+            "enabled": False,
+            "payload": {
+                **(entry.get("payload") if isinstance(entry.get("payload"), dict) else {}),
+                "disabled_reason": _RISKY_ACTION_REFUSED_REASON,
+            },
+        }
+        if entry.get("id") in _LADDER_ACTION_IDS
+        else entry
+        for entry in actions
+    ]
+    if next_action not in _LADDER_ACTION_IDS:
+        return adjusted, next_action
+    remaining = next(
+        (str(entry.get("id", "")) for entry in adjusted if entry.get("enabled") and entry.get("id")),
+        "",
+    )
+    return adjusted, remaining or next_action
 
 
 def _apply_action_gate_arbitration(
@@ -5649,10 +5718,18 @@ def _apply_action_gate_arbitration(
     When the gate armed a ladder other than the one this card leads with, the
     armed action becomes the card's next action and every other authority-ladder
     action is disabled, so one intent still produces one prompt.
+
+    A refusal arms nothing, and that is not the same as nothing having happened:
+    the operator answered no. Leaving "Open coding agent" on the card as its
+    enabled primary would offer the very action that was refused, so the ladder
+    actions are disabled there too and the card falls back to its first
+    remaining enabled action.
     """
     confirmation = gate.get("confirmation")
-    if not isinstance(confirmation, dict) or not confirmation.get("required"):
+    if not isinstance(confirmation, dict):
         return actions, next_action
+    if not confirmation.get("required"):
+        return _apply_refused_risky_action(actions, next_action, gate)
     armed = str(confirmation.get("action_id", ""))
     if not armed or armed == next_action:
         return actions, next_action

--- a/tests/test_approval_receipts.py
+++ b/tests/test_approval_receipts.py
@@ -1,0 +1,698 @@
+"""Contracts for `approval_receipt/v1` (issue #807).
+
+Grouped by acceptance criterion:
+
+- AC1: an expired or revoked approval cannot satisfy another run.
+- AC2: the exact added path, endpoint, or tool is named.
+- AC3: an approval never proves the host applied it.
+
+Plus the store invariants the family rests on: five distinct refusals for the
+five dimensions an approval binds, supersession and revocation that link instead
+of overwriting, idempotent minting, a mint that never raises into the
+confirmation flow, and an append-only store that survives concurrency and a torn
+tail.
+
+Every clock is injected. `now` is passed to every mint and every read, so no
+test sleeps and no assertion depends on wall-clock timing -- Windows CI is an
+enforcing target and a timing-sensitive receipt store is exactly the shape that
+loses there first.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+from omh.coding.action_gate import CONFIRMATION_LADDERS as GATE_CONFIRMATION_LADDERS
+from omh.coding.action_gate import MUTATING_ACTIONS as GATE_MUTATING_ACTIONS
+from omh.paths import resolve_paths
+from omh.runtime.records import (
+    APPROVAL_RECEIPT_RECORD_KEYS,
+    OPTIONAL_APPROVAL_STORE_VALIDATORS,
+    OPTIONAL_RUNTIME_STORE_VALIDATORS,
+)
+from omh.workflows.approval_receipts import (
+    APPROVABLE_ACTIONS,
+    APPROVAL_DECISION_SCHEMA_VERSION,
+    APPROVAL_DECISIONS,
+    APPROVAL_MINT_RESULT_SCHEMA_VERSION,
+    APPROVAL_RECEIPT_CONSTANT_KEYS,
+    APPROVAL_RECEIPT_KEYS,
+    APPROVAL_RECEIPT_SCHEMA_VERSION,
+    APPROVAL_TTL_SECONDS,
+    CLAIM_BOUNDARY,
+    CONFIRMATION_LADDERS,
+    REFUSAL_ABSENT,
+    REFUSAL_ACTION,
+    REFUSAL_CODES,
+    REFUSAL_DENIED,
+    REFUSAL_EXPIRED,
+    REFUSAL_OWNER,
+    REFUSAL_REASONS,
+    REFUSAL_REVISION,
+    REFUSAL_REVOKED,
+    REFUSAL_RUN,
+    REFUSAL_SCOPE,
+    REFUSAL_SUPERSEDED,
+    SCOPE_CLASSES,
+    SCOPE_REFUSAL_CODES,
+    UNKNOWN_AGE_SECONDS,
+    ApprovalReceiptError,
+    append_approval_receipt,
+    approval_age_seconds,
+    approval_id,
+    approval_satisfies_request,
+    approval_satisfies_request_in,
+    build_approval_receipt,
+    compact_approval_receipt,
+    mint_approval_receipt,
+    read_approval_mint_failures,
+    read_approval_receipts,
+    record_approval_receipt,
+    validate_approval_receipt,
+    validate_approval_receipt_store,
+)
+from omh.runtime.artifacts import validate_runtime
+from omh.workflows.goal_loop import LOOP_ACTIONS
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+T0 = "2026-08-06T12:00:00Z"
+T_PLUS_10S = "2026-08-06T12:00:10Z"
+T_PLUS_2H = "2026-08-06T14:00:00Z"
+
+GRANT: dict[str, str] = {
+    "approved_action": "repo_edit",
+    "scope_class": "filesystem_path",
+    "scope_ref": "src/omh/paths.py",
+    "owner": "codex",
+    "run_id": "run-1",
+    "safety_profile_revision": "rev-1",
+    "confirmation_ladder": "operator_confirmation",
+}
+# The same five dimensions, as a satisfaction request (no ladder: which ladder
+# asked the question is a property of the answer, not of the request).
+REQUEST: dict[str, str] = {key: value for key, value in GRANT.items() if key != "confirmation_ladder"}
+
+
+def _paths(tmp: str):
+    return resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+
+
+def _valid_receipt(**overrides: Any) -> dict[str, Any]:
+    return build_approval_receipt(**{**GRANT, "decided_at": T0, **overrides})
+
+
+class ApprovalReceiptShapeTests(unittest.TestCase):
+    def test_receipt_record_keys_are_exact(self) -> None:
+        record = _valid_receipt()
+        self.assertEqual(tuple(sorted(record)), APPROVAL_RECEIPT_KEYS)
+        self.assertEqual(record["schema_version"], APPROVAL_RECEIPT_SCHEMA_VERSION)
+        self.assertEqual(record["claim_boundary"], CLAIM_BOUNDARY)
+        self.assertEqual(record["privacy"], "metadata_only")
+        self.assertEqual(validate_approval_receipt(record), [])
+
+    def test_the_compactor_renders_every_key_that_is_not_a_fixed_constant(self) -> None:
+        # A key in the tuple and missing from the compactor is a field that is
+        # stored and never seen. That drift has cost this repo twice.
+        record = _valid_receipt()
+        rendered = compact_approval_receipt(record, now=T_PLUS_10S)
+        expected = set(APPROVAL_RECEIPT_KEYS) - set(APPROVAL_RECEIPT_CONSTANT_KEYS)
+        self.assertTrue(expected <= set(rendered), sorted(expected - set(rendered)))
+        self.assertEqual(rendered["age_seconds"], 10)
+        self.assertFalse(rendered["expired"])
+
+    def test_closed_vocabularies_are_enforced_at_build_and_at_render(self) -> None:
+        for field, value in (
+            ("approved_action", "research"),
+            ("scope_class", "anything"),
+            ("confirmation_ladder", "someone_asked_nicely"),
+            ("decision", "applied"),
+        ):
+            with self.subTest(field=field), self.assertRaises(ApprovalReceiptError):
+                _valid_receipt(**{field: value})
+        tampered = {**_valid_receipt(), "decision": "applied"}
+        self.assertEqual(compact_approval_receipt(tampered, now=T0)["decision"], "")
+
+    def test_the_approvable_action_vocabulary_stays_inside_the_gate_vocabulary(self) -> None:
+        # Held locally rather than imported: the action gate will call into this
+        # module, so importing it here would be a cycle. The relationship is
+        # pinned instead.
+        self.assertTrue(set(APPROVABLE_ACTIONS) <= set(LOOP_ACTIONS))
+        self.assertTrue(set(GATE_MUTATING_ACTIONS) <= set(APPROVABLE_ACTIONS))
+        self.assertEqual(set(CONFIRMATION_LADDERS), set(GATE_CONFIRMATION_LADDERS))
+
+    def test_the_scope_vocabulary_covers_what_an_escalation_can_add(self) -> None:
+        # AC3 of #807 names three: the added path, endpoint, or tool. The other
+        # two are the escalations the confirmation ladders themselves ask about.
+        self.assertEqual(
+            SCOPE_CLASSES,
+            ("executor_profile", "filesystem_path", "network_endpoint", "permission_profile", "tool"),
+        )
+
+    def test_a_scope_ref_must_name_something_inside_the_workspace(self) -> None:
+        for scope_ref in ("../outside.py", "src/../../outside.py", "C:/Windows/system32", "https://evil.test/x"):
+            with self.subTest(scope_ref=scope_ref), self.assertRaises(ApprovalReceiptError):
+                _valid_receipt(scope_ref=scope_ref)
+
+    def test_the_receipt_store_is_registered_beside_the_other_runtime_records(self) -> None:
+        self.assertEqual(APPROVAL_RECEIPT_RECORD_KEYS, APPROVAL_RECEIPT_KEYS)
+        self.assertEqual(
+            [name for name, _ in OPTIONAL_APPROVAL_STORE_VALIDATORS],
+            ["approval_receipts.jsonl"],
+        )
+        validator = dict(OPTIONAL_APPROVAL_STORE_VALIDATORS)["approval_receipts.jsonl"]
+        self.assertEqual(validator(_valid_receipt()), [])
+        self.assertTrue(validator({"schema_version": "wrong"}))
+        # Deliberately not joined to the external-effect registry: its one
+        # consumer applies every entry to the external effect receipts it read.
+        self.assertNotIn("approval_receipts.jsonl", [name for name, _ in OPTIONAL_RUNTIME_STORE_VALIDATORS])
+
+
+class ApprovalNeverAssertsExecutionTests(unittest.TestCase):
+    """AC3: an approval never proves the host applied it."""
+
+    def test_the_claim_boundary_denies_execution_on_every_record(self) -> None:
+        record = _valid_receipt()
+        self.assertIn("proves consent was given", record["claim_boundary"])
+        self.assertIn("not dispatch, execution", record["claim_boundary"])
+
+    def test_a_record_cannot_be_constructed_in_a_shape_that_claims_execution(self) -> None:
+        for key in ("applied", "executed", "execution_result", "exit_code", "host_applied", "observed_result", "result"):
+            with self.subTest(key=key):
+                errors = validate_approval_receipt({**_valid_receipt(), key: "yes"})
+                self.assertTrue(
+                    any("must not carry execution-claim keys" in error for error in errors),
+                    errors,
+                )
+
+    def test_raw_and_hidden_keys_are_refused_by_name(self) -> None:
+        errors = validate_approval_receipt({**_valid_receipt(), "prompt": "do the thing"})
+        self.assertTrue(any("must not carry raw or hidden keys" in error for error in errors), errors)
+
+    def test_the_decision_vocabulary_has_no_execution_state(self) -> None:
+        self.assertEqual(APPROVAL_DECISIONS, ("granted", "denied", "revoked"))
+        errors = validate_approval_receipt({**_valid_receipt(), "decision": "executed"})
+        self.assertTrue(any("decision is unsupported" in error for error in errors), errors)
+
+
+class ApprovalScopeRefusalTests(unittest.TestCase):
+    """The five dimensions an approval binds, each with its own refusal code."""
+
+    def setUp(self) -> None:
+        self._tmp = TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = _paths(self._tmp.name)
+        mint_approval_receipt(self.paths, now=T0, **GRANT)
+
+    def _refusal(self, **overrides: str) -> dict[str, Any]:
+        return approval_satisfies_request(self.paths, now=T_PLUS_10S, **{**REQUEST, **overrides})
+
+    def test_the_exact_request_is_satisfied(self) -> None:
+        decision = self._refusal()
+        self.assertTrue(decision["satisfied"])
+        self.assertEqual(decision["reason_code"], "")
+        self.assertEqual(decision["schema_version"], APPROVAL_DECISION_SCHEMA_VERSION)
+        self.assertEqual(decision["expires_after_seconds"], APPROVAL_TTL_SECONDS)
+        self.assertTrue(decision["receipt_id"])
+
+    def test_five_dimensions_refuse_with_five_distinct_codes(self) -> None:
+        cases = (
+            ("sibling action", {"approved_action": "pr_creation"}, REFUSAL_ACTION),
+            ("broader scope", {"scope_ref": "src"}, REFUSAL_SCOPE),
+            ("another owner", {"owner": "claude-code"}, REFUSAL_OWNER),
+            ("another run", {"run_id": "run-2"}, REFUSAL_RUN),
+            ("stale safety revision", {"safety_profile_revision": "rev-2"}, REFUSAL_REVISION),
+        )
+        seen = []
+        for label, override, expected in cases:
+            with self.subTest(case=label):
+                decision = self._refusal(**override)
+                self.assertFalse(decision["satisfied"])
+                self.assertEqual(decision["reason_code"], expected)
+                self.assertEqual(decision["reason"], REFUSAL_REASONS[expected])
+                seen.append(decision["reason_code"])
+        self.assertEqual(sorted(seen), sorted(set(seen)))
+        self.assertEqual(set(seen), set(SCOPE_REFUSAL_CODES))
+
+    def test_widening_is_structurally_impossible_in_both_directions(self) -> None:
+        # An approval for a narrower scope satisfies that same narrower scope
+        # only: the parent directory is refused, and so is a sibling under it.
+        for scope_ref in ("src", "src/omh", "src/omh/paths.py.bak", "src/omh/local_store.py"):
+            with self.subTest(scope_ref=scope_ref):
+                self.assertEqual(self._refusal(scope_ref=scope_ref)["reason_code"], REFUSAL_SCOPE)
+
+    def test_another_scope_class_over_the_same_ref_is_still_another_scope(self) -> None:
+        self.assertEqual(self._refusal(scope_class="tool")["reason_code"], REFUSAL_SCOPE)
+
+    def test_an_empty_store_refuses_with_the_absent_code(self) -> None:
+        with TemporaryDirectory() as tmp:
+            decision = approval_satisfies_request(_paths(tmp), now=T0, **REQUEST)
+            self.assertEqual(decision["reason_code"], REFUSAL_ABSENT)
+            self.assertEqual(decision["receipt_id"], "")
+            self.assertEqual(decision["age_seconds"], UNKNOWN_AGE_SECONDS)
+
+    def test_every_refusal_code_has_a_constant_reason_line(self) -> None:
+        self.assertEqual(sorted(REFUSAL_REASONS), sorted(REFUSAL_CODES))
+        for code in REFUSAL_CODES:
+            self.assertTrue(REFUSAL_REASONS[code].strip())
+
+
+class ApprovalLifetimeTests(unittest.TestCase):
+    """AC1: an expired or revoked approval cannot satisfy another run."""
+
+    def test_an_expired_approval_refuses_at_read_time(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            mint_approval_receipt(paths, now=T0, **GRANT)
+            self.assertTrue(approval_satisfies_request(paths, now=T_PLUS_10S, **REQUEST)["satisfied"])
+            expired = approval_satisfies_request(paths, now=T_PLUS_2H, **REQUEST)
+            self.assertFalse(expired["satisfied"])
+            self.assertEqual(expired["reason_code"], REFUSAL_EXPIRED)
+            # Nothing on disk changed: expiry is recomputed, never written.
+            stored = read_approval_receipts(paths)
+            self.assertEqual(len(stored), 1)
+            self.assertEqual(sorted(stored[0]), list(APPROVAL_RECEIPT_KEYS))
+            self.assertNotIn("expires_at", stored[0])
+
+    def test_an_expired_approval_cannot_satisfy_another_run(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            mint_approval_receipt(paths, now=T0, **GRANT)
+            decision = approval_satisfies_request(paths, now=T_PLUS_2H, **{**REQUEST, "run_id": "run-2"})
+            self.assertFalse(decision["satisfied"])
+            self.assertEqual(decision["reason_code"], REFUSAL_RUN)
+
+    def test_a_revoked_approval_cannot_satisfy_its_own_run_or_another(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            mint_approval_receipt(paths, now=T0, **GRANT)
+            mint_approval_receipt(paths, now="2026-08-06T12:00:05Z", **{**GRANT, "decision": "revoked"})
+            same_run = approval_satisfies_request(paths, now=T_PLUS_10S, **REQUEST)
+            other_run = approval_satisfies_request(paths, now=T_PLUS_10S, **{**REQUEST, "run_id": "run-2"})
+            self.assertEqual(same_run["reason_code"], REFUSAL_REVOKED)
+            self.assertFalse(other_run["satisfied"])
+            self.assertEqual(other_run["reason_code"], REFUSAL_ABSENT)
+
+    def test_a_denied_confirmation_is_recorded_and_never_satisfies(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            mint_approval_receipt(paths, now=T0, **{**GRANT, "decision": "denied"})
+            decision = approval_satisfies_request(paths, now=T_PLUS_10S, **REQUEST)
+            self.assertEqual(decision["reason_code"], REFUSAL_DENIED)
+
+    def test_a_decision_stamped_in_the_future_cannot_be_shown_to_be_fresh(self) -> None:
+        # Clamping a future stamp to age zero would make "edit the timestamp
+        # forward" a way to widen the window from disk.
+        self.assertEqual(approval_age_seconds("2026-08-06T13:00:00Z", T0), UNKNOWN_AGE_SECONDS)
+        self.assertEqual(approval_age_seconds("not-a-timestamp", T0), UNKNOWN_AGE_SECONDS)
+        forged = _valid_receipt(decided_at="2026-08-06T13:00:00Z")
+        decision = approval_satisfies_request_in([forged], now=T0, **REQUEST)
+        self.assertEqual(decision["reason_code"], REFUSAL_EXPIRED)
+
+    def test_the_window_lives_in_code_and_is_bounded(self) -> None:
+        # Shorter than the six-hour horizon an advisory limit signal gets, and
+        # far below the seven-day cap a stale-read override may carry.
+        self.assertEqual(APPROVAL_TTL_SECONDS, 60 * 60)
+        self.assertLess(APPROVAL_TTL_SECONDS, 6 * 60 * 60)
+
+
+class ApprovalSupersessionTests(unittest.TestCase):
+    def test_a_superseded_approval_refuses_and_its_predecessor_stays_byte_identical(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            mint_approval_receipt(paths, now=T0, **GRANT)
+            first_line = paths.runtime_approval_receipts_path.read_bytes()
+            # The safety profile moved, so the operator answers the same
+            # question again under the new revision.
+            mint_approval_receipt(
+                paths,
+                now="2026-08-06T12:00:05Z",
+                **{**GRANT, "safety_profile_revision": "rev-2"},
+            )
+
+            stale = approval_satisfies_request(paths, now=T_PLUS_10S, **REQUEST)
+            fresh = approval_satisfies_request(
+                paths,
+                now=T_PLUS_10S,
+                **{**REQUEST, "safety_profile_revision": "rev-2"},
+            )
+
+            self.assertFalse(stale["satisfied"])
+            self.assertEqual(stale["reason_code"], REFUSAL_SUPERSEDED)
+            self.assertTrue(fresh["satisfied"])
+            # History is linked, never rewritten: the predecessor's line is the
+            # same bytes it was before the successor landed.
+            lines = paths.runtime_approval_receipts_path.read_bytes().splitlines(keepends=True)
+            self.assertEqual(lines[0], first_line)
+            receipts = read_approval_receipts(paths)
+            self.assertEqual(receipts[1]["supersedes_receipt_ref"], receipts[0]["receipt_id"])
+
+    def test_answers_to_one_confirmation_share_one_chain(self) -> None:
+        identity = approval_id(
+            run_id=GRANT["run_id"],
+            owner=GRANT["owner"],
+            approved_action=GRANT["approved_action"],
+            scope_class=GRANT["scope_class"],
+            scope_ref=GRANT["scope_ref"],
+        )
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            mint_approval_receipt(paths, now=T0, **GRANT)
+            mint_approval_receipt(paths, now="2026-08-06T12:00:05Z", **{**GRANT, "decision": "revoked"})
+            self.assertEqual(
+                [receipt["approval_id"] for receipt in read_approval_receipts(paths)],
+                [identity, identity],
+            )
+            self.assertEqual(len(read_approval_receipts(paths, approval_id=identity)), 2)
+
+
+class ApprovalStoreValidatorTests(unittest.TestCase):
+    def test_the_store_validator_rejects_a_self_cycle(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            record = _valid_receipt()
+            forged = {**record, "supersedes_receipt_ref": record["receipt_id"]}
+            path = paths.runtime_approval_receipts_path
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(json.dumps(forged, sort_keys=True) + "\n", encoding="utf-8")
+            result = validate_approval_receipt_store(path)
+            self.assertFalse(result["ok"])
+            self.assertTrue(any("must not name itself" in error for error in result["errors"]), result["errors"])
+
+    def test_the_store_validator_rejects_a_fork(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            first = record_approval_receipt(paths, now=T0, **GRANT)
+            # Two answers that both believe they replaced the first one: the
+            # store can no longer say which is current.
+            for revision in ("rev-2", "rev-3"):
+                append_approval_receipt(
+                    paths,
+                    build_approval_receipt(
+                        **{**GRANT, "safety_profile_revision": revision},
+                        decided_at="2026-08-06T12:00:05Z",
+                        supersedes_receipt_ref=first["receipt_id"],
+                    ),
+                )
+            result = validate_approval_receipt_store(paths.runtime_approval_receipts_path)
+            self.assertFalse(result["ok"])
+            self.assertTrue(any("forks the chain" in error for error in result["errors"]), result["errors"])
+
+    def test_the_store_validator_rejects_a_link_to_a_receipt_that_does_not_exist(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            append_approval_receipt(
+                paths,
+                build_approval_receipt(**GRANT, decided_at=T0, supersedes_receipt_ref="approval-receipt-nope"),
+            )
+            result = validate_approval_receipt_store(paths.runtime_approval_receipts_path)
+            self.assertFalse(result["ok"])
+            self.assertTrue(
+                any("does not name an earlier receipt" in error for error in result["errors"]),
+                result["errors"],
+            )
+
+    def test_runtime_validate_really_opens_the_approval_store(self) -> None:
+        """The registry had no consumer, so the chain validator was unreachable.
+
+        A forked chain is the fault that matters: two answers that both believe
+        they replaced the same predecessor make "the current answer" ambiguous,
+        and an ambiguous approval is the one thing a consent record must never
+        be. Before this wiring `omh runtime validate` reported `ok` over it.
+        """
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            first = record_approval_receipt(paths, now=T0, **GRANT)
+            for revision in ("rev-2", "rev-3"):
+                append_approval_receipt(
+                    paths,
+                    build_approval_receipt(
+                        **{**GRANT, "safety_profile_revision": revision},
+                        decided_at=T_PLUS_10S,
+                        supersedes_receipt_ref=first["receipt_id"],
+                    ),
+                )
+            result = validate_runtime(paths)
+            self.assertIn("approval_receipts", result)
+            self.assertFalse(result["approval_receipts"]["ok"])
+            self.assertFalse(result["ok"])
+            self.assertTrue(
+                any("forks the chain" in error for error in result["approval_receipts"]["errors"]),
+                result["approval_receipts"]["errors"],
+            )
+
+    def test_runtime_validate_stays_green_on_a_clean_or_absent_store(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            self.assertTrue(validate_runtime(paths)["approval_receipts"]["ok"])
+            record_approval_receipt(paths, now=T0, **GRANT)
+            self.assertTrue(validate_runtime(paths)["approval_receipts"]["ok"])
+
+    def test_a_hand_moved_approval_id_is_refused(self) -> None:
+        # Without this an edited store could move one grant onto another
+        # question's chain and have it supersede an approval it never answered.
+        forged = {**_valid_receipt(), "approval_id": "approval-0000000000000000"}
+        errors = validate_approval_receipt(forged)
+        self.assertTrue(any("does not identify its own" in error for error in errors), errors)
+
+
+class ApprovalMintTests(unittest.TestCase):
+    def test_minting_is_idempotent_while_the_answer_is_live(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            first = mint_approval_receipt(paths, now=T0, **GRANT)
+            again = mint_approval_receipt(paths, now="2026-08-06T12:00:05Z", **GRANT)
+            third = mint_approval_receipt(paths, now=T_PLUS_10S, **GRANT)
+
+            self.assertEqual(first["schema_version"], APPROVAL_MINT_RESULT_SCHEMA_VERSION)
+            self.assertEqual(first["outcome"], "recorded")
+            self.assertTrue(first["minted"])
+            for repeat in (again, third):
+                self.assertEqual(repeat["outcome"], "already_recorded")
+                self.assertFalse(repeat["minted"])
+                self.assertEqual(repeat["receipt_id"], first["receipt_id"])
+            self.assertEqual(len(read_approval_receipts(paths)), 1)
+
+    def test_consent_re_given_after_expiry_is_new_consent(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            first = mint_approval_receipt(paths, now=T0, **GRANT)
+            renewed = mint_approval_receipt(paths, now=T_PLUS_2H, **GRANT)
+            self.assertEqual(renewed["outcome"], "recorded")
+            self.assertNotEqual(renewed["receipt_id"], first["receipt_id"])
+            self.assertEqual(len(read_approval_receipts(paths)), 2)
+            self.assertTrue(approval_satisfies_request(paths, now=T_PLUS_2H, **REQUEST)["satisfied"])
+
+    def test_a_mint_failure_neither_raises_nor_loses_the_receipt(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            # The store path is unwritable: a directory stands where the file
+            # belongs, which is what an OS-level failure looks like from here.
+            store_path = paths.runtime_approval_receipts_path
+            store_path.parent.mkdir(parents=True, exist_ok=True)
+            store_path.mkdir()
+
+            failed = mint_approval_receipt(paths, now=T0, **GRANT)
+
+            self.assertEqual(failed["schema_version"], APPROVAL_MINT_RESULT_SCHEMA_VERSION)
+            self.assertFalse(failed["minted"])
+            self.assertEqual(failed["outcome"], "not_written")
+            self.assertTrue(failed["error"])
+            self.assertEqual(failed["receipt_id"], "")
+            failures = read_approval_mint_failures(store_path)
+            self.assertEqual(len(failures), 1)
+            self.assertEqual(failures[0]["outcome"], "not_written")
+            self.assertEqual(failures[0]["approved_action"], GRANT["approved_action"])
+            self.assertEqual(failures[0]["decision"], "granted")
+
+    def test_a_refused_mint_is_returned_not_raised(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            refused = mint_approval_receipt(paths, now=T0, **{**GRANT, "approved_action": "research"})
+            self.assertEqual(refused["outcome"], "refused")
+            self.assertFalse(refused["minted"])
+            self.assertEqual(read_approval_receipts(paths), [])
+            self.assertEqual(read_approval_mint_failures(paths.runtime_approval_receipts_path)[0]["outcome"], "refused")
+
+    def test_the_strict_entry_point_still_raises(self) -> None:
+        with TemporaryDirectory() as tmp:
+            with self.assertRaises(ApprovalReceiptError):
+                record_approval_receipt(_paths(tmp), now=T0, **{**GRANT, "approved_action": "research"})
+
+
+class ApprovalStoreDurabilityTests(unittest.TestCase):
+    def test_concurrent_appends_do_not_interleave(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            writers = 12
+            barrier = threading.Barrier(writers)
+            failures: list[Exception] = []
+
+            def append(index: int) -> None:
+                record = build_approval_receipt(
+                    **{**GRANT, "run_id": f"run-{index}", "scope_ref": f"src/omh/mod_{index}.py"},
+                    decided_at=T0,
+                )
+                barrier.wait()
+                try:
+                    append_approval_receipt(paths, record)
+                except Exception as exc:  # reported on the main thread, never silently dropped
+                    failures.append(exc)
+
+            threads = [threading.Thread(target=append, args=(index,)) for index in range(writers)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+            self.assertEqual(failures, [])
+            lines = paths.runtime_approval_receipts_path.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(lines), writers)
+            for line in lines:
+                self.assertEqual(validate_approval_receipt(json.loads(line)), [])
+            self.assertEqual(
+                sorted(json.loads(line)["run_id"] for line in lines),
+                sorted(f"run-{index}" for index in range(writers)),
+            )
+
+    def test_concurrent_answers_to_one_confirmation_keep_an_unbroken_chain(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            writers = 8
+            barrier = threading.Barrier(writers)
+            failures: list[Exception] = []
+
+            def answer(index: int) -> None:
+                barrier.wait()
+                try:
+                    record_approval_receipt(
+                        paths,
+                        now=T0,
+                        **{**GRANT, "safety_profile_revision": f"rev-{index}"},
+                    )
+                except Exception as exc:  # reported on the main thread, never silently dropped
+                    failures.append(exc)
+
+            threads = [threading.Thread(target=answer, args=(index,)) for index in range(writers)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+            self.assertEqual(failures, [])
+            result = validate_approval_receipt_store(paths.runtime_approval_receipts_path)
+            receipts = read_approval_receipts(paths)
+            self.assertTrue(result["ok"], result["errors"])
+            self.assertEqual(len(receipts), writers)
+            links = [receipt["supersedes_receipt_ref"] for receipt in receipts[1:]]
+            self.assertEqual(links, [receipt["receipt_id"] for receipt in receipts[:-1]])
+
+    def test_a_torn_last_line_cannot_swallow_the_next_append(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            record_approval_receipt(paths, now=T0, **GRANT)
+            path = paths.runtime_approval_receipts_path
+            # A short write: the process died mid-line, so the tail has no
+            # newline terminating it.
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write('{"schema_version": "approval_rec')
+
+            record_approval_receipt(paths, now=T0, **{**GRANT, "run_id": "run-2"})
+
+            lines = path.read_text(encoding="utf-8").splitlines()
+            store = validate_approval_receipt_store(path)
+
+            self.assertEqual(len(lines), 3)
+            self.assertEqual(json.loads(lines[0])["run_id"], "run-1")
+            self.assertEqual(lines[1], '{"schema_version": "approval_rec')
+            self.assertEqual(json.loads(lines[2])["run_id"], "run-2")
+            # The torn line is the only casualty, and the store says so once.
+            self.assertEqual(len(store["errors"]), 1, store["errors"])
+            self.assertIn(":2:", store["errors"][0])
+            self.assertEqual([receipt["run_id"] for receipt in read_approval_receipts(paths)], ["run-1", "run-2"])
+
+
+class ApprovalCliTests(unittest.TestCase):
+    def test_the_approvals_view_reads_the_store_in_plain_text_and_json(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            base = ["--omh-home", str(paths.omh_home), "--hermes-home", str(paths.hermes_home)]
+            mint_approval_receipt(paths, now=T0, **GRANT)
+
+            status, text, stderr = run_cli(base + ["runtime", "approvals"], output_json=False)
+            self.assertEqual(status, 0, stderr)
+            self.assertIn("Approval receipts (1 shown)", text)
+            self.assertIn(GRANT["scope_ref"], text)
+            self.assertIn("granted", text)
+            self.assertIn("proves consent was given", text)
+
+            status, stdout, stderr = run_cli(base + ["runtime", "approvals", "--json"])
+            self.assertEqual(status, 0, stderr)
+            payload = json.loads(stdout)
+            self.assertEqual(payload["schema_version"], "runtime_approval_receipts_view/v1")
+            self.assertEqual(payload["receipt_count"], 1)
+            self.assertTrue(payload["store_ok"])
+            self.assertEqual(payload["expires_after_seconds"], APPROVAL_TTL_SECONDS)
+            self.assertEqual(payload["receipts"][0]["scope_ref"], GRANT["scope_ref"])
+            self.assertEqual(payload["claim_boundary"], CLAIM_BOUNDARY)
+
+    def test_the_approvals_view_scopes_to_one_run(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            base = ["--omh-home", str(paths.omh_home), "--hermes-home", str(paths.hermes_home)]
+            mint_approval_receipt(paths, now=T0, **GRANT)
+            mint_approval_receipt(paths, now=T0, **{**GRANT, "run_id": "run-2"})
+            status, stdout, stderr = run_cli(base + ["runtime", "approvals", "--run", "run-2", "--json"])
+            self.assertEqual(status, 0, stderr)
+            payload = json.loads(stdout)
+            self.assertEqual([row["run_id"] for row in payload["receipts"]], ["run-2"])
+
+    def test_no_cli_path_mints_an_approval(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            base = ["--omh-home", str(paths.omh_home), "--hermes-home", str(paths.hermes_home)]
+            for attempt in (
+                ["runtime", "approvals", "--grant"],
+                ["runtime", "approvals", "--decision", "granted"],
+                ["runtime", "approvals", "--record", "--action", "repo_edit"],
+                ["runtime", "approvals", "--approve", "src/omh/paths.py"],
+            ):
+                with self.subTest(attempt=attempt), self.assertRaises(SystemExit):
+                    run_cli(base + attempt, output_json=False)
+            self.assertEqual(read_approval_receipts(paths), [])
+
+    def test_no_command_module_can_reach_a_mint(self) -> None:
+        """The structural half: an approval comes from the confirmation flow.
+
+        The flag test above proves today's parser refuses today's guesses. This
+        proves no command module holds a writer at all, so a future flag cannot
+        quietly acquire one.
+        """
+        writers = (
+            "mint_approval_receipt",
+            "mint_approval_receipt_at",
+            "record_approval_receipt",
+            "append_approval_receipt",
+            "build_approval_receipt",
+        )
+        offenders = []
+        for path in sorted((REPO_ROOT / "src" / "commands").rglob("*.py")):
+            text = path.read_text(encoding="utf-8")
+            offenders.extend(
+                f"{path.name}:{writer}" for writer in writers if writer in text
+            )
+        self.assertEqual(offenders, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_data_boundary.py
+++ b/tests/test_data_boundary.py
@@ -1,0 +1,553 @@
+"""Contract tests for the native data boundary (#801).
+
+Three acceptance criteria, three things these tests refuse to let regress: a
+prepared action cannot claim access outside its approved boundary, OMH labels
+which limits the selected host can enforce, and out-of-workspace paths and
+prohibited data classes are rejected before a handoff exists.
+
+The boundary rides on the safety preflight rather than a module of its own, so
+the tests that matter most are the ones proving that decision did not cost
+anything: the profile digest still moves only on profile content, the per-host
+facts stay *out* of the digest, and ordinary coding work still routes.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from unittest import mock
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.coding.coding_delegation import (  # noqa: E402
+    _safety_preflight_request,
+    build_coding_delegation_payload,
+)
+from omh.quality.safety_preflight import (  # noqa: E402
+    ACCESS_INTENTS,
+    DATA_BOUNDARY_ENFORCEMENT_KINDS,
+    DATA_BOUNDARY_ENFORCEMENT_SCHEMA_VERSION,
+    DATA_BOUNDARY_LIMIT_NAMES,
+    DATA_BOUNDARY_LIMITS,
+    DATA_CLASSES,
+    PERMITTED_DATA_CLASSES,
+    PROHIBITED_DATA_CLASSES,
+    REQUEST_FIELDS,
+    RULE_ACCESS_INTENT_DECLARED,
+    RULE_DATA_CLASSES_PERMITTED,
+    RULE_DESTINATIONS_APPROVED,
+    RULE_TARGET_PATHS_BOUNDED,
+    data_boundary_enforcement_facts,
+    evaluate_safety_preflight,
+    safety_profile_digest,
+    safety_profile_revision,
+    safety_rule_profile,
+)
+
+from test_safety_preflight import request, sharing_request  # noqa: E402
+
+
+class ApprovedBoundaryTests(unittest.TestCase):
+    """A prepared action cannot claim access outside its approved boundary."""
+
+    def test_a_target_inside_a_declared_root_is_allowed(self) -> None:
+        verdict = evaluate_safety_preflight(
+            request(workspace_roots=["src/quality"], target_paths=["src/quality/safety_preflight.py"])
+        )
+        self.assertEqual(verdict["status"], "allow")
+
+    def test_a_target_outside_every_declared_root_is_refused(self) -> None:
+        verdict = evaluate_safety_preflight(
+            request(workspace_roots=["docs", "examples"], target_paths=["docs/x.md", "src/quality/a.py"])
+        )
+        self.assertEqual(verdict["status"], "deny")
+        self.assertEqual(verdict["rule_id"], RULE_TARGET_PATHS_BOUNDED)
+        self.assertEqual(verdict["field"], "target_paths[1]")
+        self.assertEqual(verdict["reason_code"], "target_path_outside_workspace_roots")
+        self.assertTrue(verdict["correction"])
+
+    def test_a_root_prefix_is_compared_by_segment_not_by_substring(self) -> None:
+        """`src/quality` must not approve `src/quality-secrets/`."""
+        verdict = evaluate_safety_preflight(
+            request(workspace_roots=["src/quality"], target_paths=["src/quality-secrets/keys.py"])
+        )
+        self.assertEqual(verdict["reason_code"], "target_path_outside_workspace_roots")
+
+    def test_both_separators_and_dot_segments_describe_the_same_boundary(self) -> None:
+        for root, path in (
+            ("src/quality", "src/quality/a.py"),
+            ("./src/quality/", "src/quality/a.py"),
+            ("src\\quality", "src/quality/a.py"),
+            ("src/quality", "src\\quality\\a.py"),
+            (".", "src/quality/a.py"),
+        ):
+            with self.subTest(root=root, path=path):
+                verdict = evaluate_safety_preflight(request(workspace_roots=[root], target_paths=[path]))
+                self.assertEqual(verdict["status"], "allow", verdict)
+
+    def test_an_undeclared_boundary_leaves_the_project_as_the_boundary(self) -> None:
+        """No root declared narrows nothing and widens nothing."""
+        self.assertEqual(evaluate_safety_preflight(request(workspace_roots=[]))["status"], "allow")
+        escaping = evaluate_safety_preflight(request(workspace_roots=[], target_paths=["../elsewhere/a.py"]))
+        self.assertEqual(escaping["reason_code"], "target_path_escapes_project")
+
+    def test_an_out_of_workspace_path_still_denies_with_its_existing_reason_code(self) -> None:
+        """#801 added a reason code to this rule; it replaced none of them."""
+        for path, reason_code in (
+            ("/etc/passwd", "target_path_absolute"),
+            ("~/keys.py", "target_path_absolute"),
+            ("C:\\Windows\\system32", "target_path_absolute"),
+            ("../other-project/a.py", "target_path_escapes_project"),
+        ):
+            with self.subTest(path=path):
+                verdict = evaluate_safety_preflight(request(workspace_roots=["src"], target_paths=[path]))
+                self.assertEqual(verdict["status"], "deny")
+                self.assertEqual(verdict["rule_id"], RULE_TARGET_PATHS_BOUNDED)
+                self.assertEqual(verdict["reason_code"], reason_code)
+
+    def test_a_declared_destination_is_reachable_and_an_undeclared_one_is_not(self) -> None:
+        self.assertEqual(evaluate_safety_preflight(sharing_request())["status"], "allow")
+        verdict = evaluate_safety_preflight(
+            sharing_request(approved_destinations=[{"kind": "git_remote", "ref": "upstream"}])
+        )
+        self.assertEqual(verdict["status"], "deny")
+        self.assertEqual(verdict["rule_id"], RULE_DESTINATIONS_APPROVED)
+        self.assertEqual(verdict["field"], "remote_targets[0]")
+        self.assertEqual(verdict["reason_code"], "destination_not_declared")
+
+    def test_approving_a_kind_does_not_approve_every_destination_of_that_kind(self) -> None:
+        """The pair is the boundary. `git_remote` in the abstract is not one."""
+        verdict = evaluate_safety_preflight(
+            sharing_request(
+                remote_targets=[{"kind": "git_remote", "ref": "attacker-host"}],
+                approved_destinations=[{"kind": "git_remote", "ref": "origin"}],
+            )
+        )
+        self.assertEqual(verdict["reason_code"], "destination_not_declared")
+
+    def test_an_empty_approval_approves_nothing_rather_than_everything(self) -> None:
+        verdict = evaluate_safety_preflight(
+            request(remote_targets=[{"kind": "git_remote", "ref": "origin"}], access_intents=["read", "share"])
+        )
+        self.assertEqual(verdict["status"], "deny")
+        self.assertEqual(verdict["reason_code"], "destination_not_declared")
+
+    def test_the_share_axis_is_checked_in_both_directions(self) -> None:
+        reaching = evaluate_safety_preflight(sharing_request(access_intents=["read"]))
+        self.assertEqual(reaching["rule_id"], RULE_ACCESS_INTENT_DECLARED)
+        self.assertEqual(reaching["reason_code"], "access_intent_undeclared")
+        claiming = evaluate_safety_preflight(request(access_intents=["share"]))
+        self.assertEqual(claiming["rule_id"], RULE_ACCESS_INTENT_DECLARED)
+        self.assertEqual(claiming["reason_code"], "access_intent_unapproved")
+
+
+class ProhibitedDataClassTests(unittest.TestCase):
+    """Prohibited data classes are rejected before a handoff exists."""
+
+    def test_every_permitted_class_is_reachable_from_a_real_request(self) -> None:
+        for name in PERMITTED_DATA_CLASSES:
+            with self.subTest(data_class=name):
+                self.assertEqual(evaluate_safety_preflight(request(data_classes=[name]))["status"], "allow")
+
+    def test_every_prohibited_class_is_refused_by_name(self) -> None:
+        for name in PROHIBITED_DATA_CLASSES:
+            with self.subTest(data_class=name):
+                verdict = evaluate_safety_preflight(request(data_classes=[name]))
+                self.assertEqual(verdict["status"], "deny")
+                self.assertEqual(verdict["rule_id"], RULE_DATA_CLASSES_PERMITTED)
+                self.assertEqual(verdict["field"], "data_classes[0]")
+                self.assertEqual(verdict["reason_code"], "data_class_prohibited")
+                self.assertIn(name, str(verdict["correction"]))
+
+    def test_the_vocabulary_is_exactly_the_permitted_set_plus_the_prohibited_set(self) -> None:
+        self.assertEqual(DATA_CLASSES, (*PERMITTED_DATA_CLASSES, *PROHIBITED_DATA_CLASSES))
+        self.assertEqual(set(PERMITTED_DATA_CLASSES) & set(PROHIBITED_DATA_CLASSES), set())
+        self.assertEqual(evaluate_safety_preflight(request(data_classes=["telemetry"]))["reason_code"], "data_class_unknown")
+
+    def test_prohibited_class_content_is_refused_even_when_no_class_is_declared(self) -> None:
+        """Declaring nothing is not a way past the boundary.
+
+        Each value below is one of the shapes the prohibited vocabulary names,
+        caught by the detectors this tree already owns rather than by a pattern
+        written for this rule.
+        """
+        for label, field, value in (
+            ("personal data: ssn", "persisted_content_refs", ["ssn-123-45-6789"]),
+            ("personal data: email", "observed_record_refs", ["run/dev@example.com"]),
+            ("transcript: role marker", "approved_scope", "assistant:reply"),
+            ("transcript: sensitive assignment", "owner", "passwd:hunter2"),
+        ):
+            with self.subTest(label=label):
+                verdict = evaluate_safety_preflight(request(**{field: value}))
+                self.assertEqual(verdict["status"], "deny")
+                self.assertEqual(verdict["rule_id"], RULE_DATA_CLASSES_PERMITTED)
+                self.assertEqual(verdict["reason_code"], "prohibited_data_class_content")
+                self.assertTrue(verdict["field"])
+                self.assertTrue(verdict["correction"])
+
+    def test_credential_material_keeps_naming_the_credential_rule(self) -> None:
+        """`secrets_absent` predates #801 and still answers for its own class."""
+        verdict = evaluate_safety_preflight(request(owner="AKIAIOSFODNN7EXAMPLE"))
+        self.assertEqual(verdict["reason_code"], "secret_shaped_value")
+
+    def test_the_prohibited_content_scan_never_reads_a_user_named_path(self) -> None:
+        """The lesson that produced the field-class map, re-proved for the new scan.
+
+        A filename is not a credential, an SSN, or an email address. Running
+        the wider detector over the path class would deny ordinary coding work
+        exactly the way credential shape once did.
+        """
+        for path in (
+            "src/auth/token_store.py",
+            "tests/test_authorization_headers.py",
+            "src/api/credentials_loader.py",
+            "lib/tokenizer.py",
+            "bearer_channel.py",
+            "src/users/dev@example.com.fixture.py",
+            "tests/fixtures/ssn-123-45-6789.json",
+            "src/agent/system-prompt.py",
+        ):
+            with self.subTest(path=path):
+                self.assertEqual(evaluate_safety_preflight(request(target_paths=[path]))["status"], "allow")
+
+    def test_a_declared_prohibited_class_is_refused_before_any_handoff_is_built(self) -> None:
+        """Rejected `before handoff` is structural, not a claim: the request the
+        rule reads is pre-expansion metadata, so nothing has been prepared yet."""
+        for forbidden in ("message", "delegation_prompt", "raw_content", "prompt", "diff"):
+            self.assertNotIn(forbidden, REQUEST_FIELDS)
+        verdict = evaluate_safety_preflight(request(data_classes=["credential_material"]))
+        self.assertEqual(verdict["status"], "deny")
+        self.assertEqual(verdict["reason_code"], "data_class_prohibited")
+
+
+class BoundaryVocabularyReachabilityTests(unittest.TestCase):
+    def test_every_access_intent_is_reachable_from_a_real_request(self) -> None:
+        for intent in ACCESS_INTENTS:
+            with self.subTest(intent=intent):
+                candidate = sharing_request(access_intents=[intent]) if intent == "share" else request(access_intents=[intent])
+                self.assertEqual(evaluate_safety_preflight(candidate)["status"], "allow", candidate)
+
+    def test_every_new_request_field_has_a_declared_class_and_a_rule(self) -> None:
+        profile = safety_rule_profile()
+        classes = profile["field_classes"]
+        axes = {str(rule["axis"]) for rule in profile["rules"]}
+        for field, expected_class, axis in (
+            ("data_classes", "vocabulary", "data_classes"),
+            ("workspace_roots", "path", "workspace_roots"),
+            ("approved_destinations", "opaque_ref", "destinations"),
+            ("access_intents", "vocabulary", "access_intent"),
+        ):
+            with self.subTest(field=field):
+                self.assertIn(field, REQUEST_FIELDS)
+                self.assertEqual(classes[field], expected_class)
+                self.assertIn(axis, axes)
+        # Which class the two scans read is pinned by the revision, for the
+        # same reason `field_classes` is: pointing either at the path class
+        # would deny ordinary work, and that must not change silently.
+        self.assertEqual(profile["secret_shape_field_classes"], ["opaque_ref"])
+        self.assertEqual(profile["prohibited_content_field_classes"], ["opaque_ref"])
+        self.assertEqual(profile["destination_fields"], ["remote_targets", "approved_destinations"])
+        mutated = safety_rule_profile()
+        mutated["prohibited_content_field_classes"] = ["path"]
+        self.assertNotEqual(safety_profile_digest(mutated), safety_profile_revision())
+
+    def test_read_and_write_are_declarations_that_no_rule_denies_on_their_own(self) -> None:
+        """Stated so the reader is not misled about what is enforced.
+
+        Read and write stay inside the workspace, where `workspace_roots` and
+        the path rules are the whole boundary. Only the share axis leaves the
+        workspace, so only the share axis carries an intent denial.
+        """
+        for intents in (["read"], ["write"], ["read", "write"]):
+            with self.subTest(intents=intents):
+                self.assertEqual(evaluate_safety_preflight(request(access_intents=intents))["status"], "allow")
+
+
+class BoundaryDeterminismTests(unittest.TestCase):
+    def test_the_same_boundary_request_yields_the_same_decision_byte_for_byte(self) -> None:
+        candidates = (
+            request(workspace_roots=["src"], target_paths=["src/a.py"]),
+            request(workspace_roots=["docs"], target_paths=["src/a.py"]),
+            sharing_request(),
+            request(data_classes=["personal_data"]),
+            request(access_intents=["share"]),
+        )
+        for index, candidate in enumerate(candidates):
+            with self.subTest(index=index):
+                first = json.dumps(evaluate_safety_preflight(candidate), sort_keys=True)
+                for _ in range(5):
+                    self.assertEqual(json.dumps(evaluate_safety_preflight(candidate), sort_keys=True), first)
+                self.assertEqual(json.dumps(evaluate_safety_preflight(dict(candidate)), sort_keys=True), first)
+                self.assertIn(f'"safety_profile_revision": "{safety_profile_revision()}"', first)
+
+
+class EnforcementFactsTests(unittest.TestCase):
+    """OMH labels which limits the selected host can enforce."""
+
+    def facts(self) -> dict[str, object]:
+        return data_boundary_enforcement_facts()
+
+    def test_the_facts_cover_every_declared_limit_exactly_once(self) -> None:
+        facts = self.facts()
+        self.assertEqual(facts["schema_version"], DATA_BOUNDARY_ENFORCEMENT_SCHEMA_VERSION)
+        limits = facts["limits"]
+        self.assertEqual([entry["limit"] for entry in limits], list(DATA_BOUNDARY_LIMIT_NAMES))
+        self.assertEqual(len(set(DATA_BOUNDARY_LIMIT_NAMES)), len(DATA_BOUNDARY_LIMIT_NAMES))
+        for entry in limits:
+            with self.subTest(limit=entry["limit"]):
+                self.assertIn(entry["enforcement_kind"], DATA_BOUNDARY_ENFORCEMENT_KINDS)
+
+    def test_an_enforced_limit_names_an_enforcer_and_an_unenforced_one_names_a_blocker(self) -> None:
+        """The anti-decoration rule `action_gate` applies, applied to these facts."""
+        for entry in self.facts()["limits"]:
+            with self.subTest(limit=entry["limit"]):
+                if entry["enforced_here"]:
+                    self.assertTrue(entry["enforced_by"])
+                    self.assertEqual(entry["blocked_by"], "")
+                else:
+                    self.assertEqual(entry["enforced_by"], [])
+                    self.assertTrue(str(entry["blocked_by"]).strip())
+
+    def test_every_named_enforcer_is_a_symbol_a_reader_can_open(self) -> None:
+        import importlib
+
+        for entry in self.facts()["limits"]:
+            for symbol in entry["enforced_by"]:
+                with self.subTest(symbol=symbol):
+                    self.assertTrue(symbol.startswith("omh."))
+                    self.assertGreaterEqual(symbol.count("."), 2)
+                    module_name, _, attribute = symbol.rpartition(".")
+                    module = importlib.import_module(module_name)
+                    self.assertTrue(hasattr(module, attribute), symbol)
+
+    def test_refused_before_handoff_limits_hold_on_every_host(self) -> None:
+        """No host and no executor is involved, so there is nothing for a host to lack."""
+        for entry in self.facts()["limits"]:
+            if entry["enforcement_kind"] == "refused_before_handoff":
+                with self.subTest(limit=entry["limit"]):
+                    self.assertTrue(entry["host_can_enforce"])
+                    self.assertTrue(entry["enforced_here"])
+
+    def test_a_host_confinement_limit_is_unenforced_and_says_which_kind_of_unenforced(self) -> None:
+        """The genuine per-host difference: which blocker stands in the way.
+
+        A host with a confinement backend is blocked on #820 alone; a host with
+        none could not enforce a runtime limit even after #820 lands, and says
+        so with its own reason.
+        """
+        facts = self.facts()
+        entries = [entry for entry in facts["limits"] if entry["enforcement_kind"] == "host_confinement"]
+        self.assertTrue(entries)
+        for entry in entries:
+            with self.subTest(limit=entry["limit"]):
+                self.assertFalse(entry["enforced_here"])
+                self.assertEqual(entry["host_can_enforce"], facts["host_confinement_available"])
+                expected = "#820" if facts["host_confinement_available"] else facts["host_confinement_unavailable_reason"]
+                self.assertEqual(entry["blocked_by"], expected)
+
+    def test_an_advisory_limit_is_enforced_on_no_host(self) -> None:
+        for entry in self.facts()["limits"]:
+            if entry["enforcement_kind"] == "advisory":
+                with self.subTest(limit=entry["limit"]):
+                    self.assertFalse(entry["host_can_enforce"])
+                    self.assertFalse(entry["enforced_here"])
+
+    def test_the_backend_answer_agrees_with_the_lane_that_builds_the_sandbox(self) -> None:
+        """One answer to "which backend", probed twice rather than invented twice."""
+        from omh.quality.cross_harness_adapter_sandbox import backend, backend_available
+
+        facts = self.facts()
+        selected = str(facts["host_confinement_backend"])
+        self.assertEqual(selected, backend("auto"))
+        if facts["host_confinement_available"]:
+            # Availability here is at least as strict as the lane's own check:
+            # the Linux half additionally requires a trusted binary on disk.
+            self.assertTrue(backend_available(selected))
+        else:
+            self.assertTrue(str(facts["host_confinement_unavailable_reason"]).strip())
+
+    def test_each_platform_branch_is_probed_rather_than_assumed(self) -> None:
+        """All three answers, proved on one host so none of them is folklore.
+
+        The unsupported branch is what a Windows runner really takes; the two
+        Linux branches are the difference between "bwrap is the backend here"
+        and "bwrap is the backend here and is actually installed".
+        """
+        import omh.quality.safety_preflight as module
+
+        with mock.patch("sys.platform", "sunos5"):
+            unsupported = module.data_boundary_enforcement_facts()
+        self.assertEqual(unsupported["host_confinement_backend"], "unsupported")
+        self.assertFalse(unsupported["host_confinement_available"])
+        self.assertEqual(
+            unsupported["host_confinement_unavailable_reason"], "no_os_confinement_backend_on_this_platform"
+        )
+        for entry in unsupported["limits"]:
+            if entry["enforcement_kind"] == "host_confinement":
+                with self.subTest(limit=entry["limit"]):
+                    self.assertFalse(entry["host_can_enforce"])
+                    self.assertEqual(entry["blocked_by"], "no_os_confinement_backend_on_this_platform")
+
+        with mock.patch("sys.platform", "linux"), mock.patch.object(module, "_trusted_bwrap_present", lambda: False):
+            untrusted = module.data_boundary_enforcement_facts()
+        self.assertEqual(untrusted["host_confinement_backend"], "bwrap")
+        self.assertFalse(untrusted["host_confinement_available"])
+        self.assertEqual(untrusted["host_confinement_unavailable_reason"], "bwrap_absent_or_untrusted")
+
+        with mock.patch("sys.platform", "linux"), mock.patch.object(module, "_trusted_bwrap_present", lambda: True):
+            trusted = module.data_boundary_enforcement_facts()
+        self.assertTrue(trusted["host_confinement_available"])
+        self.assertEqual(trusted["host_confinement_unavailable_reason"], "")
+
+        with mock.patch("sys.platform", "darwin"), mock.patch("os.path.exists", return_value=False):
+            missing = module.data_boundary_enforcement_facts()
+        self.assertEqual(missing["host_confinement_backend"], "sandbox-exec")
+        self.assertFalse(missing["host_confinement_available"])
+        self.assertEqual(missing["host_confinement_unavailable_reason"], "sandbox_exec_absent")
+
+    def test_no_platform_answer_moves_the_pinned_revision(self) -> None:
+        import omh.quality.safety_preflight as module
+
+        live = safety_profile_revision()
+        for platform in ("darwin", "linux", "win32", "sunos5"):
+            with self.subTest(platform=platform), mock.patch("sys.platform", platform):
+                self.assertEqual(module.safety_profile_revision(), live)
+
+    def test_the_facts_are_stable_within_a_host(self) -> None:
+        first = json.dumps(self.facts(), sort_keys=True)
+        for _ in range(3):
+            self.assertEqual(json.dumps(self.facts(), sort_keys=True), first)
+
+    def test_the_per_host_answer_is_not_part_of_the_pinned_revision(self) -> None:
+        """A host-dependent digest would read as drift on every second machine."""
+        profile = safety_rule_profile()
+        encoded = json.dumps(profile, sort_keys=True)
+        for key in ("host_confinement_backend", "host_confinement_available", "enforced_here", "host_can_enforce"):
+            self.assertNotIn(key, encoded)
+        self.assertEqual(
+            profile["data_boundary_limits"],
+            [
+                {"limit": limit, "enforcement_kind": kind, "enforced_by": list(symbols), "blocked_by": blocker}
+                for limit, kind, symbols, blocker in DATA_BOUNDARY_LIMITS
+            ],
+        )
+        self.assertEqual(safety_profile_digest(profile), safety_profile_revision())
+
+
+class DelegationLaneBoundaryTests(unittest.TestCase):
+    """The boundary the chat delegation lane actually declares."""
+
+    CODING = "implement pagination in src/routing/chat.py and add unit tests"
+
+    def test_the_lane_declares_its_data_classes_intents_and_boundary_halves(self) -> None:
+        prepared = _safety_preflight_request(
+            self.CODING,
+            owner="codex",
+            workflow="plan",
+            message_context_mode="full",
+            raw_content_included=True,
+            intent="coding",
+            action="delegate",
+        )
+        self.assertEqual(prepared["data_classes"], ["workspace_metadata", "workspace_source", "user_request_text"])
+        self.assertEqual(prepared["access_intents"], ["read", "write"])
+        self.assertEqual(prepared["workspace_roots"], [])
+        self.assertEqual(prepared["approved_destinations"], [])
+        self.assertEqual(prepared["target_paths"], ["src/routing/chat.py"])
+        self.assertLessEqual(set(prepared), set(REQUEST_FIELDS))
+        self.assertEqual(evaluate_safety_preflight(prepared)["status"], "allow")
+
+    def test_the_lane_never_declares_a_prohibited_class_or_the_share_intent(self) -> None:
+        for intent, action, expected in (
+            ("coding", "delegate", ["read", "write"]),
+            ("review", "delegate", ["read"]),
+            ("coding", "clarify", ["read"]),
+            ("research", "delegate", ["read"]),
+        ):
+            with self.subTest(intent=intent, action=action):
+                prepared = _safety_preflight_request(
+                    self.CODING,
+                    owner="codex",
+                    workflow="plan",
+                    message_context_mode="bounded",
+                    raw_content_included=False,
+                    intent=intent,
+                    action=action,
+                )
+                self.assertEqual(prepared["access_intents"], expected)
+                self.assertNotIn("share", prepared["access_intents"])
+                self.assertEqual(set(prepared["data_classes"]) & set(PROHIBITED_DATA_CLASSES), set())
+                self.assertEqual(evaluate_safety_preflight(prepared)["status"], "allow")
+
+    def test_a_message_with_no_named_file_declares_no_workspace_source(self) -> None:
+        prepared = _safety_preflight_request(
+            "add a caching layer and unit tests",
+            owner="codex",
+            workflow="plan",
+            message_context_mode="bounded",
+            raw_content_included=False,
+            intent="coding",
+            action="delegate",
+        )
+        self.assertEqual(prepared["target_paths"], [])
+        self.assertEqual(prepared["data_classes"], ["workspace_metadata"])
+
+    def test_ordinary_coding_work_is_still_not_denied(self) -> None:
+        """The exact class that broke when the preflight first landed.
+
+        Filenames carrying `token`, `authorization`, `credential`, `bearer`,
+        and a pasted repository URL. Each one was denied once, and each one has
+        to survive every later rule added to this evaluator.
+        """
+        for message in (
+            "refactor src/auth/token_store.py to use a shared cache and add unit tests",
+            "fix the failing unit tests in tests/test_authorization_headers.py",
+            "refactor src/api/credentials_loader.py error handling and add unit tests",
+            "add tests for lib/tokenizer.py",
+            "fix the bearer_channel.py backpressure bug",
+            "implement pagination in src/routing/chat.py and add unit tests",
+            "implement pagination in "
+            "https://github.com/rlaope/oh-my-hermes/blob/main/src/routing/chat.py and add unit tests",
+            "implement pagination in src/routing/chat.py, see "
+            "https://github.com/rlaope/oh-my-hermes/blob/main/src/routing/chat.py, and add unit tests",
+        ):
+            with self.subTest(message=message):
+                gate = build_coding_delegation_payload(message, executor_target="codex")["action_gate"]
+                self.assertEqual(gate["outcome"], "allow", gate.get("denial"))
+
+    def test_an_out_of_workspace_path_is_still_denied_end_to_end(self) -> None:
+        gate = build_coding_delegation_payload("refactor /etc/passwd.py now", executor_target="codex")["action_gate"]
+        self.assertEqual(gate["outcome"], "deny")
+        self.assertEqual(gate["denial"]["rule_id"], "target_paths_bounded")
+        self.assertIn("target_path_absolute", gate["denial"]["reason_codes"])
+
+    def test_the_boundary_introduces_no_second_allowed_targets_list(self) -> None:
+        """The #820 desync this change deliberately did not create.
+
+        `action_gate._allowed_targets_for` already derives the symbolic target
+        from the isolation plan and equality-checks it into the contract. The
+        workspace boundary is expressed as bounded roots on the preflight
+        request instead, where the path rules already refuse an escape, so
+        there is one answer to "which target" rather than two that can
+        disagree. Declaring roots here as well would have been the second one.
+        """
+        payload = build_coding_delegation_payload(self.CODING, executor_target="codex")
+        envelope = payload["action_gate"]["authority_envelope"]
+        self.assertEqual(envelope["allowed_targets"], ["current_workspace"])
+        prepared = _safety_preflight_request(
+            self.CODING,
+            owner="codex",
+            workflow="plan",
+            message_context_mode="bounded",
+            raw_content_included=False,
+            intent="coding",
+            action="delegate",
+        )
+        self.assertEqual(prepared["workspace_roots"], [])
+        self.assertNotIn("allowed_targets", prepared)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_handoff_safety_contract.py
+++ b/tests/test_handoff_safety_contract.py
@@ -49,6 +49,7 @@ from omh.coding.action_gate import (  # noqa: E402
 )
 from omh.coding.coding_delegation import build_coding_delegation_payload  # noqa: E402
 from omh.commands import setup as setup_command  # noqa: E402
+from omh.quality.safety_preflight import data_boundary_enforcement_facts  # noqa: E402
 from omh.runtime.claims import (  # noqa: E402
     RUNTIME_CLAIM_LADDER,
     Claim,
@@ -79,10 +80,19 @@ _ALLOW_VERDICT = {
 # The boundaries that name a real enforcing symbol today. Hardcoded on purpose:
 # it has to be edited by hand, in the same commit, whenever a boundary gains or
 # loses an enforcer, so neither direction of drift can land quietly.
+#
+# `confirmation_answered` is deliberately *not* here. The gate really does
+# refuse a risky action with no live approval, but only for a caller that holds
+# a run an approval could bind to, and the shipped delegation lane has none —
+# see `action_gate.RISK_CONSENT_BLOCKER`. A boundary that refuses nothing on the
+# path users travel is a declaration, so it is declared.
 _ENFORCED_BOUNDARIES = frozenset(
     {
         "confirmation_arming",
         "credential",
+        "data_declared_destination",
+        "data_prohibited_data_class",
+        "data_workspace_root_claim",
         "dispatch",
         "evidence_separation",
         "file",
@@ -95,16 +105,40 @@ _ENFORCED_BOUNDARIES = frozenset(
     }
 )
 # The boundaries the contract declares but does not guard, each with the issue
-# that must land before it can move. `unfiled` means the gap is real and has no
-# issue yet; it is still stated rather than implied away.
+# that must land before it can move. A blocker is not always an issue number:
+# `account_authorization` names the reason instead, because nothing that could
+# be filed would close it — OMH cannot observe a consent flow owned by someone
+# else's website.
 _DECLARED_NOT_ENFORCED = {
-    "confirmation_answered": "#807",
+    "account_authorization": "host_owned_consent_flow_is_not_observable_by_omh",
+    "confirmation_answered": "no_confirmation_answer_intake_mints_a_run_bound_approval",
     "recovery": "#821",
     "review_receipt": "#844",
     "start_evidence": "#826",
     "storage_retention": "#835",
     "workspace": "#820",
 }
+# The three data-boundary rows whose blocker is a *host* fact rather than a
+# repository fact: a host with an OS confinement backend is blocked on #820,
+# and a host without one is blocked on not having one. Pinning either string
+# here would make this test pass on macOS and fail on Windows, so the expected
+# value is read from the same facts the contract read.
+_HOST_DEPENDENT_BOUNDARIES = frozenset(
+    {
+        "data_executor_honours_declared_targets",
+        "data_runtime_filesystem_confinement",
+        "data_runtime_network_confinement",
+    }
+)
+
+
+def _host_dependent_blockers() -> dict[str, str]:
+    facts = data_boundary_enforcement_facts()
+    return {
+        f"data_{limit['limit']}": str(limit["blocked_by"])
+        for limit in facts["limits"]  # type: ignore[index]
+        if f"data_{limit['limit']}" in _HOST_DEPENDENT_BOUNDARIES
+    }
 
 
 def _envelope(**overrides: object) -> dict[str, object]:
@@ -291,7 +325,7 @@ class AntiDecorationTests(unittest.TestCase):
             for entry in contract["boundaries"]
             if entry["enforcement"] == "declared_not_enforced"
         }
-        self.assertEqual(declared, _DECLARED_NOT_ENFORCED)
+        self.assertEqual(declared, {**_DECLARED_NOT_ENFORCED, **_host_dependent_blockers()})
         self.assertEqual(set(SAFETY_BOUNDARY_NAMES), enforced | set(declared))
 
     def test_every_cited_enforcer_resolves_to_a_real_symbol(self) -> None:
@@ -347,7 +381,7 @@ class AntiDecorationTests(unittest.TestCase):
     def test_unenforced_boundaries_state_the_gap_in_words(self) -> None:
         contract = _contract()
         self.assertIn("nothing binds a running executor", _boundary(contract, "workspace")["statement"])
-        self.assertIn("never be read as an approval", _boundary(contract, "confirmation_answered")["statement"])
+        self.assertIn("not a state OMH can observe", _boundary(contract, "account_authorization")["statement"])
         self.assertIn("persist until the operator deletes them", _boundary(contract, "storage_retention")["statement"])
         self.assertIn("no external effect", _boundary(contract, "review_receipt")["statement"])
         self.assertIn("no observed start", _boundary(contract, "start_evidence")["statement"])

--- a/tests/test_risky_action_confirmation.py
+++ b/tests/test_risky_action_confirmation.py
@@ -1,0 +1,1292 @@
+"""The risky-action confirmation ladder and the account-authorization projection.
+
+Two issues meet here.
+
+#800 asks that a risky action get an explainable allow, deny, or ask, that the
+approval binding it never stretch to a sibling action, a broader scope, another
+owner, or a later session, and that one intent still produce one prompt. The
+load-bearing tests below are therefore not "a risky action asks": they are that
+the *classifier never reads message text*, and that arming a fourth ladder did
+not create a fourth prompt.
+
+#799 asks for account authorization. Roughly three quarters of it is a
+projection over things the tree already derives; the rest cannot be implemented
+at all, because a consent flow owned by a provider's website is not observable
+from here. The tests hold both halves in place: the projection is asserted, and
+the declaration that the rest is not enforced is asserted just as hard, so a
+later change cannot quietly promote a rendered instruction into a guarantee.
+"""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import inspect
+import json
+import socket
+import subprocess
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.coding import isolation as isolation_module  # noqa: E402
+from omh.coding.action_gate import (  # noqa: E402
+    ACCOUNT_ACCESS_STATES,
+    ACCOUNT_AUTHORIZATION_BLOCKER,
+    ACCOUNT_BACKED_ACTIONS,
+    ACCOUNT_BLOCKER_NAMES,
+    ACCOUNT_SIGNAL_STALE_AFTER_SECONDS,
+    ACTION_RISK_INPUTS,
+    CONFIRMATION_LADDERS,
+    DATA_BOUNDARY_LIMIT_NAMES,
+    DATA_BOUNDARY_NAMES,
+    LADDER_ACTION_IDS,
+    MAX_UNCONFIRMED_TARGET_PATHS,
+    MUTATING_ACTIONS,
+    RISK_CLASS_NAMES,
+    RISK_CONSENT_BLOCKER,
+    RISK_CONSENT_ENFORCERS,
+    RISKY_ACTION_CLASSES,
+    SAFETY_BOUNDARY_NAMES,
+    build_account_authorization,
+    build_task_authority_envelope,
+    build_task_handoff_safety_contract,
+    classify_action_risk,
+    data_boundary_facts,
+    evaluate_action_gate,
+    granted_risk_actions,
+    loop_actions,
+    risk_classes_present,
+    safety_boundary_names,
+    split_handoff_safety_contract,
+    validate_account_authorization,
+    validate_action_gate_verdict,
+    validate_action_risk,
+    validate_task_authority_envelope,
+)
+from omh.coding.coding_delegation import build_coding_delegation_payload  # noqa: E402
+from omh.quality import safety_preflight as safety_preflight_module  # noqa: E402
+from omh.quality.safety_preflight import (  # noqa: E402
+    ACCESS_INTENTS,
+    DATA_BOUNDARY_LIMIT_NAMES as PREFLIGHT_DATA_BOUNDARY_LIMIT_NAMES,
+    MAX_TARGET_PATHS,
+    data_boundary_enforcement_facts,
+)
+from omh.system.metadata_safety import is_secret_value_shaped  # noqa: E402
+from omh.workflows.approval_receipts import (  # noqa: E402
+    APPROVABLE_ACTIONS,
+    APPROVAL_TTL_SECONDS,
+    CONFIRMATION_LADDERS as RECEIPT_CONFIRMATION_LADDERS,
+    build_approval_receipt,
+)
+from omh.wrapper import contract as wrapper_contract  # noqa: E402
+from omh.wrapper.contract import build_chat_response_from_delegation  # noqa: E402
+
+
+_MESSAGE = "fix the broken login flow in src/auth.py and add a regression test"
+_ALLOW_VERDICT = {
+    "schema_version": "omh_safety_preflight_verdict/v1",
+    "status": "allow",
+    "rule_id": "",
+    "field": "",
+    "correction": "",
+    "safety_profile_revision": "rev-frozen",
+}
+_DENY_VERDICT = {
+    **_ALLOW_VERDICT,
+    "status": "deny",
+    "rule_id": "target_paths_bounded",
+    "field": "target_paths[0]",
+    "correction": "Use a project-relative target path.",
+}
+
+# A request that declares a write over more paths than an operator can read
+# from the request itself. Every value here is a *declaration*, which is the
+# whole point: nothing about the message produced it.
+_BROAD_WRITE_REQUEST = {
+    "access_intents": ["read", "write"],
+    "target_paths": [f"src/module{index}/thing.py" for index in range(MAX_UNCONFIRMED_TARGET_PATHS + 4)],
+    "approved_destinations": [],
+    "remote_targets": [],
+}
+_NARROW_REQUEST = {
+    "access_intents": ["read", "write"],
+    "target_paths": ["src/auth.py"],
+    "approved_destinations": [],
+    "remote_targets": [],
+}
+_PUBLISHING_REQUEST = {**_NARROW_REQUEST, "access_intents": ["read", "share"]}
+_DESTINATION_REQUEST = {
+    **_NARROW_REQUEST,
+    "approved_destinations": [{"kind": "git_remote", "ref": "origin"}],
+}
+
+_T0 = "2026-08-06T00:00:00Z"
+_T_PLUS_10M = "2026-08-06T00:10:00Z"
+_T_PAST_WINDOW = "2026-08-06T09:00:00Z"
+
+
+def _gate(**overrides: object) -> dict[str, object]:
+    arguments: dict[str, object] = {
+        "message": _MESSAGE,
+        "delegation_action": "delegate",
+        "intent": "coding",
+        "review_required": False,
+        "work_owner_mode": "external_executor",
+        "selected_executor_profile": "codex",
+        "dispatch_policy": "ask_before_dispatch",
+        "dispatchable": True,
+        "choice_required": False,
+        "executor_selection_status": "handoff_prepared",
+        "isolation_plan": {"strategy": "same_workspace_ok"},
+        "safety_preflight": _ALLOW_VERDICT,
+        "run_id": "run-800",
+    }
+    arguments.update(overrides)
+    return evaluate_action_gate(**arguments)  # type: ignore[arg-type]
+
+
+def _receipt(**overrides: object) -> dict[str, object]:
+    arguments: dict[str, object] = {
+        "approved_action": "repo_edit",
+        "scope_class": "permission_profile",
+        "scope_ref": "execute_with_gates",
+        "owner": "codex",
+        "run_id": "run-800",
+        "safety_profile_revision": "rev-frozen",
+        "confirmation_ladder": "risky_action",
+        "decision": "granted",
+        "decided_at": _T0,
+    }
+    arguments.update(overrides)
+    return build_approval_receipt(**arguments)  # type: ignore[arg-type]
+
+
+def _envelope(*, grants: tuple[str, ...] = (), **overrides: object) -> dict[str, object]:
+    envelope = build_task_authority_envelope(
+        denied=False,
+        delegation_action="delegate",
+        intent="coding",
+        review_required=False,
+        work_owner_mode="external_executor",
+        selected_executor_profile="codex",
+        dispatchable=True,
+        choice_required=False,
+        isolation_plan={"strategy": "same_workspace_ok"},
+        message=_MESSAGE,
+        safety_profile_revision="rev-frozen",
+    )
+    if grants:
+        # `required_actions_for` never yields merge, a pull-request action, or
+        # external_posting, so the only way to exercise those classes is an
+        # envelope a caller handed in. It is widened *consistently* — every
+        # derived field moved with the action set — because an envelope whose
+        # `merge_authority` disagrees with its allowed actions is one the
+        # validator refuses, and a test built on one would be testing a shape
+        # that cannot exist.
+        allowed = sorted(set(envelope["allowed_actions"]) | set(grants))  # type: ignore[arg-type]
+        blocked = sorted(set(loop_actions()) - set(allowed))
+        envelope["allowed_actions"] = allowed
+        envelope["blocked_actions"] = blocked
+        envelope["exclusions"] = [
+            entry for entry in envelope["exclusions"] if entry["action"] in blocked  # type: ignore[index]
+        ]
+        envelope["mutation_rights"] = sorted(set(allowed) & set(MUTATING_ACTIONS))
+        envelope["merge_authority"] = "granted" if "merge" in allowed else "disabled"
+        envelope["external_action_authority"] = (
+            "publish_allowed" if "external_posting" in allowed else "prepare_only"
+        )
+    envelope.update(overrides)
+    return envelope
+
+
+class LadderRegistrationTests(unittest.TestCase):
+    """The ladder is registered, not bolted on beside the others."""
+
+    def test_the_risky_action_ladder_is_a_registered_ladder_with_an_action_id(self) -> None:
+        self.assertIn("risky_action", CONFIRMATION_LADDERS)
+        self.assertEqual(LADDER_ACTION_IDS["risky_action"], "confirm_risky_action")
+        self.assertEqual(set(LADDER_ACTION_IDS), set(CONFIRMATION_LADDERS))
+
+    def test_precedence_places_it_between_the_profile_question_and_the_go_ahead(self) -> None:
+        # The tuple order *is* the documented precedence, so it is asserted
+        # rather than left to the arbitration body to imply.
+        self.assertEqual(
+            CONFIRMATION_LADDERS,
+            ("executor_selection", "permission_profile", "risky_action", "operator_confirmation"),
+        )
+
+    def test_the_receipt_vocabulary_moved_with_it(self) -> None:
+        # A ladder the gate can arm and the receipt store cannot name would be a
+        # confirmation whose answer is unmintable.
+        self.assertEqual(set(RECEIPT_CONFIRMATION_LADDERS), set(CONFIRMATION_LADDERS))
+        self.assertEqual(_receipt()["confirmation_ladder"], "risky_action")
+
+    def test_the_wrapper_ladder_list_is_derived_from_the_gate_rather_than_retyped(self) -> None:
+        """The two lists had already drifted; now one is derived from the other.
+
+        `send_to_codex` was in the wrapper's copy and not in the gate's map, and
+        nothing failed. The wrapper list is now the gate's values plus the two
+        groups this lane really owns, so the same drift cannot recur.
+        """
+        self.assertTrue(set(LADDER_ACTION_IDS.values()) <= set(wrapper_contract._LADDER_ACTION_IDS))
+        self.assertIn("send_to_codex", wrapper_contract._LADDER_ACTION_IDS)
+        self.assertEqual(wrapper_contract._LADDER_ACTION_ALIASES["send_to_codex"], "send_to_executor")
+        for confirm_id in wrapper_contract._OPERATOR_CARD_CONFIRM_ACTION_IDS:
+            with self.subTest(confirm_id=confirm_id):
+                self.assertIn(confirm_id, wrapper_contract._LADDER_ACTION_IDS)
+                self.assertIn(confirm_id, wrapper_contract.VISIBLE_ACTIONS)
+        source = inspect.getsource(wrapper_contract)
+        self.assertIn("_LADDER_ACTION_IDS = tuple(", source)
+        self.assertIn("LADDER_ACTION_IDS.values()", source)
+
+    def test_the_armed_action_is_renderable(self) -> None:
+        self.assertIn("confirm_risky_action", wrapper_contract.VISIBLE_ACTIONS)
+        self.assertEqual(wrapper_contract._LADDER_ACTION_LABELS["confirm_risky_action"], "Confirm risky action")
+
+
+class OnePromptTests(unittest.TestCase):
+    """One intent, one prompt — over every combination that can co-occur."""
+
+    def _verdict(
+        self,
+        *,
+        denied: bool,
+        choice_required: bool,
+        expansion: bool,
+        risky: bool,
+        approved: bool,
+        dispatchable: bool,
+    ) -> dict[str, object]:
+        return _gate(
+            work_owner_mode="external_executor" if dispatchable or choice_required else "prompt_only_handoff",
+            selected_executor_profile=None if choice_required else ("codex" if dispatchable else "claude-code"),
+            dispatch_policy="ask_before_dispatch" if dispatchable else "prepare_only",
+            dispatchable=dispatchable,
+            choice_required=choice_required,
+            executor_selection_status="executor_choice_required" if choice_required else "handoff_prepared",
+            safety_preflight=_DENY_VERDICT if denied else _ALLOW_VERDICT,
+            safety_preflight_request=_BROAD_WRITE_REQUEST if risky else _NARROW_REQUEST,
+            requested_actions=["merge"] if expansion else [],
+            approval_receipts=[_receipt(owner="codex" if dispatchable else "claude-code")] if approved else [],
+            now=_T_PLUS_10M,
+        )
+
+    def test_one_intent_arms_at_most_one_ladder_over_every_combination(self) -> None:
+        for denied in (False, True):
+            for choice_required in (False, True):
+                for expansion in (False, True):
+                    for risky in (False, True):
+                        for approved in (False, True):
+                            for dispatchable in (False, True):
+                                if choice_required and dispatchable:
+                                    continue  # a choice-required selection is never dispatchable
+                                with self.subTest(
+                                    denied=denied,
+                                    choice_required=choice_required,
+                                    expansion=expansion,
+                                    risky=risky,
+                                    approved=approved,
+                                    dispatchable=dispatchable,
+                                ):
+                                    verdict = self._verdict(
+                                        denied=denied,
+                                        choice_required=choice_required,
+                                        expansion=expansion,
+                                        risky=risky,
+                                        approved=approved,
+                                        dispatchable=dispatchable,
+                                    )
+                                    confirmation = verdict["confirmation"]
+                                    armed = confirmation["armed_ladders"]
+                                    self.assertLessEqual(len(armed), 1)
+                                    self.assertEqual(confirmation["required"], bool(armed))
+                                    suppressed = [entry["ladder"] for entry in confirmation["suppressed_ladders"]]
+                                    self.assertEqual(sorted(armed + suppressed), sorted(CONFIRMATION_LADDERS))
+                                    for entry in confirmation["suppressed_ladders"]:
+                                        self.assertTrue(entry["reason"].strip())
+                                    gate, _ = split_handoff_safety_contract(verdict)
+                                    self.assertEqual(validate_action_gate_verdict(gate), [])
+
+    def test_precedence_is_deny_then_selection_then_profile_then_risk_then_operator(self) -> None:
+        def ladder(**kwargs: object) -> str:
+            return self._verdict(**kwargs)["confirmation"]["ladder"]  # type: ignore[arg-type,index]
+
+        base = {"denied": False, "choice_required": False, "expansion": False, "risky": False, "approved": False}
+        self.assertEqual(ladder(**{**base, "denied": True, "risky": True, "dispatchable": False}), "none")
+        self.assertEqual(
+            ladder(**{**base, "choice_required": True, "expansion": True, "risky": True, "dispatchable": False}),
+            "executor_selection",
+        )
+        self.assertEqual(
+            ladder(**{**base, "expansion": True, "risky": True, "dispatchable": True}), "permission_profile"
+        )
+        self.assertEqual(ladder(**{**base, "risky": True, "dispatchable": True}), "risky_action")
+        self.assertEqual(ladder(**{**base, "dispatchable": True}), "operator_confirmation")
+        self.assertEqual(ladder(**{**base, "dispatchable": False}), "none")
+
+    def test_a_card_never_asks_a_second_authority_question_when_the_risk_ladder_wins(self) -> None:
+        # The card renders the arbitrated ladder; it does not add one of its own.
+        payload = build_coding_delegation_payload(_MESSAGE, executor_target="codex")
+        payload["action_gate"] = _gate(safety_preflight_request=_BROAD_WRITE_REQUEST)
+        payload["dispatchable"] = payload["action_gate"]["dispatchable"]
+        response = build_chat_response_from_delegation(payload)
+        enabled = [action["id"] for action in response["actions"] if action["enabled"]]
+        self.assertEqual(response["state"]["next_action"], "confirm_risky_action")
+        self.assertIn("confirm_risky_action", enabled)
+        self.assertNotIn("send_to_executor", enabled)
+        self.assertNotIn("send_to_codex", enabled)
+        primaries = [
+            action["id"]
+            for action in response["actions"]
+            if action["enabled"] and action["style"] == "primary"
+        ]
+        self.assertEqual(primaries, ["confirm_risky_action"])
+
+    def test_drift_still_denies_before_any_arbitration(self) -> None:
+        """The ordering invariant: a user is never asked to approve doomed work."""
+        verdict = _gate(
+            safety_preflight_request=_BROAD_WRITE_REQUEST,
+            live_safety_profile_revision="rev-moved",
+        )
+        self.assertEqual(verdict["outcome"], "deny")
+        self.assertEqual(verdict["denial"]["rule_id"], "safety_profile_revision_drift")
+        self.assertEqual(verdict["confirmation"]["ladder"], "none")
+        self.assertEqual(verdict["confirmation"]["armed_ladders"], [])
+        self.assertFalse(verdict["dispatchable"])
+        # The denial withdrew the authority, so nothing risky is left to classify.
+        self.assertEqual(verdict["action_risk"]["decision"], "allow")
+        self.assertEqual(verdict["action_risk"]["classes"], [])
+
+
+class RiskDerivationTests(unittest.TestCase):
+    """What the classifier reads, and — precisely — what that does not promise.
+
+    The earlier version of this class asserted that action risk "is not
+    message-derived". That sentence is true at this function's boundary and
+    false end to end: on the shipped lane the declared `target_paths` the
+    `broad_write` rule counts are regex-scraped out of the user's message by
+    `coding_delegation._safety_preflight_target_paths`. Both halves are now
+    asserted, because a claim that only holds at a boundary a user never sees is
+    the kind of claim this repo has had to correct twice.
+    """
+
+    def test_the_same_message_under_different_policy_inputs_yields_a_different_risk(self) -> None:
+        narrow = _gate(safety_preflight_request=_NARROW_REQUEST)
+        broad = _gate(safety_preflight_request=_BROAD_WRITE_REQUEST)
+        self.assertEqual(narrow["action_risk"]["level"], "none")
+        self.assertEqual(broad["action_risk"]["level"], "elevated")
+        self.assertNotEqual(narrow["action_risk"]["decision"], broad["action_risk"]["decision"])
+
+    def test_a_different_message_under_the_same_policy_inputs_yields_an_identical_risk(self) -> None:
+        messages = (
+            _MESSAGE,
+            "delete every file in the repository and force push to main",
+            "정말 위험한 리팩터링을 병렬로 진행해줘",
+            "",
+        )
+        baseline = None
+        for message in messages:
+            with self.subTest(message=message):
+                risk = _gate(message=message, safety_preflight_request=_BROAD_WRITE_REQUEST)["action_risk"]
+                if baseline is None:
+                    baseline = json.dumps(risk, sort_keys=True)
+                self.assertEqual(json.dumps(risk, sort_keys=True), baseline)
+
+    def test_the_classifier_has_no_parameter_that_could_carry_message_text(self) -> None:
+        parameters = set(inspect.signature(classify_action_risk).parameters)
+        for text_surface in ("message", "context_pack", "memory_recall_pack", "text"):
+            self.assertNotIn(text_surface, parameters)
+
+    def test_it_does_not_reuse_the_message_derived_isolation_risk_level(self) -> None:
+        """`isolation._risk_level` reads `message.lower()`; a safety decision may not.
+
+        Read from the tree rather than asserted in prose, so the sentence cannot
+        outlive the function it describes.
+        """
+        self.assertIn("lowered", inspect.getsource(isolation_module._risk_level))
+        self.assertIn("message.lower()", inspect.getsource(isolation_module.build_isolation_plan))
+        classifier = inspect.getsource(classify_action_risk) + inspect.getsource(risk_classes_present)
+        # It never reads the key and never calls the function that computes it.
+        self.assertNotIn('"risk_level"', classifier)
+        self.assertNotIn("_risk_level(", classifier)
+        self.assertNotIn(".lower()", classifier)
+
+    def test_the_two_risk_levels_are_named_apart_and_their_relationship_is_written_down(self) -> None:
+        payload = build_coding_delegation_payload("refactor the parallel worker pool", executor_target="codex")
+        isolation_risk = payload["isolation_plan"]["risk_level"]
+        action_risk = payload["action_gate"]["action_risk"]
+        self.assertEqual(isolation_risk, "high")
+        # They disagree, which is allowed, and the record says why in words.
+        self.assertEqual(action_risk["level"], "none")
+        self.assertIn("never compared", action_risk["isolation_risk_relationship"])
+        self.assertIn("isolation_plan.risk_level", action_risk["isolation_risk_relationship"])
+
+    def test_every_declared_input_is_a_policy_input(self) -> None:
+        for declared in ACTION_RISK_INPUTS:
+            with self.subTest(declared=declared):
+                self.assertTrue(
+                    declared.startswith(("isolation_plan.", "safety_preflight_request.", "task_authority_envelope."))
+                )
+
+    def test_the_broad_write_bound_is_a_count_of_declared_paths(self) -> None:
+        envelope = _envelope()
+        for count, expected in (
+            (MAX_UNCONFIRMED_TARGET_PATHS, []),
+            (MAX_UNCONFIRMED_TARGET_PATHS + 1, ["broad_write"]),
+        ):
+            with self.subTest(count=count):
+                request = {
+                    **_NARROW_REQUEST,
+                    "target_paths": [f"src/f{index}.py" for index in range(count)],
+                }
+                self.assertEqual(risk_classes_present(envelope=envelope, safety_preflight_request=request), expected)
+        # Well inside the bound at which the preflight denies outright, so the
+        # ask is reachable rather than shadowed by a refusal.
+        self.assertLess(MAX_UNCONFIRMED_TARGET_PATHS, MAX_TARGET_PATHS)
+
+    def test_a_declared_share_intent_or_destination_alone_raises_no_class(self) -> None:
+        """A declaration the envelope cannot act on is not a risk, it is a denial upstream.
+
+        Reading either as a risky class produced a class whose approvable action
+        the envelope never granted, so the confirmation asked about something no
+        approval could ever match. The preflight's own destination and access
+        intent rules are what refuse a reach nobody approved.
+        """
+        envelope = _envelope()
+        self.assertNotIn("external_posting", envelope["allowed_actions"])
+        self.assertEqual(risk_classes_present(envelope=envelope, safety_preflight_request=_PUBLISHING_REQUEST), [])
+        self.assertEqual(risk_classes_present(envelope=envelope, safety_preflight_request=_DESTINATION_REQUEST), [])
+        self.assertEqual(_gate(safety_preflight_request=_PUBLISHING_REQUEST)["action_risk"]["level"], "none")
+
+    def test_a_granted_external_action_is_risky_with_no_request_at_all(self) -> None:
+        for grant, expected in (("merge", "external_mutation"), ("external_posting", "publication")):
+            with self.subTest(grant=grant):
+                envelope = _envelope(grants=(grant,))
+                self.assertEqual(validate_task_authority_envelope(envelope, parent_dispatchable=True), [])
+                self.assertEqual(risk_classes_present(envelope=envelope), [expected])
+                # Present only because the envelope grants an action that can
+                # perform it, so the confirmation has something to ask about.
+                self.assertEqual(granted_risk_actions(envelope, expected), [grant])
+
+    def test_every_present_class_names_only_actions_the_envelope_granted(self) -> None:
+        envelope = _envelope(grants=("merge", "external_posting"))
+        risk = classify_action_risk(
+            envelope=envelope,
+            safety_preflight_request=_BROAD_WRITE_REQUEST,
+            owner="codex",
+            run_id="run-800",
+        )
+        allowed = set(envelope["allowed_actions"])  # type: ignore[arg-type]
+        for entry in risk["classes"]:
+            with self.subTest(risk_class=entry["class"]):
+                self.assertTrue(entry["approvable_actions"])
+                self.assertTrue(set(entry["approvable_actions"]) <= allowed)
+        for entry in risk["consent"]:
+            self.assertIn(entry["approved_action"], allowed)
+
+    def test_the_broad_write_class_is_message_sensitive_end_to_end_and_the_record_says_so(self) -> None:
+        """The honest half. This is the property that is actually true.
+
+        `broad_write` is `request_declared`, and on the shipped lane that
+        declaration is scraped out of the message, so two phrasings of one
+        intent classify differently and a request that names no path evades the
+        class entirely. The text policy has to state that, in those terms.
+        """
+        listed = "refactor the auth module: update " + " ".join(
+            f"src/module{index}/thing.py" for index in range(MAX_UNCONFIRMED_TARGET_PATHS + 2)
+        )
+        vague = "rewrite everything under src/"
+        listed_risk = build_coding_delegation_payload(listed, executor_target="codex")["action_gate"]["action_risk"]
+        vague_risk = build_coding_delegation_payload(vague, executor_target="codex")["action_gate"]["action_risk"]
+        # One intent, two phrasings, two different classifications.
+        self.assertEqual([entry["class"] for entry in listed_risk["classes"]], ["broad_write"])
+        self.assertEqual(vague_risk["classes"], [])
+        self.assertEqual(vague_risk["level"], "none")
+        entry = listed_risk["classes"][0]
+        self.assertEqual(entry["derivation"], "request_declared")
+        policy = listed_risk["text_policy"]
+        self.assertIn("_safety_preflight_target_paths", policy)
+        self.assertIn("message-sensitive", policy)
+        self.assertIn("rewrite everything under src/", policy)
+        # And the classes the envelope decides alone are named as the ones a
+        # phrasing cannot move.
+        for name in ("external_mutation", "publication"):
+            self.assertIn(name, policy)
+
+    def test_the_derivation_vocabulary_matches_what_each_rule_reads(self) -> None:
+        risk = classify_action_risk(
+            envelope=_envelope(grants=("merge", "external_posting")),
+            safety_preflight_request=_BROAD_WRITE_REQUEST,
+            owner="codex",
+            run_id="run-800",
+        )
+        derivations = {entry["class"]: entry["derivation"] for entry in risk["classes"]}
+        self.assertEqual(
+            derivations,
+            {
+                "broad_write": "request_declared",
+                "external_mutation": "policy_derived",
+                "publication": "policy_derived",
+            },
+        )
+
+
+class ExplainableVerdictTests(unittest.TestCase):
+    """Allow, deny, or ask — each one says why, and each one is checkable."""
+
+    def test_every_decision_is_explained_and_validates(self) -> None:
+        cases = {
+            "allow": _gate(safety_preflight_request=_NARROW_REQUEST),
+            "ask": _gate(safety_preflight_request=_BROAD_WRITE_REQUEST),
+            "deny": _gate(
+                safety_preflight_request=_BROAD_WRITE_REQUEST,
+                approval_receipts=[_receipt(decision="denied")],
+                now=_T_PLUS_10M,
+            ),
+            "approved": _gate(
+                safety_preflight_request=_BROAD_WRITE_REQUEST,
+                approval_receipts=[_receipt()],
+                now=_T_PLUS_10M,
+            ),
+        }
+        expected = {"allow": "allow", "ask": "ask", "deny": "deny", "approved": "allow"}
+        for label, verdict in cases.items():
+            with self.subTest(label=label):
+                risk = verdict["action_risk"]
+                self.assertEqual(risk["decision"], expected[label])
+                self.assertTrue(risk["reason"].strip())
+                self.assertEqual(validate_action_risk(risk), [])
+                gate, _ = split_handoff_safety_contract(verdict)
+                self.assertEqual(validate_action_gate_verdict(gate), [])
+
+    def test_the_five_risky_kinds_800_names_are_all_accounted_for(self) -> None:
+        self.assertEqual(
+            RISKY_ACTION_CLASSES,
+            ("broad_write", "deletion", "external_mutation", "identity_change", "publication"),
+        )
+        self.assertEqual(set(RISK_CLASS_NAMES), set(RISKY_ACTION_CLASSES))
+        risk = _gate(safety_preflight_request=_BROAD_WRITE_REQUEST)["action_risk"]
+        covered = {entry["class"] for entry in risk["classes"]} | {
+            entry["class"] for entry in risk["subsumed_classes"]
+        }
+        # The vocabulary is covered in full: nothing is quietly dropped because
+        # no declared input could assert it.
+        self.assertTrue(set(RISKY_ACTION_CLASSES) <= covered | {"external_mutation", "publication"})
+        for entry in risk["subsumed_classes"]:
+            with self.subTest(entry=entry["class"]):
+                self.assertEqual(entry["derivation"], "subsumed")
+                self.assertIn(entry["carrier"], {"broad_write", "external_mutation"})
+                self.assertTrue(entry["statement"].strip())
+
+    def test_deletion_states_why_it_cannot_be_told_apart_from_a_write(self) -> None:
+        risk = _gate(safety_preflight_request=_BROAD_WRITE_REQUEST)["action_risk"]
+        deletion = next(entry for entry in risk["subsumed_classes"] if entry["class"] == "deletion")
+        self.assertEqual(deletion["carrier"], "broad_write")
+        # The reason is read from the vocabulary that causes it.
+        self.assertEqual(ACCESS_INTENTS, ("read", "write", "share"))
+        self.assertIn("read, write, and share", deletion["statement"])
+
+    def test_identity_change_points_at_the_projection_that_would_derive_it(self) -> None:
+        risk = _gate(safety_preflight_request=_BROAD_WRITE_REQUEST)["action_risk"]
+        identity = next(entry for entry in risk["subsumed_classes"] if entry["class"] == "identity_change")
+        self.assertEqual(identity["carrier"], "external_mutation")
+        self.assertIn("account_authorization", identity["statement"])
+
+    def test_a_verdict_that_allows_while_a_present_class_is_unapproved_is_rejected(self) -> None:
+        risk = _gate(safety_preflight_request=_BROAD_WRITE_REQUEST)["action_risk"]
+        risk["decision"] = "allow"
+        errors = validate_action_risk(risk)
+        self.assertTrue(
+            any("cannot allow while a present class is unapproved" in error for error in errors), errors
+        )
+
+    def test_a_verdict_that_allows_one_class_and_ignores_another_is_rejected(self) -> None:
+        """The collapse, as a validator case: one answer may not speak for two questions."""
+        risk = classify_action_risk(
+            envelope=_envelope(grants=("merge", "external_posting")),
+            safety_preflight_request=_BROAD_WRITE_REQUEST,
+            owner="codex",
+            run_id="run-800",
+            approval_receipts=[_receipt()],
+            now=_T_PLUS_10M,
+        )
+        self.assertEqual(risk["decision"], "ask")
+        # Drop the classes that are still unapproved and claim an allow anyway.
+        risk["decision"] = "allow"
+        risk["consent"] = [entry for entry in risk["consent"] if entry["decision"] == "allow"]
+        risk["withheld_actions"] = []
+        errors = validate_action_risk(risk)
+        self.assertTrue(any("must ask about every present class" in error for error in errors), errors)
+
+    def test_a_verdict_naming_an_action_the_envelope_never_granted_is_rejected(self) -> None:
+        """The phantom-action case: a confirmation nothing could ever satisfy."""
+        verdict = _gate(safety_preflight_request=_BROAD_WRITE_REQUEST)
+        gate, _ = split_handoff_safety_contract(verdict)
+        for entry in gate["action_risk"]["consent"]:
+            entry["approved_action"] = "merge"
+            entry["approval_request"]["approved_action"] = "merge"
+        gate["action_risk"]["withheld_actions"] = ["merge"]
+        errors = validate_action_gate_verdict(gate)
+        self.assertTrue(
+            any("neither allows nor withheld" in error for error in errors), errors
+        )
+
+    def test_withheld_actions_must_be_exactly_the_unapproved_ones(self) -> None:
+        risk = _gate(safety_preflight_request=_BROAD_WRITE_REQUEST)["action_risk"]
+        risk["withheld_actions"] = []
+        errors = validate_action_risk(risk)
+        self.assertTrue(any("withheld_actions must be exactly" in error for error in errors), errors)
+
+    def test_a_verdict_with_no_reason_is_rejected(self) -> None:
+        risk = _gate(safety_preflight_request=_BROAD_WRITE_REQUEST)["action_risk"]
+        risk["reason"] = "  "
+        self.assertTrue(any("must be explained" in error for error in validate_action_risk(risk)))
+
+    def test_a_subsumed_class_with_no_carrier_is_rejected(self) -> None:
+        risk = _gate(safety_preflight_request=_BROAD_WRITE_REQUEST)["action_risk"]
+        risk["subsumed_classes"][0]["carrier"] = ""
+        errors = validate_action_risk(risk)
+        self.assertTrue(any("must name a derivable carrier" in error for error in errors), errors)
+
+    def test_a_present_class_pretending_to_be_carried_is_rejected(self) -> None:
+        risk = _gate(safety_preflight_request=_BROAD_WRITE_REQUEST)["action_risk"]
+        risk["classes"][0]["carrier"] = "publication"
+        errors = validate_action_risk(risk)
+        self.assertTrue(any("must not name a carrier" in error for error in errors), errors)
+
+    def test_a_non_object_risk_verdict_is_rejected(self) -> None:
+        self.assertEqual(validate_action_risk("risky"), ["action_risk must be an object"])
+
+
+class ApprovalBindingTests(unittest.TestCase):
+    """The five dimensions, exercised through the gate rather than the receipt module."""
+
+    def _decision(self, receipts: list[dict[str, object]], *, now: str = _T_PLUS_10M) -> dict[str, object]:
+        return _gate(
+            safety_preflight_request=_BROAD_WRITE_REQUEST,
+            approval_receipts=receipts,
+            now=now,
+        )
+
+    def _only_consent(self, verdict: dict[str, object]) -> dict[str, object]:
+        entries = verdict["action_risk"]["consent"]  # type: ignore[index]
+        self.assertEqual(len(entries), 1)
+        return entries[0]
+
+    def test_an_approval_covers_exactly_what_it_named_and_nothing_beside_it(self) -> None:
+        cases = (
+            ("sibling action", _receipt(approved_action="merge"), "action_not_approved"),
+            ("broader scope", _receipt(scope_ref="handoff_only"), "scope_not_approved"),
+            ("another owner", _receipt(owner="claude-code"), "owner_not_approved"),
+            ("another run", _receipt(run_id="run-801"), "run_not_approved"),
+            ("stale revision", _receipt(safety_profile_revision="rev-old"), "safety_revision_not_approved"),
+        )
+        for label, receipt, reason_code in cases:
+            with self.subTest(label=label):
+                verdict = self._decision([receipt])
+                self.assertEqual(verdict["action_risk"]["decision"], "ask")
+                self.assertEqual(self._only_consent(verdict)["approval"]["reason_code"], reason_code)
+                self.assertFalse(verdict["dispatchable"])
+                self.assertEqual(verdict["confirmation"]["ladder"], "risky_action")
+
+    def test_the_matching_approval_lets_the_work_proceed(self) -> None:
+        verdict = self._decision([_receipt()])
+        self.assertEqual(verdict["action_risk"]["decision"], "allow")
+        self.assertTrue(self._only_consent(verdict)["approval"]["satisfied"])
+        self.assertTrue(verdict["dispatchable"])
+        self.assertEqual(verdict["confirmation"]["ladder"], "operator_confirmation")
+
+    def test_a_missing_expired_or_revoked_approval_refuses_the_work(self) -> None:
+        """The refusal the `confirmation_answered` boundary is declared against."""
+        revoked = _receipt(decision="revoked", decided_at="2026-08-06T00:05:00Z")
+        cases = {
+            "missing": ([], _T_PLUS_10M, "ask", "approval_absent"),
+            "expired": ([_receipt()], _T_PAST_WINDOW, "ask", "approval_expired"),
+            "revoked": ([_receipt(), revoked], _T_PLUS_10M, "deny", "approval_revoked"),
+            "denied": ([_receipt(decision="denied")], _T_PLUS_10M, "deny", "approval_denied"),
+        }
+        for label, (receipts, now, decision, reason_code) in cases.items():
+            with self.subTest(label=label):
+                verdict = self._decision(receipts, now=now)
+                self.assertEqual(verdict["action_risk"]["decision"], decision)
+                self.assertEqual(self._only_consent(verdict)["approval"]["reason_code"], reason_code)
+                # Refused, not merely recorded: the escalated action is gone
+                # from the envelope and the verdict is not dispatchable.
+                self.assertFalse(verdict["dispatchable"])
+                self.assertNotIn("repo_edit", verdict["authority_envelope"]["allowed_actions"])
+                self.assertNotIn("executor_dispatch", verdict["authority_envelope"]["allowed_actions"])
+                withheld = [
+                    entry
+                    for entry in verdict["authority_envelope"]["exclusions"]
+                    if entry["reason_code"] == "withheld_pending_approval"
+                ]
+                self.assertTrue(withheld)
+                for entry in withheld:
+                    self.assertIn("until an approval on record covers it", entry["explanation"])
+
+    def test_a_refused_approval_is_not_asked_again(self) -> None:
+        verdict = self._decision([_receipt(decision="denied")])
+        confirmation = verdict["confirmation"]
+        self.assertEqual(confirmation["ladder"], "none")
+        self.assertEqual(confirmation["armed_ladders"], [])
+        self.assertIn("already refused or revoked", confirmation["reason"])
+        for entry in confirmation["suppressed_ladders"]:
+            self.assertEqual(entry["reason"], "suppressed_by:refused_approval")
+
+    def test_a_refusal_takes_the_refused_action_off_the_card(self) -> None:
+        """An operator who said no must not be offered the thing they refused."""
+        payload = build_coding_delegation_payload(_MESSAGE, executor_target="codex")
+        payload["action_gate"] = self._decision([_receipt(decision="denied")])
+        payload["dispatchable"] = payload["action_gate"]["dispatchable"]
+        response = build_chat_response_from_delegation(payload)
+        enabled = [action["id"] for action in response["actions"] if action["enabled"]]
+        self.assertNotIn("send_to_executor", enabled)
+        self.assertNotIn("send_to_codex", enabled)
+        self.assertNotEqual(response["state"]["next_action"], "send_to_executor")
+        self.assertTrue(enabled, "a refusal must still leave the user somewhere to go")
+        refused_actions = [
+            action for action in response["actions"] if action["id"] == "send_to_executor"
+        ]
+        self.assertTrue(refused_actions)
+        self.assertIn("refused or revoked", refused_actions[0]["payload"]["disabled_reason"])
+
+    def test_a_report_only_classification_disables_nothing_on_the_card(self) -> None:
+        """The overroute guard for the fix above: no run id means no refusal to render."""
+        payload = build_coding_delegation_payload(_MESSAGE, executor_target="codex")
+        payload["action_gate"] = _gate(
+            safety_preflight_request=_BROAD_WRITE_REQUEST,
+            approval_receipts=[_receipt(run_id="run-800", decision="denied")],
+            run_id="",
+            now=_T_PLUS_10M,
+        )
+        self.assertEqual(payload["action_gate"]["action_risk"]["enforcement"], "declared_not_enforced")
+        response = build_chat_response_from_delegation(payload)
+        self.assertIn("send_to_executor", [action["id"] for action in response["actions"] if action["enabled"]])
+
+    def test_the_approvals_the_gate_asks_for_are_the_ones_it_named(self) -> None:
+        risk = self._decision([])["action_risk"]
+        entry = risk["consent"][0]
+        request = entry["approval_request"]
+        self.assertEqual(entry["class"], "broad_write")
+        self.assertEqual(request["approved_action"], "repo_edit")
+        self.assertIn(request["approved_action"], APPROVABLE_ACTIONS)
+        self.assertEqual(request["scope_class"], "permission_profile")
+        self.assertEqual(request["scope_ref"], "execute_with_gates")
+        self.assertEqual(request["owner"], "codex")
+        self.assertEqual(request["run_id"], "run-800")
+        self.assertEqual(request["safety_profile_revision"], "rev-frozen")
+        self.assertEqual(entry["approval"]["expires_after_seconds"], APPROVAL_TTL_SECONDS)
+
+    def test_a_receipt_for_one_class_never_releases_another(self) -> None:
+        """The collapse, through the public API that produced it.
+
+        One receipt naming `merge` used to release `broad_write`,
+        `external_mutation`, and `publication` together, while a receipt for
+        `repo_edit` — the action that actually performs the write — was refused
+        outright because the collapsed question only ever named `merge`.
+        """
+        envelope = _envelope(grants=("merge", "external_posting"))
+
+        def classify(receipts: list[dict[str, object]]) -> dict[str, object]:
+            return classify_action_risk(
+                envelope=envelope,
+                safety_preflight_request=_BROAD_WRITE_REQUEST,
+                approval_receipts=receipts,
+                owner="codex",
+                run_id="run-800",
+                now=_T_PLUS_10M,
+            )
+
+        unanswered = classify([])
+        self.assertEqual(
+            [(entry["class"], entry["approved_action"]) for entry in unanswered["consent"]],
+            [
+                ("broad_write", "repo_edit"),
+                ("external_mutation", "merge"),
+                ("publication", "external_posting"),
+            ],
+        )
+        self.assertEqual(unanswered["withheld_actions"], ["external_posting", "merge", "repo_edit"])
+
+        merge_only = classify([_receipt(approved_action="merge")])
+        self.assertEqual(merge_only["decision"], "ask")
+        self.assertEqual(merge_only["withheld_actions"], ["external_posting", "repo_edit"])
+
+        # And the receipt naming the action that performs the write is accepted.
+        repo_only = classify([_receipt()])
+        self.assertEqual(
+            [entry["decision"] for entry in repo_only["consent"] if entry["class"] == "broad_write"], ["allow"]
+        )
+        self.assertEqual(repo_only["decision"], "ask")
+
+        every = classify(
+            [_receipt(), _receipt(approved_action="merge"), _receipt(approved_action="external_posting")]
+        )
+        self.assertEqual(every["decision"], "allow")
+        self.assertEqual(every["withheld_actions"], [])
+        self.assertEqual(validate_action_risk(every), [])
+
+    def test_declaring_more_risk_never_withholds_less_authority(self) -> None:
+        """The withhold gap: the multi-class verdict used to leave `repo_edit` granted."""
+        single = _gate(safety_preflight_request=_BROAD_WRITE_REQUEST)
+        single_withheld = {
+            entry["action"]
+            for entry in single["authority_envelope"]["exclusions"]
+            if entry["reason_code"] == "withheld_pending_approval"
+        }
+        self.assertEqual(single_withheld, {"executor_dispatch", "repo_edit"})
+        risk = classify_action_risk(
+            envelope=_envelope(grants=("merge", "external_posting")),
+            safety_preflight_request=_BROAD_WRITE_REQUEST,
+            owner="codex",
+            run_id="run-800",
+        )
+        self.assertTrue({"repo_edit"} <= set(risk["withheld_actions"]))
+        self.assertTrue(single_withheld - {"executor_dispatch"} <= set(risk["withheld_actions"]))
+
+    def test_the_gate_never_reads_the_receipt_store_itself(self) -> None:
+        """Approvals arrive already read, so the gate stays free of I/O."""
+        _gate()  # warm the lazy imports the way the contract's own offline test does
+
+        def _refuse(*args: object, **kwargs: object) -> None:
+            raise AssertionError("the action gate must not perform I/O")
+
+        with (
+            mock.patch.object(builtins, "open", _refuse),
+            mock.patch.object(socket, "socket", _refuse),
+            mock.patch.object(socket, "create_connection", _refuse),
+            mock.patch.object(subprocess, "run", _refuse),
+            mock.patch.object(subprocess, "Popen", _refuse),
+        ):
+            verdict = _gate(safety_preflight_request=_BROAD_WRITE_REQUEST, approval_receipts=[_receipt()], now=_T_PLUS_10M)
+        self.assertEqual(verdict["action_risk"]["decision"], "allow")
+
+
+class NarrowAnswerTests(unittest.TestCase):
+    """#800's "narrow" answer, through the seam that already existed for it."""
+
+    def test_the_narrowing_route_names_the_parameter_it_travels_on(self) -> None:
+        route = _gate(safety_preflight_request=_BROAD_WRITE_REQUEST)["action_risk"]["narrowing_route"]
+        self.assertEqual(route["parameter"], "requested_authority_actions")
+        self.assertNotIn("repo_edit", route["narrowed_actions"])
+        self.assertTrue(route["explanation"].strip())
+
+    def test_the_narrowed_set_removes_every_carrier_and_not_just_one(self) -> None:
+        """The promise is that re-running removes the question; one carrier is not enough.
+
+        With three classes present the route used to return the envelope's own
+        action set unchanged, because the single collapsed action it subtracted
+        (`merge`) was one the envelope never granted. Re-running with it changed
+        nothing at all.
+        """
+        envelope = _envelope(grants=("merge", "external_posting"))
+        risk = classify_action_risk(
+            envelope=envelope,
+            safety_preflight_request=_BROAD_WRITE_REQUEST,
+            owner="codex",
+            run_id="run-800",
+        )
+        route = risk["narrowing_route"]
+        self.assertNotEqual(sorted(route["narrowed_actions"]), sorted(envelope["allowed_actions"]))
+        for action in ("repo_edit", "merge", "external_posting"):
+            self.assertNotIn(action, route["narrowed_actions"])
+        # And the promise holds: the same envelope narrowed to that set carries
+        # no risky class at all.
+        narrowed_envelope = _envelope()
+        narrowed_envelope["allowed_actions"] = sorted(
+            set(route["narrowed_actions"]) & set(narrowed_envelope["allowed_actions"])  # type: ignore[arg-type]
+        )
+        narrowed_envelope["mutation_rights"] = sorted(
+            set(narrowed_envelope["allowed_actions"]) & set(MUTATING_ACTIONS)  # type: ignore[arg-type]
+        )
+        self.assertEqual(
+            risk_classes_present(
+                envelope=narrowed_envelope, safety_preflight_request=_BROAD_WRITE_REQUEST
+            ),
+            [],
+        )
+
+    def test_feeding_the_narrowed_set_back_removes_the_question(self) -> None:
+        asking = _gate(safety_preflight_request=_BROAD_WRITE_REQUEST)
+        narrowed = _gate(
+            safety_preflight_request=_BROAD_WRITE_REQUEST,
+            requested_actions=asking["action_risk"]["narrowing_route"]["narrowed_actions"],
+        )
+        self.assertEqual(narrowed["action_risk"]["decision"], "allow")
+        self.assertEqual(narrowed["confirmation"]["ladder"], "operator_confirmation")
+        self.assertNotIn("repo_edit", narrowed["authority_envelope"]["allowed_actions"])
+        narrowed_exclusions = [
+            entry
+            for entry in narrowed["authority_envelope"]["exclusions"]
+            if entry["reason_code"] == "narrowed_by_request"
+        ]
+        self.assertTrue(narrowed_exclusions)
+
+    def test_the_same_parameter_still_widens_when_it_asks_for_more(self) -> None:
+        widening = _gate(safety_preflight_request=_NARROW_REQUEST, requested_actions=["merge"])
+        self.assertEqual(widening["confirmation"]["ladder"], "permission_profile")
+        self.assertNotIn("merge", widening["authority_envelope"]["allowed_actions"])
+
+    def test_the_seam_has_a_production_caller_now(self) -> None:
+        payload = build_coding_delegation_payload(
+            _MESSAGE, executor_target="codex", requested_authority_actions=["research", "planning"]
+        )
+        envelope = payload["action_gate"]["authority_envelope"]
+        self.assertEqual(sorted(envelope["allowed_actions"]), ["planning", "research"])
+        self.assertTrue(
+            any(entry["reason_code"] == "narrowed_by_request" for entry in envelope["exclusions"])
+        )
+
+
+class AccountAuthorizationTests(unittest.TestCase):
+    """#799: the projection is implemented, the rest is declared."""
+
+    def test_a_task_that_needs_account_backed_access_says_so_and_names_the_scopes(self) -> None:
+        block = _gate()["account_authorization"]
+        self.assertTrue(block["required"])
+        self.assertEqual(block["accounts"][0]["minimum_scopes"], ["executor_dispatch"])
+        self.assertTrue(set(block["accounts"][0]["minimum_scopes"]) <= set(ACCOUNT_BACKED_ACTIONS))
+        self.assertEqual(validate_account_authorization(block), [])
+
+    def test_a_task_that_reaches_no_account_says_that_too(self) -> None:
+        block = _gate(
+            delegation_action="clarify",
+            dispatchable=False,
+            work_owner_mode="retained_hermes",
+            selected_executor_profile=None,
+            dispatch_policy="prepare_only",
+        )["account_authorization"]
+        self.assertFalse(block["required"])
+        self.assertEqual(block["accounts"], [])
+
+    def test_the_four_states_are_derived_from_signals_the_caller_already_read(self) -> None:
+        envelope = _envelope()
+        cases = (
+            ({}, "missing", "readiness_probe"),
+            ({"login_marker": "present", "observed_at": _T0}, "authorized-unverified", "login_marker"),
+            (
+                {"login_marker": "present", "probe_status": "ready", "exit_code": 0, "observed_at": _T0},
+                "observed-ready",
+                "probe_exit_code",
+            ),
+            ({"login_marker": "present", "observed_at": "2026-08-05T00:00:00Z"}, "expired", "stored_timestamp"),
+        )
+        for signal, state, source in cases:
+            with self.subTest(state=state):
+                block = build_account_authorization(
+                    envelope=envelope,
+                    auth_signals={"profiles": {"codex": signal}} if signal else None,
+                    now=_T_PLUS_10M,
+                )
+                self.assertEqual(block["accounts"][0]["state"], state)
+                self.assertEqual(block["accounts"][0]["state_source"], source)
+                self.assertIn(state, ACCOUNT_ACCESS_STATES)
+
+    def test_a_ready_probe_that_did_not_exit_zero_is_not_ready(self) -> None:
+        block = build_account_authorization(
+            envelope=_envelope(),
+            auth_signals={"profiles": {"codex": {"probe_status": "ready", "exit_code": 1, "observed_at": _T0}}},
+            now=_T_PLUS_10M,
+        )
+        self.assertEqual(block["accounts"][0]["state"], "missing")
+
+    def test_the_staleness_horizon_matches_the_signal_precedent_it_cites(self) -> None:
+        from omh.coding.executor_auth_signals import LIMIT_SIGNAL_STALE_AFTER_SECONDS
+
+        self.assertEqual(ACCOUNT_SIGNAL_STALE_AFTER_SECONDS, LIMIT_SIGNAL_STALE_AFTER_SECONDS)
+
+    def test_only_safe_references_are_carried(self) -> None:
+        envelope = _envelope()
+        named = build_account_authorization(
+            envelope=envelope, account_references={"codex": "CODEX_API_KEY"}
+        )
+        self.assertEqual(named["accounts"][0]["reference_kind"], "env_var_name")
+        self.assertEqual(named["accounts"][0]["account_ref"], "CODEX_API_KEY")
+        # A value-shaped reference is not an environment variable name, so it is
+        # never accepted as one.
+        for unsafe in ("sk-live-0123456789abcdef", "codex_api_key", "A", ""):
+            with self.subTest(unsafe=unsafe):
+                block = build_account_authorization(envelope=envelope, account_references={"codex": unsafe})
+                self.assertEqual(block["accounts"][0]["reference_kind"], "opaque_handle")
+                self.assertEqual(block["accounts"][0]["account_ref"], "codex")
+
+    def test_a_credential_value_that_matches_the_name_shape_is_still_refused(self) -> None:
+        """An AWS key id is upper-case alphanumerics; the shape alone accepted it verbatim."""
+        envelope = _envelope()
+        for value in ("AKIAIOSFODNN7EXAMPLE", "ASIAIOSFODNN7EXAMPLE"):
+            with self.subTest(value=value):
+                self.assertTrue(is_secret_value_shaped(value))
+                block = build_account_authorization(
+                    envelope=envelope, account_references={"codex": value}
+                )
+                account = block["accounts"][0]
+                self.assertEqual(account["reference_kind"], "opaque_handle")
+                self.assertNotIn(value, json.dumps(block))
+        # And the screen stays narrow: a *name* that mentions a secret is not a
+        # secret, so the ordinary case keeps working.
+        for name in ("GITHUB_TOKEN", "CODEX_API_KEY", "ANTHROPIC_API_KEY"):
+            with self.subTest(name=name):
+                self.assertFalse(is_secret_value_shaped(name))
+                block = build_account_authorization(envelope=envelope, account_references={"codex": name})
+                self.assertEqual(block["accounts"][0]["reference_kind"], "env_var_name")
+
+    def test_required_tracks_the_authority_the_task_needs_not_the_authority_it_still_has(self) -> None:
+        """`required` used to report false exactly when a risky action was withheld."""
+        withheld = _gate(safety_preflight_request=_BROAD_WRITE_REQUEST)
+        self.assertNotIn("executor_dispatch", withheld["authority_envelope"]["allowed_actions"])
+        block = withheld["account_authorization"]
+        self.assertTrue(block["required"])
+        self.assertEqual(block["accounts"][0]["minimum_scopes"], ["executor_dispatch"])
+        self.assertEqual(validate_account_authorization(block), [])
+
+    def test_a_receipt_style_credential_value_never_reaches_the_record(self) -> None:
+        block = _gate()["account_authorization"]
+        self.assertNotIn("secret", json.dumps(block).lower())
+        self.assertIn("credential", block["credential_boundary"].lower())
+
+    def test_the_unimplementable_half_is_declared_rather_than_faked(self) -> None:
+        block = _gate()["account_authorization"]
+        self.assertEqual(block["enforcement"], "declared_not_enforced")
+        self.assertEqual(block["enforced_by"], [])
+        self.assertEqual(block["blocked_by"], ACCOUNT_AUTHORIZATION_BLOCKER)
+        self.assertEqual([entry["blocker"] for entry in block["blockers"]], list(ACCOUNT_BLOCKER_NAMES))
+        consent = block["blockers"][0]
+        # The approval receipt closes the adjacent gap; the honest answer is
+        # that it is a different question, and the record says which.
+        self.assertIn("omh.workflows.approval_receipts.approval_satisfies_request_in", consent["cites"])
+        self.assertIn("different question", consent["statement"])
+        self.assertIn("rendered", block["blockers"][1]["statement"])
+
+    def test_a_projection_that_claims_enforcement_is_rejected(self) -> None:
+        block = _gate()["account_authorization"]
+        block.update({"enforcement": "enforced", "enforced_by": ["omh.coding.action_gate.evaluate_action_gate"], "blocked_by": ""})
+        errors = validate_account_authorization(block)
+        self.assertTrue(any("must stay declared_not_enforced" in error for error in errors), errors)
+
+    def test_a_credential_value_passed_off_as_a_name_is_rejected(self) -> None:
+        block = _gate()["account_authorization"]
+        block["accounts"] = [
+            {
+                "account_ref": "sk-live-secret",
+                "reference_kind": "env_var_name",
+                "minimum_scopes": ["executor_dispatch"],
+                "state": "missing",
+                "state_source": "readiness_probe",
+            }
+        ]
+        errors = validate_account_authorization(block)
+        self.assertTrue(any("never a value" in error for error in errors), errors)
+
+    def test_no_module_under_commands_launches_a_browser_or_an_auth_cli(self) -> None:
+        """The blocker says it can only ever be rendered instructions; that has to be true."""
+        source = inspect.getsource(importlib.import_module("omh.coding.action_gate"))
+        for forbidden in ("webbrowser", "subprocess", "os.system", "Popen"):
+            self.assertNotIn(forbidden, source)
+
+
+class ContractTests(unittest.TestCase):
+    """The contract changes: a flipped boundary, and the data-boundary rows."""
+
+    def _contract(self) -> dict[str, object]:
+        return build_task_handoff_safety_contract(_envelope())
+
+    def _boundary(self, name: str) -> dict[str, object]:
+        for entry in self._contract()["boundaries"]:  # type: ignore[index]
+            if entry["boundary"] == name:
+                return entry
+        raise AssertionError(f"no boundary named {name}")
+
+    def test_confirmation_answered_is_declared_and_names_the_missing_mint_path(self) -> None:
+        """The label the code backs, not the one the design wanted.
+
+        The gate does refuse — but only for a caller holding a run an approval
+        could bind to, and the shipped delegation lane has none. A boundary that
+        refuses nothing on the path users travel is `declared_not_enforced`, and
+        the blocker names why rather than pointing at an issue nobody filed.
+        """
+        entry = self._boundary("confirmation_answered")
+        self.assertEqual(entry["enforcement"], "declared_not_enforced")
+        self.assertEqual(entry["enforced_by"], [])
+        self.assertEqual(entry["blocked_by"], RISK_CONSENT_BLOCKER)
+        self.assertIn("Nothing is withheld on the shipped lane", entry["statement"])
+
+    def test_the_refusal_the_declaration_describes_is_real_for_a_run_bearing_caller(self) -> None:
+        refused = _gate(safety_preflight_request=_BROAD_WRITE_REQUEST)
+        self.assertEqual(refused["action_risk"]["enforcement"], "enforced")
+        self.assertEqual(refused["action_risk"]["enforced_by"], list(RISK_CONSENT_ENFORCERS))
+        self.assertFalse(refused["dispatchable"])
+        self.assertNotIn("repo_edit", refused["authority_envelope"]["allowed_actions"])
+
+    def test_the_dispatchable_flag_cannot_survive_an_enforced_unapproved_risky_action(self) -> None:
+        verdict = _gate(safety_preflight_request=_BROAD_WRITE_REQUEST)
+        gate, _ = split_handoff_safety_contract(verdict)
+        gate["dispatchable"] = True
+        errors = validate_action_gate_verdict(gate)
+        self.assertTrue(any("cannot stay dispatchable" in error for error in errors), errors)
+
+    def test_a_report_only_verdict_may_stay_dispatchable_and_must_say_why(self) -> None:
+        verdict = _gate(safety_preflight_request=_BROAD_WRITE_REQUEST, run_id="")
+        gate, _ = split_handoff_safety_contract(verdict)
+        self.assertTrue(gate["dispatchable"])
+        self.assertEqual(gate["action_risk"]["decision"], "ask")
+        self.assertEqual(gate["action_risk"]["enforcement"], "declared_not_enforced")
+        self.assertEqual(gate["action_risk"]["blocked_by"], RISK_CONSENT_BLOCKER)
+        self.assertEqual(validate_action_gate_verdict(gate), [])
+
+    def test_the_blocker_is_a_real_property_of_the_receipt_store_and_not_a_slogan(self) -> None:
+        """The claim behind the declaration: with no run, no receipt can exist."""
+        from omh.workflows.approval_receipts import mint_approval_receipt_at
+
+        with TemporaryDirectory() as tmp:
+            result = mint_approval_receipt_at(
+                Path(tmp) / "approval_receipts.jsonl",
+                approved_action="repo_edit",
+                scope_class="permission_profile",
+                scope_ref="execute_with_gates",
+                owner="codex",
+                run_id="",
+                safety_profile_revision="rev-frozen",
+                confirmation_ladder="risky_action",
+            )
+        self.assertFalse(result["minted"])
+        self.assertEqual(result["outcome"], "refused")
+        self.assertIn("run_id is required", result["error"])
+
+    def test_the_data_boundary_rows_come_from_the_801_facts_and_not_a_second_label_set(self) -> None:
+        facts = data_boundary_enforcement_facts()
+        by_limit = {str(limit["limit"]): limit for limit in facts["limits"]}  # type: ignore[index]
+        for limit_name in DATA_BOUNDARY_LIMIT_NAMES:
+            with self.subTest(limit=limit_name):
+                entry = self._boundary(f"data_{limit_name}")
+                limit = by_limit[limit_name]
+                self.assertEqual(entry["enforcement"], "enforced" if limit["enforced_here"] else "declared_not_enforced")
+                self.assertEqual(entry["enforced_by"], list(limit["enforced_by"]))
+                self.assertEqual(entry["blocked_by"], limit["blocked_by"])
+                self.assertTrue(entry["statement"].strip())
+
+    def test_the_advisory_row_reports_its_own_blocker_on_a_host_with_no_backend(self) -> None:
+        """A missing OS sandbox explains a host_confinement limit and nothing else.
+
+        On a host with no confinement backend the advisory row used to report
+        `no_os_confinement_backend_on_this_platform` — an OS-confinement blocker
+        for a limit no OS feature could ever enforce, and a host-dependent answer
+        to a host-independent question.
+        """
+
+        def _rows(backend: tuple[str, bool, str]) -> dict[str, dict[str, object]]:
+            with mock.patch.object(safety_preflight_module, "_host_confinement_backend", lambda: backend):
+                facts = data_boundary_enforcement_facts()
+            return {str(limit["limit"]): limit for limit in facts["limits"]}  # type: ignore[index]
+
+        capable = _rows(("sandbox-exec", True, ""))
+        bare = _rows(("unsupported", False, "no_os_confinement_backend_on_this_platform"))
+        advisory = "executor_honours_declared_targets"
+        self.assertEqual(capable[advisory]["enforcement_kind"], "advisory")
+        self.assertEqual(bare[advisory]["blocked_by"], capable[advisory]["blocked_by"])
+        self.assertNotIn("confinement_backend", str(bare[advisory]["blocked_by"]))
+        # The host_confinement rows still do move, which is the distinction.
+        self.assertEqual(capable["runtime_network_confinement"]["blocked_by"], "#820")
+        self.assertEqual(
+            bare["runtime_network_confinement"]["blocked_by"],
+            "no_os_confinement_backend_on_this_platform",
+        )
+
+    def test_the_limit_names_are_pinned_to_the_evaluator_that_owns_them(self) -> None:
+        # Mirrored rather than imported at module scope so no probe runs at
+        # import time; the pin is what stops the mirror drifting.
+        self.assertEqual(set(DATA_BOUNDARY_LIMIT_NAMES), set(PREFLIGHT_DATA_BOUNDARY_LIMIT_NAMES))
+        self.assertEqual(DATA_BOUNDARY_NAMES, tuple(f"data_{name}" for name in DATA_BOUNDARY_LIMIT_NAMES))
+
+    def test_the_declared_boundary_set_is_what_a_complete_install_produces(self) -> None:
+        self.assertEqual(safety_boundary_names(), SAFETY_BOUNDARY_NAMES)
+        self.assertIn("account_authorization", SAFETY_BOUNDARY_NAMES)
+        for name in DATA_BOUNDARY_NAMES:
+            self.assertIn(name, SAFETY_BOUNDARY_NAMES)
+
+    def test_the_host_probe_is_declared_as_an_input_source_rather_than_hidden(self) -> None:
+        self.assertIn("data_boundary_enforcement_facts", self._contract()["input_sources"])
+        self.assertTrue(self._contract()["produced_offline"])
+        # Memoized, so a delegation build does not re-probe the host.
+        self.assertIs(data_boundary_facts(), data_boundary_facts())
+
+    def test_every_newly_cited_enforcer_resolves(self) -> None:
+        cited = {
+            symbol
+            for entry in self._contract()["boundaries"]  # type: ignore[index]
+            for symbol in entry["enforced_by"]
+        }
+        self.assertTrue(cited)
+        for symbol in sorted(cited):
+            with self.subTest(symbol=symbol):
+                module_name, _, attribute = symbol.rpartition(".")
+                module = importlib.import_module(module_name)
+                self.assertTrue(hasattr(module, attribute), f"{symbol} does not exist")
+
+
+class OrdinaryCodingWorkStillFlowsTests(unittest.TestCase):
+    """The overroute guard: a normal request must not gain a new prompt."""
+
+    def test_a_normal_coding_request_never_arms_the_risky_ladder(self) -> None:
+        messages = (
+            _MESSAGE,
+            "add pagination to src/routing/chat.py and cover it with unit tests",
+            "review the changes on this branch",
+            "clean up the ai slop in src/wrapper/contract.py",
+        )
+        for message in messages:
+            for target in ("codex", "claude-code", "hermes", "generic", "choose"):
+                with self.subTest(message=message, target=target):
+                    payload = build_coding_delegation_payload(message, executor_target=target)
+                    gate = payload["action_gate"]
+                    self.assertEqual(gate["action_risk"]["decision"], "allow")
+                    self.assertEqual(gate["action_risk"]["level"], "none")
+                    self.assertNotEqual(gate["confirmation"]["ladder"], "risky_action")
+
+    def test_a_request_naming_more_files_than_the_bound_is_reported_not_blocked(self) -> None:
+        """No user request may end permanently non-dispatchable with no route forward.
+
+        The class is classified and reported. The ladder is *not* armed, because
+        the delegation lane has no run id and `build_approval_receipt` refuses
+        an empty one, so nothing an operator could do would ever produce a
+        receipt that releases the work. Arming there did not gate the request,
+        it ended it.
+        """
+        message = "fix the broken login flow and add a regression test across " + " ".join(
+            f"src/module{index}/thing.py" for index in range(MAX_UNCONFIRMED_TARGET_PATHS + 3)
+        )
+        payload = build_coding_delegation_payload(message, executor_target="codex")
+        self.assertEqual(payload["delegation"]["action"], "delegate")
+        gate = payload["action_gate"]
+        risk = gate["action_risk"]
+        self.assertEqual([entry["class"] for entry in risk["classes"]], ["broad_write"])
+        self.assertEqual(risk["decision"], "ask")
+        self.assertEqual(risk["enforcement"], "declared_not_enforced")
+        self.assertEqual(risk["blocked_by"], RISK_CONSENT_BLOCKER)
+        self.assertNotEqual(gate["confirmation"]["ladder"], "risky_action")
+        self.assertTrue(gate["dispatchable"])
+        self.assertIn("repo_edit", gate["authority_envelope"]["allowed_actions"])
+        response = build_chat_response_from_delegation(payload)
+        self.assertNotEqual(response["state"]["next_action"], "confirm_risky_action")
+
+    def test_no_ordinary_request_ends_with_nothing_the_user_can_do(self) -> None:
+        messages = (
+            _MESSAGE,
+            "refactor the auth module: update "
+            + " ".join(f"src/module{index}/thing.py" for index in range(12)),
+            "rewrite everything under src/",
+        )
+        for message in messages:
+            with self.subTest(message=message[:40]):
+                payload = build_coding_delegation_payload(message, executor_target="codex")
+                response = build_chat_response_from_delegation(payload)
+                self.assertTrue([action for action in response["actions"] if action["enabled"]])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_safety_preflight.py
+++ b/tests/test_safety_preflight.py
@@ -44,14 +44,21 @@ from omh.quality.safety_preflight import (  # noqa: E402
     FIELD_CLASS_PATH,
     FIELD_CLASS_VOCABULARY,
     FIELD_CLASSES,
+    MAX_ACCESS_INTENTS,
+    MAX_APPROVED_DESTINATIONS,
+    MAX_DATA_CLASSES,
     MAX_EVIDENCE_CLAIMS,
     MAX_PATH_CHARS,
     MAX_PERSISTED_CONTENT_REFS,
     MAX_REMOTE_TARGETS,
     MAX_TARGET_PATHS,
+    MAX_WORKSPACE_ROOTS,
     REMOTE_TARGET_KINDS,
     REQUEST_FIELDS,
+    RULE_ACCESS_INTENT_DECLARED,
     RULE_APPROVED_SCOPE_DECLARED,
+    RULE_DATA_CLASSES_PERMITTED,
+    RULE_DESTINATIONS_APPROVED,
     RULE_EVIDENCE_CLAIM_BOUNDED,
     RULE_INPUT_METADATA_BOUNDED,
     RULE_ORG_RULE_SOURCE,
@@ -61,6 +68,7 @@ from omh.quality.safety_preflight import (  # noqa: E402
     RULE_REMOTE_TARGETS_DECLARED,
     RULE_SECRETS_ABSENT,
     RULE_TARGET_PATHS_BOUNDED,
+    RULE_WORKSPACE_ROOTS_DECLARED,
     SAFETY_PREFLIGHT_PRECEDENCE,
     SECRET_SHAPE_FIELD_CLASSES,
     evaluate_safety_preflight,
@@ -79,11 +87,15 @@ GOVERNANCE_SOURCE = REPO_ROOT / "src" / "coding" / "project_governance.py"
 EXPECTED_RULE_IDS = [
     "input_metadata_bounded",
     "secrets_absent",
+    "data_classes_permitted",
     "owner_declared",
     "approved_scope_declared",
     "raw_context_declared",
+    "workspace_roots_declared",
     "target_paths_bounded",
     "remote_targets_declared",
+    "destinations_approved",
+    "access_intent_declared",
     "persisted_content_referenced",
     "evidence_claim_bounded",
     "org_rule_source",
@@ -97,14 +109,35 @@ def request(**overrides: object) -> dict[str, object]:
         "approved_scope": "issue-804",
         "message_context_mode": "bounded",
         "raw_content_included": False,
+        "data_classes": ["workspace_metadata"],
+        "workspace_roots": [],
         "target_paths": ["src/quality/safety_preflight.py"],
         "remote_targets": [],
+        "approved_destinations": [],
+        "access_intents": ["read"],
         "persisted_content_refs": [],
         "evidence_claims": ["prepared_not_observed"],
         "observed_record_refs": [],
     }
     base.update(overrides)
     return base
+
+
+def sharing_request(kind: str = "git_remote", ref: str = "origin", **overrides: object) -> dict[str, object]:
+    """A request that reaches one destination the boundary declared, with the intent that covers it.
+
+    Naming a remote target is not enough on its own after #801: the boundary
+    has to have approved that exact destination and the request has to declare
+    the share intent, so every remote-target fixture carries all three.
+    """
+    destination = {"kind": kind, "ref": ref}
+    base: dict[str, object] = {
+        "remote_targets": [dict(destination)],
+        "approved_destinations": [dict(destination)],
+        "access_intents": ["read", "share"],
+    }
+    base.update(overrides)
+    return request(**base)
 
 
 def org_document(**overrides: object) -> dict[str, object]:
@@ -163,6 +196,12 @@ class SafetyProfileIdentityTests(unittest.TestCase):
             lambda profile: profile["corrections"].__setitem__("owner_missing", "different sentence"),
             lambda profile: profile["rules"].append({"id": "extra", "axis": "x", "level": "org", "reason_codes": []}),
             lambda profile: profile["vocabularies"]["remote_target_kinds"].append("smtp"),
+            lambda profile: profile["vocabularies"]["data_classes"].append("telemetry"),
+            lambda profile: profile["vocabularies"]["prohibited_data_classes"].clear(),
+            lambda profile: profile["vocabularies"]["access_intents"].append("delete"),
+            lambda profile: profile["bounds"].__setitem__("max_workspace_roots", MAX_WORKSPACE_ROOTS + 1),
+            lambda profile: profile["data_boundary_limits"][0].__setitem__("enforcement_kind", "advisory"),
+            lambda profile: profile["boundary_fields"].append("target_paths"),
         ):
             with self.subTest(mutate=mutate):
                 mutated = safety_rule_profile()
@@ -467,6 +506,153 @@ class SafetyPreflightDenialTests(unittest.TestCase):
                 "observed_record_refs[0]",
                 "observed_record_ref_invalid",
             ),
+            # #801 data boundary. Same contract as every rule above: the
+            # verdict names the rule, the offending field, and the correction.
+            (
+                "data classes not a list",
+                request(data_classes="workspace_source"),
+                RULE_DATA_CLASSES_PERMITTED,
+                "data_classes",
+                "data_class_not_bounded",
+            ),
+            (
+                "too many data classes",
+                request(data_classes=["workspace_source"] * (MAX_DATA_CLASSES + 1)),
+                RULE_DATA_CLASSES_PERMITTED,
+                "data_classes",
+                "data_class_count_exceeded",
+            ),
+            (
+                "unknown data class",
+                request(data_classes=["telemetry"]),
+                RULE_DATA_CLASSES_PERMITTED,
+                "data_classes[0]",
+                "data_class_unknown",
+            ),
+            (
+                "prohibited data class",
+                request(data_classes=["workspace_source", "personal_data"]),
+                RULE_DATA_CLASSES_PERMITTED,
+                "data_classes[1]",
+                "data_class_prohibited",
+            ),
+            (
+                "prohibited class content in an opaque ref",
+                request(persisted_content_refs=["ssn-123-45-6789"]),
+                RULE_DATA_CLASSES_PERMITTED,
+                "persisted_content_refs[0]",
+                "prohibited_data_class_content",
+            ),
+            (
+                "workspace roots not a list",
+                request(workspace_roots="src"),
+                RULE_WORKSPACE_ROOTS_DECLARED,
+                "workspace_roots",
+                "workspace_root_not_bounded",
+            ),
+            (
+                "too many workspace roots",
+                request(workspace_roots=[f"src/p{index}" for index in range(MAX_WORKSPACE_ROOTS + 1)]),
+                RULE_WORKSPACE_ROOTS_DECLARED,
+                "workspace_roots",
+                "workspace_root_count_exceeded",
+            ),
+            (
+                "absolute workspace root",
+                request(workspace_roots=["/etc"]),
+                RULE_WORKSPACE_ROOTS_DECLARED,
+                "workspace_roots[0]",
+                "workspace_root_absolute",
+            ),
+            (
+                "escaping workspace root",
+                request(workspace_roots=["../other-project"]),
+                RULE_WORKSPACE_ROOTS_DECLARED,
+                "workspace_roots[0]",
+                "workspace_root_escapes_project",
+            ),
+            (
+                "target outside the approved roots",
+                request(workspace_roots=["docs"], target_paths=["src/quality/safety_preflight.py"]),
+                RULE_TARGET_PATHS_BOUNDED,
+                "target_paths[0]",
+                "target_path_outside_workspace_roots",
+            ),
+            (
+                "approved destination without a ref key",
+                request(approved_destinations=[{"kind": "git_remote"}]),
+                RULE_DESTINATIONS_APPROVED,
+                "approved_destinations[0]",
+                "approved_destination_not_bounded",
+            ),
+            (
+                "too many approved destinations",
+                request(
+                    approved_destinations=[
+                        {"kind": "git_remote", "ref": f"remote-{index}"}
+                        for index in range(MAX_APPROVED_DESTINATIONS + 1)
+                    ]
+                ),
+                RULE_DESTINATIONS_APPROVED,
+                "approved_destinations",
+                "approved_destination_count_exceeded",
+            ),
+            (
+                "unknown approved destination kind",
+                request(approved_destinations=[{"kind": "smtp", "ref": "mail"}]),
+                RULE_DESTINATIONS_APPROVED,
+                "approved_destinations[0].kind",
+                "approved_destination_kind_unknown",
+            ),
+            (
+                "approved destination without a ref",
+                request(approved_destinations=[{"kind": "git_remote", "ref": ""}]),
+                RULE_DESTINATIONS_APPROVED,
+                "approved_destinations[0].ref",
+                "approved_destination_ref_missing",
+            ),
+            (
+                "destination the boundary never declared",
+                request(remote_targets=[{"kind": "git_remote", "ref": "origin"}]),
+                RULE_DESTINATIONS_APPROVED,
+                "remote_targets[0]",
+                "destination_not_declared",
+            ),
+            (
+                "access intents not a list",
+                request(access_intents="read"),
+                RULE_ACCESS_INTENT_DECLARED,
+                "access_intents",
+                "access_intent_not_bounded",
+            ),
+            (
+                "too many access intents",
+                request(access_intents=["read"] * (MAX_ACCESS_INTENTS + 1)),
+                RULE_ACCESS_INTENT_DECLARED,
+                "access_intents",
+                "access_intent_count_exceeded",
+            ),
+            (
+                "unknown access intent",
+                request(access_intents=["exfiltrate"]),
+                RULE_ACCESS_INTENT_DECLARED,
+                "access_intents[0]",
+                "access_intent_unknown",
+            ),
+            (
+                "declared destination reached without the share intent",
+                sharing_request(access_intents=["read"]),
+                RULE_ACCESS_INTENT_DECLARED,
+                "access_intents",
+                "access_intent_undeclared",
+            ),
+            (
+                "share intent the boundary approved no destination for",
+                request(access_intents=["read", "share"]),
+                RULE_ACCESS_INTENT_DECLARED,
+                "access_intents",
+                "access_intent_unapproved",
+            ),
         ]
 
     def test_every_denial_names_the_rule_the_field_and_a_correction(self) -> None:
@@ -705,7 +891,7 @@ class OrgLevelTests(unittest.TestCase):
 
     def test_the_org_level_narrows_and_names_the_offending_field(self) -> None:
         verdict = evaluate_safety_preflight(
-            request(remote_targets=[{"kind": "public_internet", "ref": "example-host"}]),
+            sharing_request("public_internet", "example-host"),
             org_rule_source=self.available(denied_remote_target_kinds=["public_internet"]),
         )
         self.assertEqual(verdict["status"], "deny")
@@ -749,7 +935,7 @@ class OrgLevelTests(unittest.TestCase):
 
     def test_the_same_input_and_revision_yields_the_same_decision_with_the_org_level(self) -> None:
         source = self.available(denied_remote_target_kinds=["public_internet"], max_target_paths=2)
-        candidate = request(remote_targets=[{"kind": "git_remote", "ref": "origin"}])
+        candidate = sharing_request()
         first = json.dumps(evaluate_safety_preflight(candidate, org_rule_source=source), sort_keys=True)
         for _ in range(5):
             self.assertEqual(
@@ -785,8 +971,11 @@ class RevisionRecheckTests(unittest.TestCase):
 class NoModelNoNetworkNoDependencyTests(unittest.TestCase):
     """Asserted by construction: the imports are the whole story."""
 
+    # `sys` joined the set for `data_boundary_enforcement_facts()`: naming the
+    # platform is how the per-host confinement answer stays a probe instead of
+    # a claim. Still stdlib, still no process, no socket, no model.
     ALLOWED_IMPORTS = frozenset(
-        {"__future__", "ast", "collections", "hashlib", "json", "os", "pathlib", "re", "time", "typing"}
+        {"__future__", "ast", "collections", "hashlib", "json", "os", "pathlib", "re", "sys", "time", "typing"}
     )
     FORBIDDEN_IMPORTS = frozenset(
         {"socket", "ssl", "urllib", "http", "requests", "httpx", "aiohttp", "subprocess", "asyncio"}
@@ -915,13 +1104,10 @@ class EndToEndOrgSourceTests(unittest.TestCase):
             path = write_org_source(root, denied_remote_target_kinds=["public_internet"])
             source = read_org_safety_rule_source(path)
             denied = evaluate_safety_preflight(
-                request(remote_targets=[{"kind": "public_internet", "ref": "example-host"}]),
+                sharing_request("public_internet", "example-host"),
                 org_rule_source=source,
             )
-            allowed = evaluate_safety_preflight(
-                request(remote_targets=[{"kind": "git_remote", "ref": "origin"}]),
-                org_rule_source=source,
-            )
+            allowed = evaluate_safety_preflight(sharing_request(), org_rule_source=source)
         self.assertEqual(denied["status"], "deny")
         self.assertEqual(denied["reason_code"], "org_rule_denied")
         self.assertEqual(allowed["status"], "allow")

--- a/tests/test_task_authority_envelope.py
+++ b/tests/test_task_authority_envelope.py
@@ -893,14 +893,16 @@ class WhatThePreflightStillDeniesTests(unittest.TestCase):
         no org failure mode can deny it. The org level is reachable only from a
         direct evaluator call today.
         """
-        from omh.coding.coding_delegation import _safety_preflight_verdict
+        from omh.coding.coding_delegation import _safety_preflight_request, _safety_preflight_verdict
 
         verdict = _safety_preflight_verdict(
-            _MESSAGE,
-            owner="codex",
-            workflow="plan",
-            message_context_mode="full",
-            raw_content_included=False,
+            _safety_preflight_request(
+                _MESSAGE,
+                owner="codex",
+                workflow="plan",
+                message_context_mode="full",
+                raw_content_included=False,
+            )
         )
         self.assertEqual(verdict["levels_applied"], ["builtin_omh"])
         self.assertEqual(verdict["org_reason_codes"], [])


### PR DESCRIPTION
# Consent triad: data boundaries, run-bound approval receipts, and risky-action classification (closes #801, #807, #799; advances #800)

## What capability changed

- **#801 data boundaries** — a delegation now declares workspace roots, read/write/share intent, data classes, and approved destinations, evaluated by the same rule profile that already gates paths and secrets, so the declaration is pinned by `safety_profile_revision`.
- **#807 approval receipts** — a new append-only store records an operator's answer as a record with its own lifetime, bound to one action, scope, owner, run, and safety revision.
- **#800 risky-action classification** — every prepared delegation carries a per-class risk verdict with an explicit consent entry per risky class, and says on its own record whether that verdict was backed by enforcement.
- **#799 account authorization** — the account states OMH can honestly derive (missing, authorized-unverified, observed-ready, expired) are projected from existing readiness and auth-marker signals; the parts OMH cannot observe are declared, not implied.

## Why

Three P0 issues describe one thing from three angles: what may this task touch, what did the operator agree to, and does it need an account. Each was previously either folklore or a field nothing read.

## What is honest about this PR

`#800` is **advanced, not closed**, and the reason is the interesting part.

The first implementation classified risk, withheld authority, armed a confirmation ladder, and flipped the contract's `confirmation_answered` boundary to `enforced`. An adversarial review then reproduced, through the real APIs, that the prompt could never be answered: `run_id` is empty when a delegation is built, and an approval receipt requires one, so no receipt that could satisfy the request was constructible. A user naming nine files in a message ended up permanently non-dispatchable with no route forward, behind a button whose answer nothing could record.

Building an answer path here would have meant a new intake surface plus run-id plumbing at prepare time — and minting a receipt from inside the build would be self-approval. So the enforcement was **taken back down**: risk is classified and reported, authority is withheld only when a caller supplies a real run, and `confirmation_answered` returns to `declared_not_enforced` naming the missing intake as its blocker. Every verdict now carries `enforcement` / `enforced_by` / `blocked_by` so a record says for itself whether its decision was backed.

That follows the rule #818 established: a label the code does not back is worse than no label.

## Implementation at the boundary level

**Consent is per risky class.** An earlier shape collapsed every present class into one approvable action and asked about that. A single receipt naming `merge` — an action the envelope never grants — released a broad repo write and a publication, while a receipt for `repo_edit`, the action that actually performs the write, was refused. Worse, the withheld set named the phantom, so declaring *more* risk withheld *less* authority. Now each present class carries its own consent entry against an action the envelope can actually grant, `allow` requires every class approved, and two validators reject a verdict that approves what it did not ask about.

**Approvals cannot widen.** Matching is equality on action, scope, owner, run, and safety revision, with no containment rule anywhere — five distinct refusal codes, verified through the gate and not only the receipt module. Expiry is evaluated at read time against a TTL in code rather than a deadline on disk, because nothing deletes the artifact and a stored deadline is a second writable field.

**Risk classification is message-sensitive and now says so.** It was documented as policy-derived and never message-derived, and a test asserted it — true at the function boundary, false end to end, because the target paths it reads are scraped from the user's message. Two phrasings of one intent classified differently and "rewrite everything under src/" sailed through with zero declared paths. The claim is now replaced everywhere with a statement of exactly what is read and how it can be evaded, and the test was rewritten to check the property that is actually true.

**Data boundaries live in the rule profile,** not a parallel module, so "approval binds to a safety revision" binds to the data boundary for free. Data classes are a closed vocabulary field class on purpose: classing them as opaque references would run credential-shape detection over the literal string `credential_material` and deny the request that correctly declares what it must not carry. Host confinement facts sit **outside** the digest, because a host-dependent digest reads as drift on another machine.

## Verification observed

- Full suite **Ran 3971 tests, OK** (baseline on merged main: 3815; +156).
- `ruff check src tests` clean; `docs workflows/roles/capability-families --check` all ok; `compileall` and `git diff --check` clean.
- Adversarial review confirmed 18 findings (8 high) against the first implementation. Every fix was then verified by mutation: the tree was copied, each fix reverted in turn across twelve mutations, and each produced failures in exactly the targeted tests before the sources were restored.
- The review's own probes were re-run and their new output recorded: the collapse now yields one consent entry per class, a `repo_edit` receipt approves the broad write it actually performs, withholding grows with declared risk, a refused verdict leaves no refused action enabled on the card, and the shipped lane no longer blocks an ordinary multi-file request.

## Risks and follow-ups

- `#800` needs an answer-intake surface and run-id plumbing before its ladder can be armed on the shipped lane; that is the named blocker on `confirmation_answered`.
- Within one run, one hour, and one owner/profile/revision, a second delegation is covered by the first answer for the same class and action. That is the designed scope of a run-bound approval, probed and written into the docstring rather than claimed otherwise.
- `deletion` and `identity_change` remain subsumed: no request vocabulary asserts a delete intent or an account rotation.
- The env-var-name screen is bounded to the tree's existing credential detectors; a credential none of them recognises still passes the name shape.
- The optional-store validator registry still needs one reader per store (#846).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
