### PR TITLE
feat: record language-server deltas as scoped verification evidence

### DIFF
--- a/docs/CODING-OBSERVABILITY.md
+++ b/docs/CODING-OBSERVABILITY.md
@@ -254,6 +254,65 @@ citation: a link, a path, a secret, or anything with a newline or an ANSI escape
 in it becomes `[redacted]` in free text and a `ref-<digest>` handle in an
 identifier, and a value outside a closed vocabulary renders empty.
 
+## Language diagnostics, and why "clean" is not "verified"
+
+A language server answers one narrow question fast: at this revision, which
+positions in these files does the analyser object to? That is genuinely useful
+right after an edit, and it is the single most over-read signal in a coding
+report. "No diagnostics" gets written up as "verified", and the reader hears
+compilation, tests, review, and CI — none of which a diagnostic pass performs.
+
+`language_diagnostic_evidence/v1` records the narrow answer with the narrow
+label attached. OMH installs no language server, starts no process, and opens
+no socket; the diagnostics are supplied by a caller that ran the provider
+itself, and the record is metadata only — severity, code, workspace-relative
+path, and position. A diagnostic *message* is not a field, and an input
+carrying one is refused by key name, because a message is where a source body
+would arrive.
+
+The verdict is derived from what the caller supplied, never accepted from it:
+
+| Verdict | Means |
+| --- | --- |
+| `no_new_diagnostics_observed` | a fresh, attributable check found nothing new |
+| `new_diagnostics_observed` | a fresh, attributable check found N new diagnostics |
+| `attribution_unavailable` | no workspace, no baseline revision, or no end revision |
+| `stale_diagnostics` | the diagnostics were observed at a revision other than the interval end |
+| `freshness_unknown` | the caller did not say which revision the diagnostics came from |
+| `provider_unsupported` | no diagnostic provider was available for this workspace |
+| `provider_failed` | the provider ran and failed |
+| `not_observed` | no check happened |
+
+The last six are preserved rather than collapsed, because a provider that never
+ran and a provider that found nothing are exactly the two states this record
+exists to keep apart. A zero-diagnostic result observed at the wrong revision
+is `stale_diagnostics`, not a clean run.
+
+One predicate decides what any of it proves.
+`language_diagnostic_supports_claim` returns `True` only for
+`fresh_language_diagnostic_check`, and only for the first two verdicts. Asked
+about verification, compilation, tests, review, CI, merge-readiness, or merge,
+it returns `False` for every record the contract can build, including a
+perfectly clean one — there is no argument that reaches a `True`, and no verdict
+in the vocabulary that reads as verification. The human-readable
+`summary_label` is derived too, so a caller cannot hand in prose that upgrades
+its own result, and validation re-derives freshness, attribution, verdict, and
+label on the read path so a hand-edited record cannot reach a status line.
+
+Operators and wrappers can scope one supplied observation without recording
+anything:
+
+```sh
+omh quality-evidence language-diagnostics \
+  --owner claude-code --provider <provider> \
+  --workspace <id> --baseline-revision <sha> --end-revision <sha> \
+  --diagnostics-revision <sha> [--introduced <json>] [--resolved <json>] [--json]
+```
+
+It is read-only in both directions: it starts nothing and writes nothing. Plain
+text is the default and prints the claim support next to the verdict, so the
+line a reader quotes already says what the check does not settle.
+
 ## Boundary
 
 A status board is observed activity metadata. It is not result, verification,
@@ -262,3 +321,7 @@ review, CI, merge-readiness, or merge evidence, and a unit appearing as
 
 A receipt is narrower still: it is one acting surface's observation of one
 external effect, and it proves nothing about any other effect.
+
+A language diagnostic record is narrower again: it is one language-diagnostic
+check over one workspace revision interval. A clean result means no new
+diagnostics were observed in that check, and nothing more.

--- a/src/commands/quality_evidence.py
+++ b/src/commands/quality_evidence.py
@@ -5,11 +5,18 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from typing import Mapping
+from typing import Any, Mapping
 
 from ..installer import OmhError
 from ..quality.evidence_records import assess_quality_evidence, build_quality_evidence_package
-from .common import _paths, _print_json
+from ..quality.language_diagnostic_evidence import (
+    LANGUAGE_DIAGNOSTIC_CHECK_STATES,
+    LANGUAGE_DIAGNOSTIC_OWNERS,
+    LanguageDiagnosticEvidenceError,
+    build_language_diagnostic_evidence,
+    language_diagnostic_claim_support,
+)
+from .common import _paths, _print_json, _wants_json
 
 
 def cmd_quality_evidence_prepare(args: argparse.Namespace) -> int:
@@ -42,6 +49,65 @@ def cmd_quality_evidence_assess(args: argparse.Namespace) -> int:
         raise OmhError(str(exc)) from exc
     _print_json(assessment)
     return 0
+
+
+def cmd_quality_evidence_language_diagnostics(args: argparse.Namespace) -> int:
+    """Render one supplied language-diagnostic observation as a scoped record.
+
+    Read-only in both directions: OMH starts no language server and writes no
+    file. The diagnostics come from a caller that ran the provider, and the
+    verdict is derived from them rather than accepted from them.
+    """
+    try:
+        record = build_language_diagnostic_evidence(
+            owner=args.owner,
+            provider=args.provider,
+            workspace_id=args.workspace,
+            baseline_revision=args.baseline_revision,
+            end_revision=args.end_revision,
+            diagnostics_revision=args.diagnostics_revision,
+            check_state=args.check_state,
+            config_digest=args.config_digest,
+            changed_paths=_json_strings(args.changed_paths_json, args.changed_paths_file, "changed paths"),
+            introduced=_json_list(args.introduced_json, args.introduced_file, "introduced diagnostics"),
+            resolved=_json_list(args.resolved_json, args.resolved_file, "resolved diagnostics"),
+            observed_at=args.observed_at,
+            evidence_refs=_json_strings(args.evidence_refs_json, None, "evidence refs"),
+        )
+    except (OSError, json.JSONDecodeError, TypeError, LanguageDiagnosticEvidenceError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    support = language_diagnostic_claim_support(record)
+    if _wants_json(args):
+        _print_json({"record": record, "claim_support": support})
+    else:
+        _print_language_diagnostic_summary(record, support)
+    return 0
+
+
+def _print_language_diagnostic_summary(record: Mapping[str, Any], support: Mapping[str, Any]) -> None:
+    print("OMH language diagnostic evidence")
+    print(f"  Verdict: {record['verdict']}")
+    print(f"  {record['summary_label']}")
+    print("Check")
+    print(f"  Owner: {record['owner']}    Provider: {record['provider']}    State: {record['check_state']}")
+    print(f"  Workspace: {record['workspace_id'] or '(not stated)'}")
+    print(
+        f"  Interval: {record['baseline_revision'] or '(not stated)'}"
+        f" -> {record['end_revision'] or '(not stated)'}"
+        f"    Diagnostics at: {record['diagnostics_revision'] or '(not stated)'}"
+    )
+    print(f"  Freshness: {record['freshness']}    Attribution: {record['attribution']}")
+    print(
+        f"  Introduced: {record['introduced_count']}"
+        f"    Resolved: {record['resolved_count']}"
+        f"    Changed paths: {record['changed_path_count']}"
+    )
+    print("Boundary")
+    supported = support.get("supported_claims") or []
+    unsupported = support.get("unsupported_claims") or []
+    print(f"  Supports: {', '.join(str(item) for item in supported) or 'nothing'}")
+    print(f"  Does not support: {', '.join(str(item) for item in unsupported)}")
+    print(f"  {record['claim_boundary']}")
 
 
 def _add_quality_evidence_commands(sub: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
@@ -82,10 +148,39 @@ def _add_quality_evidence_commands(sub: argparse._SubParsersAction[argparse.Argu
     assess.add_argument("--observations-file", help="Path to observations JSON.")
     assess.set_defaults(func=cmd_quality_evidence_assess)
 
+    language = commands.add_parser(
+        "language-diagnostics",
+        help="Scope a supplied language-server diagnostic delta as a language-diagnostic check.",
+        description=(
+            "Render supplied diagnostics as a language_diagnostic_evidence/v1 record. OMH starts no "
+            "language server and observes nothing; a clean result is labelled only as a fresh "
+            "language-diagnostic check and never as verification, tests, review, CI, or merge evidence."
+        ),
+    )
+    language.add_argument("--owner", required=True, choices=LANGUAGE_DIAGNOSTIC_OWNERS, help="Surface that observed the check.")
+    language.add_argument("--provider", required=True, help="Diagnostic provider label, such as a language-server name.")
+    language.add_argument("--workspace", default="", help="Workspace identifier the interval is attributed to.")
+    language.add_argument("--baseline-revision", default="", help="Revision the interval starts at.")
+    language.add_argument("--end-revision", default="", help="Revision the interval ends at.")
+    language.add_argument("--diagnostics-revision", default="", help="Revision the diagnostics were observed at.")
+    language.add_argument("--check-state", default="observed", choices=LANGUAGE_DIAGNOSTIC_CHECK_STATES)
+    language.add_argument("--config-digest", default="", help="Digest of the provider configuration in effect.")
+    language.add_argument("--observed-at", default="", help="Caller-supplied observation timestamp.")
+    _add_json_input(language, "changed-paths", "changed workspace-relative paths")
+    _add_json_input(language, "introduced", "introduced diagnostics")
+    _add_json_input(language, "resolved", "resolved diagnostics")
+    language.add_argument("--evidence-refs-json", "--evidence-refs", dest="evidence_refs_json", help="Inline bounded evidence reference JSON array.")
+    language.add_argument("--json", action="store_true", help="Print the machine-readable record and claim support.")
+    language.set_defaults(func=cmd_quality_evidence_language_diagnostics)
+
 
 def _add_json_input(parser: argparse.ArgumentParser, name: str, label: str) -> None:
-    parser.add_argument(f"--{name}-json", f"--{name}", dest=f"{name}_json", help=f"Inline {label} JSON array.")
-    parser.add_argument(f"--{name}-file", dest=f"{name}_file", help=f"Path to {label} JSON array.")
+    # A multi-word flag is hyphenated on the command line and underscored in the
+    # namespace; argparse only derives that for positionals, so `dest` is set
+    # here or `--changed-paths-json` lands on an unreachable attribute name.
+    dest = name.replace("-", "_")
+    parser.add_argument(f"--{name}-json", f"--{name}", dest=f"{dest}_json", help=f"Inline {label} JSON array.")
+    parser.add_argument(f"--{name}-file", dest=f"{dest}_file", help=f"Path to {label} JSON array.")
 
 
 def _json_object(path: str) -> dict[str, object]:

--- a/src/quality/language_diagnostic_evidence.py
+++ b/src/quality/language_diagnostic_evidence.py
@@ -1,0 +1,674 @@
+"""One language-diagnostic check over one workspace revision interval.
+
+A language server answers a narrow question quickly: at this revision, which
+positions in these files does the analyser object to? That answer is genuinely
+useful right after an edit, and it is routinely overstated. "No diagnostics"
+gets reported as "verified", and the reader hears compilation, tests, review,
+and CI -- none of which a diagnostic pass performs.
+
+This module records the narrow answer with the narrow label attached, so the
+overstatement has nowhere to happen:
+
+- `verdict` is a closed vocabulary whose clean member is
+  `no_new_diagnostics_observed`, not `passed`. There is no verdict that reads
+  as verification because none exists to select.
+- `summary_label` is derived, never supplied. A caller cannot hand in prose
+  that upgrades its own result.
+- `language_diagnostic_supports_claim` answers every claim except
+  `fresh_language_diagnostic_check` with False, for every record, including a
+  perfectly clean one. The refusal is structural, not a policy string.
+- A record whose diagnostics were observed at a revision other than the
+  interval end is `stale_diagnostics`, and a record missing its workspace or
+  either interval endpoint is `attribution_unavailable`. Neither backs the one
+  claim this record can back, because a diagnostic result that cannot be
+  attributed to an interval says nothing about what that interval introduced.
+
+OMH observes nothing here. It starts no language server, opens no socket, and
+reads no source file; every diagnostic on a record was supplied by a caller
+that ran the provider itself. The record is metadata only -- severity, code,
+workspace-relative path, and position. Diagnostic *messages* are not a field,
+and an input diagnostic carrying one is refused by key name, because a message
+is where a source body would arrive.
+
+Every value is derived from the arguments alone. No clock is read: `observed_at`
+is a parameter, and it is deliberately excluded from `record_id`, so the same
+observation reported twice is the same record.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any, Iterable, Mapping
+
+from ..coding.executors import EXECUTOR_PROFILES
+from ..system.metadata_safety import require_opaque_metadata_ref
+
+LANGUAGE_DIAGNOSTIC_EVIDENCE_SCHEMA_VERSION = "language_diagnostic_evidence/v1"
+LANGUAGE_DIAGNOSTIC_EVIDENCE_PRIVACY = "metadata_only"
+
+# Who observed the check. `wrapper` plus the canonical executor profiles, so a
+# record never has to name Codex to describe a Claude Code or Hermes run.
+LANGUAGE_DIAGNOSTIC_OWNERS = ("wrapper", *EXECUTOR_PROFILES)
+
+# What the caller's provider actually did. Only `observed` can produce a usable
+# result; the other three are preserved rather than collapsed into "clean",
+# because a provider that never ran and a provider that found nothing are the
+# two states this record exists to keep apart.
+LANGUAGE_DIAGNOSTIC_CHECK_STATES = ("observed", "unsupported", "failed", "not_observed")
+
+LANGUAGE_DIAGNOSTIC_SEVERITIES = ("error", "warning", "information", "hint")
+
+# Derived from the revisions, never supplied. `fresh` means the diagnostics
+# were observed at the interval end; `stale` means they were observed
+# somewhere else; `unknown` means the caller did not say where.
+LANGUAGE_DIAGNOSTIC_FRESHNESS_STATES = ("fresh", "stale", "unknown")
+
+LANGUAGE_DIAGNOSTIC_ATTRIBUTION_STATES = ("attributable", "unavailable")
+
+LANGUAGE_DIAGNOSTIC_VERDICTS = (
+    "no_new_diagnostics_observed",
+    "new_diagnostics_observed",
+    "attribution_unavailable",
+    "stale_diagnostics",
+    "freshness_unknown",
+    "provider_unsupported",
+    "provider_failed",
+    "not_observed",
+)
+# The two verdicts that describe a fresh, attributable check. Every other
+# verdict names a reason the check cannot be read as a result at all.
+LANGUAGE_DIAGNOSTIC_USABLE_VERDICTS = ("no_new_diagnostics_observed", "new_diagnostics_observed")
+
+# Claims a reader might try to settle with this record.
+LANGUAGE_DIAGNOSTIC_CLAIMS = (
+    "fresh_language_diagnostic_check",
+    "verification",
+    "compilation",
+    "test_execution",
+    "review",
+    "ci",
+    "merge_readiness",
+    "merge",
+)
+# The only one it can ever settle. Kept as a tuple rather than a bare string so
+# the "everything else is False" invariant is expressible as set arithmetic.
+LANGUAGE_DIAGNOSTIC_SUPPORTABLE_CLAIMS = ("fresh_language_diagnostic_check",)
+LANGUAGE_DIAGNOSTIC_NOT_EVIDENCE_FOR = tuple(
+    claim for claim in LANGUAGE_DIAGNOSTIC_CLAIMS if claim not in LANGUAGE_DIAGNOSTIC_SUPPORTABLE_CLAIMS
+)
+
+LANGUAGE_DIAGNOSTIC_CLAIM_BOUNDARY = (
+    "A language diagnostic evidence record is one language-diagnostic check over one workspace revision "
+    "interval. A clean result means no new diagnostics were observed in that check; it is not compilation, "
+    "test, verification, review, CI, merge-readiness, or merge evidence."
+)
+
+LANGUAGE_DIAGNOSTIC_EVIDENCE_KEYS = (
+    "attribution",
+    "baseline_revision",
+    "changed_path_count",
+    "changed_paths",
+    "check_state",
+    "claim_boundary",
+    "config_digest",
+    "diagnostics_revision",
+    "end_revision",
+    "evidence_refs",
+    "freshness",
+    "introduced",
+    "introduced_count",
+    "not_evidence_for",
+    "observed_at",
+    "owner",
+    "privacy",
+    "provider",
+    "record_id",
+    "resolved",
+    "resolved_count",
+    "schema_version",
+    "summary_label",
+    "verdict",
+    "workspace_id",
+)
+
+# The whole of one normalized diagnostic. There is no message, body, snippet,
+# or fix field, and there is no room for one: an input carrying a key outside
+# this set is refused by name.
+LANGUAGE_DIAGNOSTIC_ITEM_KEYS = ("character", "code", "line", "path", "severity", "source")
+
+MAX_REFERENCE_CHARS = 120
+MAX_CHANGED_PATHS = 200
+MAX_DIAGNOSTICS = 200
+MAX_EVIDENCE_REFS = 8
+MAX_SUMMARY_LABEL_CHARS = 512
+MAX_POSITION = 1_000_000
+
+_ABSOLUTE_WINDOWS_PATH = re.compile(r"^[A-Za-z]:/")
+
+
+class LanguageDiagnosticEvidenceError(ValueError):
+    """Raised when a language-diagnostic observation cannot become a record."""
+
+
+def build_language_diagnostic_evidence(
+    *,
+    owner: str,
+    provider: str,
+    workspace_id: str = "",
+    baseline_revision: str = "",
+    end_revision: str = "",
+    diagnostics_revision: str = "",
+    check_state: str = "observed",
+    config_digest: str = "",
+    changed_paths: Iterable[str] = (),
+    introduced: Iterable[Mapping[str, Any]] = (),
+    resolved: Iterable[Mapping[str, Any]] = (),
+    observed_at: str = "",
+    evidence_refs: Iterable[str] = (),
+) -> dict[str, Any]:
+    """Build one record, or refuse.
+
+    Nothing about the outcome is a parameter. `freshness`, `attribution`,
+    `verdict`, and `summary_label` are all derived below, so a caller supplies
+    what it observed and never what that observation proves.
+    """
+    if owner not in LANGUAGE_DIAGNOSTIC_OWNERS:
+        raise LanguageDiagnosticEvidenceError(f"language_diagnostic_evidence owner is unsupported: {owner!r}")
+    if check_state not in LANGUAGE_DIAGNOSTIC_CHECK_STATES:
+        raise LanguageDiagnosticEvidenceError(
+            f"language_diagnostic_evidence check_state is unsupported: {check_state!r}"
+        )
+    safe_provider = _required_ref(provider, field="language_diagnostic_evidence provider")
+    safe_workspace = _optional_ref(workspace_id, field="language_diagnostic_evidence workspace_id")
+    safe_baseline = _optional_ref(baseline_revision, field="language_diagnostic_evidence baseline_revision")
+    safe_end = _optional_ref(end_revision, field="language_diagnostic_evidence end_revision")
+    safe_diagnostics_revision = _optional_ref(
+        diagnostics_revision, field="language_diagnostic_evidence diagnostics_revision"
+    )
+    safe_config_digest = _optional_ref(config_digest, field="language_diagnostic_evidence config_digest")
+    safe_observed_at = _optional_ref(observed_at, field="language_diagnostic_evidence observed_at")
+
+    normalized_changed_paths = _normalized_paths(changed_paths)
+    normalized_introduced = _normalized_diagnostics(introduced, field="introduced")
+    normalized_resolved = _normalized_diagnostics(resolved, field="resolved")
+    normalized_refs = _normalized_evidence_refs(evidence_refs)
+
+    freshness = _derive_freshness(check_state, safe_end, safe_diagnostics_revision)
+    attribution = _derive_attribution(check_state, safe_workspace, safe_baseline, safe_end)
+    verdict = _derive_verdict(check_state, freshness, attribution, len(normalized_introduced))
+    record = {
+        "schema_version": LANGUAGE_DIAGNOSTIC_EVIDENCE_SCHEMA_VERSION,
+        "record_id": _record_id(
+            owner,
+            safe_provider,
+            safe_workspace,
+            safe_baseline,
+            safe_end,
+            safe_diagnostics_revision,
+            safe_config_digest,
+            check_state,
+            normalized_introduced,
+            normalized_resolved,
+        ),
+        "owner": owner,
+        "provider": safe_provider,
+        "config_digest": safe_config_digest,
+        "check_state": check_state,
+        "workspace_id": safe_workspace,
+        "baseline_revision": safe_baseline,
+        "end_revision": safe_end,
+        "diagnostics_revision": safe_diagnostics_revision,
+        "changed_paths": normalized_changed_paths,
+        "changed_path_count": len(normalized_changed_paths),
+        "observed_at": safe_observed_at,
+        "freshness": freshness,
+        "attribution": attribution,
+        "introduced": normalized_introduced,
+        "introduced_count": len(normalized_introduced),
+        "resolved": normalized_resolved,
+        "resolved_count": len(normalized_resolved),
+        "verdict": verdict,
+        "summary_label": _summary_label(
+            verdict,
+            workspace_id=safe_workspace,
+            baseline_revision=safe_baseline,
+            end_revision=safe_end,
+            diagnostics_revision=safe_diagnostics_revision,
+            introduced_count=len(normalized_introduced),
+        ),
+        "evidence_refs": normalized_refs,
+        "privacy": LANGUAGE_DIAGNOSTIC_EVIDENCE_PRIVACY,
+        "not_evidence_for": list(LANGUAGE_DIAGNOSTIC_NOT_EVIDENCE_FOR),
+        "claim_boundary": LANGUAGE_DIAGNOSTIC_CLAIM_BOUNDARY,
+    }
+    errors = validate_language_diagnostic_evidence(record)
+    if errors:
+        raise LanguageDiagnosticEvidenceError(errors[0])
+    return record
+
+
+def validate_language_diagnostic_evidence(record: Any) -> list[str]:
+    """Return every reason the payload is not a valid record.
+
+    The derived fields are re-derived here rather than merely type-checked. A
+    record that reached disk, a wrapper, or a status line with its `verdict`
+    edited to a clean one is the exact failure this contract exists to prevent,
+    so the check that catches it lives on the read path too.
+    """
+    if not isinstance(record, dict):
+        return ["language_diagnostic_evidence must be an object"]
+    errors: list[str] = []
+    extra_keys = sorted(set(record) - set(LANGUAGE_DIAGNOSTIC_EVIDENCE_KEYS))
+    if extra_keys:
+        errors.append(f"language_diagnostic_evidence has unsupported keys: {extra_keys}")
+    missing_keys = sorted(set(LANGUAGE_DIAGNOSTIC_EVIDENCE_KEYS) - set(record))
+    if missing_keys:
+        errors.append(f"language_diagnostic_evidence is missing keys: {missing_keys}")
+    if missing_keys:
+        return errors
+
+    if record.get("schema_version") != LANGUAGE_DIAGNOSTIC_EVIDENCE_SCHEMA_VERSION:
+        errors.append(
+            f"language_diagnostic_evidence schema_version must be {LANGUAGE_DIAGNOSTIC_EVIDENCE_SCHEMA_VERSION}"
+        )
+    if record.get("privacy") != LANGUAGE_DIAGNOSTIC_EVIDENCE_PRIVACY:
+        errors.append("language_diagnostic_evidence privacy must be metadata_only")
+    if record.get("claim_boundary") != LANGUAGE_DIAGNOSTIC_CLAIM_BOUNDARY:
+        errors.append("language_diagnostic_evidence claim_boundary must state the language-diagnostic boundary")
+    if list(record.get("not_evidence_for") or ()) != list(LANGUAGE_DIAGNOSTIC_NOT_EVIDENCE_FOR):
+        errors.append(
+            "language_diagnostic_evidence not_evidence_for must list every claim this record cannot settle"
+        )
+    for field, vocabulary in (
+        ("owner", LANGUAGE_DIAGNOSTIC_OWNERS),
+        ("check_state", LANGUAGE_DIAGNOSTIC_CHECK_STATES),
+        ("freshness", LANGUAGE_DIAGNOSTIC_FRESHNESS_STATES),
+        ("attribution", LANGUAGE_DIAGNOSTIC_ATTRIBUTION_STATES),
+        ("verdict", LANGUAGE_DIAGNOSTIC_VERDICTS),
+    ):
+        if record.get(field) not in vocabulary:
+            errors.append(f"language_diagnostic_evidence {field} is unsupported: {record.get(field)!r}")
+
+    errors.extend(_reference_errors(record.get("record_id"), field="record_id", required=True))
+    errors.extend(_reference_errors(record.get("provider"), field="provider", required=True))
+    for field in ("workspace_id", "baseline_revision", "end_revision", "diagnostics_revision", "config_digest", "observed_at"):
+        errors.extend(_reference_errors(record.get(field), field=field, required=False))
+
+    errors.extend(_path_list_errors(record.get("changed_paths")))
+    for field in ("introduced", "resolved"):
+        errors.extend(_diagnostic_list_errors(record.get(field), field=field))
+    errors.extend(_evidence_ref_errors(record.get("evidence_refs")))
+    for count_field, list_field in (
+        ("changed_path_count", "changed_paths"),
+        ("introduced_count", "introduced"),
+        ("resolved_count", "resolved"),
+    ):
+        values = record.get(list_field)
+        if isinstance(values, list) and record.get(count_field) != len(values):
+            errors.append(f"language_diagnostic_evidence {count_field} must equal len({list_field})")
+
+    label = record.get("summary_label")
+    if not isinstance(label, str) or not label.strip():
+        errors.append("language_diagnostic_evidence summary_label must be a nonblank string")
+    elif len(label) > MAX_SUMMARY_LABEL_CHARS:
+        errors.append(
+            f"language_diagnostic_evidence summary_label must be at most {MAX_SUMMARY_LABEL_CHARS} characters"
+        )
+
+    if errors:
+        return errors
+    return _derivation_errors(record)
+
+
+def language_diagnostic_supports_claim(record: Any, claim: str) -> bool:
+    """True only for a fresh, attributable check asked about its own claim.
+
+    Every other question -- verification, compilation, tests, review, CI,
+    merge-readiness, merge -- is False for every record this module can build.
+    A caller cannot reach a True by supplying a cleaner input, because no input
+    selects the claim.
+    """
+    if claim not in LANGUAGE_DIAGNOSTIC_SUPPORTABLE_CLAIMS:
+        return False
+    if validate_language_diagnostic_evidence(record):
+        return False
+    return record["verdict"] in LANGUAGE_DIAGNOSTIC_USABLE_VERDICTS
+
+
+def language_diagnostic_claim_support(record: Any) -> dict[str, Any]:
+    """One reportable answer per claim, for a status surface to render."""
+    return {
+        "schema_version": LANGUAGE_DIAGNOSTIC_EVIDENCE_SCHEMA_VERSION,
+        "supported_claims": [
+            claim for claim in LANGUAGE_DIAGNOSTIC_CLAIMS if language_diagnostic_supports_claim(record, claim)
+        ],
+        "unsupported_claims": [
+            claim for claim in LANGUAGE_DIAGNOSTIC_CLAIMS if not language_diagnostic_supports_claim(record, claim)
+        ],
+        "claim_boundary": LANGUAGE_DIAGNOSTIC_CLAIM_BOUNDARY,
+    }
+
+
+def _derive_freshness(check_state: str, end_revision: str, diagnostics_revision: str) -> str:
+    if check_state != "observed":
+        return "unknown"
+    if not end_revision or not diagnostics_revision:
+        return "unknown"
+    return "fresh" if diagnostics_revision == end_revision else "stale"
+
+
+def _derive_attribution(check_state: str, workspace_id: str, baseline_revision: str, end_revision: str) -> str:
+    if check_state != "observed":
+        return "unavailable"
+    if workspace_id and baseline_revision and end_revision:
+        return "attributable"
+    return "unavailable"
+
+
+def _derive_verdict(check_state: str, freshness: str, attribution: str, introduced_count: int) -> str:
+    if check_state == "unsupported":
+        return "provider_unsupported"
+    if check_state == "failed":
+        return "provider_failed"
+    if check_state == "not_observed":
+        return "not_observed"
+    if attribution != "attributable":
+        return "attribution_unavailable"
+    if freshness == "stale":
+        return "stale_diagnostics"
+    if freshness != "fresh":
+        return "freshness_unknown"
+    return "new_diagnostics_observed" if introduced_count else "no_new_diagnostics_observed"
+
+
+def _summary_label(
+    verdict: str,
+    *,
+    workspace_id: str,
+    baseline_revision: str,
+    end_revision: str,
+    diagnostics_revision: str,
+    introduced_count: int,
+) -> str:
+    """The one line a human reads, derived so no caller can write it.
+
+    Every branch names the check as a language-diagnostic check and none uses
+    a word that reads as verification, so the clean branch cannot be quoted
+    into a stronger claim than it makes.
+    """
+    interval = f"workspace {workspace_id} between {baseline_revision} and {end_revision}"
+    if verdict == "no_new_diagnostics_observed":
+        return (
+            f"No new diagnostics were observed in a fresh language-diagnostic check of {interval}. "
+            "Compilation, tests, review, and CI are separate and unobserved here."
+        )
+    if verdict == "new_diagnostics_observed":
+        return (
+            f"{introduced_count} newly introduced diagnostics were observed in a fresh language-diagnostic "
+            f"check of {interval}. Compilation, tests, review, and CI are separate and unobserved here."
+        )
+    if verdict == "attribution_unavailable":
+        return (
+            "Diagnostics were observed but cannot be attributed to a workspace and revision interval, "
+            "so they are not a language-diagnostic result for any interval."
+        )
+    if verdict == "stale_diagnostics":
+        return (
+            f"Diagnostics were observed at revision {diagnostics_revision}, which is not the interval end "
+            f"{end_revision}, so this language-diagnostic check is stale."
+        )
+    if verdict == "freshness_unknown":
+        return (
+            "Diagnostics were observed without naming the revision they were observed at, so the freshness "
+            "of this language-diagnostic check is unknown."
+        )
+    if verdict == "provider_unsupported":
+        return "No language-diagnostic provider was available for this workspace, so no check was run."
+    if verdict == "provider_failed":
+        return "The language-diagnostic provider failed, so no diagnostics were observed."
+    return "No language-diagnostic check was observed."
+
+
+def _derivation_errors(record: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    check_state = str(record["check_state"])
+    end_revision = str(record["end_revision"])
+    diagnostics_revision = str(record["diagnostics_revision"])
+    freshness = _derive_freshness(check_state, end_revision, diagnostics_revision)
+    attribution = _derive_attribution(
+        check_state, str(record["workspace_id"]), str(record["baseline_revision"]), end_revision
+    )
+    introduced_count = int(record["introduced_count"])
+    verdict = _derive_verdict(check_state, freshness, attribution, introduced_count)
+    if record["freshness"] != freshness:
+        errors.append(f"language_diagnostic_evidence freshness must be derived as {freshness!r}")
+    if record["attribution"] != attribution:
+        errors.append(f"language_diagnostic_evidence attribution must be derived as {attribution!r}")
+    if record["verdict"] != verdict:
+        errors.append(f"language_diagnostic_evidence verdict must be derived as {verdict!r}")
+    expected_label = _summary_label(
+        verdict,
+        workspace_id=str(record["workspace_id"]),
+        baseline_revision=str(record["baseline_revision"]),
+        end_revision=end_revision,
+        diagnostics_revision=diagnostics_revision,
+        introduced_count=introduced_count,
+    )
+    if record["summary_label"] != expected_label:
+        errors.append("language_diagnostic_evidence summary_label must be the derived label for its verdict")
+    return errors
+
+
+def _normalized_paths(values: Iterable[str]) -> list[str]:
+    paths = sorted({_workspace_relative_path(value, field="changed_paths") for value in values})
+    if len(paths) > MAX_CHANGED_PATHS:
+        raise LanguageDiagnosticEvidenceError(
+            f"language_diagnostic_evidence changed_paths must have at most {MAX_CHANGED_PATHS} entries"
+        )
+    return paths
+
+
+def _normalized_diagnostics(values: Iterable[Mapping[str, Any]], *, field: str) -> list[dict[str, Any]]:
+    normalized = [_normalized_diagnostic(value, field=field) for value in values]
+    unique = {tuple(item[key] for key in LANGUAGE_DIAGNOSTIC_ITEM_KEYS): item for item in normalized}
+    ordered = [unique[key] for key in sorted(unique)]
+    if len(ordered) > MAX_DIAGNOSTICS:
+        raise LanguageDiagnosticEvidenceError(
+            f"language_diagnostic_evidence {field} must have at most {MAX_DIAGNOSTICS} entries"
+        )
+    return ordered
+
+
+def _normalized_diagnostic(value: Any, *, field: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise LanguageDiagnosticEvidenceError(f"language_diagnostic_evidence {field} entries must be objects")
+    extra = sorted(str(key) for key in value if str(key) not in LANGUAGE_DIAGNOSTIC_ITEM_KEYS)
+    if extra:
+        # `message` arrives here. It is refused rather than dropped so a caller
+        # learns the record carries no source body, instead of silently
+        # believing it sent one.
+        raise LanguageDiagnosticEvidenceError(
+            f"language_diagnostic_evidence {field} entries carry unsupported keys: {extra}; "
+            f"a diagnostic is metadata only ({', '.join(LANGUAGE_DIAGNOSTIC_ITEM_KEYS)})"
+        )
+    severity = str(value.get("severity", "")).strip().lower()
+    if severity not in LANGUAGE_DIAGNOSTIC_SEVERITIES:
+        raise LanguageDiagnosticEvidenceError(
+            f"language_diagnostic_evidence {field} severity is unsupported: {value.get('severity')!r}"
+        )
+    return {
+        "severity": severity,
+        "code": _optional_ref(str(value.get("code", "") or ""), field=f"language_diagnostic_evidence {field} code"),
+        "path": _workspace_relative_path(value.get("path", ""), field=f"{field} path"),
+        "line": _position(value.get("line", 0), field=f"{field} line"),
+        "character": _position(value.get("character", 0), field=f"{field} character"),
+        "source": _optional_ref(
+            str(value.get("source", "") or ""), field=f"language_diagnostic_evidence {field} source"
+        ),
+    }
+
+
+def _normalized_evidence_refs(values: Iterable[str]) -> list[str]:
+    refs: list[str] = []
+    for value in values:
+        ref = _required_ref(value, field="language_diagnostic_evidence evidence_refs")
+        if ref not in refs:
+            refs.append(ref)
+    if len(refs) > MAX_EVIDENCE_REFS:
+        raise LanguageDiagnosticEvidenceError(
+            f"language_diagnostic_evidence evidence_refs must have at most {MAX_EVIDENCE_REFS} entries"
+        )
+    return refs
+
+
+def _workspace_relative_path(value: Any, *, field: str) -> str:
+    """A workspace-relative posix path, or a refusal.
+
+    Separators are normalized so a Windows caller and a POSIX caller recording
+    the same file produce the same record, and an absolute or escaping path is
+    refused because it names a machine rather than a position in the workspace
+    the interval is attributed to.
+    """
+    if not isinstance(value, str) or not value.strip():
+        raise LanguageDiagnosticEvidenceError(f"language_diagnostic_evidence {field} must be a nonblank path")
+    text = value.strip().replace("\\", "/")
+    if text.startswith("/") or _ABSOLUTE_WINDOWS_PATH.match(text):
+        raise LanguageDiagnosticEvidenceError(
+            f"language_diagnostic_evidence {field} must be workspace-relative, not absolute: {value!r}"
+        )
+    parts = [part for part in text.split("/") if part not in ("", ".")]
+    if not parts or any(part == ".." for part in parts):
+        raise LanguageDiagnosticEvidenceError(
+            f"language_diagnostic_evidence {field} must stay inside the workspace: {value!r}"
+        )
+    return _required_ref("/".join(parts), field=f"language_diagnostic_evidence {field}")
+
+
+def _position(value: Any, *, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise LanguageDiagnosticEvidenceError(
+            f"language_diagnostic_evidence {field} must be an integer offset"
+        )
+    if value < 0 or value > MAX_POSITION:
+        raise LanguageDiagnosticEvidenceError(
+            f"language_diagnostic_evidence {field} must be between 0 and {MAX_POSITION}"
+        )
+    return value
+
+
+def _required_ref(value: Any, *, field: str) -> str:
+    try:
+        text = require_opaque_metadata_ref(value, field=field)
+    except ValueError as error:
+        raise LanguageDiagnosticEvidenceError(str(error)) from error
+    if len(text) > MAX_REFERENCE_CHARS:
+        raise LanguageDiagnosticEvidenceError(f"{field} must be at most {MAX_REFERENCE_CHARS} characters")
+    return text
+
+
+def _optional_ref(value: Any, *, field: str) -> str:
+    if value == "":
+        return ""
+    return _required_ref(value, field=field)
+
+
+def _reference_errors(value: Any, *, field: str, required: bool) -> list[str]:
+    if not isinstance(value, str):
+        return [f"language_diagnostic_evidence {field} must be a string"]
+    if not value:
+        return [] if not required else [f"language_diagnostic_evidence {field} must not be empty"]
+    try:
+        _required_ref(value, field=f"language_diagnostic_evidence {field}")
+    except LanguageDiagnosticEvidenceError as error:
+        return [str(error)]
+    return []
+
+
+def _path_list_errors(values: Any) -> list[str]:
+    if not isinstance(values, list):
+        return ["language_diagnostic_evidence changed_paths must be a list"]
+    errors: list[str] = []
+    if len(values) > MAX_CHANGED_PATHS:
+        errors.append(f"language_diagnostic_evidence changed_paths must have at most {MAX_CHANGED_PATHS} entries")
+    for index, value in enumerate(values):
+        try:
+            normalized = _workspace_relative_path(value, field=f"changed_paths[{index}]")
+        except LanguageDiagnosticEvidenceError as error:
+            errors.append(str(error))
+            continue
+        if normalized != value:
+            errors.append(f"language_diagnostic_evidence changed_paths[{index}] must be a normalized relative path")
+    if values != sorted(str(value) for value in values if isinstance(value, str)) or len(set(values)) != len(values):
+        errors.append("language_diagnostic_evidence changed_paths must be sorted and unique")
+    return errors
+
+
+def _diagnostic_list_errors(values: Any, *, field: str) -> list[str]:
+    if not isinstance(values, list):
+        return [f"language_diagnostic_evidence {field} must be a list"]
+    errors: list[str] = []
+    if len(values) > MAX_DIAGNOSTICS:
+        errors.append(f"language_diagnostic_evidence {field} must have at most {MAX_DIAGNOSTICS} entries")
+    keys: list[tuple[Any, ...]] = []
+    for index, value in enumerate(values):
+        if not isinstance(value, dict) or set(value) != set(LANGUAGE_DIAGNOSTIC_ITEM_KEYS):
+            errors.append(
+                f"language_diagnostic_evidence {field}[{index}] must carry exactly "
+                f"{list(LANGUAGE_DIAGNOSTIC_ITEM_KEYS)}"
+            )
+            continue
+        try:
+            normalized = _normalized_diagnostic(value, field=field)
+        except LanguageDiagnosticEvidenceError as error:
+            errors.append(str(error))
+            continue
+        if normalized != value:
+            errors.append(f"language_diagnostic_evidence {field}[{index}] must be normalized")
+        keys.append(tuple(normalized[key] for key in LANGUAGE_DIAGNOSTIC_ITEM_KEYS))
+    # Only meaningful once every entry normalized: a list with a rejected entry
+    # is short here, and reporting it as unsorted on top of the real fault would
+    # bury the reason it was rejected.
+    if len(keys) == len(values) and keys != sorted(set(keys)):
+        errors.append(f"language_diagnostic_evidence {field} must be sorted and unique")
+    return errors
+
+
+def _evidence_ref_errors(values: Any) -> list[str]:
+    if not isinstance(values, list):
+        return ["language_diagnostic_evidence evidence_refs must be a list"]
+    errors: list[str] = []
+    if len(values) > MAX_EVIDENCE_REFS:
+        errors.append(f"language_diagnostic_evidence evidence_refs must have at most {MAX_EVIDENCE_REFS} entries")
+    if len(set(map(str, values))) != len(values):
+        errors.append("language_diagnostic_evidence evidence_refs must be unique")
+    for index, value in enumerate(values):
+        errors.extend(_reference_errors(value, field=f"evidence_refs[{index}]", required=True))
+    return errors
+
+
+def _record_id(
+    owner: str,
+    provider: str,
+    workspace_id: str,
+    baseline_revision: str,
+    end_revision: str,
+    diagnostics_revision: str,
+    config_digest: str,
+    check_state: str,
+    introduced: list[dict[str, Any]],
+    resolved: list[dict[str, Any]],
+) -> str:
+    """Identity of *which* check, not of when it was reported.
+
+    `observed_at` is excluded on purpose: the same observation recorded twice
+    is one record, and a clock in the seed would make it two.
+    """
+    parts = [owner, provider, workspace_id, baseline_revision, end_revision, diagnostics_revision, config_digest, check_state]
+    for label, items in (("introduced", introduced), ("resolved", resolved)):
+        parts.append(label)
+        parts.extend(
+            ":".join(str(item[key]) for key in LANGUAGE_DIAGNOSTIC_ITEM_KEYS) for item in items
+        )
+    digest = hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()[:16]
+    return f"langdiag-{digest}"

--- a/tests/test_language_diagnostic_evidence.py
+++ b/tests/test_language_diagnostic_evidence.py
@@ -1,0 +1,466 @@
+"""Contract tests for `language_diagnostic_evidence/v1`.
+
+The three acceptance criteria of issue #822 each get a class, and each is
+followed by the guards that keep it from being satisfied by accident:
+
+- AC1 -- a clean result is labelled only as a fresh language-diagnostic check.
+- AC2 -- introduced diagnostics are attributable to a workspace and interval.
+- AC3 -- missing or stale diagnostics cannot satisfy verification.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+import unittest
+
+from _cli_harness import run_cli
+from omh.quality import language_diagnostic_evidence as module
+from omh.quality.language_diagnostic_evidence import (
+    LANGUAGE_DIAGNOSTIC_CHECK_STATES,
+    LANGUAGE_DIAGNOSTIC_CLAIMS,
+    LANGUAGE_DIAGNOSTIC_CLAIM_BOUNDARY,
+    LANGUAGE_DIAGNOSTIC_EVIDENCE_KEYS,
+    LANGUAGE_DIAGNOSTIC_EVIDENCE_SCHEMA_VERSION,
+    LANGUAGE_DIAGNOSTIC_ITEM_KEYS,
+    LANGUAGE_DIAGNOSTIC_NOT_EVIDENCE_FOR,
+    LANGUAGE_DIAGNOSTIC_OWNERS,
+    LANGUAGE_DIAGNOSTIC_SUPPORTABLE_CLAIMS,
+    LANGUAGE_DIAGNOSTIC_USABLE_VERDICTS,
+    LANGUAGE_DIAGNOSTIC_VERDICTS,
+    MAX_DIAGNOSTICS,
+    LanguageDiagnosticEvidenceError,
+    build_language_diagnostic_evidence,
+    language_diagnostic_claim_support,
+    language_diagnostic_supports_claim,
+    validate_language_diagnostic_evidence,
+)
+
+
+def _record(**overrides: object) -> dict[str, object]:
+    """A fresh, attributable, clean check unless a test says otherwise."""
+    fields: dict[str, object] = {
+        "owner": "claude-code",
+        "provider": "pyright",
+        "workspace_id": "local/omh",
+        "baseline_revision": "rev-baseline",
+        "end_revision": "rev-end",
+        "diagnostics_revision": "rev-end",
+    }
+    fields.update(overrides)
+    return build_language_diagnostic_evidence(**fields)  # type: ignore[arg-type]
+
+
+def _diagnostic(**overrides: object) -> dict[str, object]:
+    item: dict[str, object] = {
+        "severity": "error",
+        "code": "reportUndefinedVariable",
+        "path": "src/quality/example.py",
+        "line": 41,
+        "character": 8,
+        "source": "pyright",
+    }
+    item.update(overrides)
+    return item
+
+
+def _every_reachable_record() -> dict[str, dict[str, object]]:
+    """One record per verdict, so an invariant can be asserted over all of them."""
+    records = {
+        "no_new_diagnostics_observed": _record(),
+        "new_diagnostics_observed": _record(introduced=[_diagnostic()]),
+        "attribution_unavailable": _record(baseline_revision=""),
+        "stale_diagnostics": _record(diagnostics_revision="rev-baseline"),
+        "freshness_unknown": _record(diagnostics_revision=""),
+        "provider_unsupported": _record(check_state="unsupported"),
+        "provider_failed": _record(check_state="failed"),
+        "not_observed": _record(check_state="not_observed"),
+    }
+    assert sorted(records) == sorted(LANGUAGE_DIAGNOSTIC_VERDICTS), "a verdict has no reachable record"
+    for verdict, record in records.items():
+        assert record["verdict"] == verdict, f"{verdict} fixture derived {record['verdict']}"
+    return records
+
+
+class CleanIsOnlyAFreshLanguageDiagnosticCheckTests(unittest.TestCase):
+    """AC1: a clean result is labelled a language-diagnostic check, never verification."""
+
+    def test_a_clean_check_says_no_new_diagnostics_were_observed(self) -> None:
+        record = _record()
+
+        self.assertEqual(record["verdict"], "no_new_diagnostics_observed")
+        self.assertIn("No new diagnostics were observed", record["summary_label"])
+        self.assertIn("fresh language-diagnostic check", record["summary_label"])
+
+    def test_no_summary_label_ever_reads_as_verification(self) -> None:
+        # The label is the sentence a human quotes, so the overstatement this
+        # contract exists to prevent would appear here first.
+        for verdict, record in _every_reachable_record().items():
+            label = str(record["summary_label"]).lower()
+            with self.subTest(verdict=verdict):
+                self.assertIn("language-diagnostic", label)
+                for word in ("verified", "verification", "passed", "all clear", "ready to merge", "safe to merge"):
+                    self.assertNotIn(word, label)
+
+    def test_a_clean_record_backs_no_claim_other_than_its_own(self) -> None:
+        clean = _record()
+
+        self.assertTrue(language_diagnostic_supports_claim(clean, "fresh_language_diagnostic_check"))
+        for claim in LANGUAGE_DIAGNOSTIC_CLAIMS:
+            if claim in LANGUAGE_DIAGNOSTIC_SUPPORTABLE_CLAIMS:
+                continue
+            with self.subTest(claim=claim):
+                self.assertFalse(language_diagnostic_supports_claim(clean, claim))
+
+    def test_no_record_of_any_verdict_backs_verification_tests_review_ci_or_merge(self) -> None:
+        for verdict, record in _every_reachable_record().items():
+            for claim in LANGUAGE_DIAGNOSTIC_CLAIMS:
+                if claim in LANGUAGE_DIAGNOSTIC_SUPPORTABLE_CLAIMS:
+                    continue
+                with self.subTest(verdict=verdict, claim=claim):
+                    self.assertFalse(language_diagnostic_supports_claim(record, claim))
+
+    def test_a_clean_result_cannot_be_promoted_into_a_verification_claim(self) -> None:
+        # Three promotion routes, all closed. This is the failure mode issue
+        # #822 names, so each is asserted rather than assumed.
+        clean = _record()
+
+        # 1. Asking the predicate for verification. There is no argument that
+        #    turns this True, including the claim it does support.
+        self.assertFalse(language_diagnostic_supports_claim(clean, "verification"))
+        self.assertNotIn("verification", LANGUAGE_DIAGNOSTIC_SUPPORTABLE_CLAIMS)
+
+        # 2. Editing the record on the way to a status surface. The verdict
+        #    vocabulary has no verification member, and validation re-derives
+        #    the verdict rather than trusting it.
+        self.assertNotIn("verification", " ".join(LANGUAGE_DIAGNOSTIC_VERDICTS))
+        forged = dict(clean, verdict="new_diagnostics_observed")
+        self.assertIn(
+            "verdict must be derived as 'no_new_diagnostics_observed'",
+            " ".join(validate_language_diagnostic_evidence(forged)),
+        )
+        self.assertFalse(language_diagnostic_supports_claim(forged, "fresh_language_diagnostic_check"))
+
+        # 3. Rewriting the prose while leaving the verdict alone.
+        relabelled = dict(clean, summary_label="Verified: the workspace passed every check.")
+        self.assertIn(
+            "summary_label must be the derived label",
+            " ".join(validate_language_diagnostic_evidence(relabelled)),
+        )
+        self.assertFalse(language_diagnostic_supports_claim(relabelled, "fresh_language_diagnostic_check"))
+
+    def test_the_record_names_every_claim_it_cannot_settle(self) -> None:
+        record = _record()
+
+        self.assertEqual(record["not_evidence_for"], list(LANGUAGE_DIAGNOSTIC_NOT_EVIDENCE_FOR))
+        for claim in ("verification", "compilation", "test_execution", "review", "ci", "merge_readiness", "merge"):
+            with self.subTest(claim=claim):
+                self.assertIn(claim, record["not_evidence_for"])
+        self.assertEqual(record["claim_boundary"], LANGUAGE_DIAGNOSTIC_CLAIM_BOUNDARY)
+        for phrase in ("compilation", "test", "verification", "review", "CI", "merge"):
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, LANGUAGE_DIAGNOSTIC_CLAIM_BOUNDARY)
+
+    def test_claim_support_partitions_every_claim(self) -> None:
+        support = language_diagnostic_claim_support(_record())
+
+        self.assertEqual(support["supported_claims"], ["fresh_language_diagnostic_check"])
+        self.assertEqual(
+            sorted([*support["supported_claims"], *support["unsupported_claims"]]),
+            sorted(LANGUAGE_DIAGNOSTIC_CLAIMS),
+        )
+
+    def test_an_unknown_claim_name_is_refused_rather_than_defaulted(self) -> None:
+        self.assertFalse(language_diagnostic_supports_claim(_record(), "everything_is_fine"))
+
+
+class IntroducedDiagnosticsAreAttributableTests(unittest.TestCase):
+    """AC2: an introduced diagnostic names the workspace and the interval it came from."""
+
+    def test_an_introduced_diagnostic_carries_its_workspace_and_revision_interval(self) -> None:
+        record = _record(introduced=[_diagnostic()], changed_paths=["src/quality/example.py"])
+
+        self.assertEqual(record["verdict"], "new_diagnostics_observed")
+        self.assertEqual(record["attribution"], "attributable")
+        self.assertEqual(record["workspace_id"], "local/omh")
+        self.assertEqual(record["baseline_revision"], "rev-baseline")
+        self.assertEqual(record["end_revision"], "rev-end")
+        self.assertEqual(record["introduced_count"], 1)
+        self.assertIn("workspace local/omh between rev-baseline and rev-end", record["summary_label"])
+
+    def test_a_missing_interval_endpoint_marks_attribution_unavailable(self) -> None:
+        for missing in ("workspace_id", "baseline_revision", "end_revision"):
+            record = _record(**{missing: "", "introduced": [_diagnostic()]})
+            with self.subTest(missing=missing):
+                self.assertEqual(record["attribution"], "unavailable")
+                self.assertEqual(record["verdict"], "attribution_unavailable")
+                self.assertFalse(language_diagnostic_supports_claim(record, "fresh_language_diagnostic_check"))
+                self.assertIn("cannot be attributed", record["summary_label"])
+
+    def test_resolved_and_introduced_are_reported_separately(self) -> None:
+        record = _record(
+            introduced=[_diagnostic(line=10)],
+            resolved=[_diagnostic(line=20), _diagnostic(line=30)],
+        )
+
+        self.assertEqual(record["introduced_count"], 1)
+        self.assertEqual(record["resolved_count"], 2)
+        self.assertEqual([item["line"] for item in record["resolved"]], [20, 30])
+
+    def test_a_diagnostic_is_normalized_to_severity_code_path_and_location(self) -> None:
+        record = _record(introduced=[_diagnostic(severity="WARNING", path="src\\quality\\example.py")])
+        item = record["introduced"][0]
+
+        self.assertEqual(sorted(item), sorted(LANGUAGE_DIAGNOSTIC_ITEM_KEYS))
+        self.assertEqual(item["severity"], "warning")
+        self.assertEqual(item["path"], "src/quality/example.py")
+        self.assertEqual(item["line"], 41)
+        self.assertEqual(item["character"], 8)
+
+    def test_a_diagnostic_carrying_a_source_body_is_refused_by_key_name(self) -> None:
+        for body_key in ("message", "snippet", "source_text", "fix"):
+            with self.subTest(body_key=body_key):
+                with self.assertRaises(LanguageDiagnosticEvidenceError) as caught:
+                    _record(introduced=[dict(_diagnostic(), **{body_key: "x = undefined_name  # boom"})])
+                self.assertIn("metadata only", str(caught.exception))
+                self.assertIn(body_key, str(caught.exception))
+
+    def test_a_path_outside_the_workspace_is_refused(self) -> None:
+        for path in ("/etc/passwd", "C:\\Users\\me\\secret.py", "../outside/other.py"):
+            with self.subTest(path=path):
+                with self.assertRaises(LanguageDiagnosticEvidenceError):
+                    _record(changed_paths=[path])
+                with self.assertRaises(LanguageDiagnosticEvidenceError):
+                    _record(introduced=[_diagnostic(path=path)])
+
+    def test_an_unsupported_severity_or_owner_is_refused(self) -> None:
+        with self.assertRaises(LanguageDiagnosticEvidenceError):
+            _record(introduced=[_diagnostic(severity="catastrophe")])
+        with self.assertRaises(LanguageDiagnosticEvidenceError):
+            _record(owner="some-vendor-agent")
+        self.assertNotIn("unknown", LANGUAGE_DIAGNOSTIC_OWNERS)
+
+    def test_a_non_integer_position_is_refused(self) -> None:
+        for value in ("41", 4.5, True, -1):
+            with self.subTest(value=value):
+                with self.assertRaises(LanguageDiagnosticEvidenceError):
+                    _record(introduced=[_diagnostic(line=value)])
+
+    def test_diagnostic_and_path_lists_are_bounded(self) -> None:
+        oversized = [_diagnostic(line=index) for index in range(MAX_DIAGNOSTICS + 1)]
+        with self.assertRaises(LanguageDiagnosticEvidenceError) as caught:
+            _record(introduced=oversized)
+        self.assertIn(str(MAX_DIAGNOSTICS), str(caught.exception))
+
+
+class MissingOrStaleCannotSatisfyVerificationTests(unittest.TestCase):
+    """AC3: a check that did not happen, or happened elsewhere, settles nothing."""
+
+    def test_diagnostics_observed_off_the_interval_end_are_stale(self) -> None:
+        record = _record(diagnostics_revision="rev-baseline")
+
+        self.assertEqual(record["freshness"], "stale")
+        self.assertEqual(record["verdict"], "stale_diagnostics")
+        self.assertFalse(language_diagnostic_supports_claim(record, "fresh_language_diagnostic_check"))
+        self.assertIn("stale", record["summary_label"])
+
+    def test_a_stale_check_with_zero_diagnostics_is_still_not_a_clean_result(self) -> None:
+        # The dangerous case: nothing to report, reported from the wrong
+        # revision. It must not collapse into `no_new_diagnostics_observed`.
+        stale_clean = _record(diagnostics_revision="rev-baseline", introduced=[])
+
+        self.assertEqual(stale_clean["introduced_count"], 0)
+        self.assertNotEqual(stale_clean["verdict"], "no_new_diagnostics_observed")
+        self.assertNotIn(stale_clean["verdict"], LANGUAGE_DIAGNOSTIC_USABLE_VERDICTS)
+        self.assertFalse(language_diagnostic_supports_claim(stale_clean, "fresh_language_diagnostic_check"))
+
+    def test_diagnostics_without_a_stated_revision_have_unknown_freshness(self) -> None:
+        record = _record(diagnostics_revision="")
+
+        self.assertEqual(record["freshness"], "unknown")
+        self.assertEqual(record["verdict"], "freshness_unknown")
+        self.assertFalse(language_diagnostic_supports_claim(record, "fresh_language_diagnostic_check"))
+
+    def test_unsupported_failed_and_not_observed_states_are_preserved_not_collapsed(self) -> None:
+        expected = {
+            "unsupported": "provider_unsupported",
+            "failed": "provider_failed",
+            "not_observed": "not_observed",
+        }
+        for state, verdict in expected.items():
+            record = _record(check_state=state)
+            with self.subTest(state=state):
+                self.assertEqual(record["check_state"], state)
+                self.assertEqual(record["verdict"], verdict)
+                self.assertEqual(record["freshness"], "unknown")
+                self.assertEqual(record["attribution"], "unavailable")
+                self.assertFalse(language_diagnostic_supports_claim(record, "fresh_language_diagnostic_check"))
+        self.assertEqual(sorted([*expected, "observed"]), sorted(LANGUAGE_DIAGNOSTIC_CHECK_STATES))
+
+    def test_only_the_two_fresh_attributable_verdicts_are_usable(self) -> None:
+        for verdict, record in _every_reachable_record().items():
+            with self.subTest(verdict=verdict):
+                self.assertEqual(
+                    language_diagnostic_supports_claim(record, "fresh_language_diagnostic_check"),
+                    verdict in LANGUAGE_DIAGNOSTIC_USABLE_VERDICTS,
+                )
+
+
+class LanguageDiagnosticRecordShapeTests(unittest.TestCase):
+    def test_the_key_set_is_exact_and_closed(self) -> None:
+        record = _record()
+
+        self.assertEqual(sorted(record), sorted(LANGUAGE_DIAGNOSTIC_EVIDENCE_KEYS))
+        self.assertEqual(record["schema_version"], LANGUAGE_DIAGNOSTIC_EVIDENCE_SCHEMA_VERSION)
+        self.assertEqual(record["privacy"], "metadata_only")
+        self.assertEqual(validate_language_diagnostic_evidence(record), [])
+
+    def test_an_extra_or_missing_key_is_reported(self) -> None:
+        record = _record()
+
+        self.assertIn(
+            "unsupported keys: ['lsp_transcript']",
+            " ".join(validate_language_diagnostic_evidence(dict(record, lsp_transcript="..."))),
+        )
+        without_verdict = {key: value for key, value in record.items() if key != "verdict"}
+        self.assertIn("missing keys: ['verdict']", " ".join(validate_language_diagnostic_evidence(without_verdict)))
+
+    def test_a_reordered_or_duplicated_diagnostic_list_is_reported(self) -> None:
+        record = _record(introduced=[_diagnostic(line=10), _diagnostic(line=20)])
+        first, second = record["introduced"]
+
+        for broken in ([second, first], [first, first]):
+            with self.subTest(broken=broken):
+                self.assertIn(
+                    "introduced must be sorted and unique",
+                    " ".join(validate_language_diagnostic_evidence(dict(record, introduced=broken))),
+                )
+
+    def test_a_rejected_diagnostic_entry_reports_its_own_reason_only(self) -> None:
+        record = _record(introduced=[_diagnostic(line=10), _diagnostic(line=20)])
+        reported = validate_language_diagnostic_evidence(
+            dict(record, introduced=[dict(record["introduced"][0], severity="catastrophe")], introduced_count=1)
+        )
+
+        self.assertTrue(any("severity is unsupported" in error for error in reported))
+        self.assertFalse(any("sorted and unique" in error for error in reported))
+
+    def test_a_non_object_payload_is_reported_rather_than_raising(self) -> None:
+        self.assertEqual(
+            validate_language_diagnostic_evidence(["not", "a", "record"]),
+            ["language_diagnostic_evidence must be an object"],
+        )
+        self.assertFalse(language_diagnostic_supports_claim(None, "fresh_language_diagnostic_check"))
+
+    def test_the_record_is_deterministic_and_holds_no_clock(self) -> None:
+        first = _record(
+            changed_paths=["src/b.py", "src/a.py"],
+            introduced=[_diagnostic(line=20), _diagnostic(line=10)],
+            observed_at="2026-08-09T00:00:00Z",
+        )
+        # Same observation, different report order and a later timestamp.
+        second = _record(
+            changed_paths=["src/a.py", "src/b.py", "src/a.py"],
+            introduced=[_diagnostic(line=10), _diagnostic(line=20)],
+            observed_at="2027-01-01T00:00:00Z",
+        )
+
+        self.assertEqual(first["record_id"], second["record_id"])
+        self.assertEqual(first["changed_paths"], ["src/a.py", "src/b.py"])
+        self.assertEqual({key: value for key, value in first.items() if key != "observed_at"},
+                         {key: value for key, value in second.items() if key != "observed_at"})
+
+    def test_the_record_id_changes_when_the_observation_changes(self) -> None:
+        clean = _record()
+        dirty = _record(introduced=[_diagnostic()])
+
+        self.assertNotEqual(clean["record_id"], dirty["record_id"])
+        self.assertTrue(str(clean["record_id"]).startswith("langdiag-"))
+
+    def test_a_control_character_or_secret_shaped_reference_is_refused(self) -> None:
+        for field, value in (
+            ("provider", "pyright\x1b[2K\r"),
+            ("workspace_id", "ws\nrogue"),
+            ("config_digest", "ghp_0123456789abcdefghij"),
+        ):
+            with self.subTest(field=field):
+                with self.assertRaises(LanguageDiagnosticEvidenceError):
+                    _record(**{field: value})
+
+
+class LanguageDiagnosticCliTests(unittest.TestCase):
+    _ARGS = [
+        "quality-evidence", "language-diagnostics",
+        "--owner", "claude-code", "--provider", "pyright",
+        "--workspace", "local/omh",
+        "--baseline-revision", "rev-baseline", "--end-revision", "rev-end",
+    ]
+
+    def test_json_output_carries_the_record_and_its_claim_support(self) -> None:
+        status, stdout, stderr = run_cli([
+            *self._ARGS, "--diagnostics-revision", "rev-end",
+            "--changed-paths", '["src/quality/example.py"]',
+            "--introduced", '[{"severity":"error","code":"E1","path":"src/quality/example.py","line":4,"character":1,"source":"pyright"}]',
+        ])
+
+        self.assertEqual(status, 0, stderr)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["record"]["verdict"], "new_diagnostics_observed")
+        self.assertEqual(payload["record"]["introduced_count"], 1)
+        self.assertEqual(payload["claim_support"]["supported_claims"], ["fresh_language_diagnostic_check"])
+        self.assertIn("verification", payload["claim_support"]["unsupported_claims"])
+
+    def test_plain_text_is_the_default_and_states_what_the_check_does_not_support(self) -> None:
+        status, stdout, stderr = run_cli(
+            [*self._ARGS, "--diagnostics-revision", "rev-end"], output_json=False
+        )
+
+        self.assertEqual(status, 0, stderr)
+        self.assertFalse(stdout.lstrip().startswith("{"))
+        self.assertIn("Verdict: no_new_diagnostics_observed", stdout)
+        self.assertIn("No new diagnostics were observed", stdout)
+        self.assertIn("Does not support: verification", stdout)
+        self.assertNotIn("Verified", stdout)
+
+    def test_a_stale_check_reports_stale_on_the_cli(self) -> None:
+        status, stdout, stderr = run_cli(
+            [*self._ARGS, "--diagnostics-revision", "rev-baseline"], output_json=False
+        )
+
+        self.assertEqual(status, 0, stderr)
+        self.assertIn("Verdict: stale_diagnostics", stdout)
+        self.assertIn("Supports: nothing", stdout)
+
+    def test_a_refused_observation_exits_non_zero_with_the_reason(self) -> None:
+        status, _, stderr = run_cli([
+            *self._ARGS, "--diagnostics-revision", "rev-end",
+            "--introduced", '[{"severity":"error","path":"src/a.py","message":"undefined name"}]',
+        ])
+
+        self.assertNotEqual(status, 0)
+        self.assertIn("metadata only", stderr)
+
+
+class LanguageDiagnosticModuleBoundaryTests(unittest.TestCase):
+    """The contract records diagnostics; it must never be able to produce them."""
+
+    def test_the_module_imports_nothing_that_could_start_a_server_or_touch_disk(self) -> None:
+        # Derived from the import graph rather than from prose, so the module
+        # docstring naming a socket cannot pass or fail the check.
+        source = Path(module.__file__ or "").read_text(encoding="utf-8")
+        imported: set[str] = set()
+        for node in ast.walk(ast.parse(source)):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and not node.level:
+                imported.add((node.module or "").split(".")[0])
+
+        self.assertEqual(imported, {"__future__", "hashlib", "re", "typing"})
+        for capability in ("subprocess", "socket", "urllib", "http", "pathlib", "os", "shutil", "time", "datetime"):
+            with self.subTest(capability=capability):
+                self.assertNotIn(capability, imported)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New contract `language_diagnostic_evidence/v1` in `src/quality/language_diagnostic_evidence.py`:
  `build_language_diagnostic_evidence(...)`, `validate_language_diagnostic_evidence(...)`,
  `language_diagnostic_supports_claim(record, claim)`, and
  `language_diagnostic_claim_support(record)`. It records one supplied
  language-server diagnostic delta over one workspace revision interval and
  states exactly what that delta does and does not settle.
- New read-only CLI surface `omh quality-evidence language-diagnostics`,
  registered beside the existing `prepare` / `assess` subcommands in
  `src/commands/quality_evidence.py`. Plain text is the default; `--json` is the
  opt-in.
- New test module `tests/test_language_diagnostic_evidence.py` — 35 tests, one
  class per acceptance criterion plus shape, determinism, module-boundary, and
  CLI guards.
- New section in `docs/CODING-OBSERVABILITY.md` ("Language diagnostics, and why
  'clean' is not 'verified'"), sitting next to the existing external-effect
  receipt section, plus one paragraph added to that document's Boundary section.

No skill, routing case, or demo card was added, so no generated artifact family
and no exact-count fixture moved.

### Why This Exists

Issue #822. A language server answers one narrow question fast: at this
revision, which positions in these files does the analyser object to? That is
genuinely useful right after an edit, and it is the single most over-read signal
in a coding report. "No diagnostics" gets written up as "verified", and the
reader hears compilation, tests, review, and CI — none of which a diagnostic
pass performs.

There was no LSP integration anywhere in `src/` before this change (verified by
sweeping `src/` for `lsp` and `language.server`; nothing matched), so there was
also no contract in which to say the narrow thing narrowly. A report either
omitted the signal or overstated it.

### User / Operator Impact

A wrapper, executor, or operator that ran a diagnostic provider itself can now
hand the result to OMH and get back a record that is safe to quote:

- A clean run reads *"No new diagnostics were observed in a fresh
  language-diagnostic check of workspace `<id>` between `<base>` and `<end>`.
  Compilation, tests, review, and CI are separate and unobserved here."* — never
  "verified", "passed", or "clean".
- A run with new diagnostics names how many were introduced and the exact
  workspace and revision interval they are attributed to.
- A run whose diagnostics came from the wrong revision reads `stale_diagnostics`
  even when the delta is empty, so the most dangerous case — nothing to report,
  reported from the wrong revision — cannot present itself as a clean result.
- The plain-text block prints `Does not support: verification, compilation,
  test_execution, review, ci, merge_readiness, merge` directly under the verdict,
  so the boundary travels with the sentence a human copies.

What an operator cannot do after this change: get OMH to run a language server.
That is out of scope in the issue and would breach the no-process/no-network
boundary in `AGENTS.md`.

### How It Works

**Nothing about the outcome is a parameter.** A caller supplies what it
observed — owner, provider, config digest, workspace id, baseline revision, end
revision, the revision the diagnostics were actually observed at, changed paths,
introduced and resolved diagnostics. `freshness`, `attribution`, `verdict`, and
the human-readable `summary_label` are all derived from those inputs.

- `freshness` is `fresh` when `diagnostics_revision == end_revision`, `stale`
  when it differs, `unknown` when the caller did not say. It is revision-based,
  not clock-based, on purpose: a wall clock inside a compared payload turns
  equality into a race.
- `attribution` is `attributable` only when the check was observed and the
  workspace id, baseline revision, and end revision are all present. Otherwise
  it is `unavailable`, per the issue's "require baseline and end revision or
  mark attribution unavailable".
- `verdict` is one of eight closed values. Six of them name a reason the check
  settles nothing (`attribution_unavailable`, `stale_diagnostics`,
  `freshness_unknown`, `provider_unsupported`, `provider_failed`,
  `not_observed`). The `unsupported` / `failed` / `not_observed` provider states
  are preserved rather than collapsed, because a provider that never ran and a
  provider that found nothing are the two states this record exists to separate.
- None of the eight reads as verification, so there is no verdict to select
  that would overstate the check.

**One predicate decides what any of it proves.**
`language_diagnostic_supports_claim` returns `True` only for
`fresh_language_diagnostic_check`, and only for the two fresh, attributable
verdicts. Asked about verification, compilation, tests, review, CI,
merge-readiness, or merge it returns `False` for every record the contract can
build, including a perfectly clean one. There is no argument that reaches a
`True`.

**Validation re-derives instead of trusting.**
`validate_language_diagnostic_evidence` recomputes freshness, attribution,
verdict, and label from the record's own fields, so a record edited on its way to
disk or a status line is rejected rather than rendered. It also enforces the
exact closed key set (25 keys), the closed diagnostic key set (6 keys), sorted
and deduplicated lists, and count-equals-length for all three counts.

**Metadata only, and structurally so.** A diagnostic carries severity, code,
workspace-relative posix path, line, character, and provider source label. There
is no `message` field and no room for one: an input diagnostic carrying a key
outside the set is refused *by key name* rather than dropped, because a message
is where a source body would arrive. Paths are normalized (backslashes to
forward slashes, so a Windows and a POSIX caller produce the same record) and
absolute or `..`-escaping paths are refused. Every identifier goes through the
existing `require_opaque_metadata_ref` guard, so a control character, a link, or
a secret-shaped value cannot reach a rendered line.

**OMH still observes nothing.** The module imports exactly `hashlib`, `re`, and
`typing` — asserted from the import graph, not from prose — so it cannot start a
language server, spawn a process, open a socket, or touch disk. `record_id` is a
sha256 over the observation's identity and deliberately excludes `observed_at`,
so the same observation reported twice is one record.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/quality/language_diagnostic_evidence.py` | New. The whole contract: constants, builder, validator, claim predicate, claim-support projection. |
| `src/commands/quality_evidence.py` | Adds `cmd_quality_evidence_language_diagnostics`, its plain-text renderer, and the `language-diagnostics` subparser. Also fixes `_add_json_input` to underscore its `dest` — argparse only derives that for positionals, so `--changed-paths-json` would otherwise land on an unreachable attribute name. Existing `prepare` / `assess` callers are unaffected (their names have no hyphen). |
| `tests/test_language_diagnostic_evidence.py` | New. 35 tests. |
| `docs/CODING-OBSERVABILITY.md` | New section documenting the contract and the CLI, plus one Boundary paragraph. Hand-authored file, not generated. |

Contracts: adds `language_diagnostic_evidence/v1`. Changes no existing schema,
no persisted state, no wrapper contract, and no generated artifact.

## Validation

- [x] `uv run --group lint ruff check src tests` — `All checks passed!` (the pre-existing `# noqa: SIZE_OK` warning on `src/commands/main.py:1` is unchanged by this PR)
- [x] `python3 -m unittest discover -s tests` — `Ran 4289 tests in 155.363s / OK`. The branch point ran 4254; the 35 added tests account for the whole delta. Run twice with an identical result: once on the branch point, and again after rebasing onto `origin/main` at `04309ffc`, so the count is observed against merged main rather than only against the base this work started from. Every other gate below was also rerun after the rebase.
- [x] `python3 -m compileall src` — `uv run python -m compileall -q src tests`, exit 0
- [x] `python3 -m omh.cli docs workflows --check` — `{"ok":true, "tap_skills":{"checked":115,"expected":115,"missing":[],"stale":[],"extra":[],"ok":true}}`
- [x] `python3 -m omh.cli harness validate` — `{"counts":{"harnesses":72,"skills":104},"errors":[],"ok":true,"warnings":[]}`
- [x] `python3 -m omh.cli release checklist --json` — exit 0
- [x] `python3 -m omh.cli release hermes-smoke` — `Status: ok` (mode: plan, observed evidence: no)
- [x] `omh --help` — exit 0
- [x] `omh --omh-home … --hermes-home … release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — run against `/tmp/i822-omh-smoke` and `/tmp/i822-hermes-smoke` rather than the template's paths. `Status: ok`; installed-command smoke `Mode: live; observed: yes; PATH: ok`.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: **not applicable** — no learning contract, catalog entry, or persisted record was touched.
- [x] Relevant dry-run or smoke command: `omh quality-evidence language-diagnostics` exercised on both output paths and on the refusal path (see `LanguageDiagnosticCliTests`), and manually for the clean, stale, and rejected-input cases.
- [ ] Manual Hermes/TUI check: **not run**. This PR adds no chat, routing, skill, or wrapper surface — it is a contract module plus one operator/agent-facing subcommand — so there is no Hermes-visible behaviour to check. The routing tables are untouched.

Two additional byte gates beyond the template, run because the repo requires all
four artifact families to stay in sync:

- `python3 -m omh.cli docs roles --check` — `{"ok":true}`
- `python3 -m omh.cli docs capability-families --check` — `{"ok":true}`
- `git diff --check` — clean

## Risk

Low, and bounded by having no callers yet.

- **Blast radius.** One new module with no importers besides its own CLI
  subcommand and its tests. No existing schema, record, persisted file, or
  rendered surface changed shape.
- **The one shared edit** is `_add_json_input` in `src/commands/quality_evidence.py`.
  Its `dest` is now underscored. The three existing call sites pass
  `scenarios`, `reviews`, and `claims` — none contains a hyphen, so their
  `dest` values are byte-identical to before, and the existing
  `tests/test_quality_evidence_cli.py` cases pass unchanged.
- **The contract is strict by construction**, which is the intended risk
  direction: an input it cannot normalize is refused rather than coerced. A
  caller that sends a diagnostic message, an absolute path, a float line number,
  or a path with a space gets an error instead of a lossy record. That will be
  the first thing a wiring PR hits, and it should be.
- **Not a risk this PR takes:** nothing runs a language server. The module's
  import set is asserted, so a future change that adds `subprocess`, `socket`,
  `urllib`, or `pathlib` to it fails a test rather than silently widening the
  boundary.

## Compatibility / Rollout

- Additive only. No migration, no state format change, no removed or renamed
  flag, no behaviour change to any existing command.
- `omh quality-evidence language-diagnostics` is an operator/agent control-plane
  command, documented under the agent-facing observability doc rather than the
  user quick start, per the Command Audience boundary in `AGENTS.md` and
  `docs/DIRECTION.md`.
- Plain text is the default and `--json` is the opt-in, following the DIRECTION
  default-UX rule that applies to new commands, even though the two sibling
  `quality-evidence` subcommands predate it and still print JSON unconditionally.
- Existing installs need no action; an install picks the subcommand up with the
  next `omh update`.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`) — no
  version file, changelog, or release manifest touched. This rides the next
  ordinary release; it introduces no channel-specific behaviour.
- [x] Runtime/native capability claims are backed by evidence or marked as not
  observed — the record's own `claim_boundary` and `not_evidence_for` fields
  state what it cannot settle, the predicate enforces it, and every number in
  the Validation section above is a command I ran and read.
- [x] Known manual Hermes checks are listed, including any
  `omh release hermes-smoke --live` gap — `release hermes-smoke` ran in plan
  mode only (`observed evidence: no`); no live Hermes install was exercised, and
  no manual Hermes/TUI check was performed, for the reason given above.

## Follow-Up

- **Wire the record into the lanes issue #822 names.** The issue describes
  handoffs requesting the artifact when supported, wrappers recording it, status
  summarizing it, and conformance keeping it narrow. This PR deliberately ships
  the contract and its operator surface first; each of those four is a separate
  consumer with its own coverage gates (awareness lane, context card, chat-card
  coverage, conformance ladder), and wiring them in the same change would mix
  four surfaces' worth of fixture churn into one review.
- **Decide whether the record should be appendable.** It is currently derived
  and rendered, never stored. If a status board is to cite a past diagnostic
  check the way it cites an external-effect receipt, the record needs a journal
  store and the append-only guards that go with one.
- **Consider a `verification` dimension in `assess_quality_evidence`** that reads
  a language-diagnostic record as a *negative* signal only — new errors block,
  a clean check never satisfies. The predicate already makes that safe to add;
  nothing consumes it yet.
