### PR TITLE
feat: carry evidence-backed user goals across Hermes conversations

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1300,6 +1300,62 @@ Initial transition policy is intentionally conservative: clarification can hand
 off to planning, and planning can hand off to execution or QA. Other active
 workflow conflicts must be finished or cleared explicitly.
 
+## Goal Journey Projection
+
+`goal_journey/v1` (`src/workflows/goal_journey.py`) answers one question a
+resumed conversation has to answer honestly: what already advanced this goal,
+and what still stands between it and completion. It is a read-only projection —
+`build_goal_journey()` writes nothing and mutates nothing — exposed as `omh goal
+journey --goal <id>`, which prints readable lines by default and the machine
+payload under `--json` or `OMH_OUTPUT=json`.
+
+The goal ledger stores no session, plan, handoff, or owner link. The projection
+does not add writers for them; it re-derives the edges from artifacts that
+already exist:
+
+| Edge | Derived from |
+| --- | --- |
+| goal → run | `linked_runtime_runs` in the ledger |
+| run → handoff, owner, execution | `summarize_delegated_coding_status()` for that run |
+| goal → session | a wrapper session whose `current_run_id` is one of those runs |
+| session → plan | the session's own `plan` block and plan `decision` |
+| goal → checkpoints, criteria | the ledger's own lists |
+
+Three properties are the contract, and each is a test:
+
+- **Criteria need accepted evidence.** A criterion reads as satisfied only when
+  the ledger says satisfied, it carries evidence refs, *and* a done checkpoint
+  actually referenced it while carrying evidence. A ledger hand-edited to
+  `satisfied` therefore projects as pending. That makes the journey stricter
+  than `build_goal_completion_gate()` and never looser: `completion.ready` is
+  the conjunction of the ledger gate and an empty blocking-gate list, and
+  `completion.ledger_gate_ready` reports the ledger's own verdict beside it.
+- **Completion stays blocked while any required gate lacks evidence.**
+  `required_gates` flattens the four gate kinds the ledger blocks on —
+  acceptance criterion, active blocker, linked runtime run, goal status — each
+  with an `evidence_accepted` boolean. `validate_goal_journey()` refuses a
+  payload whose `completion.ready` is true while any gate is unsatisfied, so the
+  invariant is enforced on the payload and not only in the builder.
+- **Stages distinguish intent from proof.** `intent`, `preparation`,
+  `activity`, `blocked`, `verified_complete`, `cancelled`. A ledger that says
+  complete while a required gate lacks evidence reads as `blocked`, never as
+  verified.
+
+Two determinism rules apply. `now` is a parameter, never a wall-clock read
+inside the payload, so two projections of an unchanged goal compare equal; the
+CLI supplies `utc_now()` and tests pin it. Without `now`, evidence freshness
+reports `unknown` rather than guessing. The checkpoint list is tail-bounded at
+`GOAL_JOURNEY_CHECKPOINT_LIMIT` with a `checkpoint_history` block, because a
+goal spanning months is exactly the case this projection exists for; criteria,
+gates, and the stage are derived from the *full* checkpoint list first, so
+bounding output never moves a verdict.
+
+The payload is metadata-only in the same sense as the ledger: the objective
+travels as `objective_hash` plus the ledger's bounded summary, and a linked
+session contributes its id, status, decision, and `message_sha256` — never a
+transcript. `claim_boundary` and `not_evidence` state what the projection is
+not, and `validate_goal_journey()` rejects a payload that weakens either.
+
 ## Record Revisions and Idempotent Mutations
 
 Wrapper sessions, goal ledgers, loop cycles, executor sessions, and workflow

--- a/src/commands/goal.py
+++ b/src/commands/goal.py
@@ -17,11 +17,13 @@ from ..goal_ledger import (
     record_goal_checkpoint,
 )
 from ..installer import OmhError
+from ..system.local_store import utc_now
 from ..workflows.coordination_board import (
     DEFAULT_LIMIT as COORDINATION_BOARD_DEFAULT_LIMIT,
     build_coordination_board,
     render_coordination_board_text,
 )
+from ..workflows.goal_journey import build_goal_journey, render_goal_journey_text
 from .common import _paths, _print_json, _wants_json, add_revision_guard_arguments
 
 
@@ -178,6 +180,22 @@ def cmd_goal_status(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_goal_journey(args: argparse.Namespace) -> int:
+    paths = _paths(args)
+    try:
+        # The wall clock is read here, in the command, and passed in: the
+        # projection itself never reads one, so a test can pin freshness and
+        # two reads of an unchanged goal stay comparable.
+        journey = build_goal_journey(paths, args.goal_id, now=utc_now())
+    except (FileNotFoundError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    if _wants_json(args):
+        _print_json({"journey": journey})
+        return 0
+    print(render_goal_journey_text(journey))
+    return 0
+
+
 def cmd_goal_continue(args: argparse.Namespace) -> int:
     try:
         _print_json({"continuation": build_goal_continuation(_paths(args), args.goal_id)})
@@ -290,3 +308,16 @@ def _add_goal_commands(sub) -> None:
     )
     goal_board.add_argument("--json", action="store_true", help="Emit the machine payload instead of plain text.")
     goal_board.set_defaults(func=cmd_goal_board)
+
+    goal_journey = goal_sub.add_parser("journey")
+    goal_journey.add_argument("--goal", dest="goal_id", required=True)
+    # New surface, so DIRECTION applies without a compatibility exception:
+    # plain text is the default user experience and the machine payload is the
+    # opt-in. The older `goal` subcommands keep their JSON default because
+    # wrappers already parse them.
+    goal_journey.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the machine-readable goal_journey/v1 payload instead of readable lines.",
+    )
+    goal_journey.set_defaults(func=cmd_goal_journey)

--- a/src/workflows/goal_journey.py
+++ b/src/workflows/goal_journey.py
@@ -1,0 +1,646 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Final
+
+from ..paths import OmhPaths
+from ..runtime.artifacts import list_wrapper_session_records, summarize_delegated_coding_status
+from .goal_ledger import build_goal_completion_gate, read_goal_ledger
+
+
+GOAL_JOURNEY_SCHEMA_VERSION = "goal_journey/v1"
+
+# The five states the issue asks a resumed conversation to tell apart, plus
+# `cancelled`. Folding a cancelled goal into `blocked` would read as "still
+# working on it" for a goal nobody may work on again, so it gets its own name.
+GOAL_JOURNEY_STAGES = (
+    "intent",
+    "preparation",
+    "activity",
+    "blocked",
+    "verified_complete",
+    "cancelled",
+)
+
+GOAL_JOURNEY_GATE_KINDS = (
+    "acceptance_criterion",
+    "active_blocker",
+    "linked_runtime_run",
+    "goal_status",
+)
+
+GOAL_JOURNEY_CRITERION_STATUSES = ("pending", "satisfied")
+
+GOAL_JOURNEY_FRESHNESS_STATES = ("unknown", "fresh", "stale")
+
+# Newest-last tail bound on the checkpoint list. A goal that spans months
+# accumulates checkpoints without bound, and this projection is meant to be
+# read again in every later conversation. Bounding output never changes a
+# verdict: criteria, gates, and the stage are derived from the full checkpoint
+# list before this limit is applied.
+GOAL_JOURNEY_CHECKPOINT_LIMIT: Final[int] = 20
+
+# One window, named once. Freshness is only computed when the caller passes
+# `now`; the default projection reports "unknown" so two reads of an unchanged
+# goal produce the identical payload.
+GOAL_JOURNEY_FRESH_WINDOW_SECONDS: Final[int] = 7 * 24 * 60 * 60
+
+GOAL_JOURNEY_CLAIM_BOUNDARY: Final[str] = (
+    "A goal journey is a read-only projection over local goal, wrapper-session, and runtime "
+    "metadata. It reports what was recorded and linked, not what was verified, and it is not "
+    "execution, review, CI, or merge evidence."
+)
+
+GOAL_JOURNEY_NOT_EVIDENCE = (
+    "goal_completion",
+    "criterion_verification",
+    "handoff_execution",
+    "review_execution",
+    "ci_execution",
+    "merge_execution",
+)
+
+_GOAL_JOURNEY_STAGE_SUMMARIES = {
+    "intent": "The goal is recorded; no preparation or activity is linked yet.",
+    "preparation": "A handoff is prepared for this goal; execution is not observed.",
+    "activity": "Work has been recorded against this goal.",
+    "blocked": "Progress is blocked; completion cannot be claimed from this state.",
+    "verified_complete": "Every required gate carries accepted evidence.",
+    "cancelled": "The goal was cancelled; it is terminal and cannot be completed.",
+}
+
+_GOAL_ACTIVE_BLOCKED_STATUSES = {"blocked", "failed"}
+_GOAL_STATUS_GATE_STATUSES = ("blocked", "failed", "cancelled")
+
+
+def build_goal_journey(paths: OmhPaths, goal_id: str, *, now: str = "") -> dict[str, Any]:
+    """Link one goal to the sessions, plans, handoffs, owners, and runs behind it.
+
+    Read-only: nothing here writes or mutates goal state. Every edge is derived
+    from artifacts that already exist -- the ledger names its linked runtime
+    runs, a wrapper session names the run it currently owns, and a run names the
+    handoff and owner it was prepared for -- rather than from a new writer.
+
+    `now` is a parameter, never a wall-clock read inside the payload, so two
+    projections of an unchanged goal compare equal. Omitted, evidence freshness
+    reports "unknown" instead of guessing.
+    """
+    goal = read_goal_ledger(paths, goal_id)
+    gate = build_goal_completion_gate(paths, goal_id)
+    checkpoints = [item for item in goal["checkpoints"] if isinstance(item, dict)]
+    run_ids = [str(run_id) for run_id in goal.get("linked_runtime_runs", [])]
+    checks_by_run_id = {str(check.get("run_id", "")): check for check in gate["linked_runtime_checks"]}
+    runs = [_journey_run(paths, run_id, checks_by_run_id.get(run_id, {})) for run_id in run_ids]
+    session_records = _linked_session_records(paths, set(run_ids))
+    sessions = [_journey_session(session) for session in session_records]
+    plans = [plan for plan in (_journey_plan(session) for session in session_records) if plan]
+    handoffs = _journey_handoffs(session_records, runs)
+    owners = _journey_owners(session_records, runs)
+    criteria = [_journey_criterion(criterion, checkpoints, now=now) for criterion in goal["acceptance_criteria"]]
+    required_gates = _required_gates(goal, criteria, gate)
+    blocking_gate_ids = [item["gate_id"] for item in required_gates if not item["evidence_accepted"]]
+    stage = _journey_stage(goal, runs, handoffs, blocking_gate_ids)
+    return {
+        "schema_version": GOAL_JOURNEY_SCHEMA_VERSION,
+        "goal_id": str(goal["goal_id"]),
+        "goal_status": str(goal["status"]),
+        # The stable identity a later conversation resumes on, carried without
+        # the objective text the ledger deliberately never stored.
+        "objective_hash": str(goal["objective_hash"]),
+        "objective_summary": str(goal["objective_summary"]),
+        "source": str(goal.get("source", "")),
+        "created_at": str(goal.get("created_at", "")),
+        "updated_at": str(goal.get("updated_at", "")),
+        "stage": stage,
+        "stage_summary": _GOAL_JOURNEY_STAGE_SUMMARIES[stage],
+        "sessions": sessions,
+        "plans": plans,
+        "handoffs": handoffs,
+        "owners": owners,
+        "runs": runs,
+        "checkpoints": [_journey_checkpoint(item) for item in checkpoints[-GOAL_JOURNEY_CHECKPOINT_LIMIT:]],
+        "checkpoint_history": _checkpoint_history(len(checkpoints)),
+        "criteria": criteria,
+        "required_gates": required_gates,
+        "completion": _journey_completion(gate, required_gates, blocking_gate_ids),
+        "resume": _journey_resume(goal, stage, gate, blocking_gate_ids),
+        "claim_boundary": GOAL_JOURNEY_CLAIM_BOUNDARY,
+        "not_evidence": list(GOAL_JOURNEY_NOT_EVIDENCE),
+    }
+
+
+def validate_goal_journey(payload: dict[str, Any]) -> list[str]:
+    """Errors that make a journey payload unsafe to report, empty when it is sound.
+
+    Two of the checks are the issue's acceptance criteria written down as
+    invariants rather than as tests only: a criterion may not read as satisfied
+    without accepted evidence, and completion may not read as ready while any
+    required gate lacks evidence.
+    """
+    errors: list[str] = []
+    if payload.get("schema_version") != GOAL_JOURNEY_SCHEMA_VERSION:
+        errors.append("schema_version must be goal_journey/v1")
+    if not str(payload.get("goal_id", "")).strip():
+        errors.append("goal_id is required")
+    if "objective" in payload:
+        errors.append("raw objective field is not allowed")
+    if not _is_sha256_hex(str(payload.get("objective_hash", ""))):
+        errors.append("objective_hash must be a sha256 hex digest")
+    if payload.get("stage") not in GOAL_JOURNEY_STAGES:
+        errors.append("stage is unsupported")
+    for key in ("sessions", "plans", "handoffs", "owners", "runs", "checkpoints", "criteria", "required_gates"):
+        if not isinstance(payload.get(key), list):
+            errors.append(f"{key} must be a list")
+    errors.extend(_criteria_errors(payload.get("criteria")))
+    errors.extend(_required_gate_errors(payload.get("required_gates")))
+    errors.extend(_completion_errors(payload.get("completion")))
+    if str(payload.get("claim_boundary", "")) != GOAL_JOURNEY_CLAIM_BOUNDARY:
+        errors.append("claim_boundary must deny that the projection is execution, review, CI, or merge evidence")
+    not_evidence = payload.get("not_evidence")
+    if not isinstance(not_evidence, list) or not set(GOAL_JOURNEY_NOT_EVIDENCE).issubset(set(not_evidence)):
+        errors.append("not_evidence must include all goal journey boundaries")
+    return errors
+
+
+def render_goal_journey_text(journey: dict[str, Any]) -> str:
+    """The journey as exact lines for a terminal or a messenger relay.
+
+    Dash lines only. A markdown table is dropped outright by Slack and Telegram,
+    which is where a resumed goal is most often read.
+    """
+    completion = journey.get("completion") if isinstance(journey.get("completion"), dict) else {}
+    lines = [
+        f"Goal {journey.get('goal_id', '')} — {journey.get('stage', '')}",
+        "",
+        str(journey.get("objective_summary", "") or "(no objective recorded)"),
+        "",
+        f"Stage: {journey.get('stage', '')} — {journey.get('stage_summary', '')}",
+        f"Completion: {'ready' if completion.get('ready') else 'blocked'} "
+        f"({int(completion.get('unsatisfied_required_gates', 0))} required gates lack evidence)",
+        f"Next action: {completion.get('next_action', '') or 'unknown'}",
+    ]
+    lines.extend(_journey_text_block("Criteria", journey.get("criteria"), _criterion_line))
+    lines.extend(_journey_text_block("Blocking gates", _blocking_gates(journey), _gate_line))
+    lines.extend(_journey_text_block("Sessions", journey.get("sessions"), _session_line))
+    lines.extend(_journey_text_block("Handoffs", journey.get("handoffs"), _handoff_line))
+    lines.extend(_journey_text_block("Runs", journey.get("runs"), _run_line))
+    lines.extend(_journey_text_block("Owners", journey.get("owners"), _owner_line))
+    lines.extend(_journey_text_block("Checkpoints", journey.get("checkpoints"), _checkpoint_line))
+    resume = journey.get("resume") if isinstance(journey.get("resume"), dict) else {}
+    if resume:
+        lines.extend(["", f"Resume: {resume.get('continue_command', '')}"])
+    lines.extend(["", GOAL_JOURNEY_CLAIM_BOUNDARY])
+    return "\n".join(lines).strip()
+
+
+def _journey_run(paths: OmhPaths, run_id: str, check: dict[str, Any]) -> dict[str, Any]:
+    status = _delegated_status(paths, run_id)
+    prepared = status.get("prepared", {}) if status else {}
+    execution = status.get("execution", {}) if status else {}
+    return {
+        "run_id": run_id,
+        "found": status is not None,
+        "workflow": str(prepared.get("workflow", "") or ""),
+        "harness": str(prepared.get("harness", "") or ""),
+        "owner": str(prepared.get("executor_target", "") or ""),
+        "handoff_available": bool(prepared.get("handoff_available", False)),
+        "handoff_schema_version": str(prepared.get("handoff_schema_version") or ""),
+        "execution_observed": bool(execution.get("observed", False)),
+        "next_action": str(status.get("next_action", "")) if status else "record_runtime_evidence",
+        "evidence_accepted": bool(check.get("satisfied", False)),
+        "summary": str(check.get("summary", "") or "Linked runtime run was not checked."),
+    }
+
+
+def _delegated_status(paths: OmhPaths, run_id: str) -> dict[str, Any] | None:
+    # Mirrors `_delegated_runtime_status` in goal_ledger: a linked run the user
+    # deleted is a missing edge, not a crashed projection.
+    try:
+        return summarize_delegated_coding_status(paths, run_id)
+    except FileNotFoundError:
+        return None
+
+
+def _linked_session_records(paths: OmhPaths, run_ids: set[str]) -> list[dict[str, Any]]:
+    """Wrapper sessions that own one of the goal's linked runtime runs.
+
+    `current_run_id` is the only session-to-run edge the store already keeps, and
+    runtime validation refuses two sessions claiming one run, so this is a real
+    ownership link rather than a guess.
+    """
+    matched = [
+        session
+        for session in list_wrapper_session_records(paths)
+        if str(session.get("current_run_id", "")) and str(session.get("current_run_id", "")) in run_ids
+    ]
+    return sorted(matched, key=lambda session: str(session.get("session_id", "")))
+
+
+def _journey_session(session: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "session_id": str(session.get("session_id", "")),
+        "source": str(session.get("source", "")),
+        "status": str(session.get("status", "")),
+        "decision": str(session.get("decision", "")),
+        "linked_run_id": str(session.get("current_run_id", "")),
+        # Chat identity without the chat: the ledger stores no transcript and
+        # neither does this.
+        "message_sha256": str(session.get("message_sha256", "")),
+        "link_reason": "wrapper session current_run_id matches a linked runtime run",
+    }
+
+
+def _journey_plan(session: dict[str, Any]) -> dict[str, Any]:
+    plan = session.get("plan")
+    if not isinstance(plan, dict) or not plan:
+        return {}
+    return {
+        "session_id": str(session.get("session_id", "")),
+        "linked_run_id": str(session.get("current_run_id", "")),
+        "status": str(plan.get("status", "")),
+        "recommended_workflow": str(plan.get("recommended_workflow", "")),
+        "recommended_harness": str(plan.get("recommended_harness", "")),
+        "decision": str(session.get("decision", "")),
+    }
+
+
+def _journey_handoffs(session_records: list[dict[str, Any]], runs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    execution_by_run_id = {run["run_id"]: run["execution_observed"] for run in runs}
+    entries: list[dict[str, Any]] = []
+    for run in runs:
+        if not run["handoff_available"]:
+            continue
+        entries.append(
+            {
+                "origin": "runtime_run",
+                "source_ref": run["run_id"],
+                "kind": "prepared_coding_delegation",
+                "schema_version": run["handoff_schema_version"],
+                "owner": run["owner"],
+                "dispatchable": False,
+                "execution_observed": run["execution_observed"],
+            }
+        )
+    for session in session_records:
+        run_id = str(session.get("current_run_id", ""))
+        for kind in ("prompt_handoff", "runtime_handoff"):
+            handoff = session.get(kind)
+            if not isinstance(handoff, dict) or not handoff:
+                continue
+            entries.append(
+                {
+                    "origin": "wrapper_session",
+                    "source_ref": str(session.get("session_id", "")),
+                    "kind": kind,
+                    "schema_version": str(handoff.get("schema_version", "")),
+                    "owner": str(handoff.get("selected_executor_profile", "")),
+                    "dispatchable": bool(handoff.get("dispatchable", False)),
+                    "execution_observed": bool(execution_by_run_id.get(run_id, False)),
+                }
+            )
+    return sorted(entries, key=lambda entry: (entry["origin"], entry["source_ref"], entry["kind"]))
+
+
+def _journey_owners(session_records: list[dict[str, Any]], runs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Who was named as the coding owner, and by which artifact.
+
+    Executor-neutral by construction: the owner strings come from whatever the
+    run or session recorded, so `codex`, `claude-code`, a runtime profile, and
+    `generic` all project identically.
+    """
+    refs_by_owner: dict[str, set[str]] = {}
+    for run in runs:
+        if run["found"] and run["owner"]:
+            refs_by_owner.setdefault(run["owner"], set()).add(f"run:{run['run_id']}")
+    for session in session_records:
+        owner = str(session.get("selected_executor_profile") or "")
+        if owner:
+            refs_by_owner.setdefault(owner, set()).add(f"session:{session.get('session_id', '')}")
+    return [
+        {"owner": owner, "refs": sorted(refs)}
+        for owner, refs in sorted(refs_by_owner.items())
+    ]
+
+
+def _journey_checkpoint(checkpoint: dict[str, Any]) -> dict[str, Any]:
+    evidence_refs = [str(ref) for ref in checkpoint.get("evidence_refs", [])]
+    return {
+        "checkpoint_id": str(checkpoint.get("checkpoint_id", "")),
+        "created_at": str(checkpoint.get("created_at", "")),
+        "status": str(checkpoint.get("status", "")),
+        "summary": str(checkpoint.get("summary", "")),
+        "criteria_refs": [str(ref) for ref in checkpoint.get("criteria_refs", [])],
+        "evidence_refs": evidence_refs,
+        "evidence_accepted": bool(evidence_refs),
+        "linked_runtime_run_id": str(checkpoint.get("linked_runtime_run_id", "")),
+    }
+
+
+def _checkpoint_history(total: int) -> dict[str, Any]:
+    returned = min(total, GOAL_JOURNEY_CHECKPOINT_LIMIT)
+    return {
+        "total": total,
+        "returned": returned,
+        "limit": GOAL_JOURNEY_CHECKPOINT_LIMIT,
+        "truncated": total > returned,
+        "order": "oldest_to_newest_tail",
+    }
+
+
+def _journey_criterion(criterion: dict[str, Any], checkpoints: list[dict[str, Any]], *, now: str) -> dict[str, Any]:
+    criterion_id = str(criterion.get("id", ""))
+    accepting = _accepting_checkpoints(criterion_id, checkpoints)
+    evidence_refs = [str(ref) for ref in criterion.get("evidence_refs", [])]
+    ledger_status = str(criterion.get("status", ""))
+    # Three conditions, all required: the ledger says satisfied, the criterion
+    # carries evidence refs, and a done checkpoint actually referenced this
+    # criterion while carrying evidence. A ledger hand-edited to "satisfied"
+    # therefore stays pending here, which is the point of the projection.
+    accepted = ledger_status == "satisfied" and bool(evidence_refs) and bool(accepting)
+    recorded_at = max((str(item.get("created_at", "")) for item in accepting), default="")
+    return {
+        "id": criterion_id,
+        "summary": str(criterion.get("summary", "")),
+        "required": bool(criterion.get("required", True)),
+        "ledger_status": ledger_status,
+        "journey_status": "satisfied" if accepted else "pending",
+        "evidence_accepted": accepted,
+        "evidence_refs": evidence_refs,
+        "satisfied_by_checkpoints": [str(item.get("checkpoint_id", "")) for item in accepting],
+        "evidence_recorded_at": recorded_at,
+        **_evidence_freshness(recorded_at, now),
+    }
+
+
+def _accepting_checkpoints(criterion_id: str, checkpoints: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        checkpoint
+        for checkpoint in checkpoints
+        if str(checkpoint.get("status", "")) == "done"
+        and criterion_id in [str(ref) for ref in checkpoint.get("criteria_refs", [])]
+        and checkpoint.get("evidence_refs")
+    ]
+
+
+def _evidence_freshness(recorded_at: str, now: str) -> dict[str, Any]:
+    recorded = _parse_time(recorded_at)
+    current = _parse_time(now)
+    if recorded is None or current is None:
+        return {"evidence_age_seconds": None, "evidence_freshness": "unknown"}
+    age = int((current - recorded).total_seconds())
+    if age < 0:
+        # Evidence stamped after `now` says the two clocks disagree, not that
+        # the evidence is fresh.
+        return {"evidence_age_seconds": None, "evidence_freshness": "unknown"}
+    return {
+        "evidence_age_seconds": age,
+        "evidence_freshness": "fresh" if age <= GOAL_JOURNEY_FRESH_WINDOW_SECONDS else "stale",
+    }
+
+
+def _parse_time(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=timezone.utc) if parsed.tzinfo is None else parsed.astimezone(timezone.utc)
+
+
+def _required_gates(
+    goal: dict[str, Any], criteria: list[dict[str, Any]], gate: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Every gate that must carry evidence before completion, and whether it does.
+
+    The kinds mirror what `build_goal_completion_gate` already refuses to pass,
+    so the journey can never report a gate as satisfied that the ledger blocks
+    on. The criterion entries are stricter than the ledger's own check, which
+    only makes the journey block more, never less.
+    """
+    gates: list[dict[str, Any]] = [
+        {
+            "gate_id": f"criterion:{criterion['id']}",
+            "kind": "acceptance_criterion",
+            "summary": criterion["summary"],
+            "evidence_accepted": criterion["evidence_accepted"],
+            "evidence_refs": criterion["evidence_refs"],
+        }
+        for criterion in criteria
+        if criterion["required"]
+    ]
+    gates.extend(
+        {
+            "gate_id": f"blocker:{blocker['id']}",
+            "kind": "active_blocker",
+            "summary": blocker["summary"],
+            "evidence_accepted": False,
+            "evidence_refs": [],
+        }
+        for blocker in gate["active_blockers"]
+    )
+    gates.extend(
+        {
+            "gate_id": f"runtime_run:{check['run_id']}",
+            "kind": "linked_runtime_run",
+            "summary": check["summary"],
+            "evidence_accepted": bool(check["satisfied"]),
+            "evidence_refs": [],
+        }
+        for check in gate["linked_runtime_checks"]
+    )
+    status = str(goal["status"])
+    if status in _GOAL_STATUS_GATE_STATUSES:
+        gates.append(
+            {
+                "gate_id": f"goal_status:{status}",
+                "kind": "goal_status",
+                "summary": f"Goal status is {status}.",
+                "evidence_accepted": False,
+                "evidence_refs": [],
+            }
+        )
+    return gates
+
+
+def _journey_completion(
+    gate: dict[str, Any], required_gates: list[dict[str, Any]], blocking_gate_ids: list[str]
+) -> dict[str, Any]:
+    return {
+        # Both conditions, never one: the journey may be stricter than the
+        # ledger gate, and it must never be looser.
+        "ready": bool(gate["ready"]) and not blocking_gate_ids,
+        "ledger_gate_ready": bool(gate["ready"]),
+        "next_action": str(gate["next_action"]),
+        "summary": str(gate["summary"]),
+        "required_gates_total": len(required_gates),
+        "unsatisfied_required_gates": len(blocking_gate_ids),
+        "blocking_gate_ids": list(blocking_gate_ids),
+    }
+
+
+def _journey_resume(
+    goal: dict[str, Any], stage: str, gate: dict[str, Any], blocking_gate_ids: list[str]
+) -> dict[str, Any]:
+    goal_id = str(goal["goal_id"])
+    return {
+        "goal_id": goal_id,
+        "objective_hash": str(goal["objective_hash"]),
+        "stage": stage,
+        "next_action": str(gate["next_action"]),
+        "remaining_required_gates": len(blocking_gate_ids),
+        "journey_command": f"omh goal journey --goal {goal_id}",
+        "continue_command": f"omh goal continue --goal {goal_id}",
+    }
+
+
+def _journey_stage(
+    goal: dict[str, Any], runs: list[dict[str, Any]], handoffs: list[dict[str, Any]], blocking_gate_ids: list[str]
+) -> str:
+    status = str(goal["status"])
+    if status == "cancelled":
+        return "cancelled"
+    if status == "complete":
+        # A ledger that says complete while a required gate still lacks
+        # evidence reads as blocked here. Reporting it as verified is the exact
+        # overclaim this projection exists to refuse.
+        return "verified_complete" if not blocking_gate_ids else "blocked"
+    if status in _GOAL_ACTIVE_BLOCKED_STATUSES:
+        return "blocked"
+    if any(blocker.get("status") == "active" for blocker in goal["blockers"]):
+        return "blocked"
+    if goal["checkpoints"] or any(run["execution_observed"] for run in runs):
+        return "activity"
+    if handoffs:
+        return "preparation"
+    return "intent"
+
+
+def _criteria_errors(criteria: Any) -> list[str]:
+    if not isinstance(criteria, list):
+        return []
+    errors: list[str] = []
+    for index, criterion in enumerate(criteria, start=1):
+        if not isinstance(criterion, dict):
+            errors.append(f"criteria[{index}] must be an object")
+            continue
+        if criterion.get("journey_status") not in GOAL_JOURNEY_CRITERION_STATUSES:
+            errors.append(f"criteria[{index}].journey_status is invalid")
+        if criterion.get("evidence_freshness") not in GOAL_JOURNEY_FRESHNESS_STATES:
+            errors.append(f"criteria[{index}].evidence_freshness is invalid")
+        if criterion.get("journey_status") == "satisfied" and not _criterion_has_accepted_evidence(criterion):
+            errors.append(f"criteria[{index}] is satisfied without accepted evidence")
+    return errors
+
+
+def _criterion_has_accepted_evidence(criterion: dict[str, Any]) -> bool:
+    return (
+        bool(criterion.get("evidence_accepted"))
+        and bool(criterion.get("evidence_refs"))
+        and bool(criterion.get("satisfied_by_checkpoints"))
+    )
+
+
+def _required_gate_errors(required_gates: Any) -> list[str]:
+    if not isinstance(required_gates, list):
+        return []
+    errors: list[str] = []
+    seen: set[str] = set()
+    for index, item in enumerate(required_gates, start=1):
+        if not isinstance(item, dict):
+            errors.append(f"required_gates[{index}] must be an object")
+            continue
+        gate_id = str(item.get("gate_id", ""))
+        if not gate_id:
+            errors.append(f"required_gates[{index}].gate_id is required")
+        elif gate_id in seen:
+            errors.append(f"duplicate required gate id: {gate_id}")
+        seen.add(gate_id)
+        if item.get("kind") not in GOAL_JOURNEY_GATE_KINDS:
+            errors.append(f"required_gates[{index}].kind is unsupported")
+        if not isinstance(item.get("evidence_accepted"), bool):
+            errors.append(f"required_gates[{index}].evidence_accepted must be boolean")
+    return errors
+
+
+def _completion_errors(completion: Any) -> list[str]:
+    if not isinstance(completion, dict):
+        return ["completion must be an object"]
+    errors: list[str] = []
+    blocking = completion.get("blocking_gate_ids")
+    if not isinstance(blocking, list):
+        errors.append("completion.blocking_gate_ids must be a list")
+        blocking = []
+    if not isinstance(completion.get("ready"), bool):
+        errors.append("completion.ready must be boolean")
+    if not isinstance(completion.get("ledger_gate_ready"), bool):
+        errors.append("completion.ledger_gate_ready must be boolean")
+    if completion.get("unsatisfied_required_gates") != len(blocking):
+        errors.append("completion.unsatisfied_required_gates must count the blocking gates")
+    if completion.get("ready") and blocking:
+        errors.append("completion.ready must be false while a required gate lacks evidence")
+    if completion.get("ready") and not completion.get("ledger_gate_ready"):
+        errors.append("completion.ready must not be true while the ledger completion gate is not ready")
+    return errors
+
+
+def _is_sha256_hex(value: str) -> bool:
+    return len(value) == 64 and all(character in "0123456789abcdef" for character in value)
+
+
+def _blocking_gates(journey: dict[str, Any]) -> list[dict[str, Any]]:
+    gates = journey.get("required_gates")
+    if not isinstance(gates, list):
+        return []
+    return [gate for gate in gates if isinstance(gate, dict) and not gate.get("evidence_accepted")]
+
+
+def _journey_text_block(label: str, items: Any, line: Any) -> list[str]:
+    if not isinstance(items, list) or not items:
+        return ["", f"No {label.lower()} recorded."]
+    return ["", f"{label}:", *(f"- {line(item)}" for item in items if isinstance(item, dict))]
+
+
+def _criterion_line(criterion: dict[str, Any]) -> str:
+    evidence = "evidence accepted" if criterion.get("evidence_accepted") else "no accepted evidence"
+    return (
+        f"{criterion.get('id', '')}: {criterion.get('summary', '')} — "
+        f"{criterion.get('journey_status', '')}, {evidence}, "
+        f"freshness {criterion.get('evidence_freshness', 'unknown')}"
+    )
+
+
+def _gate_line(gate: dict[str, Any]) -> str:
+    return f"{gate.get('gate_id', '')} ({gate.get('kind', '')}): {gate.get('summary', '')}"
+
+
+def _session_line(session: dict[str, Any]) -> str:
+    return (
+        f"{session.get('session_id', '')}: {session.get('status', '')}, "
+        f"decision {session.get('decision', '')}, run {session.get('linked_run_id', '')}"
+    )
+
+
+def _handoff_line(handoff: dict[str, Any]) -> str:
+    observed = "execution observed" if handoff.get("execution_observed") else "execution not observed"
+    return (
+        f"{handoff.get('origin', '')} {handoff.get('source_ref', '')}: {handoff.get('kind', '')}, "
+        f"owner {handoff.get('owner', '') or 'unknown'}, {observed}"
+    )
+
+
+def _run_line(run: dict[str, Any]) -> str:
+    evidence = "evidence accepted" if run.get("evidence_accepted") else "evidence missing"
+    return (
+        f"{run.get('run_id', '')}: owner {run.get('owner', '') or 'unknown'}, "
+        f"workflow {run.get('workflow', '') or 'unknown'}, {evidence}"
+    )
+
+
+def _owner_line(owner: dict[str, Any]) -> str:
+    return f"{owner.get('owner', '')}: {', '.join(str(ref) for ref in owner.get('refs', []))}"
+
+
+def _checkpoint_line(checkpoint: dict[str, Any]) -> str:
+    evidence = "observed" if checkpoint.get("evidence_accepted") else "prepared"
+    return f"{checkpoint.get('checkpoint_id', '')}: {checkpoint.get('summary', '')} — {checkpoint.get('status', '')}, {evidence}"

--- a/tests/test_goal_journey.py
+++ b/tests/test_goal_journey.py
@@ -1,0 +1,561 @@
+from __future__ import annotations
+
+import json
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+from omh.goal_ledger import (
+    build_goal_completion_gate,
+    cancel_goal_ledger,
+    complete_goal_ledger,
+    create_goal_ledger,
+    goal_ledger_path,
+    record_goal_blocker,
+    record_goal_checkpoint,
+)
+from omh.paths import OmhPaths, resolve_paths
+from omh.wrapper.sessions import (
+    create_or_resume_wrapper_session,
+    prepare_wrapper_session_handoff,
+    record_plan_decision,
+    select_wrapper_session_executor,
+)
+from omh.workflows.goal_journey import (
+    GOAL_JOURNEY_CHECKPOINT_LIMIT,
+    GOAL_JOURNEY_CLAIM_BOUNDARY,
+    GOAL_JOURNEY_FRESH_WINDOW_SECONDS,
+    GOAL_JOURNEY_SCHEMA_VERSION,
+    build_goal_journey,
+    render_goal_journey_text,
+    validate_goal_journey,
+)
+
+
+PINNED_NOW = "2026-08-09T00:00:00Z"
+# The message this repo's wrapper-session tests use to reach `plan_presented`,
+# which is the only status `record_plan_decision("accept")` will take.
+HANDOFF_MESSAGE = "risky refactor with private-token-123"
+
+
+def _paths(root: Path) -> OmhPaths:
+    return resolve_paths(root / ".omh", root / ".hermes")
+
+
+def _base(root: Path) -> list[str]:
+    return ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+
+def _prepared_handoff_run(paths: OmhPaths) -> tuple[str, str]:
+    """A real wrapper session carried to a prepared handoff, and the run it owns.
+
+    Built through the actual writers rather than by planting records: the
+    projection claims to read the artifacts the product already produces, and a
+    fixture that forges them would not test that claim.
+    """
+    started = create_or_resume_wrapper_session(
+        paths,
+        HANDOFF_MESSAGE,
+        source="discord",
+        source_metadata={"source_event_id": "m1", "channel_ref": "c1"},
+    )
+    session_id = str(started["session"]["session_id"])
+    record_plan_decision(paths, session_id, "accept")
+    select_wrapper_session_executor(paths, session_id, "codex")
+    prepared = prepare_wrapper_session_handoff(paths, session_id, HANDOFF_MESSAGE)
+    return session_id, str(prepared["session"]["current_run_id"])
+
+
+def _tree_snapshot(root: Path) -> dict[str, bytes]:
+    return {
+        str(path.relative_to(root)): path.read_bytes()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def _criterion(journey: dict[str, object], criterion_id: str) -> dict[str, object]:
+    return next(item for item in journey["criteria"] if item["id"] == criterion_id)
+
+
+class GoalJourneyProjectionTests(unittest.TestCase):
+    def test_a_later_session_reconstructs_the_journey_from_local_metadata(self) -> None:
+        # Acceptance criterion 1. Nothing is handed in but the goal id: the
+        # session, plan, handoff, owner, and run edges are all re-derived from
+        # what is already on disk.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = _paths(root)
+            session_id, run_id = _prepared_handoff_run(paths)
+            create_goal_ledger(
+                paths,
+                "Carry an evidence-backed goal across conversations",
+                ["Journey links the work that advanced the goal"],
+                goal_id="goal-journey",
+                linked_runtime_runs=[run_id],
+            )
+            record_goal_checkpoint(
+                paths,
+                "goal-journey",
+                "Projection landed",
+                criteria_refs=["AC001"],
+                evidence_refs=["tests/test_goal_journey.py"],
+                linked_runtime_run_id=run_id,
+            )
+
+            # A separate resolve_paths stands in for the later conversation:
+            # no in-memory state survives, only the local store.
+            journey = build_goal_journey(_paths(root), "goal-journey", now=PINNED_NOW)
+
+            self.assertEqual(journey["schema_version"], GOAL_JOURNEY_SCHEMA_VERSION)
+            self.assertEqual(validate_goal_journey(journey), [])
+            self.assertEqual(journey["goal_id"], "goal-journey")
+            self.assertEqual([item["session_id"] for item in journey["sessions"]], [session_id])
+            self.assertEqual([item["linked_run_id"] for item in journey["sessions"]], [run_id])
+            self.assertEqual([item["session_id"] for item in journey["plans"]], [session_id])
+            self.assertEqual([item["run_id"] for item in journey["runs"]], [run_id])
+            self.assertEqual([item["owner"] for item in journey["owners"]], ["codex"])
+            self.assertEqual(
+                sorted(journey["owners"][0]["refs"]), [f"run:{run_id}", f"session:{session_id}"]
+            )
+            self.assertEqual(
+                [(item["origin"], item["source_ref"]) for item in journey["handoffs"]],
+                [("runtime_run", run_id)],
+            )
+            self.assertEqual([item["criteria_refs"] for item in journey["checkpoints"]], [["AC001"]])
+            self.assertEqual(journey["resume"]["continue_command"], "omh goal continue --goal goal-journey")
+
+    def test_the_journey_carries_the_stable_goal_id_without_any_transcript(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = _paths(root)
+            _session_id, run_id = _prepared_handoff_run(paths)
+            objective = "Finish the long goal, private detail SECRET-JOURNEY-1"
+            goal = create_goal_ledger(
+                paths,
+                objective,
+                ["Journey stays metadata only"],
+                goal_id="goal-private",
+                linked_runtime_runs=[run_id],
+            )
+
+            journey = build_goal_journey(paths, "goal-private", now=PINNED_NOW)
+
+            serialized = json.dumps(journey)
+            self.assertEqual(journey["objective_hash"], goal["objective_hash"])
+            self.assertEqual(journey["resume"]["objective_hash"], goal["objective_hash"])
+            self.assertNotIn(objective, serialized)
+            self.assertNotIn("SECRET-JOURNEY-1", serialized)
+            self.assertNotIn(HANDOFF_MESSAGE, serialized)
+            self.assertNotIn("private-token-123", serialized)
+
+    def test_a_criterion_marked_satisfied_without_a_checkpoint_trail_stays_pending(self) -> None:
+        # Acceptance criterion 2. The ledger's own gate accepts a criterion that
+        # merely *says* satisfied and carries refs; the journey refuses it,
+        # because no done checkpoint ever accepted evidence for it.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = _paths(root)
+            create_goal_ledger(paths, "Finish the goal", ["Criterion one"], goal_id="goal-forged")
+            path = goal_ledger_path(paths, "goal-forged")
+            stored = json.loads(path.read_text(encoding="utf-8"))
+            stored["acceptance_criteria"][0]["status"] = "satisfied"
+            stored["acceptance_criteria"][0]["evidence_refs"] = ["trust me"]
+            path.write_text(json.dumps(stored, sort_keys=True), encoding="utf-8")
+
+            journey = build_goal_journey(paths, "goal-forged", now=PINNED_NOW)
+
+            criterion = _criterion(journey, "AC001")
+            self.assertEqual(criterion["ledger_status"], "satisfied")
+            self.assertEqual(criterion["journey_status"], "pending")
+            self.assertFalse(criterion["evidence_accepted"])
+            self.assertEqual(criterion["satisfied_by_checkpoints"], [])
+            # The ledger gate is ready and the journey still is not: the
+            # projection may be stricter than the ledger, never looser.
+            self.assertTrue(build_goal_completion_gate(paths, "goal-forged")["ready"])
+            self.assertTrue(journey["completion"]["ledger_gate_ready"])
+            self.assertFalse(journey["completion"]["ready"])
+            self.assertEqual(journey["completion"]["blocking_gate_ids"], ["criterion:AC001"])
+            self.assertEqual(validate_goal_journey(journey), [])
+
+    def test_completion_stays_blocked_while_a_required_gate_lacks_evidence(self) -> None:
+        # Acceptance criterion 3. Every acceptance criterion is satisfied with
+        # accepted evidence, and completion is still blocked because the linked
+        # runtime run carries no observed evidence.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = _paths(root)
+            _session_id, run_id = _prepared_handoff_run(paths)
+            create_goal_ledger(
+                paths,
+                "Finish the delegated goal",
+                ["Criterion one"],
+                goal_id="goal-runtime-gate",
+                linked_runtime_runs=[run_id],
+            )
+            record_goal_checkpoint(
+                paths,
+                "goal-runtime-gate",
+                "Implementation landed",
+                criteria_refs=["AC001"],
+                evidence_refs=["unit"],
+            )
+
+            journey = build_goal_journey(paths, "goal-runtime-gate", now=PINNED_NOW)
+
+            self.assertTrue(_criterion(journey, "AC001")["evidence_accepted"])
+            self.assertEqual(journey["completion"]["blocking_gate_ids"], [f"runtime_run:{run_id}"])
+            self.assertFalse(journey["completion"]["ready"])
+            self.assertFalse(journey["completion"]["ledger_gate_ready"])
+            self.assertEqual(journey["completion"]["unsatisfied_required_gates"], 1)
+            gate_kinds = {item["gate_id"]: item["kind"] for item in journey["required_gates"]}
+            self.assertEqual(gate_kinds[f"runtime_run:{run_id}"], "linked_runtime_run")
+            self.assertEqual(gate_kinds["criterion:AC001"], "acceptance_criterion")
+            # The ledger refuses the completion the journey reports as blocked.
+            self.assertFalse(
+                complete_goal_ledger(paths, "goal-runtime-gate", evidence_refs=["unit"])["completed"]
+            )
+
+    def test_a_generic_done_checkpoint_does_not_satisfy_a_specific_criterion(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = _paths(root)
+            create_goal_ledger(
+                paths,
+                "Finish two separate criteria",
+                ["Parser is fixed", "Docs are updated"],
+                goal_id="goal-generic-done",
+            )
+            # A "done, everything works" checkpoint that names no criterion, and
+            # a real one that names exactly one.
+            record_goal_checkpoint(
+                paths, "goal-generic-done", "Everything is done", evidence_refs=["looks fine"]
+            )
+            record_goal_checkpoint(
+                paths,
+                "goal-generic-done",
+                "Parser fix landed",
+                criteria_refs=["AC001"],
+                evidence_refs=["tests/test_parser.py"],
+            )
+
+            journey = build_goal_journey(paths, "goal-generic-done", now=PINNED_NOW)
+
+            self.assertEqual(_criterion(journey, "AC001")["journey_status"], "satisfied")
+            self.assertEqual(_criterion(journey, "AC002")["journey_status"], "pending")
+            self.assertEqual(journey["completion"]["blocking_gate_ids"], ["criterion:AC002"])
+            self.assertFalse(journey["completion"]["ready"])
+
+    def test_a_complete_ledger_with_an_unproven_criterion_reads_as_blocked(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = _paths(root)
+            create_goal_ledger(paths, "Finish the goal", ["Criterion one"], goal_id="goal-overclaim")
+            record_goal_checkpoint(
+                paths, "goal-overclaim", "Landed", criteria_refs=["AC001"], evidence_refs=["unit"]
+            )
+            complete_goal_ledger(paths, "goal-overclaim", evidence_refs=["unit"])
+            path = goal_ledger_path(paths, "goal-overclaim")
+            stored = json.loads(path.read_text(encoding="utf-8"))
+            # Strip the evidence the checkpoint carried, leaving a ledger that
+            # still says complete.
+            stored["checkpoints"][0]["evidence_refs"] = []
+            path.write_text(json.dumps(stored, sort_keys=True), encoding="utf-8")
+
+            journey = build_goal_journey(paths, "goal-overclaim", now=PINNED_NOW)
+
+            self.assertEqual(journey["goal_status"], "complete")
+            self.assertEqual(journey["stage"], "blocked")
+            self.assertFalse(journey["completion"]["ready"])
+            self.assertEqual(validate_goal_journey(journey), [])
+
+    def test_stage_names_intent_preparation_activity_blocked_and_verified_complete(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = _paths(root)
+            create_goal_ledger(paths, "Plain goal", ["Criterion one"], goal_id="goal-intent")
+            self.assertEqual(build_goal_journey(paths, "goal-intent")["stage"], "intent")
+
+            _session_id, run_id = _prepared_handoff_run(paths)
+            create_goal_ledger(
+                paths, "Prepared goal", ["Criterion one"], goal_id="goal-prep", linked_runtime_runs=[run_id]
+            )
+            self.assertEqual(build_goal_journey(paths, "goal-prep")["stage"], "preparation")
+
+            record_goal_checkpoint(paths, "goal-prep", "Started", status="in_progress")
+            self.assertEqual(build_goal_journey(paths, "goal-prep")["stage"], "activity")
+
+            record_goal_blocker(paths, "goal-prep", "Waiting on review authority", mark_goal_blocked=True)
+            self.assertEqual(build_goal_journey(paths, "goal-prep")["stage"], "blocked")
+
+            create_goal_ledger(paths, "Cancelled goal", ["Criterion one"], goal_id="goal-cancelled")
+            cancel_goal_ledger(paths, "goal-cancelled", reason="Superseded")
+            self.assertEqual(build_goal_journey(paths, "goal-cancelled")["stage"], "cancelled")
+
+            create_goal_ledger(paths, "Finished goal", ["Criterion one"], goal_id="goal-done")
+            record_goal_checkpoint(
+                paths, "goal-done", "Landed", criteria_refs=["AC001"], evidence_refs=["unit"]
+            )
+            complete_goal_ledger(paths, "goal-done", evidence_refs=["unit"])
+            finished = build_goal_journey(paths, "goal-done", now=PINNED_NOW)
+            self.assertEqual(finished["stage"], "verified_complete")
+            self.assertTrue(finished["completion"]["ready"])
+            self.assertEqual(finished["completion"]["blocking_gate_ids"], [])
+
+    def test_building_the_journey_writes_nothing_to_the_local_store(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = _paths(root)
+            _session_id, run_id = _prepared_handoff_run(paths)
+            create_goal_ledger(
+                paths,
+                "Read-only projection",
+                ["Criterion one"],
+                goal_id="goal-readonly",
+                linked_runtime_runs=[run_id],
+            )
+            record_goal_checkpoint(
+                paths, "goal-readonly", "Landed", criteria_refs=["AC001"], evidence_refs=["unit"]
+            )
+            before = _tree_snapshot(paths.omh_home)
+
+            build_goal_journey(paths, "goal-readonly", now=PINNED_NOW)
+
+            self.assertEqual(_tree_snapshot(paths.omh_home), before)
+
+    def test_two_projections_of_an_unchanged_goal_are_identical(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = _paths(root)
+            create_goal_ledger(paths, "Deterministic goal", ["Criterion one"], goal_id="goal-stable")
+            record_goal_checkpoint(
+                paths, "goal-stable", "Landed", criteria_refs=["AC001"], evidence_refs=["unit"]
+            )
+
+            first = build_goal_journey(paths, "goal-stable", now=PINNED_NOW)
+            second = build_goal_journey(paths, "goal-stable", now=PINNED_NOW)
+
+            self.assertEqual(json.dumps(first, sort_keys=True), json.dumps(second, sort_keys=True))
+            # No wall clock inside the payload: omitting `now` is also stable.
+            self.assertEqual(
+                json.dumps(build_goal_journey(paths, "goal-stable"), sort_keys=True),
+                json.dumps(build_goal_journey(paths, "goal-stable"), sort_keys=True),
+            )
+
+    def test_evidence_freshness_is_unknown_without_now_and_stale_past_the_window(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = _paths(root)
+            create_goal_ledger(paths, "Aging goal", ["Criterion one"], goal_id="goal-fresh")
+            record_goal_checkpoint(
+                paths, "goal-fresh", "Landed", criteria_refs=["AC001"], evidence_refs=["unit"]
+            )
+            undated = build_goal_journey(paths, "goal-fresh")
+            recorded_at = str(_criterion(undated, "AC001")["evidence_recorded_at"])
+            recorded = datetime.fromisoformat(recorded_at.replace("Z", "+00:00"))
+
+            self.assertEqual(_criterion(undated, "AC001")["evidence_freshness"], "unknown")
+            self.assertIsNone(_criterion(undated, "AC001")["evidence_age_seconds"])
+
+            fresh = build_goal_journey(paths, "goal-fresh", now=_stamp(recorded + timedelta(hours=1)))
+            self.assertEqual(_criterion(fresh, "AC001")["evidence_freshness"], "fresh")
+            self.assertEqual(_criterion(fresh, "AC001")["evidence_age_seconds"], 3600)
+
+            stale_at = recorded + timedelta(seconds=GOAL_JOURNEY_FRESH_WINDOW_SECONDS + 60)
+            stale = build_goal_journey(paths, "goal-fresh", now=_stamp(stale_at))
+            self.assertEqual(_criterion(stale, "AC001")["evidence_freshness"], "stale")
+
+            # A clock that disagrees is reported as unknown, never as fresh.
+            skewed = build_goal_journey(paths, "goal-fresh", now=_stamp(recorded - timedelta(hours=1)))
+            self.assertEqual(_criterion(skewed, "AC001")["evidence_freshness"], "unknown")
+
+    def test_checkpoint_history_is_tail_bounded_without_changing_the_verdict(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = _paths(root)
+            create_goal_ledger(paths, "Long goal", ["Criterion one"], goal_id="goal-long")
+            satisfying = record_goal_checkpoint(
+                paths, "goal-long", "Landed", criteria_refs=["AC001"], evidence_refs=["unit"]
+            )["checkpoints"][0]["checkpoint_id"]
+            extra = GOAL_JOURNEY_CHECKPOINT_LIMIT + 5
+            for index in range(extra):
+                record_goal_checkpoint(
+                    paths, "goal-long", f"Filler {index}", status="in_progress", mutation_id=f"cp-{index:03d}"
+                )
+
+            journey = build_goal_journey(paths, "goal-long", now=PINNED_NOW)
+
+            self.assertEqual(len(journey["checkpoints"]), GOAL_JOURNEY_CHECKPOINT_LIMIT)
+            self.assertEqual(journey["checkpoint_history"]["total"], extra + 1)
+            self.assertTrue(journey["checkpoint_history"]["truncated"])
+            # The satisfying checkpoint fell off the emitted tail and the
+            # criterion is still satisfied: bounding output must never move a
+            # verdict.
+            self.assertNotIn(satisfying, [item["checkpoint_id"] for item in journey["checkpoints"]])
+            self.assertEqual(_criterion(journey, "AC001")["satisfied_by_checkpoints"], [satisfying])
+            self.assertEqual(_criterion(journey, "AC001")["journey_status"], "satisfied")
+
+    def test_a_deleted_linked_run_is_a_missing_edge_not_a_crash(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = _paths(root)
+            create_goal_ledger(
+                paths,
+                "Goal with a vanished run",
+                ["Criterion one"],
+                goal_id="goal-missing-run",
+                linked_runtime_runs=["missing-run"],
+            )
+
+            journey = build_goal_journey(paths, "goal-missing-run", now=PINNED_NOW)
+
+            self.assertEqual([item["found"] for item in journey["runs"]], [False])
+            self.assertEqual(journey["handoffs"], [])
+            self.assertEqual(journey["owners"], [])
+            self.assertIn("runtime_run:missing-run", journey["completion"]["blocking_gate_ids"])
+            self.assertEqual(validate_goal_journey(journey), [])
+
+
+class GoalJourneyValidationTests(unittest.TestCase):
+    def _journey(self, root: Path) -> dict[str, object]:
+        paths = _paths(root)
+        create_goal_ledger(paths, "Validated goal", ["Criterion one"], goal_id="goal-valid")
+        record_goal_checkpoint(
+            paths, "goal-valid", "Landed", criteria_refs=["AC001"], evidence_refs=["unit"]
+        )
+        return build_goal_journey(paths, "goal-valid", now=PINNED_NOW)
+
+    def test_validator_accepts_a_built_journey(self) -> None:
+        with TemporaryDirectory() as tmp:
+            self.assertEqual(validate_goal_journey(self._journey(Path(tmp))), [])
+
+    def test_validator_refuses_a_criterion_satisfied_without_accepted_evidence(self) -> None:
+        with TemporaryDirectory() as tmp:
+            journey = self._journey(Path(tmp))
+            journey["criteria"][0]["satisfied_by_checkpoints"] = []
+
+            errors = validate_goal_journey(journey)
+
+            self.assertIn("criteria[1] is satisfied without accepted evidence", errors)
+
+    def test_validator_refuses_completion_ready_while_a_gate_lacks_evidence(self) -> None:
+        with TemporaryDirectory() as tmp:
+            journey = self._journey(Path(tmp))
+            journey["required_gates"][0]["evidence_accepted"] = False
+            journey["completion"]["blocking_gate_ids"] = ["criterion:AC001"]
+
+            errors = validate_goal_journey(journey)
+
+            self.assertIn("completion.ready must be false while a required gate lacks evidence", errors)
+            self.assertIn("completion.unsatisfied_required_gates must count the blocking gates", errors)
+
+    def test_validator_refuses_a_raw_objective_and_a_weakened_claim_boundary(self) -> None:
+        with TemporaryDirectory() as tmp:
+            journey = self._journey(Path(tmp))
+            journey["objective"] = "the raw text"
+            journey["claim_boundary"] = "This proves the work is done."
+            journey["not_evidence"] = ["goal_completion"]
+
+            errors = validate_goal_journey(journey)
+
+            self.assertIn("raw objective field is not allowed", errors)
+            self.assertIn(
+                "claim_boundary must deny that the projection is execution, review, CI, or merge evidence",
+                errors,
+            )
+            self.assertIn("not_evidence must include all goal journey boundaries", errors)
+
+    def test_validator_refuses_a_foreign_schema_and_an_unsupported_stage(self) -> None:
+        errors = validate_goal_journey({"schema_version": "goal_status_card/v1", "stage": "shipped"})
+
+        self.assertIn("schema_version must be goal_journey/v1", errors)
+        self.assertIn("stage is unsupported", errors)
+        self.assertIn("goal_id is required", errors)
+        self.assertIn("objective_hash must be a sha256 hex digest", errors)
+
+
+class GoalJourneyRenderTests(unittest.TestCase):
+    def test_rendered_lines_use_dashes_and_end_with_the_claim_boundary(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            create_goal_ledger(
+                paths, "Rendered goal", ["Criterion one", "Criterion two"], goal_id="goal-render"
+            )
+            record_goal_checkpoint(
+                paths, "goal-render", "Landed", criteria_refs=["AC001"], evidence_refs=["unit"]
+            )
+
+            text = render_goal_journey_text(build_goal_journey(paths, "goal-render", now=PINNED_NOW))
+
+            self.assertTrue(text.startswith("Goal goal-render — activity"))
+            self.assertIn("- AC001: Criterion one — satisfied, evidence accepted", text)
+            self.assertIn("- AC002: Criterion two — pending, no accepted evidence", text)
+            self.assertIn("- criterion:AC002 (acceptance_criterion)", text)
+            self.assertTrue(text.endswith(GOAL_JOURNEY_CLAIM_BOUNDARY))
+            # Messenger surfaces drop markdown tables, so the renderer never
+            # emits one.
+            self.assertNotIn("|", text)
+
+
+class GoalJourneyCliTests(unittest.TestCase):
+    def _create(self, root: Path) -> None:
+        paths = _paths(root)
+        create_goal_ledger(paths, "CLI goal", ["Criterion one"], goal_id="goal-cli-journey")
+        record_goal_checkpoint(
+            paths, "goal-cli-journey", "Landed", criteria_refs=["AC001"], evidence_refs=["unit"]
+        )
+
+    def test_journey_defaults_to_plain_text_and_opts_into_json(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._create(root)
+            command = _base(root) + ["goal", "journey", "--goal", "goal-cli-journey"]
+
+            status, stdout, stderr = run_cli(command, output_json=False)
+
+            self.assertEqual(status, 0, stderr)
+            self.assertTrue(stdout.startswith("Goal goal-cli-journey"), stdout)
+            self.assertIn(GOAL_JOURNEY_CLAIM_BOUNDARY, stdout)
+
+            json_status, json_stdout, json_stderr = run_cli(command + ["--json"], output_json=False)
+
+            self.assertEqual(json_status, 0, json_stderr)
+            payload = json.loads(json_stdout)["journey"]
+            self.assertEqual(payload["schema_version"], GOAL_JOURNEY_SCHEMA_VERSION)
+            self.assertEqual(validate_goal_journey(payload), [])
+
+    def test_omh_output_json_reaches_the_machine_payload_without_the_flag(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._create(root)
+
+            # run_cli sets OMH_OUTPUT=json, which is how wrappers ask for the
+            # payload without spelling --json on every call.
+            status, stdout, stderr = run_cli(_base(root) + ["goal", "journey", "--goal", "goal-cli-journey"])
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(json.loads(stdout)["journey"]["goal_id"], "goal-cli-journey")
+
+    def test_missing_goal_reports_a_readable_error_not_a_traceback(self) -> None:
+        with TemporaryDirectory() as tmp:
+            status, stdout, stderr = run_cli(
+                _base(Path(tmp)) + ["goal", "journey", "--goal", "no-such-goal"], output_json=False
+            )
+
+            self.assertEqual(status, 2)
+            self.assertEqual(stdout, "")
+            self.assertTrue(stderr.startswith("omh: "), stderr)
+            self.assertNotIn("Traceback", stderr)
+
+
+def _stamp(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New contract `goal_journey/v1` in `src/workflows/goal_journey.py`: a read-only
  projection that links one goal to the wrapper sessions, plans, handoffs,
  owners, runtime runs, checkpoints, and completion decision behind it, with
  `build_goal_journey()`, `validate_goal_journey()`, and
  `render_goal_journey_text()` as the public surface.
- New CLI surface `omh goal journey --goal <id>`. It prints readable dash lines
  by default and the machine payload under `--json` or `OMH_OUTPUT=json`.
- `docs/ARCHITECTURE.md` gains a `## Goal Journey Projection` section that
  states the derived-edge table, the three contract properties, and the two
  determinism rules.
- `tests/test_goal_journey.py`: 21 tests, one per acceptance criterion plus the
  guard cases.
- Nothing else moves. No catalog, skill, routing case, demo card, or generated
  artifact changed, so no exact-count assertion moves either.

### Why This Exists

- Issue #824. A long-running outcome spans several chats, a plan, a coding
  handoff, and a runtime run, and the user needs one honest answer about what
  remains before completion. Today's ledger can answer "which criteria are
  satisfied" but not "what work advanced this, and who owned it".
- The goal ledger deliberately stores no session, plan, handoff, or owner link.
  Those edges exist in the store already — they were just never joined. A later
  Hermes conversation resuming the goal had to ask the user to re-explain the
  history, or guess.
- The second half of the problem is the honesty half. A goal record can drift
  into claiming more than its evidence supports: a criterion flipped to
  `satisfied` by hand, a "done, everything works" checkpoint that names no
  criterion, a ledger marked `complete` while a linked runtime run was never
  observed. A resume surface that repeats those claims makes "complete" mean
  less every time it is used.

### User / Operator Impact

- Before: resuming a goal meant `omh goal status`, which reports the ledger's
  criteria and blockers and nothing about the sessions, plans, handoffs, or
  owners that produced them, as escaped JSON.
- After: one command reconstructs the whole journey from local metadata and
  prints it as readable lines — which criteria carry accepted evidence and how
  fresh it is, which gates still block completion and why, which wrapper
  session and runtime run advanced the goal, which executor owned the handoff,
  and what stage the goal is actually in.
- The stage vocabulary is what makes the answer honest rather than optimistic:
  `intent`, `preparation`, `activity`, `blocked`, `verified_complete`,
  `cancelled`. A ledger that says complete while a required gate lacks evidence
  reads as `blocked`, never as verified.
- Hermes and wrappers get the same content as a schema-versioned payload; the
  `resume` block hands back the goal id, the objective hash, the stage, the next
  action, and the remaining gate count.

### How It Works

- **Edges are derived, never written.** `build_goal_journey()` reads and returns;
  it never mutates goal state. The joins:

  | Edge | Derived from |
  | --- | --- |
  | goal → run | `linked_runtime_runs` in the ledger |
  | run → handoff, owner, execution | `summarize_delegated_coding_status()` |
  | goal → session | a wrapper session whose `current_run_id` is one of those runs |
  | session → plan | the session's own `plan` block and plan `decision` |
  | goal → checkpoints, criteria | the ledger's own lists |

- **Criteria need accepted evidence** (acceptance criterion 2). A criterion
  reads as satisfied only when three things hold at once: the ledger says
  `satisfied`, the criterion carries evidence refs, and a *done checkpoint
  actually referenced it while carrying evidence*. The third condition is the
  one the ledger's own gate does not check, and it is what makes a hand-edited
  ledger project as `pending`.
- **Stricter than the ledger, never looser.** `completion.ready` is the
  conjunction of `build_goal_completion_gate()`'s verdict and an empty blocking
  list; `completion.ledger_gate_ready` reports the ledger's verdict beside it so
  a divergence is visible rather than silent. The projection can refuse a
  completion the ledger would allow; it can never allow one the ledger refuses.
- **Completion blocks while any required gate lacks evidence** (acceptance
  criterion 3). `required_gates` flattens the four kinds the ledger blocks on —
  `acceptance_criterion`, `active_blocker`, `linked_runtime_run`, `goal_status` —
  each carrying an `evidence_accepted` boolean.
  `validate_goal_journey()` refuses a payload whose `completion.ready` is true
  while any gate is unsatisfied, so the invariant lives on the payload and not
  only inside the builder.
- **Determinism.** `now` is a parameter; the projection never reads a wall clock
  into the payload, so two reads of an unchanged goal compare equal. The CLI
  supplies `utc_now()`; tests pin it. Without `now`, evidence freshness reports
  `unknown` rather than guessing.
- **Bounded.** The emitted checkpoint list is tail-bounded at
  `GOAL_JOURNEY_CHECKPOINT_LIMIT` (20) with a `checkpoint_history` block, because
  a goal spanning months is exactly the case this exists for. Criteria, gates,
  and the stage are computed from the *full* checkpoint list first, so bounding
  output never moves a verdict — a test proves the satisfying checkpoint can
  fall off the emitted tail with the criterion still reading satisfied.
- **Metadata only.** The objective travels as `objective_hash` plus the ledger's
  bounded summary. A linked session contributes its id, status, decision, and
  `message_sha256` — never a transcript. `claim_boundary` and `not_evidence`
  state what the projection is not, and the validator rejects a payload that
  weakens either.
- **No new dependencies, no network, no LLM call.** Core `omh` boundaries hold.

### Files And Contracts Touched

- `src/workflows/goal_journey.py` (new, 646 lines) — `goal_journey/v1`:
  `GOAL_JOURNEY_SCHEMA_VERSION`, `GOAL_JOURNEY_STAGES`,
  `GOAL_JOURNEY_GATE_KINDS`, `GOAL_JOURNEY_CHECKPOINT_LIMIT`,
  `GOAL_JOURNEY_FRESH_WINDOW_SECONDS`, `GOAL_JOURNEY_CLAIM_BOUNDARY`,
  `GOAL_JOURNEY_NOT_EVIDENCE`, `build_goal_journey()`,
  `validate_goal_journey()`, `render_goal_journey_text()`.
- `src/commands/goal.py` — `cmd_goal_journey()` and the `journey` subparser.
  This is the only behavioural change to an existing file; the existing goal
  subcommands are untouched.
- `tests/test_goal_journey.py` (new) — 21 tests across four classes.
- `docs/ARCHITECTURE.md` — new `## Goal Journey Projection` section between
  Workflow State and Record Revisions.
- Contracts read but not modified: `goal_ledger/v1`,
  `goal_completion_gate/v1`, `goal_runtime_evidence_check/v1`,
  `wrapper_session/v1`, `delegated_coding_status/v1`.

## Validation

- [x] `uv run --group lint ruff check src tests` — `All checks passed!`
- [x] `python3 -m unittest discover -s tests` — run as
      `PYTHONPATH=tests uv run python -m unittest discover -s tests`:
      **Ran 4275 tests in 147.419s — OK**. Baseline on this branch before the
      change was 4254; the 21 new tests are the whole delta. Rerun after
      rebasing onto `origin/main` (04309ffc), so this is the merged-state number,
      not a pre-merge one.
- [x] `python3 -m compileall src` — run as
      `uv run python -m compileall -q src tests`, exit 0.
- [x] `python3 -m omh.cli docs workflows --check` —
      `{"ok":true, "tap_skills":{"checked":115,"expected":115,"missing":[],"stale":[],"extra":[]}}`
- [x] `python3 -m omh.cli harness validate` —
      `{"counts":{"harnesses":72,"skills":104},"errors":[],"ok":true,"warnings":[]}`
- [x] `python3 -m omh.cli release checklist --json` — `"ok":true`, `"mode":"plan"`,
      35 required items, 2 manual-authority items.
- [x] `python3 -m omh.cli release hermes-smoke` — plan mode rendered with its
      plan-only boundary line; the current Hermes profile was not touched.
- [ ] `omh --help` — **not counted as evidence for this branch.** The `omh` on
      PATH here is `/Users/…/.local/bin/omh`, the user's globally installed
      release, so running it proves nothing about this diff. The branch's own
      console script was exercised instead:
      `uv run --no-editable omh goal --help` lists
      `{create,checkpoint,blocker,complete,cancel,status,continue,journey}`, and
      `uv run --no-editable python -c "import omh.workflows.goal_journey"`
      resolves to the packaged `workflows/goal_journey.py` — the new module ships
      under the already-declared `omh.workflows` package with no `pyproject.toml`
      change needed.
- [ ] `omh --omh-home /tmp/omh-smoke … release hermes-smoke --install-path setup
      --omh-command omh --include-command-smoke` — not run, for the same reason:
      it would observe the installed release rather than this branch.
- [ ] Relevant workflow-learning review queue smoke — not applicable; no
      learning contract, catalog entry, or generated artifact changed.
- [x] Relevant dry-run or smoke command: manual end-to-end against a temporary
      store. Created a goal with two criteria, confirmed `stage: intent` with
      both criteria blocking; recorded a generic `"Everything is done"`
      checkpoint carrying evidence but naming no criterion, then a real
      checkpoint naming `AC001`; confirmed `AC001` became
      `satisfied, evidence accepted, freshness fresh` while `AC002` stayed
      `pending, no accepted evidence` and remained the sole blocking gate. Both
      the default text form and `--json` were exercised.
- [ ] Manual Hermes/TUI check — **not run.** No Hermes Agent or messenger
      surface rendered the text output end to end. The renderer follows the
      existing `render_goal_status_text` discipline (dash lines only, never a
      markdown table, because Slack and Telegram drop tables) and a test asserts
      the output contains no `|`, but that is a local contract check, not
      observed messenger rendering.
- Additional gates run beyond the template:
  `python3 -m omh.cli docs roles --check` → `"ok":true`;
  `python3 -m omh.cli docs capability-families --check` → `"ok":true`;
  `git diff --check` → clean.

## Risk

- **Divergence between the journey verdict and the ledger gate is intentional
  and one-directional.** The journey can report `ready: false` while
  `build_goal_completion_gate()` reports `ready: true` — that is exactly the
  hand-edited-ledger case in acceptance criterion 2. `completion.ledger_gate_ready`
  is emitted alongside so the difference is legible rather than confusing, and
  the reverse direction is impossible by construction and asserted in tests.
- **Read cost.** The projection reads each linked runtime run twice — once
  through `build_goal_completion_gate()` for the evidence verdict and once
  directly for the handoff and owner edges. Linked runs are few per goal
  (usually one) and clarity was preferred over threading a shared cache through
  the ledger's private helpers. If a goal ever links many runs, this is the
  place to look.
- **The 7-day freshness window is a named constant, not a tuned policy.** It
  only has any effect when a caller passes `now`, and it classifies rather than
  blocks: nothing in the completion verdict depends on freshness.
- **Session linkage depends on `current_run_id`.** A wrapper session that has
  moved on to a different run no longer links to the goal. That is the store's
  existing single-run-ownership model, not a new limitation, and the missing
  edge degrades to "no session recorded" rather than to a wrong one.

## Compatibility / Rollout

- Purely additive. No existing schema, payload, command, or default changed;
  `goal_ledger/v1` is read and never written.
- `omh goal journey` is a new subcommand, so no wrapper can already be parsing
  it. That is why it takes the plain-text default DIRECTION asks for, with
  `--json` / `OMH_OUTPUT=json` as the machine opt-in, instead of inheriting the
  JSON-by-default that the older `goal` subcommands keep for compatibility. The
  reasoning is recorded as a comment at the parser.
- Release-channel impact: `stable`. The module lands inside the already-declared
  `omh.workflows` package, so no packaging change is required, and this was
  verified against a non-editable build rather than assumed.
- Rollback is deleting the module, the subparser block, the test file, and the
  docs section; nothing else depends on any of them.

## Release / Claims

- [x] Release-channel impact considered (`stable`)
- [x] Runtime/native capability claims are backed by evidence or marked as not
      observed. The projection itself makes no runtime claim: `claim_boundary`
      and `not_evidence` state that it is not execution, review, CI, or merge
      evidence, and the validator rejects a payload that weakens either. Every
      number in this PR body is pasted from a command that was run.
- [x] Known manual Hermes checks are listed, including the
      `omh release hermes-smoke --live` gap: not run, plan mode only, no live tap
      smoke, no target Hermes profile mutated.

## Follow-Up

- Coverage gap worth closing later: the "linked runtime run *carries* observed
  evidence" branch is exercised only through its unsatisfied path, because
  driving a run to `report_completion_with_evidence` needs the full
  dispatch/review/CI lifecycle. The satisfied branch is one boolean read from
  `goal_runtime_evidence_check/v1`, which the ledger already covers.
- Windows CI was not run locally; the module is pure Python with no path,
  newline, or filesystem handling of its own, so the exposure is the standard
  suite-wide one rather than anything specific to this change.
- If Hermes starts polling `omh goal journey` on a cadence, revisit whether it
  belongs in `coding_progress_policy_enforcement`'s `bounded_surfaces`. It is
  bounded by construction today (tail-limited checkpoints, no event history, no
  transcripts), and that registry is currently scoped to coding-progress
  surfaces, so it was left alone.
