### PR TITLE
feat: show which Hermes-generated artifact is current and safe to clean up

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1149,9 +1149,10 @@ uses for limit signals, rather than stored as an `expires_at` the reader must
 trust. A stored deadline is a second independently writable field: a hand-edited
 store widens the window by editing one number, while a window that lives in code
 cannot be widened by anything on disk. The honest reason matters more — the
-`storage_retention` boundary of `handoff_safety_contract/v1` is
-`declared_not_enforced` (blocked by #835) because no retention or cleanup exists
-for run artifacts. Nothing deletes an approval receipt, so claiming one
+`storage_retention` boundary of `handoff_safety_contract/v1` is still
+`declared_not_enforced`: #835 made artifact lifecycle readable, but its cleanup
+preview is a dry run and the receipt store is not one of the families it
+projects. Nothing deletes an approval receipt, so claiming one
 "expires" on disk would be a lie about a file that outlives every window it
 names. Expiry is a property every reader recomputes and never a property the
 artifact has. A decision stamped in the future returns `age_seconds = -1` and
@@ -1378,6 +1379,74 @@ contracts, executor-session state, runtime evidence, review/CI/merge status,
 pending evidence gaps, and `user_facing_lines[]`. It remains metadata-only: raw
 prompts and full interview transcripts are not reconstructed, and merge-ready is
 kept distinct from observed merge evidence.
+
+### Generated Artifact Lifecycle
+
+`generated_artifact/v1` (`runtime/generated_artifacts.py`) answers which locally
+generated artifact is current, what replaced it, why it is retained, and which
+ones could be removed. It is a read-side projection: nothing is stamped onto an
+artifact at write time, and no producing workflow was changed to support it. An
+artifact written before the projection existed reads exactly like one written
+after.
+
+Four kinds are covered, each with a *revision line* — the field the producer
+already writes that says two artifacts are two revisions of one thing — and an
+ordering key that says which came second:
+
+| Kind | Store | Revision line | Ordering key |
+| --- | --- | --- | --- |
+| `hermes_plan` | `plans/` | `task_statement_sha256` | the stamp `write_hermes_plan` puts in the filename |
+| `operation_artifact` | `operations/<surface>/` | surface, kind, title | `created_at` |
+| `plan_variant` | `plan-variants/` | parent digest and variant name | `created_at` |
+| `skill_draft` | `learning/skill-drafts/` | `proposed_skill_name` | `created_at` |
+
+Role context packs and plan handoff context packs are read as reference
+*sources* but are not projected as kinds, and the preview says so in
+`unsupported_kinds` rather than omitting them silently: a content-addressed pack
+carries no timestamp and no successor link, and a plan context pack is rewritten
+in place, so neither can be told apart by revision.
+
+The newest member of a line is `current` and every earlier member is
+`superseded`, naming its replacement in both directions. Ordering fails closed
+twice: a plan the producer already marked `superseded` is superseded whatever
+its position says, and a line whose members carry no distinct creation times
+keeps every member `current`, because guessing which of two files replaced the
+other is exactly how a live artifact reaches a cleanup list.
+
+`generated_artifact_cleanup_preview/v1` is a **dry run**. It lists what could be
+removed and why, and removes nothing — there is no delete path in the module,
+and `tests/test_generated_artifact_cleanup.py` walks its AST to keep it that
+way. An artifact is eligible only when it is superseded, no local artifact
+references it, and its retention window (built through the same
+`build_retention` the memory lane uses) has closed against the caller-supplied
+`now`. Every listed artifact, eligible or not, carries a sentence naming the
+condition that decided it; a record without one fails `validate_generated_artifact`.
+
+"Referenced" is a real reverse scan over coding delegation records, plan handoff
+context packs, plan variants, role context packs, and operation reports: every
+string in every source file is collected and matched against each artifact's
+resolved path, id, and content digest, so a pin recorded under a key this module
+has never heard of still counts. Two matches are deliberately not counted. An
+artifact never references itself. And a content digest that more than one stored
+artifact answers to identifies none of them, so it is dropped as a reference key
+for all of them: the plan renderer is a pure function of the task statement, so
+re-planning one task writes byte-identical files, and crediting one pack's
+digest to every revision would keep each duplicate forever while printing a
+reason that points at a sibling's pin. Dropping it is safe because every
+artifact pin in this tree that records a digest records the path beside it, so
+the file the pin actually meant is still held by its path match.
+
+The observation journal is also excluded — it is append-only history, so
+every artifact ever written appears in it, and treating history as a live pin
+would make the eligible set empty by construction.
+
+`omh runtime artifacts` renders the preview as plain text, takes `--json` for
+the payload, and `--retention-days` to move the window. It has no `--delete`,
+`--prune`, or `--confirm` flag, and the absence of all of them is pinned by a
+test. Removing a file stays the operator's own act. The `storage_retention`
+boundary of `handoff_safety_contract/v1` therefore stays
+`declared_not_enforced`, blocked on
+`the_preview_lists_what_could_be_removed_and_no_surface_removes_anything`.
 
 ## Hermes Planning Artifacts
 
@@ -2276,9 +2345,13 @@ a running process needs an OS-level backend the host owns);
 **confirmation answered** — the gate classifies every
 risky class and names the approval each granted carrier action would need, but
 nothing on the shipped lane can record an answer, so nothing is withheld
-(`no_confirmation_answer_intake_mints_a_run_bound_approval`); **storage retention** — run artifacts are metadata-only,
-but no retention window, expiry, or cleanup exists, so they persist until the
-operator deletes them (#835); **recovery** — no recovery anchor is attached to
+(`no_confirmation_answer_intake_mints_a_run_bound_approval`); **storage
+retention** — `generated_artifact/v1` and its dry-run cleanup preview now say
+which generated artifact is current, what replaced it, and which ones could go,
+but nothing removes one and no window expires a run artifact, so artifacts
+persist until the operator deletes them
+(`the_preview_lists_what_could_be_removed_and_no_surface_removes_anything`);
+**recovery** — no recovery anchor is attached to
 risky work (#821); **start evidence** — `runtime_start` is recordable but is
 neither a claim rung nor a journal prerequisite, so a run can claim dispatch and
 execution with no observed start (#826); **review receipt** — a review claim

--- a/src/coding/action_gate.py
+++ b/src/coding/action_gate.py
@@ -588,6 +588,17 @@ RECOVERY_ANCHOR_BLOCKER = "no_delegation_surface_holds_an_observed_baseline_to_a
 # already made it.
 START_EVIDENCE_BLOCKER = "lineage_orders_the_start_but_no_claim_rung_requires_a_lineage_chain"
 
+# Not an issue number either, and #835 is the reason it stopped being one. That
+# issue shipped `generated_artifact/v1` and its cleanup preview, so an operator
+# can now see which generated artifact is current, what replaced it, why it is
+# retained, and which ones could go. What #835 deliberately did not ship is the
+# going: the preview is a dry run with no delete path in the module at all, by
+# design, because the issue's own out-of-scope section forbids cleanup without
+# explicit confirmation and no surface in this tree can take one. Nothing
+# expires a run artifact on disk either. Naming a ticket here would promise a
+# reaper that is not planned; the reason string says what is actually missing.
+STORAGE_RETENTION_BLOCKER = "the_preview_lists_what_could_be_removed_and_no_surface_removes_anything"
+
 # (boundary, statement, enforcement, enforced_by, blocked_by).
 #
 # The `enforced_by` refs are dotted import paths that must resolve; the test
@@ -784,11 +795,16 @@ _STATIC_SAFETY_BOUNDARIES: tuple[tuple[str, str, str, tuple[str, ...], str], ...
     ),
     (
         "storage_retention",
-        "Run artifacts persist until the operator deletes them. No retention window, expiry, or cleanup "
-        "exists, so a prepared handoff and its metadata stay on disk indefinitely.",
+        "Lifecycle is now readable: `generated_artifact/v1` projects each locally generated plan, plan "
+        "variant, operation report, and skill draft with its provenance, the revision that replaced it, "
+        "the retention window it sits in, and whether removing it would be safe, and "
+        "`generated_artifact_cleanup_preview/v1` refuses to call an artifact removable while it is "
+        "current, while any local artifact still points at it, or while its window is open. What still "
+        "does not happen is deletion. The preview is a dry run with no removal path in it, nothing expires "
+        "a run artifact, and a prepared handoff and its metadata persist until the operator deletes them.",
         "declared_not_enforced",
         (),
-        "#835",
+        STORAGE_RETENTION_BLOCKER,
     ),
     (
         "untrusted_input",

--- a/src/commands/runtime.py
+++ b/src/commands/runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from datetime import datetime, timezone
 
 from ..codex_progress import summarize_codex_jsonl_file
 from ..executor_progress import (
@@ -66,6 +67,12 @@ from ..runtime.artifacts import (
     write_review_record,
     write_runtime_observation,
     write_wrapper_contract,
+)
+from ..runtime.generated_artifacts import (
+    DEFAULT_ARTIFACT_SCAN_LIMIT,
+    DEFAULT_RETENTION_DAYS,
+    build_generated_artifact_cleanup_preview,
+    render_generated_artifact_cleanup_preview_text,
 )
 from ..runtime.context_budget import (
     PROGRESS_STATUS_LEDGER_KEY,
@@ -1156,6 +1163,36 @@ def _render_approvals_text(payload: dict) -> str:
     return "\n".join(line for line in lines if line)
 
 
+def cmd_runtime_artifacts(args: argparse.Namespace) -> int:
+    """Show which locally generated artifacts are current, and preview cleanup.
+
+    Read-only by construction, and deliberately so: there is no `--delete` and
+    no confirm flag that would grow into one. The projection reports what could
+    be removed and why; removing it is the operator's own act, outside OMH.
+
+    `now` is read here, at the process edge, and passed into the projection.
+    Every retention verdict downstream is a pure function of that one value, so
+    two calls against the same store and the same stamp answer identically.
+    """
+    limit = None if getattr(args, "all", False) else int(getattr(args, "limit", DEFAULT_ARTIFACT_SCAN_LIMIT))
+    if limit is not None and limit < 1:
+        raise OmhError("--limit must be at least 1 unless --all is set")
+    retention_days = int(getattr(args, "retention_days", DEFAULT_RETENTION_DAYS))
+    if retention_days < 1:
+        raise OmhError("--retention-days must be at least 1")
+    payload = build_generated_artifact_cleanup_preview(
+        _paths(args),
+        now=datetime.now(timezone.utc),
+        retention_days=retention_days,
+        limit=limit,
+    )
+    if _wants_json(args):
+        _print_json(payload)
+    else:
+        print(render_generated_artifact_cleanup_preview_text(payload))
+    return 0
+
+
 def cmd_runtime_validate(args: argparse.Namespace) -> int:
     result = validate_runtime(_paths(args), args.run_id)
     _print_json(result)
@@ -1419,6 +1456,30 @@ def _add_runtime_commands(sub) -> None:
     runtime_approvals.add_argument("--all", action="store_true", help="Return all approvals.")
     runtime_approvals.add_argument("--json", action="store_true", help="Emit the machine payload instead of plain text.")
     runtime_approvals.set_defaults(func=cmd_runtime_approvals)
+
+    runtime_artifacts = runtime_sub.add_parser(
+        "artifacts",
+        help=(
+            "Show which locally generated artifacts are current or superseded, what replaced them, why each "
+            "is retained, and which could be removed. Dry run: this never deletes anything."
+        ),
+    )
+    runtime_artifacts.add_argument(
+        "--retention-days",
+        dest="retention_days",
+        type=int,
+        default=DEFAULT_RETENTION_DAYS,
+        help=f"Days a superseded artifact is kept before it reads as removable (default: {DEFAULT_RETENTION_DAYS}).",
+    )
+    runtime_artifacts.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_ARTIFACT_SCAN_LIMIT,
+        help=f"Maximum recent artifacts to project per kind (default: {DEFAULT_ARTIFACT_SCAN_LIMIT}).",
+    )
+    runtime_artifacts.add_argument("--all", action="store_true", help="Project every stored artifact.")
+    runtime_artifacts.add_argument("--json", action="store_true", help="Emit the machine payload instead of plain text.")
+    runtime_artifacts.set_defaults(func=cmd_runtime_artifacts)
 
     runtime_validate = runtime_sub.add_parser("validate")
     runtime_validate.add_argument("--run", dest="run_id", default=None)

--- a/src/runtime/generated_artifacts.py
+++ b/src/runtime/generated_artifacts.py
@@ -1,0 +1,955 @@
+"""Which locally generated artifact is current, and which one is safe to remove (issue #835).
+
+OMH writes plans, plan variants, operation reports, and skill drafts into local
+stores and never takes any of them back. A user looking at four files with
+similar names has no way to tell which one a handoff still points at, which one
+was replaced, or which one could go. This module answers that from what the
+producers already wrote.
+
+A read-side projection, not new producer metadata
+-------------------------------------------------
+
+Nothing here is stamped onto an artifact at write time. `generated_artifact/v1`
+is derived on read from data the producing workflows already persist: the file
+itself (its digest and, for plans, the timestamp its own writer put in the
+name), the producer's status word, the identity field that says which artifact
+is another revision of the same thing, and every local file that names it. No
+producing workflow is touched, so an artifact written before this module existed
+projects exactly like one written after.
+
+What "superseded" means here
+----------------------------
+
+Each kind declares a *revision line* -- the field that says two artifacts are
+two revisions of one thing -- and an *ordering key* that says which came second:
+
+    hermes_plan         line = task_statement_sha256   order = the stamp its writer put in the filename
+    operation_artifact  line = surface|kind|title      order = created_at
+    plan_variant        line = parent digest|name      order = created_at
+    skill_draft         line = proposed_skill_name     order = created_at
+
+The newest member of a line is `current`; every earlier member is `superseded`
+and names the artifact that replaced it. A plan whose own frontmatter already
+says `superseded` is superseded regardless of position.
+
+Ordering fails closed. If two members of one line carry no readable creation
+time, or carry the same one, nothing in the line is called superseded --
+guessing which of two files replaced the other is exactly the mistake that would
+put a live artifact on a cleanup list.
+
+Deletion
+--------
+
+There is none. `build_generated_artifact_cleanup_preview` is a dry run: it
+reports what *would* be eligible and why, and this module contains no unlink,
+no remove, no rmtree, and no write of any kind.
+`tests/test_generated_artifact_cleanup.py` walks this module's AST and fails if
+one appears.
+
+Cleanup eligibility
+-------------------
+
+An artifact is eligible only when all three hold, and the record says which one
+failed when it is not:
+
+1. it is superseded -- a current artifact is never eligible;
+2. no local artifact references it -- see the scan below;
+3. its retention window has ended, measured from its creation time against the
+   caller's `now`.
+
+"Referenced" is a real reverse scan, not a guess. Every reference-source file is
+read and every string in it is collected, so a handoff context pack that pins a
+plan by path, a run's coding delegation that pins it by path and digest, a
+variant that names its parent plan, and a report that cites another artifact all
+count. Two matches are deliberately not counted: an artifact never references
+itself, and a content digest that more than one stored artifact answers to
+identifies none of them, so it is not a reference key for any of them (see
+`_ambiguous_digests` -- re-planning one task writes byte-identical files).
+
+The observation journal is deliberately *not* a reference source. It is an
+append-only history, so every artifact ever written appears in it; treating
+history as a live pin would make the eligible set empty by construction and the
+whole preview useless. A reference here means something that would be left
+dangling if the file went away.
+
+Determinism
+-----------
+
+`now` is a required parameter, never a clock read, because the retention verdict
+depends on it and a projection whose answer changes between two calls in the
+same second cannot be compared or tested. Nothing else in a record comes from
+the clock.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+from ..plugin_bundle.omh.memory_governance import build_retention
+from ..system.local_store import read_json_object_result
+from ..system.paths import OmhPaths, project_artifact_dir
+from ..workflows.hermes_planning import read_hermes_plan_artifact
+from ..workflows.operations import SURFACES as OPERATION_SURFACES
+
+
+GENERATED_ARTIFACT_SCHEMA_VERSION = "generated_artifact/v1"
+GENERATED_ARTIFACT_REFERENCE_SCHEMA_VERSION = "generated_artifact_reference/v1"
+GENERATED_ARTIFACT_CLEANUP_PREVIEW_SCHEMA_VERSION = "generated_artifact_cleanup_preview/v1"
+
+# The kinds whose store is discoverable, whose revision line is a field the
+# producer already writes, and whose ordering key exists on the record. A kind
+# missing any of the three cannot answer AC1 and is left out rather than
+# guessed at -- see `UNSUPPORTED_ARTIFACT_KIND_REASONS`.
+GENERATED_ARTIFACT_KINDS = ("hermes_plan", "operation_artifact", "plan_variant", "skill_draft")
+LIFECYCLE_STATES = ("current", "superseded")
+
+# Local artifact families read to answer "does anything still point at this?".
+# Each one holds a pin that would dangle if the artifact it names were removed.
+GENERATED_ARTIFACT_REFERENCE_KINDS = (
+    "coding_delegation",
+    "handoff_context_pack",
+    "operation_artifact",
+    "plan_variant",
+    "role_context_pack",
+)
+
+# Where an artifact's provenance actually comes from: the symbol that writes it.
+# `tests/test_generated_artifact_cleanup.py` imports every one of these, so a
+# renamed or deleted writer fails the suite instead of leaving this table
+# claiming a producer that no longer exists.
+GENERATED_ARTIFACT_PRODUCERS = {
+    "hermes_plan": "omh.workflows.hermes_planning.write_hermes_plan",
+    "operation_artifact": "omh.workflows.operations.write_operation_artifact",
+    "plan_variant": "omh.workflows.plan_variants.write_plan_variant",
+    "skill_draft": "omh.workflows.skill_draft.write_skill_draft",
+}
+
+# Named so the gap is a documented boundary rather than an omission a reader has
+# to notice. Both families are still scanned as reference *sources* -- a pinned
+# pack is what keeps a plan off the eligible list -- they just cannot be told
+# apart by revision.
+UNSUPPORTED_ARTIFACT_KIND_REASONS = {
+    "role_context_pack": (
+        "A role context pack is content-addressed and deliberately carries no timestamp and no successor "
+        "link, so nothing on the record says which of two packs for one scope came second."
+    ),
+    "handoff_context_pack": (
+        "A plan handoff context pack is named after the plan it serves and rewritten in place, so one plan "
+        "never has two revisions of it on disk to compare."
+    ),
+}
+
+# The producer's own status word, when it has one, and what it means for
+# lifecycle. Only `superseded` forces the verdict: `cancelled` and `blocked` say
+# the work stopped, not that something replaced it.
+PLAN_STATUS_SUPERSEDED = "superseded"
+
+# The retention policy every generated artifact is measured against, built
+# through the same `build_retention` the memory lane uses so there is one
+# retention shape in the tree. `episode` is the record type because a generated
+# artifact is the output of one episode of work, and it is the one record type
+# whose standard class carries a default window at all.
+DEFAULT_RETENTION_CLASS = "standard"
+DEFAULT_RETENTION_RECORD_TYPE = "episode"
+DEFAULT_RETENTION_DAYS = 30
+
+# Scan bounds. A projection that walks an unbounded store turns a status check
+# into an unbounded read, which is the cost `show_run` already bounds for run
+# history. `--all` lifts the artifact bound; the reference scan stays bounded
+# because a missed reference source can only ever *add* an artifact to the
+# eligible list, and that is the one direction this feature must not fail in --
+# so the bound is high enough to cover a real store and the payload says when it
+# was hit.
+DEFAULT_ARTIFACT_SCAN_LIMIT = 200
+MAX_REFERENCE_SOURCE_FILES = 2000
+MAX_REFERENCE_TOKEN_LENGTH = 512
+MAX_REFERENCE_SCAN_DEPTH = 12
+
+GENERATED_ARTIFACT_KEYS = (
+    "schema_version",
+    "artifact_kind",
+    "artifact_id",
+    "path",
+    "content_digest",
+    "source_schema_version",
+    "producer",
+    "created_at",
+    "declared_status",
+    "revision_line",
+    "revision_index",
+    "revision_count",
+    "lifecycle",
+    "replaces",
+    "replaced_by",
+    "referenced_by",
+    "reference_count",
+    "retention_class",
+    "retention_days",
+    "retention_expires_at",
+    "retention_reason",
+    "cleanup_eligible",
+    "cleanup_reason",
+)
+GENERATED_ARTIFACT_REFERENCE_KEYS = ("schema_version", "ref_kind", "ref_path", "matched_on")
+GENERATED_ARTIFACT_REFERENCE_MATCHES = ("path", "artifact_id", "content_digest")
+GENERATED_ARTIFACT_CLEANUP_PREVIEW_KEYS = (
+    "schema_version",
+    "evaluated_at",
+    "retention_days",
+    "dry_run",
+    "artifact_count",
+    "eligible",
+    "eligible_count",
+    "retained",
+    "retained_count",
+    "kinds",
+    "unsupported_kinds",
+    "store_paths",
+    "reference_source_count",
+    "scan_truncated",
+    "claim_boundary",
+    "next_action",
+)
+
+CLEANUP_PREVIEW_CLAIM_BOUNDARY = (
+    "This cleanup preview is a dry run over local files. It deletes nothing, moves nothing, and writes "
+    "nothing: the module that builds it has no removal path at all, and an artifact that is current, "
+    "referenced by another local artifact, or still inside its retention window is never listed as "
+    "eligible. Every record here is a read-side projection and prepared metadata, not execution, review, "
+    "CI, merge-readiness, or merge evidence."
+)
+CLEANUP_PREVIEW_NEXT_ACTION = (
+    "Read the eligible list and remove those files by hand if you want them gone. OMH does not remove them."
+)
+
+
+def project_generated_artifacts(
+    paths: OmhPaths,
+    *,
+    now: datetime,
+    retention_days: int = DEFAULT_RETENTION_DAYS,
+    limit: int | None = DEFAULT_ARTIFACT_SCAN_LIMIT,
+) -> list[dict[str, Any]]:
+    """Every locally generated artifact, with its provenance, revision, and verdict.
+
+    `now` is required: the retention verdict is measured against it, and reading
+    a clock in here would make two calls in the same second incomparable.
+    """
+    if isinstance(retention_days, bool) or not isinstance(retention_days, int) or retention_days < 1:
+        raise ValueError("retention_days must be a positive integer")
+    current = _as_utc(now)
+    found = _scan_artifacts(paths, limit=limit)
+    references = _reference_index(paths)
+    ambiguous = _ambiguous_digests(found)
+    records: list[dict[str, Any]] = []
+    for kind in GENERATED_ARTIFACT_KINDS:
+        for member in _resolve_revision_lines(found.get(kind, [])):
+            records.append(_build_record(member, references, ambiguous, current, retention_days))
+    records.sort(key=lambda record: (str(record["artifact_kind"]), str(record["path"])))
+    return records
+
+
+def build_generated_artifact_cleanup_preview(
+    paths: OmhPaths,
+    *,
+    now: datetime,
+    retention_days: int = DEFAULT_RETENTION_DAYS,
+    limit: int | None = DEFAULT_ARTIFACT_SCAN_LIMIT,
+) -> dict[str, Any]:
+    """A dry-run cleanup list. Nothing is removed here or anywhere downstream."""
+    records = project_generated_artifacts(paths, now=now, retention_days=retention_days, limit=limit)
+    eligible = [record for record in records if record["cleanup_eligible"]]
+    retained = [record for record in records if not record["cleanup_eligible"]]
+    # Directory listings only -- `_reference_source_files` never opens a file --
+    # so counting the scan a second time costs a re-glob of a bounded set, not a
+    # second read of every pin.
+    sources = list(_reference_source_files(paths))
+    payload = {
+        "schema_version": GENERATED_ARTIFACT_CLEANUP_PREVIEW_SCHEMA_VERSION,
+        "evaluated_at": _stamp(_as_utc(now)),
+        "retention_days": retention_days,
+        "dry_run": True,
+        "artifact_count": len(records),
+        "eligible": eligible,
+        "eligible_count": len(eligible),
+        "retained": retained,
+        "retained_count": len(retained),
+        "kinds": list(GENERATED_ARTIFACT_KINDS),
+        "unsupported_kinds": [
+            {"artifact_kind": kind, "reason": reason}
+            for kind, reason in sorted(UNSUPPORTED_ARTIFACT_KIND_REASONS.items())
+        ],
+        "store_paths": generated_artifact_store_paths(paths),
+        "reference_source_count": len(sources),
+        "scan_truncated": len(sources) >= MAX_REFERENCE_SOURCE_FILES,
+        "claim_boundary": CLEANUP_PREVIEW_CLAIM_BOUNDARY,
+        "next_action": CLEANUP_PREVIEW_NEXT_ACTION,
+    }
+    return payload
+
+
+def generated_artifact_store_paths(paths: OmhPaths) -> dict[str, str]:
+    """Where each supported kind is read from, as the projection resolved it."""
+    return {
+        "hermes_plan": str(_plans_dir(paths)),
+        "operation_artifact": str(paths.operations_dir),
+        "plan_variant": str(_plan_variants_dir(paths)),
+        "skill_draft": str(paths.learning_skill_drafts_dir),
+    }
+
+
+def validate_generated_artifact(record: Any) -> list[str]:
+    """Every contract violation in one pass; empty means the record is valid.
+
+    The three cleanup invariants are checked here as well as computed, so a
+    hand-built or transport-mangled record claiming eligibility for a current or
+    referenced artifact is refused rather than rendered.
+    """
+    if not isinstance(record, dict):
+        return ["generated artifact must be an object"]
+    errors = _key_set_errors(record, GENERATED_ARTIFACT_KEYS, "generated_artifact")
+    if record.get("schema_version") != GENERATED_ARTIFACT_SCHEMA_VERSION:
+        errors.append(f"schema_version must be {GENERATED_ARTIFACT_SCHEMA_VERSION}")
+    if record.get("artifact_kind") not in GENERATED_ARTIFACT_KINDS:
+        errors.append("artifact_kind is unsupported")
+    if not str(record.get("artifact_id", "")).strip():
+        errors.append("artifact_id must not be empty")
+    if not str(record.get("path", "")).strip():
+        errors.append("path must not be empty")
+    if record.get("lifecycle") not in LIFECYCLE_STATES:
+        errors.append("lifecycle must be current or superseded")
+    if not isinstance(record.get("cleanup_eligible"), bool):
+        errors.append("cleanup_eligible must be a boolean")
+    # AC2, as a validator rule and not only as a rendering habit: an entry
+    # without a readable reason is refused, whichever list it lands in.
+    if not str(record.get("cleanup_reason", "")).strip():
+        errors.append("cleanup_reason must explain the verdict in words")
+    if not str(record.get("retention_reason", "")).strip():
+        errors.append("retention_reason must explain the retention window in words")
+    for key in ("revision_index", "revision_count", "reference_count"):
+        value = record.get(key)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            errors.append(f"{key} must be a non-negative integer")
+    references = record.get("referenced_by")
+    if not isinstance(references, list):
+        errors.append("referenced_by must be a list")
+    else:
+        for index, reference in enumerate(references):
+            for error in _reference_errors(reference):
+                errors.append(f"referenced_by[{index}]: {error}")
+        if record.get("reference_count") != len(references):
+            errors.append("reference_count must match referenced_by")
+    if record.get("cleanup_eligible") is True:
+        if record.get("lifecycle") != "superseded":
+            errors.append("a current artifact must never be cleanup_eligible")
+        if record.get("reference_count") != 0:
+            errors.append("a referenced artifact must never be cleanup_eligible")
+        if not str(record.get("retention_expires_at", "")).strip():
+            errors.append("an artifact with no evaluated retention window must never be cleanup_eligible")
+    return errors
+
+
+def validate_generated_artifact_cleanup_preview(payload: Any) -> list[str]:
+    """Refuse a preview that is not a dry run or that lists an unsafe artifact."""
+    if not isinstance(payload, dict):
+        return ["cleanup preview must be an object"]
+    errors = _key_set_errors(payload, GENERATED_ARTIFACT_CLEANUP_PREVIEW_KEYS, "cleanup_preview")
+    if payload.get("schema_version") != GENERATED_ARTIFACT_CLEANUP_PREVIEW_SCHEMA_VERSION:
+        errors.append(f"schema_version must be {GENERATED_ARTIFACT_CLEANUP_PREVIEW_SCHEMA_VERSION}")
+    if payload.get("dry_run") is not True:
+        errors.append("dry_run must be True; this preview never removes anything")
+    if payload.get("claim_boundary") != CLEANUP_PREVIEW_CLAIM_BOUNDARY:
+        errors.append("claim_boundary must state that the preview deletes nothing")
+    retention_days = payload.get("retention_days")
+    if isinstance(retention_days, bool) or not isinstance(retention_days, int) or retention_days < 1:
+        errors.append("retention_days must be a positive integer")
+    eligible = payload.get("eligible")
+    retained = payload.get("retained")
+    for label, group in (("eligible", eligible), ("retained", retained)):
+        if not isinstance(group, list):
+            errors.append(f"{label} must be a list")
+            continue
+        for index, record in enumerate(group):
+            for error in validate_generated_artifact(record):
+                errors.append(f"{label}[{index}]: {error}")
+    if isinstance(eligible, list):
+        if payload.get("eligible_count") != len(eligible):
+            errors.append("eligible_count must match eligible")
+        for index, record in enumerate(eligible):
+            if isinstance(record, dict) and record.get("cleanup_eligible") is not True:
+                errors.append(f"eligible[{index}]: a retained artifact must not be listed as eligible")
+    if isinstance(retained, list):
+        if payload.get("retained_count") != len(retained):
+            errors.append("retained_count must match retained")
+        for index, record in enumerate(retained):
+            if isinstance(record, dict) and record.get("cleanup_eligible") is not False:
+                errors.append(f"retained[{index}]: an eligible artifact must not be listed as retained")
+    if isinstance(eligible, list) and isinstance(retained, list):
+        if payload.get("artifact_count") != len(eligible) + len(retained):
+            errors.append("artifact_count must match the eligible and retained lists")
+    return errors
+
+
+def render_generated_artifact_cleanup_preview_text(payload: dict[str, Any]) -> str:
+    """Plain text for an operator: what is current, what is not, and why."""
+    eligible = [record for record in payload.get("eligible", []) or [] if isinstance(record, dict)]
+    retained = [record for record in payload.get("retained", []) or [] if isinstance(record, dict)]
+    lines = [
+        f"Generated artifacts ({payload.get('artifact_count', 0)} found, "
+        f"evaluated at {payload.get('evaluated_at', '')})",
+        f"  Retention window: {payload.get('retention_days', 0)} days from creation.",
+        "",
+        f"Safe to remove ({len(eligible)})",
+    ]
+    lines.extend(_preview_row_lines(eligible) or ["  Nothing is eligible."])
+    lines.extend(["", f"Kept ({len(retained)})"])
+    lines.extend(_preview_row_lines(retained) or ["  Nothing is stored yet."])
+    unsupported = [row for row in payload.get("unsupported_kinds", []) or [] if isinstance(row, dict)]
+    if unsupported:
+        lines.extend(["", "Not covered by revision"])
+        lines.extend(f"  {row.get('artifact_kind', '')}: {row.get('reason', '')}" for row in unsupported)
+    if payload.get("scan_truncated"):
+        lines.append("")
+        lines.append("  The reference scan hit its file bound; treat the eligible list as incomplete.")
+    lines.extend(["", str(payload.get("claim_boundary", "")), str(payload.get("next_action", ""))])
+    return "\n".join(line for line in lines if line is not None)
+
+
+def _preview_row_lines(records: list[dict[str, Any]]) -> list[str]:
+    lines: list[str] = []
+    for record in records:
+        lines.append(
+            f"  {record.get('artifact_kind', '')} — {record.get('lifecycle', '')} — "
+            f"{record.get('artifact_id', '')}"
+        )
+        lines.append(f"    {record.get('path', '')}")
+        lines.append(f"    {record.get('cleanup_reason', '')}")
+    return lines
+
+
+# --- scanning -----------------------------------------------------------------
+
+
+def _scan_artifacts(paths: OmhPaths, *, limit: int | None) -> dict[str, list[dict[str, Any]]]:
+    found: dict[str, list[dict[str, Any]]] = {}
+    for kind, members in (
+        ("hermes_plan", _scan_plans(paths)),
+        ("operation_artifact", _scan_operation_artifacts(paths)),
+        ("plan_variant", _scan_plan_variants(paths)),
+        ("skill_draft", _scan_skill_drafts(paths)),
+    ):
+        found[kind] = _bounded(members, limit)
+    return found
+
+
+def _scan_plans(paths: OmhPaths) -> list[dict[str, Any]]:
+    members: list[dict[str, Any]] = []
+    for path in _json_like_files(_plans_dir(paths), "*.md"):
+        # The plan lane's own reader, not a second parser here: it already
+        # derives the digest, the status, and the task-statement identity, and a
+        # copy of that derivation would drift the day the plan format moves.
+        try:
+            artifact = read_hermes_plan_artifact(path)
+        except (OSError, UnicodeDecodeError, ValueError):
+            continue
+        status = str(artifact.get("status", ""))
+        members.append(
+            {
+                "artifact_kind": "hermes_plan",
+                "artifact_id": path.stem,
+                "path": path,
+                "content_digest": str(artifact.get("sha256", "")),
+                "source_schema_version": str(artifact.get("schema_version", "")),
+                "declared_status": status,
+                # The plan writer puts its own creation stamp in the filename and
+                # nowhere else, so that is where creation time comes from.
+                "created": _parse_stamp(path.stem[:24]),
+                "revision_line": str(artifact.get("task_statement_sha256", "")) or path.stem,
+                "forced_superseded": status == PLAN_STATUS_SUPERSEDED,
+            }
+        )
+    return members
+
+
+def _scan_operation_artifacts(paths: OmhPaths) -> list[dict[str, Any]]:
+    members: list[dict[str, Any]] = []
+    for surface in OPERATION_SURFACES:
+        for path in _json_like_files(paths.operations_dir / surface, "*.json"):
+            record = _read_json(path)
+            if record is None:
+                continue
+            title = _normalized(str(record.get("title", "")))
+            members.append(
+                {
+                    "artifact_kind": "operation_artifact",
+                    "artifact_id": str(record.get("artifact_id", "")) or path.stem,
+                    "path": path,
+                    "content_digest": _file_digest(path),
+                    "source_schema_version": str(record.get("schema_version", "")),
+                    "declared_status": str(record.get("status", "")),
+                    "created": _parse_stamp(str(record.get("created_at", ""))),
+                    "revision_line": f"{surface}|{record.get('kind', '')}|{title}",
+                    "forced_superseded": False,
+                }
+            )
+    return members
+
+
+def _scan_plan_variants(paths: OmhPaths) -> list[dict[str, Any]]:
+    members: list[dict[str, Any]] = []
+    for path in _json_like_files(_plan_variants_dir(paths), "*.json"):
+        record = _read_json(path)
+        if record is None:
+            continue
+        parent = str(record.get("parent_plan_sha256", ""))
+        members.append(
+            {
+                "artifact_kind": "plan_variant",
+                "artifact_id": str(record.get("variant_id", "")) or path.stem,
+                "path": path,
+                "content_digest": _file_digest(path),
+                "source_schema_version": str(record.get("schema_version", "")),
+                "declared_status": str(record.get("prepared_state", "")),
+                "created": _parse_stamp(str(record.get("created_at", ""))),
+                "revision_line": f"{parent}|{_normalized(str(record.get('name', '')))}",
+                "forced_superseded": False,
+            }
+        )
+    return members
+
+
+def _scan_skill_drafts(paths: OmhPaths) -> list[dict[str, Any]]:
+    members: list[dict[str, Any]] = []
+    for path in _json_like_files(paths.learning_skill_drafts_dir, "*.json"):
+        record = _read_json(path)
+        if record is None:
+            continue
+        lifecycle = record.get("lifecycle")
+        state = str(lifecycle.get("state", "")) if isinstance(lifecycle, dict) else ""
+        members.append(
+            {
+                "artifact_kind": "skill_draft",
+                "artifact_id": str(record.get("draft_id", "")) or path.stem,
+                "path": path,
+                "content_digest": _file_digest(path),
+                "source_schema_version": str(record.get("schema_version", "")),
+                "declared_status": state,
+                "created": _parse_stamp(str(record.get("created_at", ""))),
+                "revision_line": str(record.get("proposed_skill_name", "")) or path.stem,
+                "forced_superseded": False,
+            }
+        )
+    return members
+
+
+# --- revision lines -----------------------------------------------------------
+
+
+def _resolve_revision_lines(members: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Order each line and mark every member current or superseded.
+
+    Fails closed twice. A line whose members do not all carry a readable
+    creation time, or that carries the same time twice, keeps every member
+    `current` and says so: nothing on disk orders them, so calling one superseded
+    would be a guess. And a member the producer already marked superseded is
+    superseded whatever its position says.
+    """
+    lines: dict[str, list[dict[str, Any]]] = {}
+    for member in members:
+        lines.setdefault(str(member["revision_line"]), []).append(member)
+    resolved: list[dict[str, Any]] = []
+    for line_members in lines.values():
+        resolved.extend(_resolve_one_line(line_members))
+    return resolved
+
+
+def _resolve_one_line(members: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    count = len(members)
+    stamps = [member["created"] for member in members]
+    orderable = count > 1 and all(stamp is not None for stamp in stamps) and len(set(stamps)) == count
+    if not orderable:
+        return [
+            {
+                **member,
+                "revision_index": 1,
+                "revision_count": count,
+                "lifecycle": "superseded" if member["forced_superseded"] else "current",
+                "replaces": "",
+                "replaced_by": "",
+                "ambiguous_order": count > 1,
+            }
+            for member in members
+        ]
+    ordered = sorted(members, key=lambda member: (member["created"], str(member["artifact_id"])))
+    resolved: list[dict[str, Any]] = []
+    for index, member in enumerate(ordered):
+        newest = index == count - 1
+        resolved.append(
+            {
+                **member,
+                "revision_index": index + 1,
+                "revision_count": count,
+                "lifecycle": "current" if newest and not member["forced_superseded"] else "superseded",
+                "replaces": str(ordered[index - 1]["artifact_id"]) if index else "",
+                "replaced_by": "" if newest else str(ordered[index + 1]["artifact_id"]),
+                "ambiguous_order": False,
+            }
+        )
+    return resolved
+
+
+# --- reverse reference scan ---------------------------------------------------
+
+
+def _reference_index(paths: OmhPaths) -> dict[str, list[tuple[str, str]]]:
+    """token -> [(reference kind, source file)], over every local pin.
+
+    Every string in every reference source is a token, which is what makes the
+    scan real rather than a guess about which field holds a pin: a path, a
+    digest, and an id are all just strings on disk, and a producer that starts
+    recording a pin under a new key is covered the day it does.
+    """
+    index: dict[str, list[tuple[str, str]]] = {}
+    for ref_kind, path in _reference_source_files(paths):
+        record = _read_json(path)
+        if record is None:
+            continue
+        source = str(_resolved(path))
+        for token in _collect_tokens(record, MAX_REFERENCE_SCAN_DEPTH):
+            index.setdefault(token, []).append((ref_kind, source))
+    return index
+
+
+def _reference_source_files(paths: OmhPaths) -> Iterator[tuple[str, Path]]:
+    seen = 0
+    for ref_kind, directory, pattern in (
+        ("coding_delegation", paths.runtime_runs_dir, "*/coding_delegation.json"),
+        ("handoff_context_pack", paths.runtime_plan_context_dir, "*.json"),
+        ("plan_variant", _plan_variants_dir(paths), "*.json"),
+        ("role_context_pack", paths.role_context_packs_dir, "*.json"),
+        *(("operation_artifact", paths.operations_dir / surface, "*.json") for surface in OPERATION_SURFACES),
+    ):
+        for path in _json_like_files(directory, pattern):
+            if seen >= MAX_REFERENCE_SOURCE_FILES:
+                return
+            seen += 1
+            yield ref_kind, path
+
+
+def _collect_tokens(value: Any, depth: int) -> set[str]:
+    if depth <= 0:
+        return set()
+    if isinstance(value, str):
+        token = _reference_token(value)
+        return {token} if token else set()
+    if isinstance(value, dict):
+        tokens: set[str] = set()
+        for item in value.values():
+            tokens |= _collect_tokens(item, depth - 1)
+        return tokens
+    if isinstance(value, list):
+        tokens = set()
+        for item in value:
+            tokens |= _collect_tokens(item, depth - 1)
+        return tokens
+    return set()
+
+
+def _reference_token(value: str) -> str:
+    """Normalize one string into a comparable token.
+
+    Path-shaped values are resolved, and so is the artifact path they are
+    compared against, so the two sides never differ only by separator, by a
+    relative prefix, or by a symlinked store root.
+    """
+    text = value.strip()
+    if not text or len(text) > MAX_REFERENCE_TOKEN_LENGTH:
+        return ""
+    if "/" in text or "\\" in text:
+        return str(_resolved(Path(text)))
+    return text
+
+
+def _ambiguous_digests(found: dict[str, list[dict[str, Any]]]) -> frozenset[str]:
+    """Content digests that more than one stored artifact answers to.
+
+    Two revisions of one plan really can be byte-identical: the plan renderer is
+    a pure function of the task statement, so re-planning the same task writes
+    the same bytes under a new name. A pin recorded against that digest names
+    all of them and therefore identifies none of them, and crediting it to every
+    revision would keep every duplicate on disk forever while printing a reason
+    that points at a sibling's pin.
+
+    Dropping the ambiguous digest is safe because every artifact pin in this
+    tree that records a digest records the path beside it -- a coding
+    delegation, a plan handoff context pack, and a plan variant all do -- so the
+    file the pin actually means is still held by its path match. A digest-only
+    pin would be the exception, and there is none.
+    """
+    counts: dict[str, int] = {}
+    for members in found.values():
+        for member in members:
+            digest = str(member["content_digest"])
+            if digest:
+                counts[digest] = counts.get(digest, 0) + 1
+    return frozenset(digest for digest, count in counts.items() if count > 1)
+
+
+def _references_for(
+    member: dict[str, Any],
+    index: dict[str, list[tuple[str, str]]],
+    ambiguous_digests: frozenset[str],
+) -> list[dict[str, Any]]:
+    own = str(_resolved(member["path"]))
+    digest = str(member["content_digest"])
+    found: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for matched_on, token in (
+        ("path", own),
+        ("artifact_id", _reference_token(str(member["artifact_id"]))),
+        ("content_digest", "" if digest in ambiguous_digests else _reference_token(digest)),
+    ):
+        if not token:
+            continue
+        for ref_kind, source in index.get(token, []):
+            # An artifact naming itself is not a reference. Without this, every
+            # record that stores its own id would pin itself forever.
+            if source == own:
+                continue
+            found[(ref_kind, source, matched_on)] = {
+                "schema_version": GENERATED_ARTIFACT_REFERENCE_SCHEMA_VERSION,
+                "ref_kind": ref_kind,
+                "ref_path": source,
+                "matched_on": matched_on,
+            }
+    return [found[key] for key in sorted(found)]
+
+
+# --- record assembly ----------------------------------------------------------
+
+
+def _build_record(
+    member: dict[str, Any],
+    index: dict[str, list[tuple[str, str]]],
+    ambiguous_digests: frozenset[str],
+    now: datetime,
+    retention_days: int,
+) -> dict[str, Any]:
+    references = _references_for(member, index, ambiguous_digests)
+    created = member["created"]
+    retention = (
+        build_retention(
+            DEFAULT_RETENTION_CLASS,
+            record_type=DEFAULT_RETENTION_RECORD_TYPE,
+            admitted_at=created,
+            ttl_days=retention_days,
+        )
+        if created is not None
+        else {}
+    )
+    expires_at = str(retention.get("expires_at", ""))
+    expires = _parse_stamp(expires_at)
+    eligible, cleanup_reason = _cleanup_verdict(member, references, now, expires, retention_days)
+    return {
+        "schema_version": GENERATED_ARTIFACT_SCHEMA_VERSION,
+        "artifact_kind": str(member["artifact_kind"]),
+        "artifact_id": str(member["artifact_id"]),
+        "path": str(member["path"]),
+        "content_digest": str(member["content_digest"]),
+        "source_schema_version": str(member["source_schema_version"]),
+        "producer": GENERATED_ARTIFACT_PRODUCERS[str(member["artifact_kind"])],
+        "created_at": _stamp(created) if created is not None else "",
+        "declared_status": str(member["declared_status"]),
+        "revision_line": str(member["revision_line"]),
+        "revision_index": int(member["revision_index"]),
+        "revision_count": int(member["revision_count"]),
+        "lifecycle": str(member["lifecycle"]),
+        "replaces": str(member["replaces"]),
+        "replaced_by": str(member["replaced_by"]),
+        "referenced_by": references,
+        "reference_count": len(references),
+        "retention_class": DEFAULT_RETENTION_CLASS,
+        "retention_days": retention_days,
+        "retention_expires_at": expires_at,
+        "retention_reason": _retention_reason(created, expires_at, retention_days),
+        "cleanup_eligible": eligible,
+        "cleanup_reason": cleanup_reason,
+    }
+
+
+def _retention_reason(created: datetime | None, expires_at: str, retention_days: int) -> str:
+    if created is None:
+        return (
+            "No creation time is readable from this artifact or its filename, so the retention window "
+            "cannot be evaluated and the artifact is kept."
+        )
+    return (
+        f"Kept for {retention_days} days from {_stamp(created)} under the {DEFAULT_RETENTION_CLASS} "
+        f"retention class; the window ends at {expires_at}."
+    )
+
+
+def _cleanup_verdict(
+    member: dict[str, Any],
+    references: list[dict[str, Any]],
+    now: datetime,
+    expires: datetime | None,
+    retention_days: int,
+) -> tuple[bool, str]:
+    """The eligibility answer and the sentence that explains it.
+
+    The order of the checks is the order an operator asks them in, and the first
+    blocking one is the sentence they get. Every branch returns text: a record
+    with no reason fails `validate_generated_artifact`, which is AC2.
+    """
+    if member["lifecycle"] != "superseded":
+        if member.get("ambiguous_order"):
+            return False, (
+                f"Kept: {member['revision_count']} artifacts share this revision line and do not carry "
+                "distinct creation times, so nothing on disk says which one replaced the other."
+            )
+        return False, "Kept: this is the current revision and nothing has replaced it."
+    if references:
+        first = references[0]
+        return False, (
+            f"Kept: {len(references)} local artifact(s) still point at it, starting with the "
+            f"{first['ref_kind']} at {first['ref_path']} (matched on {first['matched_on']})."
+        )
+    if expires is None:
+        return False, (
+            "Kept: no creation time is readable, so the retention window cannot be shown to have ended."
+        )
+    if now < expires:
+        return False, (
+            f"Kept: superseded by {member['replaced_by'] or 'a later revision'}, but still inside its "
+            f"{retention_days}-day retention window until {_stamp(expires)}."
+        )
+    return True, (
+        f"Eligible: superseded by {member['replaced_by'] or 'a later revision'}, no local artifact "
+        f"references it, and its {retention_days}-day retention window ended at {_stamp(expires)}."
+    )
+
+
+# --- small helpers ------------------------------------------------------------
+
+
+def _plans_dir(paths: OmhPaths) -> Path:
+    return project_artifact_dir(paths, "plans")
+
+
+def _plan_variants_dir(paths: OmhPaths) -> Path:
+    return project_artifact_dir(paths, "plan-variants")
+
+
+def _json_like_files(directory: Path, pattern: str) -> list[Path]:
+    try:
+        if not directory.is_dir():
+            return []
+        return sorted(path for path in directory.glob(pattern) if path.is_file() and not path.is_symlink())
+    except OSError:
+        return []
+
+
+def _read_text(path: Path) -> str | None:
+    try:
+        # Universal newlines on read, matching `read_hermes_plan_artifact`, so a
+        # digest taken here equals the digest the plan lane records for the same
+        # file on a host that stored it with CRLF.
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    record, error = read_json_object_result(path)
+    return None if error else record
+
+
+def _digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _file_digest(path: Path) -> str:
+    """The artifact's content digest, or empty when the bytes are unreadable.
+
+    Empty rather than the digest of an empty string: a digest is one of the
+    tokens the reference scan matches on, and giving every unreadable file the
+    same well-known digest would make them reference each other.
+    """
+    text = _read_text(path)
+    return _digest(text) if text is not None else ""
+
+
+def _resolved(path: Path) -> Path:
+    try:
+        return path.expanduser().resolve()
+    except (OSError, RuntimeError, ValueError):
+        return path
+
+
+def _bounded(members: list[dict[str, Any]], limit: int | None) -> list[dict[str, Any]]:
+    if limit is None:
+        return members
+    if limit < 1:
+        return []
+    return members[-limit:]
+
+
+def _normalized(value: str) -> str:
+    return " ".join(value.strip().lower().split())
+
+
+def _as_utc(value: datetime) -> datetime:
+    if not isinstance(value, datetime):
+        raise ValueError("now must be a datetime")
+    return value.replace(tzinfo=timezone.utc) if value.tzinfo is None else value.astimezone(timezone.utc)
+
+
+def _stamp(value: datetime) -> str:
+    return _as_utc(value).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse_stamp(value: str) -> datetime | None:
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return _as_utc(datetime.fromisoformat(text.replace("Z", "+00:00")))
+    except ValueError:
+        pass
+    for pattern in ("%Y-%m-%dT%H%M%S%fZ", "%Y%m%dT%H%M%S%fZ", "%Y%m%dT%H%M%SZ"):
+        try:
+            return _as_utc(datetime.strptime(text, pattern))
+        except ValueError:
+            continue
+    return None
+
+
+def _reference_errors(reference: Any) -> list[str]:
+    if not isinstance(reference, dict):
+        return ["reference must be an object"]
+    errors = _key_set_errors(reference, GENERATED_ARTIFACT_REFERENCE_KEYS, "reference")
+    if reference.get("schema_version") != GENERATED_ARTIFACT_REFERENCE_SCHEMA_VERSION:
+        errors.append(f"schema_version must be {GENERATED_ARTIFACT_REFERENCE_SCHEMA_VERSION}")
+    if reference.get("ref_kind") not in GENERATED_ARTIFACT_REFERENCE_KINDS:
+        errors.append("ref_kind is unsupported")
+    if reference.get("matched_on") not in GENERATED_ARTIFACT_REFERENCE_MATCHES:
+        errors.append("matched_on is unsupported")
+    if not str(reference.get("ref_path", "")).strip():
+        errors.append("ref_path must not be empty")
+    return errors
+
+
+def _key_set_errors(payload: Any, expected: tuple[str, ...], label: str) -> list[str]:
+    if not isinstance(payload, dict):
+        return [f"{label} must be an object"]
+    errors: list[str] = []
+    missing = sorted(set(expected) - set(payload))
+    if missing:
+        errors.append(f"{label} is missing keys: {', '.join(missing)}")
+    unexpected = sorted(set(payload) - set(expected))
+    if unexpected:
+        errors.append(f"{label} has unexpected keys: {', '.join(unexpected)}")
+    return errors

--- a/src/workflows/approval_receipts.py
+++ b/src/workflows/approval_receipts.py
@@ -51,11 +51,12 @@ reasons. A stored `expires_at` is a second independently writable field: a
 hand-edited store widens the window by editing one number, while a window that
 lives in `APPROVAL_TTL_SECONDS` here cannot be widened by anything on disk. And
 the honest reason -- the `storage_retention` boundary of
-`handoff_safety_contract/v1` is `declared_not_enforced` (blocked by #835)
-because no retention or cleanup exists for run artifacts. Nothing deletes an
-approval receipt. Claiming an approval "expires" on disk would be a lie about a
-file that outlives every window it names, so expiry is a property every reader
-recomputes and never a property the artifact has.
+`handoff_safety_contract/v1` is still `declared_not_enforced`. #835 made
+artifact lifecycle readable, but its cleanup preview is a dry run and this store
+is not even one of the families it projects, so nothing deletes an approval
+receipt. Claiming an approval "expires" on disk would be a lie about a file that
+outlives every window it names, so expiry is a property every reader recomputes
+and never a property the artifact has.
 
 A decision stamped in the future is not fresh either. It cannot be shown to be
 older than zero seconds, so it is refused rather than clamped, which is the

--- a/tests/test_generated_artifact_cleanup.py
+++ b/tests/test_generated_artifact_cleanup.py
@@ -1,0 +1,804 @@
+"""Contracts for `generated_artifact/v1` and its cleanup preview (issue #835).
+
+Three acceptance criteria and one structural guard:
+
+    AC1  the current and the superseded revision are identifiable, per kind
+    AC2  every listed artifact says in words why it got the verdict it got
+    AC3  a current, a referenced, and an in-retention artifact are each absent
+         from the eligible set -- three separate tests, because they are three
+         separate ways to lose an artifact somebody still needs
+    GUARD  the module has no deletion path at all
+
+The failure this whole family exists to prevent is a cleanup list that names the
+artifact a live handoff points at. Every AC3 test is written so that removing
+the guard it covers makes it fail while the other two stay green.
+"""
+
+from __future__ import annotations
+
+import ast
+import copy
+import importlib
+import inspect
+import json
+import textwrap
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+from omh.commands import runtime as runtime_command  # noqa: E402
+from omh.commands.main import build_parser  # noqa: E402
+from omh.local_store import atomic_write_text  # noqa: E402
+from omh.paths import project_artifact_dir, resolve_paths  # noqa: E402
+from omh.runtime import generated_artifacts as generated_artifacts_module  # noqa: E402
+from omh.runtime.generated_artifacts import (  # noqa: E402
+    CLEANUP_PREVIEW_CLAIM_BOUNDARY,
+    DEFAULT_RETENTION_DAYS,
+    GENERATED_ARTIFACT_CLEANUP_PREVIEW_SCHEMA_VERSION,
+    GENERATED_ARTIFACT_KINDS,
+    GENERATED_ARTIFACT_PRODUCERS,
+    GENERATED_ARTIFACT_SCHEMA_VERSION,
+    build_generated_artifact_cleanup_preview,
+    project_generated_artifacts,
+    render_generated_artifact_cleanup_preview_text,
+    validate_generated_artifact,
+    validate_generated_artifact_cleanup_preview,
+)
+from omh.workflows.hermes_planning import (  # noqa: E402
+    build_hermes_plan_payload,
+    read_hermes_plan_artifact,
+    write_hermes_plan,
+    write_plan_handoff_context_pack,
+)
+from omh.workflows.operations import build_operation_artifact, write_operation_artifact  # noqa: E402
+from omh.workflows.plan_variants import build_plan_variant, write_plan_variant  # noqa: E402
+from omh.workflows.skill_draft import build_skill_draft, write_skill_draft  # noqa: E402
+
+
+PLAN_TASK = "implement the coding delegation flow with tests"
+VARIANT_PARENT_TASK = "refactor the runtime observation journal and add tests"
+
+# Creation stamps, four days apart, both far enough in the past that a 30-day
+# window can be shown either open or closed by moving `now` alone.
+OLD_STAMP = "2026-01-01T000000000000Z"
+NEW_STAMP = "2026-01-05T000000000000Z"
+OLD_ISO = "2026-01-01T00:00:00Z"
+NEW_ISO = "2026-01-05T00:00:00Z"
+
+# Inside the older artifact's 30-day window (which closes 2026-01-31).
+NOW_INSIDE_RETENTION = datetime(2026, 1, 10, tzinfo=timezone.utc)
+# Well past it.
+NOW_AFTER_RETENTION = datetime(2026, 3, 1, tzinfo=timezone.utc)
+
+TEACH_REQUEST = "turn this into a skill: our release smoke checklist, run after every tag"
+
+OWNER_DELTA = {
+    "dimension": "coding_owner",
+    "label": "selected executor",
+    "parent_value": "codex",
+    "variant_value": "claude-code",
+}
+SCOPE_DELTA = {
+    "dimension": "scope",
+    "label": "docs",
+    "parent_value": "ship docs in the same PR",
+    "variant_value": "defer docs to a follow-up",
+}
+
+# The calls a dry-run preview must never contain. Matched on the callee name
+# through the AST rather than by grepping the text, so the module's own prose
+# about not deleting anything cannot trip the gate and a call hidden behind an
+# alias cannot slip past it.
+FORBIDDEN_CALLS = frozenset(
+    {
+        "unlink",
+        "remove",
+        "removedirs",
+        "rmdir",
+        "rmtree",
+        "write_text",
+        "write_bytes",
+        "touch",
+        "mkdir",
+        "atomic_write_text",
+        "atomic_write_json",
+        "ensure_dir",
+        "ensure_file",
+        "chmod",
+    }
+)
+FORBIDDEN_IMPORTS = frozenset({"os", "shutil"})
+
+
+def _paths(tmp: str):
+    return resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+
+
+def _artifacts_parser():
+    """The real `omh runtime artifacts` subparser, as the CLI builds it."""
+    runtime = build_parser()._subparsers._group_actions[0].choices["runtime"]  # type: ignore[union-attr]
+    return runtime._subparsers._group_actions[0].choices["artifacts"]  # type: ignore[union-attr]
+
+
+def _plan_text(task: str, status: str) -> str:
+    return "\n".join(
+        [
+            "---",
+            "schema_version: hermes_plan/v1",
+            f"status: {status}",
+            "source: generic",
+            "---",
+            "",
+            f"# Hermes Plan: {task}",
+            "",
+            "## Task Statement",
+            "",
+            task,
+            "",
+        ]
+    )
+
+
+def _write_plan(paths, *, stamp: str, token: str, task: str = PLAN_TASK, status: str = "draft") -> Path:
+    """One plan artifact with a caller-chosen creation stamp.
+
+    Written through `atomic_write_text` rather than `Path.write_text`: the bytes
+    are hashed by the projection, and a host that translated the newlines would
+    produce a different digest for the same fixture.
+    """
+    path = project_artifact_dir(paths, "plans") / f"{stamp}-delegation-flow-{token}.md"
+    atomic_write_text(path, _plan_text(task, status), private=True)
+    return path
+
+
+def _write_operation(paths, created_at: str) -> dict[str, Any]:
+    return write_operation_artifact(
+        paths,
+        build_operation_artifact(
+            surface="report-package",
+            kind="weekly-report",
+            title="Delegation weekly status",
+            summary="Weekly status for the delegation lane.",
+            source="local run ledger",
+            created_at=created_at,
+        ),
+    )
+
+
+def _write_skill_draft(paths, *, created_at: str, instruction: str) -> dict[str, Any]:
+    draft = build_skill_draft(
+        TEACH_REQUEST,
+        source_runs=["run-alpha", "run-beta"],
+        proposed_skill_name="release-smoke-check",
+        fixed_instructions=["Read the release checklist.", instruction],
+        declared_inputs=[
+            {"name": "release_tag", "description": "The tag under test."},
+            {"name": "target_host", "description": "Host the smoke suite runs against."},
+        ],
+        preconditions=["A tagged release candidate exists."],
+        stop_conditions=["Stop when the smoke suite fails twice in a row."],
+        verification_steps=["PYTHONPATH=tests uv run python -m unittest discover -s tests"],
+        created_at=created_at,
+    )
+    assert draft is not None
+    return write_skill_draft(paths, draft)
+
+
+def _write_plan_variants(paths) -> tuple[str, str]:
+    parent_path = _write_plan(
+        paths, stamp="2025-12-01T000000000000Z", token="parent", task=VARIANT_PARENT_TASK, status="accepted"
+    )
+    parent = read_hermes_plan_artifact(parent_path)
+    older = write_plan_variant(
+        paths,
+        build_plan_variant(parent_artifact=parent, name="claude-code owner", deltas=[OWNER_DELTA], created_at=OLD_ISO),
+    )
+    newer = write_plan_variant(
+        paths,
+        build_plan_variant(
+            parent_artifact=parent,
+            name="claude-code owner",
+            deltas=[OWNER_DELTA, SCOPE_DELTA],
+            created_at=NEW_ISO,
+        ),
+    )
+    return str(older["variant_id"]), str(newer["variant_id"])
+
+
+def _two_revisions_of_every_kind(paths) -> dict[str, tuple[str, str]]:
+    """One store holding an older and a newer revision of each supported kind."""
+    old_plan = _write_plan(paths, stamp=OLD_STAMP, token="aaa111")
+    new_plan = _write_plan(paths, stamp=NEW_STAMP, token="bbb222")
+    old_operation = _write_operation(paths, OLD_ISO)
+    new_operation = _write_operation(paths, NEW_ISO)
+    old_draft = _write_skill_draft(paths, created_at=OLD_ISO, instruction="Run the smoke suite against the tag.")
+    new_draft = _write_skill_draft(
+        paths, created_at=NEW_ISO, instruction="Run the smoke suite against the tag, then diff the report."
+    )
+    old_variant, new_variant = _write_plan_variants(paths)
+    return {
+        "hermes_plan": (old_plan.stem, new_plan.stem),
+        "operation_artifact": (str(old_operation["artifact_id"]), str(new_operation["artifact_id"])),
+        "plan_variant": (old_variant, new_variant),
+        "skill_draft": (str(old_draft["draft_id"]), str(new_draft["draft_id"])),
+    }
+
+
+def _by_id(records: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    return {str(record["artifact_id"]): record for record in records}
+
+
+class CurrentAndSupersededRevisionTests(unittest.TestCase):
+    """AC1: for every supported kind, which revision is current is answerable."""
+
+    def test_every_supported_kind_names_its_current_and_superseded_revision(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            expected = _two_revisions_of_every_kind(paths)
+            records = _by_id(project_generated_artifacts(paths, now=NOW_AFTER_RETENTION))
+
+            self.assertEqual(sorted(expected), sorted(GENERATED_ARTIFACT_KINDS))
+            for kind, (older_id, newer_id) in expected.items():
+                with self.subTest(artifact_kind=kind):
+                    older = records[older_id]
+                    newer = records[newer_id]
+                    self.assertEqual(older["artifact_kind"], kind)
+                    self.assertEqual(newer["artifact_kind"], kind)
+                    # Two revisions of one thing, not two unrelated artifacts.
+                    self.assertEqual(older["revision_line"], newer["revision_line"])
+                    self.assertEqual((older["revision_index"], newer["revision_index"]), (1, 2))
+                    self.assertEqual(older["revision_count"], 2)
+                    self.assertEqual(older["lifecycle"], "superseded")
+                    self.assertEqual(newer["lifecycle"], "current")
+                    # The replacement relationship is named in both directions.
+                    self.assertEqual(older["replaced_by"], newer_id)
+                    self.assertEqual(newer["replaces"], older_id)
+                    self.assertEqual(newer["replaced_by"], "")
+
+    def test_every_projected_record_carries_provenance_a_reader_can_follow(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            _two_revisions_of_every_kind(paths)
+            for record in project_generated_artifacts(paths, now=NOW_AFTER_RETENTION):
+                with self.subTest(artifact_id=record["artifact_id"]):
+                    self.assertEqual(record["schema_version"], GENERATED_ARTIFACT_SCHEMA_VERSION)
+                    self.assertEqual(validate_generated_artifact(record), [])
+                    self.assertTrue(Path(str(record["path"])).is_file())
+                    self.assertEqual(len(str(record["content_digest"])), 64)
+                    self.assertEqual(record["producer"], GENERATED_ARTIFACT_PRODUCERS[record["artifact_kind"]])
+                    self.assertTrue(str(record["created_at"]).endswith("Z"))
+                    self.assertTrue(str(record["retention_reason"]).strip())
+
+    def test_a_plan_the_producer_already_marked_superseded_is_never_current(self) -> None:
+        """The producer's own word wins even when nothing newer sits beside it."""
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            _write_plan(paths, stamp=OLD_STAMP, token="aaa111", status="superseded")
+
+            record = project_generated_artifacts(paths, now=NOW_AFTER_RETENTION)[0]
+
+            self.assertEqual(record["declared_status"], "superseded")
+            self.assertEqual(record["lifecycle"], "superseded")
+
+    def test_a_line_with_no_distinct_creation_times_keeps_every_member_current(self) -> None:
+        """Fail closed: unorderable revisions are never called superseded."""
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            _write_plan(paths, stamp=OLD_STAMP, token="aaa111")
+            _write_plan(paths, stamp=OLD_STAMP, token="bbb222")
+
+            records = project_generated_artifacts(paths, now=NOW_AFTER_RETENTION)
+
+            self.assertEqual(len(records), 2)
+            for record in records:
+                with self.subTest(artifact_id=record["artifact_id"]):
+                    self.assertEqual(record["lifecycle"], "current")
+                    self.assertFalse(record["cleanup_eligible"])
+                    self.assertIn("do not carry", record["cleanup_reason"])
+
+    def test_the_plan_writer_still_produces_a_filename_this_projection_can_date(self) -> None:
+        """The one coupling this module has to a producer, pinned.
+
+        Plan creation time lives only in the filename `write_hermes_plan`
+        chooses. If that format moves, every plan silently loses its creation
+        time and no plan can ever be shown out of retention -- safe, but the
+        feature would quietly stop working. This fails instead.
+        """
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            write_hermes_plan(paths, build_hermes_plan_payload(PLAN_TASK))
+
+            record = project_generated_artifacts(paths, now=NOW_AFTER_RETENTION)[0]
+
+            self.assertTrue(record["created_at"], "the plan filename no longer carries a readable stamp")
+            self.assertTrue(record["retention_expires_at"])
+
+
+class CleanupPreviewExplainsEveryEntryTests(unittest.TestCase):
+    """AC2: nothing is listed without a reason a person can read."""
+
+    def test_every_previewed_artifact_explains_its_verdict_in_words(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            _two_revisions_of_every_kind(paths)
+
+            preview = build_generated_artifact_cleanup_preview(paths, now=NOW_AFTER_RETENTION)
+
+            self.assertEqual(validate_generated_artifact_cleanup_preview(preview), [])
+            self.assertEqual(preview["schema_version"], GENERATED_ARTIFACT_CLEANUP_PREVIEW_SCHEMA_VERSION)
+            self.assertTrue(preview["eligible"], "the fixture is supposed to produce an eligible artifact")
+            self.assertTrue(preview["retained"])
+            for group in ("eligible", "retained"):
+                for record in preview[group]:
+                    with self.subTest(group=group, artifact_id=record["artifact_id"]):
+                        reason = str(record["cleanup_reason"])
+                        self.assertTrue(reason.strip())
+                        self.assertTrue(reason.startswith("Eligible: " if group == "eligible" else "Kept: "))
+            for record in preview["eligible"]:
+                with self.subTest(artifact_id=record["artifact_id"]):
+                    # The eligible sentence names all three conditions that had
+                    # to hold, so the reader can check the projection's work.
+                    reason = str(record["cleanup_reason"])
+                    self.assertIn("superseded by", reason)
+                    self.assertIn("no local artifact references it", reason)
+                    self.assertIn("retention window ended", reason)
+
+    def test_an_entry_with_no_eligibility_reason_fails_validation(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            _two_revisions_of_every_kind(paths)
+            preview = build_generated_artifact_cleanup_preview(paths, now=NOW_AFTER_RETENTION)
+
+            damaged = copy.deepcopy(preview)
+            damaged["eligible"][0]["cleanup_reason"] = ""
+
+            self.assertEqual(validate_generated_artifact(preview["eligible"][0]), [])
+            self.assertIn(
+                "cleanup_reason must explain the verdict in words",
+                validate_generated_artifact(damaged["eligible"][0]),
+            )
+            errors = validate_generated_artifact_cleanup_preview(damaged)
+            self.assertTrue(
+                any("cleanup_reason must explain the verdict in words" in error for error in errors), errors
+            )
+
+    def test_the_preview_says_which_kinds_it_cannot_answer_for(self) -> None:
+        """A kind left out is a stated boundary, never a silent omission."""
+        with TemporaryDirectory() as tmp:
+            preview = build_generated_artifact_cleanup_preview(_paths(tmp), now=NOW_AFTER_RETENTION)
+
+            unsupported = {str(row["artifact_kind"]): str(row["reason"]) for row in preview["unsupported_kinds"]}
+            self.assertEqual(sorted(unsupported), ["handoff_context_pack", "role_context_pack"])
+            for kind, reason in unsupported.items():
+                with self.subTest(artifact_kind=kind):
+                    self.assertTrue(reason.strip())
+                    self.assertNotIn(kind, GENERATED_ARTIFACT_KINDS)
+
+
+class CurrentArtifactIsNeverEligibleTests(unittest.TestCase):
+    """AC3, first way to lose something: listing the revision still in use."""
+
+    def test_the_current_revision_is_absent_from_the_eligible_set(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            old_plan = _write_plan(paths, stamp=OLD_STAMP, token="aaa111")
+            new_plan = _write_plan(paths, stamp=NEW_STAMP, token="bbb222")
+
+            preview = build_generated_artifact_cleanup_preview(paths, now=NOW_AFTER_RETENTION)
+            eligible = {str(record["artifact_id"]) for record in preview["eligible"]}
+            retained = _by_id(preview["retained"])
+
+            self.assertNotIn(new_plan.stem, eligible)
+            self.assertIn(old_plan.stem, eligible)
+            self.assertEqual(retained[new_plan.stem]["lifecycle"], "current")
+            self.assertIn("this is the current revision", retained[new_plan.stem]["cleanup_reason"])
+
+    def test_a_sole_artifact_with_nothing_to_replace_it_is_never_eligible(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            only = _write_plan(paths, stamp=OLD_STAMP, token="aaa111")
+
+            preview = build_generated_artifact_cleanup_preview(paths, now=NOW_AFTER_RETENTION)
+
+            self.assertEqual(preview["eligible"], [])
+            self.assertEqual([record["artifact_id"] for record in preview["retained"]], [only.stem])
+
+
+class ReferencedArtifactIsNeverEligibleTests(unittest.TestCase):
+    """AC3, second way: listing an artifact a live handoff still points at."""
+
+    def test_a_superseded_plan_a_handoff_pack_pins_is_absent_from_the_eligible_set(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            old_plan = _write_plan(paths, stamp=OLD_STAMP, token="aaa111")
+            _write_plan(paths, stamp=NEW_STAMP, token="bbb222")
+
+            # Without a pin the old plan is eligible; this is the control that
+            # makes the assertion below about the pin and not about the fixture.
+            before = build_generated_artifact_cleanup_preview(paths, now=NOW_AFTER_RETENTION)
+            self.assertIn(old_plan.stem, {str(record["artifact_id"]) for record in before["eligible"]})
+
+            write_plan_handoff_context_pack(paths, read_hermes_plan_artifact(old_plan))
+
+            after = build_generated_artifact_cleanup_preview(paths, now=NOW_AFTER_RETENTION)
+            eligible = {str(record["artifact_id"]) for record in after["eligible"]}
+            retained = _by_id(after["retained"])
+
+            self.assertNotIn(old_plan.stem, eligible)
+            pinned = retained[old_plan.stem]
+            self.assertEqual(pinned["lifecycle"], "superseded")
+            self.assertEqual(pinned["reference_count"], len(pinned["referenced_by"]))
+            self.assertGreaterEqual(pinned["reference_count"], 1)
+            self.assertEqual(
+                {str(reference["ref_kind"]) for reference in pinned["referenced_by"]},
+                {"handoff_context_pack"},
+            )
+            self.assertIn("still point at it", pinned["cleanup_reason"])
+            self.assertIn("handoff_context_pack", pinned["cleanup_reason"])
+
+    def test_a_variant_pinning_its_parent_plan_keeps_that_plan_off_the_eligible_set(self) -> None:
+        """A second, independent reference family, matched on a different field."""
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            parent_path = _write_plan(
+                paths, stamp=OLD_STAMP, token="parent", task=VARIANT_PARENT_TASK, status="accepted"
+            )
+            # A different status, so the two revisions are not byte-identical and
+            # the parent's digest is unambiguous -- otherwise the digest half of
+            # the assertion below would be dropped for the reason the next test
+            # covers, and this test would silently stop exercising it.
+            _write_plan(paths, stamp=NEW_STAMP, token="newer", task=VARIANT_PARENT_TASK, status="revised")
+            write_plan_variant(
+                paths,
+                build_plan_variant(
+                    parent_artifact=read_hermes_plan_artifact(parent_path),
+                    name="claude-code owner",
+                    deltas=[OWNER_DELTA],
+                    created_at=OLD_ISO,
+                ),
+            )
+
+            preview = build_generated_artifact_cleanup_preview(paths, now=NOW_AFTER_RETENTION)
+            retained = _by_id(preview["retained"])
+
+            self.assertNotIn(parent_path.stem, {str(record["artifact_id"]) for record in preview["eligible"]})
+            pinned = retained[parent_path.stem]
+            self.assertEqual(
+                {str(reference["ref_kind"]) for reference in pinned["referenced_by"]}, {"plan_variant"}
+            )
+            # Both the path and the digest the variant recorded are matched, so
+            # a rename on either side alone cannot silently drop the reference.
+            self.assertEqual(
+                {str(reference["matched_on"]) for reference in pinned["referenced_by"]},
+                {"path", "content_digest"},
+            )
+
+    def test_a_digest_shared_by_several_revisions_is_not_a_reference_key(self) -> None:
+        """Re-planning one task writes byte-identical files; a shared digest names none of them.
+
+        The pin still holds the file it actually meant, by path. Without this
+        rule the pack's digest would be credited to all three revisions, every
+        duplicate would be kept forever, and each one would print a reason
+        pointing at a sibling's pin.
+        """
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            oldest = _write_plan(paths, stamp=OLD_STAMP, token="aaa111")
+            middle = _write_plan(paths, stamp=NEW_STAMP, token="bbb222")
+            newest = _write_plan(paths, stamp="2026-02-01T000000000000Z", token="ccc333")
+            digests = {read_hermes_plan_artifact(path)["sha256"] for path in (oldest, middle, newest)}
+            self.assertEqual(len(digests), 1, "the fixture must produce byte-identical revisions")
+
+            write_plan_handoff_context_pack(paths, read_hermes_plan_artifact(middle))
+
+            preview = build_generated_artifact_cleanup_preview(paths, now=NOW_AFTER_RETENTION)
+            eligible = _by_id(preview["eligible"])
+            retained = _by_id(preview["retained"])
+
+            # The pinned revision is held by its path match, and only it.
+            self.assertEqual(
+                {str(reference["matched_on"]) for reference in retained[middle.stem]["referenced_by"]}, {"path"}
+            )
+            self.assertIn(oldest.stem, eligible)
+            self.assertEqual(eligible[oldest.stem]["referenced_by"], [])
+            self.assertEqual(retained[newest.stem]["lifecycle"], "current")
+
+    def test_an_artifact_that_only_names_itself_is_not_treated_as_referenced(self) -> None:
+        """Self-reference is not reference; otherwise nothing is ever eligible."""
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            older = _write_operation(paths, OLD_ISO)
+            _write_operation(paths, NEW_ISO)
+
+            preview = build_generated_artifact_cleanup_preview(paths, now=NOW_AFTER_RETENTION)
+            eligible = _by_id(preview["eligible"])
+
+            self.assertIn(str(older["artifact_id"]), eligible)
+            self.assertEqual(eligible[str(older["artifact_id"])]["referenced_by"], [])
+
+
+class RetainedArtifactIsNeverEligibleTests(unittest.TestCase):
+    """AC3, third way: listing an artifact whose retention window is still open."""
+
+    def test_a_superseded_artifact_inside_its_retention_window_is_absent_from_the_eligible_set(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            old_plan = _write_plan(paths, stamp=OLD_STAMP, token="aaa111")
+            _write_plan(paths, stamp=NEW_STAMP, token="bbb222")
+
+            inside = build_generated_artifact_cleanup_preview(paths, now=NOW_INSIDE_RETENTION)
+            retained = _by_id(inside["retained"])
+
+            self.assertEqual(inside["eligible"], [])
+            held = retained[old_plan.stem]
+            self.assertEqual(held["lifecycle"], "superseded")
+            self.assertEqual(held["reference_count"], 0)
+            self.assertEqual(held["retention_days"], DEFAULT_RETENTION_DAYS)
+            self.assertEqual(held["retention_expires_at"], "2026-01-31T00:00:00Z")
+            self.assertIn("retention window until 2026-01-31T00:00:00Z", held["cleanup_reason"])
+
+            # Same store, same artifact, only the clock moved.
+            after = build_generated_artifact_cleanup_preview(paths, now=NOW_AFTER_RETENTION)
+            self.assertIn(old_plan.stem, {str(record["artifact_id"]) for record in after["eligible"]})
+
+    def test_a_shorter_window_moves_the_boundary_and_nothing_else(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            old_plan = _write_plan(paths, stamp=OLD_STAMP, token="aaa111")
+            _write_plan(paths, stamp=NEW_STAMP, token="bbb222")
+
+            preview = build_generated_artifact_cleanup_preview(
+                paths, now=NOW_INSIDE_RETENTION, retention_days=5
+            )
+            eligible = _by_id(preview["eligible"])
+
+            self.assertIn(old_plan.stem, eligible)
+            self.assertEqual(eligible[old_plan.stem]["retention_expires_at"], "2026-01-06T00:00:00Z")
+
+    def test_an_artifact_with_no_readable_creation_time_is_kept(self) -> None:
+        """No creation time means no window, and no window means never eligible."""
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            undated = project_artifact_dir(paths, "plans") / "undated-plan.md"
+            atomic_write_text(undated, _plan_text(PLAN_TASK, "draft"), private=True)
+            _write_plan(paths, stamp=NEW_STAMP, token="bbb222")
+
+            preview = build_generated_artifact_cleanup_preview(paths, now=NOW_AFTER_RETENTION)
+            retained = _by_id(preview["retained"])
+
+            self.assertEqual(preview["eligible"], [])
+            held = retained["undated-plan"]
+            self.assertEqual(held["created_at"], "")
+            self.assertEqual(held["retention_expires_at"], "")
+            self.assertIn("cannot be evaluated", held["retention_reason"])
+
+    def test_the_validator_refuses_an_eligible_verdict_on_an_unsafe_artifact(self) -> None:
+        """AC3 as a contract rule, not only as a computation.
+
+        The projection is one code path; a record can also arrive from a
+        transport or a hand edit. Each of the three guards is checked
+        independently so a single blanket rule cannot stand in for all of them.
+        """
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            _write_plan(paths, stamp=OLD_STAMP, token="aaa111")
+            _write_plan(paths, stamp=NEW_STAMP, token="bbb222")
+            eligible = build_generated_artifact_cleanup_preview(paths, now=NOW_AFTER_RETENTION)["eligible"][0]
+
+            for mutation, expected in (
+                ({"lifecycle": "current"}, "a current artifact must never be cleanup_eligible"),
+                (
+                    {
+                        "referenced_by": [
+                            {
+                                "schema_version": "generated_artifact_reference/v1",
+                                "ref_kind": "coding_delegation",
+                                "ref_path": "/tmp/run/coding_delegation.json",
+                                "matched_on": "path",
+                            }
+                        ],
+                        "reference_count": 1,
+                    },
+                    "a referenced artifact must never be cleanup_eligible",
+                ),
+                (
+                    {"retention_expires_at": ""},
+                    "an artifact with no evaluated retention window must never be cleanup_eligible",
+                ),
+            ):
+                with self.subTest(expected=expected):
+                    self.assertIn(expected, validate_generated_artifact({**eligible, **mutation}))
+
+
+class NoDeletionPathTests(unittest.TestCase):
+    """The guard that makes "dry run" structural instead of a promise."""
+
+    def test_the_projection_module_contains_no_deletion_or_write_call(self) -> None:
+        source = Path(inspect.getsourcefile(generated_artifacts_module) or "").read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        called = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                function = node.func
+                if isinstance(function, ast.Attribute):
+                    called.add(function.attr)
+                elif isinstance(function, ast.Name):
+                    called.add(function.id)
+        self.assertEqual(sorted(called & FORBIDDEN_CALLS), [])
+
+        imported = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module.split(".")[0])
+                imported.update(alias.name for alias in node.names)
+        self.assertEqual(sorted(imported & FORBIDDEN_IMPORTS), [])
+
+    def test_the_cli_command_neither_removes_anything_nor_offers_to(self) -> None:
+        source = textwrap.dedent(inspect.getsource(runtime_command.cmd_runtime_artifacts))
+        for node in ast.walk(ast.parse(source)):
+            if isinstance(node, ast.Call):
+                function = node.func
+                name = function.attr if isinstance(function, ast.Attribute) else getattr(function, "id", "")
+                self.assertNotIn(name, FORBIDDEN_CALLS)
+
+        # The flags an operator could reach are the other half: a command that
+        # removes nothing today but advertises `--delete` is one commit away
+        # from being the thing this issue said not to build.
+        flags = set()
+        for action in _artifacts_parser()._actions:
+            flags.update(action.option_strings)
+        self.assertEqual(flags & {"--delete", "--remove", "--prune", "--confirm", "--force", "--yes"}, set())
+        self.assertEqual(sorted(flags), ["--all", "--help", "--json", "--limit", "--retention-days", "-h"])
+
+    def test_a_preview_leaves_every_artifact_byte_identical(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            _two_revisions_of_every_kind(paths)
+            root = Path(tmp)
+            before = {
+                str(path.relative_to(root)): path.read_bytes()
+                for path in sorted(root.rglob("*"))
+                if path.is_file()
+            }
+
+            preview = build_generated_artifact_cleanup_preview(paths, now=NOW_AFTER_RETENTION)
+            self.assertTrue(preview["eligible"])
+
+            after = {
+                str(path.relative_to(root)): path.read_bytes()
+                for path in sorted(root.rglob("*"))
+                if path.is_file()
+            }
+            self.assertEqual(after, before)
+
+    def test_the_preview_declares_itself_a_dry_run(self) -> None:
+        with TemporaryDirectory() as tmp:
+            preview = build_generated_artifact_cleanup_preview(_paths(tmp), now=NOW_AFTER_RETENTION)
+
+            self.assertIs(preview["dry_run"], True)
+            self.assertEqual(preview["claim_boundary"], CLEANUP_PREVIEW_CLAIM_BOUNDARY)
+            self.assertIn("deletes nothing", preview["claim_boundary"])
+            self.assertIn("OMH does not remove them", preview["next_action"])
+            damaged = {**preview, "dry_run": False}
+            self.assertIn(
+                "dry_run must be True; this preview never removes anything",
+                validate_generated_artifact_cleanup_preview(damaged),
+            )
+
+
+class ProvenanceAndDeterminismTests(unittest.TestCase):
+    def test_every_named_producer_resolves_to_a_real_symbol(self) -> None:
+        """The check that stops the provenance table drifting into fiction."""
+        for kind, symbol in sorted(GENERATED_ARTIFACT_PRODUCERS.items()):
+            with self.subTest(artifact_kind=kind):
+                module_name, _, attribute = symbol.rpartition(".")
+                self.assertTrue(module_name.startswith("omh."), symbol)
+                self.assertTrue(hasattr(importlib.import_module(module_name), attribute), f"{symbol} is gone")
+        self.assertEqual(sorted(GENERATED_ARTIFACT_PRODUCERS), sorted(GENERATED_ARTIFACT_KINDS))
+
+    def test_the_same_store_and_the_same_stamp_answer_identically(self) -> None:
+        """`now` is a parameter, so nothing here moves between two calls."""
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            _two_revisions_of_every_kind(paths)
+
+            first = build_generated_artifact_cleanup_preview(paths, now=NOW_AFTER_RETENTION)
+            second = build_generated_artifact_cleanup_preview(paths, now=NOW_AFTER_RETENTION)
+
+            self.assertEqual(first, second)
+            self.assertEqual(first["evaluated_at"], "2026-03-01T00:00:00Z")
+
+    def test_a_naive_stamp_is_read_as_utc_rather_than_refused(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            _write_plan(paths, stamp=OLD_STAMP, token="aaa111")
+
+            naive = build_generated_artifact_cleanup_preview(paths, now=datetime(2026, 3, 1))
+            aware = build_generated_artifact_cleanup_preview(paths, now=NOW_AFTER_RETENTION)
+
+            self.assertEqual(naive, aware)
+
+    def test_a_non_positive_retention_window_is_refused(self) -> None:
+        with TemporaryDirectory() as tmp:
+            with self.assertRaises(ValueError):
+                project_generated_artifacts(_paths(tmp), now=NOW_AFTER_RETENTION, retention_days=0)
+
+
+class CleanupPreviewCommandTests(unittest.TestCase):
+    def test_the_command_renders_plain_text_by_default(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            old_plan = _write_plan(paths, stamp=OLD_STAMP, token="aaa111")
+            new_plan = _write_plan(paths, stamp=NEW_STAMP, token="bbb222")
+
+            status, stdout, _ = run_cli(
+                [
+                    "--omh-home",
+                    str(paths.omh_home),
+                    "--hermes-home",
+                    str(paths.hermes_home),
+                    "runtime",
+                    "artifacts",
+                ],
+                output_json=False,
+            )
+
+            self.assertEqual(status, 0)
+            self.assertIn("Generated artifacts", stdout)
+            self.assertIn("Safe to remove", stdout)
+            self.assertIn(old_plan.stem, stdout)
+            self.assertIn(new_plan.stem, stdout)
+            self.assertIn("dry run", stdout)
+
+    def test_the_command_emits_a_payload_that_passes_its_own_validator(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            _write_plan(paths, stamp=OLD_STAMP, token="aaa111")
+            _write_plan(paths, stamp=NEW_STAMP, token="bbb222")
+
+            status, stdout, _ = run_cli(
+                [
+                    "--omh-home",
+                    str(paths.omh_home),
+                    "--hermes-home",
+                    str(paths.hermes_home),
+                    "runtime",
+                    "artifacts",
+                    "--retention-days",
+                    "1",
+                    "--json",
+                ]
+            )
+
+            payload = json.loads(stdout)
+            self.assertEqual(status, 0)
+            self.assertEqual(validate_generated_artifact_cleanup_preview(payload), [])
+            self.assertEqual(payload["retention_days"], 1)
+            self.assertEqual(payload["artifact_count"], 2)
+            self.assertEqual(payload["eligible_count"], 1)
+
+    def test_the_rendered_text_names_a_reason_for_every_listed_artifact(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            _two_revisions_of_every_kind(paths)
+            preview = build_generated_artifact_cleanup_preview(paths, now=NOW_AFTER_RETENTION)
+
+            rendered = render_generated_artifact_cleanup_preview_text(preview)
+
+            for record in preview["eligible"] + preview["retained"]:
+                with self.subTest(artifact_id=record["artifact_id"]):
+                    self.assertIn(str(record["artifact_id"]), rendered)
+                    self.assertIn(str(record["cleanup_reason"]), rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_handoff_safety_contract.py
+++ b/tests/test_handoff_safety_contract.py
@@ -126,7 +126,12 @@ _DECLARED_NOT_ENFORCED = {
     # observed start, which orders a chain; nothing makes a chain required of a
     # run, so the claim ladder is unchanged and the row stays declared.
     "start_evidence": "lineage_orders_the_start_but_no_claim_rung_requires_a_lineage_chain",
-    "storage_retention": "#835",
+    # #835 shipped `generated_artifact/v1` and its dry-run cleanup preview, so
+    # this blocker stopped being that issue too. Lifecycle is readable now;
+    # removal is not implemented and is not queued behind a ticket, because that
+    # issue puts cleanup-without-explicit-confirmation out of scope and no
+    # surface here can take a confirmation.
+    "storage_retention": "the_preview_lists_what_could_be_removed_and_no_surface_removes_anything",
     "workspace": "no_omh_side_constraint_can_bind_a_running_executor_process",
 }
 # The three data-boundary rows whose blocker is a *host* fact rather than a
@@ -398,7 +403,15 @@ class AntiDecorationTests(unittest.TestCase):
         # unenforced verdict as "nothing about workspaces is guarded".
         self.assertIn("workspace_binding_guard/v1", workspace)
         self.assertIn("not a state OMH can observe", _boundary(contract, "account_authorization")["statement"])
-        self.assertIn("persist until the operator deletes them", _boundary(contract, "storage_retention")["statement"])
+        # Same shape as the workspace and start_evidence rows: #835 closed the
+        # readable half, so the sentence has to name what now exists *and* keep
+        # stating the gap. Without the second clause a reader takes a preview
+        # that lists removable artifacts for something that removes them.
+        storage_retention = _boundary(contract, "storage_retention")["statement"]
+        self.assertIn("generated_artifact_cleanup_preview/v1", storage_retention)
+        self.assertIn("still does not happen is deletion", storage_retention)
+        self.assertIn("dry run with no removal path", storage_retention)
+        self.assertIn("persist until the operator deletes them", storage_retention)
         # Same shape as the workspace row after #820: #826 closed a half, so the
         # sentence has to name what now exists *and* keep stating the gap, or a
         # reader takes the ordered chain for a required one.


### PR DESCRIPTION
## Feature Report

### What Changed

- New `generated_artifact/v1` projection (`src/runtime/generated_artifacts.py`) that answers, for every locally generated OMH artifact: where it came from, which revision replaced it, why it is being retained, and whether removing it would be safe.
- New `generated_artifact_cleanup_preview/v1` dry-run cleanup list built on top of it. It reports what *could* be removed and removes nothing.
- New `omh runtime artifacts` command rendering that preview as plain text by default, `--json` for the payload, `--retention-days` to move the window, `--limit` / `--all` to bound the scan.
- The `storage_retention` boundary of `handoff_safety_contract/v1` now names the preview that exists and the deletion that still does not, and its `blocked_by` changed from the issue number `#835` to a reason string.

### Why This Exists

Issue #835. OMH writes plans, plan variants, operation reports, and skill drafts into local stores and never takes any of them back. A user looking at four files with similar names had no way to tell which one a prepared handoff still points at, which one was replaced, or which one could go — so nothing ever got cleaned up, or the wrong thing did.

The `storage_retention` row of the safety contract said this out loud (`declared_not_enforced`, blocked by #835): "run artifacts persist until the operator deletes them. No retention window, expiry, or cleanup exists."

### User / Operator Impact

Before: no surface answered "which of these is current?". After, from one command:

```
$ omh runtime artifacts
Generated artifacts (3 found, evaluated at 2026-08-09T06:39:20Z)
  Retention window: 30 days from creation.

Safe to remove (1)
  hermes_plan — superseded — 2026-05-01T000000000000Z-billing-retry-aaa111
    /private/tmp/omh-i835-demo/.omh/plans/2026-05-01T000000000000Z-billing-retry-aaa111.md
    Eligible: superseded by 2026-05-04T000000000000Z-billing-retry-bbb222, no local
    artifact references it, and its 30-day retention window ended at 2026-05-31T00:00:00Z.

Kept (2)
  hermes_plan — superseded — 2026-05-04T000000000000Z-billing-retry-bbb222
    Kept: 1 local artifact(s) still point at it, starting with the handoff_context_pack
    at .../plan-context/2026-05-04T...-billing-retry-bbb222-context-pack.json (matched on path).
  hermes_plan — current — 2026-06-20T000000000000Z-billing-retry-ccc333
    Kept: this is the current revision and nothing has replaced it.
```

The operator still deletes the file themselves. That is deliberate — see Risk.

### How It Works

**A read-side projection, not new producer metadata.** No producing workflow was touched. The revision line, the ordering key, the content digest, and the status word are all derived on read from data the producers already persist, so an artifact written before this change projects exactly like one written after. This was the main scoping decision: threading new supersession metadata through six write paths would have been a much larger change and would have left every already-written artifact unprojectable.

**Four kinds are covered**, each with a revision line (the producer field that says two artifacts are two revisions of one thing) and an ordering key:

| Kind | Store | Revision line | Ordering key |
| --- | --- | --- | --- |
| `hermes_plan` | `plans/` | `task_statement_sha256` | the stamp `write_hermes_plan` puts in the filename |
| `operation_artifact` | `operations/<surface>/` | surface, kind, title | `created_at` |
| `plan_variant` | `plan-variants/` | parent digest and variant name | `created_at` |
| `skill_draft` | `learning/skill-drafts/` | `proposed_skill_name` | `created_at` |

**Two kinds are covered as reference sources only, and the payload says so** in `unsupported_kinds` rather than omitting them silently: a `role_context_pack` is content-addressed and deliberately carries no timestamp and no successor link, so nothing on the record says which of two packs for one scope came second; a plan `handoff_context_pack` is named after the plan it serves and rewritten in place, so one plan never has two revisions of it to compare.

**Ordering fails closed, twice.** A plan the producer already marked `superseded` is superseded whatever its position says. And a revision line whose members do not carry distinct readable creation times keeps *every* member `current`, with a reason saying why — guessing which of two files replaced the other is exactly how a live artifact reaches a cleanup list.

**Eligibility (AC3)** requires all three: superseded, unreferenced, and out of retention. Retention is built through the same `build_retention` the memory lane uses, so there is one retention shape in the tree. `now` is a **required parameter**, read once at the CLI edge, so two calls against the same store and the same stamp answer identically.

**"Referenced" is a real reverse scan**, not a field guess. Every reference-source file (coding delegation records, plan handoff context packs, plan variants, role context packs, operation reports) is read and every string in it collected, then matched against each artifact's resolved path, id, and content digest — so a pin recorded under a key this module has never heard of still counts. Both sides of a path comparison are resolved, never substring-matched.

Three exclusions, each deliberate and documented in code:

1. **Self-reference.** An artifact that stores its own id would otherwise pin itself forever.
2. **Ambiguous digests.** The plan renderer is a pure function of the task statement, so re-planning one task writes byte-identical files. A digest that several artifacts answer to identifies none of them. This was caught by running the command against a real store before shipping: the first implementation credited one pack's digest to all three identical revisions and printed a reason pointing at a sibling's pin. Dropping the ambiguous digest is safe because every artifact pin in this tree that records a digest records the path beside it.
3. **The observation journal.** It is append-only history, so every artifact ever written appears in it. Treating history as a live pin would make the eligible set empty by construction.

**There is no delete path.** Not gated, not flagged — absent. Issue #835 puts cleanup-without-explicit-confirmation out of scope and no OMH surface can take a confirmation, so a preview was the whole deliverable. Two tests enforce this structurally: one walks the module's AST and fails on any `unlink` / `remove` / `rmtree` / write call or `os` / `shutil` import; another pins the exact option list of the `runtime artifacts` parser so `--delete`, `--prune`, `--confirm`, `--force`, `--yes` cannot appear. A third asserts every file under the store is byte-identical before and after a preview.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/runtime/generated_artifacts.py` | New. `generated_artifact/v1`, `generated_artifact_reference/v1`, `generated_artifact_cleanup_preview/v1`, their validators, and the plain-text renderer |
| `src/commands/runtime.py` | New `omh runtime artifacts` command and parser; reads `now` at the process edge |
| `src/coding/action_gate.py` | `storage_retention` statement rewritten; `blocked_by` `#835` → `STORAGE_RETENTION_BLOCKER` reason string |
| `tests/test_generated_artifact_cleanup.py` | New. 29 tests across AC1, AC2, three separate AC3 tests, the no-deletion guard, provenance, determinism, and the CLI |
| `tests/test_handoff_safety_contract.py` | `_DECLARED_NOT_ENFORCED` updated; the pinned `storage_retention` phrases now require the statement to name the preview *and* keep stating the gap |
| `src/workflows/approval_receipts.py` | Module docstring no longer says the boundary is "blocked by #835" |
| `docs/ARCHITECTURE.md` | New "Generated Artifact Lifecycle" section; two `#835` blocker references corrected |

`GENERATED_ARTIFACT_PRODUCERS` names the writer symbol behind each kind, and a test imports every one of them, so provenance cannot drift into fiction as producers move.

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed!
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` — **Ran 4949 tests in 176.886s, OK** (rebased onto `origin/main` at `f9251979` first)
- [x] `uv run python -m compileall -q src tests` — clean
- [x] `uv run python -m omh.cli docs workflows --check` — `ok:true`, tap_skills 115/115, no missing/stale/extra
- [x] `uv run python -m omh.cli docs roles --check` — `ok:true`
- [x] `uv run python -m omh.cli docs capability-families --check` — `ok:true`
- [x] `uv run python -m omh.cli harness validate` — `ok:true`, 72 harnesses / 104 skills, 0 errors, 0 warnings
- [x] `git diff --check` — clean
- [x] `python3 -m omh.cli release checklist --json` — emits the checklist payload, exit 0
- [x] `python3 -m omh.cli release hermes-smoke` — `Status: ok`, plan mode, observed evidence: no
- [x] `omh --help` — exit 0
- [x] `omh --omh-home /tmp/omh-smoke-i835 --hermes-home /tmp/hermes-smoke-i835 release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — exit 0; installed-command smoke `ok` (live, observed); profile smoke stays plan-mode
- [x] Targeted: `tests/test_generated_artifact_cleanup.py` — 29 tests, OK
- [x] Targeted: `tests/test_handoff_safety_contract.py` — 46 tests, OK
- [x] Dry-run command smoke: `omh runtime artifacts` against an empty store and against a populated store holding three plan revisions plus a handoff context pack (output quoted above). The populated run is what surfaced the ambiguous-digest defect.
- [ ] Workflow-learning review queue smoke — not run; no learning contract changed. `skill_draft/v1` is read, never written.
- [ ] Manual Hermes/TUI check — **not run.** Chat routing is not wired (see Follow-Up), so there is no Hermes chat path to check. The capability is reachable through `omh runtime artifacts` only.

## Risk

- **The safety property is "never list something still in use", and it is enforced three ways**: computed in `_cleanup_verdict`, re-checked in `validate_generated_artifact` (so a hand-built or transport-mangled record claiming eligibility for a current or referenced artifact is refused, not rendered), and covered by three separate AC3 tests plus a validator test that mutates each of the three guards independently.
- **Every failure mode in the projection biases toward keeping files.** An unreadable creation time, an unorderable revision line, a corrupt JSON record, and a truncated reference scan all end in "kept", never in "eligible". The preview reports `scan_truncated` when the reference scan hits its 2000-file bound so the list is not read as complete.
- **`storage_retention` was deliberately not flipped to `enforced`.** Nothing in this change deletes anything or expires anything, so calling it enforced would be exactly the decoration that contract exists to prevent. The statement now names `generated_artifact_cleanup_preview/v1` and then states the gap; `test_unenforced_boundaries_state_the_gap_in_words` pins both halves, matching the shape the `workspace`, `start_evidence`, and `recovery` rows already use.
- **One coupling to a producer exists and is pinned by a test.** Plan creation time lives only in the filename `write_hermes_plan` chooses. If that format moves, plans silently lose their creation time and can never leave retention — safe, but the feature would quietly stop working, so `test_the_plan_writer_still_produces_a_filename_this_projection_can_date` writes a real plan through the real writer and fails instead.
- **Cost.** The projection globs four stores and reads the reference sources; both are bounded (`--limit`, default 200 per kind; 2000 reference files). It is a read-only command, not on any hot path.

## Compatibility / Rollout

- Additive only. No schema, record, or store changed; no producer was modified; no existing payload gained or lost a field.
- Works on stores written by any previous OMH version, which is the point of deriving rather than stamping.
- No new dependency. No network, LLM, or subprocess call. Pure local reads.

## Release / Claims

- [x] Release-channel impact considered — `stable`; additive read-only command, no migration, no state change.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — the preview's `claim_boundary` states it is a read-side projection and prepared metadata, not execution, review, CI, merge-readiness, or merge evidence, and `validate_generated_artifact_cleanup_preview` refuses a payload whose boundary is missing or whose `dry_run` is not `True`.
- [x] Known manual Hermes checks are listed — `omh release hermes-smoke --live` was not run against a real Hermes profile; plan mode only, and plan mode is not evidence Hermes loaded anything.

## Follow-Up

- **Chat routing is not wired.** Issue #835 describes a user *asking* Hermes which artifacts are current. This PR delivers the projection and the operator command; a routing trigger for that intent is a separate change against `src/routing/chat.py` with its own overroute guards and the four exact-count assertions that move with it, and folding it in here would have mixed a routing change into a runtime-projection change.
- **Recall/role context packs and plan handoff context packs stay reference-only.** Covering them by revision needs a producer to record something that orders two packs for one scope. `UNSUPPORTED_ARTIFACT_KIND_REASONS` states the gap and the preview surfaces it, so the boundary is visible rather than implied.
- **No removal action is planned.** Do not add one to `omh runtime artifacts`. If OMH ever grows a confirmation intake, cleanup belongs behind that, as its own contract, with the preview as its required input — which is what the issue's boundary-level design asks for.
