### PR TITLE
feat: freeze the evidence behind a native capability design

### DIFF
--- a/src/quality/capability_inspiration_snapshot.py
+++ b/src/quality/capability_inspiration_snapshot.py
@@ -1,0 +1,854 @@
+"""The evidence behind a native capability design, frozen so it can be re-asked.
+
+A native OMH capability is often designed by reading somebody else's docs or
+release. Months later two questions arrive and neither had an answer: "base the
+OMH version on this exact release" -- which release was that? -- and "has the
+inspiration changed?" -- changed from what? Source finding records a candidate
+and how far its acquisition got; it records no revision, no content digest, and
+no license observation, so there was nothing to compare a later reading against.
+
+What this module freezes
+------------------------
+
+One snapshot per capability design, holding the sources that informed it (uri,
+revision, a digest of the content as it read at that revision, the license note
+the observer saw), the bounded findings drawn from them, and the requirements
+derived for the OMH-native version. The snapshot carries who observed the
+material and when, a reviewer reference once someone has reviewed it, and a link
+to the snapshot it replaces.
+
+OMH does not fetch
+------------------
+
+Every byte of observed material is supplied by the caller. This module imports
+nothing that can open a socket and calls nothing that can, by construction: it
+digests a string it was handed and records the revision string it was told. The
+`claim_boundary` on every artifact says so, because the failure this guards
+against is a reader treating a frozen digest as proof that OMH just checked the
+source. It did not, and it cannot.
+
+Content is digested, never stored. A snapshot is metadata about evidence; the
+evidence itself belongs wherever the observer got it.
+
+Why the digest excludes the clock
+---------------------------------
+
+`evidence_digest` is canonical over the observed material and nothing else. The
+observation time, the observer, the reviewer, and the supersede link are all
+excluded, so re-observing identical material at a later time reproduces the
+identical digest -- which is the only way "has the inspiration changed?" can be
+answered by comparing two numbers. A timestamp inside the seed would make every
+re-observation look like a change.
+
+The encoding is `skill_governance._stable_encode`, the one this tree already
+uses for a canonical digest over a nested value. A second encoding scheme would
+mean two definitions of "the same evidence" and eventually two answers.
+
+Sources are sorted by `(uri, revision)` in the built snapshot, so the order they
+were supplied in cannot change the artifact or its digest -- a set of observed
+sources has no meaningful order. Findings and derived requirements keep the
+order they were given: a requirement list reads as a list, and reordering it is
+an authoring change the digest should notice.
+
+Supersession, not rewriting
+---------------------------
+
+Changed evidence produces a new snapshot that links to the old one through
+`supersedes_snapshot_ref`. Nothing is mutated and nothing is deleted, so the
+evidence that actually shaped the shipped design stays readable after the source
+moves on. `snapshot_id` is derived from `snapshot_digest`, which has a useful
+consequence: a snapshot whose evidence did not change gets the same id, so
+"supersede it with itself" is a self-link and the chain walk refuses it.
+
+`capability_inspiration_chain_errors` is that walk, and it is deliberately not
+`system.append_only_store.supersede_chain_errors`. That function reports faults
+against a store path, and this family has no store: a chain here is a sequence a
+caller holds. Passing it a fabricated `Path` to satisfy the signature would put
+a separator-dependent string into every error line, which is precisely the shape
+that breaks on Windows. The four refusals are the same four; when a later issue
+gives these records a file, that caller should use the store walk.
+
+Citation
+--------
+
+`capability_inspiration_citation` is the accessor other capability artifacts
+bind to. It carries the digests, the capability it belongs to, and the counts --
+never the source URIs, so a cited snapshot cannot read as "go look here now".
+Its `source_availability` is pinned to the single member of
+`SOURCE_AVAILABILITY_STATES`: this vocabulary has exactly one value on purpose,
+so recording an observed availability is a visible widening of a named tuple
+rather than a string someone typed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any, Final
+
+from ..workflows.source_finder import (
+    SOURCE_FINDER_OBSERVATION_PROVENANCE,
+    normalize_observation_provenance,
+)
+from .skill_governance import _stable_encode
+
+
+CAPABILITY_INSPIRATION_SNAPSHOT_SCHEMA_VERSION: Final = "capability_inspiration_snapshot/v1"
+CAPABILITY_INSPIRATION_COMPARISON_SCHEMA_VERSION: Final = "capability_inspiration_comparison/v1"
+CAPABILITY_INSPIRATION_CITATION_SCHEMA_VERSION: Final = "capability_inspiration_citation/v1"
+
+# Only a full commit-shaped hex digest is treated as immutable evidence. A
+# branch moves by design and a tag can be moved by hand, so both are `mutable`
+# and render as visibly unstable evidence; a revision nobody supplied is
+# `unknown` rather than either. Conservative on purpose: calling moving evidence
+# immutable is the failure that makes a frozen snapshot lie.
+REVISION_STABILITIES: Final[tuple[str, ...]] = ("immutable", "mutable", "unknown")
+
+# The verdicts a comparison can reach. `unverifiable` is the honest answer when
+# the source could not be re-observed at all -- unavailable, unreadable, or
+# simply never supplied a second time -- and is never collapsed into `changed`.
+COMPARISON_VERDICTS: Final[tuple[str, ...]] = ("changed", "current", "unverifiable")
+
+# How one source differs between two snapshots. A source is matched across
+# snapshots by its uri; everything else about it is a change to report.
+SOURCE_CHANGE_KINDS: Final[tuple[str, ...]] = (
+    "added",
+    "content_changed",
+    "license_changed",
+    "removed",
+    "revision_changed",
+    "stability_changed",
+)
+
+# The whole vocabulary this family may use to describe whether a cited source
+# can be reached right now. One member, and it is "not observed": OMH performs
+# no fetch, so it has nothing else it could truthfully say.
+SOURCE_AVAILABILITY_STATES: Final[tuple[str, ...]] = ("not_observed",)
+
+# Every claim a snapshot or a citation does not make, named so a consumer can
+# check the list instead of inferring the boundary from prose.
+CAPABILITY_INSPIRATION_NOT_OBSERVED: Final[tuple[str, ...]] = (
+    "source_availability",
+    "source_reachability",
+    "source_content_re_observation",
+    "license_verification",
+    "derived_requirement_review",
+    "derived_requirement_implementation",
+)
+
+CAPABILITY_INSPIRATION_CLAIM_BOUNDARY: Final = (
+    "This snapshot records evidence a caller supplied. OMH performed no fetch, download, "
+    "clone, or network call to produce it and cannot perform one. The revision, content "
+    "digest, license note, and observation time are what the observer reported, not what "
+    "OMH verified. Freezing evidence is not a statement that the source is reachable, "
+    "unchanged, or available now."
+)
+
+CAPABILITY_INSPIRATION_CITATION_CLAIM_BOUNDARY: Final = (
+    "A cited snapshot is frozen evidence, not a live source check. Availability, "
+    "reachability, and current content stay unobserved until a caller supplies a new "
+    "observation and compares it. Citing a snapshot is not review, implementation, or "
+    "verification of the requirements derived from it."
+)
+
+CAPABILITY_INSPIRATION_SNAPSHOT_KEYS: Final[tuple[str, ...]] = (
+    "capability_id",
+    "claim_boundary",
+    "derived_requirements",
+    "derived_requirements_digest",
+    "evidence_digest",
+    "findings",
+    "not_evidence_until_observed",
+    "observed_at",
+    "observed_sources",
+    "observer",
+    "reviewer_ref",
+    "schema_version",
+    "snapshot_digest",
+    "snapshot_id",
+    "source_availability",
+    "supersedes_snapshot_ref",
+)
+
+CAPABILITY_INSPIRATION_SOURCE_KEYS: Final[tuple[str, ...]] = (
+    "content_digest",
+    "license_note",
+    "observation_provenance",
+    "revision",
+    "revision_stability",
+    "source_id",
+    "uri",
+)
+
+CAPABILITY_INSPIRATION_COMPARISON_KEYS: Final[tuple[str, ...]] = (
+    "capability_id",
+    "changed_sources",
+    "claim_boundary",
+    "derived_requirements_changed",
+    "earlier_evidence_digest",
+    "earlier_snapshot_id",
+    "later_evidence_digest",
+    "later_snapshot_id",
+    "not_evidence_until_observed",
+    "schema_version",
+    "supersedes_earlier",
+    "verdict",
+)
+
+CAPABILITY_INSPIRATION_CHANGED_SOURCE_KEYS: Final[tuple[str, ...]] = (
+    "changes",
+    "earlier_source_id",
+    "later_source_id",
+    "uri",
+)
+
+CAPABILITY_INSPIRATION_CITATION_KEYS: Final[tuple[str, ...]] = (
+    "capability_id",
+    "cited_source_count",
+    "claim_boundary",
+    "derived_requirements_digest",
+    "evidence_digest",
+    "not_evidence_until_observed",
+    "observed_at",
+    "observer",
+    "reviewer_ref",
+    "schema_version",
+    "snapshot_digest",
+    "snapshot_id",
+    "source_availability",
+)
+
+# Bounded because the issue's design is bounded findings, and because an
+# unbounded list turns a metadata artifact into a document store. Over the cap
+# is refused rather than truncated: silently dropping the twenty-first finding
+# would change the digest without telling anyone why.
+MAX_OBSERVED_SOURCES: Final = 20
+MAX_FINDINGS: Final = 20
+MAX_DERIVED_REQUIREMENTS: Final = 20
+MAX_LINE_LENGTH: Final = 200
+MAX_URI_LENGTH: Final = 512
+
+_HEX_DIGEST = re.compile(r"\A(?:[0-9a-f]{40}|[0-9a-f]{64})\Z")
+
+
+class CapabilityInspirationSnapshotError(ValueError):
+    """A snapshot that cannot be built without asserting something untrue."""
+
+
+def revision_stability(revision: str) -> str:
+    """Whether a revision identifier names a fixed point or a moving one."""
+    text = str(revision or "").strip()
+    if not text:
+        return "unknown"
+    return "immutable" if _HEX_DIGEST.match(text) else "mutable"
+
+
+def build_capability_inspiration_source(
+    *,
+    uri: str,
+    revision: str = "",
+    content: str = "",
+    license_note: str = "",
+    observation_provenance: str | None = None,
+) -> dict[str, Any]:
+    """One observed source, with its supplied content reduced to a digest.
+
+    `content` is what the observer read at `revision`. It is hashed and dropped:
+    the snapshot is metadata about evidence and never a copy of it. An empty
+    `content` means no content was supplied, which is recorded as an empty
+    digest rather than as the digest of an empty document.
+    """
+    safe_uri = str(uri or "").strip()
+    if not safe_uri:
+        raise CapabilityInspirationSnapshotError("capability_inspiration_snapshot source uri is required")
+    if len(safe_uri) > MAX_URI_LENGTH:
+        raise CapabilityInspirationSnapshotError(
+            f"capability_inspiration_snapshot source uri exceeds {MAX_URI_LENGTH} characters"
+        )
+    safe_revision = _bounded_line(revision, field="source revision")
+    return {
+        "source_id": _source_id(safe_uri, safe_revision),
+        "uri": safe_uri,
+        "revision": safe_revision,
+        "revision_stability": revision_stability(safe_revision),
+        "content_digest": _content_digest(content),
+        "license_note": _bounded_line(license_note, field="source license_note"),
+        "observation_provenance": normalize_observation_provenance(observation_provenance),
+    }
+
+
+def build_capability_inspiration_snapshot(
+    *,
+    capability_id: str,
+    observed_sources: Sequence[Mapping[str, Any]],
+    observer: str,
+    observed_at: str,
+    findings: Sequence[str] = (),
+    derived_requirements: Sequence[str] = (),
+    reviewer_ref: str = "",
+    supersedes_snapshot_ref: str = "",
+) -> dict[str, Any]:
+    """Freeze the evidence behind one native capability design.
+
+    `observed_at` is a parameter and never a clock read here, so a caller can
+    reproduce a snapshot exactly. It is excluded from every digest for the same
+    reason.
+
+    `observer` is required. A frozen artifact with nobody standing behind it
+    cannot be weighed later against the evidence somebody else supplied, so a
+    snapshot with no observer is refused rather than recorded as anonymous.
+    """
+    safe_capability = _bounded_line(capability_id, field="capability_id")
+    if not safe_capability:
+        raise CapabilityInspirationSnapshotError("capability_inspiration_snapshot capability_id is required")
+    safe_observer = _bounded_line(observer, field="observer")
+    if not safe_observer:
+        raise CapabilityInspirationSnapshotError("capability_inspiration_snapshot observer is required")
+    sources = _normalized_sources(observed_sources)
+    if not sources:
+        raise CapabilityInspirationSnapshotError(
+            "capability_inspiration_snapshot requires at least one observed source"
+        )
+    safe_findings = _bounded_lines(findings, field="findings", limit=MAX_FINDINGS)
+    safe_requirements = _bounded_lines(
+        derived_requirements, field="derived_requirements", limit=MAX_DERIVED_REQUIREMENTS
+    )
+    evidence_digest = _digest({"sources": [_evidence_identity(source) for source in sources]})
+    requirements_digest = _digest({"derived_requirements": safe_requirements})
+    snapshot_digest = _digest(
+        {
+            "capability_id": safe_capability,
+            "derived_requirements_digest": requirements_digest,
+            "evidence_digest": evidence_digest,
+            "findings": safe_findings,
+        }
+    )
+    return {
+        "schema_version": CAPABILITY_INSPIRATION_SNAPSHOT_SCHEMA_VERSION,
+        "snapshot_id": f"capability-inspiration-{snapshot_digest[:16]}",
+        "capability_id": safe_capability,
+        "observed_sources": sources,
+        "findings": safe_findings,
+        "derived_requirements": safe_requirements,
+        "evidence_digest": evidence_digest,
+        "derived_requirements_digest": requirements_digest,
+        "snapshot_digest": snapshot_digest,
+        "observer": safe_observer,
+        "observed_at": _bounded_line(observed_at, field="observed_at"),
+        "reviewer_ref": _bounded_line(reviewer_ref, field="reviewer_ref"),
+        "supersedes_snapshot_ref": _bounded_line(
+            supersedes_snapshot_ref, field="supersedes_snapshot_ref"
+        ),
+        "source_availability": SOURCE_AVAILABILITY_STATES[0],
+        "claim_boundary": CAPABILITY_INSPIRATION_CLAIM_BOUNDARY,
+        "not_evidence_until_observed": list(CAPABILITY_INSPIRATION_NOT_OBSERVED),
+    }
+
+
+def compare_capability_inspiration_snapshots(
+    earlier: Mapping[str, Any], later: Mapping[str, Any] | None
+) -> dict[str, Any]:
+    """Whether the frozen evidence still describes what a later reading found.
+
+    `later` is `None` when the sources could not be re-observed. That is
+    `unverifiable` and never `current`: nothing was compared, so nothing can be
+    reported as unchanged.
+
+    Neither argument is modified. The earlier snapshot stays exactly as it was
+    frozen, which is the whole point of superseding rather than rewriting.
+    """
+    earlier_sources = _source_index(earlier)
+    if later is None:
+        return _comparison(
+            capability_id=str(earlier.get("capability_id", "")),
+            verdict="unverifiable",
+            earlier=earlier,
+            later={},
+            changed_sources=[],
+            derived_requirements_changed=False,
+        )
+    later_sources = _source_index(later)
+    changed_sources = _changed_sources(earlier_sources, later_sources)
+    requirements_changed = earlier.get("derived_requirements_digest") != later.get(
+        "derived_requirements_digest"
+    )
+    same_evidence = (
+        bool(earlier.get("evidence_digest"))
+        and earlier.get("evidence_digest") == later.get("evidence_digest")
+    )
+    return _comparison(
+        capability_id=str(later.get("capability_id", "")),
+        verdict="current" if same_evidence else "changed",
+        earlier=earlier,
+        later=later,
+        changed_sources=changed_sources,
+        derived_requirements_changed=bool(requirements_changed),
+    )
+
+
+def capability_inspiration_citation(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    """The bindable reference other capability artifacts cite.
+
+    Digests and counts only. The source URIs stay in the snapshot: a coding
+    handoff citing this needs to name which evidence it was built on, not to
+    invite its reader to go and fetch that evidence now.
+    """
+    sources = snapshot.get("observed_sources")
+    return {
+        "schema_version": CAPABILITY_INSPIRATION_CITATION_SCHEMA_VERSION,
+        "snapshot_id": str(snapshot.get("snapshot_id", "")),
+        "capability_id": str(snapshot.get("capability_id", "")),
+        "snapshot_digest": str(snapshot.get("snapshot_digest", "")),
+        "evidence_digest": str(snapshot.get("evidence_digest", "")),
+        "derived_requirements_digest": str(snapshot.get("derived_requirements_digest", "")),
+        "cited_source_count": len(sources) if isinstance(sources, list) else 0,
+        "observer": str(snapshot.get("observer", "")),
+        "observed_at": str(snapshot.get("observed_at", "")),
+        "reviewer_ref": str(snapshot.get("reviewer_ref", "")),
+        "source_availability": SOURCE_AVAILABILITY_STATES[0],
+        "claim_boundary": CAPABILITY_INSPIRATION_CITATION_CLAIM_BOUNDARY,
+        "not_evidence_until_observed": list(CAPABILITY_INSPIRATION_NOT_OBSERVED),
+    }
+
+
+def validate_capability_inspiration_snapshot(snapshot: Any) -> list[str]:
+    """Every reason a payload is not a `capability_inspiration_snapshot/v1`."""
+    label = "capability_inspiration_snapshot"
+    if not isinstance(snapshot, Mapping):
+        return [f"{label} must be an object"]
+    errors = _key_set_errors(snapshot, CAPABILITY_INSPIRATION_SNAPSHOT_KEYS, label)
+    if snapshot.get("schema_version") != CAPABILITY_INSPIRATION_SNAPSHOT_SCHEMA_VERSION:
+        errors.append(f"{label} schema_version must be {CAPABILITY_INSPIRATION_SNAPSHOT_SCHEMA_VERSION}")
+    for key in ("capability_id", "observer", "snapshot_id"):
+        if not _non_empty_text(snapshot.get(key)):
+            errors.append(f"{label} {key} must be a non-empty string")
+    for key in ("observed_at", "reviewer_ref", "supersedes_snapshot_ref"):
+        if not isinstance(snapshot.get(key), str):
+            errors.append(f"{label} {key} must be a string")
+    if snapshot.get("source_availability") not in SOURCE_AVAILABILITY_STATES:
+        errors.append(f"{label} source_availability must be one of {list(SOURCE_AVAILABILITY_STATES)}")
+    if snapshot.get("claim_boundary") != CAPABILITY_INSPIRATION_CLAIM_BOUNDARY:
+        errors.append(f"{label} claim_boundary must state that OMH observed nothing itself")
+    errors.extend(_not_observed_errors(snapshot, label))
+    errors.extend(_bounded_list_errors(snapshot.get("findings"), field="findings", label=label, limit=MAX_FINDINGS))
+    errors.extend(
+        _bounded_list_errors(
+            snapshot.get("derived_requirements"),
+            field="derived_requirements",
+            label=label,
+            limit=MAX_DERIVED_REQUIREMENTS,
+        )
+    )
+    errors.extend(_observed_source_errors(snapshot.get("observed_sources"), label))
+    if str(snapshot.get("snapshot_id", "")) == str(snapshot.get("supersedes_snapshot_ref", "")) and str(
+        snapshot.get("supersedes_snapshot_ref", "")
+    ):
+        errors.append(f"{label} supersedes_snapshot_ref must not name itself")
+    if not errors:
+        errors.extend(_digest_errors(snapshot, label))
+    return errors
+
+
+def validate_capability_inspiration_citation(citation: Any) -> list[str]:
+    """Every reason a payload is not a `capability_inspiration_citation/v1`."""
+    label = "capability_inspiration_citation"
+    if not isinstance(citation, Mapping):
+        return [f"{label} must be an object"]
+    errors = _key_set_errors(citation, CAPABILITY_INSPIRATION_CITATION_KEYS, label)
+    if citation.get("schema_version") != CAPABILITY_INSPIRATION_CITATION_SCHEMA_VERSION:
+        errors.append(f"{label} schema_version must be {CAPABILITY_INSPIRATION_CITATION_SCHEMA_VERSION}")
+    for key in ("capability_id", "observer", "snapshot_id", "snapshot_digest", "evidence_digest"):
+        if not _non_empty_text(citation.get(key)):
+            errors.append(f"{label} {key} must be a non-empty string")
+    count = citation.get("cited_source_count")
+    if not isinstance(count, int) or isinstance(count, bool) or count < 1:
+        errors.append(f"{label} cited_source_count must be a positive integer")
+    if citation.get("source_availability") not in SOURCE_AVAILABILITY_STATES:
+        errors.append(f"{label} source_availability must be one of {list(SOURCE_AVAILABILITY_STATES)}")
+    if citation.get("claim_boundary") != CAPABILITY_INSPIRATION_CITATION_CLAIM_BOUNDARY:
+        errors.append(f"{label} claim_boundary must state that availability stays unobserved")
+    errors.extend(_not_observed_errors(citation, label))
+    return errors
+
+
+def validate_capability_inspiration_comparison(comparison: Any) -> list[str]:
+    """Every reason a payload is not a `capability_inspiration_comparison/v1`."""
+    label = "capability_inspiration_comparison"
+    if not isinstance(comparison, Mapping):
+        return [f"{label} must be an object"]
+    errors = _key_set_errors(comparison, CAPABILITY_INSPIRATION_COMPARISON_KEYS, label)
+    if comparison.get("schema_version") != CAPABILITY_INSPIRATION_COMPARISON_SCHEMA_VERSION:
+        errors.append(f"{label} schema_version must be {CAPABILITY_INSPIRATION_COMPARISON_SCHEMA_VERSION}")
+    verdict = comparison.get("verdict")
+    if verdict not in COMPARISON_VERDICTS:
+        errors.append(f"{label} verdict must be one of {list(COMPARISON_VERDICTS)}")
+    if not isinstance(comparison.get("derived_requirements_changed"), bool):
+        errors.append(f"{label} derived_requirements_changed must be a boolean")
+    if not isinstance(comparison.get("supersedes_earlier"), bool):
+        errors.append(f"{label} supersedes_earlier must be a boolean")
+    if comparison.get("claim_boundary") != CAPABILITY_INSPIRATION_CLAIM_BOUNDARY:
+        errors.append(f"{label} claim_boundary must state that OMH observed nothing itself")
+    errors.extend(_not_observed_errors(comparison, label))
+    errors.extend(_changed_source_errors(comparison.get("changed_sources"), label))
+    if verdict == "current" and comparison.get("changed_sources"):
+        errors.append(f"{label} verdict current cannot name changed sources")
+    if verdict == "unverifiable" and _non_empty_text(comparison.get("later_snapshot_id")):
+        errors.append(f"{label} verdict unverifiable cannot name a later snapshot")
+    return errors
+
+
+def capability_inspiration_chain_errors(snapshots: Sequence[Mapping[str, Any]]) -> list[str]:
+    """Reject every shape a supersede chain must not take.
+
+    A chain is a line, not a graph: a snapshot cannot repeat an id, cannot
+    supersede itself, cannot supersede a snapshot that does not already exist
+    earlier in the sequence, and cannot supersede a snapshot something else
+    already superseded. A fork means two writers each believe they replaced the
+    same frozen evidence, which makes "the snapshot in force" ambiguous.
+    """
+    label = "capability_inspiration_snapshot"
+    seen: set[str] = set()
+    successors: dict[str, str] = {}
+    errors: list[str] = []
+    for index, snapshot in enumerate(snapshots):
+        snapshot_id = str(snapshot.get("snapshot_id", ""))
+        if snapshot_id and snapshot_id in seen:
+            errors.append(f"{label}[{index}]: snapshot_id is not unique: {snapshot_id}")
+        superseded = str(snapshot.get("supersedes_snapshot_ref", ""))
+        if superseded:
+            if superseded == snapshot_id:
+                errors.append(
+                    f"{label}[{index}]: supersedes_snapshot_ref must not name itself: {snapshot_id}"
+                )
+            elif superseded not in seen:
+                errors.append(
+                    f"{label}[{index}]: supersedes_snapshot_ref does not name an earlier "
+                    f"snapshot: {superseded}"
+                )
+            elif superseded in successors:
+                errors.append(
+                    f"{label}[{index}]: supersedes_snapshot_ref forks the chain: {superseded} is "
+                    f"already superseded by {successors[superseded]}"
+                )
+            else:
+                successors[superseded] = snapshot_id
+        seen.add(snapshot_id)
+    return errors
+
+
+def _comparison(
+    *,
+    capability_id: str,
+    verdict: str,
+    earlier: Mapping[str, Any],
+    later: Mapping[str, Any],
+    changed_sources: list[dict[str, Any]],
+    derived_requirements_changed: bool,
+) -> dict[str, Any]:
+    return {
+        "schema_version": CAPABILITY_INSPIRATION_COMPARISON_SCHEMA_VERSION,
+        "capability_id": capability_id,
+        "verdict": verdict,
+        "earlier_snapshot_id": str(earlier.get("snapshot_id", "")),
+        "earlier_evidence_digest": str(earlier.get("evidence_digest", "")),
+        "later_snapshot_id": str(later.get("snapshot_id", "")),
+        "later_evidence_digest": str(later.get("evidence_digest", "")),
+        "changed_sources": changed_sources,
+        "derived_requirements_changed": derived_requirements_changed,
+        "supersedes_earlier": bool(
+            later.get("supersedes_snapshot_ref")
+            and later.get("supersedes_snapshot_ref") == earlier.get("snapshot_id")
+        ),
+        "claim_boundary": CAPABILITY_INSPIRATION_CLAIM_BOUNDARY,
+        "not_evidence_until_observed": list(CAPABILITY_INSPIRATION_NOT_OBSERVED),
+    }
+
+
+def _source_index(snapshot: Mapping[str, Any]) -> dict[str, Mapping[str, Any]]:
+    sources = snapshot.get("observed_sources")
+    if not isinstance(sources, list):
+        return {}
+    return {
+        str(source.get("uri", "")): source
+        for source in sources
+        if isinstance(source, Mapping) and str(source.get("uri", ""))
+    }
+
+
+def _changed_sources(
+    earlier: Mapping[str, Mapping[str, Any]], later: Mapping[str, Mapping[str, Any]]
+) -> list[dict[str, Any]]:
+    changed: list[dict[str, Any]] = []
+    for uri in sorted(set(earlier) | set(later)):
+        before = earlier.get(uri)
+        after = later.get(uri)
+        if before is None:
+            changes = ["added"]
+        elif after is None:
+            changes = ["removed"]
+        else:
+            changes = sorted(
+                kind
+                for field, kind in (
+                    ("revision", "revision_changed"),
+                    ("content_digest", "content_changed"),
+                    ("license_note", "license_changed"),
+                    ("revision_stability", "stability_changed"),
+                )
+                if before.get(field) != after.get(field)
+            )
+        if not changes:
+            continue
+        changed.append(
+            {
+                "uri": uri,
+                "earlier_source_id": str(before.get("source_id", "")) if before else "",
+                "later_source_id": str(after.get("source_id", "")) if after else "",
+                "changes": changes,
+            }
+        )
+    return changed
+
+
+def _normalized_sources(observed_sources: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(observed_sources, (str, bytes)) or not isinstance(observed_sources, Sequence):
+        raise CapabilityInspirationSnapshotError(
+            "capability_inspiration_snapshot observed_sources must be a sequence of sources"
+        )
+    if len(observed_sources) > MAX_OBSERVED_SOURCES:
+        raise CapabilityInspirationSnapshotError(
+            f"capability_inspiration_snapshot observed_sources exceeds {MAX_OBSERVED_SOURCES} entries"
+        )
+    normalized: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for source in observed_sources:
+        if not isinstance(source, Mapping):
+            raise CapabilityInspirationSnapshotError(
+                "capability_inspiration_snapshot observed source must be an object"
+            )
+        # Closed on the way in as well as on the way out. A caller handing this
+        # a `content` key expects the content to be digested here, and it is
+        # not: `build_capability_inspiration_source` already did that and
+        # dropped it. Refusing the key is the only answer that is not a silent
+        # loss of the evidence the caller thought it supplied.
+        unsupported = sorted(set(source) - set(CAPABILITY_INSPIRATION_SOURCE_KEYS))
+        if unsupported:
+            raise CapabilityInspirationSnapshotError(
+                f"capability_inspiration_snapshot observed source has unsupported keys: {unsupported}"
+            )
+        rebuilt = build_capability_inspiration_source(
+            uri=str(source.get("uri", "")),
+            revision=str(source.get("revision", "")),
+            license_note=str(source.get("license_note", "")),
+            observation_provenance=str(source.get("observation_provenance", "") or ""),
+        )
+        # A source arriving as a mapping has already had its content digested by
+        # `build_capability_inspiration_source`; re-digesting a digest would
+        # produce a different one. Carry the recorded digest through instead.
+        rebuilt["content_digest"] = _carried_content_digest(source)
+        if rebuilt["uri"] in seen:
+            raise CapabilityInspirationSnapshotError(
+                f"capability_inspiration_snapshot observed_sources repeats uri: {rebuilt['uri']}"
+            )
+        seen.add(str(rebuilt["uri"]))
+        normalized.append(rebuilt)
+    normalized.sort(key=lambda source: (str(source["uri"]), str(source["revision"])))
+    return normalized
+
+
+def _carried_content_digest(source: Mapping[str, Any]) -> str:
+    digest = str(source.get("content_digest", "")).strip().lower()
+    if not digest:
+        return ""
+    if not re.fullmatch(r"[0-9a-f]{64}", digest):
+        raise CapabilityInspirationSnapshotError(
+            "capability_inspiration_snapshot source content_digest must be a sha256 hex digest"
+        )
+    return digest
+
+
+def _evidence_identity(source: Mapping[str, Any]) -> dict[str, Any]:
+    """The observed material only: no derived id, no observation time."""
+    return {
+        "content_digest": source.get("content_digest", ""),
+        "license_note": source.get("license_note", ""),
+        "observation_provenance": source.get("observation_provenance", ""),
+        "revision": source.get("revision", ""),
+        "revision_stability": source.get("revision_stability", ""),
+        "uri": source.get("uri", ""),
+    }
+
+
+def _digest(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_stable_encode(value).encode("utf-8")).hexdigest()
+
+
+def _content_digest(content: str) -> str:
+    text = str(content or "")
+    if not text:
+        return ""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _source_id(uri: str, revision: str) -> str:
+    seed = _stable_encode({"revision": revision, "uri": uri})
+    return f"inspiration-source-{hashlib.sha256(seed.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _bounded_line(value: Any, *, field: str) -> str:
+    """One metadata line: whitespace collapsed, length capped, never wrapped.
+
+    Collapsing whitespace also removes the newline a caller pasted in, which is
+    what keeps a supplied value from arriving as `\\r\\n` on one platform and
+    `\\n` on another and digesting differently.
+    """
+    text = " ".join(str(value or "").split())
+    if len(text) > MAX_LINE_LENGTH:
+        raise CapabilityInspirationSnapshotError(
+            f"capability_inspiration_snapshot {field} exceeds {MAX_LINE_LENGTH} characters"
+        )
+    return text
+
+
+def _bounded_lines(values: Sequence[str], *, field: str, limit: int) -> list[str]:
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise CapabilityInspirationSnapshotError(
+            f"capability_inspiration_snapshot {field} must be a sequence of strings"
+        )
+    lines: list[str] = []
+    for value in values:
+        line = _bounded_line(value, field=field)
+        if line and line not in lines:
+            lines.append(line)
+    if len(lines) > limit:
+        raise CapabilityInspirationSnapshotError(
+            f"capability_inspiration_snapshot {field} exceeds {limit} entries"
+        )
+    return lines
+
+
+def _key_set_errors(payload: Mapping[str, Any], keys: tuple[str, ...], label: str) -> list[str]:
+    errors: list[str] = []
+    extra = sorted(set(payload) - set(keys))
+    if extra:
+        errors.append(f"{label} has unsupported keys: {extra}")
+    missing = sorted(set(keys) - set(payload))
+    if missing:
+        errors.append(f"{label} is missing keys: {missing}")
+    return errors
+
+
+def _not_observed_errors(payload: Mapping[str, Any], label: str) -> list[str]:
+    declared = payload.get("not_evidence_until_observed")
+    if not isinstance(declared, list):
+        return [f"{label} not_evidence_until_observed must be a list"]
+    if list(declared) != list(CAPABILITY_INSPIRATION_NOT_OBSERVED):
+        return [
+            f"{label} not_evidence_until_observed must be "
+            f"{list(CAPABILITY_INSPIRATION_NOT_OBSERVED)}"
+        ]
+    return []
+
+
+def _bounded_list_errors(values: Any, *, field: str, label: str, limit: int) -> list[str]:
+    if not isinstance(values, list) or not all(isinstance(value, str) for value in values):
+        return [f"{label} {field} must be a list of strings"]
+    errors: list[str] = []
+    if len(values) > limit:
+        errors.append(f"{label} {field} exceeds {limit} entries")
+    if any(not value or len(value) > MAX_LINE_LENGTH for value in values):
+        errors.append(f"{label} {field} entries must be non-empty and at most {MAX_LINE_LENGTH} characters")
+    if len(set(values)) != len(values):
+        errors.append(f"{label} {field} must not repeat an entry")
+    return errors
+
+
+def _observed_source_errors(sources: Any, label: str) -> list[str]:
+    if not isinstance(sources, list) or not sources:
+        return [f"{label} observed_sources must be a non-empty list"]
+    errors: list[str] = []
+    if len(sources) > MAX_OBSERVED_SOURCES:
+        errors.append(f"{label} observed_sources exceeds {MAX_OBSERVED_SOURCES} entries")
+    order: list[tuple[str, str]] = []
+    for source in sources:
+        if not isinstance(source, Mapping):
+            errors.append(f"{label} observed source must be an object")
+            continue
+        errors.extend(_key_set_errors(source, CAPABILITY_INSPIRATION_SOURCE_KEYS, f"{label} observed source"))
+        if not _non_empty_text(source.get("uri")):
+            errors.append(f"{label} observed source uri must be a non-empty string")
+        if source.get("revision_stability") not in REVISION_STABILITIES:
+            errors.append(f"{label} observed source revision_stability must be one of {list(REVISION_STABILITIES)}")
+        elif source.get("revision_stability") != revision_stability(str(source.get("revision", ""))):
+            errors.append(f"{label} observed source revision_stability does not match its revision")
+        if source.get("observation_provenance") not in SOURCE_FINDER_OBSERVATION_PROVENANCE:
+            errors.append(f"{label} observed source observation_provenance is unsupported")
+        digest = source.get("content_digest")
+        if not isinstance(digest, str) or (digest and not re.fullmatch(r"[0-9a-f]{64}", digest)):
+            errors.append(f"{label} observed source content_digest must be empty or a sha256 hex digest")
+        expected_id = _source_id(str(source.get("uri", "")), str(source.get("revision", "")))
+        if source.get("source_id") != expected_id:
+            errors.append(f"{label} observed source source_id does not match its uri and revision")
+        order.append((str(source.get("uri", "")), str(source.get("revision", ""))))
+    if order != sorted(order):
+        errors.append(f"{label} observed_sources must be sorted by (uri, revision)")
+    if len({uri for uri, _ in order}) != len(order):
+        errors.append(f"{label} observed_sources must not repeat a uri")
+    return errors
+
+
+def _changed_source_errors(changed: Any, label: str) -> list[str]:
+    if not isinstance(changed, list):
+        return [f"{label} changed_sources must be a list"]
+    errors: list[str] = []
+    order: list[str] = []
+    for entry in changed:
+        if not isinstance(entry, Mapping):
+            errors.append(f"{label} changed source must be an object")
+            continue
+        errors.extend(_key_set_errors(entry, CAPABILITY_INSPIRATION_CHANGED_SOURCE_KEYS, f"{label} changed source"))
+        if not _non_empty_text(entry.get("uri")):
+            errors.append(f"{label} changed source uri must be a non-empty string")
+        kinds = entry.get("changes")
+        if not isinstance(kinds, list) or not kinds or not all(kind in SOURCE_CHANGE_KINDS for kind in kinds):
+            errors.append(f"{label} changed source changes must name one or more of {list(SOURCE_CHANGE_KINDS)}")
+        elif list(kinds) != sorted(set(kinds)):
+            errors.append(f"{label} changed source changes must be sorted and distinct")
+        order.append(str(entry.get("uri", "")))
+    if order != sorted(order):
+        errors.append(f"{label} changed_sources must be sorted by uri")
+    return errors
+
+
+def _digest_errors(snapshot: Mapping[str, Any], label: str) -> list[str]:
+    """Re-derive every digest from the payload's own material.
+
+    A snapshot whose digest does not follow from what it records is not a
+    frozen artifact, it is two claims that disagree.
+    """
+    sources = [source for source in snapshot["observed_sources"] if isinstance(source, Mapping)]
+    evidence_digest = _digest({"sources": [_evidence_identity(source) for source in sources]})
+    requirements_digest = _digest({"derived_requirements": list(snapshot["derived_requirements"])})
+    snapshot_digest = _digest(
+        {
+            "capability_id": str(snapshot["capability_id"]),
+            "derived_requirements_digest": requirements_digest,
+            "evidence_digest": evidence_digest,
+            "findings": list(snapshot["findings"]),
+        }
+    )
+    errors: list[str] = []
+    if snapshot.get("evidence_digest") != evidence_digest:
+        errors.append(f"{label} evidence_digest does not match its observed sources")
+    if snapshot.get("derived_requirements_digest") != requirements_digest:
+        errors.append(f"{label} derived_requirements_digest does not match its derived requirements")
+    if snapshot.get("snapshot_digest") != snapshot_digest:
+        errors.append(f"{label} snapshot_digest does not match its frozen material")
+    elif snapshot.get("snapshot_id") != f"capability-inspiration-{snapshot_digest[:16]}":
+        errors.append(f"{label} snapshot_id does not match its snapshot_digest")
+    return errors
+
+
+def _non_empty_text(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())

--- a/tests/test_capability_inspiration_snapshot.py
+++ b/tests/test_capability_inspiration_snapshot.py
@@ -1,0 +1,623 @@
+"""Contracts for `capability_inspiration_snapshot/v1`.
+
+Three properties are load-bearing and each has its own section below.
+
+Determinism. The digest is canonical over the observed material, so the same
+evidence read twice -- at a different time, by a different observer, supplied in
+a different order -- produces the same number. Anything else makes "has the
+inspiration changed?" unanswerable, because every re-observation would look like
+a change.
+
+Supersession. Changed evidence mints a new snapshot that links to the old one.
+The old one is asserted to be byte-identical afterwards and to still validate:
+the whole reason to link rather than overwrite is that the evidence which
+actually shaped the shipped design has to stay readable.
+
+Evidence boundary. A citation is checked field by field against a list of words
+that would read as "OMH looked just now". The two claim-boundary strings are
+excluded from that scan and checked separately, because their job is to state
+the negation and a naive scan would fail them for saying the word.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.local_store import atomic_write_text
+from omh.quality.capability_inspiration_snapshot import (
+    CAPABILITY_INSPIRATION_CITATION_CLAIM_BOUNDARY,
+    CAPABILITY_INSPIRATION_CITATION_KEYS,
+    CAPABILITY_INSPIRATION_CITATION_SCHEMA_VERSION,
+    CAPABILITY_INSPIRATION_CLAIM_BOUNDARY,
+    CAPABILITY_INSPIRATION_COMPARISON_SCHEMA_VERSION,
+    CAPABILITY_INSPIRATION_NOT_OBSERVED,
+    CAPABILITY_INSPIRATION_SNAPSHOT_KEYS,
+    CAPABILITY_INSPIRATION_SNAPSHOT_SCHEMA_VERSION,
+    CAPABILITY_INSPIRATION_SOURCE_KEYS,
+    COMPARISON_VERDICTS,
+    MAX_FINDINGS,
+    REVISION_STABILITIES,
+    SOURCE_AVAILABILITY_STATES,
+    SOURCE_CHANGE_KINDS,
+    CapabilityInspirationSnapshotError,
+    build_capability_inspiration_snapshot,
+    build_capability_inspiration_source,
+    capability_inspiration_chain_errors,
+    capability_inspiration_citation,
+    compare_capability_inspiration_snapshots,
+    revision_stability,
+    validate_capability_inspiration_citation,
+    validate_capability_inspiration_comparison,
+    validate_capability_inspiration_snapshot,
+)
+
+
+_PLUGIN_DOCS = "https://docs.openclaw.ai/plugins"
+_MARKETPLACE_DOCS = "https://code.claude.com/docs/en/plugin-marketplaces"
+_IMMUTABLE_REVISION = "b" * 40
+_LATER_REVISION = "c" * 40
+
+# Words that would make a cited snapshot read as a live check. Every one of them
+# is absent from this family's field names and closed vocabularies by
+# construction, which is the property AC3 asks for.
+_ASSERTED_AVAILABILITY = (
+    "available",
+    "reachable",
+    "online",
+    "verified",
+    "fetched",
+    "downloaded",
+    "live",
+    "observed_now",
+    "up to date",
+)
+
+# Every module that could turn this into a fetcher. The snapshot records what a
+# caller supplied; a network import here would make that claim unenforceable.
+_NETWORK_MODULES = (
+    "http",
+    "httpx",
+    "requests",
+    "socket",
+    "ssl",
+    "subprocess",
+    "urllib",
+)
+
+
+def _source(
+    uri: str = _PLUGIN_DOCS,
+    *,
+    revision: str = _IMMUTABLE_REVISION,
+    content: str = "plugin manifest reference, section 3",
+    license_note: str = "Apache-2.0 as displayed on the page footer",
+    observation_provenance: str = "user",
+) -> dict[str, object]:
+    return build_capability_inspiration_source(
+        uri=uri,
+        revision=revision,
+        content=content,
+        license_note=license_note,
+        observation_provenance=observation_provenance,
+    )
+
+
+def _snapshot(
+    *,
+    sources: list[dict[str, object]] | None = None,
+    observer: str = "maintainer reading the published docs",
+    observed_at: str = "2026-08-09T10:00:00Z",
+    findings: tuple[str, ...] = ("Plugin manifests declare tools and hooks separately.",),
+    derived_requirements: tuple[str, ...] = (
+        "OMH names a capability family without installing a plugin.",
+        "OMH keeps the derived requirement separate from the cited evidence.",
+    ),
+    reviewer_ref: str = "",
+    supersedes_snapshot_ref: str = "",
+) -> dict[str, object]:
+    return build_capability_inspiration_snapshot(
+        capability_id="capability-family-projection",
+        observed_sources=sources if sources is not None else [_source()],
+        observer=observer,
+        observed_at=observed_at,
+        findings=findings,
+        derived_requirements=derived_requirements,
+        reviewer_ref=reviewer_ref,
+        supersedes_snapshot_ref=supersedes_snapshot_ref,
+    )
+
+
+class UnchangedEvidenceReproducesTheDigestTests(unittest.TestCase):
+    """AC1: the digest is canonical over the observed material."""
+
+    def test_two_separate_builds_of_the_same_evidence_agree(self) -> None:
+        first = _snapshot()
+        second = _snapshot()
+
+        self.assertEqual(first, second)
+        self.assertEqual(validate_capability_inspiration_snapshot(first), [])
+        self.assertEqual(
+            first["schema_version"], CAPABILITY_INSPIRATION_SNAPSHOT_SCHEMA_VERSION
+        )
+
+    def test_observation_metadata_is_outside_the_digest(self) -> None:
+        first = _snapshot(observer="maintainer A", observed_at="2026-01-01T00:00:00Z")
+        second = _snapshot(
+            observer="maintainer B",
+            observed_at="2026-08-09T23:59:59Z",
+            reviewer_ref="review-2026-08-09",
+        )
+
+        self.assertNotEqual(first["observed_at"], second["observed_at"])
+        self.assertNotEqual(first["observer"], second["observer"])
+        for key in ("evidence_digest", "derived_requirements_digest", "snapshot_digest", "snapshot_id"):
+            with self.subTest(key=key):
+                self.assertEqual(first[key], second[key])
+
+    def test_source_order_is_not_meaningful(self) -> None:
+        forward = _snapshot(sources=[_source(), _source(_MARKETPLACE_DOCS, content="marketplace reference")])
+        reverse = _snapshot(sources=[_source(_MARKETPLACE_DOCS, content="marketplace reference"), _source()])
+
+        self.assertEqual(forward, reverse)
+        self.assertEqual(
+            [source["uri"] for source in forward["observed_sources"]],
+            sorted(source["uri"] for source in forward["observed_sources"]),
+        )
+
+    def test_requirement_order_is_meaningful(self) -> None:
+        forward = _snapshot(derived_requirements=("first requirement", "second requirement"))
+        reverse = _snapshot(derived_requirements=("second requirement", "first requirement"))
+
+        self.assertNotEqual(
+            forward["derived_requirements_digest"], reverse["derived_requirements_digest"]
+        )
+        self.assertNotEqual(forward["snapshot_digest"], reverse["snapshot_digest"])
+
+    def test_content_digest_survives_a_file_round_trip(self) -> None:
+        content = "plugin manifest reference, section 3\nsecond line\n"
+        with TemporaryDirectory() as raw_root:
+            path = Path(raw_root) / "observed.txt"
+            atomic_write_text(path, content)
+            from_disk = path.read_bytes().decode("utf-8")
+
+        direct = _source(content=content)
+        round_tripped = _source(content=from_disk)
+
+        self.assertEqual(from_disk, content)
+        self.assertEqual(direct["content_digest"], round_tripped["content_digest"])
+        self.assertEqual(
+            direct["content_digest"], hashlib.sha256(content.encode("utf-8")).hexdigest()
+        )
+
+    def test_revision_stability_is_derived_conservatively(self) -> None:
+        cases = {
+            _IMMUTABLE_REVISION: "immutable",
+            "d" * 64: "immutable",
+            "main": "mutable",
+            "v1.2.3": "mutable",
+            "": "unknown",
+        }
+        for revision, expected in cases.items():
+            with self.subTest(revision=revision):
+                self.assertEqual(revision_stability(revision), expected)
+                self.assertIn(expected, REVISION_STABILITIES)
+
+    def test_a_mutable_revision_is_visible_on_the_snapshot(self) -> None:
+        snapshot = _snapshot(sources=[_source(revision="main")])
+
+        self.assertEqual(snapshot["observed_sources"][0]["revision_stability"], "mutable")
+        self.assertEqual(validate_capability_inspiration_snapshot(snapshot), [])
+
+    def test_the_module_cannot_fetch(self) -> None:
+        module_path = (
+            Path(__file__).resolve().parents[1]
+            / "src"
+            / "quality"
+            / "capability_inspiration_snapshot.py"
+        )
+        source = module_path.read_bytes().decode("utf-8")
+        imported = {
+            line.split()[1].split(".")[0]
+            for line in source.splitlines()
+            if line.startswith("import ") or line.startswith("from ")
+        }
+
+        for module in _NETWORK_MODULES:
+            with self.subTest(module=module):
+                self.assertNotIn(module, imported)
+
+
+class ChangedEvidenceSupersedesTests(unittest.TestCase):
+    """AC2: the earlier snapshot survives and the report names the difference."""
+
+    def test_a_changed_revision_mints_a_superseding_snapshot(self) -> None:
+        earlier = _snapshot()
+        frozen = json.dumps(earlier, sort_keys=True)
+
+        later = _snapshot(
+            sources=[_source(revision=_LATER_REVISION, content="plugin manifest reference, section 4")],
+            observed_at="2026-09-01T10:00:00Z",
+            supersedes_snapshot_ref=str(earlier["snapshot_id"]),
+        )
+
+        self.assertNotEqual(earlier["snapshot_id"], later["snapshot_id"])
+        self.assertNotEqual(earlier["evidence_digest"], later["evidence_digest"])
+        self.assertEqual(later["supersedes_snapshot_ref"], earlier["snapshot_id"])
+        self.assertEqual(json.dumps(earlier, sort_keys=True), frozen)
+        self.assertEqual(validate_capability_inspiration_snapshot(earlier), [])
+        self.assertEqual(capability_inspiration_chain_errors([earlier, later]), [])
+
+    def test_the_report_names_what_moved(self) -> None:
+        earlier = _snapshot()
+        later = _snapshot(
+            sources=[_source(revision=_LATER_REVISION, content="plugin manifest reference, section 4")],
+            supersedes_snapshot_ref=str(earlier["snapshot_id"]),
+        )
+
+        report = compare_capability_inspiration_snapshots(earlier, later)
+
+        self.assertEqual(validate_capability_inspiration_comparison(report), [])
+        self.assertEqual(report["schema_version"], CAPABILITY_INSPIRATION_COMPARISON_SCHEMA_VERSION)
+        self.assertEqual(report["verdict"], "changed")
+        self.assertTrue(report["supersedes_earlier"])
+        self.assertEqual(report["earlier_snapshot_id"], earlier["snapshot_id"])
+        self.assertEqual(report["later_snapshot_id"], later["snapshot_id"])
+        self.assertEqual(
+            report["changed_sources"],
+            [
+                {
+                    "uri": _PLUGIN_DOCS,
+                    "earlier_source_id": earlier["observed_sources"][0]["source_id"],
+                    "later_source_id": later["observed_sources"][0]["source_id"],
+                    "changes": ["content_changed", "revision_changed"],
+                }
+            ],
+        )
+
+    def test_added_and_removed_sources_are_named(self) -> None:
+        earlier = _snapshot()
+        later = _snapshot(sources=[_source(_MARKETPLACE_DOCS, content="marketplace reference")])
+
+        report = compare_capability_inspiration_snapshots(earlier, later)
+
+        self.assertEqual(validate_capability_inspiration_comparison(report), [])
+        self.assertEqual(
+            [(entry["uri"], entry["changes"]) for entry in report["changed_sources"]],
+            [(_MARKETPLACE_DOCS, ["added"]), (_PLUGIN_DOCS, ["removed"])],
+        )
+
+    def test_a_license_observation_alone_is_a_change(self) -> None:
+        earlier = _snapshot()
+        later = _snapshot(sources=[_source(license_note="MIT as displayed on the page footer")])
+
+        report = compare_capability_inspiration_snapshots(earlier, later)
+
+        self.assertEqual(report["verdict"], "changed")
+        self.assertEqual(report["changed_sources"][0]["changes"], ["license_changed"])
+
+    def test_unchanged_evidence_reports_current(self) -> None:
+        report = compare_capability_inspiration_snapshots(_snapshot(), _snapshot(observer="someone else"))
+
+        self.assertEqual(validate_capability_inspiration_comparison(report), [])
+        self.assertEqual(report["verdict"], "current")
+        self.assertEqual(report["changed_sources"], [])
+        self.assertFalse(report["derived_requirements_changed"])
+
+    def test_derived_requirements_are_reported_apart_from_the_evidence(self) -> None:
+        earlier = _snapshot()
+        later = _snapshot(derived_requirements=("OMH names a capability family without installing a plugin.",))
+
+        report = compare_capability_inspiration_snapshots(earlier, later)
+
+        self.assertEqual(report["verdict"], "current")
+        self.assertTrue(report["derived_requirements_changed"])
+
+    def test_evidence_that_could_not_be_re_observed_is_unverifiable(self) -> None:
+        earlier = _snapshot()
+
+        report = compare_capability_inspiration_snapshots(earlier, None)
+
+        self.assertEqual(validate_capability_inspiration_comparison(report), [])
+        self.assertEqual(report["verdict"], "unverifiable")
+        self.assertEqual(report["later_snapshot_id"], "")
+        self.assertEqual(report["changed_sources"], [])
+        self.assertEqual(sorted(COMPARISON_VERDICTS), ["changed", "current", "unverifiable"])
+
+    def test_unchanged_evidence_cannot_supersede_itself(self) -> None:
+        earlier = _snapshot()
+        repeat = _snapshot(supersedes_snapshot_ref=str(earlier["snapshot_id"]))
+
+        self.assertEqual(repeat["snapshot_id"], earlier["snapshot_id"])
+        self.assertIn(
+            "capability_inspiration_snapshot supersedes_snapshot_ref must not name itself",
+            validate_capability_inspiration_snapshot(repeat),
+        )
+
+
+class CitedSnapshotsClaimNoAvailabilityTests(unittest.TestCase):
+    """AC3: a handoff can cite the snapshot; availability stays unobserved."""
+
+    def test_a_citation_is_bindable_and_valid(self) -> None:
+        snapshot = _snapshot(reviewer_ref="review-2026-08-09")
+
+        citation = capability_inspiration_citation(snapshot)
+
+        self.assertEqual(validate_capability_inspiration_citation(citation), [])
+        self.assertEqual(citation["schema_version"], CAPABILITY_INSPIRATION_CITATION_SCHEMA_VERSION)
+        self.assertEqual(sorted(citation), sorted(CAPABILITY_INSPIRATION_CITATION_KEYS))
+        self.assertEqual(citation["snapshot_digest"], snapshot["snapshot_digest"])
+        self.assertEqual(citation["evidence_digest"], snapshot["evidence_digest"])
+        self.assertEqual(citation["cited_source_count"], 1)
+
+    def test_availability_has_one_state_and_it_is_unobserved(self) -> None:
+        citation = capability_inspiration_citation(_snapshot())
+
+        self.assertEqual(SOURCE_AVAILABILITY_STATES, ("not_observed",))
+        self.assertEqual(citation["source_availability"], "not_observed")
+        self.assertIn(citation["source_availability"], SOURCE_AVAILABILITY_STATES)
+
+    def test_every_unobserved_claim_is_declared(self) -> None:
+        citation = capability_inspiration_citation(_snapshot())
+
+        self.assertEqual(
+            citation["not_evidence_until_observed"], list(CAPABILITY_INSPIRATION_NOT_OBSERVED)
+        )
+        for claim in CAPABILITY_INSPIRATION_NOT_OBSERVED:
+            with self.subTest(claim=claim):
+                self.assertIn(claim, citation["not_evidence_until_observed"])
+
+    def test_nothing_in_a_cited_handoff_reads_as_observed_now(self) -> None:
+        citation = capability_inspiration_citation(_snapshot())
+        handoff = {
+            "capability_id": citation["capability_id"],
+            "inspiration_citation": citation,
+            "scope": "Implement the OMH-native capability family projection.",
+        }
+        scanned = dict(citation)
+        scanned.pop("claim_boundary")
+        rendered = json.dumps({**handoff, "inspiration_citation": scanned}, sort_keys=True).lower()
+
+        for phrase in _ASSERTED_AVAILABILITY:
+            with self.subTest(phrase=phrase):
+                self.assertNotIn(phrase, rendered)
+
+    def test_the_boundary_states_the_negation_it_owes(self) -> None:
+        citation = capability_inspiration_citation(_snapshot())
+
+        self.assertEqual(citation["claim_boundary"], CAPABILITY_INSPIRATION_CITATION_CLAIM_BOUNDARY)
+        self.assertIn("not a live source check", citation["claim_boundary"])
+        self.assertIn("stay unobserved", citation["claim_boundary"])
+        self.assertIn("no fetch", CAPABILITY_INSPIRATION_CLAIM_BOUNDARY.lower())
+
+    def test_a_citation_carries_no_source_uri(self) -> None:
+        citation = capability_inspiration_citation(_snapshot())
+        rendered = json.dumps(citation, sort_keys=True)
+
+        self.assertNotIn(_PLUGIN_DOCS, rendered)
+        self.assertNotIn("://", rendered)
+
+
+class RefusalTests(unittest.TestCase):
+    """The guards that keep a snapshot from asserting something untrue."""
+
+    def test_a_snapshot_with_no_observer_is_refused(self) -> None:
+        for observer in ("", "   "):
+            with self.subTest(observer=observer):
+                with self.assertRaises(CapabilityInspirationSnapshotError) as caught:
+                    _snapshot(observer=observer)
+                self.assertIn("observer is required", str(caught.exception))
+
+    def test_a_snapshot_with_no_source_is_refused(self) -> None:
+        with self.assertRaises(CapabilityInspirationSnapshotError) as caught:
+            _snapshot(sources=[])
+
+        self.assertIn("at least one observed source", str(caught.exception))
+
+    def test_a_source_with_no_uri_is_refused(self) -> None:
+        with self.assertRaises(CapabilityInspirationSnapshotError) as caught:
+            build_capability_inspiration_source(uri="   ")
+
+        self.assertIn("uri is required", str(caught.exception))
+
+    def test_a_repeated_uri_is_refused(self) -> None:
+        with self.assertRaises(CapabilityInspirationSnapshotError) as caught:
+            _snapshot(sources=[_source(), _source(revision=_LATER_REVISION)])
+
+        self.assertIn("repeats uri", str(caught.exception))
+
+    def test_an_unsupported_source_key_is_refused(self) -> None:
+        source = _source()
+        source["content"] = "the caller expected this to be digested here"
+
+        with self.assertRaises(CapabilityInspirationSnapshotError) as caught:
+            _snapshot(sources=[source])
+
+        self.assertIn("unsupported keys", str(caught.exception))
+
+    def test_findings_stay_bounded(self) -> None:
+        with self.assertRaises(CapabilityInspirationSnapshotError) as caught:
+            _snapshot(findings=tuple(f"finding {index}" for index in range(MAX_FINDINGS + 1)))
+
+        self.assertIn(f"exceeds {MAX_FINDINGS} entries", str(caught.exception))
+
+    def test_an_overlong_line_is_refused(self) -> None:
+        with self.assertRaises(CapabilityInspirationSnapshotError) as caught:
+            _snapshot(findings=("x" * 201,))
+
+        self.assertIn("exceeds 200 characters", str(caught.exception))
+
+    def test_a_chain_fork_is_refused(self) -> None:
+        earlier = _snapshot()
+        one = _snapshot(
+            sources=[_source(revision=_LATER_REVISION)],
+            supersedes_snapshot_ref=str(earlier["snapshot_id"]),
+        )
+        other = _snapshot(
+            sources=[_source(_MARKETPLACE_DOCS, content="marketplace reference")],
+            supersedes_snapshot_ref=str(earlier["snapshot_id"]),
+        )
+
+        errors = capability_inspiration_chain_errors([earlier, one, other])
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("forks the chain", errors[0])
+        self.assertIn(str(earlier["snapshot_id"]), errors[0])
+
+    def test_a_chain_link_to_an_unknown_snapshot_is_refused(self) -> None:
+        orphan = _snapshot(supersedes_snapshot_ref="capability-inspiration-0000000000000000")
+
+        errors = capability_inspiration_chain_errors([orphan])
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("does not name an earlier snapshot", errors[0])
+
+    def test_a_repeated_snapshot_id_is_refused(self) -> None:
+        snapshot = _snapshot()
+
+        errors = capability_inspiration_chain_errors([snapshot, _snapshot()])
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("snapshot_id is not unique", errors[0])
+        self.assertIn(str(snapshot["snapshot_id"]), errors[0])
+
+    def test_a_self_linking_snapshot_is_refused_by_the_chain_walk(self) -> None:
+        snapshot = _snapshot()
+        snapshot["supersedes_snapshot_ref"] = snapshot["snapshot_id"]
+
+        errors = capability_inspiration_chain_errors([snapshot])
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("must not name itself", errors[0])
+
+
+class ValidatorTests(unittest.TestCase):
+    """The key set is closed in both directions and the digests are re-derived."""
+
+    def test_the_built_snapshot_carries_exactly_the_declared_keys(self) -> None:
+        snapshot = _snapshot()
+
+        self.assertEqual(sorted(snapshot), sorted(CAPABILITY_INSPIRATION_SNAPSHOT_KEYS))
+        self.assertEqual(
+            sorted(snapshot["observed_sources"][0]), sorted(CAPABILITY_INSPIRATION_SOURCE_KEYS)
+        )
+
+    def test_an_extra_key_is_refused(self) -> None:
+        snapshot = _snapshot()
+        snapshot["observed_availability"] = "available"
+
+        self.assertIn(
+            "capability_inspiration_snapshot has unsupported keys: ['observed_availability']",
+            validate_capability_inspiration_snapshot(snapshot),
+        )
+
+    def test_a_missing_key_is_refused(self) -> None:
+        snapshot = _snapshot()
+        del snapshot["evidence_digest"]
+
+        self.assertIn(
+            "capability_inspiration_snapshot is missing keys: ['evidence_digest']",
+            validate_capability_inspiration_snapshot(snapshot),
+        )
+
+    def test_a_digest_that_does_not_follow_from_the_material_is_refused(self) -> None:
+        snapshot = _snapshot()
+        snapshot["derived_requirements"] = ["a requirement nobody digested"]
+
+        errors = validate_capability_inspiration_snapshot(snapshot)
+
+        self.assertIn(
+            "capability_inspiration_snapshot derived_requirements_digest does not match its derived requirements",
+            errors,
+        )
+        self.assertIn(
+            "capability_inspiration_snapshot snapshot_digest does not match its frozen material", errors
+        )
+
+    def test_a_weakened_claim_boundary_is_refused(self) -> None:
+        snapshot = _snapshot()
+        snapshot["claim_boundary"] = "OMH checked this source."
+
+        self.assertIn(
+            "capability_inspiration_snapshot claim_boundary must state that OMH observed nothing itself",
+            validate_capability_inspiration_snapshot(snapshot),
+        )
+
+    def test_a_dropped_boundary_declaration_is_refused(self) -> None:
+        snapshot = _snapshot()
+        snapshot["not_evidence_until_observed"] = ["source_availability"]
+
+        self.assertIn(
+            "capability_inspiration_snapshot not_evidence_until_observed must be "
+            f"{list(CAPABILITY_INSPIRATION_NOT_OBSERVED)}",
+            validate_capability_inspiration_snapshot(snapshot),
+        )
+
+    def test_a_mislabelled_revision_stability_is_refused(self) -> None:
+        snapshot = _snapshot(sources=[_source(revision="main")])
+        snapshot["observed_sources"][0]["revision_stability"] = "immutable"
+
+        self.assertIn(
+            "capability_inspiration_snapshot observed source revision_stability does not match its revision",
+            validate_capability_inspiration_snapshot(snapshot),
+        )
+
+    def test_a_comparison_that_contradicts_its_verdict_is_refused(self) -> None:
+        report = compare_capability_inspiration_snapshots(_snapshot(), _snapshot())
+        report["changed_sources"] = [
+            {
+                "uri": _PLUGIN_DOCS,
+                "earlier_source_id": "inspiration-source-0000000000000000",
+                "later_source_id": "inspiration-source-1111111111111111",
+                "changes": ["revision_changed"],
+            }
+        ]
+
+        self.assertIn(
+            "capability_inspiration_comparison verdict current cannot name changed sources",
+            validate_capability_inspiration_comparison(report),
+        )
+
+    def test_an_unknown_change_kind_is_refused(self) -> None:
+        report = compare_capability_inspiration_snapshots(_snapshot(), None)
+        report["changed_sources"] = [
+            {
+                "uri": _PLUGIN_DOCS,
+                "earlier_source_id": "",
+                "later_source_id": "",
+                "changes": ["rewritten"],
+            }
+        ]
+
+        self.assertIn(
+            f"capability_inspiration_comparison changed source changes must name one or more of {list(SOURCE_CHANGE_KINDS)}",
+            validate_capability_inspiration_comparison(report),
+        )
+
+    def test_a_citation_without_a_source_is_refused(self) -> None:
+        citation = capability_inspiration_citation(_snapshot())
+        citation["cited_source_count"] = 0
+
+        self.assertIn(
+            "capability_inspiration_citation cited_source_count must be a positive integer",
+            validate_capability_inspiration_citation(citation),
+        )
+
+    def test_non_objects_are_refused_by_every_validator(self) -> None:
+        for validate in (
+            validate_capability_inspiration_snapshot,
+            validate_capability_inspiration_citation,
+            validate_capability_inspiration_comparison,
+        ):
+            with self.subTest(validate=validate.__name__):
+                self.assertEqual(len(validate("not an object")), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New `capability_inspiration_snapshot/v1` (`src/quality/capability_inspiration_snapshot.py`): one frozen record of the external evidence a native OMH capability was designed from.
- Each snapshot holds the sources that informed the design (uri, revision, a digest of the content as it read at that revision, the license note the observer saw), the bounded findings drawn from them, the requirements derived for the OMH-native version, who observed the material and when, a reviewer reference once reviewed, and a link to the snapshot it replaces.

### Why This Exists

A native OMH capability is often designed by reading somebody else's docs or release. Months later two questions arrive and neither had an answer: *"base the OMH version on this exact release"* — which release was that? — and *"has the inspiration changed?"* — changed from what?

The issue's own "Current OMH base" overstates what exists. Source finding records a candidate and how far its acquisition got, but `build_source_candidate` emits only `uri`, `observed_at`, `evidence_uri`, `evidence_note`, `observation_provenance`, and `acquisition_state`. There is **no** revision, content digest, or license observation field anywhere in the tree today, so there was nothing for a later reading to be compared against.

### User / Operator Impact

A maintainer can pin a design to the exact material it was based on and later ask whether that material moved. When it has, the answer names the difference instead of just saying "different", and the earlier snapshot is still readable — which matters because the earlier reading is what the existing design was justified by.

### How It Works

The canonical digest is built with the repository's existing `_stable_encode` / `policy_decision_digest` rather than a second hashing scheme. The observation timestamp is deliberately **outside** the digest seed: with it inside, re-reading unchanged evidence could not reproduce the same digest, which is the entire point of AC1.

Changed evidence produces a new snapshot that supersedes by link, following the repo's `supersedes_*_ref` pattern, rather than overwriting.

OMH fetches nothing. Every byte of observed material is supplied by the caller; the module imports nothing that can open a socket, so "the source was read" is always the caller's claim and never OMH's. Citing a snapshot therefore never reads as "the source is available now" — that separation is what AC3 asks for and it is asserted across the availability vocabulary.

### Files And Contracts Touched

- `src/quality/capability_inspiration_snapshot.py` — new, 854 lines.
- `tests/test_capability_inspiration_snapshot.py` — new, 623 lines, 44 tests.

No generated artifact, catalog entry, routing case, or demo card touched, so no exact-count assertion moved.

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `python3 -m unittest discover -s tests` — Ran 5067 tests, OK
- [x] `python3 -m compileall src` — clean
- [x] `python3 -m omh.cli docs workflows --check` — `ok: true`
- [x] `python3 -m omh.cli harness validate` — `ok: true`, 72 harnesses / 104 skills
- [x] Also `docs roles --check`, `docs capability-families --check`, `git diff --check`
- [ ] Manual Hermes/TUI check — not run. Nothing renders a snapshot yet; there is no Hermes-visible surface to check.

Tests map to the acceptance criteria: identical observed evidence reproduces an identical digest across separate builds (AC1); changed evidence supersedes while the earlier snapshot stays readable and the report names the difference (AC2); a handoff citing a snapshot never asserts current availability (AC3).

## Risk

Low. The module is additive with no caller, so nothing in production can regress. The one thing to watch is the digest seed: if the observation timestamp is ever folded back in, AC1 breaks and the failure will look like flakiness rather than a contract break. That is stated in the commit's `Directive:` trailer.

## Compatibility / Rollout

Purely additive. `source_finder` is untouched — this is a sibling record, not an extension of the candidate.

## Release / Claims

- [x] Release-channel impact considered — `local`
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — the payload's claim boundary states the material was supplied by the caller and that citing a snapshot is not an availability claim
- [x] Known manual Hermes checks are listed — no Hermes surface exists to check

## Follow-Up

- No producer. Nothing mints a snapshot and no coding handoff cites one yet.
- #789, #792, and #794 all reference this snapshot in their designs; the citation accessor is importable for that.

Closes #790
