### PR TITLE
feat: define complete OMH-native capability blueprints

### DIFF
--- a/src/workflows/native_capability_blueprint.py
+++ b/src/workflows/native_capability_blueprint.py
@@ -1,0 +1,757 @@
+"""Native experience blueprints: `native_capability_blueprint/v1` (issue #791).
+
+What was missing
+----------------
+
+A useful feature demonstrated in some other agent tool arrives described in that
+tool's own vocabulary -- its manifest, its registry entry, its tool definitions,
+its hooks, its agents, its settings. None of that says how the behavior should
+feel when a person types a sentence at Hermes, which OMH surfaces have to move
+for it to exist, or where the claim stops.
+
+`skills/native_capability_surfaces.py` shows the *shape* of what a native
+capability touches: a skill definition, a harness, a surface exposure. It shows
+it by hardcoding three specific capabilities. There was no contract for
+describing a capability that does not exist yet, and so no way to check that a
+description of one is complete before somebody starts building it.
+
+What a blueprint is
+-------------------
+
+One design artifact for one capability OMH does not have. It names the intent,
+the sentences a person would actually type, what Hermes asks back before it
+answers, what it produces, which native surfaces have to change, what happens
+when an input is missing, what the capability is explicitly not, and the
+boundary on all of it.
+
+It is not a claim that the capability exists. `CLAIM_BOUNDARY` says so on every
+payload, `IMPLEMENTATION_CLAIM_KEYS` refuses a payload shaped to say otherwise
+by key name, and the closed key set refuses the rest.
+
+The surface vocabulary is checkable, not aspirational
+-----------------------------------------------------
+
+`NATIVE_CAPABILITY_SURFACES` is not a list of nouns somebody thought a
+capability might touch. Every member names a structure that exists in this
+repository and that a real gate fails on when a new capability misses it --
+`NATIVE_CAPABILITY_SURFACE_ANCHORS` holds the file and the structure for each,
+and `docs/ADDING-A-SKILL.md` is where that list comes from.
+
+`REQUIRED_NATIVE_CAPABILITY_SURFACES` is the subset no installable capability
+can avoid: the catalog entry, the harness and its evidence ladder, the routing
+triggers, the awareness lane and context card, the wrapper action and its label,
+the coverage case, the capability family, the regenerated docs, and the
+exact-count fixtures. A blueprint that omits one is a validation error naming
+the surface and the file it lives in -- which is #791 AC1 in its enforcing form,
+and is what makes "identifies every affected surface" something a reader can
+check rather than something an author can assert.
+
+The four remaining surfaces are conditional by design. A capability that mints
+no local artifact, reads no reviewed memory, prepares no coding handoff, and
+needs no bespoke chat card genuinely does not touch them, and requiring them
+would make the required list mean less rather than more.
+
+Observed there, required here
+-----------------------------
+
+#791 AC3 is the boundary the rest of the contract rests on, and it is modelled
+as two fields that cannot be confused for each other:
+
+    observed_source_mechanics  -- what the source host does, as inspiration
+    omh_runtime_requirements   -- what OMH will need at runtime
+
+Both are closed vocabularies and they are disjoint. Naming a source-host
+mechanic in the requirement list is refused by name, before the generic
+unsupported-value check, because "unsupported value" is the wrong sentence for
+it: the value is perfectly well-formed and the defect is that a foreign host
+became load-bearing. Naming the same mechanic as observed inspiration is fine
+and is what the field is for.
+
+There is deliberately no field through which a mechanic can be promoted. AC3
+says a source mechanic may not become a runtime requirement "without a separate
+approved boundary", and a separate approved boundary is exactly what changing
+this schema is: `OMH_RUNTIME_REQUIREMENTS` is a reviewed constant, so widening
+it is a diff somebody signs off on rather than a payload somebody writes.
+
+Determinism
+-----------
+
+`build_native_capability_blueprint` reads no clock. `prepared_at` is a
+parameter and defaults to empty, and it is excluded from `blueprint_digest`
+along with the digest itself -- a wall clock inside a compared value turns an
+equality check into a race, which this repo has already lost Windows CI time to.
+
+Closed vocabularies are normalized into their declared order before the digest
+is taken, so two authors who list the same surfaces in different orders produce
+the same digest.
+
+What reads these today
+----------------------
+
+Stated because the vocabulary here is wider than the wiring. No production
+surface mints a blueprint yet; this module is the contract and
+`tests/test_native_capability_blueprint.py` is its only caller. Issue #795's
+quality gate is the intended reader, and `blueprint_expected_surfaces` is the
+accessor it joins on: it refuses an invalid blueprint rather than returning a
+partial surface list a gate would silently pass.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any, Final
+
+from ..system.append_only_store import RAW_OR_HIDDEN_KEYS
+
+
+NATIVE_CAPABILITY_BLUEPRINT_SCHEMA_VERSION: Final[str] = "native_capability_blueprint/v1"
+
+BLUEPRINT_PRIVACY: Final[str] = "metadata_only"
+
+# On every payload. The last clause is the one #791 AC2 rests on: a blueprint is
+# a design artifact for work nobody has done.
+CLAIM_BOUNDARY: Final[str] = (
+    "A native capability blueprint is an OMH-local design artifact describing how one capability should "
+    "behave if it is built. It is not dispatch, execution, verification, review, CI, merge-readiness, or "
+    "merge evidence, it is not a claim that the capability exists, is installed, or is available, and it "
+    "never makes a source host's tools, hooks, agents, settings, manifests, or registries a runtime "
+    "requirement of OMH."
+)
+
+# Every native surface a new OMH capability can move, in the order a blueprint
+# renders them. Derived from `docs/ADDING-A-SKILL.md`: each member names a
+# structure that exists in this tree and has a gate behind it.
+NATIVE_CAPABILITY_SURFACES: Final[tuple[str, ...]] = (
+    "skill_catalog",
+    "harness",
+    "evidence_ladder",
+    "routing_triggers",
+    "awareness_lane",
+    "workflow_context_card",
+    "wrapper_action",
+    "next_action_label",
+    "chat_card",
+    "coverage_case",
+    "capability_family",
+    "generated_docs",
+    "exact_count_fixtures",
+    "runtime_artifact",
+    "memory_policy",
+    "coding_handoff",
+)
+
+# Where each surface actually lives. Quoted back in the refusal so a blueprint
+# that misses a surface reports the file to edit rather than a bare noun.
+NATIVE_CAPABILITY_SURFACE_ANCHORS: Final[dict[str, str]] = {
+    "skill_catalog": "the SkillDefinition in src/skills/catalog.py",
+    "harness": "the HarnessDefinition in src/skills/catalog.py, checked by `omh harness validate`",
+    "evidence_ladder": (
+        "HarnessDefinition.evidence_ladder in src/skills/catalog.py, alongside "
+        "src/workflows/observation_journal.py"
+    ),
+    "routing_triggers": "the phrase and token triggers in src/routing/chat.py, each with an overroute guard",
+    "awareness_lane": "the lane skills lists in awareness_primer_payload() in src/plugin_bundle/omh/awareness.py",
+    "workflow_context_card": "_WORKFLOW_CONTEXT_CARD_BY_WORKFLOW in src/plugin_bundle/omh/awareness.py",
+    "wrapper_action": "VISIBLE_ACTIONS and _ACK_PRIMARY_ACTIONS_BY_NEXT_ACTION in src/wrapper/contract.py",
+    "next_action_label": "NEXT_ACTION_LABELS in src/routing/action_copy.py",
+    "chat_card": "a *_CHAT_CARDS entry or a bespoke renderer in src/wrapper/contract.py",
+    "coverage_case": (
+        "a ChatCardCoverageCase in src/quality/chat_card_coverage.py or a RoutingInterventionCase in "
+        "src/quality/routing_precision.py"
+    ),
+    "capability_family": (
+        "src/capabilities/families.py, projected into src/plugin_bundle/omh/tools/capability_families.json"
+    ),
+    "generated_docs": "docs/WORKFLOWS.md, docs/ROLES.md, and skills/*/SKILL.md, regenerated from catalog data",
+    "exact_count_fixtures": (
+        "the exact-count assertions in tests/test_routing_precision.py, tests/test_cli.py, "
+        "tests/test_hermes_ux_quality.py, and tests/test_release_smoke.py"
+    ),
+    "runtime_artifact": "a metadata-only schema-versioned artifact under .omh/, read through src/runtime/artifacts.py",
+    "memory_policy": "reviewed OMH-local project memory under .omh/memory/",
+    "coding_handoff": "a prepared coding handoff payload from src/coding/coding_delegation.py",
+}
+
+# The surfaces no installable capability can avoid. #791 AC1's enforcing set.
+REQUIRED_NATIVE_CAPABILITY_SURFACES: Final[tuple[str, ...]] = (
+    "skill_catalog",
+    "harness",
+    "evidence_ladder",
+    "routing_triggers",
+    "awareness_lane",
+    "workflow_context_card",
+    "wrapper_action",
+    "next_action_label",
+    "coverage_case",
+    "capability_family",
+    "generated_docs",
+    "exact_count_fixtures",
+)
+
+# Genuinely conditional: a capability that mints no artifact, reads no reviewed
+# memory, prepares no coding handoff, and needs no bespoke card does not touch
+# these, and requiring them anyway would make the required list mean less.
+OPTIONAL_NATIVE_CAPABILITY_SURFACES: Final[tuple[str, ...]] = tuple(
+    surface for surface in NATIVE_CAPABILITY_SURFACES if surface not in REQUIRED_NATIVE_CAPABILITY_SURFACES
+)
+
+# How a source host packages, exposes, or runs the demonstrated feature. Every
+# member is something that belongs to the other system: a manifest it reads, a
+# registry it resolves against, an extension API it exposes, a process it runs.
+# A blueprint may record any of them as what was observed. None of them may
+# appear in `omh_runtime_requirements`.
+SOURCE_HOST_MECHANICS: Final[tuple[str, ...]] = (
+    "host_plugin_manifest",
+    "host_plugin_registry",
+    "host_marketplace_listing",
+    "host_extension_api",
+    "host_tool_definition",
+    "host_hook",
+    "host_agent_definition",
+    "host_setting",
+    "host_slash_command",
+    "host_background_service",
+    "host_remote_endpoint",
+)
+
+# What OMH is allowed to need at runtime. Every member is local, deterministic,
+# and reachable without the source host: catalog data this repo ships, a
+# contract this repo defines, an artifact under .omh/, or something the caller
+# hands in. Widening this tuple is the "separate approved boundary" #791 AC3
+# names -- a reviewed diff, never a value in a payload.
+OMH_RUNTIME_REQUIREMENTS: Final[tuple[str, ...]] = (
+    "local_catalog_metadata",
+    "local_deterministic_contract",
+    "installed_hermes_skill",
+    "metadata_only_local_artifact",
+    "reviewed_local_memory",
+    "prepared_coding_handoff",
+    "wrapper_supplied_input",
+    "user_supplied_input",
+    "omh_cli_command",
+)
+
+# What Hermes does before it answers. `answer_directly` is the only policy that
+# asks nothing, and it is the only one that may carry no clarifying questions.
+CLARIFICATION_POLICIES: Final[tuple[str, ...]] = (
+    "answer_directly",
+    "clarify_then_answer",
+    "clarify_before_handoff",
+    "always_clarify_first",
+)
+
+# What the capability does when a required input is absent. Four behaviors and
+# no "best effort" member: guessing past a missing input is how a prepared
+# artifact starts reading like an observed one.
+DEGRADATION_BEHAVIORS: Final[tuple[str, ...]] = (
+    "ask_for_missing_input",
+    "render_partial_with_not_observed",
+    "explain_gap_and_stop",
+    "route_to_another_workflow",
+)
+
+# `docs/DIRECTION.md`, Ownership Boundary, restated as vocabularies so a
+# blueprint has to place every part of the capability on one side of the line.
+HERMES_RETAINED_WORK: Final[tuple[str, ...]] = (
+    "chat_intake",
+    "clarification",
+    "source_backed_research",
+    "planning",
+    "skill_and_workflow_narration",
+    "user_facing_status_continuity",
+)
+DELEGATED_WORK: Final[tuple[str, ...]] = (
+    "main_implementation_work",
+    "code_changes",
+    "code_review_fixes",
+    "verification_execution",
+    "merge_readiness_work",
+)
+
+NATIVE_CAPABILITY_BLUEPRINT_KEYS: Final[tuple[str, ...]] = (
+    "affected_surfaces",
+    "blueprint_digest",
+    "capability_id",
+    "claim_boundary",
+    "clarification_policy",
+    "clarifying_questions",
+    "degradation_behavior",
+    "delegated_work",
+    "evidence_steps",
+    "example_requests",
+    "expected_outputs",
+    "hermes_retained_work",
+    "intent_summary",
+    "non_goals",
+    "observed_source_mechanics",
+    "omh_runtime_requirements",
+    "prepared_at",
+    "privacy",
+    "schema_version",
+)
+
+# Exactly what `blueprint_digest` seals: the design, and nothing else. The three
+# module constants are excluded because they are not design decisions, and
+# `prepared_at` is excluded because a clock inside a compared value is a race.
+BLUEPRINT_DIGEST_KEYS: Final[tuple[str, ...]] = (
+    "affected_surfaces",
+    "capability_id",
+    "clarification_policy",
+    "clarifying_questions",
+    "degradation_behavior",
+    "delegated_work",
+    "evidence_steps",
+    "example_requests",
+    "expected_outputs",
+    "hermes_retained_work",
+    "intent_summary",
+    "non_goals",
+    "observed_source_mechanics",
+    "omh_runtime_requirements",
+)
+
+# Key names under which "this capability exists" arrives. The closed key set
+# already refuses every one of them, but it refuses them as unsupported keys,
+# and the point of this family is that a design is not a delivery -- so the
+# shape is named and refused by name first.
+IMPLEMENTATION_CLAIM_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "available",
+        "built",
+        "ci_result",
+        "delivered",
+        "deployed",
+        "enabled",
+        "executed",
+        "exit_code",
+        "implemented",
+        "installed",
+        "live",
+        "merged",
+        "observed",
+        "observed_at",
+        "ran",
+        "released",
+        "result",
+        "reviewed",
+        "shipped",
+        "status",
+        "succeeded",
+        "success",
+        "verified",
+    }
+)
+
+_LABEL: Final[str] = "native_capability_blueprint"
+
+# The canonical skill name this blueprint is for: the identifier a catalog entry,
+# a tap directory, and a routing key would all use.
+_CAPABILITY_ID: Final[re.Pattern[str]] = re.compile(r"^[a-z0-9][a-z0-9-]{1,48}$")
+
+# An evidence-ladder step, in the shape the harness definitions already use.
+_EVIDENCE_STEP: Final[re.Pattern[str]] = re.compile(r"^[a-z][a-z0-9_]{2,48}$")
+
+# An example request is a sentence a person types, not a command they run.
+# `docs/DIRECTION.md` rule 1: chat users stay free of command knowledge, so an
+# example that teaches one is the wrong example.
+_COMMAND_SHAPED: Final[re.Pattern[str]] = re.compile(r"^\s*(?:omh\b|/|-)|--")
+
+# Free-text bounds. A blueprint is authored design prose, and these keep it from
+# becoming somewhere a transcript can be parked.
+_MAX_TEXT_LENGTH: Final[int] = 200
+_MAX_EXAMPLE_REQUESTS: Final[int] = 8
+_MIN_EXAMPLE_REQUESTS: Final[int] = 2
+_MAX_CLARIFYING_QUESTIONS: Final[int] = 6
+_MAX_EXPECTED_OUTPUTS: Final[int] = 8
+_MAX_NON_GOALS: Final[int] = 8
+_MAX_EVIDENCE_STEPS: Final[int] = 8
+_MIN_EVIDENCE_STEPS: Final[int] = 2
+
+
+class NativeCapabilityBlueprintError(ValueError):
+    """Raised when a description of a capability cannot become a blueprint."""
+
+
+# ---------------------------------------------------------------------------
+# Surface vocabulary
+# ---------------------------------------------------------------------------
+
+
+def blueprint_surface_anchor(surface: str) -> str:
+    """The file and structure one surface name refers to, or an empty string."""
+    return NATIVE_CAPABILITY_SURFACE_ANCHORS.get(str(surface), "")
+
+
+def unknown_surfaces(surfaces: Iterable[str]) -> tuple[str, ...]:
+    """Every named surface that is not in the vocabulary, sorted."""
+    return tuple(sorted({str(surface) for surface in surfaces} - set(NATIVE_CAPABILITY_SURFACES)))
+
+
+def missing_required_surfaces(surfaces: Iterable[str]) -> tuple[str, ...]:
+    """Every required surface the caller did not name, in declared order."""
+    named = {str(surface) for surface in surfaces}
+    return tuple(surface for surface in REQUIRED_NATIVE_CAPABILITY_SURFACES if surface not in named)
+
+
+def blueprint_expected_surfaces(blueprint: Mapping[str, Any]) -> tuple[str, ...]:
+    """The surfaces one blueprint names, in `NATIVE_CAPABILITY_SURFACES` order.
+
+    The accessor a downstream quality gate joins on. It refuses an invalid
+    blueprint outright rather than returning whatever surface list happens to be
+    on the payload: a gate handed a partial list would pass a capability for
+    surfaces nobody promised, which is the failure the surface vocabulary exists
+    to prevent.
+    """
+    errors = validate_native_capability_blueprint(blueprint)
+    if errors:
+        raise NativeCapabilityBlueprintError(errors[0])
+    named = {str(surface) for surface in blueprint.get("affected_surfaces", [])}
+    return tuple(surface for surface in NATIVE_CAPABILITY_SURFACES if surface in named)
+
+
+# ---------------------------------------------------------------------------
+# Build and validate
+# ---------------------------------------------------------------------------
+
+
+def build_native_capability_blueprint(
+    *,
+    capability_id: str,
+    intent_summary: str,
+    example_requests: Sequence[str],
+    clarification_policy: str,
+    hermes_retained_work: Sequence[str],
+    expected_outputs: Sequence[str],
+    affected_surfaces: Sequence[str],
+    omh_runtime_requirements: Sequence[str],
+    evidence_steps: Sequence[str],
+    degradation_behavior: str,
+    non_goals: Sequence[str],
+    clarifying_questions: Sequence[str] = (),
+    delegated_work: Sequence[str] = (),
+    observed_source_mechanics: Sequence[str] = (),
+    prepared_at: str = "",
+) -> dict[str, Any]:
+    """Mint one blueprint, or refuse.
+
+    Closed-vocabulary lists are normalized into their declared order and
+    deduplicated, so two authors describing the same capability in different
+    orders produce the same `blueprint_digest`. Free-text lists keep the order
+    they were written in, because the order examples are read in is a design
+    decision.
+
+    Nothing here reads a clock. `prepared_at` is whatever the caller passes and
+    is excluded from the digest.
+    """
+    blueprint: dict[str, Any] = {
+        "schema_version": NATIVE_CAPABILITY_BLUEPRINT_SCHEMA_VERSION,
+        "capability_id": str(capability_id).strip().casefold(),
+        "intent_summary": str(intent_summary).strip(),
+        "example_requests": _authored_list(example_requests),
+        "clarification_policy": str(clarification_policy).strip(),
+        "clarifying_questions": _authored_list(clarifying_questions),
+        "hermes_retained_work": _vocabulary_list(hermes_retained_work, HERMES_RETAINED_WORK),
+        "delegated_work": _vocabulary_list(delegated_work, DELEGATED_WORK),
+        "expected_outputs": _authored_list(expected_outputs),
+        "affected_surfaces": _vocabulary_list(affected_surfaces, NATIVE_CAPABILITY_SURFACES),
+        "observed_source_mechanics": _vocabulary_list(observed_source_mechanics, SOURCE_HOST_MECHANICS),
+        "omh_runtime_requirements": _vocabulary_list(omh_runtime_requirements, OMH_RUNTIME_REQUIREMENTS),
+        "evidence_steps": _authored_list(evidence_steps),
+        "degradation_behavior": str(degradation_behavior).strip(),
+        "non_goals": _authored_list(non_goals),
+        "prepared_at": str(prepared_at).strip(),
+        "privacy": BLUEPRINT_PRIVACY,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "blueprint_digest": "",
+    }
+    blueprint["blueprint_digest"] = blueprint_digest_of(blueprint)
+    errors = validate_native_capability_blueprint(blueprint)
+    if errors:
+        raise NativeCapabilityBlueprintError(errors[0])
+    return blueprint
+
+
+def blueprint_digest_of(blueprint: Mapping[str, Any]) -> str:
+    """A sha256 over the design content of a blueprint, covering no clock."""
+    identity = {key: blueprint.get(key) for key in BLUEPRINT_DIGEST_KEYS}
+    return hashlib.sha256(json.dumps(identity, sort_keys=True, default=str).encode("utf-8")).hexdigest()
+
+
+def validate_native_capability_blueprint(blueprint: Mapping[str, Any]) -> list[str]:
+    """Every reason one payload is not a native capability blueprint."""
+    if not isinstance(blueprint, Mapping):
+        return [f"{_LABEL} must be an object"]
+    errors: list[str] = []
+    claims_implementation = sorted(key for key in blueprint if str(key).lower() in IMPLEMENTATION_CLAIM_KEYS)
+    if claims_implementation:
+        errors.append(
+            f"{_LABEL} must not carry implementation-claim keys: {claims_implementation}; a blueprint "
+            "describes a capability that does not exist yet and never reports one that does"
+        )
+    forbidden = sorted(key for key in blueprint if str(key).lower() in RAW_OR_HIDDEN_KEYS)
+    if forbidden:
+        errors.append(f"{_LABEL} must not carry raw or hidden keys: {forbidden}")
+    unexpected = sorted(
+        set(blueprint) - set(NATIVE_CAPABILITY_BLUEPRINT_KEYS) - set(claims_implementation) - set(forbidden)
+    )
+    if unexpected:
+        errors.append(f"{_LABEL} has unsupported keys: {unexpected}")
+    missing = sorted(set(NATIVE_CAPABILITY_BLUEPRINT_KEYS) - set(blueprint))
+    if missing:
+        errors.append(f"{_LABEL} is missing keys: {missing}")
+    if blueprint.get("schema_version") != NATIVE_CAPABILITY_BLUEPRINT_SCHEMA_VERSION:
+        errors.append(f"{_LABEL} schema_version must be {NATIVE_CAPABILITY_BLUEPRINT_SCHEMA_VERSION}")
+    if blueprint.get("privacy") != BLUEPRINT_PRIVACY:
+        errors.append(f"{_LABEL} privacy must be {BLUEPRINT_PRIVACY}")
+    if blueprint.get("claim_boundary") != CLAIM_BOUNDARY:
+        errors.append(
+            f"{_LABEL} claim_boundary must state the blueprint boundary: a design artifact is not evidence "
+            "and is not a claim that the capability exists"
+        )
+    if not isinstance(blueprint.get("prepared_at"), str):
+        errors.append(f"{_LABEL} prepared_at must be a string")
+    errors.extend(_identity_errors(blueprint))
+    errors.extend(_experience_errors(blueprint))
+    errors.extend(_ownership_errors(blueprint))
+    errors.extend(_surface_errors(blueprint))
+    errors.extend(_boundary_errors(blueprint))
+    errors.extend(_digest_errors(blueprint))
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Validation parts
+# ---------------------------------------------------------------------------
+
+
+def _identity_errors(blueprint: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    capability_id = blueprint.get("capability_id")
+    if not isinstance(capability_id, str) or not _CAPABILITY_ID.match(capability_id):
+        errors.append(
+            f"{_LABEL} capability_id must be the canonical skill name as a lowercase slug: {capability_id!r}"
+        )
+    errors.extend(_text_errors(blueprint.get("intent_summary"), "intent_summary"))
+    return errors
+
+
+def _experience_errors(blueprint: Mapping[str, Any]) -> list[str]:
+    """#791 AC2's first half: the sentences a person would actually type."""
+    errors = _text_list_errors(
+        blueprint.get("example_requests"),
+        "example_requests",
+        minimum=_MIN_EXAMPLE_REQUESTS,
+        maximum=_MAX_EXAMPLE_REQUESTS,
+    )
+    if not errors:
+        commands = [
+            example
+            for example in blueprint.get("example_requests", [])
+            if _COMMAND_SHAPED.search(str(example))
+        ]
+        if commands:
+            errors.append(
+                f"{_LABEL} example_requests must be natural-language requests, not commands: {commands}"
+            )
+    policy = blueprint.get("clarification_policy")
+    if policy not in CLARIFICATION_POLICIES:
+        errors.append(f"{_LABEL} clarification_policy is unsupported: {policy!r}")
+    questions = blueprint.get("clarifying_questions")
+    errors.extend(
+        _text_list_errors(questions, "clarifying_questions", minimum=0, maximum=_MAX_CLARIFYING_QUESTIONS)
+    )
+    if isinstance(questions, list):
+        if policy == "answer_directly" and questions:
+            errors.append(
+                f"{_LABEL} clarifying_questions must be empty when the policy answers directly; a capability "
+                "that asks nothing has no question to record"
+            )
+        if policy in CLARIFICATION_POLICIES and policy != "answer_directly" and not questions:
+            errors.append(
+                f"{_LABEL} clarifying_questions must name what Hermes asks before it answers under the "
+                f"{policy} policy"
+            )
+    errors.extend(
+        _text_list_errors(
+            blueprint.get("expected_outputs"), "expected_outputs", minimum=1, maximum=_MAX_EXPECTED_OUTPUTS
+        )
+    )
+    if blueprint.get("degradation_behavior") not in DEGRADATION_BEHAVIORS:
+        errors.append(
+            f"{_LABEL} degradation_behavior is unsupported: {blueprint.get('degradation_behavior')!r}"
+        )
+    errors.extend(_text_list_errors(blueprint.get("non_goals"), "non_goals", minimum=1, maximum=_MAX_NON_GOALS))
+    return errors
+
+
+def _ownership_errors(blueprint: Mapping[str, Any]) -> list[str]:
+    """`docs/DIRECTION.md` Ownership Boundary, as a check.
+
+    Hermes always does something -- at minimum it takes the request in -- so an
+    empty retained list means the blueprint never said where the capability
+    lives. Delegated work is legitimately empty: plenty of capabilities hand
+    nothing to a coding owner.
+    """
+    errors = _vocabulary_list_errors(
+        blueprint.get("hermes_retained_work"), "hermes_retained_work", HERMES_RETAINED_WORK, minimum=1
+    )
+    errors.extend(
+        _vocabulary_list_errors(blueprint.get("delegated_work"), "delegated_work", DELEGATED_WORK, minimum=0)
+    )
+    steps = blueprint.get("evidence_steps")
+    errors.extend(
+        _text_list_errors(steps, "evidence_steps", minimum=_MIN_EVIDENCE_STEPS, maximum=_MAX_EVIDENCE_STEPS)
+    )
+    if isinstance(steps, list):
+        malformed = [step for step in steps if not _EVIDENCE_STEP.match(str(step))]
+        if malformed:
+            errors.append(
+                f"{_LABEL} evidence_steps must be snake_case ladder steps like the harness definitions use: "
+                f"{malformed}"
+            )
+    return errors
+
+
+def _surface_errors(blueprint: Mapping[str, Any]) -> list[str]:
+    """#791 AC1: the blueprint identifies every affected native OMH surface."""
+    surfaces = blueprint.get("affected_surfaces")
+    if not isinstance(surfaces, list) or not all(isinstance(surface, str) for surface in surfaces):
+        return [f"{_LABEL} affected_surfaces must be a list of strings"]
+    errors: list[str] = []
+    if len(set(surfaces)) != len(surfaces):
+        errors.append(f"{_LABEL} affected_surfaces must not repeat a surface")
+    unknown = unknown_surfaces(surfaces)
+    if unknown:
+        errors.append(
+            f"{_LABEL} affected_surfaces names surfaces that do not exist in this repository: {list(unknown)}; "
+            f"the vocabulary is {list(NATIVE_CAPABILITY_SURFACES)}"
+        )
+    absent = missing_required_surfaces(surfaces)
+    if absent:
+        described = [f"{surface} ({blueprint_surface_anchor(surface)})" for surface in absent]
+        errors.append(
+            f"{_LABEL} affected_surfaces is missing required surfaces: {described}; every installable "
+            "capability moves all of them, so a blueprint that omits one is incomplete rather than narrow"
+        )
+    return errors
+
+
+def _boundary_errors(blueprint: Mapping[str, Any]) -> list[str]:
+    """#791 AC3: observed there never becomes required here."""
+    errors = _vocabulary_list_errors(
+        blueprint.get("observed_source_mechanics"),
+        "observed_source_mechanics",
+        SOURCE_HOST_MECHANICS,
+        minimum=0,
+    )
+    requirements = blueprint.get("omh_runtime_requirements")
+    if not isinstance(requirements, list) or not all(isinstance(item, str) for item in requirements):
+        return [*errors, f"{_LABEL} omh_runtime_requirements must be a list of strings"]
+    smuggled = sorted(set(requirements) & set(SOURCE_HOST_MECHANICS))
+    if smuggled:
+        errors.append(
+            f"{_LABEL} omh_runtime_requirements must not name a source-host mechanic: {smuggled}; a mechanic "
+            "may be recorded in observed_source_mechanics as inspiration, and making one load-bearing at "
+            "runtime needs a separate approved boundary that this schema does not carry"
+        )
+    errors.extend(
+        _vocabulary_list_errors(
+            [item for item in requirements if item not in set(smuggled)],
+            "omh_runtime_requirements",
+            OMH_RUNTIME_REQUIREMENTS,
+            minimum=1,
+        )
+    )
+    return errors
+
+
+def _digest_errors(blueprint: Mapping[str, Any]) -> list[str]:
+    digest = blueprint.get("blueprint_digest")
+    if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+        return [f"{_LABEL} blueprint_digest must be a sha256 hex digest"]
+    if digest != blueprint_digest_of(blueprint):
+        return [
+            f"{_LABEL} blueprint_digest does not match the design it seals; the payload was edited after it "
+            "was minted"
+        ]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _authored_list(values: Sequence[str]) -> list[str]:
+    """Authored prose, in the order it was written, deduplicated."""
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        text = str(value).strip()
+        if text and text not in seen:
+            cleaned.append(text)
+            seen.add(text)
+    return cleaned
+
+
+def _vocabulary_list(values: Sequence[str], vocabulary: tuple[str, ...]) -> list[str]:
+    """Closed-vocabulary members in declared order, plus anything unrecognised.
+
+    Unrecognised values are kept rather than dropped: silently discarding one
+    would turn a caller's typo into a blueprint that validates and describes
+    something nobody asked for.
+    """
+    named = [str(value).strip() for value in values if str(value).strip()]
+    known = [item for item in vocabulary if item in named]
+    unknown = sorted({item for item in named if item not in set(vocabulary)})
+    return [*known, *unknown]
+
+
+def _text_errors(value: object, field: str) -> list[str]:
+    if not isinstance(value, str) or not value.strip():
+        return [f"{_LABEL} {field} must be a non-empty string"]
+    if len(value) > _MAX_TEXT_LENGTH:
+        return [f"{_LABEL} {field} must be at most {_MAX_TEXT_LENGTH} characters"]
+    return []
+
+
+def _text_list_errors(value: object, field: str, *, minimum: int, maximum: int) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        return [f"{_LABEL} {field} must be a list of strings"]
+    errors: list[str] = []
+    if len(value) < minimum:
+        errors.append(f"{_LABEL} {field} must name at least {minimum}")
+    if len(value) > maximum:
+        errors.append(f"{_LABEL} {field} must name at most {maximum}")
+    if len(set(value)) != len(value):
+        errors.append(f"{_LABEL} {field} must not repeat an entry")
+    blank = [item for item in value if not item.strip()]
+    overlong = [item for item in value if len(item) > _MAX_TEXT_LENGTH]
+    if blank:
+        errors.append(f"{_LABEL} {field} must not contain an empty entry")
+    if overlong:
+        errors.append(f"{_LABEL} {field} entries must be at most {_MAX_TEXT_LENGTH} characters")
+    return errors
+
+
+def _vocabulary_list_errors(
+    value: object,
+    field: str,
+    vocabulary: tuple[str, ...],
+    *,
+    minimum: int,
+) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        return [f"{_LABEL} {field} must be a list of strings"]
+    errors: list[str] = []
+    if len(value) < minimum:
+        errors.append(f"{_LABEL} {field} must name at least {minimum}")
+    if len(set(value)) != len(value):
+        errors.append(f"{_LABEL} {field} must not repeat an entry")
+    unsupported = sorted({item for item in value if item not in set(vocabulary)})
+    if unsupported:
+        errors.append(f"{_LABEL} {field} has unsupported entries: {unsupported}; allowed: {list(vocabulary)}")
+    return errors

--- a/tests/test_native_capability_blueprint.py
+++ b/tests/test_native_capability_blueprint.py
@@ -1,0 +1,506 @@
+"""Contracts for `native_capability_blueprint/v1` (issue #791).
+
+Grouped by acceptance criterion:
+
+- AC1: a blueprint identifies every affected native OMH surface, and the
+  surface vocabulary it is checked against is re-derived from this repository
+  rather than asserted.
+- AC2: every blueprint carries natural-language examples and an unobserved-work
+  claim boundary.
+- AC3: a source-host mechanic may be recorded as observed inspiration and may
+  never appear as an OMH runtime requirement. Both directions.
+
+Plus the guard the whole family exists for: a blueprint is a design artifact for
+work nobody has done, so nothing in it may read as an implemented capability.
+
+Nothing in this file writes a file. The blueprint is compared by value
+throughout, and `Path.write_text` rewrites "\\n" as CRLF on Windows, so a
+fixture written that way would compare equal on macOS and unequal on the Windows
+job. There is no fixture to get wrong.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import unittest
+from pathlib import Path
+from typing import Any
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.workflows.native_capability_blueprint import (  # noqa: E402
+    BLUEPRINT_DIGEST_KEYS,
+    BLUEPRINT_PRIVACY,
+    CLAIM_BOUNDARY,
+    CLARIFICATION_POLICIES,
+    DEGRADATION_BEHAVIORS,
+    DELEGATED_WORK,
+    HERMES_RETAINED_WORK,
+    IMPLEMENTATION_CLAIM_KEYS,
+    NATIVE_CAPABILITY_BLUEPRINT_KEYS,
+    NATIVE_CAPABILITY_BLUEPRINT_SCHEMA_VERSION,
+    NATIVE_CAPABILITY_SURFACE_ANCHORS,
+    NATIVE_CAPABILITY_SURFACES,
+    OMH_RUNTIME_REQUIREMENTS,
+    OPTIONAL_NATIVE_CAPABILITY_SURFACES,
+    REQUIRED_NATIVE_CAPABILITY_SURFACES,
+    SOURCE_HOST_MECHANICS,
+    NativeCapabilityBlueprintError,
+    blueprint_digest_of,
+    blueprint_expected_surfaces,
+    blueprint_surface_anchor,
+    build_native_capability_blueprint,
+    missing_required_surfaces,
+    unknown_surfaces,
+    validate_native_capability_blueprint,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "src" / "workflows" / "native_capability_blueprint.py"
+
+# A repository path named inside an anchor sentence.
+_ANCHOR_PATH = re.compile(r"\b[\w./*-]+\.(?:py|md|json)\b")
+# A module-level constant an anchor points at: either underscore-prefixed or
+# SCREAMING_SNAKE with a separator. Bare acronyms in prose ("OMH") are excluded
+# by requiring the underscore, so the check stays about identifiers.
+_ANCHOR_CONSTANT = re.compile(r"\b_[A-Z][A-Z0-9_]{2,}\b|\b[A-Z][A-Z0-9]*_[A-Z0-9_]+\b")
+_ANCHOR_CLASS = re.compile(r"\b[A-Z][a-zA-Z0-9]*[a-z][A-Z][a-zA-Z0-9]*\b")
+_ANCHOR_CALL = re.compile(r"\b[a-z_][a-z0-9_]*\(\)")
+
+
+def blueprint_kwargs(**overrides: Any) -> dict[str, Any]:
+    """A complete, valid blueprint's arguments, minimally overridable."""
+    base: dict[str, Any] = {
+        "capability_id": "native-capability-blueprint",
+        "intent_summary": (
+            "Turn a feature demonstrated in another agent tool into a Hermes-native experience blueprint."
+        ),
+        "example_requests": (
+            "Give Hermes the useful behavior from this tool.",
+            "Design the native version of that plugin feature.",
+        ),
+        "clarification_policy": "clarify_then_answer",
+        "clarifying_questions": ("Which behavior did you actually see, and where did you see it?",),
+        "hermes_retained_work": ("chat_intake", "clarification", "planning"),
+        "delegated_work": ("main_implementation_work",),
+        "expected_outputs": (
+            "native_capability_blueprint/v1",
+            "the affected native surfaces",
+            "the claim boundary",
+        ),
+        "affected_surfaces": REQUIRED_NATIVE_CAPABILITY_SURFACES,
+        "observed_source_mechanics": ("host_plugin_manifest", "host_tool_definition"),
+        "omh_runtime_requirements": ("local_catalog_metadata", "local_deterministic_contract"),
+        "evidence_steps": ("observed_material_scoped", "surfaces_identified", "blueprint_rendered"),
+        "degradation_behavior": "ask_for_missing_input",
+        "non_goals": ("Importing, launching, proxying, or requiring a source extension.",),
+        "prepared_at": "2026-08-09T00:00:00Z",
+    }
+    base.update(overrides)
+    return base
+
+
+def blueprint(**overrides: Any) -> dict[str, Any]:
+    return build_native_capability_blueprint(**blueprint_kwargs(**overrides))
+
+
+def resealed(**overrides: Any) -> dict[str, Any]:
+    """A payload edited after minting, with the digest re-derived to match.
+
+    Lets a test fail on the rule under test rather than on the tamper check.
+    """
+    payload = blueprint()
+    payload.update(overrides)
+    payload["blueprint_digest"] = blueprint_digest_of(payload)
+    return payload
+
+
+class SurfaceVocabularyTests(unittest.TestCase):
+    """The vocabulary AC1 is checked against is this repository's, not a wish list."""
+
+    def test_every_surface_anchors_to_a_file_that_exists(self) -> None:
+        for surface in NATIVE_CAPABILITY_SURFACES:
+            with self.subTest(surface=surface):
+                anchor = blueprint_surface_anchor(surface)
+                self.assertTrue(anchor, f"{surface} must say where it lives")
+                for token in _ANCHOR_PATH.findall(anchor):
+                    if "*" in token:
+                        self.assertTrue(
+                            list(REPO_ROOT.glob(token)),
+                            f"{surface} anchors {token}, which matches nothing",
+                        )
+                        continue
+                    self.assertTrue(
+                        (REPO_ROOT / token).is_file(),
+                        f"{surface} anchors {token}, which is not a file in this repository",
+                    )
+
+    def test_every_anchored_structure_is_present_in_the_file_it_names(self) -> None:
+        for surface in NATIVE_CAPABILITY_SURFACES:
+            with self.subTest(surface=surface):
+                anchor = blueprint_surface_anchor(surface)
+                paths = _ANCHOR_PATH.findall(anchor)
+                prose = _ANCHOR_PATH.sub(" ", anchor)
+                structures = (
+                    set(_ANCHOR_CONSTANT.findall(prose))
+                    | set(_ANCHOR_CLASS.findall(prose))
+                    | set(_ANCHOR_CALL.findall(prose))
+                )
+                if not structures:
+                    continue
+                haystack = "\n".join(
+                    (REPO_ROOT / token).read_text(encoding="utf-8")
+                    for token in paths
+                    if "*" not in token and (REPO_ROOT / token).is_file()
+                )
+                for structure in sorted(structures):
+                    self.assertIn(
+                        structure.removesuffix("()"),
+                        haystack,
+                        f"{surface} anchors {structure}, which is absent from {paths}",
+                    )
+
+    def test_required_and_optional_surfaces_partition_the_vocabulary(self) -> None:
+        self.assertEqual(len(NATIVE_CAPABILITY_SURFACES), 16)
+        self.assertEqual(len(REQUIRED_NATIVE_CAPABILITY_SURFACES), 12)
+        self.assertEqual(len(OPTIONAL_NATIVE_CAPABILITY_SURFACES), 4)
+        self.assertEqual(
+            sorted({*REQUIRED_NATIVE_CAPABILITY_SURFACES, *OPTIONAL_NATIVE_CAPABILITY_SURFACES}),
+            sorted(NATIVE_CAPABILITY_SURFACES),
+        )
+        self.assertEqual(
+            set(REQUIRED_NATIVE_CAPABILITY_SURFACES) & set(OPTIONAL_NATIVE_CAPABILITY_SURFACES), set()
+        )
+        self.assertEqual(sorted(NATIVE_CAPABILITY_SURFACE_ANCHORS), sorted(NATIVE_CAPABILITY_SURFACES))
+
+    def test_the_four_optional_surfaces_are_the_conditional_ones(self) -> None:
+        # Named rather than derived: a capability that mints no artifact, reads
+        # no reviewed memory, prepares no coding handoff, and needs no bespoke
+        # card genuinely does not touch these. Moving one into the required set
+        # is a deliberate act with a visible line to change.
+        self.assertEqual(
+            sorted(OPTIONAL_NATIVE_CAPABILITY_SURFACES),
+            ["chat_card", "coding_handoff", "memory_policy", "runtime_artifact"],
+        )
+
+
+class AffectedSurfaceTests(unittest.TestCase):
+    """AC1: the blueprint identifies every affected native OMH surface."""
+
+    def test_a_blueprint_naming_every_required_surface_validates(self) -> None:
+        payload = blueprint()
+
+        self.assertEqual(validate_native_capability_blueprint(payload), [])
+        self.assertEqual(
+            blueprint_expected_surfaces(payload), tuple(REQUIRED_NATIVE_CAPABILITY_SURFACES)
+        )
+
+    def test_a_blueprint_may_also_name_the_conditional_surfaces(self) -> None:
+        payload = blueprint(affected_surfaces=NATIVE_CAPABILITY_SURFACES)
+
+        self.assertEqual(validate_native_capability_blueprint(payload), [])
+        self.assertEqual(blueprint_expected_surfaces(payload), NATIVE_CAPABILITY_SURFACES)
+
+    def test_omitting_a_required_surface_fails_and_names_the_missing_surface(self) -> None:
+        for surface in REQUIRED_NATIVE_CAPABILITY_SURFACES:
+            with self.subTest(surface=surface):
+                kept = [item for item in REQUIRED_NATIVE_CAPABILITY_SURFACES if item != surface]
+                with self.assertRaises(NativeCapabilityBlueprintError) as raised:
+                    blueprint(affected_surfaces=kept)
+                message = str(raised.exception)
+                self.assertIn("missing required surfaces", message)
+                self.assertIn(surface, message)
+                self.assertIn(blueprint_surface_anchor(surface), message)
+
+    def test_omitting_an_optional_surface_is_not_an_error(self) -> None:
+        self.assertEqual(missing_required_surfaces(REQUIRED_NATIVE_CAPABILITY_SURFACES), ())
+        self.assertEqual(validate_native_capability_blueprint(blueprint()), [])
+
+    def test_an_unknown_surface_name_is_refused(self) -> None:
+        with self.assertRaises(NativeCapabilityBlueprintError) as raised:
+            blueprint(affected_surfaces=(*REQUIRED_NATIVE_CAPABILITY_SURFACES, "vscode_agent_plugin"))
+        message = str(raised.exception)
+        self.assertIn("do not exist in this repository", message)
+        self.assertIn("vscode_agent_plugin", message)
+        self.assertEqual(unknown_surfaces(["skill_catalog", "vscode_agent_plugin"]), ("vscode_agent_plugin",))
+
+    def test_the_surface_accessor_refuses_an_invalid_blueprint(self) -> None:
+        # A downstream gate must not receive a partial surface list from a
+        # payload that would not validate.
+        broken = resealed(affected_surfaces=["skill_catalog"])
+
+        with self.assertRaises(NativeCapabilityBlueprintError):
+            blueprint_expected_surfaces(broken)
+
+
+class ExampleAndClaimBoundaryTests(unittest.TestCase):
+    """AC2: natural-language examples and an unobserved-work claim boundary."""
+
+    def test_a_blueprint_without_examples_is_refused(self) -> None:
+        with self.assertRaises(NativeCapabilityBlueprintError) as raised:
+            blueprint(example_requests=())
+
+        self.assertIn("example_requests must name at least 2", str(raised.exception))
+
+    def test_a_single_example_is_not_enough(self) -> None:
+        with self.assertRaises(NativeCapabilityBlueprintError):
+            blueprint(example_requests=("Give Hermes the useful behavior from this tool.",))
+
+    def test_examples_must_be_sentences_rather_than_commands(self) -> None:
+        for command in ("omh chat route 'design this'", "/native-capability-blueprint", "--capability foo"):
+            with self.subTest(command=command):
+                with self.assertRaises(NativeCapabilityBlueprintError) as raised:
+                    blueprint(
+                        example_requests=("Give Hermes the useful behavior from this tool.", command)
+                    )
+                self.assertIn("natural-language requests, not commands", str(raised.exception))
+
+    def test_a_blueprint_without_the_claim_boundary_is_refused(self) -> None:
+        errors = validate_native_capability_blueprint(resealed(claim_boundary=""))
+
+        self.assertTrue(any("claim_boundary" in error for error in errors), errors)
+
+    def test_a_softened_claim_boundary_is_refused(self) -> None:
+        errors = validate_native_capability_blueprint(
+            resealed(claim_boundary="A blueprint describes a capability.")
+        )
+
+        self.assertTrue(any("claim_boundary" in error for error in errors), errors)
+
+    def test_the_claim_boundary_denies_evidence_existence_and_host_requirements(self) -> None:
+        for phrase in (
+            "not dispatch, execution, verification, review, CI, merge-readiness, or merge evidence",
+            "not a claim that the capability exists",
+            "never makes a source host",
+        ):
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, CLAIM_BOUNDARY)
+
+    def test_clarification_behavior_is_recorded_in_both_directions(self) -> None:
+        direct = blueprint(clarification_policy="answer_directly", clarifying_questions=())
+        self.assertEqual(validate_native_capability_blueprint(direct), [])
+
+        with self.assertRaises(NativeCapabilityBlueprintError) as asks_nothing:
+            blueprint(clarification_policy="clarify_before_handoff", clarifying_questions=())
+        self.assertIn("what Hermes asks before it answers", str(asks_nothing.exception))
+
+        with self.assertRaises(NativeCapabilityBlueprintError) as asks_anyway:
+            blueprint(
+                clarification_policy="answer_directly",
+                clarifying_questions=("Which behavior did you see?",),
+            )
+        self.assertIn("must be empty when the policy answers directly", str(asks_anyway.exception))
+
+    def test_expected_outputs_non_goals_and_degradation_are_all_required(self) -> None:
+        for field, value, fragment in (
+            ("expected_outputs", (), "expected_outputs must name at least 1"),
+            ("non_goals", (), "non_goals must name at least 1"),
+            ("degradation_behavior", "best_effort", "degradation_behavior is unsupported"),
+            ("hermes_retained_work", (), "hermes_retained_work must name at least 1"),
+            ("evidence_steps", ("only_one",), "evidence_steps must name at least 2"),
+            ("intent_summary", "", "intent_summary must be a non-empty string"),
+        ):
+            with self.subTest(field=field):
+                with self.assertRaises(NativeCapabilityBlueprintError) as raised:
+                    blueprint(**{field: value})
+                self.assertIn(fragment, str(raised.exception))
+
+    def test_delegated_work_may_be_empty_for_a_capability_that_delegates_nothing(self) -> None:
+        payload = blueprint(delegated_work=())
+
+        self.assertEqual(validate_native_capability_blueprint(payload), [])
+        self.assertEqual(payload["delegated_work"], [])
+
+
+class SourceMechanicBoundaryTests(unittest.TestCase):
+    """AC3: observed there never becomes required here."""
+
+    def test_a_source_mechanic_as_observed_inspiration_is_fine(self) -> None:
+        for mechanic in SOURCE_HOST_MECHANICS:
+            with self.subTest(mechanic=mechanic):
+                payload = blueprint(observed_source_mechanics=(mechanic,))
+                self.assertEqual(validate_native_capability_blueprint(payload), [])
+                self.assertEqual(payload["observed_source_mechanics"], [mechanic])
+
+    def test_the_same_mechanic_as_a_runtime_requirement_is_a_validation_error(self) -> None:
+        for mechanic in SOURCE_HOST_MECHANICS:
+            with self.subTest(mechanic=mechanic):
+                with self.assertRaises(NativeCapabilityBlueprintError) as raised:
+                    blueprint(omh_runtime_requirements=("local_catalog_metadata", mechanic))
+                message = str(raised.exception)
+                self.assertIn("must not name a source-host mechanic", message)
+                self.assertIn(mechanic, message)
+                self.assertIn("separate approved boundary", message)
+
+    def test_a_mechanic_can_be_observed_and_refused_as_a_requirement_at_once(self) -> None:
+        errors = validate_native_capability_blueprint(
+            resealed(
+                observed_source_mechanics=["host_plugin_registry"],
+                omh_runtime_requirements=["host_plugin_registry"],
+            )
+        )
+
+        self.assertTrue(any("must not name a source-host mechanic" in error for error in errors), errors)
+        self.assertFalse(any("observed_source_mechanics has unsupported" in error for error in errors), errors)
+
+    def test_an_omh_requirement_listed_as_an_observed_mechanic_is_refused(self) -> None:
+        with self.assertRaises(NativeCapabilityBlueprintError) as raised:
+            blueprint(observed_source_mechanics=("local_catalog_metadata",))
+
+        self.assertIn("observed_source_mechanics has unsupported entries", str(raised.exception))
+
+    def test_the_two_vocabularies_are_disjoint(self) -> None:
+        self.assertEqual(set(SOURCE_HOST_MECHANICS) & set(OMH_RUNTIME_REQUIREMENTS), set())
+
+    def test_a_blueprint_must_state_at_least_one_omh_runtime_requirement(self) -> None:
+        with self.assertRaises(NativeCapabilityBlueprintError) as raised:
+            blueprint(omh_runtime_requirements=())
+
+        self.assertIn("omh_runtime_requirements must name at least 1", str(raised.exception))
+
+    def test_no_omh_runtime_requirement_needs_a_foreign_host(self) -> None:
+        # The vocabulary is the enforcing half of AC3: widening it is a reviewed
+        # diff, which is the "separate approved boundary" the criterion names.
+        for requirement in OMH_RUNTIME_REQUIREMENTS:
+            with self.subTest(requirement=requirement):
+                self.assertNotIn("host", requirement)
+                self.assertNotIn("remote", requirement)
+                self.assertNotIn("network", requirement)
+
+
+class BlueprintIsNotACapabilityTests(unittest.TestCase):
+    """A blueprint never reads as an implemented capability."""
+
+    def test_an_implementation_claim_key_is_refused_by_name(self) -> None:
+        for key in sorted(IMPLEMENTATION_CLAIM_KEYS):
+            with self.subTest(key=key):
+                errors = validate_native_capability_blueprint({**blueprint(), key: True})
+                self.assertTrue(
+                    any("implementation-claim keys" in error and key in error for error in errors), errors
+                )
+
+    def test_a_raw_or_hidden_key_is_refused(self) -> None:
+        errors = validate_native_capability_blueprint({**blueprint(), "transcript": "..."})
+
+        self.assertTrue(any("raw or hidden keys" in error for error in errors), errors)
+
+    def test_the_key_set_is_closed_in_both_directions(self) -> None:
+        payload = blueprint()
+        self.assertEqual(sorted(payload), sorted(NATIVE_CAPABILITY_BLUEPRINT_KEYS))
+
+        extra = validate_native_capability_blueprint({**payload, "connector_manifest": "x"})
+        self.assertTrue(any("unsupported keys" in error for error in extra), extra)
+
+        for key in NATIVE_CAPABILITY_BLUEPRINT_KEYS:
+            with self.subTest(key=key):
+                short = {name: value for name, value in payload.items() if name != key}
+                errors = validate_native_capability_blueprint(short)
+                self.assertTrue(any("is missing keys" in error and key in error for error in errors), errors)
+
+    def test_the_payload_is_metadata_only_and_schema_versioned(self) -> None:
+        payload = blueprint()
+
+        self.assertEqual(payload["schema_version"], NATIVE_CAPABILITY_BLUEPRINT_SCHEMA_VERSION)
+        self.assertEqual(NATIVE_CAPABILITY_BLUEPRINT_SCHEMA_VERSION, "native_capability_blueprint/v1")
+        self.assertEqual(payload["privacy"], BLUEPRINT_PRIVACY)
+        self.assertEqual(BLUEPRINT_PRIVACY, "metadata_only")
+        self.assertTrue(any("privacy" in error for error in validate_native_capability_blueprint(resealed(privacy="raw"))))
+
+    def test_a_non_mapping_is_refused_rather_than_crashing(self) -> None:
+        self.assertEqual(
+            validate_native_capability_blueprint(["not", "a", "blueprint"]),  # type: ignore[arg-type]
+            ["native_capability_blueprint must be an object"],
+        )
+
+
+class DeterminismTests(unittest.TestCase):
+    """No clock reaches a compared value."""
+
+    def test_the_module_reads_no_clock(self) -> None:
+        tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+        imported = {
+            node.module.split(".")[0]
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom) and node.module
+        } | {
+            alias.name.split(".")[0]
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Import)
+            for alias in node.names
+        }
+        called = {
+            node.func.id
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+
+        self.assertEqual(imported & {"time", "datetime", "random", "secrets"}, set())
+        self.assertNotIn("utc_now", called)
+
+    def test_two_builds_of_one_design_are_identical(self) -> None:
+        self.assertEqual(blueprint(), blueprint())
+
+    def test_the_digest_ignores_the_prepared_at_stamp(self) -> None:
+        early = blueprint(prepared_at="2026-01-01T00:00:00Z")
+        late = blueprint(prepared_at="2026-12-31T23:59:59Z")
+
+        self.assertNotEqual(early["prepared_at"], late["prepared_at"])
+        self.assertEqual(early["blueprint_digest"], late["blueprint_digest"])
+        self.assertNotIn("prepared_at", BLUEPRINT_DIGEST_KEYS)
+        self.assertNotIn("blueprint_digest", BLUEPRINT_DIGEST_KEYS)
+
+    def test_closed_vocabulary_order_does_not_change_the_digest(self) -> None:
+        forward = blueprint(affected_surfaces=REQUIRED_NATIVE_CAPABILITY_SURFACES)
+        backward = blueprint(affected_surfaces=tuple(reversed(REQUIRED_NATIVE_CAPABILITY_SURFACES)))
+
+        self.assertEqual(forward, backward)
+
+    def test_an_edited_payload_fails_its_own_digest(self) -> None:
+        payload = blueprint()
+        payload["intent_summary"] = "Something else entirely."
+
+        errors = validate_native_capability_blueprint(payload)
+        self.assertTrue(any("does not match the design it seals" in error for error in errors), errors)
+
+    def test_prepared_at_is_a_parameter_and_defaults_to_empty(self) -> None:
+        payload = build_native_capability_blueprint(
+            **{key: value for key, value in blueprint_kwargs().items() if key != "prepared_at"}
+        )
+
+        self.assertEqual(payload["prepared_at"], "")
+        self.assertEqual(validate_native_capability_blueprint(payload), [])
+
+
+class OwnershipVocabularyTests(unittest.TestCase):
+    """The ownership split is `docs/DIRECTION.md`'s, not a second one."""
+
+    def test_the_vocabularies_cover_the_direction_ownership_boundary(self) -> None:
+        direction = (REPO_ROOT / "docs" / "DIRECTION.md").read_text(encoding="utf-8")
+        section = direction.split("## Ownership Boundary", 1)[1].split("## Direction Rules", 1)[0]
+        # The doc writes some of these hyphenated ("source-backed research"),
+        # so the comparison is over words rather than over separators.
+        words = section.lower().replace("-", " ")
+
+        for term in (*HERMES_RETAINED_WORK, *DELEGATED_WORK):
+            with self.subTest(term=term):
+                self.assertIn(term.replace("_", " "), words)
+
+    def test_every_vocabulary_member_is_unique_and_lowercase(self) -> None:
+        for name, vocabulary in (
+            ("NATIVE_CAPABILITY_SURFACES", NATIVE_CAPABILITY_SURFACES),
+            ("SOURCE_HOST_MECHANICS", SOURCE_HOST_MECHANICS),
+            ("OMH_RUNTIME_REQUIREMENTS", OMH_RUNTIME_REQUIREMENTS),
+            ("CLARIFICATION_POLICIES", CLARIFICATION_POLICIES),
+            ("DEGRADATION_BEHAVIORS", DEGRADATION_BEHAVIORS),
+            ("HERMES_RETAINED_WORK", HERMES_RETAINED_WORK),
+            ("DELEGATED_WORK", DELEGATED_WORK),
+        ):
+            with self.subTest(vocabulary=name):
+                self.assertEqual(len(set(vocabulary)), len(vocabulary))
+                self.assertEqual(list(vocabulary), [item.lower() for item in vocabulary])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New `native_capability_blueprint/v1` (`src/workflows/native_capability_blueprint.py`): one design artifact describing a capability OMH does **not** have, in Hermes-native terms rather than in the vocabulary of whatever tool demonstrated it.
- A checkable surface vocabulary: `NATIVE_CAPABILITY_SURFACES`, `NATIVE_CAPABILITY_SURFACE_ANCHORS`, `REQUIRED_NATIVE_CAPABILITY_SURFACES`.
- Two separate closed vocabularies for `SOURCE_HOST_MECHANICS` and `OMH_RUNTIME_REQUIREMENTS`, so inspiration cannot leak into runtime requirements.

### Why This Exists

A useful feature demonstrated in another agent tool arrives described in that tool's own terms — its manifest, its registry entry, its tool definitions, its hooks, its settings. None of that says how the behavior should feel when a person types a sentence at Hermes, which OMH surfaces have to move for it to exist, or where the claim stops.

`src/skills/native_capability_surfaces.py` shows the *shape* a native capability takes — a skill definition, a harness, a surface exposure — but it shows it by hardcoding three specific capabilities. There was no contract for describing a capability that does not exist yet, and therefore no way to check that a description of one is complete before somebody starts building from it.

### User / Operator Impact

A maintainer can now write down a proposed capability in a form that is checkable rather than persuasive. A blueprint that forgets the wrapper card, or the memory rule, or the tests, fails validation and says which surface is missing — instead of being discovered half-built.

### How It Works

`NATIVE_CAPABILITY_SURFACES` is derived from `docs/ADDING-A-SKILL.md`, and `NATIVE_CAPABILITY_SURFACE_ANCHORS` names the file and the structure behind each member. Every surface in the vocabulary is therefore one that a real gate in this repository already fails on when a new capability misses it — the list is not nouns someone thought a capability might touch. `REQUIRED_NATIVE_CAPABILITY_SURFACES` is the subset no installable capability can omit; omitting one is a validation error naming the surface.

A source-host mechanic may be recorded as observed inspiration. Listing one as something OMH will require at runtime is refused. That refusal is the boundary that stops a blueprint importing another host's assumptions into OMH.

The payload cannot be shaped to claim the capability exists: `CLAIM_BOUNDARY` states it on every payload, `IMPLEMENTATION_CLAIM_KEYS` refuses a payload carrying an implementation-claiming key by name, and the closed key set refuses the rest.

OMH fetches and reads nothing. The observed material is supplied by the caller; the module has no reader and cannot reach the source tool.

### Files And Contracts Touched

- `src/workflows/native_capability_blueprint.py` — new, 757 lines.
- `tests/test_native_capability_blueprint.py` — new, 506 lines, 39 tests.

No generated artifact, catalog entry, routing case, or demo card touched, so no exact-count assertion moved.

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `python3 -m unittest discover -s tests` — Ran 5062 tests, OK
- [x] `python3 -m compileall src` — clean
- [x] `python3 -m omh.cli docs workflows --check` — `ok: true`
- [x] `python3 -m omh.cli harness validate` — `ok: true`, 72 harnesses / 104 skills
- [x] Also `docs roles --check`, `docs capability-families --check`, `git diff --check`
- [ ] Manual Hermes/TUI check — not run. Nothing renders a blueprint yet; there is no Hermes-visible surface to check.

Tests map to the acceptance criteria: every required surface present or the blueprint fails naming the omission (AC1); examples and the unobserved-work claim boundary are both required (AC2); a source-host mechanic listed as an OMH runtime requirement is a validation error while the same mechanic recorded as observed inspiration is accepted (AC3, tested in both directions).

## Risk

Low. The module is additive and has no caller — nothing in production builds a blueprint yet, so nothing can regress. The exposure is that the surface vocabulary can drift from `docs/ADDING-A-SKILL.md` as the repo grows; the anchors make that visible but there is no gate coupling the two.

## Compatibility / Rollout

Purely additive. No schema, generated artifact, or on-disk format changes.

## Release / Claims

- [x] Release-channel impact considered — `local`
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — the payload's own claim boundary denies that a blueprint means the capability exists
- [x] Known manual Hermes checks are listed — no Hermes surface exists to check

## Follow-Up

- #795's quality gate is intended to consume blueprints as its expected-surface source of truth. `NATIVE_CAPABILITY_SURFACES` and `REQUIRED_NATIVE_CAPABILITY_SURFACES` are importable for exactly that.
- No producer. A blueprint is representable and validated but nothing mints one; wiring a Hermes-facing surface is separate work.

Closes #791
