### PR TITLE
feat: explain and repair workflow-name conflicts before behavior changes

### DIFF
--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -728,7 +728,7 @@ def _doctor_operator_summary(checks: list[object]) -> dict[str, object]:
             _doctor_group("command", check_dicts, ("command_path",)),
             _doctor_group("managed_skills", check_dicts, ("manifest", "manifest_skills_dir", "local_modifications", "skill_freshness", "skills_dir", "skill:", "guidance_projection")),
             _doctor_group("runtime", check_dicts, ("runtime_artifacts", "workflow_state", "runtime_state")),
-            _doctor_group("hermes_registration", check_dicts, ("hermes_config", "external_dir", "skill_shadowing", "runtime_context")),
+            _doctor_group("hermes_registration", check_dicts, ("hermes_config", "external_dir", "identity_conflicts", "runtime_context")),
             _doctor_group("targets", check_dicts, ("target_registry", "target_topology")),
             _doctor_group("optional_surfaces", check_dicts, ("plugin_", "team_profile_packs")),
         ],

--- a/src/install/identity_conflicts.py
+++ b/src/install/identity_conflicts.py
@@ -1,0 +1,493 @@
+"""Every OMH-facing local name that a second visible source also claims.
+
+Doctor already scanned foreign configured skill directories for names matching
+OMH's core skills. Three things were missing, and #815 needs all three.
+
+Coverage. The scan saw skill directory names and nothing else. The two other
+surfaces carrying an OMH-facing name -- the tools the managed bridge registers
+and the lifecycle hooks it subscribes to -- were invisible, so "why did a
+familiar command trigger the wrong workflow" had no answer at all when the
+competing source was a second local plugin rather than a second skill directory.
+
+Attribution. A collision was one line of text naming the foreign directory. It
+never said which side of the contest OMH owns, so an operator could not tell
+"OMH installed this twice" from "something else took the name", and those need
+opposite repairs. Ownership here is read from the install manifests --
+`manifest.json` for skills, `.omh-plugin-manifest.json` for the bridge -- never
+inferred from what a path looks like. A directory named `omh` that OMH did not
+install is precisely the case the attribution exists to catch, and a path-shaped
+guess would call it OMH's own.
+
+Precedence. OMH cannot read Hermes' resolution order from here, so a contested
+name is reported as `unknown` and never as a resolved winner. `uncontested` is
+reserved for a scan that actually enumerated every source and found no contest;
+an unreadable directory or a Hermes config that could not be read keeps the
+answer `unknown`, because "nothing was found" and "nothing was looked at" are
+different statements.
+
+Nothing in this module writes, moves, renames, or deletes. It reads directory
+names, `plugin.yaml` declarations, and two manifests, and returns a report. The
+repair it names is always the operator's to perform.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ..plugin_bundle.omh.metadata import PROVIDED_HOOKS, PROVIDED_TOOLS
+from ..skills.catalog import CORE_SKILLS
+from .plugin_pack import PLUGIN_NAME, PLUGIN_SCHEMA_VERSION, read_plugin_manifest
+
+IDENTITY_CONFLICT_REPORT_SCHEMA_VERSION = "identity_conflict_report/v1"
+
+# The three local surfaces that carry a user-visible OMH name. `command` is the
+# tool name Hermes exposes to the model; the issue's vocabulary calls it a
+# command and so does this report.
+SOURCE_KINDS = ("command", "hook", "skill")
+# Two values only. There is no `unknown` ownership: every source counted here
+# either appears in an OMH install manifest or does not, and treating "no
+# manifest record" as unknown would let an unattributed source quietly borrow
+# OMH's side of a contest.
+OWNERSHIPS = ("omh_managed", "user_owned")
+PRECEDENCE_STATES = ("uncontested", "unknown")
+CONFLICT_SEVERITIES = ("blocking", "warning")
+REPORT_SEVERITIES = ("blocking", "ok", "warning")
+
+# Whether an unknown precedence is a warning or a blocker is decided by one
+# question, and it is not ownership: after the contest, is the OMH side still
+# reachable under some name?
+#
+#   blocking -- `command`. Hermes exposes one tool per name to the model, so a
+#     second local plugin declaring `omh_status` means at most one of the two
+#     registrations answers and OMH cannot say which. The user-visible result is
+#     a capability that is installed and absent at the same time; no phrasing in
+#     chat recovers it, and every other doctor check still reports green.
+#
+#   warning -- `skill` and `hook`. Both sides stay installed and reachable. A
+#     shadowed skill directory still resolves to whichever source wins and the
+#     other workflow can be asked for by name, and Hermes' hook names are
+#     lifecycle events that every plugin subscribes to, so an overlap there is a
+#     second subscriber rather than a stolen slot. Worth reporting -- it is the
+#     honest answer to "why did that trigger the wrong workflow" -- and not
+#     worth failing an install over.
+#
+# Ownership deliberately does not decide this. AC3 forbids OMH from touching a
+# user-owned asset, so keying severity to ownership would paint the ordinary
+# case permanently red while telling the operator nothing they can act on.
+EXCLUSIVE_NAME_KINDS = frozenset({"command"})
+
+IDENTITY_CONFLICT_CLAIM_BOUNDARY = (
+    "This is a read-only scan of locally visible sources: configured skill directories, "
+    "installed Hermes plugin declarations, and OMH's own install manifests. Hermes runtime "
+    "precedence is not observed, so a contested name has no resolved winner here. Nothing is "
+    "renamed, rewritten, or removed by this diagnosis."
+)
+
+IDENTITY_CONFLICT_REPORT_KEYS = (
+    "claim_boundary",
+    "conflicts",
+    "next_action",
+    "precedence",
+    "scanned",
+    "schema_version",
+    "severity",
+    "unreadable",
+)
+IDENTITY_CONFLICT_KEYS = ("kind", "name", "severity", "sources")
+IDENTITY_CONFLICT_SOURCE_KEYS = ("location", "ownership")
+IDENTITY_CONFLICT_SCANNED_KEYS = ("plugin_dirs", "skill_dirs")
+
+_OMH_PLUGIN_MANIFEST_PACKAGE = "oh-my-hermes"
+
+
+def build_identity_conflict_report(
+    *,
+    skills_dir: Path,
+    manifest: dict[str, Any] | None,
+    plugins_dir: Path,
+    configured_skill_dirs: list[str] | None,
+) -> dict[str, Any]:
+    """Report every contested OMH-facing name with all of its visible sources.
+
+    `configured_skill_dirs` is `None` when the Hermes config could not be read
+    at all. That is not the same as an empty list: an empty list means Hermes
+    was asked and registers no foreign directory, while `None` means the
+    question went unanswered, and only the first of those may end in
+    `uncontested`.
+    """
+    unreadable: list[str] = []
+    if configured_skill_dirs is None:
+        unreadable.append(
+            "Hermes config was not read, so configured skill directories could not be enumerated"
+        )
+    foreign_dirs = _foreign_skill_dirs(skills_dir, configured_skill_dirs or [], unreadable)
+    conflicts = _skill_conflicts(skills_dir, manifest, foreign_dirs, unreadable)
+    plugin_sources = _plugin_sources(plugins_dir, unreadable)
+    conflicts.extend(_plugin_conflicts(plugin_sources))
+    conflicts.sort(key=lambda conflict: (conflict["kind"], conflict["name"]))
+    unreadable.sort()
+    severity = _severity(conflicts, unreadable)
+    return {
+        "schema_version": IDENTITY_CONFLICT_REPORT_SCHEMA_VERSION,
+        "precedence": "uncontested" if severity == "ok" else "unknown",
+        "severity": severity,
+        "conflicts": conflicts,
+        "unreadable": unreadable,
+        "scanned": {"plugin_dirs": len(plugin_sources), "skill_dirs": len(foreign_dirs)},
+        "next_action": _next_action(conflicts, unreadable),
+        "claim_boundary": IDENTITY_CONFLICT_CLAIM_BOUNDARY,
+    }
+
+
+def validate_identity_conflict_report(payload: Any) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(payload, dict):
+        return ["identity_conflict_report must be an object"]
+    extra = sorted(set(payload) - set(IDENTITY_CONFLICT_REPORT_KEYS))
+    if extra:
+        errors.append(f"identity_conflict_report has unsupported keys: {extra}")
+    missing = sorted(set(IDENTITY_CONFLICT_REPORT_KEYS) - set(payload))
+    if missing:
+        errors.append(f"identity_conflict_report is missing keys: {missing}")
+    if payload.get("schema_version") != IDENTITY_CONFLICT_REPORT_SCHEMA_VERSION:
+        errors.append(
+            f"identity_conflict_report schema_version must be {IDENTITY_CONFLICT_REPORT_SCHEMA_VERSION}"
+        )
+    if payload.get("precedence") not in PRECEDENCE_STATES:
+        errors.append(f"identity_conflict_report precedence must be one of {list(PRECEDENCE_STATES)}")
+    if payload.get("severity") not in REPORT_SEVERITIES:
+        errors.append(f"identity_conflict_report severity must be one of {list(REPORT_SEVERITIES)}")
+    for key in ("claim_boundary", "next_action"):
+        if not isinstance(payload.get(key), str) or not payload.get(key):
+            errors.append(f"identity_conflict_report {key} must be a non-empty string")
+    errors.extend(_validate_unreadable(payload.get("unreadable")))
+    errors.extend(_validate_scanned(payload.get("scanned")))
+    errors.extend(_validate_conflicts(payload.get("conflicts")))
+    errors.extend(_validate_consistency(payload))
+    return errors
+
+
+def _validate_unreadable(unreadable: Any) -> list[str]:
+    if not isinstance(unreadable, list) or not all(isinstance(item, str) for item in unreadable):
+        return ["identity_conflict_report unreadable must be a list of strings"]
+    if list(unreadable) != sorted(unreadable):
+        return ["identity_conflict_report unreadable must be sorted"]
+    return []
+
+
+def _validate_scanned(scanned: Any) -> list[str]:
+    if not isinstance(scanned, dict):
+        return ["identity_conflict_report scanned must be an object"]
+    if sorted(scanned) != sorted(IDENTITY_CONFLICT_SCANNED_KEYS):
+        return [f"identity_conflict_report scanned keys must be {list(IDENTITY_CONFLICT_SCANNED_KEYS)}"]
+    errors: list[str] = []
+    for key in IDENTITY_CONFLICT_SCANNED_KEYS:
+        value = scanned.get(key)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            errors.append(f"identity_conflict_report scanned {key} must be a non-negative integer")
+    return errors
+
+
+def _validate_conflicts(conflicts: Any) -> list[str]:
+    if not isinstance(conflicts, list):
+        return ["identity_conflict_report conflicts must be a list"]
+    errors: list[str] = []
+    order: list[tuple[str, str]] = []
+    for conflict in conflicts:
+        if not isinstance(conflict, dict):
+            errors.append("identity_conflict_report conflict must be an object")
+            continue
+        if sorted(conflict) != sorted(IDENTITY_CONFLICT_KEYS):
+            errors.append(f"identity_conflict_report conflict keys must be {list(IDENTITY_CONFLICT_KEYS)}")
+            continue
+        kind = conflict.get("kind")
+        if kind not in SOURCE_KINDS:
+            errors.append(f"identity_conflict_report conflict kind must be one of {list(SOURCE_KINDS)}")
+        if not isinstance(conflict.get("name"), str) or not conflict.get("name"):
+            errors.append("identity_conflict_report conflict name must be a non-empty string")
+        if conflict.get("severity") not in CONFLICT_SEVERITIES:
+            errors.append(
+                f"identity_conflict_report conflict severity must be one of {list(CONFLICT_SEVERITIES)}"
+            )
+        elif conflict.get("severity") != ("blocking" if kind in EXCLUSIVE_NAME_KINDS else "warning"):
+            errors.append(f"identity_conflict_report conflict severity does not match the rule for kind {kind!r}")
+        errors.extend(_validate_sources(conflict.get("sources")))
+        order.append((str(kind), str(conflict.get("name", ""))))
+    if order != sorted(order):
+        errors.append("identity_conflict_report conflicts must be sorted by (kind, name)")
+    return errors
+
+
+def _validate_sources(sources: Any) -> list[str]:
+    if not isinstance(sources, list) or len(sources) < 2:
+        # One source is not a contest. A conflict entry naming a single source
+        # would claim a competitor the scan never found.
+        return ["identity_conflict_report conflict sources must list at least two sources"]
+    errors: list[str] = []
+    ownerships: set[str] = set()
+    locations: list[str] = []
+    for source in sources:
+        if not isinstance(source, dict) or sorted(source) != sorted(IDENTITY_CONFLICT_SOURCE_KEYS):
+            errors.append(f"identity_conflict_report source keys must be {list(IDENTITY_CONFLICT_SOURCE_KEYS)}")
+            continue
+        if source.get("ownership") not in OWNERSHIPS:
+            errors.append(f"identity_conflict_report source ownership must be one of {list(OWNERSHIPS)}")
+        if not isinstance(source.get("location"), str) or not source.get("location"):
+            errors.append("identity_conflict_report source location must be a non-empty string")
+        ownerships.add(str(source.get("ownership")))
+        locations.append(str(source.get("location")))
+    if locations != sorted(locations):
+        errors.append("identity_conflict_report conflict sources must be sorted by location")
+    if len(set(locations)) != len(locations):
+        errors.append("identity_conflict_report conflict sources must not repeat a location")
+    if not errors and ownerships != set(OWNERSHIPS):
+        # A managed asset colliding with itself is not a conflict, and neither
+        # is a contest OMH takes no part in.
+        errors.append("identity_conflict_report conflict must name one omh_managed and one user_owned source")
+    return errors
+
+
+def _validate_consistency(payload: dict[str, Any]) -> list[str]:
+    conflicts = payload.get("conflicts")
+    unreadable = payload.get("unreadable")
+    if not isinstance(conflicts, list) or not isinstance(unreadable, list):
+        return []
+    errors: list[str] = []
+    expected_severity = _severity(
+        [conflict for conflict in conflicts if isinstance(conflict, dict)],
+        [str(item) for item in unreadable],
+    )
+    if payload.get("severity") != expected_severity:
+        errors.append(f"identity_conflict_report severity must be {expected_severity} for these conflicts")
+    if payload.get("precedence") != ("uncontested" if expected_severity == "ok" else "unknown"):
+        errors.append("identity_conflict_report precedence must be unknown unless the scan was complete and clean")
+    return errors
+
+
+def _severity(conflicts: list[dict[str, Any]], unreadable: list[str]) -> str:
+    if any(conflict.get("severity") == "blocking" for conflict in conflicts):
+        return "blocking"
+    if conflicts or unreadable:
+        return "warning"
+    return "ok"
+
+
+def _next_action(conflicts: list[dict[str, Any]], unreadable: list[str]) -> str:
+    if any(conflict.get("severity") == "blocking" for conflict in conflicts):
+        return (
+            "Rename or uninstall the competing tool name in the local plugin OMH did not install, then rerun "
+            "`omh doctor`; OMH will not edit or remove a plugin it does not own."
+        )
+    if conflicts:
+        return (
+            "Rename or unregister whichever competing source you own, then rerun `omh doctor`; OMH does not "
+            "rename or delete assets it did not install."
+        )
+    if unreadable:
+        return "Repair or re-read the reported source, then rerun `omh doctor` for a complete scan."
+    return (
+        "No conflict repair needed. Hermes runtime precedence stays unobserved until a host observation "
+        "records it."
+    )
+
+
+def _foreign_skill_dirs(skills_dir: Path, configured_dirs: list[str], unreadable: list[str]) -> list[Path]:
+    """Configured skill directories that are not OMH's own managed directory."""
+    try:
+        managed = skills_dir.expanduser().resolve(strict=False)
+    except (OSError, RuntimeError) as error:
+        managed = None
+        unreadable.append(f"managed skill directory {skills_dir}: {error}")
+    seen: set[Path] = set()
+    foreign: list[Path] = []
+    for raw_dir in configured_dirs:
+        try:
+            candidate = Path(raw_dir).expanduser().resolve(strict=False)
+        except (OSError, RuntimeError) as error:
+            unreadable.append(f"{raw_dir}: {error}")
+            continue
+        if candidate == managed or candidate in seen:
+            continue
+        seen.add(candidate)
+        foreign.append(candidate)
+    return foreign
+
+
+def _managed_skill_locations(skills_dir: Path, manifest: dict[str, Any] | None) -> dict[str, str]:
+    """Contested skill name -> the installed location OMH owns, per the manifest.
+
+    Keyed by both the canonical catalog name and the installed directory name,
+    because those diverged when installs moved to display-labelled directories:
+    Hermes discovers `omh-doctor` on disk while the router and the operator both
+    say `doctor`, and a foreign directory under either spelling is a contest.
+
+    A managed location is recorded only when the manifest accounts for it. A
+    file sitting under `skills_dir` that no record explains is not something OMH
+    installed, and letting it stand in for OMH's side would fabricate a
+    competitor.
+    """
+    core = frozenset(CORE_SKILLS)
+    locations: dict[str, str] = {}
+    for record in (manifest or {}).get("skills", []):
+        if not isinstance(record, dict):
+            continue
+        name = str(record.get("name", ""))
+        rel = str(record.get("path", ""))
+        if name not in core or not rel:
+            continue
+        directory = Path(rel).parent
+        location = str(skills_dir / directory)
+        locations[name] = location
+        if directory.name:
+            locations[directory.name] = location
+    return locations
+
+
+def _skill_conflicts(
+    skills_dir: Path,
+    manifest: dict[str, Any] | None,
+    foreign_dirs: list[Path],
+    unreadable: list[str],
+) -> list[dict[str, Any]]:
+    managed = _managed_skill_locations(skills_dir, manifest)
+    conflicts: list[dict[str, Any]] = []
+    for foreign_dir in foreign_dirs:
+        try:
+            children = list(foreign_dir.iterdir())
+        except OSError as error:
+            unreadable.append(f"{foreign_dir}: {error}")
+            continue
+        if not managed:
+            continue
+        for child in sorted(children, key=lambda item: item.name):
+            # Symlinks are skipped rather than followed: an alias of a directory
+            # already scanned would report the same contest twice.
+            if child.is_symlink() or not child.is_dir():
+                continue
+            location = managed.get(child.name)
+            if location is None:
+                continue
+            conflicts.append(_conflict("skill", child.name, [(location, "omh_managed"), (str(child), "user_owned")]))
+    return conflicts
+
+
+def _plugin_sources(plugins_dir: Path, unreadable: list[str]) -> list[dict[str, Any]]:
+    """Every locally installed Hermes plugin that declares tools or hooks."""
+    try:
+        children = sorted(plugins_dir.iterdir(), key=lambda item: item.name)
+    except FileNotFoundError:
+        # No plugins directory is the ordinary pre-install state, not a source
+        # the scan failed to read.
+        return []
+    except OSError as error:
+        unreadable.append(f"{plugins_dir}: {error}")
+        return []
+    sources: list[dict[str, Any]] = []
+    for child in children:
+        if child.is_symlink() or not child.is_dir():
+            continue
+        descriptor = child / "plugin.yaml"
+        if not descriptor.is_file():
+            continue
+        try:
+            text = descriptor.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as error:
+            unreadable.append(f"{descriptor}: {error}")
+            continue
+        sources.append(
+            {
+                "location": str(child),
+                "ownership": _plugin_ownership(child),
+                "command": _declared_names(text, "provides_tools"),
+                "hook": _declared_names(text, "provides_hooks"),
+            }
+        )
+    return sources
+
+
+def _plugin_ownership(plugin_dir: Path) -> str:
+    """Whether OMH's installer wrote this bundle, according to its install manifest.
+
+    Never inferred from the directory name. `~/.hermes/plugins/omh` created by
+    anyone else is a user-owned source claiming OMH's names -- exactly the
+    conflict this report exists to surface -- and a name-shaped guess would
+    silently classify it as OMH's own and report nothing.
+    """
+    manifest = read_plugin_manifest(plugin_dir)
+    if not isinstance(manifest, dict):
+        return "user_owned"
+    if str(manifest.get("schema_version", "")) != PLUGIN_SCHEMA_VERSION:
+        return "user_owned"
+    if str(manifest.get("plugin_name", "")) != PLUGIN_NAME:
+        return "user_owned"
+    if str(manifest.get("package", "")) != _OMH_PLUGIN_MANIFEST_PACKAGE:
+        return "user_owned"
+    return "omh_managed"
+
+
+def _plugin_conflicts(sources: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    conflicts: list[dict[str, Any]] = []
+    for kind, vocabulary in (("command", PROVIDED_TOOLS), ("hook", PROVIDED_HOOKS)):
+        for name in sorted(frozenset(vocabulary)):
+            claiming = [source for source in sources if name in source[kind]]
+            ownerships = {str(source["ownership"]) for source in claiming}
+            # Both sides are required. OMH's own bridge declaring a name it owns
+            # is not a conflict with itself, and a contest between two foreign
+            # plugins over a name OMH does not currently register is not OMH's
+            # to report.
+            if ownerships != set(OWNERSHIPS):
+                continue
+            conflicts.append(
+                _conflict(kind, name, [(str(source["location"]), str(source["ownership"])) for source in claiming])
+            )
+    return conflicts
+
+
+def _conflict(kind: str, name: str, sources: list[tuple[str, str]]) -> dict[str, Any]:
+    return {
+        "kind": kind,
+        "name": name,
+        "severity": "blocking" if kind in EXCLUSIVE_NAME_KINDS else "warning",
+        "sources": [{"location": location, "ownership": ownership} for location, ownership in sorted(sources)],
+    }
+
+
+def _declared_names(text: str, key: str) -> list[str]:
+    """Values under a top-level `key:` list in a Hermes `plugin.yaml`.
+
+    A hand-rolled reader for the same reason `install.config_adapter` has one:
+    the core carries no YAML dependency. It accepts the two shapes a plugin
+    descriptor uses in practice -- a block list and an inline list -- and reads
+    nothing else, so an unfamiliar shape yields no names rather than a guess.
+    """
+    names: list[str] = []
+    collecting = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not line.startswith(" ") and stripped:
+            head, separator, rest = stripped.partition(":")
+            if not separator or head.strip() != key:
+                collecting = False
+                continue
+            inline = rest.strip()
+            collecting = not inline
+            if inline:
+                names.extend(_inline_list(inline))
+            continue
+        if not collecting or not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("- "):
+            names.append(stripped[2:].strip().strip("\"'"))
+        else:
+            collecting = False
+    return [name for name in names if name]
+
+
+def _inline_list(value: str) -> list[str]:
+    if not (value.startswith("[") and value.endswith("]")):
+        return []
+    inner = value[1:-1].strip()
+    if not inner:
+        return []
+    return [item.strip().strip("\"'") for item in inner.split(",")]

--- a/src/maintenance/doctor.py
+++ b/src/maintenance/doctor.py
@@ -17,6 +17,7 @@ from ..config_adapter import (
 from ..hashutil import sha256_file, sha256_text
 from ..local_store import can_write_dir
 from ..install.guidance_projection import build_guidance_projection_status
+from ..install.identity_conflicts import build_identity_conflict_report
 from ..manifest import local_modifications, read_manifest
 from ..paths import OmhPaths
 from ..plugin_bundle.omh.memory_dreaming import read_dreaming_state, read_latest_consolidation
@@ -130,11 +131,15 @@ def run_doctor(paths: OmhPaths) -> list[Check]:
         checks.append(Check(f"skill:{skill}", path.exists(), str(path)))
     config_text = read_config(paths.hermes_config_path)
     dirs = external_dirs(config_text)
-    checks.append(Check("hermes_config", paths.hermes_config_path.exists(), f"{paths.hermes_config_path}"))
+    hermes_config_present = paths.hermes_config_path.exists()
+    checks.append(Check("hermes_config", hermes_config_present, f"{paths.hermes_config_path}"))
     # config.yaml stores external_dirs in POSIX form (config_adapter._normalize).
     external_registered = paths.skills_dir.as_posix() in dirs
     checks.append(Check("external_dir", external_registered, f"{paths.skills_dir} in skills.external_dirs"))
-    checks.append(_skill_shadowing_check(paths, dirs))
+    # `None`, not `dirs`, when the config is absent: `read_config` returns "" for
+    # a missing file, so an empty list there would read as "Hermes registers no
+    # foreign directory" when the truth is that Hermes was never asked.
+    checks.append(_identity_conflicts_check(paths, dirs if hermes_config_present else None, manifest))
     checks.append(_memory_provider_check(config_text))
     checks.append(_memory_consolidation_check(paths))
     checks.append(
@@ -361,65 +366,60 @@ def _memory_provider_check(config_text: str) -> Check:
     )
 
 
-def _skill_shadowing_check(paths: OmhPaths, configured_dirs: list[str]) -> Check:
-    """Report immediate foreign skill-directory name collisions without loading them."""
-    foreign_dirs: list[Path] = []
-    seen_dirs: set[Path] = set()
-    unreadable: list[str] = []
-    try:
-        managed_dir = paths.skills_dir.expanduser().resolve(strict=False)
-    except (OSError, RuntimeError) as error:
-        managed_dir = None
-        unreadable.append(f"managed skill directory {paths.skills_dir}: {error}")
-    for raw_dir in configured_dirs:
-        try:
-            candidate = Path(raw_dir).expanduser().resolve(strict=False)
-        except (OSError, RuntimeError) as error:
-            unreadable.append(f"{raw_dir}: {error}")
-            continue
-        if candidate == managed_dir or candidate in seen_dirs:
-            continue
-        seen_dirs.add(candidate)
-        foreign_dirs.append(candidate)
+def _identity_conflicts_check(
+    paths: OmhPaths,
+    configured_dirs: list[str] | None,
+    manifest: dict | None,
+) -> Check:
+    """Name every local source that also claims an OMH-facing skill, command, or hook.
 
-    collisions: list[str] = []
-    core_skill_names = frozenset(CORE_SKILLS)
-    for foreign_dir in foreign_dirs:
-        try:
-            children = list(foreign_dir.iterdir())
-        except OSError as error:
-            unreadable.append(f"{foreign_dir}: {error}")
-            continue
-        names = sorted(
-            child.name
-            for child in children
-            if not child.is_symlink() and child.is_dir() and child.name in core_skill_names
-        )
-        if names:
-            collisions.append(f"{foreign_dir}: {', '.join(names)}")
+    The question this answers is the one an operator actually asks: a familiar
+    request triggered the wrong workflow, or a bridge tool that is installed did
+    not answer -- what else on this machine holds that name? So the message
+    names both sides of every contest and says which side OMH installed, rather
+    than reporting that a foreign directory exists and leaving the operator to
+    work out whose it is.
 
-    boundary = "This is a local configured-directory scan only; Hermes runtime precedence is not observed."
-    if unreadable or collisions:
-        details = [
-            *collisions,
-            *[f"scan incomplete: unreadable external directory {item}" for item in unreadable],
-        ]
-        return Check(
-            "skill_shadowing",
-            True,
-            f"potential OMH core skill-name collision or unreadable external directory: {'; '.join(details)}. {boundary}",
-            severity="warning",
-            remediation="Review configured external skill directories and rename, remove, or repair the reported entries before relying on their skill names.",
-            next_action="Resolve the reported external skill directory entries, then rerun `omh doctor`; Hermes runtime precedence still requires separate observation.",
-        )
-    return Check(
-        "skill_shadowing",
-        True,
-        (
-            f"no potential OMH core skill-name collisions across {len(foreign_dirs)} foreign configured skill "
-            f"{'directory' if len(foreign_dirs) == 1 else 'directories'}. {boundary}"
-        ),
+    It never resolves the contest. `build_identity_conflict_report` reads local
+    declarations and OMH's install manifests; Hermes' load order is not among
+    them, so precedence stays `unknown` and this check never rewrites, renames,
+    or removes anything it found.
+    """
+    report = build_identity_conflict_report(
+        skills_dir=paths.skills_dir,
+        manifest=manifest,
+        plugins_dir=paths.hermes_plugins_dir,
+        configured_skill_dirs=configured_dirs,
     )
+    severity = str(report["severity"])
+    summary = _identity_conflict_summary(report)
+    if severity == "ok":
+        return Check("identity_conflicts", True, summary)
+    return Check(
+        "identity_conflicts",
+        severity != "blocking",
+        summary,
+        severity=severity,
+        remediation=str(report["next_action"]),
+        next_action=str(report["next_action"]),
+    )
+
+
+def _identity_conflict_summary(report: dict) -> str:
+    scanned = report["scanned"]
+    header = (
+        f"precedence={report['precedence']} conflicts={len(report['conflicts'])} "
+        f"scanned skill_dirs={scanned['skill_dirs']} plugin_dirs={scanned['plugin_dirs']}"
+    )
+    details = [
+        f"{conflict['kind']} name {conflict['name']} ({conflict['severity']}) claimed by "
+        + ", ".join(f"{source['ownership']} at {source['location']}" for source in conflict["sources"])
+        for conflict in report["conflicts"]
+    ]
+    details.extend(f"scan incomplete: {item}" for item in report["unreadable"])
+    if details:
+        return f"{header}: {'; '.join(details)}. {report['claim_boundary']}"
+    return f"{header}. {report['claim_boundary']}"
 
 
 def run_doctor_advisories(paths: OmhPaths) -> AdvisoryReport:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,7 @@ from omh.commands.main import build_parser
 from omh.commands.language import LANGUAGE_CODES, MESSAGES
 from omh.capabilities.families import CONCEPTUAL_WORKFLOW_SURFACES, capability_family_projection
 from omh.config_adapter import ensure_external_dir, external_dirs
-from omh.maintenance.doctor import _skill_shadowing_check
+from omh.maintenance.doctor import _identity_conflicts_check
 from omh.paths import resolve_paths
 from omh.plugin_bundle.omh.memory_governance import canonical_payload_digest
 from omh.record_revision import MAX_MUTATION_ID_CHARS
@@ -1758,8 +1758,9 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             clean_payload = json.loads(stdout)
             clean_checks = {check["name"]: check for check in clean_payload["checks"]}
             self.assertTrue(clean_payload["ok"])
-            self.assertEqual(clean_checks["skill_shadowing"]["severity"], "ok")
-            self.assertTrue(clean_checks["skill_shadowing"]["observed"])
+            self.assertEqual(clean_checks["identity_conflicts"]["severity"], "ok")
+            self.assertTrue(clean_checks["identity_conflicts"]["observed"])
+            self.assertIn("precedence=uncontested", clean_checks["identity_conflicts"]["message"])
 
             collision_name = installable_skill_names()[0]
             (foreign_skills / collision_name).mkdir(parents=True)
@@ -1774,7 +1775,7 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
                 status, stdout, stderr = run_cli(base + ["doctor"], output_json=False)
 
             self.assertEqual(status, 0, stderr)
-            self.assertIn("skill_shadowing:", stdout)
+            self.assertIn("identity_conflicts:", stdout)
             self.assertIn(collision_name, stdout)
             self.assertIn("Hermes runtime precedence is not observed", stdout)
 
@@ -1784,12 +1785,16 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             self.assertEqual(status, 0, stderr)
             payload = json.loads(stdout)
             checks = {check["name"]: check for check in payload["checks"]}
-            collision = checks["skill_shadowing"]
+            collision = checks["identity_conflicts"]
             self.assertTrue(payload["ok"])
             self.assertEqual(collision["severity"], "warning")
             self.assertTrue(collision["ok"])
             self.assertTrue(collision["observed"])
-            self.assertEqual(collision["message"].count(collision_name), 1)
+            # One contest, not five: the plain file, the differently-cased
+            # sibling, the nested copy, the symlink alias, and the second
+            # spelling of the same configured directory must not each mint one.
+            self.assertIn("conflicts=1", collision["message"])
+            self.assertIn(f"skill name {collision_name} (warning) claimed by", collision["message"])
             self.assertIn("Hermes runtime precedence is not observed", collision["message"])
             groups = {group["name"]: group for group in payload["summary"]["groups"]}
             self.assertEqual(groups["hermes_registration"]["status"], "warning")
@@ -1801,14 +1806,15 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             foreign_skills = root / "foreign-skills"
             foreign_skills.mkdir()
 
-            with patch("omh.maintenance.doctor.Path.iterdir", side_effect=OSError("permission denied")):
-                check = _skill_shadowing_check(paths, [str(foreign_skills)])
+            with patch("omh.install.identity_conflicts.Path.iterdir", side_effect=OSError("permission denied")):
+                check = _identity_conflicts_check(paths, [str(foreign_skills)], None)
 
         self.assertTrue(check.ok)
         self.assertEqual(check.severity, "warning")
         self.assertTrue(check.observed)
         self.assertIn("scan incomplete", check.message)
-        self.assertIn("unreadable external directory", check.message)
+        self.assertIn("permission denied", check.message)
+        self.assertIn("precedence=unknown", check.message)
         self.assertIn("Hermes runtime precedence is not observed", check.message)
 
     def test_doctor_reports_external_skill_path_resolution_failure_as_an_advisory_warning(self) -> None:
@@ -1816,8 +1822,8 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             root = Path(tmp)
             paths = resolve_paths(root / ".omh", root / ".hermes")
 
-            with patch("omh.maintenance.doctor.Path.resolve", side_effect=RuntimeError("symlink loop")):
-                check = _skill_shadowing_check(paths, [str(root / "foreign-skills")])
+            with patch("omh.install.identity_conflicts.Path.resolve", side_effect=RuntimeError("symlink loop")):
+                check = _identity_conflicts_check(paths, [str(root / "foreign-skills")], None)
 
         self.assertTrue(check.ok)
         self.assertEqual(check.severity, "warning")

--- a/tests/test_identity_conflicts.py
+++ b/tests/test_identity_conflicts.py
@@ -1,0 +1,567 @@
+"""#815: a contested OMH name names every source, its owner, and the safe repair.
+
+Three acceptance criteria are pinned here.
+
+AC1 -- diagnosis identifies all visible competing sources. Covered per kind:
+a skill directory, a plugin-declared command name, and a plugin-declared hook
+name, each asserting that *both* sides of the contest appear with an ownership
+label rather than only the foreign one.
+
+AC2 -- unknown precedence becomes a warning or a blocker. The rule lives in
+`EXCLUSIVE_NAME_KINDS` in the module under test and both branches are exercised
+against the same unknown precedence, so the split is the stated rule and not the
+kind of conflict that happened to be built first.
+
+AC3 -- no user-owned asset is rewritten or removed. `NoWriteTests` snapshots
+every byte and mtime under a tree holding a user-owned colliding asset, runs the
+diagnosis, and compares.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.commands import setup as setup_commands
+from omh.config_adapter import ensure_external_dir, read_config, write_config
+from omh.install.identity_conflicts import (
+    EXCLUSIVE_NAME_KINDS,
+    IDENTITY_CONFLICT_REPORT_KEYS,
+    IDENTITY_CONFLICT_REPORT_SCHEMA_VERSION,
+    OWNERSHIPS,
+    PRECEDENCE_STATES,
+    SOURCE_KINDS,
+    build_identity_conflict_report,
+    validate_identity_conflict_report,
+)
+from omh.local_store import atomic_write_text
+from omh.maintenance.doctor import run_doctor
+from omh.manifest import new_manifest, skill_records, write_manifest
+from omh.paths import resolve_paths
+from omh.plugin_bundle.omh.metadata import OPTIONAL_HOOKS, PROVIDED_TOOLS, REQUIRED_HOOKS
+from omh.plugin_pack import install_plugin_bundle
+from omh.skill_pack import CORE_SKILLS, builtin_skill_templates
+from omh.skills.catalog import omh_skill_display_name
+
+_DEFAULT_DIRS = object()
+
+CONTESTED_SKILL = CORE_SKILLS[1]
+CONTESTED_COMMAND = PROVIDED_TOOLS[0]
+CONTESTED_REQUIRED_HOOK = REQUIRED_HOOKS[0]
+CONTESTED_OPTIONAL_HOOK = OPTIONAL_HOOKS[0]
+
+
+def _install_managed_skills(skills_dir: Path) -> dict[str, object]:
+    """Render and manifest OMH's core skills the way the installer does.
+
+    `atomic_write_text` rather than `Path.write_text`: it writes with
+    `newline=""`, so a `\\n` in a template stays a `\\n` on disk. Default text
+    mode would translate to CRLF on Windows and change bytes this suite later
+    compares for the AC3 no-write proof.
+    """
+    wanted = frozenset(CORE_SKILLS)
+    for template in builtin_skill_templates():
+        if template.name not in wanted:
+            continue
+        path = skills_dir / omh_skill_display_name(template.name) / "SKILL.md"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write_text(path, template.content)
+    return new_manifest("builtin", skills_dir, skill_records(skills_dir, "builtin"))
+
+
+def _write_foreign_plugin(plugins_dir: Path, name: str, *, tools: tuple[str, ...] = (), hooks: tuple[str, ...] = ()) -> Path:
+    """A local Hermes plugin OMH did not install, declaring the given names."""
+    directory = plugins_dir / name
+    directory.mkdir(parents=True, exist_ok=True)
+    lines = [f"name: {name}", 'description: "a local plugin OMH did not install"']
+    if tools:
+        lines.append("provides_tools:")
+        lines.extend(f"  - {tool}" for tool in tools)
+    if hooks:
+        lines.append("provides_hooks:")
+        lines.extend(f"  - {hook}" for hook in hooks)
+    atomic_write_text(directory / "plugin.yaml", "\n".join(lines) + "\n")
+    return directory
+
+
+class _Fixture:
+    """A home with OMH's skills and bridge installed, plus whatever a test adds."""
+
+    def __init__(self, root: Path) -> None:
+        self.paths = resolve_paths(root / ".omh", root / ".hermes")
+        self.manifest = _install_managed_skills(self.paths.skills_dir)
+        write_manifest(self.paths.manifest_path, self.manifest)
+        self.paths.hermes_home.mkdir(parents=True, exist_ok=True)
+        write_config(self.paths.hermes_config_path, "version: 1\n")
+        install_plugin_bundle(self.paths)
+        self.configured_dirs: list[str] = [self.paths.skills_dir.as_posix()]
+
+    def register_skill_dir(self, directory: Path) -> None:
+        write_config(
+            self.paths.hermes_config_path,
+            ensure_external_dir(read_config(self.paths.hermes_config_path), directory).text,
+        )
+        self.configured_dirs.append(directory.as_posix())
+
+    def report(self, *, configured_skill_dirs: list[str] | None | object = _DEFAULT_DIRS) -> dict[str, object]:
+        # A sentinel default, because `None` is a meaningful argument here: it
+        # is how a caller says the Hermes config could not be read at all.
+        dirs = self.configured_dirs if configured_skill_dirs is _DEFAULT_DIRS else configured_skill_dirs
+        return build_identity_conflict_report(
+            skills_dir=self.paths.skills_dir,
+            manifest=self.manifest,
+            plugins_dir=self.paths.hermes_plugins_dir,
+            configured_skill_dirs=dirs,  # type: ignore[arg-type]
+        )
+
+
+def _conflict(report: dict[str, object], kind: str, name: str) -> dict[str, object]:
+    matches = [
+        item
+        for item in report["conflicts"]  # type: ignore[index]
+        if item["kind"] == kind and item["name"] == name
+    ]
+    if len(matches) != 1:
+        raise AssertionError(f"expected exactly one {kind} conflict on {name!r}, got {matches}")
+    return matches[0]
+
+
+def _ownership_map(conflict: dict[str, object]) -> dict[str, str]:
+    return {str(source["location"]): str(source["ownership"]) for source in conflict["sources"]}  # type: ignore[index]
+
+
+class ContractShapeTests(unittest.TestCase):
+    def test_a_clean_report_validates_and_carries_the_declared_vocabulary(self) -> None:
+        with TemporaryDirectory() as tmp:
+            report = _Fixture(Path(tmp)).report()
+
+        self.assertEqual(validate_identity_conflict_report(report), [])
+        self.assertEqual(sorted(report), sorted(IDENTITY_CONFLICT_REPORT_KEYS))
+        self.assertEqual(report["schema_version"], IDENTITY_CONFLICT_REPORT_SCHEMA_VERSION)
+        self.assertEqual(report["precedence"], "uncontested")
+        self.assertEqual(report["severity"], "ok")
+        self.assertEqual(report["conflicts"], [])
+        self.assertEqual(report["unreadable"], [])
+        self.assertEqual(report["scanned"], {"plugin_dirs": 1, "skill_dirs": 0})
+        self.assertIn("Hermes runtime precedence is not observed", str(report["claim_boundary"]))
+
+    def test_the_validator_rejects_an_unknown_key_and_an_unknown_vocabulary_value(self) -> None:
+        with TemporaryDirectory() as tmp:
+            report = _Fixture(Path(tmp)).report()
+
+        extra = {**report, "resolved_winner": "omh"}
+        self.assertIn(
+            "identity_conflict_report has unsupported keys: ['resolved_winner']",
+            validate_identity_conflict_report(extra),
+        )
+        # A resolved order is not in the vocabulary at all: OMH cannot observe
+        # Hermes precedence, so there is no value for it to report.
+        self.assertNotIn("resolved", PRECEDENCE_STATES)
+        decided = {**report, "precedence": "omh_wins"}
+        self.assertTrue(
+            any("precedence must be one of" in error for error in validate_identity_conflict_report(decided))
+        )
+
+    def test_the_validator_rejects_a_conflict_that_names_only_one_side(self) -> None:
+        with TemporaryDirectory() as tmp:
+            fixture = _Fixture(Path(tmp))
+            _write_foreign_plugin(fixture.paths.hermes_plugins_dir, "notes", tools=(CONTESTED_COMMAND,))
+            report = fixture.report()
+
+        conflict = _conflict(report, "command", CONTESTED_COMMAND)
+        halved = {
+            **report,
+            "conflicts": [{**conflict, "sources": conflict["sources"][:1]}],  # type: ignore[index]
+        }
+        self.assertTrue(
+            any("at least two sources" in error for error in validate_identity_conflict_report(halved))
+        )
+
+    def test_the_report_is_deterministic_across_repeated_scans(self) -> None:
+        with TemporaryDirectory() as tmp:
+            fixture = _Fixture(Path(tmp))
+            _write_foreign_plugin(
+                fixture.paths.hermes_plugins_dir,
+                "notes",
+                tools=(CONTESTED_COMMAND,),
+                hooks=(CONTESTED_REQUIRED_HOOK,),
+            )
+            foreign = Path(tmp) / "foreign-skills"
+            (foreign / CONTESTED_SKILL).mkdir(parents=True)
+            fixture.register_skill_dir(foreign)
+
+            first = fixture.report()
+            second = fixture.report()
+
+        self.assertEqual(first, second)
+
+
+class VisibleCompetingSourceTests(unittest.TestCase):
+    """AC1: every visible competing source is named, with its owner."""
+
+    def test_a_contested_skill_directory_names_the_managed_and_the_user_owned_side(self) -> None:
+        with TemporaryDirectory() as tmp:
+            fixture = _Fixture(Path(tmp))
+            foreign = Path(tmp) / "foreign-skills"
+            user_owned = foreign / CONTESTED_SKILL
+            user_owned.mkdir(parents=True)
+            fixture.register_skill_dir(foreign)
+
+            report = fixture.report()
+            conflict = _conflict(report, "skill", CONTESTED_SKILL)
+            managed = fixture.paths.skills_dir / omh_skill_display_name(CONTESTED_SKILL)
+
+        self.assertEqual(validate_identity_conflict_report(report), [])
+        # The foreign side is reported at its resolved location, which is what
+        # the configured-directory scan compared against the managed one.
+        self.assertEqual(
+            _ownership_map(conflict),
+            {str(managed): "omh_managed", str(user_owned.resolve()): "user_owned"},
+        )
+        self.assertEqual(report["precedence"], "unknown")
+
+    def test_a_contested_command_name_names_both_declaring_plugins(self) -> None:
+        with TemporaryDirectory() as tmp:
+            fixture = _Fixture(Path(tmp))
+            foreign = _write_foreign_plugin(
+                fixture.paths.hermes_plugins_dir, "notes", tools=(CONTESTED_COMMAND, "notes_search")
+            )
+
+            report = fixture.report()
+            conflict = _conflict(report, "command", CONTESTED_COMMAND)
+
+        self.assertEqual(validate_identity_conflict_report(report), [])
+        self.assertEqual(
+            _ownership_map(conflict),
+            {str(fixture.paths.hermes_plugin_dir): "omh_managed", str(foreign): "user_owned"},
+        )
+        # A name only the foreign plugin declares is not OMH's contest to report.
+        self.assertEqual(
+            [item for item in report["conflicts"] if item["name"] == "notes_search"],  # type: ignore[index]
+            [],
+        )
+
+    def test_a_contested_hook_name_names_both_subscribing_plugins(self) -> None:
+        with TemporaryDirectory() as tmp:
+            fixture = _Fixture(Path(tmp))
+            foreign = _write_foreign_plugin(
+                fixture.paths.hermes_plugins_dir, "notes", hooks=(CONTESTED_REQUIRED_HOOK,)
+            )
+
+            report = fixture.report()
+            conflict = _conflict(report, "hook", CONTESTED_REQUIRED_HOOK)
+
+        self.assertEqual(validate_identity_conflict_report(report), [])
+        self.assertEqual(
+            _ownership_map(conflict),
+            {str(fixture.paths.hermes_plugin_dir): "omh_managed", str(foreign): "user_owned"},
+        )
+
+    def test_three_plugins_claiming_one_command_all_appear(self) -> None:
+        with TemporaryDirectory() as tmp:
+            fixture = _Fixture(Path(tmp))
+            first = _write_foreign_plugin(fixture.paths.hermes_plugins_dir, "alpha", tools=(CONTESTED_COMMAND,))
+            second = _write_foreign_plugin(fixture.paths.hermes_plugins_dir, "beta", tools=(CONTESTED_COMMAND,))
+
+            conflict = _conflict(fixture.report(), "command", CONTESTED_COMMAND)
+
+        self.assertEqual(
+            _ownership_map(conflict),
+            {
+                str(first): "user_owned",
+                str(second): "user_owned",
+                str(fixture.paths.hermes_plugin_dir): "omh_managed",
+            },
+        )
+
+    def test_every_covered_kind_can_be_reported_at_once(self) -> None:
+        with TemporaryDirectory() as tmp:
+            fixture = _Fixture(Path(tmp))
+            _write_foreign_plugin(
+                fixture.paths.hermes_plugins_dir,
+                "notes",
+                tools=(CONTESTED_COMMAND,),
+                hooks=(CONTESTED_REQUIRED_HOOK,),
+            )
+            foreign = Path(tmp) / "foreign-skills"
+            (foreign / CONTESTED_SKILL).mkdir(parents=True)
+            fixture.register_skill_dir(foreign)
+
+            report = fixture.report()
+
+        self.assertEqual(validate_identity_conflict_report(report), [])
+        self.assertEqual({item["kind"] for item in report["conflicts"]}, set(SOURCE_KINDS))  # type: ignore[index]
+
+
+class PrecedenceSeverityTests(unittest.TestCase):
+    """AC2: the same unknown precedence is a warning or a blocker, by one rule.
+
+    The rule: a contested name blocks when Hermes can only award it to a single
+    owner, so one side becomes unreachable and OMH cannot say which. Only
+    `command` is such a name today, which is what `EXCLUSIVE_NAME_KINDS` says.
+    """
+
+    def test_the_rule_is_stated_as_data_and_not_as_the_kind_that_came_first(self) -> None:
+        self.assertEqual(EXCLUSIVE_NAME_KINDS, frozenset({"command"}))
+        self.assertTrue(EXCLUSIVE_NAME_KINDS.issubset(set(SOURCE_KINDS)))
+
+    def test_an_exclusive_command_name_makes_unknown_precedence_a_blocker(self) -> None:
+        with TemporaryDirectory() as tmp:
+            fixture = _Fixture(Path(tmp))
+            _write_foreign_plugin(fixture.paths.hermes_plugins_dir, "notes", tools=(CONTESTED_COMMAND,))
+
+            report = fixture.report()
+
+        self.assertEqual(report["precedence"], "unknown")
+        self.assertEqual(report["severity"], "blocking")
+        self.assertEqual(_conflict(report, "command", CONTESTED_COMMAND)["severity"], "blocking")
+        self.assertIn("OMH will not edit or remove a plugin it does not own", str(report["next_action"]))
+
+    def test_a_shared_hook_name_keeps_unknown_precedence_a_warning(self) -> None:
+        with TemporaryDirectory() as tmp:
+            fixture = _Fixture(Path(tmp))
+            _write_foreign_plugin(fixture.paths.hermes_plugins_dir, "notes", hooks=(CONTESTED_OPTIONAL_HOOK,))
+
+            report = fixture.report()
+
+        # Same precedence verdict as the blocking case above; only the
+        # reachability of the OMH side differs.
+        self.assertEqual(report["precedence"], "unknown")
+        self.assertEqual(report["severity"], "warning")
+        self.assertEqual(_conflict(report, "hook", CONTESTED_OPTIONAL_HOOK)["severity"], "warning")
+        self.assertIn("does not rename or delete assets it did not install", str(report["next_action"]))
+
+    def test_a_blocking_conflict_outranks_a_warning_one_in_the_report_severity(self) -> None:
+        with TemporaryDirectory() as tmp:
+            fixture = _Fixture(Path(tmp))
+            _write_foreign_plugin(
+                fixture.paths.hermes_plugins_dir,
+                "notes",
+                tools=(CONTESTED_COMMAND,),
+                hooks=(CONTESTED_OPTIONAL_HOOK,),
+            )
+
+            report = fixture.report()
+
+        self.assertEqual(report["severity"], "blocking")
+        self.assertEqual(
+            {item["kind"]: item["severity"] for item in report["conflicts"]},  # type: ignore[index]
+            {"command": "blocking", "hook": "warning"},
+        )
+
+
+class AttributionGuardTests(unittest.TestCase):
+    def test_omhs_own_bridge_is_not_a_conflict_with_itself(self) -> None:
+        with TemporaryDirectory() as tmp:
+            fixture = _Fixture(Path(tmp))
+            report = fixture.report()
+
+        # The managed bridge declares every name in PROVIDED_TOOLS; on its own
+        # that is an install, not a contest.
+        self.assertEqual(report["conflicts"], [])
+        self.assertEqual(report["severity"], "ok")
+
+    def test_omhs_own_managed_skill_directory_is_not_a_conflict_with_itself(self) -> None:
+        with TemporaryDirectory() as tmp:
+            fixture = _Fixture(Path(tmp))
+            # The managed directory is also a configured directory, and a second
+            # spelling of it must not turn OMH's own install into a competitor.
+            report = fixture.report(
+                configured_skill_dirs=[
+                    fixture.paths.skills_dir.as_posix(),
+                    (fixture.paths.skills_dir / ".." / "skills").as_posix(),
+                ]
+            )
+
+        self.assertEqual(report["conflicts"], [])
+        self.assertEqual(report["scanned"], {"plugin_dirs": 1, "skill_dirs": 0})
+
+    def test_ownership_comes_from_the_manifest_and_not_from_the_directory_name(self) -> None:
+        with TemporaryDirectory() as tmp:
+            fixture = _Fixture(Path(tmp))
+            # A plugin directory literally named `omh`, minus OMH's install
+            # manifest. Path-shaped attribution would call this OMH's own and
+            # report nothing; manifest-shaped attribution sees a stranger.
+            impostor = fixture.paths.hermes_plugins_dir / "omh"
+            for entry in sorted(impostor.glob(".omh-plugin-manifest.json")):
+                entry.unlink()
+
+            report = fixture.report()
+
+        self.assertEqual(report["conflicts"], [])
+        self.assertEqual(report["severity"], "ok")
+        # With no manifest-backed OMH source left, there is no OMH side to
+        # contest -- reporting a conflict here would invent a competitor for a
+        # bridge that is not installed.
+        self.assertEqual(report["scanned"], {"plugin_dirs": 1, "skill_dirs": 0})
+
+    def test_an_unmanaged_plugin_named_omh_beside_the_managed_one_is_user_owned(self) -> None:
+        with TemporaryDirectory() as tmp:
+            fixture = _Fixture(Path(tmp))
+            impostor = _write_foreign_plugin(
+                fixture.paths.hermes_plugins_dir, "omh-extra", tools=(CONTESTED_COMMAND,)
+            )
+
+            conflict = _conflict(fixture.report(), "command", CONTESTED_COMMAND)
+
+        self.assertEqual(_ownership_map(conflict)[str(impostor)], "user_owned")
+        self.assertEqual(set(_ownership_map(conflict).values()), set(OWNERSHIPS))
+
+    def test_a_plugin_declaring_nothing_omh_facing_is_scanned_but_never_contested(self) -> None:
+        with TemporaryDirectory() as tmp:
+            fixture = _Fixture(Path(tmp))
+            _write_foreign_plugin(fixture.paths.hermes_plugins_dir, "notes", tools=("notes_search",))
+
+            report = fixture.report()
+
+        self.assertEqual(report["conflicts"], [])
+        self.assertEqual(report["scanned"], {"plugin_dirs": 2, "skill_dirs": 0})
+
+
+class IncompleteScanTests(unittest.TestCase):
+    def test_an_unread_hermes_config_is_unknown_and_never_no_conflicts(self) -> None:
+        with TemporaryDirectory() as tmp:
+            fixture = _Fixture(Path(tmp))
+            report = fixture.report(configured_skill_dirs=None)
+
+        self.assertEqual(validate_identity_conflict_report(report), [])
+        self.assertEqual(report["precedence"], "unknown")
+        self.assertEqual(report["severity"], "warning")
+        self.assertEqual(report["conflicts"], [])
+        self.assertEqual(
+            report["unreadable"],
+            ["Hermes config was not read, so configured skill directories could not be enumerated"],
+        )
+
+    def test_an_empty_configured_list_is_an_answer_and_may_reach_uncontested(self) -> None:
+        with TemporaryDirectory() as tmp:
+            report = _Fixture(Path(tmp)).report(configured_skill_dirs=[])
+
+        self.assertEqual(report["precedence"], "uncontested")
+        self.assertEqual(report["unreadable"], [])
+
+    def test_an_unreadable_configured_directory_keeps_precedence_unknown(self) -> None:
+        with TemporaryDirectory() as tmp:
+            fixture = _Fixture(Path(tmp))
+            missing = Path(tmp) / "gone"
+            missing.mkdir()
+            report = build_identity_conflict_report(
+                skills_dir=fixture.paths.skills_dir,
+                manifest=fixture.manifest,
+                plugins_dir=fixture.paths.hermes_plugins_dir,
+                configured_skill_dirs=[str(missing)],
+            )
+            missing.rmdir()
+            after_removal = build_identity_conflict_report(
+                skills_dir=fixture.paths.skills_dir,
+                manifest=fixture.manifest,
+                plugins_dir=fixture.paths.hermes_plugins_dir,
+                configured_skill_dirs=[str(missing)],
+            )
+
+        self.assertEqual(report["precedence"], "uncontested")
+        self.assertEqual(after_removal["precedence"], "unknown")
+        self.assertEqual(after_removal["severity"], "warning")
+        self.assertTrue(any(str(missing) in item for item in after_removal["unreadable"]))
+
+
+class NoWriteTests(unittest.TestCase):
+    """AC3: the diagnosis reads a user-owned colliding asset and leaves it alone."""
+
+    def test_a_user_owned_colliding_asset_survives_the_diagnosis_byte_for_byte(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixture = _Fixture(root)
+            foreign_skills = root / "foreign-skills"
+            colliding_skill = foreign_skills / CONTESTED_SKILL
+            colliding_skill.mkdir(parents=True)
+            # `atomic_write_text`, not `Path.write_text`: the bytes below are
+            # hashed and compared, and default text mode would write CRLF on
+            # Windows and fail the comparison for the wrong reason.
+            atomic_write_text(colliding_skill / "SKILL.md", "# a workflow the user wrote\nkeep me\n")
+            fixture.register_skill_dir(foreign_skills)
+            foreign_plugin = _write_foreign_plugin(
+                fixture.paths.hermes_plugins_dir,
+                "notes",
+                tools=(CONTESTED_COMMAND,),
+                hooks=(CONTESTED_REQUIRED_HOOK,),
+            )
+
+            watched = [foreign_skills, foreign_plugin]
+            before = {
+                str(path): (path.read_bytes(), path.stat().st_mtime_ns)
+                for parent in watched
+                for path in sorted(parent.rglob("*"))
+                if path.is_file()
+            }
+            self.assertTrue(before)
+
+            report = fixture.report()
+            # Repeat: a scan that only wrote on first sight would still pass a
+            # single-pass comparison.
+            fixture.report()
+
+            after = {
+                str(path): (path.read_bytes(), path.stat().st_mtime_ns)
+                for parent in watched
+                for path in sorted(parent.rglob("*"))
+                if path.is_file()
+            }
+
+            self.assertEqual(before, after)
+            self.assertTrue(colliding_skill.is_dir())
+            self.assertTrue((colliding_skill / "SKILL.md").is_file())
+            self.assertTrue(foreign_plugin.is_dir())
+            self.assertEqual(report["severity"], "blocking")
+            self.assertNotIn("delete", str(report["next_action"]).lower().replace("does not rename or delete", ""))
+
+
+class DoctorSurfaceTests(unittest.TestCase):
+    """The surface an operator actually reaches: `omh doctor`."""
+
+    def _check(self, paths, name: str):
+        return next(item for item in run_doctor(paths) if item.name == name)
+
+    def test_the_check_reports_conflicts_and_lands_in_a_named_group(self) -> None:
+        with TemporaryDirectory() as tmp:
+            fixture = _Fixture(Path(tmp))
+            _write_foreign_plugin(fixture.paths.hermes_plugins_dir, "notes", tools=(CONTESTED_COMMAND,))
+
+            checks = run_doctor(fixture.paths)
+            check = next(item for item in checks if item.name == "identity_conflicts")
+            summary = setup_commands._doctor_operator_summary(checks)
+            group = next(item for item in summary["groups"] if item["name"] == "hermes_registration")
+
+        self.assertFalse(check.ok)
+        self.assertEqual(check.severity, "blocking")
+        self.assertIn(f"command name {CONTESTED_COMMAND} (blocking) claimed by", check.message)
+        self.assertIn("omh_managed at", check.message)
+        self.assertIn("user_owned at", check.message)
+        self.assertIn("identity_conflicts", group["failed"])
+
+    def test_a_warning_conflict_does_not_fail_doctor(self) -> None:
+        with TemporaryDirectory() as tmp:
+            fixture = _Fixture(Path(tmp))
+            _write_foreign_plugin(fixture.paths.hermes_plugins_dir, "notes", hooks=(CONTESTED_OPTIONAL_HOOK,))
+
+            check = self._check(fixture.paths, "identity_conflicts")
+
+        self.assertTrue(check.ok)
+        self.assertEqual(check.severity, "warning")
+
+    def test_a_clean_installed_home_reports_uncontested(self) -> None:
+        with TemporaryDirectory() as tmp:
+            fixture = _Fixture(Path(tmp))
+            check = self._check(fixture.paths, "identity_conflicts")
+
+        self.assertTrue(check.ok)
+        self.assertEqual(check.severity, "ok")
+        self.assertIn("precedence=uncontested", check.message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_identity_conflicts.py
+++ b/tests/test_identity_conflicts.py
@@ -466,7 +466,16 @@ class IncompleteScanTests(unittest.TestCase):
         self.assertEqual(report["precedence"], "uncontested")
         self.assertEqual(after_removal["precedence"], "unknown")
         self.assertEqual(after_removal["severity"], "warning")
-        self.assertTrue(any(str(missing) in item for item in after_removal["unreadable"]))
+        # The report records the resolved directory, so the assertion has to
+        # resolve too. Matching the raw path passed on macOS only because
+        # `/private/var/...` happens to contain `/var/...` as a substring; on
+        # Windows the temp directory resolves out of its 8.3 short form and the
+        # raw spelling is not a substring of the long one.
+        resolved = str(Path(missing).resolve(strict=False))
+        self.assertTrue(
+            any(resolved in item for item in after_removal["unreadable"]),
+            after_removal["unreadable"],
+        )
 
 
 class NoWriteTests(unittest.TestCase):


### PR DESCRIPTION
## Feature Report

Closes #815.

### What Changed

- `omh doctor` gained a real workflow-name conflict diagnosis. The old
  `skill_shadowing` check is renamed `identity_conflicts` and now covers three
  local surfaces instead of one: skill directory names, plugin-declared command
  (tool) names, and plugin-declared hook names.
- Every reported conflict now names **all** of its competing sources, each
  labelled `omh_managed` or `user_owned`, instead of printing one line naming a
  foreign directory and leaving the operator to work out whose it is.
- Unknown precedence can now be a warning **or** a blocker, by a rule recorded
  as data rather than decided per case. It was always a warning before.
- New contract module `src/install/identity_conflicts.py` carrying
  `identity_conflict_report/v1`, with `build_identity_conflict_report`,
  `validate_identity_conflict_report`, a closed key set, and a
  `claim_boundary`. The doctor check is its only consumer.

### Why This Exists

The user problem in #815: another local skill, command, or hook can overlap an
OMH-facing name and silently alter routing or availability, and the person only
notices because a familiar request triggered the wrong workflow.

What existed answered almost none of that:

- The scan read **skill directory names only**. A second local Hermes plugin
  declaring `omh_status` in its `provides_tools`, or subscribing to the same
  lifecycle hook, was completely invisible — so the most likely cause of "the
  bridge tool is installed but nothing answered" had no diagnosis at all, while
  every other doctor check reported green.
- There was **no ownership attribution**. The report never said which side of
  the contest OMH installed, and "OMH installed this twice" and "something else
  took the name" need opposite repairs.
- Unknown precedence was **always a warning**, never able to block, which AC2
  requires.

### User / Operator Impact

Before: `omh doctor` printed

```
skill_shadowing: potential OMH core skill-name collision or unreadable external
directory: /home/u/other-skills: doctor. ...
```

and said nothing at all about a competing plugin.

After, on a home with a foreign plugin claiming a bridge tool and a foreign
skill directory:

```
identity_conflicts: precedence=unknown conflicts=3 scanned skill_dirs=1 plugin_dirs=2:
  command name omh_status (blocking) claimed by user_owned at ~/.hermes/plugins/notes,
    omh_managed at ~/.hermes/plugins/omh;
  hook name pre_verify (warning) claimed by user_owned at ~/.hermes/plugins/notes,
    omh_managed at ~/.hermes/plugins/omh;
  skill name omh-doctor (warning) claimed by omh_managed at ~/.omh/skills/omh-doctor,
    user_owned at ~/foreign-skills/omh-doctor.
  This is a read-only scan of locally visible sources... Hermes runtime precedence is
  not observed... Nothing is renamed, rewritten, or removed by this diagnosis.
```

with `next_action`:

```
Rename or uninstall the competing tool name in the local plugin OMH did not
install, then rerun `omh doctor`; OMH will not edit or remove a plugin it does
not own.
```

The operator gets the competing sources, who owns each one, the safest repair,
and an explicit statement that OMH did not resolve the precedence and did not
touch anything.

### How It Works

**Sources scanned.** Configured skill directories come from
`skills.external_dirs` (already read by doctor). Command and hook names come
from `~/.hermes/plugins/*/plugin.yaml` `provides_tools:` / `provides_hooks:`,
read by a small hand-rolled block/inline list reader for the same reason
`install/config_adapter.py` has one — the core carries no YAML dependency. An
unfamiliar shape yields no names rather than a guess.

**Ownership attribution comes from the install manifests, never from the path.**
Skills: a managed location is recorded only when `manifest.json` accounts for
it, keyed by both the canonical catalog name (`doctor`) and the installed
directory name (`omh-doctor`), because those two diverged when installs moved to
display-labelled directories. Plugins: `omh_managed` requires a readable
`.omh-plugin-manifest.json` with the matching schema version, plugin name, and
package. A directory literally named `omh` that OMH did not install is therefore
`user_owned` — which is exactly the case a path-shaped guess would miss.

**A conflict requires both sides.** OMH's own bridge declaring the ten names it
owns is an install, not a contest; a contest between two foreign plugins over a
name OMH does not register is not OMH's to report. Both are covered by tests.

**Warning vs blocker — the rule.** Recorded as data in `EXCLUSIVE_NAME_KINDS`
(`frozenset({"command"})`) with the reasoning in a comment above it:

> A contested name **blocks** when Hermes can award it to only one owner, so one
> side becomes unreachable and OMH cannot say which. Hermes exposes one tool per
> name to the model, so a second local plugin declaring `omh_status` means an
> OMH capability is installed and absent at the same time, and no phrasing in
> chat recovers it.
>
> Everything else **warns**: a shadowed skill directory still resolves to
> whichever source wins and the other workflow can be asked for by name, and
> Hermes' hook names are lifecycle events that every plugin subscribes to, so an
> overlap there is a second subscriber rather than a stolen slot. Worth
> reporting; not worth failing an install over.

Ownership deliberately does **not** decide severity. AC3 forbids OMH from
touching a user-owned asset, so keying severity to ownership would paint the
ordinary case permanently red while telling the operator nothing actionable.
That alternative is recorded in the commit's `Rejected:` trailer.

**Precedence is never resolved.** `PRECEDENCE_STATES` is
`("uncontested", "unknown")` — there is no value for a winner, because OMH reads
local declarations and its own manifests and Hermes' load order is not among
them. `uncontested` is reserved for a scan that actually enumerated every
source: an unreadable directory, or a Hermes config that could not be read at
all, keeps the answer `unknown`. Doctor passes `None` rather than `[]` when
`config.yaml` is absent, because `read_config` returns `""` for a missing file
and an empty list there would read as "Hermes registers no foreign directory"
when the truth is that Hermes was never asked.

**Nothing is written.** The whole path reads directory names, `plugin.yaml`
text, and two manifests. `NoWriteTests` snapshots bytes and mtimes of a
user-owned colliding skill and a user-owned colliding plugin, runs the diagnosis
twice, and compares.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/install/identity_conflicts.py` | New. `identity_conflict_report/v1`: `build_identity_conflict_report`, `validate_identity_conflict_report`, closed key sets, `SOURCE_KINDS` / `OWNERSHIPS` / `PRECEDENCE_STATES` / `EXCLUSIVE_NAME_KINDS` vocabularies, `IDENTITY_CONFLICT_CLAIM_BOUNDARY`. |
| `src/maintenance/doctor.py` | `_skill_shadowing_check` replaced by `_identity_conflicts_check` + `_identity_conflict_summary`; call site now passes the install manifest and `None` for an unread Hermes config. |
| `src/commands/setup.py` | `_doctor_operator_summary` group prefix `skill_shadowing` → `identity_conflicts`, so the check stays inside `hermes_registration` and an operator still sees it. |
| `tests/test_identity_conflicts.py` | New, 25 tests: contract shape/validator, AC1 per kind, AC2 both branches, AC3 no-write, attribution guards, incomplete-scan guards, doctor surface. |
| `tests/test_cli.py` | The three existing shadowing tests updated for the new name, message shape, and check signature. |

No catalog, skill, docs, or generated-artifact changes: the four `--check` byte
gates were run and are unchanged. No new dependencies. No network or LLM calls.

## Validation

All commands run in this worktree at `5ada908b`, rebased onto `origin/main` at
`9b92d120` with `git fetch origin && git rebase origin/main` and re-run on the
rebased state.

- [x] `uv run --group lint ruff check src tests` → `All checks passed!` (one
      pre-existing warning about an invalid `# noqa` directive on
      `src/commands/main.py:1`, untouched by this PR)
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` →
      `Ran 4579 tests in 169.090s` / `OK`
- [x] `uv run python -m compileall -q src tests` → exit 0
- [x] `uv run python -m omh.cli docs workflows --check` → `"ok":true`,
      `tap_skills` `checked/expected 115`, no missing/stale/extra
- [x] `uv run python -m omh.cli harness validate` →
      `{"counts":{"harnesses":72,"skills":104},"errors":[],"ok":true,...}`
- [x] `uv run python -m omh.cli release checklist --json` → emitted the
      checklist payload
- [x] `uv run python -m omh.cli release hermes-smoke` → plan mode, status ok,
      `observed: no` (plan mode is not Hermes evidence)
- [x] `omh --help` (via `uv run python -m omh.cli --help`) → usage printed
- [x] `uv run python -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
      → exit 0; installed-command smoke `live` / `observed: yes`; first-use
      status `plan` / `observed: no`
- [x] Also run, beyond the template: `uv run python -m omh.cli docs roles --check`
      → `"ok":true`; `uv run python -m omh.cli docs capability-families --check`
      → `"ok":true`; `git diff --check` → clean
- [ ] Relevant workflow-learning review queue smoke, when learning contracts
      changed: **not applicable** — no learning contract touched
- [x] Relevant dry-run or smoke command: manual end-to-end probe against a
      temporary home — `omh setup --no-interactive`, then a foreign skill
      directory plus a foreign plugin declaring `omh_status` and `pre_verify`.
      Observed `identity_conflicts` go `ok` → `blocking` with all three kinds
      reported and both sides of each contest named.
- [ ] Manual Hermes/TUI check: **not run.** No Hermes host was available in this
      environment, and the thing that would need observing — which registration
      Hermes actually awards a contested tool name — is exactly what this PR
      declines to claim. The report says `unknown` for that reason.

## Risk

- **`identity_conflicts` can fail `omh doctor` (exit 1).** It is the first
  doctor check that blocks on something OMH is forbidden to repair. The blast
  radius is bounded to one case: a locally installed plugin *without* an OMH
  install manifest declaring a name in `PROVIDED_TOOLS`, while OMH's own
  manifest-backed bridge is also installed. A fresh home, a bare home, and every
  fixture home in the suite have no such plugin — verified by the full suite
  passing unchanged, including the tests that assert doctor is green after
  setup.
- **Hook overlap is reported but never blocks.** Hermes hook names are lifecycle
  events from `hermes_cli.plugins.VALID_HOOKS`, so every hook-using plugin
  declares the same handful. Treating that as an exclusive slot would fire on
  any ordinary two-plugin host. It is a warning, and the module comment says
  why.
- **`plugin.yaml` is read by a hand-rolled list reader.** It handles the block
  and inline list shapes a plugin descriptor uses in practice and reads nothing
  else, so an exotic YAML shape yields no names — under-reporting a conflict,
  never inventing one.
- **An absent Hermes config now produces a warning** where the old check was
  silent-ok. That is intentional (the "never say no conflicts when nothing was
  looked at" guard) and does not change `doctor_ok`, which is already failing on
  `hermes_config` in that state.

## Compatibility / Rollout

- The doctor check **name changes**: `skill_shadowing` → `identity_conflicts`.
  Anything parsing `omh doctor --json` for the old check name will not find it.
  Nothing in this repository, the docs, or the generated skills referenced the
  old name outside `src/commands/setup.py` and `tests/test_cli.py`, both updated
  in the same commit.
- The check message format changed. It is human-facing narrative text in the
  `message` field, not a parsed contract.
- No schema in the plugin bundle, wrapper contract, or memory store changed. No
  migration. No config is written or rewritten by any of this.
- `identity_conflict_report/v1` is internal: the doctor check is its only
  consumer and it is not exposed in `omh doctor --json`, so no output surface
  gained a new field.

## Release / Claims

- [x] Release-channel impact considered: `local` — a diagnosis inside
      `omh doctor`, no version bump, no packaging change, no new dependency.
- [x] Runtime/native capability claims are backed by evidence or marked as not
      observed. Every claim here is a local-file claim. Hermes runtime
      precedence is explicitly `unknown` in the contract vocabulary, restated in
      `IDENTITY_CONFLICT_CLAIM_BOUNDARY`, and asserted by tests. The report also
      states in the same sentence that nothing was renamed, rewritten, or
      removed.
- [x] Known manual Hermes checks are listed: no live Hermes profile was
      available, so `omh release hermes-smoke --live` was not run and the
      first-use smoke stayed `plan` / `observed: no`. Whether Hermes awards a
      contested tool name to the first or last registration remains unobserved
      and is deliberately not claimed.

## Follow-Up

- If a fourth source kind is ever scanned, decide its place in
  `EXCLUSIVE_NAME_KINDS` **before** adding the scan. A kind that defaults to
  blocking turns an ordinary multi-plugin host red. This is also recorded in the
  commit's `Directive:` trailer.
- If Hermes ever publishes a versioned precedence rule, `PRECEDENCE_STATES` is
  where a `documented` value would go — with the version as evidence, per the
  issue's own boundary-level design note. It is deliberately absent today
  because there is nothing to cite.
- Doctor still reports an unmanaged `~/.hermes/plugins/omh` through the
  `plugin_bridge` checks rather than as an identity conflict; that path has no
  manifest-backed OMH source, so this check correctly stays quiet and does not
  double-report.
