### PR TITLE
fix: give journal appends a real lock on Windows, and name the domain-store gap

### DIFF
--- a/src/maintenance/probe.py
+++ b/src/maintenance/probe.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 from ..skills.catalog import omh_skill_display_name
 
+import os
+import sys
 from dataclasses import dataclass
 from pathlib import Path
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - absent on Windows.
+    fcntl = None
 
 from ..capability_roadmap import build_capability_gap_roadmap
 from ..config_adapter import external_dirs, read_config
@@ -405,6 +412,46 @@ def _dir_capability(name: str, path: Path, found_message: str, missing_message: 
     )
 
 
+def _domain_intelligence_store_capability() -> Capability:
+    """Whether this host has the primitives the domain-intelligence store needs.
+
+    The store fails closed without dirfd-anchored opens and advisory locks, and
+    `_bind_root` turns that refusal into `None` so an unavailable expert
+    question never breaks a route. That degradation is correct, but it left a
+    Windows user with a feature that silently never engages and nothing to
+    consult about why. This row is that answer.
+
+    Probed rather than keyed off `os.name`, so it stays true on any host whose
+    Python lacks one of the primitives for its own reasons.
+    """
+    missing: list[str] = []
+    if not (
+        getattr(os, "O_NOFOLLOW", 0)
+        and getattr(os, "O_DIRECTORY", 0)
+        and os.open in os.supports_dir_fd
+        and hasattr(os, "fchmod")
+    ):
+        missing.append("dirfd-anchored opens (O_NOFOLLOW/O_DIRECTORY)")
+    if fcntl is None:
+        missing.append("fcntl advisory locks")
+    if missing:
+        return Capability(
+            "domain_intelligence_store",
+            "missing",
+            f"platform:{sys.platform}",
+            (
+                "Domain intelligence and its chat context attachment are unavailable on this host, "
+                f"which lacks {' and '.join(missing)}; routing is unaffected"
+            ),
+        )
+    return Capability(
+        "domain_intelligence_store",
+        "available",
+        f"platform:{sys.platform}",
+        "Host provides the dirfd and advisory-lock primitives the domain-intelligence store requires",
+    )
+
+
 def probe_capabilities(paths: OmhPaths, *, include_parity: bool = False, include_roadmap: bool = False) -> dict:
     config_text = read_config(paths.hermes_config_path)
     configured_dirs = external_dirs(config_text)
@@ -541,6 +588,7 @@ def probe_capabilities(paths: OmhPaths, *, include_parity: bool = False, include
             ),
         ]
     )
+    capabilities.append(_domain_intelligence_store_capability())
 
     payload = {
         "schema_version": 1,

--- a/src/plugin_bundle/omh/awareness_delivery.py
+++ b/src/plugin_bundle/omh/awareness_delivery.py
@@ -25,17 +25,35 @@ cannot grow.
 
 from __future__ import annotations
 
+import errno
 import json
 import os
 import secrets
+import time
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Iterator
 
 try:
     import fcntl
-except ImportError:  # pragma: no cover - Hermes targets POSIX hosts today.
+except ImportError:  # pragma: no cover - absent on Windows.
     fcntl = None
+
+try:
+    import msvcrt
+except ImportError:  # pragma: no cover - present only on Windows.
+    msvcrt = None
+
+LOCK_MECHANISM_FCNTL = "fcntl"
+LOCK_MECHANISM_MSVCRT = "msvcrt"
+LOCK_MECHANISM_NONE = "none"
+# Both backends report "already held" through errno rather than a dedicated
+# exception: flock uses EACCES/EAGAIN, msvcrt.locking uses EACCES for LK_NBLCK.
+_LOCK_BUSY_ERRNOS = frozenset(
+    {errno.EACCES, errno.EAGAIN, errno.EDEADLK, getattr(errno, "EDEADLOCK", errno.EDEADLK)}
+)
+_LOCK_TIMEOUT_SECONDS = 10.0
+_LOCK_POLL_INTERVAL = 0.05
 
 
 AWARENESS_DELIVERY_SCHEMA_VERSION = "omh_awareness_delivery/v1"
@@ -91,21 +109,71 @@ def _valid_delivery_record(data: dict[str, Any]) -> bool:
     return int(data.get("route_hint_count", 0)) <= int(data.get("delivery_count", 0))
 
 
+def _acquire_delivery_lock(handle: Any, lock_path: Path) -> str:
+    """Take an exclusive OS lock, on POSIX or Windows, and say which granted it.
+
+    This module is vendored into the user's Hermes install and imports nothing
+    from omh core, so it carries its own two-backend lock instead of sharing
+    `local_store.file_lock`. Before it had the msvcrt branch, a Windows host
+    took no lock at all here, and the read-modify-write below could interleave
+    between concurrent turns and lose counter increments with nothing saying so.
+
+    The POSIX path stays a blocking `LOCK_EX`, unchanged: this runs on the
+    hottest path in the system and turning it into a bounded wait would newly
+    let it raise. Windows has no blocking primitive with the same semantics --
+    `LK_LOCK` gives up after ten seconds anyway -- so it polls the non-blocking
+    flag against the same deadline.
+    """
+    if fcntl is not None:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        return LOCK_MECHANISM_FCNTL
+    if msvcrt is None:
+        return LOCK_MECHANISM_NONE
+    deadline = time.monotonic() + _LOCK_TIMEOUT_SECONDS
+    while True:
+        try:
+            # msvcrt.locking locks a byte range from the current position, so
+            # the region has to be pinned to byte 0 on acquire and release for
+            # the two calls to describe the same region.
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+            return LOCK_MECHANISM_MSVCRT
+        except OSError as exc:
+            if exc.errno not in _LOCK_BUSY_ERRNOS:
+                raise
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"could not lock {lock_path} within {_LOCK_TIMEOUT_SECONDS}s") from exc
+            time.sleep(_LOCK_POLL_INTERVAL)
+
+
+def _release_delivery_lock(handle: Any, mechanism: str) -> None:
+    if mechanism == LOCK_MECHANISM_FCNTL:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        return
+    if mechanism == LOCK_MECHANISM_MSVCRT:
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+
+
 @contextmanager
-def _awareness_delivery_lock(path: Path) -> Iterator[None]:
+def _awareness_delivery_lock(path: Path) -> Iterator[str]:
+    """Serialize the counter read-modify-write; yields the mechanism that held it.
+
+    A `none` yield means the host had neither backend and the mutual-exclusion
+    guarantee did not hold. The block still runs -- refusing would disable
+    awareness recording entirely -- but the caller can tell the difference.
+    """
     path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     path.parent.chmod(0o700)
     lock_path = path.with_name(f".{path.name}.lock")
     lock_path.touch(mode=0o600, exist_ok=True)
     lock_path.chmod(0o600)
     with lock_path.open("a+", encoding="utf-8") as handle:
-        if fcntl is not None:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        mechanism = _acquire_delivery_lock(handle, lock_path)
         try:
-            yield
+            yield mechanism
         finally:
-            if fcntl is not None:
-                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            _release_delivery_lock(handle, mechanism)
 
 
 def _write_delivery_record(path: Path, data: dict[str, Any]) -> None:

--- a/src/system/local_store.py
+++ b/src/system/local_store.py
@@ -235,6 +235,32 @@ def file_lock(
         handle.close()
 
 
+def append_jsonl_locked(path: Path, record: dict[str, Any], *, private: bool = True) -> dict[str, Any]:
+    """Append one JSON line to ``path`` while holding an exclusive OS lock.
+
+    Callers used to take ``fcntl.flock`` on the journal handle directly and
+    skip locking entirely when fcntl was missing. On Windows that meant
+    concurrent appenders had no mutual exclusion at all, and -- unlike
+    ``file_lock``, which reports ``enforced: False`` -- nothing said so, which
+    is the worse half of the bug: a guarantee that quietly is not one.
+
+    Going through ``file_lock`` gets ``msvcrt.locking`` on Windows, so the
+    guarantee actually holds there, and keeps the honest signal for a platform
+    that has neither backend.
+
+    Returns the lock status mapping so a caller can surface an unenforced
+    write. The append happens either way, because refusing to write on such a
+    platform would break every caller rather than protect anything.
+    """
+    ensure_dir(path.parent, private=private)
+    ensure_file(path, private=private)
+    with file_lock(path, private=private) as lock:
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, sort_keys=True) + "\n")
+            handle.flush()
+        return dict(lock)
+
+
 def locked_json_update(
     path: Path,
     mutate_fn: Callable[[dict[str, Any]], dict[str, Any] | None],

--- a/src/system/local_store.py
+++ b/src/system/local_store.py
@@ -255,7 +255,11 @@ def append_jsonl_locked(path: Path, record: dict[str, Any], *, private: bool = T
     ensure_dir(path.parent, private=private)
     ensure_file(path, private=private)
     with file_lock(path, private=private) as lock:
-        with path.open("a", encoding="utf-8") as handle:
+        # newline="" for the same reason atomic_write_text uses it: text mode
+        # would translate "\n" to "\r\n" on Windows, so the same record would
+        # land as different bytes per platform. The callers this replaced wrote
+        # in translating mode and had that drift.
+        with path.open("a", encoding="utf-8", newline="") as handle:
             handle.write(json.dumps(record, sort_keys=True) + "\n")
             handle.flush()
         return dict(lock)

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import hashlib
-import json
 import os
 import re
 import unicodedata
@@ -10,9 +9,9 @@ from pathlib import Path
 from typing import Any
 
 from ..local_store import (
+    append_jsonl_locked,
     atomic_write_json,
     ensure_dir,
-    ensure_file,
     file_lock,
     read_json_object,
     read_json_object_result,
@@ -20,10 +19,6 @@ from ..local_store import (
     utc_now,
 )
 
-try:  # pragma: no cover - non-POSIX fallback is exercised only on platforms without fcntl.
-    import fcntl
-except ImportError:  # pragma: no cover
-    fcntl = None  # type: ignore[assignment]
 from ..plugin_bundle.omh.hermes_memory import build_hermes_memory_bridge as _bundle_memory_bridge
 from ..plugin_bundle.omh.hermes_memory import classify_record_expiry as _classify_record_expiry
 from ..plugin_bundle.omh.memory_dreaming import consolidation_path as _consolidation_path
@@ -1587,18 +1582,7 @@ def _append_retirement_journal(paths: OmhPaths, record_id: str, retired_at: str,
         "redaction_policy": "metadata_only",
         "claim_boundary": _RETIREMENT_JOURNAL_CLAIM_BOUNDARY,
     }
-    journal_path = _retirements_journal_path(paths)
-    ensure_dir(journal_path.parent, private=True)
-    ensure_file(journal_path, private=True)
-    with journal_path.open("a", encoding="utf-8") as handle:
-        if fcntl is not None:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
-        try:
-            handle.write(json.dumps(entry, sort_keys=True) + "\n")
-            handle.flush()
-        finally:
-            if fcntl is not None:
-                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    append_jsonl_locked(_retirements_journal_path(paths), entry)
     return entry
 
 

--- a/src/workflows/observation_journal.py
+++ b/src/workflows/observation_journal.py
@@ -5,12 +5,7 @@ import json
 import secrets
 from typing import Any
 
-try:  # pragma: no cover - non-POSIX fallback is exercised only on platforms without fcntl.
-    import fcntl
-except ImportError:  # pragma: no cover
-    fcntl = None  # type: ignore[assignment]
-
-from ..local_store import ensure_dir, ensure_file, read_json_object, read_jsonl_objects, utc_now
+from ..local_store import append_jsonl_locked, read_json_object, read_jsonl_objects, utc_now
 from ..paths import OmhPaths
 
 
@@ -115,17 +110,7 @@ def append_observation_event(paths: OmhPaths, event: dict[str, Any]) -> dict[str
     sequence_errors = _validate_observation_event_prerequisites(paths, record, _prior_events_for_record(paths, record))
     if sequence_errors:
         raise ValueError(sequence_errors[0])
-    ensure_dir(paths.runtime_journal_dir, private=True)
-    ensure_file(paths.runtime_journal_events_path, private=True)
-    with paths.runtime_journal_events_path.open("a", encoding="utf-8") as handle:
-        if fcntl is not None:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
-        try:
-            handle.write(json.dumps(record, sort_keys=True) + "\n")
-            handle.flush()
-        finally:
-            if fcntl is not None:
-                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    append_jsonl_locked(paths.runtime_journal_events_path, record)
     return record
 
 

--- a/tests/test_journal_lock_portability.py
+++ b/tests/test_journal_lock_portability.py
@@ -1,0 +1,230 @@
+"""Journal appends must be mutually exclusive on Windows too.
+
+Three append paths guarded on `if fcntl is not None:` with no Windows branch, so
+on a Windows host they took no lock at all and concurrent writers could
+interleave -- and unlike `local_store.file_lock`, which reports
+`enforced: False`, nothing said the guarantee had lapsed. That silence is the
+worse half: a lock that is not one still reads as a lock.
+
+These tests pin both halves: the shared helper actually locks, and no module
+reintroduces a bare single-backend `fcntl.flock` on an append path.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+
+# `fcntl.flock` is legitimate in exactly these places:
+#   local_store          - the shared two-backend implementation itself
+#   awareness_delivery   - vendored into the user's Hermes install, imports
+#                          nothing from omh core, so it carries its own copy
+#   domain_intelligence* - fails closed off POSIX by design, so a single
+#                          backend is the contract rather than a gap
+FCNTL_FLOCK_ALLOWED = {
+    "src/system/local_store.py",
+    "src/plugin_bundle/omh/awareness_delivery.py",
+    "src/workflows/domain_intelligence_bound_store.py",
+    "src/workflows/domain_intelligence_store_security.py",
+}
+
+
+def _code_lines(path: Path) -> list[str]:
+    """Source lines with whole-line comments dropped.
+
+    The two receipt modules mention `fcntl.flock` in prose explaining why they
+    use `file_lock` instead; a text scan that counted those would flag the
+    modules that got this right.
+    """
+    lines = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.lstrip().startswith("#"):
+            continue
+        lines.append(line)
+    return lines
+
+
+class SharedAppendHelperTests(unittest.TestCase):
+    def test_append_reports_an_enforced_os_lock(self) -> None:
+        from omh.local_store import append_jsonl_locked
+
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "nested" / "journal.jsonl"
+            lock = append_jsonl_locked(path, {"b": 2, "a": 1})
+
+            self.assertTrue(lock["locked"])
+            self.assertTrue(lock["enforced"], "every host CI runs on has fcntl or msvcrt")
+            self.assertIn(lock["mechanism"], {"fcntl", "msvcrt"})
+
+    def test_append_creates_the_parent_and_appends_rather_than_truncating(self) -> None:
+        from omh.local_store import append_jsonl_locked
+
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "nested" / "journal.jsonl"
+            append_jsonl_locked(path, {"n": 1})
+            append_jsonl_locked(path, {"n": 2})
+
+            rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+            self.assertEqual(rows, [{"n": 1}, {"n": 2}])
+
+    def test_keys_are_sorted_so_the_line_is_byte_stable(self) -> None:
+        from omh.local_store import append_jsonl_locked
+
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "journal.jsonl"
+            append_jsonl_locked(path, {"b": 2, "a": 1})
+
+            self.assertEqual(path.read_text(encoding="utf-8"), '{"a": 1, "b": 2}\n')
+
+    def test_the_lock_sidecar_is_not_mistaken_for_journal_content(self) -> None:
+        from omh.local_store import append_jsonl_locked
+
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "journal.jsonl"
+            append_jsonl_locked(path, {"n": 1})
+
+            self.assertEqual(path.read_text(encoding="utf-8").count("\n"), 1)
+            self.assertTrue((path.parent / f".{path.name}.lock").exists())
+
+
+class NoSingleBackendLockOnAppendPathsTests(unittest.TestCase):
+    """Derived from source, so the bug cannot be reintroduced quietly."""
+
+    def test_only_the_sanctioned_modules_take_fcntl_flock_directly(self) -> None:
+        offenders = []
+        for path in sorted(SRC_ROOT.rglob("*.py")):
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            if rel in FCNTL_FLOCK_ALLOWED:
+                continue
+            if any("fcntl.flock" in line for line in _code_lines(path)):
+                offenders.append(rel)
+
+        self.assertEqual(
+            offenders,
+            [],
+            "take the lock through local_store.file_lock / append_jsonl_locked, "
+            "or add the module to FCNTL_FLOCK_ALLOWED with a reason",
+        )
+
+    def test_the_three_repaired_append_paths_hold_no_fcntl_reference_at_all(self) -> None:
+        for rel in ("src/workflows/memory.py", "src/workflows/observation_journal.py"):
+            source = (REPO_ROOT / rel).read_text(encoding="utf-8")
+            self.assertNotIn("fcntl", source, f"{rel} should route locking through local_store")
+
+    def test_the_vendored_bundle_carries_both_lock_backends(self) -> None:
+        # It cannot import local_store, so it has to have its own msvcrt branch.
+        source = (REPO_ROOT / "src/plugin_bundle/omh/awareness_delivery.py").read_text(encoding="utf-8")
+        self.assertIn("import msvcrt", source)
+        self.assertIn("LK_NBLCK", source)
+        self.assertIn("LK_UNLCK", source)
+        self.assertNotIn("from ..", source, "the bundle is vendored and must stay import-free of omh core")
+
+
+class AwarenessDeliveryLockTests(unittest.TestCase):
+    def test_the_lock_yields_a_real_mechanism_on_this_host(self) -> None:
+        from omh.plugin_bundle.omh.awareness_delivery import _awareness_delivery_lock
+
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "awareness_delivery.json"
+            with _awareness_delivery_lock(path) as mechanism:
+                self.assertIn(mechanism, {"fcntl", "msvcrt"})
+
+    def test_a_host_with_neither_backend_reports_none_rather_than_pretending(self) -> None:
+        from omh.plugin_bundle.omh import awareness_delivery
+
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "awareness_delivery.json"
+            with (
+                patch.object(awareness_delivery, "fcntl", None),
+                patch.object(awareness_delivery, "msvcrt", None),
+            ):
+                with awareness_delivery._awareness_delivery_lock(path) as mechanism:
+                    # The block still runs: refusing would disable awareness
+                    # recording entirely, which protects nobody.
+                    self.assertEqual(mechanism, "none")
+
+    def test_recording_still_round_trips_through_the_lock(self) -> None:
+        from omh.plugin_bundle.omh.awareness_delivery import (
+            read_awareness_delivery,
+            record_awareness_delivery,
+        )
+
+        with TemporaryDirectory() as tmp:
+            omh_home = Path(tmp) / ".omh"
+            record_awareness_delivery(
+                delivered=True, route_hint=True, context_chars=12, observed_at="2026-01-01T00:00:00Z",
+                omh_home=str(omh_home),
+            )
+            record_awareness_delivery(
+                delivered=False, route_hint=False, context_chars=0, observed_at="2026-01-01T00:00:01Z",
+                omh_home=str(omh_home),
+            )
+
+            current = read_awareness_delivery(str(omh_home))
+            self.assertEqual(int(current["delivery_count"]), 1)
+            self.assertEqual(int(current["suppressed_count"]), 1)
+
+
+class DomainIntelligenceCapabilityTests(unittest.TestCase):
+    """The Windows user's answer to 'why does this never engage?'"""
+
+    def test_this_host_reports_the_store_as_available(self) -> None:
+        from omh.maintenance.probe import _domain_intelligence_store_capability
+
+        capability = _domain_intelligence_store_capability()
+        self.assertEqual(capability.name, "domain_intelligence_store")
+        self.assertEqual(capability.status, "available")
+
+    def test_a_host_without_fcntl_reports_missing_and_names_the_primitive(self) -> None:
+        from omh.maintenance import probe
+
+        with patch.object(probe, "fcntl", None):
+            capability = probe._domain_intelligence_store_capability()
+
+        self.assertEqual(capability.status, "missing")
+        self.assertIn("fcntl advisory locks", capability.message)
+        # Routing is explicitly not implicated: the attachment degrades, the
+        # route does not.
+        self.assertIn("routing is unaffected", capability.message)
+
+    def test_the_capability_is_reachable_from_the_probe_payload(self) -> None:
+        from omh.paths import OmhPaths
+        from omh.probe import probe_capabilities
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            payload = probe_capabilities(OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes"))
+
+        names = [item["name"] for item in payload["capabilities"]]
+        self.assertIn("domain_intelligence_store", names)
+
+    def test_the_capability_status_stays_inside_the_declared_vocabulary(self) -> None:
+        from omh.maintenance.probe import PROBE_STATUSES, _domain_intelligence_store_capability
+
+        self.assertIn(_domain_intelligence_store_capability().status, PROBE_STATUSES)
+
+
+class SanctionedModuleListTests(unittest.TestCase):
+    def test_every_allowed_path_exists(self) -> None:
+        # A stale allowlist entry would silently re-permit a module that was
+        # renamed or deleted.
+        for rel in sorted(FCNTL_FLOCK_ALLOWED):
+            self.assertTrue((REPO_ROOT / rel).is_file(), f"{rel} is allowlisted but missing")
+
+    def test_every_allowed_path_actually_uses_fcntl_flock(self) -> None:
+        for rel in sorted(FCNTL_FLOCK_ALLOWED):
+            lines = _code_lines(REPO_ROOT / rel)
+            self.assertTrue(
+                any("fcntl.flock" in line for line in lines),
+                f"{rel} no longer needs its allowlist entry",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_journal_lock_portability.py
+++ b/tests/test_journal_lock_portability.py
@@ -18,6 +18,8 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
+from _platform_support import HAS_FCNTL, HAS_SECURE_DIR_IO
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SRC_ROOT = REPO_ROOT / "src"
 
@@ -73,14 +75,19 @@ class SharedAppendHelperTests(unittest.TestCase):
             rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
             self.assertEqual(rows, [{"n": 1}, {"n": 2}])
 
-    def test_keys_are_sorted_so_the_line_is_byte_stable(self) -> None:
+    def test_the_line_is_byte_identical_on_every_platform(self) -> None:
+        # Read as bytes on purpose. Sorted keys make the JSON stable, and
+        # newline="" keeps the terminator LF -- text mode would write "\r\n"
+        # here on Windows and the same record would be different bytes per
+        # platform, which is exactly what the repo's managed-write convention
+        # exists to prevent.
         from omh.local_store import append_jsonl_locked
 
         with TemporaryDirectory() as tmp:
             path = Path(tmp) / "journal.jsonl"
             append_jsonl_locked(path, {"b": 2, "a": 1})
 
-            self.assertEqual(path.read_text(encoding="utf-8"), '{"a": 1, "b": 2}\n')
+            self.assertEqual(path.read_bytes(), b'{"a": 1, "b": 2}\n')
 
     def test_the_lock_sidecar_is_not_mistaken_for_journal_content(self) -> None:
         from omh.local_store import append_jsonl_locked
@@ -89,7 +96,7 @@ class SharedAppendHelperTests(unittest.TestCase):
             path = Path(tmp) / "journal.jsonl"
             append_jsonl_locked(path, {"n": 1})
 
-            self.assertEqual(path.read_text(encoding="utf-8").count("\n"), 1)
+            self.assertEqual(path.read_bytes().count(b"\n"), 1)
             self.assertTrue((path.parent / f".{path.name}.lock").exists())
 
 
@@ -174,12 +181,21 @@ class AwarenessDeliveryLockTests(unittest.TestCase):
 class DomainIntelligenceCapabilityTests(unittest.TestCase):
     """The Windows user's answer to 'why does this never engage?'"""
 
-    def test_this_host_reports_the_store_as_available(self) -> None:
+    def test_the_verdict_matches_what_this_host_can_actually_do(self) -> None:
+        # Not pinned to "available": on Windows the honest answer is "missing",
+        # and that is the whole point of the row. The expectation is derived
+        # from the same primitives tests/_platform_support.py probes, so this
+        # passes on both platforms for the right reason rather than by being
+        # skipped on one.
         from omh.maintenance.probe import _domain_intelligence_store_capability
 
         capability = _domain_intelligence_store_capability()
+        expected = "available" if (HAS_SECURE_DIR_IO and HAS_FCNTL) else "missing"
+
         self.assertEqual(capability.name, "domain_intelligence_store")
-        self.assertEqual(capability.status, "available")
+        self.assertEqual(capability.status, expected)
+        if expected == "missing":
+            self.assertIn("unavailable on this host", capability.message)
 
     def test_a_host_without_fcntl_reports_missing_and_names_the_primitive(self) -> None:
         from omh.maintenance import probe


### PR DESCRIPTION
## Feature Report

Follow-up to #851, which listed both of these as deliberately out of scope. They are a different user goal — correctness of concurrent writes on Windows, not "can I install it" — so they get their own PR.

### What Changed

- **`local_store.append_jsonl_locked`** — one shared append-under-lock path, used by the retirement journal and the observation-event journal. Both drop their `fcntl` shim entirely.
- **`awareness_delivery`** gets its own two-backend lock, because it is vendored into the user's Hermes install and imports nothing from omh core.
- **`omh probe` gains a `domain_intelligence_store` row** naming the missing primitive when the host cannot provide it.
- **A source-derived regression gate** on every `fcntl.flock` call site in `src/`.

### Why This Exists

Three append paths were guarded on `if fcntl is not None:` with no Windows branch:

```python
with journal_path.open("a", encoding="utf-8") as handle:
    if fcntl is not None:
        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
    ...
```

On Windows that is not a degraded lock — it is **no lock**. The `with` block runs, concurrent writers can interleave a read-modify-write, and nothing reports that the guarantee lapsed. That silence is the worse half: `local_store.file_lock` has had a two-backend implementation *and* an `enforced: False` signal all along, so these three were the only places still claiming a guarantee they did not hold.

The second half: the domain-intelligence store fails closed off POSIX **by design**, and `_bind_root` swallows that refusal to `None` so an unavailable expert question never breaks a route. That degradation is correct. What was wrong is that a Windows user got a feature that silently never engages, with nothing to consult about why.

### User / Operator Impact

- Windows hosts get **real mutual exclusion** on the memory retirement journal, the runtime observation journal, and the awareness-delivery counters. Concurrent turns can no longer lose an increment or interleave a journal line.
- `omh probe` now answers "why does domain intelligence never engage here?":

```
domain_intelligence_store  missing  platform:win32
  Domain intelligence and its chat context attachment are unavailable on this
  host, which lacks dirfd-anchored opens (O_NOFOLLOW/O_DIRECTORY) and fcntl
  advisory locks; routing is unaffected
```

The "routing is unaffected" clause is deliberate — the point is to explain a missing advisory feature without implying the router is broken.

### How It Works

| Site | Before | After |
| --- | --- | --- |
| `memory._append_retirement_journal` | bare `fcntl.flock`, no-op off POSIX | `append_jsonl_locked` |
| `observation_journal.append_observation_event` | bare `fcntl.flock`, no-op off POSIX | `append_jsonl_locked` |
| `awareness_delivery._awareness_delivery_lock` | bare `fcntl.flock`, no-op off POSIX | own fcntl + msvcrt lock, yields the mechanism |

Each journal has exactly **one** writer, verified before the change, so moving the lock from the data-file handle to `file_lock`'s `.lock` sidecar cannot orphan another writer. It is also the same shape `approval_receipts` and `external_effect_receipts` already use.

The bundle keeps its POSIX path as a blocking `LOCK_EX`, unchanged — this is the hottest path in the system and converting it to a bounded wait would newly let it raise. Windows polls `LK_NBLCK` against a deadline, because it has no blocking primitive with matching semantics (`LK_LOCK` gives up after ten seconds and raises anyway).

The regression gate strips comment lines before scanning, because `approval_receipts` and `external_effect_receipts` mention `fcntl.flock` in prose explaining why they *don't* use it — a naive text scan would flag the two modules that got this right.

### Files And Contracts Touched

- `src/system/local_store.py` — new `append_jsonl_locked`
- `src/workflows/memory.py`, `src/workflows/observation_journal.py` — call sites, fcntl shims removed
- `src/plugin_bundle/omh/awareness_delivery.py` — two-backend lock, yields mechanism
- `src/maintenance/probe.py` — `domain_intelligence_store` capability
- `tests/test_journal_lock_portability.py` (new, 16 tests)

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `python3 -m unittest discover -s tests` — **Ran 4159 tests, OK** (16 new)
- [x] `python3 -m compileall src` — clean
- [x] `docs workflows / roles / capability-families --check` — ok
- [x] `omh harness validate`, `omh release checklist --json` — ok
- [x] `git diff --check` — clean
- [x] `omh probe --json` inspected on this host: `domain_intelligence_store` = `available`, evidence `platform:darwin`
- [ ] **The msvcrt branches are not exercised locally.** `local_store`'s msvcrt path predates this PR; the new one in `awareness_delivery`, and the `missing` verdict of the probe row, are first observed by the `windows-latest` job on this PR.

## Risk

- The bundle's Windows lock path is written, not run, on the authoring host. The POSIX path is unchanged and fully exercised, so the blast radius of a mistake is Windows-only.
- Moving two journals from a data-file lock to a sidecar lock is safe **because** each has a single writer. If a second writer is ever added to either journal, it must use `append_jsonl_locked` too — the regression gate enforces that it cannot quietly use bare `fcntl`.
- `_awareness_delivery_lock` changed its yield type from `None` to `str`. Its one caller uses `with ...:` without binding, so this is source-compatible.

## Compatibility / Rollout

No behavior change on macOS or Linux: same lock semantics, same journal bytes (`sort_keys=True` preserved). No schema, CLI, or config surface changed. `omh probe` gains one capability row; the bundle's own probe tool has an independent capability list and needed no update.

## Follow-Up

None outstanding from #851 — both items it deferred are closed here.
