### PR TITLE
feat: preserve immutable lineage for every OMH run transition

### DIFF
--- a/src/coding/action_gate.py
+++ b/src/coding/action_gate.py
@@ -576,6 +576,18 @@ HANDOFF_CONTRACT_CLAIM_BOUNDARY = (
 # baseline attaches an anchor, the row stays declared.
 RECOVERY_ANCHOR_BLOCKER = "no_delegation_surface_holds_an_observed_baseline_to_attach_an_anchor_from"
 
+# Not an issue number either, and #826 is the reason it stopped being one. That
+# issue shipped `run_lineage_checkpoint/v1`, whose chain refuses a dispatch
+# checkpoint unless an observed start is already in it -- so an observed start
+# is now a prerequisite of *a lineage chain*. It is still not a prerequisite of
+# a claim. Lineage is opt-in: no claim rung, journal prerequisite, or delegation
+# surface asks a run for a chain, so a run that records none reaches dispatch
+# and execution exactly as before. Making the start required would mean making
+# the chain required of every run, which is a different change against a
+# different surface, and naming a ticket here would promise that #826 had
+# already made it.
+START_EVIDENCE_BLOCKER = "lineage_orders_the_start_but_no_claim_rung_requires_a_lineage_chain"
+
 # (boundary, statement, enforcement, enforced_by, blocked_by).
 #
 # The `enforced_by` refs are dotted import paths that must resolve; the test
@@ -747,11 +759,15 @@ _STATIC_SAFETY_BOUNDARIES: tuple[tuple[str, str, str, tuple[str, ...], str], ...
     ),
     (
         "start_evidence",
-        "runtime_start is recordable but is neither a claim rung nor a journal prerequisite, so a run can "
-        "claim dispatch and execution with no observed start.",
+        "runtime_start is recordable and `run_lineage_checkpoint/v1` now orders it: a lineage chain "
+        "refuses a dispatch checkpoint unless an observed start is already in that chain, so a history "
+        "that skips the start cannot be built. What that does not do is make the start required. A "
+        "lineage chain is opt-in — no claim rung, journal prerequisite, or delegation surface asks a run "
+        "for one — so a run that records no chain can still claim dispatch and execution with no "
+        "observed start.",
         "declared_not_enforced",
         (),
-        "#826",
+        START_EVIDENCE_BLOCKER,
     ),
     (
         "storage_content",

--- a/src/runtime/artifacts.py
+++ b/src/runtime/artifacts.py
@@ -47,6 +47,7 @@ from ..external_effect_receipts import (
 )
 from ..workflows.approval_receipts import validate_approval_receipt_store
 from ..workflows.blocked_work_records import decision_history, validate_blocked_work_record_store
+from ..workflows.run_lineage import validate_run_lineage_checkpoint_store
 from ..workflows.workspace_bindings import validate_workspace_binding_store
 from ..observation_journal import (
     append_observation_event,
@@ -2246,6 +2247,17 @@ def validate_runtime(paths: OmhPaths, run_id: str | None = None) -> dict[str, An
         paths.runtime_workspace_bindings_path,
         run_id=run_id,
     )
+    # And the lineage store, which is the only one of the five whose integrity
+    # is not a property of any single record. A checkpoint that validates
+    # perfectly on its own can still be the point where the history broke: the
+    # per-record schema cannot see that a parent digest names the wrong
+    # predecessor or that a sequence is not its position in the chain. #826 AC2
+    # -- changing history or a referenced digest fails validation -- is only
+    # true because this call runs the chain walk in production.
+    run_lineage_store_result = validate_run_lineage_checkpoint_store(
+        paths.runtime_run_lineage_checkpoints_path,
+        run_id=run_id,
+    )
     _add_duplicate_wrapper_run_link_errors(session_results, session_dirs)
     return {
         "ok": all(result["ok"] for result in results)
@@ -2254,7 +2266,8 @@ def validate_runtime(paths: OmhPaths, run_id: str | None = None) -> dict[str, An
         and bool(receipt_store_result["ok"])
         and bool(approval_store_result["ok"])
         and bool(blocked_work_store_result["ok"])
-        and bool(workspace_binding_store_result["ok"]),
+        and bool(workspace_binding_store_result["ok"])
+        and bool(run_lineage_store_result["ok"]),
         "runs": results,
         "wrapper_sessions": session_results,
         "journal": journal_result,
@@ -2262,6 +2275,7 @@ def validate_runtime(paths: OmhPaths, run_id: str | None = None) -> dict[str, An
         "approval_receipts": approval_store_result,
         "blocked_work_records": blocked_work_store_result,
         "workspace_bindings": workspace_binding_store_result,
+        "run_lineage_checkpoints": run_lineage_store_result,
     }
 
 

--- a/src/runtime/records.py
+++ b/src/runtime/records.py
@@ -79,6 +79,10 @@ from ..workflows.external_effect_receipts import (
     EXTERNAL_EFFECT_RECEIPT_KEYS,
     validate_external_effect_receipt,
 )
+from ..workflows.run_lineage import (
+    RUN_LINEAGE_CHECKPOINT_KEYS,
+    validate_run_lineage_checkpoint,
+)
 from ..workflows.workspace_bindings import (
     WORKSPACE_BINDING_KEYS,
     validate_workspace_binding,
@@ -3952,6 +3956,7 @@ EXTERNAL_EFFECT_RECEIPT_RECORD_KEYS = EXTERNAL_EFFECT_RECEIPT_KEYS
 APPROVAL_RECEIPT_RECORD_KEYS = APPROVAL_RECEIPT_KEYS
 BLOCKED_WORK_RECORD_RECORD_KEYS = BLOCKED_WORK_RECORD_KEYS
 WORKSPACE_BINDING_RECORD_KEYS = WORKSPACE_BINDING_KEYS
+RUN_LINEAGE_CHECKPOINT_RECORD_KEYS = RUN_LINEAGE_CHECKPOINT_KEYS
 
 
 @dataclass(frozen=True)
@@ -3989,4 +3994,7 @@ OPTIONAL_RUNTIME_STORE_VALIDATORS = (
     OptionalRuntimeStoreValidator("approval_receipts.jsonl", validate_approval_receipt, "receipt_id"),
     OptionalRuntimeStoreValidator("blocked_work_records.jsonl", validate_blocked_work_record, "record_id"),
     OptionalRuntimeStoreValidator("workspace_bindings.jsonl", validate_workspace_binding, "record_id"),
+    OptionalRuntimeStoreValidator(
+        "run_lineage_checkpoints.jsonl", validate_run_lineage_checkpoint, "record_id"
+    ),
 )

--- a/src/system/paths.py
+++ b/src/system/paths.py
@@ -102,6 +102,20 @@ class OmhPaths:
         return self.runtime_journal_dir / "workspace_bindings.jsonl"
 
     @property
+    def runtime_run_lineage_checkpoints_path(self) -> Path:
+        # Runtime-wide, beside the other four stores, even though every
+        # checkpoint names exactly one run. A lineage chain is tamper-evidence
+        # for a run's own history, and evidence kept inside the thing it audits
+        # is not evidence: deleting or rebuilding a run directory would take the
+        # chain that proves what that run continued from with it. It is also
+        # read *after* the run it describes is over, by whatever asks what state
+        # to continue from, so it has to outlive the directory. Beside the
+        # observation journal because it mirrors that journal's transitions, and
+        # under `journal/` because that is where a per-run validator can reach
+        # it from a run directory alone.
+        return self.runtime_journal_dir / "run_lineage_checkpoints.jsonl"
+
+    @property
     def runtime_plan_context_dir(self) -> Path:
         return self.runtime_dir / "plan-context"
 

--- a/src/workflows/run_lineage.py
+++ b/src/workflows/run_lineage.py
@@ -1,0 +1,1056 @@
+"""Append-only, hash-chained run lineage checkpoints (issue #826).
+
+What was missing
+----------------
+
+A run's history was already recorded, but in pieces that only agree by
+convention. `runtime/records.py` builds the run record and its per-transition
+records; `workflows/observation_journal.py` records the ordered lifecycle
+events; the plan, the handoff, the workspace binding, and the approval each
+live in their own artifact. Asking "what state did this run continue from" meant
+joining five files by `run_id` and trusting that none of them had been edited
+since.
+
+Nothing in the tree made that trust checkable. There was no hash-chained store
+anywhere: no record carried its predecessor's digest, so an edit to a run's
+early history left every later artifact reading exactly as it did before.
+
+A lineage checkpoint is the missing spine. Each one names its predecessor by
+that predecessor's own digest, so history is append-only in a way that a reader
+can *verify* rather than assume: change any field of any earlier checkpoint and
+its digest stops matching itself, and the next checkpoint's `parent_digest`
+stops naming it.
+
+What the chain seals, and what it does not
+------------------------------------------
+
+The digest covers every field whose value carries meaning -- the transition, the
+evidence class, the owner, the safety and context revisions, the plan and
+handoff digests, the artifacts, the state, the sequence, and the parent link.
+Three fields are deliberately outside it:
+
+* `recorded_at`, because a wall clock inside a hashed artifact turns an equality
+  check into a race, and this repo has already lost Windows CI time to exactly
+  that. The honest consequence is stated rather than hidden: the chain seals
+  *what* a run continued from, not *when* each step was written down, so a stamp
+  can be edited without breaking a link. Nothing reads freshness off this store.
+* `record_id`, which carries a random tail so two checkpoints minted in the same
+  second are distinguishable. Sealing it would make the digest unreproducible.
+* `digest` itself.
+
+Two checkpoints can therefore never collide by accident despite the clock being
+out: within one run the `sequence` differs, and across runs the `run_id` and
+`lineage_id` do.
+
+Ordering is a property of the chain, not of the appender
+--------------------------------------------------------
+
+`_REQUIRED_PREDECESSORS` mirrors the journal's lifecycle prerequisites and adds
+the one the journal never had: a dispatch checkpoint requires an observed start
+earlier in the same chain. So a chain cannot be built that reaches dispatch
+without passing through `runtime_start_observed`.
+
+That is genuinely new, and it is genuinely narrow. It orders a chain; it does
+not make a chain mandatory. No claim rung, journal prerequisite, or delegation
+surface asks a run for one, so a run that records no lineage at all can still
+claim dispatch and execution with no observed start. The `start_evidence`
+boundary of `handoff_safety_contract/v1` therefore stays `declared_not_enforced`
+and says exactly this in its own words.
+
+A checkpoint is not evidence
+----------------------------
+
+`evidence_class` is derived from the transition and re-derived at validate, so a
+hand-edited `plan_accepted` checkpoint that claims `merge_observed` is refused
+rather than believed. `state` is cross-checked against it in both directions, so
+a `prepared` checkpoint cannot carry an observed class and an `observed` one
+cannot carry the prepared class. `checkpoint_implies_evidence_class` answers for
+the checkpoint's own class and nothing after it, which is #826 AC3: preparing a
+run says only that it was prepared.
+
+Even for its own class, a checkpoint states rather than proves. It is a copy of
+what the observation journal already held at that transition, so it can point at
+the observation standing behind a class and can never be that observation.
+`CLAIM_BOUNDARY` says so on every record, and `validate_run_lineage_checkpoint`
+refuses a record shaped to assert execution by key name as well as by the closed
+key set.
+
+Store mechanics
+---------------
+
+All of it is `system.append_only_store`, shared with the four families beside
+it: the torn-tail-safe binary append under a real OS lock, the opaque-reference
+guards, the digest handles, and the chain walk. The walk is
+`supersede_chain_errors` with this family's own key names -- a hash chain and a
+supersede chain reject the same four shapes (a duplicate id, a self-link, a link
+to a record that does not already exist, and two records claiming one
+predecessor), so the mechanics are the same walk and only the vocabulary
+differs. This module adds no store mechanics of its own.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from ..system.append_only_store import (
+    RAW_OR_HIDDEN_KEYS,
+    append_store_line,
+    closed_vocabulary_value,
+    mint_record_id,
+    opaque_ref,
+    record_fingerprint,
+    redacted_ref,
+    reference_errors,
+    store_errors,
+)
+from ..system.local_store import file_lock, read_jsonl_objects, utc_now
+from ..system.paths import OmhPaths
+
+
+RUN_LINEAGE_CHECKPOINT_SCHEMA_VERSION: Final[str] = "run_lineage_checkpoint/v1"
+RUN_LINEAGE_RECONSTRUCTION_SCHEMA_VERSION: Final[str] = "run_lineage_reconstruction/v1"
+RUN_LINEAGE_STORE_VALIDATION_SCHEMA_VERSION: Final[str] = "run_lineage_store_validation/v1"
+
+RUN_LINEAGE_CHECKPOINT_STORE_NAME: Final[str] = "run_lineage_checkpoints.jsonl"
+
+CHECKPOINT_PRIVACY: Final[str] = "metadata_only"
+
+# Stated on every record and echoed on every reconstruction. A checkpoint is the
+# fifth thing this tree keeps apart from the four #800 names: it is a *position
+# in history*, not an existence, an ownership, a dispatch, or a result.
+CLAIM_BOUNDARY: Final[str] = (
+    "A run lineage checkpoint is one hash-chained position in one run's transition history: what the "
+    "run continued from, under one owner, one safety profile revision, and one context revision. It "
+    "states which evidence class the run had reached when the checkpoint was written. It is not that "
+    "evidence: a checkpoint is never dispatch, execution, verification, review, CI, merge-readiness, or "
+    "merge evidence, and a prepared checkpoint states no observed class at all."
+)
+
+# The transitions a chain can record, in the order a run passes through them.
+# The names are the observation journal's own canonical event names rather than
+# a second vocabulary for the same milestones -- a lineage chain that called
+# dispatch something else could not be read against the journal it mirrors.
+LINEAGE_TRANSITIONS: Final[tuple[str, ...]] = (
+    "plan_accepted",
+    "handoff_prepared",
+    "runtime_start_observed",
+    "worktree_creation_observed",
+    "executor_dispatch_observed",
+    "executor_result_observed",
+    "verification_result_observed",
+    "review_result_observed",
+    "ci_result_observed",
+    "merge_gate_observed",
+    "merge_observed",
+)
+
+# The evidence-class vocabulary, which is `observation_journal.PROJECTION_ORDER`
+# restated here rather than imported for the reason the sibling families mirror
+# each other's key sets: a store's on-disk vocabulary must not change because
+# another module reordered a tuple. `tests/test_run_lineage_checkpoint.py` pins
+# the two equal, so drift is a failing test rather than a silent schema change.
+LINEAGE_EVIDENCE_CLASSES: Final[tuple[str, ...]] = (
+    "prepared_not_observed",
+    "runtime_start_observed",
+    "worktree_creation_observed",
+    "dispatch_observed",
+    "execution_observed",
+    "verification_observed",
+    "review_observed",
+    "ci_observed",
+    "merge_gate_observed",
+    "merge_observed",
+)
+
+# Which class each transition records. Total over `LINEAGE_TRANSITIONS` and onto
+# every member of `LINEAGE_EVIDENCE_CLASSES`, both of which are pinned: a
+# transition with no class could store anything, and a class no transition can
+# produce is a vocabulary member nothing backs -- the exact defect
+# `observation_journal` documents for its own `cancelled` status.
+#
+# The class is derived here and never accepted from a caller. That is what makes
+# #826 AC3 structural: there is no argument through which a `plan_accepted`
+# checkpoint could be given `merge_observed`.
+TRANSITION_EVIDENCE_CLASS: Final[dict[str, str]] = {
+    "plan_accepted": "prepared_not_observed",
+    "handoff_prepared": "prepared_not_observed",
+    "runtime_start_observed": "runtime_start_observed",
+    "worktree_creation_observed": "worktree_creation_observed",
+    "executor_dispatch_observed": "dispatch_observed",
+    "executor_result_observed": "execution_observed",
+    "verification_result_observed": "verification_observed",
+    "review_result_observed": "review_observed",
+    "ci_result_observed": "ci_observed",
+    "merge_gate_observed": "merge_gate_observed",
+    "merge_observed": "merge_observed",
+}
+
+# How the run stood when the checkpoint was written. Separate from the evidence
+# class because the two answer different questions: the class says how far the
+# run got, the state says how it stands there. A run can be blocked at the
+# prepared stage and failed after verification.
+LINEAGE_STATES: Final[tuple[str, ...]] = ("prepared", "observed", "blocked", "cancelled", "failed")
+
+# Terminal states say nothing about how far the run got, so they are free to
+# appear on any transition. The two positional states are not: they are the
+# prepared/observed split itself, and pinning them against the class is the
+# second structural expression of AC3.
+_PREPARED_STATE: Final[str] = "prepared"
+_OBSERVED_STATE: Final[str] = "observed"
+_PREPARED_EVIDENCE_CLASS: Final[str] = "prepared_not_observed"
+
+# What must already be in the chain before a transition may join it. The first
+# four rows mirror `observation_journal._validate_observation_event_prerequisites`
+# so the chain and the journal cannot disagree about lifecycle order.
+#
+# `executor_dispatch_observed -> runtime_start_observed` is the row the journal
+# does not have, and it is the whole of what #826 adds to start ordering: a
+# chain cannot reach dispatch without passing through an observed start. It
+# orders chains; it does not make a chain mandatory, which is why the
+# `start_evidence` safety boundary stays declared.
+#
+# Review and CI require verification only. The journal makes them conditionally
+# required of each other from the delegation's review policy, which is a
+# per-run fact this store does not read -- requiring it here would refuse a
+# legitimate chain on evidence that lives somewhere else.
+_REQUIRED_PREDECESSORS: Final[dict[str, tuple[str, ...]]] = {
+    "runtime_start_observed": ("handoff_prepared",),
+    "worktree_creation_observed": ("runtime_start_observed",),
+    "executor_dispatch_observed": ("runtime_start_observed",),
+    "executor_result_observed": ("executor_dispatch_observed",),
+    "verification_result_observed": ("executor_result_observed",),
+    "review_result_observed": ("verification_result_observed",),
+    "ci_result_observed": ("verification_result_observed",),
+    "merge_gate_observed": ("verification_result_observed",),
+    "merge_observed": ("merge_gate_observed",),
+}
+
+RUN_LINEAGE_CHECKPOINT_KEYS: Final[tuple[str, ...]] = (
+    "artifact_refs",
+    "claim_boundary",
+    "context_revision",
+    "digest",
+    "evidence_class",
+    "handoff_digest",
+    "lineage_id",
+    "owner",
+    "parent_digest",
+    "plan_digest",
+    "privacy",
+    "record_id",
+    "recorded_at",
+    "run_id",
+    "safety_profile_revision",
+    "schema_version",
+    "sequence",
+    "state",
+    "transition",
+)
+
+# The three fields outside the seal, for the reasons the module docstring gives.
+# Kept as a tuple so `CHECKPOINT_DIGEST_KEYS` is derived rather than restated: a
+# key added to the record and forgotten here would silently leave a meaningful
+# field unsealed, which is the one defect this family cannot afford.
+UNSEALED_CHECKPOINT_KEYS: Final[tuple[str, ...]] = ("digest", "record_id", "recorded_at")
+
+CHECKPOINT_DIGEST_KEYS: Final[tuple[str, ...]] = tuple(
+    key for key in RUN_LINEAGE_CHECKPOINT_KEYS if key not in UNSEALED_CHECKPOINT_KEYS
+)
+
+# The two keys whose value is a module constant rather than data.
+RUN_LINEAGE_CONSTANT_KEYS: Final[tuple[str, ...]] = ("claim_boundary", "privacy")
+
+_REQUIRED_CHECKPOINT_REFS: Final[tuple[str, ...]] = (
+    "lineage_id",
+    "owner",
+    "record_id",
+    "recorded_at",
+    "run_id",
+    "safety_profile_revision",
+)
+# Legitimately absent. A chain that starts at `handoff_prepared` has no accepted
+# plan artifact to name, and a run whose context was never revised has no
+# context revision. What each one *is* required for is `_missing_digest_errors`.
+_OPTIONAL_CHECKPOINT_REFS: Final[tuple[str, ...]] = ("context_revision", "handoff_digest", "plan_digest")
+
+# Every string field. `sequence` is an integer and `artifact_refs` is a list;
+# everything else on this record is a bounded string, and there is deliberately
+# no free text -- a note field would be one more place a prompt could arrive.
+_CHECKPOINT_STRING_FIELDS: Final[tuple[str, ...]] = tuple(
+    key for key in RUN_LINEAGE_CHECKPOINT_KEYS if key not in ("artifact_refs", "sequence")
+)
+
+# More than a dozen artifacts on one checkpoint is a directory listing rather
+# than the bounded set of things one transition produced.
+ARTIFACT_REF_LIMIT: Final[int] = 12
+
+# Key names an execution claim arrives under. The closed key set already refuses
+# every one of them, but it refuses them as "unsupported keys", and the point of
+# this family is that a position in history is not an outcome -- so the shape is
+# named and refused by name first. Mirrors
+# `workspace_bindings.EXECUTION_CLAIM_KEYS` rather than importing across two
+# unrelated record families; `tests/test_run_lineage_checkpoint.py` pins them
+# equal so the two cannot drift.
+EXECUTION_CLAIM_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "applied",
+        "attempted",
+        "completed",
+        "dispatched",
+        "effect_applied",
+        "enforced",
+        "executed",
+        "execution",
+        "execution_result",
+        "exit_code",
+        "external_ref",
+        "host_applied",
+        "observed",
+        "observed_at",
+        "observed_result",
+        "outcome",
+        "performed",
+        "ran",
+        "result",
+        "status",
+        "succeeded",
+        "success",
+    }
+)
+
+# Why a reconstruction stopped. Closed ids rather than sentences, for the reason
+# `workspace_bindings.RECOVERY_ACTIONS` is: localized copy is then a lookup per
+# locale instead of a translated constant.
+BREAK_INVALID_RECORD: Final[str] = "checkpoint_is_not_a_valid_record"
+BREAK_DIGEST_MISMATCH: Final[str] = "digest_does_not_match_the_checkpoint"
+BREAK_PARENT_MISMATCH: Final[str] = "parent_digest_does_not_name_the_previous_checkpoint"
+BREAK_SEQUENCE: Final[str] = "sequence_does_not_match_the_chain_position"
+BREAK_PREREQUISITE: Final[str] = "transition_is_missing_a_required_predecessor"
+# There is deliberately no code for "this checkpoint belongs to another run".
+# `validate_run_lineage_checkpoint` re-derives `lineage_id` from the record's
+# own `run_id`, and a chain is selected by that same `run_id`, so a grafted
+# record fails its own schema before the walk can reach it and is reported as
+# `BREAK_INVALID_RECORD` with the reason named in words. A second code for it
+# would be a branch nothing can enter.
+BREAK_CODES: Final[tuple[str, ...]] = (
+    BREAK_DIGEST_MISMATCH,
+    BREAK_INVALID_RECORD,
+    BREAK_PARENT_MISMATCH,
+    BREAK_PREREQUISITE,
+    BREAK_SEQUENCE,
+)
+
+# Constant strings, keyed by code. Nothing is interpolated into a reason: a
+# break is rendered to operators, and a line built from stored values would be
+# one more path for hand-edited text to reach a terminal.
+BREAK_REASONS: Final[dict[str, str]] = {
+    BREAK_INVALID_RECORD: (
+        "This checkpoint is not a valid run_lineage_checkpoint/v1 record, so nothing after it in the "
+        "chain can be trusted to continue from it."
+    ),
+    BREAK_DIGEST_MISMATCH: (
+        "This checkpoint's digest does not match the checkpoint itself, so one of the fields the digest "
+        "seals was changed after it was written."
+    ),
+    BREAK_PARENT_MISMATCH: (
+        "This checkpoint's parent_digest does not name the checkpoint immediately before it, so the "
+        "chain does not continue from the history it claims to continue from."
+    ),
+    BREAK_SEQUENCE: (
+        "This checkpoint's sequence is not its position in the chain, so a checkpoint was inserted, "
+        "removed, or reordered."
+    ),
+    BREAK_PREREQUISITE: (
+        "This checkpoint's transition requires an earlier transition that the chain does not carry, so "
+        "the run reached this state without passing through the state before it."
+    ),
+}
+
+# The store label every error line and every reference fault is reported under.
+_LABEL: Final[str] = "run_lineage_checkpoint"
+
+# A digest is a full sha256 hex string and nothing else. Enforced as a shape
+# rather than only by re-derivation, so a hand-edited store carrying a path, a
+# URL, or a truncated handle in a digest field is refused before anything tries
+# to walk it.
+_DIGEST: Final[re.Pattern[str]] = re.compile(r"^[0-9a-f]{64}$")
+
+# No parent. The genesis checkpoint of a chain, and the only record allowed to
+# carry it.
+GENESIS_PARENT_DIGEST: Final[str] = ""
+
+_UNKNOWN_SEQUENCE: Final[int] = -1
+
+
+class RunLineageError(ValueError):
+    """Raised when a transition cannot become a run lineage checkpoint."""
+
+
+# ---------------------------------------------------------------------------
+# Identity and digest
+# ---------------------------------------------------------------------------
+
+
+def lineage_id(run_id: str) -> str:
+    """Stable identity of one run's chain.
+
+    Derived from the run and nothing else, so a checkpoint found in the store
+    can be checked against the run it claims -- which is what stops a
+    hand-edited record from moving one run's history onto another run's chain.
+    """
+    base = json.dumps({"run_id": str(run_id)}, sort_keys=True)
+    return f"lineage-{hashlib.sha256(base.encode('utf-8')).hexdigest()[:16]}"
+
+
+def checkpoint_digest(record: Mapping[str, Any]) -> str:
+    """This checkpoint's own digest, over every field the seal covers.
+
+    `record_fingerprint` is the shared hasher; nothing here reimplements it. The
+    key tuple is what this family contributes, and `CHECKPOINT_DIGEST_KEYS` is
+    derived from the record's own key set so a new field is sealed by default.
+    """
+    return record_fingerprint(record, CHECKPOINT_DIGEST_KEYS)
+
+
+# ---------------------------------------------------------------------------
+# Build, validate, append
+# ---------------------------------------------------------------------------
+
+
+def build_run_lineage_checkpoint(
+    *,
+    run_id: str,
+    transition: str,
+    owner: str,
+    safety_profile_revision: str,
+    sequence: int,
+    parent_digest: str = GENESIS_PARENT_DIGEST,
+    plan_digest: str = "",
+    handoff_digest: str = "",
+    context_revision: str = "",
+    artifact_refs: Sequence[str] = (),
+    state: str = "",
+    recorded_at: str = "",
+) -> dict[str, Any]:
+    """Mint one checkpoint, or refuse.
+
+    `sequence` and `parent_digest` are the caller's, not this function's: a
+    checkpoint's position and its predecessor are properties of the chain it is
+    joining, and a builder that guessed them from an unread store would be the
+    one way a chain could fork without anyone noticing.
+    `append_run_lineage_checkpoint` reads both under the store's lock.
+
+    `recorded_at` is a parameter and is outside the seal, so two callers minting
+    the same checkpoint a second apart produce the same digest.
+    """
+    if transition not in TRANSITION_EVIDENCE_CLASS:
+        raise RunLineageError(f"run_lineage_checkpoint transition is unsupported: {transition!r}")
+    if isinstance(sequence, bool) or not isinstance(sequence, int) or sequence < 0:
+        raise RunLineageError(f"run_lineage_checkpoint sequence must be a non-negative integer: {sequence!r}")
+    evidence_class = TRANSITION_EVIDENCE_CLASS[transition]
+    resolved_state = str(state or _default_state(evidence_class))
+    if resolved_state not in LINEAGE_STATES:
+        raise RunLineageError(f"run_lineage_checkpoint state is unsupported: {resolved_state!r}")
+    safe_run_id = _opaque(run_id, field="run_lineage_checkpoint run_id")
+    safe_owner = _opaque(owner, field="run_lineage_checkpoint owner")
+    safe_profile = _opaque(safety_profile_revision, field="run_lineage_checkpoint safety_profile_revision")
+    safe_plan = _optional_opaque(plan_digest, field="run_lineage_checkpoint plan_digest")
+    safe_handoff = _optional_opaque(handoff_digest, field="run_lineage_checkpoint handoff_digest")
+    safe_context = _optional_opaque(context_revision, field="run_lineage_checkpoint context_revision")
+    stamp = _opaque(str(recorded_at or utc_now()), field="run_lineage_checkpoint recorded_at")
+    parent = str(parent_digest or GENESIS_PARENT_DIGEST)
+    identity = lineage_id(safe_run_id)
+    record: dict[str, Any] = {
+        "schema_version": RUN_LINEAGE_CHECKPOINT_SCHEMA_VERSION,
+        "record_id": mint_record_id(
+            prefix="run-lineage",
+            identity={"lineage_id": identity, "sequence": str(sequence), "transition": transition},
+        ),
+        "lineage_id": identity,
+        "run_id": safe_run_id,
+        "sequence": sequence,
+        "parent_digest": parent,
+        "transition": transition,
+        "evidence_class": evidence_class,
+        "state": resolved_state,
+        "owner": safe_owner,
+        "safety_profile_revision": safe_profile,
+        "context_revision": safe_context,
+        "plan_digest": safe_plan,
+        "handoff_digest": safe_handoff,
+        "artifact_refs": _normalized_artifact_refs(artifact_refs),
+        "recorded_at": stamp,
+        "privacy": CHECKPOINT_PRIVACY,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "digest": "",
+    }
+    record["digest"] = checkpoint_digest(record)
+    errors = validate_run_lineage_checkpoint(record)
+    if errors:
+        raise RunLineageError(errors[0])
+    return record
+
+
+def validate_run_lineage_checkpoint(record: dict[str, Any]) -> list[str]:
+    """Every reason one record is not a run lineage checkpoint."""
+    if not isinstance(record, dict):
+        return [f"{_LABEL} must be an object"]
+    errors: list[str] = []
+    claims_execution = sorted(key for key in record if str(key).lower() in EXECUTION_CLAIM_KEYS)
+    if claims_execution:
+        errors.append(
+            f"{_LABEL} must not carry execution-claim keys: "
+            f"{claims_execution}; a position in history is not a dispatch and not an outcome"
+        )
+    forbidden = sorted(key for key in record if str(key).lower() in RAW_OR_HIDDEN_KEYS)
+    if forbidden:
+        errors.append(f"{_LABEL} must not carry raw or hidden keys: {forbidden}")
+    extra_keys = sorted(
+        set(record) - set(RUN_LINEAGE_CHECKPOINT_KEYS) - set(claims_execution) - set(forbidden)
+    )
+    if extra_keys:
+        errors.append(f"{_LABEL} has unsupported keys: {extra_keys}")
+    missing = sorted(set(RUN_LINEAGE_CHECKPOINT_KEYS) - set(record))
+    if missing:
+        errors.append(f"{_LABEL} is missing keys: {missing}")
+    if record.get("schema_version") != RUN_LINEAGE_CHECKPOINT_SCHEMA_VERSION:
+        errors.append(f"{_LABEL} schema_version must be {RUN_LINEAGE_CHECKPOINT_SCHEMA_VERSION}")
+    for key in _CHECKPOINT_STRING_FIELDS:
+        if not isinstance(record.get(key), str):
+            errors.append(f"{_LABEL} {key} must be a string")
+    errors.extend(_sequence_errors(record.get("sequence")))
+    errors.extend(_artifact_ref_errors(record.get("artifact_refs")))
+    if record.get("transition") not in TRANSITION_EVIDENCE_CLASS:
+        errors.append(f"{_LABEL} transition is unsupported: {record.get('transition')!r}")
+    if record.get("state") not in LINEAGE_STATES:
+        errors.append(f"{_LABEL} state is unsupported: {record.get('state')!r}")
+    if record.get("evidence_class") not in LINEAGE_EVIDENCE_CLASSES:
+        errors.append(f"{_LABEL} evidence_class is unsupported: {record.get('evidence_class')!r}")
+    if record.get("privacy") != CHECKPOINT_PRIVACY:
+        errors.append(f"{_LABEL} privacy must be metadata_only")
+    if record.get("claim_boundary") != CLAIM_BOUNDARY:
+        errors.append(f"{_LABEL} claim_boundary must state the lineage boundary")
+    for field in _REQUIRED_CHECKPOINT_REFS:
+        errors.extend(reference_errors(record.get(field), field=field, label=_LABEL, required=True))
+    for field in _OPTIONAL_CHECKPOINT_REFS:
+        errors.extend(reference_errors(record.get(field), field=field, label=_LABEL, required=False))
+    errors.extend(_digest_shape_errors(record))
+    errors.extend(_evidence_class_errors(record))
+    errors.extend(_missing_digest_errors(record))
+    if str(record.get("run_id", "")) and str(record.get("lineage_id", "")) != lineage_id(
+        str(record.get("run_id", ""))
+    ):
+        # Without this a hand-edited store could graft one run's history onto
+        # another run's chain, and reconstructing either would read the other.
+        errors.append(f"{_LABEL} lineage_id does not identify its own run")
+    return errors
+
+
+def append_run_lineage_checkpoint(
+    paths: OmhPaths,
+    *,
+    run_id: str,
+    transition: str,
+    owner: str,
+    safety_profile_revision: str,
+    plan_digest: str = "",
+    handoff_digest: str = "",
+    context_revision: str = "",
+    artifact_refs: Sequence[str] = (),
+    state: str = "",
+    recorded_at: str = "",
+    continue_from: str = "",
+) -> dict[str, Any]:
+    """Extend one run's chain by one checkpoint, or refuse.
+
+    The read of the chain head and the append of the new link happen under one
+    lock, so two concurrent appends produce two links in a line rather than two
+    records claiming one predecessor.
+
+    `continue_from` is #826's "require continuation to name the lineage head":
+    once a chain exists, a caller must say which head it read, and a head that
+    has moved since is refused instead of silently overwritten. A genesis append
+    names nothing, because there is nothing to name.
+
+    `plan_digest`, `handoff_digest`, and `context_revision` are inherited from
+    the head when the caller leaves them empty. A checkpoint carries the whole
+    state a run continued from, and making every caller restate three unchanged
+    references is how one of them ends up omitted on the checkpoint that
+    mattered.
+    """
+    path = paths.runtime_run_lineage_checkpoints_path
+    with file_lock(path, private=True):
+        records, _ = read_jsonl_objects(path)
+        chain = run_lineage_chain(records, run_id=run_id)
+        head = chain[-1] if chain else {}
+        head_digest = str(head.get("digest", ""))
+        if head and str(continue_from or "") != head_digest:
+            raise RunLineageError(
+                f"{_LABEL} continuation must name the lineage head; this chain's head is not the one named"
+            )
+        _require_predecessors(chain, transition)
+        record = build_run_lineage_checkpoint(
+            run_id=run_id,
+            transition=transition,
+            owner=owner,
+            safety_profile_revision=safety_profile_revision,
+            sequence=len(chain),
+            parent_digest=head_digest,
+            plan_digest=plan_digest or str(head.get("plan_digest", "")),
+            handoff_digest=handoff_digest or str(head.get("handoff_digest", "")),
+            context_revision=context_revision or str(head.get("context_revision", "")),
+            artifact_refs=artifact_refs,
+            state=state,
+            recorded_at=recorded_at,
+        )
+        append_store_line(path, record)
+    return record
+
+
+# ---------------------------------------------------------------------------
+# Read and reconstruct
+# ---------------------------------------------------------------------------
+
+
+def read_run_lineage_checkpoints_result(paths: OmhPaths) -> tuple[list[dict[str, Any]], list[str]]:
+    return read_jsonl_objects(paths.runtime_run_lineage_checkpoints_path)
+
+
+def read_run_lineage_checkpoints(
+    paths: OmhPaths,
+    *,
+    run_id: str | None = None,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """The store, in append order, optionally scoped to one run."""
+    records, _ = read_run_lineage_checkpoints_result(paths)
+    if run_id is not None:
+        records = run_lineage_chain(records, run_id=run_id)
+    if limit is None:
+        return records
+    if limit < 1:
+        return []
+    return records[-limit:]
+
+
+def run_lineage_chain(records: Sequence[Mapping[str, Any]], *, run_id: str) -> list[dict[str, Any]]:
+    """One run's checkpoints, in append order.
+
+    Append order is chain order: the store is append-only, so the sequence a
+    reader sees is the sequence a writer wrote. `reconstruct_run_lineage` then
+    checks that claim against each record's own `sequence` rather than trusting
+    it, which is what turns a reordered store into a reported break instead of a
+    plausible history.
+    """
+    return [
+        dict(record)
+        for record in records
+        if isinstance(record, Mapping) and str(record.get("run_id", "")) == str(run_id)
+    ]
+
+
+def run_lineage_head(records: Sequence[Mapping[str, Any]], *, run_id: str) -> dict[str, Any]:
+    """The checkpoint a continuation must name, or an empty mapping."""
+    chain = run_lineage_chain(records, run_id=run_id)
+    return chain[-1] if chain else {}
+
+
+def reconstruct_run_lineage(records: Sequence[Mapping[str, Any]], *, run_id: str) -> dict[str, Any]:
+    """#826 AC1: one run's history, rebuilt from the store alone and verified.
+
+    Offline in the sense this repo means it: a pure function of records already
+    in hand, reading no clock, no network, and no artifact the checkpoints point
+    at. Every link is recomputed -- each record's own digest from its own
+    fields, and each `parent_digest` against the digest of the record before it
+    -- so an edit anywhere in the history is a reported break rather than a
+    history that still reads plausibly.
+
+    The walk stops at the first break and names the checkpoint that broke it.
+    Continuing past one would report every later link as broken too, which is
+    true and useless: the answer a reader needs is where the history stopped
+    being trustworthy, and everything after the first break is a consequence of
+    it.
+    """
+    chain = run_lineage_chain(records, run_id=run_id)
+    intact: list[dict[str, Any]] = []
+    break_code = ""
+    broken: Mapping[str, Any] = {}
+    seen_transitions: set[str] = set()
+    for index, record in enumerate(chain):
+        break_code = _checkpoint_break(record, index=index, intact=intact, seen=seen_transitions)
+        if break_code:
+            broken = record
+            break
+        intact.append(record)
+        seen_transitions.add(str(record.get("transition", "")))
+    head = intact[-1] if intact else {}
+    return {
+        "schema_version": RUN_LINEAGE_RECONSTRUCTION_SCHEMA_VERSION,
+        "run_id": _redacted(str(run_id)),
+        "lineage_id": lineage_id(str(run_id)),
+        "ok": not break_code,
+        "checkpoint_count": len(chain),
+        "intact_checkpoint_count": len(intact),
+        "transitions": [closed_vocabulary_value(item.get("transition"), LINEAGE_TRANSITIONS) for item in intact],
+        "evidence_classes": [
+            closed_vocabulary_value(item.get("evidence_class"), LINEAGE_EVIDENCE_CLASSES) for item in intact
+        ],
+        "head_digest": _rendered_digest(head.get("digest")),
+        "head_transition": closed_vocabulary_value(head.get("transition"), LINEAGE_TRANSITIONS),
+        "head_evidence_class": closed_vocabulary_value(head.get("evidence_class"), LINEAGE_EVIDENCE_CLASSES),
+        "head_state": closed_vocabulary_value(head.get("state"), LINEAGE_STATES),
+        "owner": _redacted(str(head.get("owner", ""))),
+        "safety_profile_revision": _redacted(str(head.get("safety_profile_revision", ""))),
+        "context_revision": _redacted(str(head.get("context_revision", ""))),
+        "plan_digest": _redacted(str(head.get("plan_digest", ""))),
+        "handoff_digest": _redacted(str(head.get("handoff_digest", ""))),
+        "artifact_refs": _rendered_artifact_refs(head.get("artifact_refs")),
+        "break_code": break_code,
+        "break_reason": BREAK_REASONS.get(break_code, ""),
+        "break_record_id": _redacted(str(broken.get("record_id", ""))),
+        "break_transition": closed_vocabulary_value(broken.get("transition"), LINEAGE_TRANSITIONS),
+        "break_sequence": len(intact) if break_code else _UNKNOWN_SEQUENCE,
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+
+
+def read_run_lineage(paths: OmhPaths, *, run_id: str) -> dict[str, Any]:
+    """`reconstruct_run_lineage` over the store on disk."""
+    records, _ = read_run_lineage_checkpoints_result(paths)
+    return reconstruct_run_lineage(records, run_id=run_id)
+
+
+def checkpoint_implies_evidence_class(checkpoint: Mapping[str, Any], evidence_class: str) -> bool:
+    """#826 AC3: whether one checkpoint states that one evidence class was reached.
+
+    True only for the single class the checkpoint's own transition records. A
+    prepared checkpoint -- `plan_accepted` or `handoff_prepared`, the two
+    transitions whose class is `prepared_not_observed` -- therefore answers
+    False for every observed class in the vocabulary: preparing a run says only
+    that it was prepared.
+
+    Stating a class is not being the evidence for it. A checkpoint copies what
+    the observation journal already held at that transition, so it can point at
+    the observation behind a class and is never that observation itself;
+    `CLAIM_BOUNDARY` is on every record and says so.
+    """
+    if evidence_class not in LINEAGE_EVIDENCE_CLASSES:
+        return False
+    if not isinstance(checkpoint, Mapping):
+        return False
+    return str(checkpoint.get("evidence_class", "")) == evidence_class
+
+
+# ---------------------------------------------------------------------------
+# Validate the store, render
+# ---------------------------------------------------------------------------
+
+
+def validate_run_lineage_checkpoint_store(path: Path, *, run_id: str | None = None) -> dict[str, Any]:
+    """Validate the lineage store, optionally scoped to one run's checkpoints.
+
+    Two halves, and both are load-bearing. `store_errors` gives the per-record
+    schema and the shared chain walk -- a duplicate digest, a self-link, a
+    parent naming a record that does not already exist, and two checkpoints
+    claiming one predecessor are the four shapes a hash chain and a supersede
+    chain reject identically. The reconstruction adds what only a per-run walk
+    can see: a digest that no longer matches its own record, a parent that names
+    an earlier record but not the *previous* one, a sequence that is not its
+    position, and a transition whose required predecessor is absent.
+
+    #826 AC2 lands here: changing history or a referenced digest fails
+    `omh runtime validate`, not just an in-process helper.
+    """
+    records, read_errors = read_jsonl_objects(path)
+    checkpoint_count, errors = store_errors(
+        path,
+        records,
+        read_errors,
+        run_id=run_id,
+        validate_record=validate_run_lineage_checkpoint,
+        label=_LABEL,
+        id_key="digest",
+        link_key="parent_digest",
+        noun="checkpoint",
+    )
+    # A run with no checkpoints has no lineage, so it is not counted as one. The
+    # scoped call always produces a report -- that is how a caller asks about one
+    # run -- and counting an empty one would report a chain that does not exist.
+    lineages = [report for report in _reconstructions_in(records, run_id=run_id) if report["checkpoint_count"]]
+    broken = [report for report in lineages if not report["ok"]]
+    errors.extend(
+        f"{path}: {_LABEL} chain break at sequence {report['break_sequence']} "
+        f"({report['break_record_id']}): {report['break_reason']}"
+        for report in broken
+    )
+    return {
+        "schema_version": RUN_LINEAGE_STORE_VALIDATION_SCHEMA_VERSION,
+        "path": str(path),
+        "run_id": run_id or "",
+        "ok": not errors,
+        "checkpoint_count": checkpoint_count,
+        "lineage_count": len(lineages),
+        "broken_lineage_count": len(broken),
+        "errors": errors,
+    }
+
+
+def compact_run_lineage_checkpoint(checkpoint: Mapping[str, Any]) -> dict[str, Any]:
+    """The user-facing shape, with every field through its class's guard.
+
+    Rendering is the last point at which a hand-edited store reaches a human, so
+    nothing is copied through verbatim: identifiers fold to a stable
+    non-navigable handle when they are not opaque, closed vocabularies render
+    empty outside their vocabulary, and a digest renders only in the one shape a
+    digest may be stored in.
+    """
+    return {
+        "record_id": _redacted(str(checkpoint.get("record_id", ""))),
+        "lineage_id": _redacted(str(checkpoint.get("lineage_id", ""))),
+        "run_id": _redacted(str(checkpoint.get("run_id", ""))),
+        "sequence": checkpoint.get("sequence") if isinstance(checkpoint.get("sequence"), int) else _UNKNOWN_SEQUENCE,
+        "parent_digest": _rendered_digest(checkpoint.get("parent_digest")),
+        "digest": _rendered_digest(checkpoint.get("digest")),
+        "transition": closed_vocabulary_value(checkpoint.get("transition"), LINEAGE_TRANSITIONS),
+        "evidence_class": closed_vocabulary_value(checkpoint.get("evidence_class"), LINEAGE_EVIDENCE_CLASSES),
+        "state": closed_vocabulary_value(checkpoint.get("state"), LINEAGE_STATES),
+        "owner": _redacted(str(checkpoint.get("owner", ""))),
+        "safety_profile_revision": _redacted(str(checkpoint.get("safety_profile_revision", ""))),
+        "context_revision": _redacted(str(checkpoint.get("context_revision", ""))),
+        "plan_digest": _redacted(str(checkpoint.get("plan_digest", ""))),
+        "handoff_digest": _redacted(str(checkpoint.get("handoff_digest", ""))),
+        "artifact_refs": _rendered_artifact_refs(checkpoint.get("artifact_refs")),
+        "recorded_at": _redacted(str(checkpoint.get("recorded_at", ""))),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _default_state(evidence_class: str) -> str:
+    return _PREPARED_STATE if evidence_class == _PREPARED_EVIDENCE_CLASS else _OBSERVED_STATE
+
+
+def _require_predecessors(chain: Sequence[Mapping[str, Any]], transition: str) -> None:
+    """Refuse a transition the chain has not earned yet.
+
+    Checked against the transitions already in the chain rather than against the
+    immediately previous one: a run that re-verifies after a fix appends
+    verification twice, and an ordering rule that forbade that would refuse a
+    real history to keep a tidy one.
+    """
+    required = _REQUIRED_PREDECESSORS.get(transition, ())
+    seen = {str(record.get("transition", "")) for record in chain}
+    missing = [name for name in required if name not in seen]
+    if missing:
+        raise RunLineageError(
+            f"{_LABEL} {transition} requires an earlier {', '.join(missing)} checkpoint in this chain"
+        )
+
+
+def _checkpoint_break(
+    record: Mapping[str, Any],
+    *,
+    index: int,
+    intact: Sequence[Mapping[str, Any]],
+    seen: set[str],
+) -> str:
+    """The first reason this checkpoint does not continue the chain, or "".
+
+    Order matters, and the digest goes first. Editing any sealed field makes a
+    record fail its own schema *and* fail its digest, and of the two answers
+    only the second one tells a reader what happened: the record is well-formed
+    and someone changed it. A record whose digest is not even digest-shaped, or
+    that is malformed for some unrelated reason, falls through to the general
+    verdict.
+    """
+    errors = validate_run_lineage_checkpoint(dict(record))
+    digest = record.get("digest")
+    if isinstance(digest, str) and _DIGEST.fullmatch(digest) and digest != checkpoint_digest(record):
+        return BREAK_DIGEST_MISMATCH
+    if errors:
+        return BREAK_INVALID_RECORD
+    if record.get("sequence") != index:
+        return BREAK_SEQUENCE
+    expected_parent = str(intact[-1].get("digest", "")) if intact else GENESIS_PARENT_DIGEST
+    if str(record.get("parent_digest", "")) != expected_parent:
+        return BREAK_PARENT_MISMATCH
+    required = _REQUIRED_PREDECESSORS.get(str(record.get("transition", "")), ())
+    if any(name not in seen for name in required):
+        return BREAK_PREREQUISITE
+    return ""
+
+
+def _reconstructions_in(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    run_id: str | None,
+) -> list[dict[str, Any]]:
+    """One reconstruction per run present in the store, or just the scoped one.
+
+    Run ids are collected in append order and deduplicated, so a store report is
+    deterministic and a run with no parseable id contributes no lineage rather
+    than an empty one named "".
+    """
+    if run_id is not None:
+        return [reconstruct_run_lineage(records, run_id=run_id)]
+    ordered: list[str] = []
+    for record in records:
+        if not isinstance(record, Mapping):
+            continue
+        value = str(record.get("run_id", ""))
+        if value and value not in ordered:
+            ordered.append(value)
+    return [reconstruct_run_lineage(records, run_id=value) for value in ordered]
+
+
+def _sequence_errors(value: Any) -> list[str]:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return [f"{_LABEL} sequence must be an integer"]
+    if value < 0:
+        return [f"{_LABEL} sequence must not be negative"]
+    return []
+
+
+def _artifact_ref_errors(value: Any) -> list[str]:
+    """A bounded, sorted, duplicate-free list of opaque references.
+
+    Sorted and deduplicated because the list is inside the digest seal: two
+    records naming the same artifacts in a different order would otherwise seal
+    to different digests and read as different history.
+    """
+    if not isinstance(value, list):
+        return [f"{_LABEL} artifact_refs must be a list"]
+    if len(value) > ARTIFACT_REF_LIMIT:
+        return [f"{_LABEL} artifact_refs must name at most {ARTIFACT_REF_LIMIT} artifacts"]
+    errors: list[str] = []
+    for index, item in enumerate(value):
+        errors.extend(
+            reference_errors(item, field=f"artifact_refs[{index}]", label=_LABEL, required=True)
+        )
+    if errors:
+        return errors
+    if list(value) != sorted(set(value)):
+        errors.append(f"{_LABEL} artifact_refs must be sorted and free of duplicates")
+    return errors
+
+
+def _digest_shape_errors(record: Mapping[str, Any]) -> list[str]:
+    """Both digest fields, their shapes, and the one genesis rule.
+
+    A chain has exactly one record with no parent, and it is the record at
+    position zero. Without this rule a hand-edited store could carry a second
+    parentless checkpoint mid-chain, and a reader walking from the genesis would
+    stop before reaching the real head.
+    """
+    errors: list[str] = []
+    digest = record.get("digest")
+    parent = record.get("parent_digest")
+    if not isinstance(digest, str) or not _DIGEST.fullmatch(digest):
+        errors.append(f"{_LABEL} digest must be a sha256 hex digest")
+    elif digest != checkpoint_digest(record):
+        errors.append(f"{_LABEL} digest does not match the checkpoint it seals")
+    if not isinstance(parent, str) or (parent and not _DIGEST.fullmatch(parent)):
+        errors.append(f"{_LABEL} parent_digest must be a sha256 hex digest or empty at the genesis checkpoint")
+    if isinstance(digest, str) and isinstance(parent, str) and digest and digest == parent:
+        errors.append(f"{_LABEL} parent_digest must not name the checkpoint itself")
+    sequence = record.get("sequence")
+    if isinstance(sequence, int) and not isinstance(sequence, bool) and isinstance(parent, str):
+        if (sequence == 0) != (parent == GENESIS_PARENT_DIGEST):
+            errors.append(
+                f"{_LABEL} only the checkpoint at sequence 0 has no parent_digest, and it must have none"
+            )
+    return errors
+
+
+def _evidence_class_errors(record: Mapping[str, Any]) -> list[str]:
+    """The evidence class re-derived, and the state pinned against it.
+
+    #826 AC3, structurally. The class is a function of the transition, so a
+    stored class that disagrees with its transition is refused rather than read;
+    and the two positional states are pinned to it in both directions, so a
+    prepared checkpoint cannot carry an observed class and an observed one
+    cannot carry the prepared class.
+    """
+    errors: list[str] = []
+    transition = str(record.get("transition", ""))
+    evidence_class = str(record.get("evidence_class", ""))
+    state = str(record.get("state", ""))
+    expected = TRANSITION_EVIDENCE_CLASS.get(transition)
+    if expected is not None and evidence_class != expected:
+        errors.append(
+            f"{_LABEL} evidence_class must be {expected} for transition {transition}; a checkpoint never "
+            "states a class its own transition did not reach"
+        )
+    if state == _PREPARED_STATE and evidence_class and evidence_class != _PREPARED_EVIDENCE_CLASS:
+        errors.append(f"{_LABEL} a prepared checkpoint must carry evidence_class {_PREPARED_EVIDENCE_CLASS}")
+    if state == _OBSERVED_STATE and evidence_class == _PREPARED_EVIDENCE_CLASS:
+        errors.append(f"{_LABEL} an observed checkpoint must not carry evidence_class {_PREPARED_EVIDENCE_CLASS}")
+    return errors
+
+
+def _missing_digest_errors(record: Mapping[str, Any]) -> list[str]:
+    """The references a transition cannot be recorded without.
+
+    A plan cannot be accepted without naming which plan, and nothing from the
+    handoff onward can be recorded without naming which handoff. Everything
+    else is optional, because a chain that starts at `handoff_prepared` has no
+    accepted plan artifact and a run whose context was never revised has no
+    context revision.
+    """
+    errors: list[str] = []
+    transition = str(record.get("transition", ""))
+    if transition not in TRANSITION_EVIDENCE_CLASS:
+        return errors
+    if transition == "plan_accepted" and not str(record.get("plan_digest", "")):
+        errors.append(f"{_LABEL} plan_digest is required on a plan_accepted checkpoint")
+    if LINEAGE_TRANSITIONS.index(transition) >= LINEAGE_TRANSITIONS.index("handoff_prepared"):
+        if not str(record.get("handoff_digest", "")):
+            errors.append(f"{_LABEL} handoff_digest is required from the handoff_prepared checkpoint onward")
+    return errors
+
+
+def _normalized_artifact_refs(values: Iterable[str]) -> list[str]:
+    """Sorted, deduplicated, guarded artifact references."""
+    refs = sorted({str(value).strip() for value in values if str(value).strip()})
+    if len(refs) > ARTIFACT_REF_LIMIT:
+        raise RunLineageError(f"{_LABEL} artifact_refs must name at most {ARTIFACT_REF_LIMIT} artifacts")
+    return [_opaque(ref, field="run_lineage_checkpoint artifact_refs") for ref in refs]
+
+
+def _opaque(value: str, *, field: str) -> str:
+    return opaque_ref(value, field=field, error=RunLineageError)
+
+
+def _optional_opaque(value: str, *, field: str) -> str:
+    text = str(value or "").strip()
+    return _opaque(text, field=field) if text else ""
+
+
+def _redacted(value: str) -> str:
+    """Fold any handle into a bounded, non-navigable lineage reference."""
+    return redacted_ref(value, field="run_lineage_ref")
+
+
+def _rendered_digest(value: Any) -> str:
+    """A digest renders only in the one shape it may be stored in."""
+    text = str(value or "")
+    return text if _DIGEST.fullmatch(text) else ""
+
+
+def _rendered_artifact_refs(value: Any) -> list[str]:
+    """A stored artifact list renders only when it is a list.
+
+    A hand-edited store can carry a string where the list should be, and
+    iterating that would render one entry per character.
+    """
+    if not isinstance(value, list):
+        return []
+    return [_redacted(str(item)) for item in value]

--- a/tests/test_handoff_safety_contract.py
+++ b/tests/test_handoff_safety_contract.py
@@ -121,7 +121,11 @@ _DECLARED_NOT_ENFORCED = {
     # delegation lane observes no baseline revision, so it has nothing to build
     # an anchor from, and no ticket against this repository changes that.
     "recovery": "no_delegation_surface_holds_an_observed_baseline_to_attach_an_anchor_from",
-    "start_evidence": "#826",
+    # #826 shipped `run_lineage_checkpoint/v1`, so this blocker stopped being
+    # that issue too. A lineage chain now refuses to reach dispatch without an
+    # observed start, which orders a chain; nothing makes a chain required of a
+    # run, so the claim ladder is unchanged and the row stays declared.
+    "start_evidence": "lineage_orders_the_start_but_no_claim_rung_requires_a_lineage_chain",
     "storage_retention": "#835",
     "workspace": "no_omh_side_constraint_can_bind_a_running_executor_process",
 }
@@ -395,7 +399,13 @@ class AntiDecorationTests(unittest.TestCase):
         self.assertIn("workspace_binding_guard/v1", workspace)
         self.assertIn("not a state OMH can observe", _boundary(contract, "account_authorization")["statement"])
         self.assertIn("persist until the operator deletes them", _boundary(contract, "storage_retention")["statement"])
-        self.assertIn("no observed start", _boundary(contract, "start_evidence")["statement"])
+        # Same shape as the workspace row after #820: #826 closed a half, so the
+        # sentence has to name what now exists *and* keep stating the gap, or a
+        # reader takes the ordered chain for a required one.
+        start_evidence = _boundary(contract, "start_evidence")["statement"]
+        self.assertIn("no observed start", start_evidence)
+        self.assertIn("run_lineage_checkpoint/v1", start_evidence)
+        self.assertIn("does not do is make the start required", start_evidence)
         # The recovery row is the one that names a contract that *does* exist,
         # so the sentence has to keep saying which half is missing. Without this
         # the "recovery_anchor/v1 contract exists" clause could stand alone and

--- a/tests/test_run_lineage_checkpoint.py
+++ b/tests/test_run_lineage_checkpoint.py
@@ -1,0 +1,818 @@
+"""Contracts for `run_lineage_checkpoint/v1` (issue #826).
+
+The acceptance criteria this holds, and where each one is asserted:
+
+AC1  OMH reconstructs and validates the chain offline
+     -> `AFullRunsChainIsReconstructedFromTheStoreAlone`
+AC2  changing history or referenced digests fails validation
+     -> `ChangingHistoryBreaksTheChain`,
+        `ChangingAReferencedDigestBreaksTheChain`
+AC3  prepared checkpoints never imply later evidence classes
+     -> `APreparedCheckpointImpliesNoObservedClass`
+
+Plus the two things this family is worthless without: that the store is wired
+into the registry and the validator its siblings use
+(`TheStoreIsRegisteredBesideItsSiblings`), and that an observed start really is
+a prerequisite of a dispatch checkpoint (`TheChainOrdersTheObservedStart`) --
+which is the fact the `start_evidence` safety boundary's new statement rests on,
+so it has to be true.
+
+Store mechanics -- concurrent appends, torn tails, chain forks -- are inherited
+from `system/append_only_store.py` and proved there. What is asserted here is
+this family's own contribution: the seal over the record, the walk that reports
+where a history stopped being trustworthy, and the derivation that makes an
+overclaiming checkpoint unconstructible rather than merely unusual.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.coding.action_gate import (  # noqa: E402
+    START_EVIDENCE_BLOCKER,
+    build_task_authority_envelope,
+    build_task_handoff_safety_contract,
+)
+from omh.local_store import atomic_write_text  # noqa: E402
+from omh.runtime.artifacts import validate_runtime  # noqa: E402
+from omh.runtime.records import (  # noqa: E402
+    OPTIONAL_RUNTIME_STORE_VALIDATORS,
+    RUN_LINEAGE_CHECKPOINT_RECORD_KEYS,
+)
+from omh.system.append_only_store import RAW_OR_HIDDEN_KEYS  # noqa: E402
+from omh.system.paths import OmhPaths  # noqa: E402
+from omh.workflows.observation_journal import PROJECTION_ORDER  # noqa: E402
+from omh.workflows.run_lineage import (  # noqa: E402
+    ARTIFACT_REF_LIMIT,
+    BREAK_CODES,
+    BREAK_DIGEST_MISMATCH,
+    BREAK_INVALID_RECORD,
+    BREAK_PARENT_MISMATCH,
+    BREAK_PREREQUISITE,
+    BREAK_REASONS,
+    BREAK_SEQUENCE,
+    CHECKPOINT_DIGEST_KEYS,
+    CLAIM_BOUNDARY,
+    EXECUTION_CLAIM_KEYS,
+    LINEAGE_EVIDENCE_CLASSES,
+    LINEAGE_STATES,
+    LINEAGE_TRANSITIONS,
+    RUN_LINEAGE_CHECKPOINT_KEYS,
+    RUN_LINEAGE_CHECKPOINT_SCHEMA_VERSION,
+    TRANSITION_EVIDENCE_CLASS,
+    UNSEALED_CHECKPOINT_KEYS,
+    RunLineageError,
+    append_run_lineage_checkpoint,
+    build_run_lineage_checkpoint,
+    checkpoint_digest,
+    checkpoint_implies_evidence_class,
+    compact_run_lineage_checkpoint,
+    lineage_id,
+    read_run_lineage,
+    read_run_lineage_checkpoints,
+    reconstruct_run_lineage,
+    run_lineage_head,
+    validate_run_lineage_checkpoint,
+    validate_run_lineage_checkpoint_store,
+)
+from omh.workflows.workspace_bindings import (  # noqa: E402
+    EXECUTION_CLAIM_KEYS as BINDING_EXECUTION_CLAIM_KEYS,
+)
+
+
+_RUN_ID = "run-20260809-alpha"
+_OWNER = "claude-code"
+_PROFILE = "rev-frozen"
+_PLAN = "plan-7c1f2a"
+_HANDOFF = "handoff-9b3e11"
+_MESSAGE = "fix the login bug in src/auth.py and add a regression test"
+
+# The two transitions whose evidence class is `prepared_not_observed`. Derived
+# rather than listed, so a transition that later becomes prepared joins the AC3
+# assertions without anyone remembering to add it here.
+_PREPARED_TRANSITIONS = tuple(
+    transition
+    for transition, evidence_class in TRANSITION_EVIDENCE_CLASS.items()
+    if evidence_class == "prepared_not_observed"
+)
+
+
+def _paths(root: Path) -> OmhPaths:
+    return OmhPaths(omh_home=root, hermes_home=root / "hermes")
+
+
+def _append(paths: OmhPaths, transition: str, **overrides: object) -> dict[str, object]:
+    """One checkpoint appended onto whatever head the chain already has."""
+    head = run_lineage_head(read_run_lineage_checkpoints(paths), run_id=_RUN_ID)
+    arguments: dict[str, object] = {
+        "run_id": _RUN_ID,
+        "transition": transition,
+        "owner": _OWNER,
+        "safety_profile_revision": _PROFILE,
+        "plan_digest": _PLAN,
+        "handoff_digest": _HANDOFF if transition != "plan_accepted" else "",
+        "continue_from": str(head.get("digest", "")),
+    }
+    arguments.update(overrides)
+    return append_run_lineage_checkpoint(paths, **arguments)  # type: ignore[arg-type]
+
+
+def _full_chain(paths: OmhPaths) -> list[dict[str, object]]:
+    """A whole run, from accepted plan to observed merge."""
+    return [_append(paths, transition) for transition in LINEAGE_TRANSITIONS]
+
+
+def _checkpoint(**overrides: object) -> dict[str, object]:
+    """One well-formed genesis checkpoint, built without a store."""
+    arguments: dict[str, object] = {
+        "run_id": _RUN_ID,
+        "transition": "plan_accepted",
+        "owner": _OWNER,
+        "safety_profile_revision": _PROFILE,
+        "sequence": 0,
+        "plan_digest": _PLAN,
+        "recorded_at": "2026-08-09T00:00:00Z",
+    }
+    arguments.update(overrides)
+    return build_run_lineage_checkpoint(**arguments)  # type: ignore[arg-type]
+
+
+def _write_store(path: Path, records: list[dict[str, object]]) -> None:
+    """Rewrite the store from records, byte-stable on every platform.
+
+    `atomic_write_text` and not `Path.write_text`: these bytes are read back and
+    hashed, and Windows text mode would rewrite every newline.
+    """
+    atomic_write_text(path, "".join(json.dumps(record, sort_keys=True) + "\n" for record in records))
+
+
+def _contract_boundary(name: str) -> dict[str, object]:
+    contract = build_task_handoff_safety_contract(
+        build_task_authority_envelope(
+            denied=False,
+            delegation_action="delegate",
+            intent="coding",
+            review_required=False,
+            work_owner_mode="external_executor",
+            selected_executor_profile="codex",
+            dispatchable=True,
+            choice_required=False,
+            isolation_plan={"strategy": "worktree_recommended"},
+            message=_MESSAGE,
+            safety_profile_revision=_PROFILE,
+        )
+    )
+    for entry in contract["boundaries"]:  # type: ignore[index]
+        if entry["boundary"] == name:
+            return entry  # type: ignore[return-value]
+    raise AssertionError(f"no boundary named {name}")
+
+
+class AFullRunsChainIsReconstructedFromTheStoreAlone(unittest.TestCase):
+    """AC1: the whole history, rebuilt offline and verified link by link."""
+
+    def test_a_full_run_reconstructs_in_order_and_validates(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            appended = _full_chain(paths)
+
+            # Nothing from the append call is reused: the reconstruction reads
+            # the store back from disk, which is what "offline from the store
+            # alone" has to mean.
+            report = read_run_lineage(paths, run_id=_RUN_ID)
+
+            self.assertTrue(report["ok"], report["break_reason"])
+            self.assertEqual(report["checkpoint_count"], len(LINEAGE_TRANSITIONS))
+            self.assertEqual(report["intact_checkpoint_count"], len(LINEAGE_TRANSITIONS))
+            self.assertEqual(report["transitions"], list(LINEAGE_TRANSITIONS))
+            self.assertEqual(report["head_transition"], "merge_observed")
+            self.assertEqual(report["head_evidence_class"], "merge_observed")
+            self.assertEqual(report["head_digest"], appended[-1]["digest"])
+            self.assertEqual(report["break_code"], "")
+            self.assertEqual(report["break_sequence"], -1)
+
+    def test_the_reconstruction_answers_what_the_run_continued_from(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            _full_chain(paths)
+
+            report = read_run_lineage(paths, run_id=_RUN_ID)
+
+            # Accepted plan -> handoff -> dispatch -> verification -> current
+            # evidence, which is the question #826 opens with.
+            self.assertEqual(report["plan_digest"], _PLAN)
+            self.assertEqual(report["handoff_digest"], _HANDOFF)
+            self.assertEqual(report["owner"], _OWNER)
+            self.assertEqual(report["safety_profile_revision"], _PROFILE)
+            self.assertEqual(report["evidence_classes"][0], "prepared_not_observed")
+            self.assertIn("dispatch_observed", report["evidence_classes"])
+            self.assertIn("verification_observed", report["evidence_classes"])
+            self.assertEqual(report["evidence_classes"][-1], "merge_observed")
+
+    def test_every_link_names_its_predecessors_own_digest(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            chain = _full_chain(paths)
+
+            self.assertEqual(chain[0]["parent_digest"], "")
+            for index, record in enumerate(chain):
+                with self.subTest(sequence=index):
+                    self.assertEqual(record["sequence"], index)
+                    self.assertEqual(record["digest"], checkpoint_digest(record))
+                    if index:
+                        self.assertEqual(record["parent_digest"], chain[index - 1]["digest"])
+
+    def test_the_store_validates_clean_and_names_one_lineage(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            _full_chain(paths)
+
+            report = validate_run_lineage_checkpoint_store(paths.runtime_run_lineage_checkpoints_path)
+
+            self.assertTrue(report["ok"], report["errors"])
+            self.assertEqual(report["checkpoint_count"], len(LINEAGE_TRANSITIONS))
+            self.assertEqual(report["lineage_count"], 1)
+            self.assertEqual(report["broken_lineage_count"], 0)
+
+    def test_two_runs_keep_separate_chains(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            _append(paths, "plan_accepted")
+            other = append_run_lineage_checkpoint(
+                paths,
+                run_id="run-20260809-beta",
+                transition="plan_accepted",
+                owner="codex",
+                safety_profile_revision=_PROFILE,
+                plan_digest="plan-other",
+            )
+
+            self.assertEqual(other["sequence"], 0)
+            self.assertEqual(other["parent_digest"], "")
+            self.assertNotEqual(other["lineage_id"], lineage_id(_RUN_ID))
+            self.assertTrue(read_run_lineage(paths, run_id="run-20260809-beta")["ok"])
+            self.assertTrue(read_run_lineage(paths, run_id=_RUN_ID)["ok"])
+
+    def test_the_digest_is_deterministic_and_never_seals_the_clock(self) -> None:
+        early = _checkpoint(recorded_at="2026-08-09T00:00:00Z")
+        late = _checkpoint(recorded_at="2026-08-09T23:59:59Z")
+
+        # Same history, two clocks, one digest. A wall clock inside the seal
+        # would make an equality check a race, which is why it is outside it.
+        self.assertEqual(early["digest"], late["digest"])
+        self.assertEqual(sorted(UNSEALED_CHECKPOINT_KEYS), ["digest", "record_id", "recorded_at"])
+        self.assertEqual(
+            sorted(CHECKPOINT_DIGEST_KEYS),
+            sorted(set(RUN_LINEAGE_CHECKPOINT_KEYS) - set(UNSEALED_CHECKPOINT_KEYS)),
+        )
+
+    def test_a_continuation_must_name_the_lineage_head(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            genesis = _append(paths, "plan_accepted")
+
+            with self.assertRaises(RunLineageError):
+                _append(paths, "handoff_prepared", continue_from="")
+            with self.assertRaises(RunLineageError):
+                _append(paths, "handoff_prepared", continue_from="a" * 64)
+
+            second = _append(paths, "handoff_prepared", continue_from=str(genesis["digest"]))
+            self.assertEqual(second["parent_digest"], genesis["digest"])
+
+
+class ChangingHistoryBreaksTheChain(unittest.TestCase):
+    """AC2, first half: editing an earlier record's field fails validation."""
+
+    def test_editing_an_earlier_checkpoints_field_is_reported_at_that_checkpoint(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            chain = _full_chain(paths)
+            store = paths.runtime_run_lineage_checkpoints_path
+            tampered = [dict(record) for record in chain]
+            # The owner of the second checkpoint, rewritten long after the fact.
+            # Nothing else on disk changes, and every later record still reads
+            # exactly as it did.
+            tampered[1]["owner"] = "codex"
+            _write_store(store, tampered)
+
+            report = read_run_lineage(paths, run_id=_RUN_ID)
+
+            self.assertFalse(report["ok"])
+            self.assertEqual(report["break_code"], BREAK_DIGEST_MISMATCH)
+            self.assertEqual(report["break_sequence"], 1)
+            self.assertEqual(report["break_record_id"], chain[1]["record_id"])
+            self.assertEqual(report["break_transition"], chain[1]["transition"])
+            self.assertEqual(report["intact_checkpoint_count"], 1)
+            self.assertIn("was changed after it was written", report["break_reason"])
+
+    def test_editing_an_earlier_checkpoint_fails_omh_runtime_validate(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            chain = _full_chain(paths)
+            store = paths.runtime_run_lineage_checkpoints_path
+            tampered = [dict(record) for record in chain]
+            tampered[2]["plan_digest"] = "plan-substituted"
+            _write_store(store, tampered)
+
+            store_report = validate_run_lineage_checkpoint_store(store)
+            runtime_report = validate_runtime(paths)
+
+            self.assertFalse(store_report["ok"])
+            self.assertEqual(store_report["broken_lineage_count"], 1)
+            self.assertTrue(any("chain break at sequence 2" in error for error in store_report["errors"]))
+            self.assertFalse(runtime_report["ok"])
+            self.assertFalse(runtime_report["run_lineage_checkpoints"]["ok"])
+
+    def test_deleting_a_checkpoint_from_the_middle_is_reported(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            chain = _full_chain(paths)
+            _write_store(paths.runtime_run_lineage_checkpoints_path, [*chain[:3], *chain[4:]])
+
+            report = read_run_lineage(paths, run_id=_RUN_ID)
+
+            self.assertFalse(report["ok"])
+            # The record that moved into position 3 says it is at position 4.
+            self.assertEqual(report["break_code"], BREAK_SEQUENCE)
+            self.assertEqual(report["break_sequence"], 3)
+            self.assertEqual(report["break_record_id"], chain[4]["record_id"])
+
+    def test_a_checkpoint_grafted_from_another_run_is_reported(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            store = paths.runtime_run_lineage_checkpoints_path
+            chain = _full_chain(paths)
+            tampered = [dict(record) for record in chain]
+            # Same chain, one record relabelled onto another run's lineage and
+            # resealed, so the seal itself is consistent. Only the derived
+            # lineage id catches it; without that, one run's history could be
+            # grafted onto another run's chain.
+            tampered[2]["lineage_id"] = lineage_id("run-20260809-beta")
+            tampered[2]["digest"] = checkpoint_digest(tampered[2])
+            _write_store(store, tampered)
+
+            report = read_run_lineage(paths, run_id=_RUN_ID)
+
+            self.assertFalse(report["ok"])
+            self.assertEqual(report["break_code"], BREAK_INVALID_RECORD)
+            self.assertEqual(report["break_sequence"], 2)
+            self.assertTrue(
+                any("lineage_id does not identify its own run" in error
+                    for error in validate_run_lineage_checkpoint_store(store)["errors"])
+            )
+
+    def test_every_break_code_carries_a_written_reason(self) -> None:
+        self.assertEqual(sorted(BREAK_REASONS), sorted(BREAK_CODES))
+        for code in BREAK_CODES:
+            with self.subTest(code=code):
+                self.assertTrue(BREAK_REASONS[code].strip())
+
+
+class ChangingAReferencedDigestBreaksTheChain(unittest.TestCase):
+    """AC2, second half: repointing a link fails validation.
+
+    Separate from editing a field on purpose. A field edit is caught because the
+    record no longer matches its own seal; a repointed `parent_digest` is a
+    record that matches its own seal perfectly and still does not continue the
+    history it claims to. Only the walk catches the second one, so only a
+    separate test proves the walk is there.
+    """
+
+    def test_repointing_a_parent_digest_is_reported_at_that_checkpoint(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            chain = _full_chain(paths)
+            tampered = [dict(record) for record in chain]
+            # Point checkpoint 3 back at checkpoint 0 and reseal it, so the
+            # record is internally consistent and only its position in the
+            # history is a lie.
+            tampered[3]["parent_digest"] = chain[0]["digest"]
+            tampered[3]["digest"] = checkpoint_digest(tampered[3])
+            _write_store(paths.runtime_run_lineage_checkpoints_path, tampered)
+
+            self.assertEqual(validate_run_lineage_checkpoint(tampered[3]), [])
+
+            report = read_run_lineage(paths, run_id=_RUN_ID)
+
+            self.assertFalse(report["ok"])
+            self.assertEqual(report["break_code"], BREAK_PARENT_MISMATCH)
+            self.assertEqual(report["break_sequence"], 3)
+            self.assertEqual(report["break_record_id"], chain[3]["record_id"])
+            self.assertIn("does not continue from the history it claims", report["break_reason"])
+
+    def test_a_repointed_parent_digest_fails_omh_runtime_validate(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            chain = _full_chain(paths)
+            tampered = [dict(record) for record in chain]
+            tampered[4]["parent_digest"] = chain[1]["digest"]
+            tampered[4]["digest"] = checkpoint_digest(tampered[4])
+            _write_store(paths.runtime_run_lineage_checkpoints_path, tampered)
+
+            report = validate_runtime(paths)
+
+            self.assertFalse(report["ok"])
+            self.assertFalse(report["run_lineage_checkpoints"]["ok"])
+            self.assertTrue(
+                any("chain break at sequence 4" in error for error in report["run_lineage_checkpoints"]["errors"])
+            )
+
+    def test_a_parent_digest_naming_no_checkpoint_at_all_is_reported(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            chain = _full_chain(paths)
+            tampered = [dict(record) for record in chain]
+            tampered[2]["parent_digest"] = "b" * 64
+            tampered[2]["digest"] = checkpoint_digest(tampered[2])
+            _write_store(paths.runtime_run_lineage_checkpoints_path, tampered)
+
+            store_report = validate_run_lineage_checkpoint_store(
+                paths.runtime_run_lineage_checkpoints_path
+            )
+
+            self.assertFalse(store_report["ok"])
+            # The shared walk sees a link into a record that never existed; the
+            # reconstruction sees a link to the wrong predecessor. Both are the
+            # same tamper and both have to be reported.
+            self.assertTrue(
+                any("does not name an earlier checkpoint" in error for error in store_report["errors"]),
+                store_report["errors"],
+            )
+            self.assertEqual(read_run_lineage(paths, run_id=_RUN_ID)["break_code"], BREAK_PARENT_MISMATCH)
+
+    def test_a_second_checkpoint_claiming_one_predecessor_forks_the_chain(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            chain = _full_chain(paths)
+            fork = dict(chain[2])
+            fork["record_id"] = "run-lineage-forked-000000"
+            fork["owner"] = "codex"
+            fork["digest"] = checkpoint_digest(fork)
+            _write_store(paths.runtime_run_lineage_checkpoints_path, [*chain, fork])
+
+            store_report = validate_run_lineage_checkpoint_store(
+                paths.runtime_run_lineage_checkpoints_path
+            )
+
+            self.assertFalse(store_report["ok"])
+            self.assertTrue(
+                any("forks the chain" in error for error in store_report["errors"]), store_report["errors"]
+            )
+
+    def test_a_digest_that_is_not_a_digest_is_refused_by_shape(self) -> None:
+        record = _checkpoint()
+        for value in ("", "not-a-digest", "A" * 64, "a" * 63):
+            with self.subTest(digest=value):
+                tampered = {**record, "digest": value}
+                self.assertTrue(
+                    any("digest must be a sha256 hex digest" in error
+                        for error in validate_run_lineage_checkpoint(tampered))
+                )
+
+    def test_only_the_genesis_checkpoint_has_no_parent(self) -> None:
+        record = _checkpoint()
+        orphaned = {**record, "sequence": 3}
+        orphaned["digest"] = checkpoint_digest(orphaned)
+        self.assertTrue(
+            any("only the checkpoint at sequence 0 has no parent_digest" in error
+                for error in validate_run_lineage_checkpoint(orphaned))
+        )
+
+        parented = {**record, "parent_digest": "c" * 64}
+        parented["digest"] = checkpoint_digest(parented)
+        self.assertTrue(
+            any("only the checkpoint at sequence 0 has no parent_digest" in error
+                for error in validate_run_lineage_checkpoint(parented))
+        )
+
+
+class APreparedCheckpointImpliesNoObservedClass(unittest.TestCase):
+    """AC3: preparing a run says only that it was prepared."""
+
+    def test_a_prepared_checkpoint_implies_nothing_across_the_class_vocabulary(self) -> None:
+        for transition in _PREPARED_TRANSITIONS:
+            record = _checkpoint(transition=transition, handoff_digest=_HANDOFF)
+            for evidence_class in LINEAGE_EVIDENCE_CLASSES:
+                with self.subTest(transition=transition, evidence_class=evidence_class):
+                    implied = checkpoint_implies_evidence_class(record, evidence_class)
+                    self.assertEqual(implied, evidence_class == "prepared_not_observed")
+
+    def test_no_checkpoint_implies_a_class_beyond_its_own_transition(self) -> None:
+        # The wider statement AC3 is a case of: a checkpoint states one class,
+        # the one its own transition records, and never the next rung.
+        for transition in LINEAGE_TRANSITIONS:
+            record = _checkpoint(transition=transition, handoff_digest=_HANDOFF)
+            for evidence_class in LINEAGE_EVIDENCE_CLASSES:
+                with self.subTest(transition=transition, evidence_class=evidence_class):
+                    self.assertEqual(
+                        checkpoint_implies_evidence_class(record, evidence_class),
+                        evidence_class == TRANSITION_EVIDENCE_CLASS[transition],
+                    )
+
+    def test_a_class_outside_the_vocabulary_is_never_implied(self) -> None:
+        record = _checkpoint(transition="merge_observed", handoff_digest=_HANDOFF)
+        for value in ("", "merged", "anything", "MERGE_OBSERVED"):
+            with self.subTest(value=value):
+                self.assertFalse(checkpoint_implies_evidence_class(record, value))
+
+    def test_a_prepared_checkpoint_cannot_be_built_carrying_an_observed_class(self) -> None:
+        # There is no argument for it. The class is derived from the transition,
+        # which is the structural half of AC3: an overclaiming checkpoint is
+        # unconstructible rather than merely discouraged.
+        for transition in _PREPARED_TRANSITIONS:
+            with self.subTest(transition=transition):
+                record = _checkpoint(transition=transition, handoff_digest=_HANDOFF)
+                self.assertEqual(record["evidence_class"], "prepared_not_observed")
+                self.assertEqual(record["state"], "prepared")
+                self.assertNotIn("evidence_class", build_run_lineage_checkpoint.__kwdefaults__ or {})
+
+    def test_a_hand_edited_prepared_checkpoint_claiming_a_later_class_is_refused(self) -> None:
+        record = _checkpoint()
+        for evidence_class in LINEAGE_EVIDENCE_CLASSES:
+            if evidence_class == "prepared_not_observed":
+                continue
+            with self.subTest(evidence_class=evidence_class):
+                tampered = {**record, "evidence_class": evidence_class}
+                tampered["digest"] = checkpoint_digest(tampered)
+                errors = validate_run_lineage_checkpoint(tampered)
+                self.assertTrue(
+                    any("never states a class its own transition did not reach" in error for error in errors),
+                    errors,
+                )
+
+    def test_a_prepared_state_and_an_observed_class_cannot_coexist(self) -> None:
+        observed = _checkpoint(transition="merge_observed", handoff_digest=_HANDOFF)
+        tampered = {**observed, "state": "prepared"}
+        tampered["digest"] = checkpoint_digest(tampered)
+        self.assertTrue(
+            any("a prepared checkpoint must carry evidence_class" in error
+                for error in validate_run_lineage_checkpoint(tampered))
+        )
+
+        prepared = {**_checkpoint(), "state": "observed"}
+        prepared["digest"] = checkpoint_digest(prepared)
+        self.assertTrue(
+            any("an observed checkpoint must not carry evidence_class" in error
+                for error in validate_run_lineage_checkpoint(prepared))
+        )
+
+    def test_the_claim_boundary_denies_every_later_evidence_class_on_every_record(self) -> None:
+        record = _checkpoint()
+        self.assertEqual(record["claim_boundary"], CLAIM_BOUNDARY)
+        self.assertIn("It is not that evidence", CLAIM_BOUNDARY)
+        self.assertIn(
+            "never dispatch, execution, verification, review, CI, merge-readiness, or merge evidence",
+            CLAIM_BOUNDARY,
+        )
+        self.assertIn("a prepared checkpoint states no observed class at all", CLAIM_BOUNDARY)
+
+    def test_a_record_cannot_be_constructed_in_a_shape_that_claims_execution(self) -> None:
+        record = _checkpoint()
+        for key in sorted(EXECUTION_CLAIM_KEYS):
+            with self.subTest(key=key):
+                errors = validate_run_lineage_checkpoint({**record, key: "yes"})
+                self.assertTrue(
+                    any("must not carry execution-claim keys" in error for error in errors), errors
+                )
+
+    def test_the_execution_claim_vocabulary_matches_its_sibling(self) -> None:
+        # Three families now refuse the same shape by name. Pinned pairwise so
+        # a key added to one and missed on another is a failing test.
+        self.assertEqual(EXECUTION_CLAIM_KEYS, BINDING_EXECUTION_CLAIM_KEYS)
+
+    def test_a_record_cannot_carry_raw_or_hidden_content(self) -> None:
+        record = _checkpoint()
+        for key in sorted(RAW_OR_HIDDEN_KEYS):
+            with self.subTest(key=key):
+                errors = validate_run_lineage_checkpoint({**record, key: "x"})
+                self.assertTrue(any("must not carry raw or hidden keys" in error for error in errors), errors)
+
+
+class TheChainOrdersTheObservedStart(unittest.TestCase):
+    """The fact the `start_evidence` boundary's new statement rests on."""
+
+    def test_a_dispatch_checkpoint_requires_an_observed_start_in_the_chain(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            _append(paths, "plan_accepted")
+            _append(paths, "handoff_prepared")
+
+            with self.assertRaises(RunLineageError) as raised:
+                _append(paths, "executor_dispatch_observed")
+
+            self.assertIn("runtime_start_observed", str(raised.exception))
+            self.assertEqual(len(read_run_lineage_checkpoints(paths, run_id=_RUN_ID)), 2)
+
+    def test_a_hand_written_chain_that_skips_the_start_is_reported(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            plan = _checkpoint(sequence=0)
+            handoff = _checkpoint(
+                transition="handoff_prepared",
+                handoff_digest=_HANDOFF,
+                sequence=1,
+                parent_digest=str(plan["digest"]),
+            )
+            dispatch = _checkpoint(
+                transition="executor_dispatch_observed",
+                handoff_digest=_HANDOFF,
+                sequence=2,
+                parent_digest=str(handoff["digest"]),
+            )
+            _write_store(paths.runtime_run_lineage_checkpoints_path, [plan, handoff, dispatch])
+
+            report = read_run_lineage(paths, run_id=_RUN_ID)
+
+            self.assertFalse(report["ok"])
+            self.assertEqual(report["break_code"], BREAK_PREREQUISITE)
+            self.assertEqual(report["break_sequence"], 2)
+            self.assertFalse(
+                validate_run_lineage_checkpoint_store(paths.runtime_run_lineage_checkpoints_path)["ok"]
+            )
+
+    def test_the_start_evidence_boundary_stays_declared_and_says_why(self) -> None:
+        # Honest bookkeeping. Ordering a chain is not requiring one, so the
+        # boundary does not move; what changes is the blocker, which stops being
+        # a ticket and becomes the reason nothing further can close it here.
+        boundary = _contract_boundary("start_evidence")
+
+        self.assertEqual(boundary["enforcement"], "declared_not_enforced")
+        self.assertEqual(boundary["enforced_by"], [])
+        self.assertEqual(boundary["blocked_by"], START_EVIDENCE_BLOCKER)
+        self.assertNotEqual(boundary["blocked_by"], "#826")
+        self.assertIn("run_lineage_checkpoint/v1", boundary["statement"])
+        self.assertIn("no observed start", boundary["statement"])
+
+    def test_every_other_prerequisite_mirrors_the_journals_lifecycle_order(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            _append(paths, "plan_accepted")
+            _append(paths, "handoff_prepared")
+            _append(paths, "runtime_start_observed")
+            _append(paths, "executor_dispatch_observed")
+
+            for transition in ("verification_result_observed", "review_result_observed", "merge_observed"):
+                with self.subTest(transition=transition), self.assertRaises(RunLineageError):
+                    _append(paths, transition)
+
+
+class TheStoreIsRegisteredBesideItsSiblings(unittest.TestCase):
+    """The wiring: without it nothing in production ever runs these validators."""
+
+    def test_the_family_registers_its_validator_under_its_own_store(self) -> None:
+        entries = {entry.store_name: entry for entry in OPTIONAL_RUNTIME_STORE_VALIDATORS}
+        self.assertIn("run_lineage_checkpoints.jsonl", entries)
+        entry = entries["run_lineage_checkpoints.jsonl"]
+        # `record_id`, not the `receipt_id` two of its siblings carry, so the
+        # label a fault is reported under is part of the registration.
+        self.assertEqual(entry.record_id_key, "record_id")
+        self.assertEqual(entry.validator(_checkpoint()), [])
+        self.assertTrue(entry.validator({"schema_version": "approval_receipt/v1"}))
+        self.assertTrue(entry.validator({"schema_version": "workspace_binding_guard/v1"}))
+        self.assertEqual(RUN_LINEAGE_CHECKPOINT_RECORD_KEYS, RUN_LINEAGE_CHECKPOINT_KEYS)
+
+    def test_the_store_lives_beside_its_siblings_and_not_inside_a_run(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            self.assertEqual(
+                paths.runtime_run_lineage_checkpoints_path.parent,
+                paths.runtime_workspace_bindings_path.parent,
+            )
+            self.assertNotIn("runs", paths.runtime_run_lineage_checkpoints_path.parts)
+            self.assertEqual(
+                paths.runtime_run_lineage_checkpoints_path.name, "run_lineage_checkpoints.jsonl"
+            )
+
+    def test_the_store_report_reaches_omh_runtime_validate(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            store = paths.runtime_run_lineage_checkpoints_path
+            store.parent.mkdir(parents=True, exist_ok=True)
+            atomic_write_text(store, json.dumps({"schema_version": "nonsense"}) + "\n")
+
+            report = validate_runtime(paths)
+
+            self.assertIn("run_lineage_checkpoints", report)
+            self.assertFalse(report["run_lineage_checkpoints"]["ok"])
+            self.assertFalse(report["ok"])
+
+    def test_an_absent_store_is_not_a_fault(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            store = paths.runtime_run_lineage_checkpoints_path
+            self.assertFalse(store.exists())
+
+            report = validate_run_lineage_checkpoint_store(store)
+            scoped = validate_run_lineage_checkpoint_store(store, run_id=_RUN_ID)
+
+            self.assertTrue(report["ok"], report["errors"])
+            self.assertEqual(report["checkpoint_count"], 0)
+            self.assertEqual(report["lineage_count"], 0)
+            # A run with no checkpoints has no chain, scoped or not.
+            self.assertTrue(scoped["ok"], scoped["errors"])
+            self.assertEqual(scoped["lineage_count"], 0)
+
+    def test_a_hand_edited_artifact_list_renders_as_nothing(self) -> None:
+        record = _checkpoint(artifact_refs=["a-one"])
+        self.assertEqual(compact_run_lineage_checkpoint(record)["artifact_refs"], ["a-one"])
+        # A string where the list should be would otherwise render one entry per
+        # character.
+        self.assertEqual(
+            compact_run_lineage_checkpoint({**record, "artifact_refs": "a-one"})["artifact_refs"], []
+        )
+
+
+class TheRecordShapeIsClosed(unittest.TestCase):
+    """Vocabularies, key sets, and the things a metadata-only record refuses."""
+
+    def test_the_evidence_class_vocabulary_is_the_journals_projection_order(self) -> None:
+        # Restated rather than imported, so this is where the two are pinned.
+        self.assertEqual(LINEAGE_EVIDENCE_CLASSES, PROJECTION_ORDER)
+
+    def test_every_transition_maps_onto_a_class_and_every_class_has_a_transition(self) -> None:
+        self.assertEqual(sorted(TRANSITION_EVIDENCE_CLASS), sorted(LINEAGE_TRANSITIONS))
+        self.assertEqual(set(TRANSITION_EVIDENCE_CLASS.values()), set(LINEAGE_EVIDENCE_CLASSES))
+
+    def test_the_record_keys_and_schema_are_fixed(self) -> None:
+        record = _checkpoint()
+        self.assertEqual(set(record), set(RUN_LINEAGE_CHECKPOINT_KEYS))
+        self.assertEqual(record["schema_version"], RUN_LINEAGE_CHECKPOINT_SCHEMA_VERSION)
+        self.assertEqual(record["privacy"], "metadata_only")
+        self.assertEqual(validate_run_lineage_checkpoint(record), [])
+
+    def test_an_unsupported_transition_or_state_is_refused(self) -> None:
+        with self.assertRaises(RunLineageError):
+            _checkpoint(transition="merged")
+        with self.assertRaises(RunLineageError):
+            _checkpoint(state="in_progress")
+        self.assertEqual(LINEAGE_STATES, ("prepared", "observed", "blocked", "cancelled", "failed"))
+
+    def test_a_terminal_state_is_accepted_on_any_transition(self) -> None:
+        for state in ("blocked", "cancelled", "failed"):
+            with self.subTest(state=state):
+                record = _checkpoint(state=state)
+                self.assertEqual(validate_run_lineage_checkpoint(record), [])
+
+    def test_a_url_or_a_path_cannot_enter_a_reference_field(self) -> None:
+        for value in ("https://evil.test/plan", "/Users/someone/plan.md", "plan?id=1"):
+            with self.subTest(value=value), self.assertRaises(RunLineageError):
+                _checkpoint(plan_digest=value)
+
+    def test_a_plan_accepted_checkpoint_must_name_its_plan(self) -> None:
+        with self.assertRaises(RunLineageError) as raised:
+            _checkpoint(plan_digest="")
+        self.assertIn("plan_digest is required", str(raised.exception))
+
+    def test_everything_from_the_handoff_onward_must_name_its_handoff(self) -> None:
+        for transition in LINEAGE_TRANSITIONS[1:]:
+            with self.subTest(transition=transition), self.assertRaises(RunLineageError) as raised:
+                _checkpoint(transition=transition, handoff_digest="")
+            self.assertIn("handoff_digest is required", str(raised.exception))
+
+    def test_artifact_refs_are_bounded_sorted_and_deduplicated(self) -> None:
+        record = _checkpoint(artifact_refs=["b-two", "a-one", "b-two"])
+        self.assertEqual(record["artifact_refs"], ["a-one", "b-two"])
+        with self.assertRaises(RunLineageError):
+            _checkpoint(artifact_refs=[f"artifact-{index}" for index in range(ARTIFACT_REF_LIMIT + 1)])
+        unsorted = {**record, "artifact_refs": ["b-two", "a-one"]}
+        unsorted["digest"] = checkpoint_digest(unsorted)
+        self.assertTrue(
+            any("must be sorted and free of duplicates" in error
+                for error in validate_run_lineage_checkpoint(unsorted))
+        )
+
+    def test_a_sequence_that_is_not_a_whole_number_is_refused(self) -> None:
+        for value in (-1, True, "0", 1.5):
+            with self.subTest(sequence=value), self.assertRaises(RunLineageError):
+                _checkpoint(sequence=value)
+
+    def test_rendering_refuses_anything_outside_its_vocabulary(self) -> None:
+        record = _checkpoint()
+        compact = compact_run_lineage_checkpoint(record)
+        self.assertEqual(compact["transition"], "plan_accepted")
+        self.assertEqual(compact["digest"], record["digest"])
+        self.assertEqual(compact["parent_digest"], "")
+
+        hand_edited = {**record, "transition": "invented", "digest": "/etc/passwd", "state": "whatever"}
+        rendered = compact_run_lineage_checkpoint(hand_edited)
+        self.assertEqual(rendered["transition"], "")
+        self.assertEqual(rendered["state"], "")
+        self.assertEqual(rendered["digest"], "")
+
+    def test_a_reconstruction_of_a_run_with_no_chain_is_empty_and_whole(self) -> None:
+        report = reconstruct_run_lineage([], run_id=_RUN_ID)
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["checkpoint_count"], 0)
+        self.assertEqual(report["transitions"], [])
+        self.assertEqual(report["head_digest"], "")
+        self.assertEqual(report["claim_boundary"], CLAIM_BOUNDARY)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime_artifacts.py
+++ b/tests/test_runtime_artifacts.py
@@ -2065,6 +2065,7 @@ _STORE_SCHEMA_VERSIONS = {
     "approval_receipts.jsonl": "approval_receipt/v1",
     "blocked_work_records.jsonl": "blocked_work_record/v1",
     "external_effect_receipts.jsonl": "external_effect_receipt/v1",
+    "run_lineage_checkpoints.jsonl": "run_lineage_checkpoint/v1",
     "workspace_bindings.jsonl": "workspace_binding_guard/v1",
 }
 


### PR DESCRIPTION
## Feature Report

### What Changed

- Adds `run_lineage_checkpoint/v1`: an append-only, hash-chained record of a run's
  transitions, stored at `runtime/journal/run_lineage_checkpoints.jsonl` beside the
  four append-only stores already there.
- Each checkpoint carries `parent_digest` (its predecessor's own digest) and `digest`
  (a sha256 seal over its own meaningful fields), so a run's history becomes something
  a reader can verify rather than assume.
- `reconstruct_run_lineage()` rebuilds one run's chain offline from the store alone,
  recomputing every link, and stops at the first break with the checkpoint that broke it.
- `validate_run_lineage_checkpoint_store()` carries the same walk into
  `omh runtime validate`, which now reports a `run_lineage_checkpoints` section and
  fails when any chain is broken.
- Updates the `start_evidence` boundary of `handoff_safety_contract/v1`: still
  `declared_not_enforced`, but its `blocked_by` stops being `#826` and becomes a reason
  string, and the statement now says what the chain does and does not do.

### Why This Exists

A run's history was already recorded, but only in pieces that agree by convention. The
run record, the observation journal, the plan artifact, the handoff, the workspace
binding, and the approval each live in their own file. Answering "what state did this
run continue from" meant joining them by `run_id` and trusting that none of them had
been edited since.

Nothing in the tree made that trust checkable. Before this change,
`grep -rn "run_lineage_checkpoint" src/ tests/ docs/` returned 0 hits, and so did
`grep -rEn "parent_digest|prev_digest|chain_digest|lineage_head|continued_from" src/`.
There was no hash-chained store anywhere: no record named its predecessor, so an edit to
a run's early history left every later artifact reading exactly as it did before.

### User / Operator Impact

- An operator can reconstruct a run's history from `plan_accepted` through
  `handoff_prepared`, `runtime_start_observed`, dispatch, result, verification, review,
  CI, and merge, and see the plan digest, handoff digest, owner, safety-profile
  revision, context revision, and artifacts that each step continued from.
- Tampering is detectable rather than invisible. Editing an earlier checkpoint's field
  breaks that record's own seal; repointing a `parent_digest` breaks the walk; deleting a
  checkpoint from the middle breaks the sequence. All three fail `omh runtime validate`
  and name the checkpoint and the reason.
- A prepared checkpoint cannot be dressed up as an observed one. There is no
  `evidence_class` argument to give it, and a hand-edited store carrying a later class on
  a prepared transition is refused at validate.

### How It Works

**The seal.** `checkpoint_digest()` calls the shared
`append_only_store.record_fingerprint()` over `CHECKPOINT_DIGEST_KEYS`, which is derived
as the record's own key set minus `UNSEALED_CHECKPOINT_KEYS`
(`digest`, `record_id`, `recorded_at`) — so a field added to the record is sealed by
default. `recorded_at` is a parameter and is deliberately outside the seal: a wall clock
inside a hashed artifact turns an equality check into a race. The honest consequence is
stated in the module docstring rather than hidden — the chain seals *what* a run
continued from, not *when* each step was written down, and nothing reads freshness off
this store. Two checkpoints still cannot collide: within a run the `sequence` differs,
and across runs the `run_id` and `lineage_id` do.

**The chain.** `append_run_lineage_checkpoint()` reads the head and appends the new link
under one `local_store.file_lock`, so two concurrent appends produce two links in a line
rather than two records claiming one predecessor. `continue_from` implements #826's
"require continuation to name the lineage head": once a chain exists, a caller must name
the head it read, and a head that has moved is refused. `plan_digest`, `handoff_digest`,
and `context_revision` are inherited from the head when the caller leaves them empty.

**The walk.** Two halves. `store_errors(..., id_key="digest", link_key="parent_digest",
noun="checkpoint")` is the shared supersede walk reused as a hash-chain walk — the two
reject the same four shapes (a duplicate id, a self-link, a link to a record that does
not already exist, and two records claiming one predecessor). The per-run reconstruction
adds what only an ordered walk can see: a digest that no longer matches its record, a
parent that names an earlier record but not the *previous* one, a sequence that is not
its position, and a transition whose required predecessor is absent.

**The evidence boundary.** `evidence_class` is derived from the transition via a total
`TRANSITION_EVIDENCE_CLASS` map onto the journal's own `PROJECTION_ORDER` vocabulary, and
re-derived at validate. `state` is pinned against it in both directions. There is no
argument through which a `plan_accepted` checkpoint could be given `merge_observed`, and
`checkpoint_implies_evidence_class()` answers `True` only for a checkpoint's own class.

**The start-evidence decision.** The chain's `_REQUIRED_PREDECESSORS` mirrors the
journal's lifecycle prerequisites and adds one the journal never had: a dispatch
checkpoint requires an earlier `runtime_start_observed` in the same chain. That is real,
and it is narrow — it orders a chain, it does not make a chain mandatory. No claim rung,
journal prerequisite, or delegation surface asks a run for a chain, so a run that records
none still reaches dispatch and execution with no observed start. The boundary therefore
was **not** flipped to `enforced`; it stays `declared_not_enforced`, its statement names
what now exists and keeps stating the gap, and its blocker becomes
`lineage_orders_the_start_but_no_claim_rung_requires_a_lineage_chain` on the same
precedent as the `account_authorization` and `recovery` rows.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/workflows/run_lineage.py` | New. The family: build, validate, append, reconstruct, store-validate, render (+1042 lines) |
| `src/system/paths.py` | `runtime_run_lineage_checkpoints_path`, with the comment saying why the store is runtime-wide |
| `src/runtime/records.py` | One entry in `OPTIONAL_RUNTIME_STORE_VALIDATORS` (`record_id`), plus the `RUN_LINEAGE_CHECKPOINT_RECORD_KEYS` re-export. No sibling registry tuple |
| `src/runtime/artifacts.py` | Store-level `validate_run_lineage_checkpoint_store` call in `validate_runtime`, folded into `ok` and reported as `run_lineage_checkpoints` |
| `src/coding/action_gate.py` | `START_EVIDENCE_BLOCKER`; rewritten `start_evidence` statement |
| `tests/test_run_lineage_checkpoint.py` | New. 49 tests across AC1/AC2/AC3, the registry wiring, the start ordering, and the closed record shape |
| `tests/test_handoff_safety_contract.py` | `_DECLARED_NOT_ENFORCED["start_evidence"]` updated; `test_unenforced_boundaries_state_the_gap_in_words` now pins the new clauses as well as `no observed start` |
| `tests/test_runtime_artifacts.py` | `_STORE_SCHEMA_VERSIONS` gains `run_lineage_checkpoints.jsonl` |

No generated artifact was hand-edited. No new dependency. No network, LLM, or subprocess
call is added; the module reads and writes one local JSONL file.

## Validation

- [x] `uv run --group lint ruff check src tests` — `All checks passed!`
- [x] `python3 -m unittest discover -s tests` — as `PYTHONPATH=tests uv run python -m unittest discover -s tests`: **Ran 4654 tests in 145.083s, OK**, on the rebased tree (`origin/main` = `d946a99e`). The new file alone: **Ran 49 tests, OK**.
- [x] `python3 -m compileall src` — as `uv run python -m compileall -q src tests`, exit 0
- [x] `python3 -m omh.cli docs workflows --check` — `{"ok":true, tap_skills: 115/115}`
- [x] `python3 -m omh.cli harness validate` — `{"counts":{"harnesses":72,"skills":104},"errors":[],"ok":true}`
- [x] `python3 -m omh.cli release checklist --json` — `"ok":true`, 35 required items
- [x] `python3 -m omh.cli release hermes-smoke` — plan rendered with plan-only boundary
- [ ] `omh --help` — the shell resolves `/Users/.../.local/bin/omh`, which is the previously installed 1.0.5 build and not this branch. It exits 0, but that is not evidence about this change, so the box is left unticked.
- [ ] `omh --omh-home /tmp/omh-smoke ... release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run, for the same reason: it exercises the installed console script rather than this branch.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: no learning contract changed.
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli docs roles --check` and `docs capability-families --check` both `"ok":true`; `git diff --check` clean.
- [ ] Manual Hermes/TUI check: not run. No Hermes-facing surface changed — this adds a runtime store and a validator, with no chat card, skill, router trigger, or CLI command.

## Risk

- **Low blast radius on existing runs.** The store is optional and absent by default;
  `validate_run_lineage_checkpoint_store` on a missing file reports `ok: true` with zero
  checkpoints, which is asserted. `validate_runtime` gains one key and one `ok` conjunct.
- **`omh runtime validate` can now fail on a store it could not fail on before.** That is
  the point of AC2, but it means a hand-edited or corrupted lineage file makes the whole
  runtime report not-ok. No production surface writes one yet, so today the only way to
  get a broken chain is to write one.
- **The unsealed `recorded_at` is a real, deliberate limit.** A stamp can be edited
  without breaking a link. Nothing in the tree reads freshness from this store, and the
  module docstring says so; a future surface that wants a trustworthy time must not take
  it from here.
- **The `start_evidence` boundary moved in words, not in verdict.** If a reviewer thinks
  the chain's dispatch-requires-start rule *should* flip the row to `enforced`, that is a
  disagreement worth having in review — the argument for leaving it declared is that
  nothing requires a run to have a chain at all, so the claim ladder is unchanged.

## Compatibility / Rollout

- Additive. No existing schema, key set, vocabulary, or exact-count assertion changes;
  `_STORE_SCHEMA_VERSIONS` gains a row and the safety-boundary count is unchanged (the
  `start_evidence` row was edited, not added).
- Old runtime trees are unaffected: no lineage store means no lineage report content and
  no new errors.
- No migration. A chain begins the first time something appends to it.

## Release / Claims

- [x] Release-channel impact considered — `local`. No version file, changelog, skill, or
      generated artifact changes; nothing ships to `stable` or `preview` from this PR.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed —
      every claim above is either a passing gate quoted verbatim or explicitly marked not
      run. A lineage checkpoint is metadata-only and its `claim_boundary` states on every
      record that it is not dispatch, execution, verification, review, CI,
      merge-readiness, or merge evidence.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke
      --live` gap — the live tap smoke was not run; this change touches no Hermes-visible
      surface, so there is nothing for a live profile to observe.

## Follow-Up

- No production surface appends a checkpoint yet. The natural next step is for the
  lifecycle writers that already append observation events to append the matching
  checkpoint, which is what would make `omh runtime status` able to answer "what did this
  run continue from" for a real run.
- An `omh runtime lineage <run-id>` command would put `reconstruct_run_lineage` in an
  operator's hands directly. It is deliberately out of this PR: the reconstruction is
  reachable today through `omh runtime validate` and the library, and a new CLI surface
  carries its own conventions (plain-text default, bounded surfaces, spec-side policy
  tests) that belong with a caller that needs it.
- Flipping `start_evidence` to `enforced` remains open, and the blocker now says exactly
  what would have to change: something has to require a run to carry a chain.
