### PR TITLE
feat: let users teach Hermes a proven workflow safely

### DIFF
--- a/docs/HARNESS_QUALITY.md
+++ b/docs/HARNESS_QUALITY.md
@@ -142,6 +142,44 @@ contract shaped like this:
   review, CI, merge, or proof that future routing improved. Export bundles are
   derived artifacts and are not part of the canonical learning index repair loop.
 
+## Teaching A Proven Workflow (agent-facing)
+
+A user who has just watched a workflow work can ask Hermes to keep it. The
+`omh learning skill-draft` group is the deterministic backend for that request;
+users express the intent in natural language and Hermes fills the flags.
+
+- `omh learning skill-draft new "<explicit request>" --name <slug> --source-run
+  <run-id> --instruction ... --input name=description --precondition ...
+  --stop-condition ... --verification ...` returns `skill_draft/v1`. It records
+  a draft only when the message carries an explicit learning signal such as
+  "turn this into a skill"; passive activity exits non-zero with
+  `no_explicit_learning_signal` and writes nothing. The draft keeps the fixed
+  instructions separate from the declared inputs, preconditions, stop
+  conditions, and verification steps, and its provenance names the
+  user-selected source runs, the transient identifiers redacted out of the
+  request, and the pending review decision.
+- A draft is inactive by construction. It is stored under
+  `.omh/learning/skill-drafts/`, is never written under `skills/`, never becomes
+  catalog data, and carries its proposed name under `proposed_skill_name` rather
+  than `name`. A name that collides with an installed skill fails validation,
+  and an inactive draft carries no copy-ready proposal at all.
+- `omh learning skill-draft show <draft-id>` returns the draft plus a live
+  `skill_draft_generated_output_check/v1`: the draft validates, the catalog
+  contract is clean, the draft projects to a `SkillDefinition` the catalog's own
+  per-definition validator accepts, and that definition renders a single-line
+  frontmatter description and a catalog-index line inside its byte ceiling.
+  `activation_blockers` is what a reviewer has to clear.
+- `omh learning skill-draft review <draft-id> --decision approve|revise|reject`
+  is the only activation path. Approval recomputes the generated-output checks
+  and refuses to activate when any fail, so an approval on its own can never
+  activate a draft that would not render a valid skill. Only a passing check set
+  plus an explicit approval flips the draft to `active_proposal` and mints the
+  copy-ready `skill_draft_proposal/v1`. Review notes are stored as hash and
+  length, never raw text.
+- Even an activated draft is a proposal. It is not an installed skill, not
+  catalog data, and not proof that Hermes Agent `/learn`, a maintainer, or any
+  runtime acted on it.
+
 ## Wrapper Rules
 
 - Use `wrapper_actions` as platform-neutral action ids; map them to buttons,

--- a/src/commands/learning.py
+++ b/src/commands/learning.py
@@ -43,6 +43,17 @@ from ..workflow_learning import (
     write_self_improvement_store_route,
     write_workflow_eval,
 )
+from ..workflows.skill_draft import (
+    build_skill_draft,
+    check_skill_draft_generated_output,
+    list_skill_drafts,
+    review_skill_draft,
+    show_skill_draft,
+    skill_draft_is_active,
+    skill_draft_ref,
+    write_skill_draft,
+)
+from ..local_store import utc_now
 from ..wrapper.contract import INTERACTION_MODES, build_chat_interaction_payload
 from .common import _chat_input_and_metadata, _explicit_source_metadata, _paths, _print_json
 
@@ -446,6 +457,193 @@ def cmd_learning_audit(args: argparse.Namespace) -> int:
     return 0 if payload.get("status") in {"ready", "no_records", "needs_attention"} else 1
 
 
+SKILL_DRAFT_CLAIM_BOUNDARY_NOTE = (
+    "A skill draft is review material stored under .omh/learning/skill-drafts/. OMH did not install a skill, "
+    "write anything under skills/, register catalog data, run the workflow, pass review, run CI, or merge."
+)
+
+
+def _declared_inputs(values: list[str]) -> list[dict[str, str]]:
+    inputs: list[dict[str, str]] = []
+    for value in values:
+        name, separator, description = value.partition("=")
+        if not separator or not name.strip() or not description.strip():
+            raise OmhError(f"--input must be given as name=description, got: {value}")
+        inputs.append({"name": name.strip(), "description": description.strip()})
+    return inputs
+
+
+def cmd_learning_skill_draft_new(args: argparse.Namespace) -> int:
+    try:
+        paths = _paths(args)
+        event_or_message, _ = _chat_input_and_metadata(args)
+        message = extract_message_text(event_or_message) if isinstance(event_or_message, dict) else str(event_or_message)
+        draft = build_skill_draft(
+            message,
+            source_runs=args.source_run,
+            proposed_skill_name=args.name,
+            fixed_instructions=args.instruction,
+            declared_inputs=_declared_inputs(args.input),
+            preconditions=args.precondition,
+            stop_conditions=args.stop_condition,
+            verification_steps=args.verification,
+            created_at=utc_now(),
+        )
+    except (OSError, json.JSONDecodeError, ValueError, WorkflowLearningError) as exc:
+        raise OmhError(str(exc)) from exc
+    if draft is None:
+        # AC1: no explicit teach-this-workflow request, no draft. Passive
+        # activity has no other way into this command.
+        _print_json(
+            {
+                "schema_version": "skill_draft_result/v1",
+                "status": "no_explicit_learning_signal",
+                "recorded": False,
+                "claim_boundary": (
+                    "OMH records a skill draft only from an explicit user request such as "
+                    "\"turn this into a skill\". Nothing was captured or converted."
+                ),
+            }
+        )
+        return 1
+    try:
+        checks = check_skill_draft_generated_output(draft)
+        if not args.dry_run:
+            write_skill_draft(paths, draft)
+    except (OSError, ValueError, WorkflowLearningError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(
+        {
+            "schema_version": "skill_draft_result/v1",
+            "status": "drafted",
+            "recorded": not args.dry_run,
+            "dry_run": args.dry_run,
+            "skill_draft_ref": skill_draft_ref(str(draft["draft_id"])),
+            "draft": draft,
+            "generated_output_check": checks,
+            "next_command": f"omh learning skill-draft review {draft['draft_id']} --decision approve",
+            "claim_boundary": SKILL_DRAFT_CLAIM_BOUNDARY_NOTE,
+        }
+    )
+    return 0
+
+
+def cmd_learning_skill_draft_list(args: argparse.Namespace) -> int:
+    try:
+        drafts = list_skill_drafts(_paths(args), limit=args.limit)
+    except (OSError, json.JSONDecodeError, ValueError, WorkflowLearningError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(
+        {
+            "schema_version": "skill_draft_list/v1",
+            "drafts": drafts,
+            "claim_boundary": SKILL_DRAFT_CLAIM_BOUNDARY_NOTE,
+        }
+    )
+    return 0
+
+
+def cmd_learning_skill_draft_show(args: argparse.Namespace) -> int:
+    try:
+        draft = show_skill_draft(_paths(args), args.draft_id)
+        checks = check_skill_draft_generated_output(draft)
+    except FileNotFoundError as exc:
+        raise OmhError(f"skill draft not found: {args.draft_id}") from exc
+    except (OSError, json.JSONDecodeError, ValueError, WorkflowLearningError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(
+        {
+            "schema_version": "skill_draft_show/v1",
+            "draft": draft,
+            "active": skill_draft_is_active(draft),
+            "generated_output_check": checks,
+            "activation_blockers": list(checks["errors"]),
+            "claim_boundary": SKILL_DRAFT_CLAIM_BOUNDARY_NOTE,
+        }
+    )
+    return 0
+
+
+def cmd_learning_skill_draft_review(args: argparse.Namespace) -> int:
+    try:
+        paths = _paths(args)
+        reviewed = review_skill_draft(
+            show_skill_draft(paths, args.draft_id),
+            decision=args.decision,
+            reviewer_ref=args.reviewer_ref or "operator",
+            reviewed_at=utc_now(),
+            review_note=args.review_note or "",
+        )
+        write_skill_draft(paths, reviewed)
+    except FileNotFoundError as exc:
+        raise OmhError(f"skill draft not found: {args.draft_id}") from exc
+    except (OSError, json.JSONDecodeError, ValueError, WorkflowLearningError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(
+        {
+            "schema_version": "skill_draft_review_result/v1",
+            "recorded": True,
+            "decision": args.decision,
+            "activated": skill_draft_is_active(reviewed),
+            "skill_draft_ref": skill_draft_ref(str(reviewed["draft_id"])),
+            "draft": reviewed,
+            "claim_boundary": SKILL_DRAFT_CLAIM_BOUNDARY_NOTE,
+        }
+    )
+    return 0
+
+
+def _add_skill_draft_commands(learning_sub) -> None:
+    skill_draft = learning_sub.add_parser(
+        "skill-draft",
+        help="Turn an explicitly identified proven workflow into an inactive, reviewable skill draft.",
+    )
+    skill_draft_sub = skill_draft.add_subparsers(dest="skill_draft_command", required=True)
+
+    new = skill_draft_sub.add_parser(
+        "new",
+        help="Draft a skill proposal from an explicit teach-this-workflow request and user-selected runs.",
+    )
+    new.add_argument("message", nargs="*", help="The explicit user request, for example 'turn this into a skill: ...'.")
+    new.add_argument("--source", choices=CHAT_SOURCES, default="generic")
+    new.add_argument("--stdin", action="store_true")
+    new.add_argument("--event-json", default=None)
+    new.add_argument("--source-event-id", default="")
+    new.add_argument("--channel-ref", default="")
+    new.add_argument("--user-ref", default="")
+    new.add_argument("--name", required=True, help="Proposed skill name as a lowercase-hyphen slug.")
+    new.add_argument("--source-run", action="append", default=[], help="User-selected source run id; repeat per run.")
+    new.add_argument("--instruction", action="append", default=[], help="One fixed instruction; repeat in order.")
+    new.add_argument("--input", action="append", default=[], help="One variable input as name=description; repeat per input.")
+    new.add_argument("--precondition", action="append", default=[], help="One precondition; repeat per condition.")
+    new.add_argument("--stop-condition", action="append", default=[], help="One stop condition; repeat per condition.")
+    new.add_argument("--verification", action="append", default=[], help="One required verification step; repeat per step.")
+    new.add_argument("--dry-run", action="store_true")
+    new.set_defaults(func=cmd_learning_skill_draft_new)
+
+    list_drafts = skill_draft_sub.add_parser("list", help="List local skill drafts and their review state.")
+    list_drafts.add_argument("--limit", type=int, default=None)
+    list_drafts.set_defaults(func=cmd_learning_skill_draft_list)
+
+    show = skill_draft_sub.add_parser("show", help="Show one skill draft with its current generated-output checks.")
+    show.add_argument("draft_id")
+    show.set_defaults(func=cmd_learning_skill_draft_show)
+
+    review = skill_draft_sub.add_parser(
+        "review",
+        help="Record an explicit review decision. Approval activates the draft only when the generated-output checks pass.",
+    )
+    review.add_argument("draft_id")
+    review.add_argument("--decision", choices=("approve", "revise", "reject"), required=True)
+    review.add_argument("--reviewer-ref", default="operator")
+    review.add_argument(
+        "--review-note",
+        default="",
+        help="Optional reviewer note; OMH stores only its hash and length, not the note text.",
+    )
+    review.set_defaults(func=cmd_learning_skill_draft_review)
+
+
 def _add_learning_commands(sub) -> None:
     learning = sub.add_parser(
         "learning",
@@ -641,3 +839,5 @@ def _add_learning_commands(sub) -> None:
     index_rebuild = index_sub.add_parser("rebuild", help="Rebuild learning_index.json from local learning records.")
     index_rebuild.add_argument("--dry-run", action="store_true")
     index_rebuild.set_defaults(func=cmd_learning_index_rebuild)
+
+    _add_skill_draft_commands(learning_sub)

--- a/src/skills/validation.py
+++ b/src/skills/validation.py
@@ -51,6 +51,17 @@ def validate_catalog_contract() -> dict[str, object]:
     }
 
 
+def validate_skill_definition_contract(definition: SkillDefinition) -> list[str]:
+    """Validate one definition against the same field contract the catalog gate uses.
+
+    `validate_catalog_contract()` answers "is the shipped catalog renderable".
+    A caller holding a definition that is deliberately NOT in the catalog - a
+    reviewable skill draft, for instance - needs the same per-definition answer
+    without registering anything, so the loop body is exposed rather than copied.
+    """
+    return _validate_skill_definition(definition, {harness.name for harness in builtin_harnesses()})
+
+
 def harness_summary_payload() -> dict[str, object]:
     definitions = builtin_definitions()
     skills_by_harness = _skills_by_harness(definitions)

--- a/src/system/paths.py
+++ b/src/system/paths.py
@@ -323,6 +323,10 @@ class OmhPaths:
         return self.learning_dir / "exports"
 
     @property
+    def learning_skill_drafts_dir(self) -> Path:
+        return self.learning_dir / "skill-drafts"
+
+    @property
     def learning_index_path(self) -> Path:
         return self.learning_dir / "index.json"
 

--- a/src/workflows/skill_draft.py
+++ b/src/workflows/skill_draft.py
@@ -1,0 +1,739 @@
+"""Explicit teach-this-workflow drafts: reviewable, structurally inactive skill proposals.
+
+A draft is what a user gets after they explicitly say "turn this into a skill".
+It separates the instructions that stay fixed from the inputs that vary per run,
+names the preconditions and stop conditions, carries the verification a reviewer
+must see pass, and records which user-selected runs it came from and what was
+redacted out of them.
+
+Inactive is structural here, not a flag someone remembers to check:
+
+- a draft is stored under `.omh/learning/skill-drafts/`, never under `skills/`,
+  and `write_skill_draft` refuses any path that would land in a skills tree;
+- a draft is never catalog data, so `builtin_definitions()` never grows and no
+  generated `skills/*/SKILL.md` is written;
+- the proposed name lives under `proposed_skill_name`, never `name`, so a
+  consumer reading `definition["name"]` cannot pick a draft up by accident, and
+  a name that collides with an installed skill fails validation;
+- an inactive draft carries no copy-ready proposal at all - the proposal is
+  minted by activation, so there is nothing to act on before review.
+
+Activation needs two independent things and recomputes both: the generated-output
+checks pass (the draft would project to a definition the catalog contract accepts)
+AND an explicit human review approves it. Even activated, the draft is a proposal
+a person or Hermes Agent `/learn` acts on - never an install.
+
+The redaction denylist is imported from `workflow_learning`; this module does not
+keep a second copy of it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from ..local_store import atomic_write_json, read_json_object
+from ..paths import OmhPaths
+from ..skills.catalog import SkillDefinition, builtin_definitions, omh_skill_display_name
+from ..skills.render import frontmatter_description
+from ..skills.validation import validate_catalog_contract, validate_skill_definition_contract
+from .learning_candidate import detect_learning_signal, sanitize_learning_text
+from .workflow_learning import EXPORT_FORBIDDEN_PAYLOAD_KEYS
+from .workflow_learning_errors import WorkflowLearningError
+
+
+SKILL_DRAFT_SCHEMA_VERSION = "skill_draft/v1"
+SKILL_DRAFT_CHECK_SCHEMA_VERSION = "skill_draft_generated_output_check/v1"
+SKILL_DRAFT_PROPOSAL_SCHEMA_VERSION = "skill_draft_proposal/v1"
+SKILL_DRAFT_STATUS = "prepared_not_observed"
+SKILL_DRAFT_RECORD_TYPE = "skill_draft"
+SKILL_DRAFT_INACTIVE_STATE = "inactive"
+SKILL_DRAFT_ACTIVE_STATE = "active_proposal"
+SKILL_DRAFT_STATES = (SKILL_DRAFT_INACTIVE_STATE, SKILL_DRAFT_ACTIVE_STATE)
+SKILL_DRAFT_REVIEW_DECISIONS = ("approve", "revise", "reject")
+SKILL_DRAFT_REF_PREFIX = "omh-skill-draft"
+SKILL_DRAFT_STORAGE_AREA = "omh_learning_skill_drafts"
+SKILL_DRAFT_SELECTION = "explicit_user_selection"
+SKILL_DRAFT_ACTIVATION_REQUIREMENTS = ("generated_output_checks_pass", "explicit_human_review_approval")
+SKILL_DRAFT_SECTION_KEYS = (
+    "fixed_instructions",
+    "declared_inputs",
+    "preconditions",
+    "stop_conditions",
+    "verification_steps",
+)
+SKILL_DRAFT_CHECK_NAMES = (
+    "draft_schema",
+    "catalog_contract",
+    "projected_skill_definition",
+    "rendered_frontmatter_description",
+    "rendered_catalog_index_line",
+)
+# The generated catalog index renders one "- `<display-name>`: <description>"
+# line per skill, and `tests/test_router_content.py` holds every such line under
+# 400 bytes. A draft whose summary would blow that line does not render valid
+# generated output, so it cannot activate until the summary is tightened.
+SKILL_DRAFT_CATALOG_INDEX_LINE_BYTE_LIMIT = 400
+# The one directory name a draft must never appear under. `skills/` is where the
+# catalog renders installed guidance; a draft that landed there would be read as
+# installed by every tap, install walk, and freshness gate in the repo.
+SKILL_DRAFT_INSTALL_ROOT_GUARD = "skills"
+SKILL_DRAFT_CLAIM_BOUNDARY = (
+    "A skill draft is prepared_not_observed review material stored under .omh/learning/skill-drafts/. "
+    "It is never written into skills/ and never becomes catalog data, so it cannot be read as an installed "
+    "Hermes skill. It is not skill creation evidence, install evidence, workflow execution evidence, review "
+    "evidence, CI evidence, or merge evidence."
+)
+SKILL_DRAFT_NOT_OBSERVED = (
+    "skill installed",
+    "skill rendered under skills/",
+    "catalog registration",
+    "Hermes Agent /learn execution",
+    "workflow execution",
+    "future behavior change",
+)
+
+# Slug shape for a proposed name: the same lowercase-hyphen form catalog names
+# use, so a reviewer can compare the two without translating between them.
+_PROPOSED_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9-]{2,48}$")
+_SAFE_ID_PATTERN = re.compile(r"[^a-zA-Z0-9_.:-]+")
+
+
+def build_skill_draft(
+    message: str,
+    *,
+    source_runs: Sequence[str],
+    proposed_skill_name: str,
+    fixed_instructions: Sequence[str],
+    declared_inputs: Sequence[Mapping[str, str]],
+    preconditions: Sequence[str],
+    stop_conditions: Sequence[str],
+    verification_steps: Sequence[str],
+    created_at: str = "",
+    draft_id: str | None = None,
+) -> dict[str, Any] | None:
+    """Build one inactive skill draft from an explicit teach-this-workflow request.
+
+    Returns `None` when `message` carries no explicit learning signal. That is
+    the whole of AC1: passive activity has no other entry point into this module,
+    so there is no path that records or converts it.
+
+    `created_at` is a caller-supplied parameter rather than a wall-clock read so
+    the payload stays comparable; `draft_id` is derived from the draft's content,
+    never from the time it was built.
+    """
+    signal = detect_learning_signal(message)
+    if signal is None:
+        return None
+    summary, redaction_categories = sanitize_learning_text(message)
+    runs = _source_run_refs(source_runs)
+    name = proposed_skill_name.strip()
+    sections = {
+        "fixed_instructions": _text_list(fixed_instructions),
+        "declared_inputs": _declared_input_list(declared_inputs),
+        "preconditions": _text_list(preconditions),
+        "stop_conditions": _text_list(stop_conditions),
+        "verification_steps": _text_list(verification_steps),
+    }
+    draft: dict[str, Any] = {
+        "schema_version": SKILL_DRAFT_SCHEMA_VERSION,
+        "record_type": SKILL_DRAFT_RECORD_TYPE,
+        "draft_id": draft_id or _content_draft_id(name, runs, sections),
+        "created_at": created_at,
+        "status": SKILL_DRAFT_STATUS,
+        "proposed_skill_name": name,
+        "summary": summary or f"Reusable workflow draft proposed as {name}.",
+        "instruction_set": sections,
+        "provenance": {
+            "selection": SKILL_DRAFT_SELECTION,
+            "learning_signal": dict(signal),
+            "source_runs": runs,
+            "redactions": {
+                "redaction_policy": "metadata_only",
+                "transient_identifier_categories": list(redaction_categories),
+                "denied_payload_keys": denied_payload_keys(),
+                "raw_prompt_stored": False,
+                "raw_transcript_stored": False,
+            },
+            "review": {
+                "required": True,
+                "human_approval_required": True,
+                "decision": "pending",
+                "allowed_decisions": list(SKILL_DRAFT_REVIEW_DECISIONS),
+                "reviewer_ref": "",
+                "reviewed_at": "",
+            },
+        },
+        "lifecycle": {
+            "state": SKILL_DRAFT_INACTIVE_STATE,
+            "installed": False,
+            "catalog_registered": False,
+            "generated_skill_path": "",
+            "storage_area": SKILL_DRAFT_STORAGE_AREA,
+            "activation_requires": list(SKILL_DRAFT_ACTIVATION_REQUIREMENTS),
+        },
+        "not_observed": list(SKILL_DRAFT_NOT_OBSERVED),
+        "claim_boundary": SKILL_DRAFT_CLAIM_BOUNDARY,
+    }
+    _raise_on_validation(draft)
+    return draft
+
+
+def review_skill_draft(
+    draft: Mapping[str, Any],
+    *,
+    decision: str,
+    reviewer_ref: str = "operator",
+    reviewed_at: str = "",
+    review_note: str = "",
+) -> dict[str, Any]:
+    """Record an explicit review decision, activating the draft only on approval.
+
+    AC3 lives here. `approve` recomputes the generated-output checks instead of
+    trusting anything the caller passed in, and raises when they fail, so a
+    review on its own can never activate a draft that would not render a valid
+    skill. `revise` and `reject` record the decision and leave (or return) the
+    draft inactive, dropping any activation an earlier approval minted.
+    """
+    if decision not in SKILL_DRAFT_REVIEW_DECISIONS:
+        raise WorkflowLearningError("skill draft review decision must be approve, revise, or reject")
+    reviewer = reviewer_ref.strip()
+    if not reviewer:
+        raise WorkflowLearningError("skill draft review needs an explicit reviewer_ref")
+    _raise_on_validation(draft)
+    reviewed = json.loads(json.dumps(draft))
+    # Every review starts from the inactive shape so a re-review recomputes the
+    # activation instead of nesting the previous receipt inside the new one.
+    reviewed["lifecycle"]["state"] = SKILL_DRAFT_INACTIVE_STATE
+    reviewed.pop("activation", None)
+    reviewed.pop("proposal", None)
+    review = reviewed["provenance"]["review"]
+    review["decision"] = decision
+    review["reviewer_ref"] = reviewer
+    review["reviewed_at"] = reviewed_at
+    review.pop("review_note_sha256", None)
+    review.pop("review_note_length", None)
+    if review_note:
+        review["review_note_sha256"] = hashlib.sha256(review_note.encode("utf-8")).hexdigest()
+        review["review_note_length"] = len(review_note)
+    if decision != "approve":
+        _raise_on_validation(reviewed)
+        return reviewed
+    checks = check_skill_draft_generated_output(reviewed)
+    if not checks["ok"]:
+        failed = ", ".join(check["check"] for check in checks["checks"] if check["status"] == "failed")
+        raise WorkflowLearningError(f"skill draft activation blocked by failed generated-output checks: {failed}")
+    reviewed["lifecycle"]["state"] = SKILL_DRAFT_ACTIVE_STATE
+    reviewed["activation"] = {
+        "activated": True,
+        "activated_at": reviewed_at,
+        "reviewer_ref": reviewer,
+        "requirements_met": list(SKILL_DRAFT_ACTIVATION_REQUIREMENTS),
+        "generated_output_check": checks,
+    }
+    reviewed["proposal"] = build_skill_draft_proposal(reviewed)
+    _raise_on_validation(reviewed)
+    return reviewed
+
+
+def check_skill_draft_generated_output(draft: Mapping[str, Any]) -> dict[str, Any]:
+    """Answer whether this draft would render valid generated skill output.
+
+    Five checks, in dependency order: the draft validates, the catalog contract
+    the draft would join is itself clean, the draft projects to a
+    `SkillDefinition` the catalog's own per-definition validator accepts, that
+    definition renders a usable single-line frontmatter description, and the
+    catalog-index line it would produce fits the byte ceiling that surface
+    enforces. A schema failure blocks the rest rather than letting a malformed
+    draft raise inside the projection.
+    """
+    schema_errors = validate_skill_draft(draft)
+    if schema_errors:
+        blocked = "blocked by draft schema errors"
+        return _check_payload(
+            [
+                _check("draft_schema", False, "; ".join(schema_errors)),
+                *[_check(name, False, blocked) for name in SKILL_DRAFT_CHECK_NAMES[1:]],
+            ]
+        )
+
+    checks = [_check("draft_schema", True, "skill_draft/v1 validated.")]
+
+    catalog = validate_catalog_contract()
+    checks.append(
+        _check(
+            "catalog_contract",
+            bool(catalog.get("ok")),
+            "catalog_validation/v1 is clean." if catalog.get("ok") else "; ".join(_strings(catalog.get("errors"))),
+        )
+    )
+
+    definition = project_skill_draft_definition(draft)
+    definition_errors = validate_skill_definition_contract(definition)
+    checks.append(
+        _check(
+            "projected_skill_definition",
+            not definition_errors,
+            "Projected definition satisfies the catalog skill contract."
+            if not definition_errors
+            else "; ".join(definition_errors),
+        )
+    )
+
+    description = frontmatter_description(definition)
+    # Frontmatter is one line per key, so an embedded newline would break the
+    # generated YAML rather than merely look untidy.
+    description_ok = description.startswith("[omh] ") and "\n" not in description and "\r" not in description
+    checks.append(
+        _check(
+            "rendered_frontmatter_description",
+            description_ok,
+            f"Rendered {len(description)} description characters on one line."
+            if description_ok
+            else "Projected definition does not render a single-line [omh]-prefixed frontmatter description.",
+        )
+    )
+
+    index_line = f"- `{omh_skill_display_name(definition.name)}`: {definition.description}"
+    index_bytes = len(index_line.encode("utf-8"))
+    checks.append(
+        _check(
+            "rendered_catalog_index_line",
+            index_bytes < SKILL_DRAFT_CATALOG_INDEX_LINE_BYTE_LIMIT,
+            f"Catalog index line is {index_bytes} bytes, under the "
+            f"{SKILL_DRAFT_CATALOG_INDEX_LINE_BYTE_LIMIT}-byte ceiling."
+            if index_bytes < SKILL_DRAFT_CATALOG_INDEX_LINE_BYTE_LIMIT
+            else (
+                f"Catalog index line is {index_bytes} bytes, over the "
+                f"{SKILL_DRAFT_CATALOG_INDEX_LINE_BYTE_LIMIT}-byte ceiling; shorten the draft summary."
+            ),
+        )
+    )
+    return _check_payload(checks)
+
+
+def project_skill_draft_definition(draft: Mapping[str, Any]) -> SkillDefinition:
+    """Project a draft onto the dataclass the generated skill output is built from.
+
+    Every draft section lands on the field that means the same thing: declared
+    inputs are the required inputs, stop conditions are the safety rules,
+    verification steps are the quality bar, preconditions describe when to use
+    it. Nothing is invented, and nothing is registered - the definition exists
+    only for the duration of the check.
+    """
+    sections = _object(draft.get("instruction_set"))
+    name = str(draft.get("proposed_skill_name", ""))
+    inputs = tuple(
+        f"{str(item.get('name', '')).strip()}: {str(item.get('description', '')).strip()}"
+        for item in _objects(sections.get("declared_inputs"))
+    )
+    return SkillDefinition(
+        name=name,
+        description=str(draft.get("summary", "")),
+        triggers=(name,),
+        use_when=" ".join(_strings(sections.get("preconditions"))),
+        required_inputs=inputs,
+        safety_rules=tuple(_strings(sections.get("stop_conditions"))),
+        quality_bar=tuple(_strings(sections.get("verification_steps"))),
+    )
+
+
+def build_skill_draft_proposal(draft: Mapping[str, Any]) -> dict[str, Any]:
+    """Render the copy-ready proposal an activated draft hands to a human or Hermes."""
+    sections = _object(draft.get("instruction_set"))
+    provenance = _object(draft.get("provenance"))
+    redactions = _object(provenance.get("redactions"))
+    review = _object(provenance.get("review"))
+    run_ids = [str(run.get("run_id", "")) for run in _objects(provenance.get("source_runs"))]
+    categories = _strings(redactions.get("transient_identifier_categories")) or ["none detected"]
+    lines = [
+        f"# Proposed OMH skill: {draft.get('proposed_skill_name', '')}",
+        "",
+        str(draft.get("summary", "")),
+        "",
+        "## Preconditions",
+        *_bullets(sections.get("preconditions")),
+        "",
+        "## Declared inputs (vary per run)",
+        *[
+            f"- {str(item.get('name', '')).strip()}: {str(item.get('description', '')).strip()}"
+            for item in _objects(sections.get("declared_inputs"))
+        ],
+        "",
+        "## Fixed instructions (do not vary)",
+        *[f"{index}. {step}" for index, step in enumerate(_strings(sections.get("fixed_instructions")), start=1)],
+        "",
+        "## Stop conditions",
+        *_bullets(sections.get("stop_conditions")),
+        "",
+        "## Required verification",
+        *_bullets(sections.get("verification_steps")),
+        "",
+        "## Provenance",
+        f"- Source runs selected by the user: {', '.join(run_ids)}",
+        f"- Transient identifiers redacted: {', '.join(categories)}",
+        "- Raw prompts or transcripts stored: no",
+        f"- Reviewed by: {str(review.get('reviewer_ref', ''))} (decision: {str(review.get('decision', ''))})",
+        "",
+        SKILL_DRAFT_CLAIM_BOUNDARY,
+    ]
+    return {
+        "schema_version": SKILL_DRAFT_PROPOSAL_SCHEMA_VERSION,
+        "status": SKILL_DRAFT_STATUS,
+        "copy_text": "\n".join(lines),
+        "claim_boundary": SKILL_DRAFT_CLAIM_BOUNDARY,
+    }
+
+
+def validate_skill_draft(draft: Mapping[str, Any]) -> list[str]:
+    """Return every contract violation in one pass; empty means the draft is valid."""
+    if not isinstance(draft, dict):
+        return ["skill draft must be a JSON object"]
+    errors: list[str] = []
+    if draft.get("schema_version") != SKILL_DRAFT_SCHEMA_VERSION:
+        errors.append(f"schema_version must be {SKILL_DRAFT_SCHEMA_VERSION}")
+    if draft.get("record_type") != SKILL_DRAFT_RECORD_TYPE:
+        errors.append(f"record_type must be {SKILL_DRAFT_RECORD_TYPE}")
+    if draft.get("status") != SKILL_DRAFT_STATUS:
+        errors.append(f"status must be {SKILL_DRAFT_STATUS}")
+    if not str(draft.get("draft_id", "")).strip():
+        errors.append("draft_id must be a non-empty string")
+    if "name" in draft:
+        errors.append("skill draft must not carry a `name` key; the proposal name belongs in proposed_skill_name")
+    if not str(draft.get("summary", "")).strip():
+        errors.append("summary must be a non-empty string")
+    errors.extend(_proposed_name_errors(draft.get("proposed_skill_name")))
+    errors.extend(_instruction_set_errors(draft.get("instruction_set")))
+    errors.extend(_provenance_errors(draft.get("provenance")))
+    errors.extend(_lifecycle_errors(draft))
+    boundary = str(draft.get("claim_boundary", ""))
+    if SKILL_DRAFT_STATUS not in boundary:
+        errors.append(f"claim_boundary must preserve {SKILL_DRAFT_STATUS}")
+    if "skills/" not in boundary:
+        errors.append("claim_boundary must state that a draft is never written into skills/")
+    errors.extend(_forbidden_payload_key_errors(draft))
+    return errors
+
+
+def denied_payload_keys() -> list[str]:
+    """The workflow-learning redaction denylist, as recorded in draft provenance."""
+    return sorted(EXPORT_FORBIDDEN_PAYLOAD_KEYS)
+
+
+def skill_draft_is_active(draft: Mapping[str, Any]) -> bool:
+    return _object(draft.get("lifecycle")).get("state") == SKILL_DRAFT_ACTIVE_STATE
+
+
+def skill_draft_ref(draft_id: str) -> str:
+    return f"{SKILL_DRAFT_REF_PREFIX}:{_safe_id(draft_id)}"
+
+
+def skill_draft_path(paths: OmhPaths, draft_id: str) -> Path:
+    return paths.learning_skill_drafts_dir / f"{_safe_id(draft_id)}.json"
+
+
+def write_skill_draft(paths: OmhPaths, draft: Mapping[str, Any]) -> dict[str, Any]:
+    _raise_on_validation(draft)
+    path = skill_draft_path(paths, str(draft["draft_id"]))
+    _reject_installed_skill_location(paths, path)
+    record = dict(draft)
+    atomic_write_json(path, record, private=True)
+    return record
+
+
+def show_skill_draft(paths: OmhPaths, draft_id: str) -> dict[str, Any]:
+    record = read_json_object(skill_draft_path(paths, draft_id))
+    if not record:
+        raise FileNotFoundError(draft_id)
+    _raise_on_validation(record)
+    return record
+
+
+def list_skill_drafts(paths: OmhPaths, *, limit: int | None = None) -> list[dict[str, Any]]:
+    directory = paths.learning_skill_drafts_dir
+    if not directory.exists():
+        return []
+    summaries: list[dict[str, Any]] = []
+    for path in sorted(directory.glob("*.json")):
+        record = read_json_object(path)
+        if not record:
+            continue
+        _raise_on_validation(record)
+        summaries.append(skill_draft_summary(record))
+    if limit is None or limit < 0:
+        return summaries
+    return summaries[:limit]
+
+
+def skill_draft_summary(draft: Mapping[str, Any]) -> dict[str, Any]:
+    lifecycle = _object(draft.get("lifecycle"))
+    provenance = _object(draft.get("provenance"))
+    review = _object(provenance.get("review"))
+    return {
+        "draft_id": str(draft.get("draft_id", "")),
+        "skill_draft_ref": skill_draft_ref(str(draft.get("draft_id", ""))),
+        "proposed_skill_name": str(draft.get("proposed_skill_name", "")),
+        "summary": str(draft.get("summary", "")),
+        "state": str(lifecycle.get("state", "")),
+        "installed": lifecycle.get("installed") is True,
+        "review_decision": str(review.get("decision", "")),
+        "source_run_ids": [str(run.get("run_id", "")) for run in _objects(provenance.get("source_runs"))],
+        "created_at": str(draft.get("created_at", "")),
+    }
+
+
+def _reject_installed_skill_location(paths: OmhPaths, path: Path) -> None:
+    """Refuse to write a draft anywhere a skill installer would look.
+
+    Nothing routes a draft toward `skills/` today. This exists so a later change
+    to the storage path cannot quietly turn review material into something a tap
+    or install walk would pick up. Both sides are resolved before comparing so a
+    symlinked temp root or a drive-letter path does not defeat the check.
+    """
+    try:
+        relative = path.resolve().relative_to(paths.omh_home.resolve())
+    except ValueError as exc:
+        raise WorkflowLearningError("a skill draft must be written inside the local OMH home") from exc
+    if SKILL_DRAFT_INSTALL_ROOT_GUARD in {part.casefold() for part in relative.parts}:
+        raise WorkflowLearningError("a skill draft must never be written under a skills/ directory")
+
+
+def _proposed_name_errors(value: Any) -> list[str]:
+    name = str(value or "").strip()
+    if not _PROPOSED_NAME_PATTERN.fullmatch(name):
+        return ["proposed_skill_name must be a lowercase-hyphen slug of 3-49 characters"]
+    installed = {definition.name for definition in builtin_definitions()}
+    installed |= {omh_skill_display_name(definition.name) for definition in builtin_definitions()}
+    if name in installed or omh_skill_display_name(name) in installed:
+        return [f"proposed_skill_name collides with an installed skill name: {name}"]
+    return []
+
+
+def _instruction_set_errors(value: Any) -> list[str]:
+    if not isinstance(value, dict):
+        errors = ["instruction_set must be an object carrying every draft section"]
+        return errors + [f"instruction_set.{key} is missing" for key in SKILL_DRAFT_SECTION_KEYS]
+    errors: list[str] = []
+    extra = sorted(set(value) - set(SKILL_DRAFT_SECTION_KEYS))
+    if extra:
+        errors.append(f"instruction_set has unsupported keys: {extra}")
+    for key in SKILL_DRAFT_SECTION_KEYS:
+        if key == "declared_inputs":
+            errors.extend(_declared_input_errors(value.get(key)))
+            continue
+        errors.extend(_text_list_errors(value.get(key), f"instruction_set.{key}"))
+    return errors
+
+
+def _declared_input_errors(value: Any) -> list[str]:
+    # A draft that declares nothing variable has not separated the reusable part
+    # from the run-specific part, which is the whole reason the record exists.
+    if not isinstance(value, list) or not value:
+        return ["instruction_set.declared_inputs must name at least one variable input"]
+    errors: list[str] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            errors.append(f"instruction_set.declared_inputs[{index}] must be an object with name and description")
+            continue
+        extra = sorted(set(item) - {"name", "description"})
+        if extra:
+            errors.append(f"instruction_set.declared_inputs[{index}] has unsupported keys: {extra}")
+        for field in ("name", "description"):
+            if not isinstance(item.get(field), str) or not item[field].strip():
+                errors.append(f"instruction_set.declared_inputs[{index}].{field} must be a non-empty string")
+    return errors
+
+
+def _text_list_errors(value: Any, label: str) -> list[str]:
+    if not isinstance(value, list) or not value:
+        return [f"{label} must be a non-empty list"]
+    return [
+        f"{label}[{index}] must be a non-empty string"
+        for index, item in enumerate(value)
+        if not isinstance(item, str) or not item.strip()
+    ]
+
+
+def _provenance_errors(value: Any) -> list[str]:
+    if not isinstance(value, dict):
+        return ["provenance must record the source runs, the redactions applied, and the review decision"]
+    errors: list[str] = []
+    if value.get("selection") != SKILL_DRAFT_SELECTION:
+        errors.append(f"provenance.selection must be {SKILL_DRAFT_SELECTION}")
+    signal = value.get("learning_signal")
+    if not isinstance(signal, dict) or not str(signal.get("matched", "")).strip():
+        errors.append("provenance.learning_signal must record the explicit user request that started the draft")
+    runs = value.get("source_runs")
+    if not isinstance(runs, list) or not runs:
+        errors.append("provenance.source_runs must name at least one user-selected source run")
+    else:
+        for index, run in enumerate(runs):
+            if not isinstance(run, dict) or not str(run.get("run_id", "")).strip():
+                errors.append(f"provenance.source_runs[{index}] must carry a run_id")
+    errors.extend(_redaction_errors(value.get("redactions")))
+    errors.extend(_review_errors(value.get("review")))
+    return errors
+
+
+def _redaction_errors(value: Any) -> list[str]:
+    if not isinstance(value, dict):
+        return ["provenance.redactions must record what was removed from the selected runs"]
+    errors: list[str] = []
+    if value.get("redaction_policy") != "metadata_only":
+        errors.append("provenance.redactions.redaction_policy must be metadata_only")
+    if not isinstance(value.get("transient_identifier_categories"), list):
+        errors.append("provenance.redactions.transient_identifier_categories must be a list")
+    if value.get("denied_payload_keys") != denied_payload_keys():
+        errors.append("provenance.redactions.denied_payload_keys must match the workflow-learning redaction denylist")
+    for flag in ("raw_prompt_stored", "raw_transcript_stored"):
+        if value.get(flag) is not False:
+            errors.append(f"provenance.redactions.{flag} must be false")
+    return errors
+
+
+def _review_errors(value: Any) -> list[str]:
+    if not isinstance(value, dict):
+        return ["provenance.review must record the human review gate"]
+    errors: list[str] = []
+    for flag in ("required", "human_approval_required"):
+        if value.get(flag) is not True:
+            errors.append(f"provenance.review.{flag} must be true")
+    if value.get("decision") not in ("pending", *SKILL_DRAFT_REVIEW_DECISIONS):
+        errors.append("provenance.review.decision must be pending, approve, revise, or reject")
+    if list(value.get("allowed_decisions") or ()) != list(SKILL_DRAFT_REVIEW_DECISIONS):
+        errors.append("provenance.review.allowed_decisions must be approve, revise, reject")
+    return errors
+
+
+def _lifecycle_errors(draft: Mapping[str, Any]) -> list[str]:
+    value = draft.get("lifecycle")
+    if not isinstance(value, dict):
+        return ["lifecycle must record the draft state and its never-installed boundary"]
+    errors: list[str] = []
+    state = value.get("state")
+    if state not in SKILL_DRAFT_STATES:
+        errors.append(f"lifecycle.state must be one of {list(SKILL_DRAFT_STATES)}")
+    for flag in ("installed", "catalog_registered"):
+        if value.get(flag) is not False:
+            errors.append(f"lifecycle.{flag} must be false; a draft is never an installed skill")
+    if value.get("generated_skill_path") != "":
+        errors.append("lifecycle.generated_skill_path must stay empty; a draft never renders under skills/")
+    if value.get("storage_area") != SKILL_DRAFT_STORAGE_AREA:
+        errors.append(f"lifecycle.storage_area must be {SKILL_DRAFT_STORAGE_AREA}")
+    if list(value.get("activation_requires") or ()) != list(SKILL_DRAFT_ACTIVATION_REQUIREMENTS):
+        errors.append(f"lifecycle.activation_requires must be {list(SKILL_DRAFT_ACTIVATION_REQUIREMENTS)}")
+    errors.extend(_activation_errors(draft, state))
+    return errors
+
+
+def _activation_errors(draft: Mapping[str, Any], state: Any) -> list[str]:
+    activation = draft.get("activation")
+    proposal = draft.get("proposal")
+    if state != SKILL_DRAFT_ACTIVE_STATE:
+        errors = []
+        if activation is not None:
+            errors.append("an inactive skill draft must not carry an activation receipt")
+        if proposal is not None:
+            errors.append("an inactive skill draft must not carry a copy-ready proposal")
+        return errors
+    errors = []
+    if not isinstance(activation, dict) or activation.get("activated") is not True:
+        errors.append("an active skill draft must carry an activation receipt")
+    elif list(activation.get("requirements_met") or ()) != list(SKILL_DRAFT_ACTIVATION_REQUIREMENTS):
+        errors.append(f"activation.requirements_met must be {list(SKILL_DRAFT_ACTIVATION_REQUIREMENTS)}")
+    elif _object(activation.get("generated_output_check")).get("ok") is not True:
+        errors.append("activation.generated_output_check must record a passing check payload")
+    if not isinstance(proposal, dict) or proposal.get("schema_version") != SKILL_DRAFT_PROPOSAL_SCHEMA_VERSION:
+        errors.append(f"an active skill draft must carry a {SKILL_DRAFT_PROPOSAL_SCHEMA_VERSION} proposal")
+    if str(_object(_object(draft.get("provenance")).get("review")).get("decision", "")) != "approve":
+        errors.append("an active skill draft must record an approve review decision")
+    return errors
+
+
+def _forbidden_payload_key_errors(value: Any, path: str = "") -> list[str]:
+    """Reject any key the workflow-learning export denylist forbids, at any depth."""
+    errors: list[str] = []
+    if isinstance(value, dict):
+        for key, item in value.items():
+            location = f"{path}.{key}" if path else str(key)
+            if key in EXPORT_FORBIDDEN_PAYLOAD_KEYS:
+                errors.append(f"{location} is a denied raw-content key for metadata-only records")
+            errors.extend(_forbidden_payload_key_errors(item, location))
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            errors.extend(_forbidden_payload_key_errors(item, f"{path}[{index}]"))
+    return errors
+
+
+def _raise_on_validation(draft: Mapping[str, Any]) -> None:
+    errors = validate_skill_draft(draft)
+    if errors:
+        raise WorkflowLearningError("; ".join(errors))
+
+
+def _check(name: str, passed: bool, detail: str) -> dict[str, Any]:
+    return {"check": name, "status": "passed" if passed else "failed", "detail": detail}
+
+
+def _check_payload(checks: list[dict[str, Any]]) -> dict[str, Any]:
+    failed = [check for check in checks if check["status"] == "failed"]
+    return {
+        "schema_version": SKILL_DRAFT_CHECK_SCHEMA_VERSION,
+        "ok": not failed,
+        "checks": checks,
+        "errors": [f"{check['check']}: {check['detail']}" for check in failed],
+    }
+
+
+def _source_run_refs(values: Sequence[str]) -> list[dict[str, str]]:
+    runs: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for value in values:
+        run_id = str(value).strip()
+        if not run_id or run_id in seen:
+            continue
+        seen.add(run_id)
+        runs.append({"run_id": run_id, "run_ref": f"runtime:{run_id}"})
+    return runs
+
+
+def _declared_input_list(values: Sequence[Mapping[str, str]]) -> list[dict[str, str]]:
+    return [
+        {"name": str(item.get("name", "")).strip(), "description": str(item.get("description", "")).strip()}
+        for item in values
+        if isinstance(item, Mapping)
+    ]
+
+
+def _text_list(values: Sequence[str]) -> list[str]:
+    return [str(value).strip() for value in values if str(value).strip()]
+
+
+def _bullets(value: Any) -> list[str]:
+    return [f"- {item}" for item in _strings(value)]
+
+
+def _content_draft_id(name: str, runs: list[dict[str, str]], sections: dict[str, Any]) -> str:
+    seed = json.dumps({"name": name, "runs": runs, "sections": sections}, sort_keys=True)
+    return f"sd-{hashlib.sha256(seed.encode('utf-8')).hexdigest()[:20]}"
+
+
+def _safe_id(value: str) -> str:
+    return _SAFE_ID_PATTERN.sub("-", str(value)).strip("-")[:120] or "record"
+
+
+def _object(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _objects(value: Any) -> list[dict[str, Any]]:
+    return [item for item in value if isinstance(item, dict)] if isinstance(value, list) else []
+
+
+def _strings(value: Any) -> list[str]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    return [item.strip() for item in value if isinstance(item, str) and item.strip()]

--- a/tests/test_skill_draft.py
+++ b/tests/test_skill_draft.py
@@ -1,0 +1,536 @@
+from __future__ import annotations
+
+import copy
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+from omh.paths import resolve_paths
+from omh.skills.catalog import builtin_definitions, installable_skill_names, omh_skill_display_name
+from omh.workflow_learning import WorkflowLearningError
+from omh.workflows.skill_draft import (
+    SKILL_DRAFT_ACTIVE_STATE,
+    SKILL_DRAFT_CATALOG_INDEX_LINE_BYTE_LIMIT,
+    SKILL_DRAFT_CHECK_NAMES,
+    SKILL_DRAFT_INACTIVE_STATE,
+    build_skill_draft,
+    check_skill_draft_generated_output,
+    denied_payload_keys,
+    list_skill_drafts,
+    project_skill_draft_definition,
+    review_skill_draft,
+    show_skill_draft,
+    skill_draft_is_active,
+    skill_draft_path,
+    validate_skill_draft,
+    write_skill_draft,
+)
+
+
+EXPLICIT_TEACH_REQUEST = "turn this into a skill: our release smoke checklist, run after every tag"
+
+# Real work happening around the user, none of it a request to learn anything.
+PASSIVE_ACTIVITY = (
+    "we deployed the release and it worked",
+    "the smoke suite is green on main",
+    "I rebased onto origin/main and force-pushed",
+    "CI finished in four minutes",
+    "reviewing the diff now",
+    "배포 끝났고 스모크 테스트 통과했어요",
+)
+
+DRAFT_SECTIONS = {
+    "proposed_skill_name": "release-smoke-check",
+    "fixed_instructions": ["Read the release checklist.", "Run the smoke suite against the tag."],
+    "declared_inputs": [
+        {"name": "release_tag", "description": "The tag under test."},
+        {"name": "target_host", "description": "Host the smoke suite runs against."},
+    ],
+    "preconditions": ["A tagged release candidate exists."],
+    "stop_conditions": ["Stop when the smoke suite fails twice in a row."],
+    "verification_steps": ["PYTHONPATH=tests uv run python -m unittest discover -s tests"],
+}
+
+
+def build_draft(message: str = EXPLICIT_TEACH_REQUEST, **overrides: object) -> dict[str, object] | None:
+    kwargs: dict[str, object] = {"source_runs": ["run-alpha", "run-beta"], **DRAFT_SECTIONS}
+    kwargs.update(overrides)
+    return build_skill_draft(message, **kwargs)  # type: ignore[arg-type]
+
+
+class SkillDraftExplicitRequestTests(unittest.TestCase):
+    """AC1: passive activity is never recorded or converted without an explicit request."""
+
+    def test_passive_activity_produces_no_draft(self) -> None:
+        for message in PASSIVE_ACTIVITY:
+            with self.subTest(message=message):
+                self.assertIsNone(build_draft(message))
+
+    def test_explicit_request_produces_a_draft(self) -> None:
+        for message in (
+            EXPLICIT_TEACH_REQUEST,
+            "make a skill from this release smoke checklist",
+            "save this as a skill",
+            "방금 한 방식 스킬로 남겨",
+        ):
+            with self.subTest(message=message):
+                draft = build_draft(message)
+                self.assertIsNotNone(draft)
+                assert draft is not None
+                self.assertTrue(str(draft["provenance"]["learning_signal"]["matched"]).strip())  # type: ignore[index]
+
+    def test_cli_refuses_passive_activity_and_writes_nothing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+            status, stdout, stderr = run_cli(base + _new_command("we deployed the release and it worked"))
+
+            self.assertEqual(status, 1, stderr)
+            payload = json.loads(stdout)
+            self.assertEqual(payload["status"], "no_explicit_learning_signal")
+            self.assertFalse(payload["recorded"])
+            self.assertEqual(list_skill_drafts(resolve_paths(str(root / ".omh"), str(root / ".hermes"))), [])
+
+    def test_draft_records_the_signal_that_authorized_it(self) -> None:
+        draft = build_draft()
+        assert draft is not None
+
+        provenance = draft["provenance"]
+        self.assertEqual(provenance["selection"], "explicit_user_selection")  # type: ignore[index]
+        self.assertEqual(provenance["learning_signal"]["matched"], "turn this into a skill")  # type: ignore[index]
+
+        stripped = copy.deepcopy(draft)
+        stripped["provenance"]["learning_signal"] = {}  # type: ignore[index]
+        self.assertIn(
+            "provenance.learning_signal must record the explicit user request that started the draft",
+            validate_skill_draft(stripped),
+        )
+
+
+class SkillDraftContentTests(unittest.TestCase):
+    """AC2: the draft shows its source runs, redactions, variable inputs, and required verification."""
+
+    def test_draft_names_runs_redactions_inputs_and_verification(self) -> None:
+        draft = build_draft("turn this into a skill: smoke checklist we ran for PR #412 on branch release/1.2")
+        assert draft is not None
+        provenance = draft["provenance"]
+        sections = draft["instruction_set"]
+
+        self.assertEqual(
+            [run["run_id"] for run in provenance["source_runs"]],  # type: ignore[index]
+            ["run-alpha", "run-beta"],
+        )
+        redactions = provenance["redactions"]  # type: ignore[index]
+        self.assertIn("pull_request_number", redactions["transient_identifier_categories"])
+        self.assertIn("branch_ref", redactions["transient_identifier_categories"])
+        self.assertEqual(redactions["denied_payload_keys"], denied_payload_keys())
+        self.assertFalse(redactions["raw_prompt_stored"])
+        self.assertFalse(redactions["raw_transcript_stored"])
+        self.assertEqual(
+            [item["name"] for item in sections["declared_inputs"]],  # type: ignore[index]
+            ["release_tag", "target_host"],
+        )
+        self.assertEqual(
+            sections["verification_steps"],  # type: ignore[index]
+            ["PYTHONPATH=tests uv run python -m unittest discover -s tests"],
+        )
+        self.assertNotIn("412", json.dumps(draft))
+
+    def test_fixed_instructions_stay_separate_from_declared_inputs(self) -> None:
+        draft = build_draft()
+        assert draft is not None
+        sections = draft["instruction_set"]
+
+        self.assertEqual(sorted(sections), sorted(  # type: ignore[arg-type]
+            [
+                "declared_inputs",
+                "fixed_instructions",
+                "preconditions",
+                "stop_conditions",
+                "verification_steps",
+            ]
+        ))
+        self.assertTrue(all(isinstance(step, str) for step in sections["fixed_instructions"]))  # type: ignore[index]
+        self.assertTrue(all(set(item) == {"name", "description"} for item in sections["declared_inputs"]))  # type: ignore[index]
+
+    def test_payload_missing_any_required_element_fails_validation(self) -> None:
+        draft = build_draft()
+        assert draft is not None
+        cases = {
+            "source runs": (
+                lambda record: record["provenance"].__setitem__("source_runs", []),
+                "provenance.source_runs must name at least one user-selected source run",
+            ),
+            "redactions": (
+                lambda record: record["provenance"].pop("redactions"),
+                "provenance.redactions must record what was removed from the selected runs",
+            ),
+            "variable inputs": (
+                lambda record: record["instruction_set"].__setitem__("declared_inputs", []),
+                "instruction_set.declared_inputs must name at least one variable input",
+            ),
+            "required verification": (
+                lambda record: record["instruction_set"].__setitem__("verification_steps", []),
+                "instruction_set.verification_steps must be a non-empty list",
+            ),
+            "fixed instructions": (
+                lambda record: record["instruction_set"].__setitem__("fixed_instructions", []),
+                "instruction_set.fixed_instructions must be a non-empty list",
+            ),
+            "preconditions": (
+                lambda record: record["instruction_set"].__setitem__("preconditions", []),
+                "instruction_set.preconditions must be a non-empty list",
+            ),
+            "stop conditions": (
+                lambda record: record["instruction_set"].__setitem__("stop_conditions", []),
+                "instruction_set.stop_conditions must be a non-empty list",
+            ),
+        }
+        for label, (mutate, expected_error) in cases.items():
+            with self.subTest(missing=label):
+                record = copy.deepcopy(draft)
+                mutate(record)
+                self.assertIn(expected_error, validate_skill_draft(record))
+
+    def test_builder_refuses_to_emit_an_incomplete_draft(self) -> None:
+        with self.assertRaises(WorkflowLearningError):
+            build_draft(verification_steps=[])
+        with self.assertRaises(WorkflowLearningError):
+            build_draft(source_runs=[])
+
+    def test_draft_rejects_raw_content_keys_from_the_shared_denylist(self) -> None:
+        draft = build_draft()
+        assert draft is not None
+        record = copy.deepcopy(draft)
+        record["provenance"]["transcript"] = "everything the user typed"  # type: ignore[index]
+
+        self.assertIn(
+            "provenance.transcript is a denied raw-content key for metadata-only records",
+            validate_skill_draft(record),
+        )
+
+    def test_draft_is_deterministic_and_carries_no_wall_clock(self) -> None:
+        first = build_draft()
+        second = build_draft()
+
+        self.assertEqual(first, second)
+        assert first is not None
+        self.assertEqual(first["created_at"], "")
+        stamped = build_draft(created_at="2026-01-02T03:04:05Z")
+        assert stamped is not None
+        self.assertEqual(stamped["draft_id"], first["draft_id"])
+
+
+class SkillDraftActivationTests(unittest.TestCase):
+    """AC3: activation requires successful generated-output checks and explicit review."""
+
+    def test_generated_output_checks_run_every_named_check(self) -> None:
+        draft = build_draft()
+        assert draft is not None
+
+        checks = check_skill_draft_generated_output(draft)
+
+        self.assertTrue(checks["ok"], checks["errors"])
+        self.assertEqual([check["check"] for check in checks["checks"]], list(SKILL_DRAFT_CHECK_NAMES))
+
+    def test_draft_failing_generated_output_checks_cannot_activate(self) -> None:
+        # A summary this long renders a catalog-index line past the byte ceiling
+        # that surface enforces, so the draft would not render valid generated
+        # output. The draft is still reviewable; it just cannot be activated.
+        oversized = "turn this into a skill: " + ("release smoke verification across every supported host " * 8)
+        draft = build_draft(oversized)
+        assert draft is not None
+
+        checks = check_skill_draft_generated_output(draft)
+        self.assertFalse(checks["ok"])
+        self.assertIn("rendered_catalog_index_line", " ".join(checks["errors"]))
+        index_line = f"- `{omh_skill_display_name('release-smoke-check')}`: {project_skill_draft_definition(draft).description}"
+        self.assertGreaterEqual(len(index_line.encode("utf-8")), SKILL_DRAFT_CATALOG_INDEX_LINE_BYTE_LIMIT)
+
+        with self.assertRaisesRegex(WorkflowLearningError, "rendered_catalog_index_line"):
+            review_skill_draft(draft, decision="approve", reviewer_ref="maintainer", reviewed_at="2026-01-01T00:00:00Z")
+
+    def test_review_alone_without_passing_checks_cannot_activate(self) -> None:
+        draft = build_draft()
+        assert draft is not None
+        # A draft whose stored payload lost its verification steps would not
+        # render a valid skill; an explicit approval must not rescue it.
+        tampered = copy.deepcopy(draft)
+        tampered["instruction_set"]["verification_steps"] = []  # type: ignore[index]
+
+        self.assertFalse(check_skill_draft_generated_output(tampered)["ok"])
+        with self.assertRaises(WorkflowLearningError):
+            review_skill_draft(tampered, decision="approve", reviewer_ref="maintainer", reviewed_at="t")
+
+    def test_passing_checks_without_review_leave_the_draft_inactive(self) -> None:
+        draft = build_draft()
+        assert draft is not None
+
+        self.assertTrue(check_skill_draft_generated_output(draft)["ok"])
+        self.assertEqual(draft["lifecycle"]["state"], SKILL_DRAFT_INACTIVE_STATE)  # type: ignore[index]
+        self.assertFalse(skill_draft_is_active(draft))
+        self.assertNotIn("activation", draft)
+        self.assertNotIn("proposal", draft)
+
+    def test_passing_checks_plus_explicit_approval_activate_the_draft(self) -> None:
+        draft = build_draft()
+        assert draft is not None
+        note = "checked the verification step by hand"
+
+        activated = review_skill_draft(
+            draft,
+            decision="approve",
+            reviewer_ref="maintainer",
+            reviewed_at="2026-01-01T00:00:00Z",
+            review_note=note,
+        )
+
+        self.assertTrue(skill_draft_is_active(activated))
+        self.assertEqual(activated["lifecycle"]["state"], SKILL_DRAFT_ACTIVE_STATE)
+        self.assertTrue(activated["activation"]["generated_output_check"]["ok"])
+        self.assertEqual(
+            activated["activation"]["requirements_met"],
+            ["generated_output_checks_pass", "explicit_human_review_approval"],
+        )
+        self.assertEqual(activated["provenance"]["review"]["reviewer_ref"], "maintainer")
+        self.assertEqual(activated["provenance"]["review"]["decision"], "approve")
+        self.assertEqual(activated["provenance"]["review"]["review_note_length"], len(note))
+        self.assertNotIn(note, json.dumps(activated))
+        self.assertIn("release_tag: The tag under test.", activated["proposal"]["copy_text"])
+        self.assertIn("run-alpha", activated["proposal"]["copy_text"])
+
+    def test_revise_and_reject_never_activate(self) -> None:
+        draft = build_draft()
+        assert draft is not None
+        for decision in ("revise", "reject"):
+            with self.subTest(decision=decision):
+                reviewed = review_skill_draft(draft, decision=decision, reviewer_ref="maintainer", reviewed_at="t")
+
+                self.assertFalse(skill_draft_is_active(reviewed))
+                self.assertEqual(reviewed["lifecycle"]["state"], SKILL_DRAFT_INACTIVE_STATE)
+                self.assertNotIn("proposal", reviewed)
+
+    def test_a_later_reject_deactivates_an_activated_draft(self) -> None:
+        draft = build_draft()
+        assert draft is not None
+        activated = review_skill_draft(draft, decision="approve", reviewer_ref="maintainer", reviewed_at="t")
+
+        reverted = review_skill_draft(activated, decision="reject", reviewer_ref="maintainer", reviewed_at="t2")
+
+        self.assertFalse(skill_draft_is_active(reverted))
+        self.assertNotIn("activation", reverted)
+        self.assertNotIn("proposal", reverted)
+
+    def test_review_needs_an_explicit_reviewer_and_a_known_decision(self) -> None:
+        draft = build_draft()
+        assert draft is not None
+        with self.assertRaises(WorkflowLearningError):
+            review_skill_draft(draft, decision="approve", reviewer_ref="  ", reviewed_at="t")
+        with self.assertRaises(WorkflowLearningError):
+            review_skill_draft(draft, decision="install", reviewer_ref="maintainer", reviewed_at="t")
+
+    def test_an_activation_receipt_cannot_be_forged_onto_an_inactive_draft(self) -> None:
+        draft = build_draft()
+        assert draft is not None
+        forged = copy.deepcopy(draft)
+        forged["activation"] = {"activated": True, "requirements_met": [], "generated_output_check": {"ok": True}}
+
+        self.assertIn("an inactive skill draft must not carry an activation receipt", validate_skill_draft(forged))
+
+
+class SkillDraftInactiveByConstructionTests(unittest.TestCase):
+    """Guards: a draft is never written under skills/ and never reads as an installed capability."""
+
+    def test_draft_storage_never_lands_under_skills(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(str(root / ".omh"), str(root / ".hermes"))
+            draft = build_draft()
+            assert draft is not None
+
+            written = write_skill_draft(paths, draft)
+            path = skill_draft_path(paths, str(written["draft_id"]))
+
+            self.assertTrue(path.is_file())
+            self.assertNotIn("skills", [part.casefold() for part in path.parts])
+            self.assertEqual(path.parent.name, "skill-drafts")
+            self.assertEqual(path.parent.parent.name, "learning")
+            # Both separators are spelled out so the assertion means the same
+            # thing on POSIX and Windows.
+            self.assertNotIn("skills/", str(path))
+            self.assertNotIn("skills\\", str(path))
+            self.assertEqual(written["lifecycle"]["generated_skill_path"], "")
+            self.assertEqual(list(paths.omh_home.glob("**/skills")), [])
+            self.assertEqual(sorted(item.name for item in paths.learning_dir.iterdir()), ["skill-drafts"])
+
+    def test_write_refuses_a_path_inside_a_skills_directory(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(str(root / ".omh" / "skills"), str(root / ".hermes"))
+            draft = build_draft()
+            assert draft is not None
+
+            # The guard is relative to the OMH home, so a home that is itself
+            # named `skills` is allowed; a draft nested under a `skills`
+            # directory inside that home is not.
+            write_skill_draft(paths, draft)
+            hostile = resolve_paths(str(root / ".omh2"), str(root / ".hermes"))
+            with self.assertRaisesRegex(WorkflowLearningError, "never be written under a skills/ directory"):
+                from omh.workflows.skill_draft import _reject_installed_skill_location
+
+                _reject_installed_skill_location(hostile, hostile.omh_home / "skills" / "release-smoke-check.json")
+
+    def test_draft_never_reads_as_an_installed_capability(self) -> None:
+        draft = build_draft()
+        assert draft is not None
+        activated = review_skill_draft(draft, decision="approve", reviewer_ref="maintainer", reviewed_at="t")
+        catalog_names = {definition.name for definition in builtin_definitions()}
+
+        for record in (draft, activated):
+            with self.subTest(state=record["lifecycle"]["state"]):
+                self.assertNotIn("name", record)
+                self.assertEqual(record["record_type"], "skill_draft")
+                self.assertEqual(record["status"], "prepared_not_observed")
+                self.assertFalse(record["lifecycle"]["installed"])
+                self.assertFalse(record["lifecycle"]["catalog_registered"])
+                self.assertEqual(record["lifecycle"]["generated_skill_path"], "")
+                self.assertNotIn(record["proposed_skill_name"], catalog_names)
+                self.assertNotIn(record["proposed_skill_name"], installable_skill_names())
+                self.assertIn("skills/", record["claim_boundary"])
+                self.assertIn("prepared_not_observed", record["claim_boundary"])
+
+    def test_a_draft_cannot_claim_an_installed_skill_name(self) -> None:
+        with self.assertRaises(WorkflowLearningError):
+            build_draft(proposed_skill_name="memory-new")
+        with self.assertRaises(WorkflowLearningError):
+            build_draft(proposed_skill_name="omh-memory-new")
+
+    def test_a_draft_cannot_declare_itself_installed(self) -> None:
+        draft = build_draft()
+        assert draft is not None
+        for field, value in (("installed", True), ("catalog_registered", True)):
+            with self.subTest(field=field):
+                record = copy.deepcopy(draft)
+                record["lifecycle"][field] = value  # type: ignore[index]
+                self.assertIn(
+                    f"lifecycle.{field} must be false; a draft is never an installed skill",
+                    validate_skill_draft(record),
+                )
+        rendered = copy.deepcopy(draft)
+        rendered["lifecycle"]["generated_skill_path"] = "skills/omh-release-smoke-check/SKILL.md"  # type: ignore[index]
+        self.assertIn(
+            "lifecycle.generated_skill_path must stay empty; a draft never renders under skills/",
+            validate_skill_draft(rendered),
+        )
+
+    def test_building_a_draft_does_not_grow_the_catalog(self) -> None:
+        before = len(builtin_definitions())
+
+        draft = build_draft()
+        assert draft is not None
+        review_skill_draft(draft, decision="approve", reviewer_ref="maintainer", reviewed_at="t")
+
+        self.assertEqual(len(builtin_definitions()), before)
+        self.assertNotIn("release-smoke-check", {definition.name for definition in builtin_definitions()})
+
+
+class SkillDraftCliTests(unittest.TestCase):
+    def test_cli_drafts_reviews_and_activates_one_workflow(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            paths = resolve_paths(str(root / ".omh"), str(root / ".hermes"))
+
+            status, stdout, stderr = run_cli(base + _new_command(EXPLICIT_TEACH_REQUEST))
+            self.assertEqual(status, 0, stderr)
+            created = json.loads(stdout)
+            draft_id = created["draft"]["draft_id"]
+            self.assertEqual(created["status"], "drafted")
+            self.assertTrue(created["recorded"])
+            self.assertTrue(created["generated_output_check"]["ok"])
+            self.assertEqual(created["draft"]["lifecycle"]["state"], SKILL_DRAFT_INACTIVE_STATE)
+            self.assertEqual(created["skill_draft_ref"], f"omh-skill-draft:{draft_id}")
+
+            status, stdout, stderr = run_cli(base + ["learning", "skill-draft", "show", draft_id])
+            self.assertEqual(status, 0, stderr)
+            shown = json.loads(stdout)
+            self.assertFalse(shown["active"])
+            self.assertEqual(shown["activation_blockers"], [])
+
+            status, stdout, stderr = run_cli(base + ["learning", "skill-draft", "list"])
+            self.assertEqual(status, 0, stderr)
+            listed = json.loads(stdout)["drafts"]
+            self.assertEqual([item["draft_id"] for item in listed], [draft_id])
+            self.assertEqual(listed[0]["review_decision"], "pending")
+
+            status, stdout, stderr = run_cli(
+                base + ["learning", "skill-draft", "review", draft_id, "--decision", "approve", "--reviewer-ref", "maintainer"]
+            )
+            self.assertEqual(status, 0, stderr)
+            reviewed = json.loads(stdout)
+            self.assertTrue(reviewed["activated"])
+            self.assertEqual(reviewed["draft"]["lifecycle"]["state"], SKILL_DRAFT_ACTIVE_STATE)
+            self.assertFalse(reviewed["draft"]["lifecycle"]["installed"])
+
+            stored = show_skill_draft(paths, draft_id)
+            self.assertTrue(skill_draft_is_active(stored))
+            self.assertEqual(stored["provenance"]["review"]["reviewer_ref"], "maintainer")
+
+    def test_cli_dry_run_records_nothing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+            status, stdout, stderr = run_cli(base + _new_command(EXPLICIT_TEACH_REQUEST) + ["--dry-run"])
+
+            self.assertEqual(status, 0, stderr)
+            self.assertFalse(json.loads(stdout)["recorded"])
+            self.assertEqual(list_skill_drafts(resolve_paths(str(root / ".omh"), str(root / ".hermes"))), [])
+
+    def test_cli_rejects_a_malformed_declared_input(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            command = _new_command(EXPLICIT_TEACH_REQUEST)
+            command[command.index("--input") + 1] = "release_tag"
+
+            status, _, stderr = run_cli(base + command)
+
+            self.assertNotEqual(status, 0)
+            self.assertIn("--input must be given as name=description", stderr)
+
+
+def _new_command(message: str) -> list[str]:
+    command = [
+        "learning",
+        "skill-draft",
+        "new",
+        message,
+        "--name",
+        str(DRAFT_SECTIONS["proposed_skill_name"]),
+        "--source-run",
+        "run-alpha",
+        "--source-run",
+        "run-beta",
+    ]
+    for instruction in DRAFT_SECTIONS["fixed_instructions"]:  # type: ignore[union-attr]
+        command += ["--instruction", instruction]
+    for item in DRAFT_SECTIONS["declared_inputs"]:  # type: ignore[union-attr]
+        command += ["--input", f"{item['name']}={item['description']}"]
+    for precondition in DRAFT_SECTIONS["preconditions"]:  # type: ignore[union-attr]
+        command += ["--precondition", precondition]
+    for stop_condition in DRAFT_SECTIONS["stop_conditions"]:  # type: ignore[union-attr]
+        command += ["--stop-condition", stop_condition]
+    for verification in DRAFT_SECTIONS["verification_steps"]:  # type: ignore[union-attr]
+        command += ["--verification", verification]
+    return command
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New workflow lane `omh learning skill-draft` (`new`, `list`, `show`, `review`) that turns an explicitly identified proven workflow into `skill_draft/v1`: an inactive, reviewable OMH skill proposal.
- New contract `skill_draft/v1` separating fixed instructions from declared inputs, preconditions, stop conditions, and required verification steps, with provenance naming the user-selected source runs, the redactions applied, and the review decision.
- New contract `skill_draft_generated_output_check/v1`: five deterministic checks answering whether the draft would render valid generated skill output.
- New contract `skill_draft_proposal/v1`: the copy-ready proposal, minted only by activation.
- New public catalog validator `validate_skill_definition_contract()` so a definition that is deliberately *not* in the catalog can be checked against the same per-definition contract `validate_catalog_contract()` applies.
- New local store `.omh/learning/skill-drafts/` (`OmhPaths.learning_skill_drafts_dir`).
- `docs/HARNESS_QUALITY.md` gains a "Teaching A Proven Workflow (agent-facing)" section.

### Why This Exists

Issue #838: users repeat successful project workflows, but keeping one currently means hand-authoring and validating a skill.

What OMH had was `learning_candidate_card/v1` with a `hermes_learn_prompt/v1` — a copy-ready `/learn` prompt handed to Hermes Agent, whose `claim_boundary` says outright that "Hermes Agent /learn owns any skill creation evidence." OMH held nothing reviewable of its own: `grep -rn "skill_draft\|skill_proposal\|draft_skill" src/ tests/` returned zero hits before this change. Two things were missing:

- a record separating the instructions that stay fixed from the inputs that vary, plus preconditions, stop conditions, and verification;
- storage of an inactive candidate skill with provenance, pending validation.

### User / Operator Impact

A user who says "turn this into a skill" after a workflow works now gets a structured proposal a human can read and reject, instead of a prompt handed straight to another runtime. A reviewer can see which runs it came from, what was redacted, what varies per run, and what verification must pass — and nothing becomes usable guidance until they approve it and the generated-output checks pass.

Nothing is captured without that explicit request. Passive activity ("we deployed the release and it worked", "CI finished in four minutes") produces no draft and writes no file; the CLI exits non-zero with `no_explicit_learning_signal`.

### How It Works

**AC1 — passive activity is never recorded or converted.** `build_skill_draft()` starts with the existing `detect_learning_signal()` from `src/workflows/learning_candidate.py` and returns `None` when there is no explicit signal. That is the module's only entry point, so no passive-capture path exists to close. The matched phrase is stored in `provenance.learning_signal`, and a draft that loses it fails validation.

**AC2 — the draft shows its sources, redactions, inputs, and verification.** `instruction_set` carries exactly five sections (`fixed_instructions`, `declared_inputs`, `preconditions`, `stop_conditions`, `verification_steps`), each required non-empty. `provenance.source_runs` must name at least one user-selected run. `provenance.redactions` records the transient-identifier categories `sanitize_learning_text()` stripped (PR numbers, commit SHAs, run ids, branch refs, channel/thread state) and the denylist itself — imported from `workflow_learning.EXPORT_FORBIDDEN_PAYLOAD_KEYS`, not copied. A recursive scan rejects any denied raw-content key at any depth in the payload.

**AC3 — activation requires generated-output checks plus explicit review.** `review_skill_draft(..., decision="approve")` recomputes `check_skill_draft_generated_output()` rather than trusting anything passed in, and raises when any check fails. The five checks are: the draft validates; `validate_catalog_contract()` is clean; the draft projects to a `SkillDefinition` that `validate_skill_definition_contract()` accepts; that definition renders a single-line `[omh] `-prefixed frontmatter description; and the catalog-index line it would produce stays under the 400-byte per-line ceiling that surface enforces (`tests/test_router_content.py`). `revise` and `reject` record the decision and leave the draft inactive.

**Inactive is structural, not a flag.** Five independent mechanisms, each with a test:

1. Storage is `.omh/learning/skill-drafts/`. `write_skill_draft()` resolves both the target path and the OMH home and refuses any path with a `skills` part.
2. A draft is never catalog data — `builtin_definitions()` does not grow, and no `skills/*/SKILL.md` is written.
3. The proposal name lives under `proposed_skill_name`, never `name`; a top-level `name` key fails validation, so a consumer reading `definition["name"]` cannot pick a draft up.
4. A name colliding with an installed canonical or display name fails validation.
5. An inactive draft carries no copy-ready proposal at all — `skill_draft_proposal/v1` is minted by activation, so there is nothing to act on before review.

The `claim_boundary` states the `skills/` boundary in text and validation enforces that it says so.

**Determinism.** `draft_id` is a content hash of the name, runs, and sections — no wall clock. `created_at` is a caller-supplied parameter (`""` by default); the CLI passes `utc_now()`. Two builds with the same inputs are byte-identical.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/workflows/skill_draft.py` | New. Builder, validator, generated-output checks, review/activation, proposal renderer, local store. |
| `src/commands/learning.py` | New `skill-draft` subgroup and four command handlers. |
| `src/skills/validation.py` | New public `validate_skill_definition_contract()`; exposes the existing per-definition loop body rather than copying it. |
| `src/system/paths.py` | New `learning_skill_drafts_dir` property. |
| `docs/HARNESS_QUALITY.md` | New agent-facing section for the flow. |
| `tests/test_skill_draft.py` | New. 28 tests across AC1, AC2, AC3, the inactive-by-construction guards, and the CLI. |

No generated artifact changed: no catalog edit, no new installable skill, no routing case, no demo card, so no exact-count fixture moved.

## Validation

All commands run in the worktree after rebasing onto `origin/main` at `e35460ac`.

- [x] `uv run --group lint ruff check src tests` — `All checks passed!`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` — `Ran 4738 tests in 169.935s` / `OK`
- [x] `uv run python -m compileall -q src tests` — exit 0
- [x] `uv run python -m omh.cli docs workflows --check` — `{"ok":true,...,"tap_skills":{"checked":115,"expected":115,...,"ok":true,"stale":[]}}`
- [x] `uv run python -m omh.cli harness validate` — `{"counts":{"harnesses":72,"skills":104},"errors":[],"ok":true,...}`
- [x] `uv run python -m omh.cli release checklist --json` — `{"ok": true, "schema_version": "release_readiness_checklist/v1"}`
- [x] `uv run python -m omh.cli release hermes-smoke` — `Status: ok` (mode: plan; observed evidence: no)
- [x] `omh --help` — exit 0
- [x] `omh --omh-home /tmp/omh-smoke-838 --hermes-home /tmp/hermes-smoke-838 release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — `Status: ok`, install path `setup`
- [x] Also run, not in the template: `docs roles --check` (`ok:true`), `docs capability-families --check` (`ok:true`), `git diff --check` (exit 0)
- [x] Workflow-learning review queue smoke, against a home holding one skill draft: `omh learning review` → `status: empty`, `omh learning index check` → `ok: true`, `status: no_records`, `omh learning audit` → exit 0, `blocking_issues: []`. The drafts directory is deliberately outside `_scan_learning_records()`, so it cannot make the learning index look stale.
- [x] End-to-end CLI walkthrough: draft → `show` (`activation_blockers: []`) → `list` (`review_decision: pending`) → `review --decision approve` (`activated: true`, `state: active_proposal`, `installed: false`), with the passive-message case exiting 1 and writing nothing.
- [ ] Manual Hermes/TUI check — not run. Nothing in this change reaches a Hermes chat card, wrapper action, or generated skill surface, so there is no TUI path to exercise; see Follow-Up.

## Risk

- Low blast radius on existing behavior: the only edits to shipped code paths are one added `OmhPaths` property, one new public function in `src/skills/validation.py` that wraps an existing private loop body without changing it, and a new subparser under `omh learning`. No existing payload, schema, routing table, or generated artifact changed.
- The draft store sits under `.omh/learning/` but outside `_scan_learning_records()`. That is deliberate — drafts are not part of the learning index repair loop — and verified above, but a future author adding drafts to the index must also add a validator entry or `omh learning index check` will report them invalid.
- `validate_skill_definition_contract()` widens the catalog validator's public surface. It is a read-only projection with no caller inside the catalog itself.
- The `rendered_catalog_index_line` check hard-codes the 400-byte ceiling that lives today as an assertion in `tests/test_router_content.py`. If that ceiling is ever raised, `SKILL_DRAFT_CATALOG_INDEX_LINE_BYTE_LIMIT` must move with it; the constant carries a comment saying so.

## Compatibility / Rollout

- Purely additive. No migration: existing `.omh` homes gain the `skill-drafts` directory only when a draft is first written.
- Metadata-only and local. No network, LLM, or Hermes-core interaction; no raw prompt or transcript is stored, and review notes are kept as hash and length only.
- Release-channel impact: `stable`. No behavior changes for anyone who does not invoke the new subcommand.

## Release / Claims

- [x] Release-channel impact considered (`stable`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed. Every draft and proposal is `prepared_not_observed` and its `not_observed` list names "skill installed", "skill rendered under skills/", "catalog registration", "Hermes Agent /learn execution", "workflow execution", and "future behavior change".
- [x] Known manual Hermes checks listed: no live `omh release hermes-smoke --live` run, and no Hermes Agent or TUI run.

## Follow-Up

- **No chat surface reaches this flow yet.** A user still needs Hermes (or an operator) to call `omh learning skill-draft`. This matches the existing improvement-candidate lifecycle (`omh learning candidate` / `review-candidate` / `proposal`), which is also CLI-only and documented in `docs/HARNESS_QUALITY.md` — but `docs/DIRECTION.md` rule 1 wants users command-agnostic in chat. Surfacing the draft path from `learning_candidate_card/v1`'s `skill_candidate` branch, or from the `workflow-learning` catalog entry, is the natural next step; it was left out here because it touches wrapper-action, ack-coverage, and generated-artifact gates that the three acceptance criteria do not require.
- The draft's `source_runs` are opaque user-selected refs. Resolving them against local runtime run artifacts would make "observed runs" provable rather than asserted.
- Activation currently ends at a copy-ready proposal. Promoting an approved draft into a catalog `SkillDefinition` remains explicitly out of scope per the issue ("Automatically publishing or installing a generated skill").
