### PR TITLE
feat: make approval-gated OMH work durable and resumable

### DIFF
--- a/src/runtime/artifacts.py
+++ b/src/runtime/artifacts.py
@@ -47,6 +47,7 @@ from ..external_effect_receipts import (
 )
 from ..workflows.approval_receipts import validate_approval_receipt_store
 from ..workflows.blocked_work_records import decision_history, validate_blocked_work_record_store
+from ..workflows.decision_gates import validate_decision_gate_store
 from ..workflows.run_lineage import validate_run_lineage_checkpoint_store
 from ..workflows.workspace_bindings import validate_workspace_binding_store
 from ..observation_journal import (
@@ -2279,6 +2280,17 @@ def validate_runtime(paths: OmhPaths, run_id: str | None = None) -> dict[str, An
         paths.runtime_run_lineage_checkpoints_path,
         run_id=run_id,
     )
+    # And the decision-gate store, whose store-level half carries a rule no
+    # per-record validator can see: #825 AC1 says a blocked workflow has *one*
+    # open gate, and "one" is a property of the set of records, not of any
+    # record in it. `open_decision_gate` refuses to write the second one, but a
+    # hand-edited or older-build store can already hold it, and an operator
+    # presented with two open questions has no rule for which one their answer
+    # belongs to. This call is what makes the rule survive the file.
+    decision_gate_store_result = validate_decision_gate_store(
+        paths.runtime_decision_gates_path,
+        run_id=run_id,
+    )
     _add_duplicate_wrapper_run_link_errors(session_results, session_dirs)
     return {
         "ok": all(result["ok"] for result in results)
@@ -2288,7 +2300,8 @@ def validate_runtime(paths: OmhPaths, run_id: str | None = None) -> dict[str, An
         and bool(approval_store_result["ok"])
         and bool(blocked_work_store_result["ok"])
         and bool(workspace_binding_store_result["ok"])
-        and bool(run_lineage_store_result["ok"]),
+        and bool(run_lineage_store_result["ok"])
+        and bool(decision_gate_store_result["ok"]),
         "runs": results,
         "wrapper_sessions": session_results,
         "journal": journal_result,
@@ -2297,6 +2310,7 @@ def validate_runtime(paths: OmhPaths, run_id: str | None = None) -> dict[str, An
         "blocked_work_records": blocked_work_store_result,
         "workspace_bindings": workspace_binding_store_result,
         "run_lineage_checkpoints": run_lineage_store_result,
+        "decision_gates": decision_gate_store_result,
     }
 
 

--- a/src/runtime/records.py
+++ b/src/runtime/records.py
@@ -77,6 +77,10 @@ from ..workflows.blocked_work_records import (
     BLOCKED_WORK_RECORD_KEYS,
     validate_blocked_work_record,
 )
+from ..workflows.decision_gates import (
+    DECISION_GATE_KEYS,
+    validate_decision_gate,
+)
 from ..workflows.external_effect_receipts import (
     EXTERNAL_EFFECT_RECEIPT_KEYS,
     validate_external_effect_receipt,
@@ -4021,6 +4025,7 @@ APPROVAL_RECEIPT_RECORD_KEYS = APPROVAL_RECEIPT_KEYS
 BLOCKED_WORK_RECORD_RECORD_KEYS = BLOCKED_WORK_RECORD_KEYS
 WORKSPACE_BINDING_RECORD_KEYS = WORKSPACE_BINDING_KEYS
 RUN_LINEAGE_CHECKPOINT_RECORD_KEYS = RUN_LINEAGE_CHECKPOINT_KEYS
+DECISION_GATE_RECORD_KEYS = DECISION_GATE_KEYS
 
 
 @dataclass(frozen=True)
@@ -4061,4 +4066,5 @@ OPTIONAL_RUNTIME_STORE_VALIDATORS = (
     OptionalRuntimeStoreValidator(
         "run_lineage_checkpoints.jsonl", validate_run_lineage_checkpoint, "record_id"
     ),
+    OptionalRuntimeStoreValidator("decision_gates.jsonl", validate_decision_gate, "record_id"),
 )

--- a/src/system/paths.py
+++ b/src/system/paths.py
@@ -116,6 +116,19 @@ class OmhPaths:
         return self.runtime_journal_dir / "run_lineage_checkpoints.jsonl"
 
     @property
+    def runtime_decision_gates_path(self) -> Path:
+        # Runtime-wide, beside the other five stores, because the whole point of
+        # #825 is that the question outlives the turn that asked it. A gate is
+        # written when work blocks and read when somebody answers, which may be
+        # after a restart, and the answer has to be matched against the question
+        # as it was asked rather than against whatever the next turn
+        # reconstructs. Per-run placement would also defeat the one-open-gate
+        # rule the same way it defeated workspace exclusivity: the check has to
+        # see every open gate at once, and a per-run file is invisible to every
+        # other reader by construction.
+        return self.runtime_journal_dir / "decision_gates.jsonl"
+
+    @property
     def runtime_plan_context_dir(self) -> Path:
         return self.runtime_dir / "plan-context"
 

--- a/src/workflows/decision_gates.py
+++ b/src/workflows/decision_gates.py
@@ -1,0 +1,1576 @@
+"""Append-only decision gates: one question, one answer, one released transition (issue #825).
+
+What was missing
+----------------
+
+OMH could already stop work and say why. `coding.action_gate` withholds an
+action pending approval, `workflows.approval_receipts` records the consent an
+operator gave, and `workflows.blocked_work_records` keeps the decision
+explainable after the turn. What none of them holds is the *question*: which
+one thing a human is being asked right now, which choices they have, what each
+choice costs, and -- the part that survives nothing today -- exactly which
+blocked transition their answer releases.
+
+Without that, a pause is durable and a resume is not. The gate is reconstructed
+from whatever the next turn happens to remember, so an answer given to one
+question can be applied to a different one, and a restart between the question
+and the answer loses the binding entirely.
+
+Why this is its own record family
+---------------------------------
+
+The repo refused a new family twice (#811, #818) and accepted three (#807,
+#808/#806, #826) on a rule worth restating: a family joins on run id, and a join
+is where an artifact and its metadata desynchronize, so a field group on the
+record that already exists is the default. A separate family has to earn it.
+
+This one earns it on the same dimensions #807 used, and it earns it hardest
+against the family it looks most like. An approval receipt records *an answer
+that was given*. It has no shape for a question that has not been answered yet:
+`APPROVAL_DECISIONS` is `granted`/`denied`/`revoked`, all three of them past
+tense, and there is deliberately no `pending` member -- an unanswered
+confirmation must not sit in the approval store looking like a weak grant. A
+decision gate is the other half: it exists *before* the answer, which is the
+whole of what "durable and resumable" means here, and it is written by the
+surface that blocked rather than by the operator who answers.
+
+It is also bound to something an approval is not bound to. An approval binds
+five dimensions of a *request*. A gate additionally binds the *position* the run
+is paused at -- the blocked transition and the checkpoint -- because releasing
+the wrong transition on a correct subject is the failure mode #825 AC3 names.
+
+Coexisting with the name that was already here
+----------------------------------------------
+
+`decision_gate` was already a live string in this tree, in two unrelated places,
+and neither of them is this:
+
+* `catalogs.playbooks` names three wrapper stages whose declared artifact
+  contract is `decision_gate/v1` (`decision_gate`, `delivery_decision`,
+  `deploy_decision`). That string named a kind of evidence with no schema behind
+  it. This module is that schema, arriving under the name those stages have been
+  citing all along, which is why the version string here is `decision_gate/v1`
+  and not a second spelling of it.
+* `workflows.hermes_planning._wrapper_contract` carries a `decision_gate`
+  sub-dict -- `required` / `condition` / `do_not_delegate_when`. That is a
+  *contract clause*, not a record: it tells a wrapper the conditions under which
+  a prepared plan may be delegated, it is rebuilt from the plan on every call,
+  it names no subject, no approver, and no answer, and nothing about it survives
+  the turn. It is deliberately left alone. `tests/test_decision_gate.py` pins the
+  two apart so a later reader cannot collapse them.
+
+What a gate binds, and what releases it
+---------------------------------------
+
+A resume is matched on equality across four groups, each with its own refusal
+code, and the codes are `approval_receipts`' own rather than a parallel set:
+
+    run_id                              -> run_not_approved
+    (subject_class, subject_ref)        -> scope_not_approved
+    (safety_profile_revision,
+     context_revision)                  -> safety_revision_not_approved
+    (blocked_transition, checkpoint_ref)-> transition_not_unblocked
+
+The first three are `SCOPE_REFUSAL_CODES` members, reused because "this answer
+does not cover you" already has a vocabulary in this tree and a second one would
+be a second answer to the same question. The fourth is this family's own,
+because no existing code says "right subject, wrong place in the run".
+
+`resume_digest` is the single value that seals all seven of those fields at
+once. It is re-derived at validate, so a hand-edited store cannot move an answer
+onto a transition it was never given for, and it is what a caller cites when it
+says which resume it is performing.
+
+There is no containment rule anywhere in this module. Matching is equality on
+every dimension, which is what makes widening structurally impossible rather
+than merely unimplemented.
+
+One open gate per subject
+-------------------------
+
+#825 AC1 is that a blocked workflow identifies *one* open gate. That is enforced
+in both directions rather than left to a renderer: `open_decision_gate` refuses
+to open a second gate while another is open for the same subject, and
+`validate_decision_gate_store` faults a store that already holds two, so a
+hand-edited or concurrently written store fails `omh runtime validate` instead
+of presenting an operator with two questions and no rule for which one their
+answer belongs to.
+
+Nothing here can carry a sentence
+---------------------------------
+
+The key set is closed, `RAW_OR_HIDDEN_KEYS` is refused by name first, and there
+is no free-text field -- not for the question, not for the risk, not for a
+choice's consequence. Every one of those is a closed vocabulary id whose prose
+is a module constant joined at render, the idiom `approval_receipts.REFUSAL_REASONS`
+and `run_lineage.BREAK_REASONS` already use. A gate is rendered to an operator
+who is about to authorise something, so the text they read must be text this
+repo wrote, never text that arrived with the request.
+
+An answered gate is not evidence
+--------------------------------
+
+`CLAIM_BOUNDARY` is on every record and `validate_decision_gate` refuses a record
+shaped to assert execution by key name as well as by the closed key set. Choosing
+`approve` proves a human chose it. It does not prove the transition was taken,
+and it never proves anything ran.
+
+Determinism
+-----------
+
+`resume_digest` covers no clock. `opened_at` and `decided_at` are parameters, and
+freshness is recomputed by every reader from the stored stamp against a `now`
+that is passed in -- the `approval_receipts` idiom, reusing that module's
+`APPROVAL_TTL_SECONDS` and `approval_age_seconds` rather than declaring a second
+window. Nothing on disk says a decision is still good.
+
+Store mechanics
+---------------
+
+All of it is `system.append_only_store`, shared with the four families beside it:
+the torn-tail-safe binary append under a real OS lock on both platforms, the
+opaque-reference guards, the digest handles, and the chain walk. This module adds
+no store mechanics of its own.
+
+What produces and reads these records today
+-------------------------------------------
+
+Stated because the vocabularies here are wider than the wiring, and a reader who
+took `QUESTION_CODES` for a coverage claim would be wrong. No production surface
+mints a gate yet: `coding.action_gate` still withholds an action without opening
+one, exactly as `run_lineage` shipped its chain before anything appended to it.
+The one production read surface is `runtime.artifacts.validate_runtime`, which
+carries this store's integrity -- including the one-open-gate rule -- into
+`omh runtime validate`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from ..system.append_only_store import (
+    RAW_OR_HIDDEN_KEYS,
+    append_store_line,
+    closed_vocabulary_value,
+    latest_record_in,
+    mint_record_id,
+    opaque_ref,
+    record_fingerprint,
+    redacted_ref,
+    reference_errors,
+    store_errors,
+)
+from ..system.local_store import file_lock, read_jsonl_objects, utc_now
+from ..system.paths import OmhPaths
+from .approval_receipts import (
+    APPROVAL_TTL_SECONDS,
+    REFUSAL_ABSENT,
+    REFUSAL_EXPIRED,
+    REFUSAL_REVISION,
+    REFUSAL_RUN,
+    REFUSAL_SCOPE,
+    REFUSAL_SUPERSEDED,
+    SCOPE_CLASSES,
+    UNKNOWN_AGE_SECONDS,
+    approval_age_seconds,
+)
+
+
+DECISION_GATE_SCHEMA_VERSION: Final[str] = "decision_gate/v1"
+DECISION_GATE_RESUME_SCHEMA_VERSION: Final[str] = "decision_gate_resume/v1"
+DECISION_GATE_VIEW_SCHEMA_VERSION: Final[str] = "decision_gate_view/v1"
+DECISION_GATE_STORE_VALIDATION_SCHEMA_VERSION: Final[str] = "decision_gate_store_validation/v1"
+
+DECISION_GATE_STORE_NAME: Final[str] = "decision_gates.jsonl"
+
+GATE_PRIVACY: Final[str] = "metadata_only"
+
+# Stated on every record and echoed on every resume verdict and every view. The
+# claim a gate makes is deliberately small, and the last clause is the one #825
+# AC3 rests on: an answer is bound to one transition and releases that one.
+CLAIM_BOUNDARY: Final[str] = (
+    "A decision gate is one recorded question put to one named approver about one subject, under one "
+    "safety profile revision and one context revision, and at most one recorded answer to it. An answered "
+    "gate proves a human chose one of the choices they were offered. It is not dispatch, execution, "
+    "verification, review, CI, merge-readiness, or merge evidence, and it releases exactly the one blocked "
+    "transition its resume digest names and nothing else."
+)
+
+# What kind of thing `subject_ref` names. This is `approval_receipts.SCOPE_CLASSES`
+# under the name this family uses for it, imported rather than restated: a gate
+# asks about the same kinds of thing an approval is scoped to, and two answers to
+# "what class is this subject" is the defect a shared vocabulary prevents.
+SUBJECT_CLASSES: Final[tuple[str, ...]] = SCOPE_CLASSES
+
+# Where in a run's lifecycle the work is paused. The names are the observation
+# journal's own canonical event names, restated here rather than imported for the
+# reason `run_lineage.LINEAGE_EVIDENCE_CLASSES` is restated: a store's on-disk
+# vocabulary must not change because another module reordered a tuple.
+# `tests/test_decision_gate.py` pins this equal to `run_lineage.LINEAGE_TRANSITIONS`,
+# so drift is a failing test rather than a silent schema change.
+BLOCKED_TRANSITIONS: Final[tuple[str, ...]] = (
+    "plan_accepted",
+    "handoff_prepared",
+    "runtime_start_observed",
+    "worktree_creation_observed",
+    "executor_dispatch_observed",
+    "executor_result_observed",
+    "verification_result_observed",
+    "review_result_observed",
+    "ci_result_observed",
+    "merge_gate_observed",
+    "merge_observed",
+)
+
+# What a gate can ask. Closed, because the question is rendered to the person
+# authorising the thing: the words they read must be words this repo wrote.
+QUESTION_CODES: Final[tuple[str, ...]] = (
+    "accept_plan_direction",
+    "approve_scope_widening",
+    "choose_executor_owner",
+    "confirm_destructive_action",
+    "confirm_external_effect",
+    "continue_after_revision_change",
+)
+
+QUESTION_TEXT: Final[dict[str, str]] = {
+    "accept_plan_direction": "Accept this plan direction so the blocked transition can continue?",
+    "approve_scope_widening": (
+        "Widen the authority envelope to cover this subject so the blocked transition can continue?"
+    ),
+    "choose_executor_owner": "Confirm this coding owner so the blocked transition can continue?",
+    "confirm_destructive_action": (
+        "Confirm this action on this subject, knowing it changes state that is not trivially restored?"
+    ),
+    "confirm_external_effect": "Confirm this effect outside the workspace on this subject?",
+    "continue_after_revision_change": "Continue from this checkpoint under the revisions now in force?",
+}
+
+# How bad releasing the transition is if the answer turns out to be wrong. Three
+# classes rather than a score: an operator acts on "can I undo this", and a
+# number invites a threshold nobody agreed on.
+RISK_CLASSES: Final[tuple[str, ...]] = ("reversible", "costly_to_reverse", "irreversible")
+
+RISK_TEXT: Final[dict[str, str]] = {
+    "reversible": "Releasing this transition has an effect the same surface can undo.",
+    "costly_to_reverse": "Releasing this transition has an effect that can be undone only by work outside this run.",
+    "irreversible": "Releasing this transition has an effect that cannot be undone once it is applied.",
+}
+
+# The answers a gate can offer.
+GATE_CHOICES: Final[tuple[str, ...]] = ("approve", "decline", "defer")
+
+# Which choices release the blocked transition. Exactly one does, and the table
+# is what makes "rejected gates are non-resumable" a lookup rather than a string
+# comparison scattered across readers.
+CHOICE_RELEASES: Final[dict[str, bool]] = {"approve": True, "decline": False, "defer": False}
+
+CHOICE_CONSEQUENCES: Final[dict[str, str]] = {
+    "approve": (
+        "The blocked transition is released once, for this subject at these revisions, and for nothing else."
+    ),
+    "decline": "The blocked transition stays blocked and the question is closed; asking again needs a new gate.",
+    "defer": (
+        "The blocked transition stays blocked and the question is closed unanswered; ask again when the "
+        "decision can be made."
+    ),
+}
+
+# `open`     -- the question is on record and nobody has answered it.
+# `answered` -- one of the offered choices was chosen, by the approver the gate
+#               named, at a recorded time.
+#
+# There is deliberately no `withdrawn`, `pending`, or `expired` member. The first
+# would be a third way to close a question when `decline` already exists; the
+# other two are not states a record is in, they are properties a reader derives
+# -- `pending` is what `open` means, and expiry is recomputed from the stamp for
+# the reason `approval_receipts` gives at length.
+GATE_STATES: Final[tuple[str, ...]] = ("open", "answered")
+GATE_STATE_OPEN: Final[str] = "open"
+GATE_STATE_ANSWERED: Final[str] = "answered"
+
+DECISION_GATE_KEYS: Final[tuple[str, ...]] = (
+    "actor",
+    "answered_choice",
+    "approver",
+    "blocked_transition",
+    "checkpoint_ref",
+    "choices",
+    "claim_boundary",
+    "context_revision",
+    "decided_at",
+    "gate_id",
+    "opened_at",
+    "privacy",
+    "question_code",
+    "record_id",
+    "resume_digest",
+    "risk_class",
+    "run_id",
+    "safety_profile_revision",
+    "schema_version",
+    "state",
+    "subject_class",
+    "subject_id",
+    "subject_ref",
+    "supersedes_gate_ref",
+)
+
+# The three keys whose value is a module constant rather than data. Everything
+# else on a record is rendered, and `compact_decision_gate` must cover all of it
+# -- a key in the tuple and missing from the compactor is a field that is stored
+# and never seen, which has cost this repo twice.
+DECISION_GATE_CONSTANT_KEYS: Final[tuple[str, ...]] = ("claim_boundary", "privacy", "schema_version")
+
+# Exactly what `resume_digest` seals: the subject, both revisions, and the
+# position in the run. Nothing else, and no clock -- a wall clock inside a
+# compared value turns an equality check into a race, which this repo has already
+# lost Windows CI time to.
+RESUME_DIGEST_KEYS: Final[tuple[str, ...]] = (
+    "blocked_transition",
+    "checkpoint_ref",
+    "context_revision",
+    "run_id",
+    "safety_profile_revision",
+    "subject_class",
+    "subject_ref",
+)
+
+# The fields only an answered record carries. Empty on an open one, and required
+# on an answered one, both checked: an answer missing any of them is #825 AC2's
+# refusal, and an open record carrying any of them would be an answer nobody gave.
+_ANSWER_FIELDS: Final[tuple[str, ...]] = ("actor", "answered_choice", "decided_at")
+
+# Identifiers that must be present, through `require_opaque_metadata_ref`.
+_REQUIRED_GATE_REFS: Final[tuple[str, ...]] = (
+    "approver",
+    "checkpoint_ref",
+    "gate_id",
+    "opened_at",
+    "record_id",
+    "run_id",
+    "safety_profile_revision",
+    "subject_id",
+)
+# Legitimately absent. The three answer fields are empty while the gate is open,
+# a run whose context was never revised has no context revision, and the link is
+# empty on the first record for a question and only then.
+_OPTIONAL_GATE_REFS: Final[tuple[str, ...]] = (
+    "actor",
+    "context_revision",
+    "decided_at",
+    "supersedes_gate_ref",
+)
+_GATE_VOCABULARIES: Final[tuple[tuple[str, tuple[str, ...]], ...]] = (
+    ("blocked_transition", BLOCKED_TRANSITIONS),
+    ("question_code", QUESTION_CODES),
+    ("risk_class", RISK_CLASSES),
+    ("state", GATE_STATES),
+    ("subject_class", SUBJECT_CLASSES),
+)
+# The one list field. Its members are closed-vocabulary choice ids, never caller
+# text, which is why this family has a list at all and still has no free text.
+_GATE_LIST_FIELDS: Final[tuple[str, ...]] = ("choices",)
+
+_GATE_STRING_FIELDS: Final[tuple[str, ...]] = tuple(
+    key for key in DECISION_GATE_KEYS if key not in _GATE_LIST_FIELDS
+)
+
+# This family's own refusal, for the one dimension `approval_receipts` has no
+# code for. An approval binds a request; a gate additionally binds the position
+# the run is paused at, and "right subject, wrong place in the run" is the
+# failure #825 AC3 is named after.
+REFUSAL_TRANSITION: Final[str] = "transition_not_unblocked"
+# The question is on record and unanswered. Distinct from `approval_absent`,
+# which says nothing on record names this request at all: an operator who has
+# been asked and has not replied is in a different position from one who was
+# never asked, and the two need different next steps.
+REFUSAL_PENDING: Final[str] = "decision_pending"
+# Answered with a choice that does not release the transition.
+REFUSAL_DECLINED: Final[str] = "decision_declined"
+
+# Which dimension a candidate gate differs on, in the order a verdict reports
+# them when it differs on more than one. Run first because a gate borrowed from
+# another run is the failure this family shares with #807; then the subject, then
+# the revisions it was asked under, then where in the run it was asked.
+GATE_MISMATCH_CODES: Final[tuple[str, ...]] = (
+    REFUSAL_RUN,
+    REFUSAL_SCOPE,
+    REFUSAL_REVISION,
+    REFUSAL_TRANSITION,
+)
+# The lifecycle refusals, in the precedence `_lifecycle_verdict` applies.
+GATE_LIFECYCLE_CODES: Final[tuple[str, ...]] = (
+    REFUSAL_SUPERSEDED,
+    REFUSAL_PENDING,
+    REFUSAL_DECLINED,
+    REFUSAL_EXPIRED,
+    REFUSAL_ABSENT,
+)
+GATE_REFUSAL_CODES: Final[tuple[str, ...]] = GATE_MISMATCH_CODES + GATE_LIFECYCLE_CODES
+
+# The three mismatch codes this family did not invent. Pinned against
+# `approval_receipts.SCOPE_REFUSAL_CODES` by `tests/test_decision_gate.py`, so a
+# rename there is a failing test here rather than a second vocabulary.
+REUSED_REFUSAL_CODES: Final[tuple[str, ...]] = (REFUSAL_RUN, REFUSAL_SCOPE, REFUSAL_REVISION)
+
+# Constant strings, keyed by code. Nothing is interpolated into a reason: a
+# refusal is rendered to operators, and a line built from request values would be
+# one more path for caller-controlled text to reach a terminal. The prose is this
+# family's own even where the code is borrowed -- the code says which dimension
+# failed, and the sentence has to say it about a gate rather than about a receipt.
+GATE_REFUSAL_REASONS: Final[dict[str, str]] = {
+    REFUSAL_RUN: "The gate on record belongs to another run; a decision is run-bound and never carries over.",
+    REFUSAL_SCOPE: (
+        "The gate on record names another subject; an answer covers exactly the subject it was asked about "
+        "and never a broader one."
+    ),
+    REFUSAL_REVISION: (
+        "The gate on record was asked under another safety profile or context revision, so its answer speaks "
+        "for a state the run has left."
+    ),
+    REFUSAL_TRANSITION: (
+        "The gate on record unblocks another transition or another checkpoint; a resume releases exactly the "
+        "transition its digest names."
+    ),
+    REFUSAL_PENDING: "The gate on record is still open; a question nobody has answered releases nothing.",
+    REFUSAL_DECLINED: (
+        "The gate on record was answered with a choice that does not release the blocked transition."
+    ),
+    REFUSAL_EXPIRED: (
+        "The answer on record is outside the decision window, measured now from its decision stamp."
+    ),
+    REFUSAL_SUPERSEDED: "The gate on record was superseded by a later record for the same question.",
+    REFUSAL_ABSENT: (
+        "No decision gate on record names this subject, these revisions, this blocked transition, and this "
+        "checkpoint."
+    ),
+}
+
+# Key names an execution claim arrives under. The closed key set already refuses
+# every one of them, but it refuses them as "unsupported keys", and the point of
+# this family is that an answered question is not an outcome -- so the shape is
+# named and refused by name first. Mirrors `run_lineage.EXECUTION_CLAIM_KEYS`
+# rather than importing across two unrelated record families;
+# `tests/test_decision_gate.py` pins them equal so the two cannot drift.
+EXECUTION_CLAIM_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "applied",
+        "attempted",
+        "completed",
+        "dispatched",
+        "effect_applied",
+        "enforced",
+        "executed",
+        "execution",
+        "execution_result",
+        "exit_code",
+        "external_ref",
+        "host_applied",
+        "observed",
+        "observed_at",
+        "observed_result",
+        "outcome",
+        "performed",
+        "ran",
+        "result",
+        "status",
+        "succeeded",
+        "success",
+    }
+)
+
+# The store label every error line and every reference fault is reported under.
+_LABEL: Final[str] = "decision_gate"
+
+# A resume digest is a full sha256 hex string and nothing else. Enforced as a
+# shape as well as by re-derivation, so a hand-edited store carrying a path, a
+# URL, or a truncated handle in the field a resume is matched on is refused
+# before anything tries to match on it.
+_DIGEST: Final[re.Pattern[str]] = re.compile(r"^[0-9a-f]{64}$")
+
+# A subject must name something inside the workspace. The shared
+# `require_opaque_metadata_ref` already refuses a leading `/` or `~` and every
+# backslash, so what is left is the parent traversal and the Windows drive
+# prefix -- the two ways an in-bounds-looking subject reaches out. Held in the
+# same shape as `approval_receipts`, which draws the identical line for the
+# identical reason.
+_SUBJECT_TRAVERSAL: Final[re.Pattern[str]] = re.compile(r"(?:^|/)\.\.(?:/|$)")
+_WINDOWS_DRIVE: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z]:")
+
+
+class DecisionGateError(ValueError):
+    """Raised when a question or an answer cannot become a decision gate record."""
+
+
+# ---------------------------------------------------------------------------
+# Identity and digest
+# ---------------------------------------------------------------------------
+
+
+def gate_subject_id(*, run_id: str, subject_class: str, subject_ref: str) -> str:
+    """Stable identity of one subject inside one run.
+
+    The unit #825 AC1's "one open gate" is counted over. Deliberately narrower
+    than `gate_id`: two questions about one subject at two different points in a
+    run have two gate ids and one subject id, and that is exactly the state the
+    open-gate rule refuses.
+    """
+    base = json.dumps(
+        {
+            "run_id": str(run_id),
+            "subject_class": str(subject_class),
+            "subject_ref": str(subject_ref),
+        },
+        sort_keys=True,
+    )
+    return f"gate-subject-{hashlib.sha256(base.encode('utf-8')).hexdigest()[:16]}"
+
+
+def gate_id(
+    *,
+    run_id: str,
+    subject_class: str,
+    subject_ref: str,
+    blocked_transition: str,
+    checkpoint_ref: str,
+) -> str:
+    """Stable identity of one question.
+
+    The revisions are deliberately not in it, for the reason
+    `approval_receipts.approval_id` leaves the safety profile out of its own
+    identity: a revision is part of the *answer's* validity, not part of the
+    question, so re-asking after the profile moved must supersede the earlier
+    record rather than open a second parallel chain that both claim to be
+    current.
+    """
+    base = json.dumps(
+        {
+            "blocked_transition": str(blocked_transition),
+            "checkpoint_ref": str(checkpoint_ref),
+            "run_id": str(run_id),
+            "subject_class": str(subject_class),
+            "subject_ref": str(subject_ref),
+        },
+        sort_keys=True,
+    )
+    return f"gate-{hashlib.sha256(base.encode('utf-8')).hexdigest()[:16]}"
+
+
+def resume_digest(
+    *,
+    run_id: str,
+    subject_class: str,
+    subject_ref: str,
+    blocked_transition: str,
+    checkpoint_ref: str,
+    safety_profile_revision: str,
+    context_revision: str = "",
+) -> str:
+    """The one value that identifies which blocked transition an answer releases.
+
+    `record_fingerprint` is the shared hasher; nothing here reimplements it. The
+    key tuple is what this family contributes, and it covers no clock, so the
+    same resume computed a second apart is the same digest.
+
+    A caller performing a resume computes this from what it holds and cites it.
+    `validate_decision_gate` re-derives it from the record's own fields, so an
+    answer cannot be moved onto a transition it was never given for by editing
+    one number on disk.
+    """
+    return record_fingerprint(
+        {
+            "blocked_transition": str(blocked_transition),
+            "checkpoint_ref": str(checkpoint_ref),
+            "context_revision": str(context_revision or ""),
+            "run_id": str(run_id),
+            "safety_profile_revision": str(safety_profile_revision),
+            "subject_class": str(subject_class),
+            "subject_ref": str(subject_ref),
+        },
+        RESUME_DIGEST_KEYS,
+    )
+
+
+def resume_digest_of(record: Mapping[str, Any]) -> str:
+    """`resume_digest` over the sealed fields of a record already in hand."""
+    return record_fingerprint(record, RESUME_DIGEST_KEYS)
+
+
+# ---------------------------------------------------------------------------
+# Build, validate, append
+# ---------------------------------------------------------------------------
+
+
+def build_decision_gate(
+    *,
+    run_id: str,
+    subject_class: str,
+    subject_ref: str,
+    blocked_transition: str,
+    checkpoint_ref: str,
+    question_code: str,
+    risk_class: str,
+    choices: Sequence[str],
+    approver: str,
+    safety_profile_revision: str,
+    context_revision: str = "",
+    opened_at: str = "",
+    supersedes_gate_ref: str = "",
+) -> dict[str, Any]:
+    """Mint one open gate, or refuse.
+
+    There is no `state` argument and no way to reach `answered` from here. An
+    answer is built by `build_decision_gate_answer` *from the open record it
+    answers*, which is what makes "the answer names the same subject, the same
+    revisions, and the same transition as the question" a property of the
+    constructor rather than a check somebody has to remember to run.
+    """
+    if question_code not in QUESTION_CODES:
+        raise DecisionGateError(f"decision_gate question_code is unsupported: {question_code!r}")
+    if risk_class not in RISK_CLASSES:
+        raise DecisionGateError(f"decision_gate risk_class is unsupported: {risk_class!r}")
+    if subject_class not in SUBJECT_CLASSES:
+        raise DecisionGateError(f"decision_gate subject_class is unsupported: {subject_class!r}")
+    if blocked_transition not in BLOCKED_TRANSITIONS:
+        raise DecisionGateError(f"decision_gate blocked_transition is unsupported: {blocked_transition!r}")
+    offered = _normalized_choices(choices)
+    safe_subject_ref = _subject_ref(subject_ref)
+    safe_run_id = _opaque(run_id, field="decision_gate run_id")
+    safe_checkpoint = _opaque(checkpoint_ref, field="decision_gate checkpoint_ref")
+    safe_approver = _opaque(approver, field="decision_gate approver")
+    safe_revision = _opaque(safety_profile_revision, field="decision_gate safety_profile_revision")
+    safe_context = (
+        _opaque(context_revision, field="decision_gate context_revision") if context_revision else ""
+    )
+    stamp = _opaque(str(opened_at or utc_now()), field="decision_gate opened_at")
+    safe_supersedes = (
+        _opaque(supersedes_gate_ref, field="decision_gate supersedes_gate_ref") if supersedes_gate_ref else ""
+    )
+    identity = gate_id(
+        run_id=safe_run_id,
+        subject_class=subject_class,
+        subject_ref=safe_subject_ref,
+        blocked_transition=blocked_transition,
+        checkpoint_ref=safe_checkpoint,
+    )
+    record: dict[str, Any] = {
+        "schema_version": DECISION_GATE_SCHEMA_VERSION,
+        "record_id": _record_id(identity, stamp, GATE_STATE_OPEN),
+        "gate_id": identity,
+        "subject_id": gate_subject_id(
+            run_id=safe_run_id, subject_class=subject_class, subject_ref=safe_subject_ref
+        ),
+        "run_id": safe_run_id,
+        "subject_class": subject_class,
+        "subject_ref": safe_subject_ref,
+        "blocked_transition": blocked_transition,
+        "checkpoint_ref": safe_checkpoint,
+        "safety_profile_revision": safe_revision,
+        "context_revision": safe_context,
+        "question_code": question_code,
+        "risk_class": risk_class,
+        "choices": offered,
+        "approver": safe_approver,
+        "opened_at": stamp,
+        "state": GATE_STATE_OPEN,
+        "answered_choice": "",
+        "actor": "",
+        "decided_at": "",
+        "resume_digest": "",
+        "supersedes_gate_ref": safe_supersedes,
+        "privacy": GATE_PRIVACY,
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+    record["resume_digest"] = resume_digest_of(record)
+    errors = validate_decision_gate(record)
+    if errors:
+        raise DecisionGateError(errors[0])
+    return record
+
+
+def build_decision_gate_answer(
+    gate: Mapping[str, Any],
+    *,
+    actor: str,
+    choice: str,
+    decided_at: str = "",
+) -> dict[str, Any]:
+    """Mint the answer to one open gate, or refuse.
+
+    Everything the answer is bound to is copied from the gate it answers, never
+    accepted from the caller. #825 AC3's "same subject, same revision, same
+    scope" is therefore not a check that can be skipped: there is no argument
+    through which an answer could name a different one.
+
+    Three refusals are #825 AC2 in its enforcing form. An answer must name an
+    actor, must name a choice the gate actually offered, and must be stamped;
+    and the actor must be the approver the gate named, because an answer from
+    somebody the question was not put to is the "unattended or inferred
+    approval" #825 puts out of scope.
+    """
+    if not isinstance(gate, Mapping):
+        raise DecisionGateError("decision_gate answer must be built from a gate record")
+    if str(gate.get("state", "")) != GATE_STATE_OPEN:
+        raise DecisionGateError("decision_gate answer must answer an open gate")
+    errors = validate_decision_gate(dict(gate))
+    if errors:
+        raise DecisionGateError(f"decision_gate answer must answer a valid gate: {errors[0]}")
+    offered = [str(item) for item in gate.get("choices", []) if isinstance(item, str)]
+    if choice not in offered:
+        raise DecisionGateError(f"decision_gate answered_choice was not offered by this gate: {choice!r}")
+    safe_actor = _opaque(actor, field="decision_gate actor")
+    if safe_actor != str(gate.get("approver", "")):
+        raise DecisionGateError(
+            "decision_gate actor must be the approver this gate named; an answer from anyone else is not an "
+            "answer to this question"
+        )
+    stamp = _opaque(str(decided_at or utc_now()), field="decision_gate decided_at")
+    record = dict(gate)
+    record.update(
+        {
+            "record_id": _record_id(str(gate.get("gate_id", "")), stamp, GATE_STATE_ANSWERED),
+            "state": GATE_STATE_ANSWERED,
+            "answered_choice": choice,
+            "actor": safe_actor,
+            "decided_at": stamp,
+            "supersedes_gate_ref": str(gate.get("record_id", "")),
+        }
+    )
+    # Re-derived rather than copied. The seal covers only fields the answer
+    # inherits verbatim, so this must equal the gate's -- and deriving it again
+    # is what proves that, instead of assuming it.
+    record["resume_digest"] = resume_digest_of(record)
+    answer_errors = validate_decision_gate(record)
+    if answer_errors:
+        raise DecisionGateError(answer_errors[0])
+    return record
+
+
+def validate_decision_gate(record: dict[str, Any]) -> list[str]:
+    """Every reason one record is not a decision gate."""
+    if not isinstance(record, dict):
+        return [f"{_LABEL} must be an object"]
+    errors: list[str] = []
+    claims_execution = sorted(key for key in record if str(key).lower() in EXECUTION_CLAIM_KEYS)
+    if claims_execution:
+        errors.append(
+            f"{_LABEL} must not carry execution-claim keys: "
+            f"{claims_execution}; an answered question is not an attempt and not an outcome"
+        )
+    forbidden = sorted(key for key in record if str(key).lower() in RAW_OR_HIDDEN_KEYS)
+    if forbidden:
+        errors.append(f"{_LABEL} must not carry raw or hidden keys: {forbidden}")
+    extra_keys = sorted(set(record) - set(DECISION_GATE_KEYS) - set(claims_execution) - set(forbidden))
+    if extra_keys:
+        errors.append(f"{_LABEL} has unsupported keys: {extra_keys}")
+    missing = sorted(set(DECISION_GATE_KEYS) - set(record))
+    if missing:
+        errors.append(f"{_LABEL} is missing keys: {missing}")
+    if record.get("schema_version") != DECISION_GATE_SCHEMA_VERSION:
+        errors.append(f"{_LABEL} schema_version must be {DECISION_GATE_SCHEMA_VERSION}")
+    for key in _GATE_STRING_FIELDS:
+        if not isinstance(record.get(key), str):
+            errors.append(f"{_LABEL} {key} must be a string")
+    for key, vocabulary in _GATE_VOCABULARIES:
+        if record.get(key) not in vocabulary:
+            errors.append(f"{_LABEL} {key} is unsupported: {record.get(key)!r}")
+    if record.get("privacy") != GATE_PRIVACY:
+        errors.append(f"{_LABEL} privacy must be metadata_only")
+    if record.get("claim_boundary") != CLAIM_BOUNDARY:
+        errors.append(f"{_LABEL} claim_boundary must state the decision gate boundary")
+    for field in _REQUIRED_GATE_REFS:
+        errors.extend(reference_errors(record.get(field), field=field, label=_LABEL, required=True))
+    for field in _OPTIONAL_GATE_REFS:
+        errors.extend(reference_errors(record.get(field), field=field, label=_LABEL, required=False))
+    errors.extend(_subject_ref_errors(record.get("subject_ref")))
+    errors.extend(_choices_errors(record.get("choices")))
+    errors.extend(_state_errors(record))
+    errors.extend(_identity_errors(record))
+    return errors
+
+
+def append_decision_gate(paths: OmhPaths, record: dict[str, Any]) -> dict[str, Any]:
+    """Append one validated record. Never rewrites, never reorders."""
+    errors = validate_decision_gate(record)
+    if errors:
+        raise DecisionGateError(errors[0])
+    path = paths.runtime_decision_gates_path
+    with file_lock(path, private=True):
+        append_store_line(path, record)
+    return record
+
+
+def open_decision_gate(
+    paths: OmhPaths,
+    *,
+    run_id: str,
+    subject_class: str,
+    subject_ref: str,
+    blocked_transition: str,
+    checkpoint_ref: str,
+    question_code: str,
+    risk_class: str,
+    choices: Sequence[str],
+    approver: str,
+    safety_profile_revision: str,
+    context_revision: str = "",
+    now: str = "",
+) -> dict[str, Any]:
+    """Put one question on record, or refuse. #825 AC1's enforcing half.
+
+    The read of the store and the append happen under one lock, so two surfaces
+    blocking on one subject at the same moment cannot both believe they opened
+    the only gate.
+
+    Re-asking a question that is already open appends nothing and returns the
+    record already on file: one block reported three times is one question, not
+    three. Asking a *different* question about a subject that already has an open
+    gate is refused outright -- that is the state #825 AC1 forbids, and refusing
+    it here is why no renderer ever has to choose between two open gates.
+    """
+    path = paths.runtime_decision_gates_path
+    with file_lock(path, private=True):
+        records, _ = read_jsonl_objects(path)
+        identity = gate_id(
+            run_id=str(run_id),
+            subject_class=str(subject_class),
+            subject_ref=str(subject_ref),
+            blocked_transition=str(blocked_transition),
+            checkpoint_ref=str(checkpoint_ref),
+        )
+        subject = gate_subject_id(
+            run_id=str(run_id), subject_class=str(subject_class), subject_ref=str(subject_ref)
+        )
+        for head in open_gates_in(records):
+            if str(head.get("gate_id", "")) == identity:
+                return dict(head)
+            if str(head.get("subject_id", "")) == subject:
+                raise DecisionGateError(
+                    f"{_LABEL} subject already has an open gate; one subject carries at most one open "
+                    "question, so answer or decline the open one before asking another"
+                )
+        prior = latest_record_in(records, key="gate_id", value=identity)
+        record = build_decision_gate(
+            run_id=run_id,
+            subject_class=subject_class,
+            subject_ref=subject_ref,
+            blocked_transition=blocked_transition,
+            checkpoint_ref=checkpoint_ref,
+            question_code=question_code,
+            risk_class=risk_class,
+            choices=choices,
+            approver=approver,
+            safety_profile_revision=safety_profile_revision,
+            context_revision=context_revision,
+            opened_at=now,
+            supersedes_gate_ref=str(prior.get("record_id", "")) if prior else "",
+        )
+        append_store_line(path, record)
+    return record
+
+
+def answer_decision_gate(
+    paths: OmhPaths,
+    *,
+    gate_id_value: str,
+    actor: str,
+    choice: str,
+    now: str = "",
+) -> dict[str, Any]:
+    """Record one answer to one open question, or refuse. #825 AC2.
+
+    The read of the open record and the append of the answer happen under one
+    lock, so two answers to one question cannot both link to the same open
+    record and fork the chain -- the second finds the gate already answered and
+    is refused.
+
+    Nothing on disk is edited. The answer is a new record linked through
+    `supersedes_gate_ref`, so the question as it was asked stays readable beside
+    the answer it got.
+    """
+    path = paths.runtime_decision_gates_path
+    with file_lock(path, private=True):
+        records, _ = read_jsonl_objects(path)
+        head = latest_record_in(records, key="gate_id", value=str(gate_id_value))
+        if not head:
+            raise DecisionGateError(f"{_LABEL} has no gate on record for this question")
+        if str(head.get("state", "")) != GATE_STATE_OPEN:
+            raise DecisionGateError(
+                f"{_LABEL} is already answered; a recorded answer is never rewritten, so asking again needs "
+                "a new gate"
+            )
+        record = build_decision_gate_answer(head, actor=actor, choice=choice, decided_at=now)
+        append_store_line(path, record)
+    return record
+
+
+# ---------------------------------------------------------------------------
+# Read
+# ---------------------------------------------------------------------------
+
+
+def read_decision_gates_result(paths: OmhPaths) -> tuple[list[dict[str, Any]], list[str]]:
+    return read_jsonl_objects(paths.runtime_decision_gates_path)
+
+
+def read_decision_gates(
+    paths: OmhPaths,
+    *,
+    run_id: str | None = None,
+    gate_id_value: str | None = None,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """The store, in append order, optionally scoped to one run or one question."""
+    records, _ = read_decision_gates_result(paths)
+    if run_id is not None:
+        records = [record for record in records if str(record.get("run_id", "")) == run_id]
+    if gate_id_value is not None:
+        records = [record for record in records if str(record.get("gate_id", "")) == gate_id_value]
+    if limit is None:
+        return records
+    if limit < 1:
+        return []
+    return records[-limit:]
+
+
+def latest_gate_in(records: Sequence[Mapping[str, Any]], gate_id_value: str) -> dict[str, Any]:
+    """The record that speaks for one question: the one selection rule.
+
+    The store is append-only, so store order is arrival order and the last record
+    for a question is its current state. Every surface that judges a gate selects
+    through this function, which is what stops the store validator and the resume
+    predicate from picking different records for one question and reaching
+    opposite conclusions about it.
+    """
+    return dict(latest_record_in(records, key="gate_id", value=str(gate_id_value)))
+
+
+def open_gates_in(records: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Every question currently open, in append order.
+
+    Chain heads only: a superseded open record was replaced by whatever came
+    after it and is not a question anybody is being asked.
+    """
+    heads = _chain_heads(records)
+    return [
+        dict(record)
+        for record in records
+        if isinstance(record, Mapping)
+        and str(record.get("state", "")) == GATE_STATE_OPEN
+        and heads.get(str(record.get("gate_id", ""))) == str(record.get("record_id", ""))
+    ]
+
+
+# ---------------------------------------------------------------------------
+# #825 AC3: does an answer release this resume?
+# ---------------------------------------------------------------------------
+
+
+def resume_satisfies_gate(
+    paths: OmhPaths,
+    *,
+    run_id: str,
+    subject_class: str,
+    subject_ref: str,
+    blocked_transition: str,
+    checkpoint_ref: str,
+    safety_profile_revision: str,
+    context_revision: str = "",
+    now: str = "",
+) -> dict[str, Any]:
+    """Does an answered, unexpired, matching gate release exactly this transition?
+
+    The entry point a blocked surface calls before continuing. Returns a
+    `decision_gate_resume/v1` mapping; see `resume_satisfies_gate_in` for the
+    shape and for how the refusal code is chosen.
+    """
+    return resume_satisfies_gate_in(
+        read_decision_gates(paths),
+        run_id=run_id,
+        subject_class=subject_class,
+        subject_ref=subject_ref,
+        blocked_transition=blocked_transition,
+        checkpoint_ref=checkpoint_ref,
+        safety_profile_revision=safety_profile_revision,
+        context_revision=context_revision,
+        now=now,
+    )
+
+
+def resume_satisfies_gate_in(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    run_id: str,
+    subject_class: str,
+    subject_ref: str,
+    blocked_transition: str,
+    checkpoint_ref: str,
+    safety_profile_revision: str,
+    context_revision: str = "",
+    now: str = "",
+) -> dict[str, Any]:
+    """`resume_satisfies_gate` over records already in hand.
+
+    A `decision_gate_resume/v1` mapping:
+
+        released              -- True only when a live answer releases exactly
+                                 this subject, these revisions, this transition,
+                                 and this checkpoint
+        reason_code           -- "" when released, otherwise one of
+                                 GATE_REFUSAL_CODES
+        reason                -- the constant line for that code
+        gate_id / record_id   -- the gate this verdict is about, "" when none
+        resume_digest         -- the digest this resume was matched on
+        answered_choice       -- the choice on record, "" when none
+        actor / decided_at    -- who answered and when, "" when nobody has
+        age_seconds           -- age of that record, computed now
+        expires_after_seconds -- APPROVAL_TTL_SECONDS, so a caller can cite it
+
+    A gate that names this resume exactly is judged on its lifecycle: superseded,
+    then pending, then declined, then expired. Otherwise the nearest gate
+    explains what it does cover, reporting its first differing dimension in
+    `GATE_MISMATCH_CODES` order. There is no containment rule anywhere in that
+    walk, so nothing widens.
+    """
+    request = (
+        str(run_id),
+        (str(subject_class), str(subject_ref)),
+        (str(safety_profile_revision), str(context_revision or "")),
+        (str(blocked_transition), str(checkpoint_ref)),
+    )
+    digest = resume_digest(
+        run_id=run_id,
+        subject_class=subject_class,
+        subject_ref=subject_ref,
+        blocked_transition=blocked_transition,
+        checkpoint_ref=checkpoint_ref,
+        safety_profile_revision=safety_profile_revision,
+        context_revision=context_revision,
+    )
+    known = [record for record in records if isinstance(record, Mapping)]
+    exact = [record for record in known if not _dimension_mismatches(record, request)]
+    if exact:
+        return _lifecycle_verdict(known, exact[-1], digest, now)
+    candidate, mismatches = _nearest_gate(known, request)
+    if candidate is None:
+        return _resume_payload(
+            released=False, reason_code=REFUSAL_ABSENT, record={}, digest=digest, now=now
+        )
+    return _resume_payload(
+        released=False, reason_code=mismatches[0], record=candidate, digest=digest, now=now
+    )
+
+
+def gate_age_seconds(record: Mapping[str, Any], now: str = "") -> int:
+    """How old the record's own stamp is, computed now, or `UNKNOWN_AGE_SECONDS`.
+
+    An answered record is measured from `decided_at` and an open one from
+    `opened_at`: the stamp that made the record what it is. `approval_age_seconds`
+    does the arithmetic, so a stamp that does not parse and a stamp in the future
+    are refused here exactly as they are there.
+    """
+    return approval_age_seconds(_decision_stamp(record), now)
+
+
+def gate_is_expired(record: Mapping[str, Any], now: str = "") -> bool:
+    """Whether this record is outside the decision window, evaluated now.
+
+    The window is `approval_receipts.APPROVAL_TTL_SECONDS`, imported rather than
+    redeclared. A decision gate authorises the same kind of escalation an
+    approval receipt does, so a second, longer window here would be a way to
+    outlive the consent rules by asking the question through a different surface.
+    """
+    age = gate_age_seconds(record, now)
+    return age == UNKNOWN_AGE_SECONDS or age > APPROVAL_TTL_SECONDS
+
+
+# ---------------------------------------------------------------------------
+# #825 AC1: what one blocked run is being asked
+# ---------------------------------------------------------------------------
+
+
+def project_blocked_decision_gate(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    run_id: str,
+    now: str = "",
+) -> dict[str, Any]:
+    """The one question one blocked run is waiting on, and the checkpoint it sits at.
+
+    A projection and not a second store, for the reason `project_decision_history`
+    is one: a second store over one decision sequence is a fork by construction,
+    and `supersede_chain_errors` already rejects forks.
+
+    `ok` is False when the run holds more than one open gate. That state is
+    refused at write and faulted at validate, so reaching it means the store was
+    edited or written by an older build -- and a renderer that silently picked
+    one of the two would be choosing which question an operator answers.
+    """
+    scoped = [
+        record
+        for record in open_gates_in(records)
+        if str(record.get("run_id", "")) == str(run_id)
+    ]
+    gate = scoped[0] if len(scoped) == 1 else {}
+    return {
+        "schema_version": DECISION_GATE_VIEW_SCHEMA_VERSION,
+        "run_id": _redacted(str(run_id)),
+        "ok": len(scoped) <= 1,
+        "blocked": bool(scoped),
+        "open_gate_count": len(scoped),
+        "gate": compact_decision_gate(gate, now=now) if gate else {},
+        "checkpoint_ref": _redacted(str(gate.get("checkpoint_ref", ""))) if gate else "",
+        "blocked_transition": closed_vocabulary_value(gate.get("blocked_transition"), BLOCKED_TRANSITIONS),
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+
+
+def blocked_decision_gate(paths: OmhPaths, *, run_id: str, now: str = "") -> dict[str, Any]:
+    """`project_blocked_decision_gate` over the store on disk."""
+    records, _ = read_decision_gates_result(paths)
+    return project_blocked_decision_gate(records, run_id=run_id, now=now)
+
+
+# ---------------------------------------------------------------------------
+# Validate the store, render
+# ---------------------------------------------------------------------------
+
+
+def validate_decision_gate_store(path: Path, *, run_id: str | None = None) -> dict[str, Any]:
+    """Validate the gate store, optionally scoped to one run's records.
+
+    Two halves. `store_errors` gives the per-record schema and the shared chain
+    walk, told this family's key names so its findings read as gate records
+    rather than as receipts it has none of. The second half is #825 AC1's
+    enforcing counterpart at rest: two open gates for one subject is a fault of
+    the store, and reporting it here is what makes the rule survive a
+    hand-edited file rather than only a well-behaved writer.
+    """
+    records, read_errors = read_jsonl_objects(path)
+    gate_count, errors = store_errors(
+        path,
+        records,
+        read_errors,
+        run_id=run_id,
+        validate_record=validate_decision_gate,
+        label=_LABEL,
+        id_key="record_id",
+        link_key="supersedes_gate_ref",
+        noun="gate record",
+    )
+    open_gates = [
+        record
+        for record in open_gates_in(records)
+        if run_id is None or str(record.get("run_id", "")) == run_id
+    ]
+    contested = _contested_subjects(open_gates)
+    errors.extend(
+        f"{path}: {_LABEL} subject {subject} has {count} open gates; one subject carries at most one open question"
+        for subject, count in contested
+    )
+    return {
+        "schema_version": DECISION_GATE_STORE_VALIDATION_SCHEMA_VERSION,
+        "path": str(path),
+        "run_id": run_id or "",
+        "ok": not errors,
+        "gate_count": gate_count,
+        "open_gate_count": len(open_gates),
+        "contested_subject_count": len(contested),
+        "errors": errors,
+    }
+
+
+def compact_decision_gate(record: Mapping[str, Any], *, now: str = "") -> dict[str, Any]:
+    """The user-facing shape, with every field through its class's guard.
+
+    Rendering is the last point at which a hand-edited store reaches a human, so
+    nothing is copied through verbatim: identifiers fold to a stable
+    non-navigable handle when they are not opaque, closed vocabularies render
+    empty outside their vocabulary, and the digest renders only in the one shape
+    it may be stored in.
+
+    `question`, `risk`, and each choice's `consequence` are joined here from the
+    module's constant tables rather than stored, which is why a gate can be
+    rendered at all without a free-text field. `age_seconds` and `expired` are
+    derived for the reason `approval_receipts` derives them: nothing on disk says
+    a decision is still good.
+    """
+    question_code = closed_vocabulary_value(record.get("question_code"), QUESTION_CODES)
+    risk_class = closed_vocabulary_value(record.get("risk_class"), RISK_CLASSES)
+    answered_choice = closed_vocabulary_value(record.get("answered_choice"), GATE_CHOICES)
+    return {
+        "record_id": _redacted(str(record.get("record_id", ""))),
+        "gate_id": _redacted(str(record.get("gate_id", ""))),
+        "subject_id": _redacted(str(record.get("subject_id", ""))),
+        "run_id": _redacted(str(record.get("run_id", ""))),
+        "subject_class": closed_vocabulary_value(record.get("subject_class"), SUBJECT_CLASSES),
+        "subject_ref": _redacted(str(record.get("subject_ref", ""))),
+        "blocked_transition": closed_vocabulary_value(record.get("blocked_transition"), BLOCKED_TRANSITIONS),
+        "checkpoint_ref": _redacted(str(record.get("checkpoint_ref", ""))),
+        "safety_profile_revision": _redacted(str(record.get("safety_profile_revision", ""))),
+        "context_revision": _redacted(str(record.get("context_revision", ""))),
+        "question_code": question_code,
+        "question": QUESTION_TEXT.get(question_code, ""),
+        "risk_class": risk_class,
+        "risk": RISK_TEXT.get(risk_class, ""),
+        "choices": [
+            {
+                "choice": choice,
+                "consequence": CHOICE_CONSEQUENCES.get(choice, ""),
+                "releases": CHOICE_RELEASES.get(choice, False),
+            }
+            for choice in _rendered_choices(record.get("choices"))
+        ],
+        "approver": _redacted(str(record.get("approver", ""))),
+        "opened_at": _redacted(str(record.get("opened_at", ""))),
+        "state": closed_vocabulary_value(record.get("state"), GATE_STATES),
+        "answered_choice": answered_choice,
+        "answered_consequence": CHOICE_CONSEQUENCES.get(answered_choice, ""),
+        "releases_transition": CHOICE_RELEASES.get(answered_choice, False),
+        "actor": _redacted(str(record.get("actor", ""))),
+        "decided_at": _redacted(str(record.get("decided_at", ""))),
+        "resume_digest": _rendered_digest(record.get("resume_digest")),
+        "supersedes_gate_ref": _redacted(str(record.get("supersedes_gate_ref", ""))),
+        "age_seconds": gate_age_seconds(record, now),
+        "expired": gate_is_expired(record, now),
+        "expires_after_seconds": APPROVAL_TTL_SECONDS,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _chain_heads(records: Sequence[Mapping[str, Any]]) -> dict[str, str]:
+    """The current record for every question in one pass over the store.
+
+    The same selection rule as `latest_gate_in` -- last record wins -- built once
+    so judging a store of n records does not walk it n times.
+    """
+    heads: dict[str, str] = {}
+    for record in records:
+        if isinstance(record, Mapping):
+            heads[str(record.get("gate_id", ""))] = str(record.get("record_id", ""))
+    return heads
+
+
+def _contested_subjects(open_gates: Sequence[Mapping[str, Any]]) -> list[tuple[str, int]]:
+    """Every subject carrying more than one open gate, and how many.
+
+    Sorted by subject so the report is deterministic, and the subject is folded
+    through the render guard because the line reaches an operator.
+    """
+    counts: dict[str, int] = {}
+    for record in open_gates:
+        subject = str(record.get("subject_id", ""))
+        counts[subject] = counts.get(subject, 0) + 1
+    return [(_redacted(subject), count) for subject, count in sorted(counts.items()) if count > 1]
+
+
+def _lifecycle_verdict(
+    records: Sequence[Mapping[str, Any]],
+    exact: Mapping[str, Any],
+    digest: str,
+    now: str,
+) -> dict[str, Any]:
+    """Judge a gate that names this resume exactly.
+
+    Order matters, and the first two checks are worth separating honestly.
+
+    Superseded goes first and, in a well-formed store, never fires: every record
+    matching these dimensions carries the same `gate_id` -- the id is derived
+    from four of them -- so the last dimension match is also the chain head, and
+    an answer that was replaced is simply never the record judged. The check is
+    here for the store this family cannot assume it is reading. Edit the head
+    record's subject on disk and it stops matching, which would otherwise leave
+    an older, replaced answer speaking for a question whose current record says
+    something else. `tests/test_decision_gate.py` reaches it that way and no
+    other.
+
+    Then pending, because an unanswered question is the state a caller most needs
+    told apart from a refusal. Then the choice, then the window.
+
+    The digest is checked last and separately. Every dimension it seals has
+    already been compared, so a mismatch here can only mean the stored digest was
+    edited to disagree with the record carrying it -- which is a resume for a
+    transition nobody was asked about, and is refused as one.
+    """
+    head = latest_gate_in(records, str(exact.get("gate_id", "")))
+    if str(head.get("record_id", "")) != str(exact.get("record_id", "")):
+        return _resume_payload(
+            released=False, reason_code=REFUSAL_SUPERSEDED, record=exact, digest=digest, now=now
+        )
+    if str(exact.get("state", "")) != GATE_STATE_ANSWERED:
+        return _resume_payload(
+            released=False, reason_code=REFUSAL_PENDING, record=exact, digest=digest, now=now
+        )
+    if not CHOICE_RELEASES.get(str(exact.get("answered_choice", "")), False):
+        return _resume_payload(
+            released=False, reason_code=REFUSAL_DECLINED, record=exact, digest=digest, now=now
+        )
+    if gate_is_expired(exact, now):
+        return _resume_payload(
+            released=False, reason_code=REFUSAL_EXPIRED, record=exact, digest=digest, now=now
+        )
+    if str(exact.get("resume_digest", "")) != digest:
+        return _resume_payload(
+            released=False, reason_code=REFUSAL_TRANSITION, record=exact, digest=digest, now=now
+        )
+    return _resume_payload(released=True, reason_code="", record=exact, digest=digest, now=now)
+
+
+def _nearest_gate(
+    records: Sequence[Mapping[str, Any]],
+    request: tuple[Any, ...],
+) -> tuple[Mapping[str, Any] | None, tuple[str, ...]]:
+    """The gate closest to this resume, and how it differs.
+
+    Only chain heads are considered: a superseded record explains nothing about
+    what is being asked now. An answered head that differs stays a candidate on
+    purpose -- "there is an answer, for another transition" is a more useful
+    refusal than "there is no gate", and it refuses either way.
+    """
+    heads = _chain_heads(records)
+    best: Mapping[str, Any] | None = None
+    best_mismatches: tuple[str, ...] = ()
+    for record in records:
+        if heads.get(str(record.get("gate_id", ""))) != str(record.get("record_id", "")):
+            continue
+        mismatches = _dimension_mismatches(record, request)
+        if not mismatches:
+            continue
+        if best is None or len(mismatches) <= len(best_mismatches):
+            best = record
+            best_mismatches = mismatches
+    return best, best_mismatches
+
+
+def _dimension_mismatches(record: Mapping[str, Any], request: tuple[Any, ...]) -> tuple[str, ...]:
+    """Which of the four bound dimensions this record does not match.
+
+    Append order is `GATE_MISMATCH_CODES` order, which is the reporting
+    precedence. Every comparison is equality, including the pairs: there is no
+    containment rule here, and that absence is what makes widening structurally
+    impossible rather than merely unimplemented.
+    """
+    run_id, subject, revisions, position = request
+    mismatches: list[str] = []
+    if str(record.get("run_id", "")) != run_id:
+        mismatches.append(REFUSAL_RUN)
+    if (str(record.get("subject_class", "")), str(record.get("subject_ref", ""))) != subject:
+        mismatches.append(REFUSAL_SCOPE)
+    if (
+        str(record.get("safety_profile_revision", "")),
+        str(record.get("context_revision", "")),
+    ) != revisions:
+        mismatches.append(REFUSAL_REVISION)
+    if (str(record.get("blocked_transition", "")), str(record.get("checkpoint_ref", ""))) != position:
+        mismatches.append(REFUSAL_TRANSITION)
+    return tuple(mismatches)
+
+
+def _resume_payload(
+    *,
+    released: bool,
+    reason_code: str,
+    record: Mapping[str, Any],
+    digest: str,
+    now: str,
+) -> dict[str, Any]:
+    return {
+        "schema_version": DECISION_GATE_RESUME_SCHEMA_VERSION,
+        "released": released,
+        "reason_code": reason_code,
+        "reason": GATE_REFUSAL_REASONS.get(reason_code, ""),
+        "gate_id": _redacted(str(record.get("gate_id", ""))),
+        "record_id": _redacted(str(record.get("record_id", ""))),
+        "resume_digest": _rendered_digest(digest),
+        "state": closed_vocabulary_value(record.get("state"), GATE_STATES),
+        "answered_choice": closed_vocabulary_value(record.get("answered_choice"), GATE_CHOICES),
+        "actor": _redacted(str(record.get("actor", ""))),
+        "decided_at": _redacted(str(record.get("decided_at", ""))),
+        "age_seconds": gate_age_seconds(record, now) if record else UNKNOWN_AGE_SECONDS,
+        "expires_after_seconds": APPROVAL_TTL_SECONDS,
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+
+
+def _state_errors(record: Mapping[str, Any]) -> list[str]:
+    """The open/answered split, checked in both directions.
+
+    #825 AC2 lives here at rest. An answered record missing an actor, a choice,
+    or a stamp is refused, and so is one whose choice was never offered or whose
+    actor is not the approver the question was put to. The mirror is just as
+    load-bearing: an open record carrying any of those three would be an answer
+    nobody gave.
+    """
+    errors: list[str] = []
+    state = str(record.get("state", ""))
+    if state == GATE_STATE_OPEN:
+        present = sorted(field for field in _ANSWER_FIELDS if str(record.get(field, "")))
+        if present:
+            errors.append(f"{_LABEL} an open gate must carry no answer; it carries {present}")
+        errors.extend(_self_link_errors(record))
+        return errors
+    if state != GATE_STATE_ANSWERED:
+        return errors
+    absent = sorted(field for field in _ANSWER_FIELDS if not str(record.get(field, "")))
+    if absent:
+        errors.append(f"{_LABEL} an answered gate must record {absent}")
+    choice = str(record.get("answered_choice", ""))
+    if choice and choice not in GATE_CHOICES:
+        errors.append(f"{_LABEL} answered_choice is unsupported: {choice!r}")
+    offered = record.get("choices")
+    if choice and isinstance(offered, list) and choice not in offered:
+        errors.append(f"{_LABEL} answered_choice was not offered by this gate: {choice!r}")
+    actor = str(record.get("actor", ""))
+    if actor and actor != str(record.get("approver", "")):
+        errors.append(
+            f"{_LABEL} actor must be the approver this gate named; an answer from anyone else is not an "
+            "answer to this question"
+        )
+    if not str(record.get("supersedes_gate_ref", "")):
+        errors.append(f"{_LABEL} an answered gate must supersede the open record it answers")
+    errors.extend(_self_link_errors(record))
+    return errors
+
+
+def _self_link_errors(record: Mapping[str, Any]) -> list[str]:
+    """A record cannot replace itself, whatever state it is in."""
+    record_id = str(record.get("record_id", ""))
+    if record_id and record_id == str(record.get("supersedes_gate_ref", "")):
+        return [f"{_LABEL} supersedes_gate_ref must not name itself"]
+    return []
+
+
+def _identity_errors(record: Mapping[str, Any]) -> list[str]:
+    """The three derived identifiers, re-derived.
+
+    Without these a hand-edited store could move one question's answer onto
+    another question's chain, count one subject's open gate against a different
+    subject, or -- the one that matters most -- point an answer's resume digest
+    at a transition nobody was asked about.
+    """
+    errors: list[str] = []
+    run_id = str(record.get("run_id", ""))
+    subject_class = str(record.get("subject_class", ""))
+    subject_ref = str(record.get("subject_ref", ""))
+    if str(record.get("gate_id", "")) != gate_id(
+        run_id=run_id,
+        subject_class=subject_class,
+        subject_ref=subject_ref,
+        blocked_transition=str(record.get("blocked_transition", "")),
+        checkpoint_ref=str(record.get("checkpoint_ref", "")),
+    ):
+        errors.append(f"{_LABEL} gate_id does not identify its own run, subject, transition, and checkpoint")
+    if str(record.get("subject_id", "")) != gate_subject_id(
+        run_id=run_id, subject_class=subject_class, subject_ref=subject_ref
+    ):
+        errors.append(f"{_LABEL} subject_id does not identify its own run and subject")
+    digest = record.get("resume_digest")
+    if not isinstance(digest, str) or not _DIGEST.fullmatch(digest):
+        errors.append(f"{_LABEL} resume_digest must be a sha256 hex digest")
+    elif digest != resume_digest_of(record):
+        errors.append(f"{_LABEL} resume_digest does not name the transition this gate blocks")
+    return errors
+
+
+def _choices_errors(value: Any) -> list[str]:
+    """A sorted, duplicate-free set of offered choices that is a real question.
+
+    The last rule is the one worth stating: a gate whose every choice releases
+    the transition is not a decision, it is a formality, and a gate with no
+    releasing choice can never be resumed and so should never have been asked.
+    Both are refused, which is what makes "choices with consequences" a property
+    of the record rather than of the wording.
+    """
+    if not isinstance(value, list):
+        return [f"{_LABEL} choices must be a list"]
+    errors: list[str] = []
+    for index, choice in enumerate(value):
+        if not isinstance(choice, str):
+            errors.append(f"{_LABEL} choices[{index}] must be a string")
+        elif choice not in GATE_CHOICES:
+            errors.append(f"{_LABEL} choices[{index}] is unsupported: {choice!r}")
+    if errors:
+        return errors
+    if list(value) != sorted(set(value)):
+        errors.append(f"{_LABEL} choices must be sorted and free of duplicates")
+        return errors
+    if not any(CHOICE_RELEASES.get(choice, False) for choice in value):
+        errors.append(f"{_LABEL} choices must offer at least one choice that releases the transition")
+    if all(CHOICE_RELEASES.get(choice, False) for choice in value):
+        errors.append(f"{_LABEL} choices must offer at least one choice that does not release the transition")
+    return errors
+
+
+def _normalized_choices(values: Sequence[str]) -> list[str]:
+    choices = sorted({str(value).strip() for value in values if str(value).strip()})
+    errors = _choices_errors(choices)
+    if errors:
+        raise DecisionGateError(errors[0])
+    return choices
+
+
+def _subject_ref_errors(value: Any) -> list[str]:
+    errors = reference_errors(value, field="subject_ref", label=_LABEL, required=True)
+    if errors or not isinstance(value, str):
+        return errors
+    if _SUBJECT_TRAVERSAL.search(value):
+        return [f"{_LABEL} subject_ref must not escape the workspace"]
+    if _WINDOWS_DRIVE.match(value):
+        return [f"{_LABEL} subject_ref must be workspace-relative, not drive-anchored"]
+    return []
+
+
+def _subject_ref(value: str) -> str:
+    text = _opaque(value, field="decision_gate subject_ref")
+    errors = _subject_ref_errors(text)
+    if errors:
+        raise DecisionGateError(errors[0])
+    return text
+
+
+def _decision_stamp(record: Mapping[str, Any]) -> str:
+    """The stamp a record's freshness is measured from."""
+    return str(record.get("decided_at", "") or record.get("opened_at", ""))
+
+
+def _opaque(value: str, *, field: str) -> str:
+    return opaque_ref(value, field=field, error=DecisionGateError)
+
+
+def _redacted(value: str) -> str:
+    """Fold any handle into a bounded, non-navigable gate reference."""
+    return redacted_ref(value, field="decision_gate_ref")
+
+
+def _rendered_digest(value: Any) -> str:
+    """A digest renders only in the one shape it may be stored in."""
+    text = str(value or "")
+    return text if _DIGEST.fullmatch(text) else ""
+
+
+def _rendered_choices(value: Any) -> list[str]:
+    """A stored choice list renders only when it is a list of known choices.
+
+    A hand-edited store can carry a string where the list should be, and
+    iterating that would render one row per character.
+    """
+    if not isinstance(value, list):
+        return []
+    return [choice for choice in value if isinstance(choice, str) and choice in GATE_CHOICES]
+
+
+def _record_id(gate_id_value: str, stamp: str, state: str) -> str:
+    return mint_record_id(
+        prefix="decision-gate",
+        identity={"gate_id": gate_id_value, "stamp": stamp, "state": state},
+    )

--- a/tests/test_decision_gate.py
+++ b/tests/test_decision_gate.py
@@ -1,0 +1,1032 @@
+"""Contracts for `decision_gate/v1` (issue #825).
+
+The acceptance criteria this holds, and where each one is asserted:
+
+AC1  a blocked workflow identifies one open gate and checkpoint
+     -> `ABlockedWorkflowIdentifiesOneOpenGateAndCheckpoint`
+AC2  a resume records actor, choice, timestamp, and revisions
+     -> `AResumeRecordsWhoChoseWhatWhenAndUnderWhichRevisions`
+AC3  no gated action continues while the decision is pending or mismatched
+     -> `APendingDecisionReleasesNothing`,
+        `AnExpiredDecisionReleasesNothing`,
+        `AMismatchedDecisionReleasesNothing`
+
+Plus the three things this family is worthless without. That the question and
+its answer survive a restart (`TheGateAndItsAnswerSurviveARestart`) -- durability
+is the whole of what #825 asks for, and a store nobody re-reads proves none of
+it. That the store is wired into the registry and the validator its siblings use
+(`TheStoreIsRegisteredBesideItsSiblings`), without which nothing in production
+ever runs these checks. And that the name `decision_gate` this repo was already
+using in two other places is coexisted with rather than collided into
+(`TheNameThatWasAlreadyHere`).
+
+Store mechanics -- concurrent appends, torn tails, chain forks -- are inherited
+from `system/append_only_store.py` and proved there. What is asserted here is
+this family's own contribution: the binding between an answer and the one
+transition it releases, the one-open-gate rule in both its enforcing and its
+at-rest form, and the derivations that make an over-reaching answer
+unconstructible rather than merely unusual.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.catalogs.playbooks import inspect_playbook, list_playbooks  # noqa: E402
+from omh.local_store import atomic_write_text  # noqa: E402
+from omh.runtime.artifacts import validate_runtime  # noqa: E402
+from omh.runtime.records import (  # noqa: E402
+    DECISION_GATE_RECORD_KEYS,
+    OPTIONAL_RUNTIME_STORE_VALIDATORS,
+)
+from omh.system.append_only_store import RAW_OR_HIDDEN_KEYS  # noqa: E402
+from omh.system.paths import OmhPaths  # noqa: E402
+from omh.workflows.approval_receipts import (  # noqa: E402
+    APPROVAL_TTL_SECONDS,
+    REFUSAL_ABSENT,
+    REFUSAL_CODES,
+    REFUSAL_EXPIRED,
+    REFUSAL_REVISION,
+    REFUSAL_RUN,
+    REFUSAL_SCOPE,
+    REFUSAL_SUPERSEDED,
+    SCOPE_CLASSES,
+    SCOPE_REFUSAL_CODES,
+)
+from omh.workflows.decision_gates import (  # noqa: E402
+    BLOCKED_TRANSITIONS,
+    CHOICE_CONSEQUENCES,
+    CHOICE_RELEASES,
+    CLAIM_BOUNDARY,
+    DECISION_GATE_KEYS,
+    DECISION_GATE_SCHEMA_VERSION,
+    EXECUTION_CLAIM_KEYS,
+    GATE_CHOICES,
+    GATE_REFUSAL_CODES,
+    GATE_REFUSAL_REASONS,
+    GATE_STATES,
+    QUESTION_CODES,
+    QUESTION_TEXT,
+    REFUSAL_DECLINED,
+    REFUSAL_PENDING,
+    REFUSAL_TRANSITION,
+    RESUME_DIGEST_KEYS,
+    REUSED_REFUSAL_CODES,
+    RISK_CLASSES,
+    RISK_TEXT,
+    SUBJECT_CLASSES,
+    DecisionGateError,
+    answer_decision_gate,
+    append_decision_gate,
+    blocked_decision_gate,
+    build_decision_gate,
+    build_decision_gate_answer,
+    compact_decision_gate,
+    gate_id,
+    gate_subject_id,
+    open_decision_gate,
+    open_gates_in,
+    project_blocked_decision_gate,
+    read_decision_gates,
+    resume_digest,
+    resume_satisfies_gate,
+    resume_satisfies_gate_in,
+    validate_decision_gate,
+    validate_decision_gate_store,
+)
+from omh.workflows.hermes_planning import build_hermes_plan_payload  # noqa: E402
+from omh.workflows.run_lineage import EXECUTION_CLAIM_KEYS as LINEAGE_EXECUTION_CLAIM_KEYS  # noqa: E402
+from omh.workflows.run_lineage import LINEAGE_TRANSITIONS  # noqa: E402
+
+
+_RUN = "run-2026-08-09-aaaa"
+_OTHER_RUN = "run-2026-08-09-bbbb"
+_APPROVER = "operator-anna"
+_OPENED = "2026-08-09T10:00:00Z"
+_DECIDED = "2026-08-09T10:05:00Z"
+# Six minutes after the answer: inside the window by a wide margin.
+_SOON = "2026-08-09T10:06:00Z"
+# Three hours after the answer, against a one-hour window.
+_LATE = "2026-08-09T13:00:00Z"
+
+_QUESTION: dict[str, Any] = {
+    "run_id": _RUN,
+    "subject_class": "filesystem_path",
+    "subject_ref": "src/auth/session.py",
+    "blocked_transition": "executor_dispatch_observed",
+    "checkpoint_ref": "checkpoint-0004",
+    "question_code": "confirm_destructive_action",
+    "risk_class": "irreversible",
+    "choices": ("approve", "decline"),
+    "approver": _APPROVER,
+    "safety_profile_revision": "safety-rev-7",
+    "context_revision": "context-rev-3",
+}
+
+# The seven dimensions a resume is matched on, as a caller holds them.
+_RESUME: dict[str, Any] = {
+    "run_id": _RUN,
+    "subject_class": "filesystem_path",
+    "subject_ref": "src/auth/session.py",
+    "blocked_transition": "executor_dispatch_observed",
+    "checkpoint_ref": "checkpoint-0004",
+    "safety_profile_revision": "safety-rev-7",
+    "context_revision": "context-rev-3",
+}
+
+
+def _paths(root: Path) -> OmhPaths:
+    return OmhPaths(root / ".omh", root / ".hermes")
+
+
+def _gate(**overrides: Any) -> dict[str, Any]:
+    """One open gate, built without touching a store."""
+    return build_decision_gate(**{**_QUESTION, "opened_at": _OPENED, **overrides})
+
+
+def _answered(**overrides: Any) -> dict[str, Any]:
+    """One answered gate, built from the open record it answers."""
+    choice = overrides.pop("choice", "approve")
+    actor = overrides.pop("actor", _APPROVER)
+    decided_at = overrides.pop("decided_at", _DECIDED)
+    return build_decision_gate_answer(_gate(**overrides), actor=actor, choice=choice, decided_at=decided_at)
+
+
+def _opened_and_answered(paths: OmhPaths, **overrides: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+    """One question on the store, and its answer, through the live entry points."""
+    choice = overrides.pop("choice", "approve")
+    actor = overrides.pop("actor", _APPROVER)
+    gate = open_decision_gate(paths, now=_OPENED, **{**_QUESTION, **overrides})
+    answer = answer_decision_gate(
+        paths, gate_id_value=gate["gate_id"], actor=actor, choice=choice, now=_DECIDED
+    )
+    return gate, answer
+
+
+# ---------------------------------------------------------------------------
+# AC1
+# ---------------------------------------------------------------------------
+
+
+class ABlockedWorkflowIdentifiesOneOpenGateAndCheckpoint(unittest.TestCase):
+    """#825 AC1. One question, one checkpoint, and no way to have two."""
+
+    def test_a_blocked_run_names_exactly_one_open_gate_and_its_checkpoint(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            gate = open_decision_gate(paths, now=_OPENED, **_QUESTION)
+
+            view = blocked_decision_gate(paths, run_id=_RUN, now=_SOON)
+
+            self.assertTrue(view["ok"])
+            self.assertTrue(view["blocked"])
+            self.assertEqual(view["open_gate_count"], 1)
+            self.assertEqual(view["gate"]["gate_id"], gate["gate_id"])
+            self.assertEqual(view["checkpoint_ref"], "checkpoint-0004")
+            self.assertEqual(view["blocked_transition"], "executor_dispatch_observed")
+            # The question and its consequences are rendered from this module's
+            # constants, which is what lets the record carry no free text.
+            self.assertEqual(view["gate"]["question"], QUESTION_TEXT["confirm_destructive_action"])
+            self.assertEqual(view["gate"]["risk"], RISK_TEXT["irreversible"])
+            self.assertEqual(
+                [choice["choice"] for choice in view["gate"]["choices"]], ["approve", "decline"]
+            )
+            self.assertEqual(
+                [choice["releases"] for choice in view["gate"]["choices"]], [True, False]
+            )
+            for choice in view["gate"]["choices"]:
+                self.assertEqual(choice["consequence"], CHOICE_CONSEQUENCES[choice["choice"]])
+
+    def test_a_run_with_no_open_gate_is_not_blocked(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            view = blocked_decision_gate(paths, run_id=_RUN, now=_SOON)
+
+            self.assertTrue(view["ok"])
+            self.assertFalse(view["blocked"])
+            self.assertEqual(view["open_gate_count"], 0)
+            self.assertEqual(view["gate"], {})
+            self.assertEqual(view["checkpoint_ref"], "")
+
+    def test_answering_the_gate_leaves_the_run_unblocked(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            _opened_and_answered(paths)
+
+            view = blocked_decision_gate(paths, run_id=_RUN, now=_SOON)
+
+            self.assertFalse(view["blocked"])
+            self.assertEqual(view["open_gate_count"], 0)
+
+    def test_a_second_open_gate_for_the_same_subject_is_refused(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            open_decision_gate(paths, now=_OPENED, **_QUESTION)
+
+            with self.assertRaises(DecisionGateError) as raised:
+                open_decision_gate(
+                    paths,
+                    now=_OPENED,
+                    **{
+                        **_QUESTION,
+                        "blocked_transition": "merge_observed",
+                        "checkpoint_ref": "checkpoint-0009",
+                    },
+                )
+
+            self.assertIn("open gate", str(raised.exception))
+            self.assertEqual(len(read_decision_gates(paths)), 1)
+
+    def test_reasking_the_same_question_returns_the_gate_already_on_record(self) -> None:
+        # One block reported three times is one question, not three. Without
+        # this a surface that retries would fill the store with duplicates and
+        # then trip its own one-open-gate rule.
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            first = open_decision_gate(paths, now=_OPENED, **_QUESTION)
+            again = open_decision_gate(paths, now=_SOON, **_QUESTION)
+
+            self.assertEqual(again["record_id"], first["record_id"])
+            self.assertEqual(len(read_decision_gates(paths)), 1)
+
+    def test_another_subject_may_have_its_own_open_gate(self) -> None:
+        # The rule is one gate per *subject*, not one per run. Two subjects
+        # blocked at once is a normal state and must not be refused.
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            open_decision_gate(paths, now=_OPENED, **_QUESTION)
+            open_decision_gate(paths, now=_OPENED, **{**_QUESTION, "subject_ref": "src/auth/rotate.py"})
+
+            view = blocked_decision_gate(paths, run_id=_RUN, now=_SOON)
+
+            self.assertEqual(view["open_gate_count"], 2)
+            # Two subjects is legal; naming one of them as *the* question is not.
+            self.assertFalse(view["ok"])
+            self.assertEqual(view["gate"], {})
+
+    def test_a_store_already_holding_two_open_gates_for_one_subject_is_a_fault(self) -> None:
+        # `open_decision_gate` refuses to write the second one, so reaching this
+        # state means the store was hand-edited or written by an older build.
+        # The rule has to survive the file, not only the writer.
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            append_decision_gate(paths, _gate())
+            append_decision_gate(
+                paths,
+                _gate(blocked_transition="merge_observed", checkpoint_ref="checkpoint-0009"),
+            )
+
+            report = validate_decision_gate_store(paths.runtime_decision_gates_path)
+
+            self.assertFalse(report["ok"])
+            self.assertEqual(report["open_gate_count"], 2)
+            self.assertEqual(report["contested_subject_count"], 1)
+            self.assertTrue(any("open gates" in error for error in report["errors"]), report["errors"])
+            self.assertFalse(validate_runtime(paths)["ok"])
+
+    def test_the_subject_id_counts_the_subject_and_not_the_question(self) -> None:
+        one = gate_subject_id(run_id=_RUN, subject_class="filesystem_path", subject_ref="src/a.py")
+        same_subject_other_question = _gate(
+            blocked_transition="merge_observed", checkpoint_ref="checkpoint-0009"
+        )
+        self.assertEqual(_gate()["subject_id"], same_subject_other_question["subject_id"])
+        self.assertNotEqual(_gate()["gate_id"], same_subject_other_question["gate_id"])
+        self.assertNotEqual(
+            one, gate_subject_id(run_id=_RUN, subject_class="filesystem_path", subject_ref="src/b.py")
+        )
+        self.assertNotEqual(
+            one, gate_subject_id(run_id=_OTHER_RUN, subject_class="filesystem_path", subject_ref="src/a.py")
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC2
+# ---------------------------------------------------------------------------
+
+
+class AResumeRecordsWhoChoseWhatWhenAndUnderWhichRevisions(unittest.TestCase):
+    """#825 AC2. An answer that is missing any of the four is not an answer."""
+
+    def test_an_answer_records_the_actor_the_choice_the_time_and_both_revisions(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            gate, answer = _opened_and_answered(paths)
+
+            self.assertEqual(answer["state"], "answered")
+            self.assertEqual(answer["actor"], _APPROVER)
+            self.assertEqual(answer["answered_choice"], "approve")
+            self.assertEqual(answer["decided_at"], _DECIDED)
+            self.assertEqual(answer["safety_profile_revision"], "safety-rev-7")
+            self.assertEqual(answer["context_revision"], "context-rev-3")
+            # The question as it was asked is still on record beside its answer.
+            self.assertEqual(answer["supersedes_gate_ref"], gate["record_id"])
+            self.assertEqual(gate["state"], "open")
+            self.assertEqual(len(read_decision_gates(paths)), 2)
+
+    def test_an_answer_cannot_name_a_subject_the_question_did_not(self) -> None:
+        # Structural rather than checked: the answer is built *from* the gate,
+        # so there is no argument through which it could name another subject,
+        # another revision, or another transition.
+        answer = _answered()
+        gate = _gate()
+        for field in RESUME_DIGEST_KEYS:
+            with self.subTest(field=field):
+                self.assertEqual(answer[field], gate[field])
+        self.assertEqual(answer["resume_digest"], gate["resume_digest"])
+
+    def test_an_answer_missing_the_actor_the_choice_or_the_stamp_is_refused(self) -> None:
+        for field in ("actor", "answered_choice", "decided_at"):
+            with self.subTest(field=field):
+                errors = validate_decision_gate({**_answered(), field: ""})
+                self.assertTrue(errors)
+                self.assertTrue(
+                    any("an answered gate must record" in error for error in errors), errors
+                )
+
+    def test_an_answer_from_someone_the_question_was_not_put_to_is_refused(self) -> None:
+        # #825 puts unattended or inferred approval out of scope. An answer from
+        # anyone but the named approver is exactly that.
+        with self.assertRaises(DecisionGateError) as raised:
+            build_decision_gate_answer(_gate(), actor="operator-bob", choice="approve", decided_at=_DECIDED)
+        self.assertIn("approver", str(raised.exception))
+        self.assertTrue(validate_decision_gate({**_answered(), "actor": "operator-bob"}))
+
+    def test_an_answer_cannot_choose_something_the_gate_did_not_offer(self) -> None:
+        with self.assertRaises(DecisionGateError) as raised:
+            build_decision_gate_answer(_gate(), actor=_APPROVER, choice="defer", decided_at=_DECIDED)
+        self.assertIn("not offered", str(raised.exception))
+        self.assertTrue(validate_decision_gate({**_answered(), "answered_choice": "defer"}))
+
+    def test_an_answered_gate_is_never_answered_twice(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            gate, _ = _opened_and_answered(paths)
+
+            with self.assertRaises(DecisionGateError) as raised:
+                answer_decision_gate(
+                    paths, gate_id_value=gate["gate_id"], actor=_APPROVER, choice="decline", now=_SOON
+                )
+
+            self.assertIn("already answered", str(raised.exception))
+            self.assertEqual(len(read_decision_gates(paths)), 2)
+
+    def test_answering_a_question_nobody_asked_is_refused(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            with self.assertRaises(DecisionGateError) as raised:
+                answer_decision_gate(
+                    paths, gate_id_value="gate-000000000000dead", actor=_APPROVER, choice="approve", now=_DECIDED
+                )
+            self.assertIn("no gate on record", str(raised.exception))
+
+    def test_an_open_gate_carrying_an_answer_nobody_gave_is_refused(self) -> None:
+        for field in ("actor", "answered_choice", "decided_at"):
+            with self.subTest(field=field):
+                value = "approve" if field == "answered_choice" else _DECIDED
+                errors = validate_decision_gate({**_gate(), field: value})
+                self.assertTrue(any("must carry no answer" in error for error in errors), errors)
+
+
+# ---------------------------------------------------------------------------
+# AC3
+# ---------------------------------------------------------------------------
+
+
+class APendingDecisionReleasesNothing(unittest.TestCase):
+    """#825 AC3, first of three. A question is not an answer."""
+
+    def test_an_open_gate_does_not_release_the_transition_it_blocks(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            open_decision_gate(paths, now=_OPENED, **_QUESTION)
+
+            verdict = resume_satisfies_gate(paths, now=_SOON, **_RESUME)
+
+            self.assertFalse(verdict["released"])
+            self.assertEqual(verdict["reason_code"], REFUSAL_PENDING)
+            self.assertEqual(verdict["reason"], GATE_REFUSAL_REASONS[REFUSAL_PENDING])
+            self.assertEqual(verdict["state"], "open")
+            self.assertEqual(verdict["answered_choice"], "")
+            self.assertEqual(verdict["actor"], "")
+
+    def test_a_declined_gate_does_not_release_the_transition(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            _opened_and_answered(paths, choice="decline")
+
+            verdict = resume_satisfies_gate(paths, now=_SOON, **_RESUME)
+
+            self.assertFalse(verdict["released"])
+            self.assertEqual(verdict["reason_code"], REFUSAL_DECLINED)
+            self.assertEqual(verdict["answered_choice"], "decline")
+
+    def test_a_superseded_answer_does_not_release_the_transition(self) -> None:
+        # A later record for the same question is the current one. An answer the
+        # operator replaced must not still be binding.
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            _opened_and_answered(paths)
+            reopened = open_decision_gate(paths, now=_SOON, **_QUESTION)
+            self.assertEqual(reopened["state"], "open")
+
+            verdict = resume_satisfies_gate(paths, now=_SOON, **_RESUME)
+
+            self.assertFalse(verdict["released"])
+            self.assertEqual(verdict["reason_code"], REFUSAL_PENDING)
+            records = read_decision_gates(paths)
+            self.assertEqual(len(records), 3)
+            # The replaced answer is still on file, and is reported as replaced
+            # rather than as current.
+            superseded = resume_satisfies_gate_in(records[:2], now=_SOON, **_RESUME)
+            self.assertTrue(superseded["released"])
+            self.assertEqual(
+                resume_satisfies_gate_in(records, now=_SOON, **_RESUME)["reason_code"], REFUSAL_PENDING
+            )
+
+    def test_a_replaced_answer_never_speaks_for_a_question_that_moved_on(self) -> None:
+        # In a well-formed store the superseded branch cannot fire: every record
+        # matching these dimensions shares one `gate_id`, so the last match is
+        # the chain head and a replaced answer is simply never judged. The branch
+        # exists for the store this family cannot assume it is reading -- edit
+        # the head's subject on disk and it stops matching, which would otherwise
+        # hand the resume back to the answer it replaced.
+        gate = _gate()
+        answer = _answered()
+        moved_head = {
+            **_gate(opened_at=_SOON),
+            "record_id": "decision-gate-moved-000001",
+            "subject_ref": "src/auth/rotate.py",
+            "supersedes_gate_ref": answer["record_id"],
+        }
+        self.assertTrue(validate_decision_gate(moved_head), "the tampered head must not be a valid record")
+
+        verdict = resume_satisfies_gate_in([gate, answer, moved_head], now=_SOON, **_RESUME)
+
+        self.assertFalse(verdict["released"])
+        self.assertEqual(verdict["reason_code"], REFUSAL_SUPERSEDED)
+        self.assertEqual(verdict["reason"], GATE_REFUSAL_REASONS[REFUSAL_SUPERSEDED])
+
+
+class AnExpiredDecisionReleasesNothing(unittest.TestCase):
+    """#825 AC3, second of three. Consent has a clock, and it is not on disk."""
+
+    def test_an_answer_outside_the_window_does_not_release_the_transition(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            _opened_and_answered(paths)
+
+            fresh = resume_satisfies_gate(paths, now=_SOON, **_RESUME)
+            stale = resume_satisfies_gate(paths, now=_LATE, **_RESUME)
+
+            self.assertTrue(fresh["released"])
+            self.assertFalse(stale["released"])
+            self.assertEqual(stale["reason_code"], REFUSAL_EXPIRED)
+            self.assertEqual(stale["expires_after_seconds"], APPROVAL_TTL_SECONDS)
+            self.assertGreater(stale["age_seconds"], APPROVAL_TTL_SECONDS)
+
+    def test_expiry_is_recomputed_and_never_read_off_the_record(self) -> None:
+        # There is no `expires_at` field to edit. The only way to widen the
+        # window from disk would be to move the stamp forward, and a stamp in
+        # the future cannot be shown to be fresh, so it refuses too.
+        self.assertNotIn("expires_at", DECISION_GATE_KEYS)
+        answer = _answered()
+        future = {**answer, "decided_at": "2027-01-01T00:00:00Z"}
+        verdict = resume_satisfies_gate_in([_gate(), future], now=_SOON, **_RESUME)
+        self.assertFalse(verdict["released"])
+        self.assertEqual(verdict["reason_code"], REFUSAL_EXPIRED)
+
+    def test_the_window_is_the_approval_window_and_not_a_second_one(self) -> None:
+        self.assertEqual(compact_decision_gate(_answered())["expires_after_seconds"], APPROVAL_TTL_SECONDS)
+
+
+class AMismatchedDecisionReleasesNothing(unittest.TestCase):
+    """#825 AC3, third of three. An answer releases what it was given for.
+
+    Every dimension is compared by equality. There is no containment rule
+    anywhere in the module, which is what makes widening structurally impossible
+    rather than merely unimplemented.
+    """
+
+    def _verdict(self, paths: OmhPaths, **overrides: Any) -> dict[str, Any]:
+        return resume_satisfies_gate(paths, now=_SOON, **{**_RESUME, **overrides})
+
+    def test_a_wrong_subject_does_not_release_the_transition(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            _opened_and_answered(paths)
+
+            self.assertTrue(self._verdict(paths)["released"])
+            for override in (
+                {"subject_ref": "src/auth/rotate.py"},
+                {"subject_ref": "src/auth"},
+                {"subject_class": "tool"},
+            ):
+                with self.subTest(override=override):
+                    verdict = self._verdict(paths, **override)
+                    self.assertFalse(verdict["released"])
+                    self.assertEqual(verdict["reason_code"], REFUSAL_SCOPE)
+
+    def test_a_wrong_revision_does_not_release_the_transition(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            _opened_and_answered(paths)
+
+            for override in (
+                {"safety_profile_revision": "safety-rev-8"},
+                {"context_revision": "context-rev-4"},
+                {"context_revision": ""},
+            ):
+                with self.subTest(override=override):
+                    verdict = self._verdict(paths, **override)
+                    self.assertFalse(verdict["released"])
+                    self.assertEqual(verdict["reason_code"], REFUSAL_REVISION)
+
+    def test_a_wrong_scope_of_run_or_position_does_not_release_the_transition(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            _opened_and_answered(paths)
+
+            self.assertEqual(self._verdict(paths, run_id=_OTHER_RUN)["reason_code"], REFUSAL_RUN)
+            self.assertEqual(
+                self._verdict(paths, blocked_transition="merge_observed")["reason_code"],
+                REFUSAL_TRANSITION,
+            )
+            self.assertEqual(
+                self._verdict(paths, checkpoint_ref="checkpoint-0009")["reason_code"],
+                REFUSAL_TRANSITION,
+            )
+
+    def test_nothing_on_record_at_all_is_reported_as_absent(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            verdict = resume_satisfies_gate(paths, now=_SOON, **_RESUME)
+            self.assertFalse(verdict["released"])
+            self.assertEqual(verdict["reason_code"], REFUSAL_ABSENT)
+            self.assertEqual(verdict["gate_id"], "")
+
+    def test_the_resume_digest_seals_every_matched_dimension_and_no_clock(self) -> None:
+        base = resume_digest(**_RESUME)
+        self.assertEqual(base, _gate()["resume_digest"])
+        # Two gates for one question opened an hour apart seal identically: a
+        # wall clock inside a compared value would make this a race.
+        self.assertEqual(_gate(opened_at=_LATE)["resume_digest"], base)
+        self.assertEqual(_answered()["resume_digest"], base)
+        for field, value in (
+            ("run_id", _OTHER_RUN),
+            ("subject_class", "tool"),
+            ("subject_ref", "src/auth/rotate.py"),
+            ("blocked_transition", "merge_observed"),
+            ("checkpoint_ref", "checkpoint-0009"),
+            ("safety_profile_revision", "safety-rev-8"),
+            ("context_revision", "context-rev-4"),
+        ):
+            with self.subTest(field=field):
+                self.assertNotEqual(resume_digest(**{**_RESUME, field: value}), base)
+
+    def test_a_hand_edited_digest_cannot_move_an_answer_onto_another_transition(self) -> None:
+        other = resume_digest(**{**_RESUME, "blocked_transition": "merge_observed"})
+        errors = validate_decision_gate({**_answered(), "resume_digest": other})
+        self.assertTrue(any("does not name the transition" in error for error in errors), errors)
+        self.assertTrue(validate_decision_gate({**_answered(), "resume_digest": "not-a-digest"}))
+
+    def test_a_hand_edited_identity_cannot_graft_a_question_onto_another_chain(self) -> None:
+        moved = gate_id(
+            run_id=_OTHER_RUN,
+            subject_class="filesystem_path",
+            subject_ref="src/auth/session.py",
+            blocked_transition="executor_dispatch_observed",
+            checkpoint_ref="checkpoint-0004",
+        )
+        self.assertTrue(
+            any(
+                "gate_id does not identify" in error
+                for error in validate_decision_gate({**_gate(), "gate_id": moved})
+            )
+        )
+        self.assertTrue(
+            any(
+                "subject_id does not identify" in error
+                for error in validate_decision_gate(
+                    {
+                        **_gate(),
+                        "subject_id": gate_subject_id(
+                            run_id=_OTHER_RUN, subject_class="tool", subject_ref="x"
+                        ),
+                    }
+                )
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# Durability
+# ---------------------------------------------------------------------------
+
+
+class TheGateAndItsAnswerSurviveARestart(unittest.TestCase):
+    """#825's whole point: the pause and the resume outlive the process."""
+
+    def test_the_question_survives_being_re_read_from_disk(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            written = open_decision_gate(_paths(root), now=_OPENED, **_QUESTION)
+
+            # A fresh `OmhPaths` and a fresh read: nothing in memory carries over.
+            reread = read_decision_gates(_paths(root))
+
+            self.assertEqual(len(reread), 1)
+            self.assertEqual(reread[0], written)
+            view = blocked_decision_gate(_paths(root), run_id=_RUN, now=_SOON)
+            self.assertTrue(view["blocked"])
+            self.assertEqual(view["gate"]["gate_id"], written["gate_id"])
+            self.assertEqual(view["gate"]["question"], QUESTION_TEXT["confirm_destructive_action"])
+
+    def test_the_answer_survives_and_still_releases_the_same_transition(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            gate, answer = _opened_and_answered(_paths(root))
+
+            reread = read_decision_gates(_paths(root))
+            verdict = resume_satisfies_gate(_paths(root), now=_SOON, **_RESUME)
+
+            self.assertEqual([record["record_id"] for record in reread], [gate["record_id"], answer["record_id"]])
+            self.assertEqual(reread[1]["actor"], _APPROVER)
+            self.assertEqual(reread[1]["answered_choice"], "approve")
+            self.assertEqual(reread[1]["decided_at"], _DECIDED)
+            self.assertTrue(verdict["released"])
+            self.assertEqual(verdict["reason_code"], "")
+
+    def test_a_restart_between_the_question_and_the_answer_loses_nothing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            gate = open_decision_gate(_paths(root), now=_OPENED, **_QUESTION)
+
+            # Everything below runs against a store read from scratch, which is
+            # the only thing a process that restarted has.
+            pending = resume_satisfies_gate(_paths(root), now=_SOON, **_RESUME)
+            self.assertEqual(pending["reason_code"], REFUSAL_PENDING)
+            answer_decision_gate(
+                _paths(root), gate_id_value=gate["gate_id"], actor=_APPROVER, choice="approve", now=_DECIDED
+            )
+
+            self.assertTrue(resume_satisfies_gate(_paths(root), now=_SOON, **_RESUME)["released"])
+
+    def test_the_store_is_append_only_across_calls(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _opened_and_answered(_paths(root))
+            lines = _paths(root).runtime_decision_gates_path.read_bytes().splitlines()
+
+            self.assertEqual(len(lines), 2)
+            first = json.loads(lines[0])
+            second = json.loads(lines[1])
+            self.assertEqual(first["state"], "open")
+            self.assertEqual(second["state"], "answered")
+            # The question as asked was never rewritten.
+            self.assertEqual(first["actor"], "")
+            self.assertEqual(second["supersedes_gate_ref"], first["record_id"])
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+class TheStoreIsRegisteredBesideItsSiblings(unittest.TestCase):
+    """The wiring: without it nothing in production ever runs these validators."""
+
+    def test_the_family_registers_its_validator_under_its_own_store(self) -> None:
+        entries = {entry.store_name: entry for entry in OPTIONAL_RUNTIME_STORE_VALIDATORS}
+        self.assertIn("decision_gates.jsonl", entries)
+        entry = entries["decision_gates.jsonl"]
+        self.assertEqual(entry.record_id_key, "record_id")
+        self.assertEqual(entry.validator(_gate()), [])
+        self.assertEqual(entry.validator(_answered()), [])
+        self.assertTrue(entry.validator({"schema_version": "approval_receipt/v1"}))
+        self.assertTrue(entry.validator({"schema_version": "run_lineage_checkpoint/v1"}))
+        self.assertEqual(DECISION_GATE_RECORD_KEYS, DECISION_GATE_KEYS)
+
+    def test_the_store_lives_beside_its_siblings_and_not_inside_a_run(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            self.assertEqual(
+                paths.runtime_decision_gates_path.parent,
+                paths.runtime_approval_receipts_path.parent,
+            )
+            self.assertNotIn("runs", paths.runtime_decision_gates_path.parts)
+            self.assertEqual(paths.runtime_decision_gates_path.name, "decision_gates.jsonl")
+
+    def test_the_store_report_reaches_omh_runtime_validate(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            store = paths.runtime_decision_gates_path
+            store.parent.mkdir(parents=True, exist_ok=True)
+            atomic_write_text(store, json.dumps({"schema_version": "nonsense"}) + "\n")
+
+            report = validate_runtime(paths)
+
+            self.assertIn("decision_gates", report)
+            self.assertFalse(report["decision_gates"]["ok"])
+            self.assertFalse(report["ok"])
+
+    def test_an_absent_store_is_not_a_fault(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            store = paths.runtime_decision_gates_path
+            self.assertFalse(store.exists())
+
+            report = validate_decision_gate_store(store)
+            scoped = validate_decision_gate_store(store, run_id=_RUN)
+
+            self.assertTrue(report["ok"], report["errors"])
+            self.assertEqual(report["gate_count"], 0)
+            self.assertEqual(report["open_gate_count"], 0)
+            self.assertTrue(scoped["ok"], scoped["errors"])
+            self.assertTrue(validate_runtime(paths)["ok"])
+
+    def test_a_well_formed_store_validates_clean(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            _opened_and_answered(paths)
+
+            report = validate_decision_gate_store(paths.runtime_decision_gates_path)
+
+            self.assertTrue(report["ok"], report["errors"])
+            self.assertEqual(report["gate_count"], 2)
+            self.assertEqual(report["open_gate_count"], 0)
+            self.assertEqual(report["contested_subject_count"], 0)
+            self.assertTrue(validate_runtime(paths)["ok"])
+
+    def test_a_corrupt_line_faults_the_store_and_not_a_clean_run(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            store = paths.runtime_decision_gates_path
+            store.parent.mkdir(parents=True, exist_ok=True)
+            atomic_write_text(store, "{ not json\n")
+
+            unscoped = validate_decision_gate_store(store)
+            scoped = validate_decision_gate_store(store, run_id=_RUN)
+
+            self.assertFalse(unscoped["ok"])
+            # A line that does not parse belongs to no run.
+            self.assertTrue(scoped["ok"], scoped["errors"])
+
+
+# ---------------------------------------------------------------------------
+# The name that was already here, and the vocabularies that were already here
+# ---------------------------------------------------------------------------
+
+
+class TheNameThatWasAlreadyHere(unittest.TestCase):
+    """`decision_gate` was a live string in two other places. Neither is this.
+
+    Both are left alone on purpose, and this pins the boundary so a later reader
+    cannot collapse them into one thing.
+    """
+
+    def test_the_playbook_stages_that_declared_this_contract_now_have_a_schema(self) -> None:
+        # Three wrapper stages already declared `decision_gate/v1` as the kind of
+        # evidence they produce, with nothing behind the name. This module is
+        # that schema arriving under the name they were citing.
+        declared = []
+        for summary in list_playbooks()["playbooks"]:
+            playbook = inspect_playbook(str(summary["id"]))["playbook"]
+            for stage in playbook["stages"]:
+                if stage["contract"] == DECISION_GATE_SCHEMA_VERSION:
+                    declared.append((playbook["id"], stage["id"]))
+        self.assertTrue(declared, "no playbook stage declares decision_gate/v1")
+        self.assertEqual(
+            sorted(stage for _, stage in declared),
+            ["decision_gate", "delivery_decision", "deploy_decision"],
+        )
+
+    def test_the_wrapper_contract_clause_is_not_a_record_and_stays_untouched(self) -> None:
+        # `hermes_planning` carries a `decision_gate` sub-dict in the wrapper
+        # contract. It is a delegation condition rebuilt on every call, not a
+        # durable record: it names no subject, no approver, and no answer, and
+        # `validate_decision_gate` refuses it as the wrong shape entirely.
+        payload = build_hermes_plan_payload("add a retry to the fetch helper", source="generic")
+        contract = payload["wrapper_contract"]
+        assert isinstance(contract, dict)
+        clause = contract["decision_gate"]
+        assert isinstance(clause, dict)
+        self.assertEqual(sorted(clause), ["condition", "do_not_delegate_when", "required"])
+        self.assertNotIn("schema_version", clause)
+        # Not one key of the clause is a key of the record, and the record's own
+        # required keys are all absent from it.
+        self.assertEqual(set(clause) & set(DECISION_GATE_KEYS), set())
+        self.assertTrue(validate_decision_gate(dict(clause)))
+
+
+class TheVocabularyIsBorrowedAndNotForked(unittest.TestCase):
+    """Reused vocabularies, pinned so a rename upstream is a failing test here."""
+
+    def test_the_subject_classes_are_the_approval_scope_classes(self) -> None:
+        self.assertEqual(SUBJECT_CLASSES, SCOPE_CLASSES)
+
+    def test_the_blocked_transitions_are_the_lineage_transitions(self) -> None:
+        self.assertEqual(BLOCKED_TRANSITIONS, LINEAGE_TRANSITIONS)
+
+    def test_the_mismatch_codes_this_family_did_not_invent_belong_to_approvals(self) -> None:
+        for code in REUSED_REFUSAL_CODES:
+            with self.subTest(code=code):
+                self.assertIn(code, SCOPE_REFUSAL_CODES)
+                self.assertIn(code, REFUSAL_CODES)
+        for code in (REFUSAL_EXPIRED, REFUSAL_SUPERSEDED, REFUSAL_ABSENT):
+            with self.subTest(code=code):
+                self.assertIn(code, REFUSAL_CODES)
+        # And the two this family did have to add are not already spoken for.
+        for code in (REFUSAL_PENDING, REFUSAL_DECLINED, REFUSAL_TRANSITION):
+            with self.subTest(code=code):
+                self.assertNotIn(code, REFUSAL_CODES)
+
+    def test_every_refusal_code_has_a_reason_and_every_reason_a_code(self) -> None:
+        self.assertEqual(sorted(GATE_REFUSAL_REASONS), sorted(GATE_REFUSAL_CODES))
+        for code, reason in GATE_REFUSAL_REASONS.items():
+            with self.subTest(code=code):
+                self.assertTrue(reason.strip())
+                # Nothing is interpolated into a refusal line.
+                self.assertNotIn("{", reason)
+
+    def test_the_execution_claim_keys_match_the_sibling_family(self) -> None:
+        self.assertEqual(EXECUTION_CLAIM_KEYS, LINEAGE_EXECUTION_CLAIM_KEYS)
+
+
+# ---------------------------------------------------------------------------
+# The record's own shape
+# ---------------------------------------------------------------------------
+
+
+class TheRecordCarriesMetadataAndNeverContent(unittest.TestCase):
+    """The closed key set, the closed vocabularies, and the absence of prose."""
+
+    def test_the_key_set_is_closed_and_complete(self) -> None:
+        for record in (_gate(), _answered()):
+            with self.subTest(state=record["state"]):
+                self.assertEqual(sorted(record), sorted(DECISION_GATE_KEYS))
+                self.assertEqual(validate_decision_gate(record), [])
+        self.assertTrue(validate_decision_gate({**_gate(), "note": "anything"}))
+        self.assertTrue(validate_decision_gate({key: "" for key in DECISION_GATE_KEYS}))
+
+    def test_raw_and_hidden_keys_are_refused_by_name(self) -> None:
+        for key in sorted(RAW_OR_HIDDEN_KEYS):
+            with self.subTest(key=key):
+                errors = validate_decision_gate({**_gate(), key: "x"})
+                self.assertTrue(any("raw or hidden keys" in error for error in errors), errors)
+
+    def test_execution_claim_keys_are_refused_by_name(self) -> None:
+        for key in sorted(EXECUTION_CLAIM_KEYS):
+            with self.subTest(key=key):
+                errors = validate_decision_gate({**_gate(), key: "x"})
+                self.assertTrue(any("execution-claim keys" in error for error in errors), errors)
+
+    def test_the_record_states_its_boundary_and_its_privacy(self) -> None:
+        record = _answered()
+        self.assertEqual(record["claim_boundary"], CLAIM_BOUNDARY)
+        self.assertEqual(record["privacy"], "metadata_only")
+        self.assertIn("not dispatch, execution", CLAIM_BOUNDARY)
+        self.assertTrue(validate_decision_gate({**record, "claim_boundary": "it ran"}))
+        self.assertTrue(validate_decision_gate({**record, "privacy": "full"}))
+        # And every surface that renders a verdict repeats it.
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            _opened_and_answered(paths)
+            self.assertEqual(
+                resume_satisfies_gate(paths, now=_SOON, **_RESUME)["claim_boundary"], CLAIM_BOUNDARY
+            )
+            self.assertEqual(blocked_decision_gate(paths, run_id=_RUN, now=_SOON)["claim_boundary"], CLAIM_BOUNDARY)
+
+    def test_a_subject_cannot_reach_outside_the_workspace(self) -> None:
+        for bad in ("../secrets.env", "src/../../etc/passwd", "C:/Windows/system32"):
+            with self.subTest(subject_ref=bad), self.assertRaises(DecisionGateError):
+                _gate(subject_ref=bad)
+
+    def test_every_closed_vocabulary_is_checked_on_the_way_in_and_at_rest(self) -> None:
+        for field, value in (
+            ("question_code", "invent_a_question"),
+            ("risk_class", "catastrophic"),
+            ("subject_class", "database"),
+            ("blocked_transition", "shipped"),
+        ):
+            with self.subTest(field=field):
+                with self.assertRaises(DecisionGateError):
+                    _gate(**{field: value})
+                self.assertTrue(validate_decision_gate({**_gate(), field: value}))
+        self.assertTrue(validate_decision_gate({**_gate(), "state": "maybe"}))
+
+    def test_every_vocabulary_member_has_the_prose_a_render_needs(self) -> None:
+        self.assertEqual(sorted(QUESTION_TEXT), sorted(QUESTION_CODES))
+        self.assertEqual(sorted(RISK_TEXT), sorted(RISK_CLASSES))
+        self.assertEqual(sorted(CHOICE_CONSEQUENCES), sorted(GATE_CHOICES))
+        self.assertEqual(sorted(CHOICE_RELEASES), sorted(GATE_CHOICES))
+        self.assertEqual(sorted(GATE_STATES), ["answered", "open"])
+
+    def test_a_question_must_offer_a_real_choice(self) -> None:
+        # Every choice releasing is a formality, not a decision; none releasing
+        # is a question that can never be resumed.
+        with self.assertRaises(DecisionGateError):
+            _gate(choices=("approve",))
+        with self.assertRaises(DecisionGateError):
+            _gate(choices=("decline", "defer"))
+        self.assertEqual(_gate(choices=("defer", "approve", "approve"))["choices"], ["approve", "defer"])
+        self.assertTrue(validate_decision_gate({**_gate(), "choices": ["decline", "approve"]}))
+        self.assertTrue(validate_decision_gate({**_gate(), "choices": "approve"}))
+
+    def test_a_hand_edited_store_renders_as_nothing_rather_than_as_itself(self) -> None:
+        record = _answered()
+        rendered = compact_decision_gate(record, now=_SOON)
+        self.assertEqual(rendered["state"], "answered")
+        self.assertEqual(rendered["answered_choice"], "approve")
+        self.assertTrue(rendered["releases_transition"])
+        self.assertEqual(rendered["age_seconds"], 60)
+        self.assertFalse(rendered["expired"])
+        # A value outside its vocabulary is not a new state, it is a value with
+        # no meaning, so it renders empty.
+        broken = compact_decision_gate({**record, "risk_class": "catastrophic", "state": "maybe"}, now=_SOON)
+        self.assertEqual(broken["risk_class"], "")
+        self.assertEqual(broken["risk"], "")
+        self.assertEqual(broken["state"], "")
+        # A string where the list belongs would otherwise render one row per
+        # character.
+        self.assertEqual(compact_decision_gate({**record, "choices": "approve"})["choices"], [])
+        self.assertEqual(compact_decision_gate({**record, "resume_digest": "nope"})["resume_digest"], "")
+
+    def test_the_compactor_covers_every_stored_field(self) -> None:
+        rendered = compact_decision_gate(_answered(), now=_SOON)
+        constants = {"claim_boundary", "privacy", "schema_version"}
+        for key in DECISION_GATE_KEYS:
+            if key in constants:
+                continue
+            with self.subTest(key=key):
+                self.assertIn(key, rendered)
+
+    def test_a_second_record_for_one_question_never_forks_the_chain(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            gate, answer = _opened_and_answered(paths)
+            forked = {
+                **_gate(opened_at=_SOON),
+                "record_id": "decision-gate-fork-000001",
+                "supersedes_gate_ref": gate["record_id"],
+            }
+            append_decision_gate(paths, forked)
+
+            report = validate_decision_gate_store(paths.runtime_decision_gates_path)
+
+            self.assertFalse(report["ok"])
+            self.assertTrue(any("forks the chain" in error for error in report["errors"]), report["errors"])
+            self.assertEqual(answer["supersedes_gate_ref"], gate["record_id"])
+
+    def test_a_record_cannot_replace_itself(self) -> None:
+        record = _gate()
+        errors = validate_decision_gate({**record, "supersedes_gate_ref": record["record_id"]})
+        self.assertTrue(any("must not name itself" in error for error in errors), errors)
+
+
+class OpenGatesAreSelectedTheSameWayEverywhere(unittest.TestCase):
+    """One selection rule, so two surfaces cannot disagree about one question."""
+
+    def test_only_chain_heads_count_as_open(self) -> None:
+        gate = _gate()
+        answer = build_decision_gate_answer(gate, actor=_APPROVER, choice="approve", decided_at=_DECIDED)
+        self.assertEqual([record["record_id"] for record in open_gates_in([gate])], [gate["record_id"]])
+        # The open record is superseded by its own answer, so it is no longer a
+        # question anybody is being asked.
+        self.assertEqual(open_gates_in([gate, answer]), [])
+
+    def test_the_view_and_the_store_report_agree_about_how_many_are_open(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            append_decision_gate(paths, _gate())
+            append_decision_gate(paths, _gate(subject_ref="src/auth/rotate.py"))
+            records = read_decision_gates(paths)
+
+            view = project_blocked_decision_gate(records, run_id=_RUN, now=_SOON)
+            report = validate_decision_gate_store(paths.runtime_decision_gates_path)
+
+            self.assertEqual(view["open_gate_count"], report["open_gate_count"])
+            self.assertEqual(view["open_gate_count"], 2)
+            # Two subjects, so no subject is contested and the store is clean.
+            self.assertTrue(report["ok"], report["errors"])
+            # But no single question can be named, which is the state a renderer
+            # must not resolve by guessing.
+            self.assertFalse(view["ok"])
+
+    def test_another_runs_gate_is_invisible_to_this_run(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            open_decision_gate(paths, now=_OPENED, **{**_QUESTION, "run_id": _OTHER_RUN})
+
+            self.assertFalse(blocked_decision_gate(paths, run_id=_RUN, now=_SOON)["blocked"])
+            self.assertTrue(blocked_decision_gate(paths, run_id=_OTHER_RUN, now=_SOON)["blocked"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime_artifacts.py
+++ b/tests/test_runtime_artifacts.py
@@ -2064,6 +2064,7 @@ class RuntimeArtifactTests(unittest.TestCase):
 _STORE_SCHEMA_VERSIONS = {
     "approval_receipts.jsonl": "approval_receipt/v1",
     "blocked_work_records.jsonl": "blocked_work_record/v1",
+    "decision_gates.jsonl": "decision_gate/v1",
     "external_effect_receipts.jsonl": "external_effect_receipt/v1",
     "run_lineage_checkpoints.jsonl": "run_lineage_checkpoint/v1",
     "workspace_bindings.jsonl": "workspace_binding_guard/v1",


### PR DESCRIPTION
## Feature Report

### What Changed

- Adds `decision_gate/v1`, a sixth append-only record family under
  `runtime/journal/decision_gates.jsonl`. One record is one question put to one
  named approver about one subject, at one checkpoint in one run, under one
  safety-profile revision and one context revision; a second, linked record is
  the answer to it.
- Adds the resume predicate `resume_satisfies_gate` — the thing #825 AC3 is
  about. It returns a `decision_gate_resume/v1` verdict and releases a blocked
  transition only when a matching, answered, unexpired gate names exactly that
  transition.
- Adds the operator-facing projection `blocked_decision_gate`
  (`decision_gate_view/v1`): the one open question a blocked run is waiting on,
  its checkpoint, and the choices with their consequences.
- Wires the store into `omh runtime validate` through the existing
  `OPTIONAL_RUNTIME_STORE_VALIDATORS` registry and a store-level
  `validate_decision_gate_store` call.
- No producer wiring. Nothing in production mints a gate yet, and the PR says so
  in the module docstring rather than implying coverage. This is the same shape
  #826 shipped `run_lineage_checkpoint/v1` in.

### Why This Exists

Permission-sensitive OMH work can already pause and explain itself, but the
question does not survive the turn.

- `coding.action_gate` withholds an action pending approval, and says only that
  it is withheld.
- `workflows.approval_receipts` records consent **after** it is given.
  `APPROVAL_DECISIONS` is `granted` / `denied` / `revoked` — all past tense, with
  deliberately no `pending` member, because an unanswered confirmation must not
  sit in the approval store looking like a weak grant.
- `workflows.blocked_work_records` keeps the decision explainable after the
  turn, as a class shape and a reason code.

None of the three holds *which one thing a human is being asked right now*,
*what each choice costs*, or *which blocked transition their answer releases*.
So a pause was durable and a resume was not: the gate got reconstructed from
whatever the next turn happened to remember, an answer given to one question
could be applied to a different one, and a restart between the question and the
answer lost the binding entirely.

That last part is the safety property, not a UI nicety. A resume that does not
match the gate it answers does not unblock anything specific — it unblocks
whatever the caller was doing.

### User / Operator Impact

After this change a blocked workflow can be asked exactly one precise question,
and the answer is durable and bound:

- **One question, not several.** A run holding two open gates for one subject is
  refused at write and faulted at validate. An operator is never shown two
  questions with no rule for which one their answer belongs to.
- **The question renders without free text.** `question`, `risk`, and each
  choice's `consequence` are joined at render from module constants. The record
  has no free-text field at all, so the words an operator reads while
  authorising something are words this repo wrote, never words that arrived with
  the request.
- **The answer survives a restart.** Write the question, lose the process, read
  the store, answer it, and the resume still releases the same transition. Four
  tests in `TheGateAndItsAnswerSurviveARestart` do exactly that.
- **A mismatched resume refuses, with the dimension named.** Wrong subject →
  `scope_not_approved`; wrong revision → `safety_revision_not_approved`; wrong
  run → `run_not_approved`; wrong transition or checkpoint →
  `transition_not_unblocked`. Pending → `decision_pending`; declined →
  `decision_declined`; stale → `approval_expired`.

Not yet available: no `omh` command renders a gate and no gate is minted on a
live run. Both need producer wiring in `coding.action_gate` and a status-card
surface, listed under Follow-Up.

### How It Works

**What a resume is matched on.** Seven fields, sealed into one `resume_digest`
(`RESUME_DIGEST_KEYS`): `run_id`, `subject_class`, `subject_ref`,
`safety_profile_revision`, `context_revision`, `blocked_transition`,
`checkpoint_ref`. Matching is equality on every one. There is no containment,
prefix, or subsumption rule anywhere in the module, which is what makes widening
structurally impossible rather than merely unimplemented. The digest is
re-derived in `validate_decision_gate`, so a hand-edited store cannot move an
answer onto a transition it was never given for.

**Vocabulary is borrowed, not forked.** Three of the four mismatch codes are
`approval_receipts`' own `SCOPE_REFUSAL_CODES` members, `SUBJECT_CLASSES` **is**
`approval_receipts.SCOPE_CLASSES`, and the expiry window is
`APPROVAL_TTL_SECONDS` with `approval_age_seconds` doing the arithmetic — all
imported rather than redeclared. A second window here would have been a way to
outlive the consent rules by asking the question through a different surface.
`BLOCKED_TRANSITIONS` mirrors `run_lineage.LINEAGE_TRANSITIONS`.
`TheVocabularyIsBorrowedAndNotForked` pins every one of these, so a rename
upstream is a failing test here.

**An over-reaching answer is unconstructible, not merely refused.**
`build_decision_gate` can only produce an *open* record — there is no `state`
argument. An answer is built by `build_decision_gate_answer` **from the open
record it answers**, inheriting all seven sealed fields, so "same subject, same
revision, same scope" is a property of the constructor rather than a check
somebody has to remember to run. The answer must also name a choice the gate
offered, and its actor must be the approver the gate named — #825's
"unattended or inferred approval is out of scope", enforced.

**One open gate is enforced in both directions.** `open_decision_gate` reads and
appends under one lock and refuses a second open question for a subject
(re-asking the *same* question is idempotent and appends nothing).
`validate_decision_gate_store` independently faults a store that already holds
two, because reaching that state means the file was hand-edited or written by an
older build, and the rule has to survive the file and not only the writer.

**Determinism.** `resume_digest` covers no clock — `opened_at` and `decided_at`
are outside it and are parameters, so two callers minting the same gate a second
apart produce the same digest. Freshness is recomputed by every reader from the
stored stamp against a `now` that is passed in. There is no `expires_at` field,
so the window cannot be widened from disk; a stamp edited into the future cannot
be shown to be fresh and refuses too.

**The `decision_gate` name that was already here.** The string was live in two
unrelated places and both are left untouched:

- `catalogs.playbooks` declares `decision_gate/v1` as the artifact contract of
  three wrapper stages (`decision_gate`, `delivery_decision`, `deploy_decision`).
  That named a kind of evidence with no schema behind it. **This module is that
  schema**, arriving under the name those stages have been citing — which is why
  the version string is `decision_gate/v1` and not a second spelling of it.
- `workflows.hermes_planning._wrapper_contract` carries a `decision_gate`
  sub-dict (`required` / `condition` / `do_not_delegate_when`) pinned by
  `tests/test_cli.py`. That is a per-turn delegation *clause*, not a record: it
  is rebuilt on every call, names no subject, approver, or answer, and nothing
  about it survives the turn. `TheNameThatWasAlreadyHere` asserts the two key
  sets are disjoint and that `validate_decision_gate` refuses the clause, so a
  later reader cannot collapse them.

**Store mechanics** are entirely `system/append_only_store.py`, shared with the
five families beside it: the torn-tail-safe binary append under a real OS lock
on POSIX and Windows, the opaque-reference guards, the digest handles, and
`supersede_chain_errors` told this family's key names. This module adds no store
mechanics of its own.

### Files And Contracts Touched

| File | ± | What |
| --- | --- | --- |
| `src/workflows/decision_gates.py` | +1576 (new) | The family: `decision_gate/v1`, `decision_gate_resume/v1`, `decision_gate_view/v1`, `decision_gate_store_validation/v1` |
| `src/system/paths.py` | +13 | `runtime_decision_gates_path` → `runtime/journal/decision_gates.jsonl` |
| `src/runtime/records.py` | +6 | `DECISION_GATE_RECORD_KEYS` re-export and one `OptionalRuntimeStoreValidator` entry (no sibling registry tuple) |
| `src/runtime/artifacts.py` | +16/−1 | Store-level `validate_decision_gate_store` call in `validate_runtime`, folded into `ok`, reported under a new `decision_gates` key |
| `tests/test_decision_gate.py` | +1032 (new) | 62 tests |
| `tests/test_runtime_artifacts.py` | +1 | `_STORE_SCHEMA_VERSIONS["decision_gates.jsonl"]` |

New public contracts: `decision_gate/v1` (24 closed keys, `metadata_only`,
`claim_boundary` on every record), `decision_gate_resume/v1`,
`decision_gate_view/v1`, `decision_gate_store_validation/v1`. No generated
artifact changed, so no regeneration was needed — the byte gates were still run
and are recorded below.

## Validation

All commands below were run in this worktree **after** rebasing onto
`origin/main` at `f9251979`, and the output pasted is the output observed.

- [x] `uv run --group lint ruff check src tests` → `All checks passed!`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` →
      `Ran 4982 tests in 185.981s` / `OK`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_decision_gate.py` →
      `Ran 62 tests in 0.069s` / `OK`
- [x] `uv run python -m compileall -q src tests` → clean
- [x] `uv run python -m omh.cli docs workflows --check` →
      `{"checked":".../docs/WORKFLOWS.md","ok":true,"tap_skills":{"checked":115,"expected":115,"extra":[],"missing":[],"ok":true,...,"stale":[]}}`
- [x] `uv run python -m omh.cli docs roles --check` →
      `{"checked":".../docs/ROLES.md","ok":true}`
- [x] `uv run python -m omh.cli docs capability-families --check` →
      `{"checked":".../capability_families.json","ok":true}`
- [x] `uv run python -m omh.cli harness validate` →
      `{"counts":{"harnesses":72,"skills":104},"errors":[],"ok":true,"schema_version":"catalog_validation/v1","warnings":[]}`
- [x] `git diff --check` → no output
- [ ] `python3 -m omh.cli release checklist --json` — not run; no release, version, or packaging surface changed.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; no installer, setup, or command-surface change. Same reason for the `--live` and `--include-command-smoke` variants.
- [ ] `omh --help` — not run; no CLI command, group, or flag was added.
- [ ] Workflow-learning review queue smoke — not applicable; no learning contract changed.
- [ ] Manual Hermes/TUI check — **not run, and not applicable yet**: no producer mints a gate and no command renders one, so there is nothing a Hermes session would display. This becomes a real gap the moment the producer lands, and is listed under Follow-Up.

Cross-platform note: Windows CI is enforcing on this repo. The test file writes
store bytes only through `omh.local_store.atomic_write_text` and the production
appender, asserts no path through `os.sep`, and never substring-matches a raw
path against a resolved one. `resume_digest` is clock-free, so no compared value
is timing-sensitive.

## Risk

- **Low blast radius by construction.** Nothing calls into this family, so no
  existing path changes behavior. The only live effect is that
  `omh runtime validate` now reads one more file — and returns `ok: true` with
  `gate_count: 0` when it is absent, asserted by
  `test_an_absent_store_is_not_a_fault`.
- **`validate_runtime` grew a key.** `decision_gates` joins the returned report
  and its `ok` joins the conjunction. No test in the repo asserts an exact key
  set for that report (every consumer indexes or uses `assertIn`), and the full
  suite confirms it.
- **The registry is N×N-checked.** `tests/test_runtime_artifacts.py` asserts
  every validator rejects every sibling's `schema_version` and that no second
  `OPTIONAL_*_STORE_VALIDATORS` tuple exists. Both hold.
- **One branch is only reachable through a hand-edited store.** The
  `approval_superseded` verdict cannot fire in a well-formed store — every
  record matching a resume's dimensions shares one `gate_id`, so the last match
  is the chain head. It is kept as a guard against a store whose head record had
  its subject edited, and the module docstring says exactly that rather than
  implying broader coverage.
  `test_a_replaced_answer_never_speaks_for_a_question_that_moved_on` reaches it
  that way and no other.
- **No broad `except` was added**, so `tests/test_broad_exception_policy.py`'s
  handler and anchor counts are untouched.

## Compatibility / Rollout

- Purely additive. New file, new store, new path property, one registry entry,
  one report key. No existing schema, vocabulary, or record changed.
- An OMH install that has never opened a gate has no `decision_gates.jsonl`, and
  an absent store is not a fault, so upgrading is a no-op until something writes
  one.
- The store is metadata-only and local. No network, no LLM, no new dependency,
  no Hermes patching.
- Downgrading is safe in the sense that matters: an older build simply ignores a
  file it does not know about. It will not enforce the one-open-gate rule while
  it runs.
- Release channel: `stable`. No packaging or version surface touched.

## Release / Claims

- [x] Release-channel impact considered — `stable`; additive contract, no
      packaging, installer, or version change.
- [x] Runtime/native capability claims are backed by evidence or marked as not
      observed. Stated plainly here and in the module docstring: **no production
      surface mints a decision gate yet.** The claim this PR makes is that the
      record, the resume predicate, the one-open-gate rule, and the store
      validation exist and are enforced — proved by 62 tests and by the store's
      presence in `omh runtime validate`. It does **not** claim that any live
      Hermes or coding run currently opens or answers one.
- [x] Known manual Hermes checks are listed — there are none that could pass or
      fail today, for the reason above; `omh release hermes-smoke --live` was not
      run and would exercise nothing this PR adds.

## Follow-Up

- **Producer wiring** (the capability's remaining half): have
  `coding.action_gate` open a gate when it raises `withheld_pending_approval`,
  and have the resume path consult `resume_satisfies_gate` before continuing.
  That is the change that turns this from an enforced contract into an observed
  lane, and it is what will make a manual Hermes check meaningful.
- **A render surface**: `blocked_decision_gate` returns a `decision_gate_view/v1`
  ready for a status card, but nothing reads it. A status-card lane or an
  `omh runtime` subcommand would give an operator the question without a
  producer needing to exist first.
- **`docs/ARCHITECTURE.md:758-769`** lists the `journal/` tree and is already
  stale — it is missing `run_lineage_checkpoints.jsonl` from #826, and now
  `decision_gates.jsonl` too. No test reads that tree. Worth one small PR that
  fixes both rather than half of it here.
- **`src/conformance/checker.py:46-58`** reads only `runs`, `wrapper_sessions`,
  and `journal` out of `validate_runtime`, so any store-level error flips `ok`
  to false while contributing no string to `violations`. That is a pre-existing
  gap shared by all six stores, not one this PR introduces, but it now has one
  more way to be hit.
