### PR TITLE
feat: fork accepted OMH plans into explicit what-if variants

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1239,6 +1239,40 @@ delegation and use `wrapper_contract.message_field` only as the JSON pointer to
 the message text inside the payload; they should not scrape the Markdown plan
 body to recover commands or state.
 
+### Plan Variants
+
+`plan_variant/v1` (`workflows/plan_variants.py`) is the what-if child of an
+accepted plan. It answers "what if we had assumed something else" without
+overwriting the artifact a prepared handoff already points at by digest.
+
+```text
+.omh/
+  plan-variants/
+    plan-variant-<digest12>.json
+```
+
+A variant records the parent plan path, the parent's immutable `sha256`, one
+explicit delta per changed input (assumption, scope, coding owner, policy,
+acceptance criteria, or verification), the readable `changed_inputs` projection
+of those deltas, the reviewed references it inherits unchanged, the references
+that must be re-evaluated against the new assumption, and an undecided
+`next_handoff` block naming both candidates. `variant_id` and `variant_digest`
+derive from the parent digest, the variant name, and the deltas, so siblings of
+different parents are never interchangeable and the same fork is reproducible.
+The caller supplies `created_at`; wall-clock time stays out of both digests.
+
+A variant is deliberately not a plan. Its key set is closed and carries no
+`status`, so nothing can read `accepted` off it, and `omh hermes plan-variant`
+refuses any parent that is not an accepted `hermes_plan/v1` artifact. Creating
+one is a pure local metadata operation: no replay, tool call, network call, or
+dispatch. Choosing a variant as the next handoff is a separate act through the
+normal plan lifecycle commands.
+
+`omh hermes plan-variant <accepted-plan.md> --name <name> --delta
+<dimension:label:parent_value:variant_value>` prints a differences-only summary
+by default, takes `--json` for the full payload, and writes the record only with
+`--record`.
+
 ## Workflow State
 
 Workflow lifecycle state is stored separately from runtime run evidence under

--- a/src/commands/hermes.py
+++ b/src/commands/hermes.py
@@ -15,9 +15,18 @@ from ..hermes_planning import (
 )
 from ..hermes_readiness import build_hermes_agent_readiness
 from ..workflows.hermes_retained_context import build_hermes_retained_context
+from ..workflows.plan_variants import (
+    PLAN_VARIANT_DELTA_DIMENSIONS,
+    build_plan_variant,
+    build_plan_variant_delta,
+    build_plan_variant_ref,
+    render_plan_variant_text,
+    write_plan_variant,
+)
 from ..ingress import CHAT_SOURCES, extract_message_text, extract_source_metadata
 from ..installer import OmhError
-from .common import _explicit_source_metadata, _paths, _print_json
+from ..system.local_store import utc_now
+from .common import _explicit_source_metadata, _paths, _print_json, _wants_json
 
 
 def cmd_hermes_plan(args: argparse.Namespace) -> int:
@@ -106,6 +115,67 @@ def cmd_hermes_plan_cancel(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_hermes_plan_variant(args: argparse.Namespace) -> int:
+    """Fork an accepted plan into a metadata-only what-if child.
+
+    The parent artifact is only read. Nothing here replays the plan, calls a
+    tool, opens a socket, or dispatches work: the command turns flags into a
+    `plan_variant/v1` dict and optionally writes that one file.
+    """
+    try:
+        artifact = read_hermes_plan_artifact(args.path)
+        variant = build_plan_variant(
+            parent_artifact=artifact,
+            name=args.name,
+            deltas=[_plan_variant_delta(value) for value in args.delta or ()],
+            refs=[
+                *[_plan_variant_ref(value, reviewed=True) for value in args.inherit or ()],
+                *[_plan_variant_ref(value, reviewed=False) for value in args.reevaluate or ()],
+            ],
+            rationale=args.rationale or "",
+            created_at=utc_now(),
+        )
+        payload: dict[str, object] = {
+            "schema_version": "hermes_plan_variant_view/v1",
+            "variant": variant,
+        }
+        if args.record:
+            payload["artifact"] = write_plan_variant(_paths(args), variant)
+    except (OSError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    if _wants_json(args):
+        _print_json(payload)
+        return 0
+    lines = [render_plan_variant_text(variant)]
+    artifact_record = payload.get("artifact")
+    if isinstance(artifact_record, dict):
+        lines.append(f"Recorded: {artifact_record.get('path', '')}")
+    print("\n".join(lines))
+    return 0
+
+
+def _plan_variant_delta(value: str) -> dict[str, object]:
+    dimension, label, parent_value, variant_value = _split_flag(value, 4, "delta")
+    return build_plan_variant_delta(
+        dimension=dimension,
+        label=label,
+        parent_value=parent_value,
+        variant_value=variant_value,
+    )
+
+
+def _plan_variant_ref(value: str, *, reviewed: bool) -> dict[str, object]:
+    kind, ref = _split_flag(value, 2, "inherit" if reviewed else "reevaluate")
+    return build_plan_variant_ref(kind=kind, ref=ref, reviewed=reviewed)
+
+
+def _split_flag(value: str, count: int, label: str) -> list[str]:
+    parts = [part.strip() for part in value.split(":", count - 1)]
+    if len(parts) != count or any(not part for part in parts):
+        raise ValueError(f"--{label} must contain exactly {count} colon-separated fields")
+    return parts
+
+
 def cmd_hermes_readiness(args: argparse.Namespace) -> int:
     try:
         payload = build_hermes_agent_readiness(_paths(args))
@@ -176,6 +246,40 @@ def _add_hermes_commands(sub) -> None:
     plan_revise.add_argument("path", help="Path to a hermes_plan/v1 Markdown artifact.")
     plan_revise.add_argument("--note", default="", help="Optional metadata-only revision note.")
     plan_revise.set_defaults(func=cmd_hermes_plan_revise)
+
+    plan_variant = hermes_sub.add_parser(
+        "plan-variant",
+        help="Fork an accepted Hermes plan into a metadata-only plan_variant/v1 what-if child.",
+    )
+    plan_variant.add_argument("path", help="Path to an accepted hermes_plan/v1 Markdown artifact.")
+    plan_variant.add_argument("--name", required=True, help="Short name for this what-if variant.")
+    plan_variant.add_argument(
+        "--delta",
+        action="append",
+        required=True,
+        metavar="DIMENSION:LABEL:PARENT_VALUE:VARIANT_VALUE",
+        help=f"One changed input; DIMENSION is one of {', '.join(PLAN_VARIANT_DELTA_DIMENSIONS)}. Repeatable.",
+    )
+    plan_variant.add_argument(
+        "--inherit",
+        action="append",
+        metavar="KIND:REF",
+        help="A reviewed reference the variant carries over unchanged. Repeatable.",
+    )
+    plan_variant.add_argument(
+        "--reevaluate",
+        action="append",
+        metavar="KIND:REF",
+        help="A reference that must be re-checked against the new assumption before any handoff. Repeatable.",
+    )
+    plan_variant.add_argument("--rationale", default="", help="Optional metadata-only reason for exploring this variant.")
+    plan_variant.add_argument(
+        "--record",
+        action="store_true",
+        help="Write the variant under <repo>/.omh/plan-variants, or the OMH home when outside a repository.",
+    )
+    plan_variant.add_argument("--json", action="store_true", help="Print the full plan_variant/v1 payload.")
+    plan_variant.set_defaults(func=cmd_hermes_plan_variant)
 
     plan_cancel = hermes_sub.add_parser("plan-cancel", help="Mark a file-backed Hermes plan as cancelled.")
     plan_cancel.add_argument("path", help="Path to a hermes_plan/v1 Markdown artifact.")

--- a/src/workflows/plan_variants.py
+++ b/src/workflows/plan_variants.py
@@ -1,0 +1,556 @@
+"""Metadata-only what-if children of an accepted Hermes plan (issue #827).
+
+A `plan_variant/v1` record answers "what if we had assumed something else"
+without touching the plan that was accepted. It names the parent plan by its
+immutable digest, lists every input that differs, lists the references it
+inherits unchanged, and leaves the next-handoff choice open for a human.
+
+Why a child record and not a second plan
+----------------------------------------
+
+Re-running `omh hermes plan` for the alternative produces a sibling artifact
+with no link back: nothing says which assumption changed, nothing says the two
+plans came from the same decision, and evidence recorded against one reads as
+evidence for the other. Rewriting the accepted plan in place is worse -- it
+destroys the artifact a handoff already points at by digest.
+
+A variant is deliberately *not* a plan. It carries no `status` field, so no
+reader can find `accepted` on it; its own key set is closed, so a caller cannot
+staple one on. Choosing a variant as the next handoff is a separate act that
+goes through the normal plan lifecycle commands, not something this record can
+perform.
+
+What the record does not do
+---------------------------
+
+Building a variant is a pure local metadata operation. It runs no replay, no
+tool, no network call, and no dispatch -- `PLAN_VARIANT_NOT_OBSERVED` names the
+classes a variant is never evidence for, and this module imports nothing that
+could produce one.
+
+Determinism
+-----------
+
+`variant_id` and `variant_digest` are derived from the parent digest, the
+variant name, and the deltas. Wall-clock time is a caller-supplied parameter
+and stays out of both, so the same fork of the same plan is the same record no
+matter when it is built.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Iterable
+
+from ..system.local_store import atomic_write_json
+from ..system.paths import OmhPaths, ensure_project_store_ignored, project_artifact_dir
+
+
+PLAN_VARIANT_SCHEMA_VERSION = "plan_variant/v1"
+PLAN_VARIANT_DELTA_SCHEMA_VERSION = "plan_variant_delta/v1"
+PLAN_VARIANT_REF_SCHEMA_VERSION = "plan_variant_ref/v1"
+PLAN_VARIANT_HANDOFF_SCHEMA_VERSION = "plan_variant_handoff/v1"
+PLAN_VARIANT_PARENT_SCHEMA_VERSION = "hermes_plan/v1"
+PLAN_VARIANT_PARENT_STATUS = "accepted"
+
+PLAN_VARIANT_DELTA_DIMENSIONS = (
+    "assumption",
+    "scope",
+    "coding_owner",
+    "policy",
+    "acceptance_criteria",
+    "verification",
+    "other",
+)
+PLAN_VARIANT_REF_KINDS = (
+    "plan_artifact",
+    "context_pack",
+    "source",
+    "evidence",
+    "memory_record",
+    "unknown",
+)
+PLAN_VARIANT_HANDOFF_DECISIONS = ("undecided", "parent_plan", "variant")
+PLAN_VARIANT_HANDOFF_CANDIDATE_KINDS = ("parent_plan", "variant")
+PLAN_VARIANT_PREPARED_STATE = "prepared_not_observed"
+PLAN_VARIANT_HANDOFF_QUESTION = (
+    "Which plan should become the next handoff: the accepted parent plan or this variant?"
+)
+PLAN_VARIANT_HANDOFF_BOUNDARY = (
+    "Recording a decision here is intent only. The accepted plan artifact stays unchanged "
+    "until a separate plan lifecycle command runs."
+)
+PLAN_VARIANT_CLAIM_BOUNDARY = (
+    "A plan_variant/v1 record is a metadata-only what-if child of an accepted Hermes plan. "
+    "It is not the accepted plan, not plan acceptance, and not replay, dispatch, execution, "
+    "verification, review, CI, merge-readiness, or merge evidence."
+)
+PLAN_VARIANT_NOT_OBSERVED = (
+    "plan_acceptance",
+    "plan_replay",
+    "tool_execution",
+    "network_call",
+    "coding_dispatch",
+    "executor_result",
+    "verification",
+    "review",
+)
+
+PLAN_VARIANT_KEYS = (
+    "schema_version",
+    "variant_id",
+    "variant_digest",
+    "name",
+    "rationale",
+    "created_at",
+    "parent_plan_path",
+    "parent_plan_status",
+    "parent_plan_schema_version",
+    "parent_plan_sha256",
+    "parent_task_statement_sha256",
+    "deltas",
+    "delta_count",
+    "changed_inputs",
+    "inherited_refs",
+    "inherited_ref_count",
+    "refs_requiring_reevaluation",
+    "prepared_state",
+    "next_handoff",
+    "claim_boundary",
+    "not_evidence_until_observed",
+)
+PLAN_VARIANT_DELTA_KEYS = ("schema_version", "dimension", "label", "parent_value", "variant_value", "reason")
+PLAN_VARIANT_REF_KEYS = ("schema_version", "kind", "ref", "reviewed", "note")
+PLAN_VARIANT_HANDOFF_KEYS = (
+    "schema_version",
+    "decision",
+    "question",
+    "requires_user_choice",
+    "candidates",
+    "boundary",
+)
+PLAN_VARIANT_HANDOFF_CANDIDATE_KEYS = ("kind", "ref", "digest")
+
+
+def normalize_plan_variant_dimension(dimension: str | None) -> str:
+    """Map a delta dimension onto the closed vocabulary, defaulting to `other`."""
+    normalized = _key(dimension or "")
+    aliases = {
+        "assumption": "assumption",
+        "assumptions": "assumption",
+        "clarified assumption": "assumption",
+        "scope": "scope",
+        "goal": "scope",
+        "non goal": "scope",
+        "coding owner": "coding_owner",
+        "owner": "coding_owner",
+        "executor": "coding_owner",
+        "policy": "policy",
+        "constraint": "policy",
+        "acceptance criteria": "acceptance_criteria",
+        "acceptance": "acceptance_criteria",
+        "verification": "verification",
+        "verification plan": "verification",
+        "other": "other",
+    }
+    return aliases.get(normalized, "other")
+
+
+def normalize_plan_variant_ref_kind(kind: str | None) -> str:
+    """Map an inherited-reference kind onto the closed vocabulary."""
+    normalized = _key(kind or "").replace(" ", "_")
+    return normalized if normalized in PLAN_VARIANT_REF_KINDS else "unknown"
+
+
+def build_plan_variant_delta(
+    *,
+    dimension: str,
+    label: str,
+    parent_value: str,
+    variant_value: str,
+    reason: str = "",
+) -> dict[str, object]:
+    """One explicit difference between the accepted plan and the variant."""
+    return {
+        "schema_version": PLAN_VARIANT_DELTA_SCHEMA_VERSION,
+        "dimension": normalize_plan_variant_dimension(dimension),
+        "label": label.strip(),
+        "parent_value": parent_value.strip(),
+        "variant_value": variant_value.strip(),
+        "reason": reason.strip(),
+    }
+
+
+def build_plan_variant_ref(
+    *,
+    kind: str,
+    ref: str,
+    reviewed: bool = False,
+    note: str = "",
+) -> dict[str, object]:
+    """One reference the variant carries over from its parent.
+
+    `reviewed` is the whole point of the field: only reviewed references are
+    inherited. Everything else is routed to `refs_requiring_reevaluation`, so a
+    variant never silently reuses context nobody checked against its new
+    assumption.
+    """
+    return {
+        "schema_version": PLAN_VARIANT_REF_SCHEMA_VERSION,
+        "kind": normalize_plan_variant_ref_kind(kind),
+        "ref": ref.strip(),
+        "reviewed": bool(reviewed),
+        "note": note.strip(),
+    }
+
+
+def build_plan_variant(
+    *,
+    parent_artifact: dict[str, Any],
+    name: str,
+    deltas: Iterable[dict[str, Any]],
+    refs: Iterable[dict[str, Any]] = (),
+    rationale: str = "",
+    created_at: str = "",
+) -> dict[str, object]:
+    """Build a `plan_variant/v1` child of one accepted plan artifact.
+
+    `parent_artifact` is a `read_hermes_plan_artifact` result. Nothing is
+    written and the parent is never mutated: this function only reads the
+    digest and identity fields off the dict it was handed.
+
+    `created_at` is a caller-supplied timestamp so the identity fields stay
+    reproducible; it is deliberately excluded from both derived digests.
+    """
+    variant_name = name.strip()
+    if not variant_name:
+        raise ValueError("plan variant requires a name")
+    parent_schema = str(parent_artifact.get("schema_version", ""))
+    if parent_schema != PLAN_VARIANT_PARENT_SCHEMA_VERSION:
+        raise ValueError(f"plan variant requires a {PLAN_VARIANT_PARENT_SCHEMA_VERSION} parent artifact")
+    parent_status = str(parent_artifact.get("status", ""))
+    if parent_status != PLAN_VARIANT_PARENT_STATUS:
+        raise ValueError("plan variant requires an accepted parent plan")
+    parent_sha256 = str(parent_artifact.get("sha256", ""))
+    if not _is_sha256(parent_sha256):
+        raise ValueError("plan variant requires a parent plan sha256 digest")
+    normalized_deltas = [_coerce_delta(delta) for delta in deltas]
+    if not normalized_deltas:
+        raise ValueError("plan variant requires at least one delta")
+
+    parent_path = str(parent_artifact.get("path", ""))
+    # The accepted parent is always an inherited reference: a variant that
+    # listed no inheritance would read as an unrelated plan.
+    supplied_refs = [
+        build_plan_variant_ref(
+            kind="plan_artifact",
+            ref=parent_path,
+            reviewed=True,
+            note="Accepted parent plan artifact; every input not named in deltas is inherited from it.",
+        ),
+        *(_coerce_ref(ref) for ref in refs),
+    ]
+    inherited = [ref for ref in supplied_refs if ref["reviewed"]]
+    reevaluate = [ref for ref in supplied_refs if not ref["reviewed"]]
+
+    digest = _variant_digest(parent_sha256, variant_name, normalized_deltas)
+    variant_id = f"plan-variant-{digest[:12]}"
+    return {
+        "schema_version": PLAN_VARIANT_SCHEMA_VERSION,
+        "variant_id": variant_id,
+        "variant_digest": digest,
+        "name": variant_name,
+        "rationale": rationale.strip(),
+        "created_at": created_at.strip(),
+        "parent_plan_path": parent_path,
+        "parent_plan_status": parent_status,
+        "parent_plan_schema_version": parent_schema,
+        "parent_plan_sha256": parent_sha256,
+        "parent_task_statement_sha256": str(parent_artifact.get("task_statement_sha256", "")),
+        "deltas": normalized_deltas,
+        "delta_count": len(normalized_deltas),
+        "changed_inputs": [_changed_input_line(delta) for delta in normalized_deltas],
+        "inherited_refs": inherited,
+        "inherited_ref_count": len(inherited),
+        "refs_requiring_reevaluation": reevaluate,
+        "prepared_state": PLAN_VARIANT_PREPARED_STATE,
+        "next_handoff": {
+            "schema_version": PLAN_VARIANT_HANDOFF_SCHEMA_VERSION,
+            "decision": "undecided",
+            "question": PLAN_VARIANT_HANDOFF_QUESTION,
+            "requires_user_choice": True,
+            "candidates": [
+                {"kind": "parent_plan", "ref": parent_path, "digest": parent_sha256},
+                {"kind": "variant", "ref": variant_id, "digest": digest},
+            ],
+            "boundary": PLAN_VARIANT_HANDOFF_BOUNDARY,
+        },
+        "claim_boundary": PLAN_VARIANT_CLAIM_BOUNDARY,
+        "not_evidence_until_observed": list(PLAN_VARIANT_NOT_OBSERVED),
+    }
+
+
+def validate_plan_variant(payload: dict[str, Any]) -> list[str]:
+    """Return every contract violation in one pass; empty means valid."""
+    errors: list[str] = []
+    if payload.get("schema_version") != PLAN_VARIANT_SCHEMA_VERSION:
+        errors.append(f"schema_version must be {PLAN_VARIANT_SCHEMA_VERSION}")
+    errors.extend(_key_set_errors(payload, PLAN_VARIANT_KEYS, "plan_variant"))
+    if not str(payload.get("variant_id", "")).startswith("plan-variant-"):
+        errors.append("variant_id must start with plan-variant-")
+    if not _is_sha256(str(payload.get("variant_digest", ""))):
+        errors.append("variant_digest must be a sha256 hex digest")
+    if not str(payload.get("name", "")).strip():
+        errors.append("name must not be empty")
+    if payload.get("parent_plan_schema_version") != PLAN_VARIANT_PARENT_SCHEMA_VERSION:
+        errors.append(f"parent_plan_schema_version must be {PLAN_VARIANT_PARENT_SCHEMA_VERSION}")
+    if payload.get("parent_plan_status") != PLAN_VARIANT_PARENT_STATUS:
+        errors.append(f"parent_plan_status must be {PLAN_VARIANT_PARENT_STATUS}")
+    if not _is_sha256(str(payload.get("parent_plan_sha256", ""))):
+        errors.append("parent_plan_sha256 must be a sha256 hex digest")
+    if payload.get("prepared_state") != PLAN_VARIANT_PREPARED_STATE:
+        errors.append(f"prepared_state must be {PLAN_VARIANT_PREPARED_STATE}")
+    if payload.get("claim_boundary") != PLAN_VARIANT_CLAIM_BOUNDARY:
+        errors.append("claim_boundary must deny that a variant is the accepted plan or evidence")
+    if not set(PLAN_VARIANT_NOT_OBSERVED).issubset(set(_string_list(payload.get("not_evidence_until_observed")))):
+        errors.append("not_evidence_until_observed must include all plan-variant boundaries")
+
+    deltas = payload.get("deltas")
+    if not isinstance(deltas, list) or not deltas:
+        errors.append("deltas must be a non-empty list")
+    else:
+        for index, delta in enumerate(deltas):
+            for error in _delta_errors(delta):
+                errors.append(f"deltas[{index}]: {error}")
+        if payload.get("delta_count") != len(deltas):
+            errors.append("delta_count must match deltas")
+        if len(_string_list(payload.get("changed_inputs"))) != len(deltas):
+            errors.append("changed_inputs must list one line per delta")
+
+    inherited = payload.get("inherited_refs")
+    if not isinstance(inherited, list) or not inherited:
+        errors.append("inherited_refs must be a non-empty list")
+    else:
+        for index, ref in enumerate(inherited):
+            for error in _ref_errors(ref):
+                errors.append(f"inherited_refs[{index}]: {error}")
+            if isinstance(ref, dict) and not ref.get("reviewed"):
+                errors.append(f"inherited_refs[{index}]: only reviewed references may be inherited")
+        if payload.get("inherited_ref_count") != len(inherited):
+            errors.append("inherited_ref_count must match inherited_refs")
+
+    reevaluate = payload.get("refs_requiring_reevaluation")
+    if not isinstance(reevaluate, list):
+        errors.append("refs_requiring_reevaluation must be a list")
+    else:
+        for index, ref in enumerate(reevaluate):
+            for error in _ref_errors(ref):
+                errors.append(f"refs_requiring_reevaluation[{index}]: {error}")
+            if isinstance(ref, dict) and ref.get("reviewed"):
+                errors.append(f"refs_requiring_reevaluation[{index}]: a reviewed reference belongs in inherited_refs")
+
+    errors.extend(_handoff_errors(payload.get("next_handoff")))
+    return errors
+
+
+def render_plan_variant_text(variant: dict[str, Any]) -> str:
+    """Plain-text rendering: only the differences, then the open question."""
+    lines = [
+        f"Plan variant: {variant.get('name', '')} ({variant.get('variant_id', '')})",
+        f"Parent plan: {variant.get('parent_plan_path', '')}",
+        f"Parent digest: {variant.get('parent_plan_sha256', '')} (unchanged by this variant)",
+    ]
+    rationale = str(variant.get("rationale", ""))
+    if rationale:
+        lines.append(f"Rationale: {rationale}")
+    lines.append("")
+    lines.append("Changed inputs:")
+    lines.extend(f"  - {line}" for line in _string_list(variant.get("changed_inputs")))
+    lines.append("")
+    lines.append("Inherited references:")
+    lines.extend(_ref_lines(variant.get("inherited_refs")))
+    reevaluate = variant.get("refs_requiring_reevaluation")
+    if isinstance(reevaluate, list) and reevaluate:
+        lines.append("")
+        lines.append("Re-evaluate before any handoff:")
+        lines.extend(_ref_lines(reevaluate))
+    handoff = variant.get("next_handoff")
+    lines.append("")
+    if isinstance(handoff, dict):
+        lines.append(f"Next handoff: {handoff.get('decision', 'undecided')}")
+        lines.append(f"  {handoff.get('question', '')}")
+        for candidate in handoff.get("candidates", []):
+            if isinstance(candidate, dict):
+                lines.append(f"  - {candidate.get('kind', '')}: {candidate.get('ref', '')}")
+    lines.append("")
+    lines.append(f"Prepared state: {variant.get('prepared_state', '')}")
+    lines.append(str(variant.get("claim_boundary", "")))
+    return "\n".join(lines)
+
+
+def write_plan_variant(paths: OmhPaths, variant: dict[str, Any]) -> dict[str, object]:
+    """Persist one variant under the project store; the parent is never opened."""
+    errors = validate_plan_variant(variant)
+    if errors:
+        raise ValueError("; ".join(errors))
+    variants_dir = project_artifact_dir(paths, "plan-variants")
+    ensure_project_store_ignored(variants_dir)
+    # Named by variant_id, not by a timestamp: re-forking the same plan the same
+    # way rewrites one file instead of accumulating near-identical siblings.
+    path = variants_dir / f"{variant['variant_id']}.json"
+    atomic_write_json(path, dict(variant), private=True)
+    return {
+        "path": str(path),
+        "kind": "plan_variant",
+        "schema_version": PLAN_VARIANT_SCHEMA_VERSION,
+        "variant_id": variant["variant_id"],
+        "parent_plan_sha256": variant["parent_plan_sha256"],
+    }
+
+
+def _coerce_delta(delta: dict[str, Any]) -> dict[str, object]:
+    return build_plan_variant_delta(
+        dimension=str(delta.get("dimension", "")),
+        label=str(delta.get("label", "")),
+        parent_value=str(delta.get("parent_value", "")),
+        variant_value=str(delta.get("variant_value", "")),
+        reason=str(delta.get("reason", "")),
+    )
+
+
+def _coerce_ref(ref: dict[str, Any]) -> dict[str, object]:
+    return build_plan_variant_ref(
+        kind=str(ref.get("kind", "")),
+        ref=str(ref.get("ref", "")),
+        reviewed=bool(ref.get("reviewed", False)),
+        note=str(ref.get("note", "")),
+    )
+
+
+def _changed_input_line(delta: dict[str, Any]) -> str:
+    label = str(delta.get("label", "")) or "unnamed input"
+    return (
+        f"{delta.get('dimension', 'other')} | {label}: "
+        f"{delta.get('parent_value', '')} -> {delta.get('variant_value', '')}"
+    )
+
+
+def _ref_lines(refs: object) -> list[str]:
+    if not isinstance(refs, list) or not refs:
+        return ["  - None recorded."]
+    lines: list[str] = []
+    for ref in refs:
+        if not isinstance(ref, dict):
+            continue
+        note = str(ref.get("note", ""))
+        suffix = f" — {note}" if note else ""
+        lines.append(f"  - {ref.get('kind', 'unknown')}: {ref.get('ref', '')}{suffix}")
+    return lines or ["  - None recorded."]
+
+
+def _delta_errors(delta: object) -> list[str]:
+    if not isinstance(delta, dict):
+        return ["delta must be an object"]
+    errors = _key_set_errors(delta, PLAN_VARIANT_DELTA_KEYS, "delta")
+    if delta.get("schema_version") != PLAN_VARIANT_DELTA_SCHEMA_VERSION:
+        errors.append(f"schema_version must be {PLAN_VARIANT_DELTA_SCHEMA_VERSION}")
+    if delta.get("dimension") not in PLAN_VARIANT_DELTA_DIMENSIONS:
+        errors.append("dimension is unsupported")
+    if not str(delta.get("label", "")).strip():
+        errors.append("label must not be empty")
+    if str(delta.get("parent_value", "")) == str(delta.get("variant_value", "")):
+        errors.append("parent_value and variant_value must differ")
+    return errors
+
+
+def _ref_errors(ref: object) -> list[str]:
+    if not isinstance(ref, dict):
+        return ["reference must be an object"]
+    errors = _key_set_errors(ref, PLAN_VARIANT_REF_KEYS, "reference")
+    if ref.get("schema_version") != PLAN_VARIANT_REF_SCHEMA_VERSION:
+        errors.append(f"schema_version must be {PLAN_VARIANT_REF_SCHEMA_VERSION}")
+    if ref.get("kind") not in PLAN_VARIANT_REF_KINDS:
+        errors.append("kind is unsupported")
+    if not str(ref.get("ref", "")).strip():
+        errors.append("ref must not be empty")
+    if not isinstance(ref.get("reviewed"), bool):
+        errors.append("reviewed must be a boolean")
+    return errors
+
+
+def _handoff_errors(handoff: object) -> list[str]:
+    if not isinstance(handoff, dict):
+        return ["next_handoff must be an object"]
+    errors = _key_set_errors(handoff, PLAN_VARIANT_HANDOFF_KEYS, "next_handoff")
+    if handoff.get("schema_version") != PLAN_VARIANT_HANDOFF_SCHEMA_VERSION:
+        errors.append(f"next_handoff schema_version must be {PLAN_VARIANT_HANDOFF_SCHEMA_VERSION}")
+    if handoff.get("decision") not in PLAN_VARIANT_HANDOFF_DECISIONS:
+        errors.append("next_handoff decision is unsupported")
+    if not isinstance(handoff.get("requires_user_choice"), bool):
+        errors.append("next_handoff requires_user_choice must be a boolean")
+    if handoff.get("boundary") != PLAN_VARIANT_HANDOFF_BOUNDARY:
+        errors.append("next_handoff boundary must keep the accepted plan unchanged")
+    candidates = handoff.get("candidates")
+    if not isinstance(candidates, list) or len(candidates) != 2:
+        errors.append("next_handoff must offer the parent plan and the variant")
+        return errors
+    for index, candidate in enumerate(candidates):
+        if not isinstance(candidate, dict):
+            errors.append(f"next_handoff candidates[{index}]: candidate must be an object")
+            continue
+        for error in _key_set_errors(candidate, PLAN_VARIANT_HANDOFF_CANDIDATE_KEYS, "candidate"):
+            errors.append(f"next_handoff candidates[{index}]: {error}")
+        if candidate.get("kind") not in PLAN_VARIANT_HANDOFF_CANDIDATE_KINDS:
+            errors.append(f"next_handoff candidates[{index}]: kind is unsupported")
+    kinds = [candidate.get("kind") for candidate in candidates if isinstance(candidate, dict)]
+    if kinds != list(PLAN_VARIANT_HANDOFF_CANDIDATE_KINDS):
+        errors.append("next_handoff candidates must be the parent plan then the variant")
+    return errors
+
+
+def _key_set_errors(payload: object, expected: tuple[str, ...], label: str) -> list[str]:
+    if not isinstance(payload, dict):
+        return [f"{label} must be an object"]
+    present = set(payload)
+    allowed = set(expected)
+    errors: list[str] = []
+    missing = sorted(allowed - present)
+    if missing:
+        errors.append(f"{label} is missing keys: {', '.join(missing)}")
+    unexpected = sorted(present - allowed)
+    if unexpected:
+        errors.append(f"{label} has unexpected keys: {', '.join(unexpected)}")
+    return errors
+
+
+def _string_list(value: object) -> list[str]:
+    return [str(item) for item in value] if isinstance(value, list) else []
+
+
+def _variant_digest(parent_sha256: str, name: str, deltas: list[dict[str, object]]) -> str:
+    seed = "|".join(
+        [
+            parent_sha256,
+            _key(name),
+            *[
+                "~".join(
+                    (
+                        str(delta["dimension"]),
+                        _key(str(delta["label"])),
+                        str(delta["parent_value"]),
+                        str(delta["variant_value"]),
+                    )
+                )
+                for delta in deltas
+            ],
+        ]
+    )
+    return hashlib.sha256(seed.encode("utf-8")).hexdigest()
+
+
+def _is_sha256(value: str) -> bool:
+    return len(value) == 64 and all(character in "0123456789abcdef" for character in value)
+
+
+def _key(value: str) -> str:
+    return " ".join(value.strip().lower().replace("_", " ").replace("-", " ").split())

--- a/tests/test_plan_variants.py
+++ b/tests/test_plan_variants.py
@@ -1,0 +1,495 @@
+"""Contracts for `plan_variant/v1` (issue #827).
+
+Three acceptance criteria, three classes, and one guard class for the failure
+the whole record family exists to prevent: a variant being read as the plan it
+forked. The accepted plan is the artifact a prepared handoff points at by
+digest, so anything that rewrites it, or that lets a what-if answer to
+"which plan is next" masquerade as that artifact, is the regression here.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import socket
+import subprocess
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+from unittest import mock
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+from omh.paths import resolve_paths  # noqa: E402
+from omh.workflows.hermes_planning import (  # noqa: E402
+    build_hermes_plan_payload,
+    read_hermes_plan_artifact,
+    update_hermes_plan_status,
+    write_hermes_plan,
+)
+from omh.workflows.plan_variants import (  # noqa: E402
+    PLAN_VARIANT_CLAIM_BOUNDARY,
+    PLAN_VARIANT_DELTA_DIMENSIONS,
+    PLAN_VARIANT_HANDOFF_BOUNDARY,
+    PLAN_VARIANT_KEYS,
+    PLAN_VARIANT_NOT_OBSERVED,
+    PLAN_VARIANT_REF_KINDS,
+    PLAN_VARIANT_SCHEMA_VERSION,
+    build_plan_variant,
+    build_plan_variant_delta,
+    build_plan_variant_ref,
+    normalize_plan_variant_dimension,
+    normalize_plan_variant_ref_kind,
+    render_plan_variant_text,
+    validate_plan_variant,
+    write_plan_variant,
+)
+
+T0 = "2026-08-09T00:00:00Z"
+T1 = "2026-08-10T12:34:56Z"
+TASK = "implement a coding delegation flow with tests"
+
+OWNER_DELTA = {
+    "dimension": "coding_owner",
+    "label": "selected executor",
+    "parent_value": "codex",
+    "variant_value": "claude-code",
+}
+SCOPE_DELTA = {
+    "dimension": "scope",
+    "label": "docs",
+    "parent_value": "ship docs in the same PR",
+    "variant_value": "defer docs to a follow-up",
+}
+
+
+def _accepted_plan(tmp: str, *, task: str = TASK) -> dict[str, Any]:
+    """Write a real plan through the real lifecycle, then accept it."""
+    paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+    artifact = write_hermes_plan(paths, build_hermes_plan_payload(task))
+    update_hermes_plan_status(paths, artifact["path"], status="accepted")
+    return read_hermes_plan_artifact(artifact["path"])
+
+
+def _variant(parent: dict[str, Any], **overrides: Any) -> dict[str, object]:
+    arguments: dict[str, Any] = {
+        "parent_artifact": parent,
+        "name": "claude-code owner",
+        "deltas": [OWNER_DELTA],
+        "created_at": T0,
+    }
+    arguments.update(overrides)
+    return build_plan_variant(**arguments)
+
+
+class OriginalPlanRemainsUnchangedTests(unittest.TestCase):
+    """AC1: forking a plan never touches the plan it forked."""
+
+    def test_building_and_recording_a_variant_leaves_the_parent_byte_identical(self) -> None:
+        with TemporaryDirectory() as tmp:
+            parent = _accepted_plan(tmp)
+            plan_path = Path(str(parent["path"]))
+            before = plan_path.read_bytes()
+
+            variant = _variant(parent, deltas=[OWNER_DELTA, SCOPE_DELTA])
+            record = write_plan_variant(resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes"), variant)
+
+            self.assertEqual(plan_path.read_bytes(), before)
+            # The digest the variant carries still describes the file on disk,
+            # which is the only reason a parent reference means anything.
+            self.assertEqual(
+                variant["parent_plan_sha256"],
+                read_hermes_plan_artifact(plan_path)["sha256"],
+            )
+            self.assertTrue(Path(str(record["path"])).exists())
+
+    def test_the_variant_is_written_outside_the_plans_directory(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            parent = _accepted_plan(tmp)
+            plans_dir = Path(str(parent["path"])).parent
+            before = sorted(path.name for path in plans_dir.iterdir())
+
+            record = write_plan_variant(paths, _variant(parent))
+
+            # A variant landing in `plans/` would be picked up by anything that
+            # scans the plan store, which is exactly the confusion AC1 forbids.
+            self.assertEqual(sorted(path.name for path in plans_dir.iterdir()), before)
+            self.assertEqual(Path(str(record["path"])).parent.name, "plan-variants")
+
+    def test_recording_the_same_fork_twice_rewrites_one_file(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            parent = _accepted_plan(tmp)
+
+            first = write_plan_variant(paths, _variant(parent, created_at=T0))
+            second = write_plan_variant(paths, _variant(parent, created_at=T1))
+
+            self.assertEqual(first["path"], second["path"])
+            variants_dir = Path(str(first["path"])).parent
+            self.assertEqual(len(list(variants_dir.glob("*.json"))), 1)
+
+
+class ChangedInputsAndInheritedRefsTests(unittest.TestCase):
+    """AC2: every variant lists changed inputs and inherited references."""
+
+    def test_every_delta_is_listed_as_a_changed_input(self) -> None:
+        with TemporaryDirectory() as tmp:
+            variant = _variant(_accepted_plan(tmp), deltas=[OWNER_DELTA, SCOPE_DELTA])
+
+            self.assertEqual(variant["delta_count"], 2)
+            self.assertEqual(
+                variant["changed_inputs"],
+                [
+                    "coding_owner | selected executor: codex -> claude-code",
+                    "scope | docs: ship docs in the same PR -> defer docs to a follow-up",
+                ],
+            )
+            self.assertEqual(validate_plan_variant(variant), [])
+
+    def test_the_accepted_parent_is_always_an_inherited_reference(self) -> None:
+        with TemporaryDirectory() as tmp:
+            parent = _accepted_plan(tmp)
+            variant = _variant(parent)
+
+            inherited = variant["inherited_refs"]
+            self.assertEqual(variant["inherited_ref_count"], 1)
+            self.assertEqual(inherited[0]["kind"], "plan_artifact")
+            self.assertEqual(inherited[0]["ref"], parent["path"])
+            self.assertTrue(inherited[0]["reviewed"])
+
+    def test_an_unreviewed_reference_is_held_for_reevaluation_not_inherited(self) -> None:
+        with TemporaryDirectory() as tmp:
+            variant = _variant(
+                _accepted_plan(tmp),
+                refs=[
+                    build_plan_variant_ref(kind="context_pack", ref="pack.json", reviewed=True),
+                    build_plan_variant_ref(kind="source", ref="https://example.invalid/spec"),
+                ],
+            )
+
+            # "Copy only reviewed metadata and re-evaluate unsafe context" is a
+            # partition, not a warning field: an unreviewed ref never appears in
+            # the list a downstream reader treats as carried over.
+            self.assertEqual([ref["kind"] for ref in variant["inherited_refs"]], ["plan_artifact", "context_pack"])
+            self.assertEqual([ref["ref"] for ref in variant["refs_requiring_reevaluation"]], ["https://example.invalid/spec"])
+            self.assertEqual(validate_plan_variant(variant), [])
+
+    def test_validation_refuses_an_unreviewed_reference_moved_into_inherited(self) -> None:
+        with TemporaryDirectory() as tmp:
+            variant = _variant(_accepted_plan(tmp))
+            variant["inherited_refs"] = [
+                *variant["inherited_refs"],
+                build_plan_variant_ref(kind="source", ref="https://example.invalid/spec"),
+            ]
+            variant["inherited_ref_count"] = 2
+
+            self.assertIn(
+                "inherited_refs[1]: only reviewed references may be inherited",
+                validate_plan_variant(variant),
+            )
+
+    def test_a_fork_with_nothing_changed_is_not_a_variant(self) -> None:
+        with TemporaryDirectory() as tmp:
+            parent = _accepted_plan(tmp)
+            with self.assertRaises(ValueError) as raised:
+                _variant(parent, deltas=[])
+            self.assertIn("at least one delta", str(raised.exception))
+
+            self.assertIn(
+                "deltas[0]: parent_value and variant_value must differ",
+                validate_plan_variant(
+                    {
+                        **_variant(parent),
+                        "deltas": [build_plan_variant_delta(dimension="scope", label="x", parent_value="a", variant_value="a")],
+                    }
+                ),
+            )
+
+    def test_the_plain_text_rendering_shows_the_differences_and_the_open_question(self) -> None:
+        with TemporaryDirectory() as tmp:
+            text = render_plan_variant_text(
+                _variant(
+                    _accepted_plan(tmp),
+                    deltas=[OWNER_DELTA, SCOPE_DELTA],
+                    refs=[build_plan_variant_ref(kind="source", ref="https://example.invalid/spec")],
+                )
+            )
+
+            self.assertIn("Changed inputs:", text)
+            self.assertIn("coding_owner | selected executor: codex -> claude-code", text)
+            self.assertIn("Inherited references:", text)
+            self.assertIn("Re-evaluate before any handoff:", text)
+            self.assertIn("Which plan should become the next handoff", text)
+            self.assertIn("prepared_not_observed", text)
+
+
+class NoReplayToolNetworkOrDispatchTests(unittest.TestCase):
+    """AC3: creating a variant is a pure local metadata operation."""
+
+    def test_the_module_imports_nothing_that_could_replay_spawn_or_connect(self) -> None:
+        source = Path(__file__).resolve().parents[1] / "src" / "workflows" / "plan_variants.py"
+        tree = ast.parse(source.read_text(encoding="utf-8"))
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                imported.add("." * node.level + (node.module or ""))
+
+        # An exact set, not a denylist: the next import that could reach a
+        # process, a socket, or the plan lifecycle has to change this line.
+        self.assertEqual(
+            imported,
+            {"__future__", "hashlib", "typing", "..system.local_store", "..system.paths"},
+        )
+
+    def test_building_a_variant_runs_with_sockets_and_subprocesses_disabled(self) -> None:
+        with TemporaryDirectory() as tmp:
+            parent = _accepted_plan(tmp)
+
+            def refuse(*args: object, **kwargs: object) -> None:
+                raise AssertionError("plan variant creation reached the network or a subprocess")
+
+            with (
+                mock.patch.object(socket, "socket", refuse),
+                mock.patch.object(subprocess, "run", refuse),
+                mock.patch.object(subprocess, "Popen", refuse),
+            ):
+                variant = _variant(parent, deltas=[OWNER_DELTA, SCOPE_DELTA])
+
+            self.assertEqual(validate_plan_variant(variant), [])
+
+    def test_building_a_variant_writes_nothing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            parent = _accepted_plan(tmp)
+            store = Path(tmp) / ".omh"
+            before = sorted(str(path) for path in store.rglob("*"))
+
+            _variant(parent, deltas=[OWNER_DELTA, SCOPE_DELTA])
+
+            # Recording is a separate call. Building one is what Hermes does to
+            # answer a what-if in chat, and it must leave the store alone.
+            self.assertEqual(sorted(str(path) for path in store.rglob("*")), before)
+
+    def test_the_record_names_every_class_it_is_not_evidence_for(self) -> None:
+        with TemporaryDirectory() as tmp:
+            variant = _variant(_accepted_plan(tmp))
+
+            self.assertEqual(variant["not_evidence_until_observed"], list(PLAN_VARIANT_NOT_OBSERVED))
+            for boundary in ("plan_replay", "tool_execution", "network_call", "coding_dispatch"):
+                self.assertIn(boundary, PLAN_VARIANT_NOT_OBSERVED)
+
+
+class AVariantIsNotThePlanTests(unittest.TestCase):
+    """The guard: nothing may read a variant as the accepted plan."""
+
+    def test_a_variant_carries_no_status_and_cannot_be_given_one(self) -> None:
+        with TemporaryDirectory() as tmp:
+            variant = _variant(_accepted_plan(tmp))
+
+            self.assertNotIn("status", variant)
+            self.assertEqual(tuple(sorted(variant)), tuple(sorted(PLAN_VARIANT_KEYS)))
+            self.assertIn(
+                "plan_variant has unexpected keys: status",
+                validate_plan_variant({**variant, "status": "accepted"}),
+            )
+
+    def test_a_variant_never_wears_the_plan_schema_version(self) -> None:
+        with TemporaryDirectory() as tmp:
+            variant = _variant(_accepted_plan(tmp))
+
+            self.assertEqual(variant["schema_version"], PLAN_VARIANT_SCHEMA_VERSION)
+            self.assertNotEqual(variant["schema_version"], variant["parent_plan_schema_version"])
+            self.assertIn(
+                f"schema_version must be {PLAN_VARIANT_SCHEMA_VERSION}",
+                validate_plan_variant({**variant, "schema_version": "hermes_plan/v1"}),
+            )
+
+    def test_the_claim_boundary_denies_the_plan_and_every_evidence_class(self) -> None:
+        self.assertIn("not the accepted plan", PLAN_VARIANT_CLAIM_BOUNDARY)
+        self.assertIn("not plan acceptance", PLAN_VARIANT_CLAIM_BOUNDARY)
+        for word in ("replay", "dispatch", "execution", "verification", "review", "CI", "merge"):
+            self.assertIn(word, PLAN_VARIANT_CLAIM_BOUNDARY)
+
+    def test_the_next_handoff_question_stays_open_and_changes_nothing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            parent = _accepted_plan(tmp)
+            handoff = _variant(parent)["next_handoff"]
+
+            self.assertEqual(handoff["decision"], "undecided")
+            self.assertTrue(handoff["requires_user_choice"])
+            self.assertEqual([item["kind"] for item in handoff["candidates"]], ["parent_plan", "variant"])
+            self.assertEqual(handoff["candidates"][0]["digest"], parent["sha256"])
+            self.assertEqual(handoff["boundary"], PLAN_VARIANT_HANDOFF_BOUNDARY)
+
+    def test_only_an_accepted_hermes_plan_can_be_forked(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            draft = read_hermes_plan_artifact(
+                write_hermes_plan(paths, build_hermes_plan_payload(TASK))["path"]
+            )
+            with self.assertRaises(ValueError) as raised:
+                _variant(draft)
+            self.assertIn("accepted parent plan", str(raised.exception))
+
+            foreign = Path(tmp) / "not-a-plan.md"
+            foreign.write_text("---\nschema_version: other/v1\nstatus: accepted\n---\n# Nope\n", encoding="utf-8")
+            with self.assertRaises(ValueError) as raised:
+                _variant(read_hermes_plan_artifact(foreign))
+            self.assertIn("hermes_plan/v1 parent artifact", str(raised.exception))
+
+    def test_a_parent_without_a_digest_cannot_be_forked(self) -> None:
+        with TemporaryDirectory() as tmp:
+            parent = {**_accepted_plan(tmp), "sha256": "not-a-digest"}
+            with self.assertRaises(ValueError) as raised:
+                _variant(parent)
+            self.assertIn("parent plan sha256", str(raised.exception))
+
+    def test_siblings_stay_non_interchangeable_across_parents_and_deltas(self) -> None:
+        with TemporaryDirectory() as tmp:
+            first = _accepted_plan(tmp)
+            second = _accepted_plan(tmp, task="refactor the router with tests")
+
+            same_delta_other_parent = _variant(second)
+            other_delta_same_parent = _variant(first, deltas=[SCOPE_DELTA])
+            baseline = _variant(first)
+
+            self.assertNotEqual(baseline["variant_id"], same_delta_other_parent["variant_id"])
+            self.assertNotEqual(baseline["variant_id"], other_delta_same_parent["variant_id"])
+
+    def test_identity_is_reproducible_and_carries_no_clock(self) -> None:
+        with TemporaryDirectory() as tmp:
+            parent = _accepted_plan(tmp)
+
+            early = _variant(parent, created_at=T0)
+            late = _variant(parent, created_at=T1)
+
+            # A timestamp inside the digest would make two forks of the same
+            # plan look like two different alternatives.
+            self.assertEqual(early["variant_id"], late["variant_id"])
+            self.assertEqual(early["variant_digest"], late["variant_digest"])
+            self.assertNotEqual(early["created_at"], late["created_at"])
+
+
+class VocabularyAndValidationTests(unittest.TestCase):
+    def test_unknown_vocabulary_falls_back_instead_of_inventing_a_dimension(self) -> None:
+        self.assertEqual(normalize_plan_variant_dimension("Coding Owner"), "coding_owner")
+        self.assertEqual(normalize_plan_variant_dimension("acceptance-criteria"), "acceptance_criteria")
+        self.assertEqual(normalize_plan_variant_dimension("vibes"), "other")
+        self.assertEqual(normalize_plan_variant_ref_kind("Context Pack"), "context_pack")
+        self.assertEqual(normalize_plan_variant_ref_kind("carrier pigeon"), "unknown")
+        self.assertIn("other", PLAN_VARIANT_DELTA_DIMENSIONS)
+        self.assertIn("unknown", PLAN_VARIANT_REF_KINDS)
+
+    def test_a_missing_key_and_a_tampered_constant_are_both_reported(self) -> None:
+        with TemporaryDirectory() as tmp:
+            variant = _variant(_accepted_plan(tmp))
+            stripped = {key: value for key, value in variant.items() if key != "prepared_state"}
+
+            self.assertIn("plan_variant is missing keys: prepared_state", validate_plan_variant(stripped))
+            self.assertIn(
+                "claim_boundary must deny that a variant is the accepted plan or evidence",
+                validate_plan_variant({**variant, "claim_boundary": "anything goes"}),
+            )
+            self.assertIn(
+                "next_handoff must offer the parent plan and the variant",
+                validate_plan_variant({**variant, "next_handoff": {**variant["next_handoff"], "candidates": []}}),
+            )
+
+    def test_a_write_of_an_invalid_variant_is_refused(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            variant = {**_variant(_accepted_plan(tmp)), "prepared_state": "observed"}
+
+            with self.assertRaises(ValueError):
+                write_plan_variant(paths, variant)
+            self.assertFalse((Path(tmp) / ".omh" / "plan-variants").exists())
+
+
+class PlanVariantCliTests(unittest.TestCase):
+    def _accepted_plan_path(self, tmp: str) -> tuple[list[str], str]:
+        base = ["--omh-home", str(Path(tmp) / ".omh"), "--hermes-home", str(Path(tmp) / ".hermes")]
+        parent = _accepted_plan(tmp)
+        return base, str(parent["path"])
+
+    def test_the_cli_summarizes_by_default_and_emits_the_payload_on_request(self) -> None:
+        with TemporaryDirectory() as tmp:
+            base, plan_path = self._accepted_plan_path(tmp)
+            arguments = base + [
+                "hermes",
+                "plan-variant",
+                plan_path,
+                "--name",
+                "claude-code owner",
+                "--delta",
+                "coding_owner:selected executor:codex:claude-code",
+                "--reevaluate",
+                "source:https://example.invalid/spec",
+            ]
+
+            status, text, stderr = run_cli(arguments, output_json=False)
+            self.assertEqual((status, stderr), (0, ""))
+            self.assertTrue(text.startswith("Plan variant: claude-code owner"))
+            self.assertIn("coding_owner | selected executor: codex -> claude-code", text)
+            self.assertIn("Re-evaluate before any handoff:", text)
+
+            status, stdout, stderr = run_cli(arguments + ["--json"], output_json=False)
+            self.assertEqual((status, stderr), (0, ""))
+            payload = json.loads(stdout)
+            self.assertEqual(payload["schema_version"], "hermes_plan_variant_view/v1")
+            self.assertEqual(validate_plan_variant(payload["variant"]), [])
+            self.assertNotIn("artifact", payload)
+
+    def test_the_cli_records_the_variant_and_leaves_the_plan_untouched(self) -> None:
+        with TemporaryDirectory() as tmp:
+            base, plan_path = self._accepted_plan_path(tmp)
+            before = Path(plan_path).read_bytes()
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "hermes",
+                    "plan-variant",
+                    plan_path,
+                    "--name",
+                    "defer docs",
+                    "--delta",
+                    "scope:docs:ship docs in the same PR:defer docs to a follow-up",
+                    "--record",
+                    "--json",
+                ]
+            )
+
+            self.assertEqual((status, stderr), (0, ""))
+            payload = json.loads(stdout)
+            recorded = Path(payload["artifact"]["path"])
+            self.assertEqual(recorded.parent.resolve(), (Path(tmp) / ".omh" / "plan-variants").resolve())
+            self.assertTrue(recorded.exists())
+            self.assertEqual(Path(plan_path).read_bytes(), before)
+
+    def test_the_cli_refuses_a_draft_plan_and_a_malformed_delta(self) -> None:
+        with TemporaryDirectory() as tmp:
+            base = ["--omh-home", str(Path(tmp) / ".omh"), "--hermes-home", str(Path(tmp) / ".hermes")]
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            draft = str(write_hermes_plan(paths, build_hermes_plan_payload(TASK))["path"])
+
+            status, _, stderr = run_cli(
+                base + ["hermes", "plan-variant", draft, "--name", "x", "--delta", "scope:docs:a:b"]
+            )
+            self.assertEqual(status, 2)
+            self.assertIn("accepted parent plan", stderr)
+
+            update_hermes_plan_status(paths, draft, status="accepted")
+            status, _, stderr = run_cli(
+                base + ["hermes", "plan-variant", draft, "--name", "x", "--delta", "scope:docs"]
+            )
+            self.assertEqual(status, 2)
+            self.assertIn("--delta must contain exactly 4 colon-separated fields", stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New contract `plan_variant/v1` in `src/workflows/plan_variants.py`: a metadata-only what-if child of an accepted `hermes_plan/v1` artifact. It records the parent plan path, the parent's immutable `sha256`, one explicit delta per changed input, a readable `changed_inputs` projection, the reviewed references it inherits unchanged, the references that must be re-evaluated against the new assumption, a `prepared_not_observed` state, and an undecided `next_handoff` block naming both candidates.
- New CLI surface `omh hermes plan-variant <accepted-plan.md> --name <name> --delta <dimension:label:parent_value:variant_value>`, alongside the existing `plan-accept` / `plan-revise` / `plan-cancel` lane. Differences-only plain-text summary by default, `--json` for the full payload, `--record` to persist under `.omh/plan-variants/`.
- New public functions: `build_plan_variant`, `validate_plan_variant`, `build_plan_variant_delta`, `build_plan_variant_ref`, `render_plan_variant_text`, `write_plan_variant`, `normalize_plan_variant_dimension`, `normalize_plan_variant_ref_kind`.
- `docs/ARCHITECTURE.md` gains a "Plan Variants" subsection under the plan-artifact store description: store layout, what a variant records, how identity is derived, and why a variant is not a plan.
- 27 new tests in `tests/test_plan_variants.py`, organized one class per acceptance criterion plus a guard class and a vocabulary/validation class.

### Why This Exists

Issue #827. Once a plan is accepted, exploring "what if the coding owner were Claude Code instead of Codex" or "what if we deferred the docs" had two bad options:

1. **Revise the accepted plan in place.** That destroys the artifact a prepared handoff already points at by digest. `build_plan_handoff_context_pack` pins `plan_artifact_sha256`; rewriting the file silently invalidates every pack and delegation that referenced it.
2. **Re-run `omh hermes plan` for the alternative.** That produces a sibling Markdown artifact with no link back. Nothing says which assumption differs, nothing says the two came from the same decision, and evidence recorded against one reads as evidence for the other — exactly the "blurred evidence lineage" the issue names.

A variant is the third option: a child record that names its parent by digest, states only what differs, and changes nothing.

### User / Operator Impact

Before: a user asking Hermes a what-if question could only get an answer by overwriting the accepted plan or by starting a disconnected second plan.

After: Hermes (or an operator) can fork the accepted plan into a named variant, show only the differences, and ask which plan should become the next handoff — with the accepted artifact provably untouched. Sibling variants are non-interchangeable by construction, so evidence attached to one alternative can never be read as evidence for another.

What the change deliberately does **not** give anyone: a way to execute, replay, or dispatch a variant. Choosing a variant as the next handoff stays a separate act through the normal plan lifecycle commands.

### How It Works

**Identity and lineage.** `variant_id` (`plan-variant-<digest12>`) and `variant_digest` both derive from `sha256(parent_digest | normalized_name | each delta)`. Two consequences are load-bearing: variants of different parents can never collide even with identical deltas, and re-forking the same plan the same way is the same record. `created_at` is a caller-supplied parameter and is excluded from the seed, so the digests carry no wall clock and cannot turn an equality check into a race.

**Refusals at build time.** `build_plan_variant` raises `ValueError` for a parent that is not `hermes_plan/v1`, a parent whose status is not `accepted`, a parent without a 64-hex `sha256`, an empty name, or an empty delta list. A fork with nothing changed is not a variant.

**Reviewed-only inheritance.** References are partitioned, not annotated. `build_plan_variant_ref(..., reviewed=True)` lands in `inherited_refs`; anything else lands in `refs_requiring_reevaluation`. The accepted parent artifact is always prepended as a reviewed `plan_artifact` reference, so `inherited_refs` is never empty and AC2 holds structurally. `validate_plan_variant` rejects an unreviewed ref moved into `inherited_refs` and a reviewed ref left in the re-evaluation list.

**A variant is not a plan.** The key set is closed and validated in both directions (missing keys and unexpected keys are both errors), and it contains no `status` field — so no reader can find `accepted` on a variant, and injecting `{"status": "accepted"}` fails validation with `plan_variant has unexpected keys: status`. `claim_boundary` and `not_evidence_until_observed` name every class the record is not evidence for: `plan_acceptance`, `plan_replay`, `tool_execution`, `network_call`, `coding_dispatch`, `executor_result`, `verification`, `review`.

**AC3 is enforced structurally, not by convention.** `plan_variants.py` imports exactly `__future__`, `hashlib`, `typing`, `..system.local_store`, and `..system.paths`. A test AST-parses the module and asserts that import set exactly, so the next import that could reach a process, a socket, or the plan lifecycle has to change that line deliberately. A second test builds a variant with `socket.socket`, `subprocess.run`, and `subprocess.Popen` patched to raise. A third asserts building a variant leaves the `.omh` store byte-for-byte unchanged — recording is a separate call.

**CLI shape.** `--delta` is repeatable and required; `--inherit` and `--reevaluate` are repeatable `KIND:REF` pairs. Colon splitting uses the repo's existing bounded `split(":", count - 1)` helper shape, so the trailing field absorbs colons (paths and URLs work) and a malformed flag produces `--delta must contain exactly 4 colon-separated fields` on stderr with exit 2. Output follows the plain-text-default / `--json` opt-in convention via `_wants_json`; the JSON envelope is `hermes_plan_variant_view/v1` wrapping the untouched `plan_variant/v1` record, so the record's closed key set is not polluted by the `artifact` pointer that `--record` adds.

**No routing, catalog, or demo-card change.** `plan-variant` is a control-plane command in the same lane as `plan-accept`, `plan-revise`, and `plan-cancel`, none of which carry routing triggers. No exact-count assertion in `tests/test_routing_precision.py`, `tests/test_cli.py`, `tests/test_hermes_ux_quality.py`, or `tests/test_release_smoke.py` moves, and no generated artifact needed regeneration (all four `--check` gates pass unchanged).

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/workflows/plan_variants.py` | New. `plan_variant/v1` plus the nested `plan_variant_delta/v1`, `plan_variant_ref/v1`, and `plan_variant_handoff/v1` shapes, their closed key sets, builders, validator, plain-text renderer, and writer. |
| `src/commands/hermes.py` | New `plan-variant` subparser and `cmd_hermes_plan_variant`, plus three small flag-parsing helpers. No existing command's behavior changed. |
| `tests/test_plan_variants.py` | New. 27 tests. |
| `docs/ARCHITECTURE.md` | New "Plan Variants" subsection. |

New persisted artifact: `.omh/plan-variants/plan-variant-<digest12>.json` (only written with `--record`, private mode, `.gitignore`-guarded through the existing `ensure_project_store_ignored` path).

## Validation

- [x] `uv run --group lint ruff check src tests` — `All checks passed!` (the `Invalid # noqa directive on src/commands/main.py:1` warning is pre-existing and on a file this PR does not touch)
- [x] `python3 -m unittest discover -s tests` — run as `PYTHONPATH=tests uv run python -m unittest discover -s tests`: **Ran 4281 tests in 156.322s, OK**
- [x] `python3 -m compileall src` — run as `uv run python -m compileall -q src tests`, exit 0
- [x] `python3 -m omh.cli docs workflows --check` — `{"ok":true,...,"tap_skills":{"checked":115,"expected":115,"extra":[],"missing":[],"ok":true,"stale":[]}}`
- [x] `python3 -m omh.cli harness validate` — `{"counts":{"harnesses":72,"skills":104},"errors":[],"ok":true,"schema_version":"catalog_validation/v1","warnings":[]}`
- [x] `python3 -m omh.cli release checklist --json` — exit 0, `required_item_count: 35`, `schema_version: release_readiness_checklist/v1` (informational; no release authority requested here)
- [ ] `python3 -m omh.cli release hermes-smoke` — not run unscoped; the isolated variant below was run instead so the local Hermes profile stays untouched
- [x] `omh --help` — exit 0
- [x] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — exit 0 against `/tmp/omh-smoke827` / `/tmp/hermes-smoke827`; plan mode, which the command itself labels as not evidence that Hermes installed, loaded, or used OMH
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable — no learning contract changed
- [x] Relevant dry-run or smoke command: also run and passing, beyond the template list — `uv run python -m omh.cli docs roles --check` → `{"ok":true}`; `uv run python -m omh.cli docs capability-families --check` → `{"ok":true}`; `git diff --check` → exit 0
- [x] Manual CLI check against a real recorded plan: `omh hermes plan --record` → `omh hermes plan-accept` → `shasum -a 256 <plan>` → `omh hermes plan-variant ... --record` → `shasum -a 256 <plan>` again. Digests identical (`bcea3707aa95…`). Also confirmed the same command against the same plan **before** acceptance exits 2 with `omh: plan variant requires an accepted parent plan`.
- [ ] Manual Hermes/TUI check: **not run.** No Hermes Agent or wrapper adapter consumed `plan_variant/v1` end to end in this change, so there is no observed evidence that a chat surface renders a variant comparison. The contract and CLI are proven; the chat experience is not.

New-test coverage, one class per acceptance criterion:

| Acceptance criterion | Class | Tests |
| --- | --- | --- |
| The original plan remains unchanged | `OriginalPlanRemainsUnchangedTests` | 3 — byte-identical parent after build **and** record, variant written outside `plans/`, re-forking rewrites one file |
| Every variant lists changed inputs and inherited references | `ChangedInputsAndInheritedRefsTests` | 6 — one `changed_inputs` line per delta, parent always inherited, unreviewed refs partitioned out, validator refuses a smuggled unreviewed ref, a no-op fork refused, plain-text rendering shows differences and the open question |
| Creating variants performs no replay, tool, network, or dispatch | `NoReplayToolNetworkOrDispatchTests` | 4 — exact import-set assertion by AST, build with sockets/subprocesses patched to raise, build writes nothing, boundary vocabulary complete |
| Guard: a variant is never the accepted plan | `AVariantIsNotThePlanTests` | 8 — no `status` and cannot be given one, never wears `hermes_plan/v1`, claim boundary denies every evidence class, handoff stays undecided, only accepted `hermes_plan/v1` parents fork, digest required, siblings non-interchangeable, identity reproducible and clock-free |
| Contract hygiene and CLI | `VocabularyAndValidationTests`, `PlanVariantCliTests` | 6 — vocabulary fallbacks, missing-key and tampered-constant reporting, invalid write refused, plain-text default vs `--json`, `--record` leaves the plan untouched, draft parent and malformed `--delta` both exit 2 |

## Risk

- **Low blast radius.** One new module with no importers other than the new CLI command, one new subparser, one new documentation subsection. No existing function signature, payload, or generated artifact changed. All four `--check` byte gates and `harness validate` pass without regeneration.
- **The strictest design decision is refusing non-accepted parents.** Forking a draft is a `ValueError`, not a warning. If a real workflow turns out to need draft forks, that is a deliberate contract change with its own negative-case tests — not something a caller can work around today.
- **`--delta` colon splitting bounds the middle fields.** `dimension` and `label` cannot contain a colon; `parent_value` cannot either (the fourth field absorbs the remainder). For values that need colons, callers should use the library function directly or place the colon-bearing value last. The failure mode is a clear stderr message and exit 2, not a silently mis-parsed delta.
- **No reader surface yet.** Recorded variants are inspectable only as JSON files on disk. There is no `omh hermes plan-variants list`, so a store that accumulates many variants has no bounded-output view. That is a deliberate omission (no polled surface, no `bounded_surfaces` obligation) rather than an oversight, but it is the most likely follow-up.

## Compatibility / Rollout

- Purely additive. No migration, no schema bump on an existing contract, no change to `hermes_plan/v1`, `handoff_context_pack/v1`, or the wrapper contract.
- Nothing writes to `.omh/plan-variants/` unless an operator passes `--record`, so an installed OMH that never runs the new command is byte-identical in behavior.
- The branch is currently 2 commits behind `origin/main` (`69b470d9`, merge `04309ffc`, the #844 review-receipt gate). Those commits touch `src/coding/action_gate.py`, `src/plugin_bundle/omh/runtime_reader.py`, `src/runtime/claims.py`, and three test files — no overlap with this PR's files and no shared count or freeze gate. Rerun the suite on the merged result anyway, since this repo has previously turned `main` red by crossing two independently green PRs.

## Release / Claims

- [x] Release-channel impact considered — `local`; additive control-plane command, no release-channel behavior change, no version file touched
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — the record's own `claim_boundary` and `not_evidence_until_observed` list carry this at runtime; `prepared_state` is fixed to `prepared_not_observed` and validated
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap — no `--live` smoke was run; the plan-mode smoke above explicitly states it is not evidence that Hermes installed, loaded, or used OMH, and no Hermes/TUI rendering of a variant was observed

## Follow-Up

- A bounded reader surface (`omh hermes plan-variants --parent <plan>`) if variant stores grow past hand-inspection. It would need the repo's `bounded_surfaces` treatment for a polled surface.
- Wrapper/adapter work so Hermes can render a variant comparison in chat and record the `next_handoff` answer — that is where the issue's "Hermes creates and compares variants in chat" experience actually lands, and it is not in this PR.
- If a variant is later chosen as the next handoff, deciding whether `build_plan_handoff_context_pack` should learn to take a variant's lineage, or whether promoting a variant should mint a normal plan artifact first. This PR deliberately leaves that unanswered rather than guessing.
