### PR TITLE
feat: choose a coding owner that can actually complete the requested work

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -118,6 +118,7 @@ src/
     executor_readiness.py
     executors.py
     isolation.py
+    owner_fit.py
     pre_handoff_readiness.py
     team_readiness.py
     worktree_creator.py
@@ -632,6 +633,60 @@ metadata from it.
 The delegation-first completion model is tracked in
 `docs/DELEGATION_FIRST_COMPLETENESS.md`. It is the product boundary for making
 OMH feel more complete without turning Hermes into the main coding executor.
+
+### Coding Owner Fit
+
+`coding/owner_fit.py` answers whether a coding owner can actually finish the
+plan that was just accepted. Owner selection used to read four inputs — an owner
+named in the request envelope, an owner named in the message, a recorded setup
+preference, a keyword route-family cue — and no capability evidence at all, so a
+gap surfaced during execution rather than before it.
+
+Two pure derivations, both with `now` as a parameter:
+
+- **Requirements** come from the accepted plan's declared fields only
+  (`ACCEPTED_PLAN_FIELDS`: the routed workflow, the work-owner mode, the
+  workspace-binding strategy). The message is never parsed here. The vocabulary
+  is the one `executor_capability_snapshot/v1` already speaks, so a requirement
+  and the evidence answering it always share a name.
+- **Classification** matches one requirement against one owner's recorded
+  snapshot and lands in `met`, `unmet`, or `unknown`. `OWNER_FIT_REASON_CODES`
+  is the single table mapping a reason to its classification, so "why" and
+  "what" cannot drift.
+
+The three states are kept apart deliberately. `met` needs fresh host-observed
+availability; `unmet` needs fresh host-observed unavailability; everything else
+— no snapshot, no record of that capability, prepared-only evidence, evidence
+scoped to a different workflow, evidence past the horizon — is `unknown`. An
+owner with an unmet requirement is `blocked` and is never recommended; an owner
+with an unknown requirement is `unproven`, which is also not recommended but is
+not reported as a gap either, because nothing was observed to be missing.
+
+Freshness reuses `CAPABILITY_EVIDENCE_STALE_AFTER_SECONDS` through
+`pre_handoff_readiness.capability_evidence_is_fresh` rather than declaring a
+second horizon. Expired evidence classifies `unknown` whatever it recorded,
+including a recorded `unavailable`: an expired observation is not knowledge of
+the present, and `unknown` still yields `unproven`, which is still not
+recommended.
+
+An explicitly named owner is still honoured. Naming an owner still selects it
+and still prepares its handoff; `resolve_coding_route_decision` is unchanged.
+When the named owner cannot do the work the report keeps it, sets
+`named_owner_honoured`, states the gap in `named_owner_gap`, and leaves it out
+of `recommended_owners`. Hermes therefore never recommends an owner with a known
+unmet capability and never silently swaps an owner a person asked for.
+
+`coding_owner_fit_report/v1` rides on every delegate-action coding payload, so
+`omh coding delegate` and the chat lane read the same answer, and
+`executor_choice_context` takes the same plan so owner fit is the first ranking
+key on the choose-executor card — an owner that cannot do the work never heads
+it. Candidates are ranked, never removed. Both artifacts are
+`prepared_not_observed`.
+
+Classification reads the snapshot and never the owner id.
+`owner_fit_without_owner_identity` drops the only two owner-identity fields
+(`owner`, `label`), and two owners holding equal evidence produce equal
+projections — the executor-neutrality property in code rather than in prose.
 
 ## Hermes Capability Boundary
 

--- a/src/coding/coding_delegation.py
+++ b/src/coding/coding_delegation.py
@@ -47,10 +47,17 @@ from .executor_capability_snapshots import (
 )
 from .executor_local_workflow import build_executor_local_workflow
 from .executor_local_workflow_selection import is_workflow
+from .owner_fit import (
+    accepted_plan_from_delegation,
+    build_owner_fit_report,
+    derive_plan_capability_requirements,
+    owner_capability_snapshots,
+)
 from .product_family_templates import product_family_template
 from .product_quality_harnesses import product_quality_harness
 from .project_governance import discover_project_governance, governance_handoff_attachment
 from ..executor_readiness import (
+    EXECUTOR_CHOICE_CONTEXT_PROFILES,
     executor_readiness_contract,
     executor_readiness_for_selection,
     with_executor_readiness_options,
@@ -526,6 +533,18 @@ def build_coding_delegation_payload(
     )
     if isolation_plan:
         payload["isolation_plan"] = isolation_plan
+    if delegation.action == "delegate":
+        # Attached here rather than in a wrapper because this is where the
+        # accepted plan is decided: the routed workflow, the workspace binding,
+        # and the work-owner mode are all final by this line, and the snapshot
+        # directory is already in hand. One attachment point serves both the
+        # chat lane and `omh coding delegate`, so neither can answer the
+        # owner-fit question differently from the other.
+        payload["coding_owner_fit"] = _coding_owner_fit(
+            payload,
+            executor_target=executor_target,
+            capability_snapshot_directory=capability_snapshot_directory,
+        )
     if _inline_coding_policy_applies(
         message.lower(), delegation.intent, delegation.action, bool(action_gate["choice_required"])
     ):
@@ -1739,6 +1758,36 @@ def _executor_local_capability_strategy(profile: str) -> dict[str, object]:
             "capabilities exist, were loaded, or were executed."
         ),
     }
+
+
+def _coding_owner_fit(
+    payload: dict[str, object],
+    *,
+    executor_target: str,
+    capability_snapshot_directory: Path | None,
+) -> dict[str, object]:
+    """The owner-fit report for the plan this build just accepted (#810).
+
+    Candidates are the same locally-probeable set the choose-executor card
+    ranks, plus the named owner when a person named one outside that set. The
+    named owner is added rather than substituted: this report never drops the
+    owner somebody asked for, it only declines to *recommend* an owner whose
+    required capabilities are recorded unavailable.
+
+    Only RECORDED snapshots are read here. `_resolved_executor_capability_snapshot`
+    falls back to a prepared snapshot so a handoff always carries one; that
+    fallback must not reach this matcher, because a prepared capability is the
+    absence of an observation and would read as evidence.
+    """
+    named_owner = executor_target if executor_target != "choose" else ""
+    candidates = list(EXECUTOR_CHOICE_CONTEXT_PROFILES)
+    if named_owner and named_owner not in candidates:
+        candidates.append(named_owner)
+    return build_owner_fit_report(
+        requirements=derive_plan_capability_requirements(accepted_plan_from_delegation(payload)),
+        owners=owner_capability_snapshots(capability_snapshot_directory, candidates),
+        named_owner=named_owner,
+    )
 
 
 def _prepared_executor_capability_snapshot(profile: str) -> dict[str, object]:

--- a/src/coding/executor_readiness.py
+++ b/src/coding/executor_readiness.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+from collections.abc import Mapping
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -487,7 +488,12 @@ EXECUTOR_CHOICE_CONTEXT_CLAIM_BOUNDARY = (
 )
 
 
-def executor_choice_context(paths: OmhPaths, *, now: str = "") -> dict[str, object]:
+def executor_choice_context(
+    paths: OmhPaths,
+    *,
+    now: str = "",
+    plan: Mapping[str, object] | None = None,
+) -> dict[str, object]:
     """Return per-candidate readiness/auth context for the choose-executor question.
 
     Reads cached readiness state and cheap local markers only — no subprocess
@@ -500,14 +506,24 @@ def executor_choice_context(paths: OmhPaths, *, now: str = "") -> dict[str, obje
     probe applies (#837), so a decision that no longer describes this machine
     reads `stale` here too. Ranking a candidate whose CLI is gone to the top of
     the choose-executor card is the failure that rule exists to prevent.
+
+    `plan` is the accepted plan's declared fields (#810). When one is supplied,
+    each candidate also carries its owner-fit verdict and the required
+    capabilities recorded unavailable for it, and fit becomes the FIRST ranking
+    key — an owner that cannot do the work must never head this card, whatever
+    its login marker says. Candidates are still never removed: the card offers
+    what the user may pick, and the verdict says what each pick would cost.
     """
     from .executor_auth_signals import auth_signal_for_profile, last_limit_signal_for_profile
     from .model_inventory import local_model_inventory
+    from .owner_fit import derive_plan_capability_requirements, evaluate_owner_fit
 
+    requirements = derive_plan_capability_requirements(plan) if plan is not None else None
     state, _ = _read_state(paths)
     candidates: list[dict[str, object]] = []
     for profile in EXECUTOR_CHOICE_CONTEXT_PROFILES:
         cached = _cached_profile(state, profile) or {}
+        snapshot = _capability_snapshot(paths, profile)
         # Same freshness rule as the probe: a stale or rebound decision must
         # not read `ready` here either, or the ranking would put a candidate
         # whose CLI is gone at the top of the choose-executor card.
@@ -515,28 +531,44 @@ def executor_choice_context(paths: OmhPaths, *, now: str = "") -> dict[str, obje
             profile=profile,
             cached=cached or None,
             binding=live_readiness_binding(paths, profile),
-            capability_snapshot=_capability_snapshot(paths, profile),
+            capability_snapshot=snapshot,
             now=now,
         )
         observed_status = str(cached.get("status", "not_observed"))
-        candidates.append(
-            {
-                "profile": profile,
-                "label": executor_label(profile),
-                "readiness_status": observed_status if (verdict["usable"] or not cached) else "stale",
-                "readiness_freshness": str(verdict["reason_code"]),
-                "auth_signal": auth_signal_for_profile(profile),
-                "last_limit_signal": last_limit_signal_for_profile(paths, profile),
-            }
-        )
-    # Advisory ranking, never a veto: logged-in first, then no fresh limit
-    # signal, then cached-ready, with the fixed profile order as tiebreak so
-    # equal candidates stay deterministic.
+        candidate: dict[str, object] = {
+            "profile": profile,
+            "label": executor_label(profile),
+            "readiness_status": observed_status if (verdict["usable"] or not cached) else "stale",
+            "readiness_freshness": str(verdict["reason_code"]),
+            "auth_signal": auth_signal_for_profile(profile),
+            "last_limit_signal": last_limit_signal_for_profile(paths, profile),
+        }
+        if requirements is not None:
+            # The same snapshot the freshness rule just read, so readiness and
+            # fit cannot describe different evidence for one candidate.
+            fit = evaluate_owner_fit(
+                owner=profile,
+                requirements=requirements,
+                capability_snapshot=snapshot,
+                now=now,
+            )
+            candidate["owner_fit_verdict"] = str(fit["verdict"])
+            candidate["owner_fit_unmet"] = list(fit["unmet"])
+            candidate["owner_fit_unknown"] = list(fit["unknown"])
+        candidates.append(candidate)
+    # Advisory ranking, never a veto: owner fit first when a plan says what the
+    # work needs, then logged-in, then no fresh limit signal, then cached-ready,
+    # with the fixed profile order as tiebreak so equal candidates stay
+    # deterministic.
     candidates.sort(key=_choice_context_rank)
     inventory = local_model_inventory()
     return {
         "candidates": candidates,
-        "ranked_by": ("login_marker", "fresh_limit_signal_absent", "readiness_status"),
+        "ranked_by": (
+            ("owner_fit_verdict", "login_marker", "fresh_limit_signal_absent", "readiness_status")
+            if requirements is not None
+            else ("login_marker", "fresh_limit_signal_absent", "readiness_status")
+        ),
         "model_inventory_hint": {
             "families_present": inventory.get("families_present", []),
             "model_count": len(inventory.get("available_models", [])),
@@ -547,14 +579,21 @@ def executor_choice_context(paths: OmhPaths, *, now: str = "") -> dict[str, obje
     }
 
 
-def _choice_context_rank(candidate: dict[str, object]) -> tuple[int, int, int, int]:
+# Absent means "no plan said what this work needs", which must leave the
+# pre-#810 ordering exactly as it was rather than sort by a verdict nobody
+# derived.
+_OWNER_FIT_RANKS: dict[str, int] = {"ready": 0, "unproven": 1, "blocked": 2}
+
+
+def _choice_context_rank(candidate: dict[str, object]) -> tuple[int, int, int, int, int]:
     auth = candidate.get("auth_signal")
     login = str(auth.get("login_marker", "")) if isinstance(auth, dict) else ""
     limit = candidate.get("last_limit_signal")
     fresh_limit = isinstance(limit, dict) and bool(limit) and not limit.get("stale", False)
     ready = str(candidate.get("readiness_status", "")) == "ready"
+    fit = _OWNER_FIT_RANKS.get(str(candidate.get("owner_fit_verdict", "")), 0)
     original = EXECUTOR_CHOICE_CONTEXT_PROFILES.index(str(candidate.get("profile", "")))
-    return (0 if login == "present" else 1, 1 if fresh_limit else 0, 0 if ready else 1, original)
+    return (fit, 0 if login == "present" else 1, 1 if fresh_limit else 0, 0 if ready else 1, original)
 
 
 def _ready_action(profile: str) -> str:

--- a/src/coding/owner_fit.py
+++ b/src/coding/owner_fit.py
@@ -1,0 +1,786 @@
+"""Owner fit: what the accepted plan requires against what a coding owner can prove.
+
+The defect this closes (#810). `routing.coding_route_actions.resolve_coding_route_decision`
+picks a coding owner from four inputs and nothing else --- an owner named in the request
+envelope, an owner named in the message text, a recorded setup preference, and a keyword
+route-family cue. It never reads a capability snapshot, never consults a readiness probe,
+and never looks at what the accepted plan needs; its payload carries no requirement, no
+gap, and no unknown. A person could therefore name an owner, be told the handoff was
+prepared, and only discover mid-execution that the owner cannot isolate a worktree, run
+parallel lanes, or invoke the routed workflow at all.
+
+Two derivations live here. Both are pure, both are deterministic, and neither reads free
+text:
+
+* **Requirements** come from the accepted plan's DECLARED fields only --- the routed
+  workflow, the workspace-binding strategy, and the work-owner mode
+  (`ACCEPTED_PLAN_FIELDS`). The message is never parsed here, so a requirement cannot
+  appear because of a word somebody happened to use. The vocabulary is the one the
+  capability snapshot already speaks (`KNOWN_CAPABILITY_NAMES` plus `local_workflow`), so a
+  requirement and the evidence that answers it always share a name.
+* **Classification** matches one requirement against one owner's recorded capability
+  snapshot and lands in exactly one of three states, kept distinct on purpose:
+
+  - `met` --- fresh host-observed evidence that the owner has the capability.
+  - `unmet` --- fresh host-observed evidence that the owner does NOT have it.
+  - `unknown` --- no snapshot, no record of that capability, prepared-only evidence,
+    evidence scoped to something else, or evidence too old to describe this machine now.
+
+  `unknown` is not a quiet `met` and not a quiet `unmet`. Its consequence is stated and
+  tested: an owner carrying an unknown required capability is `unproven`. `unproven` is
+  never recommended, which keeps AC1 strict, and it is never reported as a blocking gap,
+  which keeps the report honest --- the person is told which observation is missing
+  instead of being handed a guess.
+
+Freshness reuses the #837 horizon through
+`pre_handoff_readiness.capability_evidence_is_fresh`; adding a second horizon would let two
+surfaces disagree about the same machine. Expired evidence classifies `unknown` whatever it
+recorded, including a recorded `unavailable`. That is safe rather than permissive: an
+expired observation is not knowledge of the present, and `unknown` still yields `unproven`,
+which is still not recommended.
+
+**An explicitly named owner is still honoured, and that is a deliberate decision.**
+`resolve_coding_route_decision` is unchanged: naming an owner still selects it and still
+prepares that owner's handoff. Owner fit is additive. When the named owner cannot do the
+work the report says so --- `named_owner_honoured` stays true, `named_owner_gap` names the
+capabilities --- and the owner is simply absent from `recommended_owners`. So Hermes never
+RECOMMENDS an owner with a known unmet capability, and it never silently overrides a person
+who named one. Silently rerouting was the rejected alternative: a stated preference
+replaced without a word is an invisible decision, and the user would learn about the swap
+from the handoff rather than from Hermes.
+
+Executor-neutrality (AC3): classification reads the snapshot and never the owner id. The
+only owner-identity fields in a fit record are `owner` and `label`
+(`OWNER_FIT_OWNER_IDENTITY_KEYS`); `owner_fit_without_owner_identity` strips them, and two
+owners with equal capability evidence produce equal projections. Every reason string is
+brand-neutral for the same reason.
+
+Nothing here is execution. Both artifacts are `prepared_not_observed`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from .executor_capability_snapshots import (
+    KNOWN_CAPABILITY_NAMES,
+    LOCAL_WORKFLOW_CAPABILITY_NAME,
+    executor_capability_snapshot_path,
+    read_matching_executor_capability_snapshot,
+)
+from .executors import executor_label
+from .pre_handoff_readiness import (
+    CAPABILITY_EVIDENCE_STALE_AFTER_SECONDS,
+    capability_evidence_is_fresh,
+)
+
+
+OWNER_FIT_SCHEMA_VERSION: Final = "coding_owner_fit/v1"
+OWNER_FIT_REPORT_SCHEMA_VERSION: Final = "coding_owner_fit_report/v1"
+OWNER_FIT_STATUS: Final = "prepared_not_observed"
+
+# The declared plan fields the derivation reads. Three, and no more: every one
+# of them is a value the delegation build already decided and wrote down, so a
+# requirement can always be traced back to a field rather than to a phrase.
+# `review_required`, `dispatch_policy`, and the acceptance/verification lists
+# are deliberately NOT read --- none of them names a capability from the
+# snapshot vocabulary, and mapping prose onto a capability is exactly the
+# heuristic this module exists to avoid.
+ACCEPTED_PLAN_FIELDS: Final = ("workflow", "work_owner_mode", "isolation_strategy")
+
+_WORKTREE_REQUIRED_STRATEGY: Final = "worktree_required"
+_RUNTIME_HANDOFF_MODE: Final = "runtime_handoff"
+
+# Routed workflow -> the capabilities that workflow's lane runs on. Only lanes
+# whose meaning IS the capability appear here: a `team` lane is parallel agents,
+# a `loop` lane is recurring work. Guarded by tests on both sides --- every key
+# is a routable workflow, every value is in the snapshot vocabulary.
+WORKFLOW_CAPABILITY_REQUIREMENTS: Final[dict[str, tuple[str, ...]]] = {
+    "browser-operator": ("browser_or_computer_use",),
+    "loop": ("scheduled_or_recurring_work",),
+    "parallel-tools": ("parallel_agents",),
+    "ralph": ("long_running_continuation",),
+    "team": ("parallel_agents",),
+    "ultragoal": ("long_running_continuation",),
+    "ultrawork": ("parallel_agents", "background_work"),
+    "visual-qa": ("visual_qa",),
+}
+
+OWNER_FIT_CLASSIFICATIONS: Final = ("met", "unmet", "unknown")
+OWNER_FIT_VERDICTS: Final = ("ready", "unproven", "blocked")
+OWNER_FIT_EVIDENCE_STATUSES: Final = (
+    "no_snapshot",
+    "not_recorded",
+    "prepared",
+    "unknown",
+    "host_observed",
+    "unavailable",
+)
+
+# One table, one direction: a reason code determines its classification. Nothing
+# else may set a classification, so "why" and "what" cannot drift apart.
+OWNER_FIT_REASON_CODES: Final[dict[str, str]] = {
+    "no_capability_snapshot": "unknown",
+    "capability_not_recorded": "unknown",
+    "evidence_prepared_only": "unknown",
+    "evidence_status_unknown": "unknown",
+    "evidence_scope_mismatch": "unknown",
+    "evidence_expired": "unknown",
+    "host_observed_available": "met",
+    "host_observed_unavailable": "unmet",
+}
+
+OWNER_FIT_REQUIREMENT_KEYS: Final = (
+    "capability",
+    "source_field",
+    "source_value",
+    "scope",
+    "reason",
+)
+OWNER_FIT_CLASSIFICATION_KEYS: Final = (
+    "capability",
+    "source_field",
+    "source_value",
+    "classification",
+    "reason_code",
+    "reason",
+    "evidence_status",
+    "evidence_ref",
+    "evidence_observed_at",
+)
+OWNER_FIT_KEYS: Final = (
+    "schema_version",
+    "status",
+    "owner",
+    "label",
+    "verdict",
+    "recommendable",
+    "capabilities",
+    "met",
+    "unmet",
+    "unknown",
+    "reason",
+    "next_action",
+    "claim_boundary",
+)
+OWNER_FIT_REPORT_KEYS: Final = (
+    "schema_version",
+    "status",
+    "requirements",
+    "owners",
+    "recommended_owners",
+    "unproven_owners",
+    "blocked_owners",
+    "named_owner",
+    "named_owner_honoured",
+    "named_owner_gap",
+    "next_action",
+    "claim_boundary",
+)
+
+# The only fields of a fit record that name an owner. AC3 is the property that
+# removing exactly these makes two equally-evidenced owners indistinguishable.
+OWNER_FIT_OWNER_IDENTITY_KEYS: Final = ("owner", "label")
+
+OWNER_FIT_NEXT_ACTIONS: Final[dict[str, str]] = {
+    "ready": "prepare_handoff_for_this_owner",
+    "unproven": "record_capability_evidence",
+    "blocked": "close_the_capability_gap_or_choose_another_owner",
+}
+OWNER_FIT_REPORT_NEXT_ACTIONS: Final = (
+    "prepare_handoff_for_named_owner",
+    "confirm_named_owner_despite_capability_gap",
+    "choose_from_recommended_owners",
+    "record_capability_evidence",
+)
+
+OWNER_FIT_CLAIM_BOUNDARY: Final = (
+    "Owner fit compares the accepted plan's declared requirements against recorded capability "
+    "evidence. It is not dispatch, execution, verification, review, CI, or merge evidence, and a "
+    "ready verdict is not proof that the owner would accept or finish the handoff."
+)
+OWNER_FIT_REPORT_CLAIM_BOUNDARY: Final = (
+    "This report recommends prepared coding owners from recorded capability evidence only. It is "
+    "not dispatch, execution, verification, review, CI, or merge evidence, it never removes an "
+    "owner the user explicitly named, and it never claims a capability nobody observed."
+)
+
+# Canonical references for the cases where the snapshot supplies none. Every
+# classification carries a nonempty `evidence_ref` so "which evidence decided
+# this" is always answerable, including when the answer is "there was none".
+_NO_SNAPSHOT_EVIDENCE_REF: Final = "capability_snapshot:none"
+_NOT_RECORDED_EVIDENCE_REF: Final = "capability_snapshot:not_recorded"
+_STATUS_ONLY_EVIDENCE_REF: Final = "capability_snapshot:status_only"
+
+_MAX_TEXT_LENGTH: Final = 240
+_MAX_REASON_LENGTH: Final = 400
+_MAX_REQUIREMENTS: Final = 12
+_MAX_OWNERS: Final = 12
+_MAX_SCOPE_ITEMS: Final = 4
+
+
+class OwnerFitError(ValueError):
+    pass
+
+
+def derive_plan_capability_requirements(plan: Mapping[str, Any]) -> tuple[dict[str, Any], ...]:
+    """The capabilities an accepted plan requires, derived from its declared fields.
+
+    Deterministic and order-stable: workflow-derived requirements first in the
+    catalog's own order, then the workspace binding, then the runtime workflow
+    binding. A capability already required by an earlier rule is not repeated;
+    the first rule that asked for it owns the explanation, so `source_field`
+    always names one field rather than a set.
+    """
+    unexpected = sorted(str(key) for key in plan if str(key) not in ACCEPTED_PLAN_FIELDS)
+    if unexpected:
+        raise OwnerFitError(f"accepted plan contains unsupported fields: {', '.join(unexpected)}")
+    workflow = str(plan.get("workflow", "") or "").strip()
+    work_owner_mode = str(plan.get("work_owner_mode", "") or "").strip()
+    isolation_strategy = str(plan.get("isolation_strategy", "") or "").strip()
+
+    requirements: list[dict[str, Any]] = []
+    claimed: set[str] = set()
+
+    def _add(capability: str, source_field: str, source_value: str, scope: dict[str, str], reason: str) -> None:
+        if capability in claimed:
+            return
+        claimed.add(capability)
+        requirements.append(
+            {
+                "capability": capability,
+                "source_field": source_field,
+                "source_value": source_value,
+                "scope": dict(scope),
+                "reason": reason[:_MAX_REASON_LENGTH],
+            }
+        )
+
+    for capability in WORKFLOW_CAPABILITY_REQUIREMENTS.get(workflow, ()):
+        _add(
+            capability,
+            "workflow",
+            workflow,
+            {},
+            f"The accepted plan routes this work to the `{workflow}` workflow, whose lane runs on this capability.",
+        )
+    if isolation_strategy == _WORKTREE_REQUIRED_STRATEGY:
+        _add(
+            "worktree_isolation",
+            "isolation_strategy",
+            isolation_strategy,
+            {},
+            "The accepted plan's workspace binding declares an isolated worktree as required before the "
+            "owner opens a coding session.",
+        )
+    if work_owner_mode == _RUNTIME_HANDOFF_MODE and workflow:
+        _add(
+            LOCAL_WORKFLOW_CAPABILITY_NAME,
+            "work_owner_mode",
+            work_owner_mode,
+            {"skill_id": workflow},
+            f"The accepted plan hands the `{workflow}` workflow to the owner's own runtime, so the owner "
+            "has to carry that workflow locally.",
+        )
+    return tuple(requirements)
+
+
+def accepted_plan_from_delegation(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Project a built coding-delegation payload onto the declared plan fields.
+
+    A projection rather than a second decision: every value is read back from
+    where the delegation build already wrote it, so owner fit and the handoff
+    can never describe different plans.
+    """
+    delegation = payload.get("delegation")
+    delegation = delegation if isinstance(delegation, Mapping) else {}
+    isolation = payload.get("isolation_plan")
+    isolation = isolation if isinstance(isolation, Mapping) else {}
+    return {
+        "workflow": str(delegation.get("recommended_workflow", "") or ""),
+        "work_owner_mode": str(payload.get("work_owner_mode", "") or ""),
+        "isolation_strategy": str(isolation.get("strategy", "") or ""),
+    }
+
+
+def evaluate_owner_fit(
+    *,
+    owner: str,
+    requirements: Sequence[Mapping[str, Any]],
+    capability_snapshot: Mapping[str, Any] | None,
+    now: str = "",
+) -> dict[str, Any]:
+    """Whether one owner can prove it satisfies every capability the plan requires.
+
+    This is the reusable matcher. #812 (retarget an accepted handoff to another
+    owner) derives the requirement set once from the accepted plan and calls
+    this per candidate; nothing here knows or cares which surface asked.
+
+    `capability_snapshot` is an `executor_capability_snapshot/v1` record for THIS
+    owner, or `None` when none was recorded --- absent evidence classifies every
+    requirement `unknown` rather than inventing a verdict. `now` is a parameter
+    so the freshness derivation is deterministic under test.
+    """
+    normalized_owner = str(owner or "").strip()
+    if not normalized_owner:
+        raise OwnerFitError("owner fit requires a nonempty owner id")
+    classifications = [_classify(requirement, capability_snapshot, now) for requirement in requirements]
+    met = [str(item["capability"]) for item in classifications if item["classification"] == "met"]
+    unmet = [str(item["capability"]) for item in classifications if item["classification"] == "unmet"]
+    unknown = [str(item["capability"]) for item in classifications if item["classification"] == "unknown"]
+    verdict = "blocked" if unmet else "unproven" if unknown else "ready"
+    fit = {
+        "schema_version": OWNER_FIT_SCHEMA_VERSION,
+        "status": OWNER_FIT_STATUS,
+        "owner": normalized_owner,
+        "label": executor_label(normalized_owner),
+        "verdict": verdict,
+        "recommendable": verdict == "ready",
+        "capabilities": classifications,
+        "met": met,
+        "unmet": unmet,
+        "unknown": unknown,
+        "reason": _fit_reason(verdict, met, unmet, unknown),
+        "next_action": OWNER_FIT_NEXT_ACTIONS[verdict],
+        "claim_boundary": OWNER_FIT_CLAIM_BOUNDARY,
+    }
+    errors = validate_owner_fit(fit)
+    if errors:
+        raise OwnerFitError("; ".join(errors))
+    return fit
+
+
+def build_owner_fit_report(
+    *,
+    requirements: Sequence[Mapping[str, Any]],
+    owners: Sequence[tuple[str, Mapping[str, Any] | None]],
+    named_owner: str = "",
+    now: str = "",
+) -> dict[str, Any]:
+    """The owner-fit recommendation surface for one accepted plan.
+
+    `owners` pairs each candidate with its recorded snapshot, or `None`. A named
+    owner must be among them: the report never drops the owner a person asked
+    for, so a caller that cannot supply its evidence has a bug rather than a
+    silent omission.
+    """
+    normalized_named = str(named_owner or "").strip()
+    fits = [
+        evaluate_owner_fit(owner=owner, requirements=requirements, capability_snapshot=snapshot, now=now)
+        for owner, snapshot in owners
+    ]
+    owner_ids = [str(fit["owner"]) for fit in fits]
+    if len(owner_ids) != len(set(owner_ids)):
+        raise OwnerFitError("owner fit report must not list an owner twice")
+    if normalized_named and normalized_named not in owner_ids:
+        raise OwnerFitError(f"named owner is missing from the owner fit candidates: {normalized_named}")
+    named_fit = next((fit for fit in fits if str(fit["owner"]) == normalized_named), None)
+    named_gap = "" if named_fit is None or named_fit["verdict"] == "ready" else _named_owner_gap(named_fit)
+    recommended = [str(fit["owner"]) for fit in fits if fit["verdict"] == "ready"]
+    report = {
+        "schema_version": OWNER_FIT_REPORT_SCHEMA_VERSION,
+        "status": OWNER_FIT_STATUS,
+        "requirements": [dict(requirement) for requirement in requirements],
+        "owners": fits,
+        "recommended_owners": recommended,
+        "unproven_owners": [str(fit["owner"]) for fit in fits if fit["verdict"] == "unproven"],
+        "blocked_owners": [str(fit["owner"]) for fit in fits if fit["verdict"] == "blocked"],
+        "named_owner": normalized_named,
+        "named_owner_honoured": bool(normalized_named),
+        "named_owner_gap": named_gap,
+        "next_action": _report_next_action(normalized_named, named_gap, recommended),
+        "claim_boundary": OWNER_FIT_REPORT_CLAIM_BOUNDARY,
+    }
+    errors = validate_owner_fit_report(report)
+    if errors:
+        raise OwnerFitError("; ".join(errors))
+    return report
+
+
+def owner_capability_snapshots(
+    directory: Path | None,
+    owners: Sequence[str],
+) -> tuple[tuple[str, dict[str, Any] | None], ...]:
+    """Pair each owner with its recorded capability snapshot, or `None`.
+
+    The only I/O in this module, kept here so both the delegation build and the
+    choose-executor card read evidence the same way. An absent, unreadable, or
+    mismatched snapshot reads as `None`, which classifies every requirement
+    `unknown` rather than inventing evidence.
+    """
+    if directory is None:
+        return tuple((owner, None) for owner in owners)
+    paired: list[tuple[str, dict[str, Any] | None]] = []
+    for owner in owners:
+        try:
+            path = executor_capability_snapshot_path(directory, owner)
+        except ValueError:
+            paired.append((owner, None))
+            continue
+        paired.append((owner, read_matching_executor_capability_snapshot(path, expected_executor=owner)))
+    return tuple(paired)
+
+
+def owner_fit_without_owner_identity(fit: Mapping[str, Any]) -> dict[str, Any]:
+    """The fit record with every owner-identity field removed (AC3).
+
+    Two owners holding equal capability evidence must produce equal projections.
+    This is the executor-neutrality property in code rather than in prose: if a
+    brand ever leaks into a verdict, a reason, or a classification, the two
+    projections stop matching.
+    """
+    return {str(key): value for key, value in fit.items() if str(key) not in OWNER_FIT_OWNER_IDENTITY_KEYS}
+
+
+def validate_owner_fit(fit: Mapping[str, Any]) -> list[str]:
+    """Both directions: no key of the closed set missing, no key outside it."""
+    errors = _closed_key_errors("owner fit", fit, OWNER_FIT_KEYS)
+    if fit.get("schema_version") != OWNER_FIT_SCHEMA_VERSION:
+        errors.append(f"schema_version must be {OWNER_FIT_SCHEMA_VERSION}")
+    if fit.get("status") != OWNER_FIT_STATUS:
+        errors.append(f"status must be {OWNER_FIT_STATUS}; owner fit never claims an observation")
+    if fit.get("claim_boundary") != OWNER_FIT_CLAIM_BOUNDARY:
+        errors.append("claim_boundary must be the owner fit claim boundary")
+    for field, limit in (("owner", _MAX_TEXT_LENGTH), ("label", _MAX_TEXT_LENGTH), ("reason", _MAX_REASON_LENGTH)):
+        value = fit.get(field)
+        if not isinstance(value, str) or not value.strip() or len(value) > limit:
+            errors.append(f"{field} must be a nonempty string of at most {limit} characters")
+    verdict = fit.get("verdict")
+    if verdict not in OWNER_FIT_VERDICTS:
+        errors.append(f"verdict must be one of {', '.join(OWNER_FIT_VERDICTS)}")
+        return errors
+    if fit.get("recommendable") is not (verdict == "ready"):
+        errors.append("recommendable must be true for a ready verdict and false otherwise")
+    if fit.get("next_action") != OWNER_FIT_NEXT_ACTIONS[str(verdict)]:
+        errors.append("next_action must match the verdict it was derived from")
+    capabilities = fit.get("capabilities")
+    if not isinstance(capabilities, list):
+        errors.append("capabilities must be a list")
+        return errors
+    if len(capabilities) > _MAX_REQUIREMENTS:
+        errors.append(f"capabilities must hold at most {_MAX_REQUIREMENTS} entries")
+    grouped: dict[str, list[str]] = {name: [] for name in OWNER_FIT_CLASSIFICATIONS}
+    for entry in capabilities:
+        if not isinstance(entry, Mapping):
+            errors.append("each classified capability must be a mapping")
+            continue
+        entry_errors = _classification_errors(entry)
+        errors.extend(entry_errors)
+        if not entry_errors:
+            grouped[str(entry["classification"])].append(str(entry["capability"]))
+    for name in OWNER_FIT_CLASSIFICATIONS:
+        if fit.get(name) != grouped[name]:
+            errors.append(f"{name} must list exactly the capabilities classified {name}, in order")
+    expected_verdict = "blocked" if grouped["unmet"] else "unproven" if grouped["unknown"] else "ready"
+    if verdict != expected_verdict:
+        errors.append(f"verdict must be {expected_verdict} for this classification set")
+    return errors
+
+
+def validate_owner_fit_report(report: Mapping[str, Any]) -> list[str]:
+    """Both directions, plus the two acceptance properties the report exists for.
+
+    AC1 has teeth here: `recommended_owners` must be exactly the ready owners,
+    so an owner carrying a known unmet capability cannot appear in it however it
+    was assembled. AC2 has teeth here too: every owner must classify exactly the
+    declared requirements, in order, so a report cannot quietly drop one.
+    """
+    errors = _closed_key_errors("owner fit report", report, OWNER_FIT_REPORT_KEYS)
+    if report.get("schema_version") != OWNER_FIT_REPORT_SCHEMA_VERSION:
+        errors.append(f"schema_version must be {OWNER_FIT_REPORT_SCHEMA_VERSION}")
+    if report.get("status") != OWNER_FIT_STATUS:
+        errors.append(f"status must be {OWNER_FIT_STATUS}; the report never claims an observation")
+    if report.get("claim_boundary") != OWNER_FIT_REPORT_CLAIM_BOUNDARY:
+        errors.append("claim_boundary must be the owner fit report claim boundary")
+    if report.get("next_action") not in OWNER_FIT_REPORT_NEXT_ACTIONS:
+        errors.append(f"next_action must be one of {', '.join(OWNER_FIT_REPORT_NEXT_ACTIONS)}")
+    requirements = report.get("requirements")
+    if not isinstance(requirements, list):
+        errors.append("requirements must be a list")
+        return errors
+    if len(requirements) > _MAX_REQUIREMENTS:
+        errors.append(f"requirements must hold at most {_MAX_REQUIREMENTS} entries")
+    required_names: list[str] = []
+    for requirement in requirements:
+        if not isinstance(requirement, Mapping):
+            errors.append("each requirement must be a mapping")
+            continue
+        requirement_errors = _requirement_errors(requirement)
+        errors.extend(requirement_errors)
+        if not requirement_errors:
+            required_names.append(str(requirement["capability"]))
+    if len(required_names) != len(set(required_names)):
+        errors.append("requirements must not name the same capability twice")
+    owners = report.get("owners")
+    if not isinstance(owners, list) or not owners:
+        errors.append("owners must be a nonempty list")
+        return errors
+    if len(owners) > _MAX_OWNERS:
+        errors.append(f"owners must hold at most {_MAX_OWNERS} entries")
+    by_verdict: dict[str, list[str]] = {name: [] for name in OWNER_FIT_VERDICTS}
+    fits: dict[str, Mapping[str, Any]] = {}
+    for fit in owners:
+        if not isinstance(fit, Mapping):
+            errors.append("each owner entry must be a mapping")
+            continue
+        fit_errors = validate_owner_fit(fit)
+        errors.extend(fit_errors)
+        if fit_errors:
+            continue
+        owner_id = str(fit["owner"])
+        fits[owner_id] = fit
+        by_verdict[str(fit["verdict"])].append(owner_id)
+        classified = [str(entry["capability"]) for entry in fit["capabilities"]]
+        if classified != required_names:
+            errors.append(
+                f"owner {owner_id} must classify exactly the declared required capabilities, in order"
+            )
+    if len(fits) != len(owners):
+        return errors
+    for field, verdict in (
+        ("recommended_owners", "ready"),
+        ("unproven_owners", "unproven"),
+        ("blocked_owners", "blocked"),
+    ):
+        if report.get(field) != by_verdict[verdict]:
+            errors.append(f"{field} must list exactly the owners whose verdict is {verdict}, in order")
+    errors.extend(_named_owner_errors(report, fits))
+    return errors
+
+
+def _named_owner_errors(report: Mapping[str, Any], fits: Mapping[str, Mapping[str, Any]]) -> list[str]:
+    errors: list[str] = []
+    named = report.get("named_owner")
+    if not isinstance(named, str):
+        return ["named_owner must be a string, empty when no owner was named"]
+    if report.get("named_owner_honoured") is not bool(named):
+        errors.append("named_owner_honoured must be true exactly when an owner was named")
+    gap = report.get("named_owner_gap")
+    if not isinstance(gap, str) or len(gap) > _MAX_REASON_LENGTH:
+        return [*errors, f"named_owner_gap must be a string of at most {_MAX_REASON_LENGTH} characters"]
+    if not named:
+        if gap:
+            errors.append("named_owner_gap must be empty when no owner was named")
+        return errors
+    if named not in fits:
+        errors.append("named_owner must be one of the reported owners; the report never drops a named owner")
+        return errors
+    ready = fits[named]["verdict"] == "ready"
+    if ready and gap:
+        errors.append("named_owner_gap must be empty when the named owner is ready")
+    if not ready and not gap:
+        errors.append("named_owner_gap must name the gap when the named owner is not ready")
+    return errors
+
+
+def _classify(requirement: Mapping[str, Any], snapshot: Mapping[str, Any] | None, now: str) -> dict[str, Any]:
+    """One requirement against one snapshot.
+
+    Precedence is deliberate. Scope is checked before freshness: evidence
+    recorded about a different workflow is not stale evidence about this one, it
+    is evidence about something else, and saying "expired" would send a person
+    to re-observe the wrong thing.
+    """
+    capability = str(requirement.get("capability", ""))
+    source_field = str(requirement.get("source_field", ""))
+    source_value = str(requirement.get("source_value", ""))
+    required_scope = requirement.get("scope")
+    required_scope = required_scope if isinstance(required_scope, Mapping) else {}
+
+    def _record(evidence_status: str, evidence_ref: str, reason_code: str, observed_at: str) -> dict[str, Any]:
+        return {
+            "capability": capability,
+            "source_field": source_field,
+            "source_value": source_value,
+            "classification": OWNER_FIT_REASON_CODES[reason_code],
+            "reason_code": reason_code,
+            "reason": _classification_reason(reason_code)[:_MAX_REASON_LENGTH],
+            "evidence_status": evidence_status,
+            "evidence_ref": evidence_ref[:_MAX_TEXT_LENGTH],
+            "evidence_observed_at": observed_at[:_MAX_TEXT_LENGTH],
+        }
+
+    if not isinstance(snapshot, Mapping):
+        return _record("no_snapshot", _NO_SNAPSHOT_EVIDENCE_REF, "no_capability_snapshot", "")
+    capabilities = snapshot.get("capabilities")
+    entry = capabilities.get(capability) if isinstance(capabilities, Mapping) else None
+    if not isinstance(entry, Mapping):
+        return _record("not_recorded", _NOT_RECORDED_EVIDENCE_REF, "capability_not_recorded", "")
+    status = str(entry.get("status", ""))
+    if status == "prepared":
+        return _record("prepared", _STATUS_ONLY_EVIDENCE_REF, "evidence_prepared_only", "")
+    if status not in {"host_observed", "unavailable"}:
+        return _record("unknown", _STATUS_ONLY_EVIDENCE_REF, "evidence_status_unknown", "")
+    evidence_ref = str(entry.get("evidence_ref", "") or "").strip() or _STATUS_ONLY_EVIDENCE_REF
+    # `executor_capability_snapshot/v1` gives a per-capability `observed_at`
+    # only to `host_observed` entries and to `local_workflow`; an `unavailable`
+    # generic capability is status-only. The snapshot's own `recorded_at` is
+    # then the honest observation time --- the evidence IS "this snapshot,
+    # written then" --- and it keeps a recorded absence subject to the same
+    # freshness rule as a recorded presence.
+    observed_at = str(entry.get("observed_at", "") or "").strip() or str(snapshot.get("recorded_at", "") or "").strip()
+    if required_scope and not _scope_covers(entry.get("scope"), required_scope):
+        return _record(status, evidence_ref, "evidence_scope_mismatch", observed_at)
+    if not capability_evidence_is_fresh(observed_at, now):
+        return _record(status, evidence_ref, "evidence_expired", observed_at)
+    reason_code = "host_observed_available" if status == "host_observed" else "host_observed_unavailable"
+    return _record(status, evidence_ref, reason_code, observed_at)
+
+
+def _scope_covers(observed: Any, required: Mapping[str, Any]) -> bool:
+    if not isinstance(observed, Mapping):
+        return False
+    return all(str(observed.get(key, "")) == str(value) for key, value in required.items())
+
+
+def _classification_reason(reason_code: str) -> str:
+    hours = CAPABILITY_EVIDENCE_STALE_AFTER_SECONDS // 3600
+    match reason_code:
+        case "no_capability_snapshot":
+            return (
+                "No capability snapshot was recorded for this owner, so this requirement is unproven rather "
+                "than met or missing."
+            )
+        case "capability_not_recorded":
+            return (
+                "The recorded capability snapshot says nothing about this capability, so it is unproven "
+                "rather than met or missing."
+            )
+        case "evidence_prepared_only":
+            return (
+                "The snapshot carries prepared evidence for this capability, and prepared evidence is the "
+                "absence of an observation rather than a weaker one."
+            )
+        case "evidence_status_unknown":
+            return "The snapshot records this capability as unknown, which is not an observation either way."
+        case "evidence_scope_mismatch":
+            return (
+                "The recorded observation covers a different scope than this requirement asks about, so it "
+                "cannot answer this requirement."
+            )
+        case "evidence_expired":
+            return (
+                f"The recorded observation is older than {hours} hours, so it describes a machine state "
+                "nobody has confirmed since."
+            )
+        case "host_observed_available":
+            return "A host observation inside the freshness window records this capability as available."
+        case _:
+            return "A host observation inside the freshness window records this capability as unavailable."
+
+
+def _capability_count(names: Sequence[str]) -> str:
+    return f"{len(names)} required {'capability' if len(names) == 1 else 'capabilities'}"
+
+
+def _fit_reason(verdict: str, met: Sequence[str], unmet: Sequence[str], unknown: Sequence[str]) -> str:
+    if verdict == "blocked":
+        return (
+            f"{_capability_count(unmet)} recorded unavailable by fresh host observation: "
+            f"{', '.join(unmet)}. This owner cannot complete the accepted plan."
+        )
+    if verdict == "unproven":
+        return (
+            f"{_capability_count(unknown)} with no fresh host observation: {', '.join(unknown)}. "
+            "Nothing is known to be missing, and nothing is proven present."
+        )
+    if not met:
+        return "The accepted plan declares no required capability, so there is nothing left to prove."
+    return f"Every required capability is answered by fresh host observation: {', '.join(met)}."
+
+
+def _named_owner_gap(fit: Mapping[str, Any]) -> str:
+    unmet = [str(name) for name in fit.get("unmet", [])]
+    unknown = [str(name) for name in fit.get("unknown", [])]
+    if unmet:
+        gap = (
+            "The named owner stays selected, and fresh host observation records these required capabilities "
+            f"as unavailable: {', '.join(unmet)}. It is not recommended, and it was not swapped for another "
+            "owner without saying so."
+        )
+    else:
+        gap = (
+            "The named owner stays selected, and these required capabilities have no fresh host observation: "
+            f"{', '.join(unknown)}. Record the evidence or accept the gap explicitly."
+        )
+    return gap[:_MAX_REASON_LENGTH]
+
+
+def _report_next_action(named_owner: str, named_gap: str, recommended: Sequence[str]) -> str:
+    if named_owner:
+        return "confirm_named_owner_despite_capability_gap" if named_gap else "prepare_handoff_for_named_owner"
+    if recommended:
+        return "choose_from_recommended_owners"
+    return "record_capability_evidence"
+
+
+def _closed_key_errors(label: str, value: Mapping[str, Any], keys: Sequence[str]) -> list[str]:
+    expected = set(keys)
+    present = {str(key) for key in value}
+    errors: list[str] = []
+    missing = expected - present
+    if missing:
+        errors.append(f"{label} is missing required keys: {', '.join(sorted(missing))}")
+    unexpected = present - expected
+    if unexpected:
+        errors.append(f"{label} contains unsupported keys: {', '.join(sorted(unexpected))}")
+    return errors
+
+
+def _requirement_errors(requirement: Mapping[str, Any]) -> list[str]:
+    errors = _closed_key_errors("requirement", requirement, OWNER_FIT_REQUIREMENT_KEYS)
+    capability = requirement.get("capability")
+    if capability not in KNOWN_CAPABILITY_NAMES and capability != LOCAL_WORKFLOW_CAPABILITY_NAME:
+        errors.append(f"requirement capability must come from the snapshot vocabulary: {capability}")
+    for field, limit in (
+        ("source_field", _MAX_TEXT_LENGTH),
+        ("source_value", _MAX_TEXT_LENGTH),
+        ("reason", _MAX_REASON_LENGTH),
+    ):
+        value = requirement.get(field)
+        if not isinstance(value, str) or not value.strip() or len(value) > limit:
+            errors.append(f"requirement {field} must be a nonempty string of at most {limit} characters")
+    if requirement.get("source_field") not in ACCEPTED_PLAN_FIELDS:
+        errors.append(f"requirement source_field must be a declared plan field: {requirement.get('source_field')}")
+    scope = requirement.get("scope")
+    if not isinstance(scope, Mapping):
+        errors.append("requirement scope must be a mapping, empty when the requirement is unscoped")
+    elif len(scope) > _MAX_SCOPE_ITEMS:
+        errors.append(f"requirement scope must hold at most {_MAX_SCOPE_ITEMS} items")
+    elif any(
+        not isinstance(key, str) or not key.strip() or not isinstance(item, str) or not item.strip()
+        for key, item in scope.items()
+    ):
+        errors.append("requirement scope keys and values must be nonempty strings")
+    return errors
+
+
+def _classification_errors(entry: Mapping[str, Any]) -> list[str]:
+    errors = _closed_key_errors("classified capability", entry, OWNER_FIT_CLASSIFICATION_KEYS)
+    if errors:
+        return errors
+    capability = entry.get("capability")
+    if capability not in KNOWN_CAPABILITY_NAMES and capability != LOCAL_WORKFLOW_CAPABILITY_NAME:
+        errors.append(f"classified capability must come from the snapshot vocabulary: {capability}")
+    reason_code = entry.get("reason_code")
+    if reason_code not in OWNER_FIT_REASON_CODES:
+        errors.append(f"reason_code must be one of {', '.join(sorted(OWNER_FIT_REASON_CODES))}")
+    elif entry.get("classification") != OWNER_FIT_REASON_CODES[str(reason_code)]:
+        errors.append("classification must match the reason code it was derived from")
+    if entry.get("evidence_status") not in OWNER_FIT_EVIDENCE_STATUSES:
+        errors.append(f"evidence_status must be one of {', '.join(OWNER_FIT_EVIDENCE_STATUSES)}")
+    for field, limit in (
+        ("source_field", _MAX_TEXT_LENGTH),
+        ("source_value", _MAX_TEXT_LENGTH),
+        ("evidence_ref", _MAX_TEXT_LENGTH),
+        ("reason", _MAX_REASON_LENGTH),
+    ):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip() or len(value) > limit:
+            errors.append(f"classified capability {field} must be a nonempty string of at most {limit} characters")
+    observed_at = entry.get("evidence_observed_at")
+    if not isinstance(observed_at, str) or len(observed_at) > _MAX_TEXT_LENGTH:
+        errors.append("classified capability evidence_observed_at must be a string, empty when nothing was observed")
+    return errors

--- a/src/coding/pre_handoff_readiness.py
+++ b/src/coding/pre_handoff_readiness.py
@@ -165,6 +165,19 @@ def changed_binding_axes(stored: object, live: Mapping[str, Any]) -> list[str]:
     ]
 
 
+def capability_evidence_is_fresh(observed_at: str, now: str = "") -> bool:
+    """Whether one capability observation is still inside the #837 evidence horizon.
+
+    Exposed so the owner-fit matcher (#810) reuses this horizon instead of
+    introducing a second one; two numbers for the same question would let two
+    surfaces disagree about the same machine. Same rule
+    `_capability_evidence_state` already applies: an empty, unreadable, or
+    future stamp is older than the horizon, never fresher.
+    """
+    age = _stamp_age_seconds(observed_at, now, CAPABILITY_EVIDENCE_STALE_AFTER_SECONDS)
+    return age <= CAPABILITY_EVIDENCE_STALE_AFTER_SECONDS
+
+
 def evaluate_pre_handoff_readiness(
     *,
     profile: str,

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -110,9 +110,15 @@ def cmd_coding_delegate(args: argparse.Namespace) -> int:
             _apply_plan_handoff_source(payload)
             _accept_handoff_role_context(paths, payload)
         if payload.get("delegation_policy") or _payload_choice_required(payload):
+            from ..coding.owner_fit import accepted_plan_from_delegation
             from ..executor_readiness import executor_choice_context
 
-            payload["executor_choice_context"] = executor_choice_context(paths)
+            # Same plan the payload's own `coding_owner_fit` block was derived
+            # from, so the ranked card and the report cannot disagree.
+            payload["executor_choice_context"] = executor_choice_context(
+                paths,
+                plan=accepted_plan_from_delegation(payload),
+            )
         # The decision is recorded here, before anything decides whether a *run*
         # is worth creating, and unconditionally on `--record`. That ordering is
         # the whole point of the change: a denied gate collapses the selection,

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -4160,14 +4160,22 @@ def _attach_executor_choice_context(delegation: dict[str, object], paths: OmhPat
     Only cached readiness state and cheap local markers are read — no
     subprocess runs — so the chat lane stays as deterministic as the CLI lane
     that already attaches the same block.
+
+    The accepted plan travels with it (#810) so the card cannot rank an owner
+    whose required capabilities are recorded unavailable above one that can do
+    the work.
     """
     if paths is None:
         return
     if not (delegation.get("delegation_policy") or _nested(delegation, "executor_selection").get("choice_required")):
         return
     from ..coding.executor_readiness import executor_choice_context
+    from ..coding.owner_fit import accepted_plan_from_delegation
 
-    delegation["executor_choice_context"] = executor_choice_context(paths)
+    delegation["executor_choice_context"] = executor_choice_context(
+        paths,
+        plan=accepted_plan_from_delegation(delegation),
+    )
 
 
 def _coding_route_decision_for_delegation(

--- a/tests/test_owner_fit.py
+++ b/tests/test_owner_fit.py
@@ -1,0 +1,681 @@
+"""An owner is recommended only when evidence says it can finish the accepted plan.
+
+The defect (#810): `resolve_coding_route_decision` chose a coding owner from an
+owner named in the request envelope, an owner named in the message, a recorded
+setup preference, or a keyword route-family cue -- and from nothing else. No
+capability snapshot, no readiness probe, no look at what the plan needed. Its
+payload had no requirement field, no gap field, and no unknown field. So a
+person could name an owner, be told the handoff was prepared, and find out
+mid-execution that the owner could not isolate a worktree or run the routed
+workflow at all.
+
+What these pin:
+
+* AC1 -- an owner with a KNOWN unmet required capability is never recommended,
+  asserted on the surfaces Hermes actually reads (the built delegation payload
+  and the ranked choose-executor card), not only on the matcher.
+* AC2 -- every required capability appears with its classification AND the
+  evidence reference that produced it; a payload missing either fails
+  validation.
+* AC3 -- two owners holding equal capability evidence produce fit records that
+  are equal once the two owner-identity fields are removed. A real differential:
+  the same evidence is recorded under different owner ids and the verdicts,
+  reasons, and classifications must not move.
+
+`unknown` -- stale evidence and absent evidence both classify `unknown`, and
+`unknown` is a third state with its own consequence: the owner is `unproven`,
+which is neither recommended (AC1 stays strict) nor reported as a blocking gap.
+
+Guards: an explicitly named unfit owner is still honoured and its gap is stated
+rather than the owner disappearing, and equal evidence under different owner
+ids does not move the verdict.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.coding.coding_delegation import build_coding_delegation_payload  # noqa: E402
+from omh.coding.executor_capability_snapshots import (  # noqa: E402
+    KNOWN_CAPABILITY_NAMES,
+    LOCAL_WORKFLOW_CAPABILITY_NAME,
+    build_executor_capability_snapshot,
+    executor_capability_snapshot_path,
+    write_executor_capability_snapshot,
+)
+from omh.coding.executor_readiness import (  # noqa: E402
+    EXECUTOR_CHOICE_CONTEXT_PROFILES,
+    executor_choice_context,
+)
+from omh.coding.owner_fit import (  # noqa: E402
+    ACCEPTED_PLAN_FIELDS,
+    OWNER_FIT_CLASSIFICATION_KEYS,
+    OWNER_FIT_KEYS,
+    OWNER_FIT_OWNER_IDENTITY_KEYS,
+    OWNER_FIT_REASON_CODES,
+    OWNER_FIT_REPORT_KEYS,
+    OWNER_FIT_REPORT_SCHEMA_VERSION,
+    OWNER_FIT_REQUIREMENT_KEYS,
+    OWNER_FIT_SCHEMA_VERSION,
+    WORKFLOW_CAPABILITY_REQUIREMENTS,
+    OwnerFitError,
+    accepted_plan_from_delegation,
+    build_owner_fit_report,
+    derive_plan_capability_requirements,
+    evaluate_owner_fit,
+    owner_capability_snapshots,
+    owner_fit_without_owner_identity,
+    validate_owner_fit,
+    validate_owner_fit_report,
+)
+from omh.coding.pre_handoff_readiness import (  # noqa: E402
+    CAPABILITY_EVIDENCE_STALE_AFTER_SECONDS,
+    capability_evidence_is_fresh,
+)
+from omh.skills.catalog import routable_skill_names  # noqa: E402
+from omh.system.local_store import utc_now  # noqa: E402
+from omh.system.paths import OmhPaths  # noqa: E402
+
+
+OBSERVED_AT = "2026-01-01T00:00:00Z"
+WITHIN_WINDOW = "2026-01-01T06:00:00Z"
+PAST_WINDOW = "2026-01-03T00:00:00Z"
+
+# `build_coding_delegation_payload` is the production path and takes no clock,
+# so the surface tests record their evidence at the real current time. The
+# freshness window is 24 hours, so wall-clock drift inside one test run cannot
+# change a verdict.
+RECORDED_NOW = utc_now()
+
+# One team-shaped plan used almost everywhere: it declares a routed workflow
+# whose lane needs parallel agents and a workspace binding that requires an
+# isolated worktree, so both derivation rules are live at once.
+TEAM_PLAN: dict[str, Any] = {
+    "workflow": "team",
+    "work_owner_mode": "external_executor",
+    "isolation_strategy": "worktree_required",
+}
+TEAM_REQUIREMENTS = ("parallel_agents", "worktree_isolation")
+
+# The message that produces TEAM_PLAN through the real delegation build, so the
+# surface tests exercise a plan Hermes actually derived rather than one a test
+# handed it.
+TEAM_MESSAGE = "implement pagination in src/api/list.py with a team of workers in a worktree and run the tests"
+
+
+def _observed(capability_evidence_ref: str, observed_at: str = OBSERVED_AT, **scope: str) -> dict[str, Any]:
+    return {
+        "status": "host_observed",
+        "scope": dict(scope) or {"surface": "local"},
+        "evidence_ref": capability_evidence_ref,
+        "observed_at": observed_at,
+    }
+
+
+# `executor_capability_snapshot/v1` keeps a generic `unavailable` capability
+# status-only: no scope, no evidence_ref, no observed_at. The snapshot's own
+# `recorded_at` is therefore the observation time for a recorded absence.
+UNAVAILABLE: dict[str, Any] = {"status": "unavailable"}
+
+
+def _snapshot(executor: str, capabilities: dict[str, Any], *, recorded_at: str = OBSERVED_AT) -> dict[str, Any]:
+    return {
+        "schema_version": "executor_capability_snapshot/v1",
+        "executor": executor,
+        "recorded_at": recorded_at,
+        "capabilities": capabilities,
+    }
+
+
+def _team_capable(executor: str, *, recorded_at: str = OBSERVED_AT) -> dict[str, Any]:
+    return _snapshot(
+        executor,
+        {
+            "parallel_agents": _observed("probe:parallel-lanes", recorded_at),
+            "worktree_isolation": _observed("probe:worktree", recorded_at),
+        },
+        recorded_at=recorded_at,
+    )
+
+
+def _team_blocked(executor: str, *, recorded_at: str = OBSERVED_AT) -> dict[str, Any]:
+    return _snapshot(
+        executor,
+        {
+            "parallel_agents": _observed("probe:parallel-lanes", recorded_at),
+            # A recorded host observation that the capability is NOT there.
+            # This is the shape AC1 calls a KNOWN unmet capability.
+            "worktree_isolation": dict(UNAVAILABLE),
+        },
+        recorded_at=recorded_at,
+    )
+
+
+def _fit(owner: str, snapshot: dict[str, Any] | None, *, now: str = WITHIN_WINDOW) -> dict[str, Any]:
+    return evaluate_owner_fit(
+        owner=owner,
+        requirements=derive_plan_capability_requirements(TEAM_PLAN),
+        capability_snapshot=snapshot,
+        now=now,
+    )
+
+
+def _paths(root: Path) -> OmhPaths:
+    return OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+
+
+def _write_snapshot(directory: Path, snapshot: dict[str, Any]) -> None:
+    executor = str(snapshot["executor"])
+    write_executor_capability_snapshot(
+        executor_capability_snapshot_path(directory, executor),
+        build_executor_capability_snapshot(
+            executor=executor,
+            capabilities=snapshot["capabilities"],
+            recorded_at=str(snapshot["recorded_at"]),
+        ),
+    )
+
+
+def _snapshot_directory(root: Path) -> Path:
+    return root / ".omh" / "coding" / "executor-capability-snapshots"
+
+
+class RequirementDerivationTests(unittest.TestCase):
+    """Requirements come from declared plan fields, never from free text."""
+
+    def test_the_workflow_map_only_names_real_workflows_and_real_capabilities(self) -> None:
+        routable = set(routable_skill_names())
+        vocabulary = set(KNOWN_CAPABILITY_NAMES) | {LOCAL_WORKFLOW_CAPABILITY_NAME}
+        for workflow, capabilities in WORKFLOW_CAPABILITY_REQUIREMENTS.items():
+            with self.subTest(workflow=workflow):
+                self.assertIn(workflow, routable)
+                self.assertTrue(capabilities)
+                for capability in capabilities:
+                    self.assertIn(capability, vocabulary)
+
+    def test_a_team_plan_requires_parallel_lanes_and_worktree_isolation(self) -> None:
+        requirements = derive_plan_capability_requirements(TEAM_PLAN)
+        self.assertEqual(tuple(item["capability"] for item in requirements), TEAM_REQUIREMENTS)
+        by_capability = {str(item["capability"]): item for item in requirements}
+        self.assertEqual(by_capability["parallel_agents"]["source_field"], "workflow")
+        self.assertEqual(by_capability["parallel_agents"]["source_value"], "team")
+        self.assertEqual(by_capability["worktree_isolation"]["source_field"], "isolation_strategy")
+        self.assertEqual(by_capability["worktree_isolation"]["source_value"], "worktree_required")
+        for item in requirements:
+            self.assertEqual(set(item), set(OWNER_FIT_REQUIREMENT_KEYS))
+
+    def test_a_runtime_handoff_requires_the_routed_workflow_locally_and_scopes_it(self) -> None:
+        requirements = derive_plan_capability_requirements(
+            {"workflow": "ralph", "work_owner_mode": "runtime_handoff", "isolation_strategy": "same_workspace_ok"}
+        )
+        by_capability = {str(item["capability"]): item for item in requirements}
+        self.assertIn(LOCAL_WORKFLOW_CAPABILITY_NAME, by_capability)
+        self.assertEqual(by_capability[LOCAL_WORKFLOW_CAPABILITY_NAME]["scope"], {"skill_id": "ralph"})
+        self.assertEqual(by_capability["long_running_continuation"]["source_field"], "workflow")
+
+    def test_a_plan_that_declares_nothing_requires_nothing(self) -> None:
+        # The negative case that keeps the derivation from being a heuristic: a
+        # plan whose declared fields name no capability produces no requirement,
+        # however the request was worded.
+        plan = {"workflow": "plan", "work_owner_mode": "external_executor", "isolation_strategy": "same_workspace_ok"}
+        self.assertEqual(derive_plan_capability_requirements(plan), ())
+
+    def test_an_undeclared_plan_field_is_rejected_rather_than_ignored(self) -> None:
+        with self.assertRaises(OwnerFitError):
+            derive_plan_capability_requirements({**TEAM_PLAN, "message": "run the tests in parallel"})
+
+    def test_the_accepted_plan_field_set_is_exactly_what_the_projection_produces(self) -> None:
+        payload = build_coding_delegation_payload(TEAM_MESSAGE, executor_target="codex")
+        plan = accepted_plan_from_delegation(payload)
+        self.assertEqual(set(plan), set(ACCEPTED_PLAN_FIELDS))
+        self.assertEqual(plan["workflow"], "team")
+        self.assertEqual(plan["isolation_strategy"], "worktree_required")
+
+    def test_one_capability_is_explained_by_one_declared_field(self) -> None:
+        # `ultrawork` asks for parallel agents and the message is worktree
+        # shaped, so both rules fire. The capability must still be claimed once,
+        # by the first rule, or `source_field` would name a set instead of a
+        # field.
+        requirements = derive_plan_capability_requirements(
+            {"workflow": "ultrawork", "work_owner_mode": "runtime_handoff", "isolation_strategy": "worktree_required"}
+        )
+        names = [str(item["capability"]) for item in requirements]
+        self.assertEqual(len(names), len(set(names)))
+
+
+class KnownUnmetCapabilityTests(unittest.TestCase):
+    """AC1: a known unmet required capability is never a recommendation."""
+
+    def test_the_matcher_blocks_an_owner_whose_capability_is_observed_unavailable(self) -> None:
+        fit = _fit("codex", _team_blocked("codex"))
+        self.assertEqual(fit["verdict"], "blocked")
+        self.assertFalse(fit["recommendable"])
+        self.assertEqual(fit["unmet"], ["worktree_isolation"])
+        self.assertEqual(fit["met"], ["parallel_agents"])
+
+    def test_the_report_never_recommends_a_blocked_owner(self) -> None:
+        report = build_owner_fit_report(
+            requirements=derive_plan_capability_requirements(TEAM_PLAN),
+            owners=[("codex", _team_blocked("codex")), ("claude-code", _team_capable("claude-code"))],
+            now=WITHIN_WINDOW,
+        )
+        self.assertEqual(report["recommended_owners"], ["claude-code"])
+        self.assertEqual(report["blocked_owners"], ["codex"])
+        self.assertEqual(report["next_action"], "choose_from_recommended_owners")
+
+    def test_the_built_delegation_payload_never_recommends_a_blocked_owner(self) -> None:
+        # The surface Hermes reads, not the raw function: a real delegation
+        # build with a real snapshot on disk.
+        with TemporaryDirectory() as tmp:
+            directory = _snapshot_directory(Path(tmp))
+            _write_snapshot(directory, _team_blocked("codex", recorded_at=RECORDED_NOW))
+            _write_snapshot(directory, _team_capable("claude-code", recorded_at=RECORDED_NOW))
+            payload = build_coding_delegation_payload(
+                TEAM_MESSAGE,
+                executor_target="choose",
+                capability_snapshot_directory=directory,
+            )
+        report = payload["coding_owner_fit"]
+        self.assertEqual(validate_owner_fit_report(report), [])
+        self.assertNotIn("codex", report["recommended_owners"])
+        self.assertIn("codex", report["blocked_owners"])
+        self.assertEqual(report["recommended_owners"], ["claude-code"])
+
+    def test_the_choose_executor_card_never_ranks_a_blocked_owner_first(self) -> None:
+        # The other recommendation surface: whatever the login marker says, an
+        # owner that cannot do the work must not head the card.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = _paths(root)
+            _write_snapshot(paths.executor_capability_snapshots_dir, _team_blocked("codex"))
+            _write_snapshot(paths.executor_capability_snapshots_dir, _team_capable("claude-code"))
+            context = executor_choice_context(paths, now=WITHIN_WINDOW, plan=TEAM_PLAN)
+        by_profile = {str(entry["profile"]): entry for entry in context["candidates"]}
+        self.assertEqual(by_profile["codex"]["owner_fit_verdict"], "blocked")
+        self.assertEqual(by_profile["codex"]["owner_fit_unmet"], ["worktree_isolation"])
+        self.assertEqual(by_profile["claude-code"]["owner_fit_verdict"], "ready")
+        self.assertEqual(str(context["candidates"][0]["profile"]), "claude-code")
+        self.assertEqual(str(context["candidates"][-1]["profile"]), "codex")
+        self.assertIn("owner_fit_verdict", context["ranked_by"])
+
+    def test_a_card_built_without_a_plan_keeps_its_pre_810_shape(self) -> None:
+        # The negative case: no plan means nothing derived what the work needs,
+        # so no verdict is invented and the existing ordering is untouched.
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            context = executor_choice_context(paths, now=WITHIN_WINDOW)
+        self.assertEqual(
+            context["ranked_by"],
+            ("login_marker", "fresh_limit_signal_absent", "readiness_status"),
+        )
+        for candidate in context["candidates"]:
+            self.assertNotIn("owner_fit_verdict", candidate)
+
+    def test_a_report_that_recommends_a_blocked_owner_fails_validation(self) -> None:
+        report = build_owner_fit_report(
+            requirements=derive_plan_capability_requirements(TEAM_PLAN),
+            owners=[("codex", _team_blocked("codex"))],
+            now=WITHIN_WINDOW,
+        )
+        tampered = {**report, "recommended_owners": ["codex"]}
+        self.assertTrue(
+            any("recommended_owners" in error for error in validate_owner_fit_report(tampered)),
+            validate_owner_fit_report(tampered),
+        )
+
+
+class ExplainedRecommendationTests(unittest.TestCase):
+    """AC2: every required capability arrives with its classification and evidence."""
+
+    def test_each_required_capability_carries_a_classification_and_an_evidence_reference(self) -> None:
+        fit = _fit("codex", _team_blocked("codex"))
+        self.assertEqual([str(entry["capability"]) for entry in fit["capabilities"]], list(TEAM_REQUIREMENTS))
+        for entry in fit["capabilities"]:
+            with self.subTest(capability=entry["capability"]):
+                self.assertEqual(set(entry), set(OWNER_FIT_CLASSIFICATION_KEYS))
+                self.assertIn(entry["classification"], ("met", "unmet", "unknown"))
+                self.assertTrue(str(entry["evidence_ref"]).strip())
+                self.assertEqual(OWNER_FIT_REASON_CODES[str(entry["reason_code"])], entry["classification"])
+                self.assertTrue(str(entry["reason"]).strip())
+
+    def test_the_recorded_evidence_reference_is_the_one_the_snapshot_supplied(self) -> None:
+        fit = _fit("codex", _team_capable("codex"))
+        by_capability = {str(entry["capability"]): entry for entry in fit["capabilities"]}
+        self.assertEqual(by_capability["parallel_agents"]["evidence_ref"], "probe:parallel-lanes")
+        self.assertEqual(by_capability["worktree_isolation"]["evidence_ref"], "probe:worktree")
+        self.assertEqual(by_capability["worktree_isolation"]["evidence_observed_at"], OBSERVED_AT)
+
+    def test_a_classification_missing_its_verdict_fails_validation(self) -> None:
+        fit = _fit("codex", _team_capable("codex"))
+        stripped = dict(fit["capabilities"][0])
+        stripped.pop("classification")
+        tampered = {**fit, "capabilities": [stripped, fit["capabilities"][1]]}
+        self.assertTrue(
+            any("classification" in error for error in validate_owner_fit(tampered)),
+            validate_owner_fit(tampered),
+        )
+
+    def test_a_classification_missing_its_evidence_reference_fails_validation(self) -> None:
+        fit = _fit("codex", _team_capable("codex"))
+        stripped = dict(fit["capabilities"][0])
+        stripped.pop("evidence_ref")
+        tampered = {**fit, "capabilities": [stripped, fit["capabilities"][1]]}
+        self.assertTrue(
+            any("evidence_ref" in error for error in validate_owner_fit(tampered)),
+            validate_owner_fit(tampered),
+        )
+
+    def test_an_owner_that_skips_a_required_capability_fails_report_validation(self) -> None:
+        report = build_owner_fit_report(
+            requirements=derive_plan_capability_requirements(TEAM_PLAN),
+            owners=[("codex", _team_capable("codex"))],
+            now=WITHIN_WINDOW,
+        )
+        trimmed = dict(report["owners"][0])
+        trimmed["capabilities"] = trimmed["capabilities"][:1]
+        trimmed["met"] = ["parallel_agents"]
+        tampered = {**report, "owners": [trimmed]}
+        self.assertTrue(
+            any("declared required capabilities" in error for error in validate_owner_fit_report(tampered)),
+            validate_owner_fit_report(tampered),
+        )
+
+    def test_both_artifacts_keep_a_closed_key_set(self) -> None:
+        report = build_owner_fit_report(
+            requirements=derive_plan_capability_requirements(TEAM_PLAN),
+            owners=[("codex", _team_capable("codex"))],
+            now=WITHIN_WINDOW,
+        )
+        self.assertEqual(set(report), set(OWNER_FIT_REPORT_KEYS))
+        self.assertEqual(set(report["owners"][0]), set(OWNER_FIT_KEYS))
+        self.assertEqual(report["schema_version"], OWNER_FIT_REPORT_SCHEMA_VERSION)
+        self.assertEqual(report["owners"][0]["schema_version"], OWNER_FIT_SCHEMA_VERSION)
+        self.assertEqual(report["status"], "prepared_not_observed")
+        self.assertEqual(validate_owner_fit_report({**report, "surprise": 1})[0][:40], "owner fit report contains unsupported ke")
+
+
+class ExecutorNeutralityTests(unittest.TestCase):
+    """AC3: equal evidence, equal fit -- whoever the owner is."""
+
+    def test_equal_evidence_under_different_owner_ids_produces_an_equal_fit(self) -> None:
+        # The differential. Same capability names, same evidence refs, same
+        # observation times; only the owner id and the snapshot's executor field
+        # differ. Everything except the two owner-identity fields must match.
+        first = _fit("codex", _team_capable("codex"))
+        second = _fit("claude-code", _team_capable("claude-code"))
+        self.assertNotEqual(first["owner"], second["owner"])
+        self.assertNotEqual(first["label"], second["label"])
+        self.assertEqual(
+            owner_fit_without_owner_identity(first),
+            owner_fit_without_owner_identity(second),
+        )
+
+    def test_equal_evidence_produces_an_equal_blocked_fit_too(self) -> None:
+        # Neutrality has to hold on the failing path as well, or a brand could
+        # leak through a gap message nobody reads on the happy path.
+        first = _fit("codex", _team_blocked("codex"))
+        second = _fit("omo-runtime", _team_blocked("omo-runtime"))
+        self.assertEqual(
+            owner_fit_without_owner_identity(first),
+            owner_fit_without_owner_identity(second),
+        )
+        self.assertEqual(first["verdict"], "blocked")
+
+    def test_no_owner_name_leaks_into_a_verdict_reason_or_gap(self) -> None:
+        report = build_owner_fit_report(
+            requirements=derive_plan_capability_requirements(TEAM_PLAN),
+            owners=[("codex", _team_blocked("codex")), ("claude-code", _team_capable("claude-code"))],
+            named_owner="codex",
+            now=WITHIN_WINDOW,
+        )
+        neutral_text = " ".join(
+            [
+                str(report["named_owner_gap"]),
+                *(str(fit["reason"]) for fit in report["owners"]),
+                *(str(entry["reason"]) for fit in report["owners"] for entry in fit["capabilities"]),
+            ]
+        ).casefold()
+        for brand in ("codex", "claude", "hermes", "omo", "omx", "omc"):
+            with self.subTest(brand=brand):
+                self.assertNotIn(brand, neutral_text)
+
+    def test_the_owner_identity_field_set_is_the_only_difference_the_projection_drops(self) -> None:
+        fit = _fit("codex", _team_capable("codex"))
+        projection = owner_fit_without_owner_identity(fit)
+        self.assertEqual(set(fit) - set(projection), set(OWNER_FIT_OWNER_IDENTITY_KEYS))
+
+
+class UnknownIsItsOwnStateTests(unittest.TestCase):
+    """Unknown is neither met nor unmet, and it has its own consequence."""
+
+    def test_absent_evidence_classifies_unknown(self) -> None:
+        fit = _fit("codex", None)
+        self.assertEqual(sorted(fit["unknown"]), sorted(TEAM_REQUIREMENTS))
+        self.assertEqual(fit["met"], [])
+        self.assertEqual(fit["unmet"], [])
+        self.assertEqual(
+            [str(entry["reason_code"]) for entry in fit["capabilities"]],
+            ["no_capability_snapshot", "no_capability_snapshot"],
+        )
+
+    def test_a_capability_the_snapshot_never_mentions_classifies_unknown(self) -> None:
+        fit = _fit("codex", _snapshot("codex", {"parallel_agents": _observed("probe:parallel-lanes")}))
+        by_capability = {str(entry["capability"]): entry for entry in fit["capabilities"]}
+        self.assertEqual(by_capability["worktree_isolation"]["classification"], "unknown")
+        self.assertEqual(by_capability["worktree_isolation"]["reason_code"], "capability_not_recorded")
+        self.assertEqual(by_capability["parallel_agents"]["classification"], "met")
+
+    def test_stale_evidence_classifies_unknown_and_never_met(self) -> None:
+        fresh = _fit("codex", _team_capable("codex"), now=WITHIN_WINDOW)
+        stale = _fit("codex", _team_capable("codex"), now=PAST_WINDOW)
+        self.assertEqual(fresh["verdict"], "ready")
+        self.assertEqual(stale["verdict"], "unproven")
+        self.assertEqual(stale["met"], [])
+        self.assertEqual(sorted(stale["unknown"]), sorted(TEAM_REQUIREMENTS))
+        self.assertEqual(
+            {str(entry["reason_code"]) for entry in stale["capabilities"]},
+            {"evidence_expired"},
+        )
+
+    def test_stale_unavailable_evidence_classifies_unknown_and_never_unmet(self) -> None:
+        # Symmetry, and it is safe: an expired observation is not knowledge of
+        # the present either way, and `unknown` still yields `unproven`, which
+        # is still not recommended.
+        stale = _fit("codex", _team_blocked("codex"), now=PAST_WINDOW)
+        self.assertEqual(stale["unmet"], [])
+        self.assertEqual(stale["verdict"], "unproven")
+
+    def test_prepared_only_evidence_classifies_unknown(self) -> None:
+        fit = _fit(
+            "codex",
+            _snapshot("codex", {"parallel_agents": {"status": "prepared"}, "worktree_isolation": {"status": "unknown"}}),
+        )
+        self.assertEqual(
+            [str(entry["reason_code"]) for entry in fit["capabilities"]],
+            ["evidence_prepared_only", "evidence_status_unknown"],
+        )
+        self.assertEqual(fit["verdict"], "unproven")
+
+    def test_evidence_scoped_to_another_workflow_classifies_unknown(self) -> None:
+        requirements = derive_plan_capability_requirements(
+            {"workflow": "ralph", "work_owner_mode": "runtime_handoff", "isolation_strategy": "same_workspace_ok"}
+        )
+        snapshot = _snapshot(
+            "codex",
+            {
+                "long_running_continuation": _observed("probe:continuation"),
+                LOCAL_WORKFLOW_CAPABILITY_NAME: {
+                    "status": "host_observed",
+                    "scope": {"profile": "codex", "skill_id": "team", "environment": "local"},
+                    "evidence_ref": "probe:local-workflow",
+                    "observed_at": OBSERVED_AT,
+                },
+            },
+        )
+        fit = evaluate_owner_fit(
+            owner="codex",
+            requirements=requirements,
+            capability_snapshot=snapshot,
+            now=WITHIN_WINDOW,
+        )
+        by_capability = {str(entry["capability"]): entry for entry in fit["capabilities"]}
+        self.assertEqual(by_capability[LOCAL_WORKFLOW_CAPABILITY_NAME]["classification"], "unknown")
+        self.assertEqual(by_capability[LOCAL_WORKFLOW_CAPABILITY_NAME]["reason_code"], "evidence_scope_mismatch")
+
+    def test_unknown_is_distinguishable_from_both_met_and_unmet(self) -> None:
+        met = _fit("codex", _team_capable("codex"))
+        unmet = _fit("codex", _team_blocked("codex"))
+        unknown = _fit("codex", None)
+        self.assertEqual({met["verdict"], unmet["verdict"], unknown["verdict"]}, {"ready", "blocked", "unproven"})
+        self.assertEqual(
+            {met["next_action"], unmet["next_action"], unknown["next_action"]},
+            {
+                "prepare_handoff_for_this_owner",
+                "close_the_capability_gap_or_choose_another_owner",
+                "record_capability_evidence",
+            },
+        )
+        # An unproven owner is not recommended (AC1 stays strict) and is not a
+        # blocking gap either -- it is its own bucket with its own next action.
+        report = build_owner_fit_report(
+            requirements=derive_plan_capability_requirements(TEAM_PLAN),
+            owners=[("codex", None)],
+            now=WITHIN_WINDOW,
+        )
+        self.assertEqual(report["recommended_owners"], [])
+        self.assertEqual(report["blocked_owners"], [])
+        self.assertEqual(report["unproven_owners"], ["codex"])
+        self.assertEqual(report["next_action"], "record_capability_evidence")
+
+    def test_the_freshness_horizon_is_the_one_837_already_enforces(self) -> None:
+        self.assertTrue(capability_evidence_is_fresh(OBSERVED_AT, WITHIN_WINDOW))
+        self.assertFalse(capability_evidence_is_fresh(OBSERVED_AT, PAST_WINDOW))
+        self.assertFalse(capability_evidence_is_fresh("", WITHIN_WINDOW))
+        self.assertEqual(CAPABILITY_EVIDENCE_STALE_AFTER_SECONDS, 24 * 60 * 60)
+
+
+class NamedOwnerGuardTests(unittest.TestCase):
+    """A named owner is honoured; an unfit one surfaces its gap rather than vanishing."""
+
+    def test_a_named_unfit_owner_stays_in_the_report_with_its_gap_stated(self) -> None:
+        report = build_owner_fit_report(
+            requirements=derive_plan_capability_requirements(TEAM_PLAN),
+            owners=[("codex", _team_blocked("codex")), ("claude-code", _team_capable("claude-code"))],
+            named_owner="codex",
+            now=WITHIN_WINDOW,
+        )
+        self.assertEqual(report["named_owner"], "codex")
+        self.assertTrue(report["named_owner_honoured"])
+        self.assertIn("worktree_isolation", str(report["named_owner_gap"]))
+        self.assertEqual(report["next_action"], "confirm_named_owner_despite_capability_gap")
+        # Honoured is not the same as recommended: the owner is present, and
+        # absent from the recommendation.
+        self.assertIn("codex", [str(fit["owner"]) for fit in report["owners"]])
+        self.assertNotIn("codex", report["recommended_owners"])
+
+    def test_the_delegation_payload_keeps_a_named_unfit_owner_and_states_the_gap(self) -> None:
+        with TemporaryDirectory() as tmp:
+            directory = _snapshot_directory(Path(tmp))
+            _write_snapshot(directory, _team_blocked("codex", recorded_at=RECORDED_NOW))
+            payload = build_coding_delegation_payload(
+                TEAM_MESSAGE,
+                executor_target="codex",
+                capability_snapshot_directory=directory,
+            )
+        report = payload["coding_owner_fit"]
+        self.assertEqual(validate_owner_fit_report(report), [])
+        self.assertEqual(report["named_owner"], "codex")
+        self.assertTrue(report["named_owner_honoured"])
+        self.assertTrue(str(report["named_owner_gap"]).strip())
+        self.assertNotIn("codex", report["recommended_owners"])
+        # The route decision is untouched: naming an owner still selects it.
+        self.assertEqual(payload["selected_executor_profile"], "codex")
+
+    def test_a_named_owner_outside_the_default_candidates_is_still_reported(self) -> None:
+        with TemporaryDirectory() as tmp:
+            directory = _snapshot_directory(Path(tmp))
+            payload = build_coding_delegation_payload(
+                TEAM_MESSAGE,
+                executor_target="omx-runtime",
+                capability_snapshot_directory=directory,
+            )
+        report = payload["coding_owner_fit"]
+        self.assertNotIn("omx-runtime", EXECUTOR_CHOICE_CONTEXT_PROFILES)
+        self.assertIn("omx-runtime", [str(fit["owner"]) for fit in report["owners"]])
+        self.assertEqual(report["named_owner"], "omx-runtime")
+
+    def test_a_named_ready_owner_has_no_gap_and_prepares_its_handoff(self) -> None:
+        report = build_owner_fit_report(
+            requirements=derive_plan_capability_requirements(TEAM_PLAN),
+            owners=[("codex", _team_capable("codex"))],
+            named_owner="codex",
+            now=WITHIN_WINDOW,
+        )
+        self.assertEqual(report["named_owner_gap"], "")
+        self.assertEqual(report["next_action"], "prepare_handoff_for_named_owner")
+        self.assertEqual(report["recommended_owners"], ["codex"])
+
+    def test_a_report_cannot_name_an_owner_it_does_not_carry(self) -> None:
+        with self.assertRaises(OwnerFitError):
+            build_owner_fit_report(
+                requirements=derive_plan_capability_requirements(TEAM_PLAN),
+                owners=[("claude-code", _team_capable("claude-code"))],
+                named_owner="codex",
+                now=WITHIN_WINDOW,
+            )
+
+    def test_a_gap_erased_from_a_named_unfit_owner_fails_validation(self) -> None:
+        report = build_owner_fit_report(
+            requirements=derive_plan_capability_requirements(TEAM_PLAN),
+            owners=[("codex", _team_blocked("codex"))],
+            named_owner="codex",
+            now=WITHIN_WINDOW,
+        )
+        tampered = {**report, "named_owner_gap": ""}
+        self.assertTrue(
+            any("named_owner_gap" in error for error in validate_owner_fit_report(tampered)),
+            validate_owner_fit_report(tampered),
+        )
+
+
+class EvidenceReadingTests(unittest.TestCase):
+    """Reading snapshots off disk never invents evidence."""
+
+    def test_a_missing_directory_pairs_every_owner_with_no_snapshot(self) -> None:
+        self.assertEqual(
+            owner_capability_snapshots(None, ("codex", "claude-code")),
+            (("codex", None), ("claude-code", None)),
+        )
+
+    def test_a_snapshot_recorded_for_another_owner_is_not_read_as_evidence(self) -> None:
+        with TemporaryDirectory() as tmp:
+            directory = _snapshot_directory(Path(tmp))
+            _write_snapshot(directory, _team_capable("codex"))
+            paired = dict(owner_capability_snapshots(directory, ("codex", "claude-code")))
+        self.assertIsNotNone(paired["codex"])
+        self.assertIsNone(paired["claude-code"])
+
+    def test_an_unsafe_owner_id_reads_as_no_snapshot_rather_than_escaping_the_directory(self) -> None:
+        with TemporaryDirectory() as tmp:
+            directory = _snapshot_directory(Path(tmp))
+            paired = dict(owner_capability_snapshots(directory, ("../codex",)))
+        self.assertIsNone(paired["../codex"])
+
+    def test_a_plan_requiring_nothing_makes_every_owner_ready(self) -> None:
+        report = build_owner_fit_report(
+            requirements=(),
+            owners=[("codex", None), ("claude-code", None)],
+            now=WITHIN_WINDOW,
+        )
+        self.assertEqual(report["recommended_owners"], ["codex", "claude-code"])
+        self.assertIn("no required capability", str(report["owners"][0]["reason"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- Added `coding/owner_fit.py`: a deterministic, dependency-free comparison of the capabilities an accepted plan requires against the recorded capability evidence for each coding owner, producing `coding_owner_fit/v1` per owner and `coding_owner_fit_report/v1` for the recommendation.
- Every delegate-action coding payload now carries `coding_owner_fit`, so `omh coding delegate` and the Hermes chat lane read the same answer.
- `executor_choice_context` accepts the accepted plan and makes owner fit the **first** ranking key on the choose-executor card. Candidates are ranked, never removed.
- `pre_handoff_readiness.capability_evidence_is_fresh` exposes the #837 evidence horizon so owner fit reuses it instead of declaring a second one.
- `docs/ARCHITECTURE.md` gains a `### Coding Owner Fit` section and the new module in the package tree.
- `resolve_coding_route_decision` is deliberately **unchanged**. See "How It Works".

### Why This Exists

Coding-owner selection read four inputs and no evidence: an owner named in the request envelope (`coding_route_actions.py:163`), an owner named in the message text (`:175`), a recorded setup preference (`:203`), or a keyword route-family cue (`:216`). It never opened a capability snapshot, never consulted a readiness probe, and never looked at what the accepted plan needed. Its payload (`:253`) carried no requirement field, no gap field, and no unknown field.

The evidence side already existed — `executor_capability_snapshot/v1`, the #837 freshness rule, handoffs that already attach a snapshot — and nothing compared the two. So a person could name an owner, be told the handoff was prepared, and only discover mid-execution that the owner could not isolate a worktree, run parallel lanes, or invoke the routed workflow at all.

Closes #810.

### User / Operator Impact

- Hermes never *recommends* a coding owner whose required capability is recorded unavailable by fresh host observation.
- The recommendation explains itself: every required capability arrives with its classification, the reason code, and the evidence reference that produced it — including when the reference is "there was none".
- Naming an owner that cannot do the work no longer fails silently, and it is not silently overridden either: the owner stays selected, the report states the gap, and the owner is absent from `recommended_owners`.
- Where a person previously saw a prepared handoff and nothing else, they now see which observation is missing and the next action that would close it.

### How It Works

**Requirements come from declared plan fields only.** `derive_plan_capability_requirements` reads exactly three fields (`ACCEPTED_PLAN_FIELDS`): the routed workflow, the work-owner mode, and the workspace-binding strategy. The message is never parsed, so a requirement cannot appear because of a word somebody happened to use. `review_required`, `dispatch_policy`, and the acceptance/verification lists are deliberately not read — none of them names a capability from the snapshot vocabulary, and mapping prose onto a capability is the heuristic the module exists to avoid.

The vocabulary is the one `executor_capability_snapshot/v1` already speaks (`KNOWN_CAPABILITY_NAMES` plus `local_workflow`), so a requirement and the evidence answering it always share a name. `WORKFLOW_CAPABILITY_REQUIREMENTS` maps only lanes whose meaning *is* the capability (`team` → `parallel_agents`, `loop` → `scheduled_or_recurring_work`, and six more); a test guards that every key is a routable workflow and every value is in the vocabulary.

**Three classifications, kept apart.** `OWNER_FIT_REASON_CODES` is a single table mapping a reason code to its classification, so "why" and "what" cannot drift:

| classification | when |
| --- | --- |
| `met` | fresh host-observed availability |
| `unmet` | fresh host-observed unavailability |
| `unknown` | no snapshot, capability not recorded, prepared-only evidence, evidence scoped to a different workflow, or evidence past the horizon |

`unknown` has its own stated consequence: the owner is `unproven`, which is **not recommended** (AC1 stays strict) and **not reported as a blocking gap** (nothing was observed to be missing). Only `blocked` owners carry a gap; only `ready` owners are recommended.

**Freshness.** Reuses `CAPABILITY_EVIDENCE_STALE_AFTER_SECONDS` (24 h, #837) via the new `capability_evidence_is_fresh`. Expired evidence classifies `unknown` whatever it recorded, **including a recorded `unavailable`** — an expired observation is not knowledge of the present. That is safe rather than permissive, because `unknown` still yields `unproven`, which is still not recommended. `now` is a parameter throughout, and no wall clock is written into either artifact.

One schema constraint shaped this: `executor_capability_snapshot/v1` keeps a *generic* `unavailable` capability status-only, with no per-capability `observed_at`. Rather than exempting recorded absences from the freshness rule, the snapshot's own `recorded_at` is used as their observation time — the evidence genuinely is "this snapshot, written then".

**The named-owner decision (explicit, per the issue's caution).** `resolve_coding_route_decision` is untouched: naming an owner still selects it, still returns `prepare_named_executor_handoff`, and still prepares that owner's handoff. Owner fit is additive. When the named owner cannot do the work, the report keeps it, sets `named_owner_honoured: true`, states the gap in `named_owner_gap`, sets `next_action: confirm_named_owner_despite_capability_gap`, and leaves it out of `recommended_owners`. So Hermes never *recommends* an owner with a known unmet capability, and never *silently overrides* a person who named one. Rerouting was the rejected alternative: replacing a stated preference without a word turns a user decision into an invisible one, and the user would learn about the swap from the handoff rather than from Hermes. The reasoning is recorded in the module docstring so it survives the PR.

**Executor neutrality (AC3) is structural, not editorial.** Classification reads the snapshot and never the owner id. `OWNER_FIT_OWNER_IDENTITY_KEYS` is exactly `("owner", "label")`, `owner_fit_without_owner_identity` strips them, and the differential test records identical evidence under different owner ids and asserts the projections are equal — on the ready path and on the blocked path. A second test asserts no brand string (`codex`, `claude`, `hermes`, `omo`, `omx`, `omc`) appears in any verdict reason, classification reason, or gap sentence.

**Validators check both directions.** Closed exact key sets on the requirement, classification, fit, and report records — nothing missing, nothing extra. Two acceptance properties have teeth in the validator itself: `recommended_owners` must be exactly the ready owners (AC1), and each owner must classify exactly the declared requirements in order (AC2). A report assembled by any other path still fails validation.

**Reusable for #812.** The matcher #812 (retarget an accepted handoff to another owner) will call is:

```python
evaluate_owner_fit(
    *,
    owner: str,
    requirements: Sequence[Mapping[str, Any]],
    capability_snapshot: Mapping[str, Any] | None,
    now: str = "",
) -> dict[str, Any]
```

Derive the requirement set once with `derive_plan_capability_requirements(accepted_plan_from_delegation(payload))`, then call the matcher per retarget candidate. `#812`'s retarget path is **not** implemented here.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/coding/owner_fit.py` | New. `coding_owner_fit/v1`, `coding_owner_fit_report/v1`, derivation, matcher, validators, snapshot reader. 786 lines. |
| `src/coding/pre_handoff_readiness.py` | `capability_evidence_is_fresh` exposes the #837 horizon (+13 lines). |
| `src/coding/coding_delegation.py` | Attaches `coding_owner_fit` on delegate actions, at the point the accepted plan is final and the snapshot directory is in hand (+49 lines). |
| `src/coding/executor_readiness.py` | `executor_choice_context(..., plan=)`; per-candidate `owner_fit_verdict` / `owner_fit_unmet` / `owner_fit_unknown`; fit becomes the first ranking key (+75/-14 lines). |
| `src/wrapper/contract.py` | `_attach_executor_choice_context` passes the accepted plan (+10/-2). |
| `src/commands/coding.py` | Same plan reaches the CLI choose-executor card (+8/-2). |
| `docs/ARCHITECTURE.md` | New `### Coding Owner Fit` section, module added to the package tree (+55). |
| `tests/test_owner_fit.py` | New. 41 tests across six classes. 681 lines. |

No generated artifact (`skills/*/SKILL.md`, `docs/WORKFLOWS.md`, `docs/ROLES.md`, demo-cards JSON, capability-families sidecar) was hand-edited, and none needed regeneration — no catalog, routing case, skill, or demo card was added, so no exact-count assertion moved.

## Validation

All commands run in this worktree on the tree rebased onto `origin/main` at `f9251979`.

- [x] `uv run --group lint ruff check src tests` → `All checks passed!`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` → `Ran 4961 tests in 202.039s` / `OK`
- [x] `uv run python -m compileall -q src tests` → exit 0, no output
- [x] `uv run python -m omh.cli docs workflows --check` → `{"ok":true,"tap_skills":{"checked":115,"expected":115,"extra":[],"missing":[],"ok":true,"stale":[]}}`
- [x] `uv run python -m omh.cli harness validate` → `{"counts":{"harnesses":72,"skills":104},"errors":[],"ok":true}`
- [x] `uv run python -m omh.cli release checklist --json` → `"ok":true`, `"mode":"plan"`, `"required_item_count":35`
- [x] `uv run python -m omh.cli release hermes-smoke` → `Mode: plan; observed evidence: no` / `Status: ok`
- [x] `uv run python -m omh.cli --help` → exit 0 (module form; the installed `omh` console script was not exercised)
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — **not run.** This is an installed-command/packaging gate; this PR changes no packaging, install, or console-script surface.
- [ ] Relevant workflow-learning review queue smoke — **not applicable.** No learning contract changed.
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli docs roles --check` → `{"ok":true}`; `uv run python -m omh.cli docs capability-families --check` → `{"ok":true}`; `git diff --check` → clean
- [x] Targeted: `PYTHONPATH=tests uv run python -m unittest tests/test_owner_fit.py` → `Ran 41 tests` / `OK`
- [ ] Manual Hermes/TUI check — **not run.** No Hermes Agent chat session or TUI was driven end to end. The chat-lane surface is covered by the delegation-payload tests, which exercise the production `build_coding_delegation_payload` path with real snapshots on disk; live Hermes rendering of the new block is unobserved.

### What the tests actually pin

- **AC1** on two recommendation surfaces, not just the matcher: the built delegation payload (`recommended_owners` excludes the blocked owner, `blocked_owners` names it) and the ranked choose-executor card (the blocked owner sorts last, the ready owner first). Plus a validator test: a report hand-edited to recommend a blocked owner fails validation.
- **AC2**: every required capability carries a nonempty `evidence_ref` and a classification; removing either key from a classification record fails validation; an owner that classifies fewer capabilities than the plan declares fails report validation.
- **AC3**: the differential — identical evidence under `codex` vs `claude-code` (ready path) and `codex` vs `omo-runtime` (blocked path) produces equal `owner_fit_without_owner_identity` projections; and no brand string appears in any reason or gap.
- **`unknown`**: absent evidence, an unrecorded capability, prepared-only evidence, scope-mismatched evidence, and expired evidence all classify `unknown`; stale `host_observed` never reads `met`; stale `unavailable` never reads `unmet`; the three verdicts and their three next actions are distinct.
- **Guards**: a named unfit owner stays in the report with its gap stated and out of `recommended_owners`; a named owner outside the default candidate set is added rather than dropped; a report that names an owner it does not carry raises; a gap erased from a named unfit owner fails validation; a card built without a plan keeps its pre-#810 `ranked_by` and adds no verdict.

## Risk

- **Payload growth.** Every delegate-action coding payload gains `coding_owner_fit`. With the common two-requirement plan and four candidates that is roughly 4 KB of JSON. No size gate in the suite trips; if a wrapper is byte-sensitive the block is a single top-level key it can drop.
- **Ranking change on the choose-executor card.** `_choice_context_rank` gained a leading tier. When no plan is supplied the tier is constant `0` for every candidate, so pre-#810 ordering is bit-identical — pinned by an explicit negative test. When a plan *is* supplied the order can change, which is the intended behaviour.
- **`ranked_by` is now conditional.** It reports the four-key tuple when a plan was supplied and the original three-key tuple otherwise. Nothing in the suite asserted the old value.
- **Derivation breadth.** The workflow→capability map covers eight lanes. A plan routed to a lane outside the map declares no requirement and every owner reads `ready` — honest (nothing was required) but not the same as "verified capable". Widening the map is additive and guarded.

## Compatibility / Rollout

- Purely additive to persisted state: no new file is written, no existing schema changed, no stored record gained or lost a field. `coding_delegation_record_payload` copies an explicit key list, so recorded `coding_delegation/v1` records are byte-unchanged.
- `executor_choice_context`'s new `plan` parameter is keyword-only and defaults to `None`; every existing caller keeps its exact previous behaviour.
- No new dependency, no network call, no LLM call, no Hermes patching. All derivations are pure and take `now` as a parameter.
- No release-channel impact: nothing about install, setup, packaging, or the plugin bundle changed.

## Release / Claims

- [x] Release-channel impact considered — none. No install, setup, packaging, plugin-bundle, or version surface changed.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — both artifacts carry `status: prepared_not_observed` and a `claim_boundary` stating they are not dispatch, execution, verification, review, CI, or merge evidence. A `ready` verdict is explicitly stated not to be proof the owner would accept or finish the handoff.
- [x] Known manual Hermes checks are listed — see the unticked Validation rows. `omh release hermes-smoke --live` was not run; this PR changes no Hermes-profile surface.

## Follow-Up

- **#812** (retarget an accepted handoff to another owner) is the sibling issue and the reason `evaluate_owner_fit` has the signature it has. Its retarget path is not implemented here.
- Widening `WORKFLOW_CAPABILITY_REQUIREMENTS` beyond the eight lanes whose meaning is literally the capability. Additive, guarded by the existing routable-workflow and vocabulary tests.
- Persisting the fit decision and its evidence revisions into the handoff record, so a later readiness recheck can invalidate it — named in the issue's boundary-level design and deliberately out of this PR, which keeps owner fit derived-at-read rather than stored.
- No CLI command was added. If operators want to ask the question directly rather than reading it off a delegation payload, `omh coding owner-fit` would be the surface, and it would need the repo's bounded-surface and plain-text-default conventions.
