### PR TITLE
feat: tell users whether a requested external action is ready, blocked, or stale

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -923,6 +923,61 @@ status means a handoff was prepared; the companion run envelope is also marked
 Executor-choice, runtime-handoff, clarify, fallback, and prompt-only handoffs
 return `runtime.recorded=false` and should stay in wrapper/session state.
 
+### External Action Readiness
+
+`workflows/external_action_readiness.py` answers the one question a person
+actually asks before an external action: can Hermes do this now? It stores
+nothing. It reads records the surfaces above already wrote and derives one
+`external_action_readiness/v1` answer, scoped to a **requested outcome** rather
+than to a connector, because two outcomes over one connector routinely differ —
+the surface can be reachable while one of the two effects has never succeeded
+through it.
+
+Two axes, kept apart because welding them is the confusion the answer removes:
+
+- **Evidence tier** — the strongest class of fact anyone recorded.
+  `installed` is a local configuration fact; `host_observed` means a host
+  reported loading the surface; `usable_observed` means a host reported using
+  it; `used` means an external effect receipt records this outcome succeeding;
+  `stale` means one of those was true and is now past its horizon.
+- **State** — the answer: `ready`, `blocked`, `not_observed`, `stale`,
+  `failed`, each carrying the smallest next action.
+
+Configuration can never reach `ready`, and the guard is mechanical rather than
+advisory. `SOURCE_TIERS` declares which tiers each source may claim, the
+`local_configuration` source may claim only `installed`, and `installed` sits
+below the tier level a positive answer requires. The finished answer is
+re-checked on the way out, so a `ready` carrying a tier that cannot support one
+fails validation.
+
+Scoping follows the same split: evidence naming an outcome answers for that
+outcome and no other, so a receipt for a different effect cannot satisfy this
+one; evidence naming only a surface answers for every outcome over that surface.
+
+Freshness is derived at read time from `EXTERNAL_ACTION_STALE_AFTER_SECONDS`
+(six hours, the horizon `pre_handoff_readiness` and `action_gate` already use
+for the same kind of question). No expiry is written into a record, `now` is a
+parameter so the derivation is deterministic, and an unreadable or future stamp
+reads as older than the horizon rather than being clamped.
+
+Invalid evidence is rejected before the derivation, never after it, so bad input
+structurally cannot raise an answer. When records were supplied and none
+survived validation and scoping, the last valid answer is preserved rather than
+overwritten and the answer says so through `state_source: preserved_prior` plus
+a bounded `rejected_evidence` list naming the gap.
+
+`omh runtime action-readiness --outcome <id> --surface <host>` is the read-only
+view. It adapts plugin host observations, MCP host sessions, and external effect
+receipts; `omh_mcp_observation/v1` and `omh_evidence_probe/v1` are deliberately
+not adapted, because neither names a host or an effect and neither can therefore
+be scoped to a requested outcome. There is no flag that asserts readiness —
+every tier above `installed` exists because some other surface observed
+something — and no answer store, so a corrupt line appended to an evidence store
+today cannot erase what the valid records already say. The command is registered
+in `coding_progress_policy_enforcement()["bounded_surfaces"]`: its output is one
+verdict, at most eight rejected rows, and at most eight store faults, however
+large the stores grow.
+
 ### Approval Receipts
 
 `runtime/journal/approval_receipts.jsonl` is an append-only store of

--- a/src/coding/context_safety.py
+++ b/src/coding/context_safety.py
@@ -336,9 +336,15 @@ def coding_progress_policy_enforcement() -> dict[str, object]:
         # agent asks "is this run stuck yet" repeatedly -- and caps its own
         # output at `run_health.MAX_RUN_HEALTH_EVENTS` observations plus a fixed
         # metric set, so a longer run does not buy a longer answer.
+        #
+        # `omh runtime action-readiness` is that temptation aimed outward --
+        # "can you send it yet" -- and answers in a fixed shape: one verdict, a
+        # capped list of rejected records, and a capped list of store faults, no
+        # matter how large the evidence stores have grown.
         "bounded_surfaces": [
             "omh runtime show",
             "omh runtime health-summary",
+            "omh runtime action-readiness",
             "omh coding fanout show",
             "omh coding fanout brief",
             "omh coding status-board",

--- a/src/commands/runtime.py
+++ b/src/commands/runtime.py
@@ -23,6 +23,15 @@ from ..external_effect_receipts import (
     read_external_effect_receipts,
     validate_external_effect_receipt_store,
 )
+from ..workflows.external_action_readiness import (
+    ExternalActionReadinessError,
+    answer_external_action_readiness,
+    evidence_from_external_effect_receipt,
+    evidence_from_mcp_host_session,
+    evidence_from_plugin_host_observation,
+)
+from ..mcp.bridge import read_mcp_host_sessions
+from ..plugin_observations import read_plugin_host_observations
 from ..workflows.approval_receipts import (
     APPROVAL_TTL_SECONDS,
     CLAIM_BOUNDARY as APPROVAL_CLAIM_BOUNDARY,
@@ -938,6 +947,131 @@ def _render_receipts_text(payload: dict) -> str:
     return "\n".join(line for line in lines if line)
 
 
+ACTION_READINESS_VIEW_SCHEMA_VERSION = "runtime_action_readiness_view/v1"
+DEFAULT_ACTION_READINESS_SCAN_LIMIT = 20
+# The output of this surface is a fixed shape -- one answer, at most eight
+# rejected rows, at most this many store faults -- no matter how large the
+# evidence stores grow. That is why it is registered as a bounded surface: an
+# agent asking "can you do it yet" every thirty seconds buys the same size
+# answer every time.
+MAX_ACTION_READINESS_STORE_ERRORS = 8
+
+_ACTION_READINESS_HEADLINES = {
+    "ready": "Yes — ready now",
+    "blocked": "No — blocked",
+    "not_observed": "Unknown — nothing has been observed",
+    "stale": "Unknown — the last observation is stale",
+    "failed": "No — the last attempt failed",
+}
+
+
+def cmd_runtime_action_readiness(args: argparse.Namespace) -> int:
+    """Answer "can Hermes do this now?" for one requested outcome (#809).
+
+    Read-only, and deliberately without a way to assert readiness: every tier
+    above `installed` comes from a record some other surface wrote after it
+    observed something. A flag that said "this is ready" would put back exactly
+    the confusion between configuration and capability this surface removes.
+
+    There is no answer store and no `--prior`. The durable state is the evidence
+    stores themselves, and they are re-read in full on every call, so a corrupt
+    line appended today cannot erase what valid records already say: the
+    last-valid-state preservation the contract requires is structural here
+    rather than remembered. Unreadable lines are reported as store faults in the
+    same breath.
+    """
+    paths = _paths(args)
+    limit = _bounded_limit(args)
+    outcome_id = str(getattr(args, "outcome_id", "") or "")
+    surface = str(getattr(args, "surface", "") or "")
+    action = str(getattr(args, "action", "") or "").strip() or outcome_id
+
+    plugin_records, plugin_errors = read_plugin_host_observations(paths, limit=limit)
+    mcp_records, mcp_errors = read_mcp_host_sessions(paths, limit=limit)
+    receipts = read_external_effect_receipts(paths, effect_id=outcome_id, limit=limit)
+
+    # Host records are surface-scoped, so they are filtered by host here;
+    # receipts are outcome-scoped and were already selected by effect id.
+    from_plugin = _adapted_evidence(
+        [record for record in plugin_records if str(record.get("host", "")) == surface],
+        evidence_from_plugin_host_observation,
+    )
+    from_mcp = _adapted_evidence(
+        [record for record in mcp_records if str(record.get("host", "")) == surface],
+        evidence_from_mcp_host_session,
+    )
+    from_receipts = _adapted_evidence(receipts, evidence_from_external_effect_receipt)
+    evidence = [*from_plugin, *from_mcp, *from_receipts]
+    counts = {
+        "plugin_host_observation": len(from_plugin),
+        "mcp_host_session": len(from_mcp),
+        "external_effect_receipt": len(from_receipts),
+    }
+
+    try:
+        answer = answer_external_action_readiness(
+            outcome_id=outcome_id,
+            action=action,
+            surface=surface,
+            evidence=evidence,
+        )
+    except ExternalActionReadinessError as exc:
+        raise OmhError(str(exc)) from exc
+
+    store_errors = [str(error) for error in (*plugin_errors, *mcp_errors)]
+    payload: dict[str, object] = {
+        "schema_version": ACTION_READINESS_VIEW_SCHEMA_VERSION,
+        "answer": answer,
+        "evidence_sources": counts,
+        "scanned_limit": limit or 0,
+        "store_errors": store_errors[:MAX_ACTION_READINESS_STORE_ERRORS],
+        "store_error_count": len(store_errors),
+    }
+    if _wants_json(args):
+        _print_json(payload)
+    else:
+        print(_render_action_readiness_text(payload))
+    return 0
+
+
+def _adapted_evidence(records: list, adapt) -> list[dict]:
+    """Every record this adapter could read as evidence, dropping the rest.
+
+    A record the adapter returns nothing for is not weaker evidence: it is a
+    state that says nothing about whether the outcome can happen now, such as an
+    effect a surface observed start and could not classify.
+    """
+    adapted = [adapt(record) for record in records]
+    return [item for item in adapted if item is not None]
+
+
+def _render_action_readiness_text(payload: dict) -> str:
+    answer = payload.get("answer")
+    answer = answer if isinstance(answer, dict) else {}
+    state = str(answer.get("state", ""))
+    counts = payload.get("evidence_sources")
+    counts = counts if isinstance(counts, dict) else {}
+    lines = [
+        f"Can Hermes do this now? {_ACTION_READINESS_HEADLINES.get(state, 'Unknown')}",
+        f"  Outcome: {answer.get('outcome_id', '')} — {answer.get('action', '')}",
+        f"  Surface: {answer.get('surface', '')}",
+        f"  State: {state} (strongest evidence: {answer.get('evidence_tier', '')})",
+        f"  Why: {answer.get('reason', '')}",
+        f"  Next: {answer.get('next_step', '')}",
+        f"  Evidence: {answer.get('accepted_count', 0)} in scope, "
+        f"{answer.get('rejected_count', 0)} rejected ({answer.get('evidence_integrity', '')})",
+        "  Read from: " + ", ".join(f"{name} {counts.get(name, 0)}" for name in sorted(counts)),
+    ]
+    for row in answer.get("rejected_evidence", []) or []:
+        if isinstance(row, dict):
+            lines.append(f"    rejected record {row.get('index', '')}: {row.get('reason', '')}")
+    if payload.get("store_error_count"):
+        lines.append(f"  Store faults: {payload.get('store_error_count', 0)}")
+        lines.extend(f"    {error}" for error in payload.get("store_errors", []) or [])
+    lines.append(str(answer.get("claim_boundary", "")))
+    return "\n".join(line for line in lines if line)
+
+
 def cmd_runtime_approvals(args: argparse.Namespace) -> int:
     """Read recorded approval receipts. There is deliberately no grant command.
 
@@ -1233,6 +1367,38 @@ def _add_runtime_commands(sub) -> None:
     runtime_receipts.add_argument("--all", action="store_true", help="Return all receipts.")
     runtime_receipts.add_argument("--json", action="store_true", help="Emit the machine payload instead of plain text.")
     runtime_receipts.set_defaults(func=cmd_runtime_receipts)
+
+    runtime_action_readiness = runtime_sub.add_parser(
+        "action-readiness",
+        help=(
+            "Answer whether one requested external outcome can be done now, from recorded evidence only. "
+            "Read-only: readiness above the installed tier cannot be asserted, only observed."
+        ),
+    )
+    runtime_action_readiness.add_argument(
+        "--outcome",
+        dest="outcome_id",
+        required=True,
+        help="The requested outcome this answer is about. Matches an external effect id when one exists.",
+    )
+    runtime_action_readiness.add_argument(
+        "--surface",
+        required=True,
+        help="The host or connector the outcome runs over, as recorded by host observations.",
+    )
+    runtime_action_readiness.add_argument(
+        "--action",
+        default="",
+        help="One bounded line naming what the user asked for. Defaults to the outcome id.",
+    )
+    runtime_action_readiness.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_ACTION_READINESS_SCAN_LIMIT,
+        help="Maximum recent records to scan per evidence store.",
+    )
+    runtime_action_readiness.add_argument("--json", action="store_true", help="Emit the machine payload instead of plain text.")
+    runtime_action_readiness.set_defaults(func=cmd_runtime_action_readiness)
 
     runtime_approvals = runtime_sub.add_parser(
         "approvals",

--- a/src/workflows/external_action_readiness.py
+++ b/src/workflows/external_action_readiness.py
@@ -1,0 +1,752 @@
+"""One truthful answer to "can you do this now?" for one requested outcome.
+
+The defect this closes (#809): OMH could say a connector was installed, that a
+host had loaded it, that a probe had reached it, and that an effect had been
+recorded through it, but nothing turned those four separate facts into a single
+answer to the only question a person asks. Configuration read like capability,
+a load read like reachability, and a success from last week read like a success
+now.
+
+Two axes, kept apart on purpose, because welding them is the confusion:
+
+* **Evidence tier** -- what class of fact is the strongest thing anyone
+  recorded. ``installed`` is a local configuration fact. ``host_observed``
+  means a host reported loading the surface. ``usable_observed`` means a host
+  reported actually using it. ``used`` means an external-effect receipt records
+  a use of *this* outcome. ``stale`` means one of those was true and is now past
+  its freshness horizon.
+* **State** -- the answer itself: ``ready``, ``blocked``, ``not_observed``,
+  ``stale``, ``failed``, with the smallest next action attached to every state
+  that is not ``ready``.
+
+Configuration can never reach ``ready`` and the guard is mechanical, not
+advisory: :data:`SOURCE_TIERS` says which tiers a source is allowed to claim,
+``local_configuration`` may claim only ``installed``, and ``installed`` sits
+below the tier level a positive answer requires.
+
+Scoping is by requested OUTCOME, not by connector. Two outcomes over the same
+connector routinely have different answers -- the surface may be reachable
+while one of the two effects has never succeeded through it -- so surface-level
+evidence applies to every outcome that names the surface, and outcome-level
+evidence applies only to the outcome it names.
+
+Freshness is derived at READ time from :data:`EXTERNAL_ACTION_STALE_AFTER_SECONDS`,
+the way ``coding.action_gate._account_state`` and ``coding.pre_handoff_readiness``
+derive theirs. No expiry deadline is written into a record, so shortening the
+horizon takes effect on evidence already recorded. ``now`` is a parameter so the
+derivation is deterministic under test, and no wall clock is ever placed inside
+a compared payload.
+
+Everything here is pure. OMH probes nothing, calls nothing, and reaches no
+network: it reads what other surfaces recorded. The store adapters below convert
+records those surfaces already write; ``omh_mcp_observation/v1`` and
+``omh_evidence_probe/v1`` are deliberately NOT adapted, because neither names a
+host or an effect and therefore neither can be scoped to a requested outcome.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from typing import Any, Final
+
+from ..system.append_only_store import (
+    RAW_OR_HIDDEN_KEYS,
+    is_unsafe_metadata_line,
+    opaque_ref,
+    reference_errors,
+)
+
+
+EXTERNAL_ACTION_READINESS_SCHEMA_VERSION: Final = "external_action_readiness/v1"
+EXTERNAL_ACTION_EVIDENCE_SCHEMA_VERSION: Final = "external_action_evidence/v1"
+
+# Six hours, the horizon `coding.pre_handoff_readiness.READINESS_STALE_AFTER_SECONDS`
+# and `coding.action_gate.ACCOUNT_SIGNAL_STALE_AFTER_SECONDS` already give a
+# question of this shape -- "is the environment still the one that was
+# observed". A second, different number would only make two surfaces disagree
+# about the same machine.
+EXTERNAL_ACTION_STALE_AFTER_SECONDS: Final = 6 * 60 * 60
+
+# The four tiers a record can assert, weakest to strongest.
+EVIDENCE_TIERS: Final = ("installed", "host_observed", "usable_observed", "used")
+# The derived fifth. It is never recorded; it is what the strongest tier reads
+# as once nothing that was recorded is still fresh.
+EVIDENCE_TIER_STALE: Final = "stale"
+# The absence of any evidence. Not one of AC2's five: it is what there is when
+# nobody recorded anything at all.
+EVIDENCE_TIER_NONE: Final = "none"
+# The five an answer must tell apart (AC2), plus the empty case.
+DISTINGUISHED_EVIDENCE_TIERS: Final = (*EVIDENCE_TIERS, EVIDENCE_TIER_STALE)
+REPORTED_EVIDENCE_TIERS: Final = (EVIDENCE_TIER_NONE, *DISTINGUISHED_EVIDENCE_TIERS)
+
+_TIER_LEVELS: Final = {tier: level for level, tier in enumerate(EVIDENCE_TIERS, start=1)}
+# The lowest tier that can answer "yes, now". Below it a record describes setup
+# or presence, not the surface doing the thing.
+_READY_TIER_LEVEL: Final = _TIER_LEVELS["usable_observed"]
+
+# What one record asserts about its tier.
+#   observed -- the tier's fact holds.
+#   blocked  -- the recording surface reported something in the way.
+#   failed   -- an attempt at the outcome was observed not to happen.
+EVIDENCE_RESULTS: Final = ("observed", "blocked", "failed")
+_NEGATIVE_RESULTS: Final = ("failed", "blocked")
+
+# Where a record came from. Closed, because the tier a source may claim is the
+# mechanism behind AC1 and a free-text source would route around it.
+EVIDENCE_SOURCES: Final = (
+    "local_configuration",
+    "plugin_host_observation",
+    "mcp_host_session",
+    "external_effect_receipt",
+)
+
+# Which tiers each source is allowed to claim. `local_configuration` may claim
+# only `installed`, which is what makes "configuration alone never produces
+# ready now" a property of the schema rather than a rule someone remembers.
+SOURCE_TIERS: Final = {
+    "local_configuration": ("installed",),
+    "plugin_host_observation": ("installed", "host_observed", "usable_observed"),
+    "mcp_host_session": ("installed", "host_observed", "usable_observed"),
+    "external_effect_receipt": ("used",),
+}
+
+EXTERNAL_ACTION_READINESS_STATES: Final = ("ready", "blocked", "not_observed", "stale", "failed")
+
+# Where the reported state came from. `preserved_prior` is AC3: new evidence
+# arrived unreadable and the last valid answer was kept rather than overwritten.
+STATE_SOURCES: Final = ("derived", "preserved_prior", "no_valid_evidence")
+# How much of the supplied evidence survived validation.
+EVIDENCE_INTEGRITIES: Final = ("clean", "partial", "unusable")
+
+EXTERNAL_ACTION_EVIDENCE_KEYS: Final = (
+    "schema_version",
+    "tier",
+    "source",
+    "result",
+    "surface",
+    "outcome_id",
+    "observed_at",
+    "evidence_ref",
+)
+
+EXTERNAL_ACTION_READINESS_KEYS: Final = (
+    "schema_version",
+    "outcome_id",
+    "action",
+    "surface",
+    "state",
+    "evidence_tier",
+    "state_source",
+    "evidence_integrity",
+    "reason",
+    "next_action",
+    "next_step",
+    "accepted_count",
+    "rejected_count",
+    "rejected_evidence",
+    "age_seconds",
+    "stale_after_seconds",
+    "claim_boundary",
+)
+_REJECTED_EVIDENCE_KEYS: Final = ("index", "reason")
+
+EXTERNAL_ACTION_READINESS_CLAIM_BOUNDARY: Final = (
+    "This answer reports only what other surfaces recorded about one requested outcome. OMH ran no "
+    "probe, called no connector, and performed no external action; a ready answer says the surface "
+    "was observed working recently, not that this action will succeed, and no state here is "
+    "execution, verification, review, CI, or merge evidence."
+)
+
+NEXT_ACTIONS: Final = {
+    "ready": "perform_the_requested_action",
+    "blocked": "clear_the_recorded_blocker",
+    "not_observed": "observe_the_surface_before_acting",
+    "stale": "re_observe_the_surface_before_acting",
+    "failed": "read_the_recorded_failure_before_retrying",
+}
+
+UNKNOWN_AGE_SECONDS: Final = -1
+
+_MAX_ACTION_CHARS: Final = 160
+_MAX_REASON_CHARS: Final = 400
+_MAX_STEP_CHARS: Final = 240
+_MAX_REJECTED_ROWS: Final = 8
+_MAX_REJECTION_REASON_CHARS: Final = 200
+
+# The names each fault is reported under, so an error line says which of the two
+# record families it came from.
+_LABEL: Final = "external action evidence"
+_ANSWER_LABEL: Final = "external action readiness answer"
+
+
+class ExternalActionReadinessError(ValueError):
+    """Raised when an outcome or a piece of evidence cannot be accepted."""
+
+
+def build_external_action_evidence(
+    *,
+    tier: str,
+    source: str,
+    result: str,
+    surface: str,
+    observed_at: str,
+    outcome_id: str = "",
+    evidence_ref: str = "",
+) -> dict[str, Any]:
+    """Mint one evidence record, or refuse.
+
+    `outcome_id` is empty for surface-level evidence -- the surface is
+    installed, a host loaded it, a host used it -- and named for evidence about
+    one effect, which only the `used` tier can be. Refusing an unnamed `used`
+    record is what keeps a success on one outcome from answering for another.
+    """
+    if source not in EVIDENCE_SOURCES:
+        raise ExternalActionReadinessError(f"external action evidence source is unsupported: {source!r}")
+    if tier not in EVIDENCE_TIERS:
+        raise ExternalActionReadinessError(f"external action evidence tier is unsupported: {tier!r}")
+    if tier not in SOURCE_TIERS[source]:
+        raise ExternalActionReadinessError(
+            f"external action evidence source {source} may not claim tier {tier}"
+        )
+    if result not in EVIDENCE_RESULTS:
+        raise ExternalActionReadinessError(f"external action evidence result is unsupported: {result!r}")
+    if tier == "used" and not str(outcome_id or "").strip():
+        raise ExternalActionReadinessError(
+            "external action evidence at the used tier must name the outcome it observed"
+        )
+    record = {
+        "schema_version": EXTERNAL_ACTION_EVIDENCE_SCHEMA_VERSION,
+        "tier": tier,
+        "source": source,
+        "result": result,
+        "surface": _opaque(surface, field="external action evidence surface"),
+        "outcome_id": _opaque(outcome_id, field="external action evidence outcome_id") if outcome_id else "",
+        "observed_at": _opaque(observed_at, field="external action evidence observed_at"),
+        "evidence_ref": _opaque(evidence_ref, field="external action evidence evidence_ref") if evidence_ref else "",
+    }
+    errors = external_action_evidence_errors(record)
+    if errors:
+        raise ExternalActionReadinessError(errors[0])
+    return record
+
+
+def external_action_evidence_errors(record: Any) -> list[str]:
+    """Every reason one record is not usable evidence. Both directions on keys."""
+    if not isinstance(record, Mapping):
+        return ["external action evidence must be an object"]
+    errors: list[str] = []
+    forbidden = sorted(key for key in record if str(key).lower() in RAW_OR_HIDDEN_KEYS)
+    if forbidden:
+        errors.append(f"external action evidence must not carry raw or hidden keys: {forbidden}")
+    present = {str(key) for key in record}
+    missing = sorted(set(EXTERNAL_ACTION_EVIDENCE_KEYS) - present)
+    if missing:
+        errors.append(f"external action evidence is missing keys: {missing}")
+    unexpected = sorted(present - set(EXTERNAL_ACTION_EVIDENCE_KEYS) - set(forbidden))
+    if unexpected:
+        errors.append(f"external action evidence has unsupported keys: {unexpected}")
+    if record.get("schema_version") != EXTERNAL_ACTION_EVIDENCE_SCHEMA_VERSION:
+        errors.append(f"external action evidence schema_version must be {EXTERNAL_ACTION_EVIDENCE_SCHEMA_VERSION}")
+    source = record.get("source")
+    if source not in EVIDENCE_SOURCES:
+        errors.append(f"external action evidence source is unsupported: {source!r}")
+    tier = record.get("tier")
+    if tier not in EVIDENCE_TIERS:
+        errors.append(f"external action evidence tier is unsupported: {tier!r}")
+    elif source in EVIDENCE_SOURCES and tier not in SOURCE_TIERS[str(source)]:
+        errors.append(f"external action evidence source {source} may not claim tier {tier}")
+    if record.get("result") not in EVIDENCE_RESULTS:
+        errors.append(f"external action evidence result is unsupported: {record.get('result')!r}")
+    if tier == "used" and not str(record.get("outcome_id", "") or ""):
+        errors.append("external action evidence at the used tier must name the outcome it observed")
+    errors.extend(reference_errors(record.get("surface"), field="surface", label=_LABEL, required=True))
+    errors.extend(reference_errors(record.get("observed_at"), field="observed_at", label=_LABEL, required=True))
+    errors.extend(reference_errors(record.get("outcome_id"), field="outcome_id", label=_LABEL, required=False))
+    errors.extend(reference_errors(record.get("evidence_ref"), field="evidence_ref", label=_LABEL, required=False))
+    return errors
+
+
+def answer_external_action_readiness(
+    *,
+    outcome_id: str,
+    action: str,
+    surface: str,
+    evidence: Sequence[Mapping[str, Any]] = (),
+    prior: Mapping[str, Any] | None = None,
+    now: str = "",
+) -> dict[str, Any]:
+    """The one answer to "can you do this now?" for one requested outcome.
+
+    `evidence` is every record a caller gathered. Three things happen to it, in
+    this order, and the order is the point:
+
+    1. Each record is validated. An invalid record is rejected and never enters
+       the derivation, so bad evidence structurally cannot raise the answer.
+    2. Valid records are scoped. Evidence naming another outcome is ignored --
+       it is somebody else's truth, not weaker truth about this one -- and
+       surface-level evidence applies only to the named surface.
+    3. The answer is derived from the strongest positive evidence that is still
+       fresh. When nothing in scope is fresh, the answer is `stale`; a stale
+       observation is never allowed to read as `ready`.
+
+    `prior` is the last valid answer for this same outcome. It is used for
+    exactly one thing (AC3): when records were supplied and none of them
+    survived validation and scoping, the prior state is preserved rather than
+    overwritten, and the answer says so through `state_source` and
+    `rejected_evidence`. A preserved answer never rises above what the prior
+    already held, because a prior is itself a derived answer.
+
+    `now` is a parameter so the derivation is deterministic. An unreadable or
+    future `observed_at` reads as older than the horizon, for the reason
+    `pre_handoff_readiness._stamp_age_seconds` gives: neither can be shown to be
+    fresh, and clamping would turn editing a stored timestamp into a way to
+    widen the window.
+    """
+    safe_outcome_id = _opaque(outcome_id, field="external action outcome_id")
+    safe_surface = _opaque(surface, field="external action surface")
+    safe_action = _bounded_action(action)
+
+    supplied = list(evidence)
+    scoped: list[Mapping[str, Any]] = []
+    rejected: list[dict[str, Any]] = []
+    rejected_count = 0
+    for index, record in enumerate(supplied):
+        errors = external_action_evidence_errors(record)
+        if errors:
+            rejected_count += 1
+            if len(rejected) < _MAX_REJECTED_ROWS:
+                rejected.append({"index": index, "reason": errors[0][:_MAX_REJECTION_REASON_CHARS]})
+            continue
+        if _applies_to(record, outcome_id=safe_outcome_id, surface=safe_surface):
+            scoped.append(record)
+
+    integrity = _integrity(supplied=len(supplied), rejected=rejected_count)
+    preserved = _preserved_prior(prior, outcome_id=safe_outcome_id) if rejected_count and not scoped else None
+
+    if preserved is not None:
+        state = str(preserved["state"])
+        tier = str(preserved["evidence_tier"])
+        state_source = "preserved_prior"
+        age = UNKNOWN_AGE_SECONDS
+    elif rejected_count and not scoped:
+        state, tier, state_source, age = "not_observed", EVIDENCE_TIER_NONE, "no_valid_evidence", UNKNOWN_AGE_SECONDS
+    else:
+        state, tier, age = _derive(scoped, now=now)
+        state_source = "derived"
+
+    answer = {
+        "schema_version": EXTERNAL_ACTION_READINESS_SCHEMA_VERSION,
+        "outcome_id": safe_outcome_id,
+        "action": safe_action,
+        "surface": safe_surface,
+        "state": state,
+        "evidence_tier": tier,
+        "state_source": state_source,
+        "evidence_integrity": integrity,
+        "reason": _reason(
+            state=state,
+            tier=tier,
+            state_source=state_source,
+            action=safe_action,
+            surface=safe_surface,
+            rejected_count=rejected_count,
+        ),
+        "next_action": NEXT_ACTIONS[state],
+        "next_step": _next_step(state, surface=safe_surface),
+        "accepted_count": len(scoped),
+        "rejected_count": rejected_count,
+        "rejected_evidence": rejected,
+        "age_seconds": age,
+        "stale_after_seconds": EXTERNAL_ACTION_STALE_AFTER_SECONDS,
+        "claim_boundary": EXTERNAL_ACTION_READINESS_CLAIM_BOUNDARY,
+    }
+    errors = validate_external_action_readiness_answer(answer)
+    if errors:
+        raise ExternalActionReadinessError("; ".join(errors))
+    return answer
+
+
+def validate_external_action_readiness_answer(answer: Any) -> list[str]:
+    """Both directions: no key of the closed set missing, no key outside it."""
+    if not isinstance(answer, Mapping):
+        return ["external action readiness answer must be an object"]
+    errors: list[str] = []
+    present = {str(key) for key in answer}
+    missing = sorted(set(EXTERNAL_ACTION_READINESS_KEYS) - present)
+    if missing:
+        errors.append(f"external action readiness answer is missing keys: {missing}")
+    unexpected = sorted(present - set(EXTERNAL_ACTION_READINESS_KEYS))
+    if unexpected:
+        errors.append(f"external action readiness answer has unsupported keys: {unexpected}")
+    if answer.get("schema_version") != EXTERNAL_ACTION_READINESS_SCHEMA_VERSION:
+        errors.append(f"schema_version must be {EXTERNAL_ACTION_READINESS_SCHEMA_VERSION}")
+    state = answer.get("state")
+    if state not in EXTERNAL_ACTION_READINESS_STATES:
+        errors.append(f"state is unsupported: {state!r}")
+    elif answer.get("next_action") != NEXT_ACTIONS[str(state)]:
+        errors.append("next_action must be the action this state calls for")
+    if answer.get("evidence_tier") not in REPORTED_EVIDENCE_TIERS:
+        errors.append(f"evidence_tier is unsupported: {answer.get('evidence_tier')!r}")
+    if answer.get("state_source") not in STATE_SOURCES:
+        errors.append(f"state_source is unsupported: {answer.get('state_source')!r}")
+    if answer.get("evidence_integrity") not in EVIDENCE_INTEGRITIES:
+        errors.append(f"evidence_integrity is unsupported: {answer.get('evidence_integrity')!r}")
+    if answer.get("stale_after_seconds") != EXTERNAL_ACTION_STALE_AFTER_SECONDS:
+        errors.append(f"stale_after_seconds must be {EXTERNAL_ACTION_STALE_AFTER_SECONDS}")
+    if answer.get("claim_boundary") != EXTERNAL_ACTION_READINESS_CLAIM_BOUNDARY:
+        errors.append("claim_boundary must state the external action readiness boundary")
+    # The invariant AC1 rests on, checked on the finished answer as well as on
+    # the way in: no tier below "usable now" may be reported as ready.
+    if state == "ready" and _TIER_LEVELS.get(str(answer.get("evidence_tier")), 0) < _READY_TIER_LEVEL:
+        errors.append("ready requires fresh usable_observed or used evidence")
+    errors.extend(_bounded_text_errors(answer))
+    errors.extend(reference_errors(answer.get("outcome_id"), field="outcome_id", label=_ANSWER_LABEL, required=True))
+    errors.extend(reference_errors(answer.get("surface"), field="surface", label=_ANSWER_LABEL, required=True))
+    errors.extend(_count_errors(answer))
+    errors.extend(_rejected_evidence_errors(answer.get("rejected_evidence")))
+    return errors
+
+
+def evidence_from_plugin_host_observation(record: Any) -> dict[str, Any] | None:
+    """One `omh_plugin_host_observation/v1` record as evidence, or None.
+
+    A `not_observed` status is the `installed` tier and nothing more: the host
+    is configured for OMH and the wrapper watched it do nothing. That is the
+    honest local-configuration fact, and AC1 is exactly the rule that it can
+    never become an answer of `ready`.
+    """
+    if not isinstance(record, Mapping):
+        return None
+    return _host_record_evidence(
+        record,
+        source="plugin_host_observation",
+        usable_events=("tool_call", "hook_call", "status_query"),
+        load_events=("plugin_load", "session_end", "plugin_unload"),
+    )
+
+
+def evidence_from_mcp_host_session(record: Any) -> dict[str, Any] | None:
+    """One `omh_mcp_host_session/v1` record as evidence, or None.
+
+    Same reading as the plugin host observation, over the MCP host's own event
+    vocabulary: a tool call is the host using the bridge, a load or a session
+    boundary is the host having it.
+    """
+    if not isinstance(record, Mapping):
+        return None
+    return _host_record_evidence(
+        record,
+        source="mcp_host_session",
+        usable_events=("tool_call",),
+        load_events=("host_load", "session_start", "session_end", "host_unload"),
+    )
+
+
+def evidence_from_external_effect_receipt(record: Any) -> dict[str, Any] | None:
+    """One `external_effect_receipt/v1` record as evidence, or None.
+
+    Only `succeeded` and `failed` say anything about whether the outcome can
+    happen. `attempted` and `unknown` are, by that store's own definition,
+    observations that could not classify the effect, and an unclassifiable
+    observation is not evidence for or against.
+    """
+    if not isinstance(record, Mapping):
+        return None
+    results = {"succeeded": "observed", "failed": "failed"}
+    result = results.get(str(record.get("observed_result", "")))
+    if result is None:
+        return None
+    return _safe_evidence(
+        tier="used",
+        source="external_effect_receipt",
+        result=result,
+        surface=str(record.get("acting_surface", "")),
+        outcome_id=str(record.get("effect_id", "")),
+        observed_at=str(record.get("observed_at", "")),
+        evidence_ref=str(record.get("receipt_id", "")),
+    )
+
+
+def _host_record_evidence(
+    record: Mapping[str, Any],
+    *,
+    source: str,
+    usable_events: tuple[str, ...],
+    load_events: tuple[str, ...],
+) -> dict[str, Any] | None:
+    status = str(record.get("status", ""))
+    event = str(record.get("event", ""))
+    if status == "blocked":
+        tier, result = "host_observed", "blocked"
+    elif status == "not_observed":
+        tier, result = "installed", "observed"
+    elif status == "observed" and event in usable_events:
+        tier, result = "usable_observed", "observed"
+    elif status == "observed" and event in load_events:
+        tier, result = "host_observed", "observed"
+    else:
+        return None
+    return _safe_evidence(
+        tier=tier,
+        source=source,
+        result=result,
+        surface=str(record.get("host", "")),
+        outcome_id="",
+        observed_at=str(record.get("observed_at", "") or record.get("recorded_at", "")),
+        evidence_ref=str(record.get("session_id", "")),
+    )
+
+
+def _safe_evidence(
+    *,
+    tier: str,
+    source: str,
+    result: str,
+    surface: str,
+    outcome_id: str,
+    observed_at: str,
+    evidence_ref: str,
+) -> dict[str, Any] | None:
+    """Adapt one stored record, or drop it when the store cannot be trusted.
+
+    An adapter reads a file that can be hand-edited, so a record carrying an
+    unusable identifier is dropped rather than raised: the surface asking "can
+    you do this now" must still get an answer, and a dropped record simply is
+    not evidence.
+    """
+    try:
+        return build_external_action_evidence(
+            tier=tier,
+            source=source,
+            result=result,
+            surface=surface,
+            outcome_id=outcome_id,
+            observed_at=observed_at,
+            evidence_ref=evidence_ref,
+        )
+    except ExternalActionReadinessError:
+        return None
+
+
+def _applies_to(record: Mapping[str, Any], *, outcome_id: str, surface: str) -> bool:
+    """Whether one valid record speaks about this outcome.
+
+    Outcome-level evidence answers for the outcome it names and for no other,
+    which is the whole reason a receipt for a different effect cannot satisfy
+    this one. Surface-level evidence carries no outcome and answers for every
+    outcome that runs over the named surface.
+    """
+    named = str(record.get("outcome_id", ""))
+    if named:
+        return named == outcome_id
+    return str(record.get("surface", "")) == surface
+
+
+def _integrity(*, supplied: int, rejected: int) -> str:
+    if not rejected:
+        return "clean"
+    return "unusable" if rejected == supplied else "partial"
+
+
+def _preserved_prior(prior: Any, *, outcome_id: str) -> dict[str, Any] | None:
+    """The prior answer, when it is a valid answer about this same outcome.
+
+    A prior that does not validate is not a weaker prior; it is not an answer,
+    and preserving it would be the same defect AC3 exists to close, one level
+    up.
+    """
+    if not isinstance(prior, Mapping):
+        return None
+    if validate_external_action_readiness_answer(prior):
+        return None
+    if str(prior.get("outcome_id", "")) != outcome_id:
+        return None
+    return {"state": prior.get("state"), "evidence_tier": prior.get("evidence_tier")}
+
+
+def _derive(scoped: Sequence[Mapping[str, Any]], *, now: str) -> tuple[str, str, int]:
+    """(state, evidence tier, age of the deciding record) from scoped evidence."""
+    if not scoped:
+        return "not_observed", EVIDENCE_TIER_NONE, UNKNOWN_AGE_SECONDS
+    aged = [(_age_seconds(str(record.get("observed_at", "")), now), record) for record in scoped]
+    fresh = [(age, record) for age, record in aged if age <= EXTERNAL_ACTION_STALE_AFTER_SECONDS]
+    if not fresh:
+        # Something was true here and none of it still is. Reporting the tier it
+        # used to reach would be the exact confusion this module removes.
+        return "stale", EVIDENCE_TIER_STALE, min(age for age, _ in aged)
+    positives = [(age, record) for age, record in fresh if record.get("result") == "observed"]
+    strongest = min(positives, key=_positive_rank) if positives else None
+    tier = str(strongest[1]["tier"]) if strongest else EVIDENCE_TIER_NONE
+    for result in _NEGATIVE_RESULTS:
+        matching = [age for age, record in fresh if record.get("result") == result]
+        if matching:
+            return result, tier, min(matching)
+    if strongest is None:
+        return "not_observed", EVIDENCE_TIER_NONE, UNKNOWN_AGE_SECONDS
+    age = strongest[0]
+    if _TIER_LEVELS[str(strongest[1]["tier"])] >= _READY_TIER_LEVEL:
+        return "ready", tier, age
+    return "not_observed", tier, age
+
+
+def _positive_rank(entry: tuple[int, Mapping[str, Any]]) -> tuple[int, int]:
+    """Strongest tier first, freshest as the tiebreak, so selection is stable."""
+    age, record = entry
+    return (-_TIER_LEVELS[str(record["tier"])], age)
+
+
+def _reason(
+    *,
+    state: str,
+    tier: str,
+    state_source: str,
+    action: str,
+    surface: str,
+    rejected_count: int,
+) -> str:
+    if state_source == "preserved_prior":
+        return (
+            f"{rejected_count} new evidence record(s) about {action} could not be read, so the last "
+            f"valid answer is kept: {state}. Nothing was upgraded and nothing was overwritten; the "
+            "gap is unreadable evidence, not a change on the surface."
+        )[:_MAX_REASON_CHARS]
+    if state_source == "no_valid_evidence":
+        return (
+            f"Every supplied evidence record about {action} was unreadable and there is no earlier "
+            "valid answer to keep, so nothing about this outcome has been observed."
+        )[:_MAX_REASON_CHARS]
+    tail = f" {rejected_count} unreadable record(s) were rejected and did not affect this answer." if rejected_count else ""
+    match state:
+        case "ready":
+            body = (
+                f"{surface} was observed {'completing this outcome' if tier == 'used' else 'in use'} "
+                f"recently, so {action} can be attempted now."
+            )
+        case "blocked":
+            body = f"A surface recording {surface} reported something in the way, so {action} cannot proceed yet."
+        case "failed":
+            body = f"An attempt at {action} was observed not to happen; the recorded failure stands until something newer replaces it."
+        case "stale":
+            hours = EXTERNAL_ACTION_STALE_AFTER_SECONDS // 3600
+            body = (
+                f"Everything recorded about {action} is older than {hours} hours, so what was true then "
+                "is not evidence about now."
+            )
+        case _:
+            body = _NOT_OBSERVED_REASONS.get(tier, _NOT_OBSERVED_REASONS[EVIDENCE_TIER_NONE]).format(
+                action=action,
+                surface=surface,
+            )
+    return (body + tail)[:_MAX_REASON_CHARS]
+
+
+_NOT_OBSERVED_REASONS: Final = {
+    EVIDENCE_TIER_NONE: "Nothing has been recorded about {action}, so whether {surface} works now is unobserved.",
+    "installed": "{surface} is configured locally and nothing has been observed using it, so {action} is unproven.",
+    "host_observed": "A host reported loading {surface} but nothing was observed using it, so {action} is unproven.",
+}
+
+
+def _next_step(state: str, *, surface: str) -> str:
+    match state:
+        case "ready":
+            return f"Go ahead with the requested action over {surface}."
+        case "blocked":
+            return f"Clear what the recording surface reported about {surface}, then ask again."
+        case "failed":
+            return f"Read the recorded failure for this outcome before retrying over {surface}."
+        case "stale":
+            return f"Ask the host to record a fresh observation of {surface}, then ask again."
+        case _:
+            return f"Have the host record an observation of {surface} actually being used, then ask again."
+
+
+def _bounded_action(action: str) -> str:
+    text = " ".join(str(action or "").split())
+    if not text:
+        raise ExternalActionReadinessError("external action readiness requires the requested action")
+    if len(text) > _MAX_ACTION_CHARS:
+        raise ExternalActionReadinessError(
+            f"external action readiness action must be at most {_MAX_ACTION_CHARS} characters"
+        )
+    if is_unsafe_metadata_line(text):
+        raise ExternalActionReadinessError(
+            "external action readiness action must be one bounded metadata line without secrets, links, or paths"
+        )
+    return text
+
+
+def _bounded_text_errors(answer: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field, limit in (("action", _MAX_ACTION_CHARS), ("reason", _MAX_REASON_CHARS), ("next_step", _MAX_STEP_CHARS)):
+        value = answer.get(field)
+        if not isinstance(value, str) or not value.strip() or len(value) > limit:
+            errors.append(f"{field} must be a nonempty string of at most {limit} characters")
+        elif is_unsafe_metadata_line(value):
+            errors.append(f"{field} must not carry secrets, links, paths, or raw text")
+    return errors
+
+
+def _count_errors(answer: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field in ("accepted_count", "rejected_count"):
+        value = answer.get(field)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            errors.append(f"{field} must be a non-negative integer")
+    age = answer.get("age_seconds")
+    if not isinstance(age, int) or isinstance(age, bool) or age < UNKNOWN_AGE_SECONDS:
+        errors.append("age_seconds must be an integer, or -1 when no record decided the state")
+    return errors
+
+
+def _rejected_evidence_errors(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return ["rejected_evidence must be a list"]
+    if len(value) > _MAX_REJECTED_ROWS:
+        return [f"rejected_evidence must hold at most {_MAX_REJECTED_ROWS} rows"]
+    errors: list[str] = []
+    for row in value:
+        if not isinstance(row, Mapping) or {str(key) for key in row} != set(_REJECTED_EVIDENCE_KEYS):
+            errors.append(f"each rejected_evidence row must carry exactly {', '.join(_REJECTED_EVIDENCE_KEYS)}")
+            continue
+        index = row.get("index")
+        if not isinstance(index, int) or isinstance(index, bool) or index < 0:
+            errors.append("rejected_evidence index must be a non-negative integer")
+        reason = row.get("reason")
+        if not isinstance(reason, str) or not reason.strip() or len(reason) > _MAX_REJECTION_REASON_CHARS:
+            errors.append(
+                f"rejected_evidence reason must be a nonempty string of at most {_MAX_REJECTION_REASON_CHARS} characters"
+            )
+    return errors
+
+
+def _age_seconds(stamp: str, now: str) -> int:
+    """Age of an ISO-8601 stamp in seconds, or a value past the horizon.
+
+    Unreadable and future stamps both read as past the horizon, the rule
+    `pre_handoff_readiness._stamp_age_seconds` sets: neither can be shown to be
+    fresh, and clamping a future stamp would make editing a record a way to
+    widen the window from disk.
+    """
+    observed = _parse_stamp(stamp)
+    if observed is None:
+        return EXTERNAL_ACTION_STALE_AFTER_SECONDS + 1
+    reference = _parse_stamp(now) or datetime.now(timezone.utc)
+    age = int((reference - observed).total_seconds())
+    return EXTERNAL_ACTION_STALE_AFTER_SECONDS + 1 if age < 0 else age
+
+
+def _parse_stamp(value: str) -> datetime | None:
+    text = str(value or "").strip().replace("Z", "+00:00")
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _opaque(value: str, *, field: str) -> str:
+    return opaque_ref(value, field=field, error=ExternalActionReadinessError)

--- a/tests/test_external_action_readiness.py
+++ b/tests/test_external_action_readiness.py
@@ -1,0 +1,637 @@
+"""Contracts for `external_action_readiness/v1` (issue #809).
+
+Grouped by acceptance criterion:
+
+- AC1: configuration alone never produces "ready now".
+- AC2: installed, host-observed, usable-observed, used, and stale are five
+  distinguishable answers, not one boolean.
+- AC3: invalid evidence preserves the last valid state and explains the gap.
+
+Plus the two guards the answer would be useless without: a stale observation
+never reads as ready, and a receipt for a different outcome never answers for
+this one.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+from omh.coding.context_safety import coding_progress_policy_enforcement
+from omh.local_store import atomic_write_text
+from omh.mcp.bridge import record_mcp_host_session
+from omh.paths import resolve_paths
+from omh.plugin_observations import record_plugin_host_observation
+from omh.workflows.external_action_readiness import (
+    DISTINGUISHED_EVIDENCE_TIERS,
+    EVIDENCE_SOURCES,
+    EVIDENCE_TIERS,
+    EXTERNAL_ACTION_EVIDENCE_KEYS,
+    EXTERNAL_ACTION_EVIDENCE_SCHEMA_VERSION,
+    EXTERNAL_ACTION_READINESS_CLAIM_BOUNDARY,
+    EXTERNAL_ACTION_READINESS_KEYS,
+    EXTERNAL_ACTION_READINESS_SCHEMA_VERSION,
+    EXTERNAL_ACTION_READINESS_STATES,
+    EXTERNAL_ACTION_STALE_AFTER_SECONDS,
+    SOURCE_TIERS,
+    ExternalActionReadinessError,
+    answer_external_action_readiness,
+    build_external_action_evidence,
+    evidence_from_external_effect_receipt,
+    evidence_from_mcp_host_session,
+    evidence_from_plugin_host_observation,
+    external_action_evidence_errors,
+    validate_external_action_readiness_answer,
+)
+from omh.workflows.external_effect_receipts import build_external_effect_receipt, external_effect_id
+
+
+NOW = "2026-08-09T12:00:00Z"
+FRESH = "2026-08-09T11:00:00Z"
+STALE = "2026-08-01T00:00:00Z"
+OUTCOME = "message-sent:run-809"
+SURFACE = "claude-code"
+ACTION = "send the release note to the team channel"
+
+
+def evidence(
+    tier: str,
+    source: str,
+    result: str = "observed",
+    *,
+    surface: str = SURFACE,
+    outcome_id: str = "",
+    observed_at: str = FRESH,
+) -> dict:
+    return build_external_action_evidence(
+        tier=tier,
+        source=source,
+        result=result,
+        surface=surface,
+        outcome_id=outcome_id,
+        observed_at=observed_at,
+    )
+
+
+def answer(records: list, *, prior: dict | None = None, now: str = NOW, outcome_id: str = OUTCOME) -> dict:
+    return answer_external_action_readiness(
+        outcome_id=outcome_id,
+        action=ACTION,
+        surface=SURFACE,
+        evidence=records,
+        prior=prior,
+        now=now,
+    )
+
+
+class ConfigurationIsNeverReadyTests(unittest.TestCase):
+    """AC1: configuration alone never produces "ready now"."""
+
+    def test_configuration_present_and_nothing_observed_is_not_ready(self) -> None:
+        result = answer([evidence("installed", "local_configuration")])
+
+        self.assertEqual(result["state"], "not_observed")
+        self.assertEqual(result["evidence_tier"], "installed")
+        self.assertIn("configured locally", result["reason"])
+        self.assertEqual(result["next_action"], "observe_the_surface_before_acting")
+
+    def test_the_configuration_source_cannot_claim_a_tier_above_installed(self) -> None:
+        # The mechanism behind AC1: a configuration record is refused at the
+        # schema, so no caller can route around the rule by relabelling one.
+        self.assertEqual(SOURCE_TIERS["local_configuration"], ("installed",))
+        for tier in ("host_observed", "usable_observed", "used"):
+            with self.subTest(tier=tier):
+                with self.assertRaises(ExternalActionReadinessError):
+                    evidence(tier, "local_configuration", outcome_id=OUTCOME)
+
+    def test_no_amount_of_configuration_adds_up_to_ready(self) -> None:
+        result = answer([evidence("installed", "local_configuration", observed_at=FRESH) for _ in range(5)])
+
+        self.assertEqual(result["state"], "not_observed")
+        self.assertEqual(result["accepted_count"], 5)
+
+    def test_a_ready_answer_is_rejected_when_its_tier_cannot_support_one(self) -> None:
+        forged = answer([evidence("usable_observed", "plugin_host_observation")])
+        forged["state"] = "ready"
+        forged["evidence_tier"] = "installed"
+
+        self.assertIn("ready requires fresh usable_observed or used evidence", validate_external_action_readiness_answer(forged))
+
+
+class EvidenceTierTests(unittest.TestCase):
+    """AC2: installed, host-observed, usable-observed, used, and stale."""
+
+    def test_installed_is_a_local_fact_and_not_a_capability(self) -> None:
+        result = answer([evidence("installed", "local_configuration")])
+
+        self.assertEqual(result["evidence_tier"], "installed")
+        self.assertEqual(result["state"], "not_observed")
+
+    def test_host_observed_means_a_host_reported_loading_it(self) -> None:
+        result = answer([evidence("host_observed", "plugin_host_observation")])
+
+        self.assertEqual(result["evidence_tier"], "host_observed")
+        # A load is presence, not use, so it still cannot answer "yes, now".
+        self.assertEqual(result["state"], "not_observed")
+        self.assertIn("reported loading", result["reason"])
+
+    def test_usable_observed_means_a_host_reported_using_it(self) -> None:
+        result = answer([evidence("usable_observed", "plugin_host_observation")])
+
+        self.assertEqual(result["evidence_tier"], "usable_observed")
+        self.assertEqual(result["state"], "ready")
+
+    def test_used_means_a_receipt_records_this_outcome_succeeding(self) -> None:
+        result = answer([evidence("used", "external_effect_receipt", outcome_id=OUTCOME)])
+
+        self.assertEqual(result["evidence_tier"], "used")
+        self.assertEqual(result["state"], "ready")
+
+    def test_stale_means_what_was_true_is_past_its_horizon(self) -> None:
+        result = answer([evidence("used", "external_effect_receipt", outcome_id=OUTCOME, observed_at=STALE)])
+
+        self.assertEqual(result["evidence_tier"], "stale")
+        self.assertEqual(result["state"], "stale")
+        self.assertGreater(result["age_seconds"], EXTERNAL_ACTION_STALE_AFTER_SECONDS)
+
+    def test_all_five_tiers_are_distinguishable_from_one_another(self) -> None:
+        cases = {
+            "installed": [evidence("installed", "local_configuration")],
+            "host_observed": [evidence("host_observed", "mcp_host_session")],
+            "usable_observed": [evidence("usable_observed", "mcp_host_session")],
+            "used": [evidence("used", "external_effect_receipt", outcome_id=OUTCOME)],
+            "stale": [evidence("host_observed", "mcp_host_session", observed_at=STALE)],
+        }
+        observed = {name: answer(records) for name, records in cases.items()}
+
+        self.assertEqual(
+            {name: result["evidence_tier"] for name, result in observed.items()},
+            {name: name for name in cases},
+        )
+        self.assertEqual(sorted(cases), sorted(DISTINGUISHED_EVIDENCE_TIERS))
+        # Distinguishable is stronger than "five labels exist": no two of the
+        # five may collapse into the same (state, tier) pair.
+        pairs = [(result["state"], result["evidence_tier"]) for result in observed.values()]
+        self.assertEqual(len(set(pairs)), len(pairs))
+
+    def test_the_strongest_fresh_evidence_decides_and_a_weaker_record_cannot_lower_it(self) -> None:
+        result = answer(
+            [
+                evidence("installed", "local_configuration"),
+                evidence("host_observed", "plugin_host_observation"),
+                evidence("usable_observed", "plugin_host_observation"),
+            ]
+        )
+
+        self.assertEqual(result["evidence_tier"], "usable_observed")
+        self.assertEqual(result["state"], "ready")
+
+    def test_a_blocked_record_is_neither_ready_nor_a_failure(self) -> None:
+        result = answer(
+            [
+                evidence("usable_observed", "plugin_host_observation"),
+                evidence("host_observed", "plugin_host_observation", "blocked"),
+            ]
+        )
+
+        self.assertEqual(result["state"], "blocked")
+        self.assertEqual(result["next_action"], "clear_the_recorded_blocker")
+
+    def test_a_failed_attempt_outranks_reachability(self) -> None:
+        result = answer(
+            [
+                evidence("usable_observed", "plugin_host_observation"),
+                evidence("used", "external_effect_receipt", "failed", outcome_id=OUTCOME),
+            ]
+        )
+
+        self.assertEqual(result["state"], "failed")
+        self.assertEqual(result["next_action"], "read_the_recorded_failure_before_retrying")
+
+    def test_every_state_carries_the_next_action_it_calls_for(self) -> None:
+        cases = {
+            "ready": [evidence("usable_observed", "plugin_host_observation")],
+            "blocked": [evidence("host_observed", "plugin_host_observation", "blocked")],
+            "not_observed": [],
+            "stale": [evidence("host_observed", "plugin_host_observation", observed_at=STALE)],
+            "failed": [evidence("used", "external_effect_receipt", "failed", outcome_id=OUTCOME)],
+        }
+        for state, records in cases.items():
+            with self.subTest(state=state):
+                result = answer(records)
+                self.assertEqual(result["state"], state)
+                self.assertTrue(result["next_step"].strip())
+        self.assertEqual(sorted(cases), sorted(EXTERNAL_ACTION_READINESS_STATES))
+
+
+class InvalidEvidencePreservesTheLastValidStateTests(unittest.TestCase):
+    """AC3: bad evidence explains itself and never overwrites what was known."""
+
+    def _ready(self) -> dict:
+        return answer([evidence("used", "external_effect_receipt", outcome_id=OUTCOME)])
+
+    def test_the_prior_state_survives_unreadable_evidence(self) -> None:
+        prior = self._ready()
+
+        result = answer([{"schema_version": "external_action_evidence/v1", "tier": "used"}], prior=prior)
+
+        self.assertEqual(result["state"], prior["state"])
+        self.assertEqual(result["evidence_tier"], prior["evidence_tier"])
+        self.assertEqual(result["state_source"], "preserved_prior")
+
+    def test_the_gap_is_explained_rather_than_silently_absorbed(self) -> None:
+        result = answer([{"nonsense": True}], prior=self._ready())
+
+        self.assertEqual(result["evidence_integrity"], "unusable")
+        self.assertEqual(result["rejected_count"], 1)
+        self.assertEqual([row["index"] for row in result["rejected_evidence"]], [0])
+        self.assertTrue(result["rejected_evidence"][0]["reason"].strip())
+        self.assertIn("could not be read", result["reason"])
+
+    def test_invalid_evidence_never_upgrades_a_weaker_state(self) -> None:
+        prior = answer([evidence("installed", "local_configuration")])
+        # A record that would have said "used" if it were readable. It is not.
+        forged = {
+            "schema_version": EXTERNAL_ACTION_EVIDENCE_SCHEMA_VERSION,
+            "tier": "used",
+            "source": "external_effect_receipt",
+            "result": "observed",
+            "surface": SURFACE,
+            "outcome_id": OUTCOME,
+            "observed_at": FRESH,
+            "evidence_ref": "",
+            "note": "an unsupported key",
+        }
+
+        result = answer([forged], prior=prior)
+
+        self.assertEqual(result["state"], "not_observed")
+        self.assertEqual(result["evidence_tier"], "installed")
+        self.assertNotEqual(result["state"], "ready")
+
+    def test_invalid_evidence_beside_valid_evidence_never_raises_the_answer(self) -> None:
+        result = answer(
+            [
+                evidence("installed", "local_configuration"),
+                {"schema_version": "external_action_evidence/v1"},
+            ],
+            prior=self._ready(),
+        )
+
+        # Valid evidence spoke, so the prior is not consulted; the unreadable
+        # record is reported and contributed nothing.
+        self.assertEqual(result["state"], "not_observed")
+        self.assertEqual(result["state_source"], "derived")
+        self.assertEqual(result["evidence_integrity"], "partial")
+        self.assertEqual(result["rejected_count"], 1)
+        self.assertEqual(result["accepted_count"], 1)
+
+    def test_an_unreadable_prior_is_not_a_weaker_prior(self) -> None:
+        result = answer([{"nonsense": True}], prior={"state": "ready", "evidence_tier": "used"})
+
+        self.assertEqual(result["state"], "not_observed")
+        self.assertEqual(result["state_source"], "no_valid_evidence")
+
+    def test_a_prior_about_another_outcome_is_never_preserved_into_this_one(self) -> None:
+        other = answer_external_action_readiness(
+            outcome_id="message-sent:another-run",
+            action=ACTION,
+            surface=SURFACE,
+            evidence=[evidence("used", "external_effect_receipt", outcome_id="message-sent:another-run")],
+            now=NOW,
+        )
+        self.assertEqual(other["state"], "ready")
+
+        result = answer([{"nonsense": True}], prior=other)
+
+        self.assertEqual(result["state"], "not_observed")
+        self.assertEqual(result["state_source"], "no_valid_evidence")
+
+    def test_the_rejected_row_list_is_bounded(self) -> None:
+        result = answer([{"nonsense": index} for index in range(40)])
+
+        self.assertEqual(result["rejected_count"], 40)
+        self.assertEqual(len(result["rejected_evidence"]), 8)
+
+
+class ReadinessGuardTests(unittest.TestCase):
+    def test_stale_never_reads_as_ready(self) -> None:
+        for tier, source in (("usable_observed", "plugin_host_observation"), ("used", "external_effect_receipt")):
+            with self.subTest(tier=tier):
+                result = answer(
+                    [evidence(tier, source, outcome_id=OUTCOME if tier == "used" else "", observed_at=STALE)]
+                )
+                self.assertNotEqual(result["state"], "ready")
+                self.assertEqual(result["state"], "stale")
+                self.assertEqual(result["evidence_tier"], "stale")
+
+    def test_a_record_exactly_on_the_horizon_is_still_fresh(self) -> None:
+        result = answer(
+            [evidence("usable_observed", "plugin_host_observation", observed_at="2026-08-09T06:00:00Z")]
+        )
+
+        self.assertEqual(result["age_seconds"], EXTERNAL_ACTION_STALE_AFTER_SECONDS)
+        self.assertEqual(result["state"], "ready")
+
+    def test_a_receipt_for_a_different_outcome_does_not_satisfy_this_one(self) -> None:
+        result = answer([evidence("used", "external_effect_receipt", outcome_id="message-sent:some-other-run")])
+
+        self.assertEqual(result["state"], "not_observed")
+        self.assertEqual(result["evidence_tier"], "none")
+        self.assertEqual(result["accepted_count"], 0)
+        # Not rejected either: it is valid evidence about somebody else's
+        # outcome, which is a different thing from unreadable evidence.
+        self.assertEqual(result["rejected_count"], 0)
+
+    def test_two_outcomes_over_one_surface_can_answer_differently(self) -> None:
+        shared = [
+            evidence("usable_observed", "plugin_host_observation"),
+            evidence("used", "external_effect_receipt", "failed", outcome_id=OUTCOME),
+        ]
+
+        blocked_outcome = answer(shared)
+        other_outcome = answer(shared, outcome_id="message-sent:other-run")
+
+        self.assertEqual(blocked_outcome["state"], "failed")
+        self.assertEqual(other_outcome["state"], "ready")
+
+    def test_surface_evidence_for_another_surface_is_out_of_scope(self) -> None:
+        result = answer([evidence("usable_observed", "plugin_host_observation", surface="codex")])
+
+        self.assertEqual(result["state"], "not_observed")
+        self.assertEqual(result["accepted_count"], 0)
+
+    def test_an_unreadable_or_future_timestamp_is_never_fresh(self) -> None:
+        for stamp in ("not-a-timestamp", "2027-01-01T00:00:00Z"):
+            with self.subTest(stamp=stamp):
+                result = answer([evidence("used", "external_effect_receipt", outcome_id=OUTCOME, observed_at=stamp)])
+                self.assertEqual(result["state"], "stale")
+
+    def test_freshness_is_derived_at_read_time_and_never_stored(self) -> None:
+        record = evidence("used", "external_effect_receipt", outcome_id=OUTCOME)
+
+        self.assertEqual(sorted(record), sorted(EXTERNAL_ACTION_EVIDENCE_KEYS))
+        self.assertNotIn("expires_at", record)
+        # The same record, read at two different times, answers differently.
+        self.assertEqual(answer([record], now=FRESH)["state"], "ready")
+        self.assertEqual(answer([record], now="2026-08-10T00:00:00Z")["state"], "stale")
+
+
+class SchemaTests(unittest.TestCase):
+    def test_the_answer_key_set_is_closed_in_both_directions(self) -> None:
+        result = answer([evidence("usable_observed", "plugin_host_observation")])
+
+        self.assertEqual(sorted(result), sorted(EXTERNAL_ACTION_READINESS_KEYS))
+        self.assertEqual(result["schema_version"], EXTERNAL_ACTION_READINESS_SCHEMA_VERSION)
+        self.assertEqual(result["claim_boundary"], EXTERNAL_ACTION_READINESS_CLAIM_BOUNDARY)
+        self.assertEqual(validate_external_action_readiness_answer(result), [])
+
+        missing = {key: value for key, value in result.items() if key != "reason"}
+        self.assertIn(
+            "external action readiness answer is missing keys: ['reason']",
+            validate_external_action_readiness_answer(missing),
+        )
+        extra = {**result, "surprise": 1}
+        self.assertIn(
+            "external action readiness answer has unsupported keys: ['surprise']",
+            validate_external_action_readiness_answer(extra),
+        )
+
+    def test_the_evidence_key_set_is_closed_in_both_directions(self) -> None:
+        record = evidence("usable_observed", "plugin_host_observation")
+
+        self.assertEqual(external_action_evidence_errors(record), [])
+        self.assertTrue(external_action_evidence_errors({**record, "surprise": 1}))
+        self.assertTrue(external_action_evidence_errors({key: value for key, value in record.items() if key != "tier"}))
+
+    def test_the_answer_is_metadata_only(self) -> None:
+        with self.assertRaises(ExternalActionReadinessError):
+            answer_external_action_readiness(
+                outcome_id=OUTCOME,
+                action="send https://example.invalid/hook",
+                surface=SURFACE,
+                evidence=[],
+                now=NOW,
+            )
+        with self.assertRaises(ExternalActionReadinessError):
+            evidence("installed", "local_configuration", surface="https://example.invalid/host")
+
+    def test_raw_and_hidden_keys_are_refused_by_name(self) -> None:
+        record = {**evidence("installed", "local_configuration"), "prompt": "..."}
+
+        self.assertTrue(any("raw or hidden keys" in error for error in external_action_evidence_errors(record)))
+
+    def test_used_tier_evidence_must_name_the_outcome_it_observed(self) -> None:
+        with self.assertRaises(ExternalActionReadinessError):
+            evidence("used", "external_effect_receipt")
+
+    def test_every_source_declares_the_tiers_it_may_claim(self) -> None:
+        self.assertEqual(sorted(SOURCE_TIERS), sorted(EVIDENCE_SOURCES))
+        for source, tiers in SOURCE_TIERS.items():
+            with self.subTest(source=source):
+                self.assertTrue(tiers)
+                self.assertLessEqual(set(tiers), set(EVIDENCE_TIERS))
+
+
+class StoreAdapterTests(unittest.TestCase):
+    """The recorded shapes the four evidence tiers actually come from."""
+
+    def test_a_plugin_tool_call_reads_as_usable_observed(self) -> None:
+        record = {
+            "host": SURFACE,
+            "session_id": "session-1",
+            "event": "tool_call",
+            "status": "observed",
+            "observed_at": FRESH,
+        }
+
+        self.assertEqual(evidence_from_plugin_host_observation(record)["tier"], "usable_observed")
+
+    def test_a_plugin_load_reads_as_host_observed(self) -> None:
+        record = {"host": SURFACE, "session_id": "s", "event": "plugin_load", "status": "observed", "observed_at": FRESH}
+
+        self.assertEqual(evidence_from_plugin_host_observation(record)["tier"], "host_observed")
+
+    def test_an_unobserved_plugin_event_reads_as_installed_only(self) -> None:
+        record = {"host": SURFACE, "session_id": "s", "event": "plugin_load", "status": "not_observed", "recorded_at": FRESH}
+        adapted = evidence_from_plugin_host_observation(record)
+
+        self.assertEqual(adapted["tier"], "installed")
+        self.assertEqual(adapted["result"], "observed")
+
+    def test_a_blocked_host_event_reads_as_a_blocker(self) -> None:
+        record = {"host": SURFACE, "session_id": "s", "event": "tool_call", "status": "blocked", "recorded_at": FRESH}
+
+        self.assertEqual(evidence_from_plugin_host_observation(record)["result"], "blocked")
+
+    def test_an_mcp_tool_call_reads_as_usable_observed_and_a_load_does_not(self) -> None:
+        base = {"host": SURFACE, "session_id": "s", "status": "observed", "observed_at": FRESH}
+
+        self.assertEqual(evidence_from_mcp_host_session({**base, "event": "tool_call"})["tier"], "usable_observed")
+        self.assertEqual(evidence_from_mcp_host_session({**base, "event": "host_load"})["tier"], "host_observed")
+
+    def test_a_succeeded_receipt_reads_as_used_and_a_failed_one_as_a_failure(self) -> None:
+        succeeded = build_external_effect_receipt(
+            effect_id=external_effect_id("ci", "run-809"),
+            action="ci_run",
+            acting_surface="runtime_ci_record",
+            observed_result="succeeded",
+            run_id="run-809",
+            external_ref="check-1",
+            observed_at=FRESH,
+        )
+        failed = build_external_effect_receipt(
+            effect_id=external_effect_id("ci", "run-809"),
+            action="ci_run",
+            acting_surface="runtime_ci_record",
+            observed_result="failed",
+            run_id="run-809",
+            observed_at=FRESH,
+        )
+
+        self.assertEqual(evidence_from_external_effect_receipt(succeeded)["result"], "observed")
+        self.assertEqual(evidence_from_external_effect_receipt(succeeded)["outcome_id"], "ci:run-809")
+        self.assertEqual(evidence_from_external_effect_receipt(failed)["result"], "failed")
+
+    def test_an_unclassifiable_receipt_is_not_evidence_either_way(self) -> None:
+        for observed_result in ("attempted", "unknown"):
+            with self.subTest(observed_result=observed_result):
+                receipt = build_external_effect_receipt(
+                    effect_id=external_effect_id("ci", "run-809"),
+                    action="ci_run",
+                    acting_surface="runtime_ci_record",
+                    observed_result=observed_result,
+                    run_id="run-809",
+                    observed_at=FRESH,
+                )
+                self.assertIsNone(evidence_from_external_effect_receipt(receipt))
+
+    def test_a_record_the_adapter_cannot_read_is_dropped_rather_than_raised(self) -> None:
+        self.assertIsNone(evidence_from_plugin_host_observation({"host": "", "event": "tool_call", "status": "observed"}))
+        self.assertIsNone(evidence_from_plugin_host_observation("not a record"))
+        self.assertIsNone(evidence_from_mcp_host_session(None))
+
+
+class ActionReadinessCliTests(unittest.TestCase):
+    def _paths(self, root: Path):
+        return resolve_paths(root / ".omh", root / ".hermes")
+
+    def _base(self, paths) -> list[str]:
+        return ["--omh-home", str(paths.omh_home), "--hermes-home", str(paths.hermes_home)]
+
+    def test_plain_text_is_the_default_and_json_is_the_opt_in(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = self._paths(Path(tmp))
+            record_plugin_host_observation(
+                paths,
+                host=SURFACE,
+                session_id="session-1",
+                event="plugin_load",
+                status="not_observed",
+            )
+            command = ["runtime", "action-readiness", "--outcome", OUTCOME, "--surface", SURFACE, "--action", ACTION]
+
+            status, stdout, stderr = run_cli(self._base(paths) + command, output_json=False)
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            self.assertNotIn("{", stdout)
+            self.assertIn("Can Hermes do this now?", stdout)
+            self.assertIn("State: not_observed (strongest evidence: installed)", stdout)
+
+            status, stdout, stderr = run_cli(self._base(paths) + command + ["--json"])
+
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            self.assertEqual(payload["schema_version"], "runtime_action_readiness_view/v1")
+            self.assertEqual(payload["answer"]["state"], "not_observed")
+            self.assertEqual(payload["answer"]["evidence_tier"], "installed")
+            self.assertEqual(payload["evidence_sources"]["plugin_host_observation"], 1)
+
+    def test_an_observed_host_tool_call_makes_the_answer_ready(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = self._paths(Path(tmp))
+            record_mcp_host_session(
+                paths,
+                host=SURFACE,
+                session_id="session-1",
+                event="tool_call",
+                status="observed",
+                tool="omh_status",
+                evidence_refs=["host-session-log-1"],
+            )
+
+            status, stdout, _ = run_cli(
+                self._base(paths)
+                + ["runtime", "action-readiness", "--outcome", OUTCOME, "--surface", SURFACE, "--json"]
+            )
+
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            self.assertEqual(payload["answer"]["state"], "ready")
+            self.assertEqual(payload["answer"]["evidence_tier"], "usable_observed")
+            self.assertEqual(payload["evidence_sources"]["mcp_host_session"], 1)
+
+    def test_a_corrupt_store_line_is_reported_and_does_not_erase_valid_records(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = self._paths(Path(tmp))
+            record_plugin_host_observation(
+                paths,
+                host=SURFACE,
+                session_id="session-1",
+                event="tool_call",
+                status="observed",
+                tool="omh_status",
+                evidence_refs=["host-log-1"],
+            )
+            store = paths.runtime_plugin_host_observations_path
+            atomic_write_text(store, store.read_text(encoding="utf-8") + "not json at all\n", private=True)
+
+            status, stdout, _ = run_cli(
+                self._base(paths)
+                + ["runtime", "action-readiness", "--outcome", OUTCOME, "--surface", SURFACE, "--json"]
+            )
+
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            # The valid observation still answers; the unreadable line is a
+            # reported fault, not a silent downgrade.
+            self.assertEqual(payload["answer"]["state"], "ready")
+            self.assertEqual(payload["store_error_count"], 1)
+            self.assertTrue(payload["store_errors"])
+
+    def test_the_surface_is_read_only_and_scopes_by_host(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = self._paths(Path(tmp))
+            record_plugin_host_observation(
+                paths,
+                host="codex",
+                session_id="session-1",
+                event="tool_call",
+                status="observed",
+                tool="omh_status",
+                evidence_refs=["host-log-1"],
+            )
+
+            status, stdout, _ = run_cli(
+                self._base(paths)
+                + ["runtime", "action-readiness", "--outcome", OUTCOME, "--surface", SURFACE, "--json"]
+            )
+
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            self.assertEqual(payload["answer"]["state"], "not_observed")
+            self.assertEqual(payload["evidence_sources"]["plugin_host_observation"], 0)
+
+    def test_the_polled_surface_is_registered_as_bounded(self) -> None:
+        self.assertIn("omh runtime action-readiness", coding_progress_policy_enforcement()["bounded_surfaces"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New derivation `workflows/external_action_readiness.py` produces one
  `external_action_readiness/v1` answer to "can Hermes do this now?" for one
  **requested outcome**, over two axes that were previously welded together:
  an evidence tier (`installed`, `host_observed`, `usable_observed`, `used`,
  `stale`) and a state (`ready`, `blocked`, `not_observed`, `stale`, `failed`),
  with the smallest next action attached to every non-ready state.
- New read-only CLI `omh runtime action-readiness --outcome <id> --surface <host>`,
  plain text by default with `--json` opt-in, reading recorded evidence only.
- `omh runtime action-readiness` registered in
  `coding_progress_policy_enforcement()["bounded_surfaces"]` — it is a surface
  an agent will poll ("can you send it yet"), and its output is a fixed shape.
- New contract test file `tests/test_external_action_readiness.py` (47 tests),
  grouped by acceptance criterion.
- `docs/ARCHITECTURE.md` gains an **External Action Readiness** section beside
  the receipts and approval stores.

### Why This Exists

Issue #809. OMH could already report four separate facts — a connector is
installed, a host loaded it, a host used it, an effect succeeded through it —
and nothing turned them into an answer to the only question a person asks
before an external action. Configuration read like capability, a load read like
reachability, and a success from last week read like a success now.

`external_connector_readiness_card/v1` and `toolbelt_readiness/v1` looked like
the answer but are declarative catalog strings only
(`src/skills/catalog_harnesses.py`, `src/catalogs/playbooks.py`,
`src/wrapper/contract.py`): no builder, no validator, and scoped to a connector
rather than to a requested outcome.

### User / Operator Impact

A wrapper or agent can now ask one question and get one truthful answer scoped
to what the user actually asked for:

```
$ omh runtime action-readiness --outcome message-sent:run-809 --surface claude-code \
    --action "send the release note to the team channel"
Can Hermes do this now? Unknown — nothing has been observed
  Outcome: message-sent:run-809 — send the release note to the team channel
  Surface: claude-code
  State: not_observed (strongest evidence: installed)
  Why: claude-code is configured locally and nothing has been observed using it, so send the release note to the team channel is unproven.
  Next: Have the host record an observation of claude-code actually being used, then ask again.
  Evidence: 1 in scope, 0 rejected (clean)
  Read from: external_effect_receipt 0, mcp_host_session 0, plugin_host_observation 1
```

After the host records an observed `tool_call`, the same command answers
`Yes — ready now` with `strongest evidence: usable_observed`. Two outcomes over
the same connector can answer differently, which is the case a per-connector
reading got wrong.

### How It Works

Three properties are load-bearing, and each is mechanical rather than advisory.

**Configuration can never reach ready.** `SOURCE_TIERS` declares which tiers
each evidence source may claim; `local_configuration` may claim only
`installed`; and `installed` sits below the tier level a positive answer
requires. A caller cannot relabel a configuration record into a stronger tier —
`build_external_action_evidence` refuses it — and the finished answer is
revalidated on the way out, so a `ready` carrying a tier that cannot support one
fails validation (AC1).

**Five tiers, not one boolean.** `installed` is a local configuration fact;
`host_observed` means a host reported loading the surface; `usable_observed`
means a host reported using it; `used` means an external effect receipt records
*this* outcome succeeding; `stale` is derived at read time when nothing recorded
is still inside `EXTERNAL_ACTION_STALE_AFTER_SECONDS` (six hours — the horizon
`coding.pre_handoff_readiness` and `coding.action_gate` already use for the same
kind of question). No expiry is written into a record, `now` is a parameter so
the derivation is deterministic, and an unreadable or future stamp reads as
older than the horizon rather than being clamped (AC2).

**Invalid evidence cannot clobber a valid state.** Records are validated and
dropped *before* the derivation, never after, so bad input structurally cannot
raise an answer. When records were supplied and none survived validation and
scoping, the last valid answer is preserved instead of overwritten, and the
payload says so through `state_source: preserved_prior` plus a bounded
`rejected_evidence` list naming the gap. A prior that does not itself validate,
or that names a different outcome, is not preserved (AC3).

Scoping is by requested outcome: evidence naming an outcome answers for that
outcome and no other (so a receipt for a different effect cannot satisfy this
one), while evidence naming only a surface answers for every outcome over that
surface.

The CLI adapts three record families OMH already writes —
`omh_plugin_host_observation/v1`, `omh_mcp_host_session/v1`, and
`external_effect_receipt/v1`. `omh_mcp_observation/v1` and
`omh_evidence_probe/v1` are deliberately not adapted: neither names a host or an
effect, so neither can be scoped to a requested outcome. There is no flag that
asserts readiness and no answer store — the evidence stores are the durable
state and are re-read in full on every call, so a corrupt line appended today
cannot erase what the valid records already say; unreadable lines are reported
as store faults in the same breath.

No network, no LLM call, no probe, no new dependency. The derivation module is
pure and I/O-free.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/workflows/external_action_readiness.py` | New. `external_action_readiness/v1` and `external_action_evidence/v1`, closed key sets, both-direction validators, `claim_boundary`, three store adapters. |
| `src/commands/runtime.py` | New `cmd_runtime_action_readiness`, `runtime_action_readiness_view/v1` payload, plain-text renderer, parser registration. |
| `src/coding/context_safety.py` | `omh runtime action-readiness` added to `bounded_surfaces`. |
| `tests/test_external_action_readiness.py` | New. 47 tests grouped by AC plus guards, adapters, schema, and CLI. |
| `docs/ARCHITECTURE.md` | New `### External Action Readiness` section. |

No generated artifact was touched: no catalog change, no skill, no routing case,
no demo card, so no exact-count assertion moved.

## Validation

All of the following were run on this branch after `git rebase origin/main`
onto `8062f8b9`:

- [x] `uv run --group lint ruff check src tests` → `All checks passed!`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` → `Ran 4796 tests in 158.693s` / `OK`
- [x] `uv run python -m compileall -q src tests` → exit 0
- [x] `uv run python -m omh.cli docs workflows --check` → `"ok":true`, tap_skills `115/115`, no missing/stale/extra
- [x] `uv run python -m omh.cli harness validate` → `"ok":true`, `{"harnesses":72,"skills":104}`, no errors, no warnings
- [x] `uv run python -m omh.cli release checklist --json` → exit 0
- [x] `uv run python -m omh.cli release hermes-smoke` → `Status: ok`, mode `plan`, observed evidence: no
- [x] `omh --help` (`uv run python -m omh.cli --help`) → exit 0
- [x] `uv run python -m omh.cli docs roles --check` → `"ok":true`
- [x] `uv run python -m omh.cli docs capability-families --check` → `"ok":true`
- [x] `git diff --check` → exit 0
- [x] Targeted: `PYTHONPATH=tests uv run python -m unittest tests/test_external_action_readiness.py` → `Ran 47 tests` / `OK`
- [x] Manual CLI dry-run against a temporary `--omh-home`/`--hermes-home`: recorded a `not_observed` plugin host event and read `not_observed` / `installed`; recorded an observed `tool_call` and read `ready` / `usable_observed`; both in plain text and `--json`.
- [ ] `python3 -m omh.cli release evidence-bundle` — not run; no release artifact changed.
- [ ] Manual Hermes/TUI check — **not run**. This change adds no skill, no routing case, and no generated skill content, so there is no Hermes-visible surface to check; the capability is reachable through the CLI and the Python contract only.
- [ ] Workflow-learning review queue smoke — not applicable; no learning contract changed.

## Risk

- **Narrow blast radius.** The only change to existing behavior is one entry
  appended to `bounded_surfaces`, which is membership-asserted rather than
  count-asserted. Everything else is new code behind a new subcommand.
- **The `installed` tier reading is a judgement call.** A plugin or MCP host
  record whose `status` is `not_observed` is read as `installed`: the surface is
  configured for that host and the wrapper watched it do nothing. That is the
  most configuration-shaped fact OMH genuinely holds per host. It is deliberately
  the *weakest* tier and can never produce `ready`, so a wrong reading here
  under-claims rather than over-claims.
- **A preserved prior can carry a `ready` forward across unreadable evidence.**
  That is what AC3 asks for, and it is legible: `state_source` reads
  `preserved_prior`, `evidence_integrity` reads `unusable`, and
  `rejected_evidence` names the gap. On the CLI this path is unreachable, since
  there is no answer store and the evidence stores are re-read in full.
- **Windows.** No path is asserted through `os.sep`, no raw path is
  substring-matched against a resolved one, and the one test that appends to a
  store writes through `omh.local_store.atomic_write_text`. Windows CI is the
  enforcing check.

## Compatibility / Rollout

- Additive only. No existing schema, record, command, or generated artifact
  changed shape.
- `external_action_readiness/v1` and `external_action_evidence/v1` are new
  schema versions; nothing reads them yet outside this PR.
- Nothing is written to disk by this feature, so there is no migration and no
  new state directory.
- Rollback is removing the module, the subcommand, and the one `bounded_surfaces`
  entry.

## Release / Claims

- [x] Release-channel impact considered — `stable`; additive read-only surface,
      no installer, packaging, or version file touched.
- [x] Runtime/native capability claims are backed by evidence or marked as not
      observed — the whole point of the change. Every tier above `installed`
      requires a record another surface wrote, the answer carries a
      `claim_boundary` stating OMH ran no probe and performed no external
      action, and a `ready` answer explicitly does not claim the action will
      succeed.
- [x] Known manual Hermes checks are listed — `omh release hermes-smoke` ran in
      plan mode (`observed evidence: no`); no `--live` run was performed and no
      Hermes/TUI check applies, as stated under Validation.

## Follow-Up

- Natural-language routing. The issue's "how it blends in" names chat routing as
  the front door; this PR delivers the contract and the agent-facing command and
  leaves routing out on purpose, because a routing case means a new skill, the
  generated `skills/*/SKILL.md` + `docs/WORKFLOWS.md` + `docs/ROLES.md` +
  capability-family sidecar regeneration, and four exact-count assertion updates.
  Worth doing as its own goal once the vocabulary here has settled.
- Two more evidence sources could be adapted if they ever grow a host or effect
  identity: `omh_mcp_observation/v1` and `omh_evidence_probe/v1`.
- Per-tier freshness horizons. One six-hour horizon covers all four tiers today;
  a `used` receipt may deserve the twenty-four hours
  `CAPABILITY_EVIDENCE_STALE_AFTER_SECONDS` gives capability evidence. Not split
  now, because two numbers need a reason and there is not yet one.
