### PR TITLE
feat: gate a review success claim on an observed review receipt

### DIFF
--- a/src/coding/action_gate.py
+++ b/src/coding/action_gate.py
@@ -555,7 +555,6 @@ HANDOFF_CONTRACT_CLAIM_BOUNDARY = (
     "This safety contract is prepared metadata. It is not dispatch, execution, review, CI, or merge "
     "evidence, and an enforced boundary means a refusing check exists — not that any action ran."
 )
-REVIEW_RECEIPT_BLOCKER = "#844"
 
 # (boundary, statement, enforcement, enforced_by, blocked_by).
 #
@@ -634,8 +633,8 @@ _STATIC_SAFETY_BOUNDARIES: tuple[tuple[str, str, str, tuple[str, ...], str], ...
     (
         "evidence_separation",
         "Prepared metadata is not observed execution. Each claim rung requires its own observation, the "
-        "observation journal refuses an out-of-order lifecycle event, and CI and merge additionally "
-        "require an external effect receipt that observed that effect succeed.",
+        "observation journal refuses an out-of-order lifecycle event, and review, CI, and merge "
+        "additionally require an external effect receipt that observed that effect succeed.",
         "enforced",
         (
             "omh.runtime.claims.allowed_runtime_claims",
@@ -711,11 +710,15 @@ _STATIC_SAFETY_BOUNDARIES: tuple[tuple[str, str, str, tuple[str, ...], str], ...
     ),
     (
         "review_receipt",
-        "A review claim needs an observed review record but, unlike CI and merge, no external effect "
-        "receipt. A local record saying review passed is accepted as the evidence for itself.",
-        "declared_not_enforced",
-        (),
-        REVIEW_RECEIPT_BLOCKER,
+        "A review claim is refused unless an external effect receipt from runtime_review_record "
+        "observed this run's review succeed. A local record saying review passed is the claim, not "
+        "the evidence for it, and is no longer accepted as evidence for itself.",
+        "enforced",
+        (
+            "omh.runtime.claims._receipt_cited",
+            "omh.workflows.external_effect_receipts.receipt_satisfies_success_claim",
+        ),
+        "",
     ),
     (
         "start_evidence",

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -75,7 +75,7 @@ EXTERNAL_EFFECT_CLAIM_BOUNDARY = (
 )
 # The run-summary claims that assert an external effect, and the effect kind
 # whose receipt has to back each one.
-RECEIPT_BACKED_RUN_CLAIMS = {"ci_observed": "ci", "merge_observed": "merge"}
+RECEIPT_BACKED_RUN_CLAIMS = {"review_observed": "review", "ci_observed": "ci", "merge_observed": "merge"}
 OBSERVATION_STATUS_ORDER = (
     "unknown",
     "prepared_not_observed",
@@ -214,15 +214,16 @@ def _apply_external_effect_receipts_to_run_summary(
     summary: dict[str, Any],
     lifecycle: dict[str, Any],
 ) -> None:
-    """Withdraw a CI or merge success claim that no receipt backs.
+    """Withdraw a review, CI, or merge success claim that no receipt backs.
 
-    CI and merge are the two rungs that assert something happened outside this
-    machine. A local `ci.json` or `merge.json` is the claim, not the evidence
-    for it, and the journal event beside it is written by the same call, so
-    neither can promote itself. Before the receipt store existed this reader
-    reported `ci_observed: True` from a local record alone -- which is the state
-    of every pre-#836 store on disk today, and why the default here is to
-    withdraw the claim rather than to trust the record.
+    These are the three rungs that assert something happened outside this
+    machine. A local `review.json`, `ci.json`, or `merge.json` is the claim, not
+    the evidence for it, and the journal event beside it is written by the same
+    call, so none can promote itself. Before the receipt store existed this
+    reader reported `ci_observed: True` from a local record alone -- which is
+    the state of every pre-#836 store on disk today, and why the default here is
+    to withdraw the claim rather than to trust the record. Review joined the
+    other two in #844.
 
     The rule is the same one `omh.runtime.claims._receipt_cited` applies on the
     CLI side, so the Hermes-facing surface cannot contradict it.

--- a/src/runtime/claims.py
+++ b/src/runtime/claims.py
@@ -61,7 +61,11 @@ RUNTIME_CLAIM_BLOCK_REASONS: Final = {
     Claim.EXECUTOR_DISPATCHED: "wrapper dispatch evidence is not observed",
     Claim.EXECUTION_OBSERVED: "executor result evidence is not observed",
     Claim.VERIFICATION_OBSERVED: "verification evidence is not observed",
-    Claim.REVIEW_OBSERVED: "review evidence is not observed",
+    Claim.REVIEW_OBSERVED: (
+        "review evidence is not observed, or no external effect receipt from runtime_review_record "
+        "records this run's review as succeeded; a run recorded before external effect receipts "
+        "existed has none and cannot make this claim"
+    ),
     Claim.CI_OBSERVED: (
         "CI evidence is not observed, or no external effect receipt from runtime_ci_record "
         "records this run's CI as succeeded; a run recorded before external effect receipts "
@@ -119,7 +123,11 @@ def _claim_allowed(claim: Claim, status: Mapping[str, JsonValue]) -> bool:
             return _bool_value(_mapping_value(status, "verification"), "observed")
         case Claim.REVIEW_OBSERVED:
             review = _mapping_value(status, "review")
-            return _bool_value(review, "observed") and _string_value(review, "status") == "passed"
+            return (
+                _bool_value(review, "observed")
+                and _string_value(review, "status") == "passed"
+                and _receipt_cited(status, review, kind="review")
+            )
         case Claim.CI_OBSERVED:
             ci = _mapping_value(status, "ci")
             return (
@@ -146,11 +154,15 @@ def _claim_allowed(claim: Claim, status: Mapping[str, JsonValue]) -> bool:
 def _receipt_cited(status: Mapping[str, JsonValue], section: Mapping[str, JsonValue], *, kind: str) -> bool:
     """Whether a gate's success is backed by a receipt that names who acted.
 
-    CI and merge are the two rungs that assert something happened outside this
-    machine. A local record saying "passed" or "merged" is the claim, not the
-    evidence for it, so both rungs additionally require a receipt that observed
-    *that* effect *succeed* from the surface that gate is observed by. A
-    `failed`, `attempted`, or unrelated receipt refuses the claim.
+    Review, CI, and merge are the three rungs that assert something happened
+    outside this machine. A local record saying "passed" or "merged" is the
+    claim, not the evidence for it, so each rung additionally requires a receipt
+    that observed *that* effect *succeed* from the surface that gate is observed
+    by. A `failed`, `attempted`, or unrelated receipt refuses the claim.
+
+    Review was the last rung to skip this check (#844). It was the one place
+    OMH would report "review passed" with nothing naming the surface that
+    reviewed, which made the evidence ladder inconsistent with itself.
 
     This is the same `receipt_satisfies_success_claim` that runtime validation
     uses, called on the same receipt, so the ladder and the validator can never

--- a/tests/test_external_effect_receipts.py
+++ b/tests/test_external_effect_receipts.py
@@ -650,10 +650,13 @@ class LegacyStoreCompatibilityTests(unittest.TestCase):
                     "executor_dispatched",
                     "execution_observed",
                     "verification_observed",
-                    "review_observed",
                 ],
             )
             self.assertNotEqual(report["claim_state"], "metadata_available")
+            # #844 made review the third receipt-gated rung, so a legacy store
+            # now keeps its lower rungs through verification rather than review.
+            self.assertIn("external effect receipt", blocked["review_observed"])
+            self.assertIn("before external effect receipts existed", blocked["review_observed"])
             self.assertIn("external effect receipt", blocked["ci_observed"])
             self.assertIn("before external effect receipts existed", blocked["ci_observed"])
             self.assertIn("external effect receipt", blocked["merged"])
@@ -667,6 +670,9 @@ class LegacyStoreCompatibilityTests(unittest.TestCase):
             write_merge_record(run_dir, {"status": "merged", "target_branch": "main", "merge_commit": "abc123"})
             _remove_receipt_store(paths)
 
+            # Three gates since #844, in ladder order: each re-record mints the
+            # receipt its own rung now requires.
+            write_review_record(run_dir, {"status": "passed", "reviewer": "code-review"})
             write_ci_record(run_dir, {"status": "passed", "provider": "github-actions", "checks": ["unit:passed"]})
             write_merge_record(run_dir, {"status": "merged", "target_branch": "main", "merge_commit": "abc123"})
 
@@ -700,9 +706,10 @@ class LegacyStoreCompatibilityTests(unittest.TestCase):
 
             before = summarize_delegated_coding_status(paths, run_id)
             self.assertEqual(before["next_action"], "report_merged")
-            self.assertEqual(check_runtime_run(paths, run_id)["claim_state"], "review_observed")
+            self.assertEqual(check_runtime_run(paths, run_id)["claim_state"], "verification_observed")
 
             for command in (
+                ["runtime", "review", "--run", run_id, "--status", "passed", "--reviewer", "code-review"],
                 ["runtime", "ci", "--run", run_id, "--status", "passed", "--provider", "github-actions", "--check", "unit:passed"],
                 ["runtime", "merge", "--run", run_id, "--merged", "--target-branch", "main", "--merge-commit", "abc123"],
             ):
@@ -722,6 +729,7 @@ class LegacyStoreCompatibilityTests(unittest.TestCase):
             self.assertTrue(after["merge"]["receipt"]["receipt_id"])
             self.assertEqual(after["merge"]["receipt"]["acting_surface"], "runtime_merge_record")
             self.assertEqual(after["ci"]["receipt"]["acting_surface"], "runtime_ci_record")
+            self.assertEqual(after["review"]["receipt"]["acting_surface"], "runtime_review_record")
             self.assertIn(after["merge"]["receipt"]["receipt_id"], after["safe_summary"])
             # No false intermediate record. Every gate status written during the
             # recovery is one the operator observed; the `not_observed` CI record
@@ -729,9 +737,9 @@ class LegacyStoreCompatibilityTests(unittest.TestCase):
             recorded = [
                 str(event.get("data", {}).get("status", ""))
                 for event in _run_events(run_dir)[recovery_starts_at:]
-                if event.get("event") in {"ci_recorded", "merge_recorded"}
+                if event.get("event") in {"review_recorded", "ci_recorded", "merge_recorded"}
             ]
-            self.assertEqual(recorded, ["passed", "merged"])
+            self.assertEqual(recorded, ["passed", "passed", "merged"])
             self.assertEqual(
                 sorted(
                     (receipt["effect_id"], receipt["observed_result"])
@@ -740,6 +748,7 @@ class LegacyStoreCompatibilityTests(unittest.TestCase):
                 [
                     (external_effect_id("ci", run_id), "succeeded"),
                     (external_effect_id("merge", run_id), "succeeded"),
+                    (external_effect_id("review", run_id), "succeeded"),
                 ],
             )
 

--- a/tests/test_handoff_safety_contract.py
+++ b/tests/test_handoff_safety_contract.py
@@ -100,6 +100,7 @@ _ENFORCED_BOUNDARIES = frozenset(
         "network",
         "profile_revision",
         "prohibited_actions",
+        "review_receipt",
         "storage_content",
         "untrusted_input",
     }
@@ -113,7 +114,6 @@ _DECLARED_NOT_ENFORCED = {
     "account_authorization": "host_owned_consent_flow_is_not_observable_by_omh",
     "confirmation_answered": "no_confirmation_answer_intake_mints_a_run_bound_approval",
     "recovery": "#821",
-    "review_receipt": "#844",
     "start_evidence": "#826",
     "storage_retention": "#835",
     "workspace": "#820",
@@ -383,7 +383,6 @@ class AntiDecorationTests(unittest.TestCase):
         self.assertIn("nothing binds a running executor", _boundary(contract, "workspace")["statement"])
         self.assertIn("not a state OMH can observe", _boundary(contract, "account_authorization")["statement"])
         self.assertIn("persist until the operator deletes them", _boundary(contract, "storage_retention")["statement"])
-        self.assertIn("no external effect", _boundary(contract, "review_receipt")["statement"])
         self.assertIn("no observed start", _boundary(contract, "start_evidence")["statement"])
 
 
@@ -600,7 +599,11 @@ class EvidenceRequirementTests(unittest.TestCase):
             ("wrapper", {"prompt_dispatched": True}, Claim.EXECUTOR_DISPATCHED),
             ("execution", {"observed": True}, Claim.EXECUTION_OBSERVED),
             ("verification", {"observed": True}, Claim.VERIFICATION_OBSERVED),
-            ("review", {"observed": True, "status": "passed"}, Claim.REVIEW_OBSERVED),
+            (
+                "review",
+                {"observed": True, "status": "passed", "receipt": _receipt("review", run_id)},
+                Claim.REVIEW_OBSERVED,
+            ),
             ("ci", {"observed": True, "status": "passed", "receipt": _receipt("ci", run_id)}, Claim.CI_OBSERVED),
             ("merge_readiness", {"observed": True, "status": "ready"}, Claim.MERGE_READY),
             ("merge", {"observed": True, "status": "merged", "receipt": _receipt("merge", run_id)}, Claim.MERGED),
@@ -622,7 +625,7 @@ class EvidenceRequirementTests(unittest.TestCase):
             "wrapper": {"prompt_dispatched": True},
             "execution": {"observed": True},
             "verification": {"observed": True},
-            "review": {"observed": True, "status": "passed"},
+            "review": {"observed": True, "status": "passed", "receipt": _receipt("review", run_id)},
             "ci": {"observed": True, "status": "passed"},
         }
         self.assertNotIn(Claim.CI_OBSERVED, allowed_runtime_claims(status, validation_failed=False))
@@ -635,10 +638,10 @@ class EvidenceRequirementTests(unittest.TestCase):
         status["merge"] = {"observed": True, "status": "merged"}
         self.assertNotIn(Claim.MERGED, allowed_runtime_claims(status, validation_failed=False))
 
-    def test_review_is_claim_gated_but_not_receipt_gated_and_the_contract_says_so(self) -> None:
-        # The asymmetry against CI and merge is real and is declared rather than
-        # closed here: closing it would change the ladder for runs recorded
-        # before receipts existed, which is a separate decision.
+    def test_review_is_receipt_gated_like_ci_and_merge_and_the_contract_says_so(self) -> None:
+        # #844 closed the last asymmetry in the ladder. Review was the one stage
+        # where OMH would report "review passed" with nothing naming the surface
+        # that reviewed it.
         run_id = "run-818"
         status: dict[str, object] = {
             "external_effects": {"run_id": run_id},
@@ -648,10 +651,31 @@ class EvidenceRequirementTests(unittest.TestCase):
             "verification": {"observed": True},
             "review": {"observed": True, "status": "passed"},
         }
+        self.assertNotIn(Claim.REVIEW_OBSERVED, allowed_runtime_claims(status, validation_failed=False))
+        # The refusal reads as a receipt gap, not as a missing review record.
+        blocked = {entry["claim"]: entry["reason"] for entry in blocked_runtime_claims(
+            allowed_runtime_claims(status, validation_failed=False), validation_failed=False
+        )}
+        self.assertIn("external effect receipt", blocked["review_observed"])
+        self.assertIn("runtime_review_record", blocked["review_observed"])
+        self.assertIn("before external effect receipts existed", blocked["review_observed"])
+
+        # Only a succeeded receipt for this run's review effect lifts it.
+        for result in ("attempted", "failed", "unknown"):
+            with self.subTest(result=result):
+                status["review"] = {
+                    "observed": True,
+                    "status": "passed",
+                    "receipt": _receipt("review", run_id, result=result),
+                }
+                self.assertNotIn(Claim.REVIEW_OBSERVED, allowed_runtime_claims(status, validation_failed=False))
+        status["review"] = {"observed": True, "status": "passed", "receipt": _receipt("review", run_id)}
         self.assertIn(Claim.REVIEW_OBSERVED, allowed_runtime_claims(status, validation_failed=False))
+
         review_receipt = _boundary(_contract(), "review_receipt")
-        self.assertEqual(review_receipt["enforcement"], "declared_not_enforced")
-        self.assertEqual(review_receipt["blocked_by"], "#844")
+        self.assertEqual(review_receipt["enforcement"], "enforced")
+        self.assertEqual(review_receipt["blocked_by"], "")
+        self.assertIn("omh.runtime.claims._receipt_cited", review_receipt["enforced_by"])
 
     def test_a_failed_validation_collapses_every_claim_to_metadata(self) -> None:
         status: dict[str, object] = {

--- a/tests/test_runtime_reader_external_effect_receipts.py
+++ b/tests/test_runtime_reader_external_effect_receipts.py
@@ -83,7 +83,7 @@ def _run_summary(paths: OmhPaths, run_id: str) -> dict[str, object]:
 
 
 class VendoredReaderReceiptRuleTests(unittest.TestCase):
-    def test_ci_and_merge_success_is_not_claimed_without_a_receipt(self) -> None:
+    def test_review_ci_and_merge_success_is_not_claimed_without_a_receipt(self) -> None:
         """The pre-#836 store shape: local records claim success, nothing observed it."""
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
@@ -96,13 +96,18 @@ class VendoredReaderReceiptRuleTests(unittest.TestCase):
 
             self.assertFalse(summary["ci_observed"])
             self.assertFalse(summary["merge_observed"])
-            self.assertNotIn(summary["observation_status"], {"ci_observed", "merge_observed"})
+            # Review joined the receipt-backed rungs in #844.
+            self.assertFalse(summary["review_observed"])
+            self.assertNotIn(
+                summary["observation_status"], {"review_observed", "ci_observed", "merge_observed"}
+            )
             self.assertFalse(summary["lifecycle"]["ci_observed"])
             self.assertFalse(summary["lifecycle"]["merge_observed"])
-            self.assertEqual(summary["external_effect_claims"]["unreceipted"], ["ci", "merge"])
+            self.assertFalse(summary["lifecycle"]["review_observed"])
+            self.assertEqual(summary["external_effect_claims"]["unreceipted"], ["ci", "merge", "review"])
             self.assertEqual(summary["external_effect_claims"]["receipt_backed"], [])
 
-    def test_ci_and_merge_success_is_claimed_when_receipts_name_the_acting_surface(self) -> None:
+    def test_review_ci_and_merge_success_is_claimed_when_receipts_name_the_acting_surface(self) -> None:
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
             run_id = _executed_run(paths)
@@ -112,7 +117,10 @@ class VendoredReaderReceiptRuleTests(unittest.TestCase):
 
             self.assertTrue(summary["ci_observed"])
             self.assertTrue(summary["merge_observed"])
-            self.assertEqual(summary["external_effect_claims"]["receipt_backed"], ["ci", "merge"])
+            self.assertTrue(summary["review_observed"])
+            self.assertEqual(
+                summary["external_effect_claims"]["receipt_backed"], ["ci", "merge", "review"]
+            )
             self.assertEqual(summary["external_effect_claims"]["unreceipted"], [])
 
     def test_observation_status_is_demoted_only_to_the_rung_it_can_still_claim(self) -> None:
@@ -121,8 +129,11 @@ class VendoredReaderReceiptRuleTests(unittest.TestCase):
         self.assertEqual(demote("merge_observed", {"ci", "merge"}), "merge_observed")
         self.assertEqual(demote("merge_observed", {"ci"}), "merge_gate_observed")
         self.assertEqual(demote("merge_observed", set()), "merge_gate_observed")
-        self.assertEqual(demote("ci_observed", set()), "review_observed")
-        self.assertEqual(demote("ci_observed", {"ci"}), "ci_observed")
+        # Review is itself receipt-backed since #844, so an empty backed set
+        # walks past it down to the highest local rung.
+        self.assertEqual(demote("ci_observed", set()), "verification_observed")
+        self.assertEqual(demote("ci_observed", {"review"}), "review_observed")
+        self.assertEqual(demote("ci_observed", {"ci", "review"}), "ci_observed")
         # Local rungs are never demoted, and a terminal state is never rewritten.
         self.assertEqual(demote("execution_observed", set()), "execution_observed")
         self.assertEqual(demote("blocked", set()), "blocked")
@@ -153,7 +164,9 @@ class VendoredReaderReceiptRuleTests(unittest.TestCase):
 
             summary = _run_summary(paths, run_id)
             self.assertFalse(summary["ci_observed"])
-            self.assertEqual(summary["external_effect_claims"]["receipt_backed"], [])
+            # The review receipt this run's review record minted is untouched:
+            # a superseding CI failure withdraws the CI claim, not its siblings.
+            self.assertEqual(summary["external_effect_claims"]["receipt_backed"], ["review"])
 
     def test_another_runs_receipt_does_not_back_this_runs_claim(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -196,7 +209,7 @@ class VendoredReaderParityTests(unittest.TestCase):
     def test_vendored_effect_kinds_match_the_source_record_surfaces(self) -> None:
         self.assertEqual(
             sorted(runtime_reader.RECEIPT_BACKED_RUN_CLAIMS.values()),
-            ["ci", "merge"],
+            ["ci", "merge", "review"],
         )
         for kind in runtime_reader.RECEIPT_BACKED_RUN_CLAIMS.values():
             with self.subTest(kind=kind):


### PR DESCRIPTION
## Feature Report

### What Changed

- `Claim.REVIEW_OBSERVED` now requires a `succeeded` external effect receipt for this run's review effect, naming `runtime_review_record`, in addition to the observed review record it already required.
- The vendored Hermes-facing reader gains `review` in `RECEIPT_BACKED_RUN_CLAIMS`, so it withdraws an unbacked review claim the same way it already withdrew CI and merge.
- `handoff_safety_contract/v1` moves the `review_receipt` boundary from `declared_not_enforced` (blocked by this issue) to `enforced`, naming `omh.runtime.claims._receipt_cited` and `omh.workflows.external_effect_receipts.receipt_satisfies_success_claim`. The `evidence_separation` statement now reads "review, CI, and merge".

### Why This Exists

CI and merge success claims each required an observed `external_effect_receipt/v1` naming the acting surface. Review did not — `Claim.REVIEW_OBSERVED` was satisfied by an observed review record with `status == "passed"` and nothing else.

That was the one remaining stage where OMH would report "review passed" with nothing naming the surface that reviewed. The pieces to close it were already in place: `EXTERNAL_EFFECT_CLAIM_SURFACES` already mapped `review -> (review_submitted, runtime_review_record)`, `write_review_record` already minted a receipt from an observed review, and `_receipt_cited` already gated the two rungs above. Only the review rung skipped the check, and `handoff_safety_contract/v1` shipped that gap as a declared boundary with `blocked_by: "#844"`.

### User / Operator Impact

A run whose review is backed by a receipt is unaffected — the normal path through `omh runtime review` mints the receipt as it records, so the claim is reached exactly as before.

A run recorded before receipts existed changes: its ladder now stops at `verification_observed` instead of `review_observed`, and the blocked-claim reason says so in the same words CI and merge already used. Recovery is the same kind of step it already was, one longer: re-record review, then CI, then merge. Each re-record mints the receipt its own rung requires. Nothing about what counts as an observed review changed, and no new integration was added.

### How It Works

`_claim_allowed` for `Claim.REVIEW_OBSERVED` gains `_receipt_cited(status, review, kind="review")`, the same predicate the CI and merge rungs call, on the receipt the status projection already attached at `runtime/artifacts.py`. Because the predicate is shared with runtime validation, the ladder and the validator cannot disagree about what a receipt proves.

The absence of a receipt blocks the claim and does not fault validation. That is the rule #836 established and it is what keeps a legacy store valid rather than invalid: a refused claim can be recovered from, an invalid store cannot, and there is deliberately no mint command.

`RUNTIME_CLAIM_BLOCK_REASONS[REVIEW_OBSERVED]` was expanded to the same three-part reason CI and merge carry, so the refusal reads as a receipt gap rather than as a missing review.

### Files And Contracts Touched

- `src/runtime/claims.py` — the gate, the block reason, and the `_receipt_cited` docstring (it named only two rungs).
- `src/coding/action_gate.py` — `review_receipt` boundary flipped to `enforced`; `REVIEW_RECEIPT_BLOCKER` deleted; `evidence_separation` statement updated.
- `src/plugin_bundle/omh/runtime_reader.py` — `RECEIPT_BACKED_RUN_CLAIMS` and the withdrawal docstring.
- `tests/test_handoff_safety_contract.py`, `tests/test_external_effect_receipts.py`, `tests/test_runtime_reader_external_effect_receipts.py` — the assertions that pinned the old asymmetry.

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `python3 -m unittest discover -s tests` — Ran 4250 tests, OK (and again after rebasing onto merged `main`)
- [x] `python3 -m compileall src` — clean
- [x] `python3 -m omh.cli docs workflows --check` — `ok: true`
- [x] `python3 -m omh.cli harness validate` — `ok: true`, 72 harnesses / 104 skills
- [x] Also `docs roles --check`, `docs capability-families --check`, `git diff --check`
- [ ] Manual Hermes/TUI check — not run. The vendored reader change is covered by its parity tests; no live plugin surface was exercised.

Observed end-to-end recovery probe (not just unit assertions) on a legacy store with the receipt file removed:

```
claim_state before: verification_observed
runtime review -> status 0
runtime ci     -> status 0
runtime merge  -> status 0
claim_state after: merged
receipts: [('ci:<run>', 'succeeded'), ('merge:<run>', 'succeeded'), ('review:<run>', 'succeeded')]
```

Test changes that carry the contract:

- `test_review_is_receipt_gated_like_ci_and_merge_and_the_contract_says_so` replaces the test that asserted the asymmetry. It checks the refusal reason names the receipt and `runtime_review_record`, that `attempted`/`failed`/`unknown` receipts do not lift the claim, that a `succeeded` one does, and that the contract boundary is now `enforced` with its enforcer named.
- `test_a_receiptless_store_validates_clean_and_keeps_its_lower_rungs` now expects the ladder to stop at `verification_observed` and asserts `review_observed` is blocked for the receipt reason.
- The CLI recovery test runs three commands and asserts three succeeded receipts and the `review_recorded` event, so the longer recovery path is pinned rather than implied.

## Risk

Moderate, and concentrated in one place: any run recorded before receipts existed loses the `review_observed` rung until re-recorded. That is the intended behavior change, it is recoverable through commands that already exist, and it never invalidates a store. Every fixture in the suite that reaches `review_observed` now needs a review receipt — the three test files above were the complete set, and the full suite confirms it.

## Compatibility / Rollout

- No schema change. `external_effect_receipt/v1` and the review record are untouched; only which claim reads them changed.
- No migration. A legacy store stays valid and validates clean; it reports a lower claim state until an operator re-records the gate.
- The vendored reader and the CLI move together, so the Hermes-facing surface and `omh runtime check` cannot disagree — `test_reader_verdict_matches_the_cli_claim_gate` covers exactly that.

## Release / Claims

- [x] Release-channel impact considered — `local`; behavior change is in claim gating, not packaging
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — all validation above is observed local output
- [x] Known manual Hermes checks are listed — `omh release hermes-smoke --live` not run

## Follow-Up

- `handoff_safety_contract/v1` still declares `recovery` (#821), `start_evidence` (#826), `storage_retention` (#835), `workspace` (#820), and `confirmation_answered` as unenforced. This PR removes one row from that list.

Closes #844
