### PR TITLE
feat: keep OMH native hooks reviewed and tamper-evident

### DIFF
--- a/src/install/hook_integrity.py
+++ b/src/install/hook_integrity.py
@@ -1,0 +1,548 @@
+"""#803: reviewed, tamper-evident integrity records for the native OMH hooks.
+
+A sibling record, not more fields on `hook_manifest()`. That choice is the
+whole shape of this module, so here is why it went that way.
+
+`capabilities.hooks.hook_manifest()` is a *static* projection. It is folded into
+`capability_snapshot()` behind an `lru_cache`, which advertises itself as
+`static_projection_no_runtime_clock`, and it is mirrored byte-for-byte by a
+standalone copy inside the vendored bundle
+(`plugin_bundle/omh/tools/capability_tool.py`) so the plugin can answer without
+importing the omh package. Integrity is the opposite kind of fact: it needs
+`OmhPaths`, it reads the installed plugin directory, and it reads a local
+revocation ledger. Folding disk state into the manifest would make a cached,
+environment-independent payload depend on the environment, and would force the
+vendored mirror to grow a filesystem dependency it deliberately does not have.
+
+So this is one hook concept with two projections, not two hook concepts. The
+vocabulary of hooks is still `plugin_bundle.omh.metadata.PROVIDED_HOOKS`; every
+record here names a hook the manifest already declares, and the status carries
+`hook_manifest_schema_version` so a reader can see which manifest it refines.
+Nothing here invents a hook.
+
+Four rules the rest of the file follows:
+
+1. The digest is the one `install.plugin_pack` already computes. The reviewed
+   value comes straight out of `bundled_plugin_records()` -- the same
+   `sha256_text` over the same packaged resource -- and the installed value is
+   `sha256_file` over the file that record was copied to. There is no second
+   hashing scheme, and the bundle writer's `newline=""` is what keeps the two
+   comparable on Windows.
+2. Trust is scoped to the hook's own entry module. Whole-bundle staleness is
+   already owned by doctor's `plugin_bundle_current` check; duplicating it here
+   would report the same drift twice under two different repairs.
+3. A changed or revoked hook is dropped from `managed_hooks` *and* listed in
+   `excluded_hooks` with the capability it takes down and the command that
+   brings it back. Dropping it quietly is the bug this record exists to stop.
+4. Installation is never observation. Every record carries
+   `observed_in_this_environment: False` and the status says so in its claim
+   boundary. A reviewed digest on disk proves a file, not a Hermes invocation;
+   only `install.plugin_observations` records the latter.
+
+Revocation is data, never absence. A revoked hook stays in `records` marked
+`revoked` with its reason, so an operator reading the projection sees a hook
+that was deliberately taken out rather than a hook that silently vanished, and
+it stays revoked until the ledger entry is removed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ..capabilities.schema import HOOK_EVENT_CAPABILITY_SCHEMA_VERSION
+from ..hashutil import sha256_file
+from ..local_store import read_json_object_result
+from ..paths import OmhPaths
+from ..plugin_bundle.omh.metadata import PROVIDED_HOOKS, REQUIRED_HOOKS
+from .plugin_pack import bundled_plugin_records
+
+HOOK_INTEGRITY_SCHEMA_VERSION = "omh_hook_integrity/v1"
+HOOK_REVOCATION_LEDGER_SCHEMA_VERSION = "omh_hook_revocations/v1"
+
+# The only host surface OMH registers a hook into. It is recorded per hook
+# rather than assumed, because a future second target must be a visible change
+# to a reviewed record, not a silent widening of where a hook can run.
+HOOK_HOST_TARGET = "hermes_plugin_host"
+
+# The event vocabulary a reviewed record may claim scope over. Hermes exposes
+# its own `VALID_HOOKS` at runtime -- `plugin_bundle/omh/__init__.py` consults
+# it before registering an optional hook -- and this is the packaged mirror of
+# the subset OMH ships. A record naming anything outside it is refused rather
+# than trusted, so a typo or a widened matcher cannot arrive as a reviewed fact.
+VALID_HOOK_EVENTS = frozenset(PROVIDED_HOOKS)
+
+# Per-record axes.
+HOOK_DIGEST_STATES = ("matches", "changed", "missing", "not_installed", "not_reviewed")
+HOOK_REVIEW_STATES = ("reviewed", "unreviewed")
+HOOK_REVOCATION_STATES = ("active", "revoked")
+HOOK_HOST_REGISTRATION_STATES = ("required", "optional")
+# Status-level aggregates. Separate vocabularies from the per-record ones on
+# purpose: "one hook changed" and "this hook changed" are different sentences.
+DIGEST_AGGREGATE_STATES = ("matches", "changed", "not_installed")
+REVIEW_AGGREGATE_STATES = ("all_reviewed", "unreviewed_present")
+REVOCATION_AGGREGATE_STATES = ("none", "revoked_present")
+REVOCATION_LEDGER_STATES = ("absent", "loaded", "unreadable")
+
+HOOK_INTEGRITY_RECORD_KEYS = (
+    "capability",
+    "digest",
+    "event_scope",
+    "exclusion_reason",
+    "host_registration",
+    "host_target",
+    "installed_digest",
+    "name",
+    "observed_in_this_environment",
+    "repair",
+    "review",
+    "reviewed_digest",
+    "reviewed_timeout_ms",
+    "revocation",
+    "revocation_reason",
+    "source_path",
+    "trusted",
+)
+
+HOOK_INTEGRITY_STATUS_KEYS = (
+    "claim_boundary",
+    "digest_state",
+    "excluded_hooks",
+    "hook_manifest_schema_version",
+    "managed_hooks",
+    "next_action",
+    "observed_in_this_environment",
+    "plugin_dir",
+    "plugin_installed",
+    "records",
+    "review_state",
+    "revocation_ledger",
+    "revocation_ledger_path",
+    "revocation_state",
+    "schema_version",
+)
+
+HOOK_INTEGRITY_CLAIM_BOUNDARY = (
+    "This is the local integrity state of the reviewed OMH hooks. A matching digest proves the "
+    "installed file is the reviewed one; it is not evidence that Hermes loaded, registered, or "
+    "invoked the hook. Registration, load, and invocation stay separate axes recorded only by "
+    "omh_plugin_host_observation records."
+)
+
+# `reviewed_timeout_ms` is the review budget for a hook, not an enforced limit:
+# Hermes owns hook execution and OMH never times one out. It is recorded so a
+# change in a hook's expected cost is a reviewable change to this table rather
+# than an invisible one. 2000 for the hooks that assemble context and write a
+# local record, 1000 for the ones that only classify their input.
+HOOK_REVIEWS: dict[str, dict[str, Any]] = {
+    "on_session_end": {
+        "source_path": "hooks/session_hooks.py",
+        "event_scope": ("on_session_end",),
+        "reviewed_timeout_ms": 2000,
+        "capability": "the OMH end-of-session summary record",
+    },
+    "pre_llm_call": {
+        "source_path": "hooks/llm_hooks.py",
+        "event_scope": ("pre_llm_call",),
+        "reviewed_timeout_ms": 2000,
+        "capability": "OMH awareness, context brief, and route hint injection before a Hermes LLM call",
+    },
+    "pre_tool_call": {
+        "source_path": "hooks/tool_hooks.py",
+        "event_scope": ("pre_tool_call",),
+        "reviewed_timeout_ms": 1000,
+        "capability": "the OMH generic tool checkpoint before a Hermes tool call",
+    },
+    "pre_verify": {
+        "source_path": "hooks/verify_hooks.py",
+        "event_scope": ("pre_verify",),
+        "reviewed_timeout_ms": 1000,
+        "capability": "the OMH served-surface verification nudge before a Hermes coding verification",
+    },
+}
+
+# An operator-written reason can be any length; the doctor line that quotes it
+# cannot. Truncating on read keeps one bad ledger entry from swamping the
+# summary an operator reads to find the repair.
+REVOCATION_REASON_LIMIT = 200
+
+
+def revocation_ledger_path(paths: OmhPaths) -> Path:
+    return paths.runtime_dir / "hook_revocations.json"
+
+
+def read_hook_revocations(paths: OmhPaths) -> tuple[dict[str, str], str]:
+    """Read the local revocation ledger as `{hook name: reason}` plus its state.
+
+    An unreadable ledger returns `unreadable` with no revocations rather than
+    revoking everything. Fail-closed would be a nice slogan and a bad rule: a
+    corrupt file is not evidence that any particular hook was withdrawn, and
+    the honest report is that the ledger needs repairing, which the doctor
+    check raises on its own.
+    """
+    path = revocation_ledger_path(paths)
+    if not path.exists():
+        return {}, "absent"
+    payload, error = read_json_object_result(path)
+    if error or payload is None:
+        return {}, "unreadable"
+    if payload.get("schema_version") != HOOK_REVOCATION_LEDGER_SCHEMA_VERSION:
+        # A ledger written for a version this OMH does not understand is not an
+        # empty ledger. Reading it as one would answer "nothing is revoked"
+        # about a file that may say the opposite.
+        return {}, "unreadable"
+    entries = payload.get("revoked")
+    if not isinstance(entries, list):
+        return {}, "unreadable"
+    revoked: dict[str, str] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("hook", "")).strip()
+        if not name:
+            continue
+        revoked[name] = str(entry.get("reason", "")).strip()[:REVOCATION_REASON_LIMIT]
+    return revoked, "loaded"
+
+
+def build_hook_integrity_status(paths: OmhPaths) -> dict[str, Any]:
+    """Project every declared hook as one reviewed, tamper-evident record.
+
+    A hook the plugin bundle has not been installed for is not distrusted. It
+    keeps its reviewed digest and reports `not_installed`, because nothing has
+    changed anything -- treating an absent install as tampering would make a
+    fresh machine look compromised and would fail doctor for every operator who
+    has not run `omh setup` yet.
+    """
+    plugin_dir = paths.hermes_plugin_dir
+    plugin_installed = plugin_dir.is_dir()
+    reviewed_digests = _packaged_file_digests()
+    revoked, ledger_state = read_hook_revocations(paths)
+
+    records = [
+        _hook_record(
+            name,
+            plugin_dir=plugin_dir,
+            plugin_installed=plugin_installed,
+            reviewed_digests=reviewed_digests,
+            revoked=revoked,
+        )
+        for name in sorted(PROVIDED_HOOKS)
+    ]
+    managed = sorted(record["name"] for record in records if record["trusted"])
+    excluded = [
+        {
+            "name": record["name"],
+            "reason": record["exclusion_reason"],
+            "capability": record["capability"],
+            "repair": record["repair"],
+        }
+        for record in records
+        if not record["trusted"]
+    ]
+    return {
+        "schema_version": HOOK_INTEGRITY_SCHEMA_VERSION,
+        "hook_manifest_schema_version": HOOK_EVENT_CAPABILITY_SCHEMA_VERSION,
+        "plugin_dir": str(plugin_dir),
+        "plugin_installed": plugin_installed,
+        "records": records,
+        "managed_hooks": managed,
+        "excluded_hooks": excluded,
+        "digest_state": _digest_aggregate(records, plugin_installed=plugin_installed),
+        "review_state": _review_aggregate(records),
+        "revocation_state": _revocation_aggregate(records),
+        "revocation_ledger": ledger_state,
+        "revocation_ledger_path": str(revocation_ledger_path(paths)),
+        "next_action": _next_action(records, ledger_state=ledger_state),
+        "observed_in_this_environment": False,
+        "claim_boundary": HOOK_INTEGRITY_CLAIM_BOUNDARY,
+    }
+
+
+def validate_hook_integrity_status(payload: Any) -> list[str]:
+    if not isinstance(payload, dict):
+        return ["hook_integrity_status must be an object"]
+    errors: list[str] = []
+    extra = sorted(set(payload) - set(HOOK_INTEGRITY_STATUS_KEYS))
+    if extra:
+        errors.append(f"hook_integrity_status has unsupported keys: {extra}")
+    missing = sorted(set(HOOK_INTEGRITY_STATUS_KEYS) - set(payload))
+    if missing:
+        errors.append(f"hook_integrity_status is missing keys: {missing}")
+    if payload.get("schema_version") != HOOK_INTEGRITY_SCHEMA_VERSION:
+        errors.append(f"hook_integrity_status schema_version must be {HOOK_INTEGRITY_SCHEMA_VERSION}")
+    if payload.get("hook_manifest_schema_version") != HOOK_EVENT_CAPABILITY_SCHEMA_VERSION:
+        errors.append(
+            f"hook_integrity_status hook_manifest_schema_version must be {HOOK_EVENT_CAPABILITY_SCHEMA_VERSION}"
+        )
+    for key, vocabulary in (
+        ("digest_state", DIGEST_AGGREGATE_STATES),
+        ("review_state", REVIEW_AGGREGATE_STATES),
+        ("revocation_state", REVOCATION_AGGREGATE_STATES),
+        ("revocation_ledger", REVOCATION_LEDGER_STATES),
+    ):
+        if payload.get(key) not in vocabulary:
+            errors.append(f"hook_integrity_status {key} must be one of {list(vocabulary)}")
+    if payload.get("observed_in_this_environment") is not False:
+        # AC3, at the schema level: nothing this record can see is invocation
+        # evidence, so there is no value other than False for it to carry.
+        errors.append("hook_integrity_status observed_in_this_environment must be False")
+    records = payload.get("records")
+    if not isinstance(records, list):
+        return errors + ["hook_integrity_status records must be a list"]
+    managed = payload.get("managed_hooks")
+    if not isinstance(managed, list) or not all(isinstance(item, str) for item in managed):
+        errors.append("hook_integrity_status managed_hooks must be a list of strings")
+        managed = []
+    elif list(managed) != sorted(managed):
+        errors.append("hook_integrity_status managed_hooks must be sorted")
+    errors.extend(_record_errors(records, managed=[str(item) for item in managed]))
+    errors.extend(_exclusion_errors(payload.get("excluded_hooks"), records))
+    return errors
+
+
+def _record_errors(records: list[Any], *, managed: list[str]) -> list[str]:
+    errors: list[str] = []
+    trusted_names: list[str] = []
+    for index, record in enumerate(records):
+        label = f"hook_integrity_status records[{index}]"
+        if not isinstance(record, dict):
+            errors.append(f"{label} must be an object")
+            continue
+        name = str(record.get("name", ""))
+        extra = sorted(set(record) - set(HOOK_INTEGRITY_RECORD_KEYS))
+        if extra:
+            errors.append(f"{label} has unsupported keys: {extra}")
+        missing = sorted(set(HOOK_INTEGRITY_RECORD_KEYS) - set(record))
+        if missing:
+            errors.append(f"{label} is missing keys: {missing}")
+        for key, vocabulary in (
+            ("digest", HOOK_DIGEST_STATES),
+            ("review", HOOK_REVIEW_STATES),
+            ("revocation", HOOK_REVOCATION_STATES),
+            ("host_registration", HOOK_HOST_REGISTRATION_STATES),
+        ):
+            if record.get(key) not in vocabulary:
+                errors.append(f"{label} {key} must be one of {list(vocabulary)}")
+        if record.get("host_target") != HOOK_HOST_TARGET:
+            errors.append(f"{label} host_target must be {HOOK_HOST_TARGET}")
+        if record.get("observed_in_this_environment") is not False:
+            errors.append(f"{label} observed_in_this_environment must be False")
+        scope = record.get("event_scope")
+        if not isinstance(scope, list) or not all(isinstance(item, str) for item in scope):
+            errors.append(f"{label} event_scope must be a list of strings")
+        else:
+            unknown = sorted(set(scope) - VALID_HOOK_EVENTS)
+            if unknown:
+                errors.append(f"{label} event_scope names events outside VALID_HOOK_EVENTS: {unknown}")
+        if record.get("trusted") is True:
+            trusted_names.append(name)
+            errors.extend(_managed_record_errors(record, label=label))
+        elif record.get("trusted") is not False:
+            errors.append(f"{label} trusted must be a boolean")
+        else:
+            if not str(record.get("exclusion_reason", "")):
+                errors.append(f"{label} is excluded and must carry an exclusion_reason")
+            if not str(record.get("repair", "")):
+                errors.append(f"{label} is excluded and must carry a repair")
+            if not str(record.get("capability", "")):
+                errors.append(f"{label} is excluded and must name the unavailable capability")
+    if sorted(trusted_names) != sorted(managed):
+        errors.append("hook_integrity_status managed_hooks must list exactly the trusted records")
+    return errors
+
+
+def _managed_record_errors(record: dict[str, Any], *, label: str) -> list[str]:
+    """AC1: a managed hook without a reviewed digest and an event scope is invalid."""
+    errors: list[str] = []
+    digest = str(record.get("reviewed_digest", ""))
+    if len(digest) != 64 or any(character not in "0123456789abcdef" for character in digest):
+        errors.append(f"{label} is managed and must carry a reviewed sha256 digest")
+    scope = record.get("event_scope")
+    if not isinstance(scope, list) or not scope:
+        errors.append(f"{label} is managed and must declare a non-empty event scope")
+    if record.get("review") != "reviewed":
+        errors.append(f"{label} is managed and must be reviewed")
+    if record.get("revocation") != "active":
+        errors.append(f"{label} is managed and must not be revoked")
+    if str(record.get("exclusion_reason", "")) or str(record.get("repair", "")):
+        errors.append(f"{label} is managed and must not carry an exclusion_reason or repair")
+    return errors
+
+
+def _exclusion_errors(excluded: Any, records: list[Any]) -> list[str]:
+    if not isinstance(excluded, list):
+        return ["hook_integrity_status excluded_hooks must be a list"]
+    errors: list[str] = []
+    untrusted = sorted(
+        str(record.get("name", ""))
+        for record in records
+        if isinstance(record, dict) and record.get("trusted") is not True
+    )
+    listed = sorted(str(item.get("name", "")) for item in excluded if isinstance(item, dict))
+    if listed != untrusted:
+        errors.append("hook_integrity_status excluded_hooks must list exactly the untrusted records")
+    for index, item in enumerate(excluded):
+        label = f"hook_integrity_status excluded_hooks[{index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{label} must be an object")
+            continue
+        if sorted(item) != ["capability", "name", "reason", "repair"]:
+            errors.append(f"{label} must carry name, reason, capability, and repair")
+            continue
+        for key in ("capability", "reason", "repair"):
+            if not str(item.get(key, "")):
+                errors.append(f"{label} {key} must not be empty")
+    return errors
+
+
+def _hook_record(
+    name: str,
+    *,
+    plugin_dir: Path,
+    plugin_installed: bool,
+    reviewed_digests: dict[str, str],
+    revoked: dict[str, str],
+) -> dict[str, Any]:
+    review = HOOK_REVIEWS.get(name)
+    source_path = str(review["source_path"]) if review else ""
+    reviewed_digest = reviewed_digests.get(source_path, "") if review else ""
+    digest, installed_digest = _digest_state(
+        source_path,
+        reviewed_digest,
+        plugin_dir=plugin_dir,
+        plugin_installed=plugin_installed,
+        reviewed=review is not None,
+    )
+    record: dict[str, Any] = {
+        "name": name,
+        "event_scope": list(review["event_scope"]) if review else [],
+        "host_target": HOOK_HOST_TARGET,
+        "host_registration": "required" if name in REQUIRED_HOOKS else "optional",
+        "source_path": source_path,
+        "review": "reviewed" if review else "unreviewed",
+        "reviewed_digest": reviewed_digest,
+        "installed_digest": installed_digest,
+        "digest": digest,
+        "reviewed_timeout_ms": int(review["reviewed_timeout_ms"]) if review else 0,
+        "revocation": "revoked" if name in revoked else "active",
+        "revocation_reason": revoked.get(name, ""),
+        "capability": str(review["capability"]) if review else f"the OMH `{name}` hook",
+        "trusted": True,
+        "exclusion_reason": "",
+        "repair": "",
+        "observed_in_this_environment": False,
+    }
+    reason, repair = _exclusion(record)
+    if reason:
+        record["trusted"] = False
+        record["exclusion_reason"] = reason
+        record["repair"] = repair
+    return record
+
+
+def _exclusion(record: dict[str, Any]) -> tuple[str, str]:
+    """Why this hook is not in the managed projection, and what brings it back.
+
+    Ordered by which fact wins. A revoked hook is a decision an operator made,
+    so it is reported as revocation even when the file also drifted; telling
+    them to reinstall a hook they deliberately withdrew would be the wrong
+    repair.
+    """
+    name = record["name"]
+    capability = record["capability"]
+    if record["revocation"] == "revoked":
+        reason = str(record["revocation_reason"]) or "no reason recorded"
+        return (
+            f"revoked locally ({reason})",
+            f"Hook `{name}` is revoked locally, so {capability} is unavailable. "
+            f"Remove its entry from the OMH hook revocation ledger, then rerun `omh doctor`.",
+        )
+    if record["review"] == "unreviewed":
+        return (
+            "no reviewed digest for this hook",
+            f"Hook `{name}` carries no reviewed digest, so {capability} is unavailable. "
+            f"Upgrade OMH to a release that reviews `{name}`, then rerun `omh doctor`.",
+        )
+    if record["digest"] == "changed":
+        return (
+            "installed file no longer matches the reviewed digest",
+            f"Hook `{name}` no longer matches its reviewed digest, so {capability} is unavailable. "
+            f"Run `omh setup --force` to restore the reviewed hook, then rerun `omh doctor`.",
+        )
+    if record["digest"] == "missing":
+        return (
+            "installed file is missing",
+            f"Hook `{name}` is missing from the installed plugin bundle, so {capability} is unavailable. "
+            f"Run `omh setup --force` to restore the reviewed hook, then rerun `omh doctor`.",
+        )
+    return "", ""
+
+
+def _digest_state(
+    source_path: str,
+    reviewed_digest: str,
+    *,
+    plugin_dir: Path,
+    plugin_installed: bool,
+    reviewed: bool,
+) -> tuple[str, str]:
+    if not reviewed or not reviewed_digest:
+        return "not_reviewed", ""
+    if not plugin_installed:
+        return "not_installed", ""
+    # `source_path` is stored POSIX-style; splitting it rebuilds the path with
+    # the separator this OS uses instead of asserting one.
+    installed = plugin_dir.joinpath(*source_path.split("/"))
+    if not installed.is_file():
+        return "missing", ""
+    installed_digest = sha256_file(installed)
+    return ("matches" if installed_digest == reviewed_digest else "changed", installed_digest)
+
+
+def _packaged_file_digests() -> dict[str, str]:
+    """The reviewed digest of every packaged bundle file, keyed POSIX-style.
+
+    `bundled_plugin_records()` builds its paths with `pathlib`, so they arrive
+    separated by `\\` on Windows and `/` elsewhere. Normalizing here is what
+    lets `HOOK_REVIEWS` name one source path per hook.
+    """
+    return {
+        str(record.get("path", "")).replace("\\", "/"): str(record.get("sha256", ""))
+        for record in bundled_plugin_records()
+    }
+
+
+def _digest_aggregate(records: list[dict[str, Any]], *, plugin_installed: bool) -> str:
+    if any(record["digest"] in {"changed", "missing"} for record in records):
+        return "changed"
+    if not plugin_installed:
+        return "not_installed"
+    return "matches"
+
+
+def _review_aggregate(records: list[dict[str, Any]]) -> str:
+    return "unreviewed_present" if any(record["review"] == "unreviewed" for record in records) else "all_reviewed"
+
+
+def _revocation_aggregate(records: list[dict[str, Any]]) -> str:
+    return "revoked_present" if any(record["revocation"] == "revoked" for record in records) else "none"
+
+
+def _next_action(records: list[dict[str, Any]], *, ledger_state: str) -> str:
+    # Ordered by which repair unblocks the others: a ledger nobody can read
+    # hides revocations, and a revocation an operator chose outranks a
+    # reinstall they did not ask for.
+    if ledger_state == "unreadable":
+        return "Repair or remove the OMH hook revocation ledger, then rerun `omh doctor`."
+    revoked = [record["name"] for record in records if record["revocation"] == "revoked"]
+    if revoked:
+        return (
+            f"Remove {', '.join(sorted(revoked))} from the OMH hook revocation ledger to restore "
+            "the revoked hook(s), then rerun `omh doctor`."
+        )
+    if any(record["digest"] in {"changed", "missing"} for record in records):
+        return "Run `omh setup --force` to restore the reviewed OMH hooks, then rerun `omh doctor`."
+    if any(record["review"] == "unreviewed" for record in records):
+        return "Upgrade OMH to a release that reviews every provided hook, then rerun `omh doctor`."
+    return "No repair needed. Hermes hook registration and invocation stay unobserved until a host observation records them."

--- a/src/maintenance/doctor.py
+++ b/src/maintenance/doctor.py
@@ -17,6 +17,7 @@ from ..config_adapter import (
 from ..hashutil import sha256_file, sha256_text
 from ..local_store import can_write_dir
 from ..install.guidance_projection import build_guidance_projection_status
+from ..install.hook_integrity import HOOK_HOST_TARGET, VALID_HOOK_EVENTS, build_hook_integrity_status
 from ..install.identity_conflicts import build_identity_conflict_report
 from ..manifest import local_modifications, read_manifest
 from ..paths import OmhPaths
@@ -278,6 +279,7 @@ def run_doctor(paths: OmhPaths) -> list[Check]:
                 _awareness_delivery_check(paths),
             ]
         )
+    checks.append(_hook_integrity_check(paths))
     profile_installs = state.get("last_team_profile_install") if isinstance(state, dict) else None
     if not profile_installs:
         checks.append(Check("team_profile_packs", True, f"optional OMH team profile packs are not installed at {paths.hermes_agents_dir}"))
@@ -685,6 +687,45 @@ def _guidance_projection_check(paths: OmhPaths, manifest: dict | None, *, regist
         "guidance_projection",
         False,
         summary,
+        remediation=str(status["next_action"]),
+        next_action=str(status["next_action"]),
+    )
+
+
+def _hook_integrity_check(paths: OmhPaths) -> Check:
+    """Report the reviewed native hooks as one answer with six axes.
+
+    `plugin_bundle_current` already notices that *some* managed file drifted,
+    but it says so at bundle grain: an operator learns the bundle is stale and
+    not that `pre_llm_call` specifically is no longer the hook that was
+    reviewed, nor which capability that takes down. This check names the axis
+    that failed -- digest, event scope, timeout, review, host target, or
+    revocation -- and lists every hook dropped from the managed projection with
+    the command that brings it back.
+
+    It fails only on an actual exclusion or an unreadable revocation ledger.
+    An uninstalled bundle is not a fault: the reviewed digests are still the
+    reviewed digests, nothing has changed them, and failing here would make
+    every machine that has not run `omh setup` yet look tampered with.
+    """
+    status = build_hook_integrity_status(paths)
+    records = status["records"]
+    excluded = status["excluded_hooks"]
+    summary = (
+        f"managed={len(status['managed_hooks'])}/{len(records)} digest={status['digest_state']} "
+        f"event_scope={len(VALID_HOOK_EVENTS)} review={status['review_state']} "
+        f"host_target={HOOK_HOST_TARGET} revocation={status['revocation_state']} "
+        f"ledger={status['revocation_ledger']} observed={status['observed_in_this_environment']}"
+    )
+    if not excluded and status["revocation_ledger"] != "unreadable":
+        return Check("plugin_hook_integrity", True, summary)
+    detail = "; ".join(str(item["repair"]) for item in excluded)
+    if status["revocation_ledger"] == "unreadable":
+        detail = f"{status['revocation_ledger_path']} is unreadable" + (f"; {detail}" if detail else "")
+    return Check(
+        "plugin_hook_integrity",
+        False,
+        f"{summary}; {detail}",
         remediation=str(status["next_action"]),
         next_action=str(status["next_action"]),
     )

--- a/tests/test_hook_integrity.py
+++ b/tests/test_hook_integrity.py
@@ -1,0 +1,455 @@
+"""#803: the native OMH hooks stay reviewed, tamper-evident, and revocable.
+
+Three acceptance criteria, pinned here rather than inferred from the plugin
+distribution tests:
+
+1. Every managed hook matches a reviewed digest and a declared event scope.
+2. A changed or a revoked hook leaves the managed projection *and* produces a
+   repair message naming the capability that went with it.
+3. Installing a hook is never recorded as observing Hermes invoke it.
+
+The tampering tests write through `atomic_write_text` for the same reason the
+bundle installer does: it writes with `newline=""`, so a file's bytes on disk
+stay what the test wrote. Default text mode translates `\\n` to CRLF on
+Windows, and every assertion below compares a digest of those exact bytes.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.capabilities.hooks import hook_manifest
+from omh.commands import setup as setup_commands
+from omh.hashutil import sha256_file, sha256_text
+from omh.install.hook_integrity import (
+    DIGEST_AGGREGATE_STATES,
+    HOOK_HOST_TARGET,
+    HOOK_INTEGRITY_RECORD_KEYS,
+    HOOK_INTEGRITY_SCHEMA_VERSION,
+    HOOK_INTEGRITY_STATUS_KEYS,
+    HOOK_REVIEWS,
+    HOOK_REVOCATION_LEDGER_SCHEMA_VERSION,
+    REVOCATION_REASON_LIMIT,
+    VALID_HOOK_EVENTS,
+    build_hook_integrity_status,
+    read_hook_revocations,
+    revocation_ledger_path,
+    validate_hook_integrity_status,
+)
+from omh.local_store import atomic_write_text, ensure_dir
+from omh.maintenance.doctor import run_doctor
+from omh.paths import resolve_paths
+from omh.plugin_bundle.omh.metadata import OPTIONAL_HOOKS, PROVIDED_HOOKS, REQUIRED_HOOKS
+from omh.plugin_pack import install_plugin_bundle
+
+
+def _paths(tmp: str):
+    return resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+
+
+def _installed_paths(tmp: str):
+    paths = _paths(tmp)
+    install_plugin_bundle(paths)
+    return paths
+
+
+def _hook_file(paths, name: str) -> Path:
+    source_path = str(HOOK_REVIEWS[name]["source_path"])
+    return paths.hermes_plugin_dir.joinpath(*source_path.split("/"))
+
+
+def _tamper(paths, name: str) -> None:
+    path = _hook_file(paths, name)
+    atomic_write_text(path, path.read_text(encoding="utf-8") + "\n# local edit\n")
+
+
+def _revoke(paths, name: str, reason: str) -> None:
+    ensure_dir(paths.runtime_dir)
+    atomic_write_text(
+        revocation_ledger_path(paths),
+        json.dumps(
+            {
+                "schema_version": HOOK_REVOCATION_LEDGER_SCHEMA_VERSION,
+                "revoked": [{"hook": name, "reason": reason}],
+            }
+        ),
+    )
+
+
+def _record(status: dict, name: str) -> dict:
+    return next(item for item in status["records"] if item["name"] == name)
+
+
+def _excluded(status: dict, name: str) -> dict:
+    return next(item for item in status["excluded_hooks"] if item["name"] == name)
+
+
+class ReviewedRecordTests(unittest.TestCase):
+    """AC1: every managed hook carries a reviewed digest and an event scope."""
+
+    def test_every_declared_hook_is_reviewed_with_a_digest_and_a_scope(self) -> None:
+        with TemporaryDirectory() as tmp:
+            status = build_hook_integrity_status(_paths(tmp))
+
+            self.assertEqual(validate_hook_integrity_status(status), [])
+            self.assertEqual(status["schema_version"], HOOK_INTEGRITY_SCHEMA_VERSION)
+            self.assertEqual(sorted(status["managed_hooks"]), sorted(PROVIDED_HOOKS))
+            for record in status["records"]:
+                with self.subTest(hook=record["name"]):
+                    self.assertEqual(sorted(record), sorted(HOOK_INTEGRITY_RECORD_KEYS))
+                    self.assertEqual(len(record["reviewed_digest"]), 64)
+                    self.assertTrue(record["event_scope"])
+                    self.assertTrue(set(record["event_scope"]).issubset(VALID_HOOK_EVENTS))
+                    self.assertEqual(record["review"], "reviewed")
+                    self.assertEqual(record["host_target"], HOOK_HOST_TARGET)
+                    self.assertGreater(record["reviewed_timeout_ms"], 0)
+
+    def test_the_record_refines_the_hook_manifest_rather_than_replacing_it(self) -> None:
+        # One hook concept, two projections. If these vocabularies ever drift,
+        # a hook could be reviewed here and absent there, or the reverse.
+        with TemporaryDirectory() as tmp:
+            status = build_hook_integrity_status(_paths(tmp))
+
+            manifest_hooks = {item["name"] for item in hook_manifest()["plugin_hooks"]}
+            self.assertEqual({record["name"] for record in status["records"]}, manifest_hooks)
+            self.assertEqual(
+                status["hook_manifest_schema_version"], hook_manifest()["schema_version"]
+            )
+
+    def test_host_registration_follows_the_required_and_optional_split(self) -> None:
+        with TemporaryDirectory() as tmp:
+            status = build_hook_integrity_status(_paths(tmp))
+
+            by_name = {record["name"]: record for record in status["records"]}
+            for name in REQUIRED_HOOKS:
+                self.assertEqual(by_name[name]["host_registration"], "required")
+            for name in OPTIONAL_HOOKS:
+                self.assertEqual(by_name[name]["host_registration"], "optional")
+
+    def test_the_reviewed_digest_is_the_digest_the_installer_writes(self) -> None:
+        # The reviewed value has to be the one `plugin_pack` already computes,
+        # or "matches" would mean two different things in two places.
+        with TemporaryDirectory() as tmp:
+            paths = _installed_paths(tmp)
+
+            status = build_hook_integrity_status(paths)
+
+            self.assertEqual(status["digest_state"], "matches")
+            for record in status["records"]:
+                with self.subTest(hook=record["name"]):
+                    installed = _hook_file(paths, record["name"])
+                    self.assertEqual(record["reviewed_digest"], sha256_file(installed))
+                    self.assertEqual(
+                        record["reviewed_digest"],
+                        sha256_text(installed.read_text(encoding="utf-8")),
+                    )
+                    self.assertEqual(record["digest"], "matches")
+
+    def test_a_managed_hook_without_a_digest_or_a_scope_fails_validation(self) -> None:
+        with TemporaryDirectory() as tmp:
+            status = build_hook_integrity_status(_paths(tmp))
+
+            no_digest = json.loads(json.dumps(status))
+            _record(no_digest, "pre_llm_call")["reviewed_digest"] = ""
+            self.assertTrue(
+                any("reviewed sha256 digest" in error for error in validate_hook_integrity_status(no_digest))
+            )
+
+            no_scope = json.loads(json.dumps(status))
+            _record(no_scope, "pre_llm_call")["event_scope"] = []
+            self.assertTrue(
+                any("non-empty event scope" in error for error in validate_hook_integrity_status(no_scope))
+            )
+
+    def test_an_unknown_event_name_is_refused(self) -> None:
+        # `VALID_HOOK_EVENTS` is the vocabulary. A record that widens its own
+        # matcher must not arrive as a reviewed fact.
+        with TemporaryDirectory() as tmp:
+            status = build_hook_integrity_status(_paths(tmp))
+            widened = json.loads(json.dumps(status))
+            _record(widened, "pre_tool_call")["event_scope"] = ["pre_tool_call", "post_tool_call"]
+
+            errors = validate_hook_integrity_status(widened)
+
+            self.assertTrue(any("outside VALID_HOOK_EVENTS" in error for error in errors))
+            self.assertTrue(any("post_tool_call" in error for error in errors))
+
+    def test_the_status_shape_is_pinned(self) -> None:
+        with TemporaryDirectory() as tmp:
+            status = build_hook_integrity_status(_paths(tmp))
+
+            self.assertEqual(sorted(status), sorted(HOOK_INTEGRITY_STATUS_KEYS))
+            self.assertIn(status["digest_state"], DIGEST_AGGREGATE_STATES)
+            self.assertEqual(validate_hook_integrity_status("not a status"), ["hook_integrity_status must be an object"])
+
+
+class ChangedHookTests(unittest.TestCase):
+    """AC2, tamper half: a changed hook leaves the projection with a repair."""
+
+    def test_a_changed_hook_is_dropped_and_names_its_capability(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _installed_paths(tmp)
+            _tamper(paths, "pre_llm_call")
+
+            status = build_hook_integrity_status(paths)
+
+            self.assertEqual(validate_hook_integrity_status(status), [])
+            self.assertNotIn("pre_llm_call", status["managed_hooks"])
+            self.assertEqual(status["digest_state"], "changed")
+            record = _record(status, "pre_llm_call")
+            self.assertFalse(record["trusted"])
+            self.assertEqual(record["digest"], "changed")
+            self.assertNotEqual(record["installed_digest"], record["reviewed_digest"])
+            excluded = _excluded(status, "pre_llm_call")
+            self.assertIn("route hint", excluded["capability"])
+            self.assertIn("unavailable", excluded["repair"])
+            self.assertIn("omh setup --force", excluded["repair"])
+            # The other three hooks are untouched: one bad file must not take
+            # the whole hook surface down.
+            self.assertEqual(len(status["managed_hooks"]), len(PROVIDED_HOOKS) - 1)
+
+    def test_a_deleted_hook_file_is_dropped_and_names_its_capability(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _installed_paths(tmp)
+            _hook_file(paths, "pre_verify").unlink()
+
+            status = build_hook_integrity_status(paths)
+
+            self.assertEqual(validate_hook_integrity_status(status), [])
+            self.assertNotIn("pre_verify", status["managed_hooks"])
+            self.assertEqual(_record(status, "pre_verify")["digest"], "missing")
+            self.assertIn("verification nudge", _excluded(status, "pre_verify")["capability"])
+
+    def test_a_repaired_hook_returns_to_the_projection(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _installed_paths(tmp)
+            original = _hook_file(paths, "pre_tool_call").read_text(encoding="utf-8")
+            _tamper(paths, "pre_tool_call")
+            self.assertNotIn("pre_tool_call", build_hook_integrity_status(paths)["managed_hooks"])
+
+            atomic_write_text(_hook_file(paths, "pre_tool_call"), original)
+
+            status = build_hook_integrity_status(paths)
+            self.assertIn("pre_tool_call", status["managed_hooks"])
+            self.assertEqual(status["excluded_hooks"], [])
+            self.assertEqual(status["digest_state"], "matches")
+
+    def test_an_uninstalled_bundle_is_not_treated_as_tampering(self) -> None:
+        # Nothing has changed a hook that was never installed. Calling that a
+        # fault would fail doctor on every machine before its first setup.
+        with TemporaryDirectory() as tmp:
+            status = build_hook_integrity_status(_paths(tmp))
+
+            self.assertFalse(status["plugin_installed"])
+            self.assertEqual(status["digest_state"], "not_installed")
+            self.assertEqual(status["excluded_hooks"], [])
+            self.assertEqual(sorted(status["managed_hooks"]), sorted(PROVIDED_HOOKS))
+
+
+class RevocationTests(unittest.TestCase):
+    """AC2, revocation half: revocation is explicit data with its own repair."""
+
+    def test_a_revoked_hook_is_dropped_and_names_its_capability(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _installed_paths(tmp)
+            _revoke(paths, "pre_verify", "operator policy")
+
+            status = build_hook_integrity_status(paths)
+
+            self.assertEqual(validate_hook_integrity_status(status), [])
+            self.assertNotIn("pre_verify", status["managed_hooks"])
+            self.assertEqual(status["revocation_state"], "revoked_present")
+            self.assertEqual(status["revocation_ledger"], "loaded")
+            record = _record(status, "pre_verify")
+            self.assertEqual(record["revocation"], "revoked")
+            self.assertEqual(record["revocation_reason"], "operator policy")
+            # Revocation is data, not absence: the hook is still projected, it
+            # is projected as withdrawn.
+            self.assertEqual(record["digest"], "matches")
+            excluded = _excluded(status, "pre_verify")
+            self.assertIn("verification nudge", excluded["capability"])
+            self.assertIn("revocation ledger", excluded["repair"])
+
+    def test_a_revoked_hook_stays_revoked_until_the_ledger_is_repaired(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _installed_paths(tmp)
+            _revoke(paths, "pre_llm_call", "operator policy")
+
+            # Reinstalling restores the bytes and changes nothing about the
+            # operator's decision.
+            install_plugin_bundle(paths, force=True)
+            self.assertNotIn("pre_llm_call", build_hook_integrity_status(paths)["managed_hooks"])
+
+            revocation_ledger_path(paths).unlink()
+
+            status = build_hook_integrity_status(paths)
+            self.assertIn("pre_llm_call", status["managed_hooks"])
+            self.assertEqual(status["revocation_state"], "none")
+            self.assertEqual(status["revocation_ledger"], "absent")
+
+    def test_revocation_outranks_a_changed_digest_in_the_repair(self) -> None:
+        # Telling an operator to reinstall a hook they deliberately withdrew is
+        # the wrong instruction, even when the file also drifted.
+        with TemporaryDirectory() as tmp:
+            paths = _installed_paths(tmp)
+            _tamper(paths, "on_session_end")
+            _revoke(paths, "on_session_end", "operator policy")
+
+            status = build_hook_integrity_status(paths)
+
+            self.assertIn("revoked locally", _record(status, "on_session_end")["exclusion_reason"])
+            self.assertIn("revocation ledger", status["next_action"])
+            self.assertNotIn("omh setup --force", status["next_action"])
+
+    def test_an_unreadable_ledger_reports_itself_instead_of_revoking_everything(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _installed_paths(tmp)
+            ensure_dir(paths.runtime_dir)
+            atomic_write_text(revocation_ledger_path(paths), "{ not json")
+
+            revoked, state = read_hook_revocations(paths)
+            status = build_hook_integrity_status(paths)
+
+            self.assertEqual(revoked, {})
+            self.assertEqual(state, "unreadable")
+            self.assertEqual(status["revocation_ledger"], "unreadable")
+            self.assertEqual(sorted(status["managed_hooks"]), sorted(PROVIDED_HOOKS))
+            self.assertIn("Repair or remove", status["next_action"])
+
+    def test_a_ledger_from_an_unknown_schema_version_is_not_read_as_empty(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _installed_paths(tmp)
+            ensure_dir(paths.runtime_dir)
+            atomic_write_text(
+                revocation_ledger_path(paths),
+                json.dumps({"schema_version": "omh_hook_revocations/v99", "revoked": []}),
+            )
+
+            revoked, state = read_hook_revocations(paths)
+
+            self.assertEqual(revoked, {})
+            self.assertEqual(state, "unreadable")
+
+    def test_a_long_revocation_reason_is_bounded(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _installed_paths(tmp)
+            _revoke(paths, "pre_verify", "x" * (REVOCATION_REASON_LIMIT + 50))
+
+            record = _record(build_hook_integrity_status(paths), "pre_verify")
+
+            self.assertEqual(len(record["revocation_reason"]), REVOCATION_REASON_LIMIT)
+
+
+class ObservationBoundaryTests(unittest.TestCase):
+    """AC3: installation is never proof of load or invocation."""
+
+    def test_installing_the_bundle_never_sets_an_observed_flag(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            before = build_hook_integrity_status(paths)
+            result = install_plugin_bundle(paths)
+            after = build_hook_integrity_status(paths)
+
+            # The installer observed its own copy, and that is all it observed.
+            self.assertTrue(result["observed"])
+            self.assertIn("does not prove Hermes loaded or used the plugin", result["observed_scope"])
+            for status in (before, after):
+                self.assertFalse(status["observed_in_this_environment"])
+                for record in status["records"]:
+                    self.assertFalse(record["observed_in_this_environment"])
+
+    def test_the_claim_boundary_separates_review_from_invocation(self) -> None:
+        with TemporaryDirectory() as tmp:
+            status = build_hook_integrity_status(_installed_paths(tmp))
+
+            boundary = status["claim_boundary"]
+            self.assertIn("not evidence that Hermes loaded, registered, or invoked", boundary)
+            self.assertIn("omh_plugin_host_observation", boundary)
+            self.assertIn("unobserved", status["next_action"])
+
+    def test_an_observed_flag_set_to_true_fails_validation(self) -> None:
+        with TemporaryDirectory() as tmp:
+            status = build_hook_integrity_status(_installed_paths(tmp))
+
+            lying_status = {**status, "observed_in_this_environment": True}
+            self.assertTrue(
+                any("observed_in_this_environment must be False" in error
+                    for error in validate_hook_integrity_status(lying_status))
+            )
+
+            lying_record = json.loads(json.dumps(status))
+            _record(lying_record, "pre_llm_call")["observed_in_this_environment"] = True
+            self.assertTrue(
+                any("observed_in_this_environment must be False" in error
+                    for error in validate_hook_integrity_status(lying_record))
+            )
+
+
+class DoctorSurfaceTests(unittest.TestCase):
+    """The surface an operator actually reaches: `omh doctor`."""
+
+    def test_doctor_reports_the_six_axes_and_stays_green_on_a_bare_home(self) -> None:
+        with TemporaryDirectory() as tmp:
+            check = next(
+                item for item in run_doctor(_paths(tmp)) if item.name == "plugin_hook_integrity"
+            )
+
+            self.assertTrue(check.ok)
+            for axis in ("managed=", "digest=", "event_scope=", "review=", "host_target=", "revocation="):
+                self.assertIn(axis, check.message)
+            self.assertIn("observed=False", check.message)
+
+    def test_doctor_stays_green_for_a_freshly_installed_bundle(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _installed_paths(tmp)
+
+            check = next(item for item in run_doctor(paths) if item.name == "plugin_hook_integrity")
+
+            self.assertTrue(check.ok)
+            self.assertIn("digest=matches", check.message)
+
+    def test_doctor_names_the_lost_capability_for_a_changed_hook(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _installed_paths(tmp)
+            _tamper(paths, "pre_llm_call")
+
+            check = next(item for item in run_doctor(paths) if item.name == "plugin_hook_integrity")
+
+            self.assertFalse(check.ok)
+            self.assertIn("pre_llm_call", check.message)
+            self.assertIn("route hint", check.message)
+            self.assertIn("omh setup --force", check.next_action)
+            self.assertTrue(check.remediation)
+
+    def test_doctor_names_the_lost_capability_for_a_revoked_hook(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _installed_paths(tmp)
+            _revoke(paths, "pre_tool_call", "operator policy")
+
+            check = next(item for item in run_doctor(paths) if item.name == "plugin_hook_integrity")
+
+            self.assertFalse(check.ok)
+            self.assertIn("tool checkpoint", check.message)
+            self.assertIn("revocation ledger", check.next_action)
+
+    def test_the_check_lands_in_an_operator_visible_group(self) -> None:
+        # A check outside every group is a check no operator ever reads.
+        with TemporaryDirectory() as tmp:
+            paths = _installed_paths(tmp)
+            _tamper(paths, "on_session_end")
+
+            summary = setup_commands._doctor_operator_summary(run_doctor(paths))
+
+            group = next(item for item in summary["groups"] if item["name"] == "optional_surfaces")
+            self.assertIn("plugin_hook_integrity", group["failed"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hook_manifest.py
+++ b/tests/test_hook_manifest.py
@@ -11,6 +11,7 @@ from _local_package import load_local_package
 load_local_package()
 
 from omh.capabilities.hooks import hook_manifest
+from omh.install.hook_integrity import HOOK_REVIEWS, VALID_HOOK_EVENTS
 from omh.plugin_bundle.omh.awareness import awareness_route_hint
 from omh.plugin_bundle.omh.awareness_delivery import read_awareness_delivery
 from omh.plugin_bundle.omh.hooks.llm_hooks import pre_llm_call
@@ -87,6 +88,37 @@ class HookManifestTests(unittest.TestCase):
         self.assertIn("native_command_rendered", events)
         self.assertIn("render_kind", events["native_command_rendered"]["payload_fields"])
         self.assertIn("not proof", hooks["pre_llm_call"]["claim_boundary"])
+
+    def test_hook_manifest_never_claims_an_observed_or_invoked_hook(self) -> None:
+        """#803 AC3, on the manifest side: availability is not invocation.
+
+        The integrity record in `install.hook_integrity` refines this manifest
+        rather than replacing it, so the boundary has to hold in both. Here it
+        is the resting state of the static projection: nothing OMH can compute
+        without a host observation may set an observed flag.
+        """
+        manifest = hook_manifest()
+
+        for hook in manifest["plugin_hooks"]:
+            with self.subTest(hook=hook["name"]):
+                self.assertFalse(hook["observed_in_this_environment"])
+                self.assertIn("not proof that Hermes loaded or invoked", hook["claim_boundary"])
+        for tool in manifest["plugin_tools"]:
+            self.assertFalse(tool["observed_in_this_environment"])
+        for event in manifest["wrapper_events"]:
+            self.assertFalse(event["observed_in_this_environment"])
+
+    def test_every_manifest_hook_has_a_reviewed_integrity_record(self) -> None:
+        """#803 AC1, on the manifest side: no hook ships without a review.
+
+        Adding a hook to `PROVIDED_HOOKS` is what makes it appear here. If it
+        can appear here without a `HOOK_REVIEWS` entry, it reaches Hermes with
+        no reviewed digest and no declared event scope behind it.
+        """
+        names = {hook["name"] for hook in hook_manifest()["plugin_hooks"]}
+
+        self.assertEqual(names, set(HOOK_REVIEWS))
+        self.assertEqual(names, set(VALID_HOOK_EVENTS))
 
     def test_pre_llm_call_records_delivery_in_explicit_omh_home(self) -> None:
         with TemporaryDirectory() as explicit_home, TemporaryDirectory() as env_home:


### PR DESCRIPTION
## Feature Report

### What Changed

- New `omh_hook_integrity/v1` record (`src/install/hook_integrity.py`): one reviewed, tamper-evident projection of the four native OMH hooks (`on_session_end`, `pre_llm_call`, `pre_tool_call`, `pre_verify`) across the six axes #803 names — **digest, event scope, timeout, review, host target, revocation**.
- New `omh doctor` check `plugin_hook_integrity`: reports those six axes on one line, and when a hook fails one, names the hook, the capability that is now unavailable, and the command that restores it.
- A changed, missing, revoked, or unreviewed hook is **dropped from `managed_hooks` and listed in `excluded_hooks`** with `reason`, `capability`, and `repair`. Dropping it quietly is the behaviour this record exists to prevent.
- Local revocation ledger at `$OMH_HOME/runtime/hook_revocations.json` (`omh_hook_revocations/v1`), read by the projection. Revocation is modelled as data: a revoked hook stays in `records` marked `revoked` with its reason, and stays revoked across `omh setup --force` until the ledger entry is removed.
- `tests/test_hook_manifest.py` gained two contracts on the manifest side: no hook/tool/wrapper event may carry an observed flag, and every hook in `PROVIDED_HOOKS` must have a `HOOK_REVIEWS` entry.

### Why This Exists

`install/plugin_pack.py` already had file-level tamper evidence — per-file `sha256_text` in the managed manifest, `plugin_local_modifications()` on top of it — but it was never hook-scoped. An operator whose `pre_llm_call` had been edited learned that "the plugin bundle is stale" and had to work out on their own which hook that was, what it did, and whether the awareness primer they stopped seeing was related.

Three things did not exist at all:

- **Event scope as a checkable fact.** `provides_hooks` in `plugin.yaml` declared it; nothing refused a record that claimed scope over an event outside the vocabulary.
- **Revocation.** There was no way to say "this hook is withdrawn on this machine" other than deleting a file, which reads identically to corruption and is undone by the next `omh setup`.
- **A capability sentence.** Every existing failure message named a path or a boolean. None named what the user lost.

### User / Operator Impact

Before, on a bundle with an edited `pre_llm_call`:

```
plugin_bundle_current: plugin manifest is invalid or managed files changed
```

After, the same machine additionally reports:

```
plugin_hook_integrity: managed=3/4 digest=changed event_scope=4 review=all_reviewed
  host_target=hermes_plugin_host revocation=none ledger=absent observed=False;
  Hook `pre_llm_call` no longer matches its reviewed digest, so OMH awareness, context brief,
  and route hint injection before a Hermes LLM call is unavailable. Run `omh setup --force` to
  restore the reviewed hook, then rerun `omh doctor`.
```

The check joins the `optional_surfaces` doctor group, so it appears in the grouped operator summary rather than only in `--json`. A machine that has never run `omh setup` stays **green**: reviewed digests with nothing installed to contradict them is not tampering, and failing there would make every pre-setup machine look compromised.

### How It Works

**Sibling record, not more manifest fields.** `capabilities/hooks.py:hook_manifest()` is a static projection: it is folded into an `lru_cache`d `capability_snapshot()` that advertises itself as `static_projection_no_runtime_clock`, and it is mirrored byte-for-byte by a standalone copy inside the vendored bundle (`plugin_bundle/omh/tools/capability_tool.py`) so the plugin can answer without importing the omh package. Integrity needs `OmhPaths`, the installed plugin directory, and the revocation ledger. Folding disk state into the manifest would make a cached, environment-independent payload depend on the environment, and would force a filesystem dependency into a vendored mirror that deliberately has none.

It stays **one hook concept**: the vocabulary is still `plugin_bundle.omh.metadata.PROVIDED_HOOKS`, every record names a hook the manifest already declares, and the status carries `hook_manifest_schema_version` so a reader can see which manifest it refines. `tests/test_hook_manifest.py` fails if the two vocabularies ever diverge.

**One digest path, not two.** The reviewed value comes straight out of `plugin_pack.bundled_plugin_records()` — the same `sha256_text` over the same packaged resource the installer manifests — and the installed value is `sha256_file` over the file that record was copied to. `_copy_resource_tree`'s `newline=""` is what keeps those two comparable on Windows; a second hashing scheme would have re-litigated that. `bundled_plugin_records()` builds paths with `pathlib`, so they arrive `\`-separated on Windows; `_packaged_file_digests()` normalizes to `/` and `_digest_state()` rebuilds the OS path with `Path.joinpath(*source_path.split("/"))` rather than asserting a separator.

**Trust is scoped to the hook's own entry module.** Whole-bundle staleness is already owned by `plugin_bundle_current`; duplicating it here would report the same drift twice under two different repairs.

**Exclusion precedence.** Revocation outranks a changed digest: telling an operator to reinstall a hook they deliberately withdrew is the wrong instruction. Order is ledger-unreadable → revoked → unreviewed → changed → missing.

**Fail-open on an unreadable ledger, loudly.** A corrupt or unknown-version ledger revokes nothing (a corrupt file is not evidence that any particular hook was withdrawn) but fails the doctor check with `Repair or remove the OMH hook revocation ledger`. Reading an unknown `schema_version` as "nothing revoked" would answer a question about a file that may say the opposite.

**AC3 is enforced at the schema level.** Every record and the status carry `observed_in_this_environment: False`, and `validate_hook_integrity_status()` rejects any other value — there is no representable payload in which installation looks like invocation. The claim boundary says so in words and points at `omh_plugin_host_observation`, which remains the only record that can carry load or invocation evidence.

Deterministic and metadata-only: no wall-clock value enters the payload, no dependency was added, and nothing here makes a network or LLM call.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/install/hook_integrity.py` | New. `omh_hook_integrity/v1` + `omh_hook_revocations/v1`, `build_hook_integrity_status()`, `validate_hook_integrity_status()`, `read_hook_revocations()`, `HOOK_REVIEWS`, `VALID_HOOK_EVENTS`, `HOOK_HOST_TARGET`. |
| `src/maintenance/doctor.py` | +41 lines: import, `checks.append(_hook_integrity_check(paths))`, and `_hook_integrity_check()`. |
| `tests/test_hook_integrity.py` | New, 25 tests across `ReviewedRecordTests`, `ChangedHookTests`, `RevocationTests`, `ObservationBoundaryTests`, `DoctorSurfaceTests`. |
| `tests/test_hook_manifest.py` | +32 lines: two manifest-side contracts (observation boundary, review coverage). 20 tests total. |

No generated artifact changed: `skills/*/SKILL.md`, `docs/WORKFLOWS.md`, `docs/ROLES.md`, and the demo-cards JSON are untouched, and all four `--check` gates pass byte-exact. No exact-count fixture moved, because no routing case, skill, or demo card was added. No new broad `except` was introduced, so `tests/test_broad_exception_policy.py` needed no verdict.

Acceptance criteria mapping:

- **AC1** — `ReviewedRecordTests`: every declared hook carries a 64-hex reviewed digest and a non-empty event scope; blanking either fails `validate_hook_integrity_status()`; the reviewed digest is asserted equal to both `sha256_file` of the installed copy and `sha256_text` of its source.
- **AC2** — `ChangedHookTests` + `RevocationTests`: a tampered file, a deleted file, and a ledger revocation each drop the hook from `managed_hooks` and produce a repair naming the capability (`route hint`, `verification nudge`, `tool checkpoint`). Restoring the bytes or removing the ledger entry returns the hook. `DoctorSurfaceTests` asserts the same at the `omh doctor` surface and that the check lands in the `optional_surfaces` group.
- **AC3** — `ObservationBoundaryTests`: `install_plugin_bundle()` sets no observed flag on the status or on any record; the claim boundary says review is not invocation; a status or record with `observed_in_this_environment: True` fails validation.
- **Guards** — an event outside `VALID_HOOK_EVENTS` is refused; an uninstalled bundle is not tampering; an unreadable or unknown-version ledger does not read as empty; a revocation reason longer than 200 chars is truncated.

## Validation

Observed locally on `agent/issue-803` at `f5515e39`, rebased onto `origin/main` `e35460ac`. Every ticked box below was run and its exit code read directly (not through a pipe).

- [x] `uv run --group lint ruff check src tests` → `All checks passed!` (one pre-existing warning about an invalid `# noqa` on `src/commands/main.py:1`, untouched by this PR)
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` → **Ran 4737 tests in 177.307s — OK**
- [x] `uv run python -m compileall -q src tests` → exit 0
- [x] `uv run python -m omh.cli docs workflows --check` → `ok:true`, `tap_skills` 115/115, no missing/stale/extra
- [x] `uv run python -m omh.cli harness validate` → `ok:true`, 72 harnesses, 104 skills, 0 errors, 0 warnings
- [x] `uv run python -m omh.cli release checklist --json` → `ok:true`, `required_item_count:35`, exit 0
- [x] `uv run python -m omh.cli release hermes-smoke` → plan rendered with plan-only boundary, exit 0
- [x] `omh --help` (as `uv run python -m omh.cli --help`) → exit 0
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — **not run.** It needs an installed `omh` console script on PATH; this worktree runs the package through `uv run python -m omh.cli`. Nothing in this change touches the installer or the command package.
- [x] Also run, beyond the template: `uv run python -m omh.cli docs roles --check` → `ok:true`; `uv run python -m omh.cli docs capability-families --check` → `ok:true`; `git diff --check` → exit 0
- [ ] Relevant workflow-learning review queue smoke: **not applicable** — no learning contract changed.
- [x] Relevant dry-run or smoke command: `tests/test_hook_integrity.py` installs a real plugin bundle into a temp `--hermes-home`, tampers with `hooks/llm_hooks.py`, and reads the resulting `omh doctor` check. That is the dry-run for this feature.
- [ ] Manual Hermes/TUI check: **not run, deliberately.** No Hermes runtime was started, so nothing here observed a hook load or invocation — which is exactly the boundary AC3 asks this record to keep. Hook load/invocation evidence stays with `omh_plugin_host_observation` and is unaffected.

## Risk

- **A new doctor check that could fail an unrelated fixture.** Mitigated by the rule, not by the fixtures: the check fails only on an actual exclusion or an unreadable ledger, and an uninstalled bundle is explicitly not an exclusion. The full 4737-test suite passes on the rebased tree, including every test that asserts doctor is green after setup.
- **Reviewed digest vs. installed bundle version.** A bundle installed by an older OMH will read as `digest=changed` and exclude the hook. That is intended — an old hook is not the reviewed one — and the repair is `omh setup --force`, which is the same repair `plugin_bundle_current` already recommends for that machine. Users on a current bundle see no change.
- **Hook-entry-module scope.** A behaviour change in a module a hook *imports* (for example `awareness.py`) does not change that hook's digest. Whole-bundle drift is still caught by `plugin_bundle_current`; this record deliberately does not duplicate it.
- **The revocation ledger has no writer command.** It is read-only input. That is a bounded surface, not a stub: it is fully honoured, fully tested, and hand-writable. Adding an `omh` subcommand for it would have pulled in the whole new-CLI-command contract (plain-text default, `bounded_surfaces`, spec-side policy tests) for a maintenance path that does not yet have a caller.

## Compatibility / Rollout

- Purely additive. No existing schema version changed, no existing payload gained or lost a key, no existing message was reworded.
- `plugin_distribution/v1`, `omh_plugin_host_observation/v1`, and `omh_hook_manifest/v1` are untouched.
- A missing revocation ledger is the normal state and means "nothing revoked", so no migration and no first-run write are needed.
- No behaviour change for a user on a current bundle: the new check reports `digest=matches` or `digest=not_installed` and passes.

## Release / Claims

- [x] Release-channel impact considered — none. No installer, packaging, or version surface changed; the new module ships inside the existing `omh.install` package, which is already listed in `pyproject.toml`.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — the record's own claim boundary states that a matching digest proves a file and not a Hermes load, registration, or invocation, `observed_in_this_environment` is `False` everywhere and unrepresentable as anything else, and the doctor line prints `observed=False`.
- [x] Known manual Hermes checks are listed — no live Hermes run was performed; `omh release hermes-smoke --live` was not run and is listed as a gap above.

## Follow-Up

- An operator-facing way to revoke a hook (`omh` subcommand or a release-data import) if a caller appears. Deliberately out of scope here.
- Release data could supply reviewed digests for hooks revoked in a *previous* release, which today can only be expressed locally.
- If a hook ever attaches to more than one event, `event_scope` is already a list and the vocabulary guard already covers it; no schema change would be needed.
