### PR TITLE
feat: safe blocked-work records, a decision history, and one shared append-only store (closes #808, #806)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -152,6 +152,7 @@ src/
     quickstart.py
 
   system/
+    append_only_store.py
     hashutil.py
     ingress.py
     local_store.py
@@ -921,10 +922,73 @@ return `runtime.recorded=false` and should stay in wrapper/session state.
 
 `runtime/journal/approval_receipts.jsonl` is an append-only store of
 `approval_receipt/v1` records: one per answer an operator gave to a confirmation
-ladder. It is the second store in the journal directory and follows the same
+ladder. It is the second store in the journal directory and runs on the same
 mechanics as the first — JSONL appended under `local_store.file_lock`, an append
 that terminates a torn tail first, closed vocabularies everywhere including at
 render, idempotent minting, and supersession by link rather than by rewrite.
+
+Those mechanics are not copied between the two families; both call
+`system/append_only_store.py`, which owns the torn-tail-safe append, the
+supersede-chain walk, the opaque-reference guards, the digest handles, the
+identity fingerprint, and the best-effort mint-failure sidecar. What the base
+deliberately does not own is anything domain-shaped: each family keeps its own
+closed key tuple, field-class guard tables, vocabularies, schema versions,
+`CLAIM_BOUNDARY`, and predicates, because the reason the families are separate
+is that those must not converge.
+
+`runtime/journal/blocked_work_records.jsonl` is the third store, holding
+`blocked_work_record/v1` records: one per decision a gate reached about one
+request shape — blocked, allowed, cancelled, failed, or completed. It runs on
+the same base, told its own key names (`record_id`, `supersedes_record_ref`) so
+the shared supersede walk reports records rather than receipts it has none of.
+
+It exists because a denied gate used to leave nothing behind. `coding_delegation`
+collapses a denial through `denied_executor_selection()`, and `commands/coding`
+then returns `runtime.recorded=false`, so a preflight denial created no run,
+wrote no `coding_delegation.json`, and appended no journal event — and "why was
+this blocked?" had no answer once the turn ended. Most records in this store
+therefore carry an empty `run_id` by design: the decision precedes any run, which
+is why the store is runtime-wide and why per-run validation can never be its only
+check.
+
+Nothing on a record can name what was blocked. The key set is closed, there is no
+free-text field at all, and reference fields refuse anything path-shaped — the
+shared opaque-ref guard permits `/` because approval receipts store a scope path
+on purpose, and this family must not inherit that. What identifies a request is
+`request_fingerprint`, a digest of the *multiset of field classes and
+closed-vocabulary values present*, taken from `safety_preflight.FIELD_CLASSES`
+rather than restated. No caller-authored value is an input, so unlike a truncated
+sha of a filename it cannot be inverted by hashing a dictionary of candidate
+paths.
+
+`project_decision_history` (issue #806) is a projection over these records, in
+the shape of `project_external_effects` and `project_run_lifecycle` — derived,
+never stored, because a second store over one decision sequence is a fork by
+construction and the supersede walk already rejects forks. It records **allows**
+alongside blocks, which is what makes "an allow is never rendered as attempted or
+completed" a property of the `OUTCOME_WORK_CLAIMS` table that something can
+violate, rather than an accidental absence of rows.
+
+`DECISION_SOURCES` is split into enforcing and observing sources. The Hermes
+plugin hook contract has no deny channel — `pre_tool_call` returns injected
+context or `None`, and `pre_verify`'s only action value is `"continue"` — so a
+hook can mint a record *about* a block something else performed and is pinned to
+`declared_not_enforced` with a stated blocker. It cannot mint an allow at all.
+
+**What is wired, as opposed to declared.** The vocabularies above are wider than
+the lanes that use them, and reading `DECISION_SOURCES` as a coverage claim would
+be wrong. One producer mints today: `commands/coding.py`, one record per
+`omh coding delegate` build, from the single action-gate verdict through
+`decision_from_action_gate`. That reaches the `safety_preflight` and `action_gate`
+sources and their two reason domains. `approval_gate` and `runtime_claim_gate`
+**mint nothing yet**, and neither does any observing source; they are declared
+because the reason domains a record from those gates would cite are the ones it
+would have to join, and adding sources to a shipped record family is a migration.
+Two surfaces read the store: `omh runtime export` carries `decision_history`, and
+`omh runtime validate` carries the store's integrity report. There is no
+dedicated history command. `tests/test_blocked_work_records.py`
+(`CoverageIsWhatTheDocsSay`) fails when a producer or a read surface is added, so
+this paragraph cannot drift away from the wiring silently.
 
 **Why this is a record family and not a field group.** This repo refused a new
 family twice (#811, #818) because a family joins on run id and a join is where an

--- a/src/coding/coding_delegation.py
+++ b/src/coding/coding_delegation.py
@@ -69,6 +69,7 @@ from ..isolation import build_isolation_plan
 from ..memory import validate_handoff_context_blocked, validate_handoff_context_pack, validate_project_memory_recall_pack
 from ..routing.executor_cues import contains_boundary_phrase
 from ..routing.recommend import recommend_skills
+from ..workflows.blocked_work_records import decision_from_action_gate, request_class_shape
 from ..skills.catalog import (
     CODING_INTENT_PRIORITY,
     CODING_REVIEW_TERMS,
@@ -500,6 +501,19 @@ def build_coding_delegation_payload(
             },
             "action_gate": action_gate,
             "handoff_safety_contract": handoff_safety_contract,
+            # What the recording surface needs to persist this decision, derived
+            # here because this is where the decision was made. `commands.coding`
+            # must not re-read the verdict to decide what to store: the gate is
+            # the single decision path, and a second reading of it is a second
+            # answer. Only the request's *class shape* travels -- never the
+            # request -- so this block is safe to serialize wherever the payload
+            # goes.
+            "blocked_work_decision": decision_from_action_gate(
+                action_gate,
+                owner=preflight_request.get("owner", "hermes") or "hermes",
+                safety_profile_revision=live_safety_profile_revision or "",
+                class_shape=request_class_shape(preflight_request),
+            ),
         }
     )
     if isolation_plan:

--- a/src/coding/hermes_harness.py
+++ b/src/coding/hermes_harness.py
@@ -68,6 +68,7 @@ def build_hermes_coding_harness(
     observed_events = _string_set(observation.get("observed_events"))
     blocked_events = _string_set(observation.get("blocked_events"))
     failed_events = _string_set(observation.get("failed_events"))
+    cancelled_events = _string_set(observation.get("cancelled_events"))
     unsatisfied_events = _unsatisfied_events(observation, observed_events=observed_events)
     latest_by_event = _mapping(observation.get("latest"))
     resolved_start_mode = _resolve_start_mode(start_mode, handoff=handoff, observed_events=observed_events, latest_by_event=latest_by_event)
@@ -110,6 +111,7 @@ def build_hermes_coding_harness(
         observed_events=observed_events,
         blocked_events=blocked_events,
         failed_events=failed_events,
+        cancelled_events=cancelled_events,
         unsatisfied_events=unsatisfied_events,
         projection_missing_evidence=_projection_missing_evidence(
             verification_matrix=verification_matrix,
@@ -599,11 +601,18 @@ def _harness_status(
     observed_events: set[str],
     blocked_events: set[str],
     failed_events: set[str],
+    cancelled_events: set[str],
     unsatisfied_events: set[str],
     projection_missing_evidence: set[str],
 ) -> str:
     if failed_events:
         return "failed"
+    # Ahead of `blocked`, because a cancellation is the stronger statement: a
+    # block says work is waiting on something, a cancellation says nobody is
+    # waiting any more. Without this branch a cancelled run reported
+    # `in_progress`, which is wrong in both directions at once.
+    if cancelled_events:
+        return "cancelled"
     if blocked_events:
         return "blocked"
     if "merge" in observed_events and not unsatisfied_events and not projection_missing_evidence:

--- a/src/coding/work_reporting.py
+++ b/src/coding/work_reporting.py
@@ -19,7 +19,21 @@ WORK_OBSERVATION_SUMMARY_SCHEMA_VERSION = "work_observation_summary/v1"
 WORK_REPORT_MARKDOWN_EXPORT_SCHEMA_VERSION = "work_report_markdown_export/v1"
 WORK_OBSERVATION_EVENT_REF_SCHEMA_VERSION = "work_observation_event_ref/v1"
 REPORT_KINDS = ("progress", "completion", "blocker", "status")
-REPORT_STATUSES = ("prepared_not_observed", "in_progress", "completed", "blocked", "failed", "unknown")
+# `cancelled` is a member because a report whose only terminal options are
+# `completed`, `blocked`, and `failed` has to file a deliberate stop as one of
+# them, and each of the three is a different claim: `failed` says the work ran
+# and did not work, `blocked` says something is in the way, and neither is true
+# of work someone chose to stop. #808 AC2 requires the four to stay apart, and a
+# report is one of the places they are read.
+REPORT_STATUSES = (
+    "prepared_not_observed",
+    "in_progress",
+    "completed",
+    "blocked",
+    "cancelled",
+    "failed",
+    "unknown",
+)
 MAX_TITLE_CHARS = 120
 MAX_LEARNING_NOTE_CHARS = 180
 MAX_BLOCKERS = 5
@@ -58,8 +72,11 @@ _POST_PREPARED_NEXT_ACTIONS = {
 }
 _VERIFICATION_SUCCESS_STATUSES = {"passed", "satisfied", "completed", "verified"}
 _NON_PROGRESS_STATUSES = {"", "not_observed", "not_required", "pending"}
-_OBSERVATION_EVENT_STATUSES = ("observed", "blocked", "failed", "not_observed")
-_OBSERVATION_EVENT_EVIDENCE_STATUSES = {"observed", "blocked", "failed"}
+# Kept in step with `runtime.records.RUNTIME_OBSERVATION_STATUSES`. A status the
+# journal can hold and this tuple lacks is folded to `not_observed` by `_choice`,
+# which is how a cancelled event used to report as one nobody had looked at yet.
+_OBSERVATION_EVENT_STATUSES = ("observed", "blocked", "cancelled", "failed", "not_observed")
+_OBSERVATION_EVENT_EVIDENCE_STATUSES = {"observed", "blocked", "cancelled", "failed"}
 _INTERNAL_REPORT_MARKERS = (
     "[OMH Awareness]",
     "OMH Awareness Primer",
@@ -90,14 +107,21 @@ _CHECK_STATUS_ALIASES = {
     "failed": "fail",
     "failure": "fail",
     "error": "fail",
-    "cancelled": "fail",
-    "canceled": "fail",
+    # A cancelled check is not a failing check. Folding the two lost the only
+    # thing that separates "this ran and did not pass" from "nobody let it
+    # finish", and the first of those is a claim about the change under test
+    # that the second does not support.
+    "cancelled": "cancelled",
+    "canceled": "cancelled",
     "timed_out": "fail",
     "timed-out": "fail",
     "action_required": "fail",
     "startup_failure": "fail",
 }
-_CHECK_STATUS_ORDER = ("fail", "pending", "pass", "skipped", "unknown")
+# Reporting precedence. `cancelled` sits directly after `fail` because both are
+# reasons the gate is not satisfied, and ahead of `pending` because a cancelled
+# check will not resolve itself the way a pending one will.
+_CHECK_STATUS_ORDER = ("fail", "cancelled", "pending", "pass", "skipped", "unknown")
 _CHECK_WATCH_NOISE = (
     "refreshing checks status",
     "press ctrl+c to quit",
@@ -822,6 +846,11 @@ def _ko_status_sentence(title: str, status: str) -> str:
         return f"{title} 작업은 끝났어."
     if status == "blocked":
         return f"{title} 작업은 지금 막혀 있어."
+    # `cancelled` is a `REPORT_STATUSES` member, so a summary can carry it. With
+    # no branch here it fell through to the trailing "진행 중": the Korean report
+    # said the work was in progress about work someone had stopped.
+    if status == "cancelled":
+        return f"{title} 작업은 중간에 취소됐어."
     if status == "failed":
         return f"{title} 작업에서 실패가 확인됐어."
     if status == "prepared_not_observed":
@@ -836,6 +865,8 @@ def _ko_polite_status_sentence(title: str, status: str) -> str:
         return f"{title} 작업은 완료되었습니다."
     if status == "blocked":
         return f"{title} 작업은 현재 막혀 있습니다."
+    if status == "cancelled":
+        return f"{title} 작업은 중간에 취소되었습니다."
     if status == "failed":
         return f"{title} 작업에서 실패가 확인되었습니다."
     if status == "prepared_not_observed":
@@ -1109,13 +1140,13 @@ def _normalize_check_conclusion(value: str) -> str:
         return "pass"
     if normalized in {"skip", "skipped"}:
         return "skipped"
+    if normalized in {"cancelled", "canceled"}:
+        return "cancelled"
     if normalized in {
         "fail",
         "failed",
         "failure",
         "error",
-        "cancelled",
-        "canceled",
         "timed_out",
         "action_required",
         "startup_failure",
@@ -1137,19 +1168,19 @@ def _english_check_line(row: dict[str, str]) -> str:
 
 
 def _friendly_ko_check_summary(counts: dict[str, int]) -> str:
-    labels = {"pass": "통과", "pending": "대기 중", "fail": "실패", "skipped": "건너뜀", "unknown": "상태 미확인"}
+    labels = {"pass": "통과", "pending": "대기 중", "fail": "실패", "cancelled": "취소됨", "skipped": "건너뜀", "unknown": "상태 미확인"}
     parts = [f"{counts[status]}개 {labels[status]}" for status in _CHECK_STATUS_ORDER if counts.get(status)]
     return f"체크는 {', '.join(parts)}이야." if parts else "확인할 체크 행은 없었어."
 
 
 def _polite_ko_check_summary(counts: dict[str, int]) -> str:
-    labels = {"pass": "통과", "pending": "대기 중", "fail": "실패", "skipped": "건너뜀", "unknown": "상태 미확인"}
+    labels = {"pass": "통과", "pending": "대기 중", "fail": "실패", "cancelled": "취소됨", "skipped": "건너뜀", "unknown": "상태 미확인"}
     parts = [f"{counts[status]}개 {labels[status]}" for status in _CHECK_STATUS_ORDER if counts.get(status)]
     return f"체크는 {', '.join(parts)}입니다." if parts else "확인할 체크 행은 없습니다."
 
 
 def _ko_check_line(row: dict[str, str]) -> str:
-    labels = {"pass": "통과", "pending": "대기", "fail": "실패", "skipped": "건너뜀", "unknown": "미확인"}
+    labels = {"pass": "통과", "pending": "대기", "fail": "실패", "cancelled": "취소됨", "skipped": "건너뜀", "unknown": "미확인"}
     suffix = _check_suffix(row)
     return f"- {row['name']}: {labels.get(row['status'], row['status'])}{suffix}"
 
@@ -1297,17 +1328,25 @@ def _status_from_status_payload(status_payload: dict[str, Any]) -> str:
         "report_merge_ready",
         "report_merged",
     }
-    failed_or_blocked = _failed_or_blocked_status(execution, verification, review, ci, merge)
-    if failed_or_blocked:
-        return failed_or_blocked
-    runtime_failed_or_blocked = _runtime_failed_or_blocked_status(runtime_observation)
-    if runtime_failed_or_blocked:
-        return runtime_failed_or_blocked
+    stage_terminal = _terminal_stage_status(execution, verification, review, ci, merge)
+    if stage_terminal:
+        return stage_terminal
+    runtime_terminal = _runtime_terminal_status(runtime_observation)
+    if runtime_terminal:
+        return runtime_terminal
     runtime_terminal_requested = _runtime_terminal_requested(runtime_observation)
     if (terminal_requested or runtime_terminal_requested) and _runtime_completion_satisfied(runtime_observation):
         return "completed"
     if terminal_requested and _terminal_evidence_satisfied(execution, verification, review, ci, merge):
         return "completed"
+    # Checked ahead of the generic `surface_` fold, which returns `blocked` for
+    # everything. `summarize_runtime_observation_status` emits
+    # `surface_runtime_cancellation:` and `surface_runtime_cancelled:`, and both
+    # would otherwise have reported a cancelled run as blocked.
+    if next_action.startswith("surface_runtime_cancel"):
+        return "cancelled"
+    if next_action.startswith("surface_runtime_failed") or next_action.startswith("surface_runtime_failure"):
+        return "failed"
     if next_action.startswith("surface_") or "blocker" in next_action:
         return "blocked"
     if str(prepared.get("status", "")) == "prepared_not_observed" and not _post_prepared_work_observed(
@@ -1414,6 +1453,7 @@ def _runtime_observation_events(runtime_observation: dict[str, Any]) -> list[dic
         ("observed_events", "observed"),
         ("blocked_events", "blocked"),
         ("failed_events", "failed"),
+        ("cancelled_events", "cancelled"),
         ("not_observed_events", "not_observed"),
         ("missing_events", "not_observed"),
     ):
@@ -1434,6 +1474,7 @@ def _runtime_observation_applicable(runtime_observation: dict[str, Any]) -> bool
         _string_items(runtime_observation.get("observed_events"))
         or _string_items(runtime_observation.get("blocked_events"))
         or _string_items(runtime_observation.get("failed_events"))
+        or _string_items(runtime_observation.get("cancelled_events"))
         or _string_items(runtime_observation.get("not_observed_events"))
         or next_action in {"report_runtime_observed", "record_runtime_observation"}
         or next_action.startswith("record_runtime_observation:")
@@ -1459,26 +1500,39 @@ def _runtime_observation_event_status(record: dict[str, Any], fallback_status: s
     status = _token(record.get("status") or fallback_status)
     if status in {"observed", "completed", "passed", "satisfied", "success", "succeeded", "verified"}:
         return "observed"
-    if status in {"blocked", "failed"}:
+    if status in {"blocked", "cancelled", "failed"}:
         return status
     return "not_observed"
 
 
-def _failed_or_blocked_status(*stages: dict[str, Any]) -> str:
+def _terminal_stage_status(*stages: dict[str, Any]) -> str:
+    """The strongest ending any stage reports, or empty when none ended.
+
+    Precedence `failed` > `cancelled` > `blocked`: a failure is a claim about the
+    work, a cancellation is a claim about the decision to stop it, and a block is
+    the weakest of the three because it is the only recoverable one.
+    """
+    cancelled = False
     blocked = False
     for stage in stages:
         status = str(stage.get("status", ""))
         if status == "failed":
             return "failed"
-        if status == "blocked":
+        if status == "cancelled":
+            cancelled = True
+        elif status == "blocked":
             blocked = True
+    if cancelled:
+        return "cancelled"
     return "blocked" if blocked else ""
 
 
-def _runtime_failed_or_blocked_status(runtime_observation: dict[str, Any]) -> str:
+def _runtime_terminal_status(runtime_observation: dict[str, Any]) -> str:
+    """The same precedence over a runtime observation summary."""
     if _string_items(runtime_observation.get("failed_events")):
         return "failed"
     latest = _object(runtime_observation.get("latest"))
+    cancelled = bool(_string_items(runtime_observation.get("cancelled_events")))
     blocked = bool(_string_items(runtime_observation.get("blocked_events")))
     for record in latest.values():
         if not isinstance(record, dict):
@@ -1486,15 +1540,26 @@ def _runtime_failed_or_blocked_status(runtime_observation: dict[str, Any]) -> st
         status = _token(record.get("status") or "")
         if status == "failed":
             return "failed"
-        if status == "blocked":
+        if status == "cancelled":
+            cancelled = True
+        elif status == "blocked":
             blocked = True
+    if cancelled:
+        return "cancelled"
     return "blocked" if blocked else ""
 
 
 def _runtime_completion_satisfied(runtime_observation: dict[str, Any]) -> bool:
     if not runtime_observation:
         return False
-    if _string_items(runtime_observation.get("failed_events")) or _string_items(runtime_observation.get("blocked_events")):
+    # A cancelled milestone disqualifies completion for the same reason a failed
+    # or blocked one does: the ladder was not climbed. Leaving it out let a run
+    # whose milestone was cancelled report `completed`.
+    if (
+        _string_items(runtime_observation.get("failed_events"))
+        or _string_items(runtime_observation.get("blocked_events"))
+        or _string_items(runtime_observation.get("cancelled_events"))
+    ):
         return False
     if _string_items(runtime_observation.get("not_observed_events")) or _string_items(runtime_observation.get("missing_events")):
         return False
@@ -1546,6 +1611,7 @@ def _runtime_observation_has_progress(runtime_observation: dict[str, Any]) -> bo
         _string_items(runtime_observation.get("observed_events"))
         or _string_items(runtime_observation.get("blocked_events"))
         or _string_items(runtime_observation.get("failed_events"))
+        or _string_items(runtime_observation.get("cancelled_events"))
     )
 
 
@@ -1564,6 +1630,7 @@ def _status_phrase(status: str) -> str:
         "in_progress": "in progress",
         "completed": "completed",
         "blocked": "blocked",
+        "cancelled": "cancelled",
         "failed": "failed",
         "unknown": "at an unknown status",
     }.get(status, status.replace("_", " "))

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -30,6 +30,8 @@ from ..coding.project_governance import discover_project_governance
 from ..routing.intent import META_OR_FEEDBACK_INTENTS, classify_workflow_intent
 from ..routing.localization import normalized_phrase, routing_tokens
 from ..runtime.artifacts import append_journal_observation, create_prepared_coding_delegation_run, write_coding_delegation
+from ..system.paths import OmhPaths
+from ..workflows.blocked_work_records import mint_blocked_work_record
 from ..wrapper.lifecycle import (
     CodingLifecycleError,
     record_codex_dispatch,
@@ -109,6 +111,14 @@ def cmd_coding_delegate(args: argparse.Namespace) -> int:
             from ..executor_readiness import executor_choice_context
 
             payload["executor_choice_context"] = executor_choice_context(paths)
+        # The decision is recorded here, before anything decides whether a *run*
+        # is worth creating, and unconditionally on `--record`. That ordering is
+        # the whole point of the change: a denied gate collapses the selection,
+        # skips the run, writes no `coding_delegation.json`, and appends no
+        # journal event, so until now the one build whose reasoning most needed
+        # to outlive the turn was the one that left nothing behind. The store is
+        # runtime-wide precisely so it can hold a decision that has no run.
+        payload["blocked_work_record"] = _record_coding_decision(paths, payload)
         runtime_skip_reason = ""
         if args.record:
             runtime_skip_reason = _coding_delegate_record_readiness_skip_reason(
@@ -178,6 +188,34 @@ def cmd_coding_delegate(args: argparse.Namespace) -> int:
         raise OmhError(str(exc)) from exc
     _print_json(payload)
     return 0
+
+
+def _record_coding_decision(paths: OmhPaths, payload: dict[str, object]) -> dict[str, object]:
+    """Persist the gate's decision, and never fail the command over it.
+
+    `mint_blocked_work_record` returns its refusals and write failures rather
+    than raising, for the reason the approval store does: this runs after the
+    verdict has already been reached, and letting an unwritable store fail the
+    command would turn a missing record into a request that looks like it was
+    never judged.
+
+    The decision block is built by `coding.coding_delegation` from the one gate
+    verdict. Nothing is re-decided here; if the block is absent the payload came
+    from a path that reached no verdict, and there is no decision to record.
+    """
+    decision = payload.get("blocked_work_decision")
+    if not isinstance(decision, dict):
+        return {"recorded": False, "reason": "no_action_gate_verdict"}
+    return mint_blocked_work_record(
+        paths,
+        source=str(decision.get("source", "")),
+        outcome=str(decision.get("outcome", "")),
+        reason_domain=str(decision.get("reason_domain", "")),
+        reason_code=str(decision.get("reason_code", "")),
+        owner=str(decision.get("owner", "")),
+        safety_profile_revision=str(decision.get("safety_profile_revision", "")),
+        class_shape=[str(label) for label in decision.get("class_shape", []) or []],
+    )
 
 
 def _coding_delegate_runtime_skip_reason(payload: dict[str, object]) -> str:

--- a/src/commands/runtime.py
+++ b/src/commands/runtime.py
@@ -42,7 +42,7 @@ from ..runtime.artifacts import (
     PRIVACY_MODES,
     REVIEW_STATUSES,
     RUN_STATUSES,
-    RUNTIME_OBSERVATION_EVENTS,
+    RUNTIME_OBSERVABLE_EVENTS,
     RUNTIME_OBSERVATION_STATUSES,
     create_run,
     export_runtime,
@@ -1162,7 +1162,11 @@ def _add_runtime_commands(sub) -> None:
     target.add_argument("--run", dest="run_id", default=None)
     target.add_argument("--session", dest="session_id", default=None)
     runtime_observe.add_argument("--runtime-profile", choices=CODING_RUNTIME_HANDOFF_TARGETS, required=True)
-    runtime_observe.add_argument("--event", choices=RUNTIME_OBSERVATION_EVENTS, required=True)
+    # The milestone ladder plus the three terminal events. Before this the CLI
+    # offered the ladder only, so `cancelled` was journalable in principle --
+    # `CANONICAL_OBSERVATION_EVENTS` has always had it -- and unreachable in
+    # practice: an in-process caller could append one and an operator could not.
+    runtime_observe.add_argument("--event", choices=RUNTIME_OBSERVABLE_EVENTS, required=True)
     runtime_observe.add_argument("--status", choices=RUNTIME_OBSERVATION_STATUSES, default="observed")
     runtime_observe.add_argument("--participants", default="")
     runtime_observe.add_argument("--worktree-ref", default="")

--- a/src/quality/safety_preflight.py
+++ b/src/quality/safety_preflight.py
@@ -410,6 +410,34 @@ _CORRECTIONS: Final = {
 }
 
 
+def correction_reason_codes() -> tuple[str, ...]:
+    """Every reason code a verdict can carry, `allowed` included.
+
+    The read-only accessor a durable decision record joins on. `_CORRECTIONS`
+    stays private because it is a rendering table and not a contract, but the
+    *code set* becomes a contract the moment a record on disk cites one: a code
+    that no longer exists must be reportable as unexplainable rather than
+    silently rendered as a blank line.
+
+    `allowed` is a member because `_verdict` emits it on every pass, and a
+    decision history that records allows has to be able to cite the code its
+    own verdict carried. Its correction is empty for the obvious reason -- there
+    is nothing to correct -- which is why explainability is measured over
+    blocked entries and not over every entry.
+    """
+    return tuple(sorted(_CORRECTIONS))
+
+
+def correction_for_reason_code(reason_code: str) -> str:
+    """The constant correction line for one reason code, or empty.
+
+    Constant, never interpolated: a correction is rendered to operators, and a
+    line built from request values would be one more path for caller-controlled
+    text to reach a terminal.
+    """
+    return str(_CORRECTIONS.get(str(reason_code or ""), ""))
+
+
 # How a data-boundary limit can be enforced at all.
 #
 # `refused_before_handoff` is omh refusing to prepare the artifact, so it holds

--- a/src/runtime/artifacts.py
+++ b/src/runtime/artifacts.py
@@ -46,6 +46,7 @@ from ..external_effect_receipts import (
     validate_external_effect_receipt_store,
 )
 from ..workflows.approval_receipts import validate_approval_receipt_store
+from ..workflows.blocked_work_records import decision_history, validate_blocked_work_record_store
 from ..observation_journal import (
     append_observation_event,
     merge_lifecycle_projection,
@@ -59,10 +60,14 @@ from .records import (
     EVENT_LEVELS,
     OBSERVED_RESULTS,
     OPTIONAL_APPROVAL_STORE_VALIDATORS,
+    OPTIONAL_BLOCKED_WORK_STORE_VALIDATORS,
     OPTIONAL_RECORD_VALIDATORS,
     OPTIONAL_RUNTIME_STORE_VALIDATORS,
     PRIVACY_MODES,
+    RUNTIME_BLOCK_OBSERVATION_EVENTS,
+    RUNTIME_OBSERVABLE_EVENTS,
     RUNTIME_OBSERVATION_EVENTS,
+    RUNTIME_TERMINAL_OBSERVATION_EVENTS,
     RUNTIME_OBSERVATION_SCHEMA_VERSION,
     RUNTIME_OBSERVATION_STATUSES,
     CI_STATUSES,
@@ -1093,19 +1098,44 @@ def _requested_external_effects(
 
 def summarize_runtime_observation_status(records: list[dict[str, Any]]) -> dict[str, Any]:
     latest_by_event: dict[str, dict[str, Any]] = {}
+    # Non-ladder events are kept apart from the milestone ladder. A `cancelled`
+    # is not a rung that was climbed or skipped, it is a statement that nobody
+    # is climbing any more, so folding it into `latest_by_event` would make it
+    # compete for "which milestone is next" -- a question it answers by making
+    # moot.
+    #
+    # `blocked` is collected apart from the two that end a run, because it does
+    # not end one. A block is recoverable by definition, so it may only pin
+    # `next_action` while nothing has happened since; a ladder observation
+    # recorded after it clears the pin. Ranking it beside `failed` and
+    # `cancelled` left every recovered run reporting a block it had got past.
+    terminal_events: list[dict[str, Any]] = []
+    block_events: list[dict[str, Any]] = []
+    latest_ladder_key: tuple[str, str, str, str] | None = None
     for record in records:
         if not isinstance(record, dict):
             continue
         event_type = str(record.get("event_type", ""))
+        if event_type in RUNTIME_TERMINAL_OBSERVATION_EVENTS:
+            terminal_events.append(record)
+            continue
+        if event_type in RUNTIME_BLOCK_OBSERVATION_EVENTS:
+            block_events.append(record)
+            continue
         current = latest_by_event.get(event_type)
         if event_type in RUNTIME_OBSERVATION_EVENTS and (
             current is None or _runtime_observation_sort_key(record) >= _runtime_observation_sort_key(current)
         ):
             latest_by_event[event_type] = record
+        if event_type in RUNTIME_OBSERVATION_EVENTS:
+            key = _runtime_observation_sort_key(record)
+            if latest_ladder_key is None or key > latest_ladder_key:
+                latest_ladder_key = key
 
     observed_events: list[str] = []
     blocked_events: list[str] = []
     failed_events: list[str] = []
+    cancelled_events: list[str] = []
     not_observed_events: list[str] = []
     for event_type in RUNTIME_OBSERVATION_EVENTS:
         record = latest_by_event.get(event_type)
@@ -1118,13 +1148,38 @@ def summarize_runtime_observation_status(records: list[dict[str, Any]]) -> dict[
             blocked_events.append(event_type)
         elif status == "failed":
             failed_events.append(event_type)
+        elif status == "cancelled":
+            cancelled_events.append(event_type)
         elif status == "not_observed":
             not_observed_events.append(event_type)
 
     missing_events = [event_type for event_type in RUNTIME_OBSERVATION_EVENTS if event_type not in latest_by_event]
-    unsatisfied_events = [*not_observed_events, *missing_events]
-    if failed_events:
+    # A cancelled milestone is permanently unsatisfied: nobody is going to
+    # observe it now. Leaving it out let `hermes_harness._harness_status` reach
+    # its "merge observed and nothing unsatisfied" completion check with a
+    # cancelled rung on the ladder. `blocked` and `failed` stay out because both
+    # short-circuit ahead of that check, in `next_action` here and in
+    # `_harness_status` there; `cancelled` had no such surface until now.
+    unsatisfied_events = [*not_observed_events, *missing_events, *cancelled_events]
+    terminal_event = str(terminal_events[-1].get("event_type", "")) if terminal_events else ""
+    # A block pins only while it is the last thing that happened. Any ladder
+    # observation recorded after it is evidence the run moved on.
+    standing_block = ""
+    if block_events:
+        block_key = max(_runtime_observation_sort_key(record) for record in block_events)
+        if latest_ladder_key is None or block_key > latest_ladder_key:
+            standing_block = str(block_events[-1].get("event_type", ""))
+    if terminal_event:
+        # A run that was terminated is not a run with an outstanding milestone.
+        # Reporting "record the next observation" over a cancellation is how a
+        # stopped run reads as merely incomplete.
+        next_action = f"surface_runtime_{terminal_event}:{terminal_event}"
+    elif cancelled_events:
+        next_action = f"surface_runtime_cancellation:{cancelled_events[-1]}"
+    elif failed_events:
         next_action = f"surface_runtime_failure:{failed_events[-1]}"
+    elif standing_block:
+        next_action = f"surface_runtime_blocker:{standing_block}"
     elif blocked_events:
         next_action = f"surface_runtime_blocker:{blocked_events[-1]}"
     elif unsatisfied_events:
@@ -1139,6 +1194,10 @@ def summarize_runtime_observation_status(records: list[dict[str, Any]]) -> dict[
         "observed_events": observed_events,
         "blocked_events": blocked_events,
         "failed_events": failed_events,
+        "cancelled_events": cancelled_events,
+        "terminal_events": [str(record.get("event_type", "")) for record in terminal_events],
+        "block_events": [str(record.get("event_type", "")) for record in block_events],
+        "standing_block": standing_block,
         "not_observed_events": not_observed_events,
         "missing_events": missing_events,
         "unsatisfied_events": unsatisfied_events,
@@ -1168,6 +1227,14 @@ def runtime_observation_not_applicable(reason: str) -> dict[str, Any]:
         "observed_events": [],
         "blocked_events": [],
         "failed_events": [],
+        # Carried empty rather than omitted. Three functions publish
+        # `runtime_observation_status/v1` and a reader that has to ask which one
+        # produced a payload before it knows which keys exist is reading three
+        # schemas under one version.
+        "cancelled_events": [],
+        "terminal_events": [],
+        "block_events": [],
+        "standing_block": "",
         "not_observed_events": [],
         "missing_events": [],
         "unsatisfied_events": [],
@@ -1610,12 +1677,18 @@ def _delegated_runtime_observation_status(
     latest = _object_or_empty(lifecycle.get("latest_event"))
     blocked_events = []
     failed_events = []
+    # A cancelled latest event used to land in neither list, so the only signal
+    # a stopped run left behind was `missing_events` -- and a run someone
+    # cancelled rendered exactly like a run that simply had not got there yet.
+    cancelled_events = []
     latest_event = _runtime_event_from_journal_event(str(latest.get("event", "")))
     latest_status = str(latest.get("status", ""))
     if latest_event and latest_status == "blocked":
         blocked_events.append(latest_event)
     elif latest_event and latest_status == "failed":
         failed_events.append(latest_event)
+    elif latest_event and latest_status == "cancelled":
+        cancelled_events.append(latest_event)
     missing_events = _runtime_missing_events_for_next_action(next_action)
     return {
         "schema_version": "runtime_observation_status/v1",
@@ -1625,9 +1698,13 @@ def _delegated_runtime_observation_status(
         "observed_events": observed_events,
         "blocked_events": blocked_events,
         "failed_events": failed_events,
+        "cancelled_events": cancelled_events,
+        "terminal_events": [],
+        "block_events": blocked_events,
+        "standing_block": blocked_events[0] if blocked_events else "",
         "not_observed_events": [],
         "missing_events": missing_events,
-        "unsatisfied_events": missing_events,
+        "unsatisfied_events": [*missing_events, *cancelled_events],
         "latest": {"event": latest_event, **latest} if latest_event else latest,
         "next_action": next_action,
         "claim_boundary": (
@@ -1927,6 +2004,7 @@ def validate_run_dir(
             errors.extend(f"{path}: {error}" for error in validator(record))
     errors.extend(_validate_run_external_effect_receipts(run_dir, receipts))
     errors.extend(_validate_run_approval_receipts(run_dir))
+    errors.extend(_validate_run_blocked_work_records(run_dir))
     errors.extend(_validate_run_status_gate_consistency(run_dir, receipts))
     return {"run_id": run_dir.name, "ok": not errors, "errors": errors}
 
@@ -1991,6 +2069,35 @@ def _validate_run_approval_receipts(run_dir: Path) -> list[str]:
                 continue
             errors.extend(
                 f"{store_path}[{record.get('receipt_id', '')}]: {error}" for error in validator(record)
+            )
+    return errors
+
+
+def _validate_run_blocked_work_records(run_dir: Path) -> list[str]:
+    """Schema-validate this run's blocked work records, through the registry that names them.
+
+    The same shape `_validate_run_approval_receipts` has, and the reader
+    `OPTIONAL_BLOCKED_WORK_STORE_VALIDATORS` was registered for: a registry with
+    no consumer validates nothing, which is how the approval store spent a
+    release as the one runtime store `omh runtime validate` never opened.
+
+    Records with an empty `run_id` are skipped here rather than faulted. They are
+    the decisions minted before any run existed -- a preflight denial has nothing
+    to belong to -- so they are the store's records, and `validate_runtime`
+    covers them once at store level.
+    """
+    errors: list[str] = []
+    run_id = _safe_run_id_for_dir(run_dir)
+    for name, validator in OPTIONAL_BLOCKED_WORK_STORE_VALIDATORS:
+        store_path = runtime_store_path_for_run_dir(run_dir, name)
+        if store_path is None:
+            continue
+        records, _ = read_jsonl_objects(store_path)
+        for record in records:
+            if str(record.get("run_id", "")) != run_id:
+                continue
+            errors.extend(
+                f"{store_path}[{record.get('record_id', '')}]: {error}" for error in validator(record)
             )
     return errors
 
@@ -2145,18 +2252,29 @@ def validate_runtime(paths: OmhPaths, run_id: str | None = None) -> dict[str, An
         paths.runtime_approval_receipts_path,
         run_id=run_id,
     )
+    # And the blocked-work store, for the same reason plus one of its own: most
+    # of its records carry no `run_id` at all, because the decision they record
+    # happened before a run existed. Run-scoped validation can never reach them,
+    # so this store-level call is not a second safety net for them -- it is the
+    # only one.
+    blocked_work_store_result = validate_blocked_work_record_store(
+        paths.runtime_blocked_work_records_path,
+        run_id=run_id,
+    )
     _add_duplicate_wrapper_run_link_errors(session_results, session_dirs)
     return {
         "ok": all(result["ok"] for result in results)
         and all(result["ok"] for result in session_results)
         and bool(journal_result["ok"])
         and bool(receipt_store_result["ok"])
-        and bool(approval_store_result["ok"]),
+        and bool(approval_store_result["ok"])
+        and bool(blocked_work_store_result["ok"]),
         "runs": results,
         "wrapper_sessions": session_results,
         "journal": journal_result,
         "external_effect_receipts": receipt_store_result,
         "approval_receipts": approval_store_result,
+        "blocked_work_records": blocked_work_store_result,
     }
 
 
@@ -2324,6 +2442,22 @@ def export_runtime(
         payload["redacted"] = True
     else:
         payload["redacted"] = False
+    # #806's read surface. The blocked-work store answers "why was this blocked?"
+    # after the turn, and until this line nothing in the product read it -- the
+    # store was written, validated, and never shown, so the question was
+    # answerable only by opening the JSONL by hand. It rides on the export rather
+    # than on a new command because a decision history is a view of the runtime,
+    # which is what this payload already is.
+    #
+    # Attached after `_redact` and deliberately not through it. `_redact` works
+    # by key *name*, and this projection has a `summary` key holding counts and
+    # a `source` key holding a closed vocabulary member -- both names are on the
+    # sensitive list, so running it through would replace the counts object and
+    # every decision's source with `"[redacted]"` while protecting nothing. The
+    # projection is redacted by construction instead: it has no free-text field
+    # at all, every identifier goes through `redacted_blocked_work_ref`, and
+    # every vocabulary renders empty outside its vocabulary.
+    payload["decision_history"] = decision_history(paths, run_id=run_id, limit=limit)
     return payload
 
 

--- a/src/runtime/records.py
+++ b/src/runtime/records.py
@@ -69,6 +69,10 @@ from ..workflows.approval_receipts import (
     APPROVAL_RECEIPT_KEYS,
     validate_approval_receipt,
 )
+from ..workflows.blocked_work_records import (
+    BLOCKED_WORK_RECORD_KEYS,
+    validate_blocked_work_record,
+)
 from ..workflows.external_effect_receipts import (
     EXTERNAL_EFFECT_RECEIPT_KEYS,
     validate_external_effect_receipt,
@@ -104,7 +108,32 @@ RUNTIME_OBSERVATION_EVENTS = (
     "merge_readiness",
     "merge",
 )
-RUNTIME_OBSERVATION_STATUSES = ("observed", "blocked", "failed", "not_observed")
+# Kept equal to `observation_journal.OBSERVATION_STATUSES` by
+# `tests/test_blocked_work_records.py`: the CLI's `--status` choices come from
+# this tuple and every value it offers is written straight into the journal, so
+# a status this tuple has and that one lacks is a flag that fails at the write.
+# `cancelled` is a member for the reason given there -- the projection already
+# produces it, and a state that can only be projected can never be recorded.
+RUNTIME_OBSERVATION_STATUSES = ("observed", "blocked", "cancelled", "failed", "not_observed")
+
+# The three events `CANONICAL_OBSERVATION_EVENTS` already defines and
+# `omh runtime observe` could not emit. They are deliberately not members of
+# `RUNTIME_OBSERVATION_EVENTS` above: that tuple is the runtime milestone
+# ladder, and `summarize_runtime_observation_status` reports every member of it
+# that has no record as a *missing* milestone. Adding one of these there would
+# make every run permanently missing three milestones it was never meant to
+# reach. So the ladder stays the ladder, and the CLI offers the union.
+#
+# Only two of the three end a run. `blocked` is not terminal and must not be
+# classified as one: a block is recoverable by definition -- every blocked-work
+# record carries a recovery action -- so a run that was blocked and then
+# unblocked goes on to reach its milestones. Treating `blocked` as terminal
+# pinned `next_action` to the block permanently, so a run that recovered and
+# merged still reported the block as the thing to surface next.
+RUNTIME_BLOCK_OBSERVATION_EVENTS = ("blocked",)
+RUNTIME_TERMINAL_OBSERVATION_EVENTS = ("failed", "cancelled")
+RUNTIME_NON_LADDER_OBSERVATION_EVENTS = RUNTIME_BLOCK_OBSERVATION_EVENTS + RUNTIME_TERMINAL_OBSERVATION_EVENTS
+RUNTIME_OBSERVABLE_EVENTS = RUNTIME_OBSERVATION_EVENTS + RUNTIME_NON_LADDER_OBSERVATION_EVENTS
 RUNTIME_OBSERVATION_RECORD_KEYS = (
     "schema_version",
     "record_type",
@@ -2130,7 +2159,7 @@ def validate_runtime_observation_record(observation: dict[str, Any]) -> list[str
     _require(observation.get("target_type") in RUNTIME_OBSERVATION_TARGET_TYPES, errors, "runtime_observation target_type is invalid")
     _require(bool(str(observation.get("target_id", "")).strip()), errors, "runtime_observation target_id is required")
     _require(observation.get("runtime_profile") in CODING_RUNTIME_TARGETS, errors, "runtime_observation runtime_profile is invalid")
-    _require(observation.get("event_type") in RUNTIME_OBSERVATION_EVENTS, errors, "runtime_observation event_type is invalid")
+    _require(observation.get("event_type") in RUNTIME_OBSERVABLE_EVENTS, errors, "runtime_observation event_type is invalid")
     _require(observation.get("status") in RUNTIME_OBSERVATION_STATUSES, errors, "runtime_observation status is invalid")
     _require(isinstance(observation.get("observed"), bool), errors, "runtime_observation observed must be boolean")
     _require(isinstance(observation.get("participants"), list), errors, "runtime_observation participants must be a list")
@@ -3933,4 +3962,18 @@ OPTIONAL_RUNTIME_STORE_VALIDATORS = (
 # at all. The registry design that forces one reader per registry is #846.
 OPTIONAL_APPROVAL_STORE_VALIDATORS = (
     ("approval_receipts.jsonl", validate_approval_receipt),
+)
+
+# The third store, registered in its own tuple for the reason the second one
+# was: every consumer applies *every* entry in its registry to the records it
+# just read, so a family sharing a tuple with another would validate one
+# family's records against the other's schema and fault every run that has one.
+# One registry per store, one reader per registry -- the #846 rule. This one is
+# read by `runtime.artifacts._validate_run_blocked_work_records`, and the
+# store-level `validate_blocked_work_record_store` call in `validate_runtime` is
+# what makes `omh runtime validate` open the blocked-work store at all.
+BLOCKED_WORK_RECORD_RECORD_KEYS = BLOCKED_WORK_RECORD_KEYS
+
+OPTIONAL_BLOCKED_WORK_STORE_VALIDATORS = (
+    ("blocked_work_records.jsonl", validate_blocked_work_record),
 )

--- a/src/system/append_only_store.py
+++ b/src/system/append_only_store.py
@@ -1,0 +1,395 @@
+"""Mechanics every append-only JSONL record store in this tree shares.
+
+`workflows/external_effect_receipts.py` and `workflows/approval_receipts.py`
+are two record families with nothing in common at the domain level -- one
+records what an acting surface observed, the other records what an operator
+consented to -- and yet they were, line for line, the same store: the same
+torn-tail-safe append, the same supersede-chain walk, the same opaque-reference
+guards, the same digest handles, the same best-effort mint-failure sidecar. A
+third family arriving would have made every future drift a three-way problem,
+so the store mechanics live here once and each family keeps its own meaning.
+
+What is here is deliberately only the mechanics. There is no shared "record"
+type and no base class: a record abstraction that knew what a receipt or an
+approval is would be the wrong shape, because the whole reason these families
+are separate is that their vocabularies, key sets, claim boundaries, schema
+versions, and domain predicates must not converge. Every function below takes
+what it needs as an explicit parameter -- the caller's label, the caller's
+error class, the caller's key tuple -- rather than reading it off a config
+object, which keeps each call site readable as the thing it does.
+
+Two properties are load-bearing on both platforms and are not negotiable in any
+caller:
+
+- The append is binary-mode. Windows text mode rewrites ``\\n`` as ``\\r\\n``,
+  which would make the tail-byte check platform-dependent and the store's bytes
+  differ between CI targets.
+- The append fsyncs, and every writer holds `local_store.file_lock`, which is a
+  real OS lock through `fcntl` on POSIX and `msvcrt` on Windows. Append-only is
+  a structural property here, not a convention.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import secrets
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from .local_store import ensure_dir, ensure_file, file_lock
+from .metadata_safety import is_sensitive_metadata_text, require_opaque_metadata_ref
+
+
+# Mirrors the executor-progress guard: these key names are how raw model output
+# and private payloads arrive, so a store rejects them by name as well as by its
+# own closed key set. Held here so the families cannot drift apart on it -- they
+# were already identical, and a key added to one and missed on the other is the
+# exact defect this module exists to make impossible.
+RAW_OR_HIDDEN_KEYS: frozenset[str] = frozenset(
+    {
+        "analysis",
+        "body",
+        "body_text",
+        "chain_of_thought",
+        "conversation",
+        "cot",
+        "hidden",
+        "hidden_reasoning",
+        "message",
+        "payload",
+        "prompt",
+        "raw",
+        "raw_log",
+        "raw_logs",
+        "raw_message",
+        "raw_output",
+        "raw_payload",
+        "raw_prompt",
+        "reasoning",
+        "stderr",
+        "stdout",
+        "think",
+        "thinking",
+        "transcript",
+        "url",
+    }
+)
+
+# A reference that navigates somewhere is not an opaque identifier. Kept in the
+# same shape as `adapter_quality._URL`, which is where this repo first drew the
+# line between "a handle we can print" and "a link we must not".
+URL_SHAPED: tuple[str, ...] = ("://", "?", "#")
+
+# The free-text guard a bounded metadata line goes through: a URL scheme or any
+# of `/ ? #` is a link or a filesystem path, and a control character means the
+# value is a transcript or a prompt rather than one metadata line.
+_UNSAFE_TEXT_URL = re.compile(r"(?i)(?:[a-z][a-z0-9+.-]*://|[/?#])")
+_UNSAFE_TEXT_CONTROL = re.compile(r"[\x00-\x1f\x7f]")
+_UNSAFE_TEXT_WINDOWS_PATH = re.compile(r"(?:^|\s)(?:[A-Za-z]:\\|\\\\)")
+
+
+def append_store_line(path: Path, record: Mapping[str, Any]) -> None:
+    """Append one line, terminating a torn tail first.
+
+    A short write leaves a partial line with no trailing newline. Appending
+    straight onto it concatenates two records into one unparseable line and
+    loses both, so the tail byte is checked and a newline is written first when
+    it is missing. The torn line stays on disk as one corrupt line the store
+    validator reports; the new record survives as its own.
+
+    Binary mode on purpose: Windows text mode would rewrite ``\\n`` as
+    ``\\r\\n`` and make the tail check platform-dependent.
+
+    The caller holds the store's lock. This function does not take one, because
+    a mint reads the prior record and appends under a single lock and a second
+    acquisition here would either deadlock or open the window it closed.
+    """
+    ensure_dir(path.parent, private=True)
+    ensure_file(path, private=True)
+    payload = json.dumps(record, sort_keys=True).encode("utf-8") + b"\n"
+    with path.open("r+b") as handle:
+        handle.seek(0, os.SEEK_END)
+        if handle.tell():
+            handle.seek(-1, os.SEEK_END)
+            if handle.read(1) != b"\n":
+                payload = b"\n" + payload
+        handle.seek(0, os.SEEK_END)
+        handle.write(payload)
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def append_sidecar_line(path: Path, record: Mapping[str, Any]) -> None:
+    """Append one line to a store's sidecar log, best effort, under its own lock.
+
+    The sidecar is where a mint that never reached the store is logged. It is
+    the record that has to survive when things are already going wrong, so two
+    producers failing at once must not interleave and lose a line -- hence a
+    real lock, on the sidecar's own path.
+
+    The lock is never held while the store's lock is: a mint failure is raised
+    out of that block before this runs.
+
+    A write failure is swallowed. The sidecar lives next to the store, so the
+    same outage that lost the record can lose this line too, and the result the
+    caller already holds is the record of last resort.
+    """
+    try:
+        with file_lock(path, private=True):
+            append_store_line(path, record)
+    except OSError:
+        return
+
+
+def is_url_shaped(value: str) -> bool:
+    """Whether a reference navigates somewhere instead of naming something."""
+    return any(marker in value for marker in URL_SHAPED)
+
+
+def digest_ref(value: str) -> str:
+    """A stable, bounded, non-navigable handle for a value that is not opaque.
+
+    Stable because callers dedupe rows by it; non-navigable because a status
+    report is not a place to publish someone's links.
+    """
+    return f"ref-{hashlib.sha256(value.encode('utf-8')).hexdigest()[:12]}"
+
+
+def opaque_ref(value: str, *, field: str, error: type[Exception]) -> str:
+    """One caller-supplied identifier, or the caller's own error.
+
+    `field` is the fully qualified name the store reports, and `error` is that
+    store's exception type, so a refusal from here is indistinguishable from
+    one the store raised itself.
+    """
+    text = str(value or "").strip()
+    if not text:
+        raise error(f"{field} is required")
+    if is_url_shaped(text):
+        raise error(f"{field} must be an opaque identifier, not a URL")
+    try:
+        return require_opaque_metadata_ref(text, field=field)
+    except ValueError as exc:
+        raise error(str(exc)) from exc
+
+
+def reference_errors(value: Any, *, field: str, label: str, required: bool) -> list[str]:
+    """Every reason one stored value is not an opaque reference.
+
+    The validation-time counterpart of `opaque_ref`: it collects rather than
+    raises, because a store report names every fault at once.
+    """
+    if not isinstance(value, str):
+        return [f"{label} {field} must be a string"]
+    if not value:
+        return [f"{label} {field} is required"] if required else []
+    if is_url_shaped(value):
+        return [f"{label} {field} must be an opaque identifier, not a URL"]
+    try:
+        require_opaque_metadata_ref(value, field=f"{label} {field}")
+    except ValueError as exc:
+        return [str(exc)]
+    return []
+
+
+def redacted_ref(value: str, *, field: str) -> str:
+    """Fold any handle into a bounded, non-navigable reference for rendering.
+
+    A URL, a secret-shaped string, or anything longer than a bounded identifier
+    becomes a stable digest handle instead. Rendering is the last point at which
+    a hand-edited store reaches a human, so nothing is copied through verbatim.
+    """
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    if is_url_shaped(text) or is_sensitive_metadata_text(text):
+        return digest_ref(text)
+    try:
+        require_opaque_metadata_ref(text, field=field)
+    except ValueError:
+        return digest_ref(text)
+    return text
+
+
+def closed_vocabulary_value(value: Any, allowed: tuple[str, ...]) -> str:
+    """A closed-vocabulary field renders only what its vocabulary contains.
+
+    Rendering reads whatever is on disk, and a store can be hand-edited. A value
+    outside the vocabulary is not a new state, it is a value with no meaning, so
+    it renders empty rather than as itself.
+    """
+    text = str(value or "")
+    return text if text in allowed else ""
+
+
+def is_unsafe_metadata_line(value: str) -> bool:
+    """Whether one free-text field carries something a metadata line must not.
+
+    A secret, a link, a filesystem path, or a control character. The last one is
+    the tell that the value is a prompt, a transcript, or a log slice rather
+    than the single bounded line a stored summary is allowed to be.
+    """
+    text = str(value or "")
+    if not text:
+        return False
+    return bool(
+        is_sensitive_metadata_text(text)
+        or _UNSAFE_TEXT_CONTROL.search(text)
+        or _UNSAFE_TEXT_URL.search(text)
+        or _UNSAFE_TEXT_WINDOWS_PATH.search(text)
+    )
+
+
+def latest_record_in(records: Sequence[Mapping[str, Any]], *, key: str, value: str) -> Any:
+    """The record that speaks for one identity: the one selection rule.
+
+    An append-only store's order is arrival order, so the last record carrying
+    an identity is that identity's current state and a later append always wins
+    the tie. Every surface that judges a store selects through this function,
+    which is what stops a validator and a predicate from picking different
+    records for one identity and reaching opposite conclusions about it.
+
+    The match is returned as it was found, not copied: a caller that needs a
+    copy makes one, and a caller that does not must not pay for one.
+    """
+    matches = [record for record in records if str(record.get(key, "")) == str(value)]
+    return matches[-1] if matches else {}
+
+
+def record_fingerprint(record: Mapping[str, Any], keys: tuple[str, ...]) -> str:
+    """Which thing a record is about, ignoring when it was recorded.
+
+    `keys` is the store's own identity tuple. What it leaves out is the point:
+    a timestamp, a record id, and a supersede link must not make an identical
+    re-report mint a second record just because the clock moved.
+    """
+    identity = {key: record.get(key) for key in keys}
+    return hashlib.sha256(json.dumps(identity, sort_keys=True, default=str).encode("utf-8")).hexdigest()
+
+
+def mint_record_id(*, prefix: str, identity: Mapping[str, str]) -> str:
+    """A record id from what the record is, plus a random tail.
+
+    Random tail for the same reason `observation_journal._event_id` carries one:
+    `utc_now()` has second resolution, so two records for one identity in the
+    same second would otherwise share an id and break the supersede chain.
+    """
+    base = json.dumps(dict(identity), sort_keys=True)
+    digest = hashlib.sha256(base.encode("utf-8")).hexdigest()[:16]
+    return f"{prefix}-{digest}-{secrets.token_hex(3)}"
+
+
+def supersede_chain_errors(
+    path: Path,
+    records: list[dict[str, Any]],
+    *,
+    run_id: str | None,
+    label: str,
+    id_key: str = "receipt_id",
+    link_key: str = "supersedes_receipt_ref",
+    noun: str = "receipt",
+) -> list[str]:
+    """Reject every shape a supersede chain must not take.
+
+    A chain is a line, not a graph: a record cannot supersede itself, cannot
+    supersede a record that does not already exist, and cannot supersede a
+    record something else already superseded. A fork means two writers both
+    believe they replaced the same predecessor, which makes "the latest state"
+    ambiguous.
+
+    Every record in the store is walked even when the report is scoped to one
+    run, so a link into a record outside the scope is still a link into a record
+    that exists. Only faults on in-scope records are reported: scoping a report
+    must never invent a broken chain.
+
+    `id_key`, `link_key`, and `noun` are how a family keeps its own vocabulary
+    while sharing the walk. The defaults are the two receipt families' names, so
+    those two callers pass nothing and their error lines are unchanged to the
+    byte; a family whose records are not receipts names its own keys rather than
+    storing a `receipt_id` it has no receipts for. The names are parameters and
+    not a config object for the reason the module docstring gives: the call site
+    should read as the thing it does.
+    """
+    seen: set[str] = set()
+    successors: dict[str, str] = {}
+    errors: list[str] = []
+    for index, record in enumerate(records, start=1):
+        in_scope = run_id is None or str(record.get("run_id", "")) == run_id
+        record_id = str(record.get(id_key, ""))
+        if record_id and record_id in seen and in_scope:
+            errors.append(f"{path}:{index}: {label} {id_key} is not unique: {record_id}")
+        superseded = str(record.get(link_key, ""))
+        if superseded:
+            if superseded == record_id:
+                if in_scope:
+                    errors.append(
+                        f"{path}:{index}: {label} {link_key} must not name itself: {record_id}"
+                    )
+            elif superseded not in seen:
+                if in_scope:
+                    errors.append(
+                        f"{path}:{index}: {label} {link_key} does not name an earlier "
+                        f"{noun}: {superseded}"
+                    )
+            elif superseded in successors:
+                if in_scope:
+                    errors.append(
+                        f"{path}:{index}: {label} {link_key} forks the chain: "
+                        f"{superseded} is already superseded by {successors[superseded]}"
+                    )
+            else:
+                successors[superseded] = record_id
+        seen.add(record_id)
+    return errors
+
+
+def store_errors(
+    path: Path,
+    records: list[dict[str, Any]],
+    read_errors: list[str],
+    *,
+    run_id: str | None,
+    validate_record: Callable[[dict[str, Any]], list[str]],
+    label: str,
+    id_key: str = "receipt_id",
+    link_key: str = "supersedes_receipt_ref",
+    noun: str = "receipt",
+) -> tuple[int, list[str]]:
+    """How many records are in scope, and every fault found in them.
+
+    Unscoped (`run_id=None`) this is the store's own report: unparseable lines,
+    every record's schema, and the integrity of the supersede chain. A line that
+    does not parse belongs to no run -- it has no `run_id` to read -- so it is
+    the store's fault and is reported here, once, never against a run that
+    happened to be validated while it sat there.
+
+    Scoped to a run, only that run's records and their chain are considered, so
+    one bad line elsewhere cannot fault a run that has nothing to do with it.
+
+    The caller owns the report's wire shape: its schema version, what it names
+    the count, and its sidecar tally are all its own.
+    """
+    indexed = [
+        (index, record)
+        for index, record in enumerate(records, start=1)
+        if run_id is None or str(record.get("run_id", "")) == run_id
+    ]
+    errors: list[str] = list(read_errors) if run_id is None else []
+    for index, record in indexed:
+        errors.extend(f"{path}:{index}: {error}" for error in validate_record(record))
+    errors.extend(
+        supersede_chain_errors(
+            path,
+            records,
+            run_id=run_id,
+            label=label,
+            id_key=id_key,
+            link_key=link_key,
+            noun=noun,
+        )
+    )
+    return len(indexed), errors

--- a/src/system/paths.py
+++ b/src/system/paths.py
@@ -79,6 +79,15 @@ class OmhPaths:
         return self.runtime_journal_dir / "approval_receipts.jsonl"
 
     @property
+    def runtime_blocked_work_records_path(self) -> Path:
+        # Runtime-wide, beside the other two stores, and emphatically not inside
+        # a run directory: the records this store exists for are minted when a
+        # gate denies *before* a delegation exists, so there is no run directory
+        # to hold them. Per-run storage would lose exactly the decisions that
+        # have no run, which are the ones #806 asks to be explainable later.
+        return self.runtime_journal_dir / "blocked_work_records.jsonl"
+
+    @property
     def runtime_plan_context_dir(self) -> Path:
         return self.runtime_dir / "plan-context"
 

--- a/src/workflows/approval_receipts.py
+++ b/src/workflows/approval_receipts.py
@@ -90,16 +90,27 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 import re
-import secrets
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Final
 
-from ..system.local_store import ensure_dir, ensure_file, file_lock, read_jsonl_objects, utc_now
-from ..system.metadata_safety import is_sensitive_metadata_text, require_opaque_metadata_ref
+from ..system.append_only_store import (
+    RAW_OR_HIDDEN_KEYS,
+    append_sidecar_line,
+    append_store_line,
+    closed_vocabulary_value,
+    latest_record_in,
+    mint_record_id,
+    opaque_ref,
+    record_fingerprint,
+    redacted_ref,
+    reference_errors,
+    store_errors,
+)
+from ..system.local_store import file_lock, read_jsonl_objects, utc_now
+from ..system.metadata_safety import is_sensitive_metadata_text
 from ..system.paths import OmhPaths
 
 
@@ -335,42 +346,9 @@ _EXECUTION_CLAIM_KEYS: Final[frozenset[str]] = frozenset(
     }
 )
 
-# Mirrors the guard in `external_effect_receipts`: these are how raw model
-# output and private payloads arrive, so they are refused by name as well as by
-# the closed key set.
-_RAW_OR_HIDDEN_KEYS: Final[frozenset[str]] = frozenset(
-    {
-        "analysis",
-        "body",
-        "body_text",
-        "chain_of_thought",
-        "conversation",
-        "cot",
-        "hidden",
-        "hidden_reasoning",
-        "message",
-        "payload",
-        "prompt",
-        "raw",
-        "raw_log",
-        "raw_logs",
-        "raw_message",
-        "raw_output",
-        "raw_payload",
-        "raw_prompt",
-        "reasoning",
-        "stderr",
-        "stdout",
-        "think",
-        "thinking",
-        "transcript",
-        "url",
-    }
-)
+# The store label every error line and every reference fault is reported under.
+_LABEL: Final[str] = "approval_receipt"
 
-# A reference that navigates somewhere is not an opaque identifier. Same three
-# markers `external_effect_receipts` draws the line at.
-_URL_SHAPED: Final[tuple[str, ...]] = ("://", "?", "#")
 # A scope must name something inside the workspace. `require_opaque_metadata_ref`
 # already refuses a leading `/` or `~` (the first character must be alphanumeric)
 # and every backslash, so what is left is the parent traversal and the Windows
@@ -490,7 +468,7 @@ def validate_approval_receipt(record: dict[str, Any]) -> list[str]:
             "approval_receipt must not carry execution-claim keys: "
             f"{claims_execution}; consent is not an attempt and not an outcome"
         )
-    forbidden = sorted(key for key in record if str(key).lower() in _RAW_OR_HIDDEN_KEYS)
+    forbidden = sorted(key for key in record if str(key).lower() in RAW_OR_HIDDEN_KEYS)
     if forbidden:
         errors.append(f"approval_receipt must not carry raw or hidden keys: {forbidden}")
     extra_keys = sorted(set(record) - set(APPROVAL_RECEIPT_KEYS) - set(claims_execution) - set(forbidden))
@@ -512,9 +490,9 @@ def validate_approval_receipt(record: dict[str, Any]) -> list[str]:
     if record.get("claim_boundary") != CLAIM_BOUNDARY:
         errors.append("approval_receipt claim_boundary must state the approval boundary")
     for field in _REQUIRED_APPROVAL_REFS:
-        errors.extend(_reference_errors(record.get(field), field=field, required=True))
+        errors.extend(reference_errors(record.get(field), field=field, label=_LABEL, required=True))
     for field in _OPTIONAL_APPROVAL_REFS:
-        errors.extend(_reference_errors(record.get(field), field=field, required=False))
+        errors.extend(reference_errors(record.get(field), field=field, label=_LABEL, required=False))
     errors.extend(_scope_ref_errors(record.get("scope_ref")))
     if str(record.get("receipt_id", "")) and str(record.get("receipt_id", "")) == str(
         record.get("supersedes_receipt_ref", "")
@@ -544,7 +522,7 @@ def append_approval_receipt(paths: OmhPaths, record: dict[str, Any]) -> dict[str
     # both POSIX and Windows, and this store's mutual exclusion has to be a
     # property CI can assert on either platform.
     with file_lock(path, private=True):
-        _append_store_line(path, record)
+        append_store_line(path, record)
     return record
 
 
@@ -750,10 +728,7 @@ def latest_receipt_in(
     validator and the satisfaction predicate from picking different receipts for
     one question and reaching opposite conclusions about it.
     """
-    matches = [
-        dict(receipt) for receipt in receipts if str(receipt.get("approval_id", "")) == str(approval_id_value)
-    ]
-    return matches[-1] if matches else {}
+    return dict(latest_record_in(receipts, key="approval_id", value=str(approval_id_value)))
 
 
 def approval_age_seconds(decided_at: str, now: str = "") -> int:
@@ -887,21 +862,20 @@ def validate_approval_receipt_store(path: Path, *, run_id: str | None = None) ->
     happened to be validated while it sat there.
     """
     receipts, read_errors = read_jsonl_objects(path)
-    indexed = [
-        (index, receipt)
-        for index, receipt in enumerate(receipts, start=1)
-        if run_id is None or str(receipt.get("run_id", "")) == run_id
-    ]
-    errors: list[str] = list(read_errors) if run_id is None else []
-    for index, receipt in indexed:
-        errors.extend(f"{path}:{index}: {error}" for error in validate_approval_receipt(receipt))
-    errors.extend(_supersede_chain_errors(path, receipts, run_id=run_id))
+    receipt_count, errors = store_errors(
+        path,
+        receipts,
+        read_errors,
+        run_id=run_id,
+        validate_record=validate_approval_receipt,
+        label=_LABEL,
+    )
     return {
         "schema_version": APPROVAL_RECEIPT_STORE_VALIDATION_SCHEMA_VERSION,
         "path": str(path),
         "run_id": run_id or "",
         "ok": not errors,
-        "receipt_count": len(indexed),
+        "receipt_count": receipt_count,
         "mint_failure_count": len(read_approval_mint_failures(path)),
         "errors": errors,
     }
@@ -948,16 +922,7 @@ def compact_approval_receipt(receipt: Mapping[str, Any], *, now: str = "") -> di
 
 def redacted_approval_ref(value: str) -> str:
     """Fold any handle into a bounded, non-navigable receipt reference."""
-    text = str(value or "").strip()
-    if not text:
-        return ""
-    if _is_url_shaped(text) or is_sensitive_metadata_text(text):
-        return _digest_ref(text)
-    try:
-        require_opaque_metadata_ref(text, field="approval_ref")
-    except ValueError:
-        return _digest_ref(text)
-    return text
+    return redacted_ref(value, field="approval_ref")
 
 
 def closed_approval_value(value: Any, allowed: tuple[str, ...]) -> str:
@@ -967,8 +932,7 @@ def closed_approval_value(value: Any, allowed: tuple[str, ...]) -> str:
     outside the vocabulary is not a new state, it is a value with no meaning, so
     it renders empty rather than as itself.
     """
-    text = str(value or "")
-    return text if text in allowed else ""
+    return closed_vocabulary_value(value, allowed)
 
 
 def _record_approval(
@@ -1019,35 +983,8 @@ def _record_approval(
             # an approval that refuses one line later.
             if str(prior.get("decision", "")) != "granted" or not approval_is_expired(prior, now):
                 return prior, False
-        _append_store_line(path, record)
+        append_store_line(path, record)
     return record, True
-
-
-def _append_store_line(path: Path, record: dict[str, Any]) -> None:
-    """Append one line, terminating a torn tail first.
-
-    A short write leaves a partial line with no trailing newline. Appending
-    straight onto it concatenates two records into one unparseable line and
-    loses both, so the tail byte is checked and a newline is written first when
-    it is missing. The torn line stays on disk as one corrupt line the store
-    validator reports; the new record survives as its own.
-
-    Binary mode on purpose: Windows text mode would rewrite ``\\n`` as ``\\r\\n``
-    and make the tail check platform-dependent.
-    """
-    ensure_dir(path.parent, private=True)
-    ensure_file(path, private=True)
-    payload = json.dumps(record, sort_keys=True).encode("utf-8") + b"\n"
-    with path.open("r+b") as handle:
-        handle.seek(0, os.SEEK_END)
-        if handle.tell():
-            handle.seek(-1, os.SEEK_END)
-            if handle.read(1) != b"\n":
-                payload = b"\n" + payload
-        handle.seek(0, os.SEEK_END)
-        handle.write(payload)
-        handle.flush()
-        os.fsync(handle.fileno())
 
 
 def _mint_failure(
@@ -1083,20 +1020,7 @@ def _mint_failure(
 
 
 def _append_mint_failure(store_path: Path, failure: dict[str, Any]) -> None:
-    path = approval_mint_failures_path(store_path)
-    try:
-        # The same lock the receipt appends take, on this log's own sidecar. It
-        # is the record that has to survive when things are already going wrong,
-        # so two flows failing at once must not interleave and lose a line. The
-        # lock is never held while the receipt store's lock is: a mint failure
-        # is raised out of that block before this runs.
-        with file_lock(path, private=True):
-            _append_store_line(path, failure)
-    except OSError:
-        # The failure log lives next to the store, so the same outage that lost
-        # the receipt can lose this line too. The mint result the caller already
-        # holds is the record of last resort; there is nothing further to try.
-        return
+    append_sidecar_line(approval_mint_failures_path(store_path), failure)
 
 
 def _lifecycle_verdict(
@@ -1257,63 +1181,9 @@ def _decision_payload(
     }
 
 
-def _supersede_chain_errors(
-    path: Path,
-    receipts: list[dict[str, Any]],
-    *,
-    run_id: str | None,
-) -> list[str]:
-    """Reject every shape a supersede chain must not take.
-
-    A chain is a line, not a graph: a receipt cannot supersede itself, cannot
-    supersede a receipt that does not already exist, and cannot supersede a
-    receipt something else already superseded. A fork means two answers to one
-    confirmation both believe they replaced the same predecessor, which makes
-    "the current answer" ambiguous -- and an ambiguous approval is the one thing
-    a consent record must never be.
-
-    Every receipt in the store is walked even when the report is scoped to one
-    run, so a link into a receipt outside the scope is still a link into a
-    receipt that exists. Only faults on in-scope receipts are reported: scoping
-    a report must never invent a broken chain.
-    """
-    seen: set[str] = set()
-    successors: dict[str, str] = {}
-    errors: list[str] = []
-    for index, receipt in enumerate(receipts, start=1):
-        in_scope = run_id is None or str(receipt.get("run_id", "")) == run_id
-        receipt_id = str(receipt.get("receipt_id", ""))
-        if receipt_id and receipt_id in seen and in_scope:
-            errors.append(f"{path}:{index}: approval_receipt receipt_id is not unique: {receipt_id}")
-        superseded = str(receipt.get("supersedes_receipt_ref", ""))
-        if superseded:
-            if superseded == receipt_id:
-                if in_scope:
-                    errors.append(
-                        f"{path}:{index}: approval_receipt supersedes_receipt_ref must not name itself: {receipt_id}"
-                    )
-            elif superseded not in seen:
-                if in_scope:
-                    errors.append(
-                        f"{path}:{index}: approval_receipt supersedes_receipt_ref does not name an earlier "
-                        f"receipt: {superseded}"
-                    )
-            elif superseded in successors:
-                if in_scope:
-                    errors.append(
-                        f"{path}:{index}: approval_receipt supersedes_receipt_ref forks the chain: "
-                        f"{superseded} is already superseded by {successors[superseded]}"
-                    )
-            else:
-                successors[superseded] = receipt_id
-        seen.add(receipt_id)
-    return errors
-
-
 def _decision_fingerprint(receipt: Mapping[str, Any]) -> str:
     """Which answer a receipt records, ignoring when it was recorded."""
-    identity = {key: receipt.get(key) for key in _DECISION_IDENTITY_KEYS}
-    return hashlib.sha256(json.dumps(identity, sort_keys=True, default=str).encode("utf-8")).hexdigest()
+    return record_fingerprint(receipt, _DECISION_IDENTITY_KEYS)
 
 
 def _parse_stamp(value: str) -> datetime | None:
@@ -1327,22 +1197,8 @@ def _parse_stamp(value: str) -> datetime | None:
     return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
 
 
-def _reference_errors(value: Any, *, field: str, required: bool) -> list[str]:
-    if not isinstance(value, str):
-        return [f"approval_receipt {field} must be a string"]
-    if not value:
-        return [f"approval_receipt {field} is required"] if required else []
-    if _is_url_shaped(value):
-        return [f"approval_receipt {field} must be an opaque identifier, not a URL"]
-    try:
-        require_opaque_metadata_ref(value, field=f"approval_receipt {field}")
-    except ValueError as exc:
-        return [str(exc)]
-    return []
-
-
 def _scope_ref_errors(value: Any) -> list[str]:
-    errors = _reference_errors(value, field="scope_ref", required=True)
+    errors = reference_errors(value, field="scope_ref", label=_LABEL, required=True)
     if errors or not isinstance(value, str):
         return errors
     if _SCOPE_TRAVERSAL.search(value):
@@ -1361,23 +1217,7 @@ def _scope_ref(value: str) -> str:
 
 
 def _opaque(value: str, *, field: str) -> str:
-    text = str(value or "").strip()
-    if not text:
-        raise ApprovalReceiptError(f"{field} is required")
-    if _is_url_shaped(text):
-        raise ApprovalReceiptError(f"{field} must be an opaque identifier, not a URL")
-    try:
-        return require_opaque_metadata_ref(text, field=field)
-    except ValueError as exc:
-        raise ApprovalReceiptError(str(exc)) from exc
-
-
-def _is_url_shaped(value: str) -> bool:
-    return any(marker in value for marker in _URL_SHAPED)
-
-
-def _digest_ref(value: str) -> str:
-    return f"ref-{hashlib.sha256(value.encode('utf-8')).hexdigest()[:12]}"
+    return opaque_ref(value, field=field, error=ApprovalReceiptError)
 
 
 def _bounded_error(value: str) -> str:
@@ -1391,13 +1231,7 @@ def _bounded_error(value: str) -> str:
 
 
 def _receipt_id(decided_at: str, approval_id_value: str, decision: str) -> str:
-    # Random tail for the same reason `external_effect_receipts._receipt_id`
-    # carries one: `utc_now()` has second resolution, so two answers to one
-    # confirmation in the same second would otherwise share an id and break the
-    # supersede chain.
-    base = json.dumps(
-        {"approval_id": approval_id_value, "decided_at": decided_at, "decision": decision},
-        sort_keys=True,
+    return mint_record_id(
+        prefix="approval-receipt",
+        identity={"approval_id": approval_id_value, "decided_at": decided_at, "decision": decision},
     )
-    digest = hashlib.sha256(base.encode("utf-8")).hexdigest()[:16]
-    return f"approval-receipt-{digest}-{secrets.token_hex(3)}"

--- a/src/workflows/blocked_work_records.py
+++ b/src/workflows/blocked_work_records.py
@@ -1,0 +1,1627 @@
+"""Append-only records for work that was blocked, and for the decisions around it (issues #808, #806).
+
+Why this exists at all
+----------------------
+
+A preflight denial used to leave nothing behind. `coding.coding_delegation`
+collapses a denied gate through `denied_executor_selection()` with an empty
+isolation plan, and `commands.coding` then computes a `runtime_skip_reason` and
+returns `payload["runtime"] = {"recorded": False, ...}`. No run is created, no
+`coding_delegation.json` is written, and no journal event is appended -- so
+"why was this blocked?" had no answer once the turn ended. That is worse than
+rendering a block as a skipped success, because a skipped success can at least
+be contradicted later. This store is the durable answer.
+
+Why this is its own record family and not a field group
+-------------------------------------------------------
+
+The repo refused a new family twice (#811, #818) and accepted one once (#807),
+on a rule worth restating: a family joins on run id, and a join is where an
+artifact and its metadata desynchronize, so a field group on the record that
+already exists is the default. A separate family has to earn it.
+
+This one earns it on every dimension #807 used, and on one more:
+
+- Different creation time. The block happens *before* a delegation exists.
+- Different actor. The evaluator or the gate decides, not the router.
+- Its own lifetime. #806's whole acceptance criterion is "explainable after the
+  original turn"; the delegation's lifetime is the turn.
+- It must survive a rebuild under a moved safety-profile revision as a second
+  linked record rather than an overwrite, so the history of a decision that was
+  re-made is a chain and not a replacement.
+
+And decisively: on a preflight denial there is no host record to be a field
+group *on*. `run_id` is empty on exactly those records, which is not a defect
+to be fixed but the shape of the problem.
+
+Nothing here can name what was blocked
+--------------------------------------
+
+#808 AC1 is that raw prompts, tokens, files, and payloads cannot serialize into
+a record. That is enforced structurally rather than by scrubbing:
+
+- The key set is closed, and `RAW_OR_HIDDEN_KEYS` is refused by name first so
+  the error says *why* rather than "unsupported key".
+- There is no free-text field. Not one. Every string on a record is either an
+  opaque reference or a member of a closed vocabulary, so there is nowhere for
+  a sentence to go, let alone a transcript.
+- Reference fields additionally refuse anything path-shaped. The shared
+  `require_opaque_metadata_ref` permits `/` (approval receipts store a scope
+  path on purpose), which would let `src/auth/token.py` ride in as an
+  identifier. Here a file name is never the answer to any question the record
+  asks, so `_PATH_SHAPED` refuses it and AC1 holds by construction.
+
+The fingerprint hashes the input class, never the input
+-------------------------------------------------------
+
+A truncated sha of a filename is dictionary-reversible: anyone holding the
+repository can hash every path and read the digest straight back. It would pass
+"we stored a hash" and fail "hashes are non-reversible" in spirit, which is the
+criterion that matters.
+
+So `request_fingerprint` digests the *multiset of classes and closed-vocabulary
+values present* in the request, and no value that a caller chose. The class
+labels are the ones `quality.safety_preflight` already assigned -- `FIELD_CLASSES`
+is imported, not restated -- because two answers to "what class is this field"
+is the defect that guard tables exist to prevent. `REQUEST_CLASS_LABELS` is
+derived from the preflight's own vocabularies for the same reason, so a class
+added there cannot go unnamed here.
+
+The result: two requests with the same class shape and different values share a
+fingerprint (which is what makes it useful for grouping repeat blocks), a
+different class shape gives a different fingerprint, and no amount of
+brute-force recovers a path, because no path byte was ever an input.
+
+Decision history is a projection, not a second store
+----------------------------------------------------
+
+#806 is answered by `project_decision_history` over these records. The tree's
+precedent is `project_external_effects` and `project_run_lifecycle`, both
+derived and never stored; and a second store over one decision sequence is a
+fork by construction, which `supersede_chain_errors` already rejects.
+
+The history records **allows** as well as blocks, with their own outcome and
+lifecycle transition. That is not bookkeeping: it is what turns "an allow is
+never rendered as attempted or completed" into an enforceable invariant over
+`OUTCOME_WORK_CLAIMS` instead of an accidental absence of rows.
+
+Enforcing versus observing
+--------------------------
+
+The Hermes plugin hook contract has no deny channel. `pre_tool_call` returns
+injected context or None, and `pre_verify`'s only action value is `"continue"`.
+A hook can therefore mint a record *about* a block that something else
+performed, and can never claim OMH stopped anything. `DECISION_SOURCES` is split
+into `ENFORCING_SOURCES` and `OBSERVING_SOURCES` for that reason, an observing
+source is pinned to `declared_not_enforced` with a stated blocker, and
+`build_blocked_work_record` refuses the combination that would lie.
+
+What actually produces and reads these records today
+----------------------------------------------------
+
+Stated because the vocabularies above are wider than the wiring, and a reader
+who takes `DECISION_SOURCES` for a coverage claim would be wrong:
+
+- **One producer.** `commands.coding.cmd_coding_delegate` mints one record per
+  `omh coding delegate` build, from the one action-gate verdict, through
+  `decision_from_action_gate`. That reaches two sources -- `safety_preflight`
+  and `action_gate` -- and two reason domains.
+- **`approval_gate` and `runtime_claim_gate` mint nothing yet.** They are
+  declared here because the reason domains they join (`approval_refusal`,
+  `runtime_claim_block`) are the vocabularies a record from those gates would
+  have to cite, and a record family whose sources are invented later is a
+  migration. Until those gates call in, no record carries either source, and
+  `decision_history` therefore covers the delegation lane and nothing else.
+- **Every observing source mints nothing yet.** No plugin hook, executor, or
+  operator surface calls in; `OBSERVING_SOURCES` is the shape a report from one
+  would have to take, not a lane that exists.
+- **One read surface.** `runtime.artifacts.export_runtime` carries
+  `decision_history` into `omh runtime export`, and
+  `validate_blocked_work_record_store` carries the store's integrity into
+  `omh runtime validate`. There is no dedicated `omh` command for the history.
+
+Store mechanics
+---------------
+
+All of it is `system.append_only_store`, shared with the two receipt families:
+the torn-tail-safe binary append under a real OS lock on both platforms, the
+opaque-reference guards, the supersede-chain walk, the digest handles, and the
+best-effort mint-failure sidecar. This module adds no store mechanics of its
+own; it passes its own key names to the shared walk so its records are not
+described as receipts they are not.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from ..quality.safety_preflight import (
+    ACCESS_INTENTS,
+    DATA_CLASSES,
+    EVIDENCE_CLAIMS,
+    FIELD_CLASS_OPAQUE_REF,
+    FIELD_CLASS_PATH,
+    FIELD_CLASS_VOCABULARY,
+    FIELD_CLASSES,
+    MESSAGE_CONTEXT_MODES,
+    REMOTE_TARGET_KINDS,
+    REQUEST_FIELDS,
+)
+from ..system.append_only_store import (
+    RAW_OR_HIDDEN_KEYS,
+    append_sidecar_line,
+    append_store_line,
+    closed_vocabulary_value,
+    digest_ref,
+    latest_record_in,
+    mint_record_id,
+    opaque_ref,
+    record_fingerprint,
+    redacted_ref,
+    reference_errors,
+    store_errors,
+)
+from ..system.local_store import file_lock, read_jsonl_objects, utc_now
+from ..system.metadata_safety import is_sensitive_metadata_text
+from ..system.paths import OmhPaths
+
+
+BLOCKED_WORK_RECORD_SCHEMA_VERSION: Final[str] = "blocked_work_record/v1"
+BLOCKED_WORK_RECORD_STORE_VALIDATION_SCHEMA_VERSION: Final[str] = "blocked_work_record_store_validation/v1"
+BLOCKED_WORK_MINT_RESULT_SCHEMA_VERSION: Final[str] = "blocked_work_mint_result/v1"
+BLOCKED_WORK_MINT_FAILURE_SCHEMA_VERSION: Final[str] = "blocked_work_mint_failure/v1"
+DECISION_HISTORY_SCHEMA_VERSION: Final[str] = "decision_history/v1"
+
+BLOCKED_WORK_RECORD_STORE_NAME: Final[str] = "blocked_work_records.jsonl"
+BLOCKED_WORK_MINT_FAILURE_STORE_NAME: Final[str] = "blocked_work_mint_failures.jsonl"
+
+RECORD_PRIVACY: Final[str] = "metadata_only"
+
+# Stated on every record and echoed on every history projection. The claim a
+# blocked-work record makes is deliberately small: a decision was reached. It is
+# never evidence about what the blocked work would have done, and on an
+# observing source it is not even evidence that OMH is what stopped it.
+CLAIM_BOUNDARY: Final[str] = (
+    "A blocked work record is one recorded decision about one request shape: what was decided, by which source, "
+    "under which reason code, and what recovery it allows. It carries the class of the request and never its "
+    "content. It is not dispatch, execution, or evidence of what the work would have done, and from an observing "
+    "source it is not evidence that OMH enforced anything."
+)
+
+# Sources that can actually stop work, and sources that can only watch it stop.
+#
+# The split is not stylistic. The Hermes plugin hook contract has no deny
+# channel -- `pre_tool_call` returns injected context or None, `pre_verify`'s
+# only action value is "continue" -- so a record minted from a hook is a report
+# about someone else's block. Collapsing the two would ship an outcome that
+# implies OMH blocked a tool call it has no way to block.
+ENFORCING_SOURCES: Final[tuple[str, ...]] = (
+    "safety_preflight",
+    "action_gate",
+    "approval_gate",
+    "runtime_claim_gate",
+)
+OBSERVING_SOURCES: Final[tuple[str, ...]] = (
+    "plugin_hook_observation",
+    "executor_report",
+    "operator_report",
+)
+DECISION_SOURCES: Final[tuple[str, ...]] = ENFORCING_SOURCES + OBSERVING_SOURCES
+
+ENFORCEMENT_MODES: Final[tuple[str, ...]] = ("enforced", "declared_not_enforced")
+SOURCE_ENFORCEMENT: Final[dict[str, str]] = {
+    **{source: "enforced" for source in ENFORCING_SOURCES},
+    **{source: "declared_not_enforced" for source in OBSERVING_SOURCES},
+}
+
+# Why an observing source cannot enforce, as a closed vocabulary rather than a
+# sentence: the record has no free text, and a blocker that renders is a blocker
+# an operator can act on.
+ENFORCEMENT_BLOCKERS: Final[tuple[str, ...]] = (
+    "hermes_plugin_hooks_have_no_deny_channel",
+    "executor_runs_outside_omh",
+    "operator_report_is_not_a_control_point",
+)
+SOURCE_ENFORCEMENT_BLOCKERS: Final[dict[str, str]] = {
+    "plugin_hook_observation": "hermes_plugin_hooks_have_no_deny_channel",
+    "executor_report": "executor_runs_outside_omh",
+    "operator_report": "operator_report_is_not_a_control_point",
+}
+
+# The five states #808 AC2 requires to stay apart, plus the allow #806 AC3 needs
+# on record. Each is a different claim about the same request shape:
+#
+#   allowed   -- the gate said yes. Nothing has run. This is permission, and the
+#                reason it is stored is that "an allow is never rendered as
+#                attempted or completed" is only enforceable if allows exist.
+#   blocked   -- a gate stopped the work before anything ran. Recoverable: every
+#                blocked record carries a recovery action.
+#   cancelled -- work that had already started was stopped deliberately. The
+#                difference from `blocked` is when, and by whom.
+#   failed    -- work ran and did not succeed.
+#   completed -- work ran and succeeded.
+DECISION_OUTCOMES: Final[tuple[str, ...]] = ("allowed", "blocked", "cancelled", "completed", "failed")
+
+# Where the outcome leaves the work. `paused` is the state `blocked` maps to and
+# nothing else does: a block is not terminal, because a recovery action exists.
+# The nearest success-shaped state in the tree is a gate's `not_required`, and a
+# block must never fold into it -- `not_required` says no evidence is owed,
+# while `blocked` says work is owed and cannot proceed yet.
+LIFECYCLE_STATES: Final[tuple[str, ...]] = ("open", "paused", "terminal")
+OUTCOME_LIFECYCLE: Final[dict[str, str]] = {
+    "allowed": "open",
+    "blocked": "paused",
+    "cancelled": "terminal",
+    "completed": "terminal",
+    "failed": "terminal",
+}
+
+# What each outcome permits a renderer to claim about the work itself. This
+# table is the enforceable form of #806 AC3: `allowed` maps to `not_attempted`,
+# so no projection can render an allow as attempted or completed without
+# contradicting a constant that `tests/test_blocked_work_records.py` iterates.
+WORK_CLAIMS: Final[tuple[str, ...]] = ("not_attempted", "attempted_not_completed", "completed")
+OUTCOME_WORK_CLAIMS: Final[dict[str, str]] = {
+    # Permission is not an attempt. This is the row #806 AC3 is about.
+    "allowed": "not_attempted",
+    # A gate stopped it before anything ran, which is what separates it from
+    # `cancelled`.
+    "blocked": "not_attempted",
+    "cancelled": "attempted_not_completed",
+    "completed": "completed",
+    "failed": "attempted_not_completed",
+}
+# The only outcome a success-shaped render may be built from. Named so the
+# guard reads as the rule rather than as an equality check on a string.
+SUCCESS_OUTCOMES: Final[tuple[str, ...]] = ("completed",)
+
+# Which existing explanation vocabulary a reason code belongs to. There are
+# already four in the tree -- `RUNTIME_CLAIM_BLOCK_REASONS`, `REFUSAL_REASONS`,
+# `_CORRECTIONS`, and `EXCLUSION_REASON_CODES` -- and a fifth would be a fifth
+# answer to "why". A record therefore names the domain and the code, and the
+# prose is joined at read time from whichever module already owns it.
+REASON_DOMAIN_SAFETY_PREFLIGHT: Final[str] = "safety_preflight_correction"
+REASON_DOMAIN_ACTION_GATE: Final[str] = "action_gate_exclusion"
+REASON_DOMAIN_APPROVAL: Final[str] = "approval_refusal"
+REASON_DOMAIN_RUNTIME_CLAIM: Final[str] = "runtime_claim_block"
+REASON_DOMAINS: Final[tuple[str, ...]] = (
+    REASON_DOMAIN_ACTION_GATE,
+    REASON_DOMAIN_APPROVAL,
+    REASON_DOMAIN_RUNTIME_CLAIM,
+    REASON_DOMAIN_SAFETY_PREFLIGHT,
+)
+
+# What an operator can do about it. A closed id vocabulary keyed off the reason
+# code, so localized copy is a lookup per locale rather than a translated
+# `correction` string: `safety_preflight._CORRECTIONS` is deliberately
+# constant-only and interpolation-free, and translating one would turn a
+# constant into a formatted string built from caller values.
+RECOVERY_ACTIONS: Final[tuple[str, ...]] = (
+    "declare_missing_field",
+    "remove_prohibited_content",
+    "narrow_declared_scope",
+    "request_approval",
+    "record_observed_evidence",
+    "choose_executor",
+    "no_recovery_available",
+)
+# The recovery a decision allows when nothing was blocked. An allow is not a
+# recovery, so it names the one id that promises nothing.
+ALLOW_RECOVERY_ACTION: Final[str] = "no_recovery_available"
+
+BLOCKED_WORK_RECORD_KEYS: Final[tuple[str, ...]] = (
+    "claim_boundary",
+    "decided_at",
+    "decision_id",
+    "enforcement",
+    "enforcement_blocker",
+    "lifecycle_state",
+    "outcome",
+    "owner",
+    "privacy",
+    "reason_code",
+    "reason_domain",
+    "recovery_action",
+    "record_id",
+    "request_class_shape",
+    "request_fingerprint",
+    "run_id",
+    "safety_profile_revision",
+    "schema_version",
+    "source",
+    "supersedes_record_ref",
+)
+
+# The three keys whose value is a module constant rather than data. Everything
+# else is rendered, and `compact_blocked_work_record` must cover all of it -- a
+# key in the tuple and missing from the compactor is a field that is stored and
+# never seen, which has cost this repo twice.
+BLOCKED_WORK_RECORD_CONSTANT_KEYS: Final[tuple[str, ...]] = ("claim_boundary", "privacy", "schema_version")
+
+# The four field classes, in the sibling stores' layout. Every string field on a
+# record belongs to exactly one of them, and the union is pinned by
+# `tests/test_blocked_work_records.py` so a new field cannot arrive without a
+# class.
+#
+# Identifiers that must be present, through the opaque-reference guard plus the
+# path-shape refusal below.
+_REQUIRED_RECORD_REFS: Final[tuple[str, ...]] = (
+    "decided_at",
+    "decision_id",
+    "owner",
+    "record_id",
+    "request_fingerprint",
+    "safety_profile_revision",
+)
+# Identifiers that are legitimately absent. `run_id` is empty on exactly the
+# records this family exists for: a preflight denial happens before a run
+# exists, and inventing one would be the join #811 and #818 were refused over.
+# The link is empty on the first decision about a request shape and only then.
+_OPTIONAL_RECORD_REFS: Final[tuple[str, ...]] = ("run_id", "supersedes_record_ref")
+# Closed vocabularies, checked by membership everywhere including at render.
+# `reason_code` is absent here on purpose: it is closed *given* the domain, so
+# it is checked against `reason_codes_for_domain` instead of one flat tuple.
+_RECORD_VOCABULARIES: Final[tuple[tuple[str, tuple[str, ...]], ...]] = (
+    ("enforcement", ENFORCEMENT_MODES),
+    ("lifecycle_state", LIFECYCLE_STATES),
+    ("outcome", DECISION_OUTCOMES),
+    ("reason_domain", REASON_DOMAINS),
+    ("recovery_action", RECOVERY_ACTIONS),
+    ("source", DECISION_SOURCES),
+)
+# Closed vocabularies that may also be empty, which is a state and not a value.
+_OPTIONAL_RECORD_VOCABULARIES: Final[tuple[tuple[str, tuple[str, ...]], ...]] = (
+    ("enforcement_blocker", ENFORCEMENT_BLOCKERS),
+)
+# The one list field. Its members are closed-vocabulary class labels, never
+# caller text, which is why this family has a list at all and still has no free
+# text.
+_RECORD_LIST_FIELDS: Final[tuple[str, ...]] = ("request_class_shape",)
+
+# Every string field, which is every key that is not the one list. There is
+# deliberately no free-text member: a summary line would be one more place for a
+# prompt to arrive, and a decision needs no prose to be citable.
+_RECORD_STRING_FIELDS: Final[tuple[str, ...]] = tuple(
+    key for key in BLOCKED_WORK_RECORD_KEYS if key not in _RECORD_LIST_FIELDS
+)
+
+# What identifies *which decision* a record is about. The stamp, the record id,
+# and the supersede link are excluded: re-reporting the same decision must not
+# mint a second record just because the clock moved.
+_DECISION_IDENTITY_KEYS: Final[tuple[str, ...]] = (
+    "decision_id",
+    "outcome",
+    "reason_code",
+    "reason_domain",
+    "request_fingerprint",
+    "run_id",
+    "safety_profile_revision",
+    "source",
+)
+
+MAX_CLASS_SHAPE_ENTRIES: Final[int] = 64
+
+# What a record cites when the profile revision behind a decision cannot be
+# read. A required field with no honest value is the shape that makes readers
+# invent one, so this names the absence instead of leaving it empty.
+UNKNOWN_REVISION: Final[str] = "revision-unknown"
+
+# The store label every error line and every reference fault is reported under.
+_LABEL: Final[str] = "blocked_work_record"
+
+# A reference on this record never names a file. `require_opaque_metadata_ref`
+# permits `/` because approval receipts store a workspace scope path on purpose;
+# here a path is exactly what must not serialize, so it is refused separately
+# rather than by loosening a guard two other families depend on.
+_PATH_SHAPED: Final[re.Pattern[str]] = re.compile(r"[/\\]")
+
+
+class BlockedWorkRecordError(ValueError):
+    """Raised when a decision cannot become a blocked work record."""
+
+
+# ---------------------------------------------------------------------------
+# Request class shape and fingerprint
+# ---------------------------------------------------------------------------
+
+# Every label a class shape may contain, derived from the preflight's own
+# vocabularies rather than restated. Deriving it is what stops a data class or
+# an access intent added there from becoming an unnamed label here.
+REQUEST_CLASS_LABELS: Final[tuple[str, ...]] = tuple(
+    sorted(
+        [f"field_class:{name}" for name in (FIELD_CLASS_OPAQUE_REF, FIELD_CLASS_PATH, FIELD_CLASS_VOCABULARY)]
+        + [f"data_class:{value}" for value in DATA_CLASSES]
+        + [f"access_intent:{value}" for value in ACCESS_INTENTS]
+        + [f"remote_target_kind:{value}" for value in REMOTE_TARGET_KINDS]
+        + [f"evidence_claim:{value}" for value in EVIDENCE_CLAIMS]
+        + [f"message_context_mode:{value}" for value in MESSAGE_CONTEXT_MODES]
+        + ["raw_content:included", "raw_content:excluded"]
+    )
+)
+
+# Which closed-vocabulary request fields contribute their *values* to the shape.
+# These are safe to carry verbatim precisely because they are closed: the value
+# is a label the profile already publishes, not something a caller authored.
+_VOCABULARY_VALUE_FIELDS: Final[tuple[tuple[str, str, tuple[str, ...]], ...]] = (
+    ("data_classes", "data_class", DATA_CLASSES),
+    ("access_intents", "access_intent", ACCESS_INTENTS),
+    ("evidence_claims", "evidence_claim", EVIDENCE_CLAIMS),
+)
+
+# The three request fields read by name rather than through `REQUEST_FIELDS`,
+# named as constants so `REQUEST_FIELDS_READ` below can be pinned against the
+# preflight's own tuple. A field renamed there and left as a literal here would
+# silently stop contributing to the shape, which changes every fingerprint
+# without failing anything.
+_REMOTE_TARGETS_FIELD: Final[str] = "remote_targets"
+_MESSAGE_CONTEXT_MODE_FIELD: Final[str] = "message_context_mode"
+_RAW_CONTENT_FIELD: Final[str] = "raw_content_included"
+# The nested key on a destination entry, owned by `DESTINATION_FIELD_CLASSES`.
+_DESTINATION_KIND_KEY: Final[str] = "kind"
+
+# Every request field this module reads by name. Pinned against `REQUEST_FIELDS`
+# by `tests/test_blocked_work_records.py`.
+REQUEST_FIELDS_READ: Final[tuple[str, ...]] = tuple(
+    sorted(
+        {field for field, _, _ in _VOCABULARY_VALUE_FIELDS}
+        | {_REMOTE_TARGETS_FIELD, _MESSAGE_CONTEXT_MODE_FIELD, _RAW_CONTENT_FIELD}
+    )
+)
+
+
+def request_class_shape(request: Mapping[str, object] | None) -> list[str]:
+    """The multiset of classes and closed-vocabulary values present in a request.
+
+    This is the only thing about a request that reaches the store. A caller's
+    path, owner string, or destination reference contributes its *class* and its
+    presence, never a byte of itself, which is what makes the fingerprint built
+    from it non-reversible rather than merely hashed.
+
+    The class of each field is read from `safety_preflight.FIELD_CLASSES`, with
+    the same `opaque_ref` default that module documents for an unclassified
+    string. Re-deriving it here would be a second answer to "what class is this
+    field", and the two would drift.
+
+    A declared-empty list contributes no occurrences. It used to contribute one,
+    through a `max(1, ...)` floor, so a request that declared `target_paths: []`
+    shipped a record claiming one workspace path it did not name. Zero values of
+    a class is zero occurrences of it, and a declared-empty list is therefore
+    indistinguishable from an absent field in the shape -- which is correct,
+    because both carried nothing of that class.
+
+    Sorted, so two requests that differ only in key order share a shape.
+    """
+    if not isinstance(request, Mapping):
+        return []
+    labels: list[str] = []
+    for field in REQUEST_FIELDS:
+        if field not in request:
+            continue
+        value = request[field]
+        field_class = FIELD_CLASSES.get(field, FIELD_CLASS_OPAQUE_REF)
+        labels.extend([f"field_class:{field_class}"] * _occurrences(value))
+    for field, prefix, vocabulary in _VOCABULARY_VALUE_FIELDS:
+        for value in _string_members(request.get(field)):
+            if value in vocabulary:
+                labels.append(f"{prefix}:{value}")
+    for entry in _destination_entries(request.get(_REMOTE_TARGETS_FIELD)):
+        kind = str(entry.get(_DESTINATION_KIND_KEY, ""))
+        if kind in REMOTE_TARGET_KINDS:
+            labels.append(f"remote_target_kind:{kind}")
+    mode = str(request.get(_MESSAGE_CONTEXT_MODE_FIELD, ""))
+    if mode in MESSAGE_CONTEXT_MODES:
+        labels.append(f"message_context_mode:{mode}")
+    if _RAW_CONTENT_FIELD in request:
+        labels.append("raw_content:included" if request.get(_RAW_CONTENT_FIELD) else "raw_content:excluded")
+    return _bounded_class_shape(labels)
+
+
+def _bounded_class_shape(labels: list[str]) -> list[str]:
+    """The shape inside its budget, with every distinct label still present.
+
+    The budget used to be applied as `sorted(labels)[:MAX]`, which truncates by
+    alphabet. On a request with more than `MAX_CLASS_SHAPE_ENTRIES` field
+    occurrences that dropped whole labels from the tail of the alphabet --
+    `raw_content:included` and `message_context_mode:full` among them -- so a
+    request carrying raw content and one that excluded it collapsed onto a
+    single fingerprint. A fingerprint that merges those two is worse than no
+    fingerprint, because it is consulted to group repeat blocks.
+
+    Presence is therefore never truncated: every distinct label survives, and
+    only the repeat counts are trimmed, round-robin over the labels in sorted
+    order so no one field's occurrences can crowd out another's. The vocabulary
+    is closed and small (`REQUEST_CLASS_LABELS`), so the distinct set fits the
+    budget by construction; the guard below is what makes that a checked fact
+    rather than an assumption about a vocabulary someone may extend.
+
+    What this does *not* preserve is exact multiplicity beyond the budget: two
+    requests differing only in occurrence counts above it still share a shape.
+    That is the honest cost of a bounded field, and it is a cost in grouping
+    precision rather than in what the fingerprint distinguishes.
+    """
+    counts: dict[str, int] = {}
+    for label in labels:
+        counts[label] = counts.get(label, 0) + 1
+    distinct = sorted(counts)
+    if len(distinct) >= MAX_CLASS_SHAPE_ENTRIES:
+        return distinct[:MAX_CLASS_SHAPE_ENTRIES]
+    kept = dict.fromkeys(distinct, 1)
+    budget = MAX_CLASS_SHAPE_ENTRIES - len(distinct)
+    while budget > 0:
+        spent = 0
+        for label in distinct:
+            if budget == 0:
+                break
+            if kept[label] < counts[label]:
+                kept[label] += 1
+                budget -= 1
+                spent += 1
+        if spent == 0:
+            break
+    return sorted(label for label in distinct for _ in range(kept[label]))
+
+
+def request_fingerprint(shape: Sequence[str]) -> str:
+    """A stable handle for one request *shape*, which no input can be read back out of.
+
+    The digest's only inputs are closed-vocabulary labels and their counts.
+    Nothing a caller authored is hashed, so unlike a truncated sha of a filename
+    this cannot be inverted by hashing a dictionary: there is no dictionary of
+    candidate inputs, only the label set the profile publishes, and recovering
+    that recovers no request.
+    """
+    known = sorted(str(label) for label in shape if str(label) in REQUEST_CLASS_LABELS)
+    digest = hashlib.sha256(json.dumps(known, sort_keys=True).encode("utf-8")).hexdigest()
+    return f"shape-{digest[:32]}"
+
+
+def fingerprint_for_request(request: Mapping[str, object] | None) -> str:
+    """`request_fingerprint` over the shape of a request in hand."""
+    return request_fingerprint(request_class_shape(request))
+
+
+def decision_id(*, source: str, request_fingerprint_value: str, run_id: str) -> str:
+    """Stable identity of one decision question.
+
+    The outcome is deliberately not in it: re-deciding the same question after
+    the profile moved must supersede the earlier answer rather than open a
+    second, parallel chain that both claim to be current. That is the same rule
+    `approval_receipts.approval_id` follows, and for the same reason.
+    """
+    base = json.dumps(
+        {
+            "request_fingerprint": str(request_fingerprint_value),
+            "run_id": str(run_id),
+            "source": str(source),
+        },
+        sort_keys=True,
+    )
+    return f"decision-{hashlib.sha256(base.encode('utf-8')).hexdigest()[:16]}"
+
+
+# ---------------------------------------------------------------------------
+# Reason codes: the join, not a fifth vocabulary
+# ---------------------------------------------------------------------------
+
+
+def reason_codes_for_domain(domain: str) -> tuple[str, ...]:
+    """Every reason code one existing vocabulary defines.
+
+    Imported lazily, and only the module that owns each vocabulary is asked.
+    Lazy because `coding.action_gate` already imports `workflows.approval_receipts`
+    and `runtime.claims` already imports `workflows.external_effect_receipts`, so
+    a module-level import from here would put a workflows module underneath two
+    of its own consumers.
+    """
+    if domain == REASON_DOMAIN_SAFETY_PREFLIGHT:
+        from ..quality.safety_preflight import correction_reason_codes
+
+        return correction_reason_codes()
+    if domain == REASON_DOMAIN_ACTION_GATE:
+        from ..coding.action_gate import EXCLUSION_REASON_CODES
+
+        return tuple(EXCLUSION_REASON_CODES)
+    if domain == REASON_DOMAIN_APPROVAL:
+        from .approval_receipts import REFUSAL_CODES
+
+        return tuple(REFUSAL_CODES)
+    if domain == REASON_DOMAIN_RUNTIME_CLAIM:
+        from ..runtime.claims import RUNTIME_CLAIM_BLOCK_REASONS
+
+        return tuple(sorted(str(claim) for claim in RUNTIME_CLAIM_BLOCK_REASONS))
+    return ()
+
+
+def decision_reason_text(domain: str, reason_code: str) -> str:
+    """The constant line the owning vocabulary already publishes for this code.
+
+    Joined at read time rather than stored, which is what keeps #806 answerable
+    offline without this family owning a fifth copy of "why". A code outside its
+    domain returns empty: rendering reads whatever is on disk, and an
+    unrecognised code is not a new explanation, it is a value with no meaning.
+    """
+    code = str(reason_code or "")
+    if code not in reason_codes_for_domain(domain):
+        return ""
+    if domain == REASON_DOMAIN_SAFETY_PREFLIGHT:
+        from ..quality.safety_preflight import correction_for_reason_code
+
+        return correction_for_reason_code(code)
+    if domain == REASON_DOMAIN_APPROVAL:
+        from .approval_receipts import REFUSAL_REASONS
+
+        return str(REFUSAL_REASONS.get(code, ""))
+    if domain == REASON_DOMAIN_RUNTIME_CLAIM:
+        from ..runtime.claims import RUNTIME_CLAIM_BLOCK_REASONS
+
+        for claim, text in RUNTIME_CLAIM_BLOCK_REASONS.items():
+            if str(claim) == code:
+                return str(text)
+        return ""
+    if domain == REASON_DOMAIN_ACTION_GATE:
+        return _ACTION_GATE_REASONS.get(code, "")
+    return ""
+
+
+# `EXCLUSION_REASON_CODES` is the one of the four vocabularies that ships codes
+# without constant prose -- `action_gate` requires each exclusion to carry its
+# own `explanation` string, built where the exclusion is raised. A history read
+# back on a later turn has no such string, so the constant line lives here. This
+# is a rendering of codes that already exist, not a fifth vocabulary: the tuple
+# is `action_gate`'s, and `tests/test_blocked_work_records.py` fails when the
+# two go out of step.
+_ACTION_GATE_REASONS: Final[dict[str, str]] = {
+    "narrowed_by_request": "The request itself narrowed the authority envelope below what this action needs.",
+    "not_required_by_task": "The task does not require this action, so the envelope never granted it.",
+    "outside_permission_profile": "The active permission profile does not include this action.",
+    "safety_preflight_denied": "The safety preflight denied the request before any authority was granted.",
+    "withheld_pending_approval": "The action is withheld until an operator answers the confirmation it requires.",
+}
+
+# Which recovery a reason code allows. Keyed off the code so the copy is a
+# lookup and never an interpolation, and defaulted per domain so a code added
+# upstream still renders a usable action instead of an empty cell.
+_RECOVERY_BY_REASON_CODE: Final[dict[str, str]] = {
+    "safety_preflight_denied": "remove_prohibited_content",
+    "withheld_pending_approval": "request_approval",
+    "outside_permission_profile": "request_approval",
+    "narrowed_by_request": "narrow_declared_scope",
+    "not_required_by_task": "no_recovery_available",
+}
+_RECOVERY_BY_DOMAIN: Final[dict[str, str]] = {
+    REASON_DOMAIN_ACTION_GATE: "request_approval",
+    REASON_DOMAIN_APPROVAL: "request_approval",
+    REASON_DOMAIN_RUNTIME_CLAIM: "record_observed_evidence",
+    REASON_DOMAIN_SAFETY_PREFLIGHT: "declare_missing_field",
+}
+
+
+def recovery_action_for(domain: str, reason_code: str) -> str:
+    """The recovery id one blocked decision allows.
+
+    A closed id, never a sentence: the localized copy for it lives in
+    `wrapper.localized_copy` keyed by this id, which is what lets a recovery be
+    stated in the operator's language without translating a
+    `safety_preflight._CORRECTIONS` constant that is deliberately
+    interpolation-free.
+    """
+    code = str(reason_code or "")
+    if code in _RECOVERY_BY_REASON_CODE:
+        return _RECOVERY_BY_REASON_CODE[code]
+    if code.startswith("secret_") or code.startswith("prohibited_") or code.startswith("data_class_"):
+        return "remove_prohibited_content"
+    if code.endswith("_count_exceeded") or code.endswith("_too_long"):
+        return "narrow_declared_scope"
+    if code == "executor_choice_required":
+        return "choose_executor"
+    return _RECOVERY_BY_DOMAIN.get(domain, "no_recovery_available")
+
+
+# Every key this module reads off an action-gate verdict, and off the denial
+# that verdict carries. `tests/test_blocked_work_records.py` re-derives the
+# actual reads from this module's source and checks them against
+# `action_gate.ACTION_GATE_KEYS` and `action_gate.DENIAL_KEYS`, so these tuples
+# describe the code rather than being trusted to.
+#
+# The pin exists because the first version of this lane read
+# `denial["reason_code"]` -- singular, and not a member of the denial contract
+# at all, which has only the plural `reason_codes`. Every gate denial therefore
+# minted the fallback code instead of the one the gate raised, and the whole
+# suite stayed green because each test built its own denial dict carrying the
+# key the code was looking for.
+ACTION_GATE_VERDICT_KEYS_READ: Final[tuple[str, ...]] = ("denial", "outcome", "safety_profile_revision")
+ACTION_GATE_DENIAL_KEYS_READ: Final[tuple[str, ...]] = ("reason_codes",)
+
+# The keys `decision_from_action_gate` hands to a recording surface. Closed and
+# pinned so a consumer cannot read a key the producer never emits: `wrapper.contract`
+# read `recovery_action` off this block before the block carried one, and fell
+# through to a recomputation that happened to agree.
+BLOCKED_WORK_DECISION_KEYS: Final[tuple[str, ...]] = (
+    "class_shape",
+    "outcome",
+    "owner",
+    "reason_code",
+    "reason_domain",
+    "recovery_action",
+    "run_id",
+    "safety_profile_revision",
+    "source",
+)
+
+
+def decision_from_action_gate(
+    action_gate: Mapping[str, Any] | None,
+    *,
+    owner: str,
+    safety_profile_revision: str,
+    request: Mapping[str, object] | None = None,
+    class_shape: Sequence[str] | None = None,
+    run_id: str = "",
+) -> dict[str, Any]:
+    """The decision one action-gate verdict already reached, as mint keywords.
+
+    A translation and never a second judgement. `coding.action_gate.evaluate_action_gate`
+    is the single decision path in this tree; this function reads its outcome
+    and its denial and maps them onto this family's vocabulary, so a record can
+    never disagree with the verdict that produced it.
+
+    An allow maps to outcome `allowed` carrying the verdict's own `allowed`
+    reason code, which is what puts allows in the history at all -- and that in
+    turn is what makes "an allow is never rendered as attempted or completed" a
+    property something can violate, rather than a claim about rows that do not
+    exist.
+
+    Only the request's *class shape* leaves this function. The request itself is
+    read and dropped, because the returned block is embedded in the delegation
+    payload and that payload is serialized; returning the request would have put
+    every path and owner string a caller named into an artifact this family
+    exists to keep them out of.
+    """
+    gate = action_gate if isinstance(action_gate, Mapping) else {}
+    denial = gate.get("denial")
+    denial_map = denial if isinstance(denial, Mapping) else {}
+    # Plural. The denial contract is `DENIAL_KEYS` and carries a list of codes;
+    # there is no singular member to read.
+    listed = denial_map.get("reason_codes")
+    reason_codes = [code for code in listed if isinstance(code, str)] if isinstance(listed, (list, tuple)) else []
+    blocked = str(gate.get("outcome", "")) == "deny"
+    if blocked:
+        domain, code = _denial_reason(reason_codes)
+    else:
+        domain, code = REASON_DOMAIN_SAFETY_PREFLIGHT, "allowed"
+    return {
+        "source": "safety_preflight" if domain == REASON_DOMAIN_SAFETY_PREFLIGHT else "action_gate",
+        "outcome": "blocked" if blocked else "allowed",
+        "reason_domain": domain,
+        "reason_code": code,
+        "recovery_action": recovery_action_for(domain, code) if blocked else ALLOW_RECOVERY_ACTION,
+        "owner": str(owner or "hermes"),
+        # The verdict's own revision first: a record must cite the profile the
+        # decision was actually made under, not the one live when it is written.
+        # `UNKNOWN_REVISION` rather than an empty string when neither is
+        # available, because the field is required and "we do not know" is a
+        # thing a record may honestly say while "" is not.
+        "safety_profile_revision": (
+            str(gate.get("safety_profile_revision", "") or "")
+            or str(safety_profile_revision or "")
+            or UNKNOWN_REVISION
+        ),
+        "class_shape": list(class_shape) if class_shape is not None else request_class_shape(request),
+        "run_id": run_id,
+    }
+
+
+def _denial_reason(reason_codes: Sequence[str]) -> tuple[str, str]:
+    """Which vocabulary explains a denial, and which of its codes.
+
+    Preflight corrections are consulted before action-gate exclusions because a
+    denial the preflight raised is the more specific of the two: the gate's own
+    `safety_preflight_denied` names *that the preflight denied*, while the
+    preflight's code names *what it found*.
+
+    `allowed` is skipped. It is a member of the preflight's code set because
+    every passing verdict carries it, and a denial that somehow carries it too
+    must not be recorded as though the reason for the block were a pass.
+    """
+    preflight_codes = reason_codes_for_domain(REASON_DOMAIN_SAFETY_PREFLIGHT)
+    gate_codes = reason_codes_for_domain(REASON_DOMAIN_ACTION_GATE)
+    for code in reason_codes:
+        if code != "allowed" and code in preflight_codes:
+            return REASON_DOMAIN_SAFETY_PREFLIGHT, code
+    for code in reason_codes:
+        if code in gate_codes:
+            return REASON_DOMAIN_ACTION_GATE, code
+    # A denial whose codes this build cannot explain is still a denial --
+    # `_revision_drift_denial` is the live example, whose codes are
+    # `carried:...`/`live:...` and belong to no explanation vocabulary.
+    # Recording it as an allow to keep the vocabulary tidy would be the one
+    # unrecoverable mistake this family can make, so it is recorded as blocked
+    # under the code that names the gate's denial itself. That is deliberately a
+    # weaker claim than naming the drift: the record says the gate denied before
+    # authority was granted, which is true of every denial reaching this line,
+    # and says nothing about which rule did it.
+    return REASON_DOMAIN_ACTION_GATE, "safety_preflight_denied"
+
+
+# ---------------------------------------------------------------------------
+# Build, validate, append
+# ---------------------------------------------------------------------------
+
+
+def build_blocked_work_record(
+    *,
+    source: str,
+    outcome: str,
+    reason_domain: str,
+    reason_code: str,
+    owner: str,
+    safety_profile_revision: str,
+    request: Mapping[str, object] | None = None,
+    class_shape: Sequence[str] | None = None,
+    run_id: str = "",
+    decided_at: str = "",
+    supersedes_record_ref: str = "",
+) -> dict[str, Any]:
+    """Mint one record, or refuse.
+
+    `request` is the bounded preflight request; only its class shape is read and
+    it is never retained. A caller that already holds the shape passes
+    `class_shape` instead, which is the path the gate takes so the request is
+    not walked twice.
+    """
+    if source not in DECISION_SOURCES:
+        raise BlockedWorkRecordError(f"blocked_work_record source is unsupported: {source!r}")
+    if outcome not in DECISION_OUTCOMES:
+        raise BlockedWorkRecordError(f"blocked_work_record outcome is unsupported: {outcome!r}")
+    if reason_domain not in REASON_DOMAINS:
+        raise BlockedWorkRecordError(f"blocked_work_record reason_domain is unsupported: {reason_domain!r}")
+    if reason_code not in reason_codes_for_domain(reason_domain):
+        raise BlockedWorkRecordError(
+            f"blocked_work_record reason_code {reason_code!r} is not defined by {reason_domain}"
+        )
+    enforcement = SOURCE_ENFORCEMENT[source]
+    if enforcement == "declared_not_enforced" and outcome not in {"blocked", "failed", "cancelled", "completed"}:
+        # An observing source reports what it watched. It cannot be the thing
+        # that granted permission, so it cannot mint an allow.
+        raise BlockedWorkRecordError(
+            f"blocked_work_record source {source!r} observes decisions and cannot record outcome {outcome!r}"
+        )
+    shape = sorted(str(label) for label in (class_shape if class_shape is not None else request_class_shape(request)))
+    unknown_labels = sorted({label for label in shape if label not in REQUEST_CLASS_LABELS})
+    if unknown_labels:
+        raise BlockedWorkRecordError(f"blocked_work_record request_class_shape has unsupported labels: {unknown_labels}")
+    safe_owner = _opaque(owner, field="blocked_work_record owner")
+    safe_run_id = _opaque(run_id, field="blocked_work_record run_id") if run_id else ""
+    safe_revision = _opaque(safety_profile_revision, field="blocked_work_record safety_profile_revision")
+    safe_supersedes = (
+        _opaque(supersedes_record_ref, field="blocked_work_record supersedes_record_ref")
+        if supersedes_record_ref
+        else ""
+    )
+    stamp = _opaque(str(decided_at or utc_now()), field="blocked_work_record decided_at")
+    fingerprint = request_fingerprint(shape)
+    identity = decision_id(source=source, request_fingerprint_value=fingerprint, run_id=safe_run_id)
+    record = {
+        "schema_version": BLOCKED_WORK_RECORD_SCHEMA_VERSION,
+        "record_id": _record_id(stamp, identity, outcome),
+        "decision_id": identity,
+        "run_id": safe_run_id,
+        "owner": safe_owner,
+        "source": source,
+        "outcome": outcome,
+        "lifecycle_state": OUTCOME_LIFECYCLE[outcome],
+        "reason_domain": reason_domain,
+        "reason_code": reason_code,
+        "recovery_action": ALLOW_RECOVERY_ACTION if outcome == "allowed" else recovery_action_for(reason_domain, reason_code),
+        "enforcement": enforcement,
+        "enforcement_blocker": SOURCE_ENFORCEMENT_BLOCKERS.get(source, ""),
+        "request_fingerprint": fingerprint,
+        "request_class_shape": shape,
+        "safety_profile_revision": safe_revision,
+        "decided_at": stamp,
+        "supersedes_record_ref": safe_supersedes,
+        "privacy": RECORD_PRIVACY,
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+    errors = validate_blocked_work_record(record)
+    if errors:
+        raise BlockedWorkRecordError(errors[0])
+    return record
+
+
+def validate_blocked_work_record(record: dict[str, Any]) -> list[str]:
+    """Every reason one record is not a blocked work record."""
+    errors: list[str] = []
+    if not isinstance(record, dict):
+        return ["blocked_work_record must be an object"]
+    forbidden = sorted(key for key in record if str(key).lower() in RAW_OR_HIDDEN_KEYS)
+    if forbidden:
+        errors.append(f"blocked_work_record must not carry raw or hidden keys: {forbidden}")
+    extra_keys = sorted(set(record) - set(BLOCKED_WORK_RECORD_KEYS) - set(forbidden))
+    if extra_keys:
+        errors.append(f"blocked_work_record has unsupported keys: {extra_keys}")
+    missing = sorted(set(BLOCKED_WORK_RECORD_KEYS) - set(record))
+    if missing:
+        errors.append(f"blocked_work_record is missing keys: {missing}")
+    if record.get("schema_version") != BLOCKED_WORK_RECORD_SCHEMA_VERSION:
+        errors.append(f"blocked_work_record schema_version must be {BLOCKED_WORK_RECORD_SCHEMA_VERSION}")
+    for key in _RECORD_STRING_FIELDS:
+        if not isinstance(record.get(key), str):
+            errors.append(f"blocked_work_record {key} must be a string")
+    for key, vocabulary in _RECORD_VOCABULARIES:
+        if record.get(key) not in vocabulary:
+            errors.append(f"blocked_work_record {key} is unsupported: {record.get(key)!r}")
+    for key, vocabulary in _OPTIONAL_RECORD_VOCABULARIES:
+        value = record.get(key)
+        if value and value not in vocabulary:
+            errors.append(f"blocked_work_record {key} is unsupported: {value!r}")
+    if record.get("privacy") != RECORD_PRIVACY:
+        errors.append("blocked_work_record privacy must be metadata_only")
+    if record.get("claim_boundary") != CLAIM_BOUNDARY:
+        errors.append("blocked_work_record claim_boundary must state the decision boundary")
+    for field in _REQUIRED_RECORD_REFS:
+        errors.extend(_ref_errors(record.get(field), field=field, required=True))
+    for field in _OPTIONAL_RECORD_REFS:
+        errors.extend(_ref_errors(record.get(field), field=field, required=False))
+    errors.extend(_class_shape_errors(record.get("request_class_shape")))
+    errors.extend(_reason_errors(record))
+    errors.extend(_consistency_errors(record))
+    return errors
+
+
+def _reason_errors(record: Mapping[str, Any]) -> list[str]:
+    domain = str(record.get("reason_domain", ""))
+    if domain not in REASON_DOMAINS:
+        return []
+    code = record.get("reason_code")
+    if not isinstance(code, str) or code not in reason_codes_for_domain(domain):
+        return [f"blocked_work_record reason_code is not defined by {domain}: {code!r}"]
+    return []
+
+
+def _consistency_errors(record: Mapping[str, Any]) -> list[str]:
+    """The derived fields, re-derived.
+
+    Without this a hand-edited store could pair `blocked` with a terminal
+    lifecycle, or hang an `enforced` claim off a hook that has no deny channel,
+    and every reader downstream would believe it.
+    """
+    errors: list[str] = []
+    outcome = str(record.get("outcome", ""))
+    source = str(record.get("source", ""))
+    if outcome in OUTCOME_LIFECYCLE and record.get("lifecycle_state") != OUTCOME_LIFECYCLE[outcome]:
+        errors.append(
+            f"blocked_work_record lifecycle_state must be {OUTCOME_LIFECYCLE[outcome]} for outcome {outcome}"
+        )
+    if source in SOURCE_ENFORCEMENT and record.get("enforcement") != SOURCE_ENFORCEMENT[source]:
+        errors.append(f"blocked_work_record enforcement must be {SOURCE_ENFORCEMENT[source]} for source {source}")
+    if source in SOURCE_ENFORCEMENT_BLOCKERS:
+        if record.get("enforcement_blocker") != SOURCE_ENFORCEMENT_BLOCKERS[source]:
+            errors.append(f"blocked_work_record enforcement_blocker must state why {source} cannot enforce")
+        if outcome == "allowed":
+            errors.append(f"blocked_work_record source {source} observes decisions and cannot record an allow")
+    elif record.get("enforcement_blocker"):
+        errors.append("blocked_work_record enforcement_blocker must be empty for an enforcing source")
+    if outcome == "allowed" and record.get("recovery_action") != ALLOW_RECOVERY_ACTION:
+        errors.append("blocked_work_record recovery_action must promise nothing for an allow")
+    shape = record.get("request_class_shape")
+    if isinstance(shape, list) and all(isinstance(label, str) for label in shape):
+        expected = request_fingerprint(shape)
+        if str(record.get("request_fingerprint", "")) != expected:
+            # Without this a hand-edited store could point one decision's shape
+            # at another decision's fingerprint and merge two chains.
+            errors.append("blocked_work_record request_fingerprint does not identify its own class shape")
+        expected_identity = decision_id(
+            source=source,
+            request_fingerprint_value=expected,
+            run_id=str(record.get("run_id", "")),
+        )
+        if str(record.get("decision_id", "")) != expected_identity:
+            errors.append("blocked_work_record decision_id does not identify its own source, run, and request shape")
+    if str(record.get("record_id", "")) and str(record.get("record_id", "")) == str(
+        record.get("supersedes_record_ref", "")
+    ):
+        errors.append("blocked_work_record supersedes_record_ref must not name itself")
+    return errors
+
+
+def _class_shape_errors(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return ["blocked_work_record request_class_shape must be a list"]
+    if len(value) > MAX_CLASS_SHAPE_ENTRIES:
+        return [f"blocked_work_record request_class_shape must hold at most {MAX_CLASS_SHAPE_ENTRIES} labels"]
+    errors: list[str] = []
+    for index, label in enumerate(value):
+        if not isinstance(label, str):
+            errors.append(f"blocked_work_record request_class_shape[{index}] must be a string")
+        elif label not in REQUEST_CLASS_LABELS:
+            errors.append(f"blocked_work_record request_class_shape[{index}] is unsupported: {label!r}")
+    if value != sorted(str(label) for label in value if isinstance(label, str)) and not errors:
+        errors.append("blocked_work_record request_class_shape must be sorted")
+    return errors
+
+
+def append_blocked_work_record(paths: OmhPaths, record: dict[str, Any]) -> dict[str, Any]:
+    """Append one validated record. Never rewrites, never reorders."""
+    errors = validate_blocked_work_record(record)
+    if errors:
+        raise BlockedWorkRecordError(errors[0])
+    with file_lock(paths.runtime_blocked_work_records_path, private=True):
+        append_store_line(paths.runtime_blocked_work_records_path, record)
+    return record
+
+
+def record_blocked_work(
+    paths: OmhPaths,
+    *,
+    source: str,
+    outcome: str,
+    reason_domain: str,
+    reason_code: str,
+    owner: str,
+    safety_profile_revision: str,
+    request: Mapping[str, object] | None = None,
+    class_shape: Sequence[str] | None = None,
+    run_id: str = "",
+    now: str = "",
+) -> dict[str, Any]:
+    """Mint and append one record, or return the record that already states it.
+
+    The strict entry point: it raises when the decision cannot become a record
+    and when the store cannot be written. Producers on a live turn call
+    `mint_blocked_work_record` instead, because a store outage must not fail the
+    gate that already reached its verdict.
+    """
+    record, _ = _record_decision(
+        paths.runtime_blocked_work_records_path,
+        source=source,
+        outcome=outcome,
+        reason_domain=reason_domain,
+        reason_code=reason_code,
+        owner=owner,
+        safety_profile_revision=safety_profile_revision,
+        request=request,
+        class_shape=class_shape,
+        run_id=run_id,
+        now=now,
+    )
+    return record
+
+
+def mint_blocked_work_record(
+    paths: OmhPaths,
+    *,
+    source: str,
+    outcome: str,
+    reason_domain: str,
+    reason_code: str,
+    owner: str,
+    safety_profile_revision: str,
+    request: Mapping[str, object] | None = None,
+    class_shape: Sequence[str] | None = None,
+    run_id: str = "",
+    now: str = "",
+) -> dict[str, Any]:
+    """Record one decision without ever raising into the deciding surface.
+
+    A gate records *after* it has already denied. Letting the store fail that
+    path would turn an unwritable store into a request that looks like it was
+    never judged, which is precisely the hole this family exists to close, so
+    every refusal and every write failure is returned instead of raised.
+
+    Returns a `blocked_work_mint_result/v1` mapping:
+
+        schema_version -- BLOCKED_WORK_MINT_RESULT_SCHEMA_VERSION
+        minted         -- True when a record reached the store
+        outcome        -- "recorded" | "repeat_recorded" | "refused" | "not_written"
+        decision_id    -- the decision this call was about
+        record_id      -- the record now on file, "" when there is none
+        decision       -- the outcome now on file, "" when there is none
+        error          -- the refusal or write failure, "" otherwise
+
+    `repeat_recorded` is a record that restates a decision already on file. It
+    is appended rather than folded into the earlier one, for the reason
+    `_record_decision` gives.
+
+    Failures are also appended to `blocked_work_mint_failures.jsonl` beside the
+    store, best effort, so a decision that went unrecorded is itself visible.
+    """
+    return mint_blocked_work_record_at(
+        paths.runtime_blocked_work_records_path,
+        source=source,
+        outcome=outcome,
+        reason_domain=reason_domain,
+        reason_code=reason_code,
+        owner=owner,
+        safety_profile_revision=safety_profile_revision,
+        request=request,
+        class_shape=class_shape,
+        run_id=run_id,
+        now=now,
+    )
+
+
+def mint_blocked_work_record_at(
+    store_path: Path,
+    *,
+    source: str,
+    outcome: str,
+    reason_domain: str,
+    reason_code: str,
+    owner: str,
+    safety_profile_revision: str,
+    request: Mapping[str, object] | None = None,
+    class_shape: Sequence[str] | None = None,
+    run_id: str = "",
+    now: str = "",
+) -> dict[str, Any]:
+    """`mint_blocked_work_record` against an already-resolved store path."""
+    shape = sorted(str(label) for label in (class_shape if class_shape is not None else request_class_shape(request)))
+    identity = decision_id(
+        source=str(source),
+        request_fingerprint_value=request_fingerprint(shape),
+        run_id=str(run_id),
+    )
+    try:
+        record, mint_outcome = _record_decision(
+            store_path,
+            source=source,
+            outcome=outcome,
+            reason_domain=reason_domain,
+            reason_code=reason_code,
+            owner=owner,
+            safety_profile_revision=safety_profile_revision,
+            request=None,
+            class_shape=shape,
+            run_id=run_id,
+            now=now,
+        )
+    except BlockedWorkRecordError as exc:
+        return _mint_failure(
+            store_path,
+            outcome="refused",
+            error=str(exc),
+            decision_id_value=identity,
+            source=source,
+            decision=outcome,
+            run_id=run_id,
+        )
+    except OSError as exc:
+        # Covers FileLockTimeout, which is a TimeoutError and therefore an
+        # OSError: an unavailable lock is a store that could not be written.
+        return _mint_failure(
+            store_path,
+            outcome="not_written",
+            error=str(exc),
+            decision_id_value=identity,
+            source=source,
+            decision=outcome,
+            run_id=run_id,
+        )
+    return {
+        "schema_version": BLOCKED_WORK_MINT_RESULT_SCHEMA_VERSION,
+        "minted": True,
+        "outcome": mint_outcome,
+        "decision_id": str(record.get("decision_id", "")),
+        "record_id": str(record.get("record_id", "")),
+        "decision": str(record.get("outcome", "")),
+        "error": "",
+    }
+
+
+def _record_decision(
+    path: Path,
+    *,
+    source: str,
+    outcome: str,
+    reason_domain: str,
+    reason_code: str,
+    owner: str,
+    safety_profile_revision: str,
+    request: Mapping[str, object] | None,
+    class_shape: Sequence[str] | None,
+    run_id: str,
+    now: str,
+) -> tuple[dict[str, Any], str]:
+    """The record this call put on file, and whether it restates an earlier one.
+
+    The read of the prior record and the append happen under one lock, so two
+    concurrent decisions on one question cannot both link to the same
+    predecessor and fork the chain.
+
+    A decision that restates one already on file is appended, not folded into
+    it. Folding looked like idempotent minting and was not: a decision is
+    identified by `(source, request class shape, run)`, and a class shape is
+    deliberately shared by every request of the same shape, so two *different*
+    blocks -- different requests, different turns, same shape, same reason --
+    landed on one record dated at the first of them. The store then reported one
+    decision where there had been several, and reported the wrong time for the
+    one it kept. Appending keeps every occurrence, dates the head at the latest,
+    and leaves the earlier ones on file as superseded records the history counts.
+
+    What the projection still does not do is show the repeats as separate
+    entries: `project_decision_history` renders chain heads, so a shape blocked
+    ten times is one entry with `superseded_count` 9. It is a history of
+    decisions, not of block events.
+    """
+    shape = sorted(str(label) for label in (class_shape if class_shape is not None else request_class_shape(request)))
+    with file_lock(path, private=True):
+        identity = decision_id(
+            source=str(source),
+            request_fingerprint_value=request_fingerprint(shape),
+            run_id=str(run_id),
+        )
+        records, _ = read_jsonl_objects(path)
+        prior = latest_record_in(records, key="decision_id", value=identity)
+        record = build_blocked_work_record(
+            source=source,
+            outcome=outcome,
+            reason_domain=reason_domain,
+            reason_code=reason_code,
+            owner=owner,
+            safety_profile_revision=safety_profile_revision,
+            class_shape=shape,
+            run_id=run_id,
+            decided_at=now,
+            supersedes_record_ref=str(prior.get("record_id", "")) if prior else "",
+        )
+        repeat = bool(prior) and _decision_fingerprint(prior) == _decision_fingerprint(record)
+        append_store_line(path, record)
+    return record, "repeat_recorded" if repeat else "recorded"
+
+
+# ---------------------------------------------------------------------------
+# Read, validate the store, render
+# ---------------------------------------------------------------------------
+
+
+def read_blocked_work_records_result(paths: OmhPaths) -> tuple[list[dict[str, Any]], list[str]]:
+    return read_jsonl_objects(paths.runtime_blocked_work_records_path)
+
+
+def read_blocked_work_records(
+    paths: OmhPaths,
+    *,
+    run_id: str | None = None,
+    decision_id_value: str | None = None,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """The store, in append order, optionally scoped to one run or one decision."""
+    records, _ = read_blocked_work_records_result(paths)
+    if run_id is not None:
+        records = [record for record in records if str(record.get("run_id", "")) == run_id]
+    if decision_id_value is not None:
+        records = [record for record in records if str(record.get("decision_id", "")) == decision_id_value]
+    if limit is None:
+        return records
+    if limit < 1:
+        return []
+    return records[-limit:]
+
+
+def latest_record_for_decision(
+    records: Sequence[Mapping[str, Any]],
+    decision_id_value: str,
+) -> dict[str, Any]:
+    """The record that speaks for one decision: the one selection rule."""
+    return dict(latest_record_in(records, key="decision_id", value=str(decision_id_value)))
+
+
+def validate_blocked_work_record_store(path: Path, *, run_id: str | None = None) -> dict[str, Any]:
+    """Validate the blocked-work store, optionally scoped to one run's records.
+
+    Unscoped this is the store's own report: unparseable lines, every record's
+    schema, and the integrity of the supersede chain. The chain walk is the
+    shared one, told this family's key names so its findings read as records
+    rather than as receipts it has none of.
+    """
+    records, read_errors = read_jsonl_objects(path)
+    record_count, errors = store_errors(
+        path,
+        records,
+        read_errors,
+        run_id=run_id,
+        validate_record=validate_blocked_work_record,
+        label=_LABEL,
+        id_key="record_id",
+        link_key="supersedes_record_ref",
+        noun="record",
+    )
+    return {
+        "schema_version": BLOCKED_WORK_RECORD_STORE_VALIDATION_SCHEMA_VERSION,
+        "path": str(path),
+        "run_id": run_id or "",
+        "ok": not errors,
+        "record_count": record_count,
+        "mint_failure_count": len(read_blocked_work_mint_failures(path)),
+        "errors": errors,
+    }
+
+
+def blocked_work_mint_failures_path(store_path: Path) -> Path:
+    """Where unrecorded decisions are logged, beside the store they failed to reach."""
+    return store_path.with_name(BLOCKED_WORK_MINT_FAILURE_STORE_NAME)
+
+
+def read_blocked_work_mint_failures(store_path: Path) -> list[dict[str, Any]]:
+    failures, _ = read_jsonl_objects(blocked_work_mint_failures_path(store_path))
+    return failures
+
+
+def compact_blocked_work_record(record: Mapping[str, Any]) -> dict[str, Any]:
+    """The user-facing shape, with every field through its class's guard.
+
+    Rendering is the last point at which a hand-edited store reaches a human, so
+    nothing is copied through verbatim: identifiers fold to a stable
+    non-navigable handle when they are not opaque, and closed vocabularies
+    render empty outside their vocabulary. `work_claim` and `reason` are derived
+    here rather than stored -- the first because what a renderer may claim is a
+    property of the outcome and never of the file, and the second because the
+    prose belongs to whichever vocabulary already owns the code.
+    """
+    outcome = closed_vocabulary_value(record.get("outcome"), DECISION_OUTCOMES)
+    domain = closed_vocabulary_value(record.get("reason_domain"), REASON_DOMAINS)
+    reason_code = str(record.get("reason_code", ""))
+    return {
+        "record_id": redacted_blocked_work_ref(str(record.get("record_id", ""))),
+        "decision_id": redacted_blocked_work_ref(str(record.get("decision_id", ""))),
+        "run_id": redacted_blocked_work_ref(str(record.get("run_id", ""))),
+        "owner": redacted_blocked_work_ref(str(record.get("owner", ""))),
+        "source": closed_vocabulary_value(record.get("source"), DECISION_SOURCES),
+        "outcome": outcome,
+        "lifecycle_state": closed_vocabulary_value(record.get("lifecycle_state"), LIFECYCLE_STATES),
+        "work_claim": OUTCOME_WORK_CLAIMS.get(outcome, "not_attempted"),
+        "reason_domain": domain,
+        "reason_code": reason_code if reason_code in reason_codes_for_domain(domain) else "",
+        "reason": decision_reason_text(domain, reason_code),
+        "recovery_action": closed_vocabulary_value(record.get("recovery_action"), RECOVERY_ACTIONS),
+        "enforcement": closed_vocabulary_value(record.get("enforcement"), ENFORCEMENT_MODES),
+        "enforcement_blocker": closed_vocabulary_value(record.get("enforcement_blocker"), ENFORCEMENT_BLOCKERS),
+        "request_fingerprint": redacted_blocked_work_ref(str(record.get("request_fingerprint", ""))),
+        "request_class_shape": [
+            label for label in _string_members(record.get("request_class_shape")) if label in REQUEST_CLASS_LABELS
+        ],
+        "safety_profile_revision": redacted_blocked_work_ref(str(record.get("safety_profile_revision", ""))),
+        "decided_at": redacted_blocked_work_ref(str(record.get("decided_at", ""))),
+        "supersedes_record_ref": redacted_blocked_work_ref(str(record.get("supersedes_record_ref", ""))),
+    }
+
+
+def redacted_blocked_work_ref(value: str) -> str:
+    """Fold any handle into a bounded, non-navigable record reference.
+
+    This family's path refusal, applied at the third place it is needed. `_opaque`
+    applies it on write and `_ref_errors` applies it on validate; render used to
+    delegate straight to the shared `redacted_ref`, whose opaque-ref pattern
+    permits an interior `/` because approval receipts store a workspace scope
+    path on purpose.
+
+    The accurate scope of what leaked: a leading `/`, any `\\`, and `../` are
+    already folded by `require_opaque_metadata_ref` inside `redacted_ref`. What
+    passed through verbatim was a *relative POSIX path beginning with an
+    alphanumeric* -- `src/views/home.py`. So `validate_blocked_work_record`
+    refused a record that `compact_blocked_work_record` and
+    `project_decision_history` then published as written: one file, two readers,
+    opposite answers. Folding it to a digest handle here is what makes the three
+    surfaces agree.
+    """
+    text = str(value or "").strip()
+    if text and _PATH_SHAPED.search(text):
+        return digest_ref(text)
+    return redacted_ref(text, field="blocked_work_ref")
+
+
+# ---------------------------------------------------------------------------
+# #806: decision history, projected over the records above
+# ---------------------------------------------------------------------------
+
+
+def project_decision_history(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    run_id: str | None = None,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """Every decision on file, explainable without the request that caused it.
+
+    A projection and not a second store, for the reason `project_external_effects`
+    and `project_run_lifecycle` are: a second store over one decision sequence is
+    a fork by construction, and `supersede_chain_errors` already rejects forks.
+
+    Allows appear here beside blocks. Each entry carries `work_claim` from
+    `OUTCOME_WORK_CLAIMS`, so an allow renders as `not_attempted` and there is no
+    shape in which it renders as attempted or completed.
+
+    Every entry is answerable offline: `reason` is joined from the vocabulary
+    that owns the code, `recovery_action` is a closed id, and nothing in the
+    entry needs the original request -- which is the point, because after the
+    turn the request is gone.
+
+    One entry per *decision*, not per block event. A decision is identified by
+    source, request class shape, and run, and a class shape is shared by every
+    request of that shape, so a shape blocked ten times is one entry whose
+    `decided_at` is the latest of the ten and whose nine predecessors are
+    counted in `superseded_count`. Reading it as "ten requests were blocked"
+    would be wrong; `record_count` is the number of records in scope and is the
+    number to read for that.
+    """
+    known = [record for record in records if isinstance(record, Mapping)]
+    scoped = known if run_id is None else [record for record in known if str(record.get("run_id", "")) == run_id]
+    heads = _chain_heads(scoped)
+    entries = [
+        compact_blocked_work_record(record)
+        for record in scoped
+        if heads.get(str(record.get("decision_id", ""))) == str(record.get("record_id", ""))
+    ]
+    if limit is not None:
+        entries = [] if limit < 1 else entries[-limit:]
+    superseded = len(scoped) - len(
+        [
+            record
+            for record in scoped
+            if heads.get(str(record.get("decision_id", ""))) == str(record.get("record_id", ""))
+        ]
+    )
+    return {
+        "schema_version": DECISION_HISTORY_SCHEMA_VERSION,
+        "run_id": run_id or "",
+        "entries": entries,
+        "summary": {
+            "decision_count": len(entries),
+            # Every record in scope, heads and superseded alike. `decision_count`
+            # counts decisions and this counts the times one was recorded, and
+            # the two differ by exactly the repeats.
+            "record_count": len(scoped),
+            "superseded_count": superseded,
+            "outcome_counts": {
+                outcome: sum(1 for entry in entries if entry["outcome"] == outcome) for outcome in DECISION_OUTCOMES
+            },
+            "lifecycle_counts": {
+                state: sum(1 for entry in entries if entry["lifecycle_state"] == state) for state in LIFECYCLE_STATES
+            },
+            # Explainability is measured over the entries that need explaining.
+            # An allow carries reason code `allowed`, whose correction is empty
+            # because there is nothing to correct, so counting allows here would
+            # dilute the one number #806 AC1 is about. Counts rather than a
+            # boolean because a store written by an older build can hold codes a
+            # newer one dropped, and "part of this history is no longer
+            # explainable" is the honest report of that.
+            "blocked_count": sum(1 for entry in entries if entry["outcome"] == "blocked"),
+            "explainable_blocked_count": sum(
+                1 for entry in entries if entry["outcome"] == "blocked" and entry["reason"]
+            ),
+            "unexplainable_blocked_count": sum(
+                1 for entry in entries if entry["outcome"] == "blocked" and not entry["reason"]
+            ),
+            "enforced_count": sum(1 for entry in entries if entry["enforcement"] == "enforced"),
+            "declared_not_enforced_count": sum(
+                1 for entry in entries if entry["enforcement"] == "declared_not_enforced"
+            ),
+        },
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+
+
+def decision_history(paths: OmhPaths, *, run_id: str | None = None, limit: int | None = None) -> dict[str, Any]:
+    """`project_decision_history` over the store on disk."""
+    records, _ = read_blocked_work_records_result(paths)
+    return project_decision_history(records, run_id=run_id, limit=limit)
+
+
+def _chain_heads(records: Sequence[Mapping[str, Any]]) -> dict[str, str]:
+    """The current record for every decision in one pass over the store.
+
+    The same selection rule as `latest_record_for_decision` -- last record wins
+    -- built once so projecting a store of n records does not walk it n times.
+    """
+    heads: dict[str, str] = {}
+    for record in records:
+        heads[str(record.get("decision_id", ""))] = str(record.get("record_id", ""))
+    return heads
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mint_failure(
+    store_path: Path,
+    *,
+    outcome: str,
+    error: str,
+    decision_id_value: str,
+    source: str,
+    decision: str,
+    run_id: str,
+) -> dict[str, Any]:
+    failure = {
+        "schema_version": BLOCKED_WORK_MINT_FAILURE_SCHEMA_VERSION,
+        "recorded_at": utc_now(),
+        "outcome": outcome,
+        "decision_id": str(decision_id_value),
+        "source": str(source),
+        "decision": str(decision),
+        "run_id": str(run_id),
+        "error": _bounded_error(error),
+    }
+    append_sidecar_line(blocked_work_mint_failures_path(store_path), failure)
+    return {
+        "schema_version": BLOCKED_WORK_MINT_RESULT_SCHEMA_VERSION,
+        "minted": False,
+        "outcome": outcome,
+        "decision_id": str(decision_id_value),
+        "record_id": "",
+        "decision": "",
+        "error": str(error),
+    }
+
+
+def _decision_fingerprint(record: Mapping[str, Any]) -> str:
+    """Which decision a record states, ignoring when it was recorded."""
+    return record_fingerprint(record, _DECISION_IDENTITY_KEYS)
+
+
+def _record_id(decided_at: str, decision_id_value: str, outcome: str) -> str:
+    return mint_record_id(
+        prefix="blocked-work",
+        identity={"decided_at": decided_at, "decision_id": decision_id_value, "outcome": outcome},
+    )
+
+
+def _ref_errors(value: Any, *, field: str, required: bool) -> list[str]:
+    """The shared reference guard, plus this family's refusal of anything path-shaped."""
+    errors = reference_errors(value, field=field, label=_LABEL, required=required)
+    if errors or not isinstance(value, str) or not value:
+        return errors
+    if _PATH_SHAPED.search(value):
+        return [f"{_LABEL} {field} must not name a path; this record carries the class of a request, never its content"]
+    return []
+
+
+def _opaque(value: str, *, field: str) -> str:
+    text = opaque_ref(value, field=field, error=BlockedWorkRecordError)
+    if _PATH_SHAPED.search(text):
+        raise BlockedWorkRecordError(
+            f"{field} must not name a path; this record carries the class of a request, never its content"
+        )
+    return text
+
+
+def _bounded_error(value: str) -> str:
+    """One bounded, secret-free line for the failure log."""
+    raw = " ".join(str(value or "").split())
+    if not raw:
+        return ""
+    if is_sensitive_metadata_text(raw):
+        return "[redacted]"
+    return raw[:200]
+
+
+def _occurrences(value: object) -> int:
+    """How many values one request field contributes to the class shape.
+
+    A declared-empty list contributes none. The caller used to floor this at one,
+    so `target_paths: []` -- a request declaring that it names no workspace path
+    -- shipped a record whose shape claimed one.
+    """
+    if isinstance(value, (list, tuple)):
+        return len(value)
+    return 1
+
+
+def _string_members(value: object) -> list[str]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _destination_entries(value: object) -> list[Mapping[str, Any]]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    return [item for item in value if isinstance(item, Mapping)]

--- a/src/workflows/external_effect_receipts.py
+++ b/src/workflows/external_effect_receipts.py
@@ -49,20 +49,25 @@ different receipts for the same effect.
 
 from __future__ import annotations
 
-import hashlib
-import json
-import os
-import re
-import secrets
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
-from ..system.local_store import ensure_dir, ensure_file, file_lock, read_jsonl_objects, utc_now
-from ..system.metadata_safety import (
-    is_sensitive_metadata_text,
-    require_opaque_metadata_ref,
+from ..system.append_only_store import (
+    RAW_OR_HIDDEN_KEYS,
+    append_sidecar_line,
+    append_store_line,
+    closed_vocabulary_value,
+    is_unsafe_metadata_line,
+    latest_record_in,
+    mint_record_id,
+    opaque_ref,
+    record_fingerprint,
+    redacted_ref,
+    reference_errors,
+    store_errors,
 )
+from ..system.local_store import file_lock, read_jsonl_objects, utc_now
 from ..system.paths import OmhPaths
 
 
@@ -203,51 +208,8 @@ MAX_EVIDENCE_REFS = 8
 
 REDACTED_SUMMARY = "[redacted]"
 
-# Mirrors the executor-progress guard: these key names are how raw model output
-# and private payloads arrive, so they are rejected by name as well as by the
-# closed key set.
-_RAW_OR_HIDDEN_KEYS = frozenset(
-    {
-        "analysis",
-        "body",
-        "body_text",
-        "chain_of_thought",
-        "conversation",
-        "cot",
-        "hidden",
-        "hidden_reasoning",
-        "message",
-        "payload",
-        "prompt",
-        "raw",
-        "raw_log",
-        "raw_logs",
-        "raw_message",
-        "raw_output",
-        "raw_payload",
-        "raw_prompt",
-        "reasoning",
-        "stderr",
-        "stdout",
-        "think",
-        "thinking",
-        "transcript",
-        "url",
-    }
-)
-
-# A reference that navigates somewhere is not an opaque identifier. Kept in the
-# same shape as `adapter_quality._URL`, which is where this repo first drew the
-# line between "a handle we can print" and "a link we must not".
-_URL_SHAPED = ("://", "?", "#")
-
-# The free-text guard `summary` shares with every other bounded text field in
-# this repo: `adapter_quality._safe_text` rejects the same three shapes. A URL
-# scheme or any of `/ ? #` is a link or a filesystem path; a control character
-# means the value is a transcript or a prompt rather than one metadata line.
-_UNSAFE_TEXT_URL = re.compile(r"(?i)(?:[a-z][a-z0-9+.-]*://|[/?#])")
-_UNSAFE_TEXT_CONTROL = re.compile(r"[\x00-\x1f\x7f]")
-_UNSAFE_TEXT_WINDOWS_PATH = re.compile(r"(?:^|\s)(?:[A-Za-z]:\\|\\\\)")
+# The store label every error line and every reference fault is reported under.
+_LABEL = "external_effect_receipt"
 
 
 class ExternalEffectReceiptError(ValueError):
@@ -335,7 +297,7 @@ def validate_external_effect_receipt(record: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     if not isinstance(record, dict):
         return ["external_effect_receipt must be an object"]
-    forbidden = sorted(key for key in record if str(key).lower() in _RAW_OR_HIDDEN_KEYS)
+    forbidden = sorted(key for key in record if str(key).lower() in RAW_OR_HIDDEN_KEYS)
     if forbidden:
         errors.append(f"external_effect_receipt must not carry raw or hidden keys: {forbidden}")
     extra_keys = sorted(set(record) - set(EXTERNAL_EFFECT_RECEIPT_KEYS) - set(forbidden))
@@ -370,9 +332,9 @@ def validate_external_effect_receipt(record: dict[str, Any]) -> list[str]:
     # they are rendered, and a citation built from an unguarded one is exactly
     # the string this store exists to keep out of a status report.
     for field in _REQUIRED_RECEIPT_REFS:
-        errors.extend(_reference_errors(record.get(field), field=field, required=True))
+        errors.extend(reference_errors(record.get(field), field=field, label=_LABEL, required=True))
     for field in _OPTIONAL_RECEIPT_REFS:
-        errors.extend(_reference_errors(record.get(field), field=field, required=False))
+        errors.extend(reference_errors(record.get(field), field=field, label=_LABEL, required=False))
     if record.get("observed_result") == "succeeded" and not str(record.get("external_ref", "")):
         errors.append("external_effect_receipt succeeded requires an external_ref naming the observed effect")
     refs = record.get("evidence_refs")
@@ -382,7 +344,9 @@ def validate_external_effect_receipt(record: dict[str, Any]) -> list[str]:
         if len(refs) > MAX_EVIDENCE_REFS:
             errors.append(f"external_effect_receipt evidence_refs must have at most {MAX_EVIDENCE_REFS} items")
         for index, value in enumerate(refs):
-            errors.extend(_reference_errors(value, field=f"evidence_refs[{index}]", required=True))
+            errors.extend(
+                reference_errors(value, field=f"evidence_refs[{index}]", label=_LABEL, required=True)
+            )
     for field in _RECEIPT_TEXT_FIELDS:
         text = record.get(field)
         if not isinstance(text, str):
@@ -407,35 +371,8 @@ def append_external_effect_receipt(paths: OmhPaths, record: dict[str, Any]) -> d
     # both POSIX and Windows, and this store's mutual exclusion has to be a
     # property CI can assert on either platform.
     with file_lock(path, private=True):
-        _append_store_line(path, record)
+        append_store_line(path, record)
     return record
-
-
-def _append_store_line(path: Path, record: dict[str, Any]) -> None:
-    """Append one line, terminating a torn tail first.
-
-    A short write leaves a partial line with no trailing newline. Appending
-    straight onto it concatenates two records into one unparseable line and
-    loses both, so the tail byte is checked and a newline is written first when
-    it is missing. The torn line stays on disk as one corrupt line the store
-    validator reports; the new record survives as its own.
-
-    Binary mode on purpose: Windows text mode would rewrite ``\\n`` as
-    ``\\r\\n`` and make the tail check platform-dependent.
-    """
-    ensure_dir(path.parent, private=True)
-    ensure_file(path, private=True)
-    payload = json.dumps(record, sort_keys=True).encode("utf-8") + b"\n"
-    with path.open("r+b") as handle:
-        handle.seek(0, os.SEEK_END)
-        if handle.tell():
-            handle.seek(-1, os.SEEK_END)
-            if handle.read(1) != b"\n":
-                payload = b"\n" + payload
-        handle.seek(0, os.SEEK_END)
-        handle.write(payload)
-        handle.flush()
-        os.fsync(handle.fileno())
 
 
 def record_external_effect(
@@ -508,7 +445,7 @@ def _record_external_effect(
         )
         if prior and _observation_fingerprint(prior) == _observation_fingerprint(record):
             return prior, False
-        _append_store_line(path, record)
+        append_store_line(path, record)
     return record, True
 
 
@@ -675,8 +612,7 @@ def latest_receipt_in(receipts: list[dict[str, Any]] | tuple[dict[str, Any], ...
     picking different receipts for one effect and reaching opposite conclusions
     about it.
     """
-    matches = [receipt for receipt in receipts if str(receipt.get("effect_id", "")) == str(effect_id)]
-    return matches[-1] if matches else {}
+    return latest_record_in(receipts, key="effect_id", value=str(effect_id))
 
 
 def select_effect_receipt(
@@ -765,21 +701,20 @@ def validate_external_effect_receipt_store(path: Path, *, run_id: str | None = N
     one bad line elsewhere cannot fault a run that has nothing to do with it.
     """
     receipts, read_errors = read_jsonl_objects(path)
-    indexed = [
-        (index, receipt)
-        for index, receipt in enumerate(receipts, start=1)
-        if run_id is None or str(receipt.get("run_id", "")) == run_id
-    ]
-    errors: list[str] = list(read_errors) if run_id is None else []
-    for index, receipt in indexed:
-        errors.extend(f"{path}:{index}: {error}" for error in validate_external_effect_receipt(receipt))
-    errors.extend(_supersede_chain_errors(path, receipts, run_id=run_id))
+    receipt_count, errors = store_errors(
+        path,
+        receipts,
+        read_errors,
+        run_id=run_id,
+        validate_record=validate_external_effect_receipt,
+        label=_LABEL,
+    )
     return {
         "schema_version": EXTERNAL_EFFECT_RECEIPT_STORE_VALIDATION_SCHEMA_VERSION,
         "path": str(path),
         "run_id": run_id or "",
         "ok": not errors,
-        "receipt_count": len(indexed),
+        "receipt_count": receipt_count,
         "mint_failure_count": len(read_external_effect_mint_failures(path)),
         "errors": errors,
     }
@@ -900,16 +835,7 @@ def redacted_external_effect_ref(value: str) -> str:
     by it; non-navigable because a status report is not a place to publish
     someone's links.
     """
-    text = str(value or "").strip()
-    if not text:
-        return ""
-    if _is_url_shaped(text) or is_sensitive_metadata_text(text):
-        return _digest_ref(text)
-    try:
-        require_opaque_metadata_ref(text, field="external_ref")
-    except ValueError:
-        return _digest_ref(text)
-    return text
+    return redacted_ref(value, field="external_ref")
 
 
 def is_unsafe_receipt_text(value: str) -> bool:
@@ -919,15 +845,7 @@ def is_unsafe_receipt_text(value: str) -> bool:
     is the tell that the value is a prompt, a transcript, or a log slice rather
     than the single bounded metadata line a receipt summary is allowed to be.
     """
-    text = str(value or "")
-    if not text:
-        return False
-    return bool(
-        is_sensitive_metadata_text(text)
-        or _UNSAFE_TEXT_CONTROL.search(text)
-        or _UNSAFE_TEXT_URL.search(text)
-        or _UNSAFE_TEXT_WINDOWS_PATH.search(text)
-    )
+    return is_unsafe_metadata_line(value)
 
 
 def bounded_receipt_summary(value: Any) -> str:
@@ -952,8 +870,7 @@ def closed_receipt_value(value: Any, allowed: tuple[str, ...]) -> str:
     outside the vocabulary is not a new state, it is a value with no meaning, so
     it renders empty rather than as itself.
     """
-    text = str(value or "")
-    return text if text in allowed else ""
+    return closed_vocabulary_value(value, allowed)
 
 
 def compact_external_effect_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
@@ -1015,20 +932,7 @@ def _mint_failure(
 
 
 def _append_mint_failure(store_path: Path, failure: dict[str, Any]) -> None:
-    path = external_effect_mint_failures_path(store_path)
-    try:
-        # The same lock the receipt appends take, on this log's own sidecar. It
-        # is the record that has to survive when things are already going wrong,
-        # so two producers failing at once must not interleave and lose a line.
-        # The lock is never held while the receipt store's lock is: a mint
-        # failure is raised out of that block before this runs.
-        with file_lock(path, private=True):
-            _append_store_line(path, failure)
-    except OSError:
-        # The failure log lives next to the store, so the same outage that lost
-        # the receipt can lose this line too. The mint result the caller already
-        # holds is the record of last resort; there is nothing further to try.
-        return
+    append_sidecar_line(external_effect_mint_failures_path(store_path), failure)
 
 
 def _observed_effect_row(receipt: dict[str, Any], receipt_count: int) -> dict[str, Any]:
@@ -1052,57 +956,6 @@ def _projected_effect_row(requested: dict[str, Any], state: str) -> dict[str, An
     }
 
 
-def _supersede_chain_errors(
-    path: Path,
-    receipts: list[dict[str, Any]],
-    *,
-    run_id: str | None,
-) -> list[str]:
-    """Reject every shape a supersede chain must not take.
-
-    A chain is a line, not a graph: a receipt cannot supersede itself, cannot
-    supersede a receipt that does not already exist, and cannot supersede a
-    receipt something else already superseded. A fork means two retries both
-    believe they replaced the same predecessor, which makes "the latest state of
-    this effect" ambiguous.
-
-    Every receipt in the store is walked even when the report is scoped to one
-    run, so a link into a receipt outside the scope is still a link into a
-    receipt that exists. Only faults on in-scope receipts are reported: scoping
-    a report must never invent a broken chain.
-    """
-    seen: set[str] = set()
-    successors: dict[str, str] = {}
-    errors: list[str] = []
-    for index, receipt in enumerate(receipts, start=1):
-        in_scope = run_id is None or str(receipt.get("run_id", "")) == run_id
-        receipt_id = str(receipt.get("receipt_id", ""))
-        if receipt_id and receipt_id in seen and in_scope:
-            errors.append(f"{path}:{index}: external_effect_receipt receipt_id is not unique: {receipt_id}")
-        superseded = str(receipt.get("supersedes_receipt_ref", ""))
-        if superseded:
-            if superseded == receipt_id:
-                if in_scope:
-                    errors.append(
-                        f"{path}:{index}: external_effect_receipt supersedes_receipt_ref must not name itself: {receipt_id}"
-                    )
-            elif superseded not in seen:
-                if in_scope:
-                    errors.append(
-                        f"{path}:{index}: external_effect_receipt supersedes_receipt_ref does not name an earlier receipt: {superseded}"
-                    )
-            elif superseded in successors:
-                if in_scope:
-                    errors.append(
-                        f"{path}:{index}: external_effect_receipt supersedes_receipt_ref forks the chain: "
-                        f"{superseded} is already superseded by {successors[superseded]}"
-                    )
-            else:
-                successors[superseded] = receipt_id
-        seen.add(receipt_id)
-    return errors
-
-
 def _latest_receipt_for_effect_in(path: Path, effect_id: str) -> dict[str, Any]:
     receipts, _ = read_jsonl_objects(path)
     return latest_receipt_in(receipts, str(effect_id))
@@ -1110,59 +963,23 @@ def _latest_receipt_for_effect_in(path: Path, effect_id: str) -> dict[str, Any]:
 
 def _observation_fingerprint(receipt: Mapping[str, Any]) -> str:
     """Which observation a receipt records, ignoring when it was recorded."""
-    identity = {key: receipt.get(key) for key in _OBSERVATION_IDENTITY_KEYS}
-    return hashlib.sha256(json.dumps(identity, sort_keys=True, default=str).encode("utf-8")).hexdigest()
-
-
-def _reference_errors(value: Any, *, field: str, required: bool) -> list[str]:
-    if not isinstance(value, str):
-        return [f"external_effect_receipt {field} must be a string"]
-    if not value:
-        return [f"external_effect_receipt {field} is required"] if required else []
-    if _is_url_shaped(value):
-        return [f"external_effect_receipt {field} must be an opaque identifier, not a URL"]
-    try:
-        require_opaque_metadata_ref(value, field=f"external_effect_receipt {field}")
-    except ValueError as exc:
-        return [str(exc)]
-    return []
+    return record_fingerprint(receipt, _OBSERVATION_IDENTITY_KEYS)
 
 
 def _opaque(value: str, *, field: str) -> str:
-    text = str(value or "").strip()
-    if not text:
-        raise ExternalEffectReceiptError(f"{field} is required")
-    if _is_url_shaped(text):
-        raise ExternalEffectReceiptError(f"{field} must be an opaque identifier, not a URL")
-    try:
-        return require_opaque_metadata_ref(text, field=field)
-    except ValueError as exc:
-        raise ExternalEffectReceiptError(str(exc)) from exc
-
-
-def _is_url_shaped(value: str) -> bool:
-    return any(marker in value for marker in _URL_SHAPED)
-
-
-def _digest_ref(value: str) -> str:
-    return f"ref-{hashlib.sha256(value.encode('utf-8')).hexdigest()[:12]}"
+    return opaque_ref(value, field=field, error=ExternalEffectReceiptError)
 
 
 def _receipt_id(observed_at: str, effect_id: str, acting_surface: str, observed_result: str) -> str:
-    # Random tail for the same reason `observation_journal._event_id` carries
-    # one: `utc_now()` has second resolution, so two receipts for one effect in
-    # the same second would otherwise share an id and break the supersede chain.
-    base = json.dumps(
-        {
+    return mint_record_id(
+        prefix="receipt",
+        identity={
             "observed_at": observed_at,
             "effect_id": effect_id,
             "acting_surface": acting_surface,
             "observed_result": observed_result,
         },
-        sort_keys=True,
     )
-    digest = hashlib.sha256(base.encode("utf-8")).hexdigest()[:16]
-    return f"receipt-{digest}-{secrets.token_hex(3)}"
 
 
 def _bounded_refs(values: list[str] | tuple[str, ...]) -> list[str]:

--- a/src/workflows/observation_journal.py
+++ b/src/workflows/observation_journal.py
@@ -17,7 +17,13 @@ from ..paths import OmhPaths
 OBSERVATION_EVENT_SCHEMA_VERSION = "omh_observation_event/v1"
 LIFECYCLE_PROJECTION_SCHEMA_VERSION = "omh_lifecycle_projection/v1"
 OBSERVATION_PRIVACY = "metadata_only"
-OBSERVATION_STATUSES = ("observed", "blocked", "failed", "not_observed")
+# `cancelled` is a member because the projection below already produces it:
+# `project_run_lifecycle` sets `observation_status` to "cancelled" from the
+# `cancelled` event, and `_terminal_status` already ranks it beside blocked and
+# failed. Without it here the status could be *projected* but never *recorded*,
+# so the one state that says "someone stopped this deliberately" could only
+# arrive as a side effect of an event whose own status said something else.
+OBSERVATION_STATUSES = ("observed", "blocked", "cancelled", "failed", "not_observed")
 CANONICAL_OBSERVATION_EVENTS = (
     "prepared_handoff_created",
     "plan_artifact_created",
@@ -448,6 +454,16 @@ def _fold_event(projection: dict[str, Any], event: dict[str, Any]) -> None:
     elif status == "failed":
         projection["failed"] = True
         projection["observation_status"] = "failed"
+    elif status == "cancelled":
+        # `cancelled` is a member of `OBSERVATION_STATUSES`, so an event can
+        # legally carry it. Without this branch the fold ignored the value and
+        # fell through to the `!= "observed"` return, and a run someone stopped
+        # deliberately projected as a run that had merely not got there yet --
+        # the vocabulary member was in the tuple and nothing in the code backed
+        # it. The event named `cancelled` was already handled below; a milestone
+        # event whose *status* is cancelled was not.
+        projection["cancelled"] = True
+        projection["observation_status"] = "cancelled"
     if status != "observed":
         return
     if event_name == "prepared_handoff_created":

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -65,14 +65,17 @@ from .domain_context_attachment import (
 )
 from ..skills.expert_question_rendering import domain_expert_question_body
 from .localized_copy import (
+    SUPPORTED_COPY_LOCALES,
     chat_copy,
     consolidation_notice_line,
     detect_copy_locale,
     is_localized_locale,
+    recovery_action_copy,
     skill_picker_body as localized_skill_picker_body,
     skill_picker_headline,
 )
 from .orchestration_guidance import build_omh_orchestration_guidance
+from ..workflows.blocked_work_records import recovery_action_for
 
 
 CHAT_INTERACTION_SCHEMA_VERSION = "chat_interaction/v1"
@@ -5742,6 +5745,20 @@ def _apply_action_gate_arbitration(
     return adjusted, armed
 
 
+def _delegation_copy_locale(delegation_payload: dict[str, object]) -> str:
+    """The locale a denial card should speak: whatever the caller declared, else English.
+
+    Explicitly declared and never sniffed. A delegation payload carries no
+    request text -- the message is attached only under the full context mode,
+    and a denied build has no handoff to attach it to -- so detecting a locale
+    here would mean guessing from whatever fragment happened to survive. English
+    is this repo's documented default for user-facing output and localization is
+    opt-in, so an absent declaration is answered and not inferred.
+    """
+    declared = delegation_payload.get("copy_locale")
+    return str(declared) if declared in SUPPORTED_COPY_LOCALES else "en"
+
+
 def _action_gate_state(delegation_payload: dict[str, object]) -> dict[str, object]:
     """Render the action-gate verdict onto a card without re-deciding it.
 
@@ -5771,13 +5788,24 @@ def build_chat_response_from_delegation(delegation_payload: dict[str, object], *
         rule_id = str(denial.get("rule_id", "")) or "safety_preflight_denied"
         field = str(denial.get("field", "")) or "message"
         correction = str(denial.get("correction", ""))
+        # The durable side of the denial, read off the decision block the
+        # delegation build already produced. The existing card is extended
+        # rather than joined by a new one: a second chat card would move
+        # `chat_card_case_count` across ten registration sites to say something
+        # this card is already the right place to say.
+        decision = _nested(delegation_payload, "blocked_work_decision")
+        recovery = str(decision.get("recovery_action", "")) or recovery_action_for(
+            str(decision.get("reason_domain", "")), str(decision.get("reason_code", ""))
+        )
+        recovery_line = recovery_action_copy(recovery, locale=_delegation_copy_locale(delegation_payload))
         return _chat_response(
             kind="clarification",
             headline="I cannot prepare this handoff under the current safety policy.",
             body=(
                 f"Rule `{rule_id}` blocked this on `{field}`. {correction} "
+                f"{recovery_line} "
                 "No coding agent was chosen, no handoff was prepared, and no confirmation is being asked for."
-            ),
+            ).replace("  ", " "),
             phase="clarifying",
             next_action="route_coding_request",
             thread_key=thread_key,
@@ -5792,6 +5820,15 @@ def build_chat_response_from_delegation(delegation_payload: dict[str, object], *
                 "executor_choice_required": False,
                 "dispatchable": False,
                 "prepared_handoff_boundary": "A denied request is not a prepared handoff.",
+                # `paused`, never a success-shaped state. The nearest such state
+                # a gate can reach is `not_required`, which says no evidence is
+                # owed; a block says work is owed and cannot proceed. Folding
+                # the two would render a refusal as a step that was skipped
+                # because nobody needed it.
+                "work_lifecycle_state": "paused",
+                "work_claim": "not_attempted",
+                "recovery_action": recovery,
+                "recovery_action_copy": recovery_line,
                 **gate_state,
             },
         )
@@ -9079,10 +9116,44 @@ def _handoff_step_state(status_payload: dict[str, Any], next_action: str) -> str
     return "pending"
 
 
+# The step states a status card can show. `blocked`, `failed`, and `cancelled`
+# are three different things and used to be one: every `_*_step_state` function
+# below mapped `{"blocked", "failed"}` onto `"blocked"`, so no step could ever
+# report a failure and the card said "something is in the way" where the truth
+# was "this ran and did not work". They are separated here because #808 AC2
+# requires blocked, failed, cancelled, and completed to stay apart wherever they
+# are shown, and a card is where they are shown.
+#
+# `not_required` is in this tuple and is the one success-shaped state a step can
+# reach without evidence. A blocked step must never fold into it: `not_required`
+# says no evidence is owed, and `blocked` says evidence is owed and cannot be
+# produced yet. `_terminal_step_state` exists so that distinction is made in one
+# place rather than five.
+STATUS_CARD_STEP_STATES = ("pending", "ready", "complete", "blocked", "failed", "cancelled", "not_required")
+
+# Which card state one recorded status means, for the statuses that are not
+# progress. Anything absent from this table is progress, not an ending.
+_TERMINAL_STEP_STATES = {
+    "blocked": "blocked",
+    "failed": "failed",
+    "cancelled": "cancelled",
+}
+
+
+def _terminal_step_state(status: str) -> str:
+    """The card state for a status that ended the step, or empty when it did not.
+
+    One table, read by every step builder, so a status cannot mean `failed` on
+    the execution row and `blocked` on the verification row.
+    """
+    return _TERMINAL_STEP_STATES.get(str(status), "")
+
+
 def _observed_step_state(value: dict[str, Any]) -> str:
     status = str(value.get("status", "not_observed"))
-    if status in {"blocked", "failed"}:
-        return "blocked"
+    terminal = _terminal_step_state(status)
+    if terminal:
+        return terminal
     if bool(value.get("observed", False)) and status == "completed":
         return "complete"
     return "pending"
@@ -9090,8 +9161,9 @@ def _observed_step_state(value: dict[str, Any]) -> str:
 
 def _verification_step_state(value: dict[str, Any]) -> str:
     status = str(value.get("status", ""))
-    if status in {"blocked", "failed"}:
-        return "blocked"
+    terminal = _terminal_step_state(status)
+    if terminal:
+        return terminal
     return "complete" if bool(value.get("observed", False)) else "pending"
 
 
@@ -9101,8 +9173,9 @@ def _gate_step_state(value: dict[str, Any], *, required: bool) -> str:
         return "not_required"
     if status == "passed":
         return "complete"
-    if status in {"failed", "blocked"}:
-        return "blocked"
+    terminal = _terminal_step_state(status)
+    if terminal:
+        return terminal
     return "pending"
 
 
@@ -9110,8 +9183,9 @@ def _merge_ready_step_state(value: dict[str, Any], next_action: str) -> str:
     status = str(value.get("status", "not_observed"))
     if next_action == "report_merge_ready" or status == "ready":
         return "complete"
-    if status in {"blocked", "failed"}:
-        return "blocked"
+    terminal = _terminal_step_state(status)
+    if terminal:
+        return terminal
     return "pending"
 
 
@@ -9119,8 +9193,9 @@ def _merged_step_state(value: dict[str, Any]) -> str:
     status = str(value.get("status", "not_observed"))
     if status == "merged":
         return "complete"
-    if status == "blocked":
-        return "blocked"
+    terminal = _terminal_step_state(status)
+    if terminal:
+        return terminal
     return "pending"
 
 

--- a/src/wrapper/localized_copy.py
+++ b/src/wrapper/localized_copy.py
@@ -493,6 +493,102 @@ def chat_copy(copy_id: str, *, locale: str | None = None, korean: bool | None = 
     return copy.get(selected_locale) or copy["en"]
 
 
+# One line per recovery-action id, per locale, in the `_CARD_COPY` shape and
+# with the same English fallback.
+#
+# A table of ids rather than translated corrections, on purpose. A denial's
+# `correction` comes from `safety_preflight._CORRECTIONS`, which is deliberately
+# constant-only and interpolation-free so no caller value can reach a terminal
+# through it. Translating that string would mean either a second constant table
+# keyed by the same reason codes -- a fifth explanation vocabulary -- or
+# building the localized line from the denial's fields, which is exactly the
+# interpolation the English side refuses. Keying off a closed recovery id keeps
+# the localized surface a lookup.
+_RECOVERY_ACTION_COPY: dict[str, dict[str, str]] = {
+    "declare_missing_field": {
+        "en": "Declare the missing field and send the request again.",
+        "ko": "빠진 항목을 명시한 뒤 다시 요청해 주세요.",
+        "ja": "不足している項目を明示してから、もう一度依頼してください。",
+        "zh": "补上缺少的字段后再发送一次请求。",
+        "es": "Declara el campo que falta y vuelve a enviar la solicitud.",
+        "fr": "Déclarez le champ manquant et renvoyez la demande.",
+        "de": "Deklariere das fehlende Feld und sende die Anfrage erneut.",
+    },
+    "remove_prohibited_content": {
+        "en": "Remove the credential or prohibited content and send a reference instead.",
+        "ko": "자격 증명이나 금지된 내용을 제거하고 참조값으로 대신 보내 주세요.",
+        "ja": "認証情報や禁止された内容を取り除き、参照値に置き換えてください。",
+        "zh": "移除凭据或禁止内容，改用引用值发送。",
+        "es": "Elimina la credencial o el contenido prohibido y envía una referencia en su lugar.",
+        "fr": "Retirez l'identifiant ou le contenu interdit et envoyez plutôt une référence.",
+        "de": "Entferne die Zugangsdaten oder verbotenen Inhalte und sende stattdessen eine Referenz.",
+    },
+    "narrow_declared_scope": {
+        "en": "Narrow the declared scope so it stays inside the limits and try again.",
+        "ko": "선언한 범위를 한도 안으로 좁혀서 다시 시도해 주세요.",
+        "ja": "宣言した範囲を上限内に狭めて、もう一度試してください。",
+        "zh": "把声明的范围收窄到限制以内后重试。",
+        "es": "Reduce el alcance declarado para que quede dentro de los límites e inténtalo de nuevo.",
+        "fr": "Réduisez la portée déclarée pour rester dans les limites, puis réessayez.",
+        "de": "Grenze den deklarierten Bereich auf die Limits ein und versuche es erneut.",
+    },
+    "request_approval": {
+        "en": "Ask an operator to approve this action for this scope before retrying.",
+        "ko": "다시 시도하기 전에 이 범위에 대한 작업 승인을 담당자에게 받아 주세요.",
+        "ja": "再試行の前に、この範囲に対する操作の承認を担当者から得てください。",
+        "zh": "重试前请让操作者批准此范围内的该操作。",
+        "es": "Pide a un operador que apruebe esta acción para este alcance antes de reintentar.",
+        "fr": "Demandez à un opérateur d'approuver cette action pour cette portée avant de réessayer.",
+        "de": "Lass einen Operator diese Aktion für diesen Bereich freigeben, bevor du es erneut versuchst.",
+    },
+    "record_observed_evidence": {
+        "en": "Record the observed evidence this claim needs, then ask again.",
+        "ko": "이 주장에 필요한 관측 증거를 기록한 뒤 다시 요청해 주세요.",
+        "ja": "この主張に必要な観測証跡を記録してから、もう一度依頼してください。",
+        "zh": "先记录该结论所需的观测证据，然后再次请求。",
+        "es": "Registra la evidencia observada que requiere esta afirmación y vuelve a preguntar.",
+        "fr": "Enregistrez la preuve observée requise par cette affirmation, puis redemandez.",
+        "de": "Zeichne den beobachteten Nachweis auf, den diese Aussage braucht, und frage erneut.",
+    },
+    "choose_executor": {
+        "en": "Choose a coding agent, then send the request again.",
+        "ko": "coding agent를 먼저 고른 뒤 다시 요청해 주세요.",
+        "ja": "coding agent を選んでから、もう一度依頼してください。",
+        "zh": "先选择一个 coding agent，然后再发送请求。",
+        "es": "Elige un coding agent y vuelve a enviar la solicitud.",
+        "fr": "Choisissez un coding agent, puis renvoyez la demande.",
+        "de": "Wähle einen coding agent und sende die Anfrage erneut.",
+    },
+    "no_recovery_available": {
+        "en": "No recovery is available for this decision from here.",
+        "ko": "이 결정에 대해 여기서 할 수 있는 복구 조치는 없습니다.",
+        "ja": "この判断について、ここから取れる復旧手段はありません。",
+        "zh": "对于这个决定，这里没有可用的补救方式。",
+        "es": "No hay recuperación disponible para esta decisión desde aquí.",
+        "fr": "Aucune reprise n'est possible ici pour cette décision.",
+        "de": "Für diese Entscheidung gibt es hier keine Wiederherstellung.",
+    },
+}
+
+
+def recovery_action_copy(recovery_action: str, *, locale: str | None = None, korean: bool | None = None) -> str:
+    """One localized line for a closed recovery-action id, English on any gap.
+
+    An id this table does not carry renders empty rather than as itself: the id
+    is an internal token, and printing `narrow_declared_scope` at an operator is
+    worse than printing nothing.
+    """
+    entry = _RECOVERY_ACTION_COPY.get(str(recovery_action or ""))
+    if not entry:
+        return ""
+    return entry.get(_normalize_locale(locale, korean=korean)) or entry["en"]
+
+
+def recovery_action_copy_ids() -> tuple[str, ...]:
+    """Every recovery-action id this table can render, for the coverage pin."""
+    return tuple(sorted(_RECOVERY_ACTION_COPY))
+
+
 def skill_picker_headline(*, catalog_question: bool, locale: str | None = None, korean: bool | None = None) -> str:
     selected_locale = _normalize_locale(locale, korean=korean)
     if selected_locale == "ko":

--- a/tests/test_append_only_store.py
+++ b/tests/test_append_only_store.py
@@ -1,0 +1,460 @@
+"""Contracts for the append-only store mechanics `system/append_only_store.py` owns.
+
+These are the properties that used to live twice, once in
+`workflows/external_effect_receipts.py` and once in
+`workflows/approval_receipts.py`, and that a third record family would have
+copied a third time. They are asserted here against the shared module directly,
+with no receipt and no approval in sight, because the mechanics are what is
+shared -- neither family's vocabulary, key set, or claim boundary is.
+
+Each consumer test file still covers the same mechanic through its own public
+API. That is not redundant: those tests prove the family wired the mechanic up,
+these prove the mechanic itself, and the cases below are the ones no single
+consumer fully exercises -- a torn tail that a *later* record still survives, a
+chain broken in all four ways in one store, and a sidecar that lands when the
+store beside it cannot be written at all.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.system.append_only_store import (
+    RAW_OR_HIDDEN_KEYS,
+    URL_SHAPED,
+    append_sidecar_line,
+    append_store_line,
+    closed_vocabulary_value,
+    digest_ref,
+    is_unsafe_metadata_line,
+    is_url_shaped,
+    latest_record_in,
+    mint_record_id,
+    opaque_ref,
+    record_fingerprint,
+    redacted_ref,
+    reference_errors,
+    store_errors,
+    supersede_chain_errors,
+)
+from omh.system.local_store import read_jsonl_objects
+
+LABEL = "test_record"
+
+
+def _record(record_id: str, *, run_id: str = "run-1", supersedes: str = "") -> dict[str, str]:
+    return {"receipt_id": record_id, "run_id": run_id, "supersedes_receipt_ref": supersedes}
+
+
+def _no_errors(record: dict) -> list[str]:
+    return []
+
+
+class TornTailTests(unittest.TestCase):
+    """A short write must cost exactly one line, never the next record."""
+
+    def test_an_append_onto_an_unterminated_tail_starts_its_own_line(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "store.jsonl"
+            append_store_line(path, {"id": "a"})
+            # A short write: the process died mid-line, so there is no newline.
+            with path.open("r+b") as handle:
+                handle.seek(0, 2)
+                handle.write(b'{"id": "b", "half')
+
+            append_store_line(path, {"id": "c"})
+
+            raw = path.read_bytes()
+            self.assertTrue(raw.endswith(b"\n"))
+            lines = raw.decode("utf-8").splitlines()
+            self.assertEqual(len(lines), 3)
+            self.assertEqual(json.loads(lines[0]), {"id": "a"})
+            self.assertEqual(lines[1], '{"id": "b", "half')
+            # The record after the torn one is intact and parses on its own.
+            self.assertEqual(json.loads(lines[2]), {"id": "c"})
+
+    def test_an_unterminated_tail_is_one_store_error_and_later_records_still_parse(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "store.jsonl"
+            append_store_line(path, _record("r-1"))
+            with path.open("r+b") as handle:
+                handle.seek(0, 2)
+                handle.write(b'{"receipt_id": "r-torn')
+            append_store_line(path, _record("r-2"))
+            append_store_line(path, _record("r-3"))
+
+            records, read_errors = read_jsonl_objects(path)
+            # The torn line is the only casualty, and the store says so once.
+            self.assertEqual(len(read_errors), 1)
+            self.assertEqual([record["receipt_id"] for record in records], ["r-1", "r-2", "r-3"])
+
+            count, errors = store_errors(
+                path, records, read_errors, run_id=None, validate_record=_no_errors, label=LABEL
+            )
+            self.assertEqual(count, 3)
+            self.assertEqual(errors, read_errors)
+
+    def test_a_torn_tail_is_the_stores_fault_and_never_a_scoped_runs(self) -> None:
+        """A line that does not parse has no `run_id`, so it faults no run."""
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "store.jsonl"
+            append_store_line(path, _record("r-1", run_id="run-1"))
+            with path.open("r+b") as handle:
+                handle.seek(0, 2)
+                handle.write(b'{"receipt_id": "r-torn')
+            append_store_line(path, _record("r-2", run_id="run-2"))
+
+            records, read_errors = read_jsonl_objects(path)
+            count, errors = store_errors(
+                path, records, read_errors, run_id="run-1", validate_record=_no_errors, label=LABEL
+            )
+            self.assertEqual(count, 1)
+            self.assertEqual(errors, [])
+
+    def test_every_line_is_written_binary_with_sorted_keys_and_no_carriage_return(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "store.jsonl"
+            append_store_line(path, {"z": 1, "a": 2, "m": 3})
+
+            raw = path.read_bytes()
+            self.assertNotIn(b"\r", raw)
+            self.assertEqual(raw, b'{"a": 2, "m": 3, "z": 1}\n')
+
+
+class ConcurrentAppendTests(unittest.TestCase):
+    def test_barrier_synced_appends_do_not_interleave(self) -> None:
+        """Every writer computes the same end offset unless the lock is real.
+
+        Unlocked, two appends that start together land on top of each other and
+        the store loses exactly the lines it exists to keep.
+        """
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "store.jsonl"
+            writers = 16
+            barrier = threading.Barrier(writers)
+            raised: list[Exception] = []
+
+            def append(index: int) -> None:
+                barrier.wait()
+                try:
+                    append_sidecar_line(path, {"writer": index, "payload": "x" * 64})
+                except Exception as exc:  # reported on the main thread, never silently dropped
+                    raised.append(exc)
+
+            threads = [threading.Thread(target=append, args=(index,)) for index in range(writers)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+            self.assertEqual(raised, [])
+            lines = path.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(lines), writers)
+            self.assertEqual(
+                sorted(json.loads(line)["writer"] for line in lines),
+                sorted(range(writers)),
+            )
+
+
+class SidecarTests(unittest.TestCase):
+    def test_the_sidecar_lands_when_the_store_beside_it_cannot_be_written(self) -> None:
+        """The failure log is the record that has to survive the store's outage."""
+        with TemporaryDirectory() as tmp:
+            store_path = Path(tmp) / "store.jsonl"
+            # An unwritable store: the path is a directory, so the append fails.
+            store_path.mkdir()
+            with self.assertRaises(OSError):
+                append_store_line(store_path, {"id": "a"})
+
+            sidecar_path = store_path.with_name("store_failures.jsonl")
+            append_sidecar_line(sidecar_path, {"outcome": "not_written", "id": "a"})
+
+            failures, read_errors = read_jsonl_objects(sidecar_path)
+            self.assertEqual(read_errors, [])
+            self.assertEqual(failures, [{"outcome": "not_written", "id": "a"}])
+
+    def test_an_unwritable_sidecar_is_swallowed_rather_than_raised(self) -> None:
+        """There is nothing further to try, and the caller already holds the result."""
+        with TemporaryDirectory() as tmp:
+            sidecar_path = Path(tmp) / "failures.jsonl"
+            sidecar_path.mkdir()
+
+            self.assertIsNone(append_sidecar_line(sidecar_path, {"outcome": "refused"}))
+
+
+class SupersedeChainTests(unittest.TestCase):
+    """A chain is a line, not a graph."""
+
+    def test_a_self_cycle_is_rejected(self) -> None:
+        path = Path("store.jsonl")
+        errors = supersede_chain_errors(
+            path, [_record("r-1", supersedes="r-1")], run_id=None, label=LABEL
+        )
+        self.assertEqual(errors, [f"{path}:1: {LABEL} supersedes_receipt_ref must not name itself: r-1"])
+
+    def test_a_dangling_link_is_rejected(self) -> None:
+        path = Path("store.jsonl")
+        errors = supersede_chain_errors(
+            path, [_record("r-1"), _record("r-2", supersedes="r-missing")], run_id=None, label=LABEL
+        )
+        self.assertEqual(
+            errors,
+            [f"{path}:2: {LABEL} supersedes_receipt_ref does not name an earlier receipt: r-missing"],
+        )
+
+    def test_a_forward_link_is_dangling_because_order_is_arrival_order(self) -> None:
+        path = Path("store.jsonl")
+        errors = supersede_chain_errors(
+            path, [_record("r-1", supersedes="r-2"), _record("r-2")], run_id=None, label=LABEL
+        )
+        self.assertEqual(
+            errors,
+            [f"{path}:1: {LABEL} supersedes_receipt_ref does not name an earlier receipt: r-2"],
+        )
+
+    def test_a_duplicate_record_id_is_rejected(self) -> None:
+        path = Path("store.jsonl")
+        errors = supersede_chain_errors(path, [_record("r-1"), _record("r-1")], run_id=None, label=LABEL)
+        self.assertEqual(errors, [f"{path}:2: {LABEL} receipt_id is not unique: r-1"])
+
+    def test_a_fork_is_rejected(self) -> None:
+        path = Path("store.jsonl")
+        records = [_record("r-1"), _record("r-2", supersedes="r-1"), _record("r-3", supersedes="r-1")]
+        errors = supersede_chain_errors(path, records, run_id=None, label=LABEL)
+        self.assertEqual(
+            errors,
+            [
+                f"{path}:3: {LABEL} supersedes_receipt_ref forks the chain: "
+                "r-1 is already superseded by r-2"
+            ],
+        )
+
+    def test_a_line_chain_of_any_length_is_accepted(self) -> None:
+        records = [_record("r-1")]
+        records += [_record(f"r-{index}", supersedes=f"r-{index - 1}") for index in range(2, 8)]
+        self.assertEqual(supersede_chain_errors(Path("s.jsonl"), records, run_id=None, label=LABEL), [])
+
+    def test_scoping_a_report_never_invents_a_broken_chain(self) -> None:
+        """A link into a record outside the scope still names a record that exists."""
+        records = [
+            _record("r-1", run_id="run-1"),
+            _record("r-2", run_id="run-2", supersedes="r-1"),
+        ]
+        self.assertEqual(
+            supersede_chain_errors(Path("s.jsonl"), records, run_id="run-2", label=LABEL), []
+        )
+
+    def test_an_out_of_scope_fault_is_not_reported_against_the_scoped_run(self) -> None:
+        records = [_record("r-1", run_id="run-2", supersedes="r-1"), _record("r-9", run_id="run-1")]
+        self.assertEqual(
+            supersede_chain_errors(Path("s.jsonl"), records, run_id="run-1", label=LABEL), []
+        )
+
+    def test_the_label_is_the_callers_and_nothing_else(self) -> None:
+        """The base names no record family; every error line is the caller's own."""
+        errors = supersede_chain_errors(
+            Path("s.jsonl"), [_record("r-1", supersedes="r-1")], run_id=None, label="approval_receipt"
+        )
+        self.assertIn("approval_receipt supersedes_receipt_ref must not name itself", errors[0])
+        self.assertNotIn("external_effect_receipt", errors[0])
+
+
+class StoreErrorTests(unittest.TestCase):
+    def test_record_faults_are_prefixed_with_path_and_arrival_index(self) -> None:
+        path = Path("store.jsonl")
+        records = [_record("r-1"), _record("r-2")]
+        count, errors = store_errors(
+            path,
+            records,
+            [],
+            run_id=None,
+            validate_record=lambda record: [f"{LABEL} is bad: {record['receipt_id']}"],
+            label=LABEL,
+        )
+        self.assertEqual(count, 2)
+        self.assertEqual(
+            errors,
+            [f"{path}:1: {LABEL} is bad: r-1", f"{path}:2: {LABEL} is bad: r-2"],
+        )
+
+    def test_the_index_is_the_stores_own_and_not_the_scoped_position(self) -> None:
+        """Scoping narrows what is reported, never how a line is addressed."""
+        path = Path("store.jsonl")
+        records = [_record("r-1", run_id="run-1"), _record("r-2", run_id="run-2")]
+        count, errors = store_errors(
+            path,
+            records,
+            [],
+            run_id="run-2",
+            validate_record=lambda record: ["bad"],
+            label=LABEL,
+        )
+        self.assertEqual(count, 1)
+        self.assertEqual(errors, [f"{path}:2: bad"])
+
+
+class ReferenceGuardTests(unittest.TestCase):
+    class _Refused(ValueError):
+        pass
+
+    def test_opaque_ref_raises_the_callers_own_error(self) -> None:
+        with self.assertRaises(self._Refused) as caught:
+            opaque_ref("", field="thing id", error=self._Refused)
+        self.assertEqual(str(caught.exception), "thing id is required")
+
+        with self.assertRaises(self._Refused) as caught:
+            opaque_ref("https://example.com/x", field="thing id", error=self._Refused)
+        self.assertEqual(str(caught.exception), "thing id must be an opaque identifier, not a URL")
+
+        with self.assertRaises(self._Refused):
+            opaque_ref("bad\x1bref", field="thing id", error=self._Refused)
+
+        self.assertEqual(opaque_ref("  slack:message-1  ", field="thing id", error=self._Refused),
+                         "slack:message-1")
+
+    def test_every_url_marker_is_refused_by_both_the_raiser_and_the_collector(self) -> None:
+        for marker in URL_SHAPED:
+            with self.subTest(marker=marker):
+                value = f"ref{marker}tail"
+                self.assertTrue(is_url_shaped(value))
+                with self.assertRaises(self._Refused):
+                    opaque_ref(value, field="thing id", error=self._Refused)
+                self.assertEqual(
+                    reference_errors(value, field="id", label=LABEL, required=True),
+                    [f"{LABEL} id must be an opaque identifier, not a URL"],
+                )
+
+    def test_reference_errors_collects_rather_than_raises(self) -> None:
+        self.assertEqual(
+            reference_errors(None, field="id", label=LABEL, required=True),
+            [f"{LABEL} id must be a string"],
+        )
+        self.assertEqual(
+            reference_errors("", field="id", label=LABEL, required=True),
+            [f"{LABEL} id is required"],
+        )
+        self.assertEqual(reference_errors("", field="id", label=LABEL, required=False), [])
+        self.assertEqual(reference_errors("ref-1", field="id", label=LABEL, required=True), [])
+
+    def test_a_digest_ref_is_stable_bounded_and_non_navigable(self) -> None:
+        folded = digest_ref("https://example.com/very/long/path?token=secret")
+        self.assertEqual(folded, digest_ref("https://example.com/very/long/path?token=secret"))
+        self.assertTrue(folded.startswith("ref-"))
+        self.assertEqual(len(folded), len("ref-") + 12)
+        self.assertFalse(is_url_shaped(folded))
+
+    def test_redacted_ref_keeps_opaque_handles_and_folds_everything_else(self) -> None:
+        self.assertEqual(redacted_ref("slack:message-1", field="ref"), "slack:message-1")
+        self.assertEqual(redacted_ref("", field="ref"), "")
+        for unsafe in ("https://example.com/x", "AKIAIOSFODNN7EXAMPLE", "bad\x1bref", "a" * 200):
+            with self.subTest(unsafe=unsafe):
+                folded = redacted_ref(unsafe, field="ref")
+                self.assertTrue(folded.startswith("ref-"))
+                self.assertFalse(is_url_shaped(folded))
+
+
+class BoundedTextTests(unittest.TestCase):
+    def test_links_paths_secrets_and_control_characters_are_all_unsafe(self) -> None:
+        for unsafe in (
+            "https://example.com/x",
+            "see /etc/passwd",
+            "what? no",
+            "tag#1",
+            "line\nbreak",
+            "erase\x1b[2K\r",
+            "C:\\Users\\me",
+            "\\\\host\\share",
+            "AKIAIOSFODNN7EXAMPLE",
+        ):
+            with self.subTest(unsafe=unsafe):
+                self.assertTrue(is_unsafe_metadata_line(unsafe))
+
+    def test_one_bounded_metadata_line_is_safe(self) -> None:
+        for safe in ("", "ci run observed", "merge rejected by policy", "review submitted"):
+            with self.subTest(safe=safe):
+                self.assertFalse(is_unsafe_metadata_line(safe))
+
+
+class SelectionAndIdentityTests(unittest.TestCase):
+    def test_the_last_record_carrying_an_identity_wins(self) -> None:
+        records = [
+            {"effect_id": "ci:run-1", "receipt_id": "r-1"},
+            {"effect_id": "merge:run-1", "receipt_id": "r-2"},
+            {"effect_id": "ci:run-1", "receipt_id": "r-3"},
+        ]
+        self.assertEqual(latest_record_in(records, key="effect_id", value="ci:run-1")["receipt_id"], "r-3")
+        self.assertEqual(latest_record_in(records, key="effect_id", value="none:0"), {})
+
+    def test_the_match_is_returned_as_found_and_not_copied(self) -> None:
+        """A caller that needs a copy makes one; a caller that does not must not pay."""
+        record = {"effect_id": "ci:run-1", "receipt_id": "r-1"}
+        self.assertIs(latest_record_in([record], key="effect_id", value="ci:run-1"), record)
+
+    def test_a_fingerprint_ignores_every_key_outside_its_identity_tuple(self) -> None:
+        keys = ("action", "effect_id")
+        first = {"action": "ci_run", "effect_id": "ci:run-1", "observed_at": "2026-01-01T00:00:00Z"}
+        second = {"action": "ci_run", "effect_id": "ci:run-1", "observed_at": "2026-06-06T06:06:06Z"}
+        self.assertEqual(record_fingerprint(first, keys), record_fingerprint(second, keys))
+        self.assertNotEqual(
+            record_fingerprint(first, keys),
+            record_fingerprint({**first, "action": "merge"}, keys),
+        )
+
+    def test_a_fingerprint_survives_a_value_json_cannot_serialize(self) -> None:
+        """A hand-edited store is read before it is judged, so nothing may raise here."""
+        keys = ("action",)
+        self.assertEqual(len(record_fingerprint({"action": object()}, keys)), 64)
+
+    def test_two_ids_minted_from_one_identity_in_one_second_still_differ(self) -> None:
+        identity = {"decided_at": "2026-08-06T12:00:00Z", "decision": "granted"}
+        first = mint_record_id(prefix="record", identity=identity)
+        second = mint_record_id(prefix="record", identity=identity)
+        self.assertNotEqual(first, second)
+        # Same identity digest, different random tail: the prefix and digest are
+        # what a chain is read by, the tail is what stops a collision.
+        self.assertEqual(first.rsplit("-", 1)[0], second.rsplit("-", 1)[0])
+        self.assertTrue(first.startswith("record-"))
+        self.assertFalse(is_url_shaped(first))
+
+    def test_the_identity_digest_is_order_independent(self) -> None:
+        self.assertEqual(
+            mint_record_id(prefix="r", identity={"a": "1", "b": "2"}).rsplit("-", 1)[0],
+            mint_record_id(prefix="r", identity={"b": "2", "a": "1"}).rsplit("-", 1)[0],
+        )
+
+
+class ClosedVocabularyTests(unittest.TestCase):
+    def test_a_value_outside_the_vocabulary_renders_empty(self) -> None:
+        allowed = ("granted", "denied", "revoked")
+        self.assertEqual(closed_vocabulary_value("granted", allowed), "granted")
+        self.assertEqual(closed_vocabulary_value("approved", allowed), "")
+        self.assertEqual(closed_vocabulary_value(None, allowed), "")
+        self.assertEqual(closed_vocabulary_value("\x1b[2Kgranted", allowed), "")
+
+
+class RawOrHiddenKeyTests(unittest.TestCase):
+    def test_the_guard_names_every_shape_raw_output_arrives_under(self) -> None:
+        for key in ("prompt", "raw_output", "chain_of_thought", "transcript", "stdout", "url"):
+            with self.subTest(key=key):
+                self.assertIn(key, RAW_OR_HIDDEN_KEYS)
+
+    def test_the_guard_is_lowercase_so_callers_can_fold_before_matching(self) -> None:
+        self.assertEqual(RAW_OR_HIDDEN_KEYS, frozenset(key.lower() for key in RAW_OR_HIDDEN_KEYS))
+
+    def test_both_record_families_share_one_set_rather_than_two(self) -> None:
+        """Two copies is how one gains a key and the other silently does not."""
+        from omh.workflows import approval_receipts, external_effect_receipts
+
+        self.assertIs(external_effect_receipts.RAW_OR_HIDDEN_KEYS, RAW_OR_HIDDEN_KEYS)
+        self.assertIs(approval_receipts.RAW_OR_HIDDEN_KEYS, RAW_OR_HIDDEN_KEYS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_blocked_work_records.py
+++ b/tests/test_blocked_work_records.py
@@ -1,0 +1,1409 @@
+"""Contracts for the blocked-work record family and the decision history over it.
+
+The acceptance criteria these hold, and where each one is asserted:
+
+#808
+  AC1  raw prompts, tokens, files, and payloads cannot serialize into a record
+       -> `RawContentCannotSerialize`
+  AC2  blocked, failed, cancelled, and completed are distinguished
+       -> `OutcomesStayApart`, `StatusVocabulariesDistinguishTerminalStates`
+  AC3  hashes are non-reversible
+       -> `FingerprintHashesTheClassNotTheInput`
+
+#806
+  AC1  blocked actions are explainable offline after the original turn
+       -> `HistoryExplainsBlocksAfterTheTurn`
+  AC2  no raw secrets, prompts, or payloads in history
+       -> `RawContentCannotSerialize`, `HistoryCarriesNoRequestContent`
+  AC3  an allow is never rendered as attempted or completed
+       -> `AnAllowIsNeverAttemptedOrCompleted`
+
+Store mechanics -- concurrent appends, torn tails, supersession forks -- are
+inherited from `system/append_only_store.py` and proved there. What is asserted
+here is the *wiring*: that this family reaches the shared walk with its own key
+names, and that its chain is judged at all.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import re
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.coding.action_gate import (
+    ACTION_GATE_KEYS,
+    DENIAL_KEYS,
+    EXCLUSION_REASON_CODES,
+    evaluate_action_gate,
+)
+from omh.coding.hermes_harness import _harness_status
+from omh.coding.work_reporting import (
+    REPORT_STATUSES,
+    _ko_polite_status_sentence,
+    _ko_status_sentence,
+    _runtime_completion_satisfied,
+)
+from omh.quality.safety_preflight import (
+    ACCESS_INTENTS,
+    DATA_CLASSES,
+    EVIDENCE_CLAIMS,
+    FIELD_CLASSES,
+    REMOTE_TARGET_KINDS,
+    correction_reason_codes,
+)
+from omh.quality import safety_preflight as safety_preflight_module
+from omh.runtime.artifacts import (
+    export_runtime,
+    runtime_observation_not_applicable,
+    summarize_runtime_observation_status,
+    _delegated_runtime_observation_status,
+)
+from omh.runtime.records import (
+    OPTIONAL_APPROVAL_STORE_VALIDATORS,
+    OPTIONAL_BLOCKED_WORK_STORE_VALIDATORS,
+    OPTIONAL_RUNTIME_STORE_VALIDATORS,
+    RUNTIME_BLOCK_OBSERVATION_EVENTS,
+    RUNTIME_NON_LADDER_OBSERVATION_EVENTS,
+    RUNTIME_OBSERVABLE_EVENTS,
+    RUNTIME_OBSERVATION_EVENTS,
+    RUNTIME_OBSERVATION_STATUSES,
+    RUNTIME_TERMINAL_OBSERVATION_EVENTS,
+)
+from omh.system.append_only_store import RAW_OR_HIDDEN_KEYS
+from omh.system.paths import OmhPaths
+from omh.workflows import blocked_work_records as blocked_work_records_module
+from omh.workflows.blocked_work_records import (
+    ACTION_GATE_DENIAL_KEYS_READ,
+    ACTION_GATE_VERDICT_KEYS_READ,
+    ALLOW_RECOVERY_ACTION,
+    BLOCKED_WORK_DECISION_KEYS,
+    BLOCKED_WORK_RECORD_CONSTANT_KEYS,
+    BLOCKED_WORK_RECORD_KEYS,
+    BLOCKED_WORK_RECORD_SCHEMA_VERSION,
+    DECISION_OUTCOMES,
+    DECISION_SOURCES,
+    ENFORCEMENT_MODES,
+    ENFORCING_SOURCES,
+    LIFECYCLE_STATES,
+    OBSERVING_SOURCES,
+    OUTCOME_LIFECYCLE,
+    OUTCOME_WORK_CLAIMS,
+    MAX_CLASS_SHAPE_ENTRIES,
+    REASON_DOMAINS,
+    RECOVERY_ACTIONS,
+    REQUEST_CLASS_LABELS,
+    REQUEST_FIELDS_READ,
+    SOURCE_ENFORCEMENT,
+    SOURCE_ENFORCEMENT_BLOCKERS,
+    SUCCESS_OUTCOMES,
+    WORK_CLAIMS,
+    BlockedWorkRecordError,
+    build_blocked_work_record,
+    compact_blocked_work_record,
+    decision_from_action_gate,
+    decision_history,
+    decision_reason_text,
+    fingerprint_for_request,
+    mint_blocked_work_record,
+    project_decision_history,
+    reason_codes_for_domain,
+    record_blocked_work,
+    recovery_action_for,
+    redacted_blocked_work_ref,
+    request_class_shape,
+    request_fingerprint,
+    validate_blocked_work_record,
+    validate_blocked_work_record_store,
+)
+from omh.quality.safety_preflight import REQUEST_FIELDS
+from omh.workflows.observation_journal import (
+    CANONICAL_OBSERVATION_EVENTS,
+    OBSERVATION_STATUSES,
+    project_run_lifecycle,
+)
+from omh.wrapper.contract import STATUS_CARD_STEP_STATES, build_chat_response_from_delegation
+from omh.wrapper.localized_copy import (
+    SUPPORTED_COPY_LOCALES,
+    recovery_action_copy,
+    recovery_action_copy_ids,
+)
+
+
+def _request(**overrides: object) -> dict[str, object]:
+    """A well-formed preflight request; every field is the class, not the value."""
+    request: dict[str, object] = {
+        "owner": "hermes",
+        "approved_scope": "workspace",
+        "message_context_mode": "bounded",
+        "raw_content_included": False,
+        "data_classes": ["workspace_source"],
+        "workspace_roots": ["src"],
+        "target_paths": ["src/login.py"],
+        "access_intents": ["read"],
+        "evidence_claims": ["prepared_not_observed"],
+    }
+    request.update(overrides)
+    return request
+
+
+def _record(**overrides: object) -> dict[str, object]:
+    kwargs: dict[str, object] = {
+        "source": "safety_preflight",
+        "outcome": "blocked",
+        "reason_domain": "safety_preflight_correction",
+        "reason_code": "secret_shaped_value",
+        "owner": "hermes",
+        "safety_profile_revision": "rev-1",
+        "request": _request(),
+    }
+    kwargs.update(overrides)
+    return build_blocked_work_record(**kwargs)  # type: ignore[arg-type]
+
+
+def _paths(root: Path) -> OmhPaths:
+    return OmhPaths(omh_home=root, hermes_home=root / "hermes")
+
+
+# The minimum `evaluate_action_gate` needs to reach a verdict. Every test that
+# asks what a gate decided builds the verdict through this, never by hand: a
+# hand-built gate dict is a second answer to a contract only one module owns,
+# and the defect this file now guards against was exactly that.
+_GATE_KWARGS: dict[str, object] = {
+    "message": "please add a feature",
+    "delegation_action": "delegate",
+    "intent": "implement",
+    "review_required": False,
+    "work_owner_mode": "delegated_executor",
+    "selected_executor_profile": "codex",
+    "dispatch_policy": "prepare_only",
+    "dispatchable": True,
+    "choice_required": False,
+    "executor_selection_status": "selected",
+}
+
+
+def _denied_verdict(reason_codes: list[str]) -> dict[str, object]:
+    """A real denied verdict from the one decision path in the tree."""
+    return evaluate_action_gate(
+        **{
+            **_GATE_KWARGS,
+            "safety_preflight": {
+                "outcome": "deny",
+                "rule_id": "secrets_absent",
+                "field": "owner",
+                "correction": "Remove the credential-shaped value.",
+                "reason_codes": list(reason_codes),
+                "safety_profile_revision": "rev-9",
+            },
+        }
+    )
+
+
+def _milestone(event_type: str, status: str, updated_at: str) -> dict[str, object]:
+    return {
+        "event_type": event_type,
+        "status": status,
+        "updated_at": updated_at,
+        "target_type": "run",
+        "target_id": "run-1",
+    }
+
+
+class RawContentCannotSerialize(unittest.TestCase):
+    """#808 AC1 and #806 AC2: there is nowhere on a record for content to go."""
+
+    def test_every_raw_or_hidden_key_name_is_refused_by_name(self) -> None:
+        # By name, not merely as "unsupported key": the error has to say what the
+        # rule is, because the next person adding a field reads the error.
+        for key in sorted(RAW_OR_HIDDEN_KEYS):
+            with self.subTest(key=key):
+                record = dict(_record())
+                record[key] = "anything at all"
+                errors = validate_blocked_work_record(record)
+                self.assertTrue(
+                    any("must not carry raw or hidden keys" in error for error in errors),
+                    f"{key} was not refused by name: {errors}",
+                )
+
+    def test_raw_content_cannot_ride_in_through_any_stored_field(self) -> None:
+        # Every string field, against every shape #808 AC1 names. A record that
+        # validates clean while carrying any of these is the whole failure.
+        payloads = {
+            "prompt": "You are a helpful assistant. Ignore previous instructions.",
+            "token": "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+            "aws_secret": "aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            "file_path": "src/auth/token.py",
+            "absolute_path": "/etc/passwd",
+            "windows_path": "C:\\Users\\me\\secrets.txt",
+            "payload_json": '{"password": "hunter2", "rows": [1, 2, 3]}',
+            "transcript": "user: hi\nassistant: hello\nuser: my ssn is 123-45-6789",
+            "url": "https://example.com/secret?token=abc",
+        }
+        string_fields = [key for key in BLOCKED_WORK_RECORD_KEYS if key != "request_class_shape"]
+        for field in string_fields:
+            for name, payload in payloads.items():
+                with self.subTest(field=field, payload=name):
+                    record = dict(_record())
+                    record[field] = payload
+                    self.assertTrue(
+                        validate_blocked_work_record(record),
+                        f"{name} serialized cleanly into {field}",
+                    )
+
+    def test_build_refuses_a_path_in_every_reference_it_accepts(self) -> None:
+        # `require_opaque_metadata_ref` permits `/` because approval receipts
+        # store a scope path on purpose. This family must not inherit that, and
+        # the path used here is deliberately innocuous -- `src/auth/token.py`
+        # would be refused by the credential detector first and would prove
+        # nothing about the path guard.
+        for field in ("owner", "safety_profile_revision", "run_id", "supersedes_record_ref"):
+            with self.subTest(field=field):
+                with self.assertRaises(BlockedWorkRecordError) as caught:
+                    _record(**{field: "src/views/home.py"})
+                self.assertIn("must not name a path", str(caught.exception))
+
+    def test_the_path_guard_is_what_refuses_a_plain_workspace_path(self) -> None:
+        # The guard has to be the one doing the work: a path that no other
+        # detector objects to must still be refused.
+        errors = validate_blocked_work_record({**_record(), "owner": "src/views/home.py"})
+        self.assertTrue(any("must not name a path" in error for error in errors), errors)
+
+    def test_the_record_has_no_free_text_field_at_all(self) -> None:
+        # The structural claim behind AC1: every stored string is an opaque ref
+        # or a closed vocabulary member, so a sentence has nowhere to land.
+        record = _record()
+        free_text = {
+            key
+            for key, value in record.items()
+            if isinstance(value, str)
+            and key not in BLOCKED_WORK_RECORD_CONSTANT_KEYS
+            and " " in value
+        }
+        self.assertEqual(free_text, set())
+
+    def test_a_class_shape_label_outside_the_vocabulary_is_refused(self) -> None:
+        with self.assertRaises(BlockedWorkRecordError):
+            _record(class_shape=["field_class:path", "src/auth/token.py"])
+
+    def test_the_stored_shape_names_no_file_from_the_request(self) -> None:
+        record = _record(request=_request(target_paths=["src/auth/token.py", "src/billing/card.py"]))
+        serialized = json.dumps(record)
+        self.assertNotIn("token.py", serialized)
+        self.assertNotIn("billing", serialized)
+        self.assertIn("field_class:path", record["request_class_shape"])
+
+
+class FingerprintHashesTheClassNotTheInput(unittest.TestCase):
+    """#808 AC3: the digest has no caller-authored input, so nothing inverts it."""
+
+    def test_same_class_shape_different_values_share_a_fingerprint(self) -> None:
+        first = _request(owner="hermes", target_paths=["src/a.py"], approved_scope="alpha")
+        second = _request(owner="someone-else", target_paths=["docs/b.md"], approved_scope="omega")
+        self.assertEqual(fingerprint_for_request(first), fingerprint_for_request(second))
+
+    def test_a_different_class_shape_changes_the_fingerprint(self) -> None:
+        base = _request()
+        for label, changed in (
+            ("extra path", _request(target_paths=["src/a.py", "src/b.py"])),
+            ("extra intent", _request(access_intents=["read", "write"])),
+            ("different data class", _request(data_classes=["workspace_metadata"])),
+            ("raw content included", _request(raw_content_included=True)),
+            ("full context mode", _request(message_context_mode="full")),
+            ("remote target present", _request(remote_targets=[{"kind": "git_remote", "ref": "origin"}])),
+        ):
+            with self.subTest(label):
+                self.assertNotEqual(fingerprint_for_request(base), fingerprint_for_request(changed))
+
+    def test_the_fingerprint_cannot_be_inverted_to_a_filename(self) -> None:
+        # The concrete attack: hash every candidate path the way a truncated sha
+        # of a filename would be hashed, and look for the record's fingerprint.
+        # It cannot appear, because no path byte was ever an input.
+        target = fingerprint_for_request(_request(target_paths=["src/auth/token.py"]))
+        candidates = [
+            "src/auth/token.py",
+            "src/auth/token.py\n",
+            "token.py",
+            "/etc/passwd",
+            "C:\\secrets.txt",
+        ]
+        for candidate in candidates:
+            with self.subTest(candidate=candidate):
+                self.assertNotEqual(request_fingerprint([candidate]), target)
+                self.assertNotEqual(request_fingerprint([f"field_class:{candidate}"]), target)
+
+    def test_the_fingerprint_ignores_labels_outside_the_class_vocabulary(self) -> None:
+        # A hand-edited store cannot smuggle a value into the digest by adding a
+        # label: unknown labels are dropped before hashing.
+        self.assertEqual(
+            request_fingerprint(["field_class:path"]),
+            request_fingerprint(["field_class:path", "src/auth/token.py"]),
+        )
+
+    def test_every_class_shape_label_comes_from_a_preflight_vocabulary(self) -> None:
+        # Derived, not restated: a data class or access intent added to the
+        # preflight cannot become an unnamed label here.
+        expected = set()
+        expected.update(f"field_class:{name}" for name in set(FIELD_CLASSES.values()))
+        expected.update(f"data_class:{value}" for value in DATA_CLASSES)
+        expected.update(f"access_intent:{value}" for value in ACCESS_INTENTS)
+        expected.update(f"remote_target_kind:{value}" for value in REMOTE_TARGET_KINDS)
+        expected.update(f"evidence_claim:{value}" for value in EVIDENCE_CLAIMS)
+        self.assertTrue(expected <= set(REQUEST_CLASS_LABELS))
+
+    def test_the_shape_is_a_multiset_so_counts_survive(self) -> None:
+        shape = request_class_shape(_request(target_paths=["a.py", "b.py", "c.py"]))
+        self.assertEqual(shape.count("field_class:path"), 4)  # 3 target paths + 1 workspace root
+
+    def test_the_fingerprint_does_not_move_with_the_clock(self) -> None:
+        first = _record(decided_at="2026-01-01T00:00:00Z")
+        second = _record(decided_at="2026-06-01T00:00:00Z")
+        self.assertEqual(first["request_fingerprint"], second["request_fingerprint"])
+        self.assertEqual(first["decision_id"], second["decision_id"])
+
+
+class OutcomesStayApart(unittest.TestCase):
+    """#808 AC2: four terminal states, four different claims."""
+
+    def test_every_outcome_has_exactly_one_lifecycle_and_one_work_claim(self) -> None:
+        self.assertEqual(set(OUTCOME_LIFECYCLE), set(DECISION_OUTCOMES))
+        self.assertEqual(set(OUTCOME_WORK_CLAIMS), set(DECISION_OUTCOMES))
+        self.assertTrue(set(OUTCOME_LIFECYCLE.values()) <= set(LIFECYCLE_STATES))
+        self.assertTrue(set(OUTCOME_WORK_CLAIMS.values()) <= set(WORK_CLAIMS))
+
+    def test_blocked_failed_cancelled_and_completed_render_distinctly(self) -> None:
+        rendered = {}
+        for outcome in ("blocked", "failed", "cancelled", "completed"):
+            record = _record(
+                source="executor_report" if outcome != "blocked" else "safety_preflight",
+                outcome=outcome,
+            )
+            compact = compact_blocked_work_record(record)
+            rendered[outcome] = (compact["outcome"], compact["lifecycle_state"], compact["work_claim"])
+        self.assertEqual(len(set(rendered.values())), 4, rendered)
+
+    def test_blocked_never_renders_as_a_skipped_success(self) -> None:
+        # The nearest success-shaped state a gate reaches is `not_required`.
+        # A block must never fold into it, and must never claim completion.
+        compact = compact_blocked_work_record(_record(outcome="blocked"))
+        self.assertEqual(compact["lifecycle_state"], "paused")
+        self.assertNotIn(compact["lifecycle_state"], {"not_required", "complete"})
+        self.assertNotEqual(compact["work_claim"], "completed")
+        self.assertNotIn("blocked", SUCCESS_OUTCOMES)
+
+    def test_only_completed_is_success_shaped(self) -> None:
+        self.assertEqual(
+            {outcome for outcome, claim in OUTCOME_WORK_CLAIMS.items() if claim == "completed"},
+            set(SUCCESS_OUTCOMES),
+        )
+
+    def test_a_blocked_record_always_offers_a_recovery(self) -> None:
+        for domain in REASON_DOMAINS:
+            for code in reason_codes_for_domain(domain):
+                with self.subTest(domain=domain, code=code):
+                    self.assertIn(recovery_action_for(domain, code), RECOVERY_ACTIONS)
+
+    def test_a_hand_edited_lifecycle_is_rejected(self) -> None:
+        record = dict(_record(outcome="blocked"))
+        record["lifecycle_state"] = "terminal"
+        self.assertTrue(
+            any("lifecycle_state must be paused" in error for error in validate_blocked_work_record(record))
+        )
+
+
+class AnAllowIsNeverAttemptedOrCompleted(unittest.TestCase):
+    """#806 AC3, held as a table property rather than an absence of rows."""
+
+    def test_an_allow_is_recorded_at_all(self) -> None:
+        record = _record(outcome="allowed", reason_code="allowed")
+        self.assertEqual(record["outcome"], "allowed")
+        self.assertEqual(validate_blocked_work_record(record), [])
+
+    def test_an_allow_claims_no_attempt_and_no_completion(self) -> None:
+        self.assertEqual(OUTCOME_WORK_CLAIMS["allowed"], "not_attempted")
+        self.assertEqual(OUTCOME_LIFECYCLE["allowed"], "open")
+        compact = compact_blocked_work_record(_record(outcome="allowed", reason_code="allowed"))
+        self.assertEqual(compact["work_claim"], "not_attempted")
+        self.assertNotEqual(compact["lifecycle_state"], "terminal")
+
+    def test_no_outcome_maps_an_allow_onto_a_success_shaped_state(self) -> None:
+        for outcome, claim in OUTCOME_WORK_CLAIMS.items():
+            if outcome == "allowed":
+                self.assertNotEqual(claim, "completed")
+                self.assertNotEqual(claim, "attempted_not_completed")
+
+    def test_an_allow_promises_no_recovery(self) -> None:
+        record = _record(outcome="allowed", reason_code="allowed")
+        self.assertEqual(record["recovery_action"], ALLOW_RECOVERY_ACTION)
+
+    def test_the_history_renders_an_allow_as_not_attempted(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            record_blocked_work(
+                paths,
+                source="safety_preflight",
+                outcome="allowed",
+                reason_domain="safety_preflight_correction",
+                reason_code="allowed",
+                owner="hermes",
+                safety_profile_revision="rev-1",
+                request=_request(),
+            )
+            history = decision_history(paths)
+            self.assertEqual(len(history["entries"]), 1)
+            entry = history["entries"][0]
+            self.assertEqual(entry["outcome"], "allowed")
+            self.assertEqual(entry["work_claim"], "not_attempted")
+            self.assertEqual(history["summary"]["outcome_counts"]["allowed"], 1)
+            self.assertEqual(history["summary"]["blocked_count"], 0)
+
+
+class EnforcingVersusObserving(unittest.TestCase):
+    """A hook cannot mint a record claiming OMH blocked anything."""
+
+    def test_the_two_source_classes_do_not_overlap_and_cover_the_vocabulary(self) -> None:
+        self.assertEqual(set(ENFORCING_SOURCES) & set(OBSERVING_SOURCES), set())
+        self.assertEqual(set(ENFORCING_SOURCES) | set(OBSERVING_SOURCES), set(DECISION_SOURCES))
+        self.assertEqual(set(SOURCE_ENFORCEMENT), set(DECISION_SOURCES))
+        self.assertTrue(set(SOURCE_ENFORCEMENT.values()) <= set(ENFORCEMENT_MODES))
+
+    def test_an_observing_source_is_pinned_to_declared_not_enforced(self) -> None:
+        for source in OBSERVING_SOURCES:
+            with self.subTest(source=source):
+                record = _record(source=source, outcome="blocked")
+                self.assertEqual(record["enforcement"], "declared_not_enforced")
+                self.assertEqual(record["enforcement_blocker"], SOURCE_ENFORCEMENT_BLOCKERS[source])
+
+    def test_the_plugin_hook_lane_states_the_contract_that_blocks_it(self) -> None:
+        # `pre_tool_call` returns injected context or None and `pre_verify`'s
+        # only action value is "continue"; neither can deny. The record says so.
+        record = _record(source="plugin_hook_observation", outcome="blocked")
+        self.assertEqual(record["enforcement_blocker"], "hermes_plugin_hooks_have_no_deny_channel")
+
+    def test_an_observing_source_cannot_mint_an_allow(self) -> None:
+        for source in OBSERVING_SOURCES:
+            with self.subTest(source=source):
+                with self.assertRaises(BlockedWorkRecordError) as caught:
+                    _record(source=source, outcome="allowed", reason_code="allowed")
+                self.assertIn("observes decisions", str(caught.exception))
+
+    def test_a_hand_edited_store_cannot_claim_a_hook_enforced_anything(self) -> None:
+        record = dict(_record(source="plugin_hook_observation", outcome="blocked"))
+        record["enforcement"] = "enforced"
+        record["enforcement_blocker"] = ""
+        errors = validate_blocked_work_record(record)
+        self.assertTrue(any("enforcement must be declared_not_enforced" in error for error in errors))
+
+    def test_an_enforcing_source_carries_no_blocker(self) -> None:
+        for source in ENFORCING_SOURCES:
+            with self.subTest(source=source):
+                self.assertEqual(_record(source=source)["enforcement_blocker"], "")
+
+
+class ReasonCodesJoinExistingVocabularies(unittest.TestCase):
+    """No fifth explanation vocabulary: the record cites a code and joins for prose."""
+
+    def test_every_domain_resolves_to_a_vocabulary_that_already_exists(self) -> None:
+        for domain in REASON_DOMAINS:
+            with self.subTest(domain=domain):
+                self.assertTrue(reason_codes_for_domain(domain))
+
+    def test_the_action_gate_domain_stays_in_step_with_the_gate(self) -> None:
+        self.assertEqual(
+            set(reason_codes_for_domain("action_gate_exclusion")),
+            set(EXCLUSION_REASON_CODES),
+        )
+
+    def test_the_preflight_domain_stays_in_step_with_the_corrections(self) -> None:
+        self.assertEqual(
+            set(reason_codes_for_domain("safety_preflight_correction")),
+            set(correction_reason_codes()),
+        )
+
+    def test_every_blocked_reason_code_resolves_to_prose(self) -> None:
+        for domain in REASON_DOMAINS:
+            for code in reason_codes_for_domain(domain):
+                if code == "allowed":
+                    continue
+                with self.subTest(domain=domain, code=code):
+                    self.assertTrue(decision_reason_text(domain, code), f"{domain}/{code} has no prose")
+
+    def test_a_code_from_the_wrong_domain_is_refused(self) -> None:
+        with self.assertRaises(BlockedWorkRecordError):
+            _record(reason_domain="runtime_claim_block", reason_code="secret_shaped_value")
+
+    def test_an_unrecognised_code_renders_empty_rather_than_as_itself(self) -> None:
+        self.assertEqual(decision_reason_text("safety_preflight_correction", "no_such_code"), "")
+
+
+class HistoryExplainsBlocksAfterTheTurn(unittest.TestCase):
+    """#806 AC1: the answer survives the turn that produced it."""
+
+    def test_a_block_is_explainable_from_the_store_alone(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            record_blocked_work(
+                paths,
+                source="safety_preflight",
+                outcome="blocked",
+                reason_domain="safety_preflight_correction",
+                reason_code="secret_shaped_value",
+                owner="hermes",
+                safety_profile_revision="rev-1",
+                request=_request(),
+            )
+            # A later turn: nothing but the store on disk. No request, no
+            # payload, no gate verdict in memory.
+            raw = paths.runtime_blocked_work_records_path.read_text(encoding="utf-8")
+            reloaded = [json.loads(line) for line in raw.splitlines() if line.strip()]
+            history = project_decision_history(reloaded)
+            entry = history["entries"][0]
+            self.assertEqual(entry["outcome"], "blocked")
+            self.assertEqual(entry["reason_code"], "secret_shaped_value")
+            self.assertTrue(entry["reason"])
+            self.assertIn(entry["recovery_action"], RECOVERY_ACTIONS)
+            self.assertEqual(history["summary"]["explainable_blocked_count"], 1)
+            self.assertEqual(history["summary"]["unexplainable_blocked_count"], 0)
+
+    def test_a_record_with_no_run_is_still_in_the_history(self) -> None:
+        # The case the family exists for: a preflight denial happens before a
+        # run exists, so `run_id` is empty and per-run storage would lose it.
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            record = record_blocked_work(
+                paths,
+                source="safety_preflight",
+                outcome="blocked",
+                reason_domain="safety_preflight_correction",
+                reason_code="owner_missing",
+                owner="hermes",
+                safety_profile_revision="rev-1",
+                request=_request(),
+            )
+            self.assertEqual(record["run_id"], "")
+            self.assertEqual(len(decision_history(paths)["entries"]), 1)
+
+    def test_only_the_current_record_for_a_decision_is_rendered(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            common = {
+                "source": "safety_preflight",
+                "reason_domain": "safety_preflight_correction",
+                "owner": "hermes",
+                "safety_profile_revision": "rev-1",
+                "request": _request(),
+            }
+            record_blocked_work(paths, outcome="blocked", reason_code="owner_missing", **common)
+            record_blocked_work(paths, outcome="allowed", reason_code="allowed", **common)
+            history = decision_history(paths)
+            self.assertEqual(len(history["entries"]), 1)
+            self.assertEqual(history["entries"][0]["outcome"], "allowed")
+            self.assertEqual(history["summary"]["superseded_count"], 1)
+
+    def test_a_repeat_block_is_recorded_and_the_head_reports_the_latest(self) -> None:
+        # Two distinct blocks that share a class shape are two blocks. Folding
+        # them onto one record dated at the first was not idempotent minting: a
+        # class shape is deliberately shared by every request of that shape, so
+        # the fold collapsed different requests on different turns and then
+        # reported the wrong time for the one record it kept.
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            kwargs = {
+                "source": "safety_preflight",
+                "outcome": "blocked",
+                "reason_domain": "safety_preflight_correction",
+                "reason_code": "owner_missing",
+                "owner": "hermes",
+                "safety_profile_revision": "rev-1",
+                "request": _request(),
+            }
+            first = mint_blocked_work_record(paths, now="2026-01-01T00:00:00Z", **kwargs)
+            second = mint_blocked_work_record(paths, now="2026-06-01T00:00:00Z", **kwargs)
+            self.assertEqual(first["outcome"], "recorded")
+            self.assertEqual(second["outcome"], "repeat_recorded")
+            self.assertTrue(second["minted"])
+            self.assertNotEqual(first["record_id"], second["record_id"])
+            stored = paths.runtime_blocked_work_records_path.read_text(encoding="utf-8").strip().splitlines()
+            self.assertEqual(len(stored), 2)
+            history = decision_history(paths)
+            # One decision, two records, and the head is the later occurrence.
+            self.assertEqual(history["summary"]["decision_count"], 1)
+            self.assertEqual(history["summary"]["record_count"], 2)
+            self.assertEqual(history["summary"]["superseded_count"], 1)
+            self.assertEqual(history["entries"][0]["decided_at"], "2026-06-01T00:00:00Z")
+
+    def test_the_repeat_chain_still_validates_as_one_line(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            kwargs = {
+                "source": "safety_preflight",
+                "outcome": "blocked",
+                "reason_domain": "safety_preflight_correction",
+                "reason_code": "owner_missing",
+                "owner": "hermes",
+                "safety_profile_revision": "rev-1",
+                "request": _request(),
+            }
+            for stamp in ("2026-01-01T00:00:00Z", "2026-02-01T00:00:00Z", "2026-03-01T00:00:00Z"):
+                mint_blocked_work_record(paths, now=stamp, **kwargs)
+            report = validate_blocked_work_record_store(paths.runtime_blocked_work_records_path)
+            self.assertTrue(report["ok"], report["errors"])
+            self.assertEqual(report["record_count"], 3)
+
+    def test_the_history_is_scopeable_to_one_run(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            common = {
+                "source": "safety_preflight",
+                "outcome": "blocked",
+                "reason_domain": "safety_preflight_correction",
+                "reason_code": "owner_missing",
+                "owner": "hermes",
+                "safety_profile_revision": "rev-1",
+                "request": _request(),
+            }
+            record_blocked_work(paths, run_id="run-a", **common)
+            record_blocked_work(paths, run_id="run-b", **common)
+            self.assertEqual(len(decision_history(paths, run_id="run-a")["entries"]), 1)
+            self.assertEqual(len(decision_history(paths)["entries"]), 2)
+
+
+class HistoryCarriesNoRequestContent(unittest.TestCase):
+    """#806 AC2, checked on the rendered projection rather than the stored line."""
+
+    def test_the_projection_carries_no_path_no_secret_and_no_prompt(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            record_blocked_work(
+                paths,
+                source="safety_preflight",
+                outcome="blocked",
+                reason_domain="safety_preflight_correction",
+                reason_code="secret_shaped_value",
+                owner="hermes",
+                safety_profile_revision="rev-1",
+                request=_request(target_paths=["src/auth/token.py"], approved_scope="billing"),
+            )
+            serialized = json.dumps(decision_history(paths))
+            for leak in ("token.py", "src/auth", "billing", "hunter2"):
+                self.assertNotIn(leak, serialized)
+
+    def test_the_projection_drops_a_hand_edited_label(self) -> None:
+        record = dict(_record())
+        record["request_class_shape"] = ["field_class:path", "src/auth/token.py"]
+        compact = compact_blocked_work_record(record)
+        self.assertEqual(compact["request_class_shape"], ["field_class:path"])
+
+    def test_the_projection_folds_a_hand_edited_reference(self) -> None:
+        record = dict(_record())
+        record["owner"] = "https://example.com/leak?token=abc"
+        self.assertTrue(compact_blocked_work_record(record)["owner"].startswith("ref-"))
+
+    def test_an_unrecognised_vocabulary_value_renders_empty(self) -> None:
+        record = dict(_record())
+        record["outcome"] = "totally-made-up"
+        self.assertEqual(compact_blocked_work_record(record)["outcome"], "")
+
+
+class StoreWiring(unittest.TestCase):
+    """The shared mechanics are reached, with this family's own key names."""
+
+    def test_the_store_validates_clean_and_counts_its_records(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            record_blocked_work(
+                paths,
+                source="safety_preflight",
+                outcome="blocked",
+                reason_domain="safety_preflight_correction",
+                reason_code="owner_missing",
+                owner="hermes",
+                safety_profile_revision="rev-1",
+                request=_request(),
+            )
+            report = validate_blocked_work_record_store(paths.runtime_blocked_work_records_path)
+            self.assertTrue(report["ok"], report["errors"])
+            self.assertEqual(report["record_count"], 1)
+
+    def test_the_supersede_walk_reports_this_family_key_names(self) -> None:
+        # The wiring assertion: the shared walk is reached and told `record_id`
+        # and `supersedes_record_ref`, not the receipt names it defaults to.
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "blocked_work_records.jsonl"
+            record = dict(_record())
+            record["supersedes_record_ref"] = "blocked-work-does-not-exist"
+            path.write_text(json.dumps(record, sort_keys=True) + "\n", encoding="utf-8")
+            report = validate_blocked_work_record_store(path)
+            self.assertFalse(report["ok"])
+            joined = " ".join(report["errors"])
+            self.assertIn("supersedes_record_ref", joined)
+            self.assertIn("earlier record", joined)
+            self.assertNotIn("receipt", joined)
+
+    def test_an_unparseable_line_is_reported_by_the_shared_walk(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "blocked_work_records.jsonl"
+            path.write_text("{not json\n", encoding="utf-8")
+            self.assertFalse(validate_blocked_work_record_store(path)["ok"])
+
+    def test_a_write_failure_returns_rather_than_raises_and_logs_a_sidecar(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            result = mint_blocked_work_record(
+                paths,
+                source="safety_preflight",
+                outcome="blocked",
+                reason_domain="safety_preflight_correction",
+                reason_code="no_such_code",
+                owner="hermes",
+                safety_profile_revision="rev-1",
+                request=_request(),
+            )
+            self.assertFalse(result["minted"])
+            self.assertEqual(result["outcome"], "refused")
+            self.assertTrue(result["error"])
+
+    def test_the_family_registers_its_own_validator_tuple(self) -> None:
+        # The #846 rule: one registry per store, one reader per registry. A
+        # family sharing a tuple would validate a sibling's records against its
+        # own schema.
+        names = {name for name, _ in OPTIONAL_BLOCKED_WORK_STORE_VALIDATORS}
+        self.assertEqual(names, {"blocked_work_records.jsonl"})
+        for other in (OPTIONAL_RUNTIME_STORE_VALIDATORS, OPTIONAL_APPROVAL_STORE_VALIDATORS):
+            self.assertEqual(names & {name for name, _ in other}, set())
+
+    def test_the_store_lives_beside_its_siblings_and_not_inside_a_run(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            self.assertEqual(
+                paths.runtime_blocked_work_records_path.parent,
+                paths.runtime_approval_receipts_path.parent,
+            )
+            self.assertNotIn("runs", paths.runtime_blocked_work_records_path.parts)
+
+    def test_the_schema_version_is_pinned(self) -> None:
+        self.assertEqual(_record()["schema_version"], BLOCKED_WORK_RECORD_SCHEMA_VERSION)
+        self.assertEqual(BLOCKED_WORK_RECORD_SCHEMA_VERSION, "blocked_work_record/v1")
+
+
+class StatusVocabulariesDistinguishTerminalStates(unittest.TestCase):
+    """#808 AC2 where the four states are actually read: the status vocabularies."""
+
+    def test_cancelled_is_recordable_and_not_only_projectable(self) -> None:
+        self.assertIn("cancelled", OBSERVATION_STATUSES)
+        self.assertIn("cancelled", RUNTIME_OBSERVATION_STATUSES)
+
+    def test_the_two_observation_status_tuples_stay_equal(self) -> None:
+        # The CLI's `--status` choices come from one and every value it offers
+        # is written through the other; a member in one only is a flag that
+        # fails at the write.
+        self.assertEqual(set(OBSERVATION_STATUSES), set(RUNTIME_OBSERVATION_STATUSES))
+
+    def test_the_terminal_events_are_reachable_from_the_cli(self) -> None:
+        self.assertTrue(set(RUNTIME_TERMINAL_OBSERVATION_EVENTS) <= set(RUNTIME_OBSERVABLE_EVENTS))
+        self.assertTrue(set(RUNTIME_TERMINAL_OBSERVATION_EVENTS) <= set(CANONICAL_OBSERVATION_EVENTS))
+
+    def test_the_terminal_events_stay_out_of_the_milestone_ladder(self) -> None:
+        # Adding them to the ladder would make every run permanently missing
+        # three milestones it was never meant to reach.
+        self.assertEqual(set(RUNTIME_TERMINAL_OBSERVATION_EVENTS) & set(RUNTIME_OBSERVATION_EVENTS), set())
+
+    def test_a_step_can_report_failed_and_cancelled_not_only_blocked(self) -> None:
+        for state in ("blocked", "failed", "cancelled"):
+            self.assertIn(state, STATUS_CARD_STEP_STATES)
+
+    def test_a_blocked_step_state_is_not_the_success_shaped_one(self) -> None:
+        self.assertIn("not_required", STATUS_CARD_STEP_STATES)
+        self.assertNotEqual("blocked", "not_required")
+
+    def test_a_work_report_can_say_cancelled(self) -> None:
+        for status in ("blocked", "cancelled", "completed", "failed"):
+            self.assertIn(status, REPORT_STATUSES)
+
+
+class CrossModuleKeyReadsArePinned(unittest.TestCase):
+    """Every key this module reads off another module's payload, re-derived from source.
+
+    The defect these hold against is not a typo, it is a class of bug: this
+    module reads dicts owned elsewhere, and a key that does not exist reads as
+    the default rather than as an error, so the lane keeps working and reports
+    something false. A hand-built fixture cannot catch it, because the fixture
+    is written against the same wrong assumption as the code. So the reads are
+    derived from the source text and checked against the owning module's own
+    exported tuples, in the shape `tests/test_broad_exception_policy.py` uses.
+    """
+
+    @staticmethod
+    def _gets_on(function_name: str, receiver_names: set[str]) -> set[str]:
+        source = Path(inspect.getsourcefile(blocked_work_records_module)).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        found: set[str] = set()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef) or node.name != function_name:
+                continue
+            for inner in ast.walk(node):
+                if not isinstance(inner, ast.Call) or not isinstance(inner.func, ast.Attribute):
+                    continue
+                if inner.func.attr not in {"get", "pop"}:
+                    continue
+                receiver = inner.func.value
+                if not isinstance(receiver, ast.Name) or receiver.id not in receiver_names:
+                    continue
+                if inner.args and isinstance(inner.args[0], ast.Constant) and isinstance(inner.args[0].value, str):
+                    found.add(inner.args[0].value)
+        return found
+
+    def test_the_declared_verdict_reads_are_what_the_source_actually_reads(self) -> None:
+        self.assertEqual(
+            self._gets_on("decision_from_action_gate", {"gate"}),
+            set(ACTION_GATE_VERDICT_KEYS_READ),
+        )
+
+    def test_the_declared_denial_reads_are_what_the_source_actually_reads(self) -> None:
+        self.assertEqual(
+            self._gets_on("decision_from_action_gate", {"denial_map"}),
+            set(ACTION_GATE_DENIAL_KEYS_READ),
+        )
+
+    def test_every_verdict_key_read_is_a_key_the_action_gate_exports(self) -> None:
+        self.assertTrue(
+            set(ACTION_GATE_VERDICT_KEYS_READ) <= set(ACTION_GATE_KEYS),
+            sorted(set(ACTION_GATE_VERDICT_KEYS_READ) - set(ACTION_GATE_KEYS)),
+        )
+
+    def test_every_denial_key_read_is_a_key_the_denial_contract_exports(self) -> None:
+        # The one that was false: `reason_code` is not a member and never was.
+        self.assertTrue(
+            set(ACTION_GATE_DENIAL_KEYS_READ) <= set(DENIAL_KEYS),
+            sorted(set(ACTION_GATE_DENIAL_KEYS_READ) - set(DENIAL_KEYS)),
+        )
+        self.assertNotIn("reason_code", DENIAL_KEYS)
+
+    def test_a_real_denial_carries_the_plural_key_and_not_the_singular_one(self) -> None:
+        denial = _denied_verdict(["secret_shaped_value"])["denial"]
+        self.assertEqual(set(denial), set(DENIAL_KEYS))
+        self.assertEqual(denial["reason_codes"], ["secret_shaped_value"])
+
+    def test_every_request_field_read_by_name_is_declared_by_the_preflight(self) -> None:
+        # The second read of the same kind: three request fields are read by
+        # name rather than through `REQUEST_FIELDS`, so a rename there would
+        # silently stop them contributing and move every fingerprint.
+        self.assertTrue(
+            set(REQUEST_FIELDS_READ) <= set(REQUEST_FIELDS),
+            sorted(set(REQUEST_FIELDS_READ) - set(REQUEST_FIELDS)),
+        )
+
+    def test_the_destination_kind_key_is_the_preflight_own_nested_key(self) -> None:
+        self.assertIn(
+            blocked_work_records_module._DESTINATION_KIND_KEY,
+            safety_preflight_module.DESTINATION_FIELD_CLASSES,
+        )
+
+
+class TheRenderPathAppliesThePathGuard(unittest.TestCase):
+    """#808 AC1 at the third surface: write, validate, and render must agree."""
+
+    def test_the_render_path_refuses_the_value_the_validator_refuses(self) -> None:
+        # Deliberately the same value `RawContentCannotSerialize` uses. A
+        # validator and a renderer reading one record and reaching opposite
+        # answers about it is the defect, so the proof has to be the same bytes.
+        record = {**_record(), "owner": "src/views/home.py"}
+        self.assertTrue(any("must not name a path" in error for error in validate_blocked_work_record(record)))
+        rendered = compact_blocked_work_record(record)["owner"]
+        self.assertNotEqual(rendered, "src/views/home.py")
+        self.assertTrue(rendered.startswith("ref-"), rendered)
+
+    def test_the_history_projection_publishes_no_path_either(self) -> None:
+        record = {**_record(), "owner": "src/views/home.py"}
+        serialized = json.dumps(project_decision_history([record]))
+        self.assertNotIn("src/views/home.py", serialized)
+        self.assertNotIn("views", serialized)
+
+    def test_every_path_shape_folds_at_render_not_only_the_absolute_ones(self) -> None:
+        # The accurate scope of what leaked: a leading `/`, any `\`, and `../`
+        # were already folded by the shared guard. A relative POSIX path
+        # starting with an alphanumeric was not.
+        for value in ("src/views/home.py", "docs/a.md", "a/b", "/etc/passwd", "..\\x", "../up.py"):
+            with self.subTest(value=value):
+                self.assertTrue(redacted_blocked_work_ref(value).startswith("ref-"), value)
+
+    def test_a_plain_opaque_handle_still_renders_as_itself(self) -> None:
+        # The guard must not fold ordinary identifiers, or every rendered record
+        # becomes a wall of digests.
+        for value in ("hermes", "rev-1", "shape-abc123", "run-42"):
+            with self.subTest(value=value):
+                self.assertEqual(redacted_blocked_work_ref(value), value)
+
+
+class TheClassShapeBudgetKeepsEveryDistinctLabel(unittest.TestCase):
+    """#808 AC3: a bounded field must not merge two shapes that differ."""
+
+    def test_a_large_request_keeps_every_label_it_carries(self) -> None:
+        big = _request(target_paths=[f"src/f{index}.py" for index in range(400)], raw_content_included=True)
+        shape = request_class_shape(big)
+        self.assertLessEqual(len(shape), MAX_CLASS_SHAPE_ENTRIES)
+        small = _request(target_paths=["src/f0.py"], raw_content_included=True)
+        self.assertTrue(
+            set(request_class_shape(small)) <= set(shape),
+            sorted(set(request_class_shape(small)) - set(shape)),
+        )
+        self.assertIn("raw_content:included", shape)
+        self.assertIn("message_context_mode:bounded", shape)
+
+    def test_raw_content_never_merges_with_a_request_that_excluded_it(self) -> None:
+        # The concrete failure of alphabetical truncation: `raw_content:*` sorts
+        # last, so on a large request it was the first label dropped and the two
+        # shapes collapsed onto one fingerprint.
+        paths = [f"src/f{index}.py" for index in range(400)]
+        included = _request(target_paths=paths, raw_content_included=True)
+        excluded = _request(target_paths=paths, raw_content_included=False)
+        self.assertNotEqual(fingerprint_for_request(included), fingerprint_for_request(excluded))
+
+    def test_a_large_request_still_distinguishes_every_late_sorting_label(self) -> None:
+        paths = [f"src/f{index}.py" for index in range(400)]
+        base = _request(target_paths=paths)
+        for label, changed in (
+            ("full context mode", _request(target_paths=paths, message_context_mode="full")),
+            (
+                "remote target present",
+                _request(target_paths=paths, remote_targets=[{"kind": "git_remote", "ref": "origin"}]),
+            ),
+        ):
+            with self.subTest(label):
+                self.assertNotEqual(fingerprint_for_request(base), fingerprint_for_request(changed))
+
+    def test_a_declared_empty_list_claims_no_occurrence(self) -> None:
+        # A `max(1, ...)` floor made a request declaring no workspace paths ship
+        # a record whose shape claimed one.
+        self.assertEqual(request_class_shape(_request(target_paths=[])).count("field_class:path"), 1)
+        empty = _request(target_paths=[], workspace_roots=[])
+        self.assertEqual(request_class_shape(empty).count("field_class:path"), 0)
+
+    def test_a_declared_empty_list_does_not_share_a_shape_with_a_named_file(self) -> None:
+        self.assertNotEqual(
+            fingerprint_for_request(_request(target_paths=[])),
+            fingerprint_for_request(_request(target_paths=["src/a.py"])),
+        )
+
+    def test_the_shape_stays_inside_its_budget(self) -> None:
+        shape = request_class_shape(_request(target_paths=[f"src/f{index}.py" for index in range(4000)]))
+        self.assertLessEqual(len(shape), MAX_CLASS_SHAPE_ENTRIES)
+        self.assertEqual(validate_blocked_work_record(_record(class_shape=shape)), [])
+
+
+class CancelledSurvivesEveryProjection(unittest.TestCase):
+    """#808 AC2 end to end: a vocabulary member the code does not back is a label."""
+
+    def test_a_cancelled_status_projects_as_cancelled(self) -> None:
+        # `_fold_event` ignored the status and fell through to its
+        # `!= "observed"` return, so a run someone stopped projected as one that
+        # had merely not got there yet.
+        projection = project_run_lifecycle(
+            [
+                {
+                    "run_id": "run-1",
+                    "event": "executor_dispatch_observed",
+                    "status": "cancelled",
+                    "event_id": "e1",
+                    "observed_at": "2026-01-01T00:00:00Z",
+                }
+            ],
+            run_id="run-1",
+        )
+        self.assertTrue(projection["cancelled"])
+        self.assertEqual(projection["observation_status"], "cancelled")
+        self.assertFalse(projection["blocked"])
+        self.assertFalse(projection["failed"])
+
+    def test_the_four_statuses_project_to_four_different_answers(self) -> None:
+        projected = {}
+        for status in ("blocked", "cancelled", "failed", "observed"):
+            projection = project_run_lifecycle(
+                [
+                    {
+                        "run_id": "run-1",
+                        "event": "prepared_handoff_created",
+                        "status": status,
+                        "event_id": f"e-{status}",
+                        "observed_at": "2026-01-01T00:00:00Z",
+                    }
+                ],
+                run_id="run-1",
+            )
+            projected[status] = (
+                projection["observation_status"],
+                projection["blocked"],
+                projection["cancelled"],
+                projection["failed"],
+            )
+        self.assertEqual(len(set(projected.values())), 4, projected)
+
+    def test_a_cancelled_milestone_is_unsatisfied(self) -> None:
+        summary = summarize_runtime_observation_status([_milestone("ci", "cancelled", "2026-01-01T00:00:00Z")])
+        self.assertEqual(summary["cancelled_events"], ["ci"])
+        self.assertIn("ci", summary["unsatisfied_events"])
+
+    def test_a_cancelled_milestone_never_reaches_the_completion_claim(self) -> None:
+        summary = summarize_runtime_observation_status(
+            [_milestone(event, "observed", "2026-01-01T00:00:00Z") for event in RUNTIME_OBSERVATION_EVENTS]
+            + [_milestone("ci", "cancelled", "2026-02-01T00:00:00Z")]
+        )
+        self.assertFalse(_runtime_completion_satisfied(summary))
+        status = _harness_status(
+            observed_events=set(summary["observed_events"]),
+            blocked_events=set(summary["blocked_events"]),
+            failed_events=set(summary["failed_events"]),
+            cancelled_events=set(summary["cancelled_events"]),
+            unsatisfied_events=set(summary["unsatisfied_events"]),
+            projection_missing_evidence=set(),
+        )
+        self.assertEqual(status, "cancelled")
+
+    def test_the_lifecycle_projection_status_says_cancelled_not_merely_missing(self) -> None:
+        # The second producer of `runtime_observation_status/v1`: a cancelled
+        # latest event landed in neither the blocked nor the failed list, so the
+        # only signal left was `missing_events` and a stopped run rendered
+        # exactly like one that had not got there yet.
+        delegated = _delegated_runtime_observation_status(
+            {},
+            {
+                "journal_event_count": 3,
+                "latest_event": {"event": "executor_dispatch_observed", "status": "cancelled"},
+            },
+            next_action="wait_for_executor_evidence",
+        )
+        self.assertEqual(delegated["cancelled_events"], ["worker_dispatch"])
+        self.assertIn("worker_dispatch", delegated["unsatisfied_events"])
+
+    def test_every_runtime_observation_status_producer_publishes_the_same_keys(self) -> None:
+        # One schema version, three producers. A reader that has to ask which
+        # one built a payload before it knows which keys exist is reading three
+        # schemas under one version.
+        summary = summarize_runtime_observation_status([_milestone("ci", "observed", "2026-01-01T00:00:00Z")])
+        delegated = _delegated_runtime_observation_status(
+            {},
+            {"journal_event_count": 1, "latest_event": {"event": "ci_result_observed", "status": "observed"}},
+            next_action="record_merge_readiness",
+        )
+        not_applicable = runtime_observation_not_applicable("no runtime handoff")
+        for other, label in ((delegated, "lifecycle_projection"), (not_applicable, "not_applicable")):
+            with self.subTest(label):
+                self.assertTrue(
+                    set(summary) <= set(other),
+                    sorted(set(summary) - set(other)),
+                )
+
+    def test_the_work_report_says_cancelled_in_korean_and_not_in_progress(self) -> None:
+        self.assertNotEqual(_ko_status_sentence("작업", "cancelled"), _ko_status_sentence("작업", "in_progress"))
+        self.assertNotEqual(
+            _ko_polite_status_sentence("작업", "cancelled"),
+            _ko_polite_status_sentence("작업", "in_progress"),
+        )
+        self.assertIn("취소", _ko_status_sentence("작업", "cancelled"))
+        self.assertIn("취소", _ko_polite_status_sentence("작업", "cancelled"))
+
+    def test_every_report_status_gets_its_own_korean_sentence(self) -> None:
+        for renderer in (_ko_status_sentence, _ko_polite_status_sentence):
+            rendered = {status: renderer("작업", status) for status in REPORT_STATUSES}
+            with self.subTest(renderer=renderer.__name__):
+                self.assertEqual(len(set(rendered.values())), len(REPORT_STATUSES), rendered)
+
+
+class ABlockIsRecoverableAndNotTerminal(unittest.TestCase):
+    """A block that cleared must stop being the answer to "what next"."""
+
+    def test_blocked_is_not_classified_as_a_terminal_runtime_event(self) -> None:
+        self.assertNotIn("blocked", RUNTIME_TERMINAL_OBSERVATION_EVENTS)
+        self.assertIn("blocked", RUNTIME_BLOCK_OBSERVATION_EVENTS)
+        self.assertEqual(
+            set(RUNTIME_NON_LADDER_OBSERVATION_EVENTS),
+            set(RUNTIME_BLOCK_OBSERVATION_EVENTS) | set(RUNTIME_TERMINAL_OBSERVATION_EVENTS),
+        )
+
+    def test_a_standing_block_still_pins_the_next_action(self) -> None:
+        summary = summarize_runtime_observation_status(
+            [
+                _milestone("runtime_start", "observed", "2026-01-01T00:00:00Z"),
+                _milestone("blocked", "blocked", "2026-02-01T00:00:00Z"),
+            ]
+        )
+        self.assertEqual(summary["next_action"], "surface_runtime_blocker:blocked")
+        self.assertEqual(summary["standing_block"], "blocked")
+
+    def test_a_block_that_cleared_no_longer_pins_the_next_action(self) -> None:
+        summary = summarize_runtime_observation_status(
+            [
+                _milestone("blocked", "blocked", "2026-01-01T00:00:00Z"),
+                _milestone("runtime_start", "observed", "2026-02-01T00:00:00Z"),
+                _milestone("merge", "observed", "2026-03-01T00:00:00Z"),
+            ]
+        )
+        self.assertEqual(summary["standing_block"], "")
+        self.assertNotIn("surface_runtime_block", summary["next_action"])
+        self.assertTrue(summary["next_action"].startswith("record_runtime_observation:"), summary["next_action"])
+
+    def test_a_terminal_event_still_pins_after_later_observations(self) -> None:
+        # The asymmetry is the point: a cancellation is not undone by a later
+        # milestone the way a block is.
+        for event in RUNTIME_TERMINAL_OBSERVATION_EVENTS:
+            with self.subTest(event=event):
+                summary = summarize_runtime_observation_status(
+                    [
+                        _milestone(event, "observed", "2026-01-01T00:00:00Z"),
+                        _milestone("merge", "observed", "2026-03-01T00:00:00Z"),
+                    ]
+                )
+                self.assertEqual(summary["next_action"], f"surface_runtime_{event}:{event}")
+
+
+class CoverageIsWhatTheDocsSay(unittest.TestCase):
+    """The module and the docs claim what one call site provides, and say so."""
+
+    @staticmethod
+    def _repo_root() -> Path:
+        return Path(__file__).resolve().parents[1]
+
+    def _sources(self) -> dict[Path, str]:
+        root = self._repo_root() / "src"
+        return {path: path.read_text(encoding="utf-8") for path in root.rglob("*.py")}
+
+    def test_only_the_delegation_lane_mints_records_today(self) -> None:
+        # A pin on the coverage claim, not on the code. When a second producer
+        # is wired, this fails -- and the fix is to update the "What actually
+        # produces and reads these records today" section of the module
+        # docstring and the matching paragraph in docs/ARCHITECTURE.md, then
+        # widen this set.
+        pattern = re.compile(r"\b(mint_blocked_work_record|record_blocked_work)\s*\(")
+        producers = {
+            path.relative_to(self._repo_root()).as_posix()
+            for path, text in self._sources().items()
+            if pattern.search(text) and path.name != "blocked_work_records.py"
+        }
+        self.assertEqual(producers, {"src/commands/coding.py"})
+
+    def test_the_history_has_at_least_one_production_read_surface(self) -> None:
+        readers = {
+            path.relative_to(self._repo_root()).as_posix()
+            for path, text in self._sources().items()
+            if re.search(r"\bdecision_history\s*\(", text) and path.name != "blocked_work_records.py"
+        }
+        self.assertIn("src/runtime/artifacts.py", readers)
+
+    def test_the_export_carries_the_decision_history(self) -> None:
+        # #806 asks for a block to be explainable after the turn. Until the
+        # export carried this, the only way to answer it was to open the JSONL.
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            record_blocked_work(
+                paths,
+                source="safety_preflight",
+                outcome="blocked",
+                reason_domain="safety_preflight_correction",
+                reason_code="secret_shaped_value",
+                owner="hermes",
+                safety_profile_revision="rev-1",
+                request=_request(target_paths=["src/auth/token.py"]),
+            )
+            exported = export_runtime(paths)
+            history = exported["decision_history"]
+            self.assertEqual(history["summary"]["blocked_count"], 1)
+            self.assertEqual(history["entries"][0]["reason_code"], "secret_shaped_value")
+            self.assertTrue(history["entries"][0]["reason"])
+            self.assertNotIn("token.py", json.dumps(exported["decision_history"]))
+
+    def test_the_module_docstring_states_the_sources_that_produce_nothing(self) -> None:
+        # The docs must not assert coverage the wiring does not provide.
+        doc = blocked_work_records_module.__doc__ or ""
+        for source in ("approval_gate", "runtime_claim_gate"):
+            self.assertIn(source, doc)
+        self.assertIn("mint nothing yet", doc)
+
+    def test_the_architecture_doc_states_the_same_gap(self) -> None:
+        text = (self._repo_root() / "docs" / "ARCHITECTURE.md").read_text(encoding="utf-8")
+        self.assertIn("mint nothing yet", text)
+
+
+class RecoveryActionCopy(unittest.TestCase):
+    """A closed id vocabulary with per-locale copy and an English fallback."""
+
+    def test_every_recovery_action_has_copy(self) -> None:
+        self.assertEqual(set(recovery_action_copy_ids()), set(RECOVERY_ACTIONS))
+
+    def test_every_supported_locale_falls_back_to_english_at_worst(self) -> None:
+        for action in RECOVERY_ACTIONS:
+            for locale in SUPPORTED_COPY_LOCALES:
+                with self.subTest(action=action, locale=locale):
+                    self.assertTrue(recovery_action_copy(action, locale=locale))
+
+    def test_an_unknown_id_renders_empty_rather_than_as_a_token(self) -> None:
+        self.assertEqual(recovery_action_copy("no_such_recovery"), "")
+
+    def test_the_copy_is_a_constant_and_interpolates_nothing(self) -> None:
+        for action in RECOVERY_ACTIONS:
+            for locale in SUPPORTED_COPY_LOCALES:
+                line = recovery_action_copy(action, locale=locale)
+                self.assertNotIn("{", line)
+                self.assertNotIn("}", line)
+
+
+class DeniedDelegationLeavesADurableRecord(unittest.TestCase):
+    """Anchor A: the persistence gap this change exists to close."""
+
+    def test_a_denied_gate_maps_to_a_blocked_decision(self) -> None:
+        # Built by `evaluate_action_gate` and never by hand. The first version of
+        # this test wrote its own denial dict carrying `reason_code` -- singular,
+        # and not a member of `DENIAL_KEYS` at all -- so it agreed with a lane
+        # that read a key the gate has never emitted, and every real denial
+        # recorded the fallback code instead of the one that was raised.
+        verdict = _denied_verdict(["secret_shaped_value"])
+        self.assertNotIn("reason_code", verdict["denial"])
+        decision = decision_from_action_gate(verdict, owner="hermes", safety_profile_revision="", request=_request())
+        self.assertEqual(decision["outcome"], "blocked")
+        self.assertEqual(decision["reason_code"], "secret_shaped_value")
+        self.assertEqual(decision["reason_domain"], "safety_preflight_correction")
+        self.assertEqual(decision["source"], "safety_preflight")
+        self.assertEqual(decision["safety_profile_revision"], "rev-9")
+
+    def test_an_allowed_gate_maps_to_an_allowed_decision(self) -> None:
+        decision = decision_from_action_gate(
+            {"outcome": "allow", "safety_profile_revision": "rev-9"},
+            owner="hermes",
+            safety_profile_revision="",
+            request=_request(),
+        )
+        self.assertEqual(decision["outcome"], "allowed")
+        self.assertEqual(decision["reason_code"], "allowed")
+        self.assertEqual(decision["recovery_action"], ALLOW_RECOVERY_ACTION)
+
+    def test_a_denial_with_an_unknown_code_is_still_recorded_as_blocked(self) -> None:
+        # Recording it as an allow to keep the vocabulary tidy would be the one
+        # unrecoverable mistake this family can make.
+        decision = decision_from_action_gate(
+            {"outcome": "deny", "denial": {"reason_codes": ["from_the_future"]}},
+            owner="hermes",
+            safety_profile_revision="rev-1",
+            request=_request(),
+        )
+        self.assertEqual(decision["outcome"], "blocked")
+        self.assertEqual(decision["reason_code"], "safety_preflight_denied")
+
+    def test_a_revision_drift_denial_records_the_weaker_true_claim(self) -> None:
+        # `_revision_drift_denial` carries `carried:`/`live:` codes that belong
+        # to no explanation vocabulary. The record says the gate denied before
+        # authority was granted -- true of every denial -- and does not invent a
+        # code for the drift.
+        verdict = evaluate_action_gate(
+            **{
+                **_GATE_KWARGS,
+                "safety_preflight": {"outcome": "allow", "safety_profile_revision": "rev-9"},
+                "live_safety_profile_revision": "rev-10",
+            }
+        )
+        self.assertEqual(verdict["outcome"], "deny")
+        self.assertEqual(verdict["denial"]["rule_id"], "safety_profile_revision_drift")
+        decision = decision_from_action_gate(verdict, owner="hermes", safety_profile_revision="", request=_request())
+        self.assertEqual(decision["outcome"], "blocked")
+        self.assertEqual(decision["reason_code"], "safety_preflight_denied")
+        self.assertEqual(decision["reason_domain"], "action_gate_exclusion")
+        self.assertTrue(decision_reason_text(decision["reason_domain"], decision["reason_code"]))
+
+    def test_an_action_gate_exclusion_code_keeps_its_own_domain(self) -> None:
+        decision = decision_from_action_gate(
+            {"outcome": "deny", "denial": {"reason_codes": ["withheld_pending_approval"]}},
+            owner="hermes",
+            safety_profile_revision="rev-1",
+            request=_request(),
+        )
+        self.assertEqual(decision["reason_domain"], "action_gate_exclusion")
+        self.assertEqual(decision["reason_code"], "withheld_pending_approval")
+        self.assertEqual(decision["source"], "action_gate")
+        self.assertEqual(decision["recovery_action"], "request_approval")
+
+    def test_the_decision_block_carries_every_key_a_recording_surface_reads(self) -> None:
+        # `wrapper.contract` reads `recovery_action` off this block. It did not
+        # exist on it, so the read always missed and fell through to a
+        # recomputation that happened to agree.
+        decision = decision_from_action_gate(
+            _denied_verdict(["secret_shaped_value"]),
+            owner="hermes",
+            safety_profile_revision="",
+            request=_request(),
+        )
+        self.assertEqual(set(decision), set(BLOCKED_WORK_DECISION_KEYS))
+
+    def test_the_decision_block_never_carries_the_request_itself(self) -> None:
+        # It is embedded in the delegation payload and that payload is
+        # serialized, so a returned request would put every path a caller named
+        # into an artifact this family exists to keep them out of.
+        decision = decision_from_action_gate(
+            _denied_verdict(["secret_shaped_value"]),
+            owner="hermes",
+            safety_profile_revision="",
+            request=_request(target_paths=["src/auth/token.py"]),
+        )
+        self.assertNotIn("request", decision)
+        self.assertNotIn("token.py", json.dumps(decision))
+
+    def test_the_denial_card_states_the_recovery_and_pauses_rather_than_skips(self) -> None:
+        payload = {
+            "delegation": {"action": "delegate", "intent": "implement", "recommended_workflow": "coding"},
+            "action_gate": {
+                "outcome": "deny",
+                "denial": {
+                    "rule_id": "secrets_absent",
+                    "field": "owner",
+                    "reason_code": "secret_shaped_value",
+                    "correction": "Remove the credential-shaped value and pass an opaque reference instead.",
+                },
+            },
+            "blocked_work_decision": {
+                "outcome": "blocked",
+                "reason_domain": "safety_preflight_correction",
+                "reason_code": "secret_shaped_value",
+                "recovery_action": "remove_prohibited_content",
+            },
+        }
+        response = build_chat_response_from_delegation(payload)
+        state = response["state"]
+        self.assertEqual(state["work_lifecycle_state"], "paused")
+        self.assertEqual(state["work_claim"], "not_attempted")
+        self.assertEqual(state["recovery_action"], "remove_prohibited_content")
+        self.assertTrue(state["recovery_action_copy"])
+        self.assertIn(state["recovery_action_copy"], response["body"])
+        self.assertFalse(state["dispatchable"])
+
+    def test_the_denial_card_speaks_a_declared_locale_and_defaults_to_english(self) -> None:
+        # Localization is opt-in here, never sniffed: a delegation payload
+        # carries no request text, so a detected locale would be a guess.
+        payload = {
+            "delegation": {"action": "delegate", "intent": "implement", "recommended_workflow": "coding"},
+            "action_gate": {"outcome": "deny", "denial": {"reason_code": "secret_shaped_value"}},
+            "blocked_work_decision": {
+                "outcome": "blocked",
+                "reason_domain": "safety_preflight_correction",
+                "reason_code": "secret_shaped_value",
+                "recovery_action": "remove_prohibited_content",
+            },
+        }
+        english = build_chat_response_from_delegation(payload)["state"]["recovery_action_copy"]
+        korean = build_chat_response_from_delegation({**payload, "copy_locale": "ko"})["state"][
+            "recovery_action_copy"
+        ]
+        self.assertEqual(english, recovery_action_copy("remove_prohibited_content", locale="en"))
+        self.assertEqual(korean, recovery_action_copy("remove_prohibited_content", locale="ko"))
+        self.assertNotEqual(english, korean)
+        # An unsupported declaration falls back rather than failing.
+        unknown = build_chat_response_from_delegation({**payload, "copy_locale": "xx"})["state"][
+            "recovery_action_copy"
+        ]
+        self.assertEqual(unknown, english)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cross_harness_adapters.py
+++ b/tests/test_cross_harness_adapters.py
@@ -167,7 +167,14 @@ class FailClosedAdapterRunnerTests(_RunnerMixin):
             with self.assertRaises(ProcessLookupError):
                 os.kill(pid, 0)
             self.assertTrue(outcome.repetitions[0].process_group_terminated)
-            self.assertLess(time.monotonic() - started, 4.0)
+            # The bound is the caller's own timeout plus a cleanup allowance,
+            # not a constant: a hardcoded 4.0 was below the 5s timeout one
+            # caller passes, so that test was asserting cleanup finished
+            # sooner than the timeout it had just granted. It survived only
+            # because a crash returns fast, and failed on a loaded runner at
+            # 4.36s. The property under test is that teardown is bounded, not
+            # that a shared runner is fast.
+            self.assertLess(time.monotonic() - started, timeout_seconds + 2.0)
             return outcome
 
     def test_zero_exit_descendant_with_closed_stdio_is_killed(self) -> None:


### PR DESCRIPTION
# Safe blocked-work records, a decision history, and one shared append-only store (closes #808, #806)

## What capability changed

When OMH refuses work, it now leaves a record that survives the turn — and that record cannot carry the prompt, path, token, or payload that caused the refusal, because it has no field those could occupy.

- **`blocked_work_record/v1`** — an append-only family with twenty closed keys and **no free-text field at all**. The safety property holds structurally, not by scrubbing.
- **Decision history** — a projection over those records, recording allows as well as blocks, so "an allow is never rendered as attempted or completed" is an enforceable invariant rather than an accidental absence.
- **`src/system/append_only_store.py`** — the store mechanics the two existing receipt families had each hand-copied, extracted once and shared.

## Why

A preflight denial created no run, wrote no delegation record, and appended no journal event. "Why was this blocked?" was not answerable at all on a later turn — a block rendering as *nothing*, which is worse than rendering as a skipped success. That gap is what this closes.

Separately, `external_effect_receipts` and `approval_receipts` were ~2580 lines of near-duplicate store mechanics. A third hand-copied instance would have made every future drift a three-way problem, so the mechanics were extracted first, with a proven-empty byte diff and zero test edits, and the new family was built on the result.

## Implementation at the boundary level

**The fingerprint hashes the class, never the value.** A truncated hash of a filename is dictionary-reversible, so `request_fingerprint` digests only the multiset of class labels the preflight already assigned — field classes, data classes, access intents, remote-target kinds, evidence claims. Verified: two requests with the same shape and different values collide; six shape perturbations diverge; hashing candidate filenames never reproduces a stored digest.

**Observing and enforcing sources are separate.** The Hermes plugin hook contract has no deny channel, so a hook can record that something was blocked but may never claim OMH stopped it. An observing source cannot mint an allow, and a hand-edited `enforcement: enforced` on a hook record is rejected.

**Blocked, failed, cancelled and completed are now distinguished end to end.** `cancelled` was journalable in principle but unreachable through the CLI, four step-state functions collapsed blocked into failed, and a cancelled CI check was aliased to a failing gate. All three are fixed, and the projections were taught to honour the new vocabulary member rather than merely accepting it.

## What the review caught, and what it says about the work

An adversarial review confirmed fourteen findings, five high, in code where all 4075 tests passed. The two worth naming:

- The gate lane read `denial["reason_code"]`, a key the denial contract does not have — it carries plural `reason_codes`. Every gate denial was silently landing on a fallback reason under the wrong domain. Cross-module key reads are now pinned against the exporting module's own key tuples by a source-derived test.
- The decision block returned the raw request, which is embedded in the serialized delegation payload — every path this family exists to keep out of artifacts would have ridden in through it.

Two pre-existing tests were not merely outdated but *wrong*: they hand-built a denial dict carrying the non-existent key and so agreed with the defective code. They now build the verdict through the real gate.

Every fix was proved by reverting it in a scratch copy and confirming at least one test fails — thirteen reverts, thirteen failures.

## Verification observed

- Full suite **Ran 4114 tests, OK** (baseline on merged main: 3971).
- `ruff check src tests` clean; `docs workflows/roles/capability-families --check` all ok; `compileall` and `git diff --check` clean.
- The extraction was proved behaviour-preserving by driving both existing stores through their public mint APIs under a fixed clock and diffing the stored bytes: identical hashes before and after, and neither consumer test file was edited.

Also included: a one-line fix to a flaky test. `_assert_descendant_is_killed` asserted teardown finished within a hardcoded 4.0s while one caller passes a 5s timeout — that test was asserting cleanup finished sooner than the timeout it had just granted, and it failed on a loaded runner at 4.36s. The bound is now the caller's own timeout plus a cleanup allowance, identical for the two default callers.

## Risks and follow-ups

- Coverage is stated rather than implied: one producer, two of four enforcing sources reached, the approval and claim-ladder gates and all observing sources mint nothing yet, two read surfaces, no dedicated history command. A test fails if a producer or reader is added without updating the claim.
- The history renders decisions, not block events: a shape blocked ten times is one entry with a supersession count.
- Revision-drift denials record the weaker true claim rather than inventing a drift reason code, because their codes belong to no explanation vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
