### PR TITLE
feat: prevent concurrent OMH handoffs from sharing one workspace

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -761,6 +761,10 @@ Runtime artifacts are local JSON/JSONL files under `.omh/runtime/`.
       external_effect_mint_failures.jsonl
       approval_receipts.jsonl
       approval_mint_failures.jsonl
+      blocked_work_records.jsonl
+      blocked_work_mint_failures.jsonl
+      workspace_bindings.jsonl
+      workspace_binding_mint_failures.jsonl
     wrapper_sessions/
       <session-id>/
         session.json
@@ -1115,6 +1119,62 @@ boundary of `handoff_safety_contract/v1` is `declared_not_enforced`, blocked by
 `no_confirmation_answer_intake_mints_a_run_bound_approval`. "Consent is
 classified; on the shipped lane it is not enforced" below says why arming there
 would have been worse than not arming.
+
+### Workspace Bindings
+
+`runtime/journal/workspace_bindings.jsonl` is the fourth store, holding
+`workspace_binding_guard/v1` records: one reservation of one canonical workspace
+and one branch for one handoff, under one owner and one base revision, with the
+condition that will release it. It runs on the same base as the other three,
+told its own key names (`record_id`, `supersedes_binding_ref`).
+
+It exists because nothing in the tree knew about anyone else's workspace.
+`coding/isolation.py` decides *whether* a handoff wants its own worktree, and
+`wrapper/worktree_binding.py` builds a recipe for opening one executor in one
+path; neither consults a registry of active bindings, so two handoffs pointed at
+one directory both succeeded and two handoffs on one branch were invisible. The
+guard is the missing exclusivity: `acquire_workspace_binding` reads the active
+set and appends the new claim under one `local_store.file_lock`, so two
+concurrent acquisitions on one workspace produce one held binding and one
+refusal rather than two winners.
+
+Identity is the *canonical* path — expanded, user-resolved, and symlink-resolved
+through `paths.expand_path` — then digested. `~/w`, `$HOME/w`, `/tmp/w/../w`, and
+the absolute path are one workspace, which is what stops the guard being defeated
+by typing the path differently, and no host path byte reaches the store: a stored
+`workspace_ref` that is not a digest handle is refused at build, at validate, and
+at render. There are two conflict axes and they report separately because they
+have different answers — the same canonical workspace held by another handoff,
+and the same `(repository, branch)` pair held by another active workspace.
+
+Staleness is derived at read time from the head record's stamp — the
+`action_gate._account_state` idiom — against `BINDING_STALE_AFTER_SECONDS`, and
+it **blocks reuse without ever releasing anything**. Auto-release would be the
+background lease service issue #820 puts out of scope, and it would be wrong on
+its own terms: a binding nobody has reported on is not a binding nobody is
+running. A stale conflict therefore carries a different reason code and a
+different recovery from a fresh one — release it explicitly, which is an act with
+an owner — and every refusal returns a closed `recovery_action` id together with
+the sentence for it, because an id alone is not guidance. Release itself has two
+doors: `observed_terminal_state`, accepted only from the handoff and owner on
+record, and `explicit_safe_release`, accepted from anyone, because a release only
+the absent holder could perform would lock an abandoned workspace forever.
+
+A binding is ownership evidence and nothing else. It is not evidence the
+directory exists (nothing here stats the filesystem), not dispatch, and not
+result: `CLAIM_BOUNDARY` says so on every record and on every verdict, and a
+record shaped to assert execution is refused by key name before the closed key
+set even sees it. The `workspace` boundary of `handoff_safety_contract/v1` stays
+`declared_not_enforced` for that reason — the pre-dispatch half now exists, the
+runtime half cannot, because no change on this side of the wall constrains a
+process that is already running.
+
+**What is wired, as opposed to declared.** The store, the guard, the read-only
+`inspect_workspace_binding`, the registry entry in
+`OPTIONAL_RUNTIME_STORE_VALIDATORS`, and the store-level report inside
+`omh runtime validate`. No delegation or chat lane calls the guard yet, and no
+`omh` command exposes it; wiring a caller is a separate change with its own
+user-facing surface and its own confirmation copy.
 
 ### Prepared Runtime Run Executor Matrix
 
@@ -1578,8 +1638,10 @@ known boundary, not an oversight.
 ### Adoption boundary
 
 This contract covers record-level staleness only. Cross-record binding — such as
-a session pinned to a workspace — is tracked separately as issue #820 and is not
-enforced here. Distributed locks across machines are also out of scope: the
+a session pinned to a workspace — is not enforced here; that is
+`workspace_binding_guard/v1`'s job, and it is a separate store with its own
+lock, described under **Workspace Bindings** below. Distributed locks across
+machines are also out of scope: the
 guard is a single-host advisory lock plus a revision compare. Records written
 before operation scoping keep un-prefixed `applied_mutations` keys; those keys
 are never matched again, so one legacy id can apply a second time and then
@@ -2074,8 +2136,9 @@ than onto a second label set. The facts function's `enforcement_kind` survives
 only inside the statement, where it explains *why* a limit is or is not enforced
 here; `enforced_here` is the whole mapping to `enforced` versus
 `declared_not_enforced`. Three of the rows are host-dependent by nature: a host
-with an OS confinement backend is blocked on #820, and a host without one is
-blocked on not having one, which is why the test compares those three against
+with an OS confinement backend is blocked on no delegation or fanout lane
+placing an executor under the sandbox, and a host without one is blocked on not
+having a backend at all, which is why the test compares those three against
 the same facts the contract read instead of pinning a string that would pass on
 macOS and fail on Windows. The facts are declared in
 `HANDOFF_CONTRACT_INPUT_SOURCES` and probed once per process behind
@@ -2094,8 +2157,12 @@ enforcement suite pins its exact argv, so changing it fails a test rather than
 quietly widening what the sentence covers.
 
 Declared and not enforced, each naming what must land first: **workspace** —
-`allowed_targets` is derived from the isolation plan but nothing binds a running
-executor to it (#820); **confirmation answered** — the gate classifies every
+`workspace_binding_guard/v1` now refuses a second workspace-bound handoff on a
+reserved workspace or branch before one is enabled, but `allowed_targets` is
+still derived from the isolation plan and nothing binds a running executor to it
+(`no_omh_side_constraint_can_bind_a_running_executor_process`, because confining
+a running process needs an OS-level backend the host owns);
+**confirmation answered** — the gate classifies every
 risky class and names the approval each granted carrier action would need, but
 nothing on the shipped lane can record an answer, so nothing is withheld
 (`no_confirmation_answer_intake_mints_a_run_bound_approval`); **storage retention** — run artifacts are metadata-only,
@@ -2111,8 +2178,13 @@ the minimum scopes, and a readiness state, but grants, verifies, and refuses
 nothing, because a consent flow owned by a provider's website is not observable
 from here (`host_owned_consent_flow_is_not_observable_by_omh`); and the three
 runtime `data_*` rows — the cross-harness adapter lane builds an OS confinement
-sandbox that no delegation or fanout lane places an executor under (#820 on a
-capable host, and the host's own missing backend elsewhere).
+sandbox that no delegation or fanout lane places an executor under
+(`no_delegation_or_fanout_lane_places_an_executor_under_the_sandbox` on a
+capable host, and the host's own missing backend elsewhere; the advisory row
+reports `no_omh_side_measurement_observes_whether_an_executor_honoured_its_targets`
+on every host). All three used to cite #820, which was a mis-citation even
+before that issue landed — it shipped a workspace reservation, not an executor
+sandbox — and would have become a dangling pointer once it closed.
 
 The last two are known asymmetries rather than oversights. Closing either means
 adding a rung or a prerequisite to `runtime/claims.py` and

--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -227,8 +227,9 @@ goal to Hermes in chat; these commands are the backend surface.
   `runtime_filesystem_confinement` and `runtime_network_confinement` are
   `host_confinement`, and dispatch does **not** provide them — the
   cross-harness adapter lane builds an OS confinement sandbox (`sandbox-exec`
-  on macOS, a trusted `bwrap` on Linux) and no dispatched unit runs under it
-  (#820). `executor_honours_declared_targets` is advisory everywhere: a unit's
+  on macOS, a trusted `bwrap` on Linux) and no dispatched unit runs under it,
+  which is the blocker those two rows now name in words.
+  `executor_honours_declared_targets` is advisory everywhere: a unit's
   file boundary is frozen in the contract and checked for overlaps at prepare
   time, but nothing constrains the spawned CLI to it at runtime.
   `quality/safety_preflight.py::data_boundary_enforcement_facts` reports which

--- a/src/coding/action_gate.py
+++ b/src/coding/action_gate.py
@@ -409,6 +409,14 @@ ACCOUNT_BLOCKER_KEYS = ("blocker", "statement", "cites")
 # `data_boundary_enforcement_facts` already sets the precedent of a `blocked_by`
 # that names the reason rather than a ticket.
 ACCOUNT_AUTHORIZATION_BLOCKER = "host_owned_consent_flow_is_not_observable_by_omh"
+# Also not an issue number, on the same precedent. #820 delivered the half OMH
+# owns -- `workspace_binding_guard/v1` refuses a second workspace-bound handoff
+# on a reserved workspace or branch before one is enabled -- and closing it does
+# not close this boundary, because the other half is confining a process that is
+# already running. That needs an OS-level confinement backend the host owns; no
+# change on this side of the wall can do it, so naming a ticket here would
+# promise a fix nobody can ship.
+WORKSPACE_RUNTIME_BLOCKER = "no_omh_side_constraint_can_bind_a_running_executor_process"
 ACCOUNT_AUTHORIZATION_CLAIM_BOUNDARY = (
     "This account-authorization projection is prepared metadata. It is not dispatch, execution, or "
     "evidence that any account is usable: a login marker means a local file exists, never that a "
@@ -763,11 +771,14 @@ _STATIC_SAFETY_BOUNDARIES: tuple[tuple[str, str, str, tuple[str, ...], str], ...
     ),
     (
         "workspace",
+        "The pre-dispatch half now exists: `workspace_binding_guard/v1` reserves a canonical workspace and "
+        "branch for one handoff atomically, and a second workspace-bound handoff on either is refused "
+        "before it is enabled, with the owner and the recovery named. The runtime half does not. "
         "allowed_targets is derived from the isolation plan, but nothing binds a running executor to it. "
         "The target is a declaration the executor is trusted to honour, not a constraint applied to it.",
         "declared_not_enforced",
         (),
-        "#820",
+        WORKSPACE_RUNTIME_BLOCKER,
     ),
 )
 

--- a/src/quality/safety_preflight.py
+++ b/src/quality/safety_preflight.py
@@ -448,6 +448,26 @@ def correction_for_reason_code(reason_code: str) -> str:
 # and that is the distinction issue #801 asks OMH to surface.
 DATA_BOUNDARY_ENFORCEMENT_KINDS: Final = ("refused_before_handoff", "host_confinement", "advisory")
 
+# Why each unenforced kind is unenforced. Reason strings rather than issue
+# numbers, on the `action_gate.ACCOUNT_AUTHORIZATION_BLOCKER` precedent: a
+# blocker names a ticket only when landing that ticket would close it.
+#
+# Both of these used to name `#820`, which was a mis-citation even before that
+# issue landed. #820 is about two handoffs sharing one workspace, and it shipped
+# `workspace_binding_guard/v1` for exactly that -- a pre-dispatch reservation.
+# Neither of these limits is about reservations. Every `host_confinement` limit
+# is unenforced because no delegation or fanout lane places an executor under
+# the sandbox the cross-harness adapter lane already builds, which is real,
+# fileable work that #820 was never going to do. A host that *could* confine
+# still reports the limit as unenforced; it reports a different blocker from a
+# host that could not.
+_HOST_CONFINEMENT_BLOCKER: Final = "no_delegation_or_fanout_lane_places_an_executor_under_the_sandbox"
+# The advisory limit is not fileable at all. Measuring whether a running
+# executor stayed inside its declared targets needs the same OS-level
+# confinement the host owns; on this side of the wall there is nothing to
+# observe, on any host.
+_ADVISORY_LIMIT_BLOCKER: Final = "no_omh_side_measurement_observes_whether_an_executor_honoured_its_targets"
+
 # (limit id, enforcement kind, enforcer symbols, blocker).
 #
 # The symbols are dotted import paths in `omh.coding.action_gate`'s
@@ -490,32 +510,27 @@ DATA_BOUNDARY_LIMITS: Final = (
             "omh.quality.cross_harness_adapter_sandbox.sandbox_command",
             "omh.quality.cross_harness_adapter_sandbox.read_roots_are_safe",
         ),
-        "#820",
+        _HOST_CONFINEMENT_BLOCKER,
     ),
     (
         "runtime_network_confinement",
         "host_confinement",
         ("omh.quality.cross_harness_adapter_sandbox.sandbox_command",),
-        "#820",
+        _HOST_CONFINEMENT_BLOCKER,
     ),
     (
         "executor_honours_declared_targets",
         "advisory",
         (),
-        "#820",
+        _ADVISORY_LIMIT_BLOCKER,
     ),
 )
 DATA_BOUNDARY_LIMIT_NAMES: Final = tuple(entry[0] for entry in DATA_BOUNDARY_LIMITS)
 
 # The confinement tool each platform would use, and the reason a platform with
-# neither can never enforce a runtime limit no matter which issue lands.
+# neither can never enforce a runtime limit no matter what else lands.
 _MACOS_CONFINEMENT_TOOL: Final = "/usr/bin/sandbox-exec"
 _NO_HOST_BACKEND_REASON: Final = "no_os_confinement_backend_on_this_platform"
-# Every host_confinement limit is blocked on the same issue today, because no
-# delegation or fanout lane places an executor under the sandbox the adapter
-# lane already builds. A host that *could* confine still reports the limit as
-# unenforced; it reports a different blocker from a host that could not.
-_HOST_CONFINEMENT_BLOCKER: Final = "#820"
 
 
 def safety_rule_profile() -> dict[str, object]:
@@ -679,9 +694,9 @@ def data_boundary_enforcement_facts() -> dict[str, object]:
 
     Today every `host_confinement` limit is still unenforced even where the
     host is capable, because no delegation or fanout lane places an executor
-    under the sandbox the cross-harness adapter lane builds (#820). The
-    capability flag is what separates "the host could, once #820 lands" from
-    "this host never could", and that separation is the deliverable.
+    under the sandbox the cross-harness adapter lane builds. The capability flag
+    is what separates "the host could, once a lane does that" from "this host
+    never could", and that separation is the deliverable.
 
     Deliberately not part of `safety_rule_profile()`: the answer differs per
     machine, and a host-dependent digest would read as profile drift on every

--- a/src/runtime/artifacts.py
+++ b/src/runtime/artifacts.py
@@ -47,6 +47,7 @@ from ..external_effect_receipts import (
 )
 from ..workflows.approval_receipts import validate_approval_receipt_store
 from ..workflows.blocked_work_records import decision_history, validate_blocked_work_record_store
+from ..workflows.workspace_bindings import validate_workspace_binding_store
 from ..observation_journal import (
     append_observation_event,
     merge_lifecycle_projection,
@@ -2232,6 +2233,16 @@ def validate_runtime(paths: OmhPaths, run_id: str | None = None) -> dict[str, An
         paths.runtime_blocked_work_records_path,
         run_id=run_id,
     )
+    # And the workspace-binding store, where the supersede chain is not a
+    # bookkeeping detail: it is what answers "which record holds this
+    # directory". A fork in it is two records both claiming to be the current
+    # state of one workspace, which is the exact ambiguity the guard exists to
+    # remove, and most of its records carry no `run_id` because the guard runs
+    # before a workspace-bound handoff has a run.
+    workspace_binding_store_result = validate_workspace_binding_store(
+        paths.runtime_workspace_bindings_path,
+        run_id=run_id,
+    )
     _add_duplicate_wrapper_run_link_errors(session_results, session_dirs)
     return {
         "ok": all(result["ok"] for result in results)
@@ -2239,13 +2250,15 @@ def validate_runtime(paths: OmhPaths, run_id: str | None = None) -> dict[str, An
         and bool(journal_result["ok"])
         and bool(receipt_store_result["ok"])
         and bool(approval_store_result["ok"])
-        and bool(blocked_work_store_result["ok"]),
+        and bool(blocked_work_store_result["ok"])
+        and bool(workspace_binding_store_result["ok"]),
         "runs": results,
         "wrapper_sessions": session_results,
         "journal": journal_result,
         "external_effect_receipts": receipt_store_result,
         "approval_receipts": approval_store_result,
         "blocked_work_records": blocked_work_store_result,
+        "workspace_bindings": workspace_binding_store_result,
     }
 
 

--- a/src/runtime/records.py
+++ b/src/runtime/records.py
@@ -79,6 +79,10 @@ from ..workflows.external_effect_receipts import (
     EXTERNAL_EFFECT_RECEIPT_KEYS,
     validate_external_effect_receipt,
 )
+from ..workflows.workspace_bindings import (
+    WORKSPACE_BINDING_KEYS,
+    validate_workspace_binding,
+)
 
 
 SCHEMA_VERSION = 1
@@ -3947,6 +3951,7 @@ OPTIONAL_RECORD_VALIDATORS = (
 EXTERNAL_EFFECT_RECEIPT_RECORD_KEYS = EXTERNAL_EFFECT_RECEIPT_KEYS
 APPROVAL_RECEIPT_RECORD_KEYS = APPROVAL_RECEIPT_KEYS
 BLOCKED_WORK_RECORD_RECORD_KEYS = BLOCKED_WORK_RECORD_KEYS
+WORKSPACE_BINDING_RECORD_KEYS = WORKSPACE_BINDING_KEYS
 
 
 @dataclass(frozen=True)
@@ -3983,4 +3988,5 @@ OPTIONAL_RUNTIME_STORE_VALIDATORS = (
     ),
     OptionalRuntimeStoreValidator("approval_receipts.jsonl", validate_approval_receipt, "receipt_id"),
     OptionalRuntimeStoreValidator("blocked_work_records.jsonl", validate_blocked_work_record, "record_id"),
+    OptionalRuntimeStoreValidator("workspace_bindings.jsonl", validate_workspace_binding, "record_id"),
 )

--- a/src/system/paths.py
+++ b/src/system/paths.py
@@ -89,6 +89,19 @@ class OmhPaths:
         return self.runtime_journal_dir / "blocked_work_records.jsonl"
 
     @property
+    def runtime_workspace_bindings_path(self) -> Path:
+        # Runtime-wide, beside the other three stores, and it is the one store
+        # for which per-run placement would defeat the feature outright. A
+        # binding exists to be read by a handoff that has nothing to do with the
+        # one that wrote it: exclusivity means the *second* handoff sees the
+        # first handoff's claim. A per-run file is invisible to every other run
+        # by construction, which is exactly the blind spot that let two
+        # handoffs bind one workspace. The guard also runs before a
+        # workspace-bound handoff is enabled, which on the delegation lane is
+        # before a run directory exists to hold anything.
+        return self.runtime_journal_dir / "workspace_bindings.jsonl"
+
+    @property
     def runtime_plan_context_dir(self) -> Path:
         return self.runtime_dir / "plan-context"
 

--- a/src/workflows/workspace_bindings.py
+++ b/src/workflows/workspace_bindings.py
@@ -1,0 +1,1472 @@
+"""Append-only workspace bindings: one workspace, one active handoff (issue #820).
+
+What was missing
+----------------
+
+`coding/isolation.py` decides *whether* a handoff should run in its own
+worktree, and `wrapper/worktree_binding.py` builds a recipe for opening one
+executor in one path. Neither consults anything about the other handoffs. Two
+`build_worktree_executor_binding` calls naming the same directory both
+succeeded, and two handoffs on one branch were equally invisible, so the first
+sign of a collision was a dirty tree or a lost commit.
+
+This store is the missing exclusivity: an acquisition that either reserves a
+canonical workspace for exactly one handoff, or explains who already holds it
+and what to do about it.
+
+Why this is its own record family
+---------------------------------
+
+The tree refused a new family twice (#811, #818) and accepted one twice (#807,
+#808), on a rule worth restating: a family joins on run id, and a join is where
+an artifact and its metadata desynchronize, so a field group on the record that
+already exists is the default.
+
+A binding earns a family on the dimension the rule is really about -- whose
+question it answers. Every other record in this tree describes one run: what it
+asked for, what a gate decided about it, what an operator consented to. A
+binding describes a *resource*, and its whole value is that it is readable by a
+handoff that has nothing to do with the one that wrote it. A field group on a
+delegation is invisible to the next delegation by construction, which is
+exactly the shape that let two handoffs claim one directory. It also outlives
+the run that took it, because a released binding and an abandoned one must be
+distinguishable after the turn that created either is over.
+
+Exclusivity, and what it costs
+------------------------------
+
+Acquisition is serialized on the store's own OS lock -- `local_store.file_lock`,
+real on POSIX and on Windows -- so the read of the active set and the append of
+the new claim cannot interleave. Two concurrent acquisitions on one workspace
+therefore produce one held binding and one refusal, not two winners.
+
+That is exclusivity over *this store*, and the honest limit is that it is
+exclusivity over nothing else. Nothing stops a person running `git worktree
+add` twice, and nothing stops an executor already running from writing wherever
+it likes. #820's own out-of-scope list excludes creating, deleting, or merging
+worktrees, and the `workspace` boundary of `handoff_safety_contract/v1` still
+reports `declared_not_enforced` because no OMH-side change can constrain a
+running process. What the guard removes is the case OMH *does* own: enabling a
+second workspace-bound handoff on a workspace or branch that is already spoken
+for.
+
+Two spellings of one directory are one workspace
+------------------------------------------------
+
+Identity is the canonical path -- expanded, user-resolved, symlink-resolved,
+through the same `paths.expand_path` every other path-taking surface uses --
+and never the string the caller typed. `~/w`, `$HOME/w`, `/tmp/w/../w`, and the
+absolute path all collide, which is the entire point: a guard that could be
+defeated by typing the path differently would be decoration.
+
+The canonical path is then digested. No host path byte reaches the store, and
+`_WORKSPACE_REF` refuses a stored `workspace_ref` that is not a digest handle,
+so `privacy: "metadata_only"` is structural here rather than a habit -- the
+same discipline `blocked_work_records._PATH_SHAPED` applies for the same
+reason. The cost is that a store cannot be read back into a path; a caller that
+wants to know whether *its* workspace is bound digests its own path and asks.
+
+Staleness blocks, and never releases
+------------------------------------
+
+Freshness is derived at read time from the head record's stamp, the idiom
+`action_gate._account_state` uses for account signals and `approval_receipts`
+uses for consent, rather than stored as a deadline a reader must trust. A
+stored expiry is a second independently writable field: hand-editing one number
+would widen the window, while `BINDING_STALE_AFTER_SECONDS` cannot be widened
+by anything on disk.
+
+A stale binding is refused, not reclaimed. Auto-release would be the background
+lease service #820 puts out of scope, and it would be wrong on its own terms: a
+binding older than the horizon means nobody reported back, which is not the
+same as nobody running. So the refusal names a different reason code from a
+fresh conflict and carries a different recovery -- release it explicitly, an
+act with an owner -- and reuse stays blocked until someone does.
+
+A binding is not dispatch
+-------------------------
+
+The four claims #800 keeps apart are existence, ownership, dispatch, and
+result. A binding is the second one and nothing else: it does not say the
+directory exists (nothing here stats the filesystem), it does not say an
+executor started, and it does not say any work finished. `CLAIM_BOUNDARY` says
+so on every record, and `validate_workspace_binding` refuses a record shaped to
+assert execution by key name as well as by the closed key set.
+
+Store mechanics
+---------------
+
+All of it is `system.append_only_store`, shared with the three families beside
+it: the torn-tail-safe binary append under a real OS lock, the
+opaque-reference guards, the supersede-chain walk, the digest handles, and the
+best-effort mint-failure sidecar. This module adds no store mechanics of its
+own; it passes its own key names to the shared walk so its records are not
+described as receipts they are not.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Final
+
+from ..system.append_only_store import (
+    RAW_OR_HIDDEN_KEYS,
+    append_sidecar_line,
+    append_store_line,
+    closed_vocabulary_value,
+    digest_ref,
+    latest_record_in,
+    mint_record_id,
+    opaque_ref,
+    record_fingerprint,
+    redacted_ref,
+    reference_errors,
+    store_errors,
+)
+from ..system.local_store import file_lock, read_jsonl_objects, utc_now
+from ..system.metadata_safety import is_sensitive_metadata_text
+from ..system.paths import OmhPaths, expand_path
+
+
+WORKSPACE_BINDING_SCHEMA_VERSION: Final[str] = "workspace_binding_guard/v1"
+WORKSPACE_BINDING_DECISION_SCHEMA_VERSION: Final[str] = "workspace_binding_decision/v1"
+WORKSPACE_BINDING_STORE_VALIDATION_SCHEMA_VERSION: Final[str] = "workspace_binding_store_validation/v1"
+WORKSPACE_BINDING_MINT_FAILURE_SCHEMA_VERSION: Final[str] = "workspace_binding_mint_failure/v1"
+
+WORKSPACE_BINDING_STORE_NAME: Final[str] = "workspace_bindings.jsonl"
+WORKSPACE_BINDING_MINT_FAILURE_STORE_NAME: Final[str] = "workspace_binding_mint_failures.jsonl"
+
+BINDING_PRIVACY: Final[str] = "metadata_only"
+
+# Stated on every record and echoed on every decision. The claim a binding
+# makes is deliberately one of the four #800 keeps apart: ownership. It is not
+# existence, not dispatch, and not result.
+CLAIM_BOUNDARY: Final[str] = (
+    "A workspace binding is one reservation of one canonical workspace and one branch for one handoff, "
+    "under one owner and one base revision. It records who holds the workspace. It is not evidence that "
+    "the workspace exists, that any executor was dispatched into it, or that any work ran or finished."
+)
+
+# `held`     -- the binding is active and the workspace is spoken for.
+# `released` -- the binding is over. Appended as its own record linked to the
+#               claim it ends; the held record is never rewritten.
+BINDING_STATES: Final[tuple[str, ...]] = ("held", "released")
+
+# What must happen before a binding may be released, declared when it is taken.
+#
+# `observed_terminal_state` -- the handoff reached a terminal state something
+#     observed, and the binding may also be released explicitly.
+# `explicit_safe_release`   -- only a deliberate release ends it. A terminal
+#     observation is not enough, which is what a caller declares when the
+#     workspace needs an operator's eyes before anyone else may take it.
+RELEASE_CONDITIONS: Final[tuple[str, ...]] = ("observed_terminal_state", "explicit_safe_release")
+
+# Why a binding ended, named on the release record. Same vocabulary as the
+# conditions because a release cites the kind of event that ended it; which of
+# the two a given binding will accept is `_PERMITTED_RELEASE_REASONS`.
+RELEASE_REASONS: Final[tuple[str, ...]] = RELEASE_CONDITIONS
+
+# An explicit safe release always works. It is the recovery path a stale
+# binding points at, so a condition that could refuse it would leave an
+# abandoned workspace with no way out short of editing the store by hand.
+_PERMITTED_RELEASE_REASONS: Final[dict[str, tuple[str, ...]]] = {
+    "observed_terminal_state": ("observed_terminal_state", "explicit_safe_release"),
+    "explicit_safe_release": ("explicit_safe_release",),
+}
+
+# Six hours, the horizon `action_gate.ACCOUNT_SIGNAL_STALE_AFTER_SECONDS` and
+# `executor_auth_signals.LIMIT_SIGNAL_STALE_AFTER_SECONDS` already use for a
+# locally recorded state that stops being current state and becomes history.
+# Deliberately far above `approval_receipts.APPROVAL_TTL_SECONDS` (one hour): an
+# approval authorises one action and a coding handoff holds its workspace for as
+# long as the work takes, so an hour would call ordinary work abandoned.
+BINDING_STALE_AFTER_SECONDS: Final[int] = 6 * 60 * 60
+
+# `age_seconds` when a stamp cannot be read, or is stamped in the future. Both
+# mean the binding cannot be shown to be fresh, so both read as stale.
+UNKNOWN_AGE_SECONDS: Final[int] = -1
+
+WORKSPACE_BINDING_KEYS: Final[tuple[str, ...]] = (
+    "base_revision",
+    "binding_id",
+    "branch_ref",
+    "claim_boundary",
+    "handoff_ref",
+    "owner",
+    "privacy",
+    "recorded_at",
+    "record_id",
+    "release_condition",
+    "release_reason",
+    "repository_ref",
+    "run_id",
+    "safety_profile_revision",
+    "schema_version",
+    "state",
+    "supersedes_binding_ref",
+    "workspace_ref",
+)
+
+# The three keys whose value is a module constant rather than data. Everything
+# else is rendered, and `compact_workspace_binding` must cover all of it -- a
+# key in the tuple and missing from the compactor is a field that is stored and
+# never seen, which has cost this repo twice.
+WORKSPACE_BINDING_CONSTANT_KEYS: Final[tuple[str, ...]] = ("claim_boundary", "privacy", "schema_version")
+
+# Identifiers that must be present, through `require_opaque_metadata_ref`.
+_REQUIRED_BINDING_REFS: Final[tuple[str, ...]] = (
+    "base_revision",
+    "binding_id",
+    "branch_ref",
+    "handoff_ref",
+    "owner",
+    "record_id",
+    "recorded_at",
+    "repository_ref",
+    "safety_profile_revision",
+    "workspace_ref",
+)
+# `run_id` is legitimately absent: the guard runs *before* a workspace-bound
+# handoff is enabled, and on the delegation lane that is before a run exists.
+# The link is empty on the first record of a chain and only then.
+_OPTIONAL_BINDING_REFS: Final[tuple[str, ...]] = ("run_id", "supersedes_binding_ref")
+_BINDING_VOCABULARIES: Final[tuple[tuple[str, tuple[str, ...]], ...]] = (
+    ("release_condition", RELEASE_CONDITIONS),
+    ("state", BINDING_STATES),
+)
+# Closed vocabularies that may also be empty, which is a state and not a value.
+_OPTIONAL_BINDING_VOCABULARIES: Final[tuple[tuple[str, tuple[str, ...]], ...]] = (
+    ("release_reason", RELEASE_REASONS),
+)
+# Every string field, which on this record is every field: there is no list, no
+# nested object, and deliberately no free text. A note field would be one more
+# place for a prompt to arrive, and a reservation needs no prose to be citable.
+_BINDING_STRING_FIELDS: Final[tuple[str, ...]] = WORKSPACE_BINDING_KEYS
+
+# What the *terms* of a binding are: everything a re-acquisition must match for
+# the claim to be the same claim. These are exactly the fields a caller names
+# when it asks for a workspace, which is what lets a request and a stored record
+# be fingerprinted against the same key set -- comparing two different key sets
+# would never match, and every re-acquisition would read as a change of terms.
+#
+# `run_id`, `safety_profile_revision`, and `release_condition` are deliberately
+# out. They describe the record, not the reservation: which run wrote it, which
+# profile it was cleared under, and what will end it. The reservation itself is
+# a repository, a workspace, a branch, a base revision, a handoff, and an owner.
+_BINDING_TERMS_KEYS: Final[tuple[str, ...]] = (
+    "base_revision",
+    "binding_id",
+    "branch_ref",
+    "handoff_ref",
+    "owner",
+    "repository_ref",
+    "workspace_ref",
+)
+
+# What a call did. `bound` on the decision says whether the requesting handoff
+# holds the binding afterwards; this says how it got there.
+OUTCOME_ACQUIRED: Final[str] = "acquired"
+OUTCOME_ALREADY_HELD: Final[str] = "already_held"
+OUTCOME_RELEASED: Final[str] = "released"
+OUTCOME_ALREADY_RELEASED: Final[str] = "already_released"
+OUTCOME_UNBOUND: Final[str] = "unbound"
+OUTCOME_REFUSED: Final[str] = "refused"
+OUTCOME_NOT_WRITTEN: Final[str] = "not_written"
+BINDING_OUTCOMES: Final[tuple[str, ...]] = (
+    OUTCOME_ACQUIRED,
+    OUTCOME_ALREADY_HELD,
+    OUTCOME_ALREADY_RELEASED,
+    OUTCOME_NOT_WRITTEN,
+    OUTCOME_REFUSED,
+    OUTCOME_RELEASED,
+    OUTCOME_UNBOUND,
+)
+
+# Refusal codes. The workspace pair and the branch pair are separate codes
+# because "this workspace is taken" and "this branch is taken somewhere else"
+# have different answers, and a caller that has to decide what to do next
+# cannot act on a merged one. Fresh and stale are separate for the same reason:
+# one is waited out, the other is released.
+REFUSAL_WORKSPACE_BOUND: Final[str] = "workspace_already_bound"
+REFUSAL_WORKSPACE_STALE: Final[str] = "workspace_binding_stale"
+REFUSAL_BRANCH_BOUND: Final[str] = "branch_already_bound"
+REFUSAL_BRANCH_STALE: Final[str] = "branch_binding_stale"
+REFUSAL_TERMS_CHANGED: Final[str] = "binding_terms_changed"
+REFUSAL_NOT_HELD: Final[str] = "binding_not_held"
+REFUSAL_CONDITION_UNMET: Final[str] = "release_condition_unmet"
+REFUSAL_MALFORMED: Final[str] = "binding_request_refused"
+REFUSAL_NOT_WRITTEN: Final[str] = "binding_not_written"
+REFUSAL_CODES: Final[tuple[str, ...]] = (
+    REFUSAL_BRANCH_BOUND,
+    REFUSAL_BRANCH_STALE,
+    REFUSAL_CONDITION_UNMET,
+    REFUSAL_MALFORMED,
+    REFUSAL_NOT_HELD,
+    REFUSAL_NOT_WRITTEN,
+    REFUSAL_TERMS_CHANGED,
+    REFUSAL_WORKSPACE_BOUND,
+    REFUSAL_WORKSPACE_STALE,
+)
+
+# Constant strings, keyed by code. Nothing is interpolated into a reason: a
+# refusal line is rendered to operators, and a line built from request values
+# would be one more path for caller-controlled text to reach a terminal.
+REFUSAL_REASONS: Final[dict[str, str]] = {
+    REFUSAL_WORKSPACE_BOUND: (
+        "This workspace is already bound to another active handoff; two handoffs cannot share one checkout."
+    ),
+    REFUSAL_WORKSPACE_STALE: (
+        "This workspace is bound to a handoff that has not been heard from inside the freshness window. "
+        "A binding that old is not reclaimed automatically, because nobody reporting back is not the same "
+        "as nobody running."
+    ),
+    REFUSAL_BRANCH_BOUND: (
+        "This branch is already bound to another active workspace in this repository; two checkouts cannot "
+        "share one branch."
+    ),
+    REFUSAL_BRANCH_STALE: (
+        "This branch is bound to a workspace that has not been heard from inside the freshness window. "
+        "A binding that old is not reclaimed automatically."
+    ),
+    REFUSAL_TERMS_CHANGED: (
+        "This handoff already holds this workspace on other terms; a binding is never rewritten in place."
+    ),
+    REFUSAL_NOT_HELD: "No active binding on record names this workspace for this handoff and owner.",
+    REFUSAL_CONDITION_UNMET: (
+        "The binding on record was taken under a condition that only an explicit safe release satisfies."
+    ),
+    REFUSAL_MALFORMED: "The binding request could not become a record.",
+    REFUSAL_NOT_WRITTEN: "The binding store could not be written, so nothing was reserved or released.",
+}
+
+# What an operator can do about it. A closed id, never a sentence, for the
+# reason `blocked_work_records.RECOVERY_ACTIONS` is: localized copy is then a
+# lookup per locale rather than a translated constant.
+RECOVERY_WAIT: Final[str] = "wait_for_owner_release"
+RECOVERY_RELEASE_STALE: Final[str] = "release_stale_binding_explicitly"
+RECOVERY_REACQUIRE: Final[str] = "release_then_reacquire"
+RECOVERY_ACQUIRE_FIRST: Final[str] = "acquire_before_releasing"
+RECOVERY_EXPLICIT_RELEASE: Final[str] = "release_with_an_explicit_safe_release"
+RECOVERY_CORRECT_REQUEST: Final[str] = "correct_the_binding_request"
+RECOVERY_RETRY_WRITE: Final[str] = "retry_when_the_store_is_writable"
+RECOVERY_ACTIONS: Final[tuple[str, ...]] = (
+    RECOVERY_ACQUIRE_FIRST,
+    RECOVERY_CORRECT_REQUEST,
+    RECOVERY_EXPLICIT_RELEASE,
+    RECOVERY_REACQUIRE,
+    RECOVERY_RELEASE_STALE,
+    RECOVERY_RETRY_WRITE,
+    RECOVERY_WAIT,
+)
+
+# One recovery per refusal. Total over `REFUSAL_CODES`, which
+# `tests/test_workspace_binding_guard.py` pins: a refusal with no recovery is
+# the shape that makes a guard unusable, and #820 AC3 is precisely about the
+# refusal that has to come with the way out.
+REFUSAL_RECOVERY: Final[dict[str, str]] = {
+    REFUSAL_WORKSPACE_BOUND: RECOVERY_WAIT,
+    REFUSAL_WORKSPACE_STALE: RECOVERY_RELEASE_STALE,
+    REFUSAL_BRANCH_BOUND: RECOVERY_WAIT,
+    REFUSAL_BRANCH_STALE: RECOVERY_RELEASE_STALE,
+    REFUSAL_TERMS_CHANGED: RECOVERY_REACQUIRE,
+    REFUSAL_NOT_HELD: RECOVERY_ACQUIRE_FIRST,
+    REFUSAL_CONDITION_UNMET: RECOVERY_EXPLICIT_RELEASE,
+    REFUSAL_MALFORMED: RECOVERY_CORRECT_REQUEST,
+    REFUSAL_NOT_WRITTEN: RECOVERY_RETRY_WRITE,
+}
+
+# The guidance itself, keyed by recovery id. Constant, uninterpolated, and
+# written for the person reading the refusal rather than for the caller.
+RECOVERY_GUIDANCE: Final[dict[str, str]] = {
+    RECOVERY_WAIT: (
+        "Wait for the handoff that holds it to release the binding, or bind a different workspace or "
+        "branch. Nothing here creates, deletes, or moves a worktree or a branch."
+    ),
+    RECOVERY_RELEASE_STALE: (
+        "Confirm the holding handoff is really finished, then release the binding explicitly with reason "
+        "explicit_safe_release. Nothing releases it on a timer, so the confirmation is a person's."
+    ),
+    RECOVERY_REACQUIRE: (
+        "Release the binding this handoff already holds, then acquire it again on the new branch or base "
+        "revision. A binding's terms are never rewritten in place."
+    ),
+    RECOVERY_ACQUIRE_FIRST: "Acquire the binding before releasing it; there is nothing on record to release.",
+    RECOVERY_EXPLICIT_RELEASE: (
+        "Release this binding with reason explicit_safe_release. It was taken under a condition that an "
+        "observed terminal state alone does not satisfy."
+    ),
+    RECOVERY_CORRECT_REQUEST: (
+        "Correct the binding request and try again; the reported error names the field that could not be "
+        "stored."
+    ),
+    RECOVERY_RETRY_WRITE: (
+        "Retry once the binding store is writable. Nothing was reserved or released, so no workspace "
+        "changed hands."
+    ),
+}
+
+# Key names an execution claim arrives under. The closed key set already refuses
+# every one of them, but it refuses them as "unsupported keys", and the whole
+# point of this family is that a reservation is not a dispatch -- so the shape
+# is named and refused by name first. Mirrors
+# `approval_receipts._EXECUTION_CLAIM_KEYS` rather than importing a private name
+# across modules; `tests/test_workspace_binding_guard.py` pins the two equal.
+EXECUTION_CLAIM_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "applied",
+        "attempted",
+        "completed",
+        "dispatched",
+        "effect_applied",
+        "enforced",
+        "executed",
+        "execution",
+        "execution_result",
+        "exit_code",
+        "external_ref",
+        "host_applied",
+        "observed",
+        "observed_at",
+        "observed_result",
+        "outcome",
+        "performed",
+        "ran",
+        "result",
+        "status",
+        "succeeded",
+        "success",
+    }
+)
+
+# The store label every error line and every reference fault is reported under.
+_LABEL: Final[str] = "workspace_binding"
+
+# A stored workspace reference is a digest handle and nothing else. This is what
+# makes "no host path byte reaches the store" a property of the file rather than
+# a property of the one function that happens to write it: a hand-edited record
+# carrying `/Users/someone/work` is refused here, at validate, at render, and at
+# every read that goes through them.
+_WORKSPACE_REF: Final[re.Pattern[str]] = re.compile(r"^ref-[0-9a-f]{12}$")
+
+
+class WorkspaceBindingError(ValueError):
+    """Raised when a reservation cannot become a workspace binding record."""
+
+
+# ---------------------------------------------------------------------------
+# Identity: one directory, however it was spelled
+# ---------------------------------------------------------------------------
+
+
+def canonical_workspace_path(workspace_path: str | Path) -> str:
+    """The one spelling of a directory this guard knows it by.
+
+    Expanded, user-resolved, and symlink-resolved through `paths.expand_path`,
+    which is the same normalization every other path-taking surface in the tree
+    uses. An empty value is refused rather than normalized: `Path("")` resolves
+    to the current directory, so accepting it would silently bind whatever
+    directory the caller happened to be standing in.
+    """
+    text = str(workspace_path or "").strip()
+    if not text:
+        raise WorkspaceBindingError("workspace_binding workspace_path is required")
+    return str(expand_path(text))
+
+
+def workspace_ref(workspace_path: str | Path) -> str:
+    """The stored handle for one canonical workspace.
+
+    A digest of the canonical path, so two spellings of one directory produce
+    one handle and no path byte is stored. Not reversible into a path, which is
+    the trade: a caller asks about a workspace by digesting its own path.
+    """
+    return digest_ref(canonical_workspace_path(workspace_path))
+
+
+def binding_id(*, repository_ref: str, workspace_ref_value: str) -> str:
+    """Stable identity of one workspace claim, in one repository.
+
+    The branch, the handoff, and the owner are deliberately not in it. They are
+    properties of *who holds* the workspace, not of which workspace is being
+    held: folding them in would open a second parallel chain per branch, and
+    both chains would claim to be current for one directory.
+    """
+    base = json.dumps(
+        {"repository_ref": str(repository_ref), "workspace_ref": str(workspace_ref_value)},
+        sort_keys=True,
+    )
+    return f"binding-{hashlib.sha256(base.encode('utf-8')).hexdigest()[:16]}"
+
+
+# ---------------------------------------------------------------------------
+# Build, validate, append
+# ---------------------------------------------------------------------------
+
+
+def build_workspace_binding(
+    *,
+    repository_ref: str,
+    workspace_path: str | Path,
+    branch_ref: str,
+    base_revision: str,
+    handoff_ref: str,
+    owner: str,
+    safety_profile_revision: str,
+    release_condition: str = "observed_terminal_state",
+    state: str = "held",
+    release_reason: str = "",
+    run_id: str = "",
+    recorded_at: str = "",
+    supersedes_binding_ref: str = "",
+) -> dict[str, Any]:
+    """Mint one binding record, or refuse.
+
+    Every refusal here is the invariant this module exists for: a record can
+    only describe one canonical workspace, reserved for one handoff, under one
+    owner, on one branch, at one base revision.
+    """
+    if state not in BINDING_STATES:
+        raise WorkspaceBindingError(f"workspace_binding state is unsupported: {state!r}")
+    if release_condition not in RELEASE_CONDITIONS:
+        raise WorkspaceBindingError(
+            f"workspace_binding release_condition is unsupported: {release_condition!r}"
+        )
+    if release_reason and release_reason not in RELEASE_REASONS:
+        raise WorkspaceBindingError(f"workspace_binding release_reason is unsupported: {release_reason!r}")
+    workspace = workspace_ref(workspace_path)
+    safe_repository = _opaque(repository_ref, field="workspace_binding repository_ref")
+    safe_branch = _opaque(branch_ref, field="workspace_binding branch_ref")
+    safe_revision = _opaque(base_revision, field="workspace_binding base_revision")
+    safe_handoff = _opaque(handoff_ref, field="workspace_binding handoff_ref")
+    safe_owner = _opaque(owner, field="workspace_binding owner")
+    safe_profile = _opaque(safety_profile_revision, field="workspace_binding safety_profile_revision")
+    safe_run_id = _opaque(run_id, field="workspace_binding run_id") if run_id else ""
+    safe_supersedes = (
+        _opaque(supersedes_binding_ref, field="workspace_binding supersedes_binding_ref")
+        if supersedes_binding_ref
+        else ""
+    )
+    stamp = _opaque(str(recorded_at or utc_now()), field="workspace_binding recorded_at")
+    identity = binding_id(repository_ref=safe_repository, workspace_ref_value=workspace)
+    record = {
+        "schema_version": WORKSPACE_BINDING_SCHEMA_VERSION,
+        "record_id": _record_id(stamp, identity, state),
+        "binding_id": identity,
+        "repository_ref": safe_repository,
+        "workspace_ref": workspace,
+        "branch_ref": safe_branch,
+        "base_revision": safe_revision,
+        "handoff_ref": safe_handoff,
+        "owner": safe_owner,
+        "run_id": safe_run_id,
+        "safety_profile_revision": safe_profile,
+        "state": state,
+        "release_condition": release_condition,
+        "release_reason": release_reason if state == "released" else "",
+        "recorded_at": stamp,
+        "supersedes_binding_ref": safe_supersedes,
+        "privacy": BINDING_PRIVACY,
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+    errors = validate_workspace_binding(record)
+    if errors:
+        raise WorkspaceBindingError(errors[0])
+    return record
+
+
+def validate_workspace_binding(record: dict[str, Any]) -> list[str]:
+    """Every reason one record is not a workspace binding."""
+    errors: list[str] = []
+    if not isinstance(record, dict):
+        return ["workspace_binding must be an object"]
+    claims_execution = sorted(key for key in record if str(key).lower() in EXECUTION_CLAIM_KEYS)
+    if claims_execution:
+        errors.append(
+            "workspace_binding must not carry execution-claim keys: "
+            f"{claims_execution}; a reservation is not a dispatch and not an outcome"
+        )
+    forbidden = sorted(key for key in record if str(key).lower() in RAW_OR_HIDDEN_KEYS)
+    if forbidden:
+        errors.append(f"workspace_binding must not carry raw or hidden keys: {forbidden}")
+    extra_keys = sorted(set(record) - set(WORKSPACE_BINDING_KEYS) - set(claims_execution) - set(forbidden))
+    if extra_keys:
+        errors.append(f"workspace_binding has unsupported keys: {extra_keys}")
+    missing = sorted(set(WORKSPACE_BINDING_KEYS) - set(record))
+    if missing:
+        errors.append(f"workspace_binding is missing keys: {missing}")
+    if record.get("schema_version") != WORKSPACE_BINDING_SCHEMA_VERSION:
+        errors.append(f"workspace_binding schema_version must be {WORKSPACE_BINDING_SCHEMA_VERSION}")
+    for key in _BINDING_STRING_FIELDS:
+        if not isinstance(record.get(key), str):
+            errors.append(f"workspace_binding {key} must be a string")
+    for key, vocabulary in _BINDING_VOCABULARIES:
+        if record.get(key) not in vocabulary:
+            errors.append(f"workspace_binding {key} is unsupported: {record.get(key)!r}")
+    for key, vocabulary in _OPTIONAL_BINDING_VOCABULARIES:
+        value = record.get(key)
+        if value and value not in vocabulary:
+            errors.append(f"workspace_binding {key} is unsupported: {value!r}")
+    if record.get("privacy") != BINDING_PRIVACY:
+        errors.append("workspace_binding privacy must be metadata_only")
+    if record.get("claim_boundary") != CLAIM_BOUNDARY:
+        errors.append("workspace_binding claim_boundary must state the binding boundary")
+    for field in _REQUIRED_BINDING_REFS:
+        errors.extend(reference_errors(record.get(field), field=field, label=_LABEL, required=True))
+    for field in _OPTIONAL_BINDING_REFS:
+        errors.extend(reference_errors(record.get(field), field=field, label=_LABEL, required=False))
+    errors.extend(_workspace_ref_errors(record.get("workspace_ref")))
+    errors.extend(_lifecycle_errors(record))
+    if str(record.get("record_id", "")) and str(record.get("record_id", "")) == str(
+        record.get("supersedes_binding_ref", "")
+    ):
+        errors.append("workspace_binding supersedes_binding_ref must not name itself")
+    expected_identity = binding_id(
+        repository_ref=str(record.get("repository_ref", "")),
+        workspace_ref_value=str(record.get("workspace_ref", "")),
+    )
+    if str(record.get("binding_id", "")) != expected_identity:
+        # Without this a hand-edited store could move one workspace's claim onto
+        # another workspace's chain, and the release of one would free the other.
+        errors.append("workspace_binding binding_id does not identify its own repository and workspace")
+    return errors
+
+
+def _lifecycle_errors(record: Mapping[str, Any]) -> list[str]:
+    """The state and its release reason, re-derived.
+
+    Without this a hand-edited store could carry a `held` record that names why
+    it ended, or a `released` record that names nothing -- and the active set,
+    which is the whole guard, is read straight off `state`.
+    """
+    errors: list[str] = []
+    state = str(record.get("state", ""))
+    condition = str(record.get("release_condition", ""))
+    reason = str(record.get("release_reason", ""))
+    if state == "held" and reason:
+        errors.append("workspace_binding release_reason must be empty while the binding is held")
+    if state == "released":
+        if not reason:
+            errors.append("workspace_binding release_reason must name why a released binding ended")
+        elif reason in RELEASE_REASONS and condition in _PERMITTED_RELEASE_REASONS:
+            if reason not in _PERMITTED_RELEASE_REASONS[condition]:
+                errors.append(
+                    f"workspace_binding release_reason {reason!r} does not satisfy release_condition "
+                    f"{condition!r}"
+                )
+    return errors
+
+
+def append_workspace_binding(paths: OmhPaths, record: dict[str, Any]) -> dict[str, Any]:
+    """Append one validated binding. Never rewrites, never reorders."""
+    errors = validate_workspace_binding(record)
+    if errors:
+        raise WorkspaceBindingError(errors[0])
+    path = paths.runtime_workspace_bindings_path
+    # `file_lock` rather than a bare `fcntl.flock`: it holds a real OS lock on
+    # both POSIX and Windows, and this store's mutual exclusion has to be a
+    # property CI can assert on either platform.
+    with file_lock(path, private=True):
+        append_store_line(path, record)
+    return record
+
+
+# ---------------------------------------------------------------------------
+# The guard: acquire, inspect, release
+# ---------------------------------------------------------------------------
+
+
+def acquire_workspace_binding(
+    paths: OmhPaths,
+    *,
+    repository_ref: str,
+    workspace_path: str | Path,
+    branch_ref: str,
+    base_revision: str,
+    handoff_ref: str,
+    owner: str,
+    safety_profile_revision: str,
+    release_condition: str = "observed_terminal_state",
+    run_id: str = "",
+    now: str = "",
+) -> dict[str, Any]:
+    """Reserve one canonical workspace for one handoff, or explain who holds it.
+
+    Returns a `workspace_binding_decision/v1` mapping and never raises. A guard
+    that raised would be a guard callers wrap in a bare `except`, and #820 AC3
+    is that a refusal comes back *with* the way out rather than as a traceback.
+
+    The read of the active set and the append of the new claim happen under one
+    lock, so two concurrent acquisitions on one workspace produce one held
+    binding and one refusal.
+    """
+    return acquire_workspace_binding_at(
+        paths.runtime_workspace_bindings_path,
+        repository_ref=repository_ref,
+        workspace_path=workspace_path,
+        branch_ref=branch_ref,
+        base_revision=base_revision,
+        handoff_ref=handoff_ref,
+        owner=owner,
+        safety_profile_revision=safety_profile_revision,
+        release_condition=release_condition,
+        run_id=run_id,
+        now=now,
+    )
+
+
+def acquire_workspace_binding_at(
+    store_path: Path,
+    *,
+    repository_ref: str,
+    workspace_path: str | Path,
+    branch_ref: str,
+    base_revision: str,
+    handoff_ref: str,
+    owner: str,
+    safety_profile_revision: str,
+    release_condition: str = "observed_terminal_state",
+    run_id: str = "",
+    now: str = "",
+) -> dict[str, Any]:
+    """`acquire_workspace_binding` against an already-resolved store path.
+
+    Callers that hold a runtime directory rather than an `OmhPaths` use this, so
+    every path they touch is derived from the directory they were given and none
+    is reconstructed from an environment they are not running in.
+    """
+    try:
+        request = _acquire_request(
+            repository_ref=repository_ref,
+            workspace_path=workspace_path,
+            branch_ref=branch_ref,
+            base_revision=base_revision,
+            handoff_ref=handoff_ref,
+            owner=owner,
+        )
+    except WorkspaceBindingError as exc:
+        return _malformed(store_path, error=str(exc), request={}, action="acquire")
+    try:
+        with file_lock(store_path, private=True):
+            bindings, _ = read_jsonl_objects(store_path)
+            verdict = workspace_binding_conflict_in(bindings, request=request, now=now)
+            if verdict["reason_code"] or verdict["outcome"] == OUTCOME_ALREADY_HELD:
+                # A refusal, or the same handoff restating an unchanged claim.
+                # The restatement is returned as it stands rather than appended
+                # again: a binding is a reservation, not an event log, and a
+                # second identical record would make "when was this taken"
+                # ambiguous -- which is the question staleness is measured from.
+                return verdict
+            head = _head_for(bindings, str(request["binding_id"]))
+            record = build_workspace_binding(
+                repository_ref=repository_ref,
+                workspace_path=workspace_path,
+                branch_ref=branch_ref,
+                base_revision=base_revision,
+                handoff_ref=handoff_ref,
+                owner=owner,
+                safety_profile_revision=safety_profile_revision,
+                release_condition=release_condition,
+                state="held",
+                run_id=run_id,
+                # `now` is the clock for this call: it stamps the new record and
+                # it is the instant every prior binding's freshness was judged
+                # against above. Two clocks here -- a real stamp and an injected
+                # comparison -- is how a binding ends up looking stale the
+                # moment it is taken.
+                recorded_at=now,
+                supersedes_binding_ref=str(head.get("record_id", "")) if head else "",
+            )
+            append_store_line(store_path, record)
+    except WorkspaceBindingError as exc:
+        return _malformed(store_path, error=str(exc), request=request, action="acquire")
+    except OSError as exc:
+        # Covers FileLockTimeout, which is a TimeoutError and therefore an
+        # OSError: an unavailable lock is a store that could not be written, and
+        # a workspace that could not be reserved is never reported as reserved.
+        return _not_written(store_path, error=str(exc), request=request, action="acquire")
+    return _decision(
+        outcome=OUTCOME_ACQUIRED,
+        bound=True,
+        reason_code="",
+        request=request,
+        holder=record,
+        now=now,
+    )
+
+
+def inspect_workspace_binding(
+    paths: OmhPaths,
+    *,
+    repository_ref: str,
+    workspace_path: str | Path,
+    branch_ref: str,
+    base_revision: str,
+    handoff_ref: str,
+    owner: str,
+    now: str = "",
+) -> dict[str, Any]:
+    """What acquiring would answer, without reserving anything.
+
+    The read-only half of the guard: a surface that has to say "this workspace
+    is reserved, or here is who owns it" before offering a workspace-bound
+    handoff asks this, and nothing is appended. The verdict comes from the same
+    function `acquire_workspace_binding` calls, so what a caller is shown and
+    what it gets one call later cannot disagree by construction -- with the one
+    honest caveat that another handoff may acquire in between, which is why the
+    acquisition re-checks under the lock rather than trusting this answer.
+    """
+    try:
+        request = _acquire_request(
+            repository_ref=repository_ref,
+            workspace_path=workspace_path,
+            branch_ref=branch_ref,
+            base_revision=base_revision,
+            handoff_ref=handoff_ref,
+            owner=owner,
+        )
+    except WorkspaceBindingError as exc:
+        return _decision(
+            outcome=OUTCOME_REFUSED,
+            bound=False,
+            reason_code=REFUSAL_MALFORMED,
+            request={},
+            holder={},
+            now=now,
+            error=str(exc),
+        )
+    bindings, _ = read_jsonl_objects(paths.runtime_workspace_bindings_path)
+    return workspace_binding_conflict_in(bindings, request=request, now=now)
+
+
+def release_workspace_binding(
+    paths: OmhPaths,
+    *,
+    repository_ref: str,
+    workspace_path: str | Path,
+    handoff_ref: str,
+    owner: str,
+    release_reason: str,
+    run_id: str = "",
+    now: str = "",
+) -> dict[str, Any]:
+    """End one binding, or explain why it cannot end yet.
+
+    Two ways in, and they are not interchangeable. `observed_terminal_state` is
+    the holder reporting its own work finished, so it is accepted only from the
+    handoff and owner on record. `explicit_safe_release` is a deliberate act and
+    is accepted from anyone, because it is the recovery a stale binding points
+    at -- a release only the absent holder could perform would leave an
+    abandoned workspace locked forever.
+    """
+    return release_workspace_binding_at(
+        paths.runtime_workspace_bindings_path,
+        repository_ref=repository_ref,
+        workspace_path=workspace_path,
+        handoff_ref=handoff_ref,
+        owner=owner,
+        release_reason=release_reason,
+        run_id=run_id,
+        now=now,
+    )
+
+
+def release_workspace_binding_at(
+    store_path: Path,
+    *,
+    repository_ref: str,
+    workspace_path: str | Path,
+    handoff_ref: str,
+    owner: str,
+    release_reason: str,
+    run_id: str = "",
+    now: str = "",
+) -> dict[str, Any]:
+    """`release_workspace_binding` against an already-resolved store path."""
+    try:
+        request = _release_request(
+            repository_ref=repository_ref,
+            workspace_path=workspace_path,
+            handoff_ref=handoff_ref,
+            owner=owner,
+        )
+        if release_reason not in RELEASE_REASONS:
+            raise WorkspaceBindingError(f"workspace_binding release_reason is unsupported: {release_reason!r}")
+    except WorkspaceBindingError as exc:
+        return _malformed(store_path, error=str(exc), request={}, action="release")
+    try:
+        with file_lock(store_path, private=True):
+            bindings, _ = read_jsonl_objects(store_path)
+            head = _head_for(bindings, str(request["binding_id"]))
+            if not head:
+                return _decision(
+                    outcome=OUTCOME_REFUSED,
+                    bound=False,
+                    reason_code=REFUSAL_NOT_HELD,
+                    request=request,
+                    holder={},
+                    now=now,
+                )
+            if str(head.get("state", "")) != "held":
+                # Releasing twice is harmless and is not a refusal: the caller
+                # asked for a workspace that is free, and it is free.
+                return _decision(
+                    outcome=OUTCOME_ALREADY_RELEASED,
+                    bound=False,
+                    reason_code="",
+                    request=request,
+                    holder=head,
+                    now=now,
+                )
+            refusal = _release_refusal(head, request=request, release_reason=release_reason)
+            if refusal:
+                return _decision(
+                    outcome=OUTCOME_REFUSED,
+                    bound=False,
+                    reason_code=refusal,
+                    request=request,
+                    holder=head,
+                    now=now,
+                )
+            record = build_workspace_binding(
+                repository_ref=repository_ref,
+                workspace_path=workspace_path,
+                # The terms come off the record being released, never off the
+                # caller. A release is the end of the claim on file and must not
+                # be a second place its branch or revision can be stated.
+                branch_ref=str(head.get("branch_ref", "")),
+                base_revision=str(head.get("base_revision", "")),
+                handoff_ref=str(head.get("handoff_ref", "")),
+                owner=str(head.get("owner", "")),
+                safety_profile_revision=str(head.get("safety_profile_revision", "")),
+                release_condition=str(head.get("release_condition", "")),
+                state="released",
+                release_reason=release_reason,
+                run_id=run_id or str(head.get("run_id", "")),
+                recorded_at=now,
+                supersedes_binding_ref=str(head.get("record_id", "")),
+            )
+            append_store_line(store_path, record)
+    except WorkspaceBindingError as exc:
+        return _malformed(store_path, error=str(exc), request=request, action="release")
+    except OSError as exc:
+        return _not_written(store_path, error=str(exc), request=request, action="release")
+    return _decision(
+        outcome=OUTCOME_RELEASED,
+        bound=False,
+        reason_code="",
+        request=request,
+        holder=record,
+        now=now,
+    )
+
+
+def workspace_binding_conflict_in(
+    bindings: Sequence[Mapping[str, Any]],
+    *,
+    request: Mapping[str, Any],
+    now: str = "",
+) -> dict[str, Any]:
+    """The refusal an acquisition would hit, over bindings already in hand.
+
+    A `workspace_binding_decision/v1` mapping whose `reason_code` is empty when
+    nothing stands in the way. Two conflict axes, in this order:
+
+    * the same canonical workspace, in the same repository, held by another
+      handoff or owner -- the collision #820 is named after;
+    * the same branch, in the same repository, held by another active workspace
+      -- two checkouts on one branch, which is the other half of AC1.
+
+    The workspace axis is checked first because it is the more specific answer:
+    a caller told "this branch is taken" when its own directory is also taken
+    would fix the branch and hit the second refusal immediately.
+
+    Staleness is derived here, at read time, and it refuses rather than
+    reclaims. It gets its own reason code on both axes because the recovery
+    differs: a fresh conflict is waited out, a stale one is released by a person.
+    """
+    known = [binding for binding in bindings if isinstance(binding, Mapping)]
+    active = active_workspace_bindings(known)
+    identity = str(request.get("binding_id", ""))
+    for binding in active:
+        if str(binding.get("binding_id", "")) != identity:
+            continue
+        if _is_same_holder(binding, request):
+            if _binding_terms(binding) == _binding_terms(request):
+                return _decision(
+                    outcome=OUTCOME_ALREADY_HELD, bound=True, reason_code="", request=request,
+                    holder=binding, now=now,
+                )
+            return _decision(
+                outcome=OUTCOME_REFUSED, bound=False, reason_code=REFUSAL_TERMS_CHANGED, request=request,
+                holder=binding, now=now,
+            )
+        stale = binding_is_stale(binding, now)
+        return _decision(
+            outcome=OUTCOME_REFUSED,
+            bound=False,
+            reason_code=REFUSAL_WORKSPACE_STALE if stale else REFUSAL_WORKSPACE_BOUND,
+            request=request,
+            holder=binding,
+            now=now,
+        )
+    for binding in active:
+        if str(binding.get("repository_ref", "")) != str(request.get("repository_ref", "")):
+            continue
+        if str(binding.get("branch_ref", "")) != str(request.get("branch_ref", "")):
+            continue
+        stale = binding_is_stale(binding, now)
+        return _decision(
+            outcome=OUTCOME_REFUSED,
+            bound=False,
+            reason_code=REFUSAL_BRANCH_STALE if stale else REFUSAL_BRANCH_BOUND,
+            request=request,
+            holder=binding,
+            now=now,
+        )
+    return _decision(
+        outcome=OUTCOME_UNBOUND, bound=False, reason_code="", request=request, holder={}, now=now,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Read, derive, validate the store, render
+# ---------------------------------------------------------------------------
+
+
+def read_workspace_bindings_result(paths: OmhPaths) -> tuple[list[dict[str, Any]], list[str]]:
+    return read_jsonl_objects(paths.runtime_workspace_bindings_path)
+
+
+def read_workspace_bindings(
+    paths: OmhPaths,
+    *,
+    run_id: str | None = None,
+    binding_id_value: str | None = None,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """The store, in append order, optionally scoped to one run or one binding."""
+    bindings, _ = read_workspace_bindings_result(paths)
+    if run_id is not None:
+        bindings = [binding for binding in bindings if str(binding.get("run_id", "")) == run_id]
+    if binding_id_value is not None:
+        bindings = [binding for binding in bindings if str(binding.get("binding_id", "")) == binding_id_value]
+    if limit is None:
+        return bindings
+    if limit < 1:
+        return []
+    return bindings[-limit:]
+
+
+def latest_binding_in(bindings: Sequence[Mapping[str, Any]], binding_id_value: str) -> dict[str, Any]:
+    """The record that speaks for one workspace claim: the one selection rule.
+
+    The store is append-only, so store order is arrival order and the last
+    record for a claim is its current state. Every surface that judges a binding
+    selects through this function, which is what stops the store validator and
+    the conflict predicate from picking different records for one workspace and
+    reaching opposite conclusions about it.
+    """
+    return dict(latest_record_in(bindings, key="binding_id", value=str(binding_id_value)))
+
+
+def active_workspace_bindings(bindings: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Every workspace claim whose current record still holds it.
+
+    Chain heads only. A superseded `held` record is not active -- something
+    later replaced it -- and a stale one still is: staleness blocks reuse and
+    does not end a binding, for the reason the module docstring gives.
+    """
+    heads: dict[str, dict[str, Any]] = {}
+    for binding in bindings:
+        if not isinstance(binding, Mapping):
+            continue
+        heads[str(binding.get("binding_id", ""))] = dict(binding)
+    return [binding for binding in heads.values() if str(binding.get("state", "")) == "held"]
+
+
+def binding_age_seconds(recorded_at: str, now: str = "") -> int:
+    """How old a binding record is, computed now, or `UNKNOWN_AGE_SECONDS`.
+
+    A stamp that does not parse and a stamp in the future both return
+    `UNKNOWN_AGE_SECONDS`: neither can be shown to be inside the window, and
+    clamping a future stamp to zero would make "edit the timestamp forward" a
+    way to hold a workspace indefinitely from disk.
+    """
+    recorded = _parse_stamp(recorded_at)
+    if recorded is None:
+        return UNKNOWN_AGE_SECONDS
+    reference = _parse_stamp(now) or datetime.now(timezone.utc)
+    age = int((reference - recorded).total_seconds())
+    if age < 0:
+        return UNKNOWN_AGE_SECONDS
+    return age
+
+
+def binding_is_stale(binding: Mapping[str, Any], now: str = "") -> bool:
+    """Whether this binding is outside the freshness window, evaluated now."""
+    age = binding_age_seconds(str(binding.get("recorded_at", "")), now)
+    return age == UNKNOWN_AGE_SECONDS or age > BINDING_STALE_AFTER_SECONDS
+
+
+def validate_workspace_binding_store(path: Path, *, run_id: str | None = None) -> dict[str, Any]:
+    """Validate the binding store, optionally scoped to one run's records.
+
+    Unscoped (`run_id=None`) this is the store's own report: unparseable lines,
+    every record's schema, and the integrity of the supersede chain. That chain
+    is what makes "which record holds this workspace" answerable, so a fork in
+    it is not a cosmetic fault -- it is two records both claiming to be the
+    current state of one directory.
+    """
+    bindings, read_errors = read_jsonl_objects(path)
+    binding_count, errors = store_errors(
+        path,
+        bindings,
+        read_errors,
+        run_id=run_id,
+        validate_record=validate_workspace_binding,
+        label=_LABEL,
+        id_key="record_id",
+        link_key="supersedes_binding_ref",
+        noun="binding",
+    )
+    return {
+        "schema_version": WORKSPACE_BINDING_STORE_VALIDATION_SCHEMA_VERSION,
+        "path": str(path),
+        "run_id": run_id or "",
+        "ok": not errors,
+        "binding_count": binding_count,
+        "mint_failure_count": len(read_workspace_binding_mint_failures(path)),
+        "errors": errors,
+    }
+
+
+def workspace_binding_mint_failures_path(store_path: Path) -> Path:
+    """Where unrecorded acquisitions are logged, beside the store they failed to reach."""
+    return store_path.with_name(WORKSPACE_BINDING_MINT_FAILURE_STORE_NAME)
+
+
+def read_workspace_binding_mint_failures(store_path: Path) -> list[dict[str, Any]]:
+    failures, _ = read_jsonl_objects(workspace_binding_mint_failures_path(store_path))
+    return failures
+
+
+def compact_workspace_binding(binding: Mapping[str, Any], *, now: str = "") -> dict[str, Any]:
+    """The user-facing shape, with every field through its class's guard.
+
+    Rendering is the last point at which a hand-edited store reaches a human, so
+    nothing is copied through verbatim: identifiers fold to a stable
+    non-navigable handle when they are not opaque, and closed vocabularies
+    render empty outside their vocabulary. `age_seconds` and `stale` are derived
+    here rather than stored, which is the whole point -- nothing on disk says a
+    binding is still current.
+    """
+    return {
+        "record_id": redacted_workspace_binding_ref(str(binding.get("record_id", ""))),
+        "binding_id": redacted_workspace_binding_ref(str(binding.get("binding_id", ""))),
+        "repository_ref": redacted_workspace_binding_ref(str(binding.get("repository_ref", ""))),
+        "workspace_ref": _rendered_workspace_ref(binding.get("workspace_ref")),
+        "branch_ref": redacted_workspace_binding_ref(str(binding.get("branch_ref", ""))),
+        "base_revision": redacted_workspace_binding_ref(str(binding.get("base_revision", ""))),
+        "handoff_ref": redacted_workspace_binding_ref(str(binding.get("handoff_ref", ""))),
+        "owner": redacted_workspace_binding_ref(str(binding.get("owner", ""))),
+        "run_id": redacted_workspace_binding_ref(str(binding.get("run_id", ""))),
+        "safety_profile_revision": redacted_workspace_binding_ref(
+            str(binding.get("safety_profile_revision", ""))
+        ),
+        "state": closed_workspace_binding_value(binding.get("state"), BINDING_STATES),
+        "release_condition": closed_workspace_binding_value(
+            binding.get("release_condition"), RELEASE_CONDITIONS
+        ),
+        "release_reason": closed_workspace_binding_value(binding.get("release_reason"), RELEASE_REASONS),
+        "recorded_at": redacted_workspace_binding_ref(str(binding.get("recorded_at", ""))),
+        "supersedes_binding_ref": redacted_workspace_binding_ref(
+            str(binding.get("supersedes_binding_ref", ""))
+        ),
+        "age_seconds": binding_age_seconds(str(binding.get("recorded_at", "")), now),
+        "stale": binding_is_stale(binding, now),
+    }
+
+
+def redacted_workspace_binding_ref(value: str) -> str:
+    """Fold any handle into a bounded, non-navigable binding reference."""
+    return redacted_ref(value, field="workspace_binding_ref")
+
+
+def closed_workspace_binding_value(value: Any, allowed: tuple[str, ...]) -> str:
+    """A closed-vocabulary field renders only what its vocabulary contains."""
+    return closed_vocabulary_value(value, allowed)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _acquire_request(
+    *,
+    repository_ref: str,
+    workspace_path: str | Path,
+    branch_ref: str,
+    base_revision: str,
+    handoff_ref: str,
+    owner: str,
+) -> dict[str, Any]:
+    """The guarded, canonicalized form of what an acquisition asked for.
+
+    Built before the store is touched, so a malformed request is refused without
+    holding the lock, and carrying exactly `_BINDING_TERMS_KEYS` so a request and
+    a stored record are fingerprinted over one key set rather than two.
+    """
+    return {
+        **_release_request(
+            repository_ref=repository_ref,
+            workspace_path=workspace_path,
+            handoff_ref=handoff_ref,
+            owner=owner,
+        ),
+        "branch_ref": _opaque(branch_ref, field="workspace_binding branch_ref"),
+        "base_revision": _opaque(base_revision, field="workspace_binding base_revision"),
+    }
+
+
+def _release_request(
+    *,
+    repository_ref: str,
+    workspace_path: str | Path,
+    handoff_ref: str,
+    owner: str,
+) -> dict[str, Any]:
+    """The identity and the claimed holder, with no terms.
+
+    A release names no branch and no base revision on purpose: it ends the claim
+    on record, whatever that claim said. Reading terms from the caller here
+    would make a release a second place a binding's branch or revision could be
+    stated, and the two statements could disagree.
+    """
+    workspace = workspace_ref(workspace_path)
+    safe_repository = _opaque(repository_ref, field="workspace_binding repository_ref")
+    return {
+        "binding_id": binding_id(repository_ref=safe_repository, workspace_ref_value=workspace),
+        "repository_ref": safe_repository,
+        "workspace_ref": workspace,
+        "branch_ref": "",
+        "base_revision": "",
+        "handoff_ref": _opaque(handoff_ref, field="workspace_binding handoff_ref"),
+        "owner": _opaque(owner, field="workspace_binding owner"),
+    }
+
+
+def _head_for(bindings: Sequence[Mapping[str, Any]], binding_id_value: str) -> dict[str, Any]:
+    return latest_binding_in(bindings, binding_id_value)
+
+
+def _is_same_holder(binding: Mapping[str, Any], request: Mapping[str, Any]) -> bool:
+    """Whether one binding is held by the handoff and owner now asking for it.
+
+    Both halves. A second owner reporting the same handoff reference is not the
+    same claim -- ownership is exactly what a binding records, and collapsing
+    the two would let any caller inherit a reservation by quoting its handoff.
+    """
+    return str(binding.get("handoff_ref", "")) == str(request.get("handoff_ref", "")) and str(
+        binding.get("owner", "")
+    ) == str(request.get("owner", ""))
+
+
+def _release_refusal(
+    head: Mapping[str, Any],
+    *,
+    request: Mapping[str, Any],
+    release_reason: str,
+) -> str:
+    """Why this release cannot end this binding, or "" when it can."""
+    if release_reason == "observed_terminal_state" and not _is_same_holder(head, request):
+        return REFUSAL_NOT_HELD
+    condition = str(head.get("release_condition", ""))
+    permitted = _PERMITTED_RELEASE_REASONS.get(condition, RELEASE_REASONS)
+    if release_reason not in permitted:
+        return REFUSAL_CONDITION_UNMET
+    return ""
+
+
+def _binding_terms(record: Mapping[str, Any]) -> str:
+    """Which claim a record or a request states, ignoring when it was recorded.
+
+    One key tuple for both sides. `_acquire_request` builds exactly these keys
+    for that reason: fingerprinting a request over the keys it happens to carry
+    and a record over the keys it happens to carry would never match, and every
+    re-acquisition would read as a change of terms.
+    """
+    return record_fingerprint(record, _BINDING_TERMS_KEYS)
+
+
+def _decision(
+    *,
+    outcome: str,
+    bound: bool,
+    reason_code: str,
+    request: Mapping[str, Any],
+    holder: Mapping[str, Any],
+    now: str,
+    error: str = "",
+) -> dict[str, Any]:
+    """One `workspace_binding_decision/v1` verdict.
+
+    Everything a caller needs to act, and nothing it has to look up: what
+    happened, whether it holds the workspace now, why not, who does, how stale
+    that claim is, and the recovery -- as a closed id *and* as the sentence for
+    it, because #820 AC3 asks for guidance and an id alone is not guidance.
+    """
+    recovery = REFUSAL_RECOVERY.get(reason_code, "")
+    return {
+        "schema_version": WORKSPACE_BINDING_DECISION_SCHEMA_VERSION,
+        "outcome": outcome,
+        "bound": bound,
+        "reason_code": reason_code,
+        "reason": REFUSAL_REASONS.get(reason_code, ""),
+        "recovery_action": recovery,
+        "recovery_guidance": RECOVERY_GUIDANCE.get(recovery, ""),
+        "error": error,
+        "binding_id": redacted_workspace_binding_ref(str(request.get("binding_id", ""))),
+        "record_id": redacted_workspace_binding_ref(str(holder.get("record_id", ""))),
+        "state": closed_workspace_binding_value(holder.get("state"), BINDING_STATES),
+        "holder_owner": redacted_workspace_binding_ref(str(holder.get("owner", ""))),
+        "holder_handoff_ref": redacted_workspace_binding_ref(str(holder.get("handoff_ref", ""))),
+        "holder_branch_ref": redacted_workspace_binding_ref(str(holder.get("branch_ref", ""))),
+        "holder_base_revision": redacted_workspace_binding_ref(str(holder.get("base_revision", ""))),
+        "release_condition": closed_workspace_binding_value(
+            holder.get("release_condition"), RELEASE_CONDITIONS
+        ),
+        "requested_workspace_ref": _rendered_workspace_ref(request.get("workspace_ref")),
+        "requested_repository_ref": redacted_workspace_binding_ref(str(request.get("repository_ref", ""))),
+        "requested_branch_ref": redacted_workspace_binding_ref(str(request.get("branch_ref", ""))),
+        "requested_base_revision": redacted_workspace_binding_ref(str(request.get("base_revision", ""))),
+        "requested_handoff_ref": redacted_workspace_binding_ref(str(request.get("handoff_ref", ""))),
+        "requested_owner": redacted_workspace_binding_ref(str(request.get("owner", ""))),
+        "age_seconds": binding_age_seconds(str(holder.get("recorded_at", "")), now) if holder else UNKNOWN_AGE_SECONDS,
+        "stale": binding_is_stale(holder, now) if holder else False,
+        "stale_after_seconds": BINDING_STALE_AFTER_SECONDS,
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+
+
+def _malformed(
+    store_path: Path,
+    *,
+    error: str,
+    request: Mapping[str, Any],
+    action: str,
+) -> dict[str, Any]:
+    _append_mint_failure(store_path, outcome=OUTCOME_REFUSED, error=error, request=request, action=action)
+    return _decision(
+        outcome=OUTCOME_REFUSED,
+        bound=False,
+        reason_code=REFUSAL_MALFORMED,
+        request=request,
+        holder={},
+        now="",
+        error=error,
+    )
+
+
+def _not_written(
+    store_path: Path,
+    *,
+    error: str,
+    request: Mapping[str, Any],
+    action: str,
+) -> dict[str, Any]:
+    _append_mint_failure(store_path, outcome=OUTCOME_NOT_WRITTEN, error=error, request=request, action=action)
+    return _decision(
+        outcome=OUTCOME_NOT_WRITTEN,
+        bound=False,
+        reason_code=REFUSAL_NOT_WRITTEN,
+        request=request,
+        holder={},
+        now="",
+        error=error,
+    )
+
+
+def _append_mint_failure(
+    store_path: Path,
+    *,
+    outcome: str,
+    error: str,
+    request: Mapping[str, Any],
+    action: str,
+) -> None:
+    """Log an acquisition or release that never reached the store, best effort.
+
+    A refusal the caller already holds is the record of last resort; this is so
+    a workspace that could not be reserved is visible without the calling flow
+    having to invent a channel for it.
+    """
+    append_sidecar_line(
+        workspace_binding_mint_failures_path(store_path),
+        {
+            "schema_version": WORKSPACE_BINDING_MINT_FAILURE_SCHEMA_VERSION,
+            "recorded_at": utc_now(),
+            "action": str(action),
+            "outcome": str(outcome),
+            "binding_id": str(request.get("binding_id", "")),
+            "handoff_ref": str(request.get("handoff_ref", "")),
+            "owner": str(request.get("owner", "")),
+            "error": _bounded_error(error),
+        },
+    )
+
+
+def _workspace_ref_errors(value: Any) -> list[str]:
+    """A stored workspace reference is a digest handle and never a path."""
+    errors = reference_errors(value, field="workspace_ref", label=_LABEL, required=True)
+    if errors or not isinstance(value, str):
+        return errors
+    if not _WORKSPACE_REF.fullmatch(value):
+        return [
+            f"{_LABEL} workspace_ref must be a canonical-path digest handle; this record carries the "
+            "identity of a workspace, never its path"
+        ]
+    return []
+
+
+def _rendered_workspace_ref(value: Any) -> str:
+    """A workspace reference renders only in the one shape it may be stored in."""
+    text = str(value or "")
+    return text if _WORKSPACE_REF.fullmatch(text) else ""
+
+
+def _parse_stamp(value: str) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
+
+
+def _opaque(value: str, *, field: str) -> str:
+    return opaque_ref(value, field=field, error=WorkspaceBindingError)
+
+
+def _bounded_error(value: str) -> str:
+    """One bounded, secret-free line for the failure log."""
+    raw = " ".join(str(value or "").split())
+    if not raw:
+        return ""
+    if is_sensitive_metadata_text(raw):
+        return "[redacted]"
+    return raw[:200]
+
+
+def _record_id(recorded_at: str, binding_id_value: str, state: str) -> str:
+    return mint_record_id(
+        prefix="workspace-binding",
+        identity={"binding_id": binding_id_value, "recorded_at": recorded_at, "state": state},
+    )

--- a/tests/test_data_boundary.py
+++ b/tests/test_data_boundary.py
@@ -333,9 +333,9 @@ class EnforcementFactsTests(unittest.TestCase):
     def test_a_host_confinement_limit_is_unenforced_and_says_which_kind_of_unenforced(self) -> None:
         """The genuine per-host difference: which blocker stands in the way.
 
-        A host with a confinement backend is blocked on #820 alone; a host with
-        none could not enforce a runtime limit even after #820 lands, and says
-        so with its own reason.
+        A host with a confinement backend is blocked only on no lane placing an
+        executor under the sandbox; a host with none could not enforce a runtime
+        limit even after such a lane exists, and says so with its own reason.
         """
         facts = self.facts()
         entries = [entry for entry in facts["limits"] if entry["enforcement_kind"] == "host_confinement"]
@@ -344,8 +344,26 @@ class EnforcementFactsTests(unittest.TestCase):
             with self.subTest(limit=entry["limit"]):
                 self.assertFalse(entry["enforced_here"])
                 self.assertEqual(entry["host_can_enforce"], facts["host_confinement_available"])
-                expected = "#820" if facts["host_confinement_available"] else facts["host_confinement_unavailable_reason"]
+                expected = (
+                    "no_delegation_or_fanout_lane_places_an_executor_under_the_sandbox"
+                    if facts["host_confinement_available"]
+                    else facts["host_confinement_unavailable_reason"]
+                )
                 self.assertEqual(entry["blocked_by"], expected)
+
+    def test_no_data_boundary_blocker_names_the_workspace_binding_issue(self) -> None:
+        """#820 shipped a workspace reservation, not an executor sandbox.
+
+        All three unenforced rows used to cite it. That was a mis-citation even
+        before the issue landed -- placing a dispatched executor under the
+        adapter lane's sandbox was never in its scope -- and it became a
+        dangling pointer once it closed. A blocker names a ticket only when
+        landing that ticket would close it, which is the rule
+        `action_gate.ACCOUNT_AUTHORIZATION_BLOCKER` already follows.
+        """
+        for entry in self.facts()["limits"]:
+            with self.subTest(limit=entry["limit"]):
+                self.assertNotIn("#820", str(entry["blocked_by"]))
 
     def test_an_advisory_limit_is_enforced_on_no_host(self) -> None:
         for entry in self.facts()["limits"]:

--- a/tests/test_handoff_safety_contract.py
+++ b/tests/test_handoff_safety_contract.py
@@ -109,20 +109,24 @@ _ENFORCED_BOUNDARIES = frozenset(
 # that must land before it can move. A blocker is not always an issue number:
 # `account_authorization` names the reason instead, because nothing that could
 # be filed would close it — OMH cannot observe a consent flow owned by someone
-# else's website.
+# else's website. `workspace` joined it when #820 landed: that issue shipped the
+# pre-dispatch half (`workspace_binding_guard/v1` reserves a workspace and a
+# branch for one handoff), and the half that remains is confining a process that
+# is already running, which no change on this side of the wall can do.
 _DECLARED_NOT_ENFORCED = {
     "account_authorization": "host_owned_consent_flow_is_not_observable_by_omh",
     "confirmation_answered": "no_confirmation_answer_intake_mints_a_run_bound_approval",
     "recovery": "#821",
     "start_evidence": "#826",
     "storage_retention": "#835",
-    "workspace": "#820",
+    "workspace": "no_omh_side_constraint_can_bind_a_running_executor_process",
 }
 # The three data-boundary rows whose blocker is a *host* fact rather than a
-# repository fact: a host with an OS confinement backend is blocked on #820,
-# and a host without one is blocked on not having one. Pinning either string
-# here would make this test pass on macOS and fail on Windows, so the expected
-# value is read from the same facts the contract read.
+# repository fact: a host with an OS confinement backend is blocked on no lane
+# placing an executor under the sandbox, and a host without one is blocked on
+# not having a backend at all. Pinning either string here would make this test
+# pass on macOS and fail on Windows, so the expected value is read from the same
+# facts the contract read.
 _HOST_DEPENDENT_BOUNDARIES = frozenset(
     {
         "data_executor_honours_declared_targets",
@@ -380,7 +384,11 @@ class AntiDecorationTests(unittest.TestCase):
 
     def test_unenforced_boundaries_state_the_gap_in_words(self) -> None:
         contract = _contract()
-        self.assertIn("nothing binds a running executor", _boundary(contract, "workspace")["statement"])
+        workspace = _boundary(contract, "workspace")["statement"]
+        self.assertIn("nothing binds a running executor", workspace)
+        # And it says which half #820 did close, so a reader does not read the
+        # unenforced verdict as "nothing about workspaces is guarded".
+        self.assertIn("workspace_binding_guard/v1", workspace)
         self.assertIn("not a state OMH can observe", _boundary(contract, "account_authorization")["statement"])
         self.assertIn("persist until the operator deletes them", _boundary(contract, "storage_retention")["statement"])
         self.assertIn("no observed start", _boundary(contract, "start_evidence")["statement"])

--- a/tests/test_risky_action_confirmation.py
+++ b/tests/test_risky_action_confirmation.py
@@ -1191,7 +1191,10 @@ class ContractTests(unittest.TestCase):
         self.assertEqual(bare[advisory]["blocked_by"], capable[advisory]["blocked_by"])
         self.assertNotIn("confinement_backend", str(bare[advisory]["blocked_by"]))
         # The host_confinement rows still do move, which is the distinction.
-        self.assertEqual(capable["runtime_network_confinement"]["blocked_by"], "#820")
+        self.assertEqual(
+            capable["runtime_network_confinement"]["blocked_by"],
+            "no_delegation_or_fanout_lane_places_an_executor_under_the_sandbox",
+        )
         self.assertEqual(
             bare["runtime_network_confinement"]["blocked_by"],
             "no_os_confinement_backend_on_this_platform",

--- a/tests/test_runtime_artifacts.py
+++ b/tests/test_runtime_artifacts.py
@@ -2065,6 +2065,7 @@ _STORE_SCHEMA_VERSIONS = {
     "approval_receipts.jsonl": "approval_receipt/v1",
     "blocked_work_records.jsonl": "blocked_work_record/v1",
     "external_effect_receipts.jsonl": "external_effect_receipt/v1",
+    "workspace_bindings.jsonl": "workspace_binding_guard/v1",
 }
 
 

--- a/tests/test_workspace_binding_guard.py
+++ b/tests/test_workspace_binding_guard.py
@@ -1,0 +1,1063 @@
+"""Contracts for `workspace_binding_guard/v1` (issue #820).
+
+The acceptance criteria this holds, and where each one is asserted:
+
+AC1  two active handoffs cannot bind the same workspace or branch
+     -> `TwoActiveHandoffsCannotShareOneWorkspace`,
+        `TwoActiveHandoffsCannotShareOneBranch`,
+        `OneDirectoryHasOneIdentityHoweverItIsSpelled`
+AC2  every bound handoff includes binding id, owner, and base revision
+     -> `EveryBoundHandoffNamesItsBindingOwnerAndBaseRevision`
+AC3  stale bindings block reuse and return recovery guidance
+     -> `StaleBindingsBlockReuseAndSayHowToRecover`
+
+Plus the two things a guard is worthless without: that a release really frees
+the workspace (`ReleaseFreesTheWorkspace`), and that holding a binding is never
+mistaken for having dispatched anything (`ABindingIsNotDispatchEvidence`).
+
+Store mechanics -- concurrent appends, torn tails, supersession forks -- are
+inherited from `system/append_only_store.py` and proved there. What is asserted
+here is the *wiring*: that this family reaches the shared walk with its own key
+names, that its chain is judged at all, and that its exclusivity survives the
+one thing a path-keyed guard is most easily defeated by, which is spelling the
+path differently.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.coding.action_gate import (
+    WORKSPACE_RUNTIME_BLOCKER,
+    build_task_authority_envelope,
+    build_task_handoff_safety_contract,
+)
+from omh.runtime.artifacts import validate_runtime
+from omh.runtime.records import (
+    OPTIONAL_RUNTIME_STORE_VALIDATORS,
+    WORKSPACE_BINDING_RECORD_KEYS,
+)
+from omh.system.append_only_store import RAW_OR_HIDDEN_KEYS
+from omh.system.paths import OmhPaths
+from omh.workflows.approval_receipts import _EXECUTION_CLAIM_KEYS as APPROVAL_EXECUTION_CLAIM_KEYS
+from omh.workflows.workspace_bindings import (
+    BINDING_STALE_AFTER_SECONDS,
+    BINDING_STATES,
+    CLAIM_BOUNDARY,
+    EXECUTION_CLAIM_KEYS,
+    OUTCOME_ACQUIRED,
+    OUTCOME_ALREADY_HELD,
+    OUTCOME_ALREADY_RELEASED,
+    OUTCOME_REFUSED,
+    OUTCOME_RELEASED,
+    OUTCOME_UNBOUND,
+    RECOVERY_ACTIONS,
+    RECOVERY_EXPLICIT_RELEASE,
+    RECOVERY_GUIDANCE,
+    RECOVERY_REACQUIRE,
+    RECOVERY_RELEASE_STALE,
+    RECOVERY_WAIT,
+    REFUSAL_BRANCH_BOUND,
+    REFUSAL_BRANCH_STALE,
+    REFUSAL_CODES,
+    REFUSAL_CONDITION_UNMET,
+    REFUSAL_MALFORMED,
+    REFUSAL_NOT_HELD,
+    REFUSAL_REASONS,
+    REFUSAL_RECOVERY,
+    REFUSAL_TERMS_CHANGED,
+    REFUSAL_WORKSPACE_BOUND,
+    REFUSAL_WORKSPACE_STALE,
+    RELEASE_CONDITIONS,
+    WORKSPACE_BINDING_CONSTANT_KEYS,
+    WORKSPACE_BINDING_KEYS,
+    WORKSPACE_BINDING_SCHEMA_VERSION,
+    WorkspaceBindingError,
+    acquire_workspace_binding,
+    active_workspace_bindings,
+    binding_age_seconds,
+    binding_is_stale,
+    build_workspace_binding,
+    canonical_workspace_path,
+    compact_workspace_binding,
+    inspect_workspace_binding,
+    read_workspace_bindings,
+    release_workspace_binding,
+    validate_workspace_binding,
+    validate_workspace_binding_store,
+    workspace_ref,
+)
+
+_NOW = "2026-08-09T12:00:00Z"
+
+
+def _later(seconds: int) -> str:
+    """`_NOW` moved forward, so freshness is compared against an injected clock."""
+    moment = datetime.fromisoformat(_NOW.replace("Z", "+00:00")) + timedelta(seconds=seconds)
+    return moment.isoformat().replace("+00:00", "Z")
+
+
+def _paths(root: Path) -> OmhPaths:
+    return OmhPaths(omh_home=root, hermes_home=root / "hermes")
+
+
+def _claim(**overrides: object) -> dict[str, object]:
+    """One well-formed acquisition, as keyword arguments."""
+    claim: dict[str, object] = {
+        "repository_ref": "rlaope/oh-my-hermes",
+        "branch_ref": "agent/issue-820",
+        "base_revision": "c7f9218b",
+        "handoff_ref": "handoff-alpha",
+        "owner": "codex",
+        "safety_profile_revision": "rev-1",
+        "now": _NOW,
+    }
+    claim.update(overrides)
+    return claim
+
+
+def _record(workspace: Path, **overrides: object) -> dict[str, object]:
+    kwargs: dict[str, object] = {
+        "repository_ref": "rlaope/oh-my-hermes",
+        "workspace_path": workspace,
+        "branch_ref": "agent/issue-820",
+        "base_revision": "c7f9218b",
+        "handoff_ref": "handoff-alpha",
+        "owner": "codex",
+        "safety_profile_revision": "rev-1",
+        "recorded_at": _NOW,
+    }
+    kwargs.update(overrides)
+    return build_workspace_binding(**kwargs)  # type: ignore[arg-type]
+
+
+class TwoActiveHandoffsCannotShareOneWorkspace(unittest.TestCase):
+    """AC1, the workspace axis: the collision #820 is named after."""
+
+    def test_the_first_handoff_acquires_and_the_second_is_refused(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            workspace = Path(tmp) / "work"
+
+            first = acquire_workspace_binding(paths, workspace_path=workspace, **_claim())
+            second = acquire_workspace_binding(
+                paths,
+                workspace_path=workspace,
+                **_claim(handoff_ref="handoff-beta", owner="claude-code", branch_ref="agent/other"),
+            )
+
+            self.assertTrue(first["bound"])
+            self.assertEqual(first["outcome"], OUTCOME_ACQUIRED)
+            self.assertFalse(second["bound"])
+            self.assertEqual(second["outcome"], OUTCOME_REFUSED)
+            self.assertEqual(second["reason_code"], REFUSAL_WORKSPACE_BOUND)
+            # Only one record reached the store: a refusal is not an event that
+            # gets written into the reservation's own chain.
+            self.assertEqual(len(read_workspace_bindings(paths)), 1)
+
+    def test_the_refusal_is_readable_and_names_who_owns_it(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            workspace = Path(tmp) / "work"
+            acquire_workspace_binding(paths, workspace_path=workspace, **_claim())
+
+            refusal = acquire_workspace_binding(
+                paths,
+                workspace_path=workspace,
+                **_claim(handoff_ref="handoff-beta", owner="claude-code"),
+            )
+
+            self.assertEqual(refusal["reason"], REFUSAL_REASONS[REFUSAL_WORKSPACE_BOUND])
+            self.assertIn("two handoffs cannot share one checkout", refusal["reason"])
+            # "explains who owns it" is the native-experience half of #820.
+            self.assertEqual(refusal["holder_owner"], "codex")
+            self.assertEqual(refusal["holder_handoff_ref"], "handoff-alpha")
+            self.assertEqual(refusal["holder_branch_ref"], "agent/issue-820")
+            self.assertEqual(refusal["requested_owner"], "claude-code")
+
+    def test_the_same_handoff_restating_its_own_claim_is_not_a_conflict(self) -> None:
+        """Idempotence. A retry must not be refused as a collision with itself."""
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            workspace = Path(tmp) / "work"
+            first = acquire_workspace_binding(paths, workspace_path=workspace, **_claim())
+
+            again = acquire_workspace_binding(
+                paths, workspace_path=workspace, **_claim(now=_later(60))
+            )
+
+            self.assertTrue(again["bound"])
+            self.assertEqual(again["outcome"], OUTCOME_ALREADY_HELD)
+            self.assertEqual(again["reason_code"], "")
+            self.assertEqual(again["record_id"], first["record_id"])
+            self.assertEqual(len(read_workspace_bindings(paths)), 1)
+
+    def test_a_second_owner_quoting_the_same_handoff_is_still_refused(self) -> None:
+        """Ownership is what a binding records; quoting a handoff cannot inherit it."""
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            workspace = Path(tmp) / "work"
+            acquire_workspace_binding(paths, workspace_path=workspace, **_claim())
+
+            refusal = acquire_workspace_binding(
+                paths, workspace_path=workspace, **_claim(owner="claude-code")
+            )
+
+            self.assertFalse(refusal["bound"])
+            self.assertEqual(refusal["reason_code"], REFUSAL_WORKSPACE_BOUND)
+
+    def test_the_same_handoff_on_new_terms_must_release_first(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            workspace = Path(tmp) / "work"
+            acquire_workspace_binding(paths, workspace_path=workspace, **_claim())
+
+            moved = acquire_workspace_binding(
+                paths, workspace_path=workspace, **_claim(base_revision="deadbeef")
+            )
+
+            self.assertFalse(moved["bound"])
+            self.assertEqual(moved["reason_code"], REFUSAL_TERMS_CHANGED)
+            self.assertEqual(moved["recovery_action"], RECOVERY_REACQUIRE)
+
+
+class TwoActiveHandoffsCannotShareOneBranch(unittest.TestCase):
+    """AC1, the branch axis: two checkouts on one branch is the other half."""
+
+    def test_a_second_workspace_on_a_held_branch_is_refused(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            acquire_workspace_binding(paths, workspace_path=Path(tmp) / "one", **_claim())
+
+            refusal = acquire_workspace_binding(
+                paths,
+                workspace_path=Path(tmp) / "two",
+                **_claim(handoff_ref="handoff-beta", owner="claude-code"),
+            )
+
+            self.assertFalse(refusal["bound"])
+            self.assertEqual(refusal["reason_code"], REFUSAL_BRANCH_BOUND)
+            self.assertIn("two checkouts cannot share one branch", refusal["reason"])
+            self.assertEqual(refusal["holder_owner"], "codex")
+
+    def test_a_second_workspace_on_another_branch_is_allowed(self) -> None:
+        """The guard bounds collisions, not parallelism. The negative case."""
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            acquire_workspace_binding(paths, workspace_path=Path(tmp) / "one", **_claim())
+
+            second = acquire_workspace_binding(
+                paths,
+                workspace_path=Path(tmp) / "two",
+                **_claim(branch_ref="agent/issue-821", handoff_ref="handoff-beta", owner="claude-code"),
+            )
+
+            self.assertTrue(second["bound"])
+            self.assertEqual(second["outcome"], OUTCOME_ACQUIRED)
+            self.assertEqual(len(active_workspace_bindings(read_workspace_bindings(paths))), 2)
+
+    def test_the_same_branch_in_another_repository_is_allowed(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            acquire_workspace_binding(paths, workspace_path=Path(tmp) / "one", **_claim())
+
+            other = acquire_workspace_binding(
+                paths,
+                workspace_path=Path(tmp) / "two",
+                **_claim(repository_ref="rlaope/other", handoff_ref="handoff-beta"),
+            )
+
+            self.assertTrue(other["bound"])
+
+    def test_the_workspace_axis_is_reported_before_the_branch_axis(self) -> None:
+        """The more specific answer first: fixing the branch alone would not help."""
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            workspace = Path(tmp) / "work"
+            acquire_workspace_binding(paths, workspace_path=workspace, **_claim())
+
+            both = acquire_workspace_binding(
+                paths, workspace_path=workspace, **_claim(handoff_ref="handoff-beta")
+            )
+
+            self.assertEqual(both["reason_code"], REFUSAL_WORKSPACE_BOUND)
+
+
+class AcquisitionIsAtomicByWorkspaceIdentity(unittest.TestCase):
+    """The whole guard rests on this: a check-then-write with a gap is no guard."""
+
+    def test_barrier_synced_acquisitions_produce_one_winner(self) -> None:
+        """Unlocked, every racer reads an empty store and every racer writes.
+
+        `file_lock` opens its own handle per call, so `flock` really does
+        serialize threads in one process -- the same property
+        `tests/test_append_only_store.py::ConcurrentAppendTests` relies on.
+        """
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            workspace = Path(tmp) / "contested"
+            racers = 8
+            barrier = threading.Barrier(racers)
+            decisions: list[dict[str, object]] = []
+            raised: list[Exception] = []
+            guard = threading.Lock()
+
+            def race(index: int) -> None:
+                barrier.wait()
+                try:
+                    decision = acquire_workspace_binding(
+                        paths,
+                        workspace_path=workspace,
+                        **_claim(handoff_ref=f"handoff-{index}", owner=f"owner-{index}"),
+                    )
+                except Exception as exc:  # reported on the main thread, never dropped
+                    with guard:
+                        raised.append(exc)
+                    return
+                with guard:
+                    decisions.append(decision)
+
+            threads = [threading.Thread(target=race, args=(index,)) for index in range(racers)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+            self.assertEqual(raised, [])
+            self.assertEqual(len(decisions), racers)
+            winners = [decision for decision in decisions if decision["bound"]]
+            self.assertEqual(len(winners), 1)
+            for decision in decisions:
+                if decision is winners[0]:
+                    continue
+                self.assertEqual(decision["reason_code"], REFUSAL_WORKSPACE_BOUND)
+            # One reservation on disk, and it is the winner's.
+            records = read_workspace_bindings(paths)
+            self.assertEqual(len(records), 1)
+            self.assertEqual(records[0]["record_id"], winners[0]["record_id"])
+
+
+class OneDirectoryHasOneIdentityHoweverItIsSpelled(unittest.TestCase):
+    """A guard defeated by typing the path differently would be decoration."""
+
+    def test_two_spellings_of_one_directory_collide(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            root = Path(tmp) / "work"
+            root.mkdir()
+            (root / "nested").mkdir()
+            spellings = (
+                root,
+                Path(tmp) / "." / "work",
+                root / "nested" / "..",
+                Path(f"{root}{Path('/')}"),
+            )
+            acquire_workspace_binding(paths, workspace_path=root, **_claim())
+
+            for spelling in spellings:
+                with self.subTest(spelling=str(spelling)):
+                    self.assertEqual(workspace_ref(spelling), workspace_ref(root))
+                    refusal = acquire_workspace_binding(
+                        paths,
+                        workspace_path=spelling,
+                        **_claim(handoff_ref="handoff-beta", branch_ref="agent/other"),
+                    )
+                    self.assertFalse(refusal["bound"])
+                    self.assertEqual(refusal["reason_code"], REFUSAL_WORKSPACE_BOUND)
+
+    def test_a_sibling_directory_is_a_different_workspace(self) -> None:
+        with TemporaryDirectory() as tmp:
+            self.assertNotEqual(
+                workspace_ref(Path(tmp) / "work"), workspace_ref(Path(tmp) / "work-2")
+            )
+
+    def test_no_path_byte_reaches_the_store(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            # A directory name that shares no substring with the record's own
+            # vocabulary, so the assertion below fails only on a real leak.
+            workspace = Path(tmp) / "zephyr-checkout"
+            acquire_workspace_binding(paths, workspace_path=workspace, **_claim())
+
+            raw = paths.runtime_workspace_bindings_path.read_text(encoding="utf-8")
+
+            self.assertNotIn(str(workspace), raw)
+            self.assertNotIn(workspace.name, raw)
+            self.assertNotIn(tmp, raw)
+            self.assertEqual(json.loads(raw)["workspace_ref"], workspace_ref(workspace))
+
+    def test_a_stored_reference_that_is_a_path_is_refused(self) -> None:
+        with TemporaryDirectory() as tmp:
+            record = _record(Path(tmp) / "work")
+            record["workspace_ref"] = "home/someone/work"
+
+            errors = validate_workspace_binding(record)
+
+            self.assertTrue(any("canonical-path digest handle" in error for error in errors), errors)
+
+    def test_an_empty_workspace_path_is_refused_rather_than_resolved(self) -> None:
+        """`Path("")` resolves to the current directory; binding it would be silent."""
+        with self.assertRaises(WorkspaceBindingError):
+            canonical_workspace_path("")
+        with TemporaryDirectory() as tmp:
+            refusal = acquire_workspace_binding(_paths(Path(tmp)), workspace_path="", **_claim())
+            self.assertEqual(refusal["reason_code"], REFUSAL_MALFORMED)
+            self.assertTrue(refusal["error"])
+
+
+class EveryBoundHandoffNamesItsBindingOwnerAndBaseRevision(unittest.TestCase):
+    """AC2, on the record and on the verdict a caller is handed."""
+
+    def test_the_record_carries_all_three(self) -> None:
+        with TemporaryDirectory() as tmp:
+            record = _record(Path(tmp) / "work")
+
+            self.assertTrue(record["binding_id"].startswith("binding-"))
+            self.assertEqual(record["owner"], "codex")
+            self.assertEqual(record["base_revision"], "c7f9218b")
+            self.assertEqual(record["state"], "held")
+            self.assertEqual(validate_workspace_binding(record), [])
+
+    def test_the_acquisition_verdict_carries_all_three(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+
+            decision = acquire_workspace_binding(paths, workspace_path=Path(tmp) / "work", **_claim())
+
+            self.assertTrue(decision["binding_id"].startswith("binding-"))
+            self.assertEqual(decision["holder_owner"], "codex")
+            self.assertEqual(decision["holder_base_revision"], "c7f9218b")
+
+    def test_every_dimension_the_issue_names_is_a_stored_field(self) -> None:
+        """Repository, path, branch, base revision, handoff, owner, revision, condition."""
+        for field in (
+            "repository_ref",
+            "workspace_ref",
+            "branch_ref",
+            "base_revision",
+            "handoff_ref",
+            "owner",
+            "safety_profile_revision",
+            "release_condition",
+        ):
+            with self.subTest(field=field):
+                self.assertIn(field, WORKSPACE_BINDING_KEYS)
+
+    def test_a_missing_identifier_is_refused_rather_than_defaulted(self) -> None:
+        with TemporaryDirectory() as tmp:
+            for field in ("repository_ref", "branch_ref", "base_revision", "handoff_ref", "owner"):
+                with self.subTest(field=field), self.assertRaises(WorkspaceBindingError):
+                    _record(Path(tmp) / "work", **{field: ""})
+
+    def test_the_key_set_is_closed_and_every_key_renders(self) -> None:
+        with TemporaryDirectory() as tmp:
+            record = _record(Path(tmp) / "work")
+            self.assertEqual(sorted(record), sorted(WORKSPACE_BINDING_KEYS))
+
+            rendered = compact_workspace_binding(record, now=_NOW)
+
+            # A key stored and never rendered is a field nobody can see. The
+            # three constants are the deliberate exception.
+            for key in WORKSPACE_BINDING_KEYS:
+                if key in WORKSPACE_BINDING_CONSTANT_KEYS:
+                    continue
+                with self.subTest(key=key):
+                    self.assertIn(key, rendered)
+
+    def test_an_unsupported_key_is_refused(self) -> None:
+        with TemporaryDirectory() as tmp:
+            record = dict(_record(Path(tmp) / "work"))
+            record["lease_holder_pid"] = "4242"
+
+            errors = validate_workspace_binding(record)
+
+            self.assertTrue(any("unsupported keys" in error for error in errors), errors)
+
+    def test_raw_and_hidden_keys_are_refused_by_name(self) -> None:
+        with TemporaryDirectory() as tmp:
+            record = dict(_record(Path(tmp) / "work"))
+            record["prompt"] = "do the thing"
+
+            errors = validate_workspace_binding(record)
+
+            self.assertTrue(any("raw or hidden keys" in error for error in errors), errors)
+            self.assertIn("prompt", RAW_OR_HIDDEN_KEYS)
+
+
+class StaleBindingsBlockReuseAndSayHowToRecover(unittest.TestCase):
+    """AC3. Both halves: reuse is blocked, and the way out comes back with it."""
+
+    def test_a_stale_binding_refuses_reuse_by_another_handoff(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            workspace = Path(tmp) / "work"
+            acquire_workspace_binding(paths, workspace_path=workspace, **_claim())
+
+            refusal = acquire_workspace_binding(
+                paths,
+                workspace_path=workspace,
+                **_claim(
+                    handoff_ref="handoff-beta",
+                    owner="claude-code",
+                    branch_ref="agent/other",
+                    now=_later(BINDING_STALE_AFTER_SECONDS + 1),
+                ),
+            )
+
+            self.assertFalse(refusal["bound"])
+            self.assertEqual(refusal["outcome"], OUTCOME_REFUSED)
+            self.assertEqual(refusal["reason_code"], REFUSAL_WORKSPACE_STALE)
+            self.assertTrue(refusal["stale"])
+
+    def test_the_stale_refusal_returns_recovery_guidance(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            workspace = Path(tmp) / "work"
+            acquire_workspace_binding(paths, workspace_path=workspace, **_claim())
+
+            refusal = acquire_workspace_binding(
+                paths,
+                workspace_path=workspace,
+                **_claim(handoff_ref="handoff-beta", now=_later(BINDING_STALE_AFTER_SECONDS + 1)),
+            )
+
+            self.assertEqual(refusal["recovery_action"], RECOVERY_RELEASE_STALE)
+            self.assertEqual(refusal["recovery_guidance"], RECOVERY_GUIDANCE[RECOVERY_RELEASE_STALE])
+            # Guidance, not an identifier: an id alone is not guidance.
+            self.assertIn("explicit_safe_release", refusal["recovery_guidance"])
+            self.assertEqual(refusal["stale_after_seconds"], BINDING_STALE_AFTER_SECONDS)
+            self.assertGreater(refusal["age_seconds"], BINDING_STALE_AFTER_SECONDS)
+
+    def test_the_stale_refusal_is_a_different_code_from_a_fresh_one(self) -> None:
+        """Different recoveries: one is waited out, the other is released."""
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            workspace = Path(tmp) / "work"
+            acquire_workspace_binding(paths, workspace_path=workspace, **_claim())
+            second = _claim(handoff_ref="handoff-beta", branch_ref="agent/other")
+
+            fresh = acquire_workspace_binding(
+                paths, workspace_path=workspace, **{**second, "now": _later(60)}
+            )
+            stale = acquire_workspace_binding(
+                paths,
+                workspace_path=workspace,
+                **{**second, "now": _later(BINDING_STALE_AFTER_SECONDS + 1)},
+            )
+
+            self.assertEqual(fresh["reason_code"], REFUSAL_WORKSPACE_BOUND)
+            self.assertEqual(fresh["recovery_action"], RECOVERY_WAIT)
+            self.assertEqual(stale["reason_code"], REFUSAL_WORKSPACE_STALE)
+            self.assertEqual(stale["recovery_action"], RECOVERY_RELEASE_STALE)
+
+    def test_a_stale_branch_conflict_has_its_own_code(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            acquire_workspace_binding(paths, workspace_path=Path(tmp) / "one", **_claim())
+
+            refusal = acquire_workspace_binding(
+                paths,
+                workspace_path=Path(tmp) / "two",
+                **_claim(handoff_ref="handoff-beta", now=_later(BINDING_STALE_AFTER_SECONDS + 1)),
+            )
+
+            self.assertEqual(refusal["reason_code"], REFUSAL_BRANCH_STALE)
+            self.assertEqual(refusal["recovery_action"], RECOVERY_RELEASE_STALE)
+
+    def test_staleness_never_releases_the_binding_by_itself(self) -> None:
+        """No background lease service: #820 puts one out of scope, and it would be wrong."""
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            workspace = Path(tmp) / "work"
+            acquire_workspace_binding(paths, workspace_path=workspace, **_claim())
+
+            acquire_workspace_binding(
+                paths,
+                workspace_path=workspace,
+                **_claim(handoff_ref="handoff-beta", now=_later(BINDING_STALE_AFTER_SECONDS * 10)),
+            )
+
+            still_held = active_workspace_bindings(read_workspace_bindings(paths))
+            self.assertEqual(len(still_held), 1)
+            self.assertEqual(still_held[0]["handoff_ref"], "handoff-alpha")
+
+    def test_the_stale_workspace_can_be_taken_after_an_explicit_release(self) -> None:
+        """The recovery the guidance names actually works."""
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            workspace = Path(tmp) / "work"
+            acquire_workspace_binding(paths, workspace_path=workspace, **_claim())
+            stale_now = _later(BINDING_STALE_AFTER_SECONDS + 1)
+
+            released = release_workspace_binding(
+                paths,
+                repository_ref="rlaope/oh-my-hermes",
+                workspace_path=workspace,
+                handoff_ref="handoff-beta",
+                owner="claude-code",
+                release_reason="explicit_safe_release",
+                now=stale_now,
+            )
+            taken = acquire_workspace_binding(
+                paths,
+                workspace_path=workspace,
+                **_claim(handoff_ref="handoff-beta", owner="claude-code", now=stale_now),
+            )
+
+            self.assertEqual(released["outcome"], OUTCOME_RELEASED)
+            self.assertTrue(taken["bound"])
+
+    def test_an_unreadable_or_future_stamp_reads_as_stale(self) -> None:
+        """Neither can be shown to be fresh, and clamping would widen the window from disk."""
+        self.assertTrue(binding_is_stale({"recorded_at": "not-a-date"}, _NOW))
+        self.assertTrue(binding_is_stale({"recorded_at": _later(3600)}, _NOW))
+        self.assertEqual(binding_age_seconds(_later(3600), _NOW), -1)
+        self.assertFalse(binding_is_stale({"recorded_at": _NOW}, _later(60)))
+
+    def test_no_stored_field_declares_when_a_binding_expires(self) -> None:
+        """Freshness is derived at read time, never a deadline a reader must trust."""
+        with TemporaryDirectory() as tmp:
+            record = _record(Path(tmp) / "work")
+            for key in record:
+                with self.subTest(key=key):
+                    self.assertNotIn("expire", key)
+                    self.assertNotIn("deadline", key)
+                    self.assertNotIn("valid_until", key)
+                    self.assertNotIn("ttl", key)
+
+
+class EveryRefusalCarriesAWayOut(unittest.TestCase):
+    """A refusal with no recovery is what makes a guard unusable."""
+
+    def test_every_refusal_code_has_a_reason_and_a_recovery(self) -> None:
+        for code in REFUSAL_CODES:
+            with self.subTest(code=code):
+                self.assertIn(code, REFUSAL_REASONS)
+                self.assertTrue(REFUSAL_REASONS[code].strip())
+                self.assertIn(code, REFUSAL_RECOVERY)
+                recovery = REFUSAL_RECOVERY[code]
+                self.assertIn(recovery, RECOVERY_ACTIONS)
+                self.assertTrue(RECOVERY_GUIDANCE[recovery].strip())
+
+    def test_every_recovery_id_is_reachable_from_some_refusal(self) -> None:
+        self.assertEqual(sorted(set(REFUSAL_RECOVERY.values())), sorted(RECOVERY_ACTIONS))
+
+    def test_no_reason_line_interpolates_a_caller_value(self) -> None:
+        """A refusal is rendered to a person; a formatted line is a path for text."""
+        for text in (*REFUSAL_REASONS.values(), *RECOVERY_GUIDANCE.values()):
+            with self.subTest(text=text[:40]):
+                self.assertNotIn("{", text)
+                self.assertNotIn("%s", text)
+
+
+class ReleaseFreesTheWorkspace(unittest.TestCase):
+    """Release only after an observed terminal state or an explicit safe release."""
+
+    def test_a_released_binding_can_be_re_acquired(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            workspace = Path(tmp) / "work"
+            acquire_workspace_binding(paths, workspace_path=workspace, **_claim())
+
+            released = release_workspace_binding(
+                paths,
+                repository_ref="rlaope/oh-my-hermes",
+                workspace_path=workspace,
+                handoff_ref="handoff-alpha",
+                owner="codex",
+                release_reason="observed_terminal_state",
+                now=_later(60),
+            )
+            retaken = acquire_workspace_binding(
+                paths,
+                workspace_path=workspace,
+                **_claim(handoff_ref="handoff-beta", owner="claude-code", now=_later(120)),
+            )
+
+            self.assertEqual(released["outcome"], OUTCOME_RELEASED)
+            self.assertFalse(released["bound"])
+            self.assertTrue(retaken["bound"])
+            self.assertEqual(retaken["outcome"], OUTCOME_ACQUIRED)
+            # Three records, one chain, nothing rewritten.
+            records = read_workspace_bindings(paths)
+            self.assertEqual([record["state"] for record in records], ["held", "released", "held"])
+            self.assertEqual(records[1]["supersedes_binding_ref"], records[0]["record_id"])
+            self.assertEqual(records[2]["supersedes_binding_ref"], records[1]["record_id"])
+
+    def test_releasing_frees_the_branch_too(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            acquire_workspace_binding(paths, workspace_path=Path(tmp) / "one", **_claim())
+            release_workspace_binding(
+                paths,
+                repository_ref="rlaope/oh-my-hermes",
+                workspace_path=Path(tmp) / "one",
+                handoff_ref="handoff-alpha",
+                owner="codex",
+                release_reason="observed_terminal_state",
+                now=_later(60),
+            )
+
+            elsewhere = acquire_workspace_binding(
+                paths,
+                workspace_path=Path(tmp) / "two",
+                **_claim(handoff_ref="handoff-beta", now=_later(120)),
+            )
+
+            self.assertTrue(elsewhere["bound"])
+
+    def test_a_terminal_state_release_is_accepted_only_from_the_holder(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            workspace = Path(tmp) / "work"
+            acquire_workspace_binding(paths, workspace_path=workspace, **_claim())
+
+            refusal = release_workspace_binding(
+                paths,
+                repository_ref="rlaope/oh-my-hermes",
+                workspace_path=workspace,
+                handoff_ref="handoff-beta",
+                owner="claude-code",
+                release_reason="observed_terminal_state",
+                now=_later(60),
+            )
+
+            self.assertEqual(refusal["outcome"], OUTCOME_REFUSED)
+            self.assertEqual(refusal["reason_code"], REFUSAL_NOT_HELD)
+            self.assertEqual(len(active_workspace_bindings(read_workspace_bindings(paths))), 1)
+
+    def test_a_binding_taken_under_explicit_release_refuses_a_terminal_release(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            workspace = Path(tmp) / "work"
+            acquire_workspace_binding(
+                paths,
+                workspace_path=workspace,
+                **_claim(release_condition="explicit_safe_release"),
+            )
+
+            refusal = release_workspace_binding(
+                paths,
+                repository_ref="rlaope/oh-my-hermes",
+                workspace_path=workspace,
+                handoff_ref="handoff-alpha",
+                owner="codex",
+                release_reason="observed_terminal_state",
+                now=_later(60),
+            )
+
+            self.assertEqual(refusal["reason_code"], REFUSAL_CONDITION_UNMET)
+            self.assertEqual(refusal["recovery_action"], RECOVERY_EXPLICIT_RELEASE)
+
+    def test_releasing_a_workspace_nobody_holds_is_refused_with_the_way_out(self) -> None:
+        with TemporaryDirectory() as tmp:
+            refusal = release_workspace_binding(
+                _paths(Path(tmp)),
+                repository_ref="rlaope/oh-my-hermes",
+                workspace_path=Path(tmp) / "work",
+                handoff_ref="handoff-alpha",
+                owner="codex",
+                release_reason="explicit_safe_release",
+                now=_NOW,
+            )
+
+            self.assertEqual(refusal["reason_code"], REFUSAL_NOT_HELD)
+            self.assertTrue(refusal["recovery_guidance"].strip())
+
+    def test_releasing_twice_is_idempotent_and_not_a_refusal(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            workspace = Path(tmp) / "work"
+            acquire_workspace_binding(paths, workspace_path=workspace, **_claim())
+            release = {
+                "repository_ref": "rlaope/oh-my-hermes",
+                "workspace_path": workspace,
+                "handoff_ref": "handoff-alpha",
+                "owner": "codex",
+                "release_reason": "observed_terminal_state",
+            }
+            release_workspace_binding(paths, now=_later(60), **release)  # type: ignore[arg-type]
+
+            again = release_workspace_binding(paths, now=_later(120), **release)  # type: ignore[arg-type]
+
+            self.assertEqual(again["outcome"], OUTCOME_ALREADY_RELEASED)
+            self.assertEqual(again["reason_code"], "")
+            self.assertEqual(len(read_workspace_bindings(paths)), 2)
+
+    def test_a_release_never_rewrites_the_terms_it_ends(self) -> None:
+        """The branch and revision come off the record, never off the caller."""
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            workspace = Path(tmp) / "work"
+            acquire_workspace_binding(paths, workspace_path=workspace, **_claim())
+            release_workspace_binding(
+                paths,
+                repository_ref="rlaope/oh-my-hermes",
+                workspace_path=workspace,
+                handoff_ref="handoff-alpha",
+                owner="codex",
+                release_reason="observed_terminal_state",
+                now=_later(60),
+            )
+
+            held, released = read_workspace_bindings(paths)
+
+            for field in ("branch_ref", "base_revision", "handoff_ref", "owner", "release_condition"):
+                with self.subTest(field=field):
+                    self.assertEqual(released[field], held[field])
+
+    def test_a_held_record_cannot_name_why_it_ended(self) -> None:
+        with TemporaryDirectory() as tmp:
+            record = dict(_record(Path(tmp) / "work"))
+            record["release_reason"] = "explicit_safe_release"
+
+            errors = validate_workspace_binding(record)
+
+            self.assertTrue(any("must be empty while the binding is held" in e for e in errors), errors)
+
+    def test_a_released_record_must_name_why(self) -> None:
+        with TemporaryDirectory() as tmp:
+            record = dict(_record(Path(tmp) / "work"))
+            record["state"] = "released"
+
+            errors = validate_workspace_binding(record)
+
+            self.assertTrue(any("must name why a released binding ended" in e for e in errors), errors)
+
+    def test_a_release_reason_outside_the_stored_condition_is_refused(self) -> None:
+        with TemporaryDirectory() as tmp:
+            record = dict(_record(Path(tmp) / "work"))
+            record["state"] = "released"
+            record["release_condition"] = "explicit_safe_release"
+            record["release_reason"] = "observed_terminal_state"
+
+            errors = validate_workspace_binding(record)
+
+            self.assertTrue(any("does not satisfy release_condition" in e for e in errors), errors)
+
+
+class ABindingIsNotDispatchEvidence(unittest.TestCase):
+    """Existence, ownership, dispatch, and result stay four separate claims."""
+
+    def test_the_claim_boundary_denies_all_three_other_claims_on_every_record(self) -> None:
+        with TemporaryDirectory() as tmp:
+            record = _record(Path(tmp) / "work")
+
+            self.assertEqual(record["claim_boundary"], CLAIM_BOUNDARY)
+            self.assertIn("not evidence that the workspace exists", CLAIM_BOUNDARY)
+            self.assertIn("any executor was dispatched", CLAIM_BOUNDARY)
+            self.assertIn("any work ran or finished", CLAIM_BOUNDARY)
+
+    def test_the_decision_carries_the_same_boundary(self) -> None:
+        with TemporaryDirectory() as tmp:
+            decision = acquire_workspace_binding(
+                _paths(Path(tmp)), workspace_path=Path(tmp) / "work", **_claim()
+            )
+
+            self.assertEqual(decision["claim_boundary"], CLAIM_BOUNDARY)
+
+    def test_a_record_shaped_to_assert_execution_is_refused_by_key_name(self) -> None:
+        with TemporaryDirectory() as tmp:
+            for key in ("dispatched", "executed", "exit_code", "result", "observed"):
+                record = dict(_record(Path(tmp) / "work"))
+                record[key] = "yes"
+                with self.subTest(key=key):
+                    errors = validate_workspace_binding(record)
+                    self.assertTrue(any("execution-claim keys" in error for error in errors), errors)
+
+    def test_the_execution_claim_guard_matches_the_family_that_first_wrote_it(self) -> None:
+        """Mirrored rather than imported privately; the pin is what stops drift."""
+        self.assertEqual(EXECUTION_CLAIM_KEYS, APPROVAL_EXECUTION_CLAIM_KEYS)
+
+    def test_no_stored_field_could_be_read_as_an_outcome(self) -> None:
+        with TemporaryDirectory() as tmp:
+            record = _record(Path(tmp) / "work")
+            self.assertFalse(set(record) & EXECUTION_CLAIM_KEYS)
+            self.assertEqual(record["privacy"], "metadata_only")
+
+    def test_binding_a_workspace_never_asks_whether_it_exists(self) -> None:
+        """A path that is not there binds exactly as well, and says nothing about it."""
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            absent = Path(tmp) / "not-created-by-anything"
+
+            decision = acquire_workspace_binding(paths, workspace_path=absent, **_claim())
+
+            self.assertFalse(absent.exists())
+            self.assertTrue(decision["bound"])
+
+
+class TheGuardCanBeAskedWithoutReserving(unittest.TestCase):
+    """"Confirm the workspace is reserved, or explain who owns it", read-only."""
+
+    def test_inspecting_a_free_workspace_reports_unbound_and_writes_nothing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+
+            verdict = inspect_workspace_binding(
+                paths,
+                repository_ref="rlaope/oh-my-hermes",
+                workspace_path=Path(tmp) / "work",
+                branch_ref="agent/issue-820",
+                base_revision="c7f9218b",
+                handoff_ref="handoff-alpha",
+                owner="codex",
+                now=_NOW,
+            )
+
+            self.assertEqual(verdict["outcome"], OUTCOME_UNBOUND)
+            self.assertEqual(verdict["reason_code"], "")
+            self.assertFalse(paths.runtime_workspace_bindings_path.exists())
+
+    def test_inspecting_a_held_workspace_names_the_owner_and_writes_nothing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            workspace = Path(tmp) / "work"
+            acquire_workspace_binding(paths, workspace_path=workspace, **_claim())
+
+            verdict = inspect_workspace_binding(
+                paths,
+                repository_ref="rlaope/oh-my-hermes",
+                workspace_path=workspace,
+                branch_ref="agent/other",
+                base_revision="c7f9218b",
+                handoff_ref="handoff-beta",
+                owner="claude-code",
+                now=_later(60),
+            )
+
+            self.assertEqual(verdict["reason_code"], REFUSAL_WORKSPACE_BOUND)
+            self.assertEqual(verdict["holder_owner"], "codex")
+            self.assertEqual(len(read_workspace_bindings(paths)), 1)
+
+
+class TheStoreIsRegisteredBesideItsSiblings(unittest.TestCase):
+    """The wiring: without it nothing in production ever runs these validators."""
+
+    def test_the_family_registers_its_validator_under_its_own_store(self) -> None:
+        with TemporaryDirectory() as tmp:
+            entries = {entry.store_name: entry for entry in OPTIONAL_RUNTIME_STORE_VALIDATORS}
+            self.assertIn("workspace_bindings.jsonl", entries)
+            entry = entries["workspace_bindings.jsonl"]
+            # `record_id`, not the `receipt_id` two of its siblings carry, so the
+            # label a fault is reported under is part of the registration.
+            self.assertEqual(entry.record_id_key, "record_id")
+            self.assertEqual(entry.validator(_record(Path(tmp) / "work")), [])
+            self.assertTrue(entry.validator({"schema_version": "approval_receipt/v1"}))
+            self.assertEqual(WORKSPACE_BINDING_RECORD_KEYS, WORKSPACE_BINDING_KEYS)
+
+    def test_the_store_lives_beside_its_siblings_and_not_inside_a_run(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            self.assertEqual(
+                paths.runtime_workspace_bindings_path.parent,
+                paths.runtime_blocked_work_records_path.parent,
+            )
+            self.assertNotIn("runs", paths.runtime_workspace_bindings_path.parts)
+
+    def test_the_store_report_reaches_omh_runtime_validate(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            store = paths.runtime_workspace_bindings_path
+            store.parent.mkdir(parents=True, exist_ok=True)
+            store.write_text(json.dumps({"schema_version": "nonsense"}) + "\n", encoding="utf-8")
+
+            report = validate_runtime(paths)
+
+            self.assertIn("workspace_bindings", report)
+            self.assertFalse(report["workspace_bindings"]["ok"])
+            self.assertFalse(report["ok"])
+
+    def test_a_forked_supersede_chain_is_reported(self) -> None:
+        """Two records claiming to be the current state of one directory."""
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            workspace = Path(tmp) / "work"
+            first = _record(workspace)
+            fork_a = _record(workspace, recorded_at=_later(1), supersedes_binding_ref=first["record_id"])
+            fork_b = _record(workspace, recorded_at=_later(2), supersedes_binding_ref=first["record_id"])
+            store = paths.runtime_workspace_bindings_path
+            store.parent.mkdir(parents=True, exist_ok=True)
+            store.write_text(
+                "".join(json.dumps(record, sort_keys=True) + "\n" for record in (first, fork_a, fork_b)),
+                encoding="utf-8",
+            )
+
+            report = validate_workspace_binding_store(store)
+
+            self.assertFalse(report["ok"])
+            self.assertTrue(any("forks the chain" in error for error in report["errors"]), report)
+            self.assertEqual(report["binding_count"], 3)
+
+    def test_a_clean_store_validates(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            acquire_workspace_binding(paths, workspace_path=Path(tmp) / "work", **_claim())
+
+            report = validate_workspace_binding_store(paths.runtime_workspace_bindings_path)
+
+            self.assertTrue(report["ok"], report["errors"])
+            self.assertEqual(report["binding_count"], 1)
+            self.assertEqual(report["mint_failure_count"], 0)
+
+    def test_the_schema_version_is_pinned(self) -> None:
+        with TemporaryDirectory() as tmp:
+            self.assertEqual(_record(Path(tmp) / "work")["schema_version"], WORKSPACE_BINDING_SCHEMA_VERSION)
+            self.assertEqual(WORKSPACE_BINDING_SCHEMA_VERSION, "workspace_binding_guard/v1")
+
+    def test_the_vocabularies_are_closed(self) -> None:
+        self.assertEqual(BINDING_STATES, ("held", "released"))
+        self.assertEqual(RELEASE_CONDITIONS, ("observed_terminal_state", "explicit_safe_release"))
+
+
+class TheWorkspaceBoundaryStaysHonestAboutWhatIsStillOpen(unittest.TestCase):
+    """#820 closed the pre-dispatch half and could never close the other one."""
+
+    def _workspace_boundary(self) -> dict[str, object]:
+        envelope = build_task_authority_envelope(
+            denied=False,
+            delegation_action="delegate",
+            intent="coding",
+            review_required=False,
+            work_owner_mode="external_executor",
+            selected_executor_profile="codex",
+            dispatchable=True,
+            choice_required=False,
+            isolation_plan={"strategy": "worktree_recommended"},
+            message="refactor the login flow in src/login.py",
+            safety_profile_revision="rev-frozen",
+        )
+        contract = build_task_handoff_safety_contract(envelope)
+        return next(
+            entry for entry in contract["boundaries"] if entry["boundary"] == "workspace"
+        )
+
+    def test_the_boundary_is_still_declared_not_enforced(self) -> None:
+        """Nothing on this side of the wall can constrain a process already running."""
+        boundary = self._workspace_boundary()
+
+        self.assertEqual(boundary["enforcement"], "declared_not_enforced")
+        self.assertEqual(boundary["enforced_by"], [])
+
+    def test_the_blocker_is_a_reason_and_not_a_closed_issue(self) -> None:
+        boundary = self._workspace_boundary()
+
+        self.assertEqual(boundary["blocked_by"], WORKSPACE_RUNTIME_BLOCKER)
+        self.assertNotIn("#", str(boundary["blocked_by"]))
+        self.assertEqual(
+            WORKSPACE_RUNTIME_BLOCKER, "no_omh_side_constraint_can_bind_a_running_executor_process"
+        )
+
+    def test_the_statement_names_the_half_that_now_exists_and_the_half_that_does_not(self) -> None:
+        statement = str(self._workspace_boundary()["statement"])
+
+        self.assertIn("workspace_binding_guard/v1", statement)
+        self.assertIn("nothing binds a running executor", statement)


### PR DESCRIPTION
## Feature Report

### What Changed

- New append-only runtime store and guard: `workspace_binding_guard/v1`, in
  `src/workflows/workspace_bindings.py`, backed by
  `runtime/journal/workspace_bindings.jsonl`. One record reserves one canonical
  workspace and one branch for one handoff, under one owner, at one base
  revision, with the condition that will release it.
- `acquire_workspace_binding` / `acquire_workspace_binding_at` reserve
  atomically; `inspect_workspace_binding` answers the same question read-only;
  `release_workspace_binding` / `release_workspace_binding_at` end a binding
  through one of two doors; `workspace_binding_conflict_in` is the pure
  predicate both the write and the read path share.
- `OmhPaths.runtime_workspace_bindings_path` joins the three sibling stores in
  `runtime/journal/`, with a comment stating why it is runtime-wide.
- One entry added to `OPTIONAL_RUNTIME_STORE_VALIDATORS` in
  `src/runtime/records.py` (`store_name="workspace_bindings.jsonl"`,
  `record_id_key="record_id"`), plus a store-level `validate_workspace_binding_store`
  call in `validate_runtime`, so `omh runtime validate` reports both malformed
  records inside a run and faults that belong to no run.
- The `workspace` boundary of `handoff_safety_contract/v1` keeps its
  `declared_not_enforced` verdict but stops pointing at `#820`. Its blocker is
  now the reason string `no_omh_side_constraint_can_bind_a_running_executor_process`,
  and its statement names the half that now exists alongside the half that
  cannot.
- The three `data_*` rows fed by `data_boundary_enforcement_facts()` stop citing
  `#820` for the same reason, in the same honest way.

### Why This Exists

Two active coding handoffs could share one checkout or one branch, and nothing
in the tree noticed. `coding/isolation.py` decides *whether* a handoff wants its
own worktree; `wrapper/worktree_binding.py` builds a recipe for opening one
executor in one path. Neither consults any registry of other active bindings, so
`build_worktree_executor_binding` called twice on the same directory returned two
confident "ready" recipes, and two handoffs on one branch were invisible to each
other. `grep -rn "workspace_binding_guard" src/ tests/ docs/` returned nothing
before this change; there was no exclusivity logic of any kind.

The failure that follows is a collision with ambiguous ownership: two agents
editing one tree, or two checkouts fighting over one branch, discovered only by
a dirty working tree or a lost commit.

### User / Operator Impact

Before enabling a workspace-bound handoff, a surface can now ask whether the
workspace is free and get one of three answers: it is free, this handoff already
holds it, or someone else does — with the owner, the handoff, the branch, the age
of that claim, and a recovery. A second handoff pointed at a reserved workspace
or branch is refused instead of quietly proceeding.

The refusal is usable, not just correct. Every refusal code maps to a closed
`recovery_action` id *and* the sentence for it, because an id alone is not
guidance:

| Refusal | Recovery |
| --- | --- |
| `workspace_already_bound` / `branch_already_bound` | `wait_for_owner_release` |
| `workspace_binding_stale` / `branch_binding_stale` | `release_stale_binding_explicitly` |
| `binding_terms_changed` | `release_then_reacquire` |
| `binding_not_held` | `acquire_before_releasing` |
| `release_condition_unmet` | `release_with_an_explicit_safe_release` |
| `binding_request_refused` | `correct_the_binding_request` |
| `binding_not_written` | `retry_when_the_store_is_writable` |

Honest limit: no delegation or chat lane calls the guard yet, and no `omh`
command exposes it. This PR ships the guard, the store, the validation wiring,
and the contract change. Wiring a caller is a separate change with its own
user-facing surface and its own confirmation copy, and this PR does not claim
that surface exists.

### How It Works

**Atomic acquisition.** `acquire_workspace_binding_at` reads the active set and
appends the new claim inside a single `local_store.file_lock` — a real OS lock
through `fcntl` on POSIX and `msvcrt` on Windows. Two concurrent acquisitions on
one workspace therefore produce one held binding and one refusal, not two
winners. This is asserted by a barrier-synchronised 8-thread race, and the test
was verified to have teeth: with `file_lock` replaced by a no-op the same test
reports 4 winners instead of 1.

**Canonical identity.** The path is expanded, user-resolved, and symlink-resolved
through the existing `paths.expand_path`, then digested. `~/w`, `$HOME/w`,
`/tmp/w/../w`, and the absolute path are one workspace — a guard defeated by
typing the path differently would be decoration. The digest is what is stored: no
host path byte reaches the file, and a `workspace_ref` that is not a digest handle
is refused at build, at validate, and at render. An empty path is refused rather
than normalized, because `Path("")` resolves to the current directory.

**Two conflict axes, reported separately.** The same canonical workspace held by
another handoff, and the same `(repository, branch)` pair held by another active
workspace. They have different answers, so they get different codes. The
workspace axis is reported first because it is the more specific one.

**Staleness blocks, and never releases.** Freshness is derived at read time from
the head record's stamp against `BINDING_STALE_AFTER_SECONDS` (six hours, the
horizon `action_gate.ACCOUNT_SIGNAL_STALE_AFTER_SECONDS` already uses), following
the `_account_state` precedent. Nothing on disk declares an expiry, so nothing on
disk can widen the window. A stale binding is refused with its own code and its
own recovery and is **not** reclaimed: auto-release would be the background lease
service #820 puts out of scope, and it would be wrong anyway — nobody reporting
back is not the same as nobody running.

**Release has two doors.** `observed_terminal_state` is the holder reporting its
own work finished, accepted only from the handoff and owner on record.
`explicit_safe_release` is a deliberate act, accepted from anyone, because it is
the recovery a stale binding points at and a release only the absent holder could
perform would lock an abandoned workspace forever. A binding taken under
`release_condition="explicit_safe_release"` refuses a terminal-state release.
Release terms come off the record being released, never off the caller.

**Determinism.** `now` is a parameter on every entry point, and no wall clock
appears inside a hashed or compared payload: `binding_id` is a digest of
`(repository_ref, workspace_ref)` only, and the terms fingerprint excludes the
stamp, the record id, and the supersede link.

**Evidence separation.** A binding is ownership and nothing else. It does not say
the directory exists (nothing here stats the filesystem — a binding on a
non-existent path succeeds and says nothing about it), it does not say an executor
started, and it does not say work finished. `CLAIM_BOUNDARY` says so on every
record and every verdict, and a record shaped to assert execution is refused by
key name before the closed key set sees it; that key set is pinned equal to
`approval_receipts._EXECUTION_CLAIM_KEYS` by a test.

**The contract change, and why it is not a promotion.** The `workspace` boundary
stays `declared_not_enforced`. Its statement is about binding a *running*
executor, and no change on this side of the wall can do that — it needs OS-level
confinement the host owns. So the blocker moves from `#820` to a reason string,
following the `account_authorization` precedent, and the statement names the
pre-dispatch guard that now exists so a reader does not read the verdict as
"nothing about workspaces is guarded". The same reasoning applies to the three
`data_*` rows: they cited `#820` for work that issue was never going to do
(placing a dispatched executor under the adapter lane's sandbox), which would have
become a dangling pointer the moment it closed.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/workflows/workspace_bindings.py` | New. The record family, the guard, the store validator. |
| `src/system/paths.py` | `runtime_workspace_bindings_path`, with the runtime-wide rationale. |
| `src/runtime/records.py` | One `OptionalRuntimeStoreValidator` entry; `WORKSPACE_BINDING_RECORD_KEYS` re-export. |
| `src/runtime/artifacts.py` | Store-level `validate_workspace_binding_store` call in `validate_runtime`; new `workspace_bindings` key in the report and in its `ok`. |
| `src/coding/action_gate.py` | `WORKSPACE_RUNTIME_BLOCKER`; `workspace` boundary statement and blocker. |
| `src/quality/safety_preflight.py` | `_HOST_CONFINEMENT_BLOCKER` and new `_ADVISORY_LIMIT_BLOCKER` become reason strings; the `DATA_BOUNDARY_LIMITS` rows reference the constants instead of literals. |
| `tests/test_workspace_binding_guard.py` | New. 61 tests, one class per acceptance criterion plus guards. |
| — | The branch is 10 commits behind `origin/main` at the time of writing; those commits touch none of the files above except `docs/ARCHITECTURE.md`, and no shared count or freeze gate. Rerun the suite on the merge result before merging. |
| `tests/test_runtime_artifacts.py` | `_STORE_SCHEMA_VERSIONS` gains the fourth store, which is what the keyed-registry test compares against. |
| `tests/test_handoff_safety_contract.py` | `_DECLARED_NOT_ENFORCED["workspace"]`; the statement assertion now also pins the guard's name. |
| `tests/test_data_boundary.py` | Host-confinement blocker expectation; new test that no `data_*` blocker names `#820`. |
| `tests/test_risky_action_confirmation.py` | Capable-host blocker expectation. |
| `docs/ARCHITECTURE.md` | New **Workspace Bindings** section; journal tree listing; the three stale `#820` references. |
| `docs/FANOUT.md` | The stale `#820` reference in the data-boundary bullet. |

No generated artifact was hand-edited. No new dependency. No network or LLM call.
No routing case, skill, or demo card was added, so no exact-count assertion moved.

## Validation

Every box below was run in this worktree and its real output is quoted.

- [x] `uv run --group lint ruff check src tests` → `All checks passed!`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` → `Ran 4316 tests in 167.931s` / `OK` (62 added by this branch: 61 in the new file, 1 in `tests/test_data_boundary.py`)
- [x] `uv run python -m compileall -q src tests` → exit 0
- [x] `uv run python -m omh.cli docs workflows --check` → `{"checked":".../docs/WORKFLOWS.md","ok":true,"tap_skills":{"checked":115,"expected":115,"extra":[],"missing":[],"ok":true,...,"stale":[]}}`
- [x] `uv run python -m omh.cli docs roles --check` → `{"checked":".../docs/ROLES.md","ok":true}`
- [x] `uv run python -m omh.cli docs capability-families --check` → `{"checked":".../src/plugin_bundle/omh/tools/capability_families.json","ok":true}`
- [x] `uv run python -m omh.cli harness validate` → `{"counts":{"harnesses":72,"skills":104},"errors":[],"ok":true,"schema_version":"catalog_validation/v1","warnings":[]}`
- [x] `git diff --check` → exit 0, no output
- [x] Targeted: `PYTHONPATH=tests uv run python -m unittest tests/test_workspace_binding_guard.py` → `Ran 61 tests` / `OK`
- [x] Mutation check on the concurrency test: with `workspace_bindings.file_lock`
      monkeypatched to a no-op context manager, the 8-thread race fails with
      `AssertionError: 4 != 1`. The lock is what the test measures, not the
      absence of a race.
- [x] Concurrency test run 5 times consecutively; no flake.
- [ ] `python3 -m omh.cli release checklist --json` — not run. Nothing in this
      change touches release metadata, version files, or the changelog.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run, same reason.
- [ ] `omh --help` / `omh ... release hermes-smoke --install-path setup ...` — not
      run. This change adds no CLI surface; the full suite covers the CLI
      contracts it does touch.
- [ ] Manual Hermes/TUI check — **not run, and there is nothing to check.** The
      guard has no chat, TUI, or command surface in this PR. A manual check
      becomes meaningful when a caller is wired.
- [ ] Workflow-learning review queue smoke — not applicable; no learning
      contract changed.

## Risk

- **Windows.** The store's mutual exclusion rests on `local_store.file_lock`,
  which is real on both platforms, and the append is binary-mode through the
  shared `append_store_line`, so no newline rewriting. The path spellings the
  collision test uses (`.`, `..`, a trailing separator) normalize identically on
  both. What is *not* covered: NTFS is case-insensitive while `Path.resolve()`
  does not case-fold, so `C:\Work` and `C:\work` would be two bindings on one
  directory on Windows. The tests deliberately do not assert a case-only
  collision, because claiming one would be a lie on POSIX and a promise this
  code does not keep on Windows.
- **Scope of the exclusivity.** It is exclusivity over this store and nothing
  else. Nothing stops a person running `git worktree add` twice, and nothing
  stops an already-running executor writing where it likes. The module docstring
  and the contract boundary both say so; the risk is a reader taking the guard
  for a filesystem lock.
- **`validate_runtime` return shape.** A `workspace_bindings` key is added and
  folded into the top-level `ok`. A store with a corrupt line now makes
  `omh runtime validate` report not-ok where it previously ignored the file — the
  file did not exist before, so nothing regresses, but a consumer pinning the
  exact key set of the report would see one more key. No test in the tree pins
  that set.
- **Blocker-string change is observable.** `handoff_safety_contract/v1` and
  `data_boundary_enforcement/v1` are schema-versioned payloads read by wrapper
  surfaces. The *values* of four `blocked_by` fields changed; no key, no schema
  version, and no enforcement verdict did. A consumer matching on the literal
  `"#820"` would stop matching — which is the point, since the issue is closed.

## Compatibility / Rollout

- Additive on disk. `workspace_bindings.jsonl` is created on first acquisition;
  an install that never calls the guard never grows the file, and
  `read_jsonl_objects` treats a missing store as empty.
- No migration. There is no prior version of this record family.
- No behaviour change for any existing lane: nothing calls the guard yet, so the
  only runtime-visible differences are the extra key in `omh runtime validate`
  and the four blocker strings.
- Release channel: no impact. No version file, changelog entry, or capability
  claim moved.

## Release / Claims

- [x] Release-channel impact considered — none; no version or changelog surface
      is touched.
- [x] Runtime/native capability claims are backed by evidence or marked as not
      observed. The store's `privacy` is `metadata_only` and every record carries
      a `CLAIM_BOUNDARY` denying existence, dispatch, and result. The
      `workspace` contract boundary remains `declared_not_enforced`; this PR
      claims a pre-dispatch guard and explicitly does not claim a runtime one.
- [x] Known manual gaps listed above, including the `omh release hermes-smoke
      --live` gap and the fact that there is no Hermes-visible surface to check.

## Follow-Up

- Wire a caller. The delegation and worktree-binding lanes are the two natural
  ones: `build_worktree_executor_binding` could refuse a `ready_*` status when
  the workspace is bound elsewhere, and the coding delegation lane could acquire
  before enabling a workspace-bound handoff. Both need operator-facing copy for
  the refusal and the recovery, which is why they are not in this PR.
- Localize `RECOVERY_GUIDANCE`. The recovery ids are closed precisely so the
  copy can be a per-locale lookup, the way `wrapper.localized_copy` already keys
  `blocked_work_records.RECOVERY_ACTIONS`. This PR ships English only.
- Windows case-folding for `workspace_ref`, if the guard is ever wired on a
  Windows host. It needs a platform-conditional canonicalization, and getting it
  wrong is worse than the current honest gap.
- File the work the `data_*` host-confinement rows now name in words: placing a
  delegation or fanout executor under the sandbox the cross-harness adapter lane
  already builds. That is real, fileable work with no issue behind it today.
