### PR TITLE
feat: let users save recurring work through Hermes safely

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -3080,6 +3080,7 @@ These surfaces are generated command references, not installed Hermes workflow s
   - Why: A blueprint can prepare the scheduled operation, but it cannot prove runtime execution or delivery.
 - Quality bar:
   - Name cadence/timezone uncertainty, delivery target, silence/no-change rule, selected skills, and context chain.
+  - When the recurring work is saved, say it is paused and name what activation needs: an explicit overlap posture, an approval reference, and an observer from the approved runtime surface.
   - Expose whether a no-agent watchdog is a candidate without claiming it exists or ran.
   - List host automation, gateway delivery, source retrieval, and no-agent execution as not evidence until observed.
 - Completion checklist:
@@ -3096,14 +3097,17 @@ These surfaces are generated command references, not installed Hermes workflow s
   - silence/no-change preference
 - Expected outputs:
   - hermes_ops_blueprint/v1 projection
+  - hermes_recurring_intent/v1 paused lifecycle record when the user wants the recurring work saved
   - schedule/delivery/silence confirmation needs
   - status-card boundary
   - not-evidence list
 - Artifact expectations:
   - hermes_ops_blueprint/v1 under .omh/hermes-ops/blueprints when a wrapper or CLI records it
+  - hermes_recurring_intent/v1 under .omh/hermes-ops/recurring-intents when the user asks to save the recurring work
 - Safety rules:
   - Do not claim host cron, Hermes automation, gateway delivery, source retrieval, no-agent execution, plugin load, or connector work from a prepared blueprint.
   - Keep scheduled operations as projection metadata until the host runtime supplies observed evidence.
+  - A saved recurring intent is paused; never report that an occurrence ran without a runtime run reference recorded against that exact intent revision.
   - Route later coding, material generation, or report delivery into separate accepted handoffs when needed.
 
 ### reliability-review
@@ -8471,6 +8475,7 @@ Prepare recurring Hermes operations as schedule/delivery/silence blueprints with
   - silence/no-change policy
 - Outputs:
   - hermes_ops_blueprint/v1
+  - hermes_recurring_intent/v1 when the recurring work is saved
   - schedule/delivery/silence policy
   - skill context chain
   - not-evidence boundary
@@ -8481,6 +8486,7 @@ Prepare recurring Hermes operations as schedule/delivery/silence blueprints with
 - Verification:
   - validate hermes_ops_blueprint/v1
   - check schedule/delivery/silence fields
+  - verify a saved recurring intent is paused and names its overlap posture, approval, and activation observer
   - verify not_evidence_until_observed lists runtime and gateway claims
 - Evidence ladder:
   - `blueprint_scope_recorded`
@@ -8505,6 +8511,7 @@ Prepare recurring Hermes operations as schedule/delivery/silence blueprints with
 - Privacy default: `metadata_only`
 - Overclaim guards:
   - A hermes_ops_blueprint/v1 artifact is not host cron creation, Hermes automation, gateway delivery, source retrieval, no-agent execution, plugin load, or connector evidence.
+  - A hermes_recurring_intent/v1 record stays paused until an approved runtime surface records an activation observer, and an activated intent is still not occurrence-execution evidence.
   - A silence policy is not proof that a run happened or that there were no changes.
   - No-agent suitability is only a design hint until a no-agent runtime record exists.
 - Fallback: If cadence, delivery, or silence policy is missing, prepare the blueprint and ask for the smallest missing confirmation.

--- a/skills/omh-automation-blueprint/SKILL.md
+++ b/skills/omh-automation-blueprint/SKILL.md
@@ -72,6 +72,7 @@ Reasoning demand: `light`
 Quality bar:
 
 - Name cadence/timezone uncertainty, delivery target, silence/no-change rule, selected skills, and context chain.
+- When the recurring work is saved, say it is paused and name what activation needs: an explicit overlap posture, an approval reference, and an observer from the approved runtime surface.
 - Expose whether a no-agent watchdog is a candidate without claiming it exists or ran.
 - List host automation, gateway delivery, source retrieval, and no-agent execution as not evidence until observed.
 
@@ -89,6 +90,7 @@ Required inputs:
 Expected outputs:
 
 - hermes_ops_blueprint/v1 projection
+- hermes_recurring_intent/v1 paused lifecycle record when the user wants the recurring work saved
 - schedule/delivery/silence confirmation needs
 - status-card boundary
 - not-evidence list
@@ -96,11 +98,13 @@ Expected outputs:
 Artifact expectations:
 
 - hermes_ops_blueprint/v1 under .omh/hermes-ops/blueprints when a wrapper or CLI records it
+- hermes_recurring_intent/v1 under .omh/hermes-ops/recurring-intents when the user asks to save the recurring work
 
 Safety rules:
 
 - Do not claim host cron, Hermes automation, gateway delivery, source retrieval, no-agent execution, plugin load, or connector work from a prepared blueprint.
 - Keep scheduled operations as projection metadata until the host runtime supplies observed evidence.
+- A saved recurring intent is paused; never report that an occurrence ran without a runtime run reference recorded against that exact intent revision.
 - Route later coding, material generation, or report delivery into separate accepted handoffs when needed.
 
 ## Runtime Evidence

--- a/src/commands/ops.py
+++ b/src/commands/ops.py
@@ -64,7 +64,27 @@ from ..research_department import (
     validate_research_department_store,
     write_research_department_plan,
 )
-from .common import _paths, _print_json
+from ..workflows.recurring_intents import (
+    ACTIVATION_OBSERVER_KINDS,
+    OCCURRENCE_OBSERVER_KINDS,
+    OCCURRENCE_OUTCOMES,
+    OVERLAP_POSTURES,
+    OWNER_KINDS,
+    activate_recurring_intent,
+    build_recurring_intent,
+    list_recurring_intents,
+    preview_recurring_intent,
+    record_recurring_intent_occurrence,
+    render_recurring_intent_list_text,
+    render_recurring_intent_text,
+    revise_recurring_intent,
+    show_recurring_intent,
+    summarize_recurring_intent,
+    update_recurring_intent,
+    validate_recurring_intent_store,
+    write_recurring_intent,
+)
+from .common import _paths, _print_json, _wants_json
 
 
 DEFAULT_OPS_LIST_LIMIT = 20
@@ -72,6 +92,16 @@ DEFAULT_OPS_EXPORT_LIMIT = 20
 DEFAULT_BLUEPRINT_LIST_LIMIT = 20
 DEFAULT_RESEARCH_DEPARTMENT_LIST_LIMIT = 20
 DEFAULT_AGENT_OPS_LIST_LIMIT = 20
+DEFAULT_RECURRING_INTENT_LIST_LIMIT = 20
+
+RECURRING_INTENT_BOUNDARY = {
+    "prepared_is_not_observed": True,
+    "activated_is_not_executed": True,
+    "omh_runs_no_scheduler": True,
+    "host_schedule_created": False,
+    "occurrence_executed_by_omh": False,
+    "gateway_delivery_observed": False,
+}
 
 
 def cmd_ops_write(args: argparse.Namespace) -> int:
@@ -214,6 +244,155 @@ def cmd_ops_blueprint(args: argparse.Namespace) -> int:
             },
         }
     )
+    return 0
+
+
+def cmd_ops_recurring_intent(args: argparse.Namespace) -> int:
+    try:
+        paths = _paths(args)
+        intent = build_recurring_intent(
+            " ".join(args.request),
+            title=args.title,
+            schedule=args.schedule,
+            delivery=args.delivery,
+            silence=args.silence,
+            scope=args.scope_note,
+            owner=args.owner,
+            owner_kind=args.owner_kind,
+            overlap_posture=args.overlap_posture,
+            source=args.source,
+        )
+        written = intent if args.dry_run else write_recurring_intent(paths, intent)
+    except ValueError as exc:
+        raise OmhError(str(exc)) from exc
+    return _emit_recurring_intent(args, paths, written, saved=not args.dry_run)
+
+
+def cmd_ops_recurring_intent_revise(args: argparse.Namespace) -> int:
+    try:
+        paths = _paths(args)
+        current = show_recurring_intent(paths, args.intent_id)
+        revised = revise_recurring_intent(
+            current,
+            title=args.title or None,
+            schedule=args.schedule if args.schedule != "" else None,
+            delivery=args.delivery if args.delivery != "" else None,
+            silence=args.silence if args.silence != "" else None,
+            scope=args.scope_note if args.scope_note != "" else None,
+            owner=args.owner if args.owner != "" else None,
+            owner_kind=args.owner_kind or None,
+            overlap_posture=args.overlap_posture or None,
+        )
+        written = update_recurring_intent(paths, revised)
+    except (FileNotFoundError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    return _emit_recurring_intent(args, paths, written, saved=True)
+
+
+def cmd_ops_recurring_intent_activate(args: argparse.Namespace) -> int:
+    try:
+        paths = _paths(args)
+        current = show_recurring_intent(paths, args.intent_id)
+        activated = activate_recurring_intent(
+            current,
+            observer=args.observer,
+            observer_kind=args.observer_kind,
+            approval_ref=args.approval_ref,
+            activation_surface=args.activation_surface,
+        )
+        written = update_recurring_intent(paths, activated)
+    except (FileNotFoundError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    return _emit_recurring_intent(args, paths, written, saved=True)
+
+
+def cmd_ops_recurring_intent_occurrence(args: argparse.Namespace) -> int:
+    try:
+        paths = _paths(args)
+        current = show_recurring_intent(paths, args.intent_id)
+        recorded = record_recurring_intent_occurrence(
+            current,
+            runtime_run_ref=args.runtime_run_ref,
+            runtime_surface=args.runtime_surface,
+            observer=args.observer,
+            observer_kind=args.observer_kind,
+            outcome=args.outcome,
+        )
+        written = update_recurring_intent(paths, recorded)
+    except (FileNotFoundError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    return _emit_recurring_intent(args, paths, written, saved=True)
+
+
+def cmd_ops_recurring_intent_list(args: argparse.Namespace) -> int:
+    paths = _paths(args)
+    try:
+        limit = _limit_from_args(args, default=DEFAULT_RECURRING_INTENT_LIST_LIMIT)
+    except ValueError as exc:
+        raise OmhError(str(exc)) from exc
+    all_records = list_recurring_intents(paths)
+    records = all_records if limit is None else all_records[-limit:]
+    payload = {
+        "schema_version": "omh_ops_recurring_intent_list/v1",
+        "count": len(records),
+        "total_count": len(all_records),
+        "limit": limit if limit is not None else "all",
+        "truncated": limit is not None and len(all_records) > len(records),
+        "summary_only": True,
+        "index_authority": "cache_only",
+        "intents": [summarize_recurring_intent(record) for record in records],
+    }
+    if _wants_json(args):
+        _print_json(payload)
+    else:
+        print(render_recurring_intent_list_text(payload))
+    return 0
+
+
+def cmd_ops_recurring_intent_show(args: argparse.Namespace) -> int:
+    try:
+        paths = _paths(args)
+        intent = show_recurring_intent(paths, args.intent_id)
+    except (FileNotFoundError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    if _wants_json(args):
+        _print_json({"schema_version": "omh_ops_recurring_intent_show/v1", "intent": intent})
+    else:
+        print(render_recurring_intent_text(intent))
+    return 0
+
+
+def _emit_recurring_intent(args: argparse.Namespace, paths, record: dict, *, saved: bool) -> int:
+    """One writer for every recurring-intent surface so the boundary never drifts.
+
+    An unsaved intent emits the preview payload the wrapper reads back to the
+    user before saving; both shapes carry `intent`, `store`, and `boundary`, so
+    a consumer that only reads those does not have to branch.
+    """
+    if not _wants_json(args):
+        print(render_recurring_intent_text(record))
+        return 0
+    store = {
+        "omh_home": str(paths.omh_home),
+        "hermes_ops_dir": str(paths.hermes_ops_dir),
+        "recurring_intents_dir": str(paths.recurring_intents_dir),
+        "index_path": str(paths.recurring_intents_index_path),
+        "index_authority": "cache_only",
+        "written": saved,
+    }
+    boundary = {
+        **RECURRING_INTENT_BOUNDARY,
+        "not_evidence_until_observed": list(record["not_evidence_until_observed"]),
+        "observed_evidence_required": list(record["observed_evidence_required"]),
+    }
+    payload = (
+        {"schema_version": "omh_ops_recurring_intent_result/v1", "intent": record}
+        if saved
+        else dict(preview_recurring_intent(record))
+    )
+    payload["store"] = store
+    payload["boundary"] = boundary
+    _print_json(payload)
     return 0
 
 
@@ -422,14 +601,17 @@ def cmd_ops_validate(args: argparse.Namespace) -> int:
     paths = _paths(args)
     result = validate_operations_store(paths)
     blueprint_result = validate_hermes_ops_store(paths)
+    recurring_intent_result = validate_recurring_intent_store(paths)
     research_department_result = validate_research_department_store(paths)
     agent_ops_result = validate_agent_operator_productivity_store(paths)
     result["hermes_ops_blueprints"] = blueprint_result
+    result["recurring_intents"] = recurring_intent_result
     result["research_department_plans"] = research_department_result
     result["agent_ops_reviews"] = agent_ops_result
     result["ok"] = (
         bool(result["ok"])
         and bool(blueprint_result["ok"])
+        and bool(recurring_intent_result["ok"])
         and bool(research_department_result["ok"])
         and bool(agent_ops_result["ok"])
     )
@@ -530,6 +712,35 @@ def _add_artifact_args(parser: argparse.ArgumentParser, *, surface: str, default
     observation.add_argument("--not-observed", action="store_true", help="Mark the artifact as explicitly not observed.")
 
 
+def _add_recurring_intent_shape_args(parser: argparse.ArgumentParser, *, revising: bool = False) -> None:
+    """The fields that shape a recurring intent, spelled identically on build and revise.
+
+    On revise an empty string means "leave this field alone", which is why the
+    two parsers share one definition instead of drifting into two vocabularies.
+    """
+    parser.add_argument("--schedule", default="", help="Explicit schedule/cadence hint.")
+    parser.add_argument("--delivery", default="", help="Explicit delivery target hint.")
+    parser.add_argument("--silence", default="", help="Explicit silence/no-change policy hint.")
+    parser.add_argument("--scope", dest="scope_note", default="", help="What this recurring work is allowed to touch.")
+    parser.add_argument("--owner", default="", help="Owner accountable for this recurring work.")
+    parser.add_argument(
+        "--owner-kind",
+        choices=("", *OWNER_KINDS) if revising else OWNER_KINDS,
+        default="" if revising else "unassigned",
+        help="Kind of owner accountable for this recurring work.",
+    )
+    parser.add_argument(
+        "--overlap-posture",
+        choices=("", *OVERLAP_POSTURES) if revising else OVERLAP_POSTURES,
+        default="" if revising else "unspecified",
+        help="What happens when an occurrence is still running; must be explicit before activation.",
+    )
+
+
+def _add_recurring_intent_json_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--json", action="store_true", help="Emit the machine payload instead of plain text.")
+
+
 def _add_ops_commands(sub) -> None:
     from .plugin_risk_audit import add_ops_plugin_risk_audit_command
     from .provider_profile_posture import add_ops_provider_profile_posture_command
@@ -609,6 +820,68 @@ def _add_ops_commands(sub) -> None:
     blueprint.add_argument("--source", default="", help="Optional metadata source label.")
     blueprint.add_argument("--dry-run", action="store_true", help="Print the prepared blueprint without writing it.")
     blueprint.set_defaults(func=cmd_ops_blueprint)
+
+    recurring_intent = ops_sub.add_parser(
+        "recurring-intent",
+        help="Prepare a paused recurring intent from a natural-language request; OMH never activates or runs it.",
+    )
+    recurring_intent.add_argument("request", nargs="+", help="Natural-language recurring work request.")
+    recurring_intent.add_argument("--title", default="")
+    _add_recurring_intent_shape_args(recurring_intent)
+    recurring_intent.add_argument("--source", default="", help="Optional metadata source label.")
+    recurring_intent.add_argument("--dry-run", action="store_true", help="Print the preview without saving it.")
+    _add_recurring_intent_json_arg(recurring_intent)
+    recurring_intent.set_defaults(func=cmd_ops_recurring_intent)
+
+    recurring_intent_revise = ops_sub.add_parser(
+        "recurring-intent-revise",
+        help="Revise a stored recurring intent; the new revision pauses it again so activation is re-observed.",
+    )
+    recurring_intent_revise.add_argument("intent_id")
+    recurring_intent_revise.add_argument("--title", default="")
+    _add_recurring_intent_shape_args(recurring_intent_revise, revising=True)
+    _add_recurring_intent_json_arg(recurring_intent_revise)
+    recurring_intent_revise.set_defaults(func=cmd_ops_recurring_intent_revise)
+
+    recurring_intent_activate = ops_sub.add_parser(
+        "recurring-intent-activate",
+        help="Record that an approved runtime surface activated a recurring intent. OMH does not activate it.",
+    )
+    recurring_intent_activate.add_argument("intent_id")
+    recurring_intent_activate.add_argument("--observer", required=True, help="Who or what observed the activation.")
+    recurring_intent_activate.add_argument("--observer-kind", choices=ACTIVATION_OBSERVER_KINDS, default="approved_runtime_surface")
+    recurring_intent_activate.add_argument("--approval-ref", required=True, help="Recorded approval reference.")
+    recurring_intent_activate.add_argument(
+        "--activation-surface",
+        required=True,
+        help="The approved runtime surface that performed the activation.",
+    )
+    _add_recurring_intent_json_arg(recurring_intent_activate)
+    recurring_intent_activate.set_defaults(func=cmd_ops_recurring_intent_activate)
+
+    recurring_intent_occurrence = ops_sub.add_parser(
+        "recurring-intent-occurrence",
+        help="Link one observed runtime run back to the exact recurring intent revision it ran under.",
+    )
+    recurring_intent_occurrence.add_argument("intent_id")
+    recurring_intent_occurrence.add_argument("--runtime-run-ref", required=True, help="Run reference owned by the runtime.")
+    recurring_intent_occurrence.add_argument("--runtime-surface", required=True, help="Runtime surface that ran it.")
+    recurring_intent_occurrence.add_argument("--observer", required=True, help="Who or what observed the run.")
+    recurring_intent_occurrence.add_argument("--observer-kind", choices=OCCURRENCE_OBSERVER_KINDS, default="approved_runtime_surface")
+    recurring_intent_occurrence.add_argument("--outcome", choices=OCCURRENCE_OUTCOMES, default="ran")
+    _add_recurring_intent_json_arg(recurring_intent_occurrence)
+    recurring_intent_occurrence.set_defaults(func=cmd_ops_recurring_intent_occurrence)
+
+    recurring_intent_list = ops_sub.add_parser("recurring-intent-list", help="List stored recurring intents.")
+    recurring_intent_list.add_argument("--limit", type=int, default=None)
+    recurring_intent_list.add_argument("--all", action="store_true", help="Return all intent summaries instead of the default bounded window.")
+    _add_recurring_intent_json_arg(recurring_intent_list)
+    recurring_intent_list.set_defaults(func=cmd_ops_recurring_intent_list)
+
+    recurring_intent_show = ops_sub.add_parser("recurring-intent-show", help="Show one stored recurring intent by id.")
+    recurring_intent_show.add_argument("intent_id")
+    _add_recurring_intent_json_arg(recurring_intent_show)
+    recurring_intent_show.set_defaults(func=cmd_ops_recurring_intent_show)
 
     research_department = ops_sub.add_parser(
         "research-department",

--- a/src/skills/catalog_definitions.py
+++ b/src/skills/catalog_definitions.py
@@ -3854,16 +3854,27 @@ _DEFINITIONS = [
             "prepare host automation or no-agent follow-up only after an operator/wrapper records observed runtime evidence."
         ),
         required_inputs=("recurring request", "schedule or cadence hint", "delivery target or current-thread default", "silence/no-change preference"),
-        expected_outputs=("hermes_ops_blueprint/v1 projection", "schedule/delivery/silence confirmation needs", "status-card boundary", "not-evidence list"),
-        artifact_expectations=("hermes_ops_blueprint/v1 under .omh/hermes-ops/blueprints when a wrapper or CLI records it",),
+        expected_outputs=(
+            "hermes_ops_blueprint/v1 projection",
+            "hermes_recurring_intent/v1 paused lifecycle record when the user wants the recurring work saved",
+            "schedule/delivery/silence confirmation needs",
+            "status-card boundary",
+            "not-evidence list",
+        ),
+        artifact_expectations=(
+            "hermes_ops_blueprint/v1 under .omh/hermes-ops/blueprints when a wrapper or CLI records it",
+            "hermes_recurring_intent/v1 under .omh/hermes-ops/recurring-intents when the user asks to save the recurring work",
+        ),
         safety_rules=(
             "Do not claim host cron, Hermes automation, gateway delivery, source retrieval, no-agent execution, plugin load, or connector work from a prepared blueprint.",
             "Keep scheduled operations as projection metadata until the host runtime supplies observed evidence.",
+            "A saved recurring intent is paused; never report that an occurrence ran without a runtime run reference recorded against that exact intent revision.",
             "Route later coding, material generation, or report delivery into separate accepted handoffs when needed.",
         ),
         quality_tier="ops-blueprint-gated",
         quality_bar=(
             "Name cadence/timezone uncertainty, delivery target, silence/no-change rule, selected skills, and context chain.",
+            "When the recurring work is saved, say it is paused and name what activation needs: an explicit overlap posture, an approval reference, and an observer from the approved runtime surface.",
             "Expose whether a no-agent watchdog is a candidate without claiming it exists or ran.",
             "List host automation, gateway delivery, source retrieval, and no-agent execution as not evidence until observed.",
         ),

--- a/src/skills/catalog_harnesses.py
+++ b/src/skills/catalog_harnesses.py
@@ -1809,11 +1809,18 @@ _HARNESSES = [
         "Prepare recurring Hermes operations as schedule/delivery/silence blueprints without claiming runtime execution.",
         "Use when recurring, cron-like, digest, monitoring, or platform-delivery requests need a Hermes-native setup plan and status card.",
         ("recurring request", "cadence or schedule hint", "delivery target", "silence/no-change policy"),
-        ("hermes_ops_blueprint/v1", "schedule/delivery/silence policy", "skill context chain", "not-evidence boundary"),
+        (
+            "hermes_ops_blueprint/v1",
+            "hermes_recurring_intent/v1 when the recurring work is saved",
+            "schedule/delivery/silence policy",
+            "skill context chain",
+            "not-evidence boundary",
+        ),
         ("blueprint is prepared", "missing schedule/delivery decisions are explicit", "runtime and delivery claims remain observed-only"),
         (
             "validate hermes_ops_blueprint/v1",
             "check schedule/delivery/silence fields",
+            "verify a saved recurring intent is paused and names its overlap posture, approval, and activation observer",
             "verify not_evidence_until_observed lists runtime and gateway claims",
         ),
         "If cadence, delivery, or silence policy is missing, prepare the blueprint and ask for the smallest missing confirmation.",
@@ -1845,6 +1852,7 @@ _HARNESSES = [
         ),
         overclaim_guards=(
             "A hermes_ops_blueprint/v1 artifact is not host cron creation, Hermes automation, gateway delivery, source retrieval, no-agent execution, plugin load, or connector evidence.",
+            "A hermes_recurring_intent/v1 record stays paused until an approved runtime surface records an activation observer, and an activated intent is still not occurrence-execution evidence.",
             "A silence policy is not proof that a run happened or that there were no changes.",
             "No-agent suitability is only a design hint until a no-agent runtime record exists.",
         ),

--- a/src/system/paths.py
+++ b/src/system/paths.py
@@ -138,6 +138,21 @@ class OmhPaths:
         return self.hermes_ops_dir / "index.json"
 
     @property
+    def recurring_intents_root(self) -> Path:
+        # A recurring intent is the lifecycle envelope around a scheduled-ops
+        # blueprint, so it lives under the same hermes-ops home instead of
+        # reading on disk as a second recurring-work concept.
+        return self.hermes_ops_dir / "recurring-intents"
+
+    @property
+    def recurring_intents_dir(self) -> Path:
+        return self.recurring_intents_root / "intents"
+
+    @property
+    def recurring_intents_index_path(self) -> Path:
+        return self.recurring_intents_root / "index.json"
+
+    @property
     def research_department_dir(self) -> Path:
         return self.omh_home / "research-department"
 

--- a/src/workflows/hermes_ops.py
+++ b/src/workflows/hermes_ops.py
@@ -398,6 +398,16 @@ def hermes_ops_blueprint_exists(paths: OmhPaths, blueprint_id: str) -> bool:
     return _valid_blueprint_id(blueprint_id) and _blueprint_path(paths, blueprint_id).exists()
 
 
+def nested_status_boundary_errors(record: dict[str, Any], *, path: str = "$") -> list[str]:
+    """The prepared-vs-observed status walk, shared with sibling ops records.
+
+    Exposed so the recurring-intent lifecycle record reuses this exact guard
+    instead of copying it. A copy is how two guards drift, and this walk is the
+    reason a prepared ops artifact cannot quietly grow an observed claim.
+    """
+    return _nested_status_boundary_errors(record, path=path)
+
+
 def staged_gap_map() -> list[dict[str, str]]:
     return [
         {

--- a/src/workflows/recurring_intents.py
+++ b/src/workflows/recurring_intents.py
@@ -1,0 +1,1014 @@
+"""Recurring-intent lifecycle records (`hermes_recurring_intent/v1`).
+
+# Why this is a sibling record and not more fields on `hermes_ops_blueprint/v1`
+
+There is one recurring-work concept in OMH, not two. A recurring intent is the
+*lifecycle envelope* around a scheduled-ops blueprint: it never re-derives
+cadence, delivery, or silence, it calls `build_scheduled_ops_blueprint` and
+keeps the sub-records that builder produced. The blueprint stays the single
+normalizer, and both records live under `.omh/hermes-ops/`.
+
+The blueprint could not carry the lifecycle itself for three reasons:
+
+1. `hermes_ops_blueprint/v1` is `projection_only` and write-once.
+   `write_hermes_ops_blueprint` refuses to overwrite an existing id and there is
+   no update path, because a projection of catalog metadata has nothing to
+   update. A recurring intent is revised, activated, and accumulates occurrence
+   links, so it needs a mutable record with a revision identity.
+2. The blueprint validator refuses any nested `status` outside
+   `{prepared, not_observed}` and any `*_status` that claims observation. An
+   occurrence has to name an observed runtime run. Putting occurrences inside a
+   blueprint would mean weakening exactly the guard that keeps blueprints
+   honest, so occurrences live here and the guard itself is reused unchanged
+   (`nested_status_boundary_errors`).
+3. Blueprint identity is a timestamp plus a random suffix. Linking an
+   occurrence to the exact intent it ran under needs a content digest, so a
+   changed intent produces a different identifier on its own.
+
+# What "paused" means structurally
+
+`build_recurring_intent` has no parameter that can set an activation state or an
+occurrence: a freshly built intent is not merely defaulted to paused, it has no
+vocabulary for "an occurrence ran". The validator enforces the same rule for
+records that arrive from disk or from a wrapper: with no recorded `activated`
+transition, `occurrences` must be empty.
+
+# What activation is
+
+A recorded transition, never a flag flip. OMH runs no scheduler and no
+background service. Activation is performed by an approved runtime surface
+outside OMH; this record only stores who or what observed it, under which
+approval reference, and at which revision. An activated intent is still not
+execution evidence — each occurrence points at the runtime run that owns its
+evidence.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import secrets
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from ..hashutil import sha256_text
+from ..local_store import atomic_write_json, ensure_dir, read_json_object, read_json_object_result, utc_now
+from ..paths import OmhPaths
+from .hermes_ops import (
+    PROJECTION_SOURCE_REFS,
+    build_scheduled_ops_blueprint,
+    nested_status_boundary_errors,
+)
+
+
+RECURRING_INTENT_SCHEMA_VERSION = "hermes_recurring_intent/v1"
+RECURRING_INTENT_INDEX_SCHEMA_VERSION = "hermes_recurring_intent_index/v1"
+RECURRING_INTENT_VALIDATION_SCHEMA_VERSION = "hermes_recurring_intent_validation/v1"
+RECURRING_INTENT_PREVIEW_SCHEMA_VERSION = "hermes_recurring_intent_preview/v1"
+RECURRING_OCCURRENCE_SCHEMA_VERSION = "hermes_recurring_occurrence/v1"
+RECURRING_INTENT_STATUS_CARD_SCHEMA_VERSION = "hermes_recurring_intent_status_card/v1"
+
+RECURRING_INTENT_KINDS = ("recurring-intent",)
+RECURRING_INTENT_STATUSES = ("prepared", "blocked", "archived")
+RECURRING_INTENT_OBSERVATION_STATUSES = ("prepared", "not_observed")
+LIFECYCLE_STATES = ("paused", "activated")
+OWNER_KINDS = ("unassigned", "human", "team", "runtime_surface", "executor_profile")
+OVERLAP_POSTURES = ("unspecified", "skip_when_running", "queue_after_running", "allow_concurrent")
+ACTIVATION_OBSERVER_KINDS = ("human", "approved_runtime_surface")
+OCCURRENCE_OBSERVER_KINDS = ("human", "approved_runtime_surface")
+OCCURRENCE_OUTCOMES = ("ran", "failed", "skipped")
+REQUIRED_APPROVAL_KIND = "human_or_approved_runtime_surface"
+ACTIVATION_PERFORMED_BY = "approved_runtime_surface_outside_omh"
+
+INTENT_SUMMARY_LIMIT = 240
+# The runtime run owns the durable evidence for an occurrence, so this record
+# keeps a bounded local index of the most recent links rather than growing one
+# JSON file forever -- every mutation reads and rewrites the whole record.
+# `occurrences_recorded_total` keeps the count honest after truncation.
+RETAINED_OCCURRENCE_LIMIT = 50
+
+RECURRING_INTENT_NOT_EVIDENCE = (
+    "host_cron_created",
+    "hermes_automation_enabled",
+    "omh_scheduler_started",
+    "occurrence_executed",
+    "runtime_run_started",
+    "gateway_delivery_sent",
+    "review",
+    "ci",
+    "merge_readiness",
+    "merge",
+)
+RECURRING_INTENT_OBSERVED_EVIDENCE_REQUIRED = (
+    "An approval reference from a human or an approved runtime surface, recorded before activation.",
+    "The approved runtime surface that performed activation, named in the activation transition.",
+    "A runtime run reference for every occurrence, owned by the runtime that ran it.",
+)
+PREPARED_RECURRING_INTENT_IS_NOT = (
+    "A Hermes recurring intent is local lifecycle metadata only. OMH runs no scheduler and no background "
+    "service, so neither a paused nor an activated intent is host cron creation, scheduler startup, "
+    "occurrence execution, gateway delivery, review, CI, merge-readiness, or merge evidence."
+)
+OCCURRENCE_CLAIM_BOUNDARY = (
+    "The linked runtime run owns this execution evidence. This occurrence is only the local link back to the "
+    "exact intent revision the run was started under."
+)
+ACTIVATION_REQUIREMENTS = (
+    "explicit_overlap_posture",
+    "recorded_approval_reference",
+    "recorded_observer_of_the_activating_runtime_surface",
+)
+
+# Meaningful fields of the intent, in the order they enter the revision digest.
+# Deliberately excluded: intent_id, created_at, updated_at, the revision block
+# itself, approval grant state, lifecycle transitions, and occurrences. Times
+# never enter the digest -- they are passed in as parameters so the same intent
+# always digests to the same revision. Approval grant state is excluded so that
+# activating an intent cannot silently orphan the occurrences recorded under it.
+REVISION_DIGEST_FIELDS = (
+    "title",
+    "request_summary",
+    "schedule_intent.cadence",
+    "schedule_intent.time_hint",
+    "schedule_intent.explicit_schedule",
+    "delivery_intent.surfaces",
+    "delivery_intent.explicit_delivery",
+    "silence_policy.mode",
+    "silence_policy.explicit_policy",
+    "scope.summary",
+    "scope.explicit_scope",
+    "owner_profile.owner",
+    "owner_profile.owner_kind",
+    "overlap_posture.posture",
+    "required_approval.required",
+    "required_approval.approval_kind",
+)
+
+_INTENT_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9-]{0,159}$")
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def build_recurring_intent(
+    request: str,
+    *,
+    title: str = "",
+    schedule: str = "",
+    delivery: str = "",
+    silence: str = "",
+    scope: str = "",
+    owner: str = "",
+    owner_kind: str = "unassigned",
+    overlap_posture: str = "unspecified",
+    source: str = "",
+    intent_id: str | None = None,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    """Prepare a paused recurring intent from a natural-language request.
+
+    There is no activation or occurrence parameter on purpose: the returned
+    record cannot express "an occurrence ran" no matter what the caller passes.
+    """
+    clean_request = " ".join(str(request).split())
+    if not clean_request:
+        raise ValueError("recurring intent request is required")
+    if owner_kind not in OWNER_KINDS:
+        raise ValueError(f"unsupported recurring intent owner_kind: {owner_kind}")
+    if overlap_posture not in OVERLAP_POSTURES:
+        raise ValueError(f"unsupported recurring intent overlap_posture: {overlap_posture}")
+    created = created_at or utc_now()
+    hints = {"schedule": schedule.strip(), "delivery": delivery.strip(), "silence": silence.strip()}
+    derived = _derived_intents(clean_request, hints, created)
+    record: dict[str, Any] = {
+        "schema_version": RECURRING_INTENT_SCHEMA_VERSION,
+        "intent_id": intent_id or new_recurring_intent_id(clean_request, created),
+        "kind": "recurring-intent",
+        "title": title.strip() or _default_title(clean_request),
+        "status": "prepared",
+        "observation_status": "prepared",
+        "created_at": created,
+        "updated_at": created,
+        "source": source.strip(),
+        "request_summary": _preview(clean_request, limit=INTENT_SUMMARY_LIMIT),
+        "derived_from": {
+            "schema_version": "hermes_ops_blueprint/v1",
+            "authority": "projection_only",
+            "normalizer": "build_scheduled_ops_blueprint",
+            "source_refs": list(PROJECTION_SOURCE_REFS),
+        },
+        "derivation_hints": hints,
+        "schedule_intent": derived["schedule_intent"],
+        "delivery_intent": derived["delivery_intent"],
+        "silence_policy": derived["silence_policy"],
+        "scope": _scope(clean_request, scope=scope),
+        "owner_profile": _owner_profile(owner=owner, owner_kind=owner_kind),
+        "overlap_posture": _overlap_posture(overlap_posture),
+        "required_approval": {
+            "required": True,
+            "approval_kind": REQUIRED_APPROVAL_KIND,
+            "granted": False,
+            "approval_ref": "",
+        },
+        "lifecycle": {
+            "state": "paused",
+            "activation_requires": list(ACTIVATION_REQUIREMENTS),
+            "activation_performed_by": ACTIVATION_PERFORMED_BY,
+            "transitions": [],
+        },
+        "occurrences": [],
+        "occurrences_recorded_total": 0,
+        "revision_history": [],
+        "not_evidence_until_observed": list(RECURRING_INTENT_NOT_EVIDENCE),
+        "observed_evidence_required": list(RECURRING_INTENT_OBSERVED_EVIDENCE_REQUIRED),
+        "prepared_is_not": PREPARED_RECURRING_INTENT_IS_NOT,
+        "claim_boundary": _claim_boundary(),
+    }
+    _refresh_derived_blocks(record, revised_at=created)
+    errors = validate_recurring_intent(record)
+    if errors:
+        raise ValueError("; ".join(errors))
+    return record
+
+
+def preview_recurring_intent(record: dict[str, Any]) -> dict[str, Any]:
+    """Wrap a prepared intent as a preview a wrapper can show before saving.
+
+    The user described recurring work in chat; this payload is what Hermes reads
+    back to them. `save.requires_user_command` is false because confirming the
+    summary is the whole user action -- the command below it is the agent-facing
+    surface, not something the user types.
+    """
+    return {
+        "schema_version": RECURRING_INTENT_PREVIEW_SCHEMA_VERSION,
+        "preview_only": True,
+        "saved": False,
+        "human_summary": record["human_summary"],
+        "open_decisions": list(record["open_decisions"]),
+        "save": {
+            "requires_user_command": False,
+            "user_action": "confirm_or_correct_the_summary",
+            "entry_action": "prepare_scheduled_ops_blueprint",
+            "agent_surface": "omh ops recurring-intent",
+        },
+        "intent": record,
+        "claim_boundary": dict(record["claim_boundary"]),
+    }
+
+
+def revise_recurring_intent(
+    record: dict[str, Any],
+    *,
+    revised_at: str | None = None,
+    title: str | None = None,
+    schedule: str | None = None,
+    delivery: str | None = None,
+    silence: str | None = None,
+    scope: str | None = None,
+    owner: str | None = None,
+    owner_kind: str | None = None,
+    overlap_posture: str | None = None,
+) -> dict[str, Any]:
+    """Return a revised copy with a new revision id, paused again if it was active.
+
+    Revising an activated intent pauses it: the approved runtime surface
+    approved a specific revision, and re-activation must record a fresh
+    observer against the revision that will actually run.
+    """
+    if owner_kind is not None and owner_kind not in OWNER_KINDS:
+        raise ValueError(f"unsupported recurring intent owner_kind: {owner_kind}")
+    if overlap_posture is not None and overlap_posture not in OVERLAP_POSTURES:
+        raise ValueError(f"unsupported recurring intent overlap_posture: {overlap_posture}")
+    revised = revised_at or utc_now()
+    updated = _clone(record)
+    previous_revision = str(updated["revision"]["revision_id"])
+    if title is not None:
+        clean_title = title.strip()
+        if not clean_title:
+            raise ValueError("recurring intent title must not be blank")
+        updated["title"] = clean_title
+    hints = dict(updated.get("derivation_hints", {}))
+    for key, value in (("schedule", schedule), ("delivery", delivery), ("silence", silence)):
+        if value is not None:
+            hints[key] = value.strip()
+    if hints != updated.get("derivation_hints"):
+        updated["derivation_hints"] = hints
+        # The record deliberately does not retain the raw request (metadata-only
+        # by default), so a revision re-derives from the bounded request_summary.
+        # For a request longer than INTENT_SUMMARY_LIMIT that is the truncated
+        # text, which is why the explicit hints exist.
+        updated.update(_derived_intents(str(updated["request_summary"]), hints, revised))
+    if scope is not None:
+        updated["scope"] = _scope(str(updated["request_summary"]), scope=scope)
+    if owner is not None or owner_kind is not None:
+        profile = updated["owner_profile"]
+        updated["owner_profile"] = _owner_profile(
+            owner=str(profile["owner"]) if owner is None else owner,
+            owner_kind=str(profile["owner_kind"]) if owner_kind is None else owner_kind,
+        )
+    if overlap_posture is not None:
+        updated["overlap_posture"] = _overlap_posture(overlap_posture)
+    updated["updated_at"] = revised
+    _refresh_derived_blocks(updated, revised_at=revised)
+    if str(updated["revision"]["revision_id"]) == previous_revision:
+        raise ValueError("recurring intent revision must change at least one meaningful field")
+    updated["revision_history"] = [
+        *record.get("revision_history", []),
+        {"revision_id": previous_revision, "superseded_at": revised},
+    ]
+    if str(updated["lifecycle"]["state"]) == "activated":
+        updated["lifecycle"]["state"] = "paused"
+        updated["lifecycle"]["transitions"] = [
+            *updated["lifecycle"]["transitions"],
+            {
+                "transition": "paused_by_revision",
+                "intent_revision_id": str(updated["revision"]["revision_id"]),
+                "observer": "",
+                "observer_kind": "local_policy",
+                "approval_ref": "",
+                "activation_surface": "",
+                "reason": "intent fields changed; re-activation must record a new observer against this revision",
+                "recorded_at": revised,
+            },
+        ]
+        updated["required_approval"] = {
+            **updated["required_approval"],
+            "granted": False,
+            "approval_ref": "",
+        }
+    _refresh_derived_blocks(updated, revised_at=revised)
+    errors = validate_recurring_intent(updated)
+    if errors:
+        raise ValueError("; ".join(errors))
+    return updated
+
+
+def activate_recurring_intent(
+    record: dict[str, Any],
+    *,
+    observer: str,
+    approval_ref: str,
+    activation_surface: str,
+    observer_kind: str = "approved_runtime_surface",
+    observed_at: str | None = None,
+) -> dict[str, Any]:
+    """Record that an approved runtime surface activated this intent revision.
+
+    OMH does not activate anything here. This appends the transition that says
+    who or what observed the activation, so a later occurrence can be read
+    against a named observer instead of an anonymous flag.
+    """
+    if not str(observer).strip():
+        raise ValueError("recurring intent activation requires a recorded observer")
+    if observer_kind not in ACTIVATION_OBSERVER_KINDS:
+        raise ValueError(f"unsupported recurring intent activation observer_kind: {observer_kind}")
+    if not str(approval_ref).strip():
+        raise ValueError("recurring intent activation requires a recorded approval reference")
+    if not str(activation_surface).strip():
+        raise ValueError("recurring intent activation requires the approved runtime surface that performed it")
+    if str(record["overlap_posture"]["posture"]) == "unspecified":
+        raise ValueError("recurring intent activation requires an explicit overlap posture")
+    if str(record["lifecycle"]["state"]) == "activated":
+        raise ValueError("recurring intent is already activated")
+    observed = observed_at or utc_now()
+    updated = _clone(record)
+    updated["lifecycle"]["state"] = "activated"
+    updated["lifecycle"]["transitions"] = [
+        *updated["lifecycle"]["transitions"],
+        {
+            "transition": "activated",
+            "intent_revision_id": str(updated["revision"]["revision_id"]),
+            "observer": str(observer).strip(),
+            "observer_kind": observer_kind,
+            "approval_ref": str(approval_ref).strip(),
+            "activation_surface": str(activation_surface).strip(),
+            "reason": "approved runtime surface reported activation",
+            "recorded_at": observed,
+        },
+    ]
+    updated["required_approval"] = {
+        **updated["required_approval"],
+        "granted": True,
+        "approval_ref": str(approval_ref).strip(),
+    }
+    updated["updated_at"] = observed
+    _refresh_derived_blocks(updated, revised_at=str(updated["revision"]["revised_at"]))
+    errors = validate_recurring_intent(updated)
+    if errors:
+        raise ValueError("; ".join(errors))
+    return updated
+
+
+def record_recurring_intent_occurrence(
+    record: dict[str, Any],
+    *,
+    runtime_run_ref: str,
+    runtime_surface: str,
+    observer: str,
+    observer_kind: str = "approved_runtime_surface",
+    outcome: str = "ran",
+    observed_at: str | None = None,
+    occurrence_id: str | None = None,
+) -> dict[str, Any]:
+    """Link one observed runtime run back to the exact intent revision it ran under."""
+    if str(record["lifecycle"]["state"]) != "activated":
+        raise ValueError(
+            "a paused recurring intent cannot record an occurrence: activate it with a recorded observer first"
+        )
+    if outcome not in OCCURRENCE_OUTCOMES:
+        raise ValueError(f"unsupported recurring intent occurrence outcome: {outcome}")
+    if observer_kind not in OCCURRENCE_OBSERVER_KINDS:
+        raise ValueError(f"unsupported recurring intent occurrence observer_kind: {observer_kind}")
+    if not str(runtime_run_ref).strip():
+        raise ValueError("recurring intent occurrence requires a runtime run reference")
+    if not str(runtime_surface).strip():
+        raise ValueError("recurring intent occurrence requires the runtime surface that ran it")
+    if not str(observer).strip():
+        raise ValueError("recurring intent occurrence requires a recorded observer")
+    observed = observed_at or utc_now()
+    updated = _clone(record)
+    clean_run_ref = str(runtime_run_ref).strip()
+    if any(str(item.get("runtime_run", {}).get("run_ref", "")) == clean_run_ref for item in updated["occurrences"]):
+        raise ValueError(f"runtime run {clean_run_ref} is already linked to this recurring intent")
+    revision_id = str(updated["revision"]["revision_id"])
+    occurrence = {
+        "schema_version": RECURRING_OCCURRENCE_SCHEMA_VERSION,
+        "occurrence_id": occurrence_id or new_recurring_occurrence_id(revision_id, observed),
+        "intent_id": str(updated["intent_id"]),
+        "intent_revision_id": revision_id,
+        "outcome": outcome,
+        "observer": str(observer).strip(),
+        "observer_kind": observer_kind,
+        "observed_at": observed,
+        "runtime_run": {"surface": str(runtime_surface).strip(), "run_ref": clean_run_ref},
+        "evidence_authority": "linked_runtime_run",
+        "claim_boundary": OCCURRENCE_CLAIM_BOUNDARY,
+    }
+    updated["occurrences"] = [*updated["occurrences"], occurrence][-RETAINED_OCCURRENCE_LIMIT:]
+    updated["occurrences_recorded_total"] = int(updated["occurrences_recorded_total"]) + 1
+    updated["updated_at"] = observed
+    _refresh_derived_blocks(updated, revised_at=str(updated["revision"]["revised_at"]))
+    errors = validate_recurring_intent(updated)
+    if errors:
+        raise ValueError("; ".join(errors))
+    return updated
+
+
+def recurring_intent_revision_id(record: dict[str, Any]) -> str:
+    """Deterministic revision id for the intent's meaningful fields.
+
+    No wall clock enters the digest, so the same intent always produces the same
+    revision and any meaningful change produces a different one.
+    """
+    material = {field: _digest_value(record, field) for field in REVISION_DIGEST_FIELDS}
+    canonical = json.dumps(material, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+    return f"rev-{sha256_text(canonical)[:16]}"
+
+
+def new_recurring_intent_id(request: str, now: datetime | str | None = None) -> str:
+    stamp = _stamp(now)
+    slug = _slugify(request)[:48] or "recurring-intent"
+    return f"{stamp}-recurring-intent-{slug}-{secrets.token_hex(3)}"
+
+
+def new_recurring_occurrence_id(revision_id: str, now: datetime | str | None = None) -> str:
+    return f"{_stamp(now)}-occurrence-{_slugify(revision_id)[:32]}-{secrets.token_hex(3)}"
+
+
+def validate_recurring_intent(record: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if record.get("schema_version") != RECURRING_INTENT_SCHEMA_VERSION:
+        errors.append("schema_version must be hermes_recurring_intent/v1")
+    if record.get("kind") not in RECURRING_INTENT_KINDS:
+        errors.append(f"unsupported recurring intent kind: {record.get('kind', '')}")
+    intent_id = str(record.get("intent_id", ""))
+    if not intent_id.strip():
+        errors.append("intent_id is required")
+    elif not _valid_intent_id(intent_id):
+        errors.append("intent_id must contain only letters, digits, and hyphens, and must not contain path separators")
+    if not str(record.get("title", "")).strip():
+        errors.append("title is required")
+    if record.get("status") not in RECURRING_INTENT_STATUSES:
+        errors.append(f"unsupported recurring intent status: {record.get('status', '')}")
+    if record.get("observation_status") not in RECURRING_INTENT_OBSERVATION_STATUSES:
+        errors.append(f"unsupported recurring intent observation_status: {record.get('observation_status', '')}")
+    derived_from = record.get("derived_from")
+    if not isinstance(derived_from, dict):
+        errors.append("derived_from must be an object")
+    else:
+        if derived_from.get("schema_version") != "hermes_ops_blueprint/v1":
+            errors.append("derived_from.schema_version must be hermes_ops_blueprint/v1")
+        if derived_from.get("authority") != "projection_only":
+            errors.append("derived_from.authority must be projection_only")
+    for key in (
+        "schedule_intent",
+        "delivery_intent",
+        "silence_policy",
+        "scope",
+        "owner_profile",
+        "overlap_posture",
+        "required_approval",
+        "revision",
+        "lifecycle",
+        "claim_boundary",
+        "status_card",
+    ):
+        if not isinstance(record.get(key), dict):
+            errors.append(f"{key} must be an object")
+    for key in (
+        "occurrences",
+        "revision_history",
+        "open_decisions",
+        "not_evidence_until_observed",
+        "observed_evidence_required",
+    ):
+        if not isinstance(record.get(key), list):
+            errors.append(f"{key} must be a list")
+    if errors:
+        return errors
+    if record["owner_profile"].get("owner_kind") not in OWNER_KINDS:
+        errors.append(f"unsupported owner_profile.owner_kind: {record['owner_profile'].get('owner_kind', '')}")
+    if record["overlap_posture"].get("posture") not in OVERLAP_POSTURES:
+        errors.append(f"unsupported overlap_posture.posture: {record['overlap_posture'].get('posture', '')}")
+    if record["required_approval"].get("required") is not True:
+        errors.append("required_approval.required must stay true: activation always needs an approval reference")
+    if record["required_approval"].get("approval_kind") != REQUIRED_APPROVAL_KIND:
+        errors.append(f"required_approval.approval_kind must be {REQUIRED_APPROVAL_KIND}")
+    expected_revision = recurring_intent_revision_id(record)
+    if str(record["revision"].get("revision_id", "")) != expected_revision:
+        errors.append(
+            f"revision.revision_id must be the digest of the intent's meaningful fields ({expected_revision})"
+        )
+    if not set(RECURRING_INTENT_NOT_EVIDENCE).issubset(set(_string_list(record["not_evidence_until_observed"]))):
+        errors.append("not_evidence_until_observed must include the default prepared-vs-observed guard list")
+    errors.extend(_lifecycle_errors(record))
+    errors.extend(_occurrence_errors(record))
+    errors.extend(nested_status_boundary_errors(record))
+    return errors
+
+
+def write_recurring_intent(paths: OmhPaths, record: dict[str, Any]) -> dict[str, Any]:
+    errors = validate_recurring_intent(record)
+    if errors:
+        raise ValueError("; ".join(errors))
+    intent_id = str(record["intent_id"])
+    if recurring_intent_exists(paths, intent_id):
+        raise ValueError(f"recurring intent already exists: {intent_id}")
+    atomic_write_json(_intent_path(paths, intent_id), record, private=True)
+    _write_index_cache(paths)
+    return record
+
+
+def update_recurring_intent(paths: OmhPaths, record: dict[str, Any]) -> dict[str, Any]:
+    """Replace a stored intent in place; unlike a blueprint, an intent has a lifecycle."""
+    errors = validate_recurring_intent(record)
+    if errors:
+        raise ValueError("; ".join(errors))
+    intent_id = str(record["intent_id"])
+    if not recurring_intent_exists(paths, intent_id):
+        raise FileNotFoundError(intent_id)
+    atomic_write_json(_intent_path(paths, intent_id), record, private=True)
+    _write_index_cache(paths)
+    return record
+
+
+def list_recurring_intents(paths: OmhPaths, *, limit: int | None = None) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for intent_path in sorted(paths.recurring_intents_dir.glob("*.json")):
+        record, error = read_json_object_result(intent_path)
+        if error:
+            continue
+        if record:
+            records.append(record)
+    records.sort(key=lambda item: str(item.get("created_at", "")))
+    if limit is not None:
+        if limit < 1:
+            return []
+        records = records[-limit:]
+    return records
+
+
+def show_recurring_intent(paths: OmhPaths, intent_id: str) -> dict[str, Any]:
+    if not _valid_intent_id(intent_id):
+        raise FileNotFoundError(intent_id)
+    record = read_json_object(_intent_path(paths, intent_id))
+    if record:
+        return record
+    raise FileNotFoundError(intent_id)
+
+
+def recurring_intent_exists(paths: OmhPaths, intent_id: str) -> bool:
+    return _valid_intent_id(intent_id) and _intent_path(paths, intent_id).exists()
+
+
+def summarize_recurring_intent(record: dict[str, Any]) -> dict[str, Any]:
+    revision_id = str(record.get("revision", {}).get("revision_id", ""))
+    occurrences = record.get("occurrences", [])
+    occurrences = occurrences if isinstance(occurrences, list) else []
+    return {
+        "intent_id": str(record.get("intent_id", "")),
+        "kind": str(record.get("kind", "")),
+        "title": str(record.get("title", "")),
+        "status": str(record.get("status", "")),
+        "observation_status": str(record.get("observation_status", "")),
+        "lifecycle_state": str(record.get("lifecycle", {}).get("state", "")),
+        "revision_id": revision_id,
+        "updated_at": str(record.get("updated_at", "")),
+        "cadence": str(record.get("schedule_intent", {}).get("cadence", "unspecified")),
+        "overlap_posture": str(record.get("overlap_posture", {}).get("posture", "unspecified")),
+        "owner": str(record.get("owner_profile", {}).get("owner", "")),
+        "occurrence_count": int(record.get("occurrences_recorded_total", 0) or 0),
+        "retained_occurrence_count": len(occurrences),
+        "current_revision_occurrence_count": sum(
+            1 for item in occurrences if isinstance(item, dict) and str(item.get("intent_revision_id", "")) == revision_id
+        ),
+        "summary": _preview(str(record.get("request_summary", "")), limit=INTENT_SUMMARY_LIMIT),
+    }
+
+
+def validate_recurring_intent_store(paths: OmhPaths) -> dict[str, Any]:
+    records: list[dict[str, Any]] = []
+    errors: list[str] = []
+    seen: set[str] = set()
+    for intent_path in sorted(paths.recurring_intents_dir.glob("*.json")):
+        record, error = read_json_object_result(intent_path)
+        if error:
+            errors.append(f"{intent_path}: {error}")
+            continue
+        if record:
+            records.append(record)
+    for record in records:
+        intent_id = str(record.get("intent_id", ""))
+        if intent_id in seen:
+            errors.append(f"duplicate intent_id: {intent_id}")
+        seen.add(intent_id)
+        for error in validate_recurring_intent(record):
+            errors.append(f"{intent_id or '<unknown>'}: {error}")
+    index = read_json_object(paths.recurring_intents_index_path)
+    if index and index.get("schema_version") != RECURRING_INTENT_INDEX_SCHEMA_VERSION:
+        errors.append("recurring intent index cache has unsupported schema_version")
+    return {
+        "schema_version": RECURRING_INTENT_VALIDATION_SCHEMA_VERSION,
+        "ok": not errors,
+        "intent_count": len(records),
+        "errors": errors,
+        "index_authority": "cache_only",
+    }
+
+
+def render_recurring_intent_text(record: dict[str, Any]) -> str:
+    schedule = record["schedule_intent"]
+    time_hint = str(schedule["time_hint"])
+    cadence = str(schedule["cadence"]) + (f" ({time_hint})" if time_hint else "")
+    approval = record["required_approval"]
+    approval_line = f"granted, ref {approval['approval_ref']}" if approval["granted"] else "required, not granted"
+    owner = str(record["owner_profile"]["owner"]) or "unassigned"
+    linked = summarize_recurring_intent(record)["current_revision_occurrence_count"]
+    lines = [
+        str(record["title"]),
+        f"  id: {record['intent_id']}",
+        f"  revision: {record['revision']['revision_id']}",
+        f"  lifecycle: {record['lifecycle']['state']}",
+        f"  cadence: {cadence}",
+        f"  delivery: {', '.join(_string_list(record['delivery_intent']['surfaces'])) or 'unspecified'}",
+        f"  silence: {record['silence_policy']['mode']}",
+        f"  scope: {record['scope']['summary']}",
+        f"  owner: {owner} ({record['owner_profile']['owner_kind']})",
+        f"  overlap posture: {record['overlap_posture']['posture']}",
+        f"  approval: {approval_line}",
+        f"  occurrences linked to this revision: {linked}",
+        "",
+        record["human_summary"],
+    ]
+    if record["open_decisions"]:
+        lines.append("")
+        lines.append("Still needs a decision:")
+        lines.extend(f"  - {item}" for item in record["open_decisions"])
+    lines.append("")
+    lines.append(f"Not observed: {', '.join(record['not_evidence_until_observed'])}")
+    lines.append(record["prepared_is_not"])
+    return "\n".join(lines)
+
+
+def render_recurring_intent_list_text(payload: dict[str, Any]) -> str:
+    intents = payload.get("intents", [])
+    if not intents:
+        return "No recurring intents recorded."
+    lines = [f"Recurring intents: {payload['count']} of {payload['total_count']}"]
+    for item in intents:
+        lines.append(
+            f"  [{item['lifecycle_state']}] {item['title']} ({item['intent_id']}) "
+            f"cadence={item['cadence']} overlap={item['overlap_posture']} "
+            f"occurrences={item['current_revision_occurrence_count']}/{item['occurrence_count']}"
+        )
+    lines.append("A recurring intent is prepared lifecycle metadata; OMH runs no scheduler.")
+    return "\n".join(lines)
+
+
+def _derived_intents(request: str, hints: dict[str, str], created_at: str) -> dict[str, Any]:
+    """Take cadence, delivery, and silence from the blueprint builder, never re-derive them."""
+    blueprint = build_scheduled_ops_blueprint(
+        request,
+        schedule=hints.get("schedule", ""),
+        delivery=hints.get("delivery", ""),
+        silence=hints.get("silence", ""),
+        created_at=created_at,
+    )
+    return {
+        "schedule_intent": dict(blueprint["schedule_intent"]),
+        "delivery_intent": dict(blueprint["delivery_intent"]),
+        "silence_policy": dict(blueprint["silence_policy"]),
+    }
+
+
+def _scope(request: str, *, scope: str) -> dict[str, object]:
+    explicit = scope.strip()
+    return {
+        "status": "prepared",
+        "summary": explicit or _preview(request, limit=160),
+        "explicit_scope": explicit,
+        "requires_confirmation": not explicit,
+    }
+
+
+def _owner_profile(*, owner: str, owner_kind: str) -> dict[str, object]:
+    clean_owner = owner.strip()
+    return {
+        "status": "prepared",
+        "owner": clean_owner,
+        "owner_kind": owner_kind,
+        "accountable_for": [
+            "approving activation",
+            "answering for every occurrence recorded under this intent",
+        ],
+        "requires_confirmation": not clean_owner or owner_kind == "unassigned",
+    }
+
+
+def _overlap_posture(posture: str) -> dict[str, object]:
+    return {
+        "status": "prepared",
+        "posture": posture,
+        "explicit": posture != "unspecified",
+        "requires_confirmation": posture == "unspecified",
+        "failure_policy_owner": "tracked separately; this record carries the posture, not the overrun handling",
+    }
+
+
+def _claim_boundary() -> dict[str, object]:
+    return {
+        "prepared_is_not_observed": True,
+        "activated_is_not_executed": True,
+        "omh_runs_no_scheduler": True,
+        "occurrence_evidence_authority": "linked_runtime_run",
+        "statement": PREPARED_RECURRING_INTENT_IS_NOT,
+    }
+
+
+def _refresh_derived_blocks(record: dict[str, Any], *, revised_at: str) -> None:
+    """Recompute the blocks that are a function of the rest of the record."""
+    record["revision"] = {
+        "revision_id": recurring_intent_revision_id(record),
+        "digest_algorithm": "sha256",
+        "digest_inputs": list(REVISION_DIGEST_FIELDS),
+        "revised_at": revised_at,
+    }
+    record["open_decisions"] = _open_decisions(record)
+    record["human_summary"] = _human_summary(record)
+    record["claim_boundary"] = _claim_boundary()
+    record["status_card"] = _status_card(record)
+
+
+def _open_decisions(record: dict[str, Any]) -> list[str]:
+    decisions: list[str] = []
+    if record["schedule_intent"].get("requires_confirmation"):
+        decisions.append("confirm the exact schedule and timezone")
+    if record["silence_policy"].get("requires_confirmation"):
+        decisions.append("confirm whether to report every occurrence or only changes")
+    if record["delivery_intent"].get("requires_observed_gateway_evidence"):
+        decisions.append("confirm the delivery target and where its observed gateway evidence comes from")
+    if record["scope"].get("requires_confirmation"):
+        decisions.append("confirm the scope this recurring work is allowed to touch")
+    if record["owner_profile"].get("requires_confirmation"):
+        decisions.append("name the owner accountable for this recurring work")
+    if record["overlap_posture"].get("requires_confirmation"):
+        decisions.append(
+            "choose the overlap posture: skip_when_running, queue_after_running, or allow_concurrent"
+        )
+    return decisions
+
+
+def _human_summary(record: dict[str, Any]) -> str:
+    schedule = record["schedule_intent"]
+    cadence = str(schedule["cadence"])
+    when = "On an unconfirmed cadence" if cadence == "unspecified" else cadence.capitalize()
+    if schedule["time_hint"]:
+        when = f"{when} {schedule['time_hint']}"
+    surfaces = ", ".join(_string_list(record["delivery_intent"]["surfaces"])) or "the current Hermes thread"
+    reporting = (
+        "only when something changed"
+        if record["silence_policy"]["mode"] == "only_report_changes"
+        else "after every occurrence"
+    )
+    owner = str(record["owner_profile"]["owner"]) or "nobody yet"
+    if str(record["lifecycle"]["state"]) == "activated":
+        closing = (
+            "It is activated by an approved runtime surface; OMH still runs no scheduler, and each occurrence "
+            "counts only when that runtime records a run reference here."
+        )
+    else:
+        closing = (
+            "It is paused: OMH runs no scheduler, so nothing happens until an approved runtime surface "
+            "activates it with a recorded observer and approval reference."
+        )
+    return (
+        f"{when}: {record['request_summary']} Report to {surfaces}, {reporting}. "
+        f"Owner: {owner}. {closing}"
+    )
+
+
+def _status_card(record: dict[str, Any]) -> dict[str, object]:
+    activated = str(record["lifecycle"]["state"]) == "activated"
+    return {
+        "schema_version": RECURRING_INTENT_STATUS_CARD_SCHEMA_VERSION,
+        "headline": "Recurring intent activated by an approved runtime surface"
+        if activated
+        else "Recurring intent prepared and paused",
+        "lifecycle_state": str(record["lifecycle"]["state"]),
+        "revision_id": str(record["revision"]["revision_id"]),
+        "prepared": [
+            "cadence and time hint",
+            "delivery target",
+            "silence policy",
+            "scope",
+            "owner profile",
+            "overlap posture",
+            "required approval",
+        ],
+        "not_observed": list(RECURRING_INTENT_NOT_EVIDENCE),
+        "next": list(record["open_decisions"])
+        or (
+            ["record each occurrence with the runtime run reference that owns its evidence"]
+            if activated
+            else ["hand activation to an approved runtime surface and record its observer"]
+        ),
+    }
+
+
+def _lifecycle_errors(record: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    lifecycle = record["lifecycle"]
+    state = str(lifecycle.get("state", ""))
+    if state not in LIFECYCLE_STATES:
+        errors.append(f"unsupported lifecycle.state: {state}")
+    transitions = lifecycle.get("transitions")
+    if not isinstance(transitions, list):
+        return [*errors, "lifecycle.transitions must be a list"]
+    activations = [item for item in transitions if isinstance(item, dict) and item.get("transition") == "activated"]
+    for index, transition in enumerate(activations):
+        path = f"$.lifecycle.transitions[{index}]"
+        if not str(transition.get("observer", "")).strip():
+            errors.append(f"{path} records an activation without a recorded observer")
+        if transition.get("observer_kind") not in ACTIVATION_OBSERVER_KINDS:
+            errors.append(f"{path} activation observer_kind must be human or approved_runtime_surface")
+        if not str(transition.get("approval_ref", "")).strip():
+            errors.append(f"{path} records an activation without a recorded approval reference")
+        if not str(transition.get("activation_surface", "")).strip():
+            errors.append(f"{path} records an activation without the approved runtime surface that performed it")
+    if state == "activated":
+        if not activations:
+            errors.append("an activated recurring intent must carry a recorded activation transition")
+        if str(record["overlap_posture"].get("posture", "")) == "unspecified":
+            errors.append("an activated recurring intent must carry an explicit overlap posture")
+        if record["required_approval"].get("granted") is not True:
+            errors.append("an activated recurring intent must record its approval as granted")
+    return errors
+
+
+def _occurrence_errors(record: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    occurrences = record["occurrences"]
+    total = record.get("occurrences_recorded_total")
+    if not isinstance(total, int) or isinstance(total, bool) or total < 0:
+        errors.append("occurrences_recorded_total must be a non-negative integer")
+    elif total < len(occurrences):
+        errors.append("occurrences_recorded_total must not be lower than the retained occurrence count")
+    if len(occurrences) > RETAINED_OCCURRENCE_LIMIT:
+        errors.append(f"occurrences must retain at most the {RETAINED_OCCURRENCE_LIMIT} most recent links")
+    transitions = record["lifecycle"].get("transitions", [])
+    ever_activated = any(
+        isinstance(item, dict) and item.get("transition") == "activated"
+        for item in (transitions if isinstance(transitions, list) else [])
+    )
+    if occurrences and not ever_activated:
+        errors.append(
+            "a recurring intent with no recorded activation transition must not carry occurrences: "
+            "it cannot claim that any occurrence ran"
+        )
+    known_revisions = {str(record["revision"].get("revision_id", ""))}
+    for item in record["revision_history"]:
+        if isinstance(item, dict):
+            known_revisions.add(str(item.get("revision_id", "")))
+    for index, occurrence in enumerate(occurrences):
+        path = f"$.occurrences[{index}]"
+        if not isinstance(occurrence, dict):
+            errors.append(f"{path} must be an object")
+            continue
+        if occurrence.get("schema_version") != RECURRING_OCCURRENCE_SCHEMA_VERSION:
+            errors.append(f"{path}.schema_version must be {RECURRING_OCCURRENCE_SCHEMA_VERSION}")
+        if occurrence.get("outcome") not in OCCURRENCE_OUTCOMES:
+            errors.append(f"{path}.outcome must be one of {', '.join(OCCURRENCE_OUTCOMES)}")
+        if not str(occurrence.get("observer", "")).strip():
+            errors.append(f"{path} must name the observer that reported the run")
+        runtime_run = occurrence.get("runtime_run")
+        if not isinstance(runtime_run, dict) or not str(runtime_run.get("run_ref", "")).strip():
+            errors.append(f"{path} must link a runtime run reference: preparation is never execution")
+        revision_id = str(occurrence.get("intent_revision_id", ""))
+        if revision_id not in known_revisions:
+            errors.append(f"{path} names unknown intent revision {revision_id or '<missing>'}")
+    return errors
+
+
+def _digest_value(record: dict[str, Any], field: str) -> object:
+    value: object = record
+    for part in field.split("."):
+        if not isinstance(value, dict):
+            return None
+        value = value.get(part)
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    if isinstance(value, bool) or value is None:
+        return value
+    return str(value)
+
+
+def _intent_path(paths: OmhPaths, intent_id: str) -> Path:
+    if not _valid_intent_id(intent_id):
+        raise ValueError("intent_id must contain only letters, digits, and hyphens, and must not contain path separators")
+    path = paths.recurring_intents_dir / f"{intent_id}.json"
+    root = paths.recurring_intents_dir.resolve()
+    resolved = path.resolve()
+    if resolved.parent != root:
+        raise ValueError("intent_id escapes recurring intent storage")
+    return path
+
+
+def _write_index_cache(paths: OmhPaths) -> None:
+    records = list_recurring_intents(paths)
+    ensure_dir(paths.recurring_intents_root, private=True)
+    atomic_write_json(
+        paths.recurring_intents_index_path,
+        {
+            "schema_version": RECURRING_INTENT_INDEX_SCHEMA_VERSION,
+            "updated_at": utc_now(),
+            "authority": "cache_only",
+            "intents": [summarize_recurring_intent(record) for record in records],
+        },
+        private=True,
+    )
+
+
+def _clone(record: dict[str, Any]) -> dict[str, Any]:
+    return json.loads(json.dumps(record))
+
+
+def _default_title(text: str) -> str:
+    return f"Recurring intent: {_preview(text, limit=72)}"
+
+
+def _stamp(value: datetime | str | None) -> str:
+    if value is None:
+        value = datetime.now(timezone.utc)
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return _slugify(value)[:32] or datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        return _stamp(parsed)
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _slugify(value: str) -> str:
+    return (_SLUG_RE.sub("-", value.casefold()).strip("-") or "recurring-intent")[:64].strip("-")
+
+
+def _valid_intent_id(value: str) -> bool:
+    return bool(_INTENT_ID_RE.fullmatch(str(value)))
+
+
+def _string_list(value: object) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, tuple):
+        value = list(value)
+    if not isinstance(value, list):
+        return [str(value).strip()] if str(value).strip() else []
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
+def _preview(value: str, *, limit: int) -> str:
+    clean = " ".join(str(value).split())
+    if len(clean) <= limit:
+        return clean
+    return clean[: max(0, limit - 3)].rstrip() + "..."

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -700,8 +700,9 @@ _STATUS_COPY = {
 _HUMAN_ACK_BODY_BY_SKILL = {
     "automation-blueprint": (
         "I will prepare this as a recurring Hermes ops workflow: schedule, source inputs, delivery target, "
-        "silence policy, and the confirmation card. Creating the actual schedule or sending messages still "
-        "needs observed runtime evidence."
+        "silence policy, and the confirmation card. If you want it kept, I can save it as a paused recurring "
+        "intent. Activating it, creating the actual schedule, or sending messages still needs observed runtime "
+        "evidence."
     ),
     "research-department": (
         "I will shape this into a research workflow: what to watch, how raw findings move into analysis, "
@@ -1666,8 +1667,9 @@ _WORKFLOW_OPERATIONS_CHAT_CARDS: dict[str, dict[str, object]] = {
         "headline": "I can turn this into a scheduled ops blueprint.",
         "body": (
             "I will prepare the recurring workflow: schedule, source inputs, delivery target, silence policy, "
-            "confirmation card, and status update rules. Host cron creation, source retrieval, gateway delivery, "
-            "and no-agent execution stay observed-only."
+            "confirmation card, and status update rules. I can save it as a paused recurring intent, which only "
+            "an approved runtime surface can activate later, with an approval reference and a recorded observer. "
+            "Host cron creation, source retrieval, gateway delivery, and no-agent execution stay observed-only."
         ),
         "phase": "automation_blueprint_prepared",
         "next_action": "prepare_scheduled_ops_blueprint",
@@ -1682,6 +1684,7 @@ _WORKFLOW_OPERATIONS_CHAT_CARDS: dict[str, dict[str, object]] = {
             "capture_schedule",
             "define_source_inputs",
             "set_delivery_and_silence_policy",
+            "save_paused_recurring_intent",
             "prepare_confirmation_card",
         ],
         "evidence_not_observed": [

--- a/tests/test_recurring_intents.py
+++ b/tests/test_recurring_intents.py
@@ -1,0 +1,730 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+from omh.chat_router import route_chat_message
+from omh.hermes_ops import build_scheduled_ops_blueprint, validate_hermes_ops_blueprint
+from omh.paths import OmhPaths
+from omh.wrapper_contract import build_chat_interaction_payload
+from omh.workflows.recurring_intents import (
+    RECURRING_OCCURRENCE_SCHEMA_VERSION,
+    RETAINED_OCCURRENCE_LIMIT,
+    activate_recurring_intent,
+    build_recurring_intent,
+    list_recurring_intents,
+    preview_recurring_intent,
+    record_recurring_intent_occurrence,
+    recurring_intent_revision_id,
+    revise_recurring_intent,
+    show_recurring_intent,
+    summarize_recurring_intent,
+    update_recurring_intent,
+    validate_recurring_intent,
+    validate_recurring_intent_store,
+    write_recurring_intent,
+)
+
+
+REQUEST = "every weekday morning at 9am sweep stale pull requests and send a Slack digest only if something changed"
+
+
+class RecurringIntentPreparationTests(unittest.TestCase):
+    """AC1: a natural-language recurring intent is previewable and savable."""
+
+    def test_natural_language_recurring_request_reaches_the_recurring_lane(self) -> None:
+        """No new trigger was added: the recurring lane is the one chat already reaches."""
+        for message in (
+            REQUEST,
+            "make a daily competitor research digest blueprint every morning",
+            "매일 아침 경쟁사 뉴스를 조사해서 변화 있으면 슬랙으로 보내줘",
+        ):
+            with self.subTest(message=message):
+                route = route_chat_message(message)
+
+                self.assertEqual(route["action"], "dispatch")
+                self.assertEqual(route["selected_skill"], "automation-blueprint")
+                self.assertEqual(route["selected_harness"], "scheduled-ops-blueprint")
+
+    def test_one_off_requests_do_not_become_recurring_intents(self) -> None:
+        for message in (
+            "summarize this pull request for me right now",
+            "fix the failing test in src/routing/chat.py",
+            "what does the recurring intent record store?",
+        ):
+            with self.subTest(message=message):
+                route = route_chat_message(message)
+
+                self.assertNotEqual(route["selected_skill"], "automation-blueprint")
+                self.assertNotEqual(route["selected_harness"], "scheduled-ops-blueprint")
+
+    def test_the_chat_card_offers_to_save_the_paused_intent_and_names_activation(self) -> None:
+        payload = build_chat_interaction_payload(
+            "every weekday morning check release risk and tell me on Slack only if something changed",
+            source="discord",
+        )
+
+        response = payload["chat_response"]
+        self.assertEqual(payload["route"]["selected_skill"], "automation-blueprint")
+        self.assertIn("save it as a paused recurring intent", response["body"])
+        self.assertIn("only an approved runtime surface can activate later", response["body"])
+        self.assertIn("with an approval reference and a recorded observer", response["body"])
+        self.assertIn("save_paused_recurring_intent", response["state"]["recommended_flow"])
+
+    def test_preview_needs_no_command_knowledge_and_reads_back_the_plan(self) -> None:
+        intent = build_recurring_intent(REQUEST, created_at="2026-06-16T00:00:00Z")
+
+        preview = preview_recurring_intent(intent)
+
+        self.assertTrue(preview["preview_only"])
+        self.assertFalse(preview["saved"])
+        self.assertFalse(preview["save"]["requires_user_command"])
+        self.assertEqual(preview["save"]["user_action"], "confirm_or_correct_the_summary")
+        self.assertEqual(preview["save"]["entry_action"], "prepare_scheduled_ops_blueprint")
+        self.assertEqual(preview["intent"], intent)
+        self.assertIn("Weekday at 9am", preview["human_summary"])
+        self.assertIn("slack", preview["human_summary"])
+        self.assertIn("OMH runs no scheduler", preview["human_summary"])
+        self.assertIn("name the owner accountable for this recurring work", preview["open_decisions"])
+
+    def test_cadence_delivery_and_silence_come_from_the_blueprint_normalizer(self) -> None:
+        intent = build_recurring_intent(REQUEST, created_at="2026-06-16T00:00:00Z")
+        blueprint = build_scheduled_ops_blueprint(REQUEST, created_at="2026-06-16T00:00:00Z")
+
+        self.assertEqual(intent["derived_from"]["schema_version"], "hermes_ops_blueprint/v1")
+        self.assertEqual(intent["derived_from"]["authority"], "projection_only")
+        self.assertEqual(intent["schedule_intent"], blueprint["schedule_intent"])
+        self.assertEqual(intent["delivery_intent"], blueprint["delivery_intent"])
+        self.assertEqual(intent["silence_policy"], blueprint["silence_policy"])
+
+    def test_korean_recurring_request_prepares_the_same_paused_shape(self) -> None:
+        intent = build_recurring_intent(
+            "매일 아침 경쟁사 뉴스를 조사해서 변화 있으면 슬랙으로 보내줘",
+            created_at="2026-06-16T00:00:00Z",
+        )
+
+        self.assertEqual(intent["schedule_intent"]["cadence"], "daily")
+        self.assertEqual(intent["delivery_intent"]["surfaces"], ["slack"])
+        self.assertEqual(intent["lifecycle"]["state"], "paused")
+        self.assertEqual(validate_recurring_intent(intent), [])
+
+
+class RecurringIntentPausedByDefaultTests(unittest.TestCase):
+    """AC2: a new intent is paused and cannot claim that any occurrence ran."""
+
+    def test_fresh_intent_has_no_vocabulary_for_a_run(self) -> None:
+        intent = build_recurring_intent(REQUEST, created_at="2026-06-16T00:00:00Z")
+
+        self.assertEqual(intent["lifecycle"]["state"], "paused")
+        self.assertEqual(intent["lifecycle"]["transitions"], [])
+        self.assertEqual(intent["occurrences"], [])
+        self.assertFalse(intent["required_approval"]["granted"])
+        self.assertTrue(intent["required_approval"]["required"])
+        self.assertTrue(intent["claim_boundary"]["omh_runs_no_scheduler"])
+        self.assertEqual(summarize_recurring_intent(intent)["occurrence_count"], 0)
+        self.assertEqual(validate_recurring_intent(intent), [])
+
+    def test_recording_an_occurrence_on_a_paused_intent_is_refused(self) -> None:
+        intent = build_recurring_intent(REQUEST, created_at="2026-06-16T00:00:00Z")
+
+        with self.assertRaises(ValueError) as caught:
+            record_recurring_intent_occurrence(
+                intent,
+                runtime_run_ref="run-1",
+                runtime_surface="hermes-runtime",
+                observer="hermes-runtime",
+            )
+
+        self.assertIn("a paused recurring intent cannot record an occurrence", str(caught.exception))
+
+    def test_validator_refuses_a_payload_that_asserts_an_occurrence_ran(self) -> None:
+        intent = build_recurring_intent(REQUEST, created_at="2026-06-16T00:00:00Z")
+        intent["occurrences"] = [
+            {
+                "schema_version": RECURRING_OCCURRENCE_SCHEMA_VERSION,
+                "occurrence_id": "forged",
+                "intent_id": intent["intent_id"],
+                "intent_revision_id": intent["revision"]["revision_id"],
+                "outcome": "ran",
+                "observer": "someone",
+                "observer_kind": "human",
+                "observed_at": "2026-06-17T00:00:00Z",
+                "runtime_run": {"surface": "hermes-runtime", "run_ref": "run-1"},
+                "evidence_authority": "linked_runtime_run",
+                "claim_boundary": "forged",
+            }
+        ]
+
+        errors = validate_recurring_intent(intent)
+
+        self.assertIn(
+            "a recurring intent with no recorded activation transition must not carry occurrences: "
+            "it cannot claim that any occurrence ran",
+            errors,
+        )
+
+    def test_nested_prepared_or_not_observed_guard_still_holds_for_intents(self) -> None:
+        intent = build_recurring_intent(REQUEST, created_at="2026-06-16T00:00:00Z")
+        intent["schedule_intent"]["status"] = "observed"
+        intent["delivery_intent"]["delivery_status"] = "delivered"
+
+        rendered = "; ".join(validate_recurring_intent(intent))
+
+        self.assertIn("$.schedule_intent.status must remain prepared or not_observed", rendered)
+        self.assertIn("$.delivery_intent.delivery_status must not claim observed runtime", rendered)
+
+    def test_the_blueprint_guard_this_record_reuses_is_unchanged(self) -> None:
+        blueprint = build_scheduled_ops_blueprint("daily status digest", created_at="2026-06-16T00:00:00Z")
+        blueprint["schedule_intent"]["status"] = "observed"
+
+        rendered = "; ".join(validate_hermes_ops_blueprint(blueprint))
+
+        self.assertIn("$.schedule_intent.status must remain prepared or not_observed", rendered)
+
+    def test_activation_without_a_recorded_observer_is_refused(self) -> None:
+        intent = build_recurring_intent(
+            REQUEST,
+            overlap_posture="skip_when_running",
+            created_at="2026-06-16T00:00:00Z",
+        )
+
+        with self.assertRaises(ValueError) as caught:
+            activate_recurring_intent(
+                intent,
+                observer="   ",
+                approval_ref="approval-1",
+                activation_surface="hermes-automation",
+            )
+
+        self.assertIn("activation requires a recorded observer", str(caught.exception))
+
+        intent["lifecycle"]["state"] = "activated"
+        intent["lifecycle"]["transitions"] = [
+            {
+                "transition": "activated",
+                "intent_revision_id": intent["revision"]["revision_id"],
+                "observer": "",
+                "observer_kind": "approved_runtime_surface",
+                "approval_ref": "approval-1",
+                "activation_surface": "hermes-automation",
+                "reason": "forged",
+                "recorded_at": "2026-06-16T02:00:00Z",
+            }
+        ]
+        intent["required_approval"]["granted"] = True
+
+        self.assertIn(
+            "$.lifecycle.transitions[0] records an activation without a recorded observer",
+            validate_recurring_intent(intent),
+        )
+
+    def test_activation_requires_an_approval_reference_and_an_activating_surface(self) -> None:
+        intent = build_recurring_intent(
+            REQUEST,
+            overlap_posture="skip_when_running",
+            created_at="2026-06-16T00:00:00Z",
+        )
+
+        with self.assertRaises(ValueError) as missing_approval:
+            activate_recurring_intent(
+                intent,
+                observer="hermes-runtime",
+                approval_ref="",
+                activation_surface="hermes-automation",
+            )
+        with self.assertRaises(ValueError) as missing_surface:
+            activate_recurring_intent(
+                intent,
+                observer="hermes-runtime",
+                approval_ref="approval-1",
+                activation_surface="",
+            )
+
+        self.assertIn("requires a recorded approval reference", str(missing_approval.exception))
+        self.assertIn("requires the approved runtime surface that performed it", str(missing_surface.exception))
+
+    def test_overlap_posture_must_be_explicit_before_activation(self) -> None:
+        intent = build_recurring_intent(REQUEST, created_at="2026-06-16T00:00:00Z")
+
+        self.assertEqual(intent["overlap_posture"]["posture"], "unspecified")
+        self.assertFalse(intent["overlap_posture"]["explicit"])
+        with self.assertRaises(ValueError) as caught:
+            activate_recurring_intent(
+                intent,
+                observer="hermes-runtime",
+                approval_ref="approval-1",
+                activation_surface="hermes-automation",
+            )
+
+        self.assertIn("activation requires an explicit overlap posture", str(caught.exception))
+
+        intent["lifecycle"]["state"] = "activated"
+        intent["lifecycle"]["transitions"] = [
+            {
+                "transition": "activated",
+                "intent_revision_id": intent["revision"]["revision_id"],
+                "observer": "hermes-runtime",
+                "observer_kind": "approved_runtime_surface",
+                "approval_ref": "approval-1",
+                "activation_surface": "hermes-automation",
+                "reason": "forged",
+                "recorded_at": "2026-06-16T02:00:00Z",
+            }
+        ]
+        intent["required_approval"]["granted"] = True
+
+        self.assertIn(
+            "an activated recurring intent must carry an explicit overlap posture",
+            validate_recurring_intent(intent),
+        )
+
+
+class RecurringIntentRevisionLinkageTests(unittest.TestCase):
+    """AC3: every observed occurrence links back to the exact intent revision."""
+
+    def test_revision_id_is_deterministic_and_free_of_wall_clock(self) -> None:
+        first = build_recurring_intent(REQUEST, created_at="2026-06-16T00:00:00Z")
+        second = build_recurring_intent(REQUEST, created_at="2027-01-01T23:59:59Z")
+
+        self.assertNotEqual(first["intent_id"], second["intent_id"])
+        self.assertEqual(first["revision"]["revision_id"], second["revision"]["revision_id"])
+        self.assertEqual(first["revision"]["digest_algorithm"], "sha256")
+        self.assertNotIn("created_at", first["revision"]["digest_inputs"])
+        self.assertNotIn("updated_at", first["revision"]["digest_inputs"])
+        self.assertNotIn("revision.revised_at", first["revision"]["digest_inputs"])
+
+    def test_occurrence_names_the_exact_revision_it_ran_under(self) -> None:
+        activated = _activated_intent()
+
+        recorded = record_recurring_intent_occurrence(
+            activated,
+            runtime_run_ref="run-42",
+            runtime_surface="hermes-runtime",
+            observer="hermes-runtime",
+            observed_at="2026-06-17T00:00:00Z",
+        )
+
+        occurrence = recorded["occurrences"][0]
+        self.assertEqual(occurrence["intent_revision_id"], recorded["revision"]["revision_id"])
+        self.assertEqual(occurrence["runtime_run"], {"surface": "hermes-runtime", "run_ref": "run-42"})
+        self.assertEqual(occurrence["evidence_authority"], "linked_runtime_run")
+        self.assertIn("linked runtime run owns this execution evidence", occurrence["claim_boundary"])
+        self.assertEqual(recorded["observation_status"], "prepared")
+        self.assertEqual(summarize_recurring_intent(recorded)["current_revision_occurrence_count"], 1)
+        self.assertEqual(validate_recurring_intent(recorded), [])
+
+    def test_a_changed_intent_produces_a_new_revision_that_the_old_occurrence_does_not_cover(self) -> None:
+        recorded = record_recurring_intent_occurrence(
+            _activated_intent(),
+            runtime_run_ref="run-42",
+            runtime_surface="hermes-runtime",
+            observer="hermes-runtime",
+            observed_at="2026-06-17T00:00:00Z",
+        )
+        original_revision = recorded["revision"]["revision_id"]
+
+        revised = revise_recurring_intent(recorded, revised_at="2026-06-18T00:00:00Z", schedule="every week")
+
+        self.assertNotEqual(revised["revision"]["revision_id"], original_revision)
+        self.assertEqual(revised["schedule_intent"]["cadence"], "weekly")
+        self.assertEqual(
+            [item["revision_id"] for item in revised["revision_history"]],
+            [original_revision],
+        )
+        self.assertEqual(revised["occurrences"][0]["intent_revision_id"], original_revision)
+        summary = summarize_recurring_intent(revised)
+        self.assertEqual(summary["occurrence_count"], 1)
+        self.assertEqual(summary["current_revision_occurrence_count"], 0)
+        self.assertEqual(validate_recurring_intent(revised), [])
+
+    def test_revising_an_activated_intent_pauses_it_until_a_new_observer_is_recorded(self) -> None:
+        revised = revise_recurring_intent(
+            _activated_intent(),
+            revised_at="2026-06-18T00:00:00Z",
+            owner="someone-else",
+            owner_kind="human",
+        )
+
+        self.assertEqual(revised["lifecycle"]["state"], "paused")
+        self.assertEqual(revised["lifecycle"]["transitions"][-1]["transition"], "paused_by_revision")
+        self.assertFalse(revised["required_approval"]["granted"])
+        self.assertEqual(revised["required_approval"]["approval_ref"], "")
+        with self.assertRaises(ValueError):
+            record_recurring_intent_occurrence(
+                revised,
+                runtime_run_ref="run-43",
+                runtime_surface="hermes-runtime",
+                observer="hermes-runtime",
+            )
+
+    def test_a_revision_that_changes_nothing_is_refused(self) -> None:
+        intent = build_recurring_intent(REQUEST, created_at="2026-06-16T00:00:00Z")
+
+        with self.assertRaises(ValueError) as caught:
+            revise_recurring_intent(intent, revised_at="2026-06-18T00:00:00Z", owner="")
+
+        self.assertIn("must change at least one meaningful field", str(caught.exception))
+
+    def test_occurrence_naming_an_unknown_revision_is_refused(self) -> None:
+        recorded = record_recurring_intent_occurrence(
+            _activated_intent(),
+            runtime_run_ref="run-42",
+            runtime_surface="hermes-runtime",
+            observer="hermes-runtime",
+            observed_at="2026-06-17T00:00:00Z",
+        )
+        recorded["occurrences"][0]["intent_revision_id"] = "rev-0000000000000000"
+
+        self.assertIn(
+            "$.occurrences[0] names unknown intent revision rev-0000000000000000",
+            validate_recurring_intent(recorded),
+        )
+
+    def test_occurrence_without_a_runtime_run_reference_is_refused(self) -> None:
+        activated = _activated_intent()
+
+        with self.assertRaises(ValueError) as caught:
+            record_recurring_intent_occurrence(
+                activated,
+                runtime_run_ref="",
+                runtime_surface="hermes-runtime",
+                observer="hermes-runtime",
+            )
+
+        self.assertIn("occurrence requires a runtime run reference", str(caught.exception))
+
+        recorded = record_recurring_intent_occurrence(
+            activated,
+            runtime_run_ref="run-42",
+            runtime_surface="hermes-runtime",
+            observer="hermes-runtime",
+            observed_at="2026-06-17T00:00:00Z",
+        )
+        recorded["occurrences"][0]["runtime_run"] = {"surface": "hermes-runtime", "run_ref": ""}
+
+        self.assertIn(
+            "$.occurrences[0] must link a runtime run reference: preparation is never execution",
+            validate_recurring_intent(recorded),
+        )
+
+    def test_the_same_runtime_run_cannot_be_linked_twice(self) -> None:
+        recorded = record_recurring_intent_occurrence(
+            _activated_intent(),
+            runtime_run_ref="run-42",
+            runtime_surface="hermes-runtime",
+            observer="hermes-runtime",
+            observed_at="2026-06-17T00:00:00Z",
+        )
+
+        with self.assertRaises(ValueError) as caught:
+            record_recurring_intent_occurrence(
+                recorded,
+                runtime_run_ref="run-42",
+                runtime_surface="hermes-runtime",
+                observer="hermes-runtime",
+                observed_at="2026-06-18T00:00:00Z",
+            )
+
+        self.assertIn("runtime run run-42 is already linked", str(caught.exception))
+
+    def test_retained_occurrences_are_bounded_without_losing_the_recorded_total(self) -> None:
+        record = _activated_intent()
+        for index in range(RETAINED_OCCURRENCE_LIMIT + 5):
+            record = record_recurring_intent_occurrence(
+                record,
+                runtime_run_ref=f"run-{index}",
+                runtime_surface="hermes-runtime",
+                observer="hermes-runtime",
+                observed_at="2026-06-17T00:00:00Z",
+            )
+
+        self.assertEqual(len(record["occurrences"]), RETAINED_OCCURRENCE_LIMIT)
+        self.assertEqual(record["occurrences_recorded_total"], RETAINED_OCCURRENCE_LIMIT + 5)
+        self.assertEqual(record["occurrences"][-1]["runtime_run"]["run_ref"], f"run-{RETAINED_OCCURRENCE_LIMIT + 4}")
+        summary = summarize_recurring_intent(record)
+        self.assertEqual(summary["occurrence_count"], RETAINED_OCCURRENCE_LIMIT + 5)
+        self.assertEqual(summary["retained_occurrence_count"], RETAINED_OCCURRENCE_LIMIT)
+        self.assertEqual(validate_recurring_intent(record), [])
+
+        record["occurrences_recorded_total"] = 1
+
+        self.assertIn(
+            "occurrences_recorded_total must not be lower than the retained occurrence count",
+            validate_recurring_intent(record),
+        )
+
+    def test_editing_a_meaningful_field_without_bumping_the_revision_is_refused(self) -> None:
+        intent = build_recurring_intent(REQUEST, created_at="2026-06-16T00:00:00Z")
+        intent["schedule_intent"]["cadence"] = "monthly"
+
+        rendered = "; ".join(validate_recurring_intent(intent))
+
+        self.assertIn("revision.revision_id must be the digest of the intent's meaningful fields", rendered)
+        self.assertIn(recurring_intent_revision_id(intent), rendered)
+
+
+class RecurringIntentStoreTests(unittest.TestCase):
+    def test_store_round_trips_updates_and_validates(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths_from_tmp(tmp)
+            intent = build_recurring_intent(
+                REQUEST,
+                overlap_posture="skip_when_running",
+                owner="khope",
+                owner_kind="human",
+                created_at="2026-06-16T00:00:00Z",
+            )
+
+            written = write_recurring_intent(paths, intent)
+
+            self.assertEqual(show_recurring_intent(paths, written["intent_id"])["title"], written["title"])
+            self.assertEqual(len(list_recurring_intents(paths)), 1)
+            self.assertTrue(paths.recurring_intents_index_path.exists())
+            with self.assertRaises(ValueError):
+                write_recurring_intent(paths, intent)
+
+            activated = update_recurring_intent(
+                paths,
+                activate_recurring_intent(
+                    written,
+                    observer="hermes-runtime",
+                    approval_ref="approval-1",
+                    activation_surface="hermes-automation",
+                    observed_at="2026-06-16T02:00:00Z",
+                ),
+            )
+
+            self.assertEqual(show_recurring_intent(paths, activated["intent_id"])["lifecycle"]["state"], "activated")
+            self.assertEqual(len(list_recurring_intents(paths)), 1)
+            validation = validate_recurring_intent_store(paths)
+            self.assertTrue(validation["ok"])
+            self.assertEqual(validation["intent_count"], 1)
+            index = json.loads(paths.recurring_intents_index_path.read_text(encoding="utf-8"))
+            self.assertEqual(index["authority"], "cache_only")
+            self.assertEqual(index["intents"][0]["lifecycle_state"], "activated")
+
+    def test_update_requires_an_existing_record(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths_from_tmp(tmp)
+            intent = build_recurring_intent(REQUEST, created_at="2026-06-16T00:00:00Z")
+
+            with self.assertRaises(FileNotFoundError):
+                update_recurring_intent(paths, intent)
+
+    def test_show_rejects_path_traversal_intent_ids(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths_from_tmp(tmp)
+
+            for unsafe_id in ("../outside", "/tmp/outside", " unsafe"):
+                with self.subTest(unsafe_id=unsafe_id):
+                    with self.assertRaises(FileNotFoundError):
+                        show_recurring_intent(paths, unsafe_id)
+
+    def test_store_validation_reports_malformed_records(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths_from_tmp(tmp)
+            intent = build_recurring_intent(REQUEST, created_at="2026-06-16T00:00:00Z")
+            write_recurring_intent(paths, intent)
+            broken = paths.recurring_intents_dir / f"{intent['intent_id']}.json"
+            broken_record = json.loads(broken.read_text(encoding="utf-8"))
+            broken_record["overlap_posture"]["posture"] = "whenever"
+            _write_json(broken, broken_record)
+
+            validation = validate_recurring_intent_store(paths)
+
+            self.assertFalse(validation["ok"])
+            self.assertIn("unsupported overlap_posture.posture: whenever", " ".join(validation["errors"]))
+
+
+class RecurringIntentCliTests(unittest.TestCase):
+    def test_cli_previews_saves_activates_and_links_one_occurrence(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            base = ["--omh-home", str(omh_home), "ops"]
+
+            status, stdout, stderr = run_cli(base + ["recurring-intent", REQUEST, "--dry-run"])
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            preview = json.loads(stdout)
+            self.assertEqual(preview["schema_version"], "hermes_recurring_intent_preview/v1")
+            self.assertTrue(preview["preview_only"])
+            self.assertFalse(preview["saved"])
+            self.assertFalse(preview["save"]["requires_user_command"])
+            self.assertFalse(preview["store"]["written"])
+            self.assertFalse((omh_home / "hermes-ops").exists())
+            self.assertTrue(preview["boundary"]["omh_runs_no_scheduler"])
+            self.assertFalse(preview["boundary"]["occurrence_executed_by_omh"])
+            self.assertEqual(preview["intent"]["lifecycle"]["state"], "paused")
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "recurring-intent",
+                    REQUEST,
+                    "--owner",
+                    "khope",
+                    "--owner-kind",
+                    "human",
+                    "--overlap-posture",
+                    "skip_when_running",
+                ]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            saved = json.loads(stdout)
+            self.assertEqual(saved["schema_version"], "omh_ops_recurring_intent_result/v1")
+            self.assertTrue(saved["store"]["written"])
+            intent_id = saved["intent"]["intent_id"]
+            revision_id = saved["intent"]["revision"]["revision_id"]
+            self.assertTrue((omh_home / "hermes-ops" / "recurring-intents" / "intents" / f"{intent_id}.json").exists())
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "recurring-intent-occurrence",
+                    intent_id,
+                    "--runtime-run-ref",
+                    "run-42",
+                    "--runtime-surface",
+                    "hermes-runtime",
+                    "--observer",
+                    "hermes-runtime",
+                ]
+            )
+
+            self.assertNotEqual(status, 0)
+            self.assertIn("a paused recurring intent cannot record an occurrence", stderr)
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "recurring-intent-activate",
+                    intent_id,
+                    "--observer",
+                    "hermes-runtime",
+                    "--approval-ref",
+                    "approval-1",
+                    "--activation-surface",
+                    "hermes-automation",
+                ]
+            )
+
+            self.assertEqual(status, 0, stderr)
+            activated = json.loads(stdout)["intent"]
+            self.assertEqual(activated["lifecycle"]["state"], "activated")
+            self.assertEqual(activated["lifecycle"]["transitions"][-1]["observer"], "hermes-runtime")
+            self.assertEqual(activated["lifecycle"]["transitions"][-1]["approval_ref"], "approval-1")
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "recurring-intent-occurrence",
+                    intent_id,
+                    "--runtime-run-ref",
+                    "run-42",
+                    "--runtime-surface",
+                    "hermes-runtime",
+                    "--observer",
+                    "hermes-runtime",
+                ]
+            )
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(json.loads(stdout)["intent"]["occurrences"][0]["intent_revision_id"], revision_id)
+
+            status, stdout, stderr = run_cli(base + ["recurring-intent-revise", intent_id, "--schedule", "every week"])
+
+            self.assertEqual(status, 0, stderr)
+            revised = json.loads(stdout)["intent"]
+            self.assertNotEqual(revised["revision"]["revision_id"], revision_id)
+            self.assertEqual(revised["lifecycle"]["state"], "paused")
+
+            status, stdout, stderr = run_cli(base + ["recurring-intent-list"])
+
+            self.assertEqual(status, 0, stderr)
+            listing = json.loads(stdout)
+            self.assertEqual(listing["schema_version"], "omh_ops_recurring_intent_list/v1")
+            self.assertEqual(listing["intents"][0]["occurrence_count"], 1)
+            self.assertEqual(listing["intents"][0]["current_revision_occurrence_count"], 0)
+
+            status, stdout, stderr = run_cli(base + ["recurring-intent-show", intent_id])
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(json.loads(stdout)["intent"]["intent_id"], intent_id)
+
+            status, stdout, stderr = run_cli(base + ["validate"])
+
+            self.assertEqual(status, 0, stderr)
+            validation = json.loads(stdout)
+            self.assertTrue(validation["ok"])
+            self.assertEqual(validation["recurring_intents"]["intent_count"], 1)
+
+    def test_cli_defaults_to_plain_text_for_people(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home = Path(tmp) / ".omh"
+            base = ["--omh-home", str(omh_home), "ops"]
+
+            status, stdout, stderr = run_cli(base + ["recurring-intent", REQUEST, "--dry-run"], output_json=False)
+
+            self.assertEqual(status, 0, stderr)
+            self.assertFalse(stdout.lstrip().startswith("{"))
+            self.assertIn("lifecycle: paused", stdout)
+            self.assertIn("overlap posture: unspecified", stdout)
+            self.assertIn("OMH runs no scheduler", stdout)
+
+            status, stdout, stderr = run_cli(base + ["recurring-intent-list"], output_json=False)
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stdout.strip(), "No recurring intents recorded.")
+
+    def test_cli_rejects_a_traversal_intent_id(self) -> None:
+        with TemporaryDirectory() as tmp:
+            base = ["--omh-home", str(Path(tmp) / ".omh"), "ops"]
+
+            status, _stdout, stderr = run_cli(base + ["recurring-intent-show", "../outside"])
+
+            self.assertNotEqual(status, 0)
+            self.assertIn("outside", stderr)
+
+
+def _activated_intent() -> dict:
+    intent = build_recurring_intent(
+        REQUEST,
+        overlap_posture="skip_when_running",
+        owner="khope",
+        owner_kind="human",
+        created_at="2026-06-16T00:00:00Z",
+    )
+    return activate_recurring_intent(
+        intent,
+        observer="hermes-runtime",
+        approval_ref="approval-1",
+        activation_surface="hermes-automation",
+        observed_at="2026-06-16T02:00:00Z",
+    )
+
+
+def _write_json(path: Path, record: dict) -> None:
+    # Windows portability: these bytes are read back and compared, so they must
+    # not gain CRLF line endings from Path.write_text.
+    from omh.local_store import atomic_write_text
+
+    atomic_write_text(path, json.dumps(record, indent=2, sort_keys=True) + "\n")
+
+
+def _paths_from_tmp(tmp: str) -> OmhPaths:
+    root = Path(tmp)
+    return OmhPaths(root / ".omh", root / ".hermes")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New schema-versioned record `hermes_recurring_intent/v1` (`src/workflows/recurring_intents.py`) that captures cadence, scope, owner profile, overlap posture, and required approval for recurring work, and stays paused until an approved runtime surface records an activation.
- New occurrence record `hermes_recurring_occurrence/v1`, embedded in the intent, that links one observed runtime run to the exact intent revision it ran under.
- Deterministic intent revision id: `rev-<sha256[:16]>` over the intent's meaningful fields only. No wall clock is inside the digest; times are parameters.
- New agent-facing CLI: `omh ops recurring-intent`, `recurring-intent-revise`, `recurring-intent-activate`, `recurring-intent-occurrence`, `recurring-intent-list`, `recurring-intent-show`. Plain text by default, `--json` for machines. `omh ops validate` now also validates the recurring-intent store.
- The `automation-blueprint` lane now knows about the record: its skill guidance, harness contract, chat card body, and human ack copy say the saved intent is paused and name what activation needs. `docs/WORKFLOWS.md` and `skills/omh-automation-blueprint/SKILL.md` were regenerated from catalog source, not hand-edited.
- `nested_status_boundary_errors` is now a public entry on `src/workflows/hermes_ops.py` so the sibling record reuses the blueprint's prepared-vs-observed guard instead of copying it.

### Why This Exists

Closes #832. A user could already describe recurring maintenance in chat, and routing already reached `automation-blueprint`, but the only thing OMH could produce was a `hermes_ops_blueprint/v1` projection: write-once, no owner, no overlap posture, no approval field, no activation record, and no way to say "this run happened, and it ran under this exact version of the plan". `grep -rn "recurring_intent" src/ tests/` returned 0 hits before this change; so did `overlap|activat|occurrence|owner_profile|paused` in `src/workflows/hermes_ops.py`.

The risk this closes is the one the issue names: recurring work becoming hidden automation. A record that can be activated has to make activation an auditable transition, or "paused by default" is just a field someone can flip.

### User / Operator Impact

Before: a user says "every weekday morning sweep stale PRs and post a Slack digest only if something changed" and gets a blueprint that cannot be kept, owned, activated, or reconciled against what actually ran.

After, from chat and without typing a command:

- Hermes reads back a plain-language summary ("Weekday at 9am: ... Report to slack, only when something changed. Owner: nobody yet. It is paused: OMH runs no scheduler, so nothing happens until an approved runtime surface activates it with a recorded observer and approval reference.") plus the open decisions still needed.
- On confirmation it is saved, paused, under `.omh/hermes-ops/recurring-intents/intents/`.
- Activation is not something the user or OMH can do here. It is recorded, after the fact, with an observer, an approval reference, and the approved runtime surface that performed it.
- Every occurrence names a runtime run reference and the intent revision. Change the intent and the revision changes, so an old occurrence stops counting as evidence for the new plan.

### How It Works

**Sibling record, not a second concept, and not more blueprint fields.** `hermes_recurring_intent/v1` is the lifecycle envelope around a scheduled-ops blueprint. It never re-derives cadence, delivery, or silence: `_derived_intents` calls `build_scheduled_ops_blueprint` and keeps the three sub-records that builder produced, so the blueprint stays the single normalizer. Both records live under `.omh/hermes-ops/`. The module docstring records why the blueprint could not carry the lifecycle itself:

1. `hermes_ops_blueprint/v1` is `projection_only` and write-once — `write_hermes_ops_blueprint` refuses to overwrite and there is no update path. An intent is revised, activated, and accumulates occurrence links.
2. The blueprint validator refuses any nested `status` outside `{prepared, not_observed}` and any `*_status` claiming observation. An occurrence must name an observed runtime run, so putting occurrences in a blueprint would have meant weakening exactly that guard. Instead the guard is reused unchanged, and `tests/test_recurring_intents.py::test_the_blueprint_guard_this_record_reuses_is_unchanged` asserts the blueprint side still refuses.
3. Blueprint identity is a timestamp plus a random suffix. Occurrence linkage needs a content digest.

**Paused is structural.** `build_recurring_intent` has no parameter that can set an activation state or an occurrence — there is no argument to pass. For records arriving from disk or a wrapper, the validator enforces the same thing: with no recorded `activated` transition in `lifecycle.transitions`, `occurrences` must be empty ("it cannot claim that any occurrence ran"). That formulation survives the revise-after-activation case, where an intent legitimately holds occurrences while paused.

**Activation is a recorded transition.** `activate_recurring_intent` refuses a blank observer, an observer kind outside `{human, approved_runtime_surface}`, a blank approval reference, a blank activating surface, an unspecified overlap posture, and a double activation. The validator re-checks all of it on the stored record so a hand-forged payload fails too. `lifecycle.activation_performed_by` is the constant `approved_runtime_surface_outside_omh`.

**Revision digest.** `recurring_intent_revision_id` digests 16 named field paths (title, request summary, cadence/time/schedule hint, delivery surfaces, silence mode, scope, owner, overlap posture, approval requirement). Deliberately excluded: `intent_id`, `created_at`, `updated_at`, the revision block, lifecycle transitions, occurrences, and the approval *grant* state — granting approval at activation must not orphan the occurrences recorded under it. The validator recomputes the digest, so editing a meaningful field without bumping the revision is a validation error.

**Occurrence linkage.** Recording an occurrence requires an activated intent, a runtime run reference, a runtime surface, and an observer. Each occurrence carries `evidence_authority: "linked_runtime_run"` and a claim boundary saying the linked run, not this record, owns the execution evidence. Revising an activated intent pauses it and appends a `paused_by_revision` transition, and the old revision moves to `revision_history` so past occurrences stay attributable while `current_revision_occurrence_count` drops to 0.

**Bounded, deduplicated.** The same `run_ref` cannot be linked twice. Retained occurrences are capped at the 50 most recent (every mutation reads and rewrites the whole record), with `occurrences_recorded_total` keeping the count honest after truncation.

**Overlap posture** is carried and required to be explicit before activation, but its overrun failure policy is left to #833 — this PR adds the field and the gate, not the policy.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/workflows/recurring_intents.py` | New. Record, validator, lifecycle transitions, revision digest, store, renderers. |
| `src/workflows/hermes_ops.py` | Added public `nested_status_boundary_errors` wrapper so the guard is shared, not copied. No behavior change. |
| `src/system/paths.py` | `recurring_intents_root` / `_dir` / `_index_path` under `.omh/hermes-ops/recurring-intents/`. |
| `src/commands/ops.py` | Six `omh ops recurring-intent*` subcommands, plain-text default via `_wants_json`; `omh ops validate` folds in the new store. |
| `src/skills/catalog_definitions.py` | `automation-blueprint` expected outputs, artifact expectations, safety rule, quality bar. |
| `src/skills/catalog_harnesses.py` | `scheduled-ops-blueprint` expected outputs, verification step, overclaim guard. |
| `src/wrapper/contract.py` | `automation-blueprint` chat card body, recommended flow (`save_paused_recurring_intent`), human ack copy. |
| `docs/WORKFLOWS.md`, `skills/omh-automation-blueprint/SKILL.md` | Regenerated from catalog source. |
| `tests/test_recurring_intents.py` | New. 31 tests. |

No routing trigger was added. The natural-language path already reaches `automation-blueprint` / `scheduled-ops-blueprint`, which `test_natural_language_recurring_request_reaches_the_recurring_lane` asserts for an English, a blueprint-shaped, and a Korean phrasing; `test_one_off_requests_do_not_become_recurring_intents` is the negative guard. No exact-count assertion changed, no new dependency, no network or LLM call.

## Validation

- [x] `uv run --group lint ruff check src tests` — `All checks passed!` (one pre-existing warning about an invalid `# noqa` in `src/commands/main.py:1`, untouched here)
- [x] `python3 -m unittest discover -s tests` — `Ran 4618 tests in 145.209s / OK`, run as `PYTHONPATH=tests uv run python -m unittest discover -s tests` on the tree rebased onto `origin/main` `0240cd14`
- [x] `python3 -m compileall src` — run as `uv run python -m compileall -q src tests`, exit 0
- [x] `python3 -m omh.cli docs workflows --check` — `{"ok":true,"tap_skills":{"checked":115,"expected":115,"extra":[],"missing":[],"ok":true,"stale":[]}}`
- [x] `python3 -m omh.cli harness validate` — `{"counts":{"harnesses":72,"skills":104},"errors":[],"ok":true}`
- [x] `python3 -m omh.cli release checklist --json` — exit 0, `required_item_count: 35`, no release authority requested
- [x] `python3 -m omh.cli release hermes-smoke` — exit 0, plan mode, `observed: no`
- [x] `omh --help` — exit 0
- [x] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — exit 0, plan mode against a throwaway temp home
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable, no learning contract changed
- [x] Relevant dry-run or smoke command: full CLI lifecycle against a temp `--omh-home` — `recurring-intent --dry-run` (nothing written, `.omh/hermes-ops` absent), save, `recurring-intent-occurrence` on the paused intent (refused, non-zero exit), `recurring-intent-activate`, `recurring-intent-occurrence` (accepted, revision matched), `recurring-intent-revise --schedule "every week"` (new revision, back to paused), `recurring-intent-list`, `recurring-intent-show`, `ops validate` (`ok: true`, `intent_count: 1`)
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: **not run.** No live Hermes profile was touched. Everything above is local CLI and unit evidence; the chat-surface copy is asserted through `build_chat_interaction_payload`, which is the wrapper contract, not a live chat.

Also run and green: `python3 -m omh.cli docs roles --check`, `python3 -m omh.cli docs capability-families --check`, `git diff --check`.

## Risk

- Two new persisted schemas (`hermes_recurring_intent/v1`, `hermes_recurring_occurrence/v1`) with no prior version to migrate from. Low blast radius: nothing reads them except the new CLI and `omh ops validate`.
- The revision digest is now a validated invariant. Any future field added to `REVISION_DIGEST_FIELDS` changes every existing record's revision id and will make stored records fail validation until they are re-derived. That is the intended tradeoff — it is what makes an occurrence's revision link meaningful — but it is a real migration cost, and the field list is the thing to be careful with.
- Occurrence retention is capped at 50. Beyond that, older occurrence→revision links are dropped from the OMH copy. The runtime run remains the durable evidence owner, but OMH's local index is deliberately lossy for long-running intents.
- `revise_recurring_intent` re-derives cadence/delivery/silence from the bounded `request_summary` (240 chars), not the original request, because the record does not retain the raw prompt. For a request longer than that limit the re-derivation reads truncated text; the explicit `--schedule` / `--delivery` / `--silence` hints exist for that case. Commented in place.
- `src/wrapper/contract.py` chat card body grew by one sentence, which every messenger surface renders.

## Compatibility / Rollout

- Additive only. No existing schema, path, command, or count assertion changed. Existing blueprints and their store are untouched, and `hermes_ops_blueprint/v1` behavior is unchanged (the only edit there is a new public wrapper around an existing private function).
- New state lives under `.omh/hermes-ops/recurring-intents/`, created lazily on first save, so an existing install grows nothing until someone saves an intent.
- Regenerated `docs/WORKFLOWS.md` and `skills/omh-automation-blueprint/SKILL.md` ship with the change; an existing install picks up the new skill guidance with `omh update`.

## Release / Claims

- [x] Release-channel impact considered — no version bump, no channel change; this is a normal feature PR, not a release PR.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — the record's whole point is the boundary. `prepared_is_not` states OMH runs no scheduler and no background service; `not_evidence_until_observed` lists `omh_scheduler_started`, `occurrence_executed`, `runtime_run_started`, `host_cron_created`, `hermes_automation_enabled`, `gateway_delivery_sent`, `review`, `ci`, `merge_readiness`, `merge`. `observation_status` stays `prepared` even on an activated intent with occurrences, because the linked runtime run owns that evidence.
- [x] Known manual Hermes checks are listed — no live Hermes smoke was run; `omh release hermes-smoke --live` is the gap, stated above.

## Follow-Up

- #833 owns the overlap failure policy. This PR intentionally ships the posture field and the "must be explicit before activation" gate without the overrun handling.
- No runtime surface implements the activation callback yet, so in practice `recurring-intent-activate` is invoked by an operator or a wrapper on the runtime's behalf. Wiring an actual approved runtime surface to call it is separate work.
- A live Hermes chat pass to confirm the reworded automation-blueprint card reads well in Discord/Slack.
