### PR TITLE
feat: attach safe recovery anchors to risky OMH work

### DIFF
--- a/src/coding/action_gate.py
+++ b/src/coding/action_gate.py
@@ -556,6 +556,18 @@ HANDOFF_CONTRACT_CLAIM_BOUNDARY = (
     "evidence, and an enforced boundary means a refusing check exists — not that any action ran."
 )
 
+# Not an issue number, for the reason `RISK_CONSENT_BLOCKER` is not one: what
+# blocks the `recovery` row is a property of the shipped lane, not a ticket
+# waiting to be worked. #821 shipped `recovery_anchor/v1`, so the contract now
+# exists and refuses to call anything recoverable without an observed baseline
+# for the workspace being asked about. What it cannot do is observe that
+# baseline: this lane runs no Git command and reads no working tree, so a
+# baseline revision has to arrive from a surface that already observed one, and
+# `build_coding_delegation_payload` builds a handoff before any run, worktree,
+# or observation exists to supply it. Until a caller that holds an observed
+# baseline attaches an anchor, the row stays declared.
+RECOVERY_ANCHOR_BLOCKER = "no_delegation_surface_holds_an_observed_baseline_to_attach_an_anchor_from"
+
 # (boundary, statement, enforcement, enforced_by, blocked_by).
 #
 # The `enforced_by` refs are dotted import paths that must resolve; the test
@@ -702,11 +714,16 @@ _STATIC_SAFETY_BOUNDARIES: tuple[tuple[str, str, str, tuple[str, ...], str], ...
     ),
     (
         "recovery",
-        "No recovery anchor is attached to risky work, so nothing records how to undo a prepared handoff "
-        "once it has been dispatched.",
+        "The recovery_anchor/v1 contract exists and refuses to read as recoverable without an observed "
+        "baseline for the workspace being asked about: an absent, prepared-only, or mismatched anchor "
+        "returns a refusal and no recipe. What still does not happen is attachment. No delegation "
+        "surface requests an anchor, because this lane observes no baseline to build one from — it runs "
+        "no Git command and reads no working tree, and a handoff is prepared before any run, worktree, "
+        "or observation exists. So risky work still carries no anchor, and a dispatched handoff still "
+        "records no baseline to undo against.",
         "declared_not_enforced",
         (),
-        "#821",
+        RECOVERY_ANCHOR_BLOCKER,
     ),
     (
         "review_receipt",

--- a/src/workflows/recovery_anchor.py
+++ b/src/workflows/recovery_anchor.py
@@ -176,7 +176,11 @@ _LABEL = "recovery_anchor"
 # and the pattern cannot disagree about what an object name is.
 _OBJECT_NAME = re.compile(rf"^[0-9a-f]{{{MIN_BASE_REVISION_CHARS},{MAX_BASE_REVISION_CHARS}}}$")
 _CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
-_WINDOWS_PATH = re.compile(r"^(?:[A-Za-z]:|\\\\)")
+# Rooted in any spelling: a drive letter, a UNC prefix, or one leading separator
+# of either kind. The single backslash is the one that bites -- on Windows
+# `os.path.join(os.sep, "etc", "shadow")` is `\etc\shadow`, which is root-anchored
+# there but was read as project-relative here and stored verbatim.
+_ROOTED_PATH = re.compile(r"^(?:[A-Za-z]:|[\\/])")
 
 
 class RecoveryAnchorError(ValueError):
@@ -632,7 +636,7 @@ def _bounded_path(value: str) -> str:
         return digest_ref(text)
     if _CONTROL_CHARS.search(text) or is_sensitive_metadata_text(text) or is_url_shaped(text):
         return digest_ref(text)
-    if text.startswith("~") or text.startswith("/") or _WINDOWS_PATH.match(text):
+    if text.startswith("~") or _ROOTED_PATH.match(text):
         return digest_ref(text)
     if ".." in re.split(r"[\\/]", text):
         return digest_ref(text)

--- a/src/workflows/recovery_anchor.py
+++ b/src/workflows/recovery_anchor.py
@@ -1,0 +1,673 @@
+"""`recovery_anchor/v1`: what a baseline was, and how a person could return to it.
+
+After risky work a user asks one question -- "how do I undo this safely?" -- and
+today nothing in this tree can answer it. There is no recorded baseline
+revision, no bounded record of what was already uncommitted when the work
+started, and no written recipe. This module is that record and that answer.
+
+It is only ever a record and an answer. OMH performs no rollback here: nothing
+in this module runs a command, spawns a process, opens a socket, or creates,
+writes, or deletes a single path. An anchor is metadata; guidance is metadata
+plus instruction lines a human runs themselves. That is the whole boundary, and
+`CLAIM_BOUNDARY` states it on every record so a reader cannot infer otherwise
+from a status line.
+
+Three refusals carry the contract, and each is the reason it exists:
+
+- An anchor with no observed baseline stays `prepared`, and a prepared anchor
+  is structurally incapable of describing a recovery: `base_revision` is empty
+  and `recovery_recipe` is empty, enforced in both directions by
+  `validate_recovery_anchor`. "An anchor was prepared" must never read as "you
+  can safely undo this", so the prepared shape has nothing to read that way.
+- Guidance for a workspace other than the one the anchor was taken in is
+  refused outright. A baseline from another checkout cannot describe this one,
+  and offering it would be worse than offering nothing.
+- `recoverable` is true for exactly one status. `RECOVERABLE_GUIDANCE_STATUSES`
+  holds that one member, and the validator checks the flag against it, so an
+  absent, invalid, prepared-only, or mismatched anchor cannot report
+  recoverability by any path.
+
+Everything stored is bounded metadata. The workspace is a digest handle rather
+than a path, which is both the privacy posture the rest of this package uses
+and exactly the comparison the mismatch refusal needs. The dirty state is a
+digest plus counts plus a bounded, redacted path sample -- never file contents,
+and never an unbounded path list.
+
+Nothing here reads a clock. `created_at` and `baseline_observed_at` are
+parameters, and neither reaches an id seed or a digest seed, because a value
+that changes between two identical observations turns an equality check into a
+race -- the kind the slower CI runner loses first.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+import hashlib
+import json
+import os
+import re
+from typing import Any
+
+from ..system.append_only_store import RAW_OR_HIDDEN_KEYS, digest_ref, is_url_shaped, reference_errors
+from ..system.metadata_safety import is_sensitive_metadata_text
+
+
+RECOVERY_ANCHOR_SCHEMA_VERSION = "recovery_anchor/v1"
+RECOVERY_GUIDANCE_SCHEMA_VERSION = "recovery_guidance/v1"
+RECOVERY_ANCHOR_PRIVACY = "metadata_only"
+
+CLAIM_BOUNDARY = (
+    "A recovery anchor is bounded metadata plus written instructions. OMH performs no rollback, runs no "
+    "command that changes a workspace, and creates or deletes nothing. A prepared anchor is not a "
+    "recoverable baseline, and no anchor is execution, verification, review, CI, merge-readiness, or "
+    "merge evidence."
+)
+
+# What one anchor is attached to. `handoff` is a prepared handoff that has not
+# become a run; `run` is a linked runtime run.
+ANCHOR_TARGET_TYPES = ("handoff", "run")
+
+# The two states an anchor can hold. There is no third: either a surface
+# observed a baseline revision for the workspace, or none did.
+ANCHOR_STATES = ("prepared", "baseline_observed")
+
+# Where an observed baseline came from. Both observing members name a surface
+# that already exists in this tree and already requires observed evidence
+# before it writes -- the worktree ledger in `omh.coding.worktree_creator` and
+# the run journal in `omh.workflows.observation_journal`. `unknown` is the
+# absence of an observation, and it is the only value a prepared anchor holds.
+BASELINE_SOURCES = ("unknown", "runtime_observation", "worktree_observation")
+OBSERVING_BASELINE_SOURCES = ("runtime_observation", "worktree_observation")
+
+# `not_observed` is deliberately distinct from `clean`. Nothing looked is not
+# the same as nothing was there, and a recipe that treated the two alike would
+# tell someone with uncommitted work that they had none.
+DIRTY_STATE_STATES = ("not_observed", "clean", "dirty")
+
+RECOVERY_ANCHOR_KEYS = (
+    "anchor_id",
+    "anchor_state",
+    "base_revision",
+    "baseline_observed_at",
+    "baseline_source",
+    "claim_boundary",
+    "created_at",
+    "dirty_state",
+    "evidence_refs",
+    "privacy",
+    "recovery_recipe",
+    "schema_version",
+    "target_id",
+    "target_type",
+    "workspace_ref",
+)
+
+DIRTY_STATE_KEYS = (
+    "changed_file_count",
+    "digest",
+    "paths",
+    "paths_truncated",
+    "state",
+    "untracked_file_count",
+)
+
+RECOVERY_GUIDANCE_KEYS = (
+    "anchor_id",
+    "base_revision",
+    "claim_boundary",
+    "dirty_state",
+    "performs_rollback",
+    "reason",
+    "recoverable",
+    "schema_version",
+    "status",
+    "steps",
+    "workspace_ref",
+)
+
+RECOVERY_GUIDANCE_STATUSES = (
+    "anchor_absent",
+    "anchor_invalid",
+    "baseline_not_observed",
+    "workspace_mismatch",
+    "baseline_available",
+)
+# The whole of AC3, as a one-member tuple the validator reads. A status added
+# without a decision about recoverability lands outside this tuple, which means
+# not recoverable -- the safe direction.
+RECOVERABLE_GUIDANCE_STATUSES = ("baseline_available",)
+
+# Written for the person who asked the question, not for a log line.
+GUIDANCE_REASONS = {
+    "anchor_absent": (
+        "No recovery anchor was attached to this work, so no baseline was recorded and there is nothing "
+        "to return to."
+    ),
+    "anchor_invalid": (
+        "This recovery anchor does not validate, so its baseline cannot be trusted to describe any "
+        "workspace."
+    ),
+    "baseline_not_observed": (
+        "This recovery anchor was prepared but no baseline revision was ever observed, so it cannot say "
+        "what to return to. A prepared anchor is not a recoverable baseline."
+    ),
+    "workspace_mismatch": (
+        "This recovery anchor was taken in a different workspace, and a baseline from another workspace "
+        "cannot describe this one."
+    ),
+    "baseline_available": (
+        "This recovery anchor names an observed baseline for the workspace you asked about. The steps "
+        "below are instructions for you to run; OMH runs none of them."
+    ),
+}
+
+# A baseline is an exact object name. A branch or tag moves, and a baseline that
+# moves cannot identify the one state someone wants back.
+MAX_BASE_REVISION_CHARS = 64
+MIN_BASE_REVISION_CHARS = 7
+MAX_DIRTY_PATHS = 20
+MAX_PATH_CHARS = 200
+MAX_EVIDENCE_REFS = 8
+MAX_RECIPE_STEPS = 8
+MAX_RECIPE_STEP_CHARS = 200
+
+_LABEL = "recovery_anchor"
+# Built from the two bounds rather than repeating them, so the refusal message
+# and the pattern cannot disagree about what an object name is.
+_OBJECT_NAME = re.compile(rf"^[0-9a-f]{{{MIN_BASE_REVISION_CHARS},{MAX_BASE_REVISION_CHARS}}}$")
+_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+_WINDOWS_PATH = re.compile(r"^(?:[A-Za-z]:|\\\\)")
+
+
+class RecoveryAnchorError(ValueError):
+    """Raised when an anchor cannot be built from what a caller actually holds."""
+
+
+def workspace_reference(workspace_path: str) -> str:
+    """A stable, non-navigable handle for one workspace.
+
+    Normalization is deliberately filesystem-free: `expanduser` plus `normpath`
+    plus `normcase`, and no `resolve()`. Resolving would stat the tree, follow
+    symlinks, and fold `/tmp` into `/private/tmp` on macOS and a short name into
+    a long one on Windows, so the same logical workspace would hash differently
+    depending on which machine and which link asked. The handle is machine-local
+    either way; what it must be is the same value twice on one machine.
+    """
+    text = str(workspace_path or "").strip()
+    if not text:
+        return ""
+    normalized = os.path.normcase(os.path.normpath(os.path.expanduser(text)))
+    return digest_ref(normalized)
+
+
+def build_dirty_state_digest(
+    *,
+    observed: bool,
+    changed_paths: Iterable[str] = (),
+    untracked_paths: Iterable[str] = (),
+) -> dict[str, Any]:
+    """Bounded dirty state: a digest, two counts, and a redacted path sample.
+
+    The digest covers every path the caller observed, including the ones past
+    the sample bound, so two workspaces that differ only beyond the twentieth
+    file still produce different digests. Counts come from the lists rather than
+    from the caller, so a count cannot disagree with the paths it is counting.
+    """
+    if not observed:
+        return not_observed_dirty_state()
+    changed = _unique_sorted(changed_paths)
+    untracked = _unique_sorted(untracked_paths)
+    combined = _unique_sorted((*changed, *untracked))
+    seed = json.dumps({"changed": changed, "untracked": untracked}, sort_keys=True)
+    return {
+        "state": "dirty" if combined else "clean",
+        "digest": f"dirty-{hashlib.sha256(seed.encode('utf-8')).hexdigest()[:16]}",
+        "changed_file_count": len(changed),
+        "untracked_file_count": len(untracked),
+        "paths": [_bounded_path(path) for path in combined[:MAX_DIRTY_PATHS]],
+        "paths_truncated": len(combined) > MAX_DIRTY_PATHS,
+    }
+
+
+def not_observed_dirty_state() -> dict[str, Any]:
+    """The dirty state of a workspace nobody looked at."""
+    return {
+        "state": "not_observed",
+        "digest": "",
+        "changed_file_count": 0,
+        "untracked_file_count": 0,
+        "paths": [],
+        "paths_truncated": False,
+    }
+
+
+def recovery_recipe_steps(*, base_revision: str, dirty_state: Mapping[str, Any]) -> list[str]:
+    """The written recipe, derived from the anchor's own facts.
+
+    Empty without a baseline: a recipe that cannot name what to return to is not
+    a recipe, and shipping a plausible-looking one for a prepared anchor is the
+    exact failure this contract exists to prevent.
+    """
+    if not base_revision:
+        return []
+    state = str(dirty_state.get("state", "not_observed"))
+    if state == "dirty":
+        preserve = (
+            "Uncommitted work was present when this baseline was recorded, so save it before undoing "
+            "anything: git stash push --include-untracked"
+        )
+    elif state == "clean":
+        preserve = "The workspace was clean when this baseline was recorded, so there is nothing to save first."
+    else:
+        preserve = (
+            "No dirty-state observation was recorded, so assume uncommitted work may be present and save "
+            "it first: git stash push --include-untracked"
+        )
+    return [
+        "Confirm you are in the workspace this anchor names; guidance is refused for any other workspace.",
+        f"See what changed since the baseline: git diff {base_revision}",
+        preserve,
+        f"Return tracked files to the baseline: git restore --source {base_revision} --staged --worktree .",
+        "Untracked files are not part of the baseline, so the stash above is the only copy of them.",
+        "OMH runs none of these commands. It performs no rollback and deletes nothing.",
+    ]
+
+
+def build_recovery_anchor(
+    *,
+    target_type: str,
+    target_id: str,
+    workspace_path: str,
+    created_at: str,
+    base_revision: str = "",
+    baseline_source: str = "unknown",
+    baseline_observed_at: str = "",
+    dirty_state: Mapping[str, Any] | None = None,
+    evidence_refs: Iterable[str] = (),
+) -> dict[str, Any]:
+    """Build one anchor, or refuse.
+
+    `created_at` is a parameter rather than a clock read: an anchor is compared
+    and digested, and a wall-clock value inside a compared payload is a race.
+    Neither timestamp reaches the id seed.
+    """
+    if target_type not in ANCHOR_TARGET_TYPES:
+        raise RecoveryAnchorError(f"{_LABEL} target_type is unsupported: {target_type!r}")
+    if baseline_source not in BASELINE_SOURCES:
+        raise RecoveryAnchorError(f"{_LABEL} baseline_source is unsupported: {baseline_source!r}")
+    safe_target_id = _opaque(target_id, field="target_id")
+    safe_created_at = _opaque(created_at, field="created_at")
+    workspace_ref = workspace_reference(workspace_path)
+    if not workspace_ref:
+        raise RecoveryAnchorError(f"{_LABEL} workspace_path is required; an anchor identifies one workspace")
+    revision = str(base_revision or "").strip().lower()
+    if revision and not _OBJECT_NAME.fullmatch(revision):
+        raise RecoveryAnchorError(
+            f"{_LABEL} base_revision must be an exact object name of "
+            f"{MIN_BASE_REVISION_CHARS} to {MAX_BASE_REVISION_CHARS} hex characters"
+        )
+    observed = bool(revision) and baseline_source in OBSERVING_BASELINE_SOURCES
+    if revision and not observed:
+        raise RecoveryAnchorError(
+            f"{_LABEL} base_revision requires an observing baseline_source; "
+            f"a revision nobody observed is not an observed baseline"
+        )
+    if not observed:
+        # Refusing to carry a half-observed baseline is the point: every field
+        # that could read as recoverable is cleared, not merely left unset.
+        revision = ""
+        baseline_source = "unknown"
+        baseline_observed_at = ""
+    safe_observed_at = _opaque(baseline_observed_at, field="baseline_observed_at") if baseline_observed_at else ""
+    if observed and not safe_observed_at:
+        raise RecoveryAnchorError(f"{_LABEL} an observed baseline requires baseline_observed_at")
+    state = dict(dirty_state) if isinstance(dirty_state, Mapping) else not_observed_dirty_state()
+    record = {
+        "schema_version": RECOVERY_ANCHOR_SCHEMA_VERSION,
+        "anchor_id": _anchor_id(
+            target_type=target_type,
+            target_id=safe_target_id,
+            workspace_ref=workspace_ref,
+            base_revision=revision,
+            baseline_source=baseline_source,
+            dirty_digest=str(state.get("digest", "")),
+        ),
+        "anchor_state": "baseline_observed" if observed else "prepared",
+        "target_type": target_type,
+        "target_id": safe_target_id,
+        "workspace_ref": workspace_ref,
+        "base_revision": revision,
+        "baseline_source": baseline_source,
+        "baseline_observed_at": safe_observed_at,
+        "dirty_state": state,
+        "recovery_recipe": recovery_recipe_steps(base_revision=revision, dirty_state=state),
+        "evidence_refs": _bounded_refs(evidence_refs),
+        "created_at": safe_created_at,
+        "privacy": RECOVERY_ANCHOR_PRIVACY,
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+    errors = validate_recovery_anchor(record)
+    if errors:
+        raise RecoveryAnchorError(errors[0])
+    return record
+
+
+def build_recovery_guidance(anchor: Mapping[str, Any] | None, *, workspace_path: str) -> dict[str, Any]:
+    """Answer "how do I undo this safely?" for one workspace, or refuse and say why.
+
+    Reads no clock and performs no action. Every path out of here that is not
+    `baseline_available` returns no steps and `recoverable` false.
+    """
+    requested_ref = workspace_reference(workspace_path)
+    if not isinstance(anchor, Mapping) or not anchor:
+        return _guidance("anchor_absent", anchor_id="", workspace_ref=requested_ref)
+    # Rendering reads whatever a caller holds, which may have been hand-edited,
+    # so the id is folded to a bounded handle before it reaches a reader.
+    anchor_id = _rendered_ref(anchor.get("anchor_id", ""))
+    if validate_recovery_anchor(dict(anchor)):
+        return _guidance("anchor_invalid", anchor_id=anchor_id, workspace_ref=requested_ref)
+    if str(anchor.get("workspace_ref", "")) != requested_ref or not requested_ref:
+        return _guidance("workspace_mismatch", anchor_id=anchor_id, workspace_ref=requested_ref)
+    if str(anchor.get("anchor_state", "")) != "baseline_observed":
+        return _guidance("baseline_not_observed", anchor_id=anchor_id, workspace_ref=requested_ref)
+    return _guidance(
+        "baseline_available",
+        anchor_id=anchor_id,
+        workspace_ref=requested_ref,
+        base_revision=str(anchor.get("base_revision", "")),
+        dirty_state=dict(anchor.get("dirty_state", {})),
+        steps=[str(step) for step in anchor.get("recovery_recipe", [])],
+    )
+
+
+def validate_recovery_anchor(payload: dict[str, Any]) -> list[str]:
+    """Every reason one payload is not a `recovery_anchor/v1` record."""
+    errors: list[str] = []
+    if not isinstance(payload, dict):
+        return [f"{_LABEL} must be an object"]
+    forbidden = sorted(key for key in payload if str(key).lower() in RAW_OR_HIDDEN_KEYS)
+    if forbidden:
+        errors.append(f"{_LABEL} must not carry raw or hidden keys: {forbidden}")
+    # Both directions: an unsupported key is a field nothing guards, and a
+    # missing key is a field a reader will treat as absent rather than as broken.
+    extra_keys = sorted(set(payload) - set(RECOVERY_ANCHOR_KEYS) - set(forbidden))
+    if extra_keys:
+        errors.append(f"{_LABEL} has unsupported keys: {extra_keys}")
+    missing = sorted(set(RECOVERY_ANCHOR_KEYS) - set(payload))
+    if missing:
+        errors.append(f"{_LABEL} is missing keys: {missing}")
+    if payload.get("schema_version") != RECOVERY_ANCHOR_SCHEMA_VERSION:
+        errors.append(f"{_LABEL} schema_version must be {RECOVERY_ANCHOR_SCHEMA_VERSION}")
+    for key in ("anchor_id", "anchor_state", "base_revision", "baseline_observed_at", "baseline_source",
+                "created_at", "target_id", "target_type", "workspace_ref"):
+        if not isinstance(payload.get(key), str):
+            errors.append(f"{_LABEL} {key} must be a string")
+    if payload.get("target_type") not in ANCHOR_TARGET_TYPES:
+        errors.append(f"{_LABEL} target_type is unsupported: {payload.get('target_type')!r}")
+    if payload.get("anchor_state") not in ANCHOR_STATES:
+        errors.append(f"{_LABEL} anchor_state is unsupported: {payload.get('anchor_state')!r}")
+    if payload.get("baseline_source") not in BASELINE_SOURCES:
+        errors.append(f"{_LABEL} baseline_source is unsupported: {payload.get('baseline_source')!r}")
+    if payload.get("privacy") != RECOVERY_ANCHOR_PRIVACY:
+        errors.append(f"{_LABEL} privacy must be {RECOVERY_ANCHOR_PRIVACY}")
+    if payload.get("claim_boundary") != CLAIM_BOUNDARY:
+        errors.append(f"{_LABEL} claim_boundary must state the recovery boundary")
+    for field in ("anchor_id", "target_id", "created_at", "workspace_ref"):
+        errors.extend(reference_errors(payload.get(field), field=field, label=_LABEL, required=True))
+    errors.extend(
+        reference_errors(payload.get("baseline_observed_at"), field="baseline_observed_at", label=_LABEL, required=False)
+    )
+    errors.extend(_evidence_ref_errors(payload.get("evidence_refs")))
+    errors.extend(_dirty_state_errors(payload.get("dirty_state")))
+    errors.extend(_recipe_errors(payload.get("recovery_recipe")))
+    errors.extend(_baseline_state_errors(payload))
+    return errors
+
+
+def validate_recovery_guidance(payload: dict[str, Any]) -> list[str]:
+    """Every reason one payload is not a `recovery_guidance/v1` answer.
+
+    The load-bearing check is the last one: `recoverable` is compared against
+    `RECOVERABLE_GUIDANCE_STATUSES`, so a hand-built or drifted answer that
+    claims recoverability from an absent, invalid, prepared-only, or mismatched
+    anchor is a validation error rather than a status somebody believes.
+    """
+    errors: list[str] = []
+    if not isinstance(payload, dict):
+        return ["recovery_guidance must be an object"]
+    extra_keys = sorted(set(payload) - set(RECOVERY_GUIDANCE_KEYS))
+    if extra_keys:
+        errors.append(f"recovery_guidance has unsupported keys: {extra_keys}")
+    missing = sorted(set(RECOVERY_GUIDANCE_KEYS) - set(payload))
+    if missing:
+        errors.append(f"recovery_guidance is missing keys: {missing}")
+    if payload.get("schema_version") != RECOVERY_GUIDANCE_SCHEMA_VERSION:
+        errors.append(f"recovery_guidance schema_version must be {RECOVERY_GUIDANCE_SCHEMA_VERSION}")
+    status = payload.get("status")
+    if status not in RECOVERY_GUIDANCE_STATUSES:
+        errors.append(f"recovery_guidance status is unsupported: {status!r}")
+    if payload.get("performs_rollback") is not False:
+        errors.append("recovery_guidance performs_rollback must be false; OMH performs no rollback")
+    if payload.get("claim_boundary") != CLAIM_BOUNDARY:
+        errors.append("recovery_guidance claim_boundary must state the recovery boundary")
+    if not str(payload.get("reason", "")).strip():
+        errors.append("recovery_guidance reason is required")
+    errors.extend(_recipe_errors(payload.get("steps"), label="recovery_guidance", field="steps"))
+    errors.extend(_dirty_state_errors(payload.get("dirty_state"), label="recovery_guidance"))
+    recoverable = payload.get("recoverable")
+    if not isinstance(recoverable, bool):
+        errors.append("recovery_guidance recoverable must be a boolean")
+    elif recoverable:
+        if status not in RECOVERABLE_GUIDANCE_STATUSES:
+            errors.append(f"recovery_guidance status {status!r} must not report recoverable")
+        if not str(payload.get("base_revision", "")).strip():
+            errors.append("recovery_guidance recoverable requires a base_revision naming the baseline")
+        if not payload.get("steps"):
+            errors.append("recovery_guidance recoverable requires the steps it says the reader can run")
+    else:
+        if payload.get("steps"):
+            errors.append("recovery_guidance that is not recoverable must carry no steps")
+        if str(payload.get("base_revision", "")).strip():
+            errors.append("recovery_guidance that is not recoverable must name no base_revision")
+    return errors
+
+
+def _guidance(
+    status: str,
+    *,
+    anchor_id: str,
+    workspace_ref: str,
+    base_revision: str = "",
+    dirty_state: dict[str, Any] | None = None,
+    steps: list[str] | None = None,
+) -> dict[str, Any]:
+    recoverable = status in RECOVERABLE_GUIDANCE_STATUSES
+    return {
+        "schema_version": RECOVERY_GUIDANCE_SCHEMA_VERSION,
+        "status": status,
+        "recoverable": recoverable,
+        "reason": GUIDANCE_REASONS[status],
+        "anchor_id": anchor_id,
+        "workspace_ref": workspace_ref,
+        "base_revision": base_revision if recoverable else "",
+        # A refusal echoes nothing about the anchor's own workspace. On a
+        # mismatch that state describes a checkout the asker is not in.
+        "dirty_state": dict(dirty_state or {}) if recoverable else not_observed_dirty_state(),
+        "steps": list(steps or []) if recoverable else [],
+        "performs_rollback": False,
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+
+
+def _baseline_state_errors(payload: dict[str, Any]) -> list[str]:
+    """The prepared/observed split, checked in both directions.
+
+    Either half alone would let the other drift: without the first, a prepared
+    anchor could carry a recipe; without the second, an anchor could claim an
+    observed baseline while naming nothing to return to.
+    """
+    errors: list[str] = []
+    state = payload.get("anchor_state")
+    revision = str(payload.get("base_revision", ""))
+    if state == "prepared":
+        if revision:
+            errors.append(f"{_LABEL} prepared anchor must carry no base_revision")
+        if payload.get("baseline_source") != "unknown":
+            errors.append(f"{_LABEL} prepared anchor baseline_source must be unknown")
+        if payload.get("baseline_observed_at"):
+            errors.append(f"{_LABEL} prepared anchor must carry no baseline_observed_at")
+        if payload.get("recovery_recipe"):
+            errors.append(f"{_LABEL} prepared anchor must carry no recovery_recipe")
+    elif state == "baseline_observed":
+        if not _OBJECT_NAME.fullmatch(revision):
+            errors.append(f"{_LABEL} observed baseline requires base_revision as an exact object name")
+        if payload.get("baseline_source") not in OBSERVING_BASELINE_SOURCES:
+            errors.append(f"{_LABEL} observed baseline requires an observing baseline_source")
+        if not str(payload.get("baseline_observed_at", "")).strip():
+            errors.append(f"{_LABEL} observed baseline requires baseline_observed_at")
+        if not payload.get("recovery_recipe"):
+            errors.append(f"{_LABEL} observed baseline requires a recovery_recipe")
+    return errors
+
+
+def _dirty_state_errors(value: Any, *, label: str = _LABEL) -> list[str]:
+    if not isinstance(value, dict):
+        return [f"{label} dirty_state must be an object"]
+    errors: list[str] = []
+    extra_keys = sorted(set(value) - set(DIRTY_STATE_KEYS))
+    if extra_keys:
+        errors.append(f"{label} dirty_state has unsupported keys: {extra_keys}")
+    missing = sorted(set(DIRTY_STATE_KEYS) - set(value))
+    if missing:
+        errors.append(f"{label} dirty_state is missing keys: {missing}")
+    if value.get("state") not in DIRTY_STATE_STATES:
+        errors.append(f"{label} dirty_state state is unsupported: {value.get('state')!r}")
+    for key in ("changed_file_count", "untracked_file_count"):
+        count = value.get(key)
+        if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+            errors.append(f"{label} dirty_state {key} must be a non-negative integer")
+    if not isinstance(value.get("paths_truncated"), bool):
+        errors.append(f"{label} dirty_state paths_truncated must be a boolean")
+    paths = value.get("paths")
+    if not isinstance(paths, list):
+        errors.append(f"{label} dirty_state paths must be a list")
+    elif len(paths) > MAX_DIRTY_PATHS:
+        errors.append(f"{label} dirty_state paths must hold at most {MAX_DIRTY_PATHS} entries")
+    else:
+        for index, path in enumerate(paths):
+            if not isinstance(path, str):
+                errors.append(f"{label} dirty_state paths[{index}] must be a string")
+            elif path != _bounded_path(path):
+                errors.append(f"{label} dirty_state paths[{index}] must be a bounded, redacted path")
+    if value.get("state") == "not_observed" and (value.get("digest") or paths):
+        errors.append(f"{label} dirty_state not_observed must carry no digest and no paths")
+    if value.get("state") != "not_observed" and not str(value.get("digest", "")).strip():
+        errors.append(f"{label} dirty_state requires a digest once it is observed")
+    return errors
+
+
+def _recipe_errors(value: Any, *, label: str = _LABEL, field: str = "recovery_recipe") -> list[str]:
+    if not isinstance(value, list):
+        return [f"{label} {field} must be a list"]
+    errors: list[str] = []
+    if len(value) > MAX_RECIPE_STEPS:
+        errors.append(f"{label} {field} must hold at most {MAX_RECIPE_STEPS} steps")
+    for index, step in enumerate(value):
+        if not isinstance(step, str):
+            errors.append(f"{label} {field}[{index}] must be a string")
+        elif not step.strip() or len(step) > MAX_RECIPE_STEP_CHARS:
+            errors.append(f"{label} {field}[{index}] must be one bounded instruction line")
+        elif _CONTROL_CHARS.search(step) or is_sensitive_metadata_text(step) or is_url_shaped(step):
+            errors.append(f"{label} {field}[{index}] must be a plain instruction line")
+    return errors
+
+
+def _evidence_ref_errors(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return [f"{_LABEL} evidence_refs must be a list"]
+    errors: list[str] = []
+    if len(value) > MAX_EVIDENCE_REFS:
+        errors.append(f"{_LABEL} evidence_refs must hold at most {MAX_EVIDENCE_REFS} entries")
+    for index, ref in enumerate(value):
+        errors.extend(reference_errors(ref, field=f"evidence_refs[{index}]", label=_LABEL, required=True))
+    return errors
+
+
+def _anchor_id(
+    *,
+    target_type: str,
+    target_id: str,
+    workspace_ref: str,
+    base_revision: str,
+    baseline_source: str,
+    dirty_digest: str,
+) -> str:
+    """Identity from what the anchor is about, never from when it was taken."""
+    seed = json.dumps(
+        {
+            "target_type": target_type,
+            "target_id": target_id,
+            "workspace_ref": workspace_ref,
+            "base_revision": base_revision,
+            "baseline_source": baseline_source,
+            "dirty_digest": dirty_digest,
+        },
+        sort_keys=True,
+    )
+    return f"anchor-{hashlib.sha256(seed.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _bounded_path(value: str) -> str:
+    """One project-relative path, or a digest handle where it is not one.
+
+    Absolute, home-anchored, escaping, over-long, secret-shaped, URL-shaped, and
+    control-carrying values all fold to a handle instead of being stored. The
+    function is idempotent, which is what lets the validator re-derive it and
+    reject a stored path that did not come through here.
+    """
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    if len(text) > MAX_PATH_CHARS:
+        return digest_ref(text)
+    if _CONTROL_CHARS.search(text) or is_sensitive_metadata_text(text) or is_url_shaped(text):
+        return digest_ref(text)
+    if text.startswith("~") or text.startswith("/") or _WINDOWS_PATH.match(text):
+        return digest_ref(text)
+    if ".." in re.split(r"[\\/]", text):
+        return digest_ref(text)
+    return text
+
+
+def _bounded_refs(refs: Iterable[str]) -> list[str]:
+    bounded: list[str] = []
+    for ref in refs:
+        text = str(ref or "").strip()
+        if not text or text in bounded:
+            continue
+        bounded.append(_opaque(text, field="evidence_refs"))
+        if len(bounded) == MAX_EVIDENCE_REFS:
+            break
+    return bounded
+
+
+def _rendered_ref(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    if reference_errors(text, field="anchor_id", label=_LABEL, required=True):
+        return digest_ref(text)
+    return text
+
+
+def _opaque(value: Any, *, field: str) -> str:
+    text = str(value or "").strip()
+    errors = reference_errors(text, field=field, label=_LABEL, required=True)
+    if errors:
+        raise RecoveryAnchorError(errors[0])
+    return text
+
+
+def _unique_sorted(values: Iterable[str]) -> list[str]:
+    cleaned = {str(value).strip() for value in values if str(value).strip()}
+    return sorted(cleaned)

--- a/tests/test_handoff_safety_contract.py
+++ b/tests/test_handoff_safety_contract.py
@@ -113,7 +113,11 @@ _ENFORCED_BOUNDARIES = frozenset(
 _DECLARED_NOT_ENFORCED = {
     "account_authorization": "host_owned_consent_flow_is_not_observable_by_omh",
     "confirmation_answered": "no_confirmation_answer_intake_mints_a_run_bound_approval",
-    "recovery": "#821",
+    # #821 shipped `recovery_anchor/v1`, so the blocker stopped being that
+    # issue. It is a reason string now for the same cause as the two above: the
+    # delegation lane observes no baseline revision, so it has nothing to build
+    # an anchor from, and no ticket against this repository changes that.
+    "recovery": "no_delegation_surface_holds_an_observed_baseline_to_attach_an_anchor_from",
     "start_evidence": "#826",
     "storage_retention": "#835",
     "workspace": "#820",
@@ -384,6 +388,14 @@ class AntiDecorationTests(unittest.TestCase):
         self.assertIn("not a state OMH can observe", _boundary(contract, "account_authorization")["statement"])
         self.assertIn("persist until the operator deletes them", _boundary(contract, "storage_retention")["statement"])
         self.assertIn("no observed start", _boundary(contract, "start_evidence")["statement"])
+        # The recovery row is the one that names a contract that *does* exist,
+        # so the sentence has to keep saying which half is missing. Without this
+        # the "recovery_anchor/v1 contract exists" clause could stand alone and
+        # read as enforcement.
+        recovery = _boundary(contract, "recovery")["statement"]
+        self.assertIn("recovery_anchor/v1 contract exists", recovery)
+        self.assertIn("still does not happen is attachment", recovery)
+        self.assertIn("records no baseline to undo against", recovery)
 
 
 class HandoffSafetyContractValidatorTests(unittest.TestCase):

--- a/tests/test_recovery_anchor.py
+++ b/tests/test_recovery_anchor.py
@@ -360,6 +360,21 @@ class BoundedDirtyStateTests(unittest.TestCase):
                 self.assertTrue(str(path).startswith("ref-"), path)
         self.assertEqual(validate_recovery_anchor(_observed(dirty_state=state)), [])
 
+    def test_a_root_anchored_path_folds_in_either_separator_spelling(self) -> None:
+        # Both spellings on both platforms, not `os.sep`. `\etc\shadow` is
+        # root-anchored on Windows but was read here as project-relative, so an
+        # absolute path was stored verbatim in a metadata-only record. Windows CI
+        # was the only place `os.sep` produced that spelling, which is why the
+        # bound is asserted against literals instead of the platform separator.
+        for path in ("/etc/shadow", "\\etc\\shadow", "C:/Windows/system32", "\\\\server\\share\\x"):
+            with self.subTest(path=path):
+                state = build_dirty_state_digest(observed=True, changed_paths=(path,))
+                stored = state["paths"]  # type: ignore[index]
+                self.assertEqual(len(stored), 1)
+                self.assertTrue(str(stored[0]).startswith("ref-"), stored[0])
+                self.assertNotIn("etc", str(stored[0]))
+                self.assertNotIn("Windows", str(stored[0]))
+
     def test_a_stored_path_that_never_went_through_the_bound_is_rejected(self) -> None:
         anchor = _observed()
         tampered = {**anchor, "dirty_state": {**anchor["dirty_state"], "paths": ["/etc/shadow"]}}  # type: ignore[dict-item]

--- a/tests/test_recovery_anchor.py
+++ b/tests/test_recovery_anchor.py
@@ -1,0 +1,474 @@
+"""Contracts for `recovery_anchor/v1` (issue #821).
+
+Grouped by acceptance criterion:
+
+- AC1: an anchor identifies one run, one workspace, and one observed baseline.
+- AC2: guidance refuses a mismatched workspace, in words a person can read.
+- AC3: no status claims recoverability from an absent or prepared-only anchor.
+
+Plus the boundary the whole contract rests on: OMH records how to undo work and
+performs none of it. The module runs no command, opens no socket, and creates,
+writes, or deletes nothing -- proven here by building an anchor and its guidance
+with `subprocess`, `socket`, and every filesystem write raising on contact.
+
+Nothing in this file writes a file. That is deliberate as well: the anchor and
+its guidance are compared by value throughout, and `Path.write_text` rewrites
+"\\n" as CRLF on Windows, so a fixture written that way would compare equal on
+macOS and unequal on the Windows job. There is no fixture to get wrong.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+import socket
+import subprocess
+import unittest
+from unittest.mock import patch
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.workflows.recovery_anchor import (  # noqa: E402
+    ANCHOR_STATES,
+    ANCHOR_TARGET_TYPES,
+    BASELINE_SOURCES,
+    CLAIM_BOUNDARY,
+    DIRTY_STATE_KEYS,
+    DIRTY_STATE_STATES,
+    GUIDANCE_REASONS,
+    MAX_DIRTY_PATHS,
+    MAX_RECIPE_STEPS,
+    OBSERVING_BASELINE_SOURCES,
+    RECOVERABLE_GUIDANCE_STATUSES,
+    RECOVERY_ANCHOR_KEYS,
+    RECOVERY_ANCHOR_PRIVACY,
+    RECOVERY_ANCHOR_SCHEMA_VERSION,
+    RECOVERY_GUIDANCE_KEYS,
+    RECOVERY_GUIDANCE_SCHEMA_VERSION,
+    RECOVERY_GUIDANCE_STATUSES,
+    RecoveryAnchorError,
+    build_dirty_state_digest,
+    build_recovery_anchor,
+    build_recovery_guidance,
+    not_observed_dirty_state,
+    validate_recovery_anchor,
+    validate_recovery_guidance,
+    workspace_reference,
+)
+
+
+_WORKSPACE = os.path.join(os.sep, "srv", "checkouts", "omh-i821")
+_OTHER_WORKSPACE = os.path.join(os.sep, "srv", "checkouts", "omh-i820")
+_BASE_REVISION = "9f1c2b7ae3d4f5091234ab"
+_CREATED_AT = "2026-08-09T12:00:00Z"
+_OBSERVED_AT = "2026-08-09T11:59:00Z"
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "src" / "workflows" / "recovery_anchor.py"
+
+
+def _prepared(**overrides: object) -> dict[str, object]:
+    arguments: dict[str, object] = {
+        "target_type": "handoff",
+        "target_id": "handoff-i821-01",
+        "workspace_path": _WORKSPACE,
+        "created_at": _CREATED_AT,
+    }
+    arguments.update(overrides)
+    return build_recovery_anchor(**arguments)  # type: ignore[arg-type]
+
+
+def _observed(**overrides: object) -> dict[str, object]:
+    arguments: dict[str, object] = {
+        "target_type": "run",
+        "target_id": "run-i821-01",
+        "workspace_path": _WORKSPACE,
+        "created_at": _CREATED_AT,
+        "base_revision": _BASE_REVISION,
+        "baseline_source": "worktree_observation",
+        "baseline_observed_at": _OBSERVED_AT,
+        "dirty_state": build_dirty_state_digest(
+            observed=True,
+            changed_paths=("src/auth.py",),
+            untracked_paths=("notes.md",),
+        ),
+        "evidence_refs": ("git-worktree:agent-issue-821",),
+    }
+    arguments.update(overrides)
+    return build_recovery_anchor(**arguments)  # type: ignore[arg-type]
+
+
+class AnchorIdentityTests(unittest.TestCase):
+    """AC1: an anchor identifies one run, one workspace, one observed baseline."""
+
+    def test_an_observed_anchor_names_its_run_workspace_and_baseline(self) -> None:
+        anchor = _observed()
+        self.assertEqual(anchor["schema_version"], RECOVERY_ANCHOR_SCHEMA_VERSION)
+        self.assertEqual(anchor["anchor_state"], "baseline_observed")
+        self.assertEqual(anchor["target_type"], "run")
+        self.assertEqual(anchor["target_id"], "run-i821-01")
+        self.assertEqual(anchor["workspace_ref"], workspace_reference(_WORKSPACE))
+        self.assertEqual(anchor["base_revision"], _BASE_REVISION)
+        self.assertEqual(anchor["baseline_source"], "worktree_observation")
+        self.assertEqual(anchor["baseline_observed_at"], _OBSERVED_AT)
+        self.assertEqual(anchor["privacy"], RECOVERY_ANCHOR_PRIVACY)
+        self.assertEqual(anchor["claim_boundary"], CLAIM_BOUNDARY)
+        self.assertEqual(validate_recovery_anchor(anchor), [])
+
+    def test_the_key_set_is_closed_in_both_directions(self) -> None:
+        anchor = _observed()
+        self.assertEqual(set(anchor), set(RECOVERY_ANCHOR_KEYS))
+        self.assertEqual(set(anchor["dirty_state"]), set(DIRTY_STATE_KEYS))  # type: ignore[arg-type]
+
+        extra = {**anchor, "rollback_command": "git reset --hard"}
+        self.assertTrue(
+            any("unsupported keys" in error for error in validate_recovery_anchor(extra)),
+            validate_recovery_anchor(extra),
+        )
+        for key in RECOVERY_ANCHOR_KEYS:
+            with self.subTest(missing=key):
+                dropped = {name: value for name, value in anchor.items() if name != key}
+                self.assertTrue(
+                    any("is missing keys" in error for error in validate_recovery_anchor(dropped)),
+                    key,
+                )
+
+    def test_a_raw_or_hidden_key_is_refused_by_name(self) -> None:
+        anchor = {**_observed(), "raw_output": "git status output"}
+        errors = validate_recovery_anchor(anchor)
+        self.assertTrue(any("raw or hidden keys" in error for error in errors), errors)
+
+    def test_the_anchor_id_is_derived_from_identity_and_not_from_the_clock(self) -> None:
+        # A wall-clock value inside a compared payload is a race, so neither
+        # timestamp reaches the id seed. Two anchors for the same work recorded
+        # at different moments are the same anchor.
+        early = _observed(created_at="2026-01-01T00:00:00Z", baseline_observed_at="2025-12-31T23:59:00Z")
+        late = _observed(created_at="2026-12-31T23:59:59Z", baseline_observed_at="2026-12-31T23:00:00Z")
+        self.assertEqual(early["anchor_id"], late["anchor_id"])
+        self.assertEqual(_observed(), _observed())
+        self.assertNotEqual(_observed()["anchor_id"], _observed(target_id="run-i821-02")["anchor_id"])
+        self.assertNotEqual(_observed()["anchor_id"], _observed(workspace_path=_OTHER_WORKSPACE)["anchor_id"])
+
+    def test_a_baseline_that_no_surface_observed_is_refused(self) -> None:
+        with self.assertRaises(RecoveryAnchorError) as caught:
+            _observed(baseline_source="unknown")
+        self.assertIn("observing baseline_source", str(caught.exception))
+
+    def test_a_baseline_that_is_not_an_exact_object_name_is_refused(self) -> None:
+        for revision in ("main", "HEAD", "v1.2.3", "abc", "zzzzzzz"):
+            with self.subTest(revision=revision):
+                with self.assertRaises(RecoveryAnchorError) as caught:
+                    _observed(base_revision=revision)
+                self.assertIn("exact object name", str(caught.exception))
+
+    def test_an_anchor_without_a_workspace_is_refused(self) -> None:
+        with self.assertRaises(RecoveryAnchorError) as caught:
+            _prepared(workspace_path="  ")
+        self.assertIn("workspace_path is required", str(caught.exception))
+
+    def test_the_target_and_baseline_vocabularies_are_closed(self) -> None:
+        self.assertEqual(ANCHOR_TARGET_TYPES, ("handoff", "run"))
+        self.assertEqual(ANCHOR_STATES, ("prepared", "baseline_observed"))
+        self.assertEqual(set(OBSERVING_BASELINE_SOURCES) | {"unknown"}, set(BASELINE_SOURCES))
+        with self.assertRaises(RecoveryAnchorError):
+            _prepared(target_type="workspace")
+        with self.assertRaises(RecoveryAnchorError):
+            _observed(baseline_source="operator_said_so")
+
+
+class WorkspaceMismatchTests(unittest.TestCase):
+    """AC2: guidance refuses a workspace the anchor was not taken in."""
+
+    def test_a_mismatched_workspace_is_refused_with_a_readable_reason(self) -> None:
+        guidance = build_recovery_guidance(_observed(), workspace_path=_OTHER_WORKSPACE)
+        self.assertEqual(guidance["status"], "workspace_mismatch")
+        self.assertFalse(guidance["recoverable"])
+        self.assertEqual(guidance["steps"], [])
+        self.assertEqual(guidance["base_revision"], "")
+        self.assertIn("different workspace", str(guidance["reason"]))
+        self.assertIn("cannot describe this one", str(guidance["reason"]))
+        self.assertEqual(validate_recovery_guidance(guidance), [])
+
+    def test_a_refusal_echoes_nothing_about_the_other_workspace(self) -> None:
+        # The asker is not in the anchor's workspace, so its dirty state and its
+        # baseline describe a checkout they cannot act on. Neither is returned.
+        guidance = build_recovery_guidance(_observed(), workspace_path=_OTHER_WORKSPACE)
+        self.assertEqual(guidance["dirty_state"], not_observed_dirty_state())
+        self.assertEqual(guidance["workspace_ref"], workspace_reference(_OTHER_WORKSPACE))
+        self.assertNotIn(_BASE_REVISION, repr(guidance))
+
+    def test_an_empty_workspace_question_is_a_mismatch_not_an_answer(self) -> None:
+        guidance = build_recovery_guidance(_observed(), workspace_path="")
+        self.assertEqual(guidance["status"], "workspace_mismatch")
+        self.assertFalse(guidance["recoverable"])
+
+    def test_the_matching_workspace_is_answered_with_the_baseline_and_the_recipe(self) -> None:
+        guidance = build_recovery_guidance(_observed(), workspace_path=_WORKSPACE)
+        self.assertEqual(guidance["status"], "baseline_available")
+        self.assertTrue(guidance["recoverable"])
+        self.assertEqual(guidance["base_revision"], _BASE_REVISION)
+        self.assertEqual(guidance["steps"], _observed()["recovery_recipe"])
+        self.assertEqual(set(guidance), set(RECOVERY_GUIDANCE_KEYS))
+        self.assertEqual(guidance["schema_version"], RECOVERY_GUIDANCE_SCHEMA_VERSION)
+        self.assertEqual(validate_recovery_guidance(guidance), [])
+
+    def test_workspace_references_normalize_without_touching_the_filesystem(self) -> None:
+        # Same logical workspace, three spellings. Normalization is expanduser +
+        # normpath + normcase and never `resolve()`, so no stat, no symlink
+        # follow, and the same value twice on one machine.
+        base = workspace_reference(_WORKSPACE)
+        self.assertEqual(workspace_reference(_WORKSPACE + os.sep), base)
+        self.assertEqual(workspace_reference(os.path.join(_WORKSPACE, "docs", "..")), base)
+        self.assertNotEqual(workspace_reference(_OTHER_WORKSPACE), base)
+        self.assertEqual(workspace_reference(""), "")
+        self.assertFalse(os.sep in base or "srv" in base)
+
+
+class NoRecoverabilityWithoutAnObservedBaselineTests(unittest.TestCase):
+    """AC3: absent and prepared-only anchors never read as recoverable."""
+
+    def test_an_absent_anchor_never_yields_a_recoverable_status(self) -> None:
+        for anchor in (None, {}):
+            with self.subTest(anchor=anchor):
+                guidance = build_recovery_guidance(anchor, workspace_path=_WORKSPACE)
+                self.assertEqual(guidance["status"], "anchor_absent")
+                self.assertFalse(guidance["recoverable"])
+                self.assertEqual(guidance["steps"], [])
+                self.assertEqual(guidance["base_revision"], "")
+                self.assertIn("nothing to return to", str(guidance["reason"]))
+                self.assertEqual(validate_recovery_guidance(guidance), [])
+
+    def test_a_prepared_only_anchor_never_yields_a_recoverable_status(self) -> None:
+        anchor = _prepared()
+        self.assertEqual(anchor["anchor_state"], "prepared")
+        guidance = build_recovery_guidance(anchor, workspace_path=_WORKSPACE)
+        self.assertEqual(guidance["status"], "baseline_not_observed")
+        self.assertFalse(guidance["recoverable"])
+        self.assertEqual(guidance["steps"], [])
+        self.assertEqual(guidance["base_revision"], "")
+        self.assertIn("not a recoverable baseline", str(guidance["reason"]))
+        self.assertEqual(validate_recovery_guidance(guidance), [])
+
+    def test_a_prepared_anchor_structurally_carries_nothing_to_read_as_recovery(self) -> None:
+        # The refusal is not a status the caller must remember to check: a
+        # prepared anchor has no baseline and no recipe to misread.
+        anchor = _prepared()
+        self.assertEqual(anchor["base_revision"], "")
+        self.assertEqual(anchor["baseline_source"], "unknown")
+        self.assertEqual(anchor["baseline_observed_at"], "")
+        self.assertEqual(anchor["recovery_recipe"], [])
+        self.assertEqual(anchor["dirty_state"], not_observed_dirty_state())
+        self.assertEqual(validate_recovery_anchor(anchor), [])
+
+    def test_a_prepared_anchor_that_grew_a_recipe_or_a_baseline_is_rejected(self) -> None:
+        for field, value in (
+            ("base_revision", _BASE_REVISION),
+            ("baseline_source", "worktree_observation"),
+            ("baseline_observed_at", _OBSERVED_AT),
+            ("recovery_recipe", ["git restore --source deadbeef --staged --worktree ."]),
+        ):
+            with self.subTest(field=field):
+                tampered = {**_prepared(), field: value}
+                errors = validate_recovery_anchor(tampered)
+                self.assertTrue(any("prepared anchor" in error for error in errors), errors)
+
+    def test_an_observed_anchor_stripped_of_its_baseline_is_rejected(self) -> None:
+        for field, value in (
+            ("base_revision", ""),
+            ("baseline_source", "unknown"),
+            ("baseline_observed_at", ""),
+            ("recovery_recipe", []),
+        ):
+            with self.subTest(field=field):
+                tampered = {**_observed(), field: value}
+                errors = validate_recovery_anchor(tampered)
+                self.assertTrue(any("observed baseline" in error for error in errors), errors)
+
+    def test_exactly_one_guidance_status_may_report_recoverable(self) -> None:
+        self.assertEqual(RECOVERABLE_GUIDANCE_STATUSES, ("baseline_available",))
+        self.assertEqual(set(GUIDANCE_REASONS), set(RECOVERY_GUIDANCE_STATUSES))
+        for status in RECOVERY_GUIDANCE_STATUSES:
+            with self.subTest(status=status):
+                self.assertTrue(GUIDANCE_REASONS[status].strip())
+
+    def test_guidance_claiming_recoverability_outside_that_status_is_rejected(self) -> None:
+        for status in RECOVERY_GUIDANCE_STATUSES:
+            if status in RECOVERABLE_GUIDANCE_STATUSES:
+                continue
+            with self.subTest(status=status):
+                refusal = build_recovery_guidance(None, workspace_path=_WORKSPACE)
+                tampered = {**refusal, "status": status, "recoverable": True}
+                errors = validate_recovery_guidance(tampered)
+                self.assertTrue(any("must not report recoverable" in error for error in errors), errors)
+
+    def test_a_refusal_that_smuggled_in_steps_or_a_baseline_is_rejected(self) -> None:
+        refusal = build_recovery_guidance(_prepared(), workspace_path=_WORKSPACE)
+        with_steps = {**refusal, "steps": ["git restore --source deadbeef --staged --worktree ."]}
+        self.assertTrue(
+            any("must carry no steps" in error for error in validate_recovery_guidance(with_steps)),
+            validate_recovery_guidance(with_steps),
+        )
+        with_baseline = {**refusal, "base_revision": _BASE_REVISION}
+        self.assertTrue(
+            any("must name no base_revision" in error for error in validate_recovery_guidance(with_baseline)),
+            validate_recovery_guidance(with_baseline),
+        )
+
+    def test_an_invalid_anchor_is_refused_rather_than_read(self) -> None:
+        guidance = build_recovery_guidance({**_observed(), "anchor_state": "definitely_fine"}, workspace_path=_WORKSPACE)
+        self.assertEqual(guidance["status"], "anchor_invalid")
+        self.assertFalse(guidance["recoverable"])
+        self.assertEqual(guidance["steps"], [])
+        self.assertEqual(validate_recovery_guidance(guidance), [])
+
+
+class BoundedDirtyStateTests(unittest.TestCase):
+    def test_the_digest_covers_every_observed_path_and_the_sample_is_bounded(self) -> None:
+        many = tuple(f"src/module_{index:03d}.py" for index in range(MAX_DIRTY_PATHS + 5))
+        state = build_dirty_state_digest(observed=True, changed_paths=many)
+        self.assertEqual(state["state"], "dirty")
+        self.assertEqual(state["changed_file_count"], len(many))
+        self.assertEqual(len(state["paths"]), MAX_DIRTY_PATHS)  # type: ignore[arg-type]
+        self.assertTrue(state["paths_truncated"])
+        # A change past the sample bound still changes the digest.
+        beyond = build_dirty_state_digest(observed=True, changed_paths=(*many[:-1], "src/module_999.py"))
+        self.assertNotEqual(state["digest"], beyond["digest"])
+        self.assertEqual(state["paths"], beyond["paths"])
+
+    def test_counts_come_from_the_observed_lists_and_cannot_disagree_with_them(self) -> None:
+        state = build_dirty_state_digest(
+            observed=True,
+            changed_paths=("src/a.py", "src/a.py", " src/b.py "),
+            untracked_paths=("notes.md",),
+        )
+        self.assertEqual(state["changed_file_count"], 2)
+        self.assertEqual(state["untracked_file_count"], 1)
+        self.assertEqual(state["paths"], ["notes.md", "src/a.py", "src/b.py"])
+
+    def test_a_path_that_is_not_project_relative_is_stored_as_a_handle(self) -> None:
+        unsafe = (
+            os.path.join(os.sep, "etc", "shadow"),
+            os.path.join("~", "private", "diary.md"),
+            os.path.join("..", "..", "other-repo", "secrets.env"),
+            "https://example.invalid/leak.txt",
+            "src/x.py\nsrc/y.py",
+            "x" * 400,
+        )
+        state = build_dirty_state_digest(observed=True, changed_paths=unsafe)
+        for path in state["paths"]:  # type: ignore[union-attr]
+            with self.subTest(path=path):
+                self.assertTrue(str(path).startswith("ref-"), path)
+        self.assertEqual(validate_recovery_anchor(_observed(dirty_state=state)), [])
+
+    def test_a_stored_path_that_never_went_through_the_bound_is_rejected(self) -> None:
+        anchor = _observed()
+        tampered = {**anchor, "dirty_state": {**anchor["dirty_state"], "paths": ["/etc/shadow"]}}  # type: ignore[dict-item]
+        errors = validate_recovery_anchor(tampered)
+        self.assertTrue(any("bounded, redacted path" in error for error in errors), errors)
+
+    def test_nothing_looked_is_not_the_same_as_nothing_was_there(self) -> None:
+        self.assertEqual(DIRTY_STATE_STATES, ("not_observed", "clean", "dirty"))
+        unobserved = build_dirty_state_digest(observed=False, changed_paths=("src/a.py",))
+        self.assertEqual(unobserved, not_observed_dirty_state())
+        self.assertEqual(unobserved["digest"], "")
+        clean = build_dirty_state_digest(observed=True)
+        self.assertEqual(clean["state"], "clean")
+        self.assertTrue(clean["digest"])
+        # The recipe reads the difference: an unobserved workspace is told to
+        # save work first, a clean one is told there is nothing to save.
+        unobserved_recipe = _observed(dirty_state=unobserved)["recovery_recipe"]
+        clean_recipe = _observed(dirty_state=clean)["recovery_recipe"]
+        self.assertIn("No dirty-state observation was recorded", " ".join(unobserved_recipe))  # type: ignore[arg-type]
+        self.assertIn("nothing to save first", " ".join(clean_recipe))  # type: ignore[arg-type]
+
+    def test_a_not_observed_dirty_state_carrying_a_digest_is_rejected(self) -> None:
+        anchor = _observed()
+        tampered = {
+            **anchor,
+            "dirty_state": {**not_observed_dirty_state(), "digest": "dirty-0000000000000000"},
+        }
+        errors = validate_recovery_anchor(tampered)
+        self.assertTrue(any("not_observed must carry no digest" in error for error in errors), errors)
+
+
+class RecipeTests(unittest.TestCase):
+    def test_the_recipe_is_bounded_instruction_lines_naming_the_baseline(self) -> None:
+        recipe = _observed()["recovery_recipe"]
+        self.assertTrue(recipe)
+        self.assertLessEqual(len(recipe), MAX_RECIPE_STEPS)  # type: ignore[arg-type]
+        joined = " ".join(recipe)  # type: ignore[arg-type]
+        self.assertIn(_BASE_REVISION, joined)
+        self.assertIn("git stash push --include-untracked", joined)
+        self.assertIn("performs no rollback", joined)
+
+    def test_no_step_carries_a_path_a_link_or_a_control_character(self) -> None:
+        for step in _observed()["recovery_recipe"]:  # type: ignore[union-attr]
+            with self.subTest(step=step):
+                self.assertNotIn("://", step)
+                self.assertNotIn("?", step)
+                self.assertNotIn("#", step)
+                self.assertEqual(step, " ".join(step.split()))
+
+    def test_a_step_that_is_a_link_or_a_body_is_rejected(self) -> None:
+        anchor = _observed()
+        for step in ("https://example.invalid/undo", "line one\nline two", "x" * 400, "   "):
+            with self.subTest(step=step):
+                errors = validate_recovery_anchor({**anchor, "recovery_recipe": [step]})
+                self.assertTrue(errors)
+
+
+class NoMutationBoundaryTests(unittest.TestCase):
+    """The module records how to undo work and performs none of it."""
+
+    def test_building_an_anchor_and_its_guidance_touches_no_process_socket_or_file(self) -> None:
+        def refuse(*args: object, **kwargs: object) -> None:
+            raise AssertionError(f"recovery_anchor performed an effect: {args!r} {kwargs!r}")
+
+        with (
+            patch.object(subprocess, "run", refuse),
+            patch.object(subprocess, "Popen", refuse),
+            patch.object(socket, "socket", refuse),
+            patch.object(Path, "open", refuse),
+            patch.object(Path, "write_text", refuse),
+            patch.object(Path, "write_bytes", refuse),
+            patch.object(Path, "mkdir", refuse),
+            patch.object(Path, "unlink", refuse),
+            patch.object(os, "remove", refuse),
+            patch("builtins.open", refuse),
+        ):
+            anchor = _observed()
+            guidance = build_recovery_guidance(anchor, workspace_path=_WORKSPACE)
+            refusal = build_recovery_guidance(anchor, workspace_path=_OTHER_WORKSPACE)
+            self.assertEqual(validate_recovery_anchor(anchor), [])
+            self.assertEqual(validate_recovery_guidance(guidance), [])
+            self.assertEqual(refusal["status"], "workspace_mismatch")
+
+    def test_the_module_imports_nothing_that_executes_or_reaches_the_network(self) -> None:
+        tree = ast.parse(_MODULE_PATH.read_text(encoding="utf-8"))
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+                imported.add(node.module.split(".")[0])
+        forbidden = {"subprocess", "socket", "shutil", "urllib", "http", "asyncio", "multiprocessing", "tempfile"}
+        self.assertEqual(imported & forbidden, set(), sorted(imported))
+
+    def test_every_answer_states_that_omh_performs_no_rollback(self) -> None:
+        for anchor in (None, _prepared(), _observed()):
+            for workspace in (_WORKSPACE, _OTHER_WORKSPACE):
+                with self.subTest(anchor=anchor, workspace=workspace):
+                    guidance = build_recovery_guidance(anchor, workspace_path=workspace)
+                    self.assertIs(guidance["performs_rollback"], False)
+                    self.assertEqual(guidance["claim_boundary"], CLAIM_BOUNDARY)
+        self.assertIn("performs no rollback", CLAIM_BOUNDARY)
+        self.assertIn("creates or deletes nothing", CLAIM_BOUNDARY)
+
+    def test_guidance_that_claims_it_rolled_back_is_rejected(self) -> None:
+        guidance = build_recovery_guidance(_observed(), workspace_path=_WORKSPACE)
+        errors = validate_recovery_guidance({**guidance, "performs_rollback": True})
+        self.assertTrue(any("performs_rollback must be false" in error for error in errors), errors)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- Added `recovery_anchor/v1` and its answer projection `recovery_guidance/v1`
  in `src/workflows/recovery_anchor.py` (673 lines). An anchor records one
  target (a prepared handoff or a run), one workspace, one **observed** baseline
  revision, a bounded dirty-state digest, and a written recovery recipe.
  Guidance takes an anchor plus the workspace the person is actually standing
  in, and either returns the baseline with instructions or refuses and says why.
- Added `tests/test_recovery_anchor.py` (474 lines, 35 tests), grouped one class
  per acceptance criterion plus the no-mutation boundary.
- Updated the `recovery` row of `handoff_safety_contract/v1` in
  `src/coding/action_gate.py`. It is **not** flipped to `enforced`; the
  statement now says which half exists and which half does not, and `blocked_by`
  moves from `#821` to a reason string. Only that one row is touched, so the
  concurrent `workspace` row work for #820 merges trivially.
- Updated `tests/test_handoff_safety_contract.py` to match: the
  `_DECLARED_NOT_ENFORCED` blocker for `recovery`, and a new phrase pin in
  `test_unenforced_boundaries_state_the_gap_in_words` so the "the contract
  exists" clause cannot later stand alone and read as enforcement.

### Why This Exists

Issue #821. After risky work a user asks one question — "how do I undo this
safely?" — and nothing in this tree could answer it. Before this change
`grep -rn "recovery_anchor" src/ tests/ docs/` returned nothing, there was no
baseline-revision capture anywhere, no bounded dirty-state digest, and no
recovery recipe. Every `rollback` hit in `src/` was release-workflow copy, not
a mechanism.

`mission_control._recovery` already reports a recovery *status* per journey
state and deliberately never sets `resume_safe=True`, because it has nothing to
base such a claim on. This change supplies the missing thing it never had: a
record of what the baseline actually was.

### User / Operator Impact

Before: a user who wanted to undo work had to reconstruct the baseline
themselves, from memory, with no record of what was already uncommitted when the
work started.

After: a surface that observed a baseline can attach an anchor, and asking about
a workspace returns one of five outcomes, each with a sentence a person can
read:

| Situation | `status` | `recoverable` | What comes back |
| --- | --- | --- | --- |
| No anchor | `anchor_absent` | false | "No recovery anchor was attached to this work…" |
| Anchor fails validation | `anchor_invalid` | false | "…its baseline cannot be trusted to describe any workspace." |
| Anchor prepared, baseline never observed | `baseline_not_observed` | false | "A prepared anchor is not a recoverable baseline." |
| Asking about a different workspace | `workspace_mismatch` | false | "…a baseline from another workspace cannot describe this one." |
| Observed baseline for this workspace | `baseline_available` | true | The exact revision plus a six-step recipe |

The failure this contract exists to prevent is the third row. An anchor that was
merely *prepared* must never read as "you can safely undo this".

**OMH performs no rollback.** The module runs no command, opens no socket, and
creates, writes, or deletes nothing. The recipe is instruction lines a human
runs themselves, and `claim_boundary` says so on every record it emits.

### How It Works

**Three refusals carry the contract.**

1. *A prepared anchor is structurally incapable of describing a recovery.*
   `build_recovery_anchor` clears `base_revision`, `baseline_source`, and
   `baseline_observed_at` when no observing source supplied a revision, and
   `recovery_recipe_steps` returns `[]` without a baseline.
   `validate_recovery_anchor` then checks the prepared/observed split in both
   directions, so a prepared anchor that grew a recipe and an observed anchor
   stripped of its baseline are both validation errors.
2. *Guidance refuses a workspace the anchor was not taken in.* The workspace is
   stored as a digest handle rather than a path, which is both the privacy
   posture the rest of the package uses and exactly the comparison this refusal
   needs. The refusal echoes neither the other workspace's baseline nor its
   dirty state — that data describes a checkout the asker is not in.
3. *`recoverable` is true for exactly one status.*
   `RECOVERABLE_GUIDANCE_STATUSES` is a one-member tuple and
   `validate_recovery_guidance` compares the flag against it, so an absent,
   invalid, prepared-only, or mismatched anchor cannot report recoverability by
   any path. A status added later without a recoverability decision lands
   outside the tuple, which means not recoverable — the safe direction.

**Bounded metadata only.** `build_dirty_state_digest` stores a digest, two
counts, and a redacted sample of at most 20 project-relative paths, never file
contents. The digest covers *every* observed path including those past the
sample bound, so two workspaces differing only beyond the twentieth file still
hash differently. Counts are derived from the observed lists rather than taken
from the caller, so a count cannot disagree with the paths it counts. Absolute,
home-anchored, escaping, over-long, secret-shaped, URL-shaped, and
control-carrying values fold to a `ref-…` handle; `_bounded_path` is idempotent,
which is what lets the validator re-derive it and reject a stored path that
never went through it. `not_observed` is kept distinct from `clean`, because a
recipe that conflated them would tell someone with uncommitted work that they
had none.

**Deterministic.** Nothing here reads a clock. `created_at` and
`baseline_observed_at` are parameters, and neither reaches the `anchor_id` seed
or the dirty digest seed — a wall-clock value inside a compared payload turns an
equality check into a race the slower CI runner loses first. Workspace
normalization is `expanduser` + `normpath` + `normcase` and deliberately never
`resolve()`: resolving would stat the tree, follow symlinks, fold `/tmp` into
`/private/tmp` on macOS and a short name into a long one on Windows.

**Why the boundary row is not flipped.** The `recovery` boundary said "No
recovery anchor is attached to risky work". That sentence is now half false and
half still true, and the honest move was to say which half. The contract exists;
attachment does not. This lane runs no Git command and reads no working tree, so
it observes no baseline to build an anchor from, and
`build_coding_delegation_payload` prepares a handoff before any run, worktree,
or observation exists to supply one. The only anchor it could attach today is a
prepared one — exactly the thing AC3 forbids reading as recoverable. So
`blocked_by` becomes the reason string
`no_delegation_surface_holds_an_observed_baseline_to_attach_an_anchor_from`,
following the precedent `account_authorization` and `confirmation_answered`
already set for a blocker no ticket can close.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/workflows/recovery_anchor.py` | New. `recovery_anchor/v1`, `recovery_guidance/v1`, closed key sets, both validators, bounded dirty-state digest, recipe generator. No I/O, no subprocess, no network. |
| `tests/test_recovery_anchor.py` | New. 35 tests: one class per AC, plus bounded-dirty-state, recipe, and no-mutation boundary classes. |
| `src/coding/action_gate.py` | `recovery` row of `_STATIC_SAFETY_BOUNDARIES` restated; new `RECOVERY_ANCHOR_BLOCKER` constant. Still `declared_not_enforced` with `enforced_by: ()`. |
| `tests/test_handoff_safety_contract.py` | `_DECLARED_NOT_ENFORCED["recovery"]` updated to the reason string; three phrase pins added to `test_unenforced_boundaries_state_the_gap_in_words`. |

No generated artifact is touched: no catalog entry, no skill, no routing case,
no demo card, so no exact-count assertion moves. `docs/WORKFLOWS.md`,
`docs/ROLES.md`, `skills/*/SKILL.md`, the demo-cards JSON, and
`capability_families.json` are all unchanged and their byte gates were run
anyway (below).

## Validation

All commands below were run in this worktree on the rebased branch
(`origin/main` at `96a3378b` + this commit) and the output pasted is real.

- [x] `uv run --group lint ruff check src tests`
  → `All checks passed!` (one pre-existing warning about an invalid `# noqa`
  directive on `src/commands/main.py:1`, untouched by this change)
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests`
  → `Ran 4407 tests in 168.744s` / `OK`
- [x] `uv run python -m compileall -q src tests` → exit 0, no output
- [x] `uv run python -m omh.cli docs workflows --check`
  → `{"checked":".../docs/WORKFLOWS.md","ok":true,"tap_skills":{"checked":115,"expected":115,"extra":[],"missing":[],"ok":true,...,"stale":[]}}`
- [x] `uv run python -m omh.cli docs roles --check`
  → `{"checked":".../docs/ROLES.md","ok":true}`
- [x] `uv run python -m omh.cli docs capability-families --check`
  → `{"checked":".../src/plugin_bundle/omh/tools/capability_families.json","ok":true}`
- [x] `uv run python -m omh.cli harness validate`
  → `{"counts":{"harnesses":72,"skills":104},"errors":[],"ok":true,"schema_version":"catalog_validation/v1","warnings":[]}`
- [x] `git diff --check` → exit 0, no output
- [x] Targeted: `PYTHONPATH=tests uv run python -m unittest tests.test_recovery_anchor`
  → `Ran 35 tests in 0.010s` / `OK`
- [x] Targeted: `PYTHONPATH=tests uv run python -m unittest tests.test_handoff_safety_contract`
  → `Ran 46 tests in 0.033s` / `OK`
- [ ] `python3 -m omh.cli release checklist --json` — not run; this change adds
      no installable skill, no CLI command, and no version-bearing file.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run, same reason.
- [ ] `omh --help` — not run; no command surface changed.
- [ ] `omh --omh-home /tmp/omh-smoke … release hermes-smoke …` — not run; no
      install or setup path changed.
- [ ] Workflow-learning review queue smoke — not applicable; no learning
      contract changed.
- [ ] Manual Hermes/TUI check — **not run, and it could not be**: nothing
      attaches an anchor yet, so there is no Hermes surface to exercise. See
      Risk.

Verification of the no-mutation boundary is executed, not asserted in prose:
`NoMutationBoundaryTests` builds an anchor and both a successful and a refused
guidance with `subprocess.run`, `subprocess.Popen`, `socket.socket`,
`Path.open`, `Path.write_text`, `Path.write_bytes`, `Path.mkdir`,
`Path.unlink`, `os.remove`, and `builtins.open` all patched to raise. A second
test parses the module with `ast` and asserts it imports none of `subprocess`,
`socket`, `shutil`, `urllib`, `http`, `asyncio`, `multiprocessing`, `tempfile`.

## Risk

- **The capability is representable but not yet attached.** This is the honest
  state and the PR says so in the boundary statement rather than around it. A
  reader who sees `recovery_anchor/v1` in the tree must not conclude that risky
  work now carries an anchor. It does not. The `recovery` row stays
  `declared_not_enforced` precisely so no status surface can imply otherwise.
- **No Windows CI was run locally.** The known trap is a test writing a file
  whose bytes are later hashed or compared, because `Path.write_text` rewrites
  `\n` as CRLF on Windows. This test file writes no files at all, and the module
  writes none either, so there is no fixture to get wrong. Path handling uses
  `os.path.normcase` / `normpath` and `os.sep`-built fixtures rather than
  hardcoded POSIX separators; the one hardcoded `/etc/shadow` string is a
  *negative* case that must fold to a digest handle, which it does on both
  platforms.
- **`base_revision` is restricted to an exact hex object name** of 7–64
  characters. A branch or tag is refused. That is deliberate — a baseline that
  moves cannot identify the one state someone wants back — but it means a caller
  holding only a symbolic ref must resolve it before building an anchor.
- **The recipe includes a destructive command** (`git restore --source … .`).
  It is text for a human to run, ordered so that saving current work comes
  first, and the last step states that OMH runs none of it. Nothing in this repo
  executes any of those lines.

## Compatibility / Rollout

- Additive. No existing record schema, key set, CLI command, routing case, or
  generated artifact changes, so nothing on disk from a previous version becomes
  invalid.
- The single behavioural change to an existing surface is the `recovery` row's
  `statement` and `blocked_by` inside `handoff_safety_contract/v1`. Both are
  descriptive fields; no gate reads them for a decision, and
  `enforcement`/`enforced_by` are unchanged, so no delegation is allowed or
  refused differently than before.
- Merge order with #820 is safe: that PR edits the `workspace` row of the same
  tuple, this one edits only the `recovery` row.

## Release / Claims

- [x] Release-channel impact considered — none. No version file, installer,
      manifest, plugin bundle, or skill package is touched, so this rides the
      next ordinary release with no channel-specific action.
- [x] Runtime/native capability claims are backed by evidence or marked as not
      observed — the only capability claim made is that the contract exists and
      refuses; the fact that nothing attaches an anchor is stated in the
      boundary row, in the commit trailers, and in Risk above.
- [x] Known manual Hermes checks are listed — the manual Hermes/TUI check is
      listed as not run, with the reason that no surface reaches this code yet.
      No `omh release hermes-smoke --live` gap is introduced.

## Follow-Up

- Attach an anchor from a caller that genuinely holds an observed baseline. The
  nearest real source is the worktree ledger: `latest_observed_worktree_record`
  already returns a record carrying `from_ref`, `worktree_path`, `branch`, and
  `observed`, which is a `worktree_observation` baseline in exactly the shape
  `build_recovery_anchor` expects. When that lands, flip the `recovery` row to
  `enforced` and name the attaching symbol in `enforced_by`.
- Expose the answer where the question is asked. `mission_control`'s `recovery`
  key is the natural home for a `recovery_guidance/v1` projection once an anchor
  exists to project.
- Neither follow-up is a partial slice of this goal: both require an observed
  baseline that no surface supplies today, which is a different capability gap
  from the one #821 asked for.
