### PR TITLE
feat: stop stale project memory from steering Hermes

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -183,6 +183,68 @@ Expiry removes influence only; it does not move an artifact or prove any
 absence. A stale revalidation deadline requires fresh review or a bounded,
 identity-specific confirmation.
 
+## Freshness: Review-Due Dates and Source Evidence
+
+A record's freshness is one verdict derived from three stored inputs plus the
+caller's clock. Nothing is inferred from conversation, and nothing is fetched.
+
+| Input | Field | Effect |
+| --- | --- | --- |
+| Retention deadline | `ttl.expires_at` | Past it, the record is `expired`. |
+| Review-due date | `staleness.review_due_at` | Past it, the record is `stale`. |
+| Source digest | `source_evidence.sha256` | A changed source is `stale`; an unreadable one is `unknown`. |
+
+`review_due_at` is the readable name for the date `staleness.stale_after`
+always held; both are written, and when they disagree the earlier one wins, so
+editing one spelling can never restore freshness.
+
+Source evidence is opt-in and local. When `--source-ref` names an absolute
+path to a readable local file, capture records the file's SHA-256 alongside it.
+Every later freshness check re-reads that file and compares. A ref that is not
+an absolute path, a file that is gone or unreadable, and a file past the
+digest budget all read as `unknown` — never as `fresh`. OMH makes no network
+call to check anything, and never rewrites or deletes a record because its
+source moved.
+
+Both `stale` and `unknown` are ineligible for default recall, exactly like
+`expired`. `omh memory recall --include-stale` surfaces them for inspection
+carrying their ineligible replay evidence, which keeps the pack unattachable
+as approved context.
+
+### Freshness Warnings
+
+A recall pack used to drop an ineligible record silently. It now carries a
+bounded `freshness_warnings` list naming every record whose freshness is not
+confirmed, and a handoff pack is emitted even when the warning is all it has
+to say:
+
+```json
+{
+  "record_id": "mem_...",
+  "state": "stale",
+  "reason_code": "stale_review_required",
+  "review_due_at": "2026-01-01T00:00:00Z",
+  "detail": "Its revalidation deadline passed, so nobody has confirmed the record since then.",
+  "delivered": false,
+  "next_action": "Confirm, replace, or retire this record before it steers the plan."
+}
+```
+
+`delivered` says whether the record reached the pack (`--include-stale`) or
+was held back. Records excluded for reasons that are not about freshness —
+`no_query_overlap`, `over_budget` on a fresh record — never warn. Wrapper
+briefs and runtime artifact summaries carry the warnings through by name
+rather than as a count, so a summarized handoff still says which record needs
+a decision. A warning is prepared context, never execution, review, CI, or
+merge evidence.
+
+Answering the warning uses the existing lifecycle verbs: `omh memory correct`
+supersedes the record with a reviewable replacement, `omh memory retire`
+archives it once expired. Both preserve the prior revision — a correction
+writes `history/<record-id>.r<revision>.json` carrying the original payload,
+its admission provenance, its source evidence, and a `superseded_by` link to
+the successor revision.
+
 ## Recall Ranking and Delivery Usage
 
 Recall packs order eligible records relevance-first: keyword relevance rank

--- a/src/commands/memory_parser.py
+++ b/src/commands/memory_parser.py
@@ -23,7 +23,11 @@ def add_memory_commands(sub: argparse._SubParsersAction[argparse.ArgumentParser]
     capture.add_argument("--scope-kind", choices=("project", "target", "thread", "run"), default="project")
     capture.add_argument("--scope-ref", default="default")
     capture.add_argument("--source", default="cli")
-    capture.add_argument("--source-ref", default="")
+    capture.add_argument(
+        "--source-ref",
+        default="",
+        help="What this memory is about. An absolute path to a readable local file is also digested, so a later change to that file marks the record stale.",
+    )
     capture.add_argument("--tag", action="append", default=[])
     capture.add_argument("--ttl-days", type=int, default=None)
     capture.add_argument("--stale-after-days", type=int, default=None)

--- a/src/runtime/artifacts.py
+++ b/src/runtime/artifacts.py
@@ -1493,6 +1493,9 @@ def _memory_recall_pack_summary(memory_recall_pack: dict[str, Any]) -> dict[str,
         "session_id": memory_recall_pack.get("session_id", ""),
         "record_count": len(_list_or_empty(memory_recall_pack.get("included_records"))),
         "excluded_count": len(_list_or_empty(memory_recall_pack.get("excluded_records"))),
+        # Named, not counted: the runtime artifact has to say which record is
+        # due for review, or the summary hides the only actionable part.
+        "freshness_warnings": _list_or_empty(memory_recall_pack.get("freshness_warnings")),
         "redaction_policy": memory_recall_pack.get("redaction_policy", ""),
         "claim_boundary": memory_recall_pack.get("claim_boundary", ""),
     }

--- a/src/workflows/_memory_lifecycle_plans.py
+++ b/src/workflows/_memory_lifecycle_plans.py
@@ -92,15 +92,28 @@ def _tombstone(tombstone_id: str, record_id: str, revision: int, scope: Mapping[
 
 def _pending_candidate(record: Mapping[str, object], candidate_id: str, revision: int, lifecycle: str) -> dict[str, object]:
     origin = stable_artifact_identity(dict(record))
-    replacement = {key: record[key] for key in ("record_type", "summary", "scope", "source_class", "source_ref", "retention", "revalidation", "ttl", "staleness", "derived_from", "perspective") if key in record}
+    replacement = {key: record[key] for key in ("record_type", "summary", "scope", "source_class", "source_ref", "source_evidence", "retention", "revalidation", "ttl", "staleness", "derived_from", "perspective") if key in record}
     return {"schema_version": "project_memory_candidate/v2", "candidate_id": candidate_id, "candidate_revision": revision, "record_id": str(record["record_id"]), "artifact_kind": "record", "status": "pending_review", "admission": {"state": "pending_review"}, "origin": origin, "lifecycle": lifecycle, "replacement": replacement}
+
+
+def _source_evidence(replacement: Mapping[str, object]) -> dict[str, object]:
+    """Carry a reviewed revision's source digest into its successor, scalar-only.
+
+    Without this the corrected revision would silently lose the digest of the
+    file it cites, and a later source change would stop being observable
+    after the first correction.
+    """
+    evidence = replacement.get("source_evidence")
+    if not isinstance(evidence, Mapping) or not str(evidence.get("sha256", "") or ""):
+        return {}
+    return {key: str(evidence.get(key, "") or "") for key in ("path", "sha256", "captured_at")}
 
 
 def _approved_record(replacement: Mapping[str, object], record_id: str, revision: int, reviewer: str, now: datetime) -> dict[str, object]:
     record_type = str(replacement.get("record_type", "fact"))
     retention = replacement.get("retention") if isinstance(replacement.get("retention"), Mapping) else {}
     ttl_days = retention.get("ttl_days") if isinstance(retention.get("ttl_days"), int) and not isinstance(retention.get("ttl_days"), bool) else None
-    record: dict[str, object] = {"schema_version": PROJECT_MEMORY_RECORD_SCHEMA_VERSION, "record_id": record_id, "revision": revision, "record_type": record_type, "summary": str(replacement.get("summary", "")), "scope": _scope(replacement), "source_class": str(replacement.get("source_class", "omh_local")), "derived_from": [str(ref) for ref in (replacement.get("derived_from") if isinstance(replacement.get("derived_from"), list) else []) if isinstance(ref, str)], **({"perspective": {"observer": str(replacement["perspective"].get("observer", "")), "observed": str(replacement["perspective"].get("observed", ""))}} if isinstance(replacement.get("perspective"), Mapping) and str(replacement["perspective"].get("observed", "")) else {}), "retention": build_retention(str(retention.get("class", "standard")), record_type=record_type, admitted_at=now, ttl_days=ttl_days), "revalidation": {}, "admission": {"state": "approved_manual", "review_id": f"review-{record_id}-r{revision}", "reviewer_claim": reviewer, "admitted_at": stamp(now), "policy_version": MEMORY_GOVERNANCE_POLICY_VERSION, "classifier_version": MEMORY_CLASSIFIER_VERSION}}
+    record: dict[str, object] = {"schema_version": PROJECT_MEMORY_RECORD_SCHEMA_VERSION, "record_id": record_id, "revision": revision, "record_type": record_type, "summary": str(replacement.get("summary", "")), "scope": _scope(replacement), "source_class": str(replacement.get("source_class", "omh_local")), "derived_from": [str(ref) for ref in (replacement.get("derived_from") if isinstance(replacement.get("derived_from"), list) else []) if isinstance(ref, str)], **({"perspective": {"observer": str(replacement["perspective"].get("observer", "")), "observed": str(replacement["perspective"].get("observed", ""))}} if isinstance(replacement.get("perspective"), Mapping) and str(replacement["perspective"].get("observed", "")) else {}), **({"source_evidence": evidence} if (evidence := _source_evidence(replacement)) else {}), "retention": build_retention(str(retention.get("class", "standard")), record_type=record_type, admitted_at=now, ttl_days=ttl_days), "revalidation": {}, "admission": {"state": "approved_manual", "review_id": f"review-{record_id}-r{revision}", "reviewer_claim": reviewer, "admitted_at": stamp(now), "policy_version": MEMORY_GOVERNANCE_POLICY_VERSION, "classifier_version": MEMORY_CLASSIFIER_VERSION}}
     identity = stable_artifact_identity(record)
     record["admission"] = {**record["admission"], "artifact_identity": identity, "payload_digest": canonical_payload_digest(record)}
     return record

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -119,6 +119,7 @@ _PROJECT_MEMORY_RECORD_KEYS = {
     "source",
     "source_class",
     "source_ref",
+    "source_evidence",
     "admission",
     "retention",
     "revalidation",
@@ -130,6 +131,7 @@ _PROJECT_MEMORY_RECORD_KEYS = {
     "safety",
     "derived_from",
     "perspective",
+    "superseded_by",
     "redaction_policy",
     "claim_boundary",
 }
@@ -145,10 +147,20 @@ _PROJECT_MEMORY_RECALL_PACK_KEYS = {
     "query_intent",
     "included_records",
     "excluded_records",
+    "freshness_warnings",
     "record_count",
     "truncated",
     "redaction_policy",
     "claim_boundary",
+}
+_FRESHNESS_WARNING_KEYS = {
+    "record_id",
+    "state",
+    "reason_code",
+    "review_due_at",
+    "detail",
+    "delivered",
+    "next_action",
 }
 _PROJECT_MEMORY_RECALL_ITEM_KEYS = {
     "record_id",
@@ -244,6 +256,35 @@ _PROJECT_MEMORY_EXCLUDED_KEYS = {
     "replay_evaluation",
 }
 _PROJECT_MEMORY_TASK_REF_KEYS = {"sha256", "length", "query_supplied"}
+# Source-evidence freshness. Time deadlines alone cannot notice that the file
+# a record cites was rewritten the day after approval, so a record may carry
+# the digest of the local source observed at capture. Comparing that digest
+# against the file as it reads now is the only way to make "the source moved"
+# observable without a network call, which OMH never makes. Anything that
+# cannot be digested locally -- a ref that is not an absolute path, a deleted
+# or unreadable file, or one past the cheap-hash budget -- reads as `unknown`
+# and never as `fresh`: a trust signal must fail closed, and "we could not
+# look" is not "we looked and it was fine".
+_SOURCE_EVIDENCE_MAX_BYTES = 4 * 1024 * 1024
+# Freshness warnings are the pre-handoff surface: a recall pack used to drop a
+# stale record silently, so the executor saw a smaller pack and no reason. The
+# list is bounded like every other polled surface; the pack already says
+# `truncated` when its own budget cuts records.
+_FRESHNESS_WARNING_LIMIT = 12
+_FRESHNESS_NEXT_ACTION = "Confirm, replace, or retire this record before it steers the plan."
+_FRESHNESS_REASON_TEXT = {
+    "stale_review_required": "Its revalidation deadline passed, so nobody has confirmed the record since then.",
+    "source_changed": "The local source it cites changed after the record was approved.",
+    "source_unverifiable": "The local source it cites cannot be read now, so its freshness is unobservable.",
+    "superseded": "A newer revision supersedes this record.",
+    "expired_standard": "Its retention deadline passed.",
+    "expired_volatile": "Its retention deadline passed.",
+    "expired_durable": "Its retention deadline passed.",
+    "freshness_unconfirmed": "Its freshness could not be confirmed from stored metadata and local source evidence.",
+}
+# Reasons `--include-stale` may surface for inspection. They carry ineligible
+# replay evidence, so the pack still cannot be attached as approved context.
+_INSPECTABLE_STALE_REASONS = {"stale_review_required", "source_changed", "source_unverifiable"}
 _HANDOFF_CONTEXT_PACK_KEYS = {
     "schema_version",
     "executor_target",
@@ -666,13 +707,26 @@ def build_project_memory_recall_pack(
             run_id=run_id,
         )
         staleness = _record_staleness(record, now=now)
+        # Source-evidence freshness gates recall exactly like the time
+        # deadline does. The shared evaluator only knows deadlines, so the
+        # verdict `_record_staleness` derived from the record's own recorded
+        # digest is folded into the same eligibility decision here rather
+        # than becoming a second, quieter notion of stale.
+        source_state = str(staleness.get("source_state", ""))
+        if bool(evaluation["eligible"]) and source_state in {"changed", "unreadable"}:
+            evaluation = {
+                **evaluation,
+                "eligible": False,
+                "reason_code": "source_changed" if source_state == "changed" else "source_unverifiable",
+            }
         if not bool(evaluation["eligible"]):
             # --include-stale is an inspection affordance: it surfaces
-            # records whose ONLY problem is a passed revalidation deadline,
-            # carrying their ineligible replay evidence so the pack cannot
-            # be attached to a handoff. Expired and otherwise-ineligible
-            # records stay excluded regardless.
-            if include_stale and str(evaluation.get("reason_code", "")) == "stale_review_required":
+            # records whose ONLY problem is unconfirmed freshness -- a passed
+            # revalidation deadline or a moved source -- carrying their
+            # ineligible replay evidence so the pack cannot be attached to a
+            # handoff. Expired and otherwise-ineligible records stay excluded
+            # regardless.
+            if include_stale and str(evaluation.get("reason_code", "")) in _INSPECTABLE_STALE_REASONS:
                 score = _memory_recall_score(record, query)
                 if not query or score > 0 or str(record.get("record_id", "")) in pins:
                     included.append(_recall_item(record, score=score, staleness=staleness, evaluation=evaluation))
@@ -763,6 +817,7 @@ def build_project_memory_recall_pack(
         "query_intent": query_intent,
         "included_records": included,
         "excluded_records": excluded,
+        "freshness_warnings": _freshness_warnings(included, excluded),
         "record_count": len(included),
         "truncated": budget_exhausted,
         "redaction_policy": "metadata_only",
@@ -792,7 +847,11 @@ def memory_recall_pack_for_handoff(
         limit=limit,
         observed=_handoff_perspective_lens(executor_target),
     )
-    if not pack.get("enabled") or not pack.get("included_records"):
+    # A pack with no eligible records but a freshness warning still travels.
+    # Dropping it here was the silent failure: the handoff went out with no
+    # memory and no statement that a stale record had been held back, so the
+    # operator never got the chance to confirm, replace, or retire it.
+    if not pack.get("enabled") or not (pack.get("included_records") or pack.get("freshness_warnings")):
         return None
     return pack
 
@@ -2057,6 +2116,10 @@ def validate_project_memory_recall_pack(value: Any, *, label: str = "memory_reca
         errors.append(f"{label}.query_intent must be default or temporal")
     _validate_context_list(value.get("included_records"), _PROJECT_MEMORY_RECALL_ITEM_KEYS, errors, f"{label}.included_records", scope_key="scope")
     _validate_context_list(value.get("excluded_records"), _PROJECT_MEMORY_EXCLUDED_KEYS, errors, f"{label}.excluded_records")
+    # Optional so a wrapper-supplied pack written before freshness warnings
+    # existed still validates; present warnings are held to the full shape.
+    if "freshness_warnings" in value:
+        _validate_context_list(value.get("freshness_warnings"), _FRESHNESS_WARNING_KEYS, errors, f"{label}.freshness_warnings")
     _validate_context_map(value.get("task_ref"), _PROJECT_MEMORY_TASK_REF_KEYS, errors, f"{label}.task_ref")
     if not isinstance(value.get("truncated"), bool):
         errors.append(f"{label}.truncated must be a boolean")
@@ -2097,6 +2160,11 @@ def _build_project_memory_candidate(
     staleness = _staleness_metadata(stale_after_days, record_type=normalized_type, created_at=now)
     candidate_id = "cand_" + os.urandom(8).hex()
     status = "blocked_review_required" if safety["status"] == "blocked" else "pending_review"
+    # Digest the ref exactly as it will be stored, not as it was passed:
+    # redaction and truncation can change the string, and the freshness check
+    # later reads the stored one.
+    stored_source_ref = _redact(str(source_ref or ""))[:160]
+    source_evidence = _source_evidence(stored_source_ref, captured_at=now)
     return {
         "schema_version": PROJECT_MEMORY_CANDIDATE_SCHEMA_VERSION,
         "candidate_id": candidate_id,
@@ -2106,7 +2174,8 @@ def _build_project_memory_candidate(
         "scope": scope,
         "tags": normalized_tags,
         "source": str(source or "cli"),
-        "source_ref": _redact(str(source_ref or ""))[:160],
+        "source_ref": stored_source_ref,
+        **({"source_evidence": source_evidence} if source_evidence else {}),
         "created_at": now,
         "ttl": ttl,
         "staleness": staleness,
@@ -2159,6 +2228,10 @@ def _record_from_candidate(
         "source": str(candidate.get("source", "cli")),
         "source_class": "omh_local",
         "source_ref": _redact(str(candidate.get("source_ref", "")))[:160],
+        # The digest is carried over as observed at capture, never recomputed
+        # here: approval must not silently re-bless a source that changed
+        # while the candidate sat in the review queue.
+        **({"source_evidence": evidence} if (evidence := _source_evidence_projection(candidate)) else {}),
         "derived_from": _string_list(candidate.get("derived_from", [])),
         **(
             {"perspective": projection}
@@ -2238,7 +2311,7 @@ def _ttl_projection(retention: dict[str, object]) -> dict[str, object]:
 
 def _staleness_projection(revalidation: dict[str, object]) -> dict[str, object]:
     deadline = str(revalidation.get("deadline", ""))
-    return {"stale_after": deadline, "stale_after_days": None}
+    return {"stale_after": deadline, "stale_after_days": None, "review_due_at": deadline}
 
 
 def _empty_recall_pack(
@@ -2263,6 +2336,7 @@ def _empty_recall_pack(
         "query_intent": "default",
         "included_records": [],
         "excluded_records": [{"record_id": "", "reason": reason, "staleness": {"state": "not_checked"}}],
+        "freshness_warnings": [],
         "record_count": 0,
         "truncated": False,
         "redaction_policy": "metadata_only",
@@ -2308,6 +2382,55 @@ def _recall_exclusion(
         "staleness": staleness,
         **_recall_evidence_fields(evidence),
     }
+
+
+def _freshness_warnings(
+    included: list[dict[str, object]],
+    excluded: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    """Name every record in this pack whose freshness is not confirmed.
+
+    This is the surface acceptance criterion 1 asks for: before a stale,
+    expired, superseded, or source-moved record can influence a plan or a
+    handoff, the pack says which record it is, why revalidation is due, and
+    that the operator must confirm, replace, or retire it. A held-back record
+    warns exactly like a delivered one -- ``delivered`` says which happened --
+    because a record silently missing from a pack is the failure this
+    replaces, not the fix.
+
+    Records excluded for reasons that are not about freshness
+    (``no_query_overlap``, ``over_budget`` on a fresh record) never warn:
+    a warning that fires for everything is read as noise and stops working.
+    """
+    warnings: list[dict[str, object]] = []
+    seen: set[str] = set()
+    for delivered, entry in [*((True, item) for item in included), *((False, item) for item in excluded)]:
+        record_id = str(entry.get("record_id", ""))
+        staleness = entry.get("staleness") if isinstance(entry.get("staleness"), dict) else {}
+        state = str(staleness.get("state", ""))
+        reason_code = str(entry.get("eligibility_reason", "") or "")
+        known_reason = reason_code in _FRESHNESS_REASON_TEXT
+        if not known_reason and state in {"", "fresh", "not_checked"}:
+            continue
+        if not record_id or record_id in seen:
+            continue
+        seen.add(record_id)
+        if not known_reason:
+            reason_code = "freshness_unconfirmed"
+        warnings.append(
+            {
+                "record_id": record_id,
+                "state": state or "unknown",
+                "reason_code": reason_code,
+                "review_due_at": str(staleness.get("review_due_at", "") or ""),
+                "detail": _FRESHNESS_REASON_TEXT[reason_code],
+                "delivered": bool(delivered),
+                "next_action": _FRESHNESS_NEXT_ACTION,
+            }
+        )
+        if len(warnings) >= _FRESHNESS_WARNING_LIMIT:
+            break
+    return warnings
 
 
 def _recall_evidence_fields(value: Any) -> dict[str, object]:
@@ -2479,22 +2602,119 @@ def _record_scope_matches(record: dict[str, Any], *, scope_kind: str | None, sco
 
 
 def _record_staleness(record: dict[str, Any], *, now: datetime | None = None) -> dict[str, object]:
-    """TTL and staleness state at ``now`` (wall clock when omitted).
+    """The one freshness verdict: TTL, review-due date, and source evidence.
 
     The TTL half is decided by the bundle classifier, the single source of
     truth for what "expired" means: it reads naive timestamps as UTC, where
     the local ``_parse_utc`` would read them as host-local time and move the
     verdict by up to +/-14 hours depending on where the host happens to be.
+
+    The review-due half reads ``review_due_at`` and the older ``stale_after``
+    spelling of the same date, taking whichever comes first, so records
+    written before the field was named keep their deadline and a record with
+    only one spelling edited cannot read as fresh.
+
+    The source half compares the digest recorded at capture against the cited
+    local file as it reads now. It only ever makes a record less trusted: a
+    moved source is ``stale``, an unreadable one is ``unknown``, and neither
+    can turn into ``fresh``. Every input is stored metadata plus the caller's
+    ``now`` plus locally observable bytes, so the verdict is reproducible.
     """
     now = now if now is not None else datetime.now(timezone.utc)
     ttl = record.get("ttl", {}) if isinstance(record.get("ttl"), dict) else {}
-    if _classify_record_expiry(record, now=now) == "expired":
-        return {"state": "expired", "expires_at": str(ttl.get("expires_at", ""))}
     staleness = record.get("staleness", {}) if isinstance(record.get("staleness"), dict) else {}
-    stale_after = _parse_utc(str(staleness.get("stale_after", "") or ""))
-    if stale_after and stale_after <= now:
-        return {"state": "stale", "stale_after": str(staleness.get("stale_after", ""))}
-    return {"state": "fresh", "stale_after": str(staleness.get("stale_after", "")), "expires_at": str(ttl.get("expires_at", ""))}
+    expires_at = str(ttl.get("expires_at", ""))
+    stale_after = str(staleness.get("stale_after", ""))
+    review_due_at = _earliest_deadline(str(staleness.get("review_due_at", "") or ""), stale_after)
+    source_state = _source_evidence_state(record)
+    fields = {
+        "stale_after": stale_after,
+        "review_due_at": review_due_at,
+        "expires_at": expires_at,
+        "source_state": source_state,
+    }
+    if _classify_record_expiry(record, now=now) == "expired":
+        return {"state": "expired", "reason": "retention_expired", **fields}
+    deadline = _parse_utc(review_due_at)
+    if deadline and deadline <= now:
+        return {"state": "stale", "reason": "review_due", **fields}
+    if source_state == "changed":
+        return {"state": "stale", "reason": "source_changed", **fields}
+    if source_state == "unreadable":
+        return {"state": "unknown", "reason": "source_unreadable", **fields}
+    return {"state": "fresh", "reason": "", **fields}
+
+
+def _earliest_deadline(*values: str) -> str:
+    """The soonest parseable deadline among equivalent spellings, fail-closed.
+
+    ``review_due_at`` and ``stale_after`` are two names for one date, so they
+    normally agree. When something edits only one of them they must not cancel
+    each other out: whichever deadline has already passed decides, so a
+    half-updated record reads as due for review rather than as fresh.
+    """
+    best_value = ""
+    best_time: datetime | None = None
+    for value in values:
+        if not value:
+            continue
+        if not best_value:
+            best_value = value
+        parsed = _parse_utc(value)
+        if parsed is not None and (best_time is None or parsed < best_time):
+            best_time, best_value = parsed, value
+    return best_value
+
+
+def _source_evidence(source_ref: str, *, captured_at: str) -> dict[str, object]:
+    """Digest a cited local source so a later change to it becomes observable.
+
+    Only an absolute path to a readable local file earns evidence. A relative
+    ref would resolve against whatever directory the caller happened to be in,
+    which would make the same stored record read differently per invocation;
+    a ref that is not a path at all (a PR number, a decision name) has nothing
+    to digest. Both simply carry no evidence and stay on the deadline-only
+    path, exactly as records did before.
+    """
+    digest = _local_source_digest(source_ref)
+    return {"path": source_ref, "sha256": digest, "captured_at": captured_at} if digest else {}
+
+
+def _source_evidence_projection(value: Any) -> dict[str, object]:
+    """Scalar-only projection of recorded source evidence, or {}."""
+    evidence = value.get("source_evidence") if isinstance(value, dict) else None
+    if not isinstance(evidence, dict) or not str(evidence.get("sha256", "") or ""):
+        return {}
+    return {key: str(evidence.get(key, "") or "") for key in ("path", "sha256", "captured_at")}
+
+
+def _local_source_digest(source_ref: str) -> str:
+    """SHA-256 of a local file, or "" when it cannot be digested here."""
+    if not source_ref:
+        return ""
+    try:
+        path = Path(source_ref)
+        if not path.is_absolute() or not path.is_file() or path.stat().st_size > _SOURCE_EVIDENCE_MAX_BYTES:
+            return ""
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except (OSError, ValueError):
+        # Unreadable, gone, a directory, or a path this platform rejects. The
+        # caller turns an empty digest into `unreadable`, never into `fresh`.
+        return ""
+
+
+def _source_evidence_state(record: dict[str, Any]) -> str:
+    """"" (no evidence recorded) | unchanged | changed | unreadable."""
+    evidence = record.get("source_evidence")
+    if not isinstance(evidence, dict):
+        return ""
+    recorded = str(evidence.get("sha256", "") or "")
+    if not recorded:
+        return ""
+    current = _local_source_digest(str(evidence.get("path", "") or ""))
+    if not current:
+        return "unreadable"
+    return "unchanged" if current == recorded else "changed"
 
 
 def _project_memory_safety(summary: str, content: str, *, tags: list[str]) -> dict[str, object]:
@@ -2532,9 +2752,14 @@ def _ttl_metadata(ttl_days: int | None, *, record_type: str, created_at: str) ->
 
 def _staleness_metadata(stale_after_days: int | None, *, record_type: str, created_at: str) -> dict[str, object]:
     default_days = 90 if record_type in {"fact", "decision", "lesson", "procedure"} and stale_after_days is None else stale_after_days
+    deadline = _days_after(created_at, default_days) if default_days else ""
+    # `review_due_at` is the readable name for the date `stale_after` always
+    # held. Both are written so older readers keep working; nothing derives a
+    # second deadline from the new spelling.
     return {
         "stale_after_days": default_days,
-        "stale_after": _days_after(created_at, default_days) if default_days else "",
+        "stale_after": deadline,
+        "review_due_at": deadline,
     }
 
 

--- a/src/wrapper/briefing.py
+++ b/src/wrapper/briefing.py
@@ -537,6 +537,10 @@ def _memory_recall_pack_summary(memory_recall_pack: dict[str, Any]) -> dict[str,
             "session_id": str(memory_recall_pack.get("session_id", "")),
             "record_count": int(memory_recall_pack.get("record_count", 0) or 0),
             "excluded_count": int(memory_recall_pack.get("excluded_count", 0) or 0),
+            # Carried whole, not counted: a brief that says "1 warning" without
+            # naming the record or the reason cannot be acted on, and the list
+            # is already bounded where the pack builds it.
+            "freshness_warnings": _list_value(memory_recall_pack.get("freshness_warnings")),
             "replay_evidence": _memory_replay_evidence(memory_recall_pack),
             "redaction_policy": str(memory_recall_pack.get("redaction_policy", "")),
             "claim_boundary": str(memory_recall_pack.get("claim_boundary", "")),
@@ -547,6 +551,7 @@ def _memory_recall_pack_summary(memory_recall_pack: dict[str, Any]) -> dict[str,
         "session_id": str(memory_recall_pack.get("session_id", "")),
         "record_count": len(_list_value(memory_recall_pack.get("included_records"))),
         "excluded_count": len(_list_value(memory_recall_pack.get("excluded_records"))),
+        "freshness_warnings": _list_value(memory_recall_pack.get("freshness_warnings")),
         "replay_evidence": _memory_replay_evidence(memory_recall_pack),
         "redaction_policy": str(memory_recall_pack.get("redaction_policy", "")),
         "claim_boundary": str(memory_recall_pack.get("claim_boundary", "")),

--- a/tests/test_memory_staleness.py
+++ b/tests/test_memory_staleness.py
@@ -1,0 +1,448 @@
+"""Stale project memory must announce itself before it steers anything.
+
+Issue #830. Three contracts, in the order a record meets them:
+
+1. A recall pack bound for a handoff names every record whose freshness is
+   unconfirmed, instead of quietly shrinking. Silence was the defect.
+2. Correcting or superseding a record keeps the prior revision and its
+   provenance, including the digest of the source it cited.
+3. Freshness is a function of stored metadata, the caller's ``now``, and
+   locally observable source bytes -- nothing else. Unknown never reads fresh.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.local_store import atomic_write_text
+from omh.memory import (
+    approve_project_memory_candidate,
+    build_project_memory_recall_pack,
+    capture_project_memory_candidate,
+    memory_recall_pack_for_handoff,
+    validate_project_memory_record,
+    validate_project_memory_recall_pack,
+)
+from omh.paths import resolve_paths
+from omh.workflows import memory as memory_workflow
+from omh.workflows.memory_lifecycle import (
+    apply_memory_correction,
+    apply_memory_reapproval,
+    apply_memory_restore,
+    apply_memory_retirement,
+    build_memory_correction,
+    build_memory_reapproval,
+    build_memory_restore,
+    build_memory_retirement,
+)
+from omh.workflows.memory_lifecycle_executor import execute_memory_lifecycle
+from omh.runtime.artifacts import _memory_recall_pack_summary as artifact_pack_summary
+from omh.wrapper.briefing import _memory_recall_pack_summary as briefing_pack_summary
+
+PAST = "2020-01-01T00:00:00Z"
+
+
+def _approved(paths, summary: str, **capture) -> dict:
+    captured = capture_project_memory_candidate(paths, summary, **capture)
+    return approve_project_memory_candidate(paths, captured["candidate"]["candidate_id"])["record"]
+
+
+def _record_path(paths, record_id: str) -> Path:
+    return paths.memory_dir / "records" / f"{record_id}.json"
+
+
+def _mutate_record(paths, record_id: str, **fields) -> dict:
+    """Rewrite a stored record's non-digested metadata.
+
+    ``canonical_payload_digest`` covers schema/id/revision/type/summary/scope
+    only, so deadlines and source evidence can be edited without invalidating
+    the admission digest or its review record.
+    """
+    path = _record_path(paths, record_id)
+    stored = json.loads(path.read_text(encoding="utf-8"))
+    stored.update(fields)
+    atomic_write_text(path, json.dumps(stored), private=True)
+    return stored
+
+
+def _source_file(root: Path, name: str, body: str) -> Path:
+    path = root / name
+    # atomic_write_text, never Path.write_text: these bytes are hashed, and
+    # Path.write_text would newline-translate them to CRLF on Windows, which
+    # would make the same fixture digest differently per platform.
+    atomic_write_text(path, body)
+    return path
+
+
+class HandoffFreshnessWarningTests(unittest.TestCase):
+    """AC1: warn before a stale or expired record influences a handoff."""
+
+    def test_handoff_pack_names_the_stale_record_instead_of_dropping_it(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record = _approved(paths, "Release notes ship from the changelog", record_type="decision")
+            _mutate_record(
+                paths,
+                record["record_id"],
+                revalidation={"deadline": PAST},
+                staleness={"stale_after": PAST, "stale_after_days": None, "review_due_at": PAST},
+            )
+
+            pack = memory_recall_pack_for_handoff(paths, "release notes changelog", executor_target="codex")
+
+            self.assertIsNotNone(pack, "a stale-only pack must still reach the handoff as a warning")
+            assert pack is not None
+            self.assertEqual(pack["record_count"], 0, "a stale record is never promoted into the handoff")
+            self.assertEqual(pack["included_records"], [])
+            [warning] = pack["freshness_warnings"]
+            self.assertEqual(warning["record_id"], record["record_id"])
+            self.assertEqual(warning["state"], "stale")
+            self.assertEqual(warning["reason_code"], "stale_review_required")
+            self.assertEqual(warning["review_due_at"], PAST)
+            self.assertFalse(warning["delivered"], "the warning says the record was held back")
+            self.assertIn("revalidation deadline passed", warning["detail"])
+            self.assertIn("Confirm, replace, or retire", warning["next_action"])
+            self.assertEqual(validate_project_memory_recall_pack(pack), [])
+
+    def test_expired_records_warn_too_and_stay_out_of_the_pack(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record = _approved(paths, "Nightly job runs at 02:00 UTC", ttl_days=5)
+            expires_at = datetime.fromisoformat(str(record["ttl"]["expires_at"]).replace("Z", "+00:00"))
+
+            pack = build_project_memory_recall_pack(paths, "nightly job", now=expires_at + timedelta(days=1))
+
+            self.assertEqual(pack["record_count"], 0)
+            [warning] = pack["freshness_warnings"]
+            self.assertEqual(warning["record_id"], record["record_id"])
+            self.assertEqual(warning["state"], "expired")
+            self.assertEqual(warning["reason_code"], "expired_standard")
+
+    def test_fresh_records_produce_no_warning_noise(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            _approved(paths, "Docs gates are byte-exact comparisons")
+            _approved(paths, "Unrelated note about branch naming")
+
+            pack = build_project_memory_recall_pack(paths, "docs gates")
+
+            self.assertEqual(pack["record_count"], 1)
+            self.assertEqual(
+                pack["freshness_warnings"],
+                [],
+                "a record cut for no query overlap is not a freshness problem",
+            )
+
+    def test_include_stale_delivers_the_record_and_still_warns(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record = _approved(paths, "CI runner image is ubuntu-24.04")
+            _mutate_record(
+                paths,
+                record["record_id"],
+                revalidation={"deadline": PAST},
+                staleness={"stale_after": PAST, "stale_after_days": None, "review_due_at": PAST},
+            )
+
+            pack = build_project_memory_recall_pack(paths, "ci runner ubuntu", include_stale=True)
+
+            [item] = pack["included_records"]
+            self.assertFalse(item["replay_evaluation"]["eligible"], "inspection never launders eligibility")
+            [warning] = pack["freshness_warnings"]
+            self.assertTrue(warning["delivered"], "a surfaced stale record still carries its warning")
+            self.assertEqual(warning["reason_code"], "stale_review_required")
+
+    def test_the_warning_survives_delegation_and_its_brief(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record = _approved(paths, "Coverage gate sits at 80 percent")
+            _mutate_record(
+                paths,
+                record["record_id"],
+                revalidation={"deadline": PAST},
+                staleness={"stale_after": PAST, "stale_after_days": None, "review_due_at": PAST},
+            )
+            pack = memory_recall_pack_for_handoff(paths, "coverage gate percent", executor_target="codex")
+            assert pack is not None
+
+            for name, summarize in (("wrapper brief", briefing_pack_summary), ("runtime artifact", artifact_pack_summary)):
+                with self.subTest(surface=name):
+                    summary = summarize(pack)
+                    self.assertEqual(
+                        [entry["record_id"] for entry in summary["freshness_warnings"]],
+                        [record["record_id"]],
+                        "a summary that drops the warning puts the user back where they started",
+                    )
+                    self.assertEqual(summary["record_count"], 0)
+
+    def test_a_pack_with_nothing_to_say_is_still_omitted_from_the_handoff(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            _approved(paths, "Branch names start with agent or claude")
+
+            self.assertIsNone(
+                memory_recall_pack_for_handoff(paths, "wholly unrelated payment gateway topic"),
+                "no records and no warnings means no pack; warnings must not fabricate one",
+            )
+
+
+class SupersessionProvenanceTests(unittest.TestCase):
+    """AC2: revalidating or superseding preserves the prior revision."""
+
+    def test_correction_writes_the_prior_revision_with_its_supersession_link(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            source = _source_file(root, "deploy.md", "staging first\n")
+            record = _approved(paths, "Deploys go through staging first", record_type="decision", source_ref=str(source))
+            now = datetime.now(timezone.utc)
+
+            plan = build_memory_correction(paths, record["record_id"], 1, "Deploys go staging, then canary", now=now)
+            apply_memory_correction(paths, plan, transaction_executor=execute_memory_lifecycle)
+
+            history = json.loads(
+                (paths.memory_dir / "history" / f"{record['record_id']}.r1.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(history["revision"], 1, "the prior revision is preserved verbatim, not rewritten")
+            self.assertEqual(history["summary"], record["summary"])
+            self.assertEqual(history["admission"], record["admission"], "its approval provenance survives")
+            self.assertEqual(history["source_evidence"], record["source_evidence"])
+            self.assertEqual(
+                history["superseded_by"],
+                {
+                    "schema_version": "project_memory_record/v2",
+                    "id": record["record_id"],
+                    "id_key": "record_id",
+                    "revision": 2,
+                    "scope": record["scope"],
+                },
+            )
+            self.assertEqual(
+                validate_project_memory_record(history),
+                [],
+                "the superseded copy is a valid record, so supersession is a first-class record state",
+            )
+
+    def test_a_live_record_marked_superseded_is_refused_and_warned_about(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record = _approved(paths, "Config lives in pyproject.toml")
+            _mutate_record(
+                paths,
+                record["record_id"],
+                superseded_by={
+                    "schema_version": "project_memory_record/v2",
+                    "id": record["record_id"],
+                    "id_key": "record_id",
+                    "revision": 2,
+                    "scope": record["scope"],
+                },
+            )
+
+            pack = build_project_memory_recall_pack(paths, "pyproject config")
+
+            self.assertEqual(pack["record_count"], 0)
+            [warning] = pack["freshness_warnings"]
+            self.assertEqual(warning["reason_code"], "superseded")
+            self.assertIn("newer revision supersedes", warning["detail"])
+
+    def test_source_evidence_survives_capture_approve_correct_reapprove(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            source = _source_file(root, "runbook.md", "restart the worker\n")
+            record = _approved(paths, "Worker restarts are manual", source_ref=str(source))
+            now = datetime.now(timezone.utc)
+
+            plan = build_memory_correction(paths, record["record_id"], 1, "Worker restarts are scripted", now=now)
+            apply_memory_correction(paths, plan, transaction_executor=execute_memory_lifecycle)
+            candidate = next(
+                json.loads(path.read_text(encoding="utf-8"))
+                for path in sorted((paths.memory_dir / "candidates").glob("*.json"))
+                if json.loads(path.read_text(encoding="utf-8")).get("lifecycle") == "correction"
+            )
+            self.assertEqual(candidate["replacement"]["source_evidence"], record["source_evidence"])
+
+            reapproval = build_memory_reapproval(paths, candidate["candidate_id"], reviewer_claim="operator", now=now)
+            apply_memory_reapproval(paths, reapproval, transaction_executor=execute_memory_lifecycle)
+
+            live = json.loads(_record_path(paths, record["record_id"]).read_text(encoding="utf-8"))
+            self.assertEqual(live["revision"], 2)
+            self.assertEqual(
+                live["source_evidence"],
+                record["source_evidence"],
+                "a corrected revision keeps watching the same source; otherwise one correction blinds it forever",
+            )
+
+    def test_source_evidence_survives_retire_and_restore(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            source = _source_file(root, "policy.md", "two reviewers\n")
+            record = _approved(paths, "Merges need two reviewers", ttl_days=30, source_ref=str(source))
+            later = datetime.now(timezone.utc) + timedelta(days=60)
+
+            retire = build_memory_retirement(paths, record["record_id"], 1, now=later)
+            apply_memory_retirement(paths, retire, transaction_executor=execute_memory_lifecycle)
+            restore = build_memory_restore(paths, record["record_id"], 1, now=later)
+            apply_memory_restore(paths, restore, transaction_executor=execute_memory_lifecycle)
+            candidate_id = str(restore.mutations[0].payload["candidate_id"])
+            reapproval = build_memory_reapproval(paths, candidate_id, reviewer_claim="operator", now=later)
+            apply_memory_reapproval(paths, reapproval, transaction_executor=execute_memory_lifecycle)
+
+            live = json.loads(_record_path(paths, record["record_id"]).read_text(encoding="utf-8"))
+            self.assertEqual(live["revision"], 2)
+            self.assertEqual(live["source_evidence"], record["source_evidence"])
+
+
+class DeterministicFreshnessTests(unittest.TestCase):
+    """AC3: freshness derives from stored metadata and observable source bytes."""
+
+    def test_the_same_metadata_and_now_always_yield_the_same_verdict(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            source = _source_file(root, "gate.md", "byte exact\n")
+            record = _approved(paths, "Doc gates compare bytes", source_ref=str(source))
+            stored = json.loads(_record_path(paths, record["record_id"]).read_text(encoding="utf-8"))
+            probe = datetime(2026, 8, 9, 12, 0, 0, tzinfo=timezone.utc)
+
+            verdicts = [memory_workflow._record_staleness(stored, now=probe) for _ in range(3)]
+
+            self.assertEqual(verdicts[0], verdicts[1])
+            self.assertEqual(verdicts[1], verdicts[2])
+            self.assertEqual(verdicts[0]["state"], "fresh")
+            self.assertEqual(verdicts[0]["source_state"], "unchanged")
+
+    def test_a_changed_source_digest_flips_the_state_and_nothing_else_does(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            source = _source_file(root, "schema.md", "one field\n")
+            record = _approved(paths, "The schema has one field", source_ref=str(source))
+            stored = json.loads(_record_path(paths, record["record_id"]).read_text(encoding="utf-8"))
+            probe = datetime(2026, 8, 9, 12, 0, 0, tzinfo=timezone.utc)
+            self.assertEqual(memory_workflow._record_staleness(stored, now=probe)["state"], "fresh")
+
+            _source_file(root, "schema.md", "two fields\n")
+
+            after = memory_workflow._record_staleness(stored, now=probe)
+            self.assertEqual(after["state"], "stale", "the cited source moved, so the record is due for review")
+            self.assertEqual(after["reason"], "source_changed")
+            self.assertEqual(after["source_state"], "changed")
+
+    def test_an_unreadable_source_is_unknown_and_never_fresh(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            source = _source_file(root, "vanishing.md", "here for now\n")
+            record = _approved(paths, "The vanishing note still applies", source_ref=str(source))
+            stored = json.loads(_record_path(paths, record["record_id"]).read_text(encoding="utf-8"))
+            probe = datetime(2026, 8, 9, 12, 0, 0, tzinfo=timezone.utc)
+
+            source.unlink()
+
+            verdict = memory_workflow._record_staleness(stored, now=probe)
+            self.assertEqual(verdict["state"], "unknown")
+            self.assertNotEqual(verdict["state"], "fresh")
+            self.assertEqual(verdict["reason"], "source_unreadable")
+            self.assertEqual(verdict["source_state"], "unreadable")
+
+    def test_a_source_that_moved_is_kept_out_of_recall_and_named(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            source = _source_file(root, "owners.md", "team alpha owns it\n")
+            record = _approved(paths, "Team alpha owns the parser", source_ref=str(source))
+            self.assertEqual(build_project_memory_recall_pack(paths, "parser owner")["record_count"], 1)
+
+            _source_file(root, "owners.md", "team beta owns it\n")
+
+            pack = build_project_memory_recall_pack(paths, "parser owner")
+            self.assertEqual(pack["record_count"], 0, "a source-moved record is never silently promoted")
+            [excluded] = [entry for entry in pack["excluded_records"] if entry["record_id"] == record["record_id"]]
+            self.assertEqual(excluded["reason"], "source_changed")
+            [warning] = pack["freshness_warnings"]
+            self.assertEqual(warning["reason_code"], "source_changed")
+            self.assertIn("local source it cites changed", warning["detail"])
+
+    def test_an_unverifiable_source_is_kept_out_of_recall_and_named(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            source = _source_file(root, "gone.md", "still here\n")
+            record = _approved(paths, "The parser rejects empty input", source_ref=str(source))
+
+            source.unlink()
+
+            pack = build_project_memory_recall_pack(paths, "parser empty input")
+            self.assertEqual(pack["record_count"], 0, "unknown freshness must never read as approved context")
+            [warning] = pack["freshness_warnings"]
+            self.assertEqual(warning["record_id"], record["record_id"])
+            self.assertEqual(warning["state"], "unknown")
+            self.assertEqual(warning["reason_code"], "source_unverifiable")
+
+    def test_only_an_absolute_local_path_earns_source_evidence(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            _source_file(root, "relative.md", "content\n")
+
+            for source_ref in ("relative.md", "PR #123", str(root / "absent.md"), str(root)):
+                with self.subTest(source_ref=source_ref):
+                    captured = capture_project_memory_candidate(paths, f"Note about {source_ref}", source_ref=source_ref)
+                    self.assertNotIn(
+                        "source_evidence",
+                        captured["candidate"],
+                        "a ref OMH cannot digest locally carries no evidence and stays deadline-only",
+                    )
+
+    def test_review_due_at_names_the_date_stale_after_already_held(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+
+            record = _approved(paths, "Router triggers need a negative case", stale_after_days=90)
+
+            self.assertEqual(record["staleness"]["review_due_at"], record["staleness"]["stale_after"])
+            self.assertTrue(record["staleness"]["review_due_at"])
+            verdict = memory_workflow._record_staleness(record, now=datetime.now(timezone.utc))
+            self.assertEqual(verdict["review_due_at"], record["staleness"]["stale_after"])
+
+    def test_editing_only_one_deadline_spelling_cannot_restore_freshness(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record = _approved(paths, "Only one spelling was edited")
+            future = "2099-01-01T00:00:00Z"
+
+            for edited in ({"stale_after": PAST, "review_due_at": future}, {"stale_after": future, "review_due_at": PAST}):
+                with self.subTest(**edited):
+                    stored = _mutate_record(paths, record["record_id"], staleness={**edited, "stale_after_days": None})
+                    verdict = memory_workflow._record_staleness(stored, now=datetime.now(timezone.utc))
+                    self.assertEqual(verdict["state"], "stale", "the deadline that already passed decides")
+                    self.assertEqual(verdict["review_due_at"], PAST)
+
+    def test_a_legacy_record_without_review_due_at_keeps_its_deadline(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record = _approved(paths, "Older record written before the field was named")
+            stored = _mutate_record(
+                paths,
+                record["record_id"],
+                staleness={"stale_after": PAST, "stale_after_days": None},
+            )
+
+            verdict = memory_workflow._record_staleness(stored, now=datetime.now(timezone.utc))
+
+            self.assertEqual(verdict["state"], "stale")
+            self.assertEqual(verdict["review_due_at"], PAST, "the old spelling still supplies the deadline")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

Closes #830.

An approved OMH memory record stays syntactically valid long after the
decision, file, or workflow behind it has changed. Worse, when the record
did go stale, the recall pack bound for a handoff **dropped it silently** —
the executor received a smaller pack, no reason, and nobody was ever asked
whether the record should be confirmed, replaced, or retired. That is the
failure this PR removes.

### What Changed

- **`staleness.review_due_at`** is now a named field. It carries the same date
  `staleness.stale_after` always held, written alongside it. When the two
  disagree the *earlier* one decides, so editing one spelling can never
  restore freshness.
- **`source_evidence`** is a new optional record field. When `--source-ref`
  names an absolute path to a readable local file, capture records that
  file's SHA-256. Every later freshness check re-reads the file and compares.
  A changed digest makes the record `stale`; an unreadable, deleted,
  non-absolute, or over-budget ref makes it `unknown` — never `fresh`.
- **`freshness_warnings`** is a new bounded list on `project_memory_recall_pack/v1`.
  It names every record in the pack whose freshness is not confirmed: the
  record id, state, reason code, review-due date, whether it was delivered,
  a human-readable `detail`, and the `next_action`
  ("Confirm, replace, or retire this record before it steers the plan.").
- **`memory_recall_pack_for_handoff` no longer returns `None`** when the only
  thing it has to say is a warning. The warning travels with the handoff.
- **`superseded_by`** is now an allowed key on `project_memory_record/v2`, so
  the history revision written by `build_memory_correction` is a valid
  record, and the shared evaluator's already-existing `superseded` branch can
  fire for a live record instead of being unreachable.
- `source_evidence` survives the lifecycle round trips
  (capture → approve → correct → reapprove, and retire → restore → reapprove).

### Why This Exists

Acceptance criterion 1 of #830 is a warning that arrives *before* a record
influences a plan or handoff. OMH already had the freshness model — the
deadline lived under a different name (`stale_after`), the evaluator already
knew `stale_review_required` and `superseded`, and `--include-stale` already
existed for inspection. Three things were genuinely missing, and all three are
what a user actually hits:

1. Staleness was purely time-based. Nothing noticed that the file a record
   cited had been rewritten the day after approval. AC3 asks for freshness
   from "observable source evidence"; that was the substantive gap.
2. There was no surface where the warning reached a human. The recall pack
   dropped stale records and said nothing.
3. `review_due_at` did not exist as a name anywhere in `src/`
   (`grep -rn "review_due_at" src/` → zero hits before this PR).

### User / Operator Impact

Before: a stale record vanished from the pack. The handoff went out short one
record with no explanation, and the operator had no signal that a decision was
pending.

After, observed end to end through the real CLI:

```
$ omh memory capture "Deploys go through staging first" --type decision --source-ref /.../policy.md
$ omh memory approve cand_0fde43d4858342ac
record_id       : mem_170b6dcba8c2b856
review_due_at   : 2026-11-07T04:27:23Z
source_evidence : {"captured_at": "2026-08-09T04:27:23Z",
                   "path": "/.../policy.md",
                   "sha256": "af19cc6149f9835f8ea06f08148855b9e2e63d08a1cea93b5131f5b0fde32df1"}

$ omh memory recall "staging deploys"          # source unchanged
record_count       : 1
freshness_warnings : []
staleness          : {"state": "fresh", "source_state": "unchanged", ...}

# the cited file is edited
$ omh memory recall "staging deploys"
record_count : 0
excluded     : [{"record_id": "mem_170b6dcba8c2b856", "reason": "source_changed"}]
warning      : {
  "record_id": "mem_170b6dcba8c2b856",
  "state": "stale",
  "reason_code": "source_changed",
  "review_due_at": "2026-11-07T04:27:23Z",
  "detail": "The local source it cites changed after the record was approved.",
  "delivered": false,
  "next_action": "Confirm, replace, or retire this record before it steers the plan."
}

# the cited file is deleted
$ omh memory recall "staging deploys"
record_count : 0
state        : unknown | reason_code: source_unverifiable
detail       : The local source it cites cannot be read now, so its freshness is unobservable.
```

Answering the warning uses the verbs that already existed: `omh memory correct`
supersedes with a reviewable replacement, `omh memory retire` archives an
expired record. Nothing is deleted or rewritten because a source moved.

### How It Works

`_record_staleness` in `src/workflows/memory.py` stays the single freshness
authority and gained the two missing inputs. Its verdict is a uniform dict:
`state` (`fresh` / `stale` / `unknown` / `expired`), `reason`, `review_due_at`,
`stale_after`, `expires_at`, `source_state`.

- **TTL** is still decided by the bundle classifier `classify_record_expiry`,
  unchanged, because it is the single source of truth for naive-UTC parsing.
- **Review due** takes the earliest parseable of `review_due_at` and
  `stale_after` (fail-closed on partial edits).
- **Source** compares `source_evidence.sha256` against a fresh digest of
  `source_evidence.path`. `_local_source_digest` returns `""` for anything it
  cannot digest locally — non-absolute path, missing file, directory, OSError,
  or over `_SOURCE_EVIDENCE_MAX_BYTES` (4 MiB) — and the caller turns `""`
  into `unreadable`, never into `unchanged`.

The shared bundle evaluator (`evaluate_memory_replay`) was **not** forked. It
is the frozen replay-eligibility contract shared by blocks, scopes, and
provider prefetch. Instead `build_project_memory_recall_pack` folds the
record-local source verdict into the evaluator's own result, so recall keeps
exactly one eligibility decision and one set of reason codes
(`source_changed`, `source_unverifiable` join `stale_review_required` in the
`--include-stale` inspection set, all carrying ineligible replay evidence so
the pack stays unattachable as approved context).

Determinism: every input is stored metadata, the caller-supplied `now`, and
locally observable bytes. No network call, no LLM call, no wall clock inside a
compared payload. `canonical_payload_digest` covers only
schema/id/revision/record_type/summary/scope, so neither new field perturbs an
admission digest or its immutable review record.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/workflows/memory.py` | `_record_staleness` extended; new `_earliest_deadline`, `_source_evidence`, `_local_source_digest`, `_source_evidence_state`, `_source_evidence_projection`, `_freshness_warnings`; `source_evidence` + `superseded_by` added to `_PROJECT_MEMORY_RECORD_KEYS`; `freshness_warnings` added to `_PROJECT_MEMORY_RECALL_PACK_KEYS` and validated (optionally, for back-compat); `memory_recall_pack_for_handoff` emits warning-only packs |
| `src/workflows/_memory_lifecycle_plans.py` | `source_evidence` added to the `_pending_candidate` replacement key tuple and carried scalar-only into `_approved_record` |
| `src/wrapper/briefing.py` | recall-pack summary carries `freshness_warnings` by name (both legacy and current pack shapes) |
| `src/runtime/artifacts.py` | runtime recall-pack summary carries `freshness_warnings` by name |
| `src/commands/memory_parser.py` | `--source-ref` help now states that an absolute local path is digested |
| `docs/MEMORY.md` | new "Freshness: Review-Due Dates and Source Evidence" section, including the warning shape |
| `tests/test_memory_staleness.py` | new, 19 tests |

Schema versions are unchanged: `project_memory_record/v2` and
`project_memory_recall_pack/v1` gain optional fields only. No new dependency.
No generated artifact was hand-edited.

## Validation

All commands below were run in this worktree on the rebased branch
(`agent/issue-830` on top of `8dec02ad`) and passed. Ticked boxes are runs I
observed; unticked boxes were not run.

- [x] `uv run --group lint ruff check src tests` → `All checks passed!`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` → `Ran 4412 tests in 169.785s / OK`
- [x] `uv run python -m compileall -q src tests` → exit 0
- [x] `uv run python -m omh.cli docs workflows --check` → `"ok":true`, tap_skills 115/115, no missing/stale/extra
- [x] `uv run python -m omh.cli docs roles --check` → `"ok":true`
- [x] `uv run python -m omh.cli docs capability-families --check` → `"ok":true`
- [x] `uv run python -m omh.cli harness validate` → `"ok":true`, 72 harnesses / 104 skills, zero errors, zero warnings
- [x] `git diff --check` → clean
- [x] Targeted: `PYTHONPATH=tests uv run python -m unittest tests/test_memory_staleness.py` → `Ran 19 tests / OK`
- [x] Real CLI dry run: capture → approve → recall (fresh) → edit source → recall (`source_changed`) → delete source → recall (`source_unverifiable`); transcript quoted above
- [ ] `python3 -m omh.cli release checklist --json` — not run
- [ ] `python3 -m omh.cli release hermes-smoke` — not run
- [ ] `omh --help` — not run (the `omh` entry point is not installed in this worktree; the module CLI was exercised instead)
- [ ] `omh --omh-home /tmp/omh-smoke ... release hermes-smoke --install-path setup ...` — not run
- [ ] Relevant workflow-learning review queue smoke — not applicable; no learning contract changed
- [x] Relevant dry-run or smoke command: the `omh memory` capture/approve/recall sequence above
- [ ] Manual Hermes/TUI check — **not run.** No Hermes runtime was available in this worktree. The warning is produced by OMH and carried in the pack, the wrapper brief, and the runtime artifact summary; how a given Hermes build renders it is unobserved.

New test coverage in `tests/test_memory_staleness.py`, by acceptance criterion:

- **AC1** (5 tests): a handoff pack carrying a stale record names it instead of
  dropping it; expired records warn too; fresh records produce no warning
  noise; `--include-stale` delivers *and* warns (`delivered: true`); a pack
  with neither records nor warnings is still omitted, so warnings cannot
  fabricate a pack. Plus: the warning survives both the wrapper brief and the
  runtime artifact summary.
- **AC2** (4 tests): a correction writes `history/<id>.r1.json` with the prior
  summary, its admission provenance, its source evidence, and the
  `superseded_by` link — and that history payload passes
  `validate_project_memory_record`; a live record marked superseded is refused
  and warned about; `source_evidence` survives correct → reapprove and
  retire → restore → reapprove.
- **AC3** (8 tests): the same metadata plus the same `now` yields an identical
  verdict three times; a changed digest flips the state deterministically; an
  unreadable source is `unknown` and explicitly asserted **not** `fresh`; both
  states are kept out of recall and named; only an absolute readable local
  path earns evidence (relative path, non-path text, absent file, and a
  directory all correctly earn none); `review_due_at` matches `stale_after`;
  a legacy record with only `stale_after` keeps its deadline; editing one
  spelling to a future date cannot restore freshness.

Guards required by the issue are explicit assertions, not implied: a stale
record is never silently promoted (`record_count == 0` plus an
`included_records == []` assertion), and `unknown` never reads as `fresh`.

## Risk

- **Behavioral change for existing stores.** A record that only cites a
  `source_ref` gains no evidence and is unaffected. Only records captured
  *after* this change, with an absolute readable local path, can ever reach
  `source_changed` or `source_unverifiable`. Existing stores keep their
  current behavior exactly.
- **`memory_recall_pack_for_handoff` can now return a pack with zero included
  records.** Callers (`src/wrapper/lifecycle.py`, `src/wrapper/sessions.py`,
  `src/wrapper/contract.py`, `src/commands/coding.py`) treat the pack as
  optional context; `record_attached_recall_usage` iterates
  `included_records` and no-ops on an empty list. Covered by the full suite.
- **One pre-existing test needed a semantic decision.**
  `test_memory_reapproval_path.py` mutates only `staleness.stale_after` to
  force a stale record. Because approval now also writes `review_due_at`, a
  naive "new name wins" rule would have made that edit a no-op — the test
  caught it. The resolution (earliest deadline wins) is the fail-closed one
  and is itself pinned by a new test; the existing test was not modified.
- **Digest cost.** Every freshness check on a source-cited record reads and
  hashes that file. Bounded at 4 MiB per file by `_SOURCE_EVIDENCE_MAX_BYTES`;
  files over the budget earn no evidence at capture and read as `unknown`
  later. Recall already reads the whole store from disk, so this is the same
  order of I/O.
- **Absolute paths are stored in the record.** `source_evidence.path` holds
  the path the operator supplied, which is the same string already stored in
  `source_ref`. It goes through the same `_redact` / 160-char cap, so a path
  containing `secret`/`token` is redacted and simply earns no evidence.

## Compatibility / Rollout

- Additive only. `project_memory_record/v2` and
  `project_memory_recall_pack/v1` keep their schema versions; every new field
  is optional and absent from records written before this change.
- `validate_project_memory_recall_pack` validates `freshness_warnings` only
  when the key is present, so a wrapper-supplied pack from an older build
  still validates.
- `staleness.stale_after` is still written and still read. Nothing was
  renamed or removed.
- Release-channel impact: normal `stable` feature change; users pick it up
  with `omh update`.

## Release / Claims

- [x] Release-channel impact considered (`stable`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — the CLI transcript above is observed; the Hermes/TUI rendering of the warning is explicitly marked not observed
- [x] Known manual Hermes checks are listed, including the `omh release hermes-smoke --live` gap (not run)

A recall pack, including its freshness warnings, remains prepared context. It
is never execution, review, CI, merge, or Hermes internal-memory evidence.

## Follow-Up

- The warning is structured data. A plain-text rendering for
  `omh memory recall` would help operators reading the terminal directly;
  `recall` is JSON-only today, so this PR did not introduce one.
- Source evidence covers a single local file per record. A record citing a
  directory or a set of files is not covered and stays deadline-only.
- `build_handoff_context_pack` already excludes ineligible records with a
  reason code but does not yet carry a `freshness_warnings` equivalent. The
  recall pack was the surface #830 named; the context pack is the natural
  next one.
