### PR TITLE
feat: measure run health and efficiency consistently across coding owners

### DIFF
--- a/docs/CODING-OBSERVABILITY.md
+++ b/docs/CODING-OBSERVABILITY.md
@@ -313,6 +313,95 @@ It is read-only in both directions: it starts nothing and writes nothing. Plain
 text is the default and prints the claim support next to the verdict, so the
 line a reader quotes already says what the check does not settle.
 
+## Why is this run unhealthy
+
+A status board says what is happening. It does not say why a run is slow,
+stale, retrying, or missing the evidence that would settle it — and each coding
+owner narrates that in its own words, so the same unhealthy run used to read
+differently depending on who was executing it.
+
+`run_health_summary/v1` is the one answer shape. It is a read-only projection:
+
+```sh
+omh runtime health-summary --input run_health_input.json [--json]
+```
+
+A run that dispatched, explored, then failed its tests twice reads like this
+(the `Boundary:` and `--json` footer lines are elided):
+
+```
+Run health summary (OMH projection)
+Run: run-834
+Owner: claude-code (progress lane: yes, evidence ceiling: verified)
+Observed events: 6 (observed at 9000 ms)
+Freshness: fresh (idle 3000 ms, stale after 300000 ms)
+Failure class: verification_failed
+Total duration: 5000 ms
+Phase durations:
+- dispatch: 1000 ms
+- execution: 1000 ms
+- verification: 1000 ms
+Counts:
+- retries: 1
+- evidence gaps: 0
+- unobserved phases: 1
+Efficiency claim: unclaimed (baseline: none, evaluator: none, gate: no_named_baseline_and_evaluator)
+```
+
+The retry is the second `tests_started`: it moves the run backwards through the
+phase order, which is what a retry is regardless of which word the owner used
+for it. The unobserved phase is `completion` — nothing said the executor
+finished, which is exactly why the run is worth asking about.
+
+**One vocabulary, whatever the owner.** The projection runs over *normalized*
+progress events, never over raw per-owner event shapes. A codex run narrating
+`dispatch_to_executor / item.completed / turn.completed` and a Claude Code run
+narrating `system / assistant / result` normalize to the same three words, so
+they produce byte-identical summaries apart from the owner attribution block.
+`health_digest` is that equality in one comparison — it deliberately excludes
+the owner, so two owners agreeing is one `==`.
+
+The equality is not vacuous. An owner whose stream this repo cannot read
+carries a lower evidence ceiling, so an `omo-runtime` `full_tests_passed`
+normalizes to `unmapped_source_event` rather than `tests_passed`. That run gets
+a different summary, with an evidence gap counted where a verification would
+otherwise have been claimed. That is the correct answer, not a gap to close by
+guessing.
+
+**Three absences, and none of them is a number.** Every metric is a
+`{state, value, reason}` triple:
+
+| state | meaning | value |
+| --- | --- | --- |
+| `observed` | both bounds were observed, with clocks | the number, possibly a genuine `0` |
+| `unknown` | the EVENT that bounds the metric was never observed | `null`, plus the reason |
+| `unavailable` | the event was observed but carried no clock | `null`, plus the reason |
+
+A phase nothing later closed stays `unknown`. Closing it with the observation
+instant is the one estimate a projection like this is tempted to make, and it
+would turn an in-flight run into a measured one. Nothing substitutes the
+observation instant, the last event, or a neighbouring phase for a bound it did
+not observe — for the same reason an absent token count on the board renders
+`unknown` and never `0`.
+
+A run with nothing observed reports every metric as `unknown`, not `0` retries
+and `0` evidence gaps. Zero retries is an observation; nobody made it.
+
+**No efficiency claim without two names.** `efficiency_claim.direction` may be
+`unclaimed`, `improved`, `regressed`, or `unchanged`, and anything other than
+`unclaimed` requires both a named `baseline_ref` and a named `evaluator_ref`.
+The rule is enforced twice: the parser refuses to build such a payload, and
+`validate_run_health_summary` refuses to read one back, so a hand-edited record
+claiming "faster" with nobody named is rejected rather than rendered. `gate` is
+derived from the two refs, so it cannot be hand-set to agree with the claim.
+
+**Deterministic.** The module reads no clock. The observation instant arrives
+as `observed_at_ms` on the input, and `health_digest` excludes it along with
+every field derived from it (`idle_duration_ms`, `staleness`), so comparing two
+runs' health never turns into comparing two wall clocks. The validator
+re-derives every metric, the staleness verdict, the claim gate, the owner
+attribution, and the digest from the stored observations.
+
 ## Boundary
 
 A status board is observed activity metadata. It is not result, verification,
@@ -325,3 +414,9 @@ external effect, and it proves nothing about any other effect.
 A language diagnostic record is narrower again: it is one language-diagnostic
 check over one workspace revision interval. A clean result means no new
 diagnostics were observed in that check, and nothing more.
+
+A run health summary is narrow in a different direction: it explains observed
+events and settles none of them. It is metadata-only observation, not execution,
+verification, review, CI, merge-readiness, or merge evidence, and an `improved`
+efficiency claim on one is a comparison a named evaluator made against a named
+baseline — not a measurement OMH performed.

--- a/src/coding/context_safety.py
+++ b/src/coding/context_safety.py
@@ -331,8 +331,14 @@ def coding_progress_policy_enforcement() -> dict[str, object]:
         # the number of observed units. `omh goal board` is the same shape one
         # level up: polled while waiting on a multi-part goal, and capped the
         # same way.
+        #
+        # `omh runtime health-summary` is the same shape of temptation -- an
+        # agent asks "is this run stuck yet" repeatedly -- and caps its own
+        # output at `run_health.MAX_RUN_HEALTH_EVENTS` observations plus a fixed
+        # metric set, so a longer run does not buy a longer answer.
         "bounded_surfaces": [
             "omh runtime show",
+            "omh runtime health-summary",
             "omh coding fanout show",
             "omh coding fanout brief",
             "omh coding status-board",

--- a/src/commands/run_health.py
+++ b/src/commands/run_health.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from ..installer import OmhError
+from ..runtime.run_health import (
+    build_run_health_summary,
+    parse_run_health_input,
+    render_run_health_summary_text,
+    validate_run_health_summary,
+)
+from .common import _print_json, _wants_json
+
+
+def cmd_runtime_health_summary(args: argparse.Namespace) -> int:
+    try:
+        raw = json.loads(Path(args.input).expanduser().read_text(encoding="utf-8"))
+        summary = build_run_health_summary(parse_run_health_input(raw))
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    # A projection this surface just built should never fail its own validator.
+    # Checking anyway is what keeps the read path and the write path from
+    # drifting: the CLI refuses to render a summary it could not read back.
+    errors = validate_run_health_summary(summary)
+    if errors:
+        raise OmhError("; ".join(errors))
+    if _wants_json(args):
+        _print_json(summary)
+        return 0
+    print(render_run_health_summary_text(summary))
+    return 0
+
+
+def add_runtime_health_summary_command(runtime_sub: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    health = runtime_sub.add_parser(
+        "health-summary",
+        help="Explain one run's health in owner-neutral terms from normalized progress events.",
+    )
+    health.add_argument("--input", required=True, help="Path to a run_health_input/v1 JSON file.")
+    health.add_argument("--json", action="store_true", help="Emit the machine payload instead of plain text.")
+    health.set_defaults(func=cmd_runtime_health_summary)

--- a/src/commands/runtime.py
+++ b/src/commands/runtime.py
@@ -1060,6 +1060,7 @@ def _bounded_limit(args: argparse.Namespace) -> int | None:
 
 def _add_runtime_commands(sub) -> None:
     from .run_efficiency import add_runtime_efficiency_command
+    from .run_health import add_runtime_health_summary_command
 
     runtime = sub.add_parser("runtime", help="Read and record local prepared-vs-observed runtime evidence.")
     runtime_sub = runtime.add_subparsers(dest="runtime_command", required=True)
@@ -1068,6 +1069,7 @@ def _add_runtime_commands(sub) -> None:
     runtime_status.set_defaults(func=cmd_runtime_status)
 
     add_runtime_efficiency_command(runtime_sub)
+    add_runtime_health_summary_command(runtime_sub)
 
     runtime_runs = runtime_sub.add_parser("runs")
     runtime_runs.add_argument("--limit", type=int, default=50, help="Maximum recent runs to return. Use --all for an unbounded listing.")

--- a/src/runtime/run_health.py
+++ b/src/runtime/run_health.py
@@ -1,0 +1,873 @@
+"""Owner-neutral run health projection (`run_health_summary/v1`).
+
+A progress story says WHAT happened. It does not say why a run is slow, stale,
+retrying, or missing the evidence that would settle it -- and every coding owner
+narrates that in its own words, so the same unhealthy run reads differently
+depending on who was executing it. This module is the one answer shape.
+
+It projects health over NORMALIZED progress events
+(`coding.owner_progress_normalization`), never over raw per-owner event shapes.
+That is the entire mechanism behind "the same normalized events produce the same
+health summary across supported coding owners": a codex run narrating
+`dispatch_to_executor / item.completed / turn.completed` and a Claude Code run
+narrating `system / assistant / result` normalize to the same three words, so
+they project byte-identical summaries apart from `owner_attribution`.
+`health_digest` makes that equality one comparison instead of a field-by-field
+walk.
+
+The equality is not vacuous. An owner whose stream this repo cannot read carries
+a lower evidence ceiling, so its `full_tests_passed` normalizes to
+`unmapped_source_event` rather than `tests_passed`; the resulting summary
+differs, and it should.
+
+Boundaries, in order of importance:
+
+- Three distinct absences, never an estimate. Every metric is a
+  `{state, value, reason}` triple, and only `observed` carries a number.
+  `unknown` means the EVENT that bounds the metric was never observed.
+  `unavailable` means the event was observed but carried no clock, so the value
+  cannot be measured. A genuine `0` -- no retries, or two boundary events
+  sharing a millisecond -- is `observed` with value `0` and is therefore
+  distinguishable from both. Nothing here ever substitutes `observed_at_ms`, the
+  last event, or a neighbouring phase for a boundary it did not observe: a
+  plausible number is worse than an honest absence, because only the absence can
+  be noticed.
+- No clock read. This module imports nothing that can tell the time. The
+  observation instant arrives as `observed_at_ms` on the input, so the same
+  input always projects a byte-identical summary. `health_digest` additionally
+  excludes every now-dependent field (`_DIGEST_EXCLUDED_TOP_LEVEL`,
+  `_DIGEST_EXCLUDED_METRICS`), so comparing two runs' health never turns into
+  comparing two wall clocks.
+- Metadata-only, and reporting only. A summary carries normalized event names,
+  integers, and closed vocabulary words. It never carries prompts, tool output,
+  file contents, secrets, or user text. It is not execution, verification,
+  review, CI, merge-readiness, or merge evidence.
+- No efficiency claim without a named baseline AND a named evaluator. A
+  comparative `direction` is refused at parse time and again by
+  `validate_run_health_summary`, so a payload asserting "faster" with nobody
+  named cannot be built and cannot be read back. `gate` is derived from the two
+  refs rather than declared, so it cannot be hand-set to agree with itself.
+- Refuse a hand-edited record rather than render it.
+  `validate_run_health_summary` checks the key set in both directions and
+  re-derives every metric, the staleness verdict, the claim gate, the owner
+  attribution, and the digest from `observations`. A record whose numbers were
+  edited to look healthier fails; it is not shown.
+
+Reading a summary (`run_health_summary/v1`)
+-------------------------------------------
+
+    run_id                  which run this is about
+    owner_attribution       who owned the coding work, whether that owner has a
+                            progress lane, and the evidence ceiling its stream
+                            can carry -- the ONLY owner-dependent block, and the
+                            only one excluded from `health_digest`
+    observed_at_ms          the caller's observation instant; the freshness
+                            anchor, and the only now-dependent input
+    observations            the normalized event stream with its clocks, in
+                            observed order -- everything below is derived from
+                            this and nothing else
+    metrics                 the closed metric set, each a state/value/reason
+    staleness               fresh | stale | unknown | unavailable
+    staleness_threshold_ms  the line `staleness` was drawn at
+    efficiency_claim        direction, baseline_ref, evaluator_ref, derived gate
+    health_digest           the owner-independent, now-independent fingerprint
+    claim_boundary          what the summary is not
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import hashlib
+import json
+import re
+from typing import Any, Final
+
+from ..coding.owner_progress_normalization import (
+    NORMALIZED_PROGRESS_EVENT_TYPES,
+    UNMAPPED_NORMALIZED_EVENT,
+    normalize_owner_progress_event,
+    owner_evidence_ceiling,
+)
+from ..system.metadata_safety import require_opaque_metadata_ref
+
+
+RUN_HEALTH_INPUT_SCHEMA_VERSION: Final[str] = "run_health_input/v1"
+RUN_HEALTH_SUMMARY_SCHEMA_VERSION: Final[str] = "run_health_summary/v1"
+
+RUN_HEALTH_CLAIM_BOUNDARY: Final[str] = (
+    "A run health summary is an OMH-local projection over normalized owner progress events. It is "
+    "metadata-only observation, not execution, verification, review, CI, merge-readiness, or merge "
+    "evidence, and it never asserts an efficiency improvement without a named baseline and a named "
+    "evaluator."
+)
+
+# A phase is a POSITION in the run, not a bucket of similar-sounding words.
+# Verification is split in two because "the tests started" and "the tests
+# reported" are different positions, and a `tests_started` observed after a
+# `tests_failed` is the canonical retry -- a single verification phase could not
+# see it move backwards.
+RUN_HEALTH_PHASES: Final[tuple[str, ...]] = (
+    "dispatch",
+    "execution",
+    "verification_started",
+    "verification_outcome",
+    "completion",
+)
+
+# Where each normalized event places the run. `unmapped_source_event` is
+# deliberately absent: a word this repo could not translate must not define a
+# phase boundary, count as a retry, or close somebody else's phase. It is
+# counted as an evidence gap instead, which is what it is.
+_PHASE_BY_NORMALIZED_EVENT: Final[dict[str, str]] = {
+    "executor_dispatched": "dispatch",
+    "repo_exploration": "execution",
+    "running_no_diff_observed": "execution",
+    "diff_started": "execution",
+    "progress_observed": "execution",
+    "reported_change_not_observed": "execution",
+    "tests_started": "verification_started",
+    "tests_passed": "verification_outcome",
+    "tests_failed": "verification_outcome",
+    "executor_completed": "completion",
+    "executor_blocked": "completion",
+    "executor_failed": "completion",
+}
+
+# Only phases that a LATER phase can close get a duration. `verification_outcome`
+# and `completion` are instants that close earlier phases rather than spans of
+# their own, so inventing a duration for them would mean inventing an end.
+_PHASE_DURATION_METRIC: Final[dict[str, str]] = {
+    "dispatch": "dispatch_phase_duration_ms",
+    "execution": "execution_phase_duration_ms",
+    "verification_started": "verification_phase_duration_ms",
+}
+
+# Ascending severity. `failure_class` is the highest-severity class observed, so
+# a run that failed its tests and then reported the executor as failed reports
+# the terminal failure rather than whichever event happened to come last.
+RUN_HEALTH_FAILURE_CLASSES: Final[tuple[str, ...]] = (
+    "no_failure_observed",
+    "claim_not_corroborated",
+    "executor_blocked",
+    "verification_failed",
+    "executor_failed",
+)
+
+_FAILURE_CLASS_BY_NORMALIZED_EVENT: Final[dict[str, str]] = {
+    "reported_change_not_observed": "claim_not_corroborated",
+    "executor_blocked": "executor_blocked",
+    "tests_failed": "verification_failed",
+    "executor_failed": "executor_failed",
+}
+
+RUN_HEALTH_METRIC_STATES: Final[tuple[str, ...]] = ("observed", "unavailable", "unknown")
+
+# The bounding EVENT was never observed. Nothing on this list is fixable by a
+# better clock.
+_UNKNOWN_REASONS: Final[tuple[str, ...]] = (
+    "no_observed_events",
+    "fewer_than_two_observed_events",
+    "phase_not_observed",
+    "phase_not_closed_by_a_later_observed_phase",
+    "observed_at_ms_precedes_the_last_observed_event",
+)
+
+# The event WAS observed and carried no clock. Nothing on this list is fixable
+# by observing more events.
+_UNAVAILABLE_REASONS: Final[tuple[str, ...]] = ("boundary_event_carried_no_timestamp",)
+
+RUN_HEALTH_METRIC_REASONS: Final[tuple[str, ...]] = ("", *_UNKNOWN_REASONS, *_UNAVAILABLE_REASONS)
+
+# Metric name -> value kind. The kind is what makes a mixed metric set safely
+# validatable: a duration and a count are both nonnegative integers, a failure
+# class is one closed word, and nothing else is accepted in a value slot.
+RUN_HEALTH_METRIC_KINDS: Final[dict[str, str]] = {
+    "dispatch_phase_duration_ms": "duration_ms",
+    "evidence_gap_count": "count",
+    "execution_phase_duration_ms": "duration_ms",
+    "failure_class": "failure_class",
+    "idle_duration_ms": "duration_ms",
+    "retry_count": "count",
+    "total_duration_ms": "duration_ms",
+    "unobserved_phase_count": "count",
+    "verification_phase_duration_ms": "duration_ms",
+}
+
+RUN_HEALTH_METRICS: Final[tuple[str, ...]] = tuple(sorted(RUN_HEALTH_METRIC_KINDS))
+
+RUN_HEALTH_STALENESS_STATES: Final[tuple[str, ...]] = ("fresh", "stale", "unavailable", "unknown")
+
+# Five minutes. A run that has said nothing for longer is reported stale; the
+# threshold ships inside the summary so a reader never has to guess which line
+# the verdict was drawn at.
+RUN_HEALTH_STALENESS_THRESHOLD_MS: Final[int] = 300_000
+
+RUN_HEALTH_EFFICIENCY_DIRECTIONS: Final[tuple[str, ...]] = ("unclaimed", "improved", "regressed", "unchanged")
+
+RUN_HEALTH_EFFICIENCY_GATES: Final[tuple[str, ...]] = (
+    "named_baseline_and_evaluator",
+    "no_named_baseline_and_evaluator",
+)
+
+# Bounds. A health summary is a bounded projection an agent may poll, so the
+# event list is capped rather than left to grow with the run.
+MAX_RUN_HEALTH_EVENTS: Final[int] = 100
+MAX_RUN_HEALTH_REF_CHARS: Final[int] = 120
+
+_RUN_ID = re.compile(r"^[A-Za-z0-9_.:-]{1,120}$")
+
+_INPUT_KEYS: Final[frozenset[str]] = frozenset(
+    {"schema_version", "run_id", "owner", "observed_at_ms", "events", "efficiency_claim"}
+)
+_INPUT_EVENT_KEYS: Final[frozenset[str]] = frozenset({"source_event", "at_ms"})
+_INPUT_CLAIM_KEYS: Final[frozenset[str]] = frozenset({"direction", "baseline_ref", "evaluator_ref"})
+
+_SUMMARY_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "schema_version",
+        "run_id",
+        "owner_attribution",
+        "observed_at_ms",
+        "observations",
+        "metrics",
+        "staleness",
+        "staleness_threshold_ms",
+        "efficiency_claim",
+        "health_digest",
+        "claim_boundary",
+    }
+)
+_ATTRIBUTION_KEYS: Final[frozenset[str]] = frozenset({"owner", "owner_supported", "evidence_ceiling"})
+_OBSERVATION_KEYS: Final[frozenset[str]] = frozenset({"normalized_event", "at_ms"})
+_METRIC_KEYS: Final[frozenset[str]] = frozenset({"state", "value", "reason"})
+_SUMMARY_CLAIM_KEYS: Final[frozenset[str]] = frozenset({"direction", "baseline_ref", "evaluator_ref", "gate"})
+
+# What `health_digest` refuses to fingerprint. `owner_attribution` is excluded so
+# two owners producing the same normalized stream produce the same digest --
+# that IS the cross-owner guarantee. The rest are the now-dependent fields; a
+# digest that moved with the wall clock could never compare two runs.
+_DIGEST_EXCLUDED_TOP_LEVEL: Final[tuple[str, ...]] = (
+    "owner_attribution",
+    "observed_at_ms",
+    "staleness",
+    "health_digest",
+)
+_DIGEST_EXCLUDED_METRICS: Final[tuple[str, ...]] = ("idle_duration_ms",)
+
+
+@dataclass(frozen=True)
+class RunHealthEvent:
+    """One owner-narrated event, as supplied: the raw word and its clock, if any.
+
+    `at_ms` is `None` when the event was observed without a clock. That is a
+    different fact from "the event was never observed", and the metric states
+    keep them apart.
+    """
+
+    source_event: str
+    at_ms: int | None
+
+
+@dataclass(frozen=True)
+class RunHealthEfficiencyClaim:
+    direction: str
+    baseline_ref: str
+    evaluator_ref: str
+
+
+@dataclass(frozen=True)
+class RunHealthInput:
+    run_id: str
+    owner: str
+    observed_at_ms: int
+    events: tuple[RunHealthEvent, ...]
+    efficiency_claim: RunHealthEfficiencyClaim
+
+
+def unphased_normalized_events() -> tuple[str, ...]:
+    """Normalized vocabulary words this module places nowhere in the run.
+
+    Exists so adding a word to `NORMALIZED_PROGRESS_EVENT_TYPES` without giving
+    it a phase fails a test instead of silently becoming invisible to every
+    phase duration, retry count, and completeness count here. The only correct
+    answer is `unmapped_source_event`.
+    """
+    return tuple(sorted(set(NORMALIZED_PROGRESS_EVENT_TYPES) - set(_PHASE_BY_NORMALIZED_EVENT)))
+
+
+def parse_run_health_input(raw: object) -> RunHealthInput:
+    """Parse a `run_health_input/v1` payload, or raise `ValueError`.
+
+    The AC3 gate lives here as well as in the validator: a comparative
+    `direction` without both a named baseline and a named evaluator is refused
+    before a summary exists, so there is no code path that builds one.
+    """
+    if not isinstance(raw, dict) or set(raw) != _INPUT_KEYS:
+        raise ValueError("run health input must use the exact run_health_input/v1 fields")
+    if raw.get("schema_version") != RUN_HEALTH_INPUT_SCHEMA_VERSION:
+        raise ValueError("unsupported run health input schema")
+    run_id = _required_run_id(raw.get("run_id"))
+    owner = require_opaque_metadata_ref(raw.get("owner"), field="owner")
+    observed_at_ms = _nonnegative_int(raw.get("observed_at_ms"), "observed_at_ms")
+    events = _parse_events(raw.get("events"))
+    latest = _latest_event_clock(events)
+    if latest is not None and observed_at_ms < latest:
+        raise ValueError("observed_at_ms must not precede the last observed event timestamp")
+    claim = _parse_efficiency_claim(raw.get("efficiency_claim"))
+    return RunHealthInput(run_id, owner, observed_at_ms, events, claim)
+
+
+def build_run_health_summary(value: RunHealthInput) -> dict[str, object]:
+    """Project one `run_health_summary/v1` record. Pure: no clock, no I/O."""
+    attribution = owner_attribution(value.owner)
+    observations = tuple(
+        {
+            "normalized_event": str(
+                normalize_owner_progress_event(value.owner, event.source_event)["normalized_event"]
+            ),
+            "at_ms": event.at_ms,
+        }
+        for event in value.events
+    )
+    metrics = _derive_metrics(observations, observed_at_ms=value.observed_at_ms)
+    summary: dict[str, object] = {
+        "schema_version": RUN_HEALTH_SUMMARY_SCHEMA_VERSION,
+        "run_id": value.run_id,
+        "owner_attribution": attribution,
+        "observed_at_ms": value.observed_at_ms,
+        "observations": [dict(observation) for observation in observations],
+        "metrics": metrics,
+        "staleness": derive_staleness(metrics["idle_duration_ms"]),
+        "staleness_threshold_ms": RUN_HEALTH_STALENESS_THRESHOLD_MS,
+        "efficiency_claim": {
+            "direction": value.efficiency_claim.direction,
+            "baseline_ref": value.efficiency_claim.baseline_ref,
+            "evaluator_ref": value.efficiency_claim.evaluator_ref,
+            "gate": efficiency_claim_gate(
+                baseline_ref=value.efficiency_claim.baseline_ref,
+                evaluator_ref=value.efficiency_claim.evaluator_ref,
+            ),
+        },
+        "health_digest": "",
+        "claim_boundary": RUN_HEALTH_CLAIM_BOUNDARY,
+    }
+    summary["health_digest"] = run_health_digest(summary)
+    return summary
+
+
+def owner_attribution(owner: str) -> dict[str, object]:
+    """Fold the owner name and record what its stream can carry.
+
+    Derived through `normalize_owner_progress_event` with no source word so the
+    alias folding and the `owner_supported` verdict come from the normalization
+    module rather than from a second copy of its owner table here.
+    """
+    probe = normalize_owner_progress_event(owner, "")
+    label = str(probe["owner"])
+    return {
+        "owner": label,
+        "owner_supported": bool(probe["owner_supported"]),
+        "evidence_ceiling": owner_evidence_ceiling(label),
+    }
+
+
+def efficiency_claim_gate(*, baseline_ref: str, evaluator_ref: str) -> str:
+    """Derived, never declared: both refs named, or the gate is shut."""
+    if baseline_ref and evaluator_ref:
+        return "named_baseline_and_evaluator"
+    return "no_named_baseline_and_evaluator"
+
+
+def derive_staleness(idle_metric: Mapping[str, Any]) -> str:
+    """The freshness verdict, carried over from the idle metric's own state."""
+    state = idle_metric.get("state")
+    value = idle_metric.get("value")
+    if state == "unavailable":
+        return "unavailable"
+    if state != "observed" or not isinstance(value, int) or isinstance(value, bool):
+        return "unknown"
+    return "stale" if value > RUN_HEALTH_STALENESS_THRESHOLD_MS else "fresh"
+
+
+def run_health_digest(payload: Mapping[str, Any]) -> str:
+    """Fingerprint the owner-independent, now-independent health facts."""
+    seed = {key: value for key, value in payload.items() if key not in _DIGEST_EXCLUDED_TOP_LEVEL}
+    metrics = seed.get("metrics")
+    if isinstance(metrics, dict):
+        seed["metrics"] = {key: value for key, value in metrics.items() if key not in _DIGEST_EXCLUDED_METRICS}
+    encoded = json.dumps(seed, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()[:32]
+
+
+def validate_run_health_summary(payload: object) -> list[str]:
+    """Every reason this payload is not a `run_health_summary/v1` record.
+
+    Checks the key set in both directions and re-derives everything derivable,
+    so a record whose numbers were edited to read healthier is refused rather
+    than rendered.
+    """
+    if not isinstance(payload, dict):
+        return ["run_health_summary must be an object"]
+    key_errors = _key_set_errors(payload, _SUMMARY_KEYS, "run_health_summary")
+    if key_errors:
+        return key_errors
+
+    errors: list[str] = []
+    if payload.get("schema_version") != RUN_HEALTH_SUMMARY_SCHEMA_VERSION:
+        errors.append("run_health_summary.schema_version must be run_health_summary/v1")
+    if payload.get("claim_boundary") != RUN_HEALTH_CLAIM_BOUNDARY:
+        errors.append("run_health_summary.claim_boundary must be the declared boundary text")
+    if payload.get("staleness_threshold_ms") != RUN_HEALTH_STALENESS_THRESHOLD_MS:
+        errors.append("run_health_summary.staleness_threshold_ms must match the declared threshold")
+    if not _is_run_id(payload.get("run_id")):
+        errors.append("run_health_summary.run_id must contain 1 to 120 safe identifier characters")
+
+    errors.extend(_attribution_errors(payload.get("owner_attribution")))
+
+    observed_at_ms = payload.get("observed_at_ms")
+    if not _is_nonnegative_int(observed_at_ms):
+        errors.append("run_health_summary.observed_at_ms must be a nonnegative integer")
+        observed_at_ms = None
+
+    observations, observation_errors = _read_observations(payload.get("observations"))
+    errors.extend(observation_errors)
+
+    metric_shape_errors = _metric_shape_errors(payload.get("metrics"))
+    errors.extend(metric_shape_errors)
+    errors.extend(_efficiency_claim_errors(payload.get("efficiency_claim")))
+
+    if observations is not None and isinstance(observed_at_ms, int):
+        latest = _latest_observation_clock(observations)
+        if latest is not None and observed_at_ms < latest:
+            errors.append("run_health_summary.observed_at_ms must not precede the last observed event timestamp")
+        if not metric_shape_errors:
+            errors.extend(_rederivation_errors(payload, observations, observed_at_ms))
+
+    if payload.get("health_digest") != run_health_digest(payload):
+        errors.append("run_health_summary.health_digest must match the derived health digest")
+    return errors
+
+
+def render_run_health_summary_text(payload: Mapping[str, Any]) -> str:
+    """Plain-language rendering of one summary; the default CLI output.
+
+    Absent metrics render as the state word plus its reason, never as a number
+    and never as a blank, so a reader of the text surface learns the same three
+    absences the JSON surface carries.
+    """
+    metrics = payload.get("metrics")
+    metrics = metrics if isinstance(metrics, dict) else {}
+    attribution = payload.get("owner_attribution")
+    attribution = attribution if isinstance(attribution, dict) else {}
+    claim = payload.get("efficiency_claim")
+    claim = claim if isinstance(claim, dict) else {}
+    observations = payload.get("observations")
+    observations = observations if isinstance(observations, list) else []
+
+    lane = "yes" if attribution.get("owner_supported") else "no"
+    lines = [
+        "Run health summary (OMH projection)",
+        f"Run: {payload.get('run_id', '')}",
+        f"Owner: {attribution.get('owner', '')} (progress lane: {lane}, "
+        f"evidence ceiling: {attribution.get('evidence_ceiling', '')})",
+        f"Observed events: {len(observations)} (observed at {payload.get('observed_at_ms', '')} ms)",
+        f"Freshness: {payload.get('staleness', '')} "
+        f"(idle {_metric_text(metrics.get('idle_duration_ms'), unit='ms')}, "
+        f"stale after {payload.get('staleness_threshold_ms', '')} ms)",
+        f"Failure class: {_metric_text(metrics.get('failure_class'))}",
+        f"Total duration: {_metric_text(metrics.get('total_duration_ms'), unit='ms')}",
+        "Phase durations:",
+    ]
+    for phase in RUN_HEALTH_PHASES:
+        metric_name = _PHASE_DURATION_METRIC.get(phase)
+        if metric_name is None:
+            continue
+        label = metric_name.removesuffix("_phase_duration_ms")
+        lines.append(f"- {label}: {_metric_text(metrics.get(metric_name), unit='ms')}")
+    lines.append("Counts:")
+    lines.append(f"- retries: {_metric_text(metrics.get('retry_count'))}")
+    lines.append(f"- evidence gaps: {_metric_text(metrics.get('evidence_gap_count'))}")
+    lines.append(f"- unobserved phases: {_metric_text(metrics.get('unobserved_phase_count'))}")
+    lines.append(
+        f"Efficiency claim: {claim.get('direction', '')} "
+        f"(baseline: {claim.get('baseline_ref', '') or 'none'}, "
+        f"evaluator: {claim.get('evaluator_ref', '') or 'none'}, gate: {claim.get('gate', '')})"
+    )
+    lines.append(f"Boundary: {payload.get('claim_boundary', '')}")
+    lines.append("For machine-readable output, rerun with `--json`.")
+    return "\n".join(lines)
+
+
+def _metric_text(metric: object, *, unit: str = "") -> str:
+    """One metric as a person reads it: a number with its unit, or the absence and why."""
+    if not isinstance(metric, Mapping):
+        return "unknown"
+    if metric.get("state") != "observed":
+        return f"{metric.get('state', 'unknown')} ({metric.get('reason', '')})"
+    value = str(metric.get("value"))
+    return f"{value} {unit}" if unit else value
+
+
+def _observed_metric(value: int | str) -> dict[str, object]:
+    return {"state": "observed", "value": value, "reason": ""}
+
+
+def _unknown_metric(reason: str) -> dict[str, object]:
+    return {"state": "unknown", "value": None, "reason": reason}
+
+
+def _unavailable_metric(reason: str) -> dict[str, object]:
+    return {"state": "unavailable", "value": None, "reason": reason}
+
+
+def _derive_metrics(
+    observations: Sequence[Mapping[str, Any]],
+    *,
+    observed_at_ms: int,
+) -> dict[str, object]:
+    """Every metric, from the normalized observations and nothing else.
+
+    With nothing observed, every metric is `unknown`. Reporting `0` retries or
+    `0` evidence gaps for a run nobody watched would read as an observation that
+    the run had none.
+    """
+    if not observations:
+        return {name: _unknown_metric("no_observed_events") for name in RUN_HEALTH_METRICS}
+    metrics: dict[str, object] = {
+        "total_duration_ms": _total_duration(observations),
+        "idle_duration_ms": _idle_duration(observations, observed_at_ms=observed_at_ms),
+        "retry_count": _observed_metric(_retry_count(observations)),
+        "evidence_gap_count": _observed_metric(_evidence_gap_count(observations)),
+        "unobserved_phase_count": _observed_metric(_unobserved_phase_count(observations)),
+        "failure_class": _observed_metric(_failure_class(observations)),
+    }
+    for phase, metric_name in _PHASE_DURATION_METRIC.items():
+        metrics[metric_name] = _phase_duration(observations, phase)
+    return {name: metrics[name] for name in RUN_HEALTH_METRICS}
+
+
+def _total_duration(observations: Sequence[Mapping[str, Any]]) -> dict[str, object]:
+    if len(observations) < 2:
+        return _unknown_metric("fewer_than_two_observed_events")
+    return _span(observations[0].get("at_ms"), observations[-1].get("at_ms"))
+
+
+def _idle_duration(observations: Sequence[Mapping[str, Any]], *, observed_at_ms: int) -> dict[str, object]:
+    last = observations[-1].get("at_ms")
+    if not _is_nonnegative_int(last):
+        return _unavailable_metric("boundary_event_carried_no_timestamp")
+    if observed_at_ms < int(last):
+        return _unknown_metric("observed_at_ms_precedes_the_last_observed_event")
+    return _observed_metric(observed_at_ms - int(last))
+
+
+def _phase_duration(observations: Sequence[Mapping[str, Any]], phase: str) -> dict[str, object]:
+    """From the first event at this phase to the first LATER-phase event after it.
+
+    An unclosed phase stays `unknown`. Closing it with `observed_at_ms` or with
+    the last observed event would answer "how long did this phase take" with a
+    number nobody observed.
+    """
+    rank = RUN_HEALTH_PHASES.index(phase)
+    opened_at: int | None = None
+    opened_index: int | None = None
+    for index, observation in enumerate(observations):
+        if _phase_rank(observation) == rank:
+            opened_index = index
+            opened_at = observation.get("at_ms") if _is_nonnegative_int(observation.get("at_ms")) else None
+            break
+    if opened_index is None:
+        return _unknown_metric("phase_not_observed")
+    for observation in observations[opened_index + 1 :]:
+        observed_rank = _phase_rank(observation)
+        if observed_rank is not None and observed_rank > rank:
+            return _span(opened_at, observation.get("at_ms"))
+    return _unknown_metric("phase_not_closed_by_a_later_observed_phase")
+
+
+def _span(start: object, end: object) -> dict[str, object]:
+    if not _is_nonnegative_int(start) or not _is_nonnegative_int(end):
+        return _unavailable_metric("boundary_event_carried_no_timestamp")
+    return _observed_metric(int(end) - int(start))
+
+
+def _retry_count(observations: Sequence[Mapping[str, Any]]) -> int:
+    """Events that move the run backwards through the phase order.
+
+    A `tests_started` after a `tests_failed` is the canonical case; so is a
+    `diff_started` after the executor already reported completion.
+    """
+    furthest = -1
+    retries = 0
+    for observation in observations:
+        rank = _phase_rank(observation)
+        if rank is None:
+            continue
+        if rank < furthest:
+            retries += 1
+        else:
+            furthest = rank
+    return retries
+
+
+def _evidence_gap_count(observations: Sequence[Mapping[str, Any]]) -> int:
+    return sum(1 for observation in observations if observation.get("normalized_event") == UNMAPPED_NORMALIZED_EVENT)
+
+
+def _unobserved_phase_count(observations: Sequence[Mapping[str, Any]]) -> int:
+    observed = {_phase_rank(observation) for observation in observations}
+    return sum(1 for rank in range(len(RUN_HEALTH_PHASES)) if rank not in observed)
+
+
+def _failure_class(observations: Sequence[Mapping[str, Any]]) -> str:
+    worst = "no_failure_observed"
+    for observation in observations:
+        candidate = _FAILURE_CLASS_BY_NORMALIZED_EVENT.get(str(observation.get("normalized_event")))
+        if candidate is None:
+            continue
+        if RUN_HEALTH_FAILURE_CLASSES.index(candidate) > RUN_HEALTH_FAILURE_CLASSES.index(worst):
+            worst = candidate
+    return worst
+
+
+def _phase_rank(observation: Mapping[str, Any]) -> int | None:
+    phase = _PHASE_BY_NORMALIZED_EVENT.get(str(observation.get("normalized_event")))
+    if phase is None:
+        return None
+    return RUN_HEALTH_PHASES.index(phase)
+
+
+def _parse_events(raw: object) -> tuple[RunHealthEvent, ...]:
+    if not isinstance(raw, list):
+        raise ValueError("run health events must be a list")
+    if len(raw) > MAX_RUN_HEALTH_EVENTS:
+        raise ValueError(f"run health events must contain at most {MAX_RUN_HEALTH_EVENTS} items")
+    events: list[RunHealthEvent] = []
+    previous: int | None = None
+    for item in raw:
+        if not isinstance(item, dict) or set(item) != _INPUT_EVENT_KEYS:
+            raise ValueError("run health event must use exactly source_event and at_ms")
+        source_event = require_opaque_metadata_ref(item.get("source_event"), field="run health event source_event")
+        at_ms = item.get("at_ms")
+        if at_ms is not None:
+            if not _is_nonnegative_int(at_ms):
+                raise ValueError("run health event at_ms must be a nonnegative integer or null")
+            if previous is not None and int(at_ms) < previous:
+                raise ValueError("run health event timestamps must not move backwards")
+            previous = int(at_ms)
+        events.append(RunHealthEvent(source_event, None if at_ms is None else int(at_ms)))
+    return tuple(events)
+
+
+def _parse_efficiency_claim(raw: object) -> RunHealthEfficiencyClaim:
+    if not isinstance(raw, dict) or set(raw) != _INPUT_CLAIM_KEYS:
+        raise ValueError("efficiency_claim must use exactly direction, baseline_ref, and evaluator_ref")
+    direction = raw.get("direction")
+    if direction not in RUN_HEALTH_EFFICIENCY_DIRECTIONS:
+        raise ValueError("efficiency_claim.direction is unsupported")
+    baseline_ref = _optional_ref(raw.get("baseline_ref"), "efficiency_claim.baseline_ref")
+    evaluator_ref = _optional_ref(raw.get("evaluator_ref"), "efficiency_claim.evaluator_ref")
+    if direction != "unclaimed" and not (baseline_ref and evaluator_ref):
+        raise ValueError(
+            "efficiency_claim.direction other than unclaimed requires a named baseline_ref and evaluator_ref"
+        )
+    return RunHealthEfficiencyClaim(str(direction), baseline_ref, evaluator_ref)
+
+
+def _optional_ref(value: object, field: str) -> str:
+    if value == "":
+        return ""
+    if not isinstance(value, str) or len(value) > MAX_RUN_HEALTH_REF_CHARS:
+        raise ValueError(f"{field} must be an empty string or a bounded opaque reference")
+    return require_opaque_metadata_ref(value, field=field)
+
+
+def _latest_event_clock(events: Sequence[RunHealthEvent]) -> int | None:
+    clocks = [event.at_ms for event in events if event.at_ms is not None]
+    return max(clocks) if clocks else None
+
+
+def _latest_observation_clock(observations: Sequence[Mapping[str, Any]]) -> int | None:
+    clocks = [
+        int(observation["at_ms"]) for observation in observations if _is_nonnegative_int(observation.get("at_ms"))
+    ]
+    return max(clocks) if clocks else None
+
+
+def _read_observations(raw: object) -> tuple[list[dict[str, Any]] | None, list[str]]:
+    label = "run_health_summary.observations"
+    if not isinstance(raw, list):
+        return None, [f"{label} must be a list"]
+    if len(raw) > MAX_RUN_HEALTH_EVENTS:
+        return None, [f"{label} must contain at most {MAX_RUN_HEALTH_EVENTS} items"]
+    errors: list[str] = []
+    observations: list[dict[str, Any]] = []
+    previous: int | None = None
+    for index, item in enumerate(raw):
+        item_label = f"{label}[{index}]"
+        if not isinstance(item, dict) or set(item) != _OBSERVATION_KEYS:
+            errors.append(f"{item_label} must use exactly normalized_event and at_ms")
+            continue
+        if item.get("normalized_event") not in NORMALIZED_PROGRESS_EVENT_TYPES:
+            errors.append(f"{item_label}.normalized_event is not in the normalized progress vocabulary")
+        at_ms = item.get("at_ms")
+        if at_ms is not None:
+            if not _is_nonnegative_int(at_ms):
+                errors.append(f"{item_label}.at_ms must be a nonnegative integer or null")
+            else:
+                if previous is not None and int(at_ms) < previous:
+                    errors.append(f"{item_label}.at_ms must not move backwards")
+                previous = int(at_ms)
+        observations.append(dict(item))
+    if errors:
+        return None, errors
+    return observations, errors
+
+
+def _attribution_errors(raw: object) -> list[str]:
+    label = "run_health_summary.owner_attribution"
+    if not isinstance(raw, dict):
+        return [f"{label} must be an object"]
+    key_errors = _key_set_errors(raw, _ATTRIBUTION_KEYS, label)
+    if key_errors:
+        return key_errors
+    owner = raw.get("owner")
+    if not isinstance(owner, str) or not owner:
+        return [f"{label}.owner must be a non-empty string"]
+    derived = owner_attribution(owner)
+    errors: list[str] = []
+    if derived["owner"] != owner:
+        errors.append(f"{label}.owner must already be the folded owner label")
+    if raw.get("owner_supported") is not derived["owner_supported"]:
+        errors.append(f"{label}.owner_supported must match the derived progress-lane verdict")
+    if raw.get("evidence_ceiling") != derived["evidence_ceiling"]:
+        errors.append(f"{label}.evidence_ceiling must match the owner's declared evidence ceiling")
+    return errors
+
+
+def _metric_shape_errors(raw: object) -> list[str]:
+    label = "run_health_summary.metrics"
+    if not isinstance(raw, dict):
+        return [f"{label} must be an object"]
+    key_errors = _key_set_errors(raw, frozenset(RUN_HEALTH_METRICS), label)
+    if key_errors:
+        return key_errors
+    errors: list[str] = []
+    for name in RUN_HEALTH_METRICS:
+        errors.extend(_single_metric_errors(raw.get(name), f"{label}.{name}", RUN_HEALTH_METRIC_KINDS[name]))
+    return errors
+
+
+def _single_metric_errors(raw: object, label: str, kind: str) -> list[str]:
+    if not isinstance(raw, dict):
+        return [f"{label} must be an object"]
+    key_errors = _key_set_errors(raw, _METRIC_KEYS, label)
+    if key_errors:
+        return key_errors
+    state = raw.get("state")
+    reason = raw.get("reason")
+    value = raw.get("value")
+    errors: list[str] = []
+    if state not in RUN_HEALTH_METRIC_STATES:
+        return [f"{label}.state must be one of {', '.join(RUN_HEALTH_METRIC_STATES)}"]
+    if state == "observed":
+        if reason != "":
+            errors.append(f"{label}.reason must be empty when the metric is observed")
+        errors.extend(_metric_value_errors(value, label, kind))
+    else:
+        if value is not None:
+            errors.append(f"{label}.value must be null unless the metric is observed")
+        allowed = _UNKNOWN_REASONS if state == "unknown" else _UNAVAILABLE_REASONS
+        if reason not in allowed:
+            errors.append(f"{label}.reason is not a declared {state} reason")
+    return errors
+
+
+def _metric_value_errors(value: object, label: str, kind: str) -> list[str]:
+    if kind == "failure_class":
+        if value not in RUN_HEALTH_FAILURE_CLASSES:
+            return [f"{label}.value must be a declared failure class"]
+        return []
+    if not _is_nonnegative_int(value):
+        return [f"{label}.value must be a nonnegative integer"]
+    return []
+
+
+def _efficiency_claim_errors(raw: object) -> list[str]:
+    label = "run_health_summary.efficiency_claim"
+    if not isinstance(raw, dict):
+        return [f"{label} must be an object"]
+    key_errors = _key_set_errors(raw, _SUMMARY_CLAIM_KEYS, label)
+    if key_errors:
+        return key_errors
+    errors: list[str] = []
+    direction = raw.get("direction")
+    baseline_ref = raw.get("baseline_ref")
+    evaluator_ref = raw.get("evaluator_ref")
+    if direction not in RUN_HEALTH_EFFICIENCY_DIRECTIONS:
+        errors.append(f"{label}.direction is unsupported")
+    for field, value in (("baseline_ref", baseline_ref), ("evaluator_ref", evaluator_ref)):
+        if not isinstance(value, str) or len(value) > MAX_RUN_HEALTH_REF_CHARS:
+            errors.append(f"{label}.{field} must be a bounded string")
+        elif value and not _is_opaque_ref(value):
+            errors.append(f"{label}.{field} must be a safe opaque metadata reference")
+    if not isinstance(baseline_ref, str) or not isinstance(evaluator_ref, str):
+        return errors
+    gate = efficiency_claim_gate(baseline_ref=baseline_ref, evaluator_ref=evaluator_ref)
+    if raw.get("gate") != gate:
+        errors.append(f"{label}.gate must be derived from baseline_ref and evaluator_ref")
+    if direction in RUN_HEALTH_EFFICIENCY_DIRECTIONS and direction != "unclaimed" and gate != "named_baseline_and_evaluator":
+        errors.append(f"{label}.direction other than unclaimed requires a named baseline_ref and evaluator_ref")
+    return errors
+
+
+def _rederivation_errors(
+    payload: Mapping[str, Any],
+    observations: Sequence[Mapping[str, Any]],
+    observed_at_ms: int,
+) -> list[str]:
+    derived = _derive_metrics(observations, observed_at_ms=observed_at_ms)
+    errors: list[str] = []
+    stored = payload.get("metrics")
+    if isinstance(stored, dict):
+        for name in RUN_HEALTH_METRICS:
+            if stored.get(name) != derived[name]:
+                errors.append(f"run_health_summary.metrics.{name} must match the value derived from observations")
+    if payload.get("staleness") != derive_staleness(derived["idle_duration_ms"]):
+        errors.append("run_health_summary.staleness must match the verdict derived from idle_duration_ms")
+    return errors
+
+
+def _key_set_errors(payload: Mapping[str, Any], allowed: frozenset[str], label: str) -> list[str]:
+    errors = [f"{label} has an unsupported key: {key}" for key in sorted(set(payload) - allowed)]
+    errors.extend(f"{label} is missing a required key: {key}" for key in sorted(allowed - set(payload)))
+    return errors
+
+
+def _required_run_id(value: object) -> str:
+    if not _is_run_id(value):
+        raise ValueError("run_id must contain 1 to 120 safe identifier characters")
+    return require_opaque_metadata_ref(value, field="run_id")
+
+
+def _is_run_id(value: object) -> bool:
+    return isinstance(value, str) and bool(_RUN_ID.fullmatch(value)) and _is_opaque_ref(value)
+
+
+def _is_opaque_ref(value: object) -> bool:
+    try:
+        require_opaque_metadata_ref(value, field="reference")
+    except ValueError:
+        return False
+    return True
+
+
+def _is_nonnegative_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def _nonnegative_int(value: object, field: str) -> int:
+    if not _is_nonnegative_int(value):
+        raise ValueError(f"{field} must be a nonnegative integer")
+    return int(value)

--- a/tests/test_run_health_summary.py
+++ b/tests/test_run_health_summary.py
@@ -1,0 +1,623 @@
+"""Contract for `run_health_summary/v1` (issue #834).
+
+One test class per acceptance criterion, plus the guards that keep each
+criterion from passing vacuously:
+
+- AC1 is a real differential. Two owners narrating in entirely different words
+  that normalize to the same stream must produce byte-identical summaries apart
+  from the owner attribution block. The counter-case -- an owner whose evidence
+  ceiling refuses one of those words -- must produce a DIFFERENT summary, or the
+  equality would only prove that the projection ignores its input.
+- AC2 needs three states to be genuinely three. A test that only checks
+  "unavailable exists" would pass on an implementation that never reports
+  `unknown` and never reports a real `0`.
+- AC3 is checked on both the write path (the parser) and the read path (the
+  validator), because a hand-edited record never goes through the parser.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.coding.context_safety import coding_progress_policy_enforcement  # noqa: E402
+from omh.coding.owner_progress_normalization import (  # noqa: E402
+    OWNERS_WITH_PROGRESS_LANE,
+    UNMAPPED_NORMALIZED_EVENT,
+)
+from omh.local_store import atomic_write_json  # noqa: E402
+from omh.runtime.run_health import (  # noqa: E402
+    MAX_RUN_HEALTH_EVENTS,
+    RUN_HEALTH_CLAIM_BOUNDARY,
+    RUN_HEALTH_METRICS,
+    RUN_HEALTH_STALENESS_THRESHOLD_MS,
+    RUN_HEALTH_SUMMARY_SCHEMA_VERSION,
+    build_run_health_summary,
+    parse_run_health_input,
+    render_run_health_summary_text,
+    run_health_digest,
+    unphased_normalized_events,
+    validate_run_health_summary,
+)
+
+
+def _input(
+    owner: str,
+    events: list[tuple[str, int | None]],
+    *,
+    observed_at_ms: int = 9_000,
+    run_id: str = "run-834",
+    direction: str = "unclaimed",
+    baseline_ref: str = "",
+    evaluator_ref: str = "",
+) -> dict[str, object]:
+    return {
+        "schema_version": "run_health_input/v1",
+        "run_id": run_id,
+        "owner": owner,
+        "observed_at_ms": observed_at_ms,
+        "events": [{"source_event": word, "at_ms": at_ms} for word, at_ms in events],
+        "efficiency_claim": {
+            "direction": direction,
+            "baseline_ref": baseline_ref,
+            "evaluator_ref": evaluator_ref,
+        },
+    }
+
+
+def _summary(owner: str, events: list[tuple[str, int | None]], **kwargs: object) -> dict[str, object]:
+    return build_run_health_summary(parse_run_health_input(_input(owner, events, **kwargs)))  # type: ignore[arg-type]
+
+
+def _without_owner(summary: dict[str, object]) -> dict[str, object]:
+    stripped = dict(summary)
+    stripped.pop("owner_attribution")
+    return stripped
+
+
+def _metric(summary: dict[str, object], name: str) -> dict[str, object]:
+    metrics = summary["metrics"]
+    assert isinstance(metrics, dict)
+    value = metrics[name]
+    assert isinstance(value, dict)
+    return value
+
+
+# The same three positions in the run, said in two owner-native dialects that
+# share no word: codex stream words on the left, Claude Code stream envelope
+# types on the right. Both normalize to
+# executor_dispatched / progress_observed / executor_completed.
+_CODEX_NATIVE = [("dispatch_to_executor", 1_000), ("item.completed", 1_500), ("turn.completed", 2_400)]
+_CLAUDE_NATIVE = [("system", 1_000), ("assistant", 1_500), ("result", 2_400)]
+
+
+class AcceptanceCriterionOneCrossOwnerTests(unittest.TestCase):
+    """AC1: the same normalized events produce the same health summary across owners."""
+
+    def test_two_owners_with_no_shared_source_word_produce_one_summary(self) -> None:
+        codex = _summary("codex", _CODEX_NATIVE)
+        claude = _summary("claude-code", _CLAUDE_NATIVE)
+
+        self.assertEqual(
+            [observation["normalized_event"] for observation in codex["observations"]],  # type: ignore[union-attr]
+            ["executor_dispatched", "progress_observed", "executor_completed"],
+        )
+        self.assertEqual(codex["observations"], claude["observations"])
+        self.assertEqual(codex["health_digest"], claude["health_digest"])
+        self.assertEqual(_without_owner(codex), _without_owner(claude))
+        self.assertEqual(codex["owner_attribution"], {"owner": "codex", "owner_supported": True, "evidence_ceiling": "verified"})
+        self.assertEqual(
+            claude["owner_attribution"],
+            {"owner": "claude-code", "owner_supported": True, "evidence_ceiling": "verified"},
+        )
+
+    def test_every_lane_owner_agrees_on_the_shared_dialect(self) -> None:
+        shared = [("dispatch_to_executor", 1_000), ("diff_started", 2_000), ("workflow_completed", 4_000)]
+        digests = {owner: _summary(owner, shared)["health_digest"] for owner in OWNERS_WITH_PROGRESS_LANE}
+
+        self.assertEqual(len(set(digests.values())), 1, digests)
+        self.assertEqual(len(digests), 4)
+
+    def test_owner_aliases_fold_onto_the_same_summary(self) -> None:
+        self.assertEqual(_summary("claude", _CLAUDE_NATIVE), _summary("claude_code", _CLAUDE_NATIVE))
+
+    def test_an_owner_whose_ceiling_refuses_the_word_gets_a_different_summary(self) -> None:
+        """The counter-case that keeps the equality above from being vacuous.
+
+        `omo-runtime` has no readable structured stream, so its evidence ceiling
+        stops at `result_claimed` and `full_tests_passed` cannot become
+        `tests_passed`. A different normalized stream must project a different
+        health summary -- with the refusal counted as an evidence gap, not
+        rounded to the neighbouring verified event.
+        """
+        words = [("dispatch_to_executor", 1_000), ("full_tests_passed", 2_000)]
+        codex = _summary("codex", words)
+        omo = _summary("omo-runtime", words)
+
+        self.assertEqual(codex["observations"][1]["normalized_event"], "tests_passed")  # type: ignore[index]
+        self.assertEqual(omo["observations"][1]["normalized_event"], UNMAPPED_NORMALIZED_EVENT)
+        self.assertNotEqual(codex["health_digest"], omo["health_digest"])
+        self.assertNotEqual(_without_owner(codex), _without_owner(omo))
+        self.assertEqual(_metric(codex, "evidence_gap_count")["value"], 0)
+        self.assertEqual(_metric(omo, "evidence_gap_count")["value"], 1)
+
+    def test_the_projection_is_deterministic(self) -> None:
+        self.assertEqual(_summary("codex", _CODEX_NATIVE), _summary("codex", _CODEX_NATIVE))
+
+    def test_the_digest_ignores_owner_and_the_now_dependent_fields(self) -> None:
+        early = _summary("codex", _CODEX_NATIVE, observed_at_ms=3_000)
+        late = _summary("codex", _CODEX_NATIVE, observed_at_ms=800_000)
+
+        self.assertEqual(early["health_digest"], late["health_digest"])
+        self.assertEqual(early["staleness"], "fresh")
+        self.assertEqual(late["staleness"], "stale")
+        self.assertNotEqual(_metric(early, "idle_duration_ms"), _metric(late, "idle_duration_ms"))
+
+        moved = _summary("codex", [("dispatch_to_executor", 1_000), ("item.completed", 1_500), ("turn.completed", 2_401)])
+        self.assertNotEqual(early["health_digest"], moved["health_digest"])
+
+    def test_the_module_never_reads_a_clock(self) -> None:
+        source = (Path(__file__).resolve().parents[1] / "src" / "runtime" / "run_health.py").read_text(encoding="utf-8")
+
+        for forbidden in ("import time", "from time", "import datetime", "from datetime", "monotonic(", "time()"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, source)
+
+
+class AcceptanceCriterionTwoUnavailableTests(unittest.TestCase):
+    """AC2: unavailable metrics are shown as unavailable rather than estimated."""
+
+    def test_unknown_unavailable_and_zero_are_three_distinguishable_states(self) -> None:
+        summary = _summary(
+            "codex",
+            [("dispatch_to_executor", 1_000), ("diff_started", 1_000), ("progress_observed", None)],
+        )
+
+        genuine_zero = _metric(summary, "dispatch_phase_duration_ms")
+        never_observed = _metric(summary, "verification_phase_duration_ms")
+        no_clock = _metric(summary, "total_duration_ms")
+
+        self.assertEqual(genuine_zero, {"state": "observed", "value": 0, "reason": ""})
+        self.assertEqual(never_observed, {"state": "unknown", "value": None, "reason": "phase_not_observed"})
+        self.assertEqual(
+            no_clock,
+            {"state": "unavailable", "value": None, "reason": "boundary_event_carried_no_timestamp"},
+        )
+        self.assertEqual(len({genuine_zero["state"], never_observed["state"], no_clock["state"]}), 3)
+        self.assertIsNotNone(genuine_zero["value"])
+        self.assertIsNone(never_observed["value"])
+        self.assertIsNone(no_clock["value"])
+        self.assertEqual(validate_run_health_summary(summary), [])
+
+    def test_a_missing_bound_is_never_replaced_by_the_observation_instant(self) -> None:
+        """The one estimate a projection like this is tempted to make.
+
+        An execution phase that nothing later closed has a plausible "duration"
+        available -- `observed_at_ms` minus the phase start. Substituting it
+        would make an in-flight run look measured. Moving the observation
+        instant must therefore move `idle_duration_ms` and `staleness` and
+        nothing else.
+        """
+        early = _summary("codex", [("dispatch_to_executor", 1_000), ("diff_started", 2_000)], observed_at_ms=2_500)
+        late = _summary("codex", [("dispatch_to_executor", 1_000), ("diff_started", 2_000)], observed_at_ms=900_000)
+
+        execution = _metric(early, "execution_phase_duration_ms")
+        self.assertEqual(
+            execution,
+            {"state": "unknown", "value": None, "reason": "phase_not_closed_by_a_later_observed_phase"},
+        )
+        for name in RUN_HEALTH_METRICS:
+            if name == "idle_duration_ms":
+                continue
+            with self.subTest(metric=name):
+                self.assertEqual(_metric(early, name), _metric(late, name))
+        self.assertEqual(_metric(early, "idle_duration_ms")["value"], 500)
+        self.assertEqual(_metric(late, "idle_duration_ms")["value"], 898_000)
+
+    def test_a_missing_phase_never_leaks_its_time_into_a_neighbour(self) -> None:
+        closed = _summary(
+            "codex",
+            [("dispatch_to_executor", 1_000), ("diff_started", 2_000), ("tests_started", 5_000)],
+        )
+        unclosed = _summary("codex", [("dispatch_to_executor", 1_000), ("diff_started", 2_000)])
+
+        self.assertEqual(_metric(closed, "execution_phase_duration_ms")["value"], 3_000)
+        self.assertIsNone(_metric(unclosed, "execution_phase_duration_ms")["value"])
+        self.assertEqual(
+            _metric(closed, "dispatch_phase_duration_ms"),
+            _metric(unclosed, "dispatch_phase_duration_ms"),
+        )
+        self.assertEqual(_metric(closed, "total_duration_ms")["value"], 4_000)
+        self.assertEqual(_metric(unclosed, "total_duration_ms")["value"], 1_000)
+
+    def test_no_metric_in_any_shape_carries_a_value_it_did_not_observe(self) -> None:
+        shapes = [
+            [],
+            [("dispatch_to_executor", None)],
+            [("dispatch_to_executor", 1_000)],
+            [("dispatch_to_executor", None), ("diff_started", 2_000)],
+            [("dispatch_to_executor", 1_000), ("workflow_started", 1_100), ("turn.completed", 4_000)],
+            [("targeted_tests_started", 1_000), ("targeted_tests_failed", 2_000), ("targeted_tests_started", 3_000)],
+        ]
+        for events in shapes:
+            summary = _summary("codex", events)
+            with self.subTest(events=events):
+                self.assertEqual(validate_run_health_summary(summary), [])
+                for name in RUN_HEALTH_METRICS:
+                    metric = _metric(summary, name)
+                    if metric["state"] == "observed":
+                        self.assertIsNotNone(metric["value"])
+                        self.assertEqual(metric["reason"], "")
+                    else:
+                        self.assertIsNone(metric["value"])
+                        self.assertNotEqual(metric["reason"], "")
+
+    def test_nothing_observed_leaves_every_metric_unknown_rather_than_zero(self) -> None:
+        summary = _summary("codex", [])
+
+        for name in RUN_HEALTH_METRICS:
+            with self.subTest(metric=name):
+                self.assertEqual(_metric(summary, name), {"state": "unknown", "value": None, "reason": "no_observed_events"})
+        self.assertEqual(summary["staleness"], "unknown")
+
+    def test_the_validator_refuses_a_number_attached_to_an_absent_metric(self) -> None:
+        summary = _summary("codex", [("dispatch_to_executor", 1_000), ("diff_started", 2_000)])
+        summary["metrics"]["execution_phase_duration_ms"] = {  # type: ignore[index]
+            "state": "unknown",
+            "value": 1_500,
+            "reason": "phase_not_closed_by_a_later_observed_phase",
+        }
+
+        errors = validate_run_health_summary(summary)
+        self.assertTrue(any("must be null unless the metric is observed" in error for error in errors), errors)
+
+    def test_the_validator_keeps_the_two_absence_vocabularies_apart(self) -> None:
+        summary = _summary("codex", [("dispatch_to_executor", 1_000), ("diff_started", 2_000)])
+        summary["metrics"]["execution_phase_duration_ms"] = {  # type: ignore[index]
+            "state": "unknown",
+            "value": None,
+            "reason": "boundary_event_carried_no_timestamp",
+        }
+
+        errors = validate_run_health_summary(summary)
+        self.assertTrue(any("not a declared unknown reason" in error for error in errors), errors)
+
+    def test_the_text_surface_names_the_absence_instead_of_printing_a_blank(self) -> None:
+        summary = _summary(
+            "codex",
+            [("dispatch_to_executor", 1_000), ("diff_started", 1_000), ("progress_observed", None)],
+        )
+        text = render_run_health_summary_text(summary)
+
+        self.assertIn("- dispatch: 0 ms", text)
+        self.assertIn("- verification: unknown (phase_not_observed)", text)
+        self.assertIn("Total duration: unavailable (boundary_event_carried_no_timestamp)", text)
+
+
+class AcceptanceCriterionThreeEfficiencyClaimTests(unittest.TestCase):
+    """AC3: no efficiency claim without a named baseline and a named evaluator."""
+
+    def test_the_parser_refuses_a_comparative_direction_with_a_name_missing(self) -> None:
+        for direction in ("improved", "regressed", "unchanged"):
+            for baseline, evaluator in (("", ""), ("baseline-a", ""), ("", "evaluator-a")):
+                with self.subTest(direction=direction, baseline=baseline, evaluator=evaluator):
+                    with self.assertRaisesRegex(ValueError, "named baseline_ref and evaluator_ref"):
+                        parse_run_health_input(
+                            _input(
+                                "codex",
+                                _CODEX_NATIVE,
+                                direction=direction,
+                                baseline_ref=baseline,
+                                evaluator_ref=evaluator,
+                            )
+                        )
+
+    def test_a_named_baseline_and_evaluator_admits_the_claim(self) -> None:
+        summary = _summary(
+            "codex",
+            _CODEX_NATIVE,
+            direction="improved",
+            baseline_ref="run-833-baseline",
+            evaluator_ref="omh-run-health-differential",
+        )
+
+        self.assertEqual(
+            summary["efficiency_claim"],
+            {
+                "direction": "improved",
+                "baseline_ref": "run-833-baseline",
+                "evaluator_ref": "omh-run-health-differential",
+                "gate": "named_baseline_and_evaluator",
+            },
+        )
+        self.assertEqual(validate_run_health_summary(summary), [])
+
+    def test_the_validator_refuses_a_hand_edited_improvement_claim(self) -> None:
+        summary = _summary("codex", _CODEX_NATIVE)
+        summary["efficiency_claim"]["direction"] = "improved"  # type: ignore[index]
+        summary["health_digest"] = run_health_digest(summary)
+
+        errors = validate_run_health_summary(summary)
+        self.assertEqual(
+            [error for error in errors if "named baseline_ref and evaluator_ref" in error],
+            [
+                "run_health_summary.efficiency_claim.direction other than unclaimed requires a named "
+                "baseline_ref and evaluator_ref"
+            ],
+        )
+
+    def test_the_gate_cannot_be_hand_set_to_agree_with_the_claim(self) -> None:
+        summary = _summary("codex", _CODEX_NATIVE)
+        summary["efficiency_claim"].update({"direction": "improved", "gate": "named_baseline_and_evaluator"})  # type: ignore[union-attr]
+        summary["health_digest"] = run_health_digest(summary)
+
+        errors = validate_run_health_summary(summary)
+        self.assertTrue(any("gate must be derived from" in error for error in errors), errors)
+        self.assertTrue(any("named baseline_ref and evaluator_ref" in error for error in errors), errors)
+
+    def test_an_unclaimed_summary_states_the_shut_gate(self) -> None:
+        summary = _summary("codex", _CODEX_NATIVE)
+
+        self.assertEqual(summary["efficiency_claim"]["gate"], "no_named_baseline_and_evaluator")  # type: ignore[index]
+        self.assertIn("named baseline and a named evaluator", str(summary["claim_boundary"]))
+
+
+class RunHealthDerivationTests(unittest.TestCase):
+    def test_every_normalized_word_has_a_phase_except_the_unmapped_one(self) -> None:
+        self.assertEqual(unphased_normalized_events(), (UNMAPPED_NORMALIZED_EVENT,))
+
+    def test_a_repeated_verification_counts_as_a_retry(self) -> None:
+        summary = _summary(
+            "codex",
+            [
+                ("dispatch_to_executor", 1_000),
+                ("tests_started", 2_000),
+                ("targeted_tests_failed", 3_000),
+                ("tests_started", 4_000),
+                ("targeted_tests_passed", 5_000),
+                ("turn.completed", 6_000),
+            ],
+        )
+
+        self.assertEqual(_metric(summary, "retry_count")["value"], 1)
+        self.assertEqual(_metric(summary, "verification_phase_duration_ms")["value"], 1_000)
+        self.assertEqual(_metric(summary, "unobserved_phase_count")["value"], 1)
+
+    def test_an_unmapped_word_neither_retries_nor_closes_a_phase(self) -> None:
+        summary = _summary(
+            "codex",
+            [("dispatch_to_executor", 1_000), ("workflow_started", 2_000), ("diff_started", 3_000)],
+        )
+
+        self.assertEqual(summary["observations"][1]["normalized_event"], UNMAPPED_NORMALIZED_EVENT)  # type: ignore[index]
+        self.assertEqual(_metric(summary, "retry_count")["value"], 0)
+        self.assertEqual(_metric(summary, "evidence_gap_count")["value"], 1)
+        self.assertEqual(_metric(summary, "dispatch_phase_duration_ms")["value"], 2_000)
+
+    def test_failure_class_reports_the_highest_severity_observed(self) -> None:
+        cases = {
+            "no_failure_observed": [("dispatch_to_executor", 1_000), ("turn.completed", 2_000)],
+            "claim_not_corroborated": [("reported_change_not_observed", 1_000)],
+            "executor_blocked": [("blocker_encountered", 1_000), ("reported_change_not_observed", 2_000)],
+            "verification_failed": [("blocker_encountered", 1_000), ("targeted_tests_failed", 2_000)],
+            "executor_failed": [("targeted_tests_failed", 1_000), ("failure_discovered", 2_000)],
+        }
+        for expected, events in cases.items():
+            with self.subTest(expected=expected):
+                self.assertEqual(_metric(_summary("codex", events), "failure_class")["value"], expected)
+
+    def test_staleness_turns_over_exactly_at_the_declared_threshold(self) -> None:
+        events = [("dispatch_to_executor", 1_000), ("diff_started", 2_000)]
+        at_threshold = _summary("codex", events, observed_at_ms=2_000 + RUN_HEALTH_STALENESS_THRESHOLD_MS)
+        past_threshold = _summary("codex", events, observed_at_ms=2_001 + RUN_HEALTH_STALENESS_THRESHOLD_MS)
+
+        self.assertEqual(at_threshold["staleness"], "fresh")
+        self.assertEqual(past_threshold["staleness"], "stale")
+        self.assertEqual(at_threshold["staleness_threshold_ms"], RUN_HEALTH_STALENESS_THRESHOLD_MS)
+
+    def test_an_unclocked_last_event_makes_staleness_unavailable(self) -> None:
+        summary = _summary("codex", [("dispatch_to_executor", 1_000), ("diff_started", None)])
+
+        self.assertEqual(summary["staleness"], "unavailable")
+        self.assertEqual(_metric(summary, "idle_duration_ms")["reason"], "boundary_event_carried_no_timestamp")
+
+    def test_the_claim_boundary_denies_every_downstream_evidence_class(self) -> None:
+        for denied in ("execution", "verification", "review", "CI", "merge-readiness", "merge"):
+            with self.subTest(denied=denied):
+                self.assertIn(denied, RUN_HEALTH_CLAIM_BOUNDARY)
+        self.assertIn("metadata-only", RUN_HEALTH_CLAIM_BOUNDARY)
+
+
+class RunHealthInputBoundsTests(unittest.TestCase):
+    def test_the_parser_refuses_an_inexact_key_set(self) -> None:
+        extra = _input("codex", _CODEX_NATIVE)
+        extra["notes"] = "extra"
+        with self.assertRaisesRegex(ValueError, "exact run_health_input/v1 fields"):
+            parse_run_health_input(extra)
+
+        missing = _input("codex", _CODEX_NATIVE)
+        missing.pop("owner")
+        with self.assertRaisesRegex(ValueError, "exact run_health_input/v1 fields"):
+            parse_run_health_input(missing)
+
+    def test_the_parser_refuses_a_backwards_clock_and_a_stale_observation_instant(self) -> None:
+        with self.assertRaisesRegex(ValueError, "must not move backwards"):
+            parse_run_health_input(_input("codex", [("diff_started", 2_000), ("tests_started", 1_000)]))
+        with self.assertRaisesRegex(ValueError, "must not precede the last observed event"):
+            parse_run_health_input(_input("codex", [("diff_started", 2_000)], observed_at_ms=1_999))
+
+    def test_the_parser_bounds_the_event_list(self) -> None:
+        too_many = _input("codex", [("diff_started", 1_000)] * (MAX_RUN_HEALTH_EVENTS + 1))
+        with self.assertRaisesRegex(ValueError, "at most 100 items"):
+            parse_run_health_input(too_many)
+
+    def test_the_parser_refuses_secret_shaped_references(self) -> None:
+        for secret in ("AKIAIOSFODNN7EXAMPLE", "gho_12345678901234567890", "AIzaSyDUMMYABCDEFGHIJKLMNOPQRSTUVWX123"):
+            with self.subTest(secret=secret):
+                with self.assertRaisesRegex(ValueError, "safe opaque metadata reference"):
+                    parse_run_health_input(
+                        _input(
+                            "codex",
+                            _CODEX_NATIVE,
+                            direction="improved",
+                            baseline_ref=secret,
+                            evaluator_ref="omh-run-health-differential",
+                        )
+                    )
+                with self.assertRaisesRegex(ValueError, "safe opaque metadata reference"):
+                    parse_run_health_input(_input("codex", [(secret, 1_000)]))
+
+    def test_the_parser_refuses_an_event_missing_its_clock_key(self) -> None:
+        payload = _input("codex", [])
+        payload["events"] = [{"source_event": "diff_started"}]
+        with self.assertRaisesRegex(ValueError, "exactly source_event and at_ms"):
+            parse_run_health_input(payload)
+
+
+class RunHealthValidatorTests(unittest.TestCase):
+    def test_the_validator_checks_the_key_set_in_both_directions(self) -> None:
+        summary = _summary("codex", _CODEX_NATIVE)
+
+        extra = dict(summary)
+        extra["notes"] = "hand added"
+        self.assertEqual(
+            validate_run_health_summary(extra),
+            ["run_health_summary has an unsupported key: notes"],
+        )
+
+        missing = dict(summary)
+        missing.pop("staleness")
+        self.assertEqual(
+            validate_run_health_summary(missing),
+            ["run_health_summary is missing a required key: staleness"],
+        )
+
+    def test_the_validator_rederives_a_hand_edited_metric(self) -> None:
+        summary = _summary("codex", _CODEX_NATIVE)
+        summary["metrics"]["total_duration_ms"] = {"state": "observed", "value": 12, "reason": ""}  # type: ignore[index]
+        summary["health_digest"] = run_health_digest(summary)
+
+        self.assertEqual(
+            validate_run_health_summary(summary),
+            ["run_health_summary.metrics.total_duration_ms must match the value derived from observations"],
+        )
+
+    def test_the_validator_rederives_the_owner_attribution(self) -> None:
+        summary = _summary("omo-runtime", [("dispatch_to_executor", 1_000)])
+        summary["owner_attribution"]["evidence_ceiling"] = "verified"  # type: ignore[index]
+
+        errors = validate_run_health_summary(summary)
+        self.assertIn(
+            "run_health_summary.owner_attribution.evidence_ceiling must match the owner's declared evidence ceiling",
+            errors,
+        )
+
+    def test_the_validator_rederives_the_digest(self) -> None:
+        summary = _summary("codex", _CODEX_NATIVE)
+        summary["run_id"] = "run-999"
+
+        errors = validate_run_health_summary(summary)
+        self.assertIn("run_health_summary.health_digest must match the derived health digest", errors)
+
+    def test_the_validator_refuses_a_word_outside_the_normalized_vocabulary(self) -> None:
+        summary = _summary("codex", _CODEX_NATIVE)
+        summary["observations"][0]["normalized_event"] = "targeted_tests_passed"  # type: ignore[index]
+
+        errors = validate_run_health_summary(summary)
+        self.assertTrue(
+            any("not in the normalized progress vocabulary" in error for error in errors),
+            errors,
+        )
+
+    def test_the_validator_refuses_a_staleness_verdict_that_contradicts_the_idle_metric(self) -> None:
+        summary = _summary("codex", _CODEX_NATIVE)
+        summary["staleness"] = "stale"
+        summary["health_digest"] = run_health_digest(summary)
+
+        errors = validate_run_health_summary(summary)
+        self.assertIn(
+            "run_health_summary.staleness must match the verdict derived from idle_duration_ms",
+            errors,
+        )
+
+    def test_the_validator_accepts_every_summary_this_module_builds(self) -> None:
+        for owner in OWNERS_WITH_PROGRESS_LANE:
+            for events in ([], _CODEX_NATIVE, [("full_tests_passed", 1_000)]):
+                with self.subTest(owner=owner, events=events):
+                    self.assertEqual(validate_run_health_summary(_summary(owner, events)), [])
+
+
+class RunHealthCommandTests(unittest.TestCase):
+    def _write_input(self, root: Path, payload: dict[str, object]) -> Path:
+        path = root / "run_health_input.json"
+        atomic_write_json(path, payload)
+        return path
+
+    def test_the_command_defaults_to_plain_text(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = self._write_input(Path(tmp), _input("claude-code", _CLAUDE_NATIVE))
+            status, stdout, stderr = run_cli(["runtime", "health-summary", "--input", str(path)], output_json=False)
+
+        self.assertEqual(status, 0, stderr)
+        self.assertIn("Run health summary (OMH projection)", stdout)
+        self.assertIn("Owner: claude-code (progress lane: yes, evidence ceiling: verified)", stdout)
+        self.assertIn("Efficiency claim: unclaimed", stdout)
+        self.assertIn("For machine-readable output, rerun with `--json`.", stdout)
+        self.assertNotIn("\"schema_version\"", stdout)
+
+    def test_the_command_opts_into_the_machine_payload(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = self._write_input(Path(tmp), _input("codex", _CODEX_NATIVE))
+            status, stdout, stderr = run_cli(
+                ["runtime", "health-summary", "--input", str(path), "--json"],
+                output_json=False,
+            )
+
+        self.assertEqual(status, 0, stderr)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["schema_version"], RUN_HEALTH_SUMMARY_SCHEMA_VERSION)
+        self.assertEqual(payload["health_digest"], _summary("codex", _CODEX_NATIVE)["health_digest"])
+        self.assertEqual(validate_run_health_summary(payload), [])
+
+    def test_the_command_refuses_an_efficiency_claim_with_nobody_named(self) -> None:
+        with TemporaryDirectory() as tmp:
+            payload = _input("codex", _CODEX_NATIVE, direction="improved", baseline_ref="run-833")
+            path = self._write_input(Path(tmp), payload)
+            status, _stdout, stderr = run_cli(["runtime", "health-summary", "--input", str(path)], output_json=False)
+
+        self.assertEqual(status, 2)
+        self.assertIn("named baseline_ref and evaluator_ref", stderr)
+
+    def test_the_command_is_declared_a_bounded_polled_surface(self) -> None:
+        self.assertIn("omh runtime health-summary", coding_progress_policy_enforcement()["bounded_surfaces"])
+
+    def test_the_documented_example_is_the_output_the_renderer_produces(self) -> None:
+        """The doc block in `docs/CODING-OBSERVABILITY.md` is real output, not a sketch.
+
+        Read in text mode, so a CRLF checkout compares the same as an LF one.
+        """
+        events = [
+            ("system", 1_000),
+            ("assistant", 2_000),
+            ("tests_started", 3_000),
+            ("targeted_tests_failed", 4_000),
+            ("tests_started", 5_000),
+            ("targeted_tests_failed", 6_000),
+        ]
+        rendered = render_run_health_summary_text(_summary("claude-code", events))
+        # The doc elides the two trailing lines, which are constant boilerplate.
+        documented = "\n".join(rendered.splitlines()[:-2])
+        doc = (Path(__file__).resolve().parents[1] / "docs" / "CODING-OBSERVABILITY.md").read_text(encoding="utf-8")
+
+        self.assertIn(documented, doc)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New `run_health_summary/v1` projection (`src/runtime/run_health.py`, 873 lines):
  a read-only, owner-neutral explanation of why one run is slow, stale,
  retrying, or missing decisive evidence. It reports phase durations,
  idle/staleness, retries, a failure class, and evidence gaps in one vocabulary
  regardless of coding owner.
- New CLI surface `omh runtime health-summary --input <file> [--json]` — plain
  text by default, machine payload on opt-in — registered as a bounded polled
  surface.
- New `docs/CODING-OBSERVABILITY.md` section, "Why is this run unhealthy",
  with real rendered output (gated by a test so the block cannot drift).
- No new dependencies, no network/LLM calls, no persisted artifact, no Hermes
  patching, nothing generated regenerated.

### Why This Exists

Issue #834. OMH already had linked runtime runs, observed progress events, owner
profiles, and status surfaces — but a progress story only says *what* happened.
It does not say why a run is unhealthy, and each coding owner narrates that in
its own words, so the same stuck run read differently depending on who was
executing it.

Verified absent before this change:
`grep -rn "run_health\|health_summary" src/ tests/ docs/` returned 0 lines.

### User / Operator Impact

A user can ask "why is this run unhealthy" and get the same answer shape for
Codex, Claude Code, Hermes runtime, or a generic executor. Concretely, a run
that dispatched, explored, then failed its tests twice now renders as:

```
Run health summary (OMH projection)
Run: run-834
Owner: claude-code (progress lane: yes, evidence ceiling: verified)
Observed events: 6 (observed at 9000 ms)
Freshness: fresh (idle 3000 ms, stale after 300000 ms)
Failure class: verification_failed
Total duration: 5000 ms
Phase durations:
- dispatch: 1000 ms
- execution: 1000 ms
- verification: 1000 ms
Counts:
- retries: 1
- evidence gaps: 0
- unobserved phases: 1
Efficiency claim: unclaimed (baseline: none, evaluator: none, gate: no_named_baseline_and_evaluator)
```

Before this change there was no surface that answered any of those lines.

### How It Works

**AC1 — same normalized events, same summary across owners.** The projection
runs over *normalized* progress events
(`coding.owner_progress_normalization.normalize_owner_progress_event`), never
over raw per-owner event shapes. A codex run narrating
`dispatch_to_executor / item.completed / turn.completed` and a Claude Code run
narrating `system / assistant / result` — no shared source word between them —
normalize to `executor_dispatched / progress_observed / executor_completed` and
project byte-identical summaries apart from `owner_attribution`.
`health_digest` makes that one comparison: it deliberately excludes the owner
block and every now-dependent field.

The equality is not vacuous, and the test suite proves it. `omo-runtime` has no
readable structured stream, so its evidence ceiling stops at `result_claimed`
and its `full_tests_passed` normalizes to `unmapped_source_event` instead of
`tests_passed`. That run gets a *different* digest, with the refusal counted as
an evidence gap rather than rounded to the neighbouring verified event.

**AC2 — three distinct absences, per metric, never an estimate.** Every metric
is a `{state, value, reason}` triple over a closed reason vocabulary:

| state | meaning | value |
| --- | --- | --- |
| `observed` | both bounds observed, with clocks | the number, possibly a genuine `0` |
| `unknown` | the EVENT bounding the metric was never observed | `null` + reason |
| `unavailable` | the event was observed but carried no clock | `null` + reason |

This is per metric, not the fixed `not_observed` block `run_efficiency.py`
carries for provider/billing/cron/host. A phase nothing later closed stays
`unknown`: closing it with `observed_at_ms` is the one estimate a projection
like this is tempted to make, and the test asserts that moving `observed_at_ms`
across a 900-second gap changes `idle_duration_ms` and `staleness` and *nothing
else*. A run with nothing observed reports every metric `unknown`, not `0`
retries and `0` evidence gaps — zero retries is an observation and nobody made
it.

**AC3 — no efficiency claim without two names.** `efficiency_claim.direction`
may be `unclaimed`, `improved`, `regressed`, or `unchanged`. Anything other than
`unclaimed` requires both a named `baseline_ref` and a named `evaluator_ref`,
enforced twice: `parse_run_health_input` raises on the write path, and
`validate_run_health_summary` refuses on the read path (a hand-edited record
never goes through the parser). `gate` is *derived* from the two refs, so it
cannot be hand-set to agree with the claim — the test edits both `direction` and
`gate`, recomputes the digest, and still gets two refusals.

**Refusing a hand-edited record.** `validate_run_health_summary(payload) ->
list[str]` checks the key set in both directions (unsupported *and* missing
keys) and re-derives every metric, the staleness verdict, the claim gate, the
owner attribution, and the digest from the stored `observations`. A record whose
numbers were edited to read healthier is refused, not rendered. The CLI runs the
validator against the summary it just built, so the read path and the write path
cannot drift.

**Determinism.** The module reads no clock — a test scans its source for
`import time`, `import datetime`, `monotonic(`, and `time()`. The observation
instant arrives as `observed_at_ms` on the input, and `health_digest` excludes
it plus everything derived from it (`idle_duration_ms`, `staleness`), so
comparing two runs' health never becomes comparing two wall clocks.

**Phase model.** One position table (`_PHASE_BY_NORMALIZED_EVENT`) drives phase
durations, retries, and completeness counts. Verification is split into
`verification_started` / `verification_outcome` so a `tests_started` after a
`tests_failed` reads as the backward move it is. `unmapped_source_event` is
deliberately unplaced: a word this repo could not translate must not define a
phase boundary or close somebody else's phase, and
`unphased_normalized_events()` is the gate that fails if a new vocabulary word
lands without a position.

**Executor-neutral throughout.** No field name, vocabulary word, default, or doc
sentence makes Codex the implicit owner. The cross-owner test iterates
`OWNERS_WITH_PROGRESS_LANE` (codex, claude-code, omo-runtime, hermes) and
asserts all four agree on the shared dialect.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/runtime/run_health.py` | new — `run_health_input/v1` parser, `run_health_summary/v1` builder, validator, digest, text renderer |
| `src/commands/run_health.py` | new — `omh runtime health-summary`, plain text default via `_wants_json` |
| `src/commands/runtime.py` | +2 — register the subcommand next to `efficiency-report` |
| `src/coding/context_safety.py` | +6 — `omh runtime health-summary` added to `coding_progress_policy_enforcement()["bounded_surfaces"]` (membership-asserted) |
| `docs/CODING-OBSERVABILITY.md` | +95 — "Why is this run unhealthy" section and a third boundary paragraph |
| `tests/test_run_health_summary.py` | new — 44 tests |

No generated artifact changed: no catalog edit, no skill, no routing case, no
demo card, so no exact-count assertion in `tests/test_routing_precision.py`,
`tests/test_cli.py`, `tests/test_hermes_ux_quality.py`, or
`tests/test_release_smoke.py` moved. All four byte gates were rerun anyway and
are green.

## Validation

All of the following were run on the rebased branch head (rebased onto
`origin/main` at `8dec02ad`, which required resolving two conflicts against
`agent/issue-827`'s language-diagnostics doc section and `agent/issue-824`'s
`omh goal board` bounded-surface entry — both resolved by keeping both).

- [x] `uv run --group lint ruff check src tests` — `All checks passed!`
- [x] `python3 -m unittest discover -s tests` — `Ran 4437 tests in 165.865s` / `OK` (as `PYTHONPATH=tests uv run python -m unittest discover -s tests`)
- [x] `python3 -m compileall src` — clean (as `uv run python -m compileall -q src tests`)
- [x] `python3 -m omh.cli docs workflows --check` — `{"ok":true,...,"tap_skills":{"checked":115,"expected":115,"extra":[],"missing":[],"ok":true,"stale":[]}}`
- [x] `python3 -m omh.cli harness validate` — `{"counts":{"harnesses":72,"skills":104},"errors":[],"ok":true}`
- [x] `python3 -m omh.cli release checklist --json` — `"ok":true`, 35 required items, mode `plan`
- [x] `python3 -m omh.cli release hermes-smoke` — plan renders with plan-only boundary
- [x] `omh --help` — help renders (as `uv run python -m omh.cli --help`; see the gap note below)
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — **not run.** The `omh` on this machine's PATH is the user's installed 1.0.4 release, not this branch's code, so the nested installed-command smoke would have observed the wrong package. Every check above was run against the branch through `python -m omh.cli`.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: **n/a** — no learning contract touched.
- [x] Relevant dry-run or smoke command: `omh runtime health-summary` exercised end to end three ways — plain text default, `--json` (payload re-validated with `validate_run_health_summary`, 0 errors), and the refused efficiency claim (exit 2, stderr names `baseline_ref and evaluator_ref`).
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: **not run.** There is no chat surface for this yet — no routing case, skill, or chat card — so the only entry point is the CLI and there is nothing for Hermes to render.

Additional gates this repo enforces beyond the template:

- [x] `uv run python -m omh.cli docs roles --check` — `{"ok":true}`
- [x] `uv run python -m omh.cli docs capability-families --check` — `{"ok":true}`
- [x] `git diff --check` — clean

**Mutation evidence.** Green tests are not evidence that the tests test
anything, so each acceptance criterion's guarantee was deleted and the suite
rerun. All three mutations were caught, and the tree was restored byte-identical
afterwards (`diff -q` against a pre-mutation copy):

| Mutation | Result |
| --- | --- |
| `owner_attribution` removed from `_DIGEST_EXCLUDED_TOP_LEVEL` (digest sees the owner) | 2 failures — AC1 cross-owner equality |
| unclosed phase estimated from the last observed event instead of staying `unknown` | 2 failures — AC2 no-estimate |
| both AC3 gates deleted (parser raise + validator error) | 12 failures across parser, validator, and CLI |

## Risk

Low. Everything added is new and read-only: a new module, a new subcommand, a
one-line addition to a declarative list, and a doc section. No existing code
path changed behavior, no record schema was modified, nothing is persisted, and
no generated artifact was regenerated.

The one shared surface touched is
`coding_progress_policy_enforcement()["bounded_surfaces"]`. It is asserted by
membership in `tests/test_context_safety.py` and `tests/test_status_board_cli.py`,
not by count, so adding an entry cannot break a sibling branch's gate. The
rebase confirmed this in practice: `agent/issue-824` added `omh goal board` to
the same list concurrently and both entries coexist.

## Compatibility / Rollout

No compatibility concern. `run_health_summary/v1` is a new schema with no prior
version and no reader anywhere else; `run_health_input/v1` is supplied by the
caller. Nothing reads or writes existing state. A user's Hermes gains the
command after `omh update`, and until then loses nothing they had.

## Release / Claims

- [x] Release-channel impact considered — no version file, changelog, or
  packaging metadata touched; `src/runtime/run_health.py` and
  `src/commands/run_health.py` are inside the already-declared `omh.runtime` and
  `omh.commands` packages, so no `pyproject.toml` package list change is needed.
- [x] Runtime/native capability claims are backed by evidence or marked as not
  observed — the payload's own `claim_boundary` denies execution, verification,
  review, CI, merge-readiness, and merge evidence, and a test asserts each of
  those six words is present. The AC3 gate is the sharper claim control: OMH
  structurally cannot say "faster" without naming who measured it against what.
- [x] Known manual Hermes checks are listed, including any
  `omh release hermes-smoke --live` gap — no live smoke was run; this change
  does not touch install, setup, or the managed skill set.

## Follow-Up

- No chat entry point. Reaching this from natural language ("why is this run
  stuck") needs a routing case, a chat card, and the awareness-lane/ack/label
  registrations in `docs/ADDING-A-SKILL.md` — deliberately out of scope here,
  since #834 asks for the projection and its vocabulary, and a skill would drag
  in the exact-count assertions across four test files.
- No producer. Today the caller assembles `run_health_input/v1` by hand. The
  natural next step is projecting it straight off a run's stored progress
  events so `omh runtime health-summary --run <id>` needs no input file.
- No persistence. There is no `--write` and no artifact path, because the issue
  asks for a projection and a second stored execution record is what it
  explicitly does not want.

Closes #834
