### PR TITLE
feat: keep Hermes project memory focused as history grows

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -349,6 +349,86 @@ deliberately do not fire as bare tokens. Relevance stays the primary sort
 key in both cases, so neither signal can change which keyword matches win —
 only how peers of equal relevance order.
 
+## Attention Tiers: Active, Reference, Archive
+
+Approved memory grows, and an old but still-true record can crowd out the few
+facts that should steer the current conversation. Every approved record
+therefore carries an explicit attention tier saying how much of the working
+context it may occupy. The tier says nothing about whether the record is true,
+approved, or fresh — expiry, scope, perspective, and review eligibility are
+unchanged by it.
+
+| Tier | Effect on recall |
+| --- | --- |
+| `active` | Leads the working context. The default for every approved record. |
+| `reference` | Stays recallable, but yields to active peers inside the same budget. |
+| `archive` | Leaves default recall. The record stays in the store and answers an explicit archived query. |
+
+The tier enters the one existing ranking ladder, which now reads: pinned
+anchors, then attention tier, then relevance rank, then the decayed fused
+score, then record id. A reference record therefore ranks below every active
+record of the same pin status, and there is no second ordering mechanism to
+keep in sync. Each included record reports its `attention_tier`, and its
+`ranking` block reports the integer `attention_rank` used for the sort. The
+fused score itself is untouched, so a tier change reorders a pack without
+rewriting the relevance evidence that explains it.
+
+Every pack carries an `attention` block disclosing what it is made of:
+
+```json
+{
+  "active_included": 2,
+  "reference_included": 1,
+  "archived_included": 0,
+  "archived_excluded": 1,
+  "include_archived": false,
+  "detail": "2 active record(s) lead this working context. 1 reference-tier record(s) are included behind them. 1 archived record(s) stayed out of the working context; they remain in the store and are listed as archived_tier exclusions."
+}
+```
+
+A tier change is previewed before it is applied, and the preview writes
+nothing:
+
+```sh
+# Agent/operator only: preview what the tier change does to the working context.
+omh memory attention <record-id> --tier reference
+
+# Agent/operator only: apply the previewed change and journal the prior tier.
+omh memory attention <record-id> --tier archive --reason "superseded by the canary policy" --apply
+
+# Agent/operator only: query the archive explicitly.
+omh memory recall "deploys" --include-archived
+```
+
+The preview projects the working context twice — as it stands, and with the
+requested tier substituted — through the same recall builder, so
+`working_context_after` is the pack the operator actually gets rather than a
+description of one. It also names `leaving_working_context` and
+`entering_working_context` by record id. Pass `--query` to preview against the
+task text the change is meant to affect. A change that would be a no-op is
+refused as `tier_unchanged`, so every journal line is a real move, and a
+missing record is refused as `record_not_found` with a readable reason.
+
+Applied changes write `attention` on the record (tier, bounded reason, prior
+tier, change timestamp) and append one `omh_memory_attention_journal/v1` line
+to `.omh/memory/attention.jsonl`. The prior tier is recorded in both places, so
+an archive is always reversible from local evidence alone. The tier lives
+outside the reviewed payload digest, so changing it never breaks a record's
+immutable review linkage — and corrections and restores carry the tier onto the
+successor revision instead of silently returning an archived record to the
+active set.
+
+**Archive the tier is not retirement the lifecycle verb.** Archiving moves no
+file: the record stays in `records/`, stays readable, stays valid, and is
+listed in every pack as an `archived_tier` exclusion rather than vanishing from
+it. Retirement moves an expired revision into `.omh/memory/archive/` and writes
+a tombstone. The tier is also not an exemption: an expired archive-tier record
+still retires on the normal schedule. Neither operation is a deletion.
+
+This is Letta's context hierarchy read deterministically: OMH keeps the
+explicit tiers and the disclosure, and drops the model-side judgement about
+what deserves attention.
+
 ## Provenance and Lineage
 
 A capture may declare which approved records a new fact was derived from:
@@ -439,6 +519,10 @@ legacy memory or silently grants replay eligibility.
   while preserving that archive. A newer live conflict remains review-blocked.
 - **prune** hard-deletes only the manifest-declared OMH-local target set for an
   expired volatile revision, after report and explicit confirmation.
+
+The `archive` attention tier is not one of these verbs. It changes only how
+much of the working context a live record may occupy; it moves no file and
+writes no tombstone. See Attention Tiers above.
 
 Restore and prune are report-first operator actions:
 

--- a/skills/omh-memory-sync/SKILL.md
+++ b/skills/omh-memory-sync/SKILL.md
@@ -61,6 +61,7 @@ Bad example:
 - **Provenance (출처)** - Ask for the source class and distinguish Hermes-native, provider, and vector material as `not_omh_reviewed`.
 - **Target (대상)** - Review existing native-memory claims only. Route a new project/product fact to `memory-new`.
 - **Review (검토)** - Prioritize stale, conflicting, duplicate, and overgeneralized claims. Offer keep, revise, or archive choices; do not describe an archive as removal.
+- **Attention (주의)** - For a reviewed OMH-local record, keep/archive is an attention tier: `active` leads the working context, `reference` stays recallable behind active peers, `archive` leaves default recall. Preview with `omh memory attention <record-id> --tier <tier>`, say which records stay in the working context and which leave it, then apply with `--apply` only after the user agrees. The preview writes nothing.
 - **Diff (차이)** - Prepare one concise native write diff with before/after claims and counts. Keep the caps: MEMORY.md about 2,200 characters and USER.md about 1,375 characters.
 - **Native-write boundary (쓰기)** - This skill can prepare guidance and a native write diff only. It never invokes, applies, or observes a `MEMORY.md`/`USER.md` write.
 
@@ -69,6 +70,8 @@ Bad example:
 The prepared artifact is `memory_curation_review/v1`, not native-memory mutation evidence. Hermes-native and external provider/vector context is `not_omh_reviewed`: it can nominate an OMH candidate but never inherits OMH approval. A configured Hermes runtime may transmit rendered OMH prefetch content in its model request.
 
 Use lifecycle words literally: expire removes influence only; retire archives recoverably; restore creates a new pending revision while preserving the archive; prune hard-deletes only the manifest-declared OMH-local target set. Report restore and prune first. No lifecycle result proves anything outside that named local target set.
+
+An attention tier is not a lifecycle state, and the two uses of "archive" are different: the `archive` tier only stops a record from occupying the default working context, leaving it in the store, readable, and answerable by `omh memory recall --include-archived`, while `retire` moves an expired revision into the local archive directory. Neither is deletion; never describe either as one.
 
 Legacy v1 material is migration/review-required. Present `memory inventory` counts and the report-first per-artifact `memory reactivate ... --apply` path; inventory and reactivation never silently grant replay eligibility. Dreaming remains reminder-only: it prepares reminders for `stale_review_required` and `expired_volatile_records`, never consolidation, retirement, restore, or prune.
 

--- a/src/commands/memory.py
+++ b/src/commands/memory.py
@@ -30,9 +30,11 @@ from ..memory import (
     LifecycleCandidateError,
     RejectedDecisionRecallRequest,
     apply_approved_memory_update_batch,
+    apply_memory_attention_change,
     apply_memory_retirement,
     apply_memory_update_batch,
     approve_project_memory_candidate,
+    build_memory_attention_change,
     build_memory_lineage,
     build_memory_perspectives,
     build_memory_retirement,
@@ -177,6 +179,7 @@ def cmd_memory_recall(args: argparse.Namespace) -> int:
             limit=_optional_positive_int(args.limit, "--limit") or 6,
             max_chars=_optional_positive_int(args.max_chars, "--max-chars"),
             include_stale=args.include_stale,
+            include_archived=args.include_archived,
             observer=args.observer,
             observed=args.observed,
         )
@@ -213,6 +216,23 @@ def cmd_memory_pin(args: argparse.Namespace) -> int:
 def cmd_memory_unpin(args: argparse.Namespace) -> int:
     try:
         payload = set_memory_pin(_paths(args), args.record_id, pinned=False)
+    except (OSError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(payload)
+    return 0
+
+
+def cmd_memory_attention(args: argparse.Namespace) -> int:
+    try:
+        change = apply_memory_attention_change if args.apply else build_memory_attention_change
+        payload = change(
+            _paths(args),
+            args.record_id,
+            tier=args.tier,
+            reason=args.reason,
+            query=" ".join(args.query).strip(),
+            limit=_optional_positive_int(args.limit, "--limit") or 6,
+        )
     except (OSError, ValueError) as exc:
         raise OmhError(str(exc)) from exc
     _print_json(payload)

--- a/src/commands/memory_parser.py
+++ b/src/commands/memory_parser.py
@@ -4,6 +4,7 @@ import argparse
 
 from ..plugin_bundle.omh.memory_blocks import DEFAULT_BLOCK_LIMIT_CHARS
 from ..plugin_bundle.omh.memory_governance import SOURCE_CLASSES
+from ..workflows.memory import MEMORY_ATTENTION_TIERS
 from . import memory
 from .domain_intelligence_parser import add_domain_intelligence_commands
 
@@ -74,6 +75,11 @@ def add_memory_commands(sub: argparse._SubParsersAction[argparse.ArgumentParser]
         help="Optional summary-character budget; records cut by it are marked over_budget and the pack says truncated.",
     )
     recall.add_argument("--include-stale", action="store_true")
+    recall.add_argument(
+        "--include-archived",
+        action="store_true",
+        help="Also recall archive-tier records. They are excluded by default as archived_tier, never deleted.",
+    )
     recall.add_argument("--observer", default=None, help="Perspective lens: only unscoped records and records with this observer pass.")
     recall.add_argument("--observed", default=None, help="Perspective lens: only unscoped records and records about this actor pass.")
     recall.set_defaults(func=memory.cmd_memory_recall)
@@ -109,6 +115,23 @@ def add_memory_commands(sub: argparse._SubParsersAction[argparse.ArgumentParser]
     unpin = memory_sub.add_parser("unpin", help="Remove one record's recall-anchor marker.")
     unpin.add_argument("record_id")
     unpin.set_defaults(func=memory.cmd_memory_unpin)
+
+    attention = memory_sub.add_parser(
+        "attention",
+        help="Report how one record's attention tier would change the working context; --apply writes the local tier change.",
+    )
+    attention.add_argument("record_id")
+    attention.add_argument(
+        "--tier",
+        choices=MEMORY_ATTENTION_TIERS,
+        required=True,
+        help="active leads the working context; reference stays recallable behind active peers; archive leaves default recall without deleting anything.",
+    )
+    attention.add_argument("--reason", default="", help="Why the tier changed; stored as bounded metadata on the record and in the local journal.")
+    attention.add_argument("--query", nargs="*", default=[], help="Optional task text so the previewed working context matches the recall this tier change affects.")
+    attention.add_argument("--limit", type=int, default=6, help="Recall budget used to preview the working context.")
+    attention.add_argument("--apply", action="store_true", help="Write the tier change (default is report-only).")
+    attention.set_defaults(func=memory.cmd_memory_attention)
 
     lineage = memory_sub.add_parser("lineage", help="Trace derived-from provenance links for one reviewed memory record.")
     lineage.add_argument("record_id")

--- a/src/runtime/records.py
+++ b/src/runtime/records.py
@@ -1873,6 +1873,11 @@ def _compact_memory_recall_item(item: dict[str, Any]) -> dict[str, Any]:
             if isinstance(item.get("staleness"), dict) and key in item.get("staleness", {})
         },
         "score": int(item.get("score", 0) or 0),
+        # The attention tier survives compaction for the same executor-parity
+        # reason as the ranking block below: it is the field that explains why
+        # an active record outranked a reference one, so dropping it would
+        # leave the run-backed path unable to explain its own pack order.
+        "attention_tier": str(item.get("attention_tier", "") or ""),
         # Ranking and provenance survive compaction for the same executor-
         # parity reason as included_records above: both are bounded scalar
         # metadata, and dropping them would leave the run-backed codex path
@@ -1891,7 +1896,7 @@ def _compact_ranking(value: Any) -> dict[str, Any]:
         return {}
     compacted: dict[str, Any] = {
         key: int(ranking.get(key, 0) or 0)
-        for key in ("rrf_score_micro", "decayed_score_micro", "relevance_rank", "recency_rank", "usage_rank", "times_recalled", "age_tier", "veracity_weight_pct")
+        for key in ("rrf_score_micro", "decayed_score_micro", "relevance_rank", "recency_rank", "usage_rank", "times_recalled", "age_tier", "attention_rank", "veracity_weight_pct")
     }
     compacted["pinned"] = bool(ranking.get("pinned", False))
     return compacted

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -1015,6 +1015,7 @@ This is a Hermes-native `{name}` workflow skill.
 - **Provenance (출처)** - Ask for the source class and distinguish Hermes-native, provider, and vector material as `not_omh_reviewed`.
 - **Target (대상)** - Review existing native-memory claims only. Route a new project/product fact to `memory-new`.
 - **Review (검토)** - Prioritize stale, conflicting, duplicate, and overgeneralized claims. Offer keep, revise, or archive choices; do not describe an archive as removal.
+- **Attention (주의)** - For a reviewed OMH-local record, keep/archive is an attention tier: `active` leads the working context, `reference` stays recallable behind active peers, `archive` leaves default recall. Preview with `omh memory attention <record-id> --tier <tier>`, say which records stay in the working context and which leave it, then apply with `--apply` only after the user agrees. The preview writes nothing.
 - **Diff (차이)** - Prepare one concise native write diff with before/after claims and counts. Keep the caps: MEMORY.md about 2,200 characters and USER.md about 1,375 characters.
 - **Native-write boundary (쓰기)** - This skill can prepare guidance and a native write diff only. It never invokes, applies, or observes a `MEMORY.md`/`USER.md` write.
 
@@ -1023,6 +1024,8 @@ This is a Hermes-native `{name}` workflow skill.
 The prepared artifact is `memory_curation_review/v1`, not native-memory mutation evidence. Hermes-native and external provider/vector context is `not_omh_reviewed`: it can nominate an OMH candidate but never inherits OMH approval. A configured Hermes runtime may transmit rendered OMH prefetch content in its model request.
 
 Use lifecycle words literally: expire removes influence only; retire archives recoverably; restore creates a new pending revision while preserving the archive; prune hard-deletes only the manifest-declared OMH-local target set. Report restore and prune first. No lifecycle result proves anything outside that named local target set.
+
+An attention tier is not a lifecycle state, and the two uses of "archive" are different: the `archive` tier only stops a record from occupying the default working context, leaving it in the store, readable, and answerable by `omh memory recall --include-archived`, while `retire` moves an expired revision into the local archive directory. Neither is deletion; never describe either as one.
 
 Legacy v1 material is migration/review-required. Present `memory inventory` counts and the report-first per-artifact `memory reactivate ... --apply` path; inventory and reactivation never silently grant replay eligibility. Dreaming remains reminder-only: it prepares reminders for `stale_review_required` and `expired_volatile_records`, never consolidation, retirement, restore, or prune.
 

--- a/src/workflows/_memory_lifecycle_plans.py
+++ b/src/workflows/_memory_lifecycle_plans.py
@@ -17,6 +17,7 @@ from ..plugin_bundle.omh.memory_governance import (
 from ..system.paths import OmhPaths
 from ._memory_lifecycle_model import LifecycleMutation, LifecyclePlan, LifecycleTransactionExecutor
 from ._memory_lifecycle_scan import ScanFinding, journal_findings, linked_to, matching_json_findings, matching_scope_findings, parse_time, read_json, safe_token, stamp
+from .memory import MEMORY_ATTENTION_SCHEMA_VERSION, MEMORY_ATTENTION_TIERS
 
 
 def _scope(value: Mapping[str, object]) -> dict[str, object]:
@@ -92,7 +93,7 @@ def _tombstone(tombstone_id: str, record_id: str, revision: int, scope: Mapping[
 
 def _pending_candidate(record: Mapping[str, object], candidate_id: str, revision: int, lifecycle: str) -> dict[str, object]:
     origin = stable_artifact_identity(dict(record))
-    replacement = {key: record[key] for key in ("record_type", "summary", "scope", "source_class", "source_ref", "source_evidence", "retention", "revalidation", "ttl", "staleness", "derived_from", "perspective") if key in record}
+    replacement = {key: record[key] for key in ("record_type", "summary", "scope", "source_class", "source_ref", "source_evidence", "retention", "revalidation", "ttl", "staleness", "derived_from", "perspective", "attention") if key in record}
     return {"schema_version": "project_memory_candidate/v2", "candidate_id": candidate_id, "candidate_revision": revision, "record_id": str(record["record_id"]), "artifact_kind": "record", "status": "pending_review", "admission": {"state": "pending_review"}, "origin": origin, "lifecycle": lifecycle, "replacement": replacement}
 
 
@@ -109,11 +110,29 @@ def _source_evidence(replacement: Mapping[str, object]) -> dict[str, object]:
     return {key: str(evidence.get(key, "") or "") for key in ("path", "sha256", "captured_at")}
 
 
+def _attention(replacement: Mapping[str, object]) -> dict[str, object]:
+    """Carry a reviewed revision's attention tier into its successor, scalar-only.
+
+    Without this a correction or a restore silently returns an archived or
+    reference record to the active working set -- the exact opposite of what
+    the operator asked for, and invisible until the record reappeared in a
+    handoff. An unreadable tier carries nothing, so the successor falls back to
+    the ordinary active default rather than inheriting a corrupt value.
+    """
+    attention = replacement.get("attention")
+    if not isinstance(attention, Mapping) or str(attention.get("tier", "") or "") not in MEMORY_ATTENTION_TIERS:
+        return {}
+    return {
+        "schema_version": MEMORY_ATTENTION_SCHEMA_VERSION,
+        **{key: str(attention.get(key, "") or "") for key in ("tier", "reason", "previous_tier", "changed_at")},
+    }
+
+
 def _approved_record(replacement: Mapping[str, object], record_id: str, revision: int, reviewer: str, now: datetime) -> dict[str, object]:
     record_type = str(replacement.get("record_type", "fact"))
     retention = replacement.get("retention") if isinstance(replacement.get("retention"), Mapping) else {}
     ttl_days = retention.get("ttl_days") if isinstance(retention.get("ttl_days"), int) and not isinstance(retention.get("ttl_days"), bool) else None
-    record: dict[str, object] = {"schema_version": PROJECT_MEMORY_RECORD_SCHEMA_VERSION, "record_id": record_id, "revision": revision, "record_type": record_type, "summary": str(replacement.get("summary", "")), "scope": _scope(replacement), "source_class": str(replacement.get("source_class", "omh_local")), "derived_from": [str(ref) for ref in (replacement.get("derived_from") if isinstance(replacement.get("derived_from"), list) else []) if isinstance(ref, str)], **({"perspective": {"observer": str(replacement["perspective"].get("observer", "")), "observed": str(replacement["perspective"].get("observed", ""))}} if isinstance(replacement.get("perspective"), Mapping) and str(replacement["perspective"].get("observed", "")) else {}), **({"source_evidence": evidence} if (evidence := _source_evidence(replacement)) else {}), "retention": build_retention(str(retention.get("class", "standard")), record_type=record_type, admitted_at=now, ttl_days=ttl_days), "revalidation": {}, "admission": {"state": "approved_manual", "review_id": f"review-{record_id}-r{revision}", "reviewer_claim": reviewer, "admitted_at": stamp(now), "policy_version": MEMORY_GOVERNANCE_POLICY_VERSION, "classifier_version": MEMORY_CLASSIFIER_VERSION}}
+    record: dict[str, object] = {"schema_version": PROJECT_MEMORY_RECORD_SCHEMA_VERSION, "record_id": record_id, "revision": revision, "record_type": record_type, "summary": str(replacement.get("summary", "")), "scope": _scope(replacement), "source_class": str(replacement.get("source_class", "omh_local")), "derived_from": [str(ref) for ref in (replacement.get("derived_from") if isinstance(replacement.get("derived_from"), list) else []) if isinstance(ref, str)], **({"perspective": {"observer": str(replacement["perspective"].get("observer", "")), "observed": str(replacement["perspective"].get("observed", ""))}} if isinstance(replacement.get("perspective"), Mapping) and str(replacement["perspective"].get("observed", "")) else {}), **({"source_evidence": evidence} if (evidence := _source_evidence(replacement)) else {}), **({"attention": attention} if (attention := _attention(replacement)) else {}), "retention": build_retention(str(retention.get("class", "standard")), record_type=record_type, admitted_at=now, ttl_days=ttl_days), "revalidation": {}, "admission": {"state": "approved_manual", "review_id": f"review-{record_id}-r{revision}", "reviewer_claim": reviewer, "admitted_at": stamp(now), "policy_version": MEMORY_GOVERNANCE_POLICY_VERSION, "classifier_version": MEMORY_CLASSIFIER_VERSION}}
     identity = stable_artifact_identity(record)
     record["admission"] = {**record["admission"], "artifact_identity": identity, "payload_digest": canonical_payload_digest(record)}
     return record

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -62,6 +62,9 @@ MEMORY_RECALL_USAGE_SCHEMA_VERSION = "omh_memory_recall_usage/v1"
 MEMORY_LINEAGE_SCHEMA_VERSION = "omh_memory_lineage/v1"
 MEMORY_PERSPECTIVES_SCHEMA_VERSION = "omh_memory_perspectives/v1"
 MEMORY_PINS_SCHEMA_VERSION = "omh_memory_pins/v1"
+MEMORY_ATTENTION_SCHEMA_VERSION = "omh_memory_attention/v1"
+MEMORY_ATTENTION_CHANGE_SCHEMA_VERSION = "memory_attention_change/v1"
+MEMORY_ATTENTION_JOURNAL_SCHEMA_VERSION = "omh_memory_attention_journal/v1"
 MEMORY_ROLLUP_SCHEMA_VERSION = "omh_memory_rollup/v1"
 HERMES_MEMORY_BRIDGE_SCHEMA_VERSION = "hermes_memory_bridge/v1"
 
@@ -131,6 +134,7 @@ _PROJECT_MEMORY_RECORD_KEYS = {
     "safety",
     "derived_from",
     "perspective",
+    "attention",
     "superseded_by",
     "redaction_policy",
     "claim_boundary",
@@ -148,6 +152,7 @@ _PROJECT_MEMORY_RECALL_PACK_KEYS = {
     "included_records",
     "excluded_records",
     "freshness_warnings",
+    "attention",
     "record_count",
     "truncated",
     "redaction_policy",
@@ -173,6 +178,7 @@ _PROJECT_MEMORY_RECALL_ITEM_KEYS = {
     "staleness",
     "score",
     "ranking",
+    "attention_tier",
     "derived_from",
     "perspective",
     "revision",
@@ -192,6 +198,7 @@ _RECALL_RANKING_KEYS = {
     "usage_rank",
     "times_recalled",
     "age_tier",
+    "attention_rank",
     "pinned",
     "veracity_weight_pct",
 }
@@ -222,6 +229,50 @@ _AGE_TIER_WEIGHTS = (1.0, 0.5, 0.25)
 # record still fails closed on expiry, scope, perspective, and review checks.
 # The cap stays small because pins occupy recall budget first.
 _MEMORY_PINS_LIMIT = 12
+# Attention tiers are Letta's context hierarchy read deterministically. A tier
+# says how much of the working context a record may occupy; it never says
+# whether the record is true, approved, or fresh. `active` is the working set,
+# `reference` stays recallable behind active peers, and `archive` leaves the
+# default pack while the record stays in the store, readable, and answerable
+# by an explicit archived query. Archive-the-tier is therefore NOT
+# retirement-the-lifecycle: retirement moves an expired revision out of
+# `records/` and writes a tombstone; a tier change moves nothing and deletes
+# nothing. The tier feeds the one existing ranking ladder in
+# `build_project_memory_recall_pack`, never a second ordering pass.
+MEMORY_ATTENTION_TIERS = ("active", "reference", "archive")
+DEFAULT_MEMORY_ATTENTION_TIER = "active"
+_MEMORY_ATTENTION_RANK = {"active": 0, "reference": 1, "archive": 2}
+_RECALL_ATTENTION_KEYS = {
+    "active_included",
+    "reference_included",
+    "archived_included",
+    "archived_excluded",
+    "include_archived",
+    "detail",
+}
+# Matches `_redact`'s own cap so the bound stays true if either side moves;
+# the reason is operator prose and must never become an unbounded field.
+_MEMORY_ATTENTION_REASON_LIMIT = 240
+_MEMORY_ATTENTION_JOURNAL_LIMIT = 20
+_MEMORY_ATTENTION_TIER_DETAIL = {
+    "active": "Active records lead the working context.",
+    "reference": "Reference records stay recallable but yield to active peers inside the same recall budget.",
+    "archive": (
+        "Archived records leave the default working context. They stay in the store, stay readable, "
+        "and still answer an explicit archived query; nothing is deleted."
+    ),
+}
+_MEMORY_ATTENTION_REFUSAL_DETAIL = {
+    "record_not_found": "No approved OMH memory record carries that id, so there is no attention tier to change.",
+    "record_unreadable": "That record file exists but could not be read as JSON, so its attention tier cannot be changed safely.",
+    "unsupported_record_schema": "That file is not a current approved OMH memory record, so attention tiers do not apply to it.",
+    "tier_unchanged": "The record already sits in the requested tier, so there is nothing to apply.",
+}
+_MEMORY_ATTENTION_CLAIM_BOUNDARY = (
+    "An attention tier is an OMH-local recall-priority marker only. It never changes whether a record is "
+    "true, approved, fresh, or eligible, it never deletes anything, and it is not execution, review, CI, "
+    "merge, or Hermes internal-memory evidence."
+)
 # Perspective is honcho's peer paradigm reinterpreted deterministically: an
 # optional (observer, observed) pair naming whose view a record is and which
 # actor it is about. Unscoped records behave exactly as before; a scoped
@@ -657,6 +708,8 @@ def build_project_memory_recall_pack(
     limit: int = 6,
     max_chars: int | None = None,
     include_stale: bool = False,
+    include_archived: bool = False,
+    attention_override: dict[str, str] | None = None,
     now: datetime | None = None,
     stale_override: dict[str, object] | None = None,
     run_id: str | None = None,
@@ -690,12 +743,29 @@ def build_project_memory_recall_pack(
     review_resolver = _project_memory_review_resolver(paths)
     included: list[dict[str, object]] = []
     excluded: list[dict[str, object]] = []
+    archived_excluded = 0
     for record in records:
         if not _record_scope_matches(record, scope_kind=scope_kind, scope_ref=scope_ref):
             continue
         # Perspective mismatch skips silently, exactly like scope mismatch:
         # the record belongs to another actor's lens, not to this pack.
         if not _record_perspective_matches(record, observer=observer, observed=observed):
+            continue
+        attention_tier = _record_attention_tier(record, override=attention_override)
+        if attention_tier == "archive" and not include_archived:
+            # Archive is an attention tier, not a deletion. The record stays
+            # in `records/`, stays readable, and returns to any pack built
+            # with include_archived -- but it leaves the default working
+            # context NAMED, never silently, so the operator can always see
+            # what the archive is holding back.
+            excluded.append(
+                {
+                    "record_id": str(record.get("record_id", "")),
+                    "reason": "archived_tier",
+                    "staleness": {"state": "not_checked"},
+                }
+            )
+            archived_excluded += 1
             continue
         evaluation = _evaluate_memory_artifact(
             record,
@@ -729,7 +799,9 @@ def build_project_memory_recall_pack(
             if include_stale and str(evaluation.get("reason_code", "")) in _INSPECTABLE_STALE_REASONS:
                 score = _memory_recall_score(record, query)
                 if not query or score > 0 or str(record.get("record_id", "")) in pins:
-                    included.append(_recall_item(record, score=score, staleness=staleness, evaluation=evaluation))
+                    included.append(
+                        _recall_item(record, score=score, staleness=staleness, evaluation=evaluation, attention_tier=attention_tier)
+                    )
                     continue
             excluded.append(_recall_exclusion(record, evaluation, staleness=staleness))
             continue
@@ -739,7 +811,7 @@ def build_project_memory_recall_pack(
         if query and score <= 0 and str(record.get("record_id", "")) not in pins:
             excluded.append(_recall_exclusion(record, evaluation, staleness=staleness, reason="no_query_overlap"))
             continue
-        included.append(_recall_item(record, score=score, staleness=staleness, evaluation=evaluation))
+        included.append(_recall_item(record, score=score, staleness=staleness, evaluation=evaluation, attention_tier=attention_tier))
     query_intent = _recall_query_intent(query)
     _attach_recall_ranking(
         included,
@@ -748,15 +820,19 @@ def build_project_memory_recall_pack(
         now=now if now is not None else datetime.now(timezone.utc),
         recency_weight=2.0 if query_intent == "temporal" else _RECALL_RRF_WEIGHTS["recency"],
     )
-    # Pinned anchors lead, then relevance; the decayed fused score orders
-    # records only within an equal relevance rank. A weaker keyword match
-    # can therefore never displace a stronger unpinned one -- including
-    # across the budget cut below -- while recency, delivery usage, and age
-    # tier decide ties and unqueried packs. Pins take priority within the
-    # budget but never own it outright: at most limit-1 pinned slots lead
-    # the pack (minimum one), and further pins compete as normal records,
-    # so a fully-used pin budget cannot blank query-driven recall.
+    # Pinned anchors lead, then attention tier, then relevance; the decayed
+    # fused score orders records only within an equal relevance rank. A weaker
+    # keyword match can therefore never displace a stronger unpinned one of
+    # the same tier -- including across the budget cut below -- while recency,
+    # delivery usage, and age tier decide ties and unqueried packs. Attention
+    # sits above relevance on purpose: that is what "build recall packs from
+    # active records first" means, and it is the one place the tier acts.
+    # Pins take priority within the budget but never own it outright: at most
+    # limit-1 pinned slots lead the pack (minimum one), and further pins
+    # compete as normal records, so a fully-used pin budget cannot blank
+    # query-driven recall.
     ranked_key = lambda item: (  # noqa: E731 - shared by both sort passes below
+        int(_ranking_field(item, "attention_rank")),
         int(_ranking_field(item, "relevance_rank")),
         -int(_ranking_field(item, "decayed_score_micro")),
         str(item.get("record_id", "")),
@@ -818,6 +894,7 @@ def build_project_memory_recall_pack(
         "included_records": included,
         "excluded_records": excluded,
         "freshness_warnings": _freshness_warnings(included, excluded),
+        "attention": _attention_disclosure(included, archived_excluded, include_archived=include_archived),
         "record_count": len(included),
         "truncated": budget_exhausted,
         "redaction_policy": "metadata_only",
@@ -1028,6 +1105,13 @@ def _attach_recall_ranking(
         )
         tier = _age_tier(str(item.get("approved_at", "")), now=now)
         veracity_pct = _ADMISSION_VERACITY_WEIGHT_PCT.get(str(item.get("admission_mode", "")), _ADMISSION_VERACITY_DEFAULT_PCT)
+        # The attention rank is an ordering key, not a score input: it never
+        # touches the fused score, so a tier change reorders records without
+        # rewriting the relevance/recency/usage evidence that explains them.
+        attention_rank = _MEMORY_ATTENTION_RANK.get(
+            str(item.get("attention_tier", "")) or DEFAULT_MEMORY_ATTENTION_TIER,
+            _MEMORY_ATTENTION_RANK[DEFAULT_MEMORY_ATTENTION_TIER],
+        )
         item["ranking"] = {
             # rrf_score_micro is undecayed rank fusion under THIS pack's
             # weights (a temporal query raises the recency weight, so scores
@@ -1041,6 +1125,7 @@ def _attach_recall_ranking(
             "usage_rank": usage_ranks[record_id],
             "times_recalled": _times_recalled(item),
             "age_tier": tier,
+            "attention_rank": attention_rank,
             "pinned": record_id in pins,
             "veracity_weight_pct": veracity_pct,
         }
@@ -1336,6 +1421,301 @@ def set_memory_pin(paths: OmhPaths, record_id: str, *, pinned: bool) -> dict[str
         "claim_boundary": (
             "A pin is an OMH-local delivery-priority marker only; it never overrides expiry, scope, "
             "perspective, or review eligibility, and it is not execution or Hermes internal-memory evidence."
+        ),
+    }
+
+
+def normalize_memory_attention_tier(value: Any) -> str:
+    """The one place a tier name is accepted. An unknown tier is refused.
+
+    Failing loudly here is deliberate: silently coercing an unrecognized tier
+    to ``active`` would quietly undo an operator's archive request.
+    """
+    tier = str(value or "").strip().lower()
+    if tier not in MEMORY_ATTENTION_TIERS:
+        raise ValueError(f"unsupported memory attention tier: {value!r}; use one of {', '.join(MEMORY_ATTENTION_TIERS)}")
+    return tier
+
+
+def record_attention_tier(record: dict[str, Any]) -> str:
+    """A stored record's attention tier; anything unreadable reads as active.
+
+    Absence is the normal case for every record approved before tiers existed,
+    and a corrupt tier value is indistinguishable from absence here. Defaulting
+    to ``active`` is safe because attention is not a trust gate: expiry, scope,
+    perspective, and review eligibility still decide what may be recalled.
+    """
+    attention = record.get("attention")
+    tier = str(attention.get("tier", "")) if isinstance(attention, dict) else ""
+    return tier if tier in MEMORY_ATTENTION_TIERS else DEFAULT_MEMORY_ATTENTION_TIER
+
+
+def _record_attention_tier(record: dict[str, Any], *, override: dict[str, str] | None = None) -> str:
+    """Stored tier, or the previewed tier when this pack is a projection.
+
+    The override exists so a preview and the pack built after apply run the
+    exact same ranking code on the exact same inputs. Recomputing the order a
+    second way would make "what will remain in the working context" a guess.
+    """
+    if override:
+        candidate = override.get(str(record.get("record_id", "")))
+        if candidate is not None:
+            return normalize_memory_attention_tier(candidate)
+    return record_attention_tier(record)
+
+
+def _attention_metadata(tier: str, *, reason: str, previous_tier: str, changed_at: str) -> dict[str, str]:
+    """Scalar-only tier metadata; nested non-scalars would be dropped by
+    correction/restore and by the recall-pack validators."""
+    return {
+        "schema_version": MEMORY_ATTENTION_SCHEMA_VERSION,
+        "tier": tier,
+        "reason": _redact(str(reason or ""))[:_MEMORY_ATTENTION_REASON_LIMIT],
+        "previous_tier": str(previous_tier or ""),
+        "changed_at": str(changed_at or ""),
+    }
+
+
+def _attention_disclosure(
+    included: list[dict[str, object]],
+    archived_excluded: int,
+    *,
+    include_archived: bool,
+) -> dict[str, object]:
+    """Say out loud which tiers this pack is made of.
+
+    The issue asks recall to disclose when reference records are included, and
+    the same sentence is the only honest way to report an archived record that
+    was held back: a smaller pack with no explanation is the failure this
+    replaces.
+    """
+    counts = dict.fromkeys(MEMORY_ATTENTION_TIERS, 0)
+    for item in included:
+        tier = str(item.get("attention_tier", "")) or DEFAULT_MEMORY_ATTENTION_TIER
+        counts[tier if tier in counts else DEFAULT_MEMORY_ATTENTION_TIER] += 1
+    parts: list[str] = []
+    if not included:
+        parts.append("No reviewed records are in the working context.")
+    else:
+        parts.append(f"{counts['active']} active record(s) lead this working context.")
+    if counts["reference"]:
+        parts.append(f"{counts['reference']} reference-tier record(s) are included behind them.")
+    if counts["archive"]:
+        parts.append(f"{counts['archive']} archived record(s) are included because this query asked for the archive.")
+    if archived_excluded:
+        parts.append(
+            f"{archived_excluded} archived record(s) stayed out of the working context; "
+            "they remain in the store and are listed as archived_tier exclusions."
+        )
+    return {
+        "active_included": counts["active"],
+        "reference_included": counts["reference"],
+        "archived_included": counts["archive"],
+        "archived_excluded": int(archived_excluded),
+        "include_archived": bool(include_archived),
+        "detail": " ".join(parts),
+    }
+
+
+def _memory_attention_journal_path(paths: OmhPaths) -> Path:
+    return paths.memory_dir / "attention.jsonl"
+
+
+def read_memory_attention_journal(
+    paths: OmhPaths,
+    *,
+    record_id: str | None = None,
+    limit: int = _MEMORY_ATTENTION_JOURNAL_LIMIT,
+) -> list[dict[str, object]]:
+    """Most recent tier changes, oldest first, bounded like every polled surface.
+
+    This is the reversibility surface: every applied change records the tier it
+    came from, so an archive is always undoable from local evidence alone.
+    """
+    # A corrupt line costs only itself: the journal is an audit trail, and a
+    # single bad append must never make the tier surface unreadable.
+    lines, _errors = read_jsonl_objects(_memory_attention_journal_path(paths))
+    entries = [
+        entry
+        for entry in lines
+        if isinstance(entry, dict)
+        and entry.get("schema_version") == MEMORY_ATTENTION_JOURNAL_SCHEMA_VERSION
+        and (record_id is None or str(entry.get("record_id", "")) == str(record_id))
+    ]
+    return entries[-max(limit, 0):] if limit > 0 else []
+
+
+def _attention_stamp(now: datetime | None) -> str:
+    if now is None:
+        return utc_now()
+    moment = now if now.tzinfo is not None else now.replace(tzinfo=timezone.utc)
+    return moment.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _attention_working_context(pack: dict[str, object]) -> dict[str, object]:
+    included = pack.get("included_records")
+    items = included if isinstance(included, list) else []
+    return {
+        "record_ids": [str(item.get("record_id", "")) for item in items if isinstance(item, dict)],
+        "record_count": len(items),
+        "truncated": bool(pack.get("truncated", False)),
+        "attention": dict(pack.get("attention", {})) if isinstance(pack.get("attention"), dict) else {},
+    }
+
+
+def _refused_attention_change(record_id: str, requested: str, reason: str, reason_code: str) -> dict[str, object]:
+    return {
+        "schema_version": MEMORY_ATTENTION_CHANGE_SCHEMA_VERSION,
+        "record_id": record_id,
+        "current_tier": "",
+        "requested_tier": requested,
+        "reason": _redact(str(reason or ""))[:_MEMORY_ATTENTION_REASON_LIMIT],
+        "eligible": False,
+        "applied": False,
+        "reason_code": reason_code,
+        "detail": _MEMORY_ATTENTION_REFUSAL_DETAIL[reason_code],
+        "tier_detail": _MEMORY_ATTENTION_TIER_DETAIL[requested],
+        "working_context_before": {"record_ids": [], "record_count": 0, "truncated": False, "attention": {}},
+        "working_context_after": {"record_ids": [], "record_count": 0, "truncated": False, "attention": {}},
+        "leaving_working_context": [],
+        "entering_working_context": [],
+        "recent_changes": [],
+        "redaction_policy": "metadata_only",
+        "next_action": "No tier change is possible: resolve the reported reason first.",
+        "claim_boundary": _MEMORY_ATTENTION_CLAIM_BOUNDARY,
+    }
+
+
+def build_memory_attention_change(
+    paths: OmhPaths,
+    record_id: str,
+    *,
+    tier: str,
+    reason: str = "",
+    query: str = "",
+    limit: int = 6,
+    now: datetime | None = None,
+) -> dict[str, object]:
+    """Preview one tier change: what the working context holds now, and after.
+
+    Nothing on disk moves. The projected "after" context is built by the same
+    recall builder with the requested tier substituted in memory, so the
+    preview is the pack the operator will actually get -- not a description of
+    one. Pass ``now`` to keep repeated previews byte-identical.
+    """
+    requested = normalize_memory_attention_tier(tier)
+    normalized_id = str(record_id).strip()
+    if not _SAFE_REF.match(normalized_id):
+        raise ValueError(f"unsafe memory record id: {record_id!r}")
+    record, error = read_json_object_result(_memory_record_path(paths, normalized_id))
+    if error:
+        return _refused_attention_change(normalized_id, requested, reason, "record_unreadable")
+    if not isinstance(record, dict) or str(record.get("record_id", "")) != normalized_id:
+        return _refused_attention_change(normalized_id, requested, reason, "record_not_found")
+    if record.get("schema_version") != PROJECT_MEMORY_RECORD_SCHEMA_VERSION:
+        return _refused_attention_change(normalized_id, requested, reason, "unsupported_record_schema")
+    current = record_attention_tier(record)
+    if current == requested:
+        return {
+            **_refused_attention_change(normalized_id, requested, reason, "tier_unchanged"),
+            "current_tier": current,
+        }
+    before = build_project_memory_recall_pack(paths, query, limit=limit, now=now)
+    after = build_project_memory_recall_pack(
+        paths,
+        query,
+        limit=limit,
+        now=now,
+        attention_override={normalized_id: requested},
+    )
+    before_context = _attention_working_context(before)
+    after_context = _attention_working_context(after)
+    before_ids = list(before_context["record_ids"]) if isinstance(before_context["record_ids"], list) else []
+    after_ids = list(after_context["record_ids"]) if isinstance(after_context["record_ids"], list) else []
+    return {
+        "schema_version": MEMORY_ATTENTION_CHANGE_SCHEMA_VERSION,
+        "record_id": normalized_id,
+        "current_tier": current,
+        "requested_tier": requested,
+        "reason": _redact(str(reason or ""))[:_MEMORY_ATTENTION_REASON_LIMIT],
+        "eligible": True,
+        "applied": False,
+        "reason_code": "planned",
+        "detail": (
+            f"Moving this record from {current} to {requested} leaves "
+            f"{after_context['record_count']} record(s) in the working context, was {before_context['record_count']}."
+        ),
+        "tier_detail": _MEMORY_ATTENTION_TIER_DETAIL[requested],
+        "working_context_before": before_context,
+        "working_context_after": after_context,
+        "leaving_working_context": [item for item in before_ids if item not in set(after_ids)],
+        "entering_working_context": [item for item in after_ids if item not in set(before_ids)],
+        "recent_changes": read_memory_attention_journal(paths, record_id=normalized_id),
+        "redaction_policy": "metadata_only",
+        "next_action": (
+            f"Apply with `omh memory attention {normalized_id} --tier {requested} --apply`. "
+            "Nothing has changed yet."
+        ),
+        "claim_boundary": _MEMORY_ATTENTION_CLAIM_BOUNDARY,
+    }
+
+
+def apply_memory_attention_change(
+    paths: OmhPaths,
+    record_id: str,
+    *,
+    tier: str,
+    reason: str = "",
+    query: str = "",
+    limit: int = 6,
+    now: datetime | None = None,
+) -> dict[str, object]:
+    """Apply the previewed tier change to the local record and journal it.
+
+    Apply re-derives the preview so both steps share one guard set, then
+    re-reads the record under the store lock: a tier change that raced another
+    operator would otherwise journal a previous tier that was never true.
+    """
+    report = build_memory_attention_change(paths, record_id, tier=tier, reason=reason, query=query, limit=limit, now=now)
+    if not bool(report.get("eligible")):
+        raise ValueError(f"{report['reason_code']}: {report['detail']}")
+    normalized_id = str(report["record_id"])
+    requested = str(report["requested_tier"])
+    current = str(report["current_tier"])
+    changed_at = _attention_stamp(now)
+    entry = {
+        "schema_version": MEMORY_ATTENTION_JOURNAL_SCHEMA_VERSION,
+        "record_id": normalized_id,
+        "previous_tier": current,
+        "tier": requested,
+        "reason": str(report["reason"]),
+        "changed_at": changed_at,
+        "actor_class": "operator",
+        "redaction_policy": "metadata_only",
+        "claim_boundary": _MEMORY_ATTENTION_CLAIM_BOUNDARY,
+    }
+    with file_lock(paths.memory_index_path, private=True):
+        stored, error = read_json_object_result(_memory_record_path(paths, normalized_id))
+        if error or not isinstance(stored, dict) or record_attention_tier(stored) != current:
+            raise ValueError(f"memory record {normalized_id} changed attention tier concurrently; re-run the preview")
+        _write_project_memory_record(
+            paths,
+            {
+                **stored,
+                "attention": _attention_metadata(requested, reason=reason, previous_tier=current, changed_at=changed_at),
+            },
+        )
+        append_jsonl_locked(_memory_attention_journal_path(paths), entry)
+        _write_memory_index_unlocked(paths)
+    return {
+        **report,
+        "applied": True,
+        "reason_code": "applied",
+        "changed_at": changed_at,
+        "journal_entry": entry,
+        "next_action": (
+            f"Reverse it with `omh memory attention {normalized_id} --tier {current} --apply`. "
+            "The record itself was never moved or deleted."
         ),
     }
 
@@ -2120,6 +2500,11 @@ def validate_project_memory_recall_pack(value: Any, *, label: str = "memory_reca
     # existed still validates; present warnings are held to the full shape.
     if "freshness_warnings" in value:
         _validate_context_list(value.get("freshness_warnings"), _FRESHNESS_WARNING_KEYS, errors, f"{label}.freshness_warnings")
+    # Optional for the same reason as freshness warnings: a pack written before
+    # attention tiers existed still validates, and a present block is held to
+    # the full scalar-only shape.
+    if "attention" in value:
+        _validate_context_map(value.get("attention"), _RECALL_ATTENTION_KEYS, errors, f"{label}.attention")
     _validate_context_map(value.get("task_ref"), _PROJECT_MEMORY_TASK_REF_KEYS, errors, f"{label}.task_ref")
     if not isinstance(value.get("truncated"), bool):
         errors.append(f"{label}.truncated must be a boolean")
@@ -2252,6 +2637,16 @@ def _record_from_candidate(
         "updated_at": approved_at,
         "ttl": _ttl_projection(retention),
         "staleness": _staleness_projection(revalidation),
+        # Every approved record states its tier explicitly. An implicit
+        # default would make "this record is active" and "nobody ever set a
+        # tier" the same fact, and the operator could not tell an intentional
+        # promotion from a record the tier system never touched.
+        "attention": _attention_metadata(
+            DEFAULT_MEMORY_ATTENTION_TIER,
+            reason="approved_default",
+            previous_tier="",
+            changed_at=approved_at,
+        ),
         "safety": candidate.get("safety", {}),
         "redaction_policy": "metadata_only",
         "claim_boundary": "Reviewed OMH project memory is prepared context only; it is not execution, review, CI, merge, or Hermes internal-memory evidence.",
@@ -2337,6 +2732,7 @@ def _empty_recall_pack(
         "included_records": [],
         "excluded_records": [{"record_id": "", "reason": reason, "staleness": {"state": "not_checked"}}],
         "freshness_warnings": [],
+        "attention": _attention_disclosure([], 0, include_archived=False),
         "record_count": 0,
         "truncated": False,
         "redaction_policy": "metadata_only",
@@ -2350,6 +2746,7 @@ def _recall_item(
     score: int,
     staleness: dict[str, object],
     evaluation: dict[str, object],
+    attention_tier: str = DEFAULT_MEMORY_ATTENTION_TIER,
 ) -> dict[str, object]:
     evidence = _replay_evaluation(record, evaluation)
     return {
@@ -2362,6 +2759,7 @@ def _recall_item(
         "approved_at": str(record.get("approved_at", "")),
         "staleness": staleness,
         "score": int(score),
+        "attention_tier": attention_tier,
         "derived_from": _string_list(record.get("derived_from", [])),
         "perspective": _perspective_projection(record.get("perspective")),
         **_recall_evidence_fields(evidence),

--- a/tests/test_memory_attention_tiers.py
+++ b/tests/test_memory_attention_tiers.py
@@ -1,0 +1,491 @@
+"""Attention tiers: active, reference, archive (issue #829).
+
+The contract under test is narrow and load-bearing:
+
+- a tier change is previewable before it is applied, and the preview writes
+  nothing (AC1);
+- identical records and tiers produce an identical recall order (AC2);
+- archive is an attention tier, not retirement: the record stays in the store,
+  stays readable, stays queryable, and is never deleted (AC3).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+from omh.memory import (
+    apply_memory_attention_change,
+    apply_memory_retirement,
+    approve_project_memory_candidate,
+    build_memory_attention_change,
+    build_project_memory_recall_pack,
+    capture_project_memory_candidate,
+    memory_recall_pack_for_handoff,
+    read_memory_attention_journal,
+    record_attention_tier,
+    validate_project_memory_record,
+    validate_project_memory_recall_pack,
+)
+from omh.paths import resolve_paths
+from omh.plugin_bundle.omh.memory_governance import canonical_payload_digest
+
+_NOW = datetime(2026, 6, 1, tzinfo=timezone.utc)
+# Approval stamps records with the real clock, so an expiry threshold has to be
+# relative to it. Nothing hashed, ordered, or byte-compared in this module
+# carries this value; it only decides whether a TTL deadline has passed.
+_AFTER_EXPIRY = datetime.now(timezone.utc) + timedelta(days=365)
+
+
+def _approve(paths, summary: str, **kwargs) -> dict:
+    captured = capture_project_memory_candidate(paths, summary, **kwargs)
+    return approve_project_memory_candidate(paths, captured["candidate"]["candidate_id"])["record"]
+
+
+def _store_digest(paths) -> str:
+    """One digest over every byte under .omh/memory, path-normalized.
+
+    Relative paths are compared as POSIX text so the digest is identical on
+    Windows and POSIX; the bytes themselves are read raw, so a line-ending
+    difference inside a stored file would still be caught.
+    """
+    root = paths.memory_dir
+    digest = hashlib.sha256()
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        digest.update(path.relative_to(root).as_posix().encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _included_ids(pack: dict) -> list[str]:
+    return [str(item["record_id"]) for item in pack["included_records"]]
+
+
+def _cli(home: Path, *args):
+    status, stdout, stderr = run_cli(["--omh-home", str(home / ".omh"), "--hermes-home", str(home / ".hermes"), *args])
+    assert status == 0, f"{args} failed: {stderr or stdout}"
+    return json.loads(stdout)
+
+
+class AttentionTierPreviewTests(unittest.TestCase):
+    """AC1: preview and apply are separate steps, and preview mutates nothing."""
+
+    def test_preview_reports_the_resulting_working_context_and_writes_nothing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            first = _approve(paths, "Deploys go through staging first", record_type="decision", tags=["deploy"])
+            second = _approve(paths, "Deploys use canary batches", record_type="decision", tags=["deploy"])
+            before_digest = _store_digest(paths)
+
+            preview = build_memory_attention_change(
+                paths, first["record_id"], tier="archive", reason="superseded by the canary policy", query="deploys", now=_NOW
+            )
+
+            self.assertTrue(preview["eligible"])
+            self.assertFalse(preview["applied"])
+            self.assertEqual(preview["reason_code"], "planned")
+            self.assertEqual(preview["current_tier"], "active")
+            self.assertEqual(preview["requested_tier"], "archive")
+            self.assertEqual(preview["leaving_working_context"], [first["record_id"]])
+            self.assertEqual(preview["working_context_after"]["record_ids"], [second["record_id"]])
+            self.assertIn("Nothing has changed yet", preview["next_action"])
+            self.assertEqual(_store_digest(paths), before_digest, "a preview must not touch a single byte of the store")
+
+    def test_apply_produces_exactly_the_previewed_working_context(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            first = _approve(paths, "Deploys go through staging first", record_type="decision", tags=["deploy"])
+            _approve(paths, "Deploys use canary batches", record_type="decision", tags=["deploy"])
+            preview = build_memory_attention_change(paths, first["record_id"], tier="archive", query="deploys", now=_NOW)
+            before_digest = _store_digest(paths)
+
+            applied = apply_memory_attention_change(paths, first["record_id"], tier="archive", query="deploys", now=_NOW)
+
+            self.assertTrue(applied["applied"])
+            self.assertEqual(applied["reason_code"], "applied")
+            self.assertNotEqual(_store_digest(paths), before_digest, "apply is the step that writes")
+            pack = build_project_memory_recall_pack(paths, "deploys", now=_NOW)
+            self.assertEqual(
+                _included_ids(pack),
+                preview["working_context_after"]["record_ids"],
+                "the previewed working context must be the one the operator actually gets",
+            )
+
+    def test_apply_journals_the_prior_tier_so_the_change_is_reversible(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record = _approve(paths, "Deploys go through staging first")
+
+            apply_memory_attention_change(paths, record["record_id"], tier="archive", reason="old policy", now=_NOW)
+
+            entries = read_memory_attention_journal(paths, record_id=record["record_id"])
+            self.assertEqual([(entry["previous_tier"], entry["tier"]) for entry in entries], [("active", "archive")])
+            self.assertEqual(entries[0]["reason"], "old policy")
+            stored = json.loads((paths.memory_dir / "records" / f"{record['record_id']}.json").read_text(encoding="utf-8"))
+            self.assertEqual(stored["attention"]["previous_tier"], "active")
+
+            apply_memory_attention_change(paths, record["record_id"], tier="active", reason="still current", now=_NOW)
+
+            self.assertEqual(record_attention_tier(_read_record(paths, record["record_id"])), "active")
+            self.assertEqual(
+                [(entry["previous_tier"], entry["tier"]) for entry in read_memory_attention_journal(paths, record_id=record["record_id"])],
+                [("active", "archive"), ("archive", "active")],
+            )
+
+    def test_cli_previews_before_it_applies(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            paths = resolve_paths(home / ".omh", home / ".hermes")
+            record = _approve(paths, "Deploys go through staging first")
+            before_digest = _store_digest(paths)
+
+            preview = _cli(home, "memory", "attention", record["record_id"], "--tier", "reference")
+
+            self.assertFalse(preview["applied"])
+            self.assertEqual(_store_digest(paths), before_digest)
+
+            applied = _cli(home, "memory", "attention", record["record_id"], "--tier", "reference", "--apply")
+
+            self.assertTrue(applied["applied"])
+            self.assertEqual(record_attention_tier(_read_record(paths, record["record_id"])), "reference")
+
+
+class AttentionTierOrderTests(unittest.TestCase):
+    """AC2: identical records and tier metadata produce an identical order."""
+
+    def test_repeated_builds_produce_the_same_order(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            for summary in ("Deploys stage first", "Deploys canary next", "Deploys roll back last"):
+                _approve(paths, summary, tags=["deploy"])
+            apply_memory_attention_change(paths, _ids(paths)[0], tier="reference", now=_NOW)
+
+            orders = {tuple(_included_ids(build_project_memory_recall_pack(paths, "deploys", now=_NOW))) for _ in range(5)}
+
+            self.assertEqual(len(orders), 1, orders)
+
+    def test_order_does_not_depend_on_the_order_files_were_written(self) -> None:
+        with TemporaryDirectory() as tmp:
+            source = resolve_paths(Path(tmp) / "a" / ".omh", Path(tmp) / "a" / ".hermes")
+            for summary in ("Deploys stage first", "Deploys canary next", "Deploys roll back last"):
+                _approve(source, summary, tags=["deploy"])
+            apply_memory_attention_change(source, _ids(source)[0], tier="reference", now=_NOW)
+            expected = _included_ids(build_project_memory_recall_pack(source, "deploys", now=_NOW))
+
+            mirror = resolve_paths(Path(tmp) / "b" / ".omh", Path(tmp) / "b" / ".hermes")
+            for path in sorted(p for p in source.memory_dir.rglob("*") if p.is_file())[::-1]:
+                target = mirror.memory_dir / path.relative_to(source.memory_dir)
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(path, target)
+
+            self.assertEqual(_included_ids(build_project_memory_recall_pack(mirror, "deploys", now=_NOW)), expected)
+
+    def test_reverting_a_tier_restores_the_original_order(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            for summary in ("Deploys stage first", "Deploys canary next", "Deploys roll back last"):
+                _approve(paths, summary, tags=["deploy"])
+            original = _included_ids(build_project_memory_recall_pack(paths, "deploys", now=_NOW))
+            demoted = original[0]
+
+            apply_memory_attention_change(paths, demoted, tier="reference", now=_NOW)
+            reordered = _included_ids(build_project_memory_recall_pack(paths, "deploys", now=_NOW))
+            apply_memory_attention_change(paths, demoted, tier="active", now=_NOW)
+
+            self.assertEqual(reordered[-1], demoted, "a reference record yields to its active peers")
+            self.assertNotEqual(reordered, original)
+            self.assertEqual(_included_ids(build_project_memory_recall_pack(paths, "deploys", now=_NOW)), original)
+
+    def test_tier_outranks_keyword_relevance_inside_the_existing_ladder(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            strong = _approve(paths, "Deploys canary rollback staging checklist", tags=["deploy", "canary", "rollback"])
+            weak = _approve(paths, "Deploys need review", tags=["deploy"])
+            query = "deploys canary rollback staging checklist"
+            self.assertEqual(_included_ids(build_project_memory_recall_pack(paths, query, now=_NOW))[0], strong["record_id"])
+
+            apply_memory_attention_change(paths, strong["record_id"], tier="reference", now=_NOW)
+
+            pack = build_project_memory_recall_pack(paths, query, now=_NOW)
+            self.assertEqual(_included_ids(pack), [weak["record_id"], strong["record_id"]])
+            ranks = {item["record_id"]: item["ranking"]["attention_rank"] for item in pack["included_records"]}
+            self.assertEqual(ranks, {weak["record_id"]: 0, strong["record_id"]: 1})
+            self.assertEqual(
+                [item["ranking"]["relevance_rank"] for item in pack["included_records"]],
+                [2, 1],
+                "the tier reorders the pack without rewriting the relevance evidence that explains it",
+            )
+
+    def test_pack_discloses_when_reference_records_are_included(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            first = _approve(paths, "Deploys stage first", tags=["deploy"])
+            _approve(paths, "Deploys canary next", tags=["deploy"])
+            apply_memory_attention_change(paths, first["record_id"], tier="reference", now=_NOW)
+
+            pack = build_project_memory_recall_pack(paths, "deploys", now=_NOW)
+
+            self.assertEqual(validate_project_memory_recall_pack(pack), [])
+            self.assertEqual(pack["attention"]["active_included"], 1)
+            self.assertEqual(pack["attention"]["reference_included"], 1)
+            self.assertIn("reference-tier record(s) are included", pack["attention"]["detail"])
+            self.assertEqual({item["attention_tier"] for item in pack["included_records"]}, {"active", "reference"})
+
+    def test_a_malformed_attention_block_fails_pack_validation(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            _approve(paths, "Deploys stage first", tags=["deploy"])
+            pack = build_project_memory_recall_pack(paths, "deploys", now=_NOW)
+
+            pack["attention"] = {**pack["attention"], "smuggled": {"nested": "value"}}
+
+            self.assertEqual(
+                validate_project_memory_recall_pack(pack),
+                [
+                    "memory_recall_pack.attention has unsupported keys: ['smuggled']",
+                    "memory_recall_pack.attention.smuggled must be scalar metadata",
+                ],
+            )
+
+
+class ArchiveTierTests(unittest.TestCase):
+    """AC3: archived records stay discoverable and are never silently deleted."""
+
+    def test_archived_record_leaves_the_default_pack_named_not_silently(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record = _approve(paths, "Deploys go through staging first", tags=["deploy"])
+            apply_memory_attention_change(paths, record["record_id"], tier="archive", now=_NOW)
+
+            pack = build_project_memory_recall_pack(paths, "deploys", now=_NOW)
+
+            self.assertEqual(_included_ids(pack), [])
+            self.assertEqual(
+                [entry for entry in pack["excluded_records"] if entry["reason"] == "archived_tier"],
+                [{"record_id": record["record_id"], "reason": "archived_tier", "staleness": {"state": "not_checked"}}],
+            )
+            self.assertEqual(pack["attention"]["archived_excluded"], 1)
+            self.assertIn("remain in the store", pack["attention"]["detail"])
+            self.assertEqual(validate_project_memory_recall_pack(pack), [])
+
+    def test_archived_record_stays_readable_and_answers_an_explicit_query(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record = _approve(paths, "Deploys go through staging first", tags=["deploy"])
+            apply_memory_attention_change(paths, record["record_id"], tier="archive", now=_NOW)
+
+            stored = _read_record(paths, record["record_id"])
+
+            self.assertEqual(validate_project_memory_record(stored), [])
+            self.assertEqual(stored["summary"], record["summary"])
+            self.assertEqual(record_attention_tier(stored), "archive")
+            explicit = build_project_memory_recall_pack(paths, "deploys", now=_NOW, include_archived=True)
+            self.assertEqual(_included_ids(explicit), [record["record_id"]])
+            self.assertEqual(explicit["attention"]["archived_included"], 1)
+            self.assertTrue(explicit["attention"]["include_archived"])
+
+    def test_a_handoff_pack_stops_carrying_an_archived_record(self) -> None:
+        """The point of the tier: what an executor receives actually shrinks."""
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            stale_policy = _approve(paths, "Deploys go through a shared runner", tags=["deploy"])
+            current = _approve(paths, "Deploys use canary batches", tags=["deploy"])
+            before = memory_recall_pack_for_handoff(paths, "deploys", executor_target="codex")
+            self.assertEqual(
+                {str(item["record_id"]) for item in before["included_records"]},
+                {stale_policy["record_id"], current["record_id"]},
+            )
+
+            apply_memory_attention_change(paths, stale_policy["record_id"], tier="archive", now=_NOW)
+
+            after = memory_recall_pack_for_handoff(paths, "deploys", executor_target="codex")
+            self.assertEqual(_included_ids(after), [current["record_id"]])
+            self.assertEqual(after["attention"]["archived_excluded"], 1)
+
+    def test_archiving_a_record_never_removes_it(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record = _approve(paths, "Deploys go through staging first")
+            record_path = paths.memory_dir / "records" / f"{record['record_id']}.json"
+            payload_before = json.loads(record_path.read_text(encoding="utf-8"))
+
+            apply_memory_attention_change(paths, record["record_id"], tier="archive", now=_NOW)
+
+            self.assertTrue(record_path.exists())
+            payload_after = json.loads(record_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                {key: value for key, value in payload_after.items() if key != "attention"},
+                {key: value for key, value in payload_before.items() if key != "attention"},
+                "a tier change rewrites the attention block and nothing else",
+            )
+            self.assertEqual(
+                payload_after["admission"]["payload_digest"],
+                canonical_payload_digest(payload_after),
+                "the tier is attention metadata, so it stays outside the reviewed payload digest",
+            )
+
+    def test_archive_the_tier_is_a_different_state_from_retirement(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            evergreen = _approve(paths, "Deploys go through staging first", record_type="decision")
+            expiring = _approve(paths, "Deploys once used a shared runner", record_type="episode", ttl_days=1)
+            both = _approve(paths, "Deploys once pinned an old image", record_type="episode", ttl_days=1)
+            apply_memory_attention_change(paths, evergreen["record_id"], tier="archive", now=_NOW)
+            apply_memory_attention_change(paths, both["record_id"], tier="archive", now=_NOW)
+
+            applied = apply_memory_retirement(paths, now=_AFTER_EXPIRY)
+
+            records_dir = paths.memory_dir / "records"
+            archive_dir = paths.memory_dir / "archive"
+            self.assertEqual(
+                [path.stem for path in sorted(records_dir.glob("*.json"))],
+                [evergreen["record_id"]],
+                "an archive-tier record is still a live record; only retirement moves a file",
+            )
+            self.assertEqual(
+                {str(row["record_id"]) for row in applied["moved"]},
+                {expiring["record_id"], both["record_id"]},
+                "the tier is not an exemption: an expired archive-tier record still retires",
+            )
+            self.assertEqual(record_attention_tier(_read_record(paths, evergreen["record_id"])), "archive")
+            self.assertFalse(
+                list(archive_dir.glob(f"{evergreen['record_id']}.*.json")),
+                "the tier writes no archive file and no tombstone",
+            )
+            self.assertTrue(list(archive_dir.glob(f"{expiring['record_id']}.*.json")))
+
+
+class AttentionTierGuardTests(unittest.TestCase):
+    def test_unknown_tier_is_refused(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record = _approve(paths, "Deploys go through staging first")
+
+            with self.assertRaises(ValueError) as raised:
+                build_memory_attention_change(paths, record["record_id"], tier="cold-storage", now=_NOW)
+
+            self.assertIn("unsupported memory attention tier", str(raised.exception))
+            self.assertIn("active, reference, archive", str(raised.exception))
+            self.assertEqual(record_attention_tier(_read_record(paths, record["record_id"])), "active")
+
+    def test_tier_change_on_a_missing_record_is_refused_with_a_readable_reason(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            _approve(paths, "Deploys go through staging first")
+            before_digest = _store_digest(paths)
+
+            report = build_memory_attention_change(paths, "mem_00000000000000ee", tier="archive", now=_NOW)
+
+            self.assertFalse(report["eligible"])
+            self.assertEqual(report["reason_code"], "record_not_found")
+            self.assertEqual(report["detail"], "No approved OMH memory record carries that id, so there is no attention tier to change.")
+            with self.assertRaises(ValueError) as raised:
+                apply_memory_attention_change(paths, "mem_00000000000000ee", tier="archive", now=_NOW)
+            self.assertIn("record_not_found", str(raised.exception))
+            self.assertEqual(_store_digest(paths), before_digest)
+
+    def test_a_no_op_tier_change_is_refused_so_every_journal_line_is_a_real_move(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record = _approve(paths, "Deploys go through staging first")
+
+            report = build_memory_attention_change(paths, record["record_id"], tier="active", now=_NOW)
+
+            self.assertFalse(report["eligible"])
+            self.assertEqual(report["reason_code"], "tier_unchanged")
+            self.assertEqual(report["current_tier"], "active")
+            with self.assertRaises(ValueError):
+                apply_memory_attention_change(paths, record["record_id"], tier="active", now=_NOW)
+            self.assertEqual(read_memory_attention_journal(paths), [])
+
+    def test_a_sensitive_reason_is_redacted_before_it_reaches_the_record(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record = _approve(paths, "Deploys go through staging first")
+
+            applied = apply_memory_attention_change(
+                paths, record["record_id"], tier="archive", reason="held the deploy password", now=_NOW
+            )
+
+            self.assertEqual(applied["reason"], "[redacted]")
+            self.assertEqual(_read_record(paths, record["record_id"])["attention"]["reason"], "[redacted]")
+            self.assertEqual(read_memory_attention_journal(paths)[0]["reason"], "[redacted]")
+
+    def test_unsafe_record_id_is_refused_before_any_store_read(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            with self.assertRaises(ValueError) as raised:
+                build_memory_attention_change(paths, "../escape", tier="archive", now=_NOW)
+            self.assertIn("unsafe memory record id", str(raised.exception))
+
+
+class AttentionTierLifecycleTests(unittest.TestCase):
+    """The tier must survive the correction/restore round trip.
+
+    A new record field that is not carried through `_pending_candidate` and
+    `_approved_record` is dropped silently by correct/restore, which would
+    quietly return an archived record to the active working set.
+    """
+
+    def test_tier_survives_capture_approve_correct_reapprove(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            paths = resolve_paths(home / ".omh", home / ".hermes")
+            record = _approve(paths, "Deploys go through staging first", record_type="decision")
+            apply_memory_attention_change(paths, record["record_id"], tier="reference", reason="background context", now=_NOW)
+
+            _cli(home, "memory", "correct", record["record_id"], "Deploys go through staging, then canary", "--revision", "1", "--apply")
+            correction = _lifecycle_candidate(paths, "correction")
+            result = _cli(home, "memory", "approve", correction)
+
+            self.assertTrue(result.get("applied"), str(result.get("reason_code")))
+            live = _read_record(paths, record["record_id"])
+            self.assertEqual(live["revision"], 2)
+            self.assertEqual(record_attention_tier(live), "reference")
+            self.assertEqual(live["attention"]["reason"], "background context")
+            self.assertEqual(live["attention"]["previous_tier"], "active")
+
+    def test_tier_survives_retire_restore_reapprove(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            paths = resolve_paths(home / ".omh", home / ".hermes")
+            record = _approve(paths, "Deploys once used a shared runner", record_type="episode", ttl_days=1)
+            apply_memory_attention_change(paths, record["record_id"], tier="reference", reason="background context", now=_NOW)
+
+            apply_memory_retirement(paths, now=_AFTER_EXPIRY)
+            _cli(home, "memory", "restore", record["record_id"], "--revision", "1", "--apply")
+            result = _cli(home, "memory", "approve", _lifecycle_candidate(paths, "restore"))
+
+            self.assertTrue(result.get("applied"), str(result.get("reason_code")))
+            self.assertEqual(record_attention_tier(_read_record(paths, record["record_id"])), "reference")
+
+
+def _ids(paths) -> list[str]:
+    return sorted(path.stem for path in (paths.memory_dir / "records").glob("*.json"))
+
+
+def _read_record(paths, record_id: str) -> dict:
+    return json.loads((paths.memory_dir / "records" / f"{record_id}.json").read_text(encoding="utf-8"))
+
+
+def _lifecycle_candidate(paths, lifecycle: str) -> str:
+    for path in sorted((paths.memory_dir / "candidates").glob("*.json")):
+        candidate = json.loads(path.read_text(encoding="utf-8"))
+        if candidate.get("lifecycle") == lifecycle:
+            return str(candidate["candidate_id"])
+    raise AssertionError(f"no {lifecycle} candidate was staged")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_memory_sync_skill.py
+++ b/tests/test_memory_sync_skill.py
@@ -169,6 +169,21 @@ class MemorySyncSkillTests(unittest.TestCase):
         ):
             self.assertIn(anchor, content, anchor)
 
+    def test_memory_sync_skill_teaches_the_preview_then_apply_attention_tier_flow(self) -> None:
+        """Without this guidance the tier is a CLI feature Hermes never reaches,
+        and the user is back to typing a control-plane command."""
+        content = _template_content("memory-sync")
+        on_disk = Path("skills/omh-memory-sync/SKILL.md").read_text(encoding="utf-8")
+        for anchor in (
+            "Attention (주의)",
+            "omh memory attention <record-id> --tier <tier>",
+            "The preview writes nothing.",
+            "An attention tier is not a lifecycle state",
+            "omh memory recall --include-archived",
+        ):
+            self.assertIn(anchor, content, anchor)
+            self.assertIn(anchor, on_disk, anchor)
+
     def test_memory_sync_skill_context_rail_markers(self) -> None:
         markers = (
             "Workflow Lane",

--- a/tests/test_parser_memory.py
+++ b/tests/test_parser_memory.py
@@ -25,6 +25,9 @@ class MemoryParserTests(unittest.TestCase):
             (["memory", "perspectives"], "cmd_memory_perspectives"),
             (["memory", "pin", "record-one"], "cmd_memory_pin"),
             (["memory", "unpin", "record-one"], "cmd_memory_unpin"),
+            (["memory", "attention", "record-one", "--tier", "reference"], "cmd_memory_attention"),
+            (["memory", "attention", "record-one", "--tier", "archive", "--apply"], "cmd_memory_attention"),
+            (["memory", "recall", "query", "--include-archived"], "cmd_memory_recall"),
             (["memory", "rollup", "--tag", "deploy"], "cmd_memory_rollup"),
             (["memory", "rollup", "--tag", "deploy", "--apply"], "cmd_memory_rollup"),
             (["memory", "capture", "summary", "--observed", "codex"], "cmd_memory_capture"),
@@ -46,6 +49,20 @@ class MemoryParserTests(unittest.TestCase):
             ["memory", "capture", "summary", "--derived-from", "mem_a", "--derived-from", "mem_b"]
         )
         self.assertEqual(args.derived_from, ["mem_a", "mem_b"])
+
+    def test_memory_attention_rejects_an_unknown_tier_at_the_parser_boundary(self) -> None:
+        with self.assertRaises(SystemExit) as raised:
+            build_parser().parse_args(["memory", "attention", "record-one", "--tier", "cold-storage"])
+        self.assertEqual(raised.exception.code, 2)
+
+    def test_memory_attention_requires_an_explicit_tier(self) -> None:
+        with self.assertRaises(SystemExit) as raised:
+            build_parser().parse_args(["memory", "attention", "record-one"])
+        self.assertEqual(raised.exception.code, 2)
+
+    def test_memory_attention_defaults_to_report_only(self) -> None:
+        args = build_parser().parse_args(["memory", "attention", "record-one", "--tier", "archive"])
+        self.assertFalse(args.apply)
 
     def test_memory_lineage_defaults_to_three_hops(self) -> None:
         args = build_parser().parse_args(["memory", "lineage", "record-one"])


### PR DESCRIPTION
## Feature Report

### What Changed

- Approved OMH project memory now carries an explicit **attention tier** — `active`, `reference`, or `archive` — as schema-versioned, scalar-only metadata (`omh_memory_attention/v1`) on the record.
- New preview-then-apply operator surface: `omh memory attention <record-id> --tier <tier> [--reason ...] [--query ...] [--apply]`. Without `--apply` it reports what the working context looks like now and what it would look like after, and writes nothing.
- Recall packs are built from active records first. The tier is the new first key of the **existing** ranking ladder (pins → attention tier → relevance rank → decayed fused score → record id); no second ordering mechanism was added.
- Every recall pack now discloses its own tier composition in an `attention` block, and each included record reports `attention_tier` plus an integer `attention_rank` inside its existing `ranking` block.
- `archive` is an attention tier, not a lifecycle state. An archived record stays in `records/`, stays readable, is named in every pack as an `archived_tier` exclusion instead of vanishing, and is recallable on demand with `omh memory recall --include-archived`.
- Applied changes append one `omh_memory_attention_journal/v1` line to `.omh/memory/attention.jsonl` recording the prior tier, so an archive is reversible from local evidence alone.
- The `memory-sync` skill now teaches Hermes the preview-then-apply flow and disambiguates the two meanings of "archive", so a user gets the capability from natural-language chat rather than by typing a control-plane command.

Closes #829.

### Why This Exists

Approved project memory only grows. Every reviewed record stays true and stays eligible, so an 8-month-old but still-correct fact competes for the same recall budget as the three facts that actually describe today's work. The only attention control that existed was pins (at most 12, guaranteed-inclusion anchors) — there was a way to push one record up and no way to push any record down.

Retirement was not the answer. It only fires on an expired record, it moves the file out of `records/`, and it writes a tombstone. "This is still true, I just do not want it in every handoff" had no expression at all. Verified absent before this change: `grep -rni "attention_tier"` returned 0 hits and the approved-record builder had no tier field.

### User / Operator Impact

A user can now tell Hermes to keep a record active, move it to reference, or archive it, and Hermes states what will remain in the working context **before** the local metadata change is applied. Concretely, from the tests in this PR: previewing a tier change on a 2-record store reports `Moving this record from active to archive leaves 1 record(s) in the working context, was 2`, names the record ids leaving and entering, and leaves the store byte-identical; applying then produces exactly the previewed pack.

Operators additionally get: a reversible archive with a journal of prior tiers, an explicit archived query, and a pack that always says how many reference and archived records are behind the active ones instead of silently shrinking.

### How It Works

**Tier storage.** `_record_from_candidate` writes `attention` on every approved record, so "this record is active" and "nobody ever set a tier" are distinguishable facts rather than the same absence. The block holds `tier`, a redacted and bounded `reason`, `previous_tier`, and `changed_at` — all scalars, because non-scalar nested values are dropped by correction/restore and rejected by the recall-pack validators.

**Ranking.** `_attach_recall_ranking` derives `attention_rank` (active 0, reference 1, archive 2) and `ranked_key` in `build_project_memory_recall_pack` takes it as its first term. The fused score is untouched, so a tier change reorders a pack without rewriting the relevance/recency/usage evidence that explains it. A reference record therefore ranks below every active record even when it is the stronger keyword match — asserted directly in `test_tier_outranks_keyword_relevance_inside_the_existing_ladder`.

**Preview.** `build_memory_attention_change` builds the recall pack twice through the same builder: once as the store stands, and once with `attention_override={record_id: requested}` substituting the tier in memory. `working_context_after` is therefore the pack the operator actually gets, not a description of one — locked by `test_apply_produces_exactly_the_previewed_working_context`. `apply_memory_attention_change` re-derives the same report so both steps share one guard set, then re-reads the record under the store lock and refuses if the tier moved underneath it.

**Determinism.** Every entry point takes `now` as a parameter; no wall clock enters a compared payload. Record reads are path-sorted, so order does not depend on write order.

**Archive vs retirement.** The archive cut happens right after the perspective check and before eligibility evaluation, emitting an `archived_tier` exclusion. Retirement is untouched and still moves expired revisions into `.omh/memory/archive/` with a tombstone. The tier is not an exemption either: an expired archive-tier record still retires on the normal schedule.

**Digest safety.** `canonical_payload_digest` whitelists payload fields (`schema_version`, ids, `revision`, `record_type`, `summary`, `scope`, `value`, `label`), so `attention` sits outside it. A tier change never invalidates a record's immutable review linkage — asserted in `test_archiving_a_record_never_removes_it`.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/workflows/memory.py` | Tier vocabulary, `record_attention_tier`, `normalize_memory_attention_tier`, `build_memory_attention_change`, `apply_memory_attention_change`, `read_memory_attention_journal`, `_attention_disclosure`; recall pack gains `include_archived` and `attention_override` |
| `src/workflows/_memory_lifecycle_plans.py` | `attention` added to the `_pending_candidate` replacement key tuple; `_attention()` carries the tier onto the successor revision in `_approved_record` |
| `src/commands/memory_parser.py`, `src/commands/memory.py` | `omh memory attention` (report-first, `--apply` to write) and `omh memory recall --include-archived` |
| `src/runtime/records.py` | `attention_tier` and `attention_rank` survive recall-pack compaction, preserving run-backed/prompt-only executor parity |
| `src/skills/render.py` → `skills/omh-memory-sync/SKILL.md` | Hermes-facing `Attention (주의)` protocol step and the archive-tier vs retire-verb disambiguation (regenerated, not hand-edited) |
| `docs/MEMORY.md` | New "Attention Tiers" section plus a pointer from "Exact Lifecycle Vocabulary" |

Allowed-key sets updated so the field survives validation and the correct/restore round trip: `_PROJECT_MEMORY_RECORD_KEYS` (+`attention`), `_PROJECT_MEMORY_RECALL_PACK_KEYS` (+`attention`), `_PROJECT_MEMORY_RECALL_ITEM_KEYS` (+`attention_tier`), `_RECALL_RANKING_KEYS` (+`attention_rank`), new `_RECALL_ATTENTION_KEYS`, and the `_pending_candidate` replacement tuple.

New schema versions: `omh_memory_attention/v1` (record block), `memory_attention_change/v1` (preview/apply report), `omh_memory_attention_journal/v1` (journal line).

## Validation

All commands below were run from this worktree on the final tree, rebased onto `origin/main` at `f9251979`.

- [x] `uv run --group lint ruff check src tests` — `All checks passed!`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` — `Ran 4946 tests in 188.276s` / `OK`. This PR adds 26 test methods: 22 in the new `tests/test_memory_attention_tiers.py`, 3 in `tests/test_parser_memory.py`, 1 in `tests/test_memory_sync_skill.py`.
- [x] `uv run python -m compileall -q src tests` — exit 0
- [x] `uv run python -m omh.cli docs workflows --check` — `ok: true`, tap skills `checked 115 / expected 115`, no missing/stale/extra
- [x] `uv run python -m omh.cli harness validate` — `ok: true`, 72 harnesses, 104 skills, 0 errors, 0 warnings
- [x] `uv run python -m omh.cli docs roles --check` — `ok: true`
- [x] `uv run python -m omh.cli docs capability-families --check` — `ok: true`
- [x] `git diff --check` — clean
- [x] `python3 -m omh.cli release checklist --json` — `ok: true`, plan mode, 35 required items
- [x] `python3 -m omh.cli release hermes-smoke` — plan mode renders with plan-only boundary
- [x] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable, no learning contract changed
- [x] Relevant dry-run or smoke command: `omh memory attention <id> --tier reference` (preview, store byte-identical) and `--apply` exercised through the CLI harness in `tests/test_memory_attention_tiers.py`
- [ ] Manual Hermes/TUI check: **not run.** No live Hermes profile was touched from this worktree. The `memory-sync` skill change is verified as generated content matching its template and as bytes on disk, which is not evidence that Hermes selected the skill or ran the flow in chat.

New tests (`tests/test_memory_attention_tiers.py`, 22 cases) cover the three acceptance criteria directly:

- **AC1** — `test_preview_reports_the_resulting_working_context_and_writes_nothing` hashes every byte under `.omh/memory` before and after the preview and asserts the digest is unchanged; `test_apply_produces_exactly_the_previewed_working_context` asserts the post-apply pack equals the previewed one; a CLI test repeats both through `omh memory attention`.
- **AC2** — five repeated builds collapse to one order; a store mirrored file-by-file in reverse write order produces the identical order; demoting then restoring a tier returns the pack to its original order exactly.
- **AC3** — an archived record is still readable and passes `validate_project_memory_record`, still answers `--include-archived`, is never removed, and `test_archive_the_tier_is_a_different_state_from_retirement` asserts the two states are distinguishable (the archive-tier record stays a live record; only retirement moves a file) while confirming the tier is not a retirement exemption. `test_a_handoff_pack_stops_carrying_an_archived_record` shows the effect where it matters: a prepared handoff for `codex` carries two records before the change and one after.

Guards: unknown tier refused with a readable message, missing record refused as `record_not_found`, a no-op change refused as `tier_unchanged`, unsafe record id refused before any store read, a sensitive `--reason` redacted before it reaches the record and the journal, and a malformed `attention` block rejected by pack validation. Parser-boundary cases live in `tests/test_parser_memory.py`; the Hermes-facing skill guidance is locked in `tests/test_memory_sync_skill.py`.

## Risk

- **Recall order changes for existing stores.** `attention_rank` is now the first sort term. Every pre-existing record reads as `active` (absence defaults to active), so `attention_rank` is 0 for all of them and the effective order is unchanged until someone sets a tier. The full suite passing unmodified is the evidence.
- **A record could be archived and then forgotten.** Mitigated deliberately: an archived record is never dropped silently — it appears in every pack as an `archived_tier` exclusion, the pack `attention.detail` counts it, and the journal records how to reverse it.
- **The default is fail-open, not fail-closed.** An unreadable or corrupt tier reads as `active`. That is intentional: attention is not a trust gate, and failing closed would blank recall for every record written before this change. Expiry, scope, perspective, and review eligibility are untouched by the tier.
- **Two meanings of "archive" now exist in the vocabulary.** Addressed in the skill text, `docs/MEMORY.md`, and a test asserting the two states differ — but it is a real naming cost, taken because the issue names the tier `archive` and renaming it would break the requested contract.

## Compatibility / Rollout

- Backward compatible with existing stores. `attention` is optional on read; a record without it behaves exactly as before.
- No new dependencies, no network or LLM calls, no Hermes core patching. Everything is local, deterministic, and metadata-only.
- Wrapper briefs, runtime artifacts, and delegation payloads already whitelist the fields they project, so the new pack field is additive and inert for them. The run-backed executor path was extended explicitly so it does not lose the tier that explains its own pack order.
- Prepared-vs-observed boundary preserved: an attention tier is an OMH-local recall-priority marker and is never execution, review, CI, merge, or Hermes internal-memory evidence. Every new payload carries that claim boundary.

## Release / Claims

- [x] Release-channel impact considered — additive local capability, no channel or version change in this PR
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — the Hermes chat flow is marked not observed above
- [x] Known manual Hermes checks are listed, including the `omh release hermes-smoke --live` gap

## Follow-Up

- `omh memory status` does not yet report per-tier counts; an operator has to build a pack to see the distribution.
- The preview builds the working context project-wide. Previewing against a specific scope or perspective lens would need `--scope-kind` / `--observed` pass-throughs; deliberately left out to keep the surface minimal.
- No bulk operation: tiering N records is N previews and N applies. Worth revisiting only if real stores show the need.
