### PR TITLE
feat: detect stale coding-owner readiness before handoff

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -118,6 +118,7 @@ src/
     executor_readiness.py
     executors.py
     isolation.py
+    pre_handoff_readiness.py
     team_readiness.py
     worktree_creator.py
 

--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -599,22 +599,41 @@ Apply the prefix once at the first line of one rendered response. Do not repeat
 long answer into separate Discord/Slack messages, it can repeat the same prefix
 once at the start of each chunk.
 
-## First-Use Coding Agent Readiness
+## Pre-Handoff Coding Agent Readiness
 
 Coding handoff responses include `executor_readiness/v1` so the wrapper can
-check Codex, Claude Code, Hermes coding, or oh-my runtime availability once per
-profile instead of discovering it after the user presses a handoff button.
+check Codex, Claude Code, Hermes coding, or oh-my runtime availability before
+the user presses a handoff button instead of discovering it afterwards.
 
 ```sh
 omh coding executor-readiness --executor codex
 omh coding executor-readiness --executor claude-code
 ```
 
+A stored observation is reused only while it is still fresh and still bound to
+the same profile, tool, permission profile, and workspace, so the check is safe
+to run before every dispatch.
+
 If readiness is `missing` or `blocked`, show a human choice instead of failing
 silently: choose another coding agent, configure the command path, continue in
 Hermes, or keep a prompt/runtime handoff. After the user changes that state,
-retry the readiness check once. The probe only proves local availability; it is
-not dispatch, implementation, review, CI, or merge evidence.
+retry the readiness check once.
+
+If readiness is `stale`, an earlier observation no longer describes this
+machine. The payload then carries `pre_handoff_readiness/v1` with the reason
+and `pre_handoff_repair_card/v1` with the missing prerequisite and the commands
+that close it:
+
+```sh
+codex --version                                       # confirm the prerequisite
+omh coding executor-readiness --executor codex --force # re-observe readiness
+```
+
+Render the card and keep the handoff prepared. `--force` is the only thing that
+replaces a stale observation, and the card is prepared guidance: OMH did not
+install a tool, change a permission, or re-probe anything. The probe only proves
+local availability; it is not dispatch, implementation, review, CI, or merge
+evidence.
 
 ## Discord-Style Handoff Status Card
 

--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -64,6 +64,15 @@ goal to Hermes in chat; these commands are the backend surface.
   write; a drifted or unprovable profile is refused and the contract must be
   re-prepared. The field is optional under `fanout_contract/v1`: a contract
   frozen before it existed carries no revision and is not gated.
+- **Owner-readiness integrity.** Each unit's owner is rechecked immediately
+  before its handoff. A stored readiness observation counts only while it is
+  still fresh and still bound to the same profile, tool, permission profile,
+  and workspace; a decision that no longer describes this machine reads
+  `stale`, never `ready`. The unit then comes back `executor_not_ready`
+  carrying `pre_handoff_repair_card/v1`, which names the prerequisite that
+  moved and the commands that confirm it. Dispatch never re-probes on its own:
+  `omh coding executor-readiness --executor <profile> --force` is the only
+  thing that replaces a stale observation.
 - **Worktrees.** One per unit at `<repo>-fanout-<unit>` on branch
   `agent/<unit>`, all branched from one SHA resolved at dispatch start
   (`--base-ref`, default HEAD). Pre-existing paths or branches are errors,

--- a/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
+++ b/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
@@ -168,12 +168,19 @@ runtime run exists and the wrapper needs a compact progress card.
    target update.
 8. If the response is a plan, wait for the user to accept or revise the plan
    before preparing a handoff.
-9. If a coding handoff is prepared, check `executor_readiness/v1` before first
-   dispatch for the selected profile. A wrapper may run
-   `omh coding executor-readiness --executor <profile>` once, cache the result,
-   and skip later probes unless the user forces a retry. If readiness is
+9. If a coding handoff is prepared, check `executor_readiness/v1` before every
+   dispatch for the selected profile by running
+   `omh coding executor-readiness --executor <profile>`. The probe reuses the
+   stored observation while it is still fresh and still bound to the same
+   profile, tool, permission profile, and workspace; that recheck is cheap and
+   local, so a wrapper does not need a cache of its own. If readiness is
    `missing` or `blocked`, ask the user to choose another coding agent,
-   configure PATH, continue in Hermes, or keep a prompt/runtime handoff.
+   configure PATH, continue in Hermes, or keep a prompt/runtime handoff. If
+   readiness is `stale`, the payload carries `pre_handoff_readiness/v1` naming
+   the gap and `pre_handoff_repair_card/v1` with the commands that close it;
+   render the card and do not dispatch. Rerunning with `--force` is the only
+   thing that replaces a stale observation, and the card never claims a repair
+   ran.
 10. If the selected profile is Hermes, render `hermes_coding_harness/v1` from
    the prepared runtime handoff or wrapper-session status. It is a read-only
    projection, so answer status questions with the current stage, lane owner,

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -856,12 +856,17 @@ The backend flow is:
    Claude Code and generic agents use prompt-only handoffs; Hermes, OMX, OMO,
    and OMC use runtime handoffs with team/swarm, worker-protocol, and worktree
    guidance. The wrapper records only what it actually observes.
-14. For a coding profile that has not been observed before, the wrapper can run
-   `omh coding executor-readiness --executor <profile>` once and cache
-   `executor_readiness/v1`. If the probe reports `missing` or `blocked`, ask the
-   user to choose another coding agent, configure PATH, continue in Hermes, or
-   keep a prompt/runtime handoff. Retry only after that state changes. Readiness
-   is not dispatch, implementation, review, CI, or merge evidence.
+14. Before dispatching to a coding profile, the wrapper runs
+   `omh coding executor-readiness --executor <profile>` and reads
+   `executor_readiness/v1`. OMH reuses its stored observation while that
+   observation is still fresh and still bound to the same profile, tool,
+   permission profile, and workspace, so the wrapper does not need a cache of
+   its own. If the probe reports `missing` or `blocked`, ask the user to choose
+   another coding agent, configure PATH, continue in Hermes, or keep a
+   prompt/runtime handoff. Retry only after that state changes. If it reports
+   `stale`, read `pre_handoff_repair_card/v1` for the missing prerequisite and
+   the repair commands, and keep the handoff prepared instead of dispatching.
+   Readiness is not dispatch, implementation, review, CI, or merge evidence.
 15. If the wrapper observes Hermes target metadata such as `agent_ref`,
    `agent_count`, or `hermes_home`, `chat_interaction/v1` may include
    `target_notice` and `target_topology`. Render the concise notice or
@@ -934,7 +939,7 @@ omh chat session select-executor "$session_id" claude-code
 omh chat session select-executor "$session_id" generic
 ```
 
-Check the selected coding agent once before first dispatch:
+Check the selected coding agent before dispatch:
 
 ```sh
 omh coding executor-readiness --executor codex
@@ -946,6 +951,17 @@ If the result is `missing` or `blocked`, keep the handoff prepared and ask the
 operator whether to choose a different coding agent, configure PATH, continue in
 Hermes, or use a prompt/runtime handoff. Do not treat this probe as proof that
 the coding agent ran.
+
+If the result is `stale`, an earlier observation no longer describes this
+machine: it aged past its window, or the profile, tool, permission profile, or
+workspace it was bound to changed. The payload names the gap in
+`pre_handoff_readiness/v1` and the repair path in
+`pre_handoff_repair_card/v1`. Keep the handoff prepared, run the card's
+commands, and re-observe readiness explicitly:
+
+```sh
+omh coding executor-readiness --executor codex --force
+```
 
 Agent and wrapper operators can record a bounded local capability observation
 separately when the host has actually exposed it. This is a control-plane

--- a/src/coding/executor_readiness.py
+++ b/src/coding/executor_readiness.py
@@ -9,7 +9,12 @@ from typing import Any
 
 from ..executors import EXECUTOR_PROFILES, executor_label
 from ..local_store import atomic_write_json, read_json_object_result, utc_now
-from ..paths import OmhPaths
+from ..paths import OmhPaths, find_project_root
+from .pre_handoff_readiness import (
+    build_pre_handoff_repair_card,
+    evaluate_pre_handoff_readiness,
+    readiness_binding,
+)
 
 
 EXECUTOR_READINESS_SCHEMA_VERSION = "executor_readiness/v1"
@@ -171,7 +176,18 @@ def probe_executor_readiness(
     *,
     force: bool = False,
     dry_run: bool = False,
+    now: str = "",
 ) -> dict[str, object]:
+    """Readiness for one profile, rechecked against the machine it was observed on.
+
+    A cached decision is reused only while it is still fresh AND still bound to
+    the same profile, tool, permission profile, and workspace. When it is not,
+    the cached decision is NOT silently re-probed: this call reports the exact
+    gap and a repair card, and `force=True` stays the only way to replace the
+    stored observation. Re-probing on staleness would hide a missing tool
+    behind a subprocess run nobody asked for, which is the same surprise #837
+    exists to remove --- only later in the handoff.
+    """
     normalized = _normalize_profile(profile)
     if normalized == "choose":
         return executor_readiness_contract("choose")
@@ -179,10 +195,32 @@ def probe_executor_readiness(
     state, state_error = _read_state(paths)
     cached = _cached_profile(state, normalized)
     if cached and not force:
+        verdict = evaluate_pre_handoff_readiness(
+            profile=normalized,
+            cached=cached,
+            binding=live_readiness_binding(paths, normalized),
+            capability_snapshot=_capability_snapshot(paths, normalized),
+            now=now,
+        )
         result = dict(cached)
-        result["cache_status"] = "cached"
-        result["first_use_skipped"] = True
+        result["pre_handoff_readiness"] = verdict
         result["claim_boundary"] = contract["claim_boundary"]
+        if verdict["usable"]:
+            result["cache_status"] = "cached"
+            result["first_use_skipped"] = True
+        else:
+            # Never `ready`: a decision that no longer describes this machine
+            # is not weaker evidence of readiness, it is none.
+            result["cache_status"] = "invalidated"
+            result["first_use_skipped"] = False
+            result["status"] = "stale"
+            result["available"] = False
+            result["summary"] = str(verdict["reason"])
+            result["next_action"] = "repair_prerequisite_then_force_readiness_probe"
+            result["repair_card"] = build_pre_handoff_repair_card(
+                verdict,
+                repair_command=_repair_command(normalized),
+            )
         return _with_advisory_signals(paths, normalized, result)
     if dry_run:
         result = dict(contract)
@@ -198,6 +236,88 @@ def probe_executor_readiness(
     result = _run_probe(contract)
     _write_state(paths, state, normalized, result)
     return _with_advisory_signals(paths, normalized, result)
+
+
+def live_readiness_binding(
+    paths: OmhPaths,
+    profile: str,
+    *,
+    workspace_ref: str | None = None,
+) -> dict[str, object]:
+    """The current value of every input whose change invalidates readiness.
+
+    Four axes, each read from where that input actually lives:
+
+    * `profile` --- the profile's own identity and what a ready result would
+      let a wrapper do, so renaming a profile or changing its ready action
+      cannot silently reuse an observation made under the old definition.
+    * `tool` --- the command the probe would run and every PATH resolution of
+      it, so an uninstall, a reinstall somewhere else, or a newer binary
+      appearing ahead of the observed one all register.
+    * `permission` --- the safety profile revision, the same content hash
+      `fanout_dispatch` already rechecks before it spawns anything.
+    * `workspace` --- the repository this readiness was observed in, because a
+      per-user readiness cache is shared across every checkout on the machine.
+
+    Local reads only: no subprocess, no network. `workspace_ref` is injectable
+    so a caller (and a test) can bind readiness to a workspace other than the
+    process working directory.
+    """
+    from ..quality.safety_preflight import safety_profile_revision
+
+    command, args = _resolved_command(profile) or ("", ())
+    probe_kind = "local_command" if command else "wrapper_observed_profile"
+    return readiness_binding(
+        profile=profile,
+        profile_revision="\x1e".join((executor_label(profile), _ready_action(profile), probe_kind)),
+        tool_paths=(command, *args, *_path_resolutions(command)) if command else (),
+        permission_revision=safety_profile_revision(),
+        workspace_ref=workspace_ref if workspace_ref is not None else _workspace_ref(paths),
+    )
+
+
+def _workspace_ref(paths: OmhPaths) -> str:
+    """The workspace a readiness observation belongs to.
+
+    The repository root when there is one, so a readiness decision made in one
+    checkout is not reused in another; the store home otherwise, which is the
+    only workspace identity a run outside a repository has.
+    """
+    root = find_project_root()
+    return str(root) if root is not None else str(paths.omh_home)
+
+
+def _capability_snapshot(paths: OmhPaths, profile: str) -> dict[str, object] | None:
+    """The recorded capability snapshot for this profile, if one exists.
+
+    Absent is not the same as prepared-only here: with no snapshot on disk
+    there is no capability claim riding the handoff, so readiness stands on its
+    own probe evidence. A snapshot that IS present is re-checked at dispatch
+    time --- prepared-only or expired evidence cannot support a ready result.
+    """
+    from .executor_capability_snapshots import (
+        executor_capability_snapshot_path,
+        read_matching_executor_capability_snapshot,
+    )
+
+    try:
+        path = executor_capability_snapshot_path(paths.executor_capability_snapshots_dir, profile)
+    except ValueError:
+        return None
+    return read_matching_executor_capability_snapshot(path, expected_executor=profile)
+
+
+def _repair_command(profile: str) -> str:
+    """The owner-specific command that confirms the missing prerequisite.
+
+    Executor-specific value inside an executor-neutral card: a probeable
+    profile confirms its own CLI, and a wrapper-observed profile has no CLI to
+    confirm, so it gets the local check that covers it instead.
+    """
+    command, args = _resolved_command(profile) or ("", ())
+    if not command:
+        return "omh doctor"
+    return " ".join((command, *args))
 
 
 def _with_advisory_signals(paths: OmhPaths, profile: str, result: dict[str, object]) -> dict[str, object]:
@@ -367,7 +487,7 @@ EXECUTOR_CHOICE_CONTEXT_CLAIM_BOUNDARY = (
 )
 
 
-def executor_choice_context(paths: OmhPaths) -> dict[str, object]:
+def executor_choice_context(paths: OmhPaths, *, now: str = "") -> dict[str, object]:
     """Return per-candidate readiness/auth context for the choose-executor question.
 
     Reads cached readiness state and cheap local markers only — no subprocess
@@ -375,6 +495,11 @@ def executor_choice_context(paths: OmhPaths) -> dict[str, object]:
     inventory hint rides along so Hermes answers the choice from what the user
     actually has instead of asking blind; the full report stays behind
     `omh coding model-inventory`.
+
+    Each candidate's stored readiness goes through the same freshness rule the
+    probe applies (#837), so a decision that no longer describes this machine
+    reads `stale` here too. Ranking a candidate whose CLI is gone to the top of
+    the choose-executor card is the failure that rule exists to prevent.
     """
     from .executor_auth_signals import auth_signal_for_profile, last_limit_signal_for_profile
     from .model_inventory import local_model_inventory
@@ -383,11 +508,23 @@ def executor_choice_context(paths: OmhPaths) -> dict[str, object]:
     candidates: list[dict[str, object]] = []
     for profile in EXECUTOR_CHOICE_CONTEXT_PROFILES:
         cached = _cached_profile(state, profile) or {}
+        # Same freshness rule as the probe: a stale or rebound decision must
+        # not read `ready` here either, or the ranking would put a candidate
+        # whose CLI is gone at the top of the choose-executor card.
+        verdict = evaluate_pre_handoff_readiness(
+            profile=profile,
+            cached=cached or None,
+            binding=live_readiness_binding(paths, profile),
+            capability_snapshot=_capability_snapshot(paths, profile),
+            now=now,
+        )
+        observed_status = str(cached.get("status", "not_observed"))
         candidates.append(
             {
                 "profile": profile,
                 "label": executor_label(profile),
-                "readiness_status": str(cached.get("status", "not_observed")),
+                "readiness_status": observed_status if (verdict["usable"] or not cached) else "stale",
+                "readiness_freshness": str(verdict["reason_code"]),
                 "auth_signal": auth_signal_for_profile(profile),
                 "last_limit_signal": last_limit_signal_for_profile(paths, profile),
             }
@@ -471,6 +608,12 @@ def _write_state(paths: OmhPaths, state: dict[str, Any], profile: str, result: d
     # login/limit state at first probe (see _with_advisory_signals).
     stored.pop("auth_signal", None)
     stored.pop("last_limit_signal", None)
+    # The binding is what makes `updated_at` readable later: without it a
+    # stored decision can only be aged, never checked against the machine it
+    # described. It carries no timestamp of its own, deliberately -- it is
+    # compared for equality, and a clock inside a compared payload turns that
+    # comparison into a race.
+    stored["readiness_binding"] = live_readiness_binding(paths, profile)
     stored["updated_at"] = utc_now()
     profiles[profile] = stored
     state.update(

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -623,7 +623,11 @@ def _dispatch_unit(
         }
     probe = readiness(paths, owner)
     if str(probe.get("status", "")) != "ready":
-        return {
+        # The pre-handoff recheck (#837) can turn a once-ready owner into
+        # `stale` right here. Carrying its repair card through means the unit
+        # result names the prerequisite that moved and the command that
+        # confirms it, instead of only reporting that the owner was not ready.
+        not_ready: dict[str, Any] = {
             "unit_id": unit_id,
             "run_ref": run_ref,
             "owner": owner,
@@ -631,6 +635,10 @@ def _dispatch_unit(
             "readiness_status": str(probe.get("status", "unknown")),
             "merge_ready": False,
         }
+        repair_card = probe.get("repair_card")
+        if isinstance(repair_card, Mapping):
+            not_ready["repair_card"] = dict(repair_card)
+        return not_ready
     discovery = (discoveries or {}).get(owner)
     prompt = build_unit_prompt(unit, goal_text, discovery)
     argv = build_dispatch_argv(owner, prompt, model_route)

--- a/src/coding/pre_handoff_readiness.py
+++ b/src/coding/pre_handoff_readiness.py
@@ -1,0 +1,507 @@
+"""Freshness-aware readiness invalidation and the pre-handoff repair card.
+
+The defect this closes (#837): a readiness decision was cached the first time a
+coding owner was probed and then reused forever. `_cached_profile` returned any
+entry carrying `observed_once`, `updated_at` was written and never read back,
+and only `force=True` re-probed. A person who uninstalled `codex`, revoked a
+permission, or moved to another checkout still got `ready`, and the handoff was
+dispatched into a gap nobody had been told about.
+
+Two derivations live here, both pure and both I/O-free:
+
+* **Freshness.** Age is derived at READ time from the stored `updated_at` plus
+  `READINESS_STALE_AFTER_SECONDS`, the way `action_gate._account_state` derives
+  `expired` from `ACCOUNT_SIGNAL_STALE_AFTER_SECONDS`. No expiry deadline is
+  ever written into the cached record, so shortening the horizon takes effect
+  on records already on disk instead of only on records written afterwards.
+* **Binding.** A readiness decision is bound to a digest per invalidating axis
+  --- profile identity, tool set, permission profile, workspace --- so a
+  changed prerequisite invalidates the decision and the verdict can name WHICH
+  prerequisite changed. The binding carries no timestamp: it is compared for
+  equality, and a wall clock inside a compared payload makes equality a race.
+
+Nothing here decides that a repair happened. The repair card is
+`prepared_not_observed`; it names the gap and the command a person may run.
+
+Executor-neutrality (AC3): the card's key set is closed and identical for every
+owner. Codex, Claude Code, the Hermes runtime, and generic profiles differ only
+in the VALUES of the owner-specific fields (`profile`, `label`,
+`missing_prerequisites`, `repair_steps[].command`, `verify_command`).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from typing import Any, Final
+
+from .executors import executor_label
+
+
+PRE_HANDOFF_READINESS_SCHEMA_VERSION: Final = "pre_handoff_readiness/v1"
+PRE_HANDOFF_REPAIR_CARD_SCHEMA_VERSION: Final = "pre_handoff_repair_card/v1"
+READINESS_BINDING_SCHEMA_VERSION: Final = "executor_readiness_binding/v1"
+
+# Six hours, the same horizon `action_gate.ACCOUNT_SIGNAL_STALE_AFTER_SECONDS`
+# gives an account signal and the same one the limit-signal advisory already
+# reports as `stale`. Readiness answers a question of the same kind --- "is the
+# local environment still the one that was observed" --- so a second, different
+# number would only make two surfaces disagree about the same machine.
+READINESS_STALE_AFTER_SECONDS: Final = 6 * 60 * 60
+
+# Twenty-four hours, mirroring the window
+# `executor_capability_snapshots._local_workflow_errors` already enforces
+# between `observed_at` and `recorded_at`. That check runs at RECORD time only;
+# this one re-applies the same window at DISPATCH time, against the clock now
+# rather than against the moment the snapshot was written.
+CAPABILITY_EVIDENCE_STALE_AFTER_SECONDS: Final = 24 * 60 * 60
+
+READINESS_BINDING_AXES: Final = ("profile", "tool", "permission", "workspace")
+
+PRE_HANDOFF_READINESS_STATES: Final = (
+    "fresh",
+    "never_observed",
+    "unbound",
+    "changed",
+    "expired",
+    "evidence_prepared_only",
+    "evidence_expired",
+)
+
+PRE_HANDOFF_REPAIR_CARD_KEYS: Final = (
+    "schema_version",
+    "status",
+    "profile",
+    "label",
+    "state",
+    "reason_code",
+    "reason",
+    "changed_axes",
+    "missing_prerequisites",
+    "repair_steps",
+    "verify_command",
+    "blocked_action",
+    "claim_boundary",
+)
+PRE_HANDOFF_REPAIR_STEP_KEYS: Final = ("id", "action", "command")
+PRE_HANDOFF_REPAIR_STEP_IDS: Final = ("restore_prerequisite", "reobserve_readiness")
+
+PRE_HANDOFF_READINESS_CLAIM_BOUNDARY: Final = (
+    "This verdict says only whether a stored readiness observation may still be reused. It is not "
+    "dispatch, execution, verification, review, CI, or merge evidence, and a fresh verdict is not "
+    "proof that the executor would accept the handoff."
+)
+PRE_HANDOFF_REPAIR_CARD_CLAIM_BOUNDARY: Final = (
+    "This card is prepared repair guidance, not a repair. OMH did not install a tool, change a "
+    "permission, rebind a workspace, or re-probe anything; each step is a command a person may "
+    "choose to run."
+)
+PRE_HANDOFF_BLOCKED_ACTION: Final = "coding_handoff_dispatch"
+
+_MAX_REASON_LENGTH: Final = 400
+_MAX_TEXT_LENGTH: Final = 240
+_MAX_PREREQUISITES: Final = 6
+_STATE_REASON_CODES: Final = {
+    "fresh": "readiness_fresh",
+    "never_observed": "readiness_never_observed",
+    "unbound": "readiness_unbound",
+    "changed": "readiness_inputs_changed",
+    "expired": "readiness_expired",
+    "evidence_prepared_only": "capability_evidence_prepared_only",
+    "evidence_expired": "capability_evidence_expired",
+}
+_AXIS_PREREQUISITE_LABELS: Final = {
+    "profile": "the executor profile identity this decision was observed against",
+    "tool": "the executor command that was observed on PATH",
+    "permission": "the safety permission profile that was in force",
+    "workspace": "the workspace this decision was observed in",
+}
+
+
+class PreHandoffRepairCardError(ValueError):
+    pass
+
+
+def readiness_binding(
+    *,
+    profile: str,
+    profile_revision: str,
+    tool_paths: Sequence[str],
+    permission_revision: str,
+    workspace_ref: str,
+) -> dict[str, Any]:
+    """Bind a readiness decision to the inputs whose change invalidates it.
+
+    One digest per axis rather than one digest overall: a single digest can say
+    "something changed", and the person then has to guess what. Per-axis
+    digests let the verdict name `tool` or `permission` by itself, which is the
+    difference between a repair card and a shrug.
+    """
+    axes = {
+        "profile": _axis_digest(profile, profile_revision),
+        "tool": _axis_digest(*tool_paths),
+        "permission": _axis_digest(permission_revision),
+        "workspace": _axis_digest(workspace_ref),
+    }
+    return {
+        "schema_version": READINESS_BINDING_SCHEMA_VERSION,
+        "axes": axes,
+        "digest": _axis_digest(*(axes[name] for name in READINESS_BINDING_AXES)),
+    }
+
+
+def changed_binding_axes(stored: object, live: Mapping[str, Any]) -> list[str]:
+    """Axes whose digest differs between a stored binding and the live one."""
+    stored_axes = stored.get("axes") if isinstance(stored, Mapping) else None
+    if not isinstance(stored_axes, Mapping):
+        return []
+    live_axes = live.get("axes")
+    live_map = live_axes if isinstance(live_axes, Mapping) else {}
+    return [
+        axis
+        for axis in READINESS_BINDING_AXES
+        if str(stored_axes.get(axis, "")) != str(live_map.get(axis, ""))
+    ]
+
+
+def evaluate_pre_handoff_readiness(
+    *,
+    profile: str,
+    cached: Mapping[str, Any] | None,
+    binding: Mapping[str, Any],
+    capability_snapshot: Mapping[str, Any] | None = None,
+    now: str = "",
+) -> dict[str, Any]:
+    """Whether a stored readiness decision may still be reused, and why not.
+
+    `usable` is deliberately narrower than "the executor is ready": it says the
+    stored observation still describes the current machine. The caller keeps
+    the status it observed when `usable` is true and downgrades it otherwise;
+    nothing here can promote a decision to `ready`.
+
+    `now` is a parameter so the derivation is deterministic under test. An
+    unreadable or future `updated_at` reads as older than every horizon, for
+    the reason `action_gate._stamp_age_seconds` gives: neither can be shown to
+    be fresh, and clamping would turn editing a stored timestamp into a way to
+    widen the window from disk.
+
+    `capability_snapshot` is optional because most readiness calls have no
+    snapshot to consult. When one IS supplied it is authoritative: a snapshot
+    with no host-observed capability is prepared-only evidence and can never
+    yield a usable decision, which is the central evidence rule of this repo
+    applied at dispatch time instead of only at record time.
+    """
+    state, changed, age = _readiness_state(
+        cached=cached,
+        binding=binding,
+        capability_snapshot=capability_snapshot,
+        now=now,
+    )
+    return {
+        "schema_version": PRE_HANDOFF_READINESS_SCHEMA_VERSION,
+        "profile": profile,
+        "state": state,
+        "usable": state == "fresh",
+        "reason_code": _STATE_REASON_CODES[state],
+        "reason": _reason_text(state, profile, changed),
+        "changed_axes": changed,
+        "age_seconds": age,
+        "stale_after_seconds": READINESS_STALE_AFTER_SECONDS,
+        "claim_boundary": PRE_HANDOFF_READINESS_CLAIM_BOUNDARY,
+    }
+
+
+def build_pre_handoff_repair_card(
+    verdict: Mapping[str, Any],
+    *,
+    repair_command: str,
+) -> dict[str, Any]:
+    """The deterministic repair card for a verdict that blocked a handoff.
+
+    `repair_command` is the one owner-specific value the caller must supply:
+    what a person runs to put the missing prerequisite back. Everything else is
+    derived from the verdict, so two owners blocked for the same reason produce
+    cards with the same keys and the same shape.
+    """
+    state = str(verdict.get("state", ""))
+    if state not in _STATE_REASON_CODES:
+        raise PreHandoffRepairCardError(f"unsupported pre-handoff readiness state: {state}")
+    if state == "fresh":
+        raise PreHandoffRepairCardError("a fresh readiness verdict has no gap to repair")
+    profile = str(verdict.get("profile", ""))
+    changed = [str(axis) for axis in verdict.get("changed_axes", []) if isinstance(axis, str)]
+    card = {
+        "schema_version": PRE_HANDOFF_REPAIR_CARD_SCHEMA_VERSION,
+        "status": "prepared_not_observed",
+        "profile": profile,
+        "label": executor_label(profile),
+        "state": state,
+        "reason_code": str(verdict.get("reason_code", "")),
+        "reason": str(verdict.get("reason", ""))[:_MAX_REASON_LENGTH],
+        "changed_axes": changed,
+        "missing_prerequisites": _missing_prerequisites(state, changed),
+        "repair_steps": [
+            {
+                "id": "restore_prerequisite",
+                "action": _restore_action(state, changed),
+                "command": repair_command[:_MAX_TEXT_LENGTH],
+            },
+            {
+                "id": "reobserve_readiness",
+                "action": (
+                    "Re-observe readiness once the prerequisite is back. A stale decision is never "
+                    "refreshed on its own; forcing the probe is the only way to replace it."
+                ),
+                "command": f"omh coding executor-readiness --executor {profile} --force",
+            },
+        ],
+        "verify_command": f"omh coding executor-readiness --executor {profile}",
+        "blocked_action": PRE_HANDOFF_BLOCKED_ACTION,
+        "claim_boundary": PRE_HANDOFF_REPAIR_CARD_CLAIM_BOUNDARY,
+    }
+    errors = validate_pre_handoff_repair_card(card)
+    if errors:
+        raise PreHandoffRepairCardError("; ".join(errors))
+    return card
+
+
+def validate_pre_handoff_repair_card(card: Mapping[str, Any]) -> list[str]:
+    """Both directions: no key of the closed set missing, no key outside it."""
+    expected = set(PRE_HANDOFF_REPAIR_CARD_KEYS)
+    present = {str(key) for key in card}
+    errors: list[str] = []
+    missing = expected - present
+    if missing:
+        errors.append(f"repair card is missing required keys: {', '.join(sorted(missing))}")
+    unexpected = present - expected
+    if unexpected:
+        errors.append(f"repair card contains unsupported keys: {', '.join(sorted(unexpected))}")
+    if card.get("schema_version") != PRE_HANDOFF_REPAIR_CARD_SCHEMA_VERSION:
+        errors.append(f"schema_version must be {PRE_HANDOFF_REPAIR_CARD_SCHEMA_VERSION}")
+    if card.get("status") != "prepared_not_observed":
+        errors.append("status must be prepared_not_observed; the card never claims a repair ran")
+    if card.get("blocked_action") != PRE_HANDOFF_BLOCKED_ACTION:
+        errors.append(f"blocked_action must be {PRE_HANDOFF_BLOCKED_ACTION}")
+    state = card.get("state")
+    if state not in PRE_HANDOFF_READINESS_STATES or state == "fresh":
+        errors.append("state must name a blocking pre-handoff readiness state")
+    elif card.get("reason_code") != _STATE_REASON_CODES[str(state)]:
+        errors.append("reason_code must match the state it was derived from")
+    errors.extend(_bounded_text_errors(card))
+    errors.extend(_axis_list_errors(card.get("changed_axes")))
+    errors.extend(_prerequisite_errors(card.get("missing_prerequisites")))
+    errors.extend(_repair_step_errors(card.get("repair_steps")))
+    return errors
+
+
+def _bounded_text_errors(card: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field, limit in (
+        ("profile", _MAX_TEXT_LENGTH),
+        ("label", _MAX_TEXT_LENGTH),
+        ("reason", _MAX_REASON_LENGTH),
+        ("verify_command", _MAX_TEXT_LENGTH),
+    ):
+        value = card.get(field)
+        if not isinstance(value, str) or not value.strip() or len(value) > limit:
+            errors.append(f"{field} must be a nonempty string of at most {limit} characters")
+    return errors
+
+
+def _axis_list_errors(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return ["changed_axes must be a list"]
+    unknown = [str(axis) for axis in value if axis not in READINESS_BINDING_AXES]
+    if unknown:
+        return [f"changed_axes contains unsupported axes: {', '.join(sorted(unknown))}"]
+    if len(value) != len(set(value)):
+        return ["changed_axes must not repeat an axis"]
+    return []
+
+
+def _prerequisite_errors(value: object) -> list[str]:
+    if not isinstance(value, list) or not value:
+        return ["missing_prerequisites must be a nonempty list"]
+    if len(value) > _MAX_PREREQUISITES:
+        return [f"missing_prerequisites must hold at most {_MAX_PREREQUISITES} entries"]
+    if any(not isinstance(entry, str) or not entry.strip() or len(entry) > _MAX_TEXT_LENGTH for entry in value):
+        return ["missing_prerequisites entries must be nonempty bounded strings"]
+    return []
+
+
+def _repair_step_errors(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return ["repair_steps must be a list"]
+    if [step.get("id") if isinstance(step, Mapping) else None for step in value] != list(PRE_HANDOFF_REPAIR_STEP_IDS):
+        return [f"repair_steps must be exactly {', '.join(PRE_HANDOFF_REPAIR_STEP_IDS)} in order"]
+    errors: list[str] = []
+    for step in value:
+        unexpected = {str(key) for key in step} - set(PRE_HANDOFF_REPAIR_STEP_KEYS)
+        if unexpected:
+            errors.append(f"repair step contains unsupported keys: {', '.join(sorted(unexpected))}")
+        for field in ("action", "command"):
+            text = step.get(field)
+            if not isinstance(text, str) or not text.strip() or len(text) > _MAX_TEXT_LENGTH:
+                errors.append(f"repair step {field} must be a nonempty string of at most {_MAX_TEXT_LENGTH} characters")
+    return errors
+
+
+def _readiness_state(
+    *,
+    cached: Mapping[str, Any] | None,
+    binding: Mapping[str, Any],
+    capability_snapshot: Mapping[str, Any] | None,
+    now: str,
+) -> tuple[str, list[str], int]:
+    """(state, changed axes, age in seconds) in a fixed precedence order.
+
+    Precedence is deliberate: an absent observation is reported before an
+    expired one, and a changed prerequisite before an expired clock, because a
+    person repairs the named prerequisite and a fresh probe follows from that.
+    Capability evidence is checked first of all --- prepared-only evidence is
+    not weaker evidence, it is the absence of evidence, and no amount of
+    freshness converts it.
+    """
+    if not isinstance(cached, Mapping) or cached.get("observed_once") is not True:
+        return "never_observed", [], _UNKNOWN_AGE_SECONDS
+    if capability_snapshot is not None:
+        evidence_state, evidence_age = _capability_evidence_state(capability_snapshot, now)
+        if evidence_state is not None:
+            return evidence_state, [], evidence_age
+    age = _stamp_age_seconds(str(cached.get("updated_at", "") or ""), now, READINESS_STALE_AFTER_SECONDS)
+    stored_binding = cached.get("readiness_binding")
+    if not isinstance(stored_binding, Mapping) or not isinstance(stored_binding.get("axes"), Mapping):
+        return "unbound", [], age
+    changed = changed_binding_axes(stored_binding, binding)
+    if changed:
+        return "changed", changed, age
+    if age > READINESS_STALE_AFTER_SECONDS:
+        return "expired", [], age
+    return "fresh", [], age
+
+
+def _capability_evidence_state(
+    snapshot: Mapping[str, Any],
+    now: str,
+) -> tuple[str | None, int]:
+    capabilities = snapshot.get("capabilities")
+    if not isinstance(capabilities, Mapping):
+        return "evidence_prepared_only", _UNKNOWN_AGE_SECONDS
+    observed = [
+        value
+        for value in capabilities.values()
+        if isinstance(value, Mapping) and value.get("status") == "host_observed"
+    ]
+    if not observed:
+        return "evidence_prepared_only", _UNKNOWN_AGE_SECONDS
+    ages = [
+        _stamp_age_seconds(
+            str(value.get("observed_at", "") or ""),
+            now,
+            CAPABILITY_EVIDENCE_STALE_AFTER_SECONDS,
+        )
+        for value in observed
+    ]
+    oldest = max(ages)
+    if oldest > CAPABILITY_EVIDENCE_STALE_AFTER_SECONDS:
+        return "evidence_expired", oldest
+    return None, oldest
+
+
+def _reason_text(state: str, profile: str, changed: Sequence[str]) -> str:
+    label = executor_label(profile)
+    match state:
+        case "fresh":
+            return f"The stored readiness observation for {label} still matches this machine."
+        case "never_observed":
+            return f"Readiness for {label} has never been observed, so there is nothing to reuse."
+        case "unbound":
+            return (
+                f"The stored readiness observation for {label} predates input binding, so no changed "
+                "prerequisite can be ruled out."
+            )
+        case "changed":
+            named = ", ".join(changed)
+            return (
+                f"A prerequisite changed since readiness for {label} was observed: {named}. The stored "
+                "decision no longer describes this machine."
+            )
+        case "expired":
+            hours = READINESS_STALE_AFTER_SECONDS // 3600
+            return (
+                f"The stored readiness observation for {label} is older than {hours} hours, so it is "
+                "expired rather than current."
+            )
+        case "evidence_prepared_only":
+            return (
+                f"The capability snapshot for {label} carries no host-observed capability, so it is "
+                "prepared evidence only and cannot support a ready decision."
+            )
+        case _:
+            hours = CAPABILITY_EVIDENCE_STALE_AFTER_SECONDS // 3600
+            return (
+                f"The capability evidence for {label} was observed more than {hours} hours ago, so it "
+                "is expired rather than current."
+            )
+
+
+def _missing_prerequisites(state: str, changed: Sequence[str]) -> list[str]:
+    if changed:
+        return [_AXIS_PREREQUISITE_LABELS[axis] for axis in changed]
+    match state:
+        case "never_observed":
+            return ["a first readiness observation for this executor"]
+        case "unbound":
+            return ["a readiness observation bound to the current profile, tool, permission, and workspace"]
+        case "expired":
+            return [f"a readiness observation newer than {READINESS_STALE_AFTER_SECONDS // 3600} hours"]
+        case "evidence_prepared_only":
+            return ["a host-observed capability snapshot instead of prepared-only capability evidence"]
+        case _:
+            return [
+                "a capability observation newer than "
+                f"{CAPABILITY_EVIDENCE_STALE_AFTER_SECONDS // 3600} hours"
+            ]
+
+
+def _restore_action(state: str, changed: Sequence[str]) -> str:
+    if changed:
+        named = ", ".join(changed)
+        return f"Put back what changed on this machine ({named}), then confirm it with the command below."
+    if state.startswith("evidence_"):
+        return "Record a host-observed capability snapshot for this executor before handing work to it."
+    return "Confirm the executor prerequisite is in place on this machine before handing work to it."
+
+
+_UNKNOWN_AGE_SECONDS: Final = -1
+
+
+def _stamp_age_seconds(stamp: str, now: str, horizon: int) -> int:
+    """Age of an ISO-8601 stamp in seconds, or a value past the given horizon."""
+
+    def _parse(value: str) -> datetime | None:
+        text = value.strip().replace("Z", "+00:00")
+        if not text:
+            return None
+        try:
+            parsed = datetime.fromisoformat(text)
+        except ValueError:
+            return None
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+    observed = _parse(stamp)
+    if observed is None:
+        return horizon + 1
+    reference = _parse(now) or datetime.now(timezone.utc)
+    age = int((reference - observed).total_seconds())
+    return horizon + 1 if age < 0 else age
+
+
+def _axis_digest(*parts: str) -> str:
+    # A joined string rather than JSON: this digest runs on the prepared
+    # readiness path, where the efficiency contract forbids JSON serialization
+    # (see `skill_governance.policy_decision_digest`). The unit separator
+    # cannot appear in a path or a revision, so no two axis inputs can collide
+    # by concatenation.
+    return hashlib.sha256("\x1f".join(str(part) for part in parts).encode("utf-8")).hexdigest()

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -603,7 +603,9 @@ def _capability_snapshot_path(args: argparse.Namespace) -> Path:
     explicit_path = getattr(args, "snapshot_path", "")
     if explicit_path:
         return Path(explicit_path).expanduser()
-    return _paths(args).omh_home / "coding" / "executor-capability-snapshots" / f"{args.executor}.json"
+    # Same directory the readiness recheck reads at dispatch time, named once
+    # on OmhPaths so the two surfaces cannot drift to different folders.
+    return _paths(args).executor_capability_snapshots_dir / f"{args.executor}.json"
 
 
 def cmd_coding_governance_discover(args: argparse.Namespace) -> int:

--- a/src/system/paths.py
+++ b/src/system/paths.py
@@ -242,6 +242,10 @@ class OmhPaths:
         return self.runtime_dir / "executor-limit-signals.json"
 
     @property
+    def executor_capability_snapshots_dir(self) -> Path:
+        return self.omh_home / "coding" / "executor-capability-snapshots"
+
+    @property
     def dynamic_coding_workflows_dir(self) -> Path:
         return self.omh_home / "coding" / "dynamic-workflows"
 

--- a/tests/test_executor_auth_signals.py
+++ b/tests/test_executor_auth_signals.py
@@ -15,8 +15,12 @@ from omh.coding.executor_auth_signals import (  # noqa: E402
     executor_auth_signals,
     last_limit_signal_for_profile,
 )
-from omh.coding.executor_readiness import executor_choice_context, probe_executor_readiness  # noqa: E402
-from omh.system.local_store import atomic_write_json  # noqa: E402
+from omh.coding.executor_readiness import (  # noqa: E402
+    executor_choice_context,
+    live_readiness_binding,
+    probe_executor_readiness,
+)
+from omh.system.local_store import atomic_write_json, utc_now  # noqa: E402
 from omh.system.paths import OmhPaths  # noqa: E402
 
 
@@ -129,6 +133,10 @@ class ReadinessAdvisoryFreshnessTests(unittest.TestCase):
             root = Path(tmp)
             paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
             # Seed a cached observed_once probe result so no subprocess runs.
+            # `updated_at` and `readiness_binding` are part of the fixture as of
+            # #837: `observed_once` alone no longer keeps a decision usable, so
+            # a cache entry has to be both fresh and bound to this machine to
+            # exercise the advisory-refresh path this test is about.
             atomic_write_json(
                 paths.executor_readiness_path,
                 {
@@ -139,6 +147,8 @@ class ReadinessAdvisoryFreshnessTests(unittest.TestCase):
                             "profile": "codex",
                             "status": "ready",
                             "observed_once": True,
+                            "updated_at": utc_now(),
+                            "readiness_binding": live_readiness_binding(paths, "codex"),
                         }
                     },
                 },

--- a/tests/test_executor_readiness_freshness.py
+++ b/tests/test_executor_readiness_freshness.py
@@ -1,0 +1,531 @@
+"""A readiness decision expires, and a changed prerequisite invalidates it.
+
+The defect (#837): `_cached_profile` returned any entry carrying
+`observed_once`, with no age check. `updated_at` was written and never read
+back, and `force=True` was the only thing that re-probed. So the first readiness
+observation on a machine was the last one: a person who uninstalled `codex`,
+lost a permission, or moved to another checkout still got `ready`, and the
+handoff was dispatched into a gap nobody had been told about.
+
+What these pin:
+
+* AC1 -- prepared-only capability evidence and a stale observation can never
+  produce `ready`.
+* AC2 -- one test per invalidating axis (profile, tool, permission, workspace);
+  each flips a decision that WAS usable to not-usable, naming the axis.
+* AC3 -- the repair card has one closed key set for every owner. Codex, Claude
+  Code, and the Hermes runtime differ only in owner-specific values.
+
+Guards: a stale decision is never silently re-probed, and `force=True` stays
+the only way to replace a stored observation.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+from unittest.mock import patch
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.coding.executor_capability_snapshots import (  # noqa: E402
+    build_executor_capability_snapshot,
+    executor_capability_snapshot_path,
+    write_executor_capability_snapshot,
+)
+from omh.coding.executor_readiness import (  # noqa: E402
+    _repair_command,
+    executor_choice_context,
+    live_readiness_binding,
+    probe_executor_readiness,
+)
+from omh.coding.pre_handoff_readiness import (  # noqa: E402
+    CAPABILITY_EVIDENCE_STALE_AFTER_SECONDS,
+    PRE_HANDOFF_REPAIR_CARD_KEYS,
+    PRE_HANDOFF_REPAIR_STEP_IDS,
+    PRE_HANDOFF_REPAIR_STEP_KEYS,
+    READINESS_BINDING_AXES,
+    READINESS_STALE_AFTER_SECONDS,
+    PreHandoffRepairCardError,
+    build_pre_handoff_repair_card,
+    evaluate_pre_handoff_readiness,
+    readiness_binding,
+    validate_pre_handoff_repair_card,
+)
+from omh.system.local_store import atomic_write_json  # noqa: E402
+from omh.system.paths import OmhPaths  # noqa: E402
+
+
+OBSERVED_AT = "2026-01-01T00:00:00Z"
+WITHIN_WINDOW = "2026-01-01T01:00:00Z"
+PAST_WINDOW = "2026-01-01T07:00:00Z"
+_UNMATCHED_DIGEST = "0" * 64
+
+
+def _binding_inputs(**overrides: Any) -> dict[str, Any]:
+    inputs: dict[str, Any] = {
+        "profile": "codex",
+        "profile_revision": "Codex CLI\x1esend_to_executor\x1elocal_command",
+        "tool_paths": ("codex", "--version", "/usr/local/bin/codex"),
+        "permission_revision": "permission-revision-a",
+        "workspace_ref": "/repos/alpha",
+    }
+    inputs.update(overrides)
+    return inputs
+
+
+def _cached_entry(*, updated_at: str, binding: dict[str, Any], status: str = "ready") -> dict[str, Any]:
+    return {
+        "schema_version": "executor_readiness/v1",
+        "profile": "codex",
+        "status": status,
+        "available": status == "ready",
+        "observed_once": True,
+        "updated_at": updated_at,
+        "readiness_binding": binding,
+    }
+
+
+def _seed_cache(paths: OmhPaths, profile: str, entry: dict[str, Any]) -> None:
+    atomic_write_json(
+        paths.executor_readiness_path,
+        {"schema_version": "executor_readiness_cache/v1", "profiles": {profile: entry}},
+        private=True,
+    )
+
+
+def _paths(root: Path) -> OmhPaths:
+    return OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+
+
+def _snapshot(capabilities: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": "executor_capability_snapshot/v1",
+        "executor": "codex",
+        "recorded_at": OBSERVED_AT,
+        "capabilities": capabilities,
+    }
+
+
+class BindingAxisTests(unittest.TestCase):
+    """The digest actually moves when its input moves -- and only that axis."""
+
+    def test_identical_inputs_produce_an_identical_binding(self) -> None:
+        first = readiness_binding(**_binding_inputs())
+        second = readiness_binding(**_binding_inputs())
+        self.assertEqual(first, second)
+
+    def test_the_binding_carries_no_timestamp(self) -> None:
+        # A wall clock inside a payload that is compared for equality turns the
+        # comparison into a race, which is why expiry is derived at read time
+        # from `updated_at` instead of stored in the binding.
+        text = json.dumps(readiness_binding(**_binding_inputs()), sort_keys=True)
+        self.assertNotIn("2026", text)
+        self.assertNotIn("Z\"", text)
+
+    def test_each_input_moves_exactly_its_own_axis(self) -> None:
+        base = readiness_binding(**_binding_inputs())
+        moved = {
+            "profile": _binding_inputs(profile_revision="Codex CLI\x1eshow_prompt_handoff\x1elocal_command"),
+            "tool": _binding_inputs(tool_paths=("codex", "--version", "/opt/homebrew/bin/codex")),
+            "permission": _binding_inputs(permission_revision="permission-revision-b"),
+            "workspace": _binding_inputs(workspace_ref="/repos/beta"),
+        }
+        self.assertEqual(sorted(moved), sorted(READINESS_BINDING_AXES))
+        for axis, inputs in moved.items():
+            with self.subTest(axis=axis):
+                changed = readiness_binding(**inputs)
+                self.assertNotEqual(changed["digest"], base["digest"])
+                differing = [name for name in READINESS_BINDING_AXES if changed["axes"][name] != base["axes"][name]]
+                self.assertEqual(differing, [axis])
+
+
+class PreparedAndStaleEvidenceTests(unittest.TestCase):
+    """AC1: prepared-only or stale evidence can never produce a ready result."""
+
+    def _fresh_verdict_inputs(self) -> dict[str, Any]:
+        binding = readiness_binding(**_binding_inputs())
+        return {
+            "profile": "codex",
+            "cached": _cached_entry(updated_at=OBSERVED_AT, binding=binding),
+            "binding": binding,
+            "now": WITHIN_WINDOW,
+        }
+
+    def test_the_control_case_is_usable(self) -> None:
+        # Without this the AC1 cases below could pass for the wrong reason.
+        verdict = evaluate_pre_handoff_readiness(**self._fresh_verdict_inputs())
+        self.assertTrue(verdict["usable"])
+        self.assertEqual(verdict["state"], "fresh")
+
+    def test_prepared_only_capability_evidence_is_never_usable(self) -> None:
+        verdict = evaluate_pre_handoff_readiness(
+            **self._fresh_verdict_inputs(),
+            capability_snapshot=_snapshot(
+                {"worktree_isolation": {"status": "prepared"}, "parallel_agents": {"status": "unknown"}}
+            ),
+        )
+        self.assertFalse(verdict["usable"])
+        self.assertEqual(verdict["state"], "evidence_prepared_only")
+        self.assertEqual(verdict["reason_code"], "capability_evidence_prepared_only")
+        self.assertIn("prepared evidence only", verdict["reason"])
+
+    def test_expired_capability_evidence_is_never_usable(self) -> None:
+        verdict = evaluate_pre_handoff_readiness(
+            **self._fresh_verdict_inputs(),
+            capability_snapshot=_snapshot(
+                {
+                    "worktree_isolation": {
+                        "status": "host_observed",
+                        "scope": {"mode": "worktree"},
+                        "evidence_ref": "local-observation-1",
+                        # Older than the 24h window the snapshot validator
+                        # already enforces at record time.
+                        "observed_at": "2025-12-30T00:00:00Z",
+                    }
+                }
+            ),
+        )
+        self.assertFalse(verdict["usable"])
+        self.assertEqual(verdict["state"], "evidence_expired")
+        self.assertGreater(verdict["age_seconds"], CAPABILITY_EVIDENCE_STALE_AFTER_SECONDS)
+
+    def test_host_observed_capability_evidence_inside_the_window_stays_usable(self) -> None:
+        verdict = evaluate_pre_handoff_readiness(
+            **self._fresh_verdict_inputs(),
+            capability_snapshot=_snapshot(
+                {
+                    "worktree_isolation": {
+                        "status": "host_observed",
+                        "scope": {"mode": "worktree"},
+                        "evidence_ref": "local-observation-1",
+                        "observed_at": OBSERVED_AT,
+                    }
+                }
+            ),
+        )
+        self.assertTrue(verdict["usable"])
+
+    def test_a_stale_observation_never_reads_ready_through_the_probe(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            _seed_cache(
+                paths,
+                "codex",
+                _cached_entry(updated_at=OBSERVED_AT, binding=live_readiness_binding(paths, "codex")),
+            )
+            result = probe_executor_readiness(paths, "codex", now=PAST_WINDOW)
+        self.assertNotEqual(result["status"], "ready")
+        self.assertEqual(result["status"], "stale")
+        self.assertFalse(result["available"])
+        self.assertEqual(result["cache_status"], "invalidated")
+        self.assertEqual(result["pre_handoff_readiness"]["state"], "expired")
+        self.assertGreater(result["pre_handoff_readiness"]["age_seconds"], READINESS_STALE_AFTER_SECONDS)
+        self.assertEqual(result["repair_card"]["reason_code"], "readiness_expired")
+
+    def test_a_fresh_bound_observation_still_reads_ready_through_the_probe(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            _seed_cache(
+                paths,
+                "codex",
+                _cached_entry(updated_at=OBSERVED_AT, binding=live_readiness_binding(paths, "codex")),
+            )
+            result = probe_executor_readiness(paths, "codex", now=WITHIN_WINDOW)
+        self.assertEqual(result["status"], "ready")
+        self.assertEqual(result["cache_status"], "cached")
+        self.assertNotIn("repair_card", result)
+
+    def test_a_prepared_only_snapshot_on_disk_invalidates_the_probe(self) -> None:
+        # The record-time window in `executor_capability_snapshots` is applied
+        # again at dispatch time: a snapshot that claims capabilities nobody
+        # observed cannot carry a ready decision to a handoff.
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            _seed_cache(
+                paths,
+                "codex",
+                _cached_entry(updated_at=OBSERVED_AT, binding=live_readiness_binding(paths, "codex")),
+            )
+            write_executor_capability_snapshot(
+                executor_capability_snapshot_path(paths.executor_capability_snapshots_dir, "codex"),
+                build_executor_capability_snapshot(
+                    executor="codex",
+                    capabilities={"worktree_isolation": {"status": "prepared"}},
+                    recorded_at=OBSERVED_AT,
+                ),
+            )
+            result = probe_executor_readiness(paths, "codex", now=WITHIN_WINDOW)
+        self.assertEqual(result["status"], "stale")
+        self.assertEqual(result["pre_handoff_readiness"]["reason_code"], "capability_evidence_prepared_only")
+        self.assertEqual(result["repair_card"]["state"], "evidence_prepared_only")
+
+    def test_a_stale_decision_never_ranks_ready_in_the_choose_executor_card(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            _seed_cache(
+                paths,
+                "codex",
+                _cached_entry(updated_at=OBSERVED_AT, binding=live_readiness_binding(paths, "codex")),
+            )
+            fresh = executor_choice_context(paths, now=WITHIN_WINDOW)
+            stale = executor_choice_context(paths, now=PAST_WINDOW)
+
+        by_profile = {entry["profile"]: entry for entry in fresh["candidates"]}
+        self.assertEqual(by_profile["codex"]["readiness_status"], "ready")
+        by_profile = {entry["profile"]: entry for entry in stale["candidates"]}
+        self.assertEqual(by_profile["codex"]["readiness_status"], "stale")
+        self.assertEqual(by_profile["codex"]["readiness_freshness"], "readiness_expired")
+        # An unprobed candidate is not stale, it is unobserved -- the two read
+        # differently so a wrapper does not offer a repair for a first probe.
+        self.assertEqual(by_profile["claude-code"]["readiness_status"], "not_observed")
+        self.assertEqual(by_profile["claude-code"]["readiness_freshness"], "readiness_never_observed")
+
+    def test_a_legacy_unbound_entry_is_invalidated_rather_than_trusted(self) -> None:
+        # Entries written before #837 carry no binding, so no changed
+        # prerequisite can be ruled out for them. One forced re-probe rebinds.
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            atomic_write_json(
+                paths.executor_readiness_path,
+                {
+                    "schema_version": "executor_readiness_cache/v1",
+                    "profiles": {
+                        "codex": {
+                            "schema_version": "executor_readiness/v1",
+                            "profile": "codex",
+                            "status": "ready",
+                            "observed_once": True,
+                            "updated_at": OBSERVED_AT,
+                        }
+                    },
+                },
+                private=True,
+            )
+            result = probe_executor_readiness(paths, "codex", now=WITHIN_WINDOW)
+        self.assertEqual(result["status"], "stale")
+        self.assertEqual(result["pre_handoff_readiness"]["reason_code"], "readiness_unbound")
+
+
+class ChangedPrerequisiteTests(unittest.TestCase):
+    """AC2: one axis per test, each flipping a usable decision to not-usable."""
+
+    def _flip(self, axis: str) -> dict[str, Any]:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            live = live_readiness_binding(paths, "codex")
+            _seed_cache(paths, "codex", _cached_entry(updated_at=OBSERVED_AT, binding=live))
+            before = probe_executor_readiness(paths, "codex", now=WITHIN_WINDOW)
+            self.assertEqual(before["status"], "ready", "the decision must be ready before the axis moves")
+
+            stale_binding = {**live, "axes": {**live["axes"], axis: _UNMATCHED_DIGEST}}
+            _seed_cache(paths, "codex", _cached_entry(updated_at=OBSERVED_AT, binding=stale_binding))
+            return probe_executor_readiness(paths, "codex", now=WITHIN_WINDOW)
+
+    def _assert_named_invalidation(self, result: dict[str, Any], axis: str) -> None:
+        self.assertEqual(result["status"], "stale")
+        self.assertEqual(result["cache_status"], "invalidated")
+        verdict = result["pre_handoff_readiness"]
+        self.assertEqual(verdict["state"], "changed")
+        self.assertEqual(verdict["reason_code"], "readiness_inputs_changed")
+        self.assertEqual(verdict["changed_axes"], [axis])
+        self.assertIn(axis, verdict["reason"])
+        self.assertEqual(result["repair_card"]["changed_axes"], [axis])
+        self.assertEqual(len(result["repair_card"]["missing_prerequisites"]), 1)
+
+    def test_a_changed_profile_identity_invalidates_the_decision(self) -> None:
+        self._assert_named_invalidation(self._flip("profile"), "profile")
+
+    def test_a_changed_tool_set_invalidates_the_decision(self) -> None:
+        self._assert_named_invalidation(self._flip("tool"), "tool")
+
+    def test_a_changed_permission_profile_invalidates_the_decision(self) -> None:
+        self._assert_named_invalidation(self._flip("permission"), "permission")
+
+    def test_a_changed_workspace_invalidates_the_decision(self) -> None:
+        self._assert_named_invalidation(self._flip("workspace"), "workspace")
+
+    def test_a_workspace_move_changes_the_live_binding(self) -> None:
+        # The end-to-end cases above substitute a digest; this one proves a real
+        # workspace change produces a different one, so they are not tautologies.
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            here = live_readiness_binding(paths, "codex", workspace_ref="/repos/alpha")
+            elsewhere = live_readiness_binding(paths, "codex", workspace_ref="/repos/beta")
+        self.assertNotEqual(here["axes"]["workspace"], elsewhere["axes"]["workspace"])
+        self.assertEqual(here["axes"]["tool"], elsewhere["axes"]["tool"])
+
+
+class RepairCardContractTests(unittest.TestCase):
+    """AC3: executor-specific values inside an executor-neutral key set."""
+
+    _OWNER_SPECIFIC_FIELDS = frozenset({"profile", "label", "reason", "repair_steps", "verify_command"})
+
+    def _card(self, profile: str) -> dict[str, Any]:
+        binding = readiness_binding(**_binding_inputs(profile=profile))
+        verdict = evaluate_pre_handoff_readiness(
+            profile=profile,
+            cached=_cached_entry(updated_at=OBSERVED_AT, binding=binding),
+            binding=binding,
+            now=PAST_WINDOW,
+        )
+        self.assertEqual(verdict["state"], "expired")
+        return build_pre_handoff_repair_card(verdict, repair_command=_repair_command(profile))
+
+    def test_every_owner_gets_the_same_closed_key_set(self) -> None:
+        for profile in ("codex", "claude-code", "hermes", "generic", "omo-runtime"):
+            with self.subTest(profile=profile):
+                card = self._card(profile)
+                self.assertEqual(sorted(card), sorted(PRE_HANDOFF_REPAIR_CARD_KEYS))
+                self.assertEqual([step["id"] for step in card["repair_steps"]], list(PRE_HANDOFF_REPAIR_STEP_IDS))
+                for step in card["repair_steps"]:
+                    self.assertEqual(sorted(step), sorted(PRE_HANDOFF_REPAIR_STEP_KEYS))
+                self.assertEqual(validate_pre_handoff_repair_card(card), [])
+
+    def test_two_owners_differ_only_in_owner_specific_values(self) -> None:
+        codex = self._card("codex")
+        claude = self._card("claude-code")
+        differing = {key for key in codex if codex[key] != claude[key]}
+        self.assertEqual(differing, self._OWNER_SPECIFIC_FIELDS)
+        # The shared half is the contract: reason code, blocked action, state,
+        # and the named gap read identically for both owners.
+        self.assertEqual(codex["reason_code"], claude["reason_code"])
+        self.assertEqual(codex["missing_prerequisites"], claude["missing_prerequisites"])
+        self.assertEqual(codex["blocked_action"], claude["blocked_action"])
+
+    def test_the_hermes_runtime_is_a_first_class_owner(self) -> None:
+        # A wrapper-observed profile has no CLI to confirm, so its owner-specific
+        # command is the local check that covers it -- same field, same shape.
+        hermes = self._card("hermes")
+        codex = self._card("codex")
+        self.assertEqual(sorted(hermes), sorted(codex))
+        self.assertEqual(hermes["repair_steps"][0]["command"], "omh doctor")
+        self.assertEqual(codex["repair_steps"][0]["command"], "codex --version")
+
+    def test_the_card_never_claims_the_repair_ran(self) -> None:
+        card = self._card("codex")
+        self.assertEqual(card["status"], "prepared_not_observed")
+        self.assertEqual(card["blocked_action"], "coding_handoff_dispatch")
+        self.assertIn("not a repair", card["claim_boundary"])
+
+    def test_a_fresh_verdict_has_no_card_to_build(self) -> None:
+        binding = readiness_binding(**_binding_inputs())
+        verdict = evaluate_pre_handoff_readiness(
+            profile="codex",
+            cached=_cached_entry(updated_at=OBSERVED_AT, binding=binding),
+            binding=binding,
+            now=WITHIN_WINDOW,
+        )
+        with self.assertRaises(PreHandoffRepairCardError):
+            build_pre_handoff_repair_card(verdict, repair_command="codex --version")
+
+
+class RepairCardValidatorTests(unittest.TestCase):
+    """The validator checks both directions: nothing missing, nothing extra."""
+
+    def _valid(self) -> dict[str, Any]:
+        binding = readiness_binding(**_binding_inputs())
+        verdict = evaluate_pre_handoff_readiness(
+            profile="codex",
+            cached=_cached_entry(updated_at=OBSERVED_AT, binding=binding),
+            binding=binding,
+            now=PAST_WINDOW,
+        )
+        return build_pre_handoff_repair_card(verdict, repair_command="codex --version")
+
+    def test_a_built_card_validates(self) -> None:
+        self.assertEqual(validate_pre_handoff_repair_card(self._valid()), [])
+
+    def test_a_missing_key_is_reported(self) -> None:
+        card = self._valid()
+        del card["verify_command"]
+        errors = validate_pre_handoff_repair_card(card)
+        self.assertTrue(any("missing required keys: verify_command" in error for error in errors))
+
+    def test_an_extra_key_is_reported(self) -> None:
+        card = self._valid()
+        card["executor_note"] = "codex only"
+        errors = validate_pre_handoff_repair_card(card)
+        self.assertTrue(any("unsupported keys: executor_note" in error for error in errors))
+
+    def test_a_claimed_repair_is_reported(self) -> None:
+        card = self._valid()
+        card["status"] = "observed"
+        errors = validate_pre_handoff_repair_card(card)
+        self.assertTrue(any("never claims a repair ran" in error for error in errors))
+
+    def test_an_unsupported_axis_is_reported(self) -> None:
+        card = self._valid()
+        card["changed_axes"] = ["network"]
+        errors = validate_pre_handoff_repair_card(card)
+        self.assertTrue(any("unsupported axes: network" in error for error in errors))
+
+    def test_a_reason_code_that_contradicts_the_state_is_reported(self) -> None:
+        card = self._valid()
+        card["reason_code"] = "readiness_fresh"
+        errors = validate_pre_handoff_repair_card(card)
+        self.assertTrue(any("reason_code must match the state" in error for error in errors))
+
+    def test_a_dropped_repair_step_is_reported(self) -> None:
+        card = self._valid()
+        card["repair_steps"] = card["repair_steps"][:1]
+        errors = validate_pre_handoff_repair_card(card)
+        self.assertTrue(any("repair_steps must be exactly" in error for error in errors))
+
+
+class ReProbeGuardTests(unittest.TestCase):
+    """`force=True` stays the only thing that replaces a stored observation."""
+
+    def test_a_stale_decision_is_not_silently_refreshed(self) -> None:
+        def _forbidden(_contract: dict[str, object]) -> dict[str, object]:
+            raise AssertionError("a stale decision must not re-probe without force")
+
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            _seed_cache(
+                paths,
+                "codex",
+                _cached_entry(updated_at=OBSERVED_AT, binding=live_readiness_binding(paths, "codex")),
+            )
+            before = paths.executor_readiness_path.read_bytes()
+            with patch("omh.coding.executor_readiness._run_probe", _forbidden):
+                result = probe_executor_readiness(paths, "codex", now=PAST_WINDOW)
+            after = paths.executor_readiness_path.read_bytes()
+
+        self.assertEqual(result["status"], "stale")
+        self.assertEqual(before, after, "an invalidated read must not rewrite the stored decision")
+
+    def test_force_is_what_replaces_a_stale_decision(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            _seed_cache(
+                paths,
+                "codex",
+                _cached_entry(updated_at=OBSERVED_AT, binding=live_readiness_binding(paths, "codex")),
+            )
+            # omx-runtime resolves no local binary in the test environment, so
+            # the forced probe stays a PATH lookup with no subprocess.
+            forced = probe_executor_readiness(paths, "omx-runtime", force=True)
+            stored = json.loads(paths.executor_readiness_path.read_text(encoding="utf-8"))
+
+        self.assertNotIn("repair_card", forced)
+        entry = stored["profiles"]["omx-runtime"]
+        self.assertTrue(entry["observed_once"])
+        self.assertTrue(entry["updated_at"])
+        self.assertEqual(sorted(entry["readiness_binding"]["axes"]), sorted(READINESS_BINDING_AXES))
+
+    def test_a_forced_probe_rebinds_a_legacy_entry(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            probe_executor_readiness(paths, "omx-runtime", force=True)
+            rebound = probe_executor_readiness(paths, "omx-runtime")
+        self.assertEqual(rebound["cache_status"], "cached")
+        self.assertEqual(rebound["pre_handoff_readiness"]["state"], "fresh")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -13,6 +13,10 @@ load_local_package()
 
 from _cli_harness import run_cli  # noqa: E402
 
+from omh.coding.executor_readiness import (  # noqa: E402
+    live_readiness_binding,
+    probe_executor_readiness,
+)
 from omh.coding.fanout import build_fanout_contract  # noqa: E402
 from omh.coding.fanout_artifacts import write_fanout_contract  # noqa: E402
 from omh.coding.fanout_artifacts import fanout_dispatch_summary_path  # noqa: E402
@@ -22,6 +26,7 @@ from omh.coding.fanout_dispatch import (  # noqa: E402
     verify_goal_matches_contract,
 )
 from omh.runtime.artifacts import show_run  # noqa: E402
+from omh.system.local_store import atomic_write_json  # noqa: E402
 from omh.system.paths import OmhPaths  # noqa: E402
 
 _GOAL = "split the sample feature across agents"
@@ -211,6 +216,59 @@ class FanoutDispatchEngineTests(unittest.TestCase):
 
             by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
             self.assertEqual(by_unit["core"]["status"], "executor_not_ready")
+            self.assertFalse((paths.runtime_runs_dir / by_unit["core"]["run_ref"]).exists())
+            # No card when the probe carried none: `missing` is already a named
+            # gap, and inventing a repair path here would be a claim.
+            self.assertNotIn("repair_card", by_unit["core"])
+
+    def test_a_stale_owner_carries_its_repair_card_into_the_unit_result(self) -> None:
+        """The #837 recheck at the handoff boundary: a decision that no longer
+        describes this machine reads `stale`, and the unit result says which
+        prerequisite moved instead of only that the owner was not ready."""
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            binding = live_readiness_binding(paths, "codex")
+            atomic_write_json(
+                paths.executor_readiness_path,
+                {
+                    "schema_version": "executor_readiness_cache/v1",
+                    "profiles": {
+                        "codex": {
+                            "schema_version": "executor_readiness/v1",
+                            "profile": "codex",
+                            "status": "ready",
+                            "observed_once": True,
+                            "updated_at": "2026-01-01T00:00:00Z",
+                            "readiness_binding": {
+                                **binding,
+                                "axes": {**binding["axes"], "tool": "0" * 64},
+                            },
+                        }
+                    },
+                },
+                private=True,
+            )
+
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                runner=_agent_runner(),
+                readiness=probe_executor_readiness,
+                # The real probe runs here, so keep it to the one owner whose
+                # cache this test seeded: an unseeded owner would probe its CLI
+                # for real and make the test depend on the host's PATH.
+                only_units=["core"],
+            )
+
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            self.assertEqual(by_unit["core"]["status"], "executor_not_ready")
+            self.assertEqual(by_unit["core"]["readiness_status"], "stale")
+            card = by_unit["core"]["repair_card"]
+            self.assertEqual(card["changed_axes"], ["tool"])
+            self.assertEqual(card["status"], "prepared_not_observed")
             self.assertFalse((paths.runtime_runs_dir / by_unit["core"]["run_ref"]).exists())
 
     def test_dry_run_plans_without_spawning_or_creating_runs(self) -> None:


### PR DESCRIPTION
## Feature Report

### What Changed

- A coding-owner readiness decision now **expires** and is **invalidated by a
  changed prerequisite**. It used to be permanent: `_cached_profile` returned
  any entry carrying `observed_once` with no age check, `updated_at` was
  written at write time and never read back, and `force=True` was the only
  thing that re-probed.
- New `pre_handoff_readiness/v1` verdict on every readiness read: `fresh`,
  `never_observed`, `unbound`, `changed`, `expired`,
  `evidence_prepared_only`, or `evidence_expired`, with the reason written out.
- New `pre_handoff_repair_card/v1`: a deterministic, closed-key-set card that
  names the missing prerequisite and the commands that close it. Validated in
  both directions (nothing missing, nothing extra).
- `omh coding executor-readiness` reports `status: "stale"` instead of `ready`
  when the stored decision no longer describes this machine, and carries the
  card. `omh coding fanout dispatch` carries the same card into its
  `executor_not_ready` unit result. The choose-executor context applies the
  same rule so a candidate whose CLI is gone cannot rank first.

### Why This Exists

Issue #837. A coding owner that was ready during setup can later lose a
required tool, a permission, a workspace binding, or a supported capability.
Before this change OMH could not notice: the first readiness observation on a
machine was also the last one. A person who uninstalled `codex`, changed the
safety profile, or moved to a different checkout still got `ready`, and the
handoff was dispatched into a gap nobody had been told about.

`updated_at` was already being written — it was simply never read. The fix is
to read it, plus bind the decision to the inputs whose change invalidates it.

### User / Operator Impact

Before: `omh coding executor-readiness --executor codex` answered `ready`
forever after the first successful probe, on any PATH, in any checkout, under
any safety profile.

After, observed on this branch (real runs, see Validation):

| Situation | Before | After |
| --- | --- | --- |
| Observation older than 6h | `ready` | `stale`, `readiness_expired` |
| `codex` no longer on PATH | `ready` | `stale`, `changed_axes: ["tool"]` |
| Same cache, different checkout | `ready` | `stale`, `changed_axes: ["workspace"]` |
| Safety profile revision changed | `ready` | `stale`, `changed_axes: ["permission"]` |
| Profile identity / ready action changed | `ready` | `stale`, `changed_axes: ["profile"]` |
| Capability snapshot with no host-observed capability | `ready` | `stale`, `capability_evidence_prepared_only` |

Instead of dispatching, the payload explains the gap and offers a repair path:

```json
{
  "state": "expired",
  "reason": "The stored readiness observation for Codex is older than 6 hours, so it is expired rather than current.",
  "missing_prerequisites": ["a readiness observation newer than 6 hours"],
  "repair_steps": [
    {"id": "restore_prerequisite", "command": "codex --version"},
    {"id": "reobserve_readiness", "command": "omh coding executor-readiness --executor codex --force"}
  ],
  "status": "prepared_not_observed",
  "blocked_action": "coding_handoff_dispatch"
}
```

OMH does not repair anything. `status` is `prepared_not_observed` and the claim
boundary says so explicitly: no tool was installed, no permission was changed,
nothing was re-probed. `--force` remains the only thing that replaces a stored
observation.

### How It Works

**Freshness is derived at read time.** `updated_at` plus a module-level
`READINESS_STALE_AFTER_SECONDS` (6h — the same horizon
`action_gate.ACCOUNT_SIGNAL_STALE_AFTER_SECONDS` gives an account signal and
the same one the limit-signal advisory already reports as `stale`). No expiry
deadline is written into the record, following `action_gate._account_state`, so
shortening the horizon takes effect on records already on disk instead of only
on records written afterwards. An unreadable or future stamp reads as older
than every horizon, for the reason `_stamp_age_seconds` gives: neither can be
shown to be fresh, and clamping would make editing a stored timestamp a way to
widen the window from disk.

**Invalidation on change is a per-axis digest.** `live_readiness_binding()`
computes one SHA-256 per axis:

| Axis | Bound to | Read from |
| --- | --- | --- |
| `profile` | label, ready action, probe kind | `executors` / `_ready_action` |
| `tool` | probe command, args, every PATH resolution | `_path_resolutions` |
| `permission` | safety profile revision | `quality.safety_preflight.safety_profile_revision()` |
| `workspace` | repository root, or the store home outside one | `paths.find_project_root` |

Per-axis rather than one overall digest, because a single digest can only say
"something changed" and the person then has to guess what. The binding carries
**no timestamp** — it is compared for equality, and a wall clock inside a
compared payload makes equality a race on a slow CI runner. `now` is a
parameter throughout, so every derivation is deterministic under test.

**Capability evidence is re-checked at dispatch time.**
`executor_capability_snapshots` already validates that `observed_at` sits within
24h *of `recorded_at`* — at record time only. The same window is now applied
against the clock now, and a snapshot with no `host_observed` capability is
prepared-only evidence that can never carry a ready decision. Absence of a
snapshot is not treated as prepared-only: with no snapshot on disk there is no
capability claim riding the handoff, so readiness stands on its own probe
evidence.

**A stale decision is never silently re-probed.** Re-probing on staleness would
hide a missing tool behind a subprocess run nobody asked for, which is the same
mid-dispatch surprise #837 exists to remove, only later. The invalidated read
does not rewrite the stored decision either — a guard test asserts the state
file is byte-identical before and after.

**Executor-neutral contract, executor-specific values (AC3).** The repair card
has one closed key set for every owner. Codex, Claude Code, the Hermes runtime,
generic, and the oh-my runtimes differ only in `profile`, `label`, `reason`,
`repair_steps[].command`, and `verify_command`. A probeable profile confirms its
own CLI (`codex --version`, `claude --version`); a wrapper-observed profile has
no CLI to confirm and gets `omh doctor` in the same field. `reason_code`,
`missing_prerequisites`, `blocked_action`, `state`, and `claim_boundary` read
identically across owners — a test asserts exactly that set difference.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/coding/pre_handoff_readiness.py` | **New.** Pure derivation: `readiness_binding`, `evaluate_pre_handoff_readiness`, `build_pre_handoff_repair_card`, `validate_pre_handoff_repair_card`. No I/O, no JSON serialization (the digest uses the repo's unit-separator encoding, per the efficiency contract cited in `skill_governance.policy_decision_digest`). |
| `src/coding/executor_readiness.py` | `probe_executor_readiness` gains `now`, runs the verdict on the cached branch, downgrades to `stale` and attaches the card. New `live_readiness_binding`, `_workspace_ref`, `_capability_snapshot`, `_repair_command`. `_write_state` persists `readiness_binding`. `executor_choice_context` gains `now` and the same downgrade. |
| `src/coding/fanout_dispatch.py` | `executor_not_ready` unit results carry `repair_card` when the probe produced one. |
| `src/system/paths.py` | New `executor_capability_snapshots_dir` property, so the recheck and the snapshot CLI cannot drift to different folders. |
| `src/commands/coding.py` | `_capability_snapshot_path` uses that property instead of an inline path. |
| `docs/INSTALLATION.md`, `docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md`, `docs/CHAT_WRAPPER_EXAMPLES.md` | These told wrappers to probe once and cache the result — now false. Rewritten to the recheck-before-dispatch contract, with the `stale` path and the repair card documented. |
| `docs/FANOUT.md` | New "Owner-readiness integrity" boundary bullet beside goal integrity and safety-profile integrity. |
| `docs/ARCHITECTURE.md` | New module listed under `coding/`. |

No generated artifact changed: no catalog, skill, role, demo-card, or
capability-family data was touched, and all four byte gates pass unchanged.

**Schema versions added:** `pre_handoff_readiness/v1`,
`pre_handoff_repair_card/v1`, `executor_readiness_binding/v1`.

### Existing Expectations That Changed

Two, both deliberate, both commented in place:

1. `tests/test_executor_auth_signals.py::ReadinessAdvisoryFreshnessTests::test_advisories_refresh_while_probe_stays_cached`
   seeded a cache entry with only `observed_once: True` and asserted
   `cache_status == "cached"`. Under the new contract `observed_once` alone no
   longer keeps a decision usable, so the fixture now also carries `updated_at`
   and a `readiness_binding`. The test's actual point — advisory login/limit
   markers refresh while the probe stays cached — is unchanged and still
   asserted.
2. `tests/test_fanout_dispatch.py::test_readiness_refusal_skips_unit_without_fabricating_a_run`
   gained one assertion: a probe that reported `missing` carries no repair
   card. `missing` is already a named gap and inventing a repair path there
   would be a claim.

Nothing else in the suite depended on "observed once stays ready forever."

**Behavior change for existing installs:** readiness entries written before
this change carry no binding, so the first read after upgrade reports
`readiness_unbound` — "this decision predates input binding, so no changed
prerequisite can be ruled out" — and asks for one forced re-probe per profile.
That is one `--force` per executor, once, and it is the honest answer: an
unbound entry genuinely cannot be shown to still describe the machine.

## Validation

- [x] `uv run --group lint ruff check src tests` — `All checks passed!`
- [x] `python3 -m unittest discover -s tests` — run as
      `PYTHONPATH=tests uv run python -m unittest discover -s tests`:
      **Ran 4426 tests in 170.608s — OK**, on the branch rebased onto
      `origin/main` (`8dec02ad`).
- [x] `python3 -m compileall src` — run as
      `uv run python -m compileall -q src tests`, clean.
- [x] `python3 -m omh.cli docs workflows --check` — `ok:true`,
      `tap_skills: 115/115`, no missing/stale/extra.
- [x] `python3 -m omh.cli harness validate` —
      `{"counts":{"harnesses":72,"skills":104},"errors":[],"ok":true}`
- [x] `python3 -m omh.cli release checklist --json` — emits the checklist.
- [x] `python3 -m omh.cli release hermes-smoke` — plan mode, completes; its own
      boundary note applies (plan mode is not evidence Hermes loaded OMH).
- [x] `omh --help` — run as `uv run python -m omh.cli --help`.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — **not run.** No installer, packaging, or command-path surface changed.
- [ ] Relevant workflow-learning review queue smoke — **not applicable.** No learning contract changed.
- [x] Relevant dry-run or smoke command — see below.
- [ ] Manual Hermes/TUI check — **not run.** This machine has no Hermes profile bound to this worktree, and the change is a JSON contract plus CLI payload; no Hermes rendering surface was modified. The wrapper-facing behavior is covered by the CLI smoke and the unit tests.

Additional gates this repo requires beyond the template:

- `uv run python -m omh.cli docs roles --check` — `ok:true`
- `uv run python -m omh.cli docs capability-families --check` — `ok:true`
- `git diff --check` — clean

### Observed CLI Smoke

Against a scratch `--omh-home`, on this branch. Steps 4 and 5 are real
environment changes, not fixtures:

```text
1. --force                      -> status: ready | summary: codex-cli 0.145.0
   stored entry                 -> axes: permission, profile, tool, workspace
2. no --force (fresh)           -> status: ready | cache_status: cached
                                   freshness: fresh / readiness_fresh
3. updated_at aged past 6h      -> status: stale | available: false
                                   cache_status: invalidated
                                   next_action: repair_prerequisite_then_force_readiness_probe
                                   repair card: missing_prerequisites =
                                     ["a readiness observation newer than 6 hours"]
4. re-observed, then run with
   PATH=/usr/bin:/bin           -> status: stale | changed_axes: ["tool"]
                                   "the executor command that was observed on PATH"
5. same cache, run from a
   different repository root    -> status: stale | changed_axes: ["workspace"]
                                   "the workspace this decision was observed in"
```

### New Test Coverage

`tests/test_executor_readiness_freshness.py`, 32 tests:

- **AC1** — prepared-only capability evidence and expired capability evidence
  are never usable; a stale observation never reads `ready` through
  `probe_executor_readiness`; plus a control case proving the AC1 cases are not
  passing for the wrong reason, and a host-observed-inside-window case proving
  the check is not simply always-fail.
- **AC2** — one test per axis (`profile`, `tool`, `permission`, `workspace`),
  each asserting the decision reads `ready` first and `stale` after, with
  `changed_axes == [axis]` and the axis named in the reason. Backed by
  `test_each_input_moves_exactly_its_own_axis`, which proves a changed input
  moves that axis's digest and no other — so the end-to-end cases are not
  tautologies — and by `test_a_workspace_move_changes_the_live_binding`.
- **AC3** — five owners (`codex`, `claude-code`, `hermes`, `generic`,
  `omo-runtime`) produce the same closed key set and the same repair-step
  shape; two owners differ in exactly `{profile, label, reason, repair_steps,
  verify_command}`; the Hermes runtime is exercised as a first-class owner.
- **Validator** — both directions (missing key, extra key) plus claimed-repair,
  unsupported axis, contradicting reason code, dropped repair step.
- **Guards** — a stale decision does not re-probe and does not rewrite the
  stored state file (byte comparison); `force=True` is what replaces it and
  rebinds the entry.
- Plus the on-disk prepared-only snapshot path, the choose-executor downgrade,
  and the legacy unbound entry.

`tests/test_fanout_dispatch.py` gains
`test_a_stale_owner_carries_its_repair_card_into_the_unit_result`, which runs
the real probe against a seeded stale cache and asserts the unit comes back
`executor_not_ready` with `readiness_status: "stale"` and
`repair_card.changed_axes == ["tool"]`.

## Risk

- **Existing installs see one `stale` result per profile after upgrade.**
  Described above; the recovery is a single documented `--force` and the card
  says so. The alternative — trusting unbound entries — would leave the #837
  defect live for every machine that already has a cache, which is all of them.
- **Six hours is a judgement call.** It matches
  `ACCOUNT_SIGNAL_STALE_AFTER_SECONDS` and the limit-signal advisory so the
  surfaces do not disagree about the same machine, and because the horizon is
  derived at read time it can be changed without a migration.
- **`workspace` binds to the repository root, so a legitimate move between
  checkouts costs one re-probe.** That is the intended trade: a per-user
  readiness cache is shared across every checkout on the machine, and reusing
  one checkout's decision in another is exactly what #837 lists as an
  invalidating change.
- **`executor_choice_context` now does a little more local work** — one
  `safety_profile_revision()`, one PATH walk, and one snapshot read per
  candidate (3 candidates). Still no subprocess and no network. The efficiency
  suite is green.
- **Blast radius is contained to the readiness lane.** No generated artifact,
  no catalog, no routing case, no skill, and no exact-count assertion moved.

## Compatibility / Rollout

- Additive on the wire: `pre_handoff_readiness` and `repair_card` are new keys
  on an existing payload. A reader that only looks at `status` keeps working
  and simply sees the new `stale` value where it used to see a stale `ready`.
- The cache file gains `readiness_binding` per profile. Old entries without it
  are handled explicitly (`readiness_unbound`), not crashed on.
- `probe_executor_readiness(..., now=...)` and
  `executor_choice_context(..., now=...)` are keyword-only with defaults; every
  existing call site is unchanged.
- Windows: no new file writes from tests; the fixtures go through
  `atomic_write_json`, and the digest inputs are path strings the platform
  produces, compared only against digests computed in the same process.

## Release / Claims

- [x] Release-channel impact considered — `local`. No installer, packaging, or
      version surface changed; the feature is live as soon as the code ships.
- [x] Runtime/native capability claims are backed by evidence or marked as not
      observed. The repair card is `prepared_not_observed` by construction, the
      validator rejects any other `status`, and a test asserts it.
- [x] Known manual Hermes checks are listed — the `--live` hermes-smoke gap and
      the missing Hermes/TUI render of the repair card are both stated above.

## Follow-Up

- The generated skill guidance (`src/skills/render.py`) still says "check
  `executor_readiness/v1` … before first dispatch". That sentence is now
  incomplete rather than wrong; updating it regenerates 115 `SKILL.md` files
  and `docs/WORKFLOWS.md`, which is a wide diff for one clause and belongs in
  its own change.
- `pre_handoff_repair_card/v1` is currently surfaced by the readiness CLI and
  the fanout unit result. Rendering it in the wrapper chat card
  (`executor_runtime_readiness_card/v1`) would put the repair path in front of
  the person who needs it without them running a control-plane command.
