### PR TITLE
feat: message gate — readable, honest status for delegated coding work

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -222,14 +222,16 @@ provider アクセスは、コア内部に隠された挙動ではなく、明�
 
 ## 主張より証拠
 
-| 状態 | 意味 |
-| --- | --- |
-| Prepared | route、plan、prompt、成果物 contract、handoff の準備ができています。 |
-| Observed | wrapper または runtime が行動や結果の発生を記録しました。 |
-| Verified | 必要な test、review、実画面確認、または別の gate が通過しました。 |
+OMH は自分が見たことだけを起きたと報告します。表示される状態は常に「どの段階か」と「OMH がどれだけ確信しているか」の二部構成です。
 
-`prepared_not_observed` は実行、provider access、成果物生成、review、CI、
-deployment、merge readiness、merge ではありません。
+| 表示 | 意味 |
+| --- | --- |
+| `Plan · not run` | prompt や plan の準備ができています。**まだ何も動いていません。** |
+| `Code · running` | executor が今動いており、OMH が観測しています。 |
+| `Code · reported done` | executor が終わったと言いました。結果は誰も確認していません。 |
+| `Test · verified` | test、review、CI gate が実際に通過しました。 |
+
+重要なのは下から二番目の行です。executor が終わったと言うことと結果が確認されたことは別ですが、多くのツールは両方を「完了」と書きます。
 
 ## ドキュメント
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -218,14 +218,18 @@ OMH는 그 작업을 둘러싼 로컬 계약, 라우팅, 기억, 품질 게이�
 
 ## 주장보다 증거
 
-| 상태 | 의미 |
-| --- | --- |
-| Prepared | route, plan, prompt, 산출물 계약 또는 handoff가 준비됐습니다. |
-| Observed | wrapper 또는 runtime이 행동이나 결과가 발생했다고 기록했습니다. |
-| Verified | 필요한 test, review, 실제 화면 검사 또는 다른 gate가 통과했습니다. |
+OMH는 직접 본 것만 일어났다고 말합니다. 화면에 뜨는 상태는 항상 두 부분입니다:
+어느 단계인지, 그리고 OMH가 그걸 얼마나 확신하는지.
 
-`prepared_not_observed`는 실행, provider 접근, 산출물 생성, review, CI, 배포,
-merge readiness 또는 merge가 아닙니다.
+| 표시 | 의미 |
+| --- | --- |
+| `Plan · not run` | prompt나 plan이 준비됐습니다. **아직 아무것도 안 돌았습니다.** |
+| `Code · running` | executor가 지금 돌고 있고 OMH가 보고 있습니다. |
+| `Code · reported done` | executor가 끝났다고 말했습니다. 결과는 아무도 확인 안 했습니다. |
+| `Test · verified` | test, review, CI gate가 실제로 통과했습니다. |
+
+중요한 건 아래에서 두 번째 줄입니다. executor가 끝났다고 말한 것과 결과가
+확인된 것은 다른데, 대부분의 도구가 둘 다 "완료"라고 씁니다.
 
 ## 문서
 

--- a/README.md
+++ b/README.md
@@ -259,18 +259,21 @@ access stay explicit integrations rather than hidden behavior inside the core.
 
 ## Evidence Before Claims
 
-OMH separates useful preparation from observed results:
+OMH never reports that work happened unless it watched it happen. Every status
+you see has two parts: the stage, and how sure OMH is about it.
 
-| State | Meaning |
+| You see | It means |
 | --- | --- |
-| Prepared | A route, plan, prompt, artifact contract, or handoff is ready. |
-| Observed | A wrapper or runtime recorded that an action or result occurred. |
-| Verified | A matching test, review, served-surface check, or other required gate passed. |
+| `Plan · not run` | A prompt or plan is ready. **Nothing has run yet.** |
+| `Code · running` | An executor is running now, and OMH is watching it. |
+| `Code · reported done` | The executor said it finished. Nobody checked the result. |
+| `Test · verified` | A test, review, or CI gate actually passed. |
 
-`prepared_not_observed` is not execution, provider access, artifact generation,
-review, CI, deployment, merge readiness, or a merge. Capability impact is
-reported across separate dimensions rather than collapsed into one marketing
-score. See [Capability Impact](docs/CAPABILITY_IMPACT.md).
+The distinction that matters is the second row from the bottom: an executor
+saying it is done is not the same as anything having been checked, and most
+tools spell both "complete". Capability impact is reported across separate
+dimensions rather than collapsed into one marketing score. See
+[Capability Impact](docs/CAPABILITY_IMPACT.md).
 
 <br>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -210,14 +210,18 @@ connector 系统都位于明确的外部 provider contract 之后。OMH 可以�
 
 ## 证据先于声明
 
-| 状态 | 含义 |
-| --- | --- |
-| Prepared | route、plan、prompt、产物 contract 或 handoff 已准备好。 |
-| Observed | wrapper 或 runtime 已记录某个操作或结果确实发生。 |
-| Verified | 所需 test、review、实际页面检查或其他 gate 已通过。 |
+OMH 只报告自己观测到的事情。你看到的每个状态都由两部分组成：处于哪个阶段，
+以及 OMH 对它有多确定。
 
-`prepared_not_observed` 不代表执行、provider 访问、产物生成、review、CI、
-deployment、merge readiness 或 merge。
+| 显示 | 含义 |
+| --- | --- |
+| `Plan · not run` | prompt 或 plan 已就绪。**还没有任何东西运行过。** |
+| `Code · running` | executor 正在运行，OMH 正在观测。 |
+| `Code · reported done` | executor 说它完成了。没有人检查过结果。 |
+| `Test · verified` | test、review 或 CI gate 确实通过了。 |
+
+关键是倒数第二行：executor 说自己完成了，与结果被检查过是两回事，
+而大多数工具把两者都写成「完成」。
 
 ## 文档
 

--- a/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
+++ b/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
@@ -139,34 +139,54 @@ runtime run exists and the wrapper needs a compact progress card.
   plugin `omh_interact` or `omh chat interact`. Render the prefix once per response, not on every
    paragraph; repeat it only when the adapter posts a long response as separate
    message chunks.
-5. If `target_notice.action` is `ask_to_apply_target_change`, render a short
+5. After every body chunk, post each element of
+   `chat_response.messenger_rendering.follow_up_texts` in order, as its own
+   message. These are not more of the body: `chunked_body_texts` is one body
+   cut to fit, while a follow-up is a separate thing to say, already sized for
+   one message on the resolved platform. The list is empty on every response
+   that has nothing to add, so an adapter can post it unconditionally. Today
+   the only producer is the message gate's `HERMES PROMPTING` block — the
+   composed order behind a coding handoff, head-bounded and fenced — and an
+   adapter that ignores this key silently drops it.
+6. When `chat_response.message_gate` is present, its provenance header is
+   already rendered into `body_text` for the resolved profile, so an adapter
+   posting `body_text` needs no extra work. Read the payload directly only to
+   build a richer surface: `fields` carries the disclosed skill, model,
+   evidence status, and prompt or objective reference; `field_order` is the
+   order to print them; `warnings` names any disclosure the gate could not
+   make (`message_gate_missing_model_label`,
+   `message_gate_unresolved_model_route`, `message_gate_missing_status`,
+   `message_gate_missing_prompt_reference`). A warning is advisory: OMH
+   renders the response either way, and the code exists so a degraded
+   disclosure is visible rather than silent.
+7. If `target_notice.action` is `ask_to_apply_target_change`, render a short
    setup-change comment and an apply action. Until accepted or auto-applied,
    keep the workflow scoped to the current thread target. The
    `apply_target_change` action payload carries
    `target_observation.source_metadata`; pass that sanitized metadata back to
    the wrapper backend with target-change apply enabled to persist the same
    target update.
-6. If the response is a plan, wait for the user to accept or revise the plan
+8. If the response is a plan, wait for the user to accept or revise the plan
    before preparing a handoff.
-7. If a coding handoff is prepared, check `executor_readiness/v1` before first
+9. If a coding handoff is prepared, check `executor_readiness/v1` before first
    dispatch for the selected profile. A wrapper may run
    `omh coding executor-readiness --executor <profile>` once, cache the result,
    and skip later probes unless the user forces a retry. If readiness is
    `missing` or `blocked`, ask the user to choose another coding agent,
    configure PATH, continue in Hermes, or keep a prompt/runtime handoff.
-8. If the selected profile is Hermes, render `hermes_coding_harness/v1` from
+10. If the selected profile is Hermes, render `hermes_coding_harness/v1` from
    the prepared runtime handoff or wrapper-session status. It is a read-only
    projection, so answer status questions with the current stage, lane owner,
    next action, and missing evidence. Do not say Hermes created a PR, passed
    review, passed CI, or reached merge readiness unless the matching
    `runtime_observation/v1` event exists.
-9. Dispatch the `coding_executor_handoff/v1`
+11. Dispatch the `coding_executor_handoff/v1`
    payload to the external executor outside OMH. For Codex targets, use
    `codex_skill` and `codex_invocation.dispatch_text_template`; this is the
    `$skill {message}` surface Codex actually receives.
-10. Record only evidence the wrapper actually observed: dispatch, executor
+12. Record only evidence the wrapper actually observed: dispatch, executor
    result, verification, review, CI, merge readiness, and merge.
-11. Re-render status from OMH after each observed transition.
+13. Re-render status from OMH after each observed transition.
 
 ## State Transition Reference
 

--- a/examples/discord-bot-runtime-flow.md
+++ b/examples/discord-bot-runtime-flow.md
@@ -24,7 +24,7 @@ status update.
 
    ```sh
    printf '%s' "$interaction_json" |
-     python -c 'import json,sys; data=json.load(sys.stdin)["chat_response"]; body=data.get("messenger_rendering", {}).get("body_text"); isinstance(body, str) or sys.exit("missing messenger_rendering.body_text"); print(data["headline"]); print(body)'
+     python -c 'import json,sys; data=json.load(sys.stdin)["chat_response"]; rendering=data.get("messenger_rendering", {}); body=rendering.get("body_text"); isinstance(body, str) or sys.exit("missing messenger_rendering.body_text"); print(data["headline"]); print(body); [print("\n---\n" + follow_up) for follow_up in rendering.get("follow_up_texts", [])]'
    ```
 
    `chat_response.headline` already starts with a visible marker such as
@@ -34,6 +34,15 @@ status update.
    Hermes TUI or web surfaces can render their own profile's `body_text` with
    tables preserved. Keep the prefix on the first line only; repeat it only
    when posting separate split messages.
+
+   Post every element of `messenger_rendering.follow_up_texts` after the body,
+   each as its own Discord message — the `---` above stands in for that message
+   boundary. The list is empty on responses with nothing to add, so reading it
+   unconditionally is safe. A bot that cherry-picks fields and does not know
+   this key silently drops what it carries: today that is the message gate's
+   `HERMES PROMPTING` block, the composed order behind a coding handoff. The
+   provenance header itself needs no bot change — it is already inside
+   `body_text`.
    Typical action ids include `accept_plan`, `revise_plan`, `choose_executor`,
    `show_prompt_handoff`, `copy_prompt_handoff`, `send_to_executor`,
    `show_status`, and `cancel`. `send_to_codex` is only a compatibility alias

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ packages = [
   "omh.commands",
   "omh.conformance",
   "omh.core",
+  "omh.evidence",
   "omh.install",
   "omh.maintenance",
   "omh.mcp",
@@ -71,6 +72,7 @@ packages = [
 "omh.commands" = "src/commands"
 "omh.conformance" = "src/conformance"
 "omh.core" = "src/core"
+"omh.evidence" = "src/evidence"
 "omh.install" = "src/install"
 "omh.maintenance" = "src/maintenance"
 "omh.mcp" = "src/mcp"

--- a/src/coding/status_board.py
+++ b/src/coding/status_board.py
@@ -38,6 +38,7 @@ from pathlib import Path
 from typing import Any, Final, Mapping
 
 from ..local_store import read_json_object_result, utc_now
+from ..evidence import PHASE_CODE, status_label
 from ..paths import OmhPaths
 from .context_safety import sanitize_user_facing_progress_text
 from .executor_progress import project_active_executor_status
@@ -266,7 +267,11 @@ def status_text_for(unit: Mapping[str, Any]) -> str:
     cannot import this module; `tests/test_coding_status_board.py` gates the two
     against each other.
     """
-    status = str(unit.get("status", "") or UNKNOWN)
+    # Every row on this board is a coding unit, so `Code` is the phase when the
+    # value does not imply a more specific one (`worktree_failed` implies
+    # `Setup`). The wire value stays in `unit["status"]` for anything parsing
+    # the payload; only this cell changes.
+    status = status_label(str(unit.get("status", "") or UNKNOWN), default_phase=PHASE_CODE)
     source = str(unit.get("unmapped_source_status", "") or "")
     return f"{status} (reported {source})" if source else status
 

--- a/src/commands/chat.py
+++ b/src/commands/chat.py
@@ -42,6 +42,7 @@ from ..wrapper.sessions import (
     show_wrapper_session,
 )
 from ..workflows.domain_project_context import bind_cli_project
+from ..evidence import confidence_label
 from .common import (
     _chat_input_and_metadata,
     _chat_message,
@@ -321,16 +322,6 @@ _ROUTE_ACTION_LABELS = {
     "fallback": "answering without a workflow",
 }
 
-_SUMMARY_STATUS_LABELS = {
-    "prepared_not_observed": "prepared, not observed",
-    "not_observed": "not observed",
-    "observed": "observed",
-    "blocked": "blocked",
-    "completed": "completed",
-    "failed": "failed",
-    "passed": "passed",
-    "pending": "pending",
-}
 
 
 def _route_action_label_without_id(action: str) -> str:
@@ -339,10 +330,18 @@ def _route_action_label_without_id(action: str) -> str:
 
 
 def _status_label_without_id(status: str) -> str:
+    """The status a person reads in the route summary.
+
+    Was a private map here saying `prepared, not observed` while the status
+    board said `prepared_not_observed` and the menubar said
+    `prepared not observed` -- three vocabularies for one state. Routed through
+    `omh.evidence.labels` so all three agree, and so an unrecognized value fails
+    closed instead of being spelled out with its underscores replaced.
+    """
     normalized = status.strip()
     if not normalized:
         return ""
-    return _SUMMARY_STATUS_LABELS.get(normalized, normalized.replace("_", " ")) or normalized
+    return confidence_label(normalized)
 
 
 def _format_summary_action(action: dict[str, object]) -> str:

--- a/src/commands/goal.py
+++ b/src/commands/goal.py
@@ -7,12 +7,12 @@ from ..goal_ledger import (
     build_goal_completion_gate,
     build_goal_continuation,
     build_goal_status_card,
-    render_goal_status_text,
     cancel_goal_ledger,
     complete_goal_ledger,
     create_goal_ledger,
     list_goal_ledgers,
     read_goal_ledger,
+    render_goal_status_text,
     record_goal_blocker,
     record_goal_checkpoint,
 )

--- a/src/commands/goal.py
+++ b/src/commands/goal.py
@@ -7,6 +7,7 @@ from ..goal_ledger import (
     build_goal_completion_gate,
     build_goal_continuation,
     build_goal_status_card,
+    render_goal_status_text,
     cancel_goal_ledger,
     complete_goal_ledger,
     create_goal_ledger,
@@ -135,13 +136,20 @@ def cmd_goal_cancel(args: argparse.Namespace) -> int:
 
 def cmd_goal_status(args: argparse.Namespace) -> int:
     paths = _paths(args)
+    wants_text = bool(getattr(args, "text", False))
+    if wants_text and not args.goal_id:
+        raise OmhError("--text renders one goal; pass --goal GOAL_ID")
     try:
         if args.goal_id:
+            card = build_goal_status_card(paths, args.goal_id)
+            if wants_text:
+                print(render_goal_status_text(card))
+                return 0
             _print_json(
                 {
                     "goal": read_goal_ledger(paths, args.goal_id),
                     "completion_gate": build_goal_completion_gate(paths, args.goal_id),
-                    "status_card": build_goal_status_card(paths, args.goal_id),
+                    "status_card": card,
                 }
             )
             return 0
@@ -221,6 +229,14 @@ def _add_goal_commands(sub) -> None:
 
     goal_status = goal_sub.add_parser("status")
     goal_status.add_argument("--goal", dest="goal_id", default="")
+    # JSON stays the default: `goal` is a control-plane group and wrappers parse
+    # it, so flipping the default would break them. `--text` is the opt-in for a
+    # human or a messenger relay, which is where escaped JSON is unreadable.
+    goal_status.add_argument(
+        "--text",
+        action="store_true",
+        help="Render one goal as readable lines instead of the machine payload (requires --goal).",
+    )
     goal_status.set_defaults(func=cmd_goal_status)
 
     goal_continue = goal_sub.add_parser("continue")

--- a/src/evidence/__init__.py
+++ b/src/evidence/__init__.py
@@ -1,0 +1,25 @@
+"""Human-readable labels for OMH's evidence vocabulary (wire values unchanged)."""
+
+from .labels import (
+    CONFIDENCES,
+    EVIDENCE_LABELS_SCHEMA_VERSION,
+    PHASE_CODE,
+    PHASES,
+    SEPARATOR,
+    confidence_label,
+    phase_label,
+    status_label,
+    status_prose,
+)
+
+__all__ = [
+    "CONFIDENCES",
+    "EVIDENCE_LABELS_SCHEMA_VERSION",
+    "PHASES",
+    "PHASE_CODE",
+    "SEPARATOR",
+    "confidence_label",
+    "phase_label",
+    "status_label",
+    "status_prose",
+]

--- a/src/evidence/labels.py
+++ b/src/evidence/labels.py
@@ -1,0 +1,215 @@
+"""Human-readable labels for OMH's evidence vocabulary.
+
+The wire values (``prepared_not_observed``, ``observed_partial``,
+``worktree_failed``, …) are a contract: external wrappers gate on them and ~169
+test assertions pin them. Nothing here changes a value. This module owns the
+separate question of what a PERSON reads when one of those values reaches a
+screen, and it is the only place those words are written down.
+
+Two axes, because the wire values weld two different questions into one token
+and that is why they are unreadable:
+
+* **Phase** -- what stage the work is at: ``Route``, ``Plan``, ``Code``,
+  ``Setup``, ``Test``, ``Review``, ``Ship``.
+* **Confidence** -- what OMH actually knows: ``not run``, ``running``,
+  ``partly seen``, ``reported done``, ``seen``, ``failed``, ``verified``.
+
+Rendered as ``Plan · not run``, ``Code · running``, ``Test · verified``.
+
+Why not one friendly word per value. Collapsing the axes is the failure this
+whole vocabulary exists to prevent: ``Code`` alone cannot say whether OMH
+watched an executor run or only wrote a prompt for one, and ``prepared_not_observed``
+is overwhelmingly the second. The phase axis is deliberately incapable of
+asserting activity -- every label on it is a noun, never a gerund, because
+"Coding" reads as *someone is coding right now* on a fast scan and "Code" does
+not.
+
+Why the phase words are nouns and why ``ready`` is not among them:
+``operator_productivity.OBSERVED_CLAIM_STATUSES`` lists ``ready`` beside
+``complete``, ``passed``, and ``merged``, and
+``_nested_observed_claim_errors`` rejects any payload whose ``status`` field
+carries one. A label reading ``ready`` would be refused by OMH's own guard as
+an unbacked observation claim. It survives only as the long-form prose
+``ready to run``, which is future tense and cannot be read as an achievement.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+EVIDENCE_LABELS_SCHEMA_VERSION: Final[str] = "omh_evidence_labels/v1"
+
+# The separator between the two axes. U+00B7 rather than an em dash because the
+# status board already joins its own fields with " — "; an em dash here would
+# make a six-field row read as seven. Already shipping elsewhere in this repo
+# under enforcing Windows CI, so the encoding is proven.
+SEPARATOR: Final[str] = " · "
+
+# --- Phase axis -------------------------------------------------------------
+
+PHASE_ROUTE: Final[str] = "Route"
+PHASE_PLAN: Final[str] = "Plan"
+PHASE_CODE: Final[str] = "Code"
+PHASE_SETUP: Final[str] = "Setup"
+PHASE_TEST: Final[str] = "Test"
+PHASE_REVIEW: Final[str] = "Review"
+PHASE_SHIP: Final[str] = "Ship"
+
+PHASES: Final[tuple[str, ...]] = (
+    PHASE_ROUTE,
+    PHASE_PLAN,
+    PHASE_CODE,
+    PHASE_SETUP,
+    PHASE_TEST,
+    PHASE_REVIEW,
+    PHASE_SHIP,
+)
+
+# --- Confidence axis --------------------------------------------------------
+
+# The load-bearing label. Three properties, each chosen against a failure:
+# the negation sits in the first three characters so every truncation budget in
+# the repo preserves it; it is a past-tense negative, so unlike "prepared" or
+# "ready" it cannot be read as an achievement; and at 7 characters against the
+# 21 of `prepared_not_observed` it loosens every width budget rather than
+# tightening one.
+CONFIDENCE_NOT_RUN: Final[str] = "not run"
+CONFIDENCE_RUNNING: Final[str] = "running"
+CONFIDENCE_PARTLY_SEEN: Final[str] = "partly seen"
+# Names the claimant inside the label. `completed` is the EXECUTOR'S OWN report
+# about itself; OMH observed the claim, never the result. Without this a
+# self-reported unit and a gate-checked unit render identically.
+CONFIDENCE_REPORTED_DONE: Final[str] = "reported done"
+CONFIDENCE_SEEN: Final[str] = "seen"
+CONFIDENCE_FAILED: Final[str] = "failed"
+CONFIDENCE_VERIFIED: Final[str] = "verified"
+# Neither a success nor a failure: something is in the way, or someone stopped
+# it. Kept distinct from `failed` because the action a reader should take is
+# different, and distinct from `not run` because a blocker IS an observation.
+CONFIDENCE_BLOCKED: Final[str] = "blocked"
+CONFIDENCE_CANCELLED: Final[str] = "cancelled"
+
+CONFIDENCES: Final[tuple[str, ...]] = (
+    CONFIDENCE_NOT_RUN,
+    CONFIDENCE_RUNNING,
+    CONFIDENCE_PARTLY_SEEN,
+    CONFIDENCE_REPORTED_DONE,
+    CONFIDENCE_SEEN,
+    CONFIDENCE_FAILED,
+    CONFIDENCE_VERIFIED,
+    CONFIDENCE_BLOCKED,
+    CONFIDENCE_CANCELLED,
+)
+
+# Long form for prose, where a sentence has room and a bare "not run" reads
+# clipped. This is the only place the owner's word `ready` appears, and only as
+# a future-tense phrase that cannot be mistaken for a past achievement.
+CONFIDENCE_PROSE: Final[dict[str, str]] = {
+    CONFIDENCE_NOT_RUN: "ready to run, nothing has run yet",
+    CONFIDENCE_RUNNING: "running now",
+    CONFIDENCE_PARTLY_SEEN: "seen partway through",
+    CONFIDENCE_REPORTED_DONE: "the executor reported it done; the result was not checked",
+    CONFIDENCE_SEEN: "seen finishing; the result was not checked",
+    CONFIDENCE_FAILED: "failed",
+    CONFIDENCE_VERIFIED: "checked and passed",
+    CONFIDENCE_BLOCKED: "blocked; something is in the way",
+    CONFIDENCE_CANCELLED: "cancelled before it finished",
+}
+
+# --- Wire value -> confidence ----------------------------------------------
+
+# Total on the values this repo emits. Anything absent fails CLOSED to
+# `not run`, mirroring `status_board.normalize_status`: an unrecognized state
+# must never render as work that happened.
+_CONFIDENCE_BY_VALUE: Final[dict[str, str]] = {
+    # `_usage_evidence_state` in src/wrapper/contract.py
+    "routing_not_execution": CONFIDENCE_NOT_RUN,
+    "prepared_not_observed": CONFIDENCE_NOT_RUN,
+    "observed_partial": CONFIDENCE_PARTLY_SEEN,
+    "observed_reportable": CONFIDENCE_SEEN,
+    # `STATUS_VOCABULARY` in src/coding/status_board.py
+    "running": CONFIDENCE_RUNNING,
+    "completed": CONFIDENCE_REPORTED_DONE,
+    "failed": CONFIDENCE_FAILED,
+    "worktree_failed": CONFIDENCE_FAILED,
+    # `REPORT_STATUSES` in src/coding/work_reporting.py
+    "in_progress": CONFIDENCE_RUNNING,
+    "blocked": CONFIDENCE_BLOCKED,
+    "cancelled": CONFIDENCE_CANCELLED,
+    # `_SUMMARY_STATUS_LABELS` in src/commands/chat.py, retired in favour of
+    # this map. `unknown` and `pending` fail closed on purpose: neither is a
+    # claim that anything happened.
+    "not_observed": CONFIDENCE_NOT_RUN,
+    "observed": CONFIDENCE_SEEN,
+    "passed": CONFIDENCE_VERIFIED,
+    "pending": CONFIDENCE_NOT_RUN,
+    "unknown": CONFIDENCE_NOT_RUN,
+}
+
+# A phase the value implies on its own, used when a caller names none.
+# `worktree_failed` is the clean case: it was always a phase plus an outcome
+# welded together, so it decomposes with nothing left over.
+_PHASE_BY_VALUE: Final[dict[str, str]] = {
+    "routing_not_execution": PHASE_ROUTE,
+    "prepared_not_observed": PHASE_PLAN,
+    "worktree_failed": PHASE_SETUP,
+}
+
+# `next_action` values that name a stage more precisely than the evidence value
+# can. Read from `usage_trace`, which already carries both axes side by side.
+_PHASE_BY_NEXT_ACTION: Final[dict[str, str]] = {
+    "record_verification_evidence": PHASE_TEST,
+    "record_ci_evidence": PHASE_TEST,
+    "record_review_evidence": PHASE_REVIEW,
+    "report_merge_ready": PHASE_SHIP,
+    "report_merged": PHASE_SHIP,
+    "dispatch_to_workflow": PHASE_ROUTE,
+    "present_plan": PHASE_PLAN,
+    "accept_or_revise_plan": PHASE_PLAN,
+    "wait_for_executor_evidence": PHASE_CODE,
+    "report_completion_with_evidence": PHASE_CODE,
+}
+
+
+def confidence_label(value: str) -> str:
+    """What OMH knows about ``value``, fail-closed to ``not run``."""
+    return _CONFIDENCE_BY_VALUE.get(str(value or "").strip(), CONFIDENCE_NOT_RUN)
+
+
+def phase_label(value: str = "", *, next_action: str = "", default: str = "") -> str:
+    """The stage to show beside the confidence, or "" when none is known.
+
+    Precedence is most-specific-first: an explicit ``next_action`` names a stage
+    the evidence value cannot (a value of ``observed_partial`` is equally true
+    of a test run and a review), then the value's own implied phase, then the
+    caller's surface default -- a coding board knows every row is ``Code`` even
+    when the value does not say so.
+    """
+    from_action = _PHASE_BY_NEXT_ACTION.get(str(next_action or "").strip())
+    if from_action:
+        return from_action
+    implied = _PHASE_BY_VALUE.get(str(value or "").strip())
+    if implied:
+        return implied
+    return default if default in PHASES else ""
+
+
+def status_label(value: str, *, next_action: str = "", default_phase: str = "") -> str:
+    """``Plan · not run`` -- the one string a human reads for ``value``.
+
+    Never returns "" and never returns the bare word ``unknown``: the message
+    gate raises ``message_gate_missing_status`` on exactly that value, and an
+    unrecognized state is a state that did not run, not a state we have no
+    opinion about.
+    """
+    confidence = confidence_label(value)
+    phase = phase_label(value, next_action=next_action, default=default_phase)
+    return f"{phase}{SEPARATOR}{confidence}" if phase else confidence
+
+
+def status_prose(value: str, *, next_action: str = "", default_phase: str = "") -> str:
+    """The sentence form, for docs and for copy with room to breathe."""
+    confidence = confidence_label(value)
+    phase = phase_label(value, next_action=next_action, default=default_phase)
+    long_form = CONFIDENCE_PROSE[confidence]
+    return f"{phase.lower()}: {long_form}" if phase else long_form

--- a/src/plugin_bundle/omh/status_board_reader.py
+++ b/src/plugin_bundle/omh/status_board_reader.py
@@ -408,12 +408,47 @@ def _unmapped_status_source(value: Any) -> str:
     return collapsed[: _STATUS_SOURCE_LIMIT - 3] + "..."
 
 
+# Hand-mirror of `omh.evidence.labels`, which this bundle cannot import. Kept
+# byte-identical in behaviour by the parity test in
+# `tests/test_coding_status_board.py`; the wire values themselves are unchanged
+# on both sides.
+_CONFIDENCE_BY_VALUE: dict[str, str] = {
+    "routing_not_execution": "not run",
+    "prepared_not_observed": "not run",
+    "observed_partial": "partly seen",
+    "observed_reportable": "seen",
+    "running": "running",
+    "completed": "reported done",
+    "failed": "failed",
+    "worktree_failed": "failed",
+}
+_PHASE_BY_VALUE: dict[str, str] = {
+    "routing_not_execution": "Route",
+    "prepared_not_observed": "Plan",
+    "worktree_failed": "Setup",
+}
+_BOARD_PHASE = "Code"
+_LABEL_SEPARATOR = " \u00b7 "
+
+
+def _status_label(value: str) -> str:
+    """`Code \u00b7 running` -- mirrors `omh.evidence.labels.status_label`.
+
+    Fails closed to `not run` for the same reason `normalize_status` does: an
+    unrecognized state must never render as work that happened.
+    """
+    key = str(value or "").strip()
+    confidence = _CONFIDENCE_BY_VALUE.get(key, "not run")
+    phase = _PHASE_BY_VALUE.get(key, _BOARD_PHASE)
+    return f"{phase}{_LABEL_SEPARATOR}{confidence}"
+
+
 def _status_text(unit: dict[str, Any]) -> str:
     """The status a person reads, with any refused source word attached.
 
     Mirrors `omh.coding.status_board.status_text_for`.
     """
-    status = str(unit.get("status", "") or "unknown")
+    status = _status_label(str(unit.get("status", "") or "unknown"))
     source = str(unit.get("unmapped_source_status", "") or "")
     return f"{status} (reported {source})" if source else status
 

--- a/src/surfaces/menubar_status.py
+++ b/src/surfaces/menubar_status.py
@@ -16,6 +16,8 @@ from ..routing.action_copy import next_action_label
 from ..targets import read_target_registry_result
 
 
+from ..evidence import status_label
+
 MENUBAR_STATUS_SCHEMA_VERSION = "menubar_status/v1"
 PROCESS_OVERLAY_SCHEMA_VERSION = "menubar_process_overlay/v1"
 DEFAULT_PROCESS_OVERLAY_TTL_SECONDS = 10
@@ -585,7 +587,10 @@ def _evidence_menu_value(hermes_agents: list[dict[str, Any]], current_executor_r
     if current_executor_row:
         evidence = _dict(current_executor_row.get("evidence"))
         state = str(evidence.get("state", "") or "prepared_not_observed")
-        return _short_text(state.replace("_", " "), limit=32)
+        # `state.replace("_", " ")` spelled the wire value out loud rather than
+        # translating it; the shared label map is what the board and the chat
+        # summary already use.
+        return _short_text(status_label(state), limit=32)
     if observed_agents:
         return f"{observed_agents} process observed"
     return "metadata only"

--- a/src/workflows/goal_ledger.py
+++ b/src/workflows/goal_ledger.py
@@ -17,7 +17,11 @@ from ..system.record_revision import (
 )
 from ..paths import OmhPaths
 from ..runtime.artifacts import summarize_delegated_coding_status
-from ..wrapper.message_gate import build_message_gate, render_message_gate_lines
+from ..wrapper.message_gate import (
+    RENDER_PROFILE_LIMITED_MARKDOWN,
+    build_message_gate,
+    render_message_gate_lines,
+)
 
 
 GOAL_LEDGER_SCHEMA = "goal_ledger/v1"
@@ -851,7 +855,9 @@ GOAL_STATUS_CLAIM_BOUNDARY: Final[str] = (
 )
 
 
-def render_goal_status_text(card: dict[str, Any], *, render_profile: str = "limited_markdown") -> str:
+def render_goal_status_text(
+    card: dict[str, Any], *, render_profile: str = RENDER_PROFILE_LIMITED_MARKDOWN
+) -> str:
     """The goal status card as exact lines, for a terminal or a messenger.
 
     `omh goal status` prints JSON by design -- it is a control-plane command and
@@ -870,6 +876,7 @@ def render_goal_status_text(card: dict[str, Any], *, render_profile: str = "limi
         prompt_sha256=_objective_digest(card),
         prompt_chars=len(str(card.get("objective_summary", "") or "")),
         discloses_model=False,
+        reference_kind="objective",
     )
     progress = card.get("progress") if isinstance(card.get("progress"), dict) else {}
     lines = [

--- a/src/workflows/goal_ledger.py
+++ b/src/workflows/goal_ledger.py
@@ -5,7 +5,7 @@ import re
 import secrets
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Final, Iterable
 
 from ..hashutil import sha256_text
 from ..local_store import ensure_dir, read_json_object, utc_now
@@ -17,6 +17,7 @@ from ..system.record_revision import (
 )
 from ..paths import OmhPaths
 from ..runtime.artifacts import summarize_delegated_coding_status
+from ..wrapper.message_gate import build_message_gate, render_message_gate_lines
 
 
 GOAL_LEDGER_SCHEMA = "goal_ledger/v1"
@@ -842,6 +843,75 @@ def build_goal_status_card(paths: OmhPaths, goal_id: str) -> dict[str, Any]:
             "Never render a markdown table: messenger surfaces (Slack, Telegram) drop tables."
         ),
     }
+
+
+GOAL_STATUS_CLAIM_BOUNDARY: Final[str] = (
+    "A goal status card is ledger state. Satisfied criteria are recorded, not verified, "
+    "and it is not execution, review, CI, or merge evidence."
+)
+
+
+def render_goal_status_text(card: dict[str, Any], *, render_profile: str = "limited_markdown") -> str:
+    """The goal status card as exact lines, for a terminal or a messenger.
+
+    `omh goal status` prints JSON by design -- it is a control-plane command and
+    wrappers parse it. That contract is fine for a wrapper and hostile to a
+    human: relayed straight into a chat client the payload arrives as one line
+    of backslash-escaped Unicode. This renders the same card instead of
+    changing what the command returns by default.
+
+    The header goes through the message gate so a goal card and a coding handoff
+    disclose their skill, status, and prompt reference in the identical shape,
+    with MODEL declared absent because a goal ledger has no executor to name.
+    """
+    gate = build_message_gate(
+        skill="ulw-goal",
+        status=str(card.get("goal_status", "")),
+        prompt_sha256=_objective_digest(card),
+        prompt_chars=len(str(card.get("objective_summary", "") or "")),
+        discloses_model=False,
+    )
+    progress = card.get("progress") if isinstance(card.get("progress"), dict) else {}
+    lines = [
+        *render_message_gate_lines(gate, render_profile=render_profile),
+        "",
+        str(card.get("objective_summary", "") or "(no objective recorded)"),
+        "",
+        # `_goal_progress` keys are `criteria_satisfied` / `criteria_total`; the
+        # shorter names render a six-criteria goal as `0 of 0`, which is worse
+        # than no line at all because it reads as a real measurement.
+        f"Criteria: {progress.get('criteria_satisfied', 0)} of "
+        f"{progress.get('criteria_total', 0)} satisfied "
+        f"({progress.get('percent_required_satisfied', 0)}% of required)",
+        f"Next action: {card.get('next_action', '') or 'unknown'}",
+    ]
+    checkpoint_lines = card.get("checkpoint_lines")
+    if isinstance(checkpoint_lines, list) and checkpoint_lines:
+        lines.extend(["", "Checkpoints:", *(str(line) for line in checkpoint_lines)])
+    else:
+        lines.extend(["", "No checkpoints recorded."])
+    for label, key in (("Missing criteria", "missing_criteria"), ("Active blockers", "active_blockers")):
+        items = card.get(key)
+        if isinstance(items, list) and items:
+            lines.extend(["", f"{label}:", *(f"- {_goal_line_item(item)}" for item in items)])
+    lines.extend(["", GOAL_STATUS_CLAIM_BOUNDARY])
+    return "\n".join(lines).strip()
+
+
+def _goal_line_item(item: Any) -> str:
+    """One bounded line per entry, whether the ledger stored a string or a dict."""
+    if isinstance(item, dict):
+        for key in ("summary", "description", "criterion", "blocker", "id"):
+            value = str(item.get(key, "") or "").strip()
+            if value:
+                return value
+        return "unnamed"
+    return " ".join(str(item or "").split()) or "unnamed"
+
+
+def _objective_digest(card: dict[str, Any]) -> str:
+    objective = str(card.get("objective_summary", "") or "")
+    return sha256_text(objective) if objective else ""
 
 
 def _linked_runtime_check(paths: OmhPaths, run_id: str) -> dict[str, Any]:

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -7082,10 +7082,15 @@ def _chat_response_with_message_gate(
         executor=executor,
         model_label=_status_model_label(state),
         status=str(trace.get("evidence_state", "")),
-        # Bounded to the same summary ceiling the show-prompt surface uses. The
-        # message reaches this payload only when the wrapper opted into
-        # `include_message`; otherwise `_base_interaction` never carried it and
-        # the TASK row is absent rather than `unknown`.
+        # Bounded to the same summary ceiling the show-prompt surface uses.
+        #
+        # This `if` is defence in depth, not the redaction mechanism. The
+        # guarantee is structural and upstream: with `include_message` unset,
+        # `_base_interaction` never puts the raw message into this payload at
+        # all -- a marker string planted in the message appears at zero paths
+        # in the serialized result. So the row is absent because there was
+        # nothing to render, and the guard only keeps that true if a future
+        # change starts carrying the message for some other reason.
         task=bounded_prompt_preview(str(payload.get("message", "") or ""), max_chars=MAX_SUMMARY_CHARS)
         if payload.get("message")
         else "",

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -5,7 +5,7 @@ from functools import lru_cache
 import hashlib
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, Final
 
 from ..context_safety import MAX_SUMMARY_CHARS, bounded_prompt_preview, compact_progress_events
 from ..coding.action_gate import LADDER_ACTION_IDS
@@ -13,6 +13,7 @@ from ..coding.agentic_playbook import maybe_build_agentic_playbook
 from ..coding.agentic_playbook_contract import chat_response_with_agentic_playbook
 from ..coding.executor_local_workflow import validate_executor_local_workflow
 from ..coding.status_board import model_label_for
+from .message_gate import build_message_gate, fence_marker_for, message_gate_body
 from ..ingress import CHAT_SOURCES, compact_source_metadata, extract_message_text, extract_source_metadata
 from ..routing.catalog_questions import is_skill_catalog_question as _is_skill_catalog_question
 from ..routing.chat import public_chat_route_payload, route_explanation_payload
@@ -3416,6 +3417,13 @@ def _copy_chat_response_payload(response: dict[str, object]) -> dict[str, object
     if isinstance(messenger_rendering, dict):
         copied["messenger_rendering"] = _copy_messenger_rendering_payload(messenger_rendering)
 
+    # The gate carries a nested `fields` dict and a `roster` list of dicts, so
+    # the shallow `dict(response)` above would hand every cached caller the same
+    # objects. Same aliasing class `chunked_body_texts` was fixed for.
+    message_gate = response.get("message_gate")
+    if isinstance(message_gate, dict):
+        copied["message_gate"] = _clone_static_dict(message_gate)
+
     actions = response.get("actions")
     if isinstance(actions, list):
         copied["actions"] = _copy_action_list(actions)
@@ -3750,6 +3758,7 @@ def _copy_messenger_rendering_payload(value: dict[str, object]) -> dict[str, obj
         "transforms_applied",
         "fallback_transforms_applied",
         "chunked_body_texts",
+        "follow_up_texts",
     ):
         items = value.get(key)
         if isinstance(items, list):
@@ -3764,6 +3773,13 @@ def _copy_messenger_rendering_payload(value: dict[str, object]) -> dict[str, obj
         item = value.get(key)
         if isinstance(item, dict):
             copied[key] = dict(item)
+    # `density_policy` nests a list, so a flat `dict()` would still alias it.
+    density_policy = value.get("density_policy")
+    if isinstance(density_policy, dict):
+        copied["density_policy"] = dict(density_policy)
+        avoid = density_policy.get("avoid")
+        if isinstance(avoid, list):
+            copied["density_policy"]["avoid"] = list(avoid)
     return copied
 
 
@@ -6170,17 +6186,11 @@ def _executor_local_workflow_state(handoff: dict[str, object], selected_profile:
 
 
 def _fence_marker_for(text: str) -> str:
-    """Backtick fence for embedding ``text``: one longer than the longest
-    backtick run inside it, minimum three, so embedded ``` fences nest safely."""
-    longest = 0
-    run = 0
-    for character in text:
-        if character == "`":
-            run += 1
-            longest = max(longest, run)
-        else:
-            run = 0
-    return "`" * max(3, longest + 1)
+    """Backtick fence for embedding ``text``, owned by ``message_gate``.
+
+    The gate fences its own prompt block with the identical rule, so the two
+    surfaces share one implementation rather than a hand-synced pair."""
+    return fence_marker_for(text)
 
 
 def _prompt_handoff_show_body(
@@ -7022,12 +7032,92 @@ def _finish_interaction(payload: dict[str, object], target_notice: dict[str, obj
         agentic_playbook = payload.get("agentic_playbook")
         if isinstance(agentic_playbook, dict):
             response = chat_response_with_agentic_playbook(response, agentic_playbook)
+        # Last, so the gate header sits above the final body every other
+        # transform has already contributed to, and immediately before the
+        # render profile is resolved so the shape gate chunks and dialects the
+        # header along with everything else.
+        response = _chat_response_with_message_gate(response, payload)
         payload["chat_response"] = _chat_response_with_render_profile(
             response,
             source=str(payload.get("source", "generic")),
             source_metadata=_nested(payload, "source_metadata"),
         )
     return payload
+
+
+# The gate attaches to coding-shaped responses only. `handoff` is the kind every
+# coding delegation lands on, so it qualifies on its own -- a handoff with no
+# resolved model is exactly the case the missing-model warning exists for.
+#
+# The harness alone does NOT qualify. `coding-handling` is the harness of the
+# `oh-my-hermes` router skill itself, so "what can OMH do?" resolves to it and
+# would have gained a header reading `model — unknown` on a capability
+# question, plus a spurious warning. Requiring a resolved executor alongside
+# the harness keeps the gate on replies about work someone is actually running.
+_MESSAGE_GATE_KINDS: Final[frozenset[str]] = frozenset({"handoff"})
+_MESSAGE_GATE_HARNESS: Final[str] = "coding-handling"
+
+
+def _chat_response_with_message_gate(
+    response: dict[str, object], payload: dict[str, object]
+) -> dict[str, object]:
+    """Attach the provenance gate and render its lines above the body.
+
+    Everything the gate prints is already computed elsewhere in this payload --
+    ``usage_trace`` resolved the workflow and evidence state, ``_status_model_label``
+    resolved the route, and ``_base_interaction`` hashed the message. Before this
+    function existed all of it was dropped at the render boundary and the
+    messenger got prose.
+    """
+    trace = _nested(response, "usage_trace")
+    state = _nested(response, "state")
+    executor = str(trace.get("selected_executor_profile", "")) or _status_executor_label(state)
+    kind = str(response.get("kind", ""))
+    coding_harness = str(trace.get("selected_harness", "")) == _MESSAGE_GATE_HARNESS
+    if kind not in _MESSAGE_GATE_KINDS and not (coding_harness and executor):
+        return response
+    delegation_payload = _nested(payload, "delegation")
+    gate = build_message_gate(
+        skill=str(trace.get("selected_workflow", "") or trace.get("label", "")),
+        executor=executor,
+        model_label=_status_model_label(state),
+        status=str(trace.get("evidence_state", "")),
+        # Bounded to the same summary ceiling the show-prompt surface uses. The
+        # message reaches this payload only when the wrapper opted into
+        # `include_message`; otherwise `_base_interaction` never carried it and
+        # the TASK row is absent rather than `unknown`.
+        task=bounded_prompt_preview(str(payload.get("message", "") or ""), max_chars=MAX_SUMMARY_CHARS)
+        if payload.get("message")
+        else "",
+        prompt_sha256=str(payload.get("message_sha256", "")),
+        prompt_chars=payload.get("message_length"),
+        composed_prompt=_message_gate_composed_prompt(delegation_payload),
+    )
+    updated = dict(response)
+    updated["message_gate"] = gate
+    updated["body"] = message_gate_body(
+        gate,
+        render_profile=render_profile_for_source(
+            str(payload.get("source", "generic")), _nested(payload, "source_metadata")
+        ),
+        body=str(updated.get("body", "")),
+    )
+    return updated
+
+
+def _message_gate_composed_prompt(delegation_payload: dict[str, Any]) -> str:
+    """The composed Hermes order behind this handoff, or "" when none exists.
+
+    Reuses ``_composed_prompt_handoff_text`` rather than reading
+    ``prompt_template`` directly so the gate inherits its redaction posture: the
+    template keeps its literal ``{message}`` placeholder unless the wrapper
+    opted into carrying the raw task.
+    """
+    handoff = _nested(delegation_payload, "executor_handoff")
+    if not handoff.get("prompt_template"):
+        return ""
+    prompt_text, _ = _composed_prompt_handoff_text(delegation_payload, handoff)
+    return prompt_text
 
 
 def _chat_response_with_route_explanation(
@@ -7134,8 +7224,21 @@ def _chat_response_with_render_profile(
             claim_boundary=str(updated.get("claim_boundary", "")),
             render_profile=render_profile_for_source(source, source_metadata),
             source=source,
+            follow_up_texts=_message_gate_follow_ups(updated),
         )
     return updated
+
+
+def _message_gate_follow_ups(response: dict[str, object]) -> tuple[str, ...]:
+    """The gate's prompt block, as the one follow-up message an adapter posts.
+
+    It is a separate message rather than more body because it answers a
+    different question -- what was actually ordered, not what state the work is
+    in -- and because a fenced block appended to a status body is what pushes a
+    Discord message past its ceiling and gets cut at an arbitrary point.
+    """
+    block = str(_nested(response, "message_gate").get("prompt_block", "") or "")
+    return (block,) if block else ()
 
 
 def _resolve_mode(mode: str, route: dict[str, object], *, message: str = "") -> str:
@@ -8189,6 +8292,7 @@ def messenger_rendering_contract(
     claim_boundary: str,
     render_profile: str = RENDER_PROFILE_LIMITED_MARKDOWN,
     source: str = "",
+    follow_up_texts: object = (),
 ) -> dict[str, object]:
     """The platform-shaping rendering payload for one chat/session response.
 
@@ -8269,6 +8373,12 @@ def messenger_rendering_contract(
         # (messenger_route_hint_rendering/v1) deliberately omits this key
         # because hint bodies are single-screen.
         "chunked_body_texts": _chunk_body_text(body_text, int(chunking["max_recommended_chars"])),
+        # Whole messages to post AFTER the body, in order, each already sized
+        # for one message. Distinct from `chunked_body_texts`, which is one body
+        # cut to fit: concatenating these would not reproduce `body_text`, and a
+        # follow-up is a separate thing to say rather than the rest of this one.
+        # Empty on every response that has nothing to add.
+        "follow_up_texts": _follow_up_texts(follow_up_texts, int(chunking["max_recommended_chars"])),
         "transforms_applied": transforms,
         "fallback_transforms_applied": fallback_transforms,
         "prefix_policy": {
@@ -8425,6 +8535,25 @@ _MESSENGER_CHAR_CEILINGS: dict[str, dict[str, int]] = {
 # now paired with a hard_limit_chars floor so an unknown source still gets an
 # enforceable number instead of only advice.
 _MESSENGER_GENERIC_CEILING: dict[str, int] = {"max_recommended_chars": 1600, "hard_limit_chars": 1800}
+
+
+def _follow_up_texts(value: object, limit: int) -> list[str]:
+    """Bound each follow-up to the platform ceiling the body already respects.
+
+    A follow-up over the ceiling is truncated with a visible marker rather than
+    chunked: these carry one self-contained block each (today, the message
+    gate's fenced prompt), and splitting a fence across two messages produces
+    an unclosed fence on the first one.
+    """
+    if not isinstance(value, (list, tuple)):
+        return []
+    texts: list[str] = []
+    for item in value:
+        text = str(item or "").strip()
+        if not text:
+            continue
+        texts.append(text if len(text) <= limit else bounded_prompt_preview(text, max_chars=limit))
+    return texts
 
 
 def _messenger_chunking_hint(source: str = "") -> dict[str, object]:

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -7074,9 +7074,14 @@ def _chat_response_with_message_gate(
     executor = str(trace.get("selected_executor_profile", "")) or _status_executor_label(state)
     kind = str(response.get("kind", ""))
     coding_harness = str(trace.get("selected_harness", "")) == _MESSAGE_GATE_HARNESS
-    if kind not in _MESSAGE_GATE_KINDS and not (coding_harness and executor):
-        return response
     delegation_payload = _nested(payload, "delegation")
+    # `kind == "handoff"` is not sufficient on its own. `build_chat_response_from_route`
+    # emits that kind for the `ultraprocess` coding-STATUS route, which prepares
+    # no delegation and resolves no executor -- "show the coding agent status"
+    # was getting a header reading `model — unknown` plus a spurious warning,
+    # the same false positive the harness clause was tightened to remove.
+    if not ((kind in _MESSAGE_GATE_KINDS and (executor or delegation_payload)) or (coding_harness and executor)):
+        return response
     gate = build_message_gate(
         skill=str(trace.get("selected_workflow", "") or trace.get("label", "")),
         executor=executor,
@@ -7099,14 +7104,14 @@ def _chat_response_with_message_gate(
         composed_prompt=_message_gate_composed_prompt(delegation_payload),
     )
     updated = dict(response)
+    # Only the payload. The header is NOT prepended to `body` here: that would
+    # bake an ingress-source-derived render profile into the canonical
+    # `chat_response.body` and into `body_blocks`, which
+    # `docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md` promises stay dialect-neutral.
+    # `messenger_rendering_contract` prepends it at the point it resolves the
+    # profile, so the rich body gets the aligned card, the fallback body gets
+    # bullets, and a wrapper relaying onto a different surface can still choose.
     updated["message_gate"] = gate
-    updated["body"] = message_gate_body(
-        gate,
-        render_profile=render_profile_for_source(
-            str(payload.get("source", "generic")), _nested(payload, "source_metadata")
-        ),
-        body=str(updated.get("body", "")),
-    )
     return updated
 
 
@@ -7118,11 +7123,17 @@ def _message_gate_composed_prompt(delegation_payload: dict[str, Any]) -> str:
     template keeps its literal ``{message}`` placeholder unless the wrapper
     opted into carrying the raw task.
     """
-    handoff = _nested(delegation_payload, "executor_handoff")
-    if not handoff.get("prompt_template"):
-        return ""
-    prompt_text, _ = _composed_prompt_handoff_text(delegation_payload, handoff)
-    return prompt_text
+    # `build_coding_delegation_payload` emits exactly one of these three, as
+    # mutually exclusive branches. Reading only `executor_handoff` meant a
+    # Hermes-runtime or prompt-only delegation showed no composed order at all
+    # while the header still carried a PROMPT digest -- no block, and no signal
+    # that a block was missing.
+    for key in ("executor_handoff", "runtime_handoff", "prompt_handoff"):
+        handoff = _nested(delegation_payload, key)
+        if handoff.get("prompt_template"):
+            prompt_text, _ = _composed_prompt_handoff_text(delegation_payload, handoff)
+            return prompt_text
+    return ""
 
 
 def _chat_response_with_route_explanation(
@@ -7230,6 +7241,7 @@ def _chat_response_with_render_profile(
             render_profile=render_profile_for_source(source, source_metadata),
             source=source,
             follow_up_texts=_message_gate_follow_ups(updated),
+            message_gate=_nested(updated, "message_gate") or None,
         )
     return updated
 
@@ -8298,6 +8310,7 @@ def messenger_rendering_contract(
     render_profile: str = RENDER_PROFILE_LIMITED_MARKDOWN,
     source: str = "",
     follow_up_texts: object = (),
+    message_gate: dict[str, object] | None = None,
 ) -> dict[str, object]:
     """The platform-shaping rendering payload for one chat/session response.
 
@@ -8308,9 +8321,14 @@ def messenger_rendering_contract(
     an adapter that consumes blocks applies its own dialect.
     """
     resolved_profile = _normalize_render_profile(render_profile)
-    safe_body_text, safe_transforms = _messenger_safe_body(body)
+    # The gate header is rendered per profile, here, so the rich body carries the
+    # aligned card and every fallback carries bullets. Prepending it upstream
+    # would have put one profile's shaping into the canonical body and blocks.
+    safe_body_text, safe_transforms = _messenger_safe_body(
+        _gate_prefixed_body(body, message_gate, RENDER_PROFILE_LIMITED_MARKDOWN)
+    )
     if resolved_profile == RENDER_PROFILE_RICH_MARKDOWN:
-        body_text = body
+        body_text = _gate_prefixed_body(body, message_gate, RENDER_PROFILE_RICH_MARKDOWN)
         body_format = "rich_markdown"
         preferred_blocks = [
             "short_paragraph",
@@ -8542,6 +8560,13 @@ _MESSENGER_CHAR_CEILINGS: dict[str, dict[str, int]] = {
 _MESSENGER_GENERIC_CEILING: dict[str, int] = {"max_recommended_chars": 1600, "hard_limit_chars": 1800}
 
 
+def _gate_prefixed_body(body: str, message_gate: dict[str, object] | None, render_profile: str) -> str:
+    """``body`` with the message gate's lines above it, or ``body`` unchanged."""
+    if not isinstance(message_gate, dict) or not message_gate:
+        return body
+    return message_gate_body(message_gate, render_profile=render_profile, body=body)
+
+
 def _follow_up_texts(value: object, limit: int) -> list[str]:
     """Bound each follow-up to the platform ceiling the body already respects.
 
@@ -8557,8 +8582,31 @@ def _follow_up_texts(value: object, limit: int) -> list[str]:
         text = str(item or "").strip()
         if not text:
             continue
-        texts.append(text if len(text) <= limit else bounded_prompt_preview(text, max_chars=limit))
+        texts.append(text if len(text) <= limit else _bounded_follow_up(text, limit))
     return texts
+
+
+def _bounded_follow_up(text: str, limit: int) -> str:
+    """Truncate to ``limit`` INCLUDING the marker, and close any fence left open.
+
+    ``bounded_prompt_preview`` slices to ``max_chars`` and then APPENDS the
+    marker, so passing the ceiling straight through returned ~35 characters over
+    it and cut mid-fence -- both of the things this function exists to prevent.
+    The marker length is knowable up front because it carries ``len(text)``.
+    """
+    marker_room = len(f"... [truncated, {len(text)} chars total]")
+    closing = _unclosed_fence_marker(bounded_prompt_preview(text, max_chars=max(1, limit - marker_room)))
+    tail = f"\n{closing}" if closing else ""
+    head = bounded_prompt_preview(text, max_chars=max(1, limit - marker_room - len(tail)))
+    return f"{head}{tail}"
+
+
+def _unclosed_fence_marker(text: str) -> str:
+    """The marker needed to close ``text``'s dangling fence, or "" when balanced."""
+    state = _FenceState()
+    for line in text.splitlines():
+        state.toggles(line)
+    return state.marker
 
 
 def _messenger_chunking_hint(source: str = "") -> dict[str, object]:

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -13,6 +13,7 @@ from ..coding.agentic_playbook import maybe_build_agentic_playbook
 from ..coding.agentic_playbook_contract import chat_response_with_agentic_playbook
 from ..coding.executor_local_workflow import validate_executor_local_workflow
 from ..coding.status_board import model_label_for
+from ..evidence import status_label
 from .message_gate import build_message_gate, fence_marker_for, message_gate_body
 from ..ingress import CHAT_SOURCES, compact_source_metadata, extract_message_text, extract_source_metadata
 from ..routing.catalog_questions import is_skill_catalog_question as _is_skill_catalog_question
@@ -7086,7 +7087,15 @@ def _chat_response_with_message_gate(
         skill=str(trace.get("selected_workflow", "") or trace.get("label", "")),
         executor=executor,
         model_label=_status_model_label(state),
-        status=str(trace.get("evidence_state", "")),
+        # The wire value is unreadable in a chat bubble, and `usage_trace`
+        # already carries the `next_action` that names the stage the evidence
+        # value alone cannot -- `observed_partial` is equally true of a test run
+        # and a review. The value itself is untouched and still ships in
+        # `usage_trace.evidence_state` for anything that parses it.
+        status=status_label(
+            str(trace.get("evidence_state", "")),
+            next_action=str(trace.get("next_action", "")),
+        ),
         # Bounded to the same summary ceiling the show-prompt surface uses.
         #
         # This `if` is defence in depth, not the redaction mechanism. The

--- a/src/wrapper/message_gate.py
+++ b/src/wrapper/message_gate.py
@@ -22,6 +22,13 @@ The gate fixes the header and the prompt block, and nothing else. The response
 body stays free prose, and every field degrades to the literal ``unknown``
 rather than being dropped or invented -- an absent model is a fact worth
 printing, and an empty ``()`` is the one shape the rule names as forbidden.
+
+Deliberately NOT here: a parallel-lane roster. ``status_board_messenger_body``
+in ``src/coding/status_board.py`` already renders observed lanes for both
+profiles with seven columns, including the tokens and resumable session ref
+this module never sees, and it builds its labels with the same
+``model_label_for``. A four-column copy here would be a worse duplicate of a
+surface that already exists; ask ``omh coding status-board`` for the roster.
 """
 
 from __future__ import annotations
@@ -50,14 +57,13 @@ _FIELDS: Final[tuple[tuple[str, str], ...]] = (
     ("STATUS", "status"),
     ("TASK", "task"),
     ("PROMPT", "prompt"),
+    # The same digest row under the name the surface can actually back: a goal
+    # ledger holds an objective, and labelling it PROMPT asserts a provenance
+    # category the card does not have.
+    ("OBJECTIVE", "objective"),
 )
 
-_ROSTER_COLUMNS: Final[tuple[tuple[str, str], ...]] = (
-    ("UNIT", "label"),
-    ("MODEL", "model"),
-    ("STATUS", "status"),
-    ("TIME", "elapsed"),
-)
+REFERENCE_KINDS: Final[tuple[str, ...]] = ("prompt", "objective")
 
 # Bounded so a long skill name or a pasted model id cannot push the header past
 # the tightest messenger ceiling on its own.
@@ -65,13 +71,6 @@ _VALUE_LIMIT: Final[int] = 96
 # The PROMPT row carries a digest prefix, never the prompt. Twelve hex
 # characters is what `omh coding fanout` already prints for a unit ref.
 _DIGEST_PREFIX: Final[int] = 12
-# A roster longer than this is a status-board question, not a header. Six is
-# not arbitrary: the limited profile renders one bullet per field plus one per
-# unit, and `messenger_rendering.density_policy` declares `max_bullets: 12`.
-# Five fields + six units + the truncation line lands exactly on that ceiling,
-# so the gate obeys the density policy OMH already publishes instead of being
-# the first surface to break it.
-_ROSTER_LIMIT: Final[int] = 6
 # How much of the composed prompt the follow-on message shows. Long enough to
 # recognize the order Hermes actually issued, short enough that the block stays
 # well inside Discord's 1700-character soft ceiling next to a header.
@@ -83,6 +82,11 @@ WARNING_MISSING_MODEL_LABEL: Final[str] = "message_gate_missing_model_label"
 WARNING_EMPTY_PARENTHESES: Final[str] = "message_gate_empty_parentheses"
 WARNING_MISSING_STATUS: Final[str] = "message_gate_missing_status"
 WARNING_MISSING_PROMPT_REFERENCE: Final[str] = "message_gate_missing_prompt_reference"
+# `codex (executor default)` is honest -- OMH did resolve an executor and did
+# apply no model override -- but it is indistinguishable from a route that was
+# never attempted, and it silenced the missing-model warning on the main
+# delegate path. This names the difference instead of overloading `unknown`.
+WARNING_UNRESOLVED_MODEL_ROUTE: Final[str] = "message_gate_unresolved_model_route"
 
 # Rendered once under the header, mirroring `goal_status_card.render_guidance`:
 # the gate hands back exact lines, so an agent relaying them has no formatting
@@ -120,8 +124,8 @@ def build_message_gate(
     prompt_sha256: str = "",
     prompt_chars: Any = None,
     composed_prompt: str = "",
-    units: object = (),
     discloses_model: bool = True,
+    reference_kind: str = "prompt",
 ) -> dict[str, Any]:
     """Project one response's execution provenance into a gate payload.
 
@@ -140,17 +144,25 @@ def build_message_gate(
     ``discloses_model=False`` says the same thing about MODEL, and only a
     surface with no executor at all may say it -- a goal ledger card tracks
     acceptance criteria, not a running lane, so "which model" is not a fact it
-    withholds but one it does not have. Every delegation surface leaves this
-    True, so a handoff that resolved no model still reads ``unknown`` and still
-    raises ``message_gate_missing_model_label``.
+    withholds but one it does not have.
+
+    Three model states, not two, because the middle one is the common one:
+    no executor reads ``unknown`` and raises ``message_gate_missing_model_label``;
+    a resolved executor with no route reads ``codex (executor default)`` and
+    raises ``message_gate_unresolved_model_route``; a resolved route reads
+    ``codex (gpt-5-codex xhigh)`` and raises nothing. Collapsing the middle
+    state into the last one is what let the main delegate path ship a header
+    that could not distinguish "OMH applied no override" from "OMH never
+    resolved a route", with no warning either way.
     """
     resolved_label = str(model_label or "").strip()
     if not resolved_label and (str(model or "").strip() or str(reasoning_effort or "").strip()):
         resolved_label = model_label_for(model, reasoning_effort)
+    reference = reference_kind if reference_kind in REFERENCE_KINDS else REFERENCE_KINDS[0]
     fields: dict[str, str] = {
         "skill": _bounded(skill) or UNKNOWN,
         "status": _bounded(status) or UNKNOWN,
-        "prompt": _prompt_reference(prompt_sha256, prompt_chars),
+        reference: _prompt_reference(prompt_sha256, prompt_chars),
     }
     if discloses_model:
         fields["model"] = _model_field(executor, resolved_label)
@@ -159,17 +171,14 @@ def build_message_gate(
         fields["task"] = bounded_task
     payload: dict[str, Any] = {
         "schema_version": MESSAGE_GATE_SCHEMA_VERSION,
+        # Whether a model route was resolved at all, which the rendered MODEL
+        # row cannot express: `codex (executor default)` is what both a
+        # deliberate no-override and an unattempted route look like.
+        "model_route_resolved": bool(resolved_label) if discloses_model else None,
         "fields": fields,
         "field_order": [key for _, key in _FIELDS if key in fields],
         "render_guidance": RENDER_GUIDANCE,
     }
-    roster = _normalize_units(units)
-    if roster:
-        payload["roster"] = roster
-        payload["roster_count"] = len(roster)
-        # The observed total, not the rendered count: a reader must be able to
-        # tell a complete roster from a capped one without opening the board.
-        payload["roster_total"] = _unit_total(units)
     prompt_block = _prompt_block(composed_prompt, fields.get("model", ""))
     if prompt_block:
         payload["prompt_block"] = prompt_block
@@ -193,27 +202,17 @@ def render_message_gate_lines(
     fields = _fields(payload)
     if not fields:
         return []
-    rows = _roster_rows(payload)
-    omission = _roster_omission_line(payload, rows)
     if render_profile == RENDER_PROFILE_RICH_MARKDOWN:
-        block = _aligned_pairs(fields, payload)
-        if rows:
-            block = [*block, "", *_aligned_roster(rows)]
-            if omission:
-                block.append(omission)
-        return ["```", *block, "```"]
+        rows = _aligned_pairs(fields, payload)
+        # An empty fence pair is a rendering fault on every messenger, so a
+        # payload this version can read no rows out of renders nothing at all.
+        return ["```", *rows, "```"] if rows else []
     labels = {key: label for label, key in _FIELDS}
-    lines = [
-        f"- {labels[key].lower()} — {fields[key]}"
+    return [
+        f"- {labels.get(key, key.upper()).lower()} — {fields[key]}"
         for key in _field_order(payload)
         if key in fields
     ]
-    lines.extend(
-        f"- {row['label']} — {row['model']} — {row['status']} — {row['elapsed']}" for row in rows
-    )
-    if omission:
-        lines.append(f"- {omission}")
-    return lines
 
 
 def message_gate_body(
@@ -229,25 +228,6 @@ def message_gate_body(
     header = "\n".join(lines)
     return f"{header}\n\n{body}" if body else header
 
-
-def message_gate_messages(
-    payload: dict[str, Any],
-    *,
-    render_profile: str = RENDER_PROFILE_LIMITED_MARKDOWN,
-    body: str = "",
-) -> list[str]:
-    """Ordered messages an adapter posts: the header+body, then the prompt block.
-
-    The prompt block is a separate message rather than more of the first one
-    because it answers a different question ("what was actually ordered?") and
-    because a fenced block appended to a status body is the shape that pushes a
-    Discord message over its ceiling and gets split at an arbitrary point.
-    """
-    messages = [message_gate_body(payload, render_profile=render_profile, body=body)]
-    block = str(payload.get("prompt_block", "") or "")
-    if block:
-        messages.append(block)
-    return [message for message in messages if message]
 
 
 def message_gate_warnings(payload: dict[str, Any]) -> list[str]:
@@ -266,15 +246,12 @@ def message_gate_warnings(payload: dict[str, Any]) -> list[str]:
         warnings.append(WARNING_MISSING_MODEL_LABEL)
     if "()" in model:
         warnings.append(WARNING_EMPTY_PARENTHESES)
+    if "model" in fields and payload.get("model_route_resolved") is False:
+        warnings.append(WARNING_UNRESOLVED_MODEL_ROUTE)
     if fields.get("status", UNKNOWN) == UNKNOWN:
         warnings.append(WARNING_MISSING_STATUS)
-    if fields.get("prompt", UNKNOWN) == UNKNOWN:
+    if any(fields.get(key, UNKNOWN) == UNKNOWN for key in REFERENCE_KINDS if key in fields):
         warnings.append(WARNING_MISSING_PROMPT_REFERENCE)
-    for row in _roster_rows(payload):
-        label = row.get("model", "")
-        if not label or label == UNKNOWN or "()" in label:
-            warnings.append(WARNING_MISSING_MODEL_LABEL)
-            break
     return sorted(set(warnings))
 
 
@@ -331,103 +308,23 @@ def _prompt_reference(prompt_sha256: str, prompt_chars: Any) -> str:
     return reference
 
 
-def _normalize_units(units: object) -> list[dict[str, str]]:
-    """Normalize parallel lanes into the board's own row vocabulary.
 
-    Shape matches ``_fanout_brief_unit_line``'s join order so a roster line and
-    an ``omh coding fanout brief`` line describe a unit the same way. Called
-    once, at build time; readers use ``_roster_rows`` and never re-normalize.
-    """
-    if not isinstance(units, (list, tuple)):
-        return []
-    rows: list[dict[str, str]] = []
-    for unit in units[:_ROSTER_LIMIT]:
-        if not isinstance(unit, dict):
-            continue
-        label = _bounded(unit.get("label", "") or unit.get("unit_id", ""))
-        if not label:
-            continue
-        model_label = str(unit.get("model_label", "") or "").strip()
-        model = str(unit.get("model", "") or "").strip()
-        effort = str(unit.get("reasoning_effort", "") or "").strip()
-        # Same guard the header field needs: `model_label_for` answers
-        # `executor default` for empty input, which is a claim about a resolved
-        # executor. A lane that reported neither owner nor model has nothing to
-        # default, so it must stay unknown and raise the warning.
-        if not model_label and (model or effort):
-            model_label = model_label_for(model, effort)
-        rows.append(
-            {
-                "label": label,
-                "model": _model_field(
-                    str(unit.get("owner", "") or unit.get("runtime", "") or ""), model_label
-                ),
-                "status": _bounded(unit.get("status", "")) or UNKNOWN,
-                "elapsed": _bounded(unit.get("elapsed_text", "")) or UNKNOWN,
-            }
-        )
-    return rows
-
-
-def _unit_total(units: object) -> int:
-    if not isinstance(units, (list, tuple)):
-        return 0
-    return sum(1 for unit in units if isinstance(unit, dict) and (unit.get("label") or unit.get("unit_id")))
-
-
-def _roster_omission_line(payload: dict[str, Any], rows: list[dict[str, str]]) -> str:
-    """State a capped roster as its own line, never silently.
-
-    Same rule ``_fanout_brief_overflow_line`` follows: a truncated roster that
-    does not say so reads as a complete one.
-    """
-    total = payload.get("roster_total")
-    if not isinstance(total, int) or isinstance(total, bool):
-        return ""
-    omitted = total - len(rows)
-    if omitted <= 0:
-        return ""
-    return f"… +{omitted} more units — omh coding status-board"
-
-
-def _roster_rows(payload: dict[str, Any]) -> list[dict[str, str]]:
-    """Already-normalized roster rows straight off the payload.
-
-    Deliberately not ``_normalize_units``: rows leave the builder keyed
-    ``elapsed``, and re-running the raw-unit normalizer over them would look for
-    ``elapsed_text``, find nothing, and silently rewrite every observed time to
-    ``unknown``.
-    """
-    roster = payload.get("roster")
-    if not isinstance(roster, (list, tuple)):
-        return []
-    rows: list[dict[str, str]] = []
-    for row in roster:
-        if not isinstance(row, dict):
-            continue
-        rows.append({key: str(row.get(key, "") or UNKNOWN) for _, key in _ROSTER_COLUMNS})
-    return rows
 
 
 def _aligned_pairs(fields: dict[str, str], payload: dict[str, Any]) -> list[str]:
-    width = max(len(label) for label, key in _FIELDS if key in fields)
-    order = _field_order(payload)
+    """Aligned ``LABEL  value`` rows, tolerant of a key this version does not know.
+
+    The payload is a public, round-trippable schema. A field key added in a
+    later version must degrade to its own uppercased name here rather than
+    crash a `max()` over an empty generator or a `labels[key]` lookup.
+    """
     labels = {key: label for label, key in _FIELDS}
-    return [f"{labels[key].ljust(width)}  {fields[key]}" for key in order if key in fields]
+    order = [key for key in _field_order(payload) if key in fields]
+    if not order:
+        return []
+    width = max(len(labels.get(key, key.upper())) for key in order)
+    return [f"{labels.get(key, key.upper()).ljust(width)}  {fields[key]}" for key in order]
 
-
-def _aligned_roster(rows: list[dict[str, str]]) -> list[str]:
-    widths = [
-        max(len(header), *(len(row[key]) for row in rows)) for header, key in _ROSTER_COLUMNS
-    ]
-    lines = [
-        "  ".join(header.ljust(widths[index]) for index, (header, _) in enumerate(_ROSTER_COLUMNS)).rstrip()
-    ]
-    lines.extend(
-        "  ".join(row[key].ljust(widths[index]) for index, (_, key) in enumerate(_ROSTER_COLUMNS)).rstrip()
-        for row in rows
-    )
-    return lines
 
 
 def _fields(payload: dict[str, Any]) -> dict[str, str]:

--- a/src/wrapper/message_gate.py
+++ b/src/wrapper/message_gate.py
@@ -1,0 +1,441 @@
+"""The message gate: the provenance header OMH renders into a messenger body.
+
+``messenger_rendering`` (``src/wrapper/contract.py``) is the SHAPE gate. It
+decides chunk ceilings, Slack mrkdwn dialect, tables-to-bullets, and fence
+handling, and it says nothing about WHAT a delegated response must disclose.
+This module is the CONTENT gate for the same body: which skill ran, which model
+and reasoning effort it ran on, what evidence class the answer belongs to, and
+which prompt produced it.
+
+Why render it here instead of asking for it. ``DELEGATE_MODEL_LABEL_RULE`` and
+``DELEGATE_PROMPT_DISPLAY_RULE`` in ``src/skills/catalog_types.py`` already
+state the ``(model effort)`` and fenced-prompt disciplines, but ``render.py``
+gates that block to handoff-shaped skills, so it reaches 7 of 103 skill bodies,
+and nothing anywhere checks that an agent actually emitted either shape. A
+prose rule that no surface validates is a hope.
+``goal_ledger.build_goal_status_card`` already reached the same conclusion
+once, for one payload, after a live Slack session rendered a markdown table
+that the surface silently dropped: it now hands back exact ``checkpoint_lines``
+plus a ``render_guidance`` sentence. This module generalizes that one-off.
+
+The gate fixes the header and the prompt block, and nothing else. The response
+body stays free prose, and every field degrades to the literal ``unknown``
+rather than being dropped or invented -- an absent model is a fact worth
+printing, and an empty ``()`` is the one shape the rule names as forbidden.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+from ..coding.context_safety import bounded_prompt_preview
+from ..coding.status_board import model_label_for
+
+MESSAGE_GATE_SCHEMA_VERSION: Final[str] = "omh_message_gate/v1"
+
+UNKNOWN: Final[str] = "unknown"
+
+# Profiles are the two the shape gate already resolves; the gate switches on
+# them rather than on the platform so a new source needs no change here.
+RENDER_PROFILE_LIMITED_MARKDOWN: Final[str] = "limited_markdown"
+RENDER_PROFILE_RICH_MARKDOWN: Final[str] = "rich_markdown"
+
+# Field order and the MODEL/STATUS labels match `_COLUMNS` in
+# `src/coding/status_board.py`: identity, then model, then status. A reader who
+# has seen the status board should not have to learn a second vocabulary for
+# the same four facts.
+_FIELDS: Final[tuple[tuple[str, str], ...]] = (
+    ("SKILL", "skill"),
+    ("MODEL", "model"),
+    ("STATUS", "status"),
+    ("TASK", "task"),
+    ("PROMPT", "prompt"),
+)
+
+_ROSTER_COLUMNS: Final[tuple[tuple[str, str], ...]] = (
+    ("UNIT", "label"),
+    ("MODEL", "model"),
+    ("STATUS", "status"),
+    ("TIME", "elapsed"),
+)
+
+# Bounded so a long skill name or a pasted model id cannot push the header past
+# the tightest messenger ceiling on its own.
+_VALUE_LIMIT: Final[int] = 96
+# The PROMPT row carries a digest prefix, never the prompt. Twelve hex
+# characters is what `omh coding fanout` already prints for a unit ref.
+_DIGEST_PREFIX: Final[int] = 12
+# A roster longer than this is a status-board question, not a header. Six is
+# not arbitrary: the limited profile renders one bullet per field plus one per
+# unit, and `messenger_rendering.density_policy` declares `max_bullets: 12`.
+# Five fields + six units + the truncation line lands exactly on that ceiling,
+# so the gate obeys the density policy OMH already publishes instead of being
+# the first surface to break it.
+_ROSTER_LIMIT: Final[int] = 6
+# How much of the composed prompt the follow-on message shows. Long enough to
+# recognize the order Hermes actually issued, short enough that the block stays
+# well inside Discord's 1700-character soft ceiling next to a header.
+PROMPT_PREVIEW_CHARS: Final[int] = 200
+
+PROMPT_BLOCK_TITLE: Final[str] = "HERMES PROMPTING"
+
+WARNING_MISSING_MODEL_LABEL: Final[str] = "message_gate_missing_model_label"
+WARNING_EMPTY_PARENTHESES: Final[str] = "message_gate_empty_parentheses"
+WARNING_MISSING_STATUS: Final[str] = "message_gate_missing_status"
+WARNING_MISSING_PROMPT_REFERENCE: Final[str] = "message_gate_missing_prompt_reference"
+
+# Rendered once under the header, mirroring `goal_status_card.render_guidance`:
+# the gate hands back exact lines, so an agent relaying them has no formatting
+# decision left to get wrong.
+RENDER_GUIDANCE: Final[str] = (
+    "Render the provided gate lines verbatim, in order, above the response body, and post "
+    "prompt_block as its own follow-on message. Never restate either as a markdown table: "
+    "messenger surfaces drop tables."
+)
+
+
+def fence_marker_for(text: str) -> str:
+    """Backtick fence for embedding ``text``: one longer than the longest
+    backtick run inside it, minimum three, so embedded ``` fences nest safely."""
+    longest = 0
+    run = 0
+    for character in text:
+        if character == "`":
+            run += 1
+            longest = max(longest, run)
+        else:
+            run = 0
+    return "`" * max(3, longest + 1)
+
+
+def build_message_gate(
+    *,
+    skill: str = "",
+    executor: str = "",
+    model: str = "",
+    reasoning_effort: str = "",
+    model_label: str = "",
+    status: str = "",
+    task: str = "",
+    prompt_sha256: str = "",
+    prompt_chars: Any = None,
+    composed_prompt: str = "",
+    units: object = (),
+) -> dict[str, Any]:
+    """Project one response's execution provenance into a gate payload.
+
+    ``model_label`` wins when a caller already resolved the label through the
+    status-board convention (``_status_model_label``); otherwise the label is
+    composed here from ``model`` plus ``reasoning_effort`` so both entry points
+    produce the identical string.
+
+    ``task`` and ``composed_prompt`` are the caller's decision, not this
+    module's: the chat envelope declares ``redaction_policy: metadata_only``
+    unless the wrapper opted into ``include_message``, so a caller that has not
+    opted in passes ``""`` and those surfaces are omitted. An omitted row is not
+    an unknown one -- the fact was never admitted to this surface, so printing
+    ``unknown`` would misdescribe a redaction as a gap.
+    """
+    resolved_label = str(model_label or "").strip()
+    if not resolved_label and (str(model or "").strip() or str(reasoning_effort or "").strip()):
+        resolved_label = model_label_for(model, reasoning_effort)
+    fields: dict[str, str] = {
+        "skill": _bounded(skill) or UNKNOWN,
+        "model": _model_field(executor, resolved_label),
+        "status": _bounded(status) or UNKNOWN,
+        "prompt": _prompt_reference(prompt_sha256, prompt_chars),
+    }
+    bounded_task = _bounded(task)
+    if bounded_task:
+        fields["task"] = bounded_task
+    payload: dict[str, Any] = {
+        "schema_version": MESSAGE_GATE_SCHEMA_VERSION,
+        "fields": fields,
+        "field_order": [key for _, key in _FIELDS if key in fields],
+        "render_guidance": RENDER_GUIDANCE,
+    }
+    roster = _normalize_units(units)
+    if roster:
+        payload["roster"] = roster
+        payload["roster_count"] = len(roster)
+        # The observed total, not the rendered count: a reader must be able to
+        # tell a complete roster from a capped one without opening the board.
+        payload["roster_total"] = _unit_total(units)
+    prompt_block = _prompt_block(composed_prompt, fields["model"])
+    if prompt_block:
+        payload["prompt_block"] = prompt_block
+    payload["warnings"] = message_gate_warnings(payload)
+    return payload
+
+
+def render_message_gate_lines(
+    payload: dict[str, Any], *, render_profile: str = RENDER_PROFILE_LIMITED_MARKDOWN
+) -> list[str]:
+    """The exact lines to print above a response body, one per element.
+
+    ``rich_markdown`` gets an aligned block inside a single fence, because
+    alignment is the whole reason a fence is worth its vertical cost, and two
+    adjacent fences read as a rendering fault rather than as two sections.
+    ``limited_markdown`` gets flat bullets -- the same branch
+    ``status_board_messenger_body`` already makes, and for the same reason: a
+    monospace block shrinks the font on a narrow phone client, where the header
+    is read most.
+    """
+    fields = _fields(payload)
+    if not fields:
+        return []
+    rows = _roster_rows(payload)
+    omission = _roster_omission_line(payload, rows)
+    if render_profile == RENDER_PROFILE_RICH_MARKDOWN:
+        block = _aligned_pairs(fields, payload)
+        if rows:
+            block = [*block, "", *_aligned_roster(rows)]
+            if omission:
+                block.append(omission)
+        return ["```", *block, "```"]
+    labels = {key: label for label, key in _FIELDS}
+    lines = [
+        f"- {labels[key].lower()} — {fields[key]}"
+        for key in _field_order(payload)
+        if key in fields
+    ]
+    lines.extend(
+        f"- {row['label']} — {row['model']} — {row['status']} — {row['elapsed']}" for row in rows
+    )
+    if omission:
+        lines.append(f"- {omission}")
+    return lines
+
+
+def message_gate_body(
+    payload: dict[str, Any],
+    *,
+    render_profile: str = RENDER_PROFILE_LIMITED_MARKDOWN,
+    body: str = "",
+) -> str:
+    """The gate lines joined above ``body``, or ``body`` unchanged when empty."""
+    lines = render_message_gate_lines(payload, render_profile=render_profile)
+    if not lines:
+        return body
+    header = "\n".join(lines)
+    return f"{header}\n\n{body}" if body else header
+
+
+def message_gate_messages(
+    payload: dict[str, Any],
+    *,
+    render_profile: str = RENDER_PROFILE_LIMITED_MARKDOWN,
+    body: str = "",
+) -> list[str]:
+    """Ordered messages an adapter posts: the header+body, then the prompt block.
+
+    The prompt block is a separate message rather than more of the first one
+    because it answers a different question ("what was actually ordered?") and
+    because a fenced block appended to a status body is the shape that pushes a
+    Discord message over its ceiling and gets split at an arbitrary point.
+    """
+    messages = [message_gate_body(payload, render_profile=render_profile, body=body)]
+    block = str(payload.get("prompt_block", "") or "")
+    if block:
+        messages.append(block)
+    return [message for message in messages if message]
+
+
+def message_gate_warnings(payload: dict[str, Any]) -> list[str]:
+    """Name the shapes that broke the disclosure rule, without refusing them.
+
+    Warnings, not errors, for the reason ``native_commands._unsafe_rendering_warnings``
+    gives: a response that discloses less than it should is still a response the
+    user is waiting on. What must not happen is that it degrades silently.
+    """
+    fields = _fields(payload)
+    warnings: list[str] = []
+    model = fields.get("model", "")
+    if not model or model == UNKNOWN:
+        warnings.append(WARNING_MISSING_MODEL_LABEL)
+    if "()" in model:
+        warnings.append(WARNING_EMPTY_PARENTHESES)
+    if fields.get("status", UNKNOWN) == UNKNOWN:
+        warnings.append(WARNING_MISSING_STATUS)
+    if fields.get("prompt", UNKNOWN) == UNKNOWN:
+        warnings.append(WARNING_MISSING_PROMPT_REFERENCE)
+    for row in _roster_rows(payload):
+        label = row.get("model", "")
+        if not label or label == UNKNOWN or "()" in label:
+            warnings.append(WARNING_MISSING_MODEL_LABEL)
+            break
+    return sorted(set(warnings))
+
+
+def _prompt_block(composed_prompt: str, model_field: str) -> str:
+    """The composed order Hermes issued, bounded and fenced, or "" when absent.
+
+    Bounded through ``bounded_prompt_preview`` so the truncation marker is the
+    exact ``... [truncated, N chars total]`` shape ``DELEGATE_PROMPT_DISPLAY_RULE``
+    promises, and fenced through a content-derived marker so a prompt that
+    itself contains a fence still nests.
+    """
+    text = str(composed_prompt or "").strip()
+    if not text:
+        return ""
+    preview = bounded_prompt_preview(text, max_chars=PROMPT_PREVIEW_CHARS)
+    fence = fence_marker_for(preview)
+    title = PROMPT_BLOCK_TITLE
+    if model_field and model_field != UNKNOWN:
+        title = f"{title} — {model_field}"
+    return "\n".join([title, fence, preview, fence])
+
+
+def _model_field(executor: str, model_label: str) -> str:
+    """``codex (gpt-5-codex xhigh)`` -- executor and model as ONE visual field.
+
+    The parenthetical is never emitted empty: ``DELEGATE_MODEL_LABEL_RULE``
+    names that exact shape as forbidden. A known executor with no resolved route
+    is ``codex (executor default)``, which is what the status board already
+    prints; knowing neither is ``unknown``, not a default label OMH cannot back.
+    """
+    owner = _bounded(executor)
+    label = _bounded(model_label)
+    if not owner:
+        return label or UNKNOWN
+    return f"{owner} ({label or model_label_for('', '')})"
+
+
+def _prompt_reference(prompt_sha256: str, prompt_chars: Any) -> str:
+    """``sha256:533d406a4863 · 412 chars`` -- a reference, never the prompt.
+
+    OMH deliberately does not persist the raw task (``_composed_prompt_handoff_text``),
+    and the chat envelope's ``metadata_only`` redaction policy says the same
+    about echoing it. A digest plus a length still answers "is this the prompt I
+    typed?" without carrying the content.
+    """
+    digest = "".join(
+        character for character in str(prompt_sha256 or "").strip() if character.isalnum()
+    )
+    if not digest:
+        return UNKNOWN
+    reference = f"sha256:{digest[:_DIGEST_PREFIX]}"
+    if isinstance(prompt_chars, int) and not isinstance(prompt_chars, bool) and prompt_chars >= 0:
+        return f"{reference} · {prompt_chars} chars"
+    return reference
+
+
+def _normalize_units(units: object) -> list[dict[str, str]]:
+    """Normalize parallel lanes into the board's own row vocabulary.
+
+    Shape matches ``_fanout_brief_unit_line``'s join order so a roster line and
+    an ``omh coding fanout brief`` line describe a unit the same way. Called
+    once, at build time; readers use ``_roster_rows`` and never re-normalize.
+    """
+    if not isinstance(units, (list, tuple)):
+        return []
+    rows: list[dict[str, str]] = []
+    for unit in units[:_ROSTER_LIMIT]:
+        if not isinstance(unit, dict):
+            continue
+        label = _bounded(unit.get("label", "") or unit.get("unit_id", ""))
+        if not label:
+            continue
+        model_label = str(unit.get("model_label", "") or "").strip()
+        model = str(unit.get("model", "") or "").strip()
+        effort = str(unit.get("reasoning_effort", "") or "").strip()
+        # Same guard the header field needs: `model_label_for` answers
+        # `executor default` for empty input, which is a claim about a resolved
+        # executor. A lane that reported neither owner nor model has nothing to
+        # default, so it must stay unknown and raise the warning.
+        if not model_label and (model or effort):
+            model_label = model_label_for(model, effort)
+        rows.append(
+            {
+                "label": label,
+                "model": _model_field(
+                    str(unit.get("owner", "") or unit.get("runtime", "") or ""), model_label
+                ),
+                "status": _bounded(unit.get("status", "")) or UNKNOWN,
+                "elapsed": _bounded(unit.get("elapsed_text", "")) or UNKNOWN,
+            }
+        )
+    return rows
+
+
+def _unit_total(units: object) -> int:
+    if not isinstance(units, (list, tuple)):
+        return 0
+    return sum(1 for unit in units if isinstance(unit, dict) and (unit.get("label") or unit.get("unit_id")))
+
+
+def _roster_omission_line(payload: dict[str, Any], rows: list[dict[str, str]]) -> str:
+    """State a capped roster as its own line, never silently.
+
+    Same rule ``_fanout_brief_overflow_line`` follows: a truncated roster that
+    does not say so reads as a complete one.
+    """
+    total = payload.get("roster_total")
+    if not isinstance(total, int) or isinstance(total, bool):
+        return ""
+    omitted = total - len(rows)
+    if omitted <= 0:
+        return ""
+    return f"… +{omitted} more units — omh coding status-board"
+
+
+def _roster_rows(payload: dict[str, Any]) -> list[dict[str, str]]:
+    """Already-normalized roster rows straight off the payload.
+
+    Deliberately not ``_normalize_units``: rows leave the builder keyed
+    ``elapsed``, and re-running the raw-unit normalizer over them would look for
+    ``elapsed_text``, find nothing, and silently rewrite every observed time to
+    ``unknown``.
+    """
+    roster = payload.get("roster")
+    if not isinstance(roster, (list, tuple)):
+        return []
+    rows: list[dict[str, str]] = []
+    for row in roster:
+        if not isinstance(row, dict):
+            continue
+        rows.append({key: str(row.get(key, "") or UNKNOWN) for _, key in _ROSTER_COLUMNS})
+    return rows
+
+
+def _aligned_pairs(fields: dict[str, str], payload: dict[str, Any]) -> list[str]:
+    width = max(len(label) for label, key in _FIELDS if key in fields)
+    order = _field_order(payload)
+    labels = {key: label for label, key in _FIELDS}
+    return [f"{labels[key].ljust(width)}  {fields[key]}" for key in order if key in fields]
+
+
+def _aligned_roster(rows: list[dict[str, str]]) -> list[str]:
+    widths = [
+        max(len(header), *(len(row[key]) for row in rows)) for header, key in _ROSTER_COLUMNS
+    ]
+    lines = [
+        "  ".join(header.ljust(widths[index]) for index, (header, _) in enumerate(_ROSTER_COLUMNS)).rstrip()
+    ]
+    lines.extend(
+        "  ".join(row[key].ljust(widths[index]) for index, (_, key) in enumerate(_ROSTER_COLUMNS)).rstrip()
+        for row in rows
+    )
+    return lines
+
+
+def _fields(payload: dict[str, Any]) -> dict[str, str]:
+    fields = payload.get("fields")
+    if not isinstance(fields, dict):
+        return {}
+    return {str(key): str(value) for key, value in fields.items() if str(value)}
+
+
+def _field_order(payload: dict[str, Any]) -> list[str]:
+    order = payload.get("field_order")
+    if isinstance(order, (list, tuple)):
+        return [str(key) for key in order]
+    return [key for _, key in _FIELDS]
+
+
+def _bounded(value: object) -> str:
+    """Single-line and length-capped: a newline in a header breaks every row below it."""
+    text = " ".join(str(value or "").split())
+    if len(text) <= _VALUE_LIMIT:
+        return text
+    return f"{text[: _VALUE_LIMIT - 1].rstrip()}…"

--- a/src/wrapper/message_gate.py
+++ b/src/wrapper/message_gate.py
@@ -121,6 +121,7 @@ def build_message_gate(
     prompt_chars: Any = None,
     composed_prompt: str = "",
     units: object = (),
+    discloses_model: bool = True,
 ) -> dict[str, Any]:
     """Project one response's execution provenance into a gate payload.
 
@@ -135,16 +136,24 @@ def build_message_gate(
     opted in passes ``""`` and those surfaces are omitted. An omitted row is not
     an unknown one -- the fact was never admitted to this surface, so printing
     ``unknown`` would misdescribe a redaction as a gap.
+
+    ``discloses_model=False`` says the same thing about MODEL, and only a
+    surface with no executor at all may say it -- a goal ledger card tracks
+    acceptance criteria, not a running lane, so "which model" is not a fact it
+    withholds but one it does not have. Every delegation surface leaves this
+    True, so a handoff that resolved no model still reads ``unknown`` and still
+    raises ``message_gate_missing_model_label``.
     """
     resolved_label = str(model_label or "").strip()
     if not resolved_label and (str(model or "").strip() or str(reasoning_effort or "").strip()):
         resolved_label = model_label_for(model, reasoning_effort)
     fields: dict[str, str] = {
         "skill": _bounded(skill) or UNKNOWN,
-        "model": _model_field(executor, resolved_label),
         "status": _bounded(status) or UNKNOWN,
         "prompt": _prompt_reference(prompt_sha256, prompt_chars),
     }
+    if discloses_model:
+        fields["model"] = _model_field(executor, resolved_label)
     bounded_task = _bounded(task)
     if bounded_task:
         fields["task"] = bounded_task
@@ -161,7 +170,7 @@ def build_message_gate(
         # The observed total, not the rendered count: a reader must be able to
         # tell a complete roster from a capped one without opening the board.
         payload["roster_total"] = _unit_total(units)
-    prompt_block = _prompt_block(composed_prompt, fields["model"])
+    prompt_block = _prompt_block(composed_prompt, fields.get("model", ""))
     if prompt_block:
         payload["prompt_block"] = prompt_block
     payload["warnings"] = message_gate_warnings(payload)
@@ -251,7 +260,9 @@ def message_gate_warnings(payload: dict[str, Any]) -> list[str]:
     fields = _fields(payload)
     warnings: list[str] = []
     model = fields.get("model", "")
-    if not model or model == UNKNOWN:
+    # An absent MODEL row is a declared non-disclosure (`discloses_model=False`),
+    # not a gap; a present-but-unknown one is the gap this warning names.
+    if "model" in fields and (not model or model == UNKNOWN):
         warnings.append(WARNING_MISSING_MODEL_LABEL)
     if "()" in model:
         warnings.append(WARNING_EMPTY_PARENTHESES)

--- a/tests/test_architecture_layout.py
+++ b/tests/test_architecture_layout.py
@@ -57,6 +57,7 @@ class ArchitectureLayoutTests(unittest.TestCase):
             "commands",
             "conformance",
             "core",
+            "evidence",
             "install",
             "maintenance",
             "mcp",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6112,7 +6112,11 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
         self.assertIn("Top recommendations:", stdout)
         self.assertIn("- ralplan: preparing a reviewed plan (high, score 32)", stdout)
         self.assertIn("Route plan:", stdout)
-        self.assertIn("- 1. triage: feedback-triage - prepared, not observed", stdout)
+        self.assertIn("- 1. triage: feedback-triage - not run", stdout)
+        # Positive twin for the negative pin below: the raw token must be gone
+        # AND a readable label must have taken its place, or a renderer that
+        # dropped the status entirely would pass both.
+        self.assertNotIn("prepared_not_observed", stdout)
         self.assertNotIn("(`prepared_not_observed`)", stdout)
         self.assertIn("Boundary:", stdout)
         self.assertIn("A recommendation or draft plan is not execution evidence.", stdout)

--- a/tests/test_coding_status_board.py
+++ b/tests/test_coding_status_board.py
@@ -204,7 +204,7 @@ class StatusBoardBuildTests(unittest.TestCase):
         text = render_status_board_text(payload)
         self.assertIn("openrouter/qwen-3.5-coder high", text)
         bullets = status_board_messenger_body(payload, render_profile="limited_markdown")
-        self.assertIn("omo work — omo (openrouter/qwen-3.5-coder high) — completed", bullets)
+        self.assertIn("omo work — omo (openrouter/qwen-3.5-coder high) — Code · reported done", bullets)
         self.assertNotIn(" — (", bullets)
 
     def test_mixed_running_and_completed_ordering_and_dedup(self) -> None:
@@ -458,8 +458,8 @@ class MessengerProfileTests(unittest.TestCase):
         # Runtime and model read as ONE field. Separating them with a dash as
         # well produced "claude — (fable-5 high)", a doubled separator around a
         # parenthetical.
-        self.assertIn("research — claude (fable-5 high) — running — 35m — tokens unknown", bullets[0])
-        self.assertIn("feature work — codex (gpt-5-codex xhigh) — completed — 35m — 10,000,000 tokens", bullets[1])
+        self.assertIn("research — claude (fable-5 high) — Code · running — 35m — tokens unknown", bullets[0])
+        self.assertIn("feature work — codex (gpt-5-codex xhigh) — Code · reported done — 35m — 10,000,000 tokens", bullets[1])
         for bullet in bullets:
             self.assertNotIn(" — (", bullet)
         self.assertIn("session sess-7", bullets[1])
@@ -529,10 +529,10 @@ class UnmappedStatusIsVisibleTests(unittest.TestCase):
 
     def test_the_aligned_board_shows_the_word_beside_the_downgrade(self) -> None:
         text = render_status_board_text(self._payload("quiesced"))
-        self.assertIn("prepared_not_observed (reported quiesced)", text)
+        self.assertIn("Plan · not run (reported quiesced)", text)
         # The accepted row is untouched, so a board with nothing refused reads
         # exactly as it did before.
-        self.assertIn("completed", text)
+        self.assertIn("Code · reported done", text)
         self.assertNotIn("completed (reported", text)
 
     def test_the_column_stays_aligned_when_the_word_widens_it(self) -> None:
@@ -546,7 +546,7 @@ class UnmappedStatusIsVisibleTests(unittest.TestCase):
         for profile in ("rich_markdown", "limited_markdown"):
             with self.subTest(profile=profile):
                 body = status_board_messenger_body(payload, render_profile=profile)
-                self.assertIn("prepared_not_observed (reported quiesced)", body)
+                self.assertIn("Plan · not run (reported quiesced)", body)
 
     def test_an_accepted_status_renders_exactly_as_before(self) -> None:
         text = render_status_board_text(self._payload("running"))
@@ -593,8 +593,8 @@ class UnmappedStatusPluginParityTests(unittest.TestCase):
         from omh.plugin_bundle.omh.status_board_reader import render_running_work_block_text
 
         source, plugin = self._boards("quiesced")
-        self.assertIn("prepared_not_observed (reported quiesced)", render_status_board_text(source))
-        self.assertIn("prepared_not_observed (reported quiesced)", render_running_work_block_text(plugin))
+        self.assertIn("Plan · not run (reported quiesced)", render_status_board_text(source))
+        self.assertIn("Plan · not run (reported quiesced)", render_running_work_block_text(plugin))
 
     def test_neither_reader_invents_a_word_for_an_accepted_status(self) -> None:
         from omh.plugin_bundle.omh.status_board_reader import render_running_work_block_text

--- a/tests/test_evidence_labels_policy.py
+++ b/tests/test_evidence_labels_policy.py
@@ -1,0 +1,261 @@
+"""The friendly evidence labels, gated against the ways they could lie.
+
+The wire vocabulary (`prepared_not_observed`, `worktree_failed`, …) is a
+contract external wrappers gate on. This module renames nothing on that side;
+it owns what a PERSON reads. That split is the whole design, so the first thing
+tested is that the split held: every wire value still ships verbatim.
+
+The rest is about the one failure that matters. A label is read faster than it
+is thought about, so the only interesting question is whether a state that
+never ran can be scanned as work that happened. Every assertion below is
+pointed at that, including the ones that look like style checks:
+
+* labels are re-derived from the producing source, so a new state added to
+  `STATUS_VOCABULARY` or `_usage_evidence_state` fails here instead of silently
+  rendering as the fail-closed default;
+* the negation survives every truncation budget in the repo, because a cell
+  clipped to `Plan · not r` is fine and one clipped to `Plan` is a lie;
+* `ready` is absent, and that is not taste — `operator_productivity`
+  rejects it as an unbacked observation claim.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.coding.status_board import STATUS_VOCABULARY, status_text_for  # noqa: E402
+from omh.evidence.labels import (  # noqa: E402
+    CONFIDENCE_NOT_RUN,
+    CONFIDENCE_PROSE,
+    CONFIDENCES,
+    PHASE_CODE,
+    PHASES,
+    SEPARATOR,
+    confidence_label,
+    phase_label,
+    status_label,
+    status_prose,
+)
+from omh.plugin_bundle.omh.status_board_reader import _status_text  # noqa: E402
+from omh.workflows.operator_productivity import OBSERVED_CLAIM_STATUSES  # noqa: E402
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+
+# Words that would let a not-run state be scanned as work that happened.
+_SUCCESS_WORDS = ("done", "complete", "completed", "ready", "passed", "success", "ok", "finished")
+
+
+def _usage_evidence_states() -> set[str]:
+    """Re-derive the states `_usage_evidence_state` can return, from its source.
+
+    Re-derived rather than restated so a new branch added to that function
+    arrives here as a failure instead of quietly taking the fail-closed label.
+    """
+    source = (SRC / "wrapper" / "contract.py").read_text(encoding="utf-8")
+    body = source.split("def _usage_evidence_state(", 1)[1].split("\ndef ", 1)[0]
+    return set(re.findall(r'return "([a-z_]+)"', body))
+
+
+class TheWireSideDidNotMoveTests(unittest.TestCase):
+    def test_every_evidence_state_still_ships_verbatim(self) -> None:
+        # The premise of the whole change: renaming what a human reads must not
+        # rename what a wrapper parses.
+        states = _usage_evidence_states()
+        self.assertIn("prepared_not_observed", states)
+        self.assertIn("routing_not_execution", states)
+        self.assertIn("observed_partial", states)
+        self.assertIn("observed_reportable", states)
+
+    def test_the_closed_status_vocabulary_still_ships_verbatim(self) -> None:
+        self.assertEqual(
+            STATUS_VOCABULARY,
+            ("running", "completed", "failed", "worktree_failed", "prepared_not_observed"),
+        )
+
+
+class EveryStateHasALabelTests(unittest.TestCase):
+    def _states(self) -> set[str]:
+        return _usage_evidence_states() | set(STATUS_VOCABULARY)
+
+    def test_no_state_falls_through_to_the_default_by_accident(self) -> None:
+        # `not run` is the fail-closed answer for an UNKNOWN state. A state this
+        # repo actually emits reaching it means someone added a state and no
+        # label, which is exactly what this test exists to catch. The two
+        # genuinely-pre-run states are named as the deliberate exceptions.
+        deliberate = {"prepared_not_observed", "routing_not_execution"}
+        for state in sorted(self._states() - deliberate):
+            with self.subTest(state=state):
+                self.assertNotEqual(
+                    confidence_label(state),
+                    CONFIDENCE_NOT_RUN,
+                    f"{state!r} has no label of its own; add one in omh/evidence/labels.py",
+                )
+
+    def test_every_label_is_from_the_declared_vocabulary(self) -> None:
+        for state in sorted(self._states()):
+            with self.subTest(state=state):
+                self.assertIn(confidence_label(state), CONFIDENCES)
+
+    def test_every_confidence_label_has_a_prose_long_form(self) -> None:
+        for confidence in CONFIDENCES:
+            with self.subTest(confidence=confidence):
+                self.assertTrue(CONFIDENCE_PROSE.get(confidence))
+
+
+class ANotRunStateCannotBeScannedAsDoneTests(unittest.TestCase):
+    def test_the_not_run_label_carries_no_success_word(self) -> None:
+        for word in _SUCCESS_WORDS:
+            self.assertNotIn(word, CONFIDENCE_NOT_RUN)
+
+    def test_the_label_fits_every_real_truncation_budget_whole(self) -> None:
+        # The budgets that actually clip a status elsewhere in the repo:
+        # `_pad(..., 20)` in src/commands/menubar.py:130, `_short_text(limit=32)`
+        # in src/surfaces/menubar_status.py:588, and `_STATUS_SOURCE_LIMIT = 80`
+        # in src/coding/status_board.py:97. Fitting WHOLE is the property worth
+        # holding — a clipped `Plan` with the negation cut off is the failure,
+        # and no partial-survival rule is needed if nothing ever clips.
+        for state in ("prepared_not_observed", "routing_not_execution", "worktree_failed", "completed"):
+            for limit in (20, 32, 80):
+                with self.subTest(state=state, limit=limit):
+                    rendered = status_label(state, default_phase=PHASE_CODE)
+                    self.assertLessEqual(len(rendered), limit, rendered)
+
+    def test_a_not_run_label_keeps_its_negation_under_a_hostile_clip(self) -> None:
+        # Belt and braces for a surface that clips tighter than any today.
+        rendered = status_label("prepared_not_observed")
+        for limit in (14, 16, 20):
+            with self.subTest(limit=limit):
+                self.assertIn("not", rendered[:limit], rendered[:limit])
+
+    def test_the_friendly_label_is_no_longer_than_the_wire_value(self) -> None:
+        # A friendlier label that blows a column budget gets truncated back into
+        # jargon, so this is a correctness property rather than a nicety.
+        for state in ("prepared_not_observed", "routing_not_execution", "worktree_failed"):
+            with self.subTest(state=state):
+                self.assertLessEqual(len(status_label(state)), len(state))
+
+    def test_an_unknown_state_fails_closed_rather_than_open(self) -> None:
+        for state in ("", "   ", "some_future_state", "completed_and_verified", "PREPARED_NOT_OBSERVED"):
+            with self.subTest(state=state):
+                self.assertEqual(confidence_label(state), CONFIDENCE_NOT_RUN)
+
+    def test_a_self_reported_finish_names_its_claimant(self) -> None:
+        # `completed` is the executor's own claim about itself; OMH observed the
+        # claim and never the result. Rendering it as a bare success word is how
+        # a self-report gets promoted to a verified one.
+        label = confidence_label("completed")
+        self.assertIn("reported", label)
+        self.assertNotEqual(label, "done")
+
+    def test_no_label_is_ever_the_bare_word_unknown(self) -> None:
+        # `message_gate` raises `message_gate_missing_status` on exactly that
+        # value, so a label of `unknown` would turn every row into a warning.
+        for state in ("", "junk", *STATUS_VOCABULARY, *_usage_evidence_states()):
+            with self.subTest(state=state):
+                self.assertNotEqual(status_label(state), "unknown")
+                self.assertNotIn("unknown", status_label(state))
+
+
+class ReadyIsRefusedByTheProjectsOwnGuardTests(unittest.TestCase):
+    def test_ready_is_a_claim_word_this_repo_rejects(self) -> None:
+        # Not a style choice: `_nested_observed_claim_errors` refuses any payload
+        # whose `status` field carries a member of this set.
+        self.assertIn("ready", OBSERVED_CLAIM_STATUSES)
+
+    def test_no_pre_run_label_collides_with_a_claim_word(self) -> None:
+        # Precise property. `running` IS a member of that set and IS a correct
+        # label, because the board only renders it when an in-flight marker was
+        # actually observed — the guard is about UNBACKED claims. What must
+        # never collide is a label for a state that did not run, and no phase
+        # word may collide at all, since the phase axis is meant to be incapable
+        # of asserting activity.
+        self.assertNotIn(CONFIDENCE_NOT_RUN, OBSERVED_CLAIM_STATUSES)
+        for phase in PHASES:
+            with self.subTest(phase=phase):
+                self.assertNotIn(phase.strip().lower(), OBSERVED_CLAIM_STATUSES)
+
+    def test_ready_survives_only_as_future_tense_prose(self) -> None:
+        # The owner asked for `ready`. It lives where it cannot be read as an
+        # achievement: a sentence that says nothing has happened yet.
+        prose = CONFIDENCE_PROSE[CONFIDENCE_NOT_RUN]
+        self.assertIn("ready to run", prose)
+        self.assertIn("nothing has run yet", prose)
+
+
+class PhaseAxisCannotAssertActivityTests(unittest.TestCase):
+    def test_no_phase_label_is_a_gerund(self) -> None:
+        # "Coding · not run" reads as someone coding right now on a fast scan.
+        # "Code · not run" cannot. Every phase label is a noun.
+        for phase in PHASES:
+            with self.subTest(phase=phase):
+                self.assertFalse(phase.lower().endswith("ing"), phase)
+
+    def test_a_more_specific_next_action_wins_over_the_implied_phase(self) -> None:
+        self.assertEqual(phase_label("observed_partial", next_action="record_review_evidence"), "Review")
+        self.assertEqual(phase_label("observed_partial", next_action="record_ci_evidence"), "Test")
+
+    def test_a_surface_default_applies_only_when_nothing_more_specific_exists(self) -> None:
+        # A coding board knows every row is Code; it must not overrule a value
+        # that already named its own phase.
+        self.assertEqual(phase_label("running", default=PHASE_CODE), PHASE_CODE)
+        self.assertEqual(phase_label("worktree_failed", default=PHASE_CODE), "Setup")
+
+    def test_an_unrecognized_default_is_ignored_rather_than_rendered(self) -> None:
+        self.assertEqual(phase_label("running", default="Deploying"), "")
+
+
+class PluginBundleMirrorParityTests(unittest.TestCase):
+    """The bundle cannot import `omh.*`, so it hand-mirrors the map."""
+
+    def test_both_renderers_agree_on_every_state(self) -> None:
+        states = ["", "junk", *STATUS_VOCABULARY, *sorted(_usage_evidence_states())]
+        for state in states:
+            with self.subTest(state=state):
+                unit = {"status": state}
+                self.assertEqual(status_text_for(unit), _status_text(unit))
+
+    def test_both_renderers_agree_when_a_word_was_refused(self) -> None:
+        unit = {"status": "prepared_not_observed", "unmapped_source_status": "quiesced"}
+        self.assertEqual(status_text_for(unit), _status_text(unit))
+        self.assertIn("(reported quiesced)", status_text_for(unit))
+
+    def test_the_separator_is_identical_on_both_sides(self) -> None:
+        unit = {"status": "running"}
+        self.assertIn(SEPARATOR, status_text_for(unit))
+        self.assertIn(SEPARATOR, _status_text(unit))
+
+
+class RenderedShapeTests(unittest.TestCase):
+    def test_the_combined_label_reads_phase_then_confidence(self) -> None:
+        self.assertEqual(status_label("prepared_not_observed"), f"Plan{SEPARATOR}not run")
+        self.assertEqual(status_label("routing_not_execution"), f"Route{SEPARATOR}not run")
+        self.assertEqual(status_label("worktree_failed"), f"Setup{SEPARATOR}failed")
+        self.assertEqual(status_label("running", default_phase=PHASE_CODE), f"Code{SEPARATOR}running")
+
+    def test_a_confidence_with_no_phase_renders_alone_not_with_a_dangling_separator(self) -> None:
+        self.assertEqual(status_label("observed_partial"), "partly seen")
+        self.assertNotIn(SEPARATOR, status_label("observed_partial"))
+
+    def test_prose_form_is_a_sentence_a_person_can_read_aloud(self) -> None:
+        self.assertEqual(
+            status_prose("prepared_not_observed"),
+            "plan: ready to run, nothing has run yet",
+        )
+
+    def test_labels_are_english_and_single_line(self) -> None:
+        # User-facing output is English by default; localized copy is opt-in via
+        # --language / OMH_LANG only, and a newline would break every table row.
+        for label in (*CONFIDENCES, *PHASES, *CONFIDENCE_PROSE.values()):
+            with self.subTest(label=label):
+                self.assertNotIn("\n", label)
+                self.assertTrue(all(ord(char) < 128 or char == "·" for char in label), label)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_message_gate.py
+++ b/tests/test_message_gate.py
@@ -1,0 +1,373 @@
+"""The message gate: what a messenger must be told about delegated coding work.
+
+Two things are under test here, and they fail for different reasons.
+
+The RENDERER is tested against shapes that have already gone wrong once. Two
+adjacent fences, a roster whose observed times all read `unknown` after a
+payload round-trip, an empty `()` the disclosure rule names as forbidden, a
+bullet list over the density ceiling OMH itself publishes -- each of these was
+a real defect in this module before it had a test.
+
+The WIRING is tested with a negative case per positive one, because the
+interesting failure is not "the gate did not attach" but "the gate attached to
+something that is not delegated coding work". The `oh-my-hermes` router skill
+carries the `coding-handling` harness, so a harness-only condition put a header
+reading `model — unknown` on the answer to "what can OMH do?" and raised a
+missing-model warning about a capability question. That case is
+`test_a_capability_question_carries_no_gate` and it is the point of this file.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.wrapper.contract import build_chat_interaction_payload  # noqa: E402
+from omh.wrapper.message_gate import (  # noqa: E402
+    MESSAGE_GATE_SCHEMA_VERSION,
+    PROMPT_PREVIEW_CHARS,
+    RENDER_PROFILE_LIMITED_MARKDOWN,
+    RENDER_PROFILE_RICH_MARKDOWN,
+    UNKNOWN,
+    WARNING_EMPTY_PARENTHESES,
+    WARNING_MISSING_MODEL_LABEL,
+    WARNING_MISSING_PROMPT_REFERENCE,
+    WARNING_MISSING_STATUS,
+    build_message_gate,
+    fence_marker_for,
+    message_gate_body,
+    message_gate_messages,
+    message_gate_warnings,
+    render_message_gate_lines,
+)
+
+# `messenger_rendering.density_policy` publishes this ceiling for every limited
+# profile. The gate is a limited-profile surface, so it owes the same number.
+DECLARED_MAX_BULLETS = 12
+
+CODING_MESSAGE = "auth 모듈 리팩터링을 코덱스한테 맡겨줘"
+
+
+def _routed_gate(**overrides: object) -> dict:
+    fields: dict = {
+        "skill": "ulw-work",
+        "executor": "codex",
+        "model": "gpt-5-codex",
+        "reasoning_effort": "xhigh",
+        "status": "prepared_not_observed",
+        "prompt_sha256": "533d406a486317830d49c302e798c242",
+        "prompt_chars": 412,
+    }
+    fields.update(overrides)
+    return build_message_gate(**fields)  # type: ignore[arg-type]
+
+
+def _units(count: int) -> list[dict[str, str]]:
+    return [
+        {
+            "label": f"unit-{index}",
+            "owner": "codex",
+            "model": "gpt-5-codex",
+            "reasoning_effort": "xhigh",
+            "status": "running",
+            "elapsed_text": f"{index}m",
+        }
+        for index in range(1, count + 1)
+    ]
+
+
+class RenderShapeTests(unittest.TestCase):
+    def test_the_rich_profile_opens_and_closes_exactly_one_fence(self) -> None:
+        # Header and roster used to be two adjacent fenced blocks, which renders
+        # as a fault rather than as two sections.
+        gate = _routed_gate(units=_units(3))
+        lines = render_message_gate_lines(gate, render_profile=RENDER_PROFILE_RICH_MARKDOWN)
+        self.assertEqual(lines.count("```"), 2)
+        self.assertEqual(lines[0], "```")
+        self.assertEqual(lines[-1], "```")
+
+    def test_the_limited_profile_never_fences_the_header(self) -> None:
+        gate = _routed_gate(units=_units(3))
+        lines = render_message_gate_lines(gate, render_profile=RENDER_PROFILE_LIMITED_MARKDOWN)
+        self.assertNotIn("```", lines)
+        self.assertTrue(all(line.startswith("- ") for line in lines), lines)
+
+    def test_a_full_limited_header_stays_inside_the_declared_bullet_ceiling(self) -> None:
+        gate = _routed_gate(task="auth 모듈 리팩터링", units=_units(20))
+        lines = render_message_gate_lines(gate, render_profile=RENDER_PROFILE_LIMITED_MARKDOWN)
+        bullets = [line for line in lines if line.startswith("- ")]
+        self.assertLessEqual(len(bullets), DECLARED_MAX_BULLETS, "\n".join(lines))
+
+    def test_a_capped_roster_says_so_on_its_own_line(self) -> None:
+        gate = _routed_gate(units=_units(20))
+        self.assertEqual(gate["roster_total"], 20)
+        self.assertLess(gate["roster_count"], 20)
+        for profile in (RENDER_PROFILE_LIMITED_MARKDOWN, RENDER_PROFILE_RICH_MARKDOWN):
+            with self.subTest(profile=profile):
+                rendered = "\n".join(render_message_gate_lines(gate, render_profile=profile))
+                self.assertIn("more units", rendered)
+
+    def test_a_complete_roster_states_no_omission(self) -> None:
+        gate = _routed_gate(units=_units(3))
+        rendered = "\n".join(render_message_gate_lines(gate, render_profile=RENDER_PROFILE_LIMITED_MARKDOWN))
+        self.assertNotIn("more units", rendered)
+
+    def test_observed_roster_times_survive_the_payload_round_trip(self) -> None:
+        # Rows leave the builder keyed `elapsed`; re-running the raw-unit
+        # normalizer over them looked for `elapsed_text`, found nothing, and
+        # rewrote every observed time to `unknown`.
+        gate = _routed_gate(units=_units(3))
+        rendered = "\n".join(render_message_gate_lines(gate, render_profile=RENDER_PROFILE_LIMITED_MARKDOWN))
+        self.assertIn("1m", rendered)
+        self.assertIn("3m", rendered)
+        self.assertNotIn(f"— {UNKNOWN}", rendered)
+
+    def test_a_newline_in_a_value_cannot_break_the_rows_below_it(self) -> None:
+        gate = _routed_gate(skill="ulw\nwork\nbroken")
+        lines = render_message_gate_lines(gate, render_profile=RENDER_PROFILE_LIMITED_MARKDOWN)
+        self.assertEqual(len(lines), len([line for line in lines if line.startswith("- ")]))
+
+
+class DisclosureHonestyTests(unittest.TestCase):
+    def test_a_known_executor_without_a_route_reads_executor_default(self) -> None:
+        gate = _routed_gate(model="", reasoning_effort="")
+        self.assertEqual(gate["fields"]["model"], "codex (executor default)")
+        self.assertNotIn(WARNING_MISSING_MODEL_LABEL, gate["warnings"])
+
+    def test_knowing_neither_executor_nor_model_reads_unknown_and_warns(self) -> None:
+        # `executor default` is a claim about a resolved executor. With no
+        # executor at all there is nothing to default, so the honest word is
+        # `unknown` and the gate says the disclosure is incomplete.
+        gate = _routed_gate(executor="", model="", reasoning_effort="")
+        self.assertEqual(gate["fields"]["model"], UNKNOWN)
+        self.assertIn(WARNING_MISSING_MODEL_LABEL, gate["warnings"])
+
+    def test_the_parenthetical_is_never_emitted_empty(self) -> None:
+        # DELEGATE_MODEL_LABEL_RULE names `()` as the one forbidden shape.
+        for overrides in (
+            {"model": "", "reasoning_effort": ""},
+            {"model": "   ", "reasoning_effort": "   "},
+            {"executor": "codex", "model_label": ""},
+        ):
+            with self.subTest(overrides=overrides):
+                gate = _routed_gate(**overrides)
+                self.assertNotIn("()", gate["fields"]["model"])
+                self.assertNotIn(WARNING_EMPTY_PARENTHESES, gate["warnings"])
+
+    def test_a_missing_status_or_prompt_reference_is_named(self) -> None:
+        gate = _routed_gate(status="", prompt_sha256="")
+        self.assertEqual(gate["fields"]["status"], UNKNOWN)
+        self.assertEqual(gate["fields"]["prompt"], UNKNOWN)
+        self.assertIn(WARNING_MISSING_STATUS, gate["warnings"])
+        self.assertIn(WARNING_MISSING_PROMPT_REFERENCE, gate["warnings"])
+
+    def test_a_roster_lane_with_no_model_warns_even_when_the_header_has_one(self) -> None:
+        gate = _routed_gate(units=[{"label": "unit-1", "status": "running", "elapsed_text": "2m"}])
+        self.assertNotEqual(gate["fields"]["model"], UNKNOWN)
+        self.assertIn(WARNING_MISSING_MODEL_LABEL, gate["warnings"])
+
+    def test_an_unadmitted_task_is_absent_rather_than_unknown(self) -> None:
+        # The chat envelope declares `metadata_only` unless the wrapper opted
+        # into `include_message`. Printing `unknown` would describe a redaction
+        # as a gap in what OMH knows.
+        gate = _routed_gate(task="")
+        self.assertNotIn("task", gate["fields"])
+        self.assertNotIn("task", gate["field_order"])
+        rendered = "\n".join(render_message_gate_lines(gate, render_profile=RENDER_PROFILE_LIMITED_MARKDOWN))
+        self.assertNotIn("task", rendered)
+
+    def test_an_admitted_task_is_rendered(self) -> None:
+        gate = _routed_gate(task="auth 모듈 리팩터링")
+        self.assertEqual(gate["fields"]["task"], "auth 모듈 리팩터링")
+
+    def test_the_prompt_row_carries_a_digest_and_never_the_prompt(self) -> None:
+        gate = _routed_gate()
+        prompt = gate["fields"]["prompt"]
+        self.assertTrue(prompt.startswith("sha256:"), prompt)
+        self.assertIn("412 chars", prompt)
+        self.assertNotIn(CODING_MESSAGE, prompt)
+
+    def test_an_unmeasured_prompt_length_is_omitted_not_zeroed(self) -> None:
+        for value in (None, "", -1, True):
+            with self.subTest(value=value):
+                gate = _routed_gate(prompt_chars=value)
+                self.assertNotIn("chars", gate["fields"]["prompt"])
+
+    def test_the_warning_vocabulary_is_closed(self) -> None:
+        # A warning code nothing declares cannot be acted on by an adapter.
+        declared = {
+            WARNING_MISSING_MODEL_LABEL,
+            WARNING_EMPTY_PARENTHESES,
+            WARNING_MISSING_STATUS,
+            WARNING_MISSING_PROMPT_REFERENCE,
+        }
+        worst = build_message_gate()
+        self.assertTrue(set(worst["warnings"]).issubset(declared), worst["warnings"])
+        self.assertEqual(message_gate_warnings(worst), worst["warnings"])
+
+    def test_a_fully_resolved_gate_raises_no_warning(self) -> None:
+        self.assertEqual(_routed_gate()["warnings"], [])
+
+
+class PromptBlockTests(unittest.TestCase):
+    LONG_PROMPT = "You are Codex, acting as the coding executor. " * 40
+
+    def test_the_block_is_bounded_with_the_documented_truncation_marker(self) -> None:
+        gate = _routed_gate(composed_prompt=self.LONG_PROMPT)
+        block = gate["prompt_block"]
+        # The reported total is the length of the stripped prompt the block was
+        # cut from, not of the caller's trailing whitespace.
+        self.assertIn(f"[truncated, {len(self.LONG_PROMPT.strip())} chars total]", block)
+        self.assertLess(len(block), len(self.LONG_PROMPT))
+
+    def test_a_short_prompt_is_shown_whole(self) -> None:
+        prompt = "You are Codex. Refactor the auth module."
+        gate = _routed_gate(composed_prompt=prompt)
+        self.assertIn(prompt, gate["prompt_block"])
+        self.assertNotIn("truncated", gate["prompt_block"])
+
+    def test_the_preview_bound_is_the_declared_one(self) -> None:
+        gate = _routed_gate(composed_prompt=self.LONG_PROMPT)
+        body = gate["prompt_block"].split("\n")[2]
+        self.assertLessEqual(len(body.split("...")[0]), PROMPT_PREVIEW_CHARS)
+
+    def test_a_prompt_that_contains_a_fence_still_nests(self) -> None:
+        gate = _routed_gate(composed_prompt="Run this:\n```sh\nmake test\n```\nThen report.")
+        block = gate["prompt_block"]
+        opening = block.split("\n")[1]
+        self.assertGreater(len(opening), 3, block)
+        self.assertEqual(opening, fence_marker_for("```"))
+
+    def test_no_composed_prompt_means_no_block(self) -> None:
+        self.assertNotIn("prompt_block", _routed_gate(composed_prompt="").keys())
+
+    def test_the_block_is_its_own_message_never_appended_to_the_body(self) -> None:
+        gate = _routed_gate(composed_prompt="You are Codex. Refactor auth.")
+        messages = message_gate_messages(
+            gate, render_profile=RENDER_PROFILE_LIMITED_MARKDOWN, body="Handoff ready."
+        )
+        self.assertEqual(len(messages), 2)
+        self.assertNotIn("HERMES PROMPTING", messages[0])
+        self.assertIn("HERMES PROMPTING", messages[1])
+
+    def test_the_block_names_the_model_it_was_ordered_on(self) -> None:
+        gate = _routed_gate(composed_prompt="You are Codex.")
+        self.assertIn("codex (gpt-5-codex xhigh)", gate["prompt_block"].split("\n")[0])
+
+
+class PayloadShapeTests(unittest.TestCase):
+    def test_the_payload_is_schema_versioned_and_json_safe(self) -> None:
+        gate = _routed_gate(units=_units(3), composed_prompt="You are Codex.", task="refactor auth")
+        self.assertEqual(gate["schema_version"], MESSAGE_GATE_SCHEMA_VERSION)
+        self.assertEqual(json.loads(json.dumps(gate)), gate)
+
+    def test_field_order_names_only_present_fields(self) -> None:
+        gate = _routed_gate(task="")
+        self.assertEqual(sorted(gate["field_order"]), sorted(gate["fields"]))
+
+    def test_an_empty_gate_renders_nothing_rather_than_a_header_of_dashes(self) -> None:
+        self.assertEqual(message_gate_body({}, body="Body only."), "Body only.")
+        self.assertEqual(render_message_gate_lines({}), [])
+
+
+class WiringTests(unittest.TestCase):
+    """Where the gate attaches -- and, more importantly, where it must not."""
+
+    def _payload(self, message: str, **kwargs: object) -> dict:
+        return build_chat_interaction_payload(message, source="discord", **kwargs)  # type: ignore[arg-type]
+
+    def test_a_coding_delegation_carries_the_gate(self) -> None:
+        response = self._payload(CODING_MESSAGE, executor_target="codex", mode="delegate")["chat_response"]
+        gate = response["message_gate"]
+        self.assertEqual(gate["schema_version"], MESSAGE_GATE_SCHEMA_VERSION)
+        self.assertIn("codex", gate["fields"]["model"])
+        self.assertTrue(gate["fields"]["prompt"].startswith("sha256:"))
+
+    def test_the_gate_lines_reach_the_body_the_messenger_actually_posts(self) -> None:
+        rendering = self._payload(CODING_MESSAGE, executor_target="codex", mode="delegate")[
+            "chat_response"
+        ]["messenger_rendering"]
+        self.assertIn("- model — ", rendering["body_text"])
+        self.assertIn("- status — ", rendering["body_text"])
+
+    def test_a_capability_question_carries_no_gate(self) -> None:
+        # The `oh-my-hermes` router skill's own harness is `coding-handling`, so
+        # a harness-only condition gave this answer a `model — unknown` header
+        # and a missing-model warning about a question with no executor at all.
+        response = self._payload("what can OMH do?")["chat_response"]
+        self.assertNotIn("message_gate", response)
+        self.assertNotIn("- model — ", response["messenger_rendering"]["body_text"])
+
+    def test_a_research_route_carries_no_gate(self) -> None:
+        response = self._payload("웹서치해서 최신 자료 정리해줘")["chat_response"]
+        self.assertNotIn("message_gate", response)
+
+    def test_a_maintenance_command_carries_no_gate(self) -> None:
+        response = self._payload("omh update")["chat_response"]
+        self.assertNotIn("message_gate", response)
+
+    def test_the_prompt_block_ships_as_a_follow_up_message_not_as_body(self) -> None:
+        rendering = self._payload(CODING_MESSAGE, executor_target="codex", mode="delegate")[
+            "chat_response"
+        ]["messenger_rendering"]
+        follow_ups = rendering["follow_up_texts"]
+        self.assertEqual(len(follow_ups), 1)
+        self.assertIn("HERMES PROMPTING", follow_ups[0])
+        self.assertNotIn("HERMES PROMPTING", rendering["body_text"])
+
+    def test_a_response_with_nothing_to_add_declares_an_empty_follow_up_list(self) -> None:
+        rendering = self._payload("웹서치해서 최신 자료 정리해줘")["chat_response"]["messenger_rendering"]
+        self.assertEqual(rendering["follow_up_texts"], [])
+
+    def test_every_follow_up_fits_one_message_on_every_platform(self) -> None:
+        for source in ("discord", "slack", "telegram", "generic", "hermes"):
+            with self.subTest(source=source):
+                rendering = build_chat_interaction_payload(
+                    CODING_MESSAGE, source=source, executor_target="codex", mode="delegate"
+                )["chat_response"]["messenger_rendering"]
+                ceiling = int(rendering["chunking"]["max_recommended_chars"])
+                for text in rendering["follow_up_texts"]:
+                    self.assertLessEqual(len(text), ceiling)
+
+    def test_the_gated_body_still_chunks_under_every_platform_ceiling(self) -> None:
+        for source in ("discord", "slack", "telegram"):
+            with self.subTest(source=source):
+                rendering = build_chat_interaction_payload(
+                    CODING_MESSAGE, source=source, executor_target="codex", mode="delegate"
+                )["chat_response"]["messenger_rendering"]
+                ceiling = int(rendering["chunking"]["hard_limit_chars"])
+                for chunk in rendering["chunked_body_texts"]:
+                    self.assertLessEqual(len(chunk), ceiling)
+
+    def test_a_cached_copy_does_not_alias_the_gate(self) -> None:
+        # `_copy_chat_response_payload` starts from a shallow `dict(response)`,
+        # so a nested `fields` dict would be shared by every cached caller.
+        first = self._payload(CODING_MESSAGE, executor_target="codex", mode="delegate")
+        second = self._payload(CODING_MESSAGE, executor_target="codex", mode="delegate")
+        first["chat_response"]["message_gate"]["fields"]["model"] = "poisoned"
+        self.assertNotEqual(second["chat_response"]["message_gate"]["fields"]["model"], "poisoned")
+
+    def test_a_cached_copy_does_not_alias_the_density_policy(self) -> None:
+        first = self._payload(CODING_MESSAGE, executor_target="codex", mode="delegate")
+        second = self._payload(CODING_MESSAGE, executor_target="codex", mode="delegate")
+        first["chat_response"]["messenger_rendering"]["density_policy"]["avoid"].append("poisoned")
+        self.assertNotIn(
+            "poisoned", second["chat_response"]["messenger_rendering"]["density_policy"]["avoid"]
+        )
+
+
+class FenceMarkerOwnershipTests(unittest.TestCase):
+    def test_the_contract_and_the_gate_share_one_fence_implementation(self) -> None:
+        from omh.wrapper.contract import _fence_marker_for
+
+        for text in ("plain", "a ``` fence", "a ```` deeper fence", "```` mixed ``` runs"):
+            with self.subTest(text=text):
+                self.assertEqual(_fence_marker_for(text), fence_marker_for(text))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_message_gate.py
+++ b/tests/test_message_gate.py
@@ -37,10 +37,10 @@ from omh.wrapper.message_gate import (  # noqa: E402
     WARNING_MISSING_MODEL_LABEL,
     WARNING_MISSING_PROMPT_REFERENCE,
     WARNING_MISSING_STATUS,
+    WARNING_UNRESOLVED_MODEL_ROUTE,
     build_message_gate,
     fence_marker_for,
     message_gate_body,
-    message_gate_messages,
     message_gate_warnings,
     render_message_gate_lines,
 )
@@ -69,66 +69,8 @@ def _routed_gate(**overrides: object) -> dict:
     return build_message_gate(**fields)  # type: ignore[arg-type]
 
 
-def _units(count: int) -> list[dict[str, str]]:
-    return [
-        {
-            "label": f"unit-{index}",
-            "owner": "codex",
-            "model": "gpt-5-codex",
-            "reasoning_effort": "xhigh",
-            "status": "running",
-            "elapsed_text": f"{index}m",
-        }
-        for index in range(1, count + 1)
-    ]
-
 
 class RenderShapeTests(unittest.TestCase):
-    def test_the_rich_profile_opens_and_closes_exactly_one_fence(self) -> None:
-        # Header and roster used to be two adjacent fenced blocks, which renders
-        # as a fault rather than as two sections.
-        gate = _routed_gate(units=_units(3))
-        lines = render_message_gate_lines(gate, render_profile=RENDER_PROFILE_RICH_MARKDOWN)
-        self.assertEqual(lines.count("```"), 2)
-        self.assertEqual(lines[0], "```")
-        self.assertEqual(lines[-1], "```")
-
-    def test_the_limited_profile_never_fences_the_header(self) -> None:
-        gate = _routed_gate(units=_units(3))
-        lines = render_message_gate_lines(gate, render_profile=RENDER_PROFILE_LIMITED_MARKDOWN)
-        self.assertNotIn("```", lines)
-        self.assertTrue(all(line.startswith("- ") for line in lines), lines)
-
-    def test_a_full_limited_header_stays_inside_the_declared_bullet_ceiling(self) -> None:
-        gate = _routed_gate(task="auth 모듈 리팩터링", units=_units(20))
-        lines = render_message_gate_lines(gate, render_profile=RENDER_PROFILE_LIMITED_MARKDOWN)
-        bullets = [line for line in lines if line.startswith("- ")]
-        self.assertLessEqual(len(bullets), DECLARED_MAX_BULLETS, "\n".join(lines))
-
-    def test_a_capped_roster_says_so_on_its_own_line(self) -> None:
-        gate = _routed_gate(units=_units(20))
-        self.assertEqual(gate["roster_total"], 20)
-        self.assertLess(gate["roster_count"], 20)
-        for profile in (RENDER_PROFILE_LIMITED_MARKDOWN, RENDER_PROFILE_RICH_MARKDOWN):
-            with self.subTest(profile=profile):
-                rendered = "\n".join(render_message_gate_lines(gate, render_profile=profile))
-                self.assertIn("more units", rendered)
-
-    def test_a_complete_roster_states_no_omission(self) -> None:
-        gate = _routed_gate(units=_units(3))
-        rendered = "\n".join(render_message_gate_lines(gate, render_profile=RENDER_PROFILE_LIMITED_MARKDOWN))
-        self.assertNotIn("more units", rendered)
-
-    def test_observed_roster_times_survive_the_payload_round_trip(self) -> None:
-        # Rows leave the builder keyed `elapsed`; re-running the raw-unit
-        # normalizer over them looked for `elapsed_text`, found nothing, and
-        # rewrote every observed time to `unknown`.
-        gate = _routed_gate(units=_units(3))
-        rendered = "\n".join(render_message_gate_lines(gate, render_profile=RENDER_PROFILE_LIMITED_MARKDOWN))
-        self.assertIn("1m", rendered)
-        self.assertIn("3m", rendered)
-        self.assertNotIn(f"— {UNKNOWN}", rendered)
-
     def test_a_newline_in_a_value_cannot_break_the_rows_below_it(self) -> None:
         gate = _routed_gate(skill="ulw\nwork\nbroken")
         lines = render_message_gate_lines(gate, render_profile=RENDER_PROFILE_LIMITED_MARKDOWN)
@@ -167,11 +109,6 @@ class DisclosureHonestyTests(unittest.TestCase):
         self.assertEqual(gate["fields"]["prompt"], UNKNOWN)
         self.assertIn(WARNING_MISSING_STATUS, gate["warnings"])
         self.assertIn(WARNING_MISSING_PROMPT_REFERENCE, gate["warnings"])
-
-    def test_a_roster_lane_with_no_model_warns_even_when_the_header_has_one(self) -> None:
-        gate = _routed_gate(units=[{"label": "unit-1", "status": "running", "elapsed_text": "2m"}])
-        self.assertNotEqual(gate["fields"]["model"], UNKNOWN)
-        self.assertIn(WARNING_MISSING_MODEL_LABEL, gate["warnings"])
 
     def test_an_unadmitted_task_is_absent_rather_than_unknown(self) -> None:
         # The chat envelope declares `metadata_only` unless the wrapper opted
@@ -219,10 +156,21 @@ class DisclosureHonestyTests(unittest.TestCase):
             WARNING_EMPTY_PARENTHESES,
             WARNING_MISSING_STATUS,
             WARNING_MISSING_PROMPT_REFERENCE,
+            WARNING_UNRESOLVED_MODEL_ROUTE,
         }
-        worst = build_message_gate()
-        self.assertTrue(set(worst["warnings"]).issubset(declared), worst["warnings"])
-        self.assertEqual(message_gate_warnings(worst), worst["warnings"])
+        # Every shape this module can produce, not just the empty one: an
+        # unnamed code reaching an adapter is a code it cannot act on.
+        for gate in (
+            build_message_gate(),
+            _routed_gate(),
+            _routed_gate(model="", reasoning_effort=""),
+            _routed_gate(executor="", model="", reasoning_effort=""),
+            _routed_gate(status="", prompt_sha256=""),
+            build_message_gate(skill="ulw-goal", status="active", discloses_model=False),
+        ):
+            with self.subTest(fields=gate["fields"]):
+                self.assertTrue(set(gate["warnings"]).issubset(declared), gate["warnings"])
+                self.assertEqual(message_gate_warnings(gate), gate["warnings"])
 
     def test_a_fully_resolved_gate_raises_no_warning(self) -> None:
         self.assertEqual(_routed_gate()["warnings"], [])
@@ -260,15 +208,6 @@ class PromptBlockTests(unittest.TestCase):
     def test_no_composed_prompt_means_no_block(self) -> None:
         self.assertNotIn("prompt_block", _routed_gate(composed_prompt="").keys())
 
-    def test_the_block_is_its_own_message_never_appended_to_the_body(self) -> None:
-        gate = _routed_gate(composed_prompt="You are Codex. Refactor auth.")
-        messages = message_gate_messages(
-            gate, render_profile=RENDER_PROFILE_LIMITED_MARKDOWN, body="Handoff ready."
-        )
-        self.assertEqual(len(messages), 2)
-        self.assertNotIn("HERMES PROMPTING", messages[0])
-        self.assertIn("HERMES PROMPTING", messages[1])
-
     def test_the_block_names_the_model_it_was_ordered_on(self) -> None:
         gate = _routed_gate(composed_prompt="You are Codex.")
         self.assertIn("codex (gpt-5-codex xhigh)", gate["prompt_block"].split("\n")[0])
@@ -276,7 +215,7 @@ class PromptBlockTests(unittest.TestCase):
 
 class PayloadShapeTests(unittest.TestCase):
     def test_the_payload_is_schema_versioned_and_json_safe(self) -> None:
-        gate = _routed_gate(units=_units(3), composed_prompt="You are Codex.", task="refactor auth")
+        gate = _routed_gate(composed_prompt="You are Codex.", task="refactor auth")
         self.assertEqual(gate["schema_version"], MESSAGE_GATE_SCHEMA_VERSION)
         self.assertEqual(json.loads(json.dumps(gate)), gate)
 
@@ -293,7 +232,8 @@ class WiringTests(unittest.TestCase):
     """Where the gate attaches -- and, more importantly, where it must not."""
 
     def _payload(self, message: str, **kwargs: object) -> dict:
-        return build_chat_interaction_payload(message, source="discord", **kwargs)  # type: ignore[arg-type]
+        kwargs.setdefault("source", "discord")
+        return build_chat_interaction_payload(message, **kwargs)  # type: ignore[arg-type]
 
     def test_a_coding_delegation_carries_the_gate(self) -> None:
         response = self._payload(CODING_MESSAGE, executor_target="codex", mode="delegate")["chat_response"]
@@ -393,10 +333,72 @@ class WiringTests(unittest.TestCase):
         self.assertEqual(payload["redaction_policy"], "stdout_includes_message")
         gate = payload["chat_response"]["message_gate"]
         self.assertIn(marker, gate["fields"]["task"])
-        # The composed prompt keeps its `{message}` placeholder even here: the
-        # gate reads the delegation payload's own message, not the envelope's.
+        # The prompt block does NOT carry the marker, but not because the
+        # message is withheld from it -- with include_message the template IS
+        # substituted, and the marker sits at offset ~4246 of a 4258-character
+        # composed prompt. It is absent because the block is head-bounded at
+        # PROMPT_PREVIEW_CHARS. Asserting the bound rather than the absence, so
+        # a raised bound fails here instead of silently changing what ships.
         for text in payload["chat_response"]["messenger_rendering"]["follow_up_texts"]:
-            self.assertNotIn(marker, text)
+            body = text.split("\n", 2)[2] if text.count("\n") >= 2 else text
+            self.assertLessEqual(len(body.split("...")[0]), PROMPT_PREVIEW_CHARS)
+
+    def test_a_coding_status_route_carries_no_gate(self) -> None:
+        # `build_chat_response_from_route` emits kind="handoff" for the
+        # `ultraprocess` coding-STATUS route, which prepares no delegation and
+        # resolves no executor. Qualifying on the kind alone put a header
+        # reading `model — unknown` plus a spurious warning on a status
+        # question -- the same false positive the harness clause was tightened
+        # to remove, arriving through a different door.
+        for message in (
+            "show the coding agent status",
+            "show coding handoff status",
+            "status of the coding agent",
+        ):
+            with self.subTest(message=message):
+                response = self._payload(message)["chat_response"]
+                self.assertEqual(response["kind"], "handoff")
+                self.assertNotIn("message_gate", response)
+                self.assertNotIn("- model — ", response["messenger_rendering"]["body_text"])
+
+    def test_the_canonical_body_carries_no_render_profile(self) -> None:
+        # `chat_response.body` and the blocks derived from it are the
+        # dialect-neutral fields the adapter runbook promises. Prepending a
+        # source-resolved header upstream baked one profile's shaping into
+        # them, so a wrapper relaying a Discord envelope onto a rich surface
+        # was stuck with bullets chosen by the ingress source.
+        bodies = {
+            source: self._payload(CODING_MESSAGE, source=source, executor_target="codex", mode="delegate")[
+                "chat_response"
+            ]["body"]
+            for source in ("discord", "generic", "hermes", "slack")
+        }
+        self.assertEqual(len(set(bodies.values())), 1, bodies)
+        for body in bodies.values():
+            self.assertNotIn("- model — ", body)
+            self.assertNotIn("MODEL   ", body)
+
+    def test_the_header_still_reaches_the_body_the_messenger_posts(self) -> None:
+        limited = self._payload(CODING_MESSAGE, source="discord", executor_target="codex", mode="delegate")
+        rich = self._payload(CODING_MESSAGE, source="hermes", executor_target="codex", mode="delegate")
+        self.assertIn("- model — ", limited["chat_response"]["messenger_rendering"]["body_text"])
+        self.assertIn("MODEL   ", rich["chat_response"]["messenger_rendering"]["body_text"])
+        # The fallback is what a rich envelope degrades to, so it takes bullets
+        # even when the primary body took the aligned card.
+        self.assertIn("- model — ", rich["chat_response"]["messenger_rendering"]["fallback_body_text"])
+
+    def test_the_main_delegate_path_names_an_unresolved_model_route(self) -> None:
+        # The guarantee this replaces was written against a shape production
+        # never emits (no executor at all). On the real path the executor IS
+        # resolved and the route is not, which read `codex (executor default)`
+        # with no warning of any kind.
+        gate = self._payload(CODING_MESSAGE, executor_target="codex", mode="delegate")["chat_response"][
+            "message_gate"
+        ]
+        self.assertEqual(gate["fields"]["model"], "codex (executor default)")
+        self.assertIs(gate["model_route_resolved"], False)
+        self.assertIn(WARNING_UNRESOLVED_MODEL_ROUTE, gate["warnings"])
+        self.assertNotIn(WARNING_MISSING_MODEL_LABEL, gate["warnings"])
 
     def test_a_cached_copy_does_not_alias_the_gate(self) -> None:
         # `_copy_chat_response_payload` starts from a shallow `dict(response)`,
@@ -415,6 +417,64 @@ class WiringTests(unittest.TestCase):
         )
 
 
+class FollowUpBoundTests(unittest.TestCase):
+    """`_follow_up_texts` is a public key; the next producer will not be 250 chars."""
+
+    def _bound(self, text: str, limit: int) -> list[str]:
+        from omh.wrapper.contract import _follow_up_texts
+
+        return _follow_up_texts([text], limit)
+
+    def test_a_long_follow_up_is_cut_to_the_limit_including_its_marker(self) -> None:
+        # `bounded_prompt_preview` slices to max_chars and THEN appends the
+        # marker, so passing the ceiling straight through returned ~35 chars
+        # over it.
+        for limit in (100, 400, 1700):
+            with self.subTest(limit=limit):
+                out = self._bound("x" * 5000, limit)
+                self.assertEqual(len(out), 1)
+                self.assertLessEqual(len(out[0]), limit)
+                self.assertIn("chars total]", out[0])
+
+    def test_a_fence_cut_in_half_is_closed_again(self) -> None:
+        # Truncation was chosen over chunking specifically to avoid an
+        # unclosed fence, and then produced one.
+        out = self._bound("HERMES PROMPTING\n```\n" + "x" * 5000 + "\n```", 300)[0]
+        self.assertLessEqual(len(out), 300)
+        self.assertTrue(out.rstrip().endswith("```"), out[-80:])
+        self.assertEqual(out.count("```"), 2)
+
+    def test_a_follow_up_already_under_the_limit_is_untouched(self) -> None:
+        text = "HERMES PROMPTING\n```\nshort\n```"
+        self.assertEqual(self._bound(text, 1700), [text])
+
+    def test_empty_and_non_list_inputs_yield_no_follow_ups(self) -> None:
+        from omh.wrapper.contract import _follow_up_texts
+
+        for value in ((), [], ["", "   ", None], "not-a-list", None, 42):
+            with self.subTest(value=value):
+                self.assertEqual(_follow_up_texts(value, 1700), [])
+
+
+class SchemaToleranceTests(unittest.TestCase):
+    def test_a_field_key_this_version_does_not_know_renders_instead_of_crashing(self) -> None:
+        # `omh_message_gate/v1` is round-trippable and public; a v2 key must
+        # degrade, not raise, in a v1 renderer.
+        payload = {
+            "schema_version": MESSAGE_GATE_SCHEMA_VERSION,
+            "fields": {"skill": "ulw-work", "future_key": "some value"},
+            "field_order": ["skill", "future_key"],
+        }
+        for profile in (RENDER_PROFILE_LIMITED_MARKDOWN, RENDER_PROFILE_RICH_MARKDOWN):
+            with self.subTest(profile=profile):
+                rendered = "\n".join(render_message_gate_lines(payload, render_profile=profile))
+                self.assertIn("some value", rendered)
+
+    def test_a_payload_of_only_unknown_keys_renders_nothing_rather_than_raising(self) -> None:
+        payload = {"fields": {"future_key": "v"}, "field_order": []}
+        self.assertEqual(render_message_gate_lines(payload, render_profile=RENDER_PROFILE_RICH_MARKDOWN), [])
+
+
 class FenceMarkerOwnershipTests(unittest.TestCase):
     def test_the_contract_and_the_gate_share_one_fence_implementation(self) -> None:
         from omh.wrapper.contract import _fence_marker_for
@@ -423,9 +483,6 @@ class FenceMarkerOwnershipTests(unittest.TestCase):
             with self.subTest(text=text):
                 self.assertEqual(_fence_marker_for(text), fence_marker_for(text))
 
-
-if __name__ == "__main__":
-    unittest.main()
 
 
 class GoalSurfaceTests(unittest.TestCase):
@@ -466,8 +523,18 @@ class GoalSurfaceTests(unittest.TestCase):
         self.assertIn("- skill — ulw-goal", rendered)
         self.assertIn("- status — active", rendered)
 
+    def test_a_goal_digest_is_labelled_objective_not_prompt(self) -> None:
+        # A goal ledger holds an objective. Calling the row PROMPT asserts a
+        # provenance category the card does not have.
+        rendered = self._render()
+        self.assertIn("- objective — sha256:", rendered)
+        self.assertNotIn("prompt", rendered)
+
     def test_a_declared_non_disclosure_raises_no_missing_model_warning(self) -> None:
-        gate = build_message_gate(skill="ulw-goal", status="active", prompt_sha256="abc123", discloses_model=False)
+        gate = build_message_gate(
+            skill="ulw-goal", status="active", prompt_sha256="abc123",
+            discloses_model=False, reference_kind="objective",
+        )
         self.assertNotIn("model", gate["fields"])
         self.assertNotIn(WARNING_MISSING_MODEL_LABEL, gate["warnings"])
 
@@ -478,7 +545,10 @@ class GoalSurfaceTests(unittest.TestCase):
 
     def test_the_rich_profile_fences_the_goal_header_too(self) -> None:
         rendered = self._render(render_profile=RENDER_PROFILE_RICH_MARKDOWN)
-        self.assertIn("SKILL   ulw-goal", rendered)
+        # Width-agnostic: the padding follows the longest label present, which
+        # OBJECTIVE changed once already.
+        self.assertRegex(rendered, r"SKILL +ulw-goal")
+        self.assertRegex(rendered, r"OBJECTIVE +sha256:")
         self.assertEqual(rendered.count("```"), 2)
 
     def test_no_table_is_ever_rendered(self) -> None:
@@ -532,3 +602,6 @@ class GoalCliTests(unittest.TestCase):
             status, stdout, _ = run_cli([*self._base(Path(tmp)), "goal", "status"], output_json=False)
         self.assertEqual(status, 0)
         self.assertEqual(json.loads(stdout), {"goals": []})
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_message_gate.py
+++ b/tests/test_message_gate.py
@@ -358,6 +358,46 @@ class WiringTests(unittest.TestCase):
                 for chunk in rendering["chunked_body_texts"]:
                     self.assertLessEqual(len(chunk), ceiling)
 
+    def test_a_message_the_wrapper_did_not_admit_reaches_no_rendered_surface(self) -> None:
+        # The strongest claim this file makes, so it is made with a marker
+        # string rather than by inspecting which field was populated: with the
+        # default `metadata_only` posture the message must not appear anywhere
+        # a messenger would post, in any form.
+        marker = "SENTINELTOKEN0413"
+        payload = build_chat_interaction_payload(
+            f"{CODING_MESSAGE} {marker}", source="discord", executor_target="codex", mode="delegate"
+        )
+        self.assertEqual(payload["redaction_policy"], "metadata_only")
+        self.assertNotIn("message", payload)
+        response = payload["chat_response"]
+        self.assertNotIn("task", response["message_gate"]["fields"])
+        rendering = response["messenger_rendering"]
+        for surface in (
+            rendering["body_text"],
+            rendering["fallback_body_text"],
+            *rendering["chunked_body_texts"],
+            *rendering["follow_up_texts"],
+            json.dumps(response["message_gate"], ensure_ascii=False),
+        ):
+            self.assertNotIn(marker, surface)
+
+    def test_an_admitted_message_reaches_the_task_row_and_only_there(self) -> None:
+        marker = "SENTINELTOKEN0413"
+        payload = build_chat_interaction_payload(
+            f"{CODING_MESSAGE} {marker}",
+            source="discord",
+            executor_target="codex",
+            mode="delegate",
+            include_message=True,
+        )
+        self.assertEqual(payload["redaction_policy"], "stdout_includes_message")
+        gate = payload["chat_response"]["message_gate"]
+        self.assertIn(marker, gate["fields"]["task"])
+        # The composed prompt keeps its `{message}` placeholder even here: the
+        # gate reads the delegation payload's own message, not the envelope's.
+        for text in payload["chat_response"]["messenger_rendering"]["follow_up_texts"]:
+            self.assertNotIn(marker, text)
+
     def test_a_cached_copy_does_not_alias_the_gate(self) -> None:
         # `_copy_chat_response_payload` starts from a shallow `dict(response)`,
         # so a nested `fields` dict would be shared by every cached caller.

--- a/tests/test_message_gate.py
+++ b/tests/test_message_gate.py
@@ -400,6 +400,33 @@ class WiringTests(unittest.TestCase):
         self.assertIn(WARNING_UNRESOLVED_MODEL_ROUTE, gate["warnings"])
         self.assertNotIn(WARNING_MISSING_MODEL_LABEL, gate["warnings"])
 
+    def test_every_delegation_shape_shows_its_composed_order(self) -> None:
+        # `build_coding_delegation_payload` emits exactly one of three handoff
+        # shapes, and reading only `executor_handoff` covered one of them.
+        # `claude-code` and `generic` produce `prompt_handoff`, `hermes`
+        # produces `runtime_handoff` -- all three shipped a PROMPT digest with
+        # no composed order and no signal that one was missing.
+        expected = {
+            "codex": "executor_handoff",
+            "claude-code": "prompt_handoff",
+            "hermes": "runtime_handoff",
+            "generic": "prompt_handoff",
+        }
+        for target, shape in expected.items():
+            with self.subTest(executor=target):
+                payload = self._payload(CODING_MESSAGE, executor_target=target, mode="delegate")
+                delegation = payload["delegation"]
+                self.assertTrue(
+                    delegation[shape].get("prompt_template"),
+                    f"{target} no longer produces {shape}; update this map",
+                )
+                gate = payload["chat_response"]["message_gate"]
+                self.assertIn("HERMES PROMPTING", gate["prompt_block"])
+                self.assertEqual(
+                    payload["chat_response"]["messenger_rendering"]["follow_up_texts"][0],
+                    gate["prompt_block"],
+                )
+
     def test_a_cached_copy_does_not_alias_the_gate(self) -> None:
         # `_copy_chat_response_payload` starts from a shallow `dict(response)`,
         # so a nested `fields` dict would be shared by every cached caller.

--- a/tests/test_message_gate.py
+++ b/tests/test_message_gate.py
@@ -48,6 +48,9 @@ from omh.wrapper.message_gate import (  # noqa: E402
 # `messenger_rendering.density_policy` publishes this ceiling for every limited
 # profile. The gate is a limited-profile surface, so it owes the same number.
 DECLARED_MAX_BULLETS = 12
+# `_DIGEST_PREFIX` in the module; restated here so a widened prefix has to be a
+# deliberate edit in two places rather than a silently longer row.
+DECLARED_DIGEST_PREFIX = 12
 
 CODING_MESSAGE = "auth 모듈 리팩터링을 코덱스한테 맡겨줘"
 
@@ -190,6 +193,18 @@ class DisclosureHonestyTests(unittest.TestCase):
         self.assertTrue(prompt.startswith("sha256:"), prompt)
         self.assertIn("412 chars", prompt)
         self.assertNotIn(CODING_MESSAGE, prompt)
+
+    def test_the_digest_is_cut_to_the_declared_prefix(self) -> None:
+        # A full 64-character digest is still a reference rather than a leak,
+        # but it costs 52 characters of a row that has a messenger ceiling to
+        # respect, and `omh coding fanout` already prints twelve.
+        digest = "533d406a486317830d49c302e798c242bbb9105fa8525e6aac89217fa397e48c"
+        gate = _routed_gate(prompt_sha256=digest)
+        self.assertEqual(gate["fields"]["prompt"].split(" ")[0], f"sha256:{digest[:DECLARED_DIGEST_PREFIX]}")
+
+    def test_a_non_hex_prompt_reference_is_stripped_to_its_alphanumerics(self) -> None:
+        gate = _routed_gate(prompt_sha256="  ab-cd ef/gh  ")
+        self.assertEqual(gate["fields"]["prompt"].split(" ")[0], "sha256:abcdefgh")
 
     def test_an_unmeasured_prompt_length_is_omitted_not_zeroed(self) -> None:
         for value in (None, "", -1, True):
@@ -371,3 +386,109 @@ class FenceMarkerOwnershipTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class GoalSurfaceTests(unittest.TestCase):
+    """`omh goal status --text` -- the second gate surface, with no executor."""
+
+    CARD = {
+        "goal_status": "active",
+        "objective_summary": "포맷 선택 화면에서 진입하는 별도 가이드 페이지.",
+        "progress": {
+            "criteria_total": 6,
+            "criteria_satisfied": 2,
+            "required_total": 4,
+            "required_satisfied": 1,
+            "active_blockers": 0,
+            "percent_required_satisfied": 25,
+        },
+        "next_action": "record_checkpoint",
+        "checkpoint_lines": ["- a1b2c3: router wired — done, observed"],
+        "missing_criteria": [{"summary": "guide page renders"}, "a bare string criterion"],
+        "active_blockers": [],
+    }
+
+    def _render(self, card: dict | None = None, **kwargs: str) -> str:
+        from omh.workflows.goal_ledger import render_goal_status_text
+
+        return render_goal_status_text(card if card is not None else self.CARD, **kwargs)  # type: ignore[arg-type]
+
+    def test_the_criteria_line_reads_the_keys_the_ledger_actually_writes(self) -> None:
+        # `_goal_progress` writes `criteria_satisfied` / `criteria_total`. Reading
+        # `satisfied` / `total` rendered a six-criteria goal as `0 of 0` -- a
+        # wrong number that reads exactly like a right one.
+        self.assertIn("Criteria: 2 of 6 satisfied", self._render())
+        self.assertIn("25% of required", self._render())
+
+    def test_a_goal_declares_no_model_rather_than_an_unknown_one(self) -> None:
+        rendered = self._render()
+        self.assertNotIn("model", rendered)
+        self.assertIn("- skill — ulw-goal", rendered)
+        self.assertIn("- status — active", rendered)
+
+    def test_a_declared_non_disclosure_raises_no_missing_model_warning(self) -> None:
+        gate = build_message_gate(skill="ulw-goal", status="active", prompt_sha256="abc123", discloses_model=False)
+        self.assertNotIn("model", gate["fields"])
+        self.assertNotIn(WARNING_MISSING_MODEL_LABEL, gate["warnings"])
+
+    def test_a_delegation_surface_still_warns_when_it_resolved_no_model(self) -> None:
+        # The escape hatch above must not weaken the guard it sits next to.
+        gate = build_message_gate(skill="ulw-work", status="prepared_not_observed", prompt_sha256="abc123")
+        self.assertIn(WARNING_MISSING_MODEL_LABEL, gate["warnings"])
+
+    def test_the_rich_profile_fences_the_goal_header_too(self) -> None:
+        rendered = self._render(render_profile=RENDER_PROFILE_RICH_MARKDOWN)
+        self.assertIn("SKILL   ulw-goal", rendered)
+        self.assertEqual(rendered.count("```"), 2)
+
+    def test_no_table_is_ever_rendered(self) -> None:
+        # The one-off `render_guidance` this generalizes exists because a live
+        # Slack session lost a markdown table.
+        for profile in (RENDER_PROFILE_LIMITED_MARKDOWN, RENDER_PROFILE_RICH_MARKDOWN):
+            with self.subTest(profile=profile):
+                self.assertNotIn(" | ", self._render(render_profile=profile))
+
+    def test_ledger_entries_render_whether_stored_as_dicts_or_strings(self) -> None:
+        rendered = self._render()
+        self.assertIn("- guide page renders", rendered)
+        self.assertIn("- a bare string criterion", rendered)
+
+    def test_an_empty_card_renders_a_sentence_rather_than_a_blank_body(self) -> None:
+        rendered = self._render({})
+        self.assertIn("(no objective recorded)", rendered)
+        self.assertIn("No checkpoints recorded.", rendered)
+
+    def test_the_last_line_is_the_claim_boundary(self) -> None:
+        from omh.workflows.goal_ledger import GOAL_STATUS_CLAIM_BOUNDARY
+
+        self.assertTrue(self._render().endswith(GOAL_STATUS_CLAIM_BOUNDARY))
+
+
+class GoalCliTests(unittest.TestCase):
+    def _base(self, root) -> list[str]:
+        return ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+    def test_text_requires_a_goal_and_says_so(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        from _cli_harness import run_cli
+
+        with tempfile.TemporaryDirectory() as tmp:
+            status, stdout, stderr = run_cli(
+                [*self._base(Path(tmp)), "goal", "status", "--text"], output_json=False
+            )
+        self.assertNotEqual(status, 0)
+        self.assertEqual(stdout, "")
+        self.assertIn("--goal", stderr)
+
+    def test_json_stays_the_default_for_this_control_plane_command(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        from _cli_harness import run_cli
+
+        with tempfile.TemporaryDirectory() as tmp:
+            status, stdout, _ = run_cli([*self._base(Path(tmp)), "goal", "status"], output_json=False)
+        self.assertEqual(status, 0)
+        self.assertEqual(json.loads(stdout), {"goals": []})

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -3213,7 +3213,13 @@ class RouterContentTests(unittest.TestCase):
             # when the four-surface demo table (22 lines) was added above the
             # h1 in every language; it still sits below README.md's length.
             self.assertLess(len(localized_readme.splitlines()), 260)
-            self.assertIn("prepared_not_observed", localized_readme)
+            # The trust surface is the evidence table, not the wire token that
+            # used to stand in for it. Pinning the token meant a README could
+            # satisfy this by naming a value no reader could decode; pinning
+            # the two rows means it has to state the distinction that matters —
+            # an executor reporting itself done is not a checked result.
+            self.assertIn("`Plan · not run`", localized_readme)
+            self.assertIn("`Code · reported done`", localized_readme)
             self.assertIn("omh setup", localized_readme)
             self.assertIn("```sh\nomh update\nomh doctor\n```", localized_readme)
             for image in (
@@ -3239,7 +3245,10 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("## Legacy Migration and Reactivation", memory)
         self.assertIn("## Batch Context Updates", memory)
         self.assertIn("Agent/operator only", memory)
-        self.assertIn("prepared_not_observed", readme)
+        # Same reason as the localized assertion above: the English README
+        # earns trust by stating the distinction, not by printing the token.
+        self.assertIn("`Plan · not run`", readme)
+        self.assertIn("`Code · reported done`", readme)
         self.assertIn("assets/hermes-agent-hero.png", readme)
         self.assertIn("assets/friren-agent-omh-callout.png", readme)
         self.assertNotIn("assets/artengine-friren-profile-card.png", readme)

--- a/tests/test_status_board_auto_surface.py
+++ b/tests/test_status_board_auto_surface.py
@@ -88,8 +88,8 @@ class RunningWorkBoardReaderTests(unittest.TestCase):
             # parenthesized shape, so drift in this plugin-bundle copy of the
             # renderer fails the suite, not just the JSON fields.
             text = render_running_work_block_text(board)
-            self.assertIn(f"- {_FANOUT_ID}/core: codex (gpt-5-codex medium) — running", text)
-            self.assertIn(f"- {_FANOUT_ID}/docs: codex (gpt-5-codex medium) — running", text)
+            self.assertIn(f"- {_FANOUT_ID}/core: codex (gpt-5-codex medium) — Code · running", text)
+            self.assertIn(f"- {_FANOUT_ID}/docs: codex (gpt-5-codex medium) — Code · running", text)
             self.assertNotIn(" — (", text)
 
     def test_more_units_than_the_limit_states_truncation(self) -> None:
@@ -122,7 +122,7 @@ class RunningWorkBoardReaderTests(unittest.TestCase):
             board = read_running_work_board(paths.omh_home)
             self.assertEqual(board["units"][0]["model_label"], "openrouter/qwen-3.5-coder high")
             text = render_running_work_block_text(board)
-            self.assertIn(f"- {_FANOUT_ID}/omo-core: omo (openrouter/qwen-3.5-coder high) — running", text)
+            self.assertIn(f"- {_FANOUT_ID}/omo-core: omo (openrouter/qwen-3.5-coder high) — Code · running", text)
             self.assertNotIn(" — (", text)
 
     def test_a_malformed_marker_is_skipped_without_raising(self) -> None:


### PR DESCRIPTION
## Capability

Two changes that answer the same complaint: OMH knew things it never told anyone, and the things it did tell you were unreadable.

**Before**
```
[omh] ai-slop-cleaner - A coding-agent handoff is ready.

I can open Codex with this prepared handoff, but I will not claim
implementation until coding-agent evidence is observed.

Prepared staged workflow: ... Status: prepared_not_observed. 기억 정리가...
```

**After** — message 1
```
- skill — ai-slop-cleaner
- model — codex (executor default)
- status — Plan · not run
- prompt — sha256:671204d076bf · 23 chars

I can open Codex with this prepared handoff, ...
```
message 2
```
HERMES PROMPTING — codex (executor default)
​```
You are Codex, acting as the coding executor for a Hermes-orchestrated request.

Executor target: codex
Keep the dispatched task text gene... [truncated, 4231 chars total]
​```
```

Terminal board:
```
LABEL   RUNTIME      MODEL              STATUS                ELAPSED
auth-1  codex        gpt-5-codex xhigh  Code · running        2m
auth-2  claude-code  opus-5 high        Code · reported done  5m
auth-3  codex        executor default   Setup · failed        unknown
auth-4  codex        executor default   Plan · not run        unknown
```

## Motivation

**The message gate.** `usage_trace` already resolved the workflow, harness, evidence state, and executor; `_status_model_label` resolved the route; `_base_interaction` hashed the message. `_chat_response` then passed one line — `visible_prefix` — to the renderer and dropped the rest. `DELEGATE_MODEL_LABEL_RULE` states the `(model effort)` discipline in prose, but `render.py` gates that block to handoff-shaped skills, so it reaches **7 of 103** skill bodies and no surface ever checked that an agent obeyed it.

**The vocabulary.** `prepared_not_observed` means nothing in a chat bubble. The project owner, who wrote the model, said they still could not parse it — including in the README.

## Implementation

- **`src/wrapper/message_gate.py`** — builds `omh_message_gate/v1` and renders per profile: a fenced aligned card on `rich_markdown`, bullets on `limited_markdown`, the same branch `status_board_messenger_body` already makes.
- **`messenger_rendering` gains `follow_up_texts`** — whole messages posted after the body, distinct from `chunked_body_texts` (one body cut to fit). Documented in the adapter runbook and the example bot.
- **`src/evidence/labels.py`** — the only place the human-facing words live. Two axes: **phase** (`Route`/`Plan`/`Code`/`Setup`/`Test`/`Review`/`Ship`) and **confidence** (`not run`/`running`/`partly seen`/`reported done`/`seen`/`verified`/`failed`/`blocked`/`cancelled`), rendered `Plan · not run`.
- **Three vocabularies became one.** `chat.py` said "prepared, not observed", `menubar_status.py` spelled the wire value out loud, the board printed the token. All route through the label module now.
- **`omh goal status --text`** — JSON stays the default because `main.py`'s epilog documents control-plane groups as JSON-by-design.

### Why two axes, and why `ready` is not a label

Collapsing them is the failure the vocabulary exists to prevent: `Code` alone cannot say whether OMH watched an executor run or only wrote a prompt for one. Every phase label is a noun — "Coding · not run" reads as in-progress on a scan; "Code · not run" cannot.

Of the owner's requested words, four survive: `planning`→**Plan**, `coding`→**Code**, `test`→**Test**, `verified`→**verified**. `ready` does not, and the reason is this repo's own code: `operator_productivity.OBSERVED_CLAIM_STATUSES` lists it beside `complete` and `merged`, and `_nested_observed_claim_errors` refuses any payload whose `status` carries one. It survives as prose — `ready to run, nothing has run yet`. `building` was dropped: OMH observes no assembly step distinct from an executor running.

**Nothing on the wire moved.** Every JSON value, dict key, and all ~169 existing assertions keep their literals. An external wrapper gating on `prepared_not_observed` gates identically.

## Verification observed

- Full suite **4250 passing** (85 new); ruff clean; three byte gates; `git diff --check` clean.
- **18 mutations against the gate, 18 killed.** Two survivors were fixed by adding the missing assertion.
- Wheel built and inspected to confirm `omh/evidence/*` ships — a new `src/` package that tests can import from a checkout but never installs is the failure mode here.
- Redaction proven with a sentinel swept across `body_text`, `fallback_body_text`, every chunk, every follow-up, and the serialized gate: **zero paths** carry it under the default `metadata_only` posture.
- Live across discord/slack/telegram/hermes/generic, `omh coding status-board`, `omh chat route`, `omh goal status --text`.

### Defects found and fixed on the way

- `density_policy` was reachable through the cached-copy path without deep-copying — every cached caller shared one dict and one list. Pre-existing.
- The goal criteria line read `progress["satisfied"]` while `_goal_progress` writes `criteria_satisfied`, rendering a six-criteria goal as `Criteria: 0 of 0`.
- `claude-code` and `generic` produce `prompt_handoff`, `hermes` produces `runtime_handoff`; reading only `executor_handoff` meant Claude Code shipped a digest with no composed order.
- `if __name__ == "__main__"` mid-file made the test script run 44 of 55 tests.

## Review

An independent review requested changes; all four HIGH and five MEDIUM findings are addressed. The header is no longer prepended upstream — it was baking an ingress-source-derived profile into `chat_response.body` and `body_blocks`, which the runbook promises stay dialect-neutral. The parallel-lane roster was **removed rather than shipped**: no production caller, and `status_board_messenger_body` already renders lanes with seven columns.

## Risks

- `follow_up_texts` is a new key. The runbook and example bot document it, but a third-party bot that cherry-picks fields will drop the prompt block until it updates. The header is unaffected — it rides in `body_text`. The bundled plugin returns the whole payload, so a Hermes host already receives it.
- `docs/WORKFLOWS.md` keeps its raw tokens deliberately: those are agent instructions naming the value to write, not prose for humans.
- ja/zh README rewrites are structurally verified; no native reader reviewed the sentences.
- No real Discord/Slack/Telegram client rendered these. Platform evidence is the simulated ceiling checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)