### PR TITLE
feat: separate reusable user outcomes from host-specific machinery

### DIFF
--- a/src/workflows/reusable_behavior_map.py
+++ b/src/workflows/reusable_behavior_map.py
@@ -1,0 +1,749 @@
+"""Reusable behavior maps: `reusable_behavior_map/v1` (issue #796).
+
+What was missing
+----------------
+
+Two halves of this already existed and nothing joined them.
+
+`plugin_risk_audit/v1` reads a bundle without running it. It walks one
+explicitly named local directory through symlink-refusing dirfd-anchored opens,
+returns aggregate risk categories, a manifest status, and two counts, and says
+in its own `claim_boundary` that it imported nothing, registered nothing, and
+executed nothing. What it deliberately does not return is *behavior*: it never
+says what the bundle is for.
+
+`awesome_hermes_plugin_outcome_matrix/v1` maps a demonstrated outcome onto OMH
+capability ids and refuses a claim that outruns its evidence. What it does not
+do is start from a bundle somebody just handed over; its rows are a reviewed
+catalog pinned to an upstream commit.
+
+So a person holding a complex demonstrated workflow could learn that it touches
+a network and spawns a process, or could read a curated table about a plugin
+somebody already reviewed, and had nothing that answered the actual question:
+*of the things this bundle does, which ones are outcomes OMH should provide
+natively, and which are the host's machinery.*
+
+What a map is
+-------------
+
+One inventory over one cited audit. Each row is one behavior somebody observed
+in the bundle, carrying the user outcome it produces, the host-free procedure
+that would reproduce it, the OMH capability that already covers it, the host
+mechanics that make it unreusable, the risk categories the audit already found,
+and a note on how OMH would stand it up independently.
+
+The map cites an audit; it never re-scans. `source_audit` is a projection of a
+real `plugin_risk_audit/v1` payload, and a behavior may only name a risk
+category that the cited audit actually observed. That is what keeps the risky
+verdict evidence-backed instead of a second opinion about the same files.
+
+Six states, and no seventh
+--------------------------
+
+#796 AC2 names six classifications. They are a closed vocabulary, and an
+unrecognised value is refused rather than passed through, because a map whose
+verdicts are open-ended is a list of adjectives.
+
+They are made distinguishable structurally rather than by prose.
+`CLASSIFICATION_REQUIRED_EVIDENCE` gives each classification the exact set of
+evidence fields it must carry, and every evidence field it does not require is
+forbidden. A behavior's non-empty evidence fields therefore *are* its
+classification's signature, the six signatures are distinct, and no payload can
+satisfy two classifications at once:
+
+    reusable    reusable_procedure
+    covered     reusable_procedure + omh_capability_ids
+    host_bound  host_mechanics
+    risky       risk_categories
+    unclear     missing_evidence
+    irrelevant  (nothing)
+
+One consequence is deliberate: a verdict is singular. A behavior whose
+demonstrated mechanic is risky is `risky`, not `reusable` with a risk note
+attached, and a behavior welded to a host hook is `host_bound` even when that
+hook is also risky. The nuance goes in `independence_note`, which every row
+carries. Letting a row be two things at once is how "we know what this bundle
+does" quietly becomes "we have opinions about this bundle".
+
+Covered is a citation, not an adjective
+---------------------------------------
+
+#796 AC3 -- no pattern is called supported or implemented without OMH evidence
+-- is enforced as resolution, not as format. `covered` requires at least one
+`omh_capability_ids` entry, and every entry must resolve against
+`omh_capability_vocabulary()`, which is re-derived from
+`POPULAR_PLUGIN_FAMILIES` in `src/quality/popular_plugin_coverage.py`. A
+well-formed slug naming a capability this repository does not have is refused
+with the ids listed. Asserting coverage therefore costs the author a real
+lookup, and a reviewer can check the claim without leaving the repo.
+
+`not_observed` carries the other half: naming an existing OMH capability says
+that capability exists, and says nothing about this map having built, run, or
+verified anything.
+
+The bundle is never run
+-----------------------
+
+The audit's boundary is inherited and restated. `CLAIM_BOUNDARY` says OMH does
+not import, install, register, or execute the inspected bundle, does not install
+its dependencies, and does not reach its endpoints. `NOT_OBSERVED` says the same
+thing as data. `IMPLEMENTATION_CLAIM_KEYS` -- reused from
+`native_capability_blueprint`, not forked, so the two families cannot drift on
+what an execution claim looks like -- refuses a payload shaped to say otherwise
+by key name, on the envelope and on every row.
+
+Determinism
+-----------
+
+#796 AC1 is literally determinism, so nothing here reads a clock. `prepared_at`
+is a parameter, defaults to empty, and is excluded from `map_digest`; a wall
+clock inside a compared value turns an equality check into a race, and this
+repo has already lost Windows CI time to exactly that.
+
+Behaviors are sorted by `behavior_id` and closed-vocabulary lists are normalized
+into their declared order, so two researchers who found the same things in a
+different order produce the same map, byte for byte. `summary` is derived rather
+than supplied, and the validator recomputes it, so a hand-edited count is a
+validation error instead of a quiet disagreement with the rows above it.
+
+What reads these today
+----------------------
+
+Stated because the vocabulary is wider than the wiring. No production surface
+mints a map yet; this module is the contract and
+`tests/test_reusable_behavior_map.py` is its only caller. The intended next step
+is the one #796 describes: a behavior classified `reusable` becomes a separate
+native capability request, and `host_mechanics` is deliberately
+`SOURCE_HOST_MECHANICS` from `native_capability_blueprint` so a host-bound
+exclusion here and a blueprint's `observed_source_mechanics` there are the same
+words.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from functools import lru_cache
+from typing import Any, Final, get_args
+
+from ..quality.popular_plugin_coverage import POPULAR_PLUGIN_FAMILIES
+from ..system.append_only_store import RAW_OR_HIDDEN_KEYS
+from .native_capability_blueprint import IMPLEMENTATION_CLAIM_KEYS, SOURCE_HOST_MECHANICS
+from .plugin_risk_audit import PLUGIN_RISK_AUDIT_SCHEMA_VERSION, ManifestStatus, RiskCategory
+
+
+REUSABLE_BEHAVIOR_MAP_SCHEMA_VERSION: Final[str] = "reusable_behavior_map/v1"
+
+MAP_PRIVACY: Final[str] = "metadata_only"
+
+# On every payload. It restates the audit's boundary rather than narrowing it:
+# the map knows less about the bundle than the audit did, never more.
+CLAIM_BOUNDARY: Final[str] = (
+    "A reusable behavior map is an OMH-local research inventory over one cited plugin_risk_audit/v1, which "
+    "read bounded text from one explicitly named local directory. OMH does not import, install, register, or "
+    "execute the inspected bundle, does not install its dependencies, and does not reach its endpoints. A "
+    "covered classification cites an OMH capability that already exists and is not execution, verification, "
+    "review, CI, merge, or delivery evidence; every other classification is a research judgement about work "
+    "OMH has not done."
+)
+
+# The same shape `plugin_risk_audit/v1` uses, so a reader who knows one knows
+# the other. `native_implementation` is the row #796 AC3 needs: citing an OMH
+# capability says that capability exists, not that this map built anything.
+NOT_OBSERVED: Final[dict[str, dict[str, str]]] = {
+    "bundle_import": {"status": "not_observed"},
+    "bundle_registration": {"status": "not_observed"},
+    "bundle_installation": {"status": "not_observed"},
+    "bundle_execution": {"status": "not_observed"},
+    "dependency_installation": {"status": "not_observed"},
+    "network_access": {"status": "not_observed"},
+    "native_implementation": {"status": "not_observed"},
+}
+
+# #796 AC2's six states, in the order the issue names them. Closed: an
+# unrecognised verdict is refused, never carried.
+BEHAVIOR_CLASSIFICATIONS: Final[tuple[str, ...]] = (
+    "reusable",
+    "covered",
+    "host_bound",
+    "risky",
+    "unclear",
+    "irrelevant",
+)
+
+# The per-behavior fields that carry evidence. Everything else on a row is
+# required of every row and so distinguishes nothing.
+BEHAVIOR_EVIDENCE_FIELDS: Final[tuple[str, ...]] = (
+    "reusable_procedure",
+    "omh_capability_ids",
+    "host_mechanics",
+    "risk_categories",
+    "missing_evidence",
+)
+
+# What each verdict has to show, and -- by omission -- what it may not show. The
+# six required sets are distinct, so a row's non-empty evidence fields identify
+# exactly one classification. That is #796 AC2's "distinguishable" as a
+# structural property rather than an assertion in prose.
+CLASSIFICATION_REQUIRED_EVIDENCE: Final[dict[str, tuple[str, ...]]] = {
+    "reusable": ("reusable_procedure",),
+    "covered": ("reusable_procedure", "omh_capability_ids"),
+    "host_bound": ("host_mechanics",),
+    "risky": ("risk_categories",),
+    "unclear": ("missing_evidence",),
+    "irrelevant": (),
+}
+
+# What the cited audit is allowed to have found. Re-derived from the audit's own
+# Literal aliases so the map cannot drift from the scanner it cites; adding a
+# category there is immediately citable here with no edit.
+AUDIT_RISK_CATEGORIES: Final[tuple[str, ...]] = tuple(get_args(RiskCategory))
+AUDIT_MANIFEST_STATUSES: Final[tuple[str, ...]] = tuple(get_args(ManifestStatus))
+
+# The projection of a `plugin_risk_audit/v1` payload the map keeps. Counts and
+# manifest status are carried so a reader can tell how much of the bundle the
+# cited audit actually saw before trusting an inventory built on it.
+SOURCE_AUDIT_KEYS: Final[tuple[str, ...]] = (
+    "manifest_status",
+    "risk_categories",
+    "scanned_byte_count",
+    "scanned_file_count",
+    "schema_version",
+)
+
+BEHAVIOR_KEYS: Final[tuple[str, ...]] = (
+    "behavior_id",
+    "classification",
+    "host_mechanics",
+    "independence_note",
+    "missing_evidence",
+    "omh_capability_ids",
+    "reusable_procedure",
+    "risk_categories",
+    "user_outcome",
+)
+
+SUMMARY_KEYS: Final[tuple[str, ...]] = (
+    "behavior_count",
+    "cited_capability_ids",
+    "cited_risk_categories",
+    "classification_counts",
+)
+
+REUSABLE_BEHAVIOR_MAP_KEYS: Final[tuple[str, ...]] = (
+    "behaviors",
+    "claim_boundary",
+    "map_digest",
+    "not_observed",
+    "prepared_at",
+    "privacy",
+    "schema_version",
+    "source_audit",
+    "summary",
+)
+
+# Exactly what `map_digest` seals: the cited evidence and the inventory built on
+# it. The three module constants are not findings, and `prepared_at` is excluded
+# because a clock inside a compared value is a race.
+MAP_DIGEST_KEYS: Final[tuple[str, ...]] = ("behaviors", "source_audit", "summary")
+
+_LABEL: Final[str] = "reusable_behavior_map"
+
+# One observed behavior's handle: a slug a follow-up request or blueprint can
+# reuse as an identifier.
+_BEHAVIOR_ID: Final[re.Pattern[str]] = re.compile(r"^[a-z0-9][a-z0-9-]{1,48}$")
+
+_SHA256_HEX: Final[re.Pattern[str]] = re.compile(r"^[0-9a-f]{64}$")
+
+# Free-text bounds. A map is authored research notes, not somewhere a bundle's
+# source or a transcript can be parked.
+_MAX_TEXT_LENGTH: Final[int] = 200
+_MAX_BEHAVIORS: Final[int] = 64
+_MAX_PROCEDURE_STEPS: Final[int] = 12
+_MAX_CAPABILITY_IDS: Final[int] = 8
+_MAX_MISSING_EVIDENCE: Final[int] = 6
+
+
+class ReusableBehaviorMapError(ValueError):
+    """Raised when observed behaviors cannot become a reusable behavior map."""
+
+
+# ---------------------------------------------------------------------------
+# OMH capability vocabulary
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=1)
+def omh_capability_vocabulary() -> tuple[str, ...]:
+    """Every OMH capability id a `covered` behavior may cite, sorted.
+
+    Re-derived from `POPULAR_PLUGIN_FAMILIES` rather than restated: the family
+    ids and the common-request case ids they map to are this repository's
+    existing answer to "which OMH capability covers this kind of request", and a
+    second hand-maintained list would be the thing that goes stale while still
+    validating.
+    """
+    ids = {family.family_id for family in POPULAR_PLUGIN_FAMILIES}
+    ids.update(case_id for family in POPULAR_PLUGIN_FAMILIES for case_id in family.case_ids)
+    return tuple(sorted(ids))
+
+
+def unresolved_capability_ids(capability_ids: Sequence[str]) -> tuple[str, ...]:
+    """Every cited id that is not an OMH capability in this repository, sorted."""
+    return tuple(sorted({str(item) for item in capability_ids} - set(omh_capability_vocabulary())))
+
+
+# ---------------------------------------------------------------------------
+# Build and validate
+# ---------------------------------------------------------------------------
+
+
+def build_reusable_behavior_map(
+    *,
+    audit: Mapping[str, Any] | None,
+    behaviors: Sequence[Mapping[str, Any]],
+    prepared_at: str = "",
+) -> dict[str, Any]:
+    """Mint one map over one cited audit, or refuse.
+
+    `audit` is a `plugin_risk_audit/v1` payload, cited and projected -- nothing
+    here opens the bundle again. Behaviors are sorted by `behavior_id` and
+    closed-vocabulary lists are normalized into their declared order, so the same
+    bounded evidence yields the same map whatever order it arrived in.
+
+    Nothing reads a clock. `prepared_at` is whatever the caller passes and is
+    excluded from `map_digest`.
+    """
+    rows = [_normalized_behavior(entry) for entry in behaviors]
+    rows.sort(key=_behavior_sort_key)
+    behavior_map: dict[str, Any] = {
+        "schema_version": REUSABLE_BEHAVIOR_MAP_SCHEMA_VERSION,
+        "source_audit": _audit_citation(audit),
+        "behaviors": rows,
+        "summary": _summary(rows),
+        "not_observed": _copied_not_observed(),
+        "prepared_at": str(prepared_at).strip(),
+        "privacy": MAP_PRIVACY,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "map_digest": "",
+    }
+    behavior_map["map_digest"] = map_digest_of(behavior_map)
+    errors = validate_reusable_behavior_map(behavior_map)
+    if errors:
+        raise ReusableBehaviorMapError(errors[0])
+    return behavior_map
+
+
+def map_digest_of(behavior_map: Mapping[str, Any]) -> str:
+    """A sha256 over the cited evidence and the inventory, covering no clock."""
+    identity = {key: behavior_map.get(key) for key in MAP_DIGEST_KEYS}
+    return hashlib.sha256(json.dumps(identity, sort_keys=True, default=str).encode("utf-8")).hexdigest()
+
+
+def validate_reusable_behavior_map(behavior_map: Mapping[str, Any]) -> list[str]:
+    """Every reason one payload is not a reusable behavior map."""
+    if not isinstance(behavior_map, Mapping):
+        return [f"{_LABEL} must be an object"]
+    errors = _forbidden_key_errors(behavior_map, _LABEL)
+    reported = {key for key in behavior_map if str(key).lower() in IMPLEMENTATION_CLAIM_KEYS | RAW_OR_HIDDEN_KEYS}
+    unexpected = sorted(set(behavior_map) - set(REUSABLE_BEHAVIOR_MAP_KEYS) - reported)
+    if unexpected:
+        errors.append(f"{_LABEL} has unsupported keys: {unexpected}")
+    missing = sorted(set(REUSABLE_BEHAVIOR_MAP_KEYS) - set(behavior_map))
+    if missing:
+        errors.append(f"{_LABEL} is missing keys: {missing}")
+    if behavior_map.get("schema_version") != REUSABLE_BEHAVIOR_MAP_SCHEMA_VERSION:
+        errors.append(f"{_LABEL} schema_version must be {REUSABLE_BEHAVIOR_MAP_SCHEMA_VERSION}")
+    if behavior_map.get("privacy") != MAP_PRIVACY:
+        errors.append(f"{_LABEL} privacy must be {MAP_PRIVACY}")
+    if behavior_map.get("claim_boundary") != CLAIM_BOUNDARY:
+        errors.append(
+            f"{_LABEL} claim_boundary must state that OMH never imports, installs, registers, or executes the "
+            "inspected bundle"
+        )
+    if behavior_map.get("not_observed") != NOT_OBSERVED:
+        errors.append(
+            f"{_LABEL} not_observed must record every unobserved bundle interaction: "
+            f"{sorted(NOT_OBSERVED)}"
+        )
+    if not isinstance(behavior_map.get("prepared_at"), str):
+        errors.append(f"{_LABEL} prepared_at must be a string")
+    audit_errors = _source_audit_errors(behavior_map.get("source_audit"))
+    errors.extend(audit_errors)
+    errors.extend(_behaviors_errors(behavior_map.get("behaviors"), cited_risks=_cited_risks(behavior_map)))
+    errors.extend(_summary_errors(behavior_map))
+    errors.extend(_digest_errors(behavior_map))
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Cited audit
+# ---------------------------------------------------------------------------
+
+
+def _audit_citation(audit: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Project the parts of a `plugin_risk_audit/v1` payload the map cites.
+
+    Values are carried through unconverted. A malformed audit becomes a
+    validation error naming the field, not a coercion that invents a count the
+    scanner never reported.
+    """
+    payload = audit if isinstance(audit, Mapping) else {}
+    source = payload.get("source")
+    summary = payload.get("summary")
+    source = source if isinstance(source, Mapping) else {}
+    summary = summary if isinstance(summary, Mapping) else {}
+    risk_categories = summary.get("risk_categories")
+    return {
+        "schema_version": payload.get("schema_version", ""),
+        "manifest_status": source.get("manifest_status", ""),
+        "scanned_file_count": summary.get("scanned_file_count", -1),
+        "scanned_byte_count": summary.get("scanned_byte_count", -1),
+        "risk_categories": list(risk_categories) if isinstance(risk_categories, list) else risk_categories,
+    }
+
+
+def _source_audit_errors(source_audit: object) -> list[str]:
+    """A map cites an audit. No audit, no map."""
+    if not isinstance(source_audit, Mapping):
+        return [f"{_LABEL} source_audit must cite a {PLUGIN_RISK_AUDIT_SCHEMA_VERSION} payload"]
+    errors: list[str] = []
+    if sorted(source_audit) != list(SOURCE_AUDIT_KEYS):
+        errors.append(f"{_LABEL} source_audit keys must be exactly {list(SOURCE_AUDIT_KEYS)}")
+    if source_audit.get("schema_version") != PLUGIN_RISK_AUDIT_SCHEMA_VERSION:
+        errors.append(
+            f"{_LABEL} source_audit must cite a {PLUGIN_RISK_AUDIT_SCHEMA_VERSION} payload; the map cites a "
+            "bounded audit and never scans the bundle itself"
+        )
+    if source_audit.get("manifest_status") not in AUDIT_MANIFEST_STATUSES:
+        errors.append(
+            f"{_LABEL} source_audit manifest_status is unsupported: {source_audit.get('manifest_status')!r}"
+        )
+    for field in ("scanned_file_count", "scanned_byte_count"):
+        value = source_audit.get(field)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            errors.append(f"{_LABEL} source_audit {field} must be a non-negative integer")
+    errors.extend(
+        _vocabulary_list_errors(
+            source_audit.get("risk_categories"),
+            "source_audit risk_categories",
+            AUDIT_RISK_CATEGORIES,
+        )
+    )
+    return errors
+
+
+def _cited_risks(behavior_map: Mapping[str, Any]) -> frozenset[str]:
+    source_audit = behavior_map.get("source_audit")
+    if not isinstance(source_audit, Mapping):
+        return frozenset()
+    categories = source_audit.get("risk_categories")
+    if not isinstance(categories, list):
+        return frozenset()
+    return frozenset(str(item) for item in categories)
+
+
+# ---------------------------------------------------------------------------
+# Behaviors
+# ---------------------------------------------------------------------------
+
+
+def _normalized_behavior(raw: Mapping[str, Any]) -> Any:
+    """One row in canonical form, with anything unrecognised carried through.
+
+    Unknown keys are kept rather than dropped so the validator can refuse them:
+    silently discarding a caller's typo produces a map that validates and says
+    something nobody wrote.
+    """
+    if not isinstance(raw, Mapping):
+        return raw
+    row: dict[str, Any] = {
+        "behavior_id": str(raw.get("behavior_id", "")).strip().casefold(),
+        "classification": str(raw.get("classification", "")).strip(),
+        "user_outcome": str(raw.get("user_outcome", "")).strip(),
+        "reusable_procedure": _authored_list(raw.get("reusable_procedure")),
+        "omh_capability_ids": _sorted_list(raw.get("omh_capability_ids")),
+        "host_mechanics": _vocabulary_list(raw.get("host_mechanics"), SOURCE_HOST_MECHANICS),
+        "risk_categories": _vocabulary_list(raw.get("risk_categories"), AUDIT_RISK_CATEGORIES),
+        "missing_evidence": _authored_list(raw.get("missing_evidence")),
+        "independence_note": str(raw.get("independence_note", "")).strip(),
+    }
+    for key, value in raw.items():
+        if key not in row:
+            row[key] = value
+    return {key: row[key] for key in sorted(row)}
+
+
+def _behavior_sort_key(row: object) -> str:
+    if not isinstance(row, Mapping):
+        return ""
+    return str(row.get("behavior_id", ""))
+
+
+def _behaviors_errors(behaviors: object, *, cited_risks: frozenset[str]) -> list[str]:
+    if not isinstance(behaviors, list) or not all(isinstance(row, Mapping) for row in behaviors):
+        return [f"{_LABEL} behaviors must be a list of objects"]
+    errors: list[str] = []
+    if not behaviors:
+        errors.append(
+            f"{_LABEL} behaviors must name at least 1 observed behavior; an empty inventory records no "
+            "research and is not a finding about the bundle"
+        )
+    if len(behaviors) > _MAX_BEHAVIORS:
+        errors.append(f"{_LABEL} behaviors must name at most {_MAX_BEHAVIORS}")
+    identifiers = [str(row.get("behavior_id", "")) for row in behaviors]
+    if identifiers != sorted(identifiers):
+        errors.append(f"{_LABEL} behaviors must be sorted by behavior_id so the same evidence renders identically")
+    duplicates = sorted({item for item in identifiers if identifiers.count(item) > 1})
+    if duplicates:
+        errors.append(f"{_LABEL} behaviors must not repeat a behavior_id: {duplicates}")
+    for row in behaviors:
+        errors.extend(_behavior_errors(row, cited_risks=cited_risks))
+    return errors
+
+
+def _behavior_errors(row: Mapping[str, Any], *, cited_risks: frozenset[str]) -> list[str]:
+    identifier = str(row.get("behavior_id", ""))
+    label = f"{_LABEL} behavior {identifier!r}"
+    errors = _forbidden_key_errors(row, label)
+    reported = {key for key in row if str(key).lower() in IMPLEMENTATION_CLAIM_KEYS | RAW_OR_HIDDEN_KEYS}
+    unexpected = sorted(set(row) - set(BEHAVIOR_KEYS) - reported)
+    if unexpected:
+        errors.append(f"{label} has unsupported keys: {unexpected}")
+    missing = sorted(set(BEHAVIOR_KEYS) - set(row))
+    if missing:
+        errors.append(f"{label} is missing keys: {missing}")
+    if not _BEHAVIOR_ID.match(identifier):
+        errors.append(f"{label} behavior_id must be a lowercase slug")
+    errors.extend(_text_errors(row.get("user_outcome"), f"{label} user_outcome"))
+    errors.extend(_text_errors(row.get("independence_note"), f"{label} independence_note"))
+    errors.extend(_evidence_shape_errors(row, label))
+    errors.extend(_evidence_content_errors(row, label, cited_risks=cited_risks))
+    return errors
+
+
+def _evidence_shape_errors(row: Mapping[str, Any], label: str) -> list[str]:
+    """#796 AC2: six states, each with its own evidence signature and no other.
+
+    A classification outside the vocabulary stops here. Checking a row's
+    evidence against an unknown verdict would report which fields the unknown
+    state wants, and it does not want anything -- it does not exist.
+    """
+    classification = row.get("classification")
+    if classification not in CLASSIFICATION_REQUIRED_EVIDENCE:
+        return [
+            f"{label} classification is unsupported: {classification!r}; the six states are "
+            f"{list(BEHAVIOR_CLASSIFICATIONS)}"
+        ]
+    errors: list[str] = []
+    required = set(CLASSIFICATION_REQUIRED_EVIDENCE[classification])
+    for field in BEHAVIOR_EVIDENCE_FIELDS:
+        value = row.get(field)
+        if not isinstance(value, list):
+            errors.append(f"{label} {field} must be a list of strings")
+            continue
+        if field in required and not value:
+            errors.append(f"{label} classified {classification} must name {field}")
+        if field not in required and value:
+            errors.append(
+                f"{label} classified {classification} must not name {field}; a behavior carries one verdict, "
+                f"and {classification} is evidenced by {sorted(required) or 'no evidence field'}"
+            )
+    return errors
+
+
+def _evidence_content_errors(row: Mapping[str, Any], label: str, *, cited_risks: frozenset[str]) -> list[str]:
+    """#796 AC3, plus the rule that keeps the risky verdict tied to the audit."""
+    errors = _text_list_errors(row.get("reusable_procedure"), f"{label} reusable_procedure", _MAX_PROCEDURE_STEPS)
+    errors.extend(_text_list_errors(row.get("missing_evidence"), f"{label} missing_evidence", _MAX_MISSING_EVIDENCE))
+    errors.extend(_vocabulary_list_errors(row.get("host_mechanics"), f"{label} host_mechanics", SOURCE_HOST_MECHANICS))
+    errors.extend(
+        _vocabulary_list_errors(row.get("risk_categories"), f"{label} risk_categories", AUDIT_RISK_CATEGORIES)
+    )
+    capability_ids = row.get("omh_capability_ids")
+    if not isinstance(capability_ids, list) or not all(isinstance(item, str) for item in capability_ids):
+        errors.append(f"{label} omh_capability_ids must be a list of strings")
+    else:
+        if len(capability_ids) > _MAX_CAPABILITY_IDS:
+            errors.append(f"{label} omh_capability_ids must name at most {_MAX_CAPABILITY_IDS}")
+        if len(set(capability_ids)) != len(capability_ids):
+            errors.append(f"{label} omh_capability_ids must not repeat an entry")
+        unresolved = unresolved_capability_ids(capability_ids)
+        if unresolved:
+            errors.append(
+                f"{label} omh_capability_ids do not name an OMH capability: {list(unresolved)}; a covered "
+                "behavior cites a capability id from src/quality/popular_plugin_coverage.py, so coverage is a "
+                "reference a reviewer can resolve rather than an assertion"
+            )
+    risk_categories = row.get("risk_categories")
+    if isinstance(risk_categories, list):
+        uncited = sorted({str(item) for item in risk_categories} - cited_risks)
+        if uncited:
+            errors.append(
+                f"{label} risk_categories are absent from the cited audit: {uncited}; the map cites "
+                f"{PLUGIN_RISK_AUDIT_SCHEMA_VERSION} for risky mechanics and never re-scans the bundle"
+            )
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+
+def _summary(rows: Sequence[Any]) -> dict[str, Any]:
+    """Counts derived from the rows, with all six states present at every build.
+
+    Every classification appears even at zero. A summary that omits the states
+    nobody used reads as though those states were not considered.
+    """
+    mappings = [row for row in rows if isinstance(row, Mapping)]
+    classifications = [str(row.get("classification", "")) for row in mappings]
+    capability_ids: set[str] = set()
+    risk_categories: set[str] = set()
+    for row in mappings:
+        capability_ids.update(str(item) for item in _string_list(row.get("omh_capability_ids")))
+        risk_categories.update(str(item) for item in _string_list(row.get("risk_categories")))
+    return {
+        "behavior_count": len(rows),
+        "classification_counts": {name: classifications.count(name) for name in BEHAVIOR_CLASSIFICATIONS},
+        "cited_capability_ids": sorted(capability_ids),
+        "cited_risk_categories": [name for name in AUDIT_RISK_CATEGORIES if name in risk_categories],
+    }
+
+
+def _summary_errors(behavior_map: Mapping[str, Any]) -> list[str]:
+    summary = behavior_map.get("summary")
+    if not isinstance(summary, Mapping):
+        return [f"{_LABEL} summary must be an object"]
+    if sorted(summary) != list(SUMMARY_KEYS):
+        return [f"{_LABEL} summary keys must be exactly {list(SUMMARY_KEYS)}"]
+    behaviors = behavior_map.get("behaviors")
+    if not isinstance(behaviors, list):
+        return []
+    derived = _summary(behaviors)
+    if dict(summary) != derived:
+        return [
+            f"{_LABEL} summary must be derived from the behaviors it summarizes; expected {derived}",
+        ]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _copied_not_observed() -> dict[str, dict[str, str]]:
+    return {key: dict(value) for key, value in NOT_OBSERVED.items()}
+
+
+def _digest_errors(behavior_map: Mapping[str, Any]) -> list[str]:
+    digest = behavior_map.get("map_digest")
+    if not isinstance(digest, str) or not _SHA256_HEX.match(digest):
+        return [f"{_LABEL} map_digest must be a sha256 hex digest"]
+    if digest != map_digest_of(behavior_map):
+        return [f"{_LABEL} map_digest does not match the inventory it seals; the payload was edited after it was minted"]
+    return []
+
+
+def _forbidden_key_errors(payload: Mapping[str, Any], label: str) -> list[str]:
+    """Key names under which "we ran it" arrives, refused by name on every row."""
+    errors: list[str] = []
+    claims = sorted(key for key in payload if str(key).lower() in IMPLEMENTATION_CLAIM_KEYS)
+    if claims:
+        errors.append(
+            f"{label} must not carry implementation-claim keys: {claims}; a map records what a bounded read "
+            "suggests the bundle does and never reports running, installing, or building anything"
+        )
+    hidden = sorted(key for key in payload if str(key).lower() in RAW_OR_HIDDEN_KEYS)
+    if hidden:
+        errors.append(f"{label} must not carry raw or hidden keys: {hidden}")
+    return errors
+
+
+def _is_list_shaped(value: object) -> bool:
+    """A sequence that is not itself text.
+
+    A caller who passes a string where a list belongs gets it back unchanged and
+    a validation error naming the field, rather than a normalized list of that
+    string's characters.
+    """
+    return isinstance(value, Sequence) and not isinstance(value, (str, bytes))
+
+
+def _authored_list(value: object) -> Any:
+    """Authored prose in the order it was written, deduplicated."""
+    if not _is_list_shaped(value):
+        return [] if value is None else value
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for item in value:  # type: ignore[union-attr]
+        text = str(item).strip()
+        if text and text not in seen:
+            cleaned.append(text)
+            seen.add(text)
+    return cleaned
+
+
+def _sorted_list(value: object) -> Any:
+    """Identifiers with no meaningful order, sorted and deduplicated."""
+    if not _is_list_shaped(value):
+        return [] if value is None else value
+    return sorted({str(item).strip() for item in value if str(item).strip()})  # type: ignore[union-attr]
+
+
+def _vocabulary_list(value: object, vocabulary: tuple[str, ...]) -> Any:
+    """Closed-vocabulary members in declared order, plus anything unrecognised.
+
+    Unrecognised values survive normalization so the validator can name them.
+    """
+    if not _is_list_shaped(value):
+        return [] if value is None else value
+    named = [str(item).strip() for item in value if str(item).strip()]  # type: ignore[union-attr]
+    known = [item for item in vocabulary if item in named]
+    unknown = sorted({item for item in named if item not in set(vocabulary)})
+    return [*known, *unknown]
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def _text_errors(value: object, field: str) -> list[str]:
+    if not isinstance(value, str) or not value.strip():
+        return [f"{field} must be a non-empty string"]
+    if len(value) > _MAX_TEXT_LENGTH:
+        return [f"{field} must be at most {_MAX_TEXT_LENGTH} characters"]
+    return []
+
+
+def _text_list_errors(value: object, field: str, maximum: int) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        return [f"{field} must be a list of strings"]
+    errors: list[str] = []
+    if len(value) > maximum:
+        errors.append(f"{field} must name at most {maximum}")
+    if len(set(value)) != len(value):
+        errors.append(f"{field} must not repeat an entry")
+    if any(not item.strip() for item in value):
+        errors.append(f"{field} must not contain an empty entry")
+    if any(len(item) > _MAX_TEXT_LENGTH for item in value):
+        errors.append(f"{field} entries must be at most {_MAX_TEXT_LENGTH} characters")
+    return errors
+
+
+def _vocabulary_list_errors(value: object, field: str, vocabulary: tuple[str, ...]) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        return [f"{field} must be a list of strings"]
+    errors: list[str] = []
+    if len(set(value)) != len(value):
+        errors.append(f"{field} must not repeat an entry")
+    unsupported = sorted({item for item in value if item not in set(vocabulary)})
+    if unsupported:
+        errors.append(f"{field} has unsupported entries: {unsupported}; allowed: {list(vocabulary)}")
+    return errors

--- a/tests/test_reusable_behavior_map.py
+++ b/tests/test_reusable_behavior_map.py
@@ -1,0 +1,662 @@
+"""Contracts for `reusable_behavior_map/v1` (issue #796).
+
+Grouped by acceptance criterion:
+
+- AC1: the same bounded evidence produces a deterministic behavior inventory,
+  ordering included. Proved twice -- over a literal cited audit, and end to end
+  over a real bounded scan of a real directory.
+- AC2: all six classifications are representable and mutually distinguishable,
+  and an unknown classification is refused.
+- AC3: a behavior marked `covered` without an OMH capability citation fails
+  validation, and a citation that does not resolve against this repository fails
+  the same way.
+
+Plus the two guards the family exists for: the map cites a `plugin_risk_audit/v1`
+rather than re-scanning, so a map citing no audit is refused; and nothing in a
+map may read as the inspected bundle having been executed or installed.
+
+Only one test writes a file, and it writes through `atomic_write_text` rather
+than `Path.write_text`: the bytes it writes are scanned and counted by the audit
+the map then cites, and `Path.write_text` rewrites "\\n" as CRLF on Windows,
+which would move the byte count the assertions are about.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.local_store import atomic_write_text  # noqa: E402
+from omh.quality.popular_plugin_coverage import POPULAR_PLUGIN_FAMILIES  # noqa: E402
+from omh.workflows.native_capability_blueprint import SOURCE_HOST_MECHANICS  # noqa: E402
+from omh.workflows.plugin_risk_audit import (  # noqa: E402
+    PLUGIN_RISK_AUDIT_SCHEMA_VERSION,
+    audit_plugin_risk,
+)
+from omh.workflows.reusable_behavior_map import (  # noqa: E402
+    AUDIT_MANIFEST_STATUSES,
+    AUDIT_RISK_CATEGORIES,
+    BEHAVIOR_CLASSIFICATIONS,
+    BEHAVIOR_EVIDENCE_FIELDS,
+    BEHAVIOR_KEYS,
+    CLAIM_BOUNDARY,
+    CLASSIFICATION_REQUIRED_EVIDENCE,
+    MAP_DIGEST_KEYS,
+    MAP_PRIVACY,
+    NOT_OBSERVED,
+    REUSABLE_BEHAVIOR_MAP_KEYS,
+    REUSABLE_BEHAVIOR_MAP_SCHEMA_VERSION,
+    SOURCE_AUDIT_KEYS,
+    ReusableBehaviorMapError,
+    build_reusable_behavior_map,
+    map_digest_of,
+    omh_capability_vocabulary,
+    unresolved_capability_ids,
+    validate_reusable_behavior_map,
+)
+
+from _platform_support import requires_secure_dir_io  # noqa: E402
+
+
+# The risk categories the fixture audit reports. Every behavior that cites a
+# risk cites one of these, because the map may not invent a finding the audit
+# did not make.
+CITED_RISKS = ["hermes_hook_capability", "network_request", "process_execution"]
+
+# One canonical value per evidence field, so a row can be assembled from a
+# classification's required set alone. Used to drive the six-by-six matrix.
+CANONICAL_EVIDENCE: dict[str, list[str]] = {
+    "reusable_procedure": [
+        "Take the workspace path the person named.",
+        "Summarize what changed and hand back the summary.",
+    ],
+    "omh_capability_ids": ["workspace-audit"],
+    "host_mechanics": ["host_hook", "host_setting"],
+    "risk_categories": ["network_request"],
+    "missing_evidence": ["The bundle ships no description of what its hook does."],
+}
+
+
+def audit_payload(**overrides: Any) -> dict[str, Any]:
+    """A `plugin_risk_audit/v1` payload in the shape `audit_plugin_risk` returns."""
+    payload: dict[str, Any] = {
+        "schema_version": PLUGIN_RISK_AUDIT_SCHEMA_VERSION,
+        "source": {"explicit_root": True, "manifest_status": "present"},
+        "summary": {
+            "scanned_file_count": 4,
+            "scanned_byte_count": 812,
+            "risk_categories": list(CITED_RISKS),
+            "risk_category_count": len(CITED_RISKS),
+        },
+        "not_observed": {"plugin_execution": {"status": "not_observed"}},
+        "claim_boundary": "The audit statically reads bounded text from one explicitly named local directory.",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def behavior(classification: str = "reusable", **overrides: Any) -> dict[str, Any]:
+    """One row carrying exactly the evidence its classification requires."""
+    row: dict[str, Any] = {
+        "behavior_id": f"observed-{classification.replace('_', '-')}",
+        "classification": classification,
+        "user_outcome": "The person gets a written summary of what a workspace directory contains.",
+        "independence_note": "OMH would read the directory through its own bounded reader and render a card.",
+    }
+    for field in CLASSIFICATION_REQUIRED_EVIDENCE.get(classification, ()):
+        row[field] = list(CANONICAL_EVIDENCE[field])
+    row.update(overrides)
+    return row
+
+
+def evidence_shaped_row(shape: str, *, classification: str) -> dict[str, Any]:
+    """A row carrying `shape`'s evidence while claiming to be `classification`."""
+    row = behavior(classification)
+    for field in BEHAVIOR_EVIDENCE_FIELDS:
+        row.pop(field, None)
+    for field in CLASSIFICATION_REQUIRED_EVIDENCE[shape]:
+        row[field] = list(CANONICAL_EVIDENCE[field])
+    row["behavior_id"] = "observed-behavior"
+    return row
+
+
+def behavior_map(*, behaviors: Any = None, audit: Any = ..., **overrides: Any) -> dict[str, Any]:
+    return build_reusable_behavior_map(
+        audit=audit_payload() if audit is ... else audit,
+        behaviors=[behavior()] if behaviors is None else behaviors,
+        **overrides,
+    )
+
+
+def every_classification() -> list[dict[str, Any]]:
+    return [behavior(name) for name in BEHAVIOR_CLASSIFICATIONS]
+
+
+def resealed(payload: dict[str, Any], **overrides: Any) -> dict[str, Any]:
+    """A payload edited after minting, with the digest re-derived to match.
+
+    Lets a test fail on the rule under test rather than on the tamper check.
+    """
+    edited = {**payload, **overrides}
+    edited["map_digest"] = map_digest_of(edited)
+    return edited
+
+
+class DeterministicInventoryTests(unittest.TestCase):
+    """AC1: the same bounded evidence produces a deterministic behavior inventory."""
+
+    def test_repeated_builds_over_the_same_evidence_are_identical(self) -> None:
+        first = behavior_map(behaviors=every_classification())
+        second = behavior_map(behaviors=every_classification())
+
+        self.assertEqual(first, second)
+        self.assertEqual(list(first), list(second))
+        self.assertEqual(json.dumps(first), json.dumps(second))
+        self.assertEqual(first["map_digest"], second["map_digest"])
+
+    def test_the_order_the_behaviors_arrived_in_does_not_change_the_map(self) -> None:
+        rows = every_classification()
+
+        forward = behavior_map(behaviors=rows)
+        backward = behavior_map(behaviors=list(reversed(rows)))
+
+        self.assertEqual(json.dumps(forward), json.dumps(backward))
+        self.assertEqual(
+            [row["behavior_id"] for row in forward["behaviors"]],
+            sorted(row["behavior_id"] for row in forward["behaviors"]),
+        )
+
+    def test_every_row_renders_its_keys_in_one_order(self) -> None:
+        payload = behavior_map(behaviors=every_classification())
+
+        for row in payload["behaviors"]:
+            with self.subTest(behavior=row["behavior_id"]):
+                self.assertEqual(list(row), sorted(BEHAVIOR_KEYS))
+
+    def test_the_digest_covers_the_findings_and_not_the_clock(self) -> None:
+        morning = behavior_map(prepared_at="2026-08-09T09:00:00Z")
+        evening = behavior_map(prepared_at="2026-08-09T21:00:00Z")
+
+        self.assertEqual(morning["map_digest"], evening["map_digest"])
+        self.assertNotEqual(morning["prepared_at"], evening["prepared_at"])
+        self.assertNotIn("prepared_at", MAP_DIGEST_KEYS)
+
+    def test_prepared_at_defaults_to_empty_so_nothing_reads_a_clock(self) -> None:
+        payload = behavior_map()
+
+        self.assertEqual(payload["prepared_at"], "")
+        self.assertEqual(validate_reusable_behavior_map(payload), [])
+
+    def test_a_changed_finding_changes_the_digest(self) -> None:
+        one = behavior_map(behaviors=[behavior("reusable")])
+        other = behavior_map(behaviors=[behavior("irrelevant")])
+
+        self.assertNotEqual(one["map_digest"], other["map_digest"])
+
+    def test_the_summary_is_derived_and_a_hand_edited_count_is_refused(self) -> None:
+        payload = behavior_map(behaviors=every_classification())
+
+        self.assertEqual(payload["summary"]["behavior_count"], len(BEHAVIOR_CLASSIFICATIONS))
+        self.assertEqual(
+            payload["summary"]["classification_counts"],
+            {name: 1 for name in BEHAVIOR_CLASSIFICATIONS},
+        )
+        self.assertEqual(payload["summary"]["cited_capability_ids"], CANONICAL_EVIDENCE["omh_capability_ids"])
+        self.assertEqual(payload["summary"]["cited_risk_categories"], CANONICAL_EVIDENCE["risk_categories"])
+
+        inflated = dict(payload["summary"])
+        inflated["behavior_count"] = 99
+        errors = validate_reusable_behavior_map(resealed(payload, summary=inflated))
+
+        self.assertTrue(any("summary must be derived" in error for error in errors), errors)
+
+    def test_every_classification_appears_in_the_counts_even_at_zero(self) -> None:
+        payload = behavior_map(behaviors=[behavior("reusable")])
+
+        self.assertEqual(sorted(payload["summary"]["classification_counts"]), sorted(BEHAVIOR_CLASSIFICATIONS))
+        self.assertEqual(payload["summary"]["classification_counts"]["irrelevant"], 0)
+
+    def test_a_map_out_of_behavior_id_order_is_refused(self) -> None:
+        payload = behavior_map(behaviors=[behavior("reusable"), behavior("covered")])
+        reordered = list(reversed(payload["behaviors"]))
+
+        errors = validate_reusable_behavior_map(
+            resealed(payload, behaviors=reordered, summary=payload["summary"])
+        )
+
+        self.assertTrue(any("sorted by behavior_id" in error for error in errors), errors)
+
+    def test_a_repeated_behavior_id_is_refused(self) -> None:
+        with self.assertRaises(ReusableBehaviorMapError) as raised:
+            behavior_map(behaviors=[behavior("reusable"), behavior("reusable")])
+
+        self.assertIn("must not repeat a behavior_id", str(raised.exception))
+
+    def test_a_map_with_no_behaviors_is_refused(self) -> None:
+        with self.assertRaises(ReusableBehaviorMapError) as raised:
+            behavior_map(behaviors=[])
+
+        self.assertIn("at least 1 observed behavior", str(raised.exception))
+
+
+class BoundedEvidenceEndToEndTests(unittest.TestCase):
+    """AC1 again, over a real bounded scan rather than a literal audit payload."""
+
+    @requires_secure_dir_io
+    def test_one_bounded_scan_produces_one_inventory_however_often_it_is_built(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            atomic_write_text(root / "plugin.json", '{"name": "example"}\n')
+            atomic_write_text(
+                root / "hook.py",
+                "import requests\n"
+                "def on_session_end() -> None:\n"
+                "    requests.get('https://example.invalid')\n",
+            )
+
+            audit = audit_plugin_risk(root)
+            rows = [
+                behavior("reusable"),
+                behavior("risky", risk_categories=["hermes_hook_capability", "network_request"]),
+            ]
+            first = build_reusable_behavior_map(audit=audit, behaviors=rows)
+            second = build_reusable_behavior_map(audit=audit, behaviors=list(reversed(rows)))
+
+        self.assertEqual(json.dumps(first), json.dumps(second))
+        self.assertEqual(first["source_audit"]["schema_version"], PLUGIN_RISK_AUDIT_SCHEMA_VERSION)
+        self.assertEqual(first["source_audit"]["manifest_status"], audit["source"]["manifest_status"])
+        self.assertEqual(first["source_audit"]["scanned_file_count"], audit["summary"]["scanned_file_count"])
+        self.assertEqual(first["source_audit"]["scanned_byte_count"], audit["summary"]["scanned_byte_count"])
+        self.assertEqual(first["source_audit"]["risk_categories"], audit["summary"]["risk_categories"])
+        # The audit refuses to disclose the directory it read; the map inherits
+        # that. Both sides are resolved paths, so this compares like with like.
+        self.assertNotIn(str(root), json.dumps(first))
+        self.assertNotIn("requests.get", json.dumps(first))
+
+    @requires_secure_dir_io
+    def test_a_behavior_may_not_cite_a_risk_the_bounded_scan_never_found(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            atomic_write_text(root / "plugin.json", '{"name": "quiet"}\n')
+
+            audit = audit_plugin_risk(root)
+
+            self.assertEqual(audit["summary"]["risk_categories"], [])
+            with self.assertRaises(ReusableBehaviorMapError) as raised:
+                build_reusable_behavior_map(audit=audit, behaviors=[behavior("risky")])
+
+        self.assertIn("absent from the cited audit", str(raised.exception))
+
+
+class SixClassificationTests(unittest.TestCase):
+    """AC2: six states, all representable, all distinguishable, no seventh."""
+
+    def test_the_vocabulary_is_the_six_states_the_issue_names(self) -> None:
+        self.assertEqual(
+            list(BEHAVIOR_CLASSIFICATIONS),
+            ["reusable", "covered", "host_bound", "risky", "unclear", "irrelevant"],
+        )
+        self.assertEqual(sorted(CLASSIFICATION_REQUIRED_EVIDENCE), sorted(BEHAVIOR_CLASSIFICATIONS))
+
+    def test_all_six_classifications_are_representable_in_one_map(self) -> None:
+        payload = behavior_map(behaviors=every_classification())
+
+        self.assertEqual(validate_reusable_behavior_map(payload), [])
+        self.assertEqual(
+            [row["classification"] for row in payload["behaviors"]],
+            sorted(BEHAVIOR_CLASSIFICATIONS, key=lambda name: behavior(name)["behavior_id"]),
+        )
+        self.assertEqual(len({row["classification"] for row in payload["behaviors"]}), 6)
+
+    def test_each_classification_has_its_own_evidence_signature(self) -> None:
+        signatures = {name: frozenset(fields) for name, fields in CLASSIFICATION_REQUIRED_EVIDENCE.items()}
+
+        self.assertEqual(len(set(signatures.values())), len(BEHAVIOR_CLASSIFICATIONS))
+        for name, signature in signatures.items():
+            with self.subTest(classification=name):
+                self.assertTrue(signature <= set(BEHAVIOR_EVIDENCE_FIELDS))
+
+    def test_each_evidence_shape_validates_under_exactly_one_classification(self) -> None:
+        for shape in BEHAVIOR_CLASSIFICATIONS:
+            for verdict in BEHAVIOR_CLASSIFICATIONS:
+                row = evidence_shaped_row(shape, classification=verdict)
+                with self.subTest(shape=shape, verdict=verdict):
+                    if shape == verdict:
+                        payload = behavior_map(behaviors=[row])
+                        self.assertEqual(validate_reusable_behavior_map(payload), [])
+                        continue
+                    with self.assertRaises(ReusableBehaviorMapError):
+                        behavior_map(behaviors=[row])
+
+    def test_a_classification_that_is_missing_its_evidence_is_refused(self) -> None:
+        for name, required in CLASSIFICATION_REQUIRED_EVIDENCE.items():
+            for field in required:
+                with self.subTest(classification=name, field=field):
+                    with self.assertRaises(ReusableBehaviorMapError) as raised:
+                        behavior_map(behaviors=[behavior(name, **{field: []})])
+                    self.assertIn(f"classified {name} must name {field}", str(raised.exception))
+
+    def test_a_classification_carrying_evidence_it_does_not_require_is_refused(self) -> None:
+        for name, required in CLASSIFICATION_REQUIRED_EVIDENCE.items():
+            for field in BEHAVIOR_EVIDENCE_FIELDS:
+                if field in required:
+                    continue
+                with self.subTest(classification=name, field=field):
+                    with self.assertRaises(ReusableBehaviorMapError) as raised:
+                        behavior_map(behaviors=[behavior(name, **{field: list(CANONICAL_EVIDENCE[field])})])
+                    self.assertIn(f"classified {name} must not name {field}", str(raised.exception))
+
+    def test_an_unknown_classification_is_refused(self) -> None:
+        for unknown in ("supported", "implemented", "maybe", "Reusable", "host-bound", ""):
+            with self.subTest(classification=unknown):
+                with self.assertRaises(ReusableBehaviorMapError) as raised:
+                    behavior_map(behaviors=[evidence_shaped_row("reusable", classification=unknown)])
+                message = str(raised.exception)
+                self.assertIn("classification is unsupported", message)
+                self.assertIn("reusable", message)
+                self.assertIn("irrelevant", message)
+
+    def test_every_row_states_a_user_outcome_and_an_independence_note(self) -> None:
+        for name in BEHAVIOR_CLASSIFICATIONS:
+            for field in ("user_outcome", "independence_note"):
+                with self.subTest(classification=name, field=field):
+                    with self.assertRaises(ReusableBehaviorMapError) as raised:
+                        behavior_map(behaviors=[behavior(name, **{field: "  "})])
+                    self.assertIn(f"{field} must be a non-empty string", str(raised.exception))
+
+    def test_a_host_bound_exclusion_speaks_the_blueprint_mechanic_vocabulary(self) -> None:
+        # Deliberate reuse: a behavior excluded here and a blueprint's observed
+        # source mechanics there name the same things in the same words.
+        for mechanic in SOURCE_HOST_MECHANICS:
+            with self.subTest(mechanic=mechanic):
+                payload = behavior_map(behaviors=[behavior("host_bound", host_mechanics=[mechanic])])
+                self.assertEqual(validate_reusable_behavior_map(payload), [])
+
+        with self.assertRaises(ReusableBehaviorMapError) as raised:
+            behavior_map(behaviors=[behavior("host_bound", host_mechanics=["host_thing"])])
+
+        self.assertIn("host_mechanics has unsupported entries", str(raised.exception))
+
+
+class CoverageCitationTests(unittest.TestCase):
+    """AC3: no pattern is called supported without an OMH capability citation."""
+
+    def test_covered_without_a_capability_citation_fails_validation(self) -> None:
+        with self.assertRaises(ReusableBehaviorMapError) as raised:
+            behavior_map(behaviors=[behavior("covered", omh_capability_ids=[])])
+
+        self.assertIn("classified covered must name omh_capability_ids", str(raised.exception))
+
+    def test_covered_with_a_capability_citation_passes(self) -> None:
+        payload = behavior_map(behaviors=[behavior("covered")])
+
+        self.assertEqual(validate_reusable_behavior_map(payload), [])
+        self.assertEqual(payload["behaviors"][0]["omh_capability_ids"], ["workspace-audit"])
+
+    def test_a_well_formed_citation_that_names_nothing_in_this_repo_is_refused(self) -> None:
+        for invented in ("universal-plugin-bridge", "bundle-runner", "reusable-behavior-map"):
+            with self.subTest(capability_id=invented):
+                with self.assertRaises(ReusableBehaviorMapError) as raised:
+                    behavior_map(behaviors=[behavior("covered", omh_capability_ids=[invented])])
+                message = str(raised.exception)
+                self.assertIn("do not name an OMH capability", message)
+                self.assertIn(invented, message)
+                self.assertIn("popular_plugin_coverage.py", message)
+
+    def test_the_capability_vocabulary_is_re_derived_from_this_repository(self) -> None:
+        expected = {family.family_id for family in POPULAR_PLUGIN_FAMILIES}
+        expected.update(case_id for family in POPULAR_PLUGIN_FAMILIES for case_id in family.case_ids)
+
+        self.assertEqual(list(omh_capability_vocabulary()), sorted(expected))
+        self.assertEqual(unresolved_capability_ids(sorted(expected)), ())
+
+    def test_every_capability_in_the_vocabulary_is_citable(self) -> None:
+        for capability_id in omh_capability_vocabulary():
+            with self.subTest(capability_id=capability_id):
+                payload = behavior_map(behaviors=[behavior("covered", omh_capability_ids=[capability_id])])
+                self.assertEqual(validate_reusable_behavior_map(payload), [])
+
+    def test_only_a_covered_behavior_may_cite_a_capability(self) -> None:
+        for name in BEHAVIOR_CLASSIFICATIONS:
+            if name == "covered":
+                continue
+            with self.subTest(classification=name):
+                with self.assertRaises(ReusableBehaviorMapError) as raised:
+                    behavior_map(behaviors=[behavior(name, omh_capability_ids=["workspace-audit"])])
+                self.assertIn("must not name omh_capability_ids", str(raised.exception))
+
+    def test_a_covered_behavior_also_states_the_procedure_it_covers(self) -> None:
+        with self.assertRaises(ReusableBehaviorMapError) as raised:
+            behavior_map(behaviors=[behavior("covered", reusable_procedure=[])])
+
+        self.assertIn("classified covered must name reusable_procedure", str(raised.exception))
+
+    def test_the_summary_collects_every_cited_capability(self) -> None:
+        payload = behavior_map(
+            behaviors=[
+                behavior("covered", behavior_id="observed-one", omh_capability_ids=["workspace-audit"]),
+                behavior("covered", behavior_id="observed-two", omh_capability_ids=["research", "file-lookup"]),
+            ]
+        )
+
+        self.assertEqual(
+            payload["summary"]["cited_capability_ids"], ["file-lookup", "research", "workspace-audit"]
+        )
+
+
+class CitedAuditTests(unittest.TestCase):
+    """The map cites a bounded audit. No audit, no map."""
+
+    def test_a_map_citing_no_audit_is_refused(self) -> None:
+        for missing in (None, {}, {"schema_version": ""}, []):
+            with self.subTest(audit=missing):
+                with self.assertRaises(ReusableBehaviorMapError) as raised:
+                    behavior_map(audit=missing)
+                self.assertIn(f"must cite a {PLUGIN_RISK_AUDIT_SCHEMA_VERSION} payload", str(raised.exception))
+
+    def test_a_map_citing_something_other_than_a_risk_audit_is_refused(self) -> None:
+        with self.assertRaises(ReusableBehaviorMapError) as raised:
+            behavior_map(audit=audit_payload(schema_version="awesome_hermes_plugin_outcome_matrix/v1"))
+
+        message = str(raised.exception)
+        self.assertIn(f"must cite a {PLUGIN_RISK_AUDIT_SCHEMA_VERSION} payload", message)
+        self.assertIn("never scans the bundle itself", message)
+
+    def test_the_citation_keeps_how_much_of_the_bundle_the_audit_saw(self) -> None:
+        payload = behavior_map()
+
+        self.assertEqual(sorted(payload["source_audit"]), sorted(SOURCE_AUDIT_KEYS))
+        self.assertEqual(payload["source_audit"]["scanned_file_count"], 4)
+        self.assertEqual(payload["source_audit"]["scanned_byte_count"], 812)
+        self.assertEqual(payload["source_audit"]["risk_categories"], CITED_RISKS)
+
+    def test_a_malformed_audit_count_is_a_validation_error_not_an_invented_count(self) -> None:
+        for value in ("many", -1, None, True):
+            with self.subTest(scanned_file_count=value):
+                broken = audit_payload()
+                broken["summary"] = {**broken["summary"], "scanned_file_count": value}
+                with self.assertRaises(ReusableBehaviorMapError) as raised:
+                    behavior_map(audit=broken)
+                self.assertIn("scanned_file_count must be a non-negative integer", str(raised.exception))
+
+    def test_an_unsupported_manifest_status_is_refused(self) -> None:
+        broken = audit_payload(source={"explicit_root": True, "manifest_status": "probably_fine"})
+
+        with self.assertRaises(ReusableBehaviorMapError) as raised:
+            behavior_map(audit=broken)
+
+        self.assertIn("manifest_status is unsupported", str(raised.exception))
+
+    def test_every_manifest_status_the_audit_can_report_is_citable(self) -> None:
+        for status in AUDIT_MANIFEST_STATUSES:
+            with self.subTest(manifest_status=status):
+                payload = behavior_map(
+                    audit=audit_payload(source={"explicit_root": True, "manifest_status": status})
+                )
+                self.assertEqual(validate_reusable_behavior_map(payload), [])
+
+    def test_a_risky_behavior_may_only_cite_a_category_the_audit_observed(self) -> None:
+        for category in AUDIT_RISK_CATEGORIES:
+            with self.subTest(risk_category=category):
+                row = behavior("risky", risk_categories=[category])
+                if category in CITED_RISKS:
+                    self.assertEqual(validate_reusable_behavior_map(behavior_map(behaviors=[row])), [])
+                    continue
+                with self.assertRaises(ReusableBehaviorMapError) as raised:
+                    behavior_map(behaviors=[row])
+                message = str(raised.exception)
+                self.assertIn("absent from the cited audit", message)
+                self.assertIn(PLUGIN_RISK_AUDIT_SCHEMA_VERSION, message)
+
+    def test_a_risk_category_the_audit_cannot_report_is_refused(self) -> None:
+        with self.assertRaises(ReusableBehaviorMapError) as raised:
+            behavior_map(behaviors=[behavior("risky", risk_categories=["reads_your_email"])])
+
+        self.assertIn("risk_categories has unsupported entries", str(raised.exception))
+
+    def test_the_risk_vocabulary_is_the_audits_own(self) -> None:
+        self.assertEqual(
+            list(AUDIT_RISK_CATEGORIES),
+            [
+                "declared_dependency",
+                "dynamic_code_execution",
+                "hermes_hook_capability",
+                "network_request",
+                "potential_committed_secret",
+                "process_execution",
+            ],
+        )
+        self.assertEqual(list(AUDIT_MANIFEST_STATUSES), ["invalid_json", "missing", "present"])
+
+
+class TheBundleIsNeverRunTests(unittest.TestCase):
+    """Nothing in a map reads as the inspected bundle having been run."""
+
+    def test_the_map_records_every_bundle_interaction_as_not_observed(self) -> None:
+        payload = behavior_map(behaviors=every_classification())
+
+        self.assertEqual(payload["not_observed"], NOT_OBSERVED)
+        for interaction in ("bundle_import", "bundle_registration", "bundle_installation", "bundle_execution"):
+            with self.subTest(interaction=interaction):
+                self.assertEqual(payload["not_observed"][interaction]["status"], "not_observed")
+
+    def test_a_map_that_drops_an_unobserved_interaction_is_refused(self) -> None:
+        payload = behavior_map()
+        for interaction in NOT_OBSERVED:
+            with self.subTest(interaction=interaction):
+                thinned = {key: value for key, value in NOT_OBSERVED.items() if key != interaction}
+                errors = validate_reusable_behavior_map(resealed(payload, not_observed=thinned))
+                self.assertTrue(any("not_observed must record" in error for error in errors), errors)
+
+    def test_a_map_claiming_the_bundle_ran_is_refused_by_key_name(self) -> None:
+        for key in ("executed", "installed", "ran", "exit_code", "result", "verified"):
+            with self.subTest(key=key):
+                errors = validate_reusable_behavior_map({**behavior_map(), key: True})
+                self.assertTrue(
+                    any("implementation-claim keys" in error and key in error for error in errors), errors
+                )
+
+    def test_a_behavior_claiming_the_bundle_ran_is_refused_by_key_name(self) -> None:
+        for key in ("executed", "installed", "succeeded"):
+            with self.subTest(key=key):
+                with self.assertRaises(ReusableBehaviorMapError) as raised:
+                    behavior_map(behaviors=[behavior("reusable", **{key: True})])
+                message = str(raised.exception)
+                self.assertIn("implementation-claim keys", message)
+                self.assertIn(key, message)
+
+    def test_a_raw_or_hidden_key_is_refused_on_the_map_and_on_a_behavior(self) -> None:
+        errors = validate_reusable_behavior_map({**behavior_map(), "transcript": "..."})
+        self.assertTrue(any("raw or hidden keys" in error for error in errors), errors)
+
+        with self.assertRaises(ReusableBehaviorMapError) as raised:
+            behavior_map(behaviors=[behavior("reusable", raw_output="...")])
+        self.assertIn("raw or hidden keys", str(raised.exception))
+
+    def test_the_claim_boundary_states_the_bundle_is_never_run(self) -> None:
+        payload = behavior_map()
+
+        self.assertEqual(payload["claim_boundary"], CLAIM_BOUNDARY)
+        self.assertEqual(payload["privacy"], MAP_PRIVACY)
+        for phrase in ("does not import, install, register, or execute", "does not install its dependencies"):
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, CLAIM_BOUNDARY)
+
+        errors = validate_reusable_behavior_map(resealed(payload, claim_boundary="Audited the bundle."))
+        self.assertTrue(any("claim_boundary must state" in error for error in errors), errors)
+
+
+class ClosedKeySetTests(unittest.TestCase):
+    """The envelope and every row are closed in both directions."""
+
+    def test_the_map_carries_exactly_its_keys(self) -> None:
+        payload = behavior_map()
+
+        self.assertEqual(sorted(payload), sorted(REUSABLE_BEHAVIOR_MAP_KEYS))
+        self.assertEqual(payload["schema_version"], REUSABLE_BEHAVIOR_MAP_SCHEMA_VERSION)
+
+        extra = validate_reusable_behavior_map({**payload, "bundle_manifest": "x"})
+        self.assertTrue(any("unsupported keys" in error for error in extra), extra)
+
+        for key in REUSABLE_BEHAVIOR_MAP_KEYS:
+            with self.subTest(key=key):
+                short = {name: value for name, value in payload.items() if name != key}
+                errors = validate_reusable_behavior_map(short)
+                self.assertTrue(any("is missing keys" in error and key in error for error in errors), errors)
+
+    def test_a_behavior_carries_exactly_its_keys(self) -> None:
+        payload = behavior_map()
+        row = payload["behaviors"][0]
+
+        self.assertEqual(sorted(row), sorted(BEHAVIOR_KEYS))
+
+        with self.assertRaises(ReusableBehaviorMapError) as raised:
+            behavior_map(behaviors=[behavior("reusable", host_namespace="acme")])
+        self.assertIn("has unsupported keys", str(raised.exception))
+
+        for key in BEHAVIOR_KEYS:
+            with self.subTest(key=key):
+                short = {name: value for name, value in row.items() if name != key}
+                errors = validate_reusable_behavior_map(resealed(payload, behaviors=[short]))
+                self.assertTrue(any("is missing keys" in error and key in error for error in errors), errors)
+
+    def test_a_behavior_id_must_be_a_lowercase_slug(self) -> None:
+        for identifier in ("Observed Behavior", "x", "observed_behavior", "-leading"):
+            with self.subTest(behavior_id=identifier):
+                with self.assertRaises(ReusableBehaviorMapError) as raised:
+                    behavior_map(behaviors=[behavior("reusable", behavior_id=identifier)])
+                self.assertIn("behavior_id must be a lowercase slug", str(raised.exception))
+
+    def test_an_edited_map_no_longer_matches_its_digest(self) -> None:
+        payload = behavior_map()
+        tampered = {**payload, "prepared_at": "2026-08-09T00:00:00Z", "summary": {"behavior_count": 0}}
+
+        errors = validate_reusable_behavior_map(tampered)
+
+        self.assertTrue(any("map_digest does not match" in error for error in errors), errors)
+
+    def test_a_non_object_is_not_a_map(self) -> None:
+        self.assertEqual(validate_reusable_behavior_map([]), ["reusable_behavior_map must be an object"])
+
+    def test_behaviors_must_be_a_list_of_objects(self) -> None:
+        payload = behavior_map()
+        errors = validate_reusable_behavior_map(resealed(payload, behaviors=["reusable"]))
+
+        self.assertTrue(any("behaviors must be a list of objects" in error for error in errors), errors)
+
+    def test_a_string_where_a_list_belongs_is_refused_rather_than_split(self) -> None:
+        with self.assertRaises(ReusableBehaviorMapError) as raised:
+            behavior_map(behaviors=[behavior("reusable", reusable_procedure="Read the file.")])
+
+        self.assertIn("reusable_procedure must be a list of strings", str(raised.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- Adds `reusable_behavior_map/v1`, the per-behavior inventory that joins OMH's
  bounded non-executing inspection of a supplied bundle to OMH's own capability
  vocabulary. One map cites one `plugin_risk_audit/v1` payload and lists the
  behaviors a researcher observed in that bundle, each classified as exactly one
  of `reusable`, `covered`, `host_bound`, `risky`, `unclear`, or `irrelevant`.
- Each row carries the user outcome the behavior produces, the host-free
  procedure that would reproduce it, the OMH capability that already covers it,
  the host mechanics that make it unreusable, the risk categories the cited
  audit already found, and an independence note on how OMH would stand it up
  without the host.
- Adds `tests/test_reusable_behavior_map.py` (52 tests) as the contract for all
  three acceptance criteria plus the two guards the family exists for.
- No new dependency, no CLI surface, no catalog or generated-artifact change.

### Why This Exists

Two halves of #796 already existed in this repository and nothing joined them.

`plugin_risk_audit/v1` (`src/workflows/plugin_risk_audit.py`) reads a bundle
without running it: symlink-refusing dirfd-anchored opens over one explicitly
named local directory, returning aggregate risk categories, a manifest status,
and two counts. It deliberately never says what the bundle is *for*.

`awesome_hermes_plugin_outcome_matrix/v1`
(`src/catalogs/awesome_hermes_agent_outcomes.py`) maps a demonstrated outcome
onto OMH capability ids and refuses a claim that outruns its evidence — but its
rows are a reviewed catalog pinned to an upstream commit, not something a person
can point at a bundle they were just handed.

So somebody holding a complex demonstrated workflow could learn that it touches
a network and spawns a process, or read a curated table about a plugin somebody
else already reviewed, and still had nothing that answered the actual question:
of the things this bundle does, which are outcomes OMH should provide natively,
and which are the host's machinery. `grep -rn "reusable_behavior_map" src/ tests/
docs/` returned zero hits before this change.

### User / Operator Impact

A person can now ask which user outcomes in a demonstrated workflow are reusable
and get a deterministic, evidence-bound answer instead of a judgement call:

- Every verdict has a required evidence shape, so "this is reusable" and "we
  already have this" are different claims with different costs.
- A `covered` verdict costs the author a real lookup. The cited id must resolve
  against `omh_capability_vocabulary()` — 91 ids re-derived from
  `POPULAR_PLUGIN_FAMILIES` (10 family ids plus 81 unique common-request case
  ids). `universal-plugin-bridge` is refused with the id named; `workspace-audit`
  is accepted. A reviewer can check the claim without leaving the repo.
- A `risky` verdict may only name a risk category the cited audit actually
  observed, so the risky-mechanics section is the scanner's finding rather than a
  second opinion about the same files.
- The map is a research artifact and says so. Selected `reusable` behaviors are
  meant to become separate native capability requests; `host_mechanics` is
  deliberately `SOURCE_HOST_MECHANICS` from `native_capability_blueprint` (11
  members) so a host-bound exclusion here and a blueprint's
  `observed_source_mechanics` there are the same words.

### How It Works

**AC1 — determinism.** `build_reusable_behavior_map` reads no clock.
`prepared_at` is a parameter, defaults to empty, and is excluded from
`map_digest`; `MAP_DIGEST_KEYS` is `("behaviors", "source_audit", "summary")`.
Behaviors are sorted by `behavior_id` and closed-vocabulary lists are normalized
into their declared order, so two researchers who found the same things in a
different order produce the same map byte for byte. `summary` is derived rather
than supplied and the validator recomputes it, so a hand-edited count is a
validation error instead of a quiet disagreement with the rows above it.

**AC2 — six states, distinguishable structurally.**
`CLASSIFICATION_REQUIRED_EVIDENCE` gives each classification the exact set of
evidence fields it must carry, and every field it does not require is forbidden:

| classification | required evidence |
| --- | --- |
| `reusable` | `reusable_procedure` |
| `covered` | `reusable_procedure` + `omh_capability_ids` |
| `host_bound` | `host_mechanics` |
| `risky` | `risk_categories` |
| `unclear` | `missing_evidence` |
| `irrelevant` | (none) |

A row's non-empty evidence fields therefore *are* its classification's
signature, the six signatures are distinct, and no payload satisfies two
classifications at once. One consequence is deliberate: a verdict is singular. A
behavior whose demonstrated mechanic is risky is `risky`, not `reusable` with a
risk note attached. The nuance goes in `independence_note`, which every row
carries. An unrecognised classification is refused before its evidence is
checked, with the six states listed in the message.

**AC3 — coverage is a citation, not an adjective.** `covered` requires at least
one `omh_capability_ids` entry, and every entry must resolve. A well-formed slug
naming a capability this repository does not have is refused with the ids listed
and `popular_plugin_coverage.py` named as where to look. No other classification
may cite a capability at all.

**The bundle is never run.** `CLAIM_BOUNDARY` states that OMH does not import,
install, register, or execute the inspected bundle, does not install its
dependencies, and does not reach its endpoints. `NOT_OBSERVED` says the same as
data across seven interactions, including `native_implementation` — citing an
OMH capability says that capability exists, not that this map built anything.
`IMPLEMENTATION_CLAIM_KEYS` is reused from `native_capability_blueprint` rather
than forked, so the two families cannot drift on what an execution claim looks
like, and it is applied to the envelope and to every row.

**Citation, not re-scan.** `source_audit` is a projection of a real
`plugin_risk_audit/v1` payload (schema version, manifest status, both counts,
risk categories). A map citing nothing, `{}`, or a different schema version is
refused. `AUDIT_RISK_CATEGORIES` and `AUDIT_MANIFEST_STATUSES` are re-derived
from the audit module's own `Literal` aliases via `typing.get_args`, so the map
cannot drift from the scanner it cites.

### Files And Contracts Touched

- `src/workflows/reusable_behavior_map.py` (new, 749 lines) — the contract:
  `build_reusable_behavior_map`, `validate_reusable_behavior_map`,
  `map_digest_of`, `omh_capability_vocabulary`, `unresolved_capability_ids`,
  `ReusableBehaviorMapError`, and the closed vocabularies.
- `tests/test_reusable_behavior_map.py` (new, 662 lines, 52 tests).
- Imported, not modified: `src/workflows/plugin_risk_audit.py` (schema version
  and the two `Literal` vocabularies), `src/workflows/native_capability_blueprint.py`
  (`SOURCE_HOST_MECHANICS`, `IMPLEMENTATION_CLAIM_KEYS`),
  `src/quality/popular_plugin_coverage.py` (`POPULAR_PLUGIN_FAMILIES`),
  `src/system/append_only_store.py` (`RAW_OR_HIDDEN_KEYS`).
- No catalog, routing, skill, awareness-lane, capability-family, or
  generated-artifact change, so no exact-count fixture moved.

## Validation

- [x] `uv run --group lint ruff check src tests` — `All checks passed!` (one
      pre-existing warning about an invalid `# noqa` directive on
      `src/commands/main.py:1`, untouched by this PR)
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` — `Ran 5247
      tests in 157.771s / OK`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_reusable_behavior_map.py`
      — `Ran 52 tests / OK`
- [x] `uv run python -m compileall -q src tests` — exit 0
- [x] `uv run python -m omh.cli docs workflows --check` — `"ok":true`,
      `tap_skills` 115/115, no missing/stale/extra
- [x] `uv run python -m omh.cli docs roles --check` — `"ok":true`
- [x] `uv run python -m omh.cli docs capability-families --check` — `"ok":true`
- [x] `uv run python -m omh.cli harness validate` — `"ok":true`,
      `{"harnesses":72,"skills":104}`, zero errors, zero warnings
- [x] `uv run python -m omh.cli release checklist --json` — `"ok":true`, mode
      `plan`, 35 required items, `observed:false` throughout (plan-only, as
      designed)
- [x] `uv run python -m omh.cli release hermes-smoke` — plan rendered, boundary
      copy intact, profile untouched
- [x] `git diff --check` — clean
- [ ] `omh --help` — **not run against this branch.** The `omh` on PATH
      (`~/.local/bin/omh`) is the operator's installed build, so running it would
      prove nothing about this checkout. `uv run python -m omh.cli --help` was run
      instead and printed usage successfully.
- [ ] `omh --omh-home /tmp/omh-smoke ... release hermes-smoke --install-path setup
      --include-command-smoke` — not run; this PR adds no installed-command,
      packaging, or setup surface.
- [ ] Workflow-learning review queue smoke — not applicable; no learning contract
      changed.
- [x] Mutation check on the new tests: eight targeted mutations of the new module
      (disable the behavior sort; add `prepared_at` to the digest keys; accept an
      unknown classification; accept forbidden evidence; skip capability-id
      resolution; accept any cited audit schema; accept an uncited risk category;
      skip the derived-summary comparison). All eight were caught by
      `tests/test_reusable_behavior_map.py`; the module was restored from a
      pre-mutation copy and the suite re-run green afterwards.
- [ ] Manual Hermes/TUI check — **not run, and not applicable.** No production
      surface mints a map yet. This module is the contract and the test file is
      its only caller, following the precedent set by
      `native_capability_blueprint/v1` (#791). There is nothing a person can type
      at Hermes that reaches this code today.

## Risk

- Low blast radius. The module is new, imports four existing modules read-only,
  and nothing in `src/` calls it. Every one of the 5247 pre-existing tests still
  passes unchanged.
- The `covered` vocabulary is narrower than "every OMH capability": it is the
  families and case ids in `src/quality/popular_plugin_coverage.py`. A future
  author who wants to cite something outside that set gets a clear refusal naming
  the file, which is the intended failure mode, but it does mean widening the
  vocabulary is a reviewed diff rather than a payload value.
- Singular verdicts are a deliberate constraint, not an oversight. A behavior
  that is both host-bound and risky must be recorded as one of the two, with the
  other stated in `independence_note`. If real use shows that loses information
  worth keeping, the fix is a schema change with a test, not a looser validator.
- Reusing `IMPLEMENTATION_CLAIM_KEYS` and `SOURCE_HOST_MECHANICS` from
  `native_capability_blueprint` couples the two families on purpose. Widening
  either constant now affects both; that is the point, and
  `tests/test_native_capability_blueprint.py` and this file both pin them.

## Compatibility / Rollout

- Additive only. No existing schema, artifact, generated file, exact-count
  fixture, routing trigger, or CLI surface changed.
- `reusable_behavior_map/v1` is a new schema version with no predecessor, so
  there is nothing to migrate.
- Release-channel impact: none beyond shipping one more module in the package.

## Release / Claims

- [x] Release-channel impact considered — `local`; no user-visible surface, no
      installed-command change, no packaging change.
- [x] Runtime/native capability claims are backed by evidence or marked as not
      observed — every payload carries `CLAIM_BOUNDARY` and a seven-entry
      `not_observed` block, and both are enforced by the validator rather than
      documented. This PR claims no Hermes runtime behavior.
- [x] Known manual Hermes checks are listed — there are none to run; see the
      unticked Hermes/TUI line above for why.

## Follow-Up

- Wire a production surface. The natural reader is the research lane described
  in #796: a person supplies a directory, OMH runs `plugin_risk_audit/v1` over
  it, and the map is authored against that audit. That needs the full
  new-capability surface set (catalog entry, harness, routing triggers with
  overroute guards, awareness lane, context card, wrapper action, next-action
  label, coverage case, capability family, regenerated docs, exact-count
  fixtures) and is a separate user goal.
- Feed selected `reusable` rows into `native_capability_blueprint/v1`. The two
  vocabularies already line up; nothing performs the handoff yet.

Closes #796
