### PR TITLE
feat: name the catalog revision behind the Hermes-visible guidance projection

### DIFF
--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -726,7 +726,7 @@ def _doctor_operator_summary(checks: list[object]) -> dict[str, object]:
         "warnings": warnings,
         "groups": [
             _doctor_group("command", check_dicts, ("command_path",)),
-            _doctor_group("managed_skills", check_dicts, ("manifest", "manifest_skills_dir", "local_modifications", "skill_freshness", "skills_dir", "skill:")),
+            _doctor_group("managed_skills", check_dicts, ("manifest", "manifest_skills_dir", "local_modifications", "skill_freshness", "skills_dir", "skill:", "guidance_projection")),
             _doctor_group("runtime", check_dicts, ("runtime_artifacts", "workflow_state", "runtime_state")),
             _doctor_group("hermes_registration", check_dicts, ("hermes_config", "external_dir", "skill_shadowing", "runtime_context")),
             _doctor_group("targets", check_dicts, ("target_registry", "target_topology")),

--- a/src/install/guidance_projection.py
+++ b/src/install/guidance_projection.py
@@ -1,0 +1,279 @@
+"""One status for the Hermes-visible projection of reviewed OMH guidance.
+
+The canonical guidance is catalog data in `src/skills/`. What Hermes reads is a
+generated projection of it under the managed skills directory. Those are two
+different things, and four different questions can be asked about the gap
+between them:
+
+1. Is the projection rendered from the catalog this package carries?
+2. Has anything rewritten the projected files since they were installed?
+3. Is the managed directory registered where Hermes would look?
+4. Has the running host actually been observed reading it?
+
+Doctor already answered fragments of all four, across `manifest`,
+`local_modifications`, `skill_freshness`, `external_dir`, and `runtime_context`.
+What it could not do was say which of the four was the problem, because there
+was no single identifier for "the catalog this package would render". Comparing
+per-file checksums against freshly rendered templates detects drift but cannot
+name the revision that drifted, so a manifest could not record what it was
+projected from.
+
+`catalog_revision` is that identifier, and `build_guidance_projection_status`
+is the projection that keeps the four answers separate. The separation is the
+point: registration is not observation, and a fresh projection is not proof
+that Hermes loaded it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ..hashutil import sha256_file, sha256_text
+from ..skill_pack import builtin_skill_reference_templates, builtin_skill_templates
+from ..skills.catalog import omh_skill_display_name
+
+GUIDANCE_PROJECTION_STATUS_SCHEMA_VERSION = "guidance_projection_status/v1"
+
+# Whether the installed files were rendered from the catalog this package
+# carries. `not_comparable` is for a projection installed from a local source
+# tree, where "the packaged catalog" is not the thing it came from.
+PROJECTION_STATES = ("fresh", "stale", "missing", "not_comparable")
+# Whether anything rewrote the projected files after they were installed. This
+# is deliberately a separate axis from `PROJECTION_STATES`: a locally edited
+# file and a file left behind by an older release both differ from the current
+# catalog, and they need different repairs.
+DRIFT_STATES = ("clean", "locally_modified", "unknown")
+REGISTRATION_STATES = ("registered", "not_registered", "unknown")
+# Whether the running host was observed reading the projection. There is no
+# `not_registered` here on purpose -- an unregistered directory that a host was
+# somehow observed reading is a real state, and collapsing the two axes would
+# hide it.
+HOST_OBSERVATION_STATES = ("observed", "not_observed")
+
+GUIDANCE_PROJECTION_STATUS_KEYS = (
+    "catalog_revision",
+    "claim_boundary",
+    "drift",
+    "host_observation",
+    "installed_revision",
+    "locally_modified",
+    "next_action",
+    "projection",
+    "registration",
+    "schema_version",
+    "skills_dir",
+)
+
+GUIDANCE_PROJECTION_CLAIM_BOUNDARY = (
+    "This is the local projection state of generated OMH guidance. A fresh projection means the "
+    "installed files match the catalog this package carries; it is not evidence that Hermes loaded, "
+    "selected, or executed them. Registration is where Hermes would look, not proof that it did."
+)
+
+
+def catalog_revision() -> str:
+    """A digest naming the guidance this package would render.
+
+    Every generated file has a template, so hashing the templates names the
+    catalog without touching disk. Names are included beside content so that
+    renaming a skill changes the revision even when no body text does, and the
+    pairs are sorted so the digest does not depend on catalog iteration order.
+    """
+    lines = [
+        f"skill\0{template.name}\0{sha256_text(template.content)}" for template in builtin_skill_templates()
+    ]
+    lines.extend(
+        f"reference\0{template.skill_name}\0{template.relative_path}\0{sha256_text(template.content)}"
+        for template in builtin_skill_reference_templates()
+    )
+    return sha256_text("\n".join(sorted(lines)))
+
+
+def projected_skill_paths() -> tuple[str, ...]:
+    """The projection-relative path of every generated SKILL.md, in catalog order."""
+    return tuple(
+        f"{omh_skill_display_name(template.name)}/SKILL.md" for template in builtin_skill_templates()
+    )
+
+
+def build_guidance_projection_status(
+    skills_dir: Path,
+    manifest: dict[str, Any] | None,
+    *,
+    registered: bool | None,
+    host_observed: bool,
+) -> dict[str, Any]:
+    """Report the four projection questions as four separate answers.
+
+    `registered` is `None` when the Hermes config could not be read at all,
+    which is `unknown` rather than `not_registered`: an unreadable config is a
+    different repair from a config that simply does not list the directory.
+
+    `host_observed` comes from the caller because OMH cannot observe a running
+    Hermes from here. Absent evidence is `not_observed`, never `observed`.
+    """
+    current = catalog_revision()
+    installed = str((manifest or {}).get("catalog_revision", ""))
+    source = str((manifest or {}).get("source", "")) or "unknown"
+    modified = _locally_modified(manifest, skills_dir)
+    projection = _projection_state(
+        skills_dir=skills_dir,
+        manifest=manifest,
+        source=source,
+        installed_revision=installed,
+        current_revision=current,
+    )
+    drift = "unknown" if manifest is None else "locally_modified" if modified else "clean"
+    registration = (
+        "unknown" if registered is None else "registered" if registered else "not_registered"
+    )
+    return {
+        "schema_version": GUIDANCE_PROJECTION_STATUS_SCHEMA_VERSION,
+        "skills_dir": str(skills_dir),
+        "catalog_revision": current,
+        "installed_revision": installed,
+        "projection": projection,
+        "drift": drift,
+        "locally_modified": modified,
+        "registration": registration,
+        "host_observation": "observed" if host_observed else "not_observed",
+        "next_action": _next_action(projection, drift, registration),
+        "claim_boundary": GUIDANCE_PROJECTION_CLAIM_BOUNDARY,
+    }
+
+
+def validate_guidance_projection_status(payload: Any) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(payload, dict):
+        return ["guidance_projection_status must be an object"]
+    extra = sorted(set(payload) - set(GUIDANCE_PROJECTION_STATUS_KEYS))
+    if extra:
+        errors.append(f"guidance_projection_status has unsupported keys: {extra}")
+    missing = sorted(set(GUIDANCE_PROJECTION_STATUS_KEYS) - set(payload))
+    if missing:
+        errors.append(f"guidance_projection_status is missing keys: {missing}")
+    if payload.get("schema_version") != GUIDANCE_PROJECTION_STATUS_SCHEMA_VERSION:
+        errors.append(
+            f"guidance_projection_status schema_version must be {GUIDANCE_PROJECTION_STATUS_SCHEMA_VERSION}"
+        )
+    for key, vocabulary in (
+        ("projection", PROJECTION_STATES),
+        ("drift", DRIFT_STATES),
+        ("registration", REGISTRATION_STATES),
+        ("host_observation", HOST_OBSERVATION_STATES),
+    ):
+        value = payload.get(key)
+        if value not in vocabulary:
+            errors.append(f"guidance_projection_status {key} must be one of {list(vocabulary)}")
+    for key in ("catalog_revision", "claim_boundary", "installed_revision", "next_action", "skills_dir"):
+        if not isinstance(payload.get(key), str):
+            errors.append(f"guidance_projection_status {key} must be a string")
+    modified = payload.get("locally_modified")
+    if not isinstance(modified, list) or not all(isinstance(item, str) for item in modified):
+        errors.append("guidance_projection_status locally_modified must be a list of strings")
+    elif list(modified) != sorted(modified):
+        errors.append("guidance_projection_status locally_modified must be sorted")
+    elif modified and payload.get("drift") != "locally_modified":
+        errors.append("guidance_projection_status drift must be locally_modified when files are listed")
+    return errors
+
+
+def _projection_state(
+    *,
+    skills_dir: Path,
+    manifest: dict[str, Any] | None,
+    source: str,
+    installed_revision: str,
+    current_revision: str,
+) -> str:
+    if manifest is None:
+        return "missing"
+    if source != "builtin":
+        # Installed from a local source tree. The packaged catalog is not what
+        # it was rendered from, so comparing the two would report drift that no
+        # `omh update` can resolve.
+        return "not_comparable"
+    installed_paths = _manifest_paths(manifest)
+    if not installed_paths:
+        return "missing"
+    # Completeness is measured against the manifest, not against the catalog.
+    # `omh setup` installs a profile subset by default (`CORE_PROFILE_SKILLS`),
+    # so "every template has a file" would report a correct install as missing.
+    if any(not (skills_dir / rel).is_file() for rel in installed_paths):
+        return "missing"
+    if not installed_revision:
+        # A manifest written before revisions were recorded. Fall back to the
+        # comparison that does not need one: does every installed file match
+        # what this package renders for it today?
+        return "fresh" if _installed_files_match_catalog(skills_dir, manifest) else "stale"
+    return "fresh" if installed_revision == current_revision else "stale"
+
+
+def _manifest_paths(manifest: dict[str, Any]) -> list[str]:
+    return [
+        str(record.get("path", ""))
+        for record in manifest.get("skills", [])
+        if isinstance(record, dict) and str(record.get("path", ""))
+    ]
+
+
+def _installed_files_match_catalog(skills_dir: Path, manifest: dict[str, Any]) -> bool:
+    """Whether every installed SKILL.md matches the template this package renders.
+
+    Only files the manifest lists are compared, for the same reason
+    `_projection_state` measures completeness that way: a profile install is
+    complete without every template on disk.
+    """
+    rendered = {
+        f"{omh_skill_display_name(template.name)}/SKILL.md": sha256_text(template.content)
+        for template in builtin_skill_templates()
+    }
+    for rel in _manifest_paths(manifest):
+        expected = rendered.get(rel)
+        if expected is None:
+            # A file with no template in this package: it cannot be compared
+            # against the packaged catalog, so it is not evidence of staleness.
+            continue
+        path = skills_dir / rel
+        if not path.is_file() or sha256_file(path) != expected:
+            return False
+    return True
+
+
+def _locally_modified(manifest: dict[str, Any] | None, skills_dir: Path) -> list[str]:
+    """Projected files whose bytes no longer match the manifest that installed them.
+
+    This is read-only and one-way. Nothing here reads a modified file back into
+    catalog data -- the projection is generated from `src/skills/`, never
+    imported from disk -- so an edited file is reported and then replaced by the
+    next `omh update`, not adopted.
+    """
+    if not manifest:
+        return []
+    modified: list[str] = []
+    for record in manifest.get("skills", []):
+        if not isinstance(record, dict):
+            continue
+        rel = str(record.get("path", ""))
+        expected = str(record.get("sha256", ""))
+        if not rel or not expected:
+            continue
+        path = skills_dir / rel
+        if not path.is_file() or sha256_file(path) != expected:
+            modified.append(rel)
+    return sorted(modified)
+
+
+def _next_action(projection: str, drift: str, registration: str) -> str:
+    # Ordered by which repair has to happen first: content the operator edited
+    # would be overwritten by an update, so it is named before the update.
+    if drift == "locally_modified":
+        return "Run `omh update --force` to replace locally modified managed skills, or keep the edits and accept drift."
+    if projection in {"stale", "missing"}:
+        return "Run `omh update` to regenerate the managed projection from this package's catalog."
+    if registration == "not_registered":
+        return "Run `omh setup` to register the managed skills directory with Hermes."
+    if registration == "unknown":
+        return "Run `omh doctor --hermes-home <the home the Hermes process uses>` to read its config."
+    return "No repair needed. Hermes runtime use stays unobserved until a host observation records it."

--- a/src/install/manifest.py
+++ b/src/install/manifest.py
@@ -10,6 +10,7 @@ from typing import Any
 from ..version import __version__
 from ..hashutil import sha256_file
 from ..local_store import atomic_write_json, read_json_object, utc_now
+from .guidance_projection import catalog_revision
 
 
 @dataclass(frozen=True)
@@ -28,6 +29,11 @@ def new_manifest(source: str, skills_dir: Path, records: list[SkillRecord]) -> d
         "source": source,
         "installed_at": utc_now(),
         "skills_dir": str(skills_dir),
+        # What the projection was rendered from, not just which release wrote
+        # it. A version string cannot distinguish two builds of the same
+        # release with different catalog data, and per-file checksums detect
+        # drift without naming what drifted. See `install.guidance_projection`.
+        "catalog_revision": catalog_revision(),
         "skills": [record.__dict__ for record in sorted(records, key=lambda item: item.name)],
     }
 

--- a/src/maintenance/doctor.py
+++ b/src/maintenance/doctor.py
@@ -16,6 +16,7 @@ from ..config_adapter import (
 )
 from ..hashutil import sha256_file, sha256_text
 from ..local_store import can_write_dir
+from ..install.guidance_projection import build_guidance_projection_status
 from ..manifest import local_modifications, read_manifest
 from ..paths import OmhPaths
 from ..plugin_bundle.omh.memory_dreaming import read_dreaming_state, read_latest_consolidation
@@ -151,6 +152,7 @@ def run_doctor(paths: OmhPaths) -> list[Check]:
             ),
         )
     )
+    checks.append(_guidance_projection_check(paths, manifest, registered=external_registered))
     target_registry, target_registry_error = read_target_registry_result(paths)
     target_topology = summarize_target_registry(paths)
     if target_registry_error:
@@ -646,6 +648,45 @@ def _skill_freshness_check(paths: OmhPaths, manifest: dict) -> Check:
         ),
         remediation="Run `omh update` to regenerate the managed skills from the current package catalog.",
         next_action="Run `omh update`, then `omh doctor` again.",
+    )
+
+
+def _guidance_projection_check(paths: OmhPaths, manifest: dict | None, *, registered: bool) -> Check:
+    """Report the Hermes-visible guidance projection as one answer with four axes.
+
+    `manifest`, `local_modifications`, `skill_freshness`, `external_dir`, and
+    `runtime_context` each answer a fragment, and an operator reading them has
+    to work out which fragment is the actual problem. This check names the
+    catalog revision the projection was rendered from and states freshness,
+    drift, registration, and observed host use as four separate values, so the
+    repair is not guessed from a list of booleans.
+
+    It fails only on the axis the others do not own: whether the projection is
+    current and untampered. Registration keeps its own check, and observed host
+    use is never a failure -- OMH cannot see a running Hermes from here, so
+    `not_observed` is the honest resting state, not a fault.
+    """
+    status = build_guidance_projection_status(
+        paths.skills_dir,
+        manifest,
+        registered=registered,
+        host_observed=False,
+    )
+    projection = str(status["projection"])
+    drift = str(status["drift"])
+    current = projection in {"fresh", "not_comparable"} and drift in {"clean", "unknown"}
+    summary = (
+        f"projection={projection} drift={drift} registration={status['registration']} "
+        f"host_observation={status['host_observation']} catalog_revision={str(status['catalog_revision'])[:12]}"
+    )
+    if current:
+        return Check("guidance_projection", True, summary)
+    return Check(
+        "guidance_projection",
+        False,
+        summary,
+        remediation=str(status["next_action"]),
+        next_action=str(status["next_action"]),
     )
 
 

--- a/tests/test_guidance_projection.py
+++ b/tests/test_guidance_projection.py
@@ -27,6 +27,7 @@ from omh.install.guidance_projection import (
     validate_guidance_projection_status,
 )
 from omh.commands import setup as setup_commands
+from omh.local_store import atomic_write_text
 from omh.maintenance.doctor import run_doctor
 from omh.manifest import SkillRecord, new_manifest, skill_records
 from omh.paths import resolve_paths
@@ -35,11 +36,18 @@ from omh.skills.catalog import omh_skill_display_name
 
 
 def _install_projection(skills_dir: Path) -> dict[str, object]:
-    """Render the projection the way the installer does, then manifest it."""
+    """Render the projection the way the installer does, then manifest it.
+
+    `atomic_write_text`, not `Path.write_text`: the installer writes through it
+    for its `newline=""`, which keeps `\\n` on disk as `\\n`. Writing in default
+    text mode translates to CRLF on Windows, and the catalog comparison hashes
+    template content that still has LF -- so the same install reads as `fresh`
+    on Linux and `stale` on Windows.
+    """
     for template in builtin_skill_templates():
         path = skills_dir / omh_skill_display_name(template.name) / "SKILL.md"
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(template.content, encoding="utf-8")
+        atomic_write_text(path, template.content)
     return new_manifest("builtin", skills_dir, skill_records(skills_dir, "builtin"))
 
 

--- a/tests/test_guidance_projection.py
+++ b/tests/test_guidance_projection.py
@@ -1,0 +1,365 @@
+"""#817: the Hermes-visible guidance projection reports one honest status.
+
+The four axes this file pins apart -- projection freshness, local drift,
+registration, and observed host use -- were previously answerable only by
+reading five doctor checks and inferring which one mattered.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.install.guidance_projection import (
+    DRIFT_STATES,
+    GUIDANCE_PROJECTION_STATUS_KEYS,
+    GUIDANCE_PROJECTION_STATUS_SCHEMA_VERSION,
+    HOST_OBSERVATION_STATES,
+    PROJECTION_STATES,
+    REGISTRATION_STATES,
+    build_guidance_projection_status,
+    catalog_revision,
+    projected_skill_paths,
+    validate_guidance_projection_status,
+)
+from omh.commands import setup as setup_commands
+from omh.maintenance.doctor import run_doctor
+from omh.manifest import SkillRecord, new_manifest, skill_records
+from omh.paths import resolve_paths
+from omh.skill_pack import builtin_skill_templates
+from omh.skills.catalog import omh_skill_display_name
+
+
+def _install_projection(skills_dir: Path) -> dict[str, object]:
+    """Render the projection the way the installer does, then manifest it."""
+    for template in builtin_skill_templates():
+        path = skills_dir / omh_skill_display_name(template.name) / "SKILL.md"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(template.content, encoding="utf-8")
+    return new_manifest("builtin", skills_dir, skill_records(skills_dir, "builtin"))
+
+
+class CatalogRevisionTests(unittest.TestCase):
+    def test_the_revision_is_a_stable_digest_of_the_packaged_catalog(self) -> None:
+        first = catalog_revision()
+        self.assertEqual(first, catalog_revision())
+        self.assertEqual(len(first), 64)
+        self.assertTrue(all(character in "0123456789abcdef" for character in first))
+
+    def test_the_revision_covers_every_projected_skill(self) -> None:
+        # If a skill were absent from the digest, renaming or rewriting it
+        # would leave a stale projection reporting `fresh`.
+        self.assertEqual(len(projected_skill_paths()), len(builtin_skill_templates()))
+        self.assertEqual(len(set(projected_skill_paths())), len(projected_skill_paths()))
+
+    def test_a_manifest_records_the_revision_it_was_rendered_from(self) -> None:
+        with TemporaryDirectory() as tmp:
+            skills_dir = Path(tmp) / "skills"
+            manifest = _install_projection(skills_dir)
+            self.assertEqual(manifest["catalog_revision"], catalog_revision())
+
+
+class ProjectionStatusTests(unittest.TestCase):
+    """AC1: a fresh projection matches the catalog revision and the checksums."""
+
+    def test_a_freshly_installed_projection_is_fresh_and_clean(self) -> None:
+        with TemporaryDirectory() as tmp:
+            skills_dir = Path(tmp) / "skills"
+            manifest = _install_projection(skills_dir)
+
+            status = build_guidance_projection_status(
+                skills_dir, manifest, registered=True, host_observed=False
+            )
+
+            self.assertEqual(validate_guidance_projection_status(status), [])
+            self.assertEqual(status["projection"], "fresh")
+            self.assertEqual(status["drift"], "clean")
+            self.assertEqual(status["locally_modified"], [])
+            self.assertEqual(status["catalog_revision"], status["installed_revision"])
+
+    def test_a_projection_rendered_from_an_older_catalog_is_stale(self) -> None:
+        with TemporaryDirectory() as tmp:
+            skills_dir = Path(tmp) / "skills"
+            manifest = _install_projection(skills_dir)
+            # What an older release's manifest looks like from here: it names a
+            # catalog revision this package does not carry.
+            aged = {**manifest, "catalog_revision": "0" * 64}
+
+            status = build_guidance_projection_status(
+                skills_dir, aged, registered=True, host_observed=False
+            )
+
+            self.assertEqual(status["projection"], "stale")
+            self.assertIn("omh update", str(status["next_action"]))
+
+    def test_a_manifest_written_before_revisions_falls_back_to_checksums(self) -> None:
+        # AC1 has to hold for stores that predate the revision field, and the
+        # only comparison available there is per-file content.
+        with TemporaryDirectory() as tmp:
+            skills_dir = Path(tmp) / "skills"
+            manifest = _install_projection(skills_dir)
+            legacy = {key: value for key, value in manifest.items() if key != "catalog_revision"}
+
+            self.assertEqual(
+                build_guidance_projection_status(
+                    skills_dir, legacy, registered=True, host_observed=False
+                )["projection"],
+                "fresh",
+            )
+
+            first = skills_dir / projected_skill_paths()[0]
+            first.write_text("content an older release rendered\n", encoding="utf-8")
+
+            self.assertEqual(
+                build_guidance_projection_status(
+                    skills_dir, legacy, registered=True, host_observed=False
+                )["projection"],
+                "stale",
+            )
+
+    def test_a_missing_projection_is_missing_rather_than_stale(self) -> None:
+        with TemporaryDirectory() as tmp:
+            skills_dir = Path(tmp) / "skills"
+            manifest = _install_projection(skills_dir)
+            (skills_dir / projected_skill_paths()[0]).unlink()
+
+            status = build_guidance_projection_status(
+                skills_dir, manifest, registered=True, host_observed=False
+            )
+
+            self.assertEqual(status["projection"], "missing")
+
+    def test_a_local_source_install_is_not_comparable_to_the_packaged_catalog(self) -> None:
+        with TemporaryDirectory() as tmp:
+            skills_dir = Path(tmp) / "skills"
+            manifest = {**_install_projection(skills_dir), "source": "/some/local/checkout"}
+
+            status = build_guidance_projection_status(
+                skills_dir, manifest, registered=True, host_observed=False
+            )
+
+            # Not "stale": no `omh update` resolves a difference from a catalog
+            # the projection was never rendered from.
+            self.assertEqual(status["projection"], "not_comparable")
+
+
+class LocalModificationTests(unittest.TestCase):
+    """AC2: modified files are detected and never imported into canonical data."""
+
+    def test_an_edited_projected_file_is_reported_as_drift(self) -> None:
+        with TemporaryDirectory() as tmp:
+            skills_dir = Path(tmp) / "skills"
+            manifest = _install_projection(skills_dir)
+            edited = projected_skill_paths()[0]
+            (skills_dir / edited).write_text("hand edit\n", encoding="utf-8")
+
+            status = build_guidance_projection_status(
+                skills_dir, manifest, registered=True, host_observed=False
+            )
+
+            self.assertEqual(status["drift"], "locally_modified")
+            self.assertEqual(status["locally_modified"], [edited])
+            self.assertIn("--force", str(status["next_action"]))
+
+    def test_an_edited_file_never_becomes_the_catalog_revision(self) -> None:
+        # The one-way boundary. Editing a projected file must not change what
+        # the package says it would render, or a hand edit would silently
+        # become canonical on the next install.
+        with TemporaryDirectory() as tmp:
+            skills_dir = Path(tmp) / "skills"
+            _install_projection(skills_dir)
+            before = catalog_revision()
+
+            (skills_dir / projected_skill_paths()[0]).write_text("hand edit\n", encoding="utf-8")
+
+            self.assertEqual(catalog_revision(), before)
+            # And a reinstall from the same tree restores the rendered content.
+            reinstalled = _install_projection(skills_dir)
+            self.assertEqual(reinstalled["catalog_revision"], before)
+            self.assertEqual(
+                build_guidance_projection_status(
+                    skills_dir, reinstalled, registered=True, host_observed=False
+                )["locally_modified"],
+                [],
+            )
+
+    def test_drift_is_reported_separately_from_freshness(self) -> None:
+        # A file the operator edited and a file an older release left behind
+        # both differ from the catalog, and they need different repairs. One
+        # axis could not say which.
+        with TemporaryDirectory() as tmp:
+            skills_dir = Path(tmp) / "skills"
+            manifest = _install_projection(skills_dir)
+            (skills_dir / projected_skill_paths()[0]).write_text("hand edit\n", encoding="utf-8")
+
+            status = build_guidance_projection_status(
+                skills_dir, manifest, registered=True, host_observed=False
+            )
+
+            self.assertEqual(status["projection"], "fresh")
+            self.assertEqual(status["drift"], "locally_modified")
+
+
+class RegistrationAndObservationTests(unittest.TestCase):
+    """AC3: status is explained without file export or config edits."""
+
+    def test_registration_and_observed_use_are_separate_axes(self) -> None:
+        with TemporaryDirectory() as tmp:
+            skills_dir = Path(tmp) / "skills"
+            manifest = _install_projection(skills_dir)
+
+            registered = build_guidance_projection_status(
+                skills_dir, manifest, registered=True, host_observed=False
+            )
+            # Registered is where Hermes would look, not proof that it did.
+            self.assertEqual(registered["registration"], "registered")
+            self.assertEqual(registered["host_observation"], "not_observed")
+
+            observed = build_guidance_projection_status(
+                skills_dir, manifest, registered=True, host_observed=True
+            )
+            self.assertEqual(observed["host_observation"], "observed")
+
+    def test_an_unreadable_config_is_unknown_and_not_unregistered(self) -> None:
+        with TemporaryDirectory() as tmp:
+            skills_dir = Path(tmp) / "skills"
+            manifest = _install_projection(skills_dir)
+
+            status = build_guidance_projection_status(
+                skills_dir, manifest, registered=None, host_observed=False
+            )
+
+            self.assertEqual(status["registration"], "unknown")
+            self.assertIn("--hermes-home", str(status["next_action"]))
+
+    def test_the_claim_boundary_denies_runtime_use(self) -> None:
+        with TemporaryDirectory() as tmp:
+            skills_dir = Path(tmp) / "skills"
+            manifest = _install_projection(skills_dir)
+
+            boundary = str(
+                build_guidance_projection_status(
+                    skills_dir, manifest, registered=True, host_observed=False
+                )["claim_boundary"]
+            )
+
+            self.assertIn("not evidence that Hermes loaded", boundary)
+            self.assertIn("Registration is where Hermes would look", boundary)
+
+    def test_an_absent_manifest_is_missing_with_unknown_drift(self) -> None:
+        with TemporaryDirectory() as tmp:
+            skills_dir = Path(tmp) / "skills"
+
+            status = build_guidance_projection_status(
+                skills_dir, None, registered=False, host_observed=False
+            )
+
+            self.assertEqual(validate_guidance_projection_status(status), [])
+            self.assertEqual(status["projection"], "missing")
+            self.assertEqual(status["drift"], "unknown")
+            self.assertEqual(status["registration"], "not_registered")
+
+
+class ValidatorTests(unittest.TestCase):
+    def test_the_key_set_is_closed_in_both_directions(self) -> None:
+        with TemporaryDirectory() as tmp:
+            skills_dir = Path(tmp) / "skills"
+            status = build_guidance_projection_status(
+                skills_dir, _install_projection(skills_dir), registered=True, host_observed=False
+            )
+            self.assertEqual(tuple(sorted(status)), GUIDANCE_PROJECTION_STATUS_KEYS)
+            self.assertEqual(status["schema_version"], GUIDANCE_PROJECTION_STATUS_SCHEMA_VERSION)
+
+            extra = {**status, "surprise": 1}
+            self.assertTrue(any("unsupported keys" in error for error in validate_guidance_projection_status(extra)))
+
+            short = {key: value for key, value in status.items() if key != "drift"}
+            self.assertTrue(any("missing keys" in error for error in validate_guidance_projection_status(short)))
+
+    def test_every_vocabulary_is_refused_outside_its_own_values(self) -> None:
+        with TemporaryDirectory() as tmp:
+            skills_dir = Path(tmp) / "skills"
+            status = build_guidance_projection_status(
+                skills_dir, _install_projection(skills_dir), registered=True, host_observed=False
+            )
+            for key, vocabulary in (
+                ("projection", PROJECTION_STATES),
+                ("drift", DRIFT_STATES),
+                ("registration", REGISTRATION_STATES),
+                ("host_observation", HOST_OBSERVATION_STATES),
+            ):
+                with self.subTest(key=key):
+                    self.assertIn(status[key], vocabulary)
+                    broken = {**status, key: "made_up"}
+                    self.assertTrue(
+                        any(key in error for error in validate_guidance_projection_status(broken))
+                    )
+
+    def test_listed_modifications_cannot_be_reported_as_clean_drift(self) -> None:
+        with TemporaryDirectory() as tmp:
+            skills_dir = Path(tmp) / "skills"
+            status = build_guidance_projection_status(
+                skills_dir, _install_projection(skills_dir), registered=True, host_observed=False
+            )
+            lying = {**status, "locally_modified": ["a/SKILL.md"], "drift": "clean"}
+            self.assertTrue(
+                any("drift must be locally_modified" in error for error in validate_guidance_projection_status(lying))
+            )
+
+    def test_a_non_object_payload_is_refused(self) -> None:
+        self.assertEqual(
+            validate_guidance_projection_status("not a status"),
+            ["guidance_projection_status must be an object"],
+        )
+
+
+class ManifestRecordTests(unittest.TestCase):
+    def test_skill_records_still_carry_canonical_names(self) -> None:
+        # The revision field is additive; it must not disturb what the manifest
+        # already recorded, which other callers compare against the catalog.
+        with TemporaryDirectory() as tmp:
+            skills_dir = Path(tmp) / "skills"
+            manifest = _install_projection(skills_dir)
+            names = {str(record["name"]) for record in manifest["skills"]}
+            self.assertTrue(names)
+            self.assertTrue(names.issubset({template.name for template in builtin_skill_templates()}))
+            self.assertTrue(all(isinstance(SkillRecord(**record), SkillRecord) for record in manifest["skills"]))
+
+
+class DoctorSurfaceTests(unittest.TestCase):
+    """AC3, at the surface a user actually reaches: `omh doctor`."""
+
+    def test_doctor_reports_the_projection_as_one_grouped_check(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            checks = run_doctor(paths)
+
+            by_name = {check.name: check for check in checks}
+            self.assertIn("guidance_projection", by_name)
+            message = by_name["guidance_projection"].message
+            for axis in ("projection=", "drift=", "registration=", "host_observation=", "catalog_revision="):
+                self.assertIn(axis, message)
+
+            # The check has to land in a named group, or an operator reading
+            # the grouped summary never sees it.
+            summary = setup_commands._doctor_operator_summary(checks)
+            managed = next(group for group in summary["groups"] if group["name"] == "managed_skills")
+            self.assertIn("guidance_projection", managed["failed"])
+
+    def test_a_failing_projection_names_the_repair(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            check = next(item for item in run_doctor(paths) if item.name == "guidance_projection")
+            # Nothing is installed in a bare home, so the projection is missing
+            # and the check has to say what fixes it rather than only that it
+            # is broken.
+            self.assertFalse(check.ok)
+            self.assertIn("omh update", check.next_action)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- `catalog_revision()` — a digest naming the guidance this package would render, over every skill and reference template.
- `new_manifest()` records that revision at install time, so a projection on disk can say what it was rendered from.
- `guidance_projection_status/v1` (`src/install/guidance_projection.py`) — one read-only status reporting four separate axes: projection freshness, local drift, registration, and observed host use.
- `omh doctor` gains a `guidance_projection` check that renders all four axes in one line and names the repair, grouped under `managed_skills`.

### Why This Exists

The canonical guidance is catalog data in `src/skills/`. What Hermes reads is a generated projection of it under the managed skills directory. Four different questions can be asked about the gap between them, and doctor already answered fragments of all four — across `manifest`, `local_modifications`, `skill_freshness`, `external_dir`, and `runtime_context`.

What it could not do was say which of the four was the actual problem. Worse, there was no identifier for "the catalog this package would render": `skill_freshness` detects drift by re-rendering templates and comparing checksums, which finds a difference but cannot name the revision that differed, so a manifest had no way to record what its projection came from. A version string is not a substitute — two builds of the same release can carry different catalog data.

### User / Operator Impact

`omh doctor` now answers "is the guidance Hermes sees current and trustworthy" in one place instead of five, and says what to run:

```
guidance_projection  projection=stale drift=clean registration=registered
                     host_observation=not_observed catalog_revision=6ee8f0a1b2c3
                     -> Run `omh update` to regenerate the managed projection
                        from this package's catalog.
```

The axes stay separate on purpose. A file the operator hand-edited and a file an older release left behind both differ from the catalog, and they need different repairs — `omh update --force` versus `omh update`. Collapsing them into one "stale" would pick the wrong one and silently discard the edit. Likewise, `registered` says where Hermes would look; it is never reported as proof that Hermes looked.

### How It Works

`catalog_revision()` hashes `name\0sha256(content)` per template — names beside content, so renaming a skill moves the revision even when no body text changes — sorted before hashing, so the digest does not depend on catalog iteration order. It touches no disk and no clock, so it is stable across processes and safe inside a compared value.

`build_guidance_projection_status(skills_dir, manifest, registered=, host_observed=)` returns a closed key set with a `claim_boundary`. Three deliberate distinctions:

- `registered=None` maps to `unknown`, not `not_registered`. An unreadable Hermes config is a different repair from a config that simply does not list the directory.
- `host_observed` is a caller input. OMH cannot see a running Hermes from here, so absent evidence is `not_observed` and never `observed`.
- `source != "builtin"` maps to `not_comparable`, not `stale`. No `omh update` resolves a difference from a catalog the projection was never rendered from.

**Completeness is measured against the manifest, not the catalog.** This was a real bug caught by the full suite: `omh setup` installs `CORE_PROFILE_SKILLS` by default, so an initial "every template has a file" rule reported a correct profile install as `missing` and failed 16 tests across `test_plugin_distribution` and `test_plugin_observations`. The rule now compares the paths the manifest lists.

A manifest written before the revision field falls back to per-file content comparison, so the acceptance criterion still holds for stores that predate this change.

### Files And Contracts Touched

- `src/install/guidance_projection.py` — new module: `catalog_revision`, `build_guidance_projection_status`, `validate_guidance_projection_status`, four state vocabularies.
- `src/install/manifest.py` — `new_manifest` records `catalog_revision`.
- `src/maintenance/doctor.py` — `_guidance_projection_check`.
- `src/commands/setup.py` — the new check joins the `managed_skills` doctor group.
- `tests/test_guidance_projection.py` — new, 22 tests.

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `python3 -m unittest discover -s tests` — Ran 4276 tests, OK
- [x] `python3 -m compileall src` — clean
- [x] `python3 -m omh.cli docs workflows --check` — `ok: true`
- [x] `python3 -m omh.cli harness validate` — `ok: true`, 72 harnesses / 104 skills
- [x] Also `docs roles --check`, `docs capability-families --check`, `git diff --check`
- [ ] Manual Hermes/TUI check — not run. `host_observed` is a caller input and doctor passes `False`, so the observed branch is covered by unit tests only; no live Hermes host observation was exercised.

The 22 new tests map to the acceptance criteria:

| Acceptance criterion | Tests |
| --- | --- |
| Fresh projection matches catalog revision and checksums | `test_a_freshly_installed_projection_is_fresh_and_clean`, `test_a_projection_rendered_from_an_older_catalog_is_stale`, `test_a_manifest_written_before_revisions_falls_back_to_checksums`, `test_a_manifest_records_the_revision_it_was_rendered_from` |
| Modified files detected, never imported into canonical data | `test_an_edited_projected_file_is_reported_as_drift`, `test_an_edited_file_never_becomes_the_catalog_revision`, `test_drift_is_reported_separately_from_freshness` |
| Hermes explains status without file export or config edits | `test_doctor_reports_the_projection_as_one_grouped_check`, `test_a_failing_projection_names_the_repair`, `test_registration_and_observed_use_are_separate_axes`, `test_the_claim_boundary_denies_runtime_use` |

The one-way boundary has its own test: editing a projected file leaves `catalog_revision()` byte-identical, and a reinstall restores the rendered content. That is what stops a hand edit from becoming canonical.

## Risk

Low-to-moderate. The new doctor check can fail where doctor previously passed — specifically on a home whose projection is stale or locally modified, which is the point. The failure mode that mattered (a healthy profile install reported as broken) was found by the full suite and fixed before this PR; the suite is green now.

`new_manifest` gains a key. Manifests are read with `.get()` throughout and the status function handles a missing `catalog_revision` explicitly, so an older manifest is not invalidated.

## Compatibility / Rollout

- Additive manifest field; no migration. Older manifests fall back to checksum comparison.
- No generated-artifact change, so no regeneration and no byte-gate movement.
- `omh update` rewrites the manifest with the revision on the next run.

## Release / Claims

- [x] Release-channel impact considered — `local`; adds a doctor check and a manifest field
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — the contract's own `claim_boundary` states that a fresh projection is not evidence Hermes loaded it
- [x] Known manual Hermes checks are listed — `omh release hermes-smoke --live` not run

## Follow-Up

- `host_observed` has no producer yet: the doctor surface passes `False`. Wiring it to `omh_plugin_host_observation/v1` would let the fourth axis report `observed` from real evidence rather than only being representable.

Closes #817
