### PR TITLE
refactor: key the optional runtime store validator registry by store

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1085,13 +1085,23 @@ module under `src/commands/` references a writer at all.
 `omh runtime validate` is the store's third consumer, and the one that reaches
 the chain validator. `runtime/artifacts.py::validate_runtime` reports the store
 under an `approval_receipts` key beside `external_effect_receipts`, and
-`_validate_run_approval_receipts` applies the per-record validator
-`records.OPTIONAL_APPROVAL_STORE_VALIDATORS` names to the receipts belonging to
-each run. Without those two callers the registry validated nothing: an
-unparseable line, a duplicate receipt id, and a forked supersede chain — two
-answers that both believe they replaced the same predecessor, which makes "the
-current answer" ambiguous — all went unreported. Why each registry needs its own
-reader rather than one shared tuple is the design problem #846 tracks.
+`_validate_run_optional_store_records` applies the per-record validator that
+`records.OPTIONAL_RUNTIME_STORE_VALIDATORS` registers for this store to the
+receipts belonging to each run. Without those two callers the registry validated
+nothing: an unparseable line, a duplicate receipt id, and a forked supersede
+chain — two answers that both believe they replaced the same predecessor, which
+makes "the current answer" ambiguous — all went unreported.
+
+That registry is keyed by store, which is what #846 fixed. It began as an
+unkeyed tuple read by a consumer that opened one store and applied every entry
+to it, so the approval and blocked-work families could not join without
+validating external-effect receipts against their own schemas and faulting
+every run that had one. Each grew a sibling tuple and a near-duplicate reader
+instead. Now one entry names one store, one consumer dispatches per store, and
+a validator is only ever handed records read from the store it registered for.
+Registering a store is what makes `omh runtime validate` fault a malformed
+record inside a run; the store-level `validate_*_store` calls are the separate
+half that reports lines belonging to no run at all.
 
 The gate is the store's other consumer. `coding/action_gate.py::classify_action_risk`
 calls `approval_satisfies_request_in` with receipts the caller already read — the

--- a/src/runtime/artifacts.py
+++ b/src/runtime/artifacts.py
@@ -59,8 +59,6 @@ from .records import (
     DELEGATION_RESULTS,
     EVENT_LEVELS,
     OBSERVED_RESULTS,
-    OPTIONAL_APPROVAL_STORE_VALIDATORS,
-    OPTIONAL_BLOCKED_WORK_STORE_VALIDATORS,
     OPTIONAL_RECORD_VALIDATORS,
     OPTIONAL_RUNTIME_STORE_VALIDATORS,
     PRIVACY_MODES,
@@ -2002,9 +2000,9 @@ def validate_run_dir(
             errors.append(f"{path}: {exc}")
         if record:
             errors.extend(f"{path}: {error}" for error in validator(record))
-    errors.extend(_validate_run_external_effect_receipts(run_dir, receipts))
-    errors.extend(_validate_run_approval_receipts(run_dir))
-    errors.extend(_validate_run_blocked_work_records(run_dir))
+    errors.extend(
+        _validate_run_optional_store_records(run_dir, {EXTERNAL_EFFECT_RECEIPT_STORE_NAME: receipts})
+    )
     errors.extend(_validate_run_status_gate_consistency(run_dir, receipts))
     return {"run_id": run_dir.name, "ok": not errors, "errors": errors}
 
@@ -2033,71 +2031,44 @@ def _run_external_effect_receipts(run_dir: Path) -> list[dict[str, Any]]:
     return [record for record in records if str(record.get("run_id", "")) == run_id]
 
 
-def _validate_run_external_effect_receipts(run_dir: Path, receipts: list[dict[str, Any]]) -> list[str]:
-    """Schema-validate only the receipts that belong to this run."""
-    errors: list[str] = []
-    for name, validator in OPTIONAL_RUNTIME_STORE_VALIDATORS:
-        store_path = runtime_store_path_for_run_dir(run_dir, name)
-        if store_path is None:
-            continue
-        for record in receipts:
-            errors.extend(
-                f"{store_path}[{record.get('receipt_id', '')}]: {error}" for error in validator(record)
-            )
-    return errors
+def _validate_run_optional_store_records(
+    run_dir: Path,
+    already_read: dict[str, list[dict[str, Any]]],
+) -> list[str]:
+    """Schema-validate this run's records in every optional store, one store at a time.
 
+    The single consumer `OPTIONAL_RUNTIME_STORE_VALIDATORS` is keyed for. Each
+    entry names the store it was registered for, so the records handed to a
+    validator are the ones read from that store and never a sibling's. Before
+    #846 each family needed its own registry and its own near-duplicate reader,
+    because a shared unkeyed tuple applied every validator to whichever store
+    the reader happened to open.
 
-def _validate_run_approval_receipts(run_dir: Path) -> list[str]:
-    """Schema-validate this run's approval receipts, through the registry that names them.
+    `already_read` lets a caller supply records it has read for another purpose,
+    keyed by store name; anything absent is read here. Entries must already be
+    filtered to this run.
 
-    The same shape `_validate_run_external_effect_receipts` has, and the reader
-    `OPTIONAL_APPROVAL_STORE_VALIDATORS` was registered for: without a consumer
-    the registry validated nothing and the approval store was the one runtime
-    store `omh runtime validate` never opened. Parse errors are dropped here for
-    the reason they are dropped there -- a line that does not parse belongs to
-    no run, and `validate_runtime` reports it once at store level.
+    Records belonging to another run, and records with an empty `run_id`, are
+    skipped rather than faulted. An unparseable line carries no `run_id` at all,
+    and a blocked-work decision minted before any run existed -- a preflight
+    denial -- has no run to belong to. Both are the store's records, and
+    `validate_runtime` reports them once at store level instead of faulting
+    every run that is validated while they sit there.
     """
     errors: list[str] = []
     run_id = _safe_run_id_for_dir(run_dir)
-    for name, validator in OPTIONAL_APPROVAL_STORE_VALIDATORS:
-        store_path = runtime_store_path_for_run_dir(run_dir, name)
+    for entry in OPTIONAL_RUNTIME_STORE_VALIDATORS:
+        store_path = runtime_store_path_for_run_dir(run_dir, entry.store_name)
         if store_path is None:
             continue
-        records, _ = read_jsonl_objects(store_path)
+        records = already_read.get(entry.store_name)
+        if records is None:
+            parsed, _ = read_jsonl_objects(store_path)
+            records = [record for record in parsed if str(record.get("run_id", "")) == run_id]
         for record in records:
-            if str(record.get("run_id", "")) != run_id:
-                continue
+            label = record.get(entry.record_id_key, "")
             errors.extend(
-                f"{store_path}[{record.get('receipt_id', '')}]: {error}" for error in validator(record)
-            )
-    return errors
-
-
-def _validate_run_blocked_work_records(run_dir: Path) -> list[str]:
-    """Schema-validate this run's blocked work records, through the registry that names them.
-
-    The same shape `_validate_run_approval_receipts` has, and the reader
-    `OPTIONAL_BLOCKED_WORK_STORE_VALIDATORS` was registered for: a registry with
-    no consumer validates nothing, which is how the approval store spent a
-    release as the one runtime store `omh runtime validate` never opened.
-
-    Records with an empty `run_id` are skipped here rather than faulted. They are
-    the decisions minted before any run existed -- a preflight denial has nothing
-    to belong to -- so they are the store's records, and `validate_runtime`
-    covers them once at store level.
-    """
-    errors: list[str] = []
-    run_id = _safe_run_id_for_dir(run_dir)
-    for name, validator in OPTIONAL_BLOCKED_WORK_STORE_VALIDATORS:
-        store_path = runtime_store_path_for_run_dir(run_dir, name)
-        if store_path is None:
-            continue
-        records, _ = read_jsonl_objects(store_path)
-        for record in records:
-            if str(record.get("run_id", "")) != run_id:
-                continue
-            errors.extend(
-                f"{store_path}[{record.get('record_id', '')}]: {error}" for error in validator(record)
+                f"{store_path}[{label}]: {error}" for error in entry.validator(record)
             )
     return errors
 

--- a/src/runtime/records.py
+++ b/src/runtime/records.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from copy import deepcopy
+from dataclasses import dataclass
 import hashlib
 from typing import Any, Literal, assert_never
 
@@ -3944,36 +3946,41 @@ OPTIONAL_RECORD_VALIDATORS = (
 # contract is discoverable next to every other runtime record contract.
 EXTERNAL_EFFECT_RECEIPT_RECORD_KEYS = EXTERNAL_EFFECT_RECEIPT_KEYS
 APPROVAL_RECEIPT_RECORD_KEYS = APPROVAL_RECEIPT_KEYS
-
-OPTIONAL_RUNTIME_STORE_VALIDATORS = (
-    ("external_effect_receipts.jsonl", validate_external_effect_receipt),
-)
-
-# The approval store registers in its own tuple following the same precedent,
-# rather than joining the one above. The tuple above has one consumer --
-# `runtime.artifacts._validate_run_external_effect_receipts` -- and that consumer
-# applies *every* entry in it to the external effect receipts it just read, so a
-# second family in the same tuple would validate external effect receipts
-# against the approval schema and fault every run that has one. Each registry
-# therefore names the single store its validators are for, and each has its own
-# reader: this one is read by `runtime.artifacts._validate_run_approval_receipts`,
-# which together with the store-level `validate_approval_receipt_store` call in
-# `validate_runtime` is what makes `omh runtime validate` open the approval store
-# at all. The registry design that forces one reader per registry is #846.
-OPTIONAL_APPROVAL_STORE_VALIDATORS = (
-    ("approval_receipts.jsonl", validate_approval_receipt),
-)
-
-# The third store, registered in its own tuple for the reason the second one
-# was: every consumer applies *every* entry in its registry to the records it
-# just read, so a family sharing a tuple with another would validate one
-# family's records against the other's schema and fault every run that has one.
-# One registry per store, one reader per registry -- the #846 rule. This one is
-# read by `runtime.artifacts._validate_run_blocked_work_records`, and the
-# store-level `validate_blocked_work_record_store` call in `validate_runtime` is
-# what makes `omh runtime validate` open the blocked-work store at all.
 BLOCKED_WORK_RECORD_RECORD_KEYS = BLOCKED_WORK_RECORD_KEYS
 
-OPTIONAL_BLOCKED_WORK_STORE_VALIDATORS = (
-    ("blocked_work_records.jsonl", validate_blocked_work_record),
+
+@dataclass(frozen=True)
+class OptionalRuntimeStoreValidator:
+    """One optional store's per-record schema validator, bound to that store.
+
+    `store_name` is the key: it is the file a consumer must read before calling
+    `validator`, so a validator never sees a sibling store's records. Before
+    #846 the registry was an unkeyed tuple whose consumer read one store and
+    applied every entry to it, which meant a second family could not join --
+    it would have validated the first family's records against its own schema
+    and faulted every run that had one. Each family therefore grew a sibling
+    tuple with a near-duplicate reader; keying by store is what collapses them.
+
+    `record_id_key` is the field a consumer puts in the error label so a fault
+    names the offending record. Receipt stores carry `receipt_id`; the
+    blocked-work store carries `record_id`.
+    """
+
+    store_name: str
+    validator: Callable[[Any], list[str]]
+    record_id_key: str
+
+
+# One registry, one consumer: `runtime.artifacts._validate_run_optional_store_records`
+# dispatches per store, reading each entry's `store_name` and applying only that
+# entry's validator to what it read. Registering a store here is what makes
+# `omh runtime validate` fault a malformed record in it; the store-level
+# `validate_*_store` calls in `validate_runtime` are the separate, run-independent
+# half that reports lines belonging to no run.
+OPTIONAL_RUNTIME_STORE_VALIDATORS = (
+    OptionalRuntimeStoreValidator(
+        "external_effect_receipts.jsonl", validate_external_effect_receipt, "receipt_id"
+    ),
+    OptionalRuntimeStoreValidator("approval_receipts.jsonl", validate_approval_receipt, "receipt_id"),
+    OptionalRuntimeStoreValidator("blocked_work_records.jsonl", validate_blocked_work_record, "record_id"),
 )

--- a/tests/test_approval_receipts.py
+++ b/tests/test_approval_receipts.py
@@ -36,7 +36,6 @@ from omh.coding.action_gate import MUTATING_ACTIONS as GATE_MUTATING_ACTIONS
 from omh.paths import resolve_paths
 from omh.runtime.records import (
     APPROVAL_RECEIPT_RECORD_KEYS,
-    OPTIONAL_APPROVAL_STORE_VALIDATORS,
     OPTIONAL_RUNTIME_STORE_VALIDATORS,
 )
 from omh.workflows.approval_receipts import (
@@ -166,16 +165,18 @@ class ApprovalReceiptShapeTests(unittest.TestCase):
 
     def test_the_receipt_store_is_registered_beside_the_other_runtime_records(self) -> None:
         self.assertEqual(APPROVAL_RECEIPT_RECORD_KEYS, APPROVAL_RECEIPT_KEYS)
-        self.assertEqual(
-            [name for name, _ in OPTIONAL_APPROVAL_STORE_VALIDATORS],
-            ["approval_receipts.jsonl"],
-        )
-        validator = dict(OPTIONAL_APPROVAL_STORE_VALIDATORS)["approval_receipts.jsonl"]
-        self.assertEqual(validator(_valid_receipt()), [])
-        self.assertTrue(validator({"schema_version": "wrong"}))
-        # Deliberately not joined to the external-effect registry: its one
-        # consumer applies every entry to the external effect receipts it read.
-        self.assertNotIn("approval_receipts.jsonl", [name for name, _ in OPTIONAL_RUNTIME_STORE_VALIDATORS])
+        entries = {entry.store_name: entry for entry in OPTIONAL_RUNTIME_STORE_VALIDATORS}
+        self.assertIn("approval_receipts.jsonl", entries)
+        entry = entries["approval_receipts.jsonl"]
+        self.assertEqual(entry.record_id_key, "receipt_id")
+        self.assertEqual(entry.validator(_valid_receipt()), [])
+        self.assertTrue(entry.validator({"schema_version": "wrong"}))
+        # #846 joined this store to the one registry. It used to need a sibling
+        # tuple because the consumer applied every entry to the single store it
+        # read, and this validator rejects anything that is not an approval
+        # receipt -- which is why the consumer must dispatch per store. That
+        # dispatch is proved in tests/test_runtime_artifacts.py.
+        self.assertTrue(entry.validator({"schema_version": "external_effect_receipt/v1"}))
 
 
 class ApprovalNeverAssertsExecutionTests(unittest.TestCase):

--- a/tests/test_blocked_work_records.py
+++ b/tests/test_blocked_work_records.py
@@ -66,8 +66,6 @@ from omh.runtime.artifacts import (
     _delegated_runtime_observation_status,
 )
 from omh.runtime.records import (
-    OPTIONAL_APPROVAL_STORE_VALIDATORS,
-    OPTIONAL_BLOCKED_WORK_STORE_VALIDATORS,
     OPTIONAL_RUNTIME_STORE_VALIDATORS,
     RUNTIME_BLOCK_OBSERVATION_EVENTS,
     RUNTIME_NON_LADDER_OBSERVATION_EVENTS,
@@ -769,14 +767,17 @@ class StoreWiring(unittest.TestCase):
             self.assertEqual(result["outcome"], "refused")
             self.assertTrue(result["error"])
 
-    def test_the_family_registers_its_own_validator_tuple(self) -> None:
-        # The #846 rule: one registry per store, one reader per registry. A
-        # family sharing a tuple would validate a sibling's records against its
-        # own schema.
-        names = {name for name, _ in OPTIONAL_BLOCKED_WORK_STORE_VALIDATORS}
-        self.assertEqual(names, {"blocked_work_records.jsonl"})
-        for other in (OPTIONAL_RUNTIME_STORE_VALIDATORS, OPTIONAL_APPROVAL_STORE_VALIDATORS):
-            self.assertEqual(names & {name for name, _ in other}, set())
+    def test_the_family_registers_its_validator_under_its_own_store(self) -> None:
+        # #846: one registry keyed by store, one consumer that dispatches per
+        # store. This family's record id is `record_id`, not the `receipt_id`
+        # its two siblings carry, so the label a fault is reported under is part
+        # of the registration rather than hardcoded in the consumer.
+        entries = {entry.store_name: entry for entry in OPTIONAL_RUNTIME_STORE_VALIDATORS}
+        self.assertIn("blocked_work_records.jsonl", entries)
+        entry = entries["blocked_work_records.jsonl"]
+        self.assertEqual(entry.record_id_key, "record_id")
+        self.assertEqual(entry.validator(_record()), [])
+        self.assertTrue(entry.validator({"schema_version": "approval_receipt/v1"}))
 
     def test_the_store_lives_beside_its_siblings_and_not_inside_a_run(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_external_effect_receipts.py
+++ b/tests/test_external_effect_receipts.py
@@ -240,13 +240,12 @@ class ExternalEffectVocabularyTests(unittest.TestCase):
 
     def test_receipt_store_is_registered_beside_the_other_runtime_records(self) -> None:
         self.assertEqual(EXTERNAL_EFFECT_RECEIPT_RECORD_KEYS, EXTERNAL_EFFECT_RECEIPT_KEYS)
-        self.assertEqual(
-            [name for name, _ in OPTIONAL_RUNTIME_STORE_VALIDATORS],
-            ["external_effect_receipts.jsonl"],
-        )
-        validator = dict(OPTIONAL_RUNTIME_STORE_VALIDATORS)["external_effect_receipts.jsonl"]
-        self.assertEqual(validator(_valid_receipt()), [])
-        self.assertTrue(validator({"schema_version": "wrong"}))
+        entries = {entry.store_name: entry for entry in OPTIONAL_RUNTIME_STORE_VALIDATORS}
+        self.assertIn("external_effect_receipts.jsonl", entries)
+        entry = entries["external_effect_receipts.jsonl"]
+        self.assertEqual(entry.record_id_key, "receipt_id")
+        self.assertEqual(entry.validator(_valid_receipt()), [])
+        self.assertTrue(entry.validator({"schema_version": "wrong"}))
 
     def test_receipt_record_keys_are_exact(self) -> None:
         record = _valid_receipt()

--- a/tests/test_runtime_artifacts.py
+++ b/tests/test_runtime_artifacts.py
@@ -49,7 +49,9 @@ from omh.runtime_artifacts import (
     write_runtime_observation,
     write_wrapper_contract,
 )
+from omh.runtime import records as runtime_records
 from omh.runtime.records import (
+    OPTIONAL_RUNTIME_STORE_VALIDATORS,
     RUNTIME_OBSERVATION_EVENTS,
     build_coding_delegation_record,
     validate_coding_executor_handoff,
@@ -2057,6 +2059,87 @@ class RuntimeArtifactTests(unittest.TestCase):
 
             self.assertEqual(state["installed_skills"], 18)
             self.assertEqual(state["last_run_id"], "r1")
+
+
+_STORE_SCHEMA_VERSIONS = {
+    "approval_receipts.jsonl": "approval_receipt/v1",
+    "blocked_work_records.jsonl": "blocked_work_record/v1",
+    "external_effect_receipts.jsonl": "external_effect_receipt/v1",
+}
+
+
+class OptionalRuntimeStoreValidatorRegistryTests(unittest.TestCase):
+    """#846: one registry keyed by store, one consumer that dispatches per store.
+
+    The registry used to be an unkeyed tuple whose consumer read a single store
+    and applied every entry to it. A second family could not join without
+    validating the first family's records against its own schema, so each new
+    store grew a sibling tuple and a near-duplicate reader instead.
+    """
+
+    def test_the_registry_names_each_store_once_and_left_no_sibling_tuples(self) -> None:
+        names = [entry.store_name for entry in OPTIONAL_RUNTIME_STORE_VALIDATORS]
+        self.assertEqual(sorted(names), sorted(set(names)))
+        self.assertEqual(set(names), set(_STORE_SCHEMA_VERSIONS))
+        forked = sorted(
+            name
+            for name in vars(runtime_records)
+            if name.startswith("OPTIONAL_") and name.endswith("_STORE_VALIDATORS")
+        )
+        self.assertEqual(forked, ["OPTIONAL_RUNTIME_STORE_VALIDATORS"])
+
+    def test_no_validator_accepts_a_sibling_stores_record(self) -> None:
+        # Why the dispatch below has to be per store. If any validator were
+        # indifferent to a sibling's records, one shared reader would be safe.
+        for entry in OPTIONAL_RUNTIME_STORE_VALIDATORS:
+            for sibling in OPTIONAL_RUNTIME_STORE_VALIDATORS:
+                if sibling.store_name == entry.store_name:
+                    continue
+                record = {"schema_version": _STORE_SCHEMA_VERSIONS[sibling.store_name]}
+                with self.subTest(validator=entry.store_name, record=sibling.store_name):
+                    self.assertTrue(entry.validator(record))
+
+    def test_a_malformed_record_faults_its_own_store_and_no_sibling(self) -> None:
+        for entry in OPTIONAL_RUNTIME_STORE_VALIDATORS:
+            with self.subTest(store=entry.store_name), TemporaryDirectory() as tmp:
+                paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+                run_id = create_run(paths, {"skill": "plan"})["run_id"]
+                store_path = paths.runtime_journal_dir / entry.store_name
+                store_path.parent.mkdir(parents=True, exist_ok=True)
+                store_path.write_text(
+                    json.dumps({"schema_version": "nonsense", "run_id": run_id, entry.record_id_key: "x-1"})
+                    + "\n",
+                    encoding="utf-8",
+                )
+
+                errors = validate_runtime(paths, run_id)["runs"][0]["errors"]
+
+                self.assertTrue(errors)
+                for error in errors:
+                    self.assertTrue(error.startswith(f"{store_path}[x-1]: "), error)
+                for sibling in OPTIONAL_RUNTIME_STORE_VALIDATORS:
+                    if sibling.store_name == entry.store_name:
+                        continue
+                    for error in errors:
+                        self.assertNotIn(sibling.store_name, error)
+
+    def test_a_malformed_record_in_one_store_leaves_an_unrelated_run_clean(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            faulted = create_run(paths, {"skill": "plan"})["run_id"]
+            clean = create_run(paths, {"skill": "plan"})["run_id"]
+            self.assertNotEqual(faulted, clean)
+            store_path = paths.runtime_approval_receipts_path
+            store_path.parent.mkdir(parents=True, exist_ok=True)
+            store_path.write_text(
+                json.dumps({"schema_version": "nonsense", "run_id": faulted, "receipt_id": "x-1"}) + "\n",
+                encoding="utf-8",
+            )
+
+            by_run = {run["run_id"]: run for run in validate_runtime(paths)["runs"]}
+
+            self.assertFalse(by_run[faulted]["ok"])
+            self.assertTrue(by_run[clean]["ok"], by_run[clean]["errors"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Feature Report

### What Changed

- `records.OPTIONAL_RUNTIME_STORE_VALIDATORS` is now keyed by store. Each entry is an `OptionalRuntimeStoreValidator` carrying the store filename it was registered for, its per-record validator, and the record-id field a fault is labelled with.
- The two sibling registries `OPTIONAL_APPROVAL_STORE_VALIDATORS` and `OPTIONAL_BLOCKED_WORK_STORE_VALIDATORS` are gone; both stores register in the one registry.
- The three near-duplicate readers in `runtime/artifacts.py` (`_validate_run_external_effect_receipts`, `_validate_run_approval_receipts`, `_validate_run_blocked_work_records`) collapse into one consumer, `_validate_run_optional_store_records`, that dispatches per store.

### Why This Exists

`OPTIONAL_RUNTIME_STORE_VALIDATORS` read as a registry of "validators for optional runtime stores", but its only consumer applied **every** entry in the tuple to the records it had just read from **one** store. That made the registry unable to hold a second store: adding `approval_receipts.jsonl` would have validated external-effect receipts against the approval schema, faulted every run that had one, and broken the exact-count assertion in `tests/test_external_effect_receipts.py`.

The approval store worked around it by registering in a sibling constant. The blocked-work store then hit the identical fork and added a third. By the time #846 was picked up there were three registries with one intent, no shared consumer, and three copies of the same read-filter-label loop — and each new store was going to face the same choice.

### User / Operator Impact

No user-visible behavior change. `omh runtime validate` reports exactly what it reported before: the same per-store faults, under the same store keys, with the same error strings. What changes is that registering the *next* optional store is one entry in one table instead of a new constant plus a new reader — and a reader that is forgotten is how the approval store spent a release as the one runtime store `omh runtime validate` never opened.

### How It Works

`OptionalRuntimeStoreValidator` is a frozen dataclass of `(store_name, validator, record_id_key)`. `store_name` is the key: the consumer resolves the store path from it, reads that file, filters to the run being validated, and applies only that entry's validator to what it read. A validator is therefore never handed a sibling store's records, which is the property that made a shared tuple unsafe.

`record_id_key` moved out of the readers and into the registration because the families disagree: the two receipt stores label a fault with `receipt_id`, the blocked-work store with `record_id`. Hardcoding it per reader was part of why three readers existed.

The pre-read escape hatch is kept for one caller: `validate_run_dir` already reads this run's external-effect receipts for the status-gate check, so it passes them in rather than making the store be read twice.

Parse errors are still dropped at run level and reported once at store level. A line that does not parse carries no `run_id`, and a blocked-work decision minted before any run existed — a preflight denial — has no run to belong to.

### Files And Contracts Touched

- `src/runtime/records.py` — new `OptionalRuntimeStoreValidator`; one registry replacing three.
- `src/runtime/artifacts.py` — one consumer replacing three readers; import list narrowed.
- `tests/test_external_effect_receipts.py`, `tests/test_approval_receipts.py`, `tests/test_blocked_work_records.py` — each family now asserts its registration in the unified registry, including its `record_id_key`.
- `tests/test_runtime_artifacts.py` — new `OptionalRuntimeStoreValidatorRegistryTests`.
- `docs/ARCHITECTURE.md` — the approval-store section described the old one-reader-per-registry rule as an open design problem; it now describes the keyed registry.

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `python3 -m unittest discover -s tests` — Ran 4254 tests, OK
- [x] `python3 -m compileall src` — clean
- [x] `python3 -m omh.cli docs workflows --check` — `ok: true`, tap_skills 115/115
- [x] `python3 -m omh.cli harness validate` — `ok: true`, 72 harnesses / 104 skills
- [x] `python3 -m omh.cli release checklist --json` — `ok: true`
- [x] `python3 -m omh.cli release hermes-smoke` — plan renders
- [x] `omh --help`
- [x] Also ran `docs roles --check` and `docs capability-families --check` (both `ok: true`) and `git diff --check`
- [ ] Manual Hermes/TUI check — not run. This change has no Hermes-visible surface: no schema, no CLI output, and no generated skill content moved.

New tests, all in `OptionalRuntimeStoreValidatorRegistryTests`:

- the registry names each of the three stores exactly once, and no `OPTIONAL_*_STORE_VALIDATORS` constant other than the unified one exists in the module (this is the test that fails if a fourth store forks the registry again)
- no validator accepts a sibling store's record — the property that makes per-store dispatch load-bearing rather than cosmetic
- a malformed record in each store faults **that** store: every resulting error is prefixed with that store's path and record id, and no error mentions a sibling store
- a malformed record bound to one run leaves an unrelated run in the same runtime tree `ok`

## Risk

Low. The consumer is behaviorally equivalent to the three it replaces — same store paths, same run filter, same error prefixes — and the full suite covers all three families. The one behavior worth naming: because all three stores now go through one loop, a future entry with a wrong `record_id_key` mislabels faults for its own store only, and cannot affect a sibling.

## Compatibility / Rollout

- `OPTIONAL_APPROVAL_STORE_VALIDATORS` and `OPTIONAL_BLOCKED_WORK_STORE_VALIDATORS` are removed. They were internal to `src/runtime` and its tests; no plugin bundle, generated skill, or public doc referenced them (verified by grep across `src`, `tests`, `docs`, `skills`, `examples`, `README.md`).
- On-disk store formats are untouched, so no migration and no re-validation of existing runtime trees.

## Release / Claims

- [x] Release-channel impact considered — `local`; internal refactor with no packaged-surface change
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — all validation above is observed local test/gate output; no Hermes runtime claim is made
- [x] Known manual Hermes checks are listed — `omh release hermes-smoke --live` was not run; this change has no Hermes-visible surface

## Follow-Up

- The `#846` rule is referenced in comments in `records.py` and `artifacts.py` as the reason the registry is keyed. Those stay as the explanation of why a new store must not fork the table.

Closes #846
