### PR TITLE
feat: explain skill risks before reproducing useful behavior natively

### DIFF
--- a/src/workflows/skill_pattern_risk_review.py
+++ b/src/workflows/skill_pattern_risk_review.py
@@ -1,0 +1,1244 @@
+"""What a third-party skill is worth, what it costs, and what OMH may copy (#793).
+
+The defect this closes: a third-party skill routinely combines a genuinely
+useful procedure with broad access, risky instructions, or side effects nobody
+described. `plugin_risk_audit/v1` already answers half of that -- it statically
+reads one explicitly named local directory and reports which risk categories it
+matched -- but a category list is evidence, not advice. It does not say what the
+skill is *for*, what authority the procedure needs, how far the scan's word can
+be trusted, which part of the pattern OMH may safely reimplement, or which part
+the native version must refuse to copy. A user asking "what is useful and risky
+about this skill?" gets a list of regex hits.
+
+`skill_pattern_risk_review/v1` is the answer to the question that was asked. One
+review, for one skill, citing one audit.
+
+Four blocks, four separate fields
+---------------------------------
+
+#793 AC1 requires usefulness, risk, confidence, and native reproduction guidance
+to be separated. They are four required keys -- :data:`USEFULNESS_KEYS`,
+:data:`RISK_KEYS`, :data:`CONFIDENCE_KEYS`, :data:`NATIVE_REPRODUCTION_KEYS` --
+and none of them is computed from another. A review missing one is a validation
+error naming it, because the closed key set is checked in both directions.
+
+Separation is the point rather than a layout preference: a skill can be very
+useful and very risky at once, the confidence in both of those judgments is a
+third thing, and what OMH should build is a fourth. Folding any pair together
+produces the summary that made the question necessary.
+
+The scanner is evidence, the reviewer is a decision
+---------------------------------------------------
+
+#793 AC2 -- "a clean scan cannot mark the source approved or active" -- is the
+boundary the rest rests on, so it is structural rather than documented:
+
+* ``audit_evidence`` is what the scanner found. ``reviewer_decision`` is what a
+  person decided. They are different keys, and a review carrying no reviewer
+  decision carries ``{}`` there.
+* ``review_status`` is **derived**, never passed.
+  :func:`build_skill_pattern_risk_review` has no status parameter, so there is
+  no argument through which a clean scan can assert approval, and
+  :func:`validate_skill_pattern_risk_review` re-derives the status and refuses a
+  payload whose status disagrees -- a hand-written dict cannot lie either.
+* :data:`REVIEW_STATUSES` contains exactly one approving member and it is
+  reachable only from a recorded decision. :func:`review_reads_as_approved` is
+  the accessor a surface asks, and it is false for every status a decisionless
+  review can hold.
+* :data:`REFUSED_REVIEW_STATUSES` holds the bare words -- ``approved``,
+  ``active``, ``trusted``, ``clean`` -- by name, so the refusal reads as a rule
+  instead of as an unrecognised value. Approval in this schema is always
+  *for native reproduction* and never approval of the source: OMH approves what
+  it will build, and never the skill it read about.
+* A decision is bound to the content it reviewed. ``reviewed_digest`` stamps
+  ``review_digest``, and material content that moves afterwards leaves the
+  status at ``superseded_by_content_change`` rather than carrying the old
+  approval forward.
+
+Risk becomes a constraint or a rejection
+----------------------------------------
+
+#793 AC3 is the field that makes the review actionable rather than descriptive.
+Every risk category in the cited audit appears exactly once in
+``risk.resolutions``, and each one resolves to either a named member of
+:data:`NATIVE_CONSTRAINTS` or a named member of :data:`PROHIBITED_BEHAVIORS`.
+The name must also appear in the review's own ``native_reproduction`` lists, so
+a resolution cannot invoke a constraint the native design never adopted. An
+audited category left unresolved is a validation error naming the category, and
+a resolution for a category the audit never reported is refused too -- a
+reviewer may not manufacture findings the evidence does not carry.
+
+Those two vocabularies are closed on purpose. A free-text constraint is a
+sentence somebody wrote; a vocabulary member is something a later gate can join
+on. It also keeps the load-bearing fields clear of
+:func:`is_unsafe_metadata_line`, which reads security nouns like "secret" and
+"credential" as evidence that a stored line carries a secret. The three
+free-text fields left in the schema -- ``intended_outcome``, ``procedure_steps``,
+``safe_pattern`` -- describe what the skill achieves and what OMH may build, and
+none of them needs those nouns.
+
+The risk categories are not restated here.
+:data:`AUDITED_RISK_CATEGORIES` is derived from ``plugin_risk_audit``'s own
+``RiskCategory``, so widening the scanner widens the review and the two can
+never drift into disagreeing about what a category is.
+
+OMH reads about a skill, and nothing more
+-----------------------------------------
+
+Nothing in this module imports, installs, registers, enables, or executes the
+skill under review, and nothing re-scans it: the audit is passed in as a payload
+that ``ops plugin-risk-audit`` already produced. ``not_observed`` says so per
+surface, :data:`SKILL_PATTERN_RISK_REVIEW_CLAIM_BOUNDARY` says so in a sentence,
+and :data:`EXECUTION_CLAIM_KEYS` refuses a payload shaped to say otherwise by
+key name before the closed key set refuses it as unsupported.
+
+Determinism
+-----------
+
+No clock is read. ``prepared_at`` is a caller parameter and is excluded from
+``review_digest``, because a wall-clock value inside a compared digest turns an
+equality check into a race. The hashing scheme is
+``quality.skill_governance.policy_decision_digest``, reused rather than
+reinvented for the same reason ``native_capability_change_preview`` reuses it: a
+second stable-encoding rule in this repository would be a second thing to keep
+in agreement with the first.
+
+What reads this today
+---------------------
+
+Stated because the contract is wider than the wiring. No production surface
+mints a review yet; this module is the contract and
+``tests/test_skill_pattern_risk_review.py`` is its only caller. The intended
+readers are the native-capability artifacts (#791, #794), which describe what
+OMH should build -- this one says which parts of a borrowed pattern they are
+allowed to describe.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Final, get_args
+
+from ..quality.skill_governance import policy_decision_digest
+from ..system.append_only_store import (
+    RAW_OR_HIDDEN_KEYS,
+    is_unsafe_metadata_line,
+    opaque_ref,
+    reference_errors,
+)
+from .plugin_risk_audit import PLUGIN_RISK_AUDIT_SCHEMA_VERSION, ManifestStatus, RiskCategory
+
+
+SKILL_PATTERN_RISK_REVIEW_SCHEMA_VERSION: Final = "skill_pattern_risk_review/v1"
+
+# Derived from the scanner, never restated. `plugin_risk_audit.RiskCategory` is
+# the single definition of what a risk category is; widening it widens the set
+# of categories a review has to resolve, which is the behavior AC3 wants.
+AUDITED_RISK_CATEGORIES: Final[tuple[str, ...]] = tuple(get_args(RiskCategory))
+AUDIT_MANIFEST_STATUSES: Final[tuple[str, ...]] = tuple(get_args(ManifestStatus))
+
+REVIEW_PRIVACY: Final = "metadata_only"
+
+# What the procedure needs permission to do. `no_additional_authority` is a real
+# answer rather than an empty list, so "needs nothing" and "nobody looked" stay
+# distinguishable.
+REQUIRED_AUTHORITY: Final = (
+    "filesystem_read",
+    "filesystem_write",
+    "process_execution",
+    "network_access",
+    "package_installation",
+    "host_hook_registration",
+    "environment_variable_read",
+    "user_confirmation",
+    "no_additional_authority",
+)
+
+# What the procedure needs to touch to do its job.
+REQUIRED_DATA: Final = (
+    "user_supplied_text",
+    "repository_source",
+    "local_configuration",
+    "environment_variables",
+    "credential_material",
+    "network_responses",
+    "conversation_history",
+    "no_additional_data",
+)
+
+# What running the skill would do to the host, as the reviewer reads it. This is
+# the reviewer's account of behavior and is deliberately not the scanner's
+# category list: a regex hit on `fetch(` is evidence, "sends network requests"
+# is a judgment about what the skill does with it. `side_effects_unclear` is
+# here because the issue's user problem names unclear side effects, and a review
+# that cannot say what a skill does must be able to say that.
+OBSERVABLE_SIDE_EFFECTS: Final = (
+    "writes_local_files",
+    "reads_local_files_outside_the_skill",
+    "reads_environment_variables",
+    "spawns_processes",
+    "sends_network_requests",
+    "installs_dependencies",
+    "registers_host_hooks",
+    "mutates_host_configuration",
+    "side_effects_unclear",
+    "no_side_effects_identified",
+)
+
+# The two ways an audited risk category can be answered. There is no third, and
+# no "noted" or "acknowledged": AC3 asks for a constraint or a rejection.
+RISK_RESOLUTIONS: Final = ("native_constraint", "rejected")
+
+# What the OMH-native version binds itself to. Closed so a later gate can join
+# on a member instead of parsing a sentence.
+NATIVE_CONSTRAINTS: Final = (
+    "no_dynamic_code_execution",
+    "no_network_access",
+    "no_subprocess_execution",
+    "no_runtime_dependencies",
+    "no_host_hook_registration",
+    "no_credential_material_retained",
+    "bounded_local_reads_only",
+    "metadata_only_artifacts",
+    "explicit_user_invocation_only",
+    "deterministic_offline_behavior",
+)
+
+# What the OMH-native version must not copy, however useful it looked.
+PROHIBITED_BEHAVIORS: Final = (
+    "execute_evaluated_source",
+    "reach_a_remote_endpoint",
+    "spawn_a_host_process",
+    "install_or_resolve_dependencies",
+    "register_a_host_hook",
+    "embed_or_read_credential_material",
+    "read_outside_the_named_source",
+    "act_without_explicit_invocation",
+)
+
+CONFIDENCE_LEVELS: Final = ("low", "medium", "high")
+
+# What the confidence rests on. Each member names material somebody actually
+# had, so a stated confidence is attributable rather than felt.
+CONFIDENCE_BASES: Final = (
+    "cited_static_scan",
+    "reviewer_read_supplied_source",
+    "supplied_documentation",
+    "comparable_native_pattern",
+    "prior_review_of_same_source",
+)
+
+# What the evidence cannot show. These are the honest limits of a bounded static
+# scan of a local directory, enumerated so a review states them instead of
+# implying the scan was exhaustive.
+EVIDENCE_LIMITS: Final = (
+    "static_scan_only_no_execution_observed",
+    "classification_can_miss_obfuscated_behavior",
+    "classification_can_flag_inert_text",
+    "unscanned_file_types_excluded",
+    "runtime_behavior_unknown",
+    "dependency_behavior_unknown",
+    "author_and_provenance_unverified",
+    "source_version_not_pinned",
+)
+
+# The reviewer's two available decisions, both about what OMH will build.
+REVIEWER_DECISIONS: Final = ("approve_native_reproduction", "reject_native_reproduction")
+
+# The lifecycle of the review. Exactly one member approves anything, it names
+# what it approves, and it is unreachable without a current reviewer decision.
+REVIEW_STATUSES: Final = (
+    "awaiting_reviewer_decision",
+    "approved_for_native_reproduction",
+    "rejected_for_native_reproduction",
+    "superseded_by_content_change",
+)
+
+# Words a status will not be, held by name so the refusal states a rule. Every
+# one of them would describe the *source* rather than OMH's own plan, and none
+# of them is something a scan can establish.
+REFUSED_REVIEW_STATUSES: Final = (
+    "approved",
+    "active",
+    "allowed",
+    "clean",
+    "cleared",
+    "enabled",
+    "installed",
+    "passed",
+    "safe",
+    "trusted",
+    "verified",
+    "whitelisted",
+)
+
+# The one sentence each status may be rendered with. Every one says the source
+# was not installed, enabled, or trusted, so no rendering of any status can read
+# as adoption of the third-party skill.
+REVIEW_STATUS_CLAIMS: Final = {
+    "awaiting_reviewer_decision": (
+        "A scan was cited and no reviewer has decided yet. A clean scan is not an approval, and the "
+        "source is not installed, enabled, or trusted."
+    ),
+    "approved_for_native_reproduction": (
+        "A reviewer approved building the described safe pattern natively under the named constraints. "
+        "The source is not installed, enabled, or trusted."
+    ),
+    "rejected_for_native_reproduction": (
+        "A reviewer decided the pattern must not be reproduced natively. The source is not installed, "
+        "enabled, or trusted."
+    ),
+    "superseded_by_content_change": (
+        "The reviewed content moved, so the earlier decision no longer covers it. The source is not "
+        "installed, enabled, or trusted."
+    ),
+}
+
+# How the recorded decision stands against the content now in the review.
+REVIEWER_DECISION_STATES: Final = ("absent", "current", "stale")
+
+# What OMH did not do to the reviewed skill, per surface, mirroring the audit's
+# own `not_observed` block.
+NOT_OBSERVED_SURFACES: Final = (
+    "skill_import",
+    "skill_installation",
+    "skill_registration",
+    "skill_execution",
+    "dependency_installation",
+    "network_access",
+)
+
+AUDIT_EVIDENCE_KEYS: Final = (
+    "schema_version",
+    "audit_digest",
+    "manifest_status",
+    "risk_categories",
+    "scanned_file_count",
+    "scanned_byte_count",
+)
+USEFULNESS_KEYS: Final = ("intended_outcome", "procedure_steps", "required_authority", "required_data")
+RISK_KEYS: Final = ("side_effects", "resolutions")
+RESOLUTION_KEYS: Final = ("category", "resolution", "native_constraint", "prohibited_behavior")
+CONFIDENCE_KEYS: Final = ("level", "basis", "evidence_limits")
+NATIVE_REPRODUCTION_KEYS: Final = ("safe_pattern", "native_constraints", "prohibited_behaviors")
+REVIEWER_DECISION_KEYS: Final = ("decided_by", "decision", "reviewed_digest")
+
+SKILL_PATTERN_RISK_REVIEW_KEYS: Final = (
+    "schema_version",
+    "skill_ref",
+    "audit_evidence",
+    "usefulness",
+    "risk",
+    "confidence",
+    "native_reproduction",
+    "reviewer_decision",
+    "review_status",
+    "not_observed",
+    "prepared_at",
+    "privacy",
+    "review_digest",
+    "claim_boundary",
+)
+
+# The review's own state: outside the digest, because recording a decision must
+# not move the digest that the decision names.
+REVIEW_STATE_KEYS: Final = ("reviewer_decision", "review_status")
+
+# A value that cannot cover itself, two module constants identical in every
+# review, and the one field that holds a clock.
+DERIVED_REVIEW_KEYS: Final = ("review_digest", "claim_boundary", "privacy", "prepared_at")
+
+# Everything else. Derived rather than listed so a key added to the schema is
+# material by default and has to be argued out, never silently left out.
+MATERIAL_REVIEW_KEYS: Final = tuple(
+    key
+    for key in SKILL_PATTERN_RISK_REVIEW_KEYS
+    if key not in set(REVIEW_STATE_KEYS) | set(DERIVED_REVIEW_KEYS)
+)
+
+# Key names under which "OMH ran the skill" arrives. The closed key set already
+# refuses every one of them, but it refuses them as unsupported keys, and the
+# point of this family is that reading about a skill is not running one.
+EXECUTION_CLAIM_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "activated",
+        "active",
+        "allowed",
+        "approved",
+        "enabled",
+        "executed",
+        "exit_code",
+        "imported",
+        "installed",
+        "invoked",
+        "loaded",
+        "ran",
+        "registered",
+        "result",
+        "returned",
+        "running",
+        "safe",
+        "started",
+        "succeeded",
+        "success",
+        "trusted",
+        "verified",
+        "whitelisted",
+    }
+)
+
+SKILL_PATTERN_RISK_REVIEW_CLAIM_BOUNDARY: Final = (
+    "This review reads a cited plugin_risk_audit/v1 payload and a reviewer's judgment about one "
+    "third-party skill. OMH never imports, installs, registers, enables, or executes the reviewed skill "
+    "and does not re-scan it here. A clean scan is scanner evidence and never an approval: only a "
+    "recorded reviewer decision approves anything, it approves building a native pattern rather than the "
+    "source, and the review is not execution, verification, review, CI, merge-readiness, or merge "
+    "evidence."
+)
+
+_MAX_NARRATIVE_CHARS: Final = 400
+_MAX_STEP_CHARS: Final = 240
+_MAX_STAMP_CHARS: Final = 64
+_MAX_PROCEDURE_STEPS: Final = 12
+_MAX_VOCABULARY_ITEMS: Final = 12
+
+_LABEL: Final = "skill pattern risk review"
+_SHA256_LENGTH: Final = 64
+
+
+class SkillPatternRiskReviewError(ValueError):
+    """Raised when a review cannot be built or a decision cannot be recorded."""
+
+
+# ---------------------------------------------------------------------------
+# Build
+# ---------------------------------------------------------------------------
+
+
+def build_skill_pattern_risk_review(
+    *,
+    skill_ref: str,
+    audit: Mapping[str, Any],
+    intended_outcome: str,
+    procedure_steps: Sequence[str],
+    required_authority: Sequence[str],
+    required_data: Sequence[str],
+    side_effects: Sequence[str],
+    risk_resolutions: Sequence[Mapping[str, Any]],
+    confidence_level: str,
+    confidence_basis: Sequence[str],
+    evidence_limits: Sequence[str],
+    safe_pattern: str,
+    native_constraints: Sequence[str],
+    prohibited_behaviors: Sequence[str] = (),
+    reviewer_decision: Mapping[str, Any] | None = None,
+    prepared_at: str = "",
+) -> dict[str, Any]:
+    """Mint one review, or refuse.
+
+    There is no `review_status` parameter. The status is derived from whether a
+    reviewer decision was recorded and whether it still covers the material
+    content, which is what makes "a clean scan cannot read as approved" a
+    property of the constructor rather than a rule a caller is asked to respect.
+
+    `reviewer_decision` defaults to absent because minting a review is not
+    deciding one. A caller that passes one supplies `decided_by` and `decision`;
+    the digest it is bound to is stamped here from the content in hand, unless
+    the caller is rebuilding a stored review and supplies `reviewed_digest`
+    itself.
+    """
+    review: dict[str, Any] = {
+        "schema_version": SKILL_PATTERN_RISK_REVIEW_SCHEMA_VERSION,
+        "skill_ref": _opaque(skill_ref, field=f"{_LABEL} skill_ref"),
+        "audit_evidence": cite_plugin_risk_audit(audit),
+        "usefulness": {
+            "intended_outcome": _bounded_line(
+                intended_outcome, field=f"{_LABEL} usefulness.intended_outcome", limit=_MAX_NARRATIVE_CHARS
+            ),
+            "procedure_steps": _line_list(
+                procedure_steps, field=f"{_LABEL} usefulness.procedure_steps", limit=_MAX_STEP_CHARS
+            ),
+            "required_authority": _vocabulary_list(
+                required_authority,
+                allowed=REQUIRED_AUTHORITY,
+                field=f"{_LABEL} usefulness.required_authority",
+            ),
+            "required_data": _vocabulary_list(
+                required_data, allowed=REQUIRED_DATA, field=f"{_LABEL} usefulness.required_data"
+            ),
+        },
+        "risk": {
+            "side_effects": _vocabulary_list(
+                side_effects, allowed=OBSERVABLE_SIDE_EFFECTS, field=f"{_LABEL} risk.side_effects"
+            ),
+            "resolutions": _resolution_rows(risk_resolutions),
+        },
+        "confidence": {
+            "level": _closed(confidence_level, allowed=CONFIDENCE_LEVELS, field=f"{_LABEL} confidence.level"),
+            "basis": _vocabulary_list(
+                confidence_basis, allowed=CONFIDENCE_BASES, field=f"{_LABEL} confidence.basis"
+            ),
+            "evidence_limits": _vocabulary_list(
+                evidence_limits, allowed=EVIDENCE_LIMITS, field=f"{_LABEL} confidence.evidence_limits"
+            ),
+        },
+        "native_reproduction": {
+            "safe_pattern": _bounded_line(
+                safe_pattern, field=f"{_LABEL} native_reproduction.safe_pattern", limit=_MAX_NARRATIVE_CHARS
+            ),
+            "native_constraints": _vocabulary_list(
+                native_constraints,
+                allowed=NATIVE_CONSTRAINTS,
+                field=f"{_LABEL} native_reproduction.native_constraints",
+            ),
+            "prohibited_behaviors": _vocabulary_list(
+                prohibited_behaviors,
+                allowed=PROHIBITED_BEHAVIORS,
+                field=f"{_LABEL} native_reproduction.prohibited_behaviors",
+            ),
+        },
+        "not_observed": {surface: {"status": "not_observed"} for surface in NOT_OBSERVED_SURFACES},
+        "prepared_at": _optional_line(prepared_at, field=f"{_LABEL} prepared_at", limit=_MAX_STAMP_CHARS),
+        "privacy": REVIEW_PRIVACY,
+        "claim_boundary": SKILL_PATTERN_RISK_REVIEW_CLAIM_BOUNDARY,
+    }
+    review["review_digest"] = skill_pattern_risk_review_digest(review)
+    review["reviewer_decision"] = _reviewer_decision(reviewer_decision, current_digest=review["review_digest"])
+    review["review_status"] = derive_review_status(review)
+    errors = validate_skill_pattern_risk_review(review)
+    if errors:
+        raise SkillPatternRiskReviewError("; ".join(errors))
+    return review
+
+
+def cite_plugin_risk_audit(audit: Mapping[str, Any]) -> dict[str, Any]:
+    """Project the scanner evidence a review cites, or refuse the review.
+
+    A review is a judgment about evidence, so there is no path that produces one
+    without evidence: anything that is not a `plugin_risk_audit/v1` payload is
+    refused here, before any of the reviewer's own fields are read.
+
+    Only the aggregate is carried over. The audit deliberately exposes no plugin
+    source and no root path, and copying its summary keeps that true of the
+    review as well.
+    """
+    if not isinstance(audit, Mapping):
+        raise SkillPatternRiskReviewError(
+            f"{_LABEL} must cite one {PLUGIN_RISK_AUDIT_SCHEMA_VERSION} payload; a review without scanner "
+            "evidence is an opinion"
+        )
+    version = audit.get("schema_version")
+    if version != PLUGIN_RISK_AUDIT_SCHEMA_VERSION:
+        raise SkillPatternRiskReviewError(
+            f"{_LABEL} must cite a {PLUGIN_RISK_AUDIT_SCHEMA_VERSION} payload, not {version!r}; a review "
+            "without scanner evidence is an opinion"
+        )
+    summary = audit.get("summary")
+    source = audit.get("source")
+    if not isinstance(summary, Mapping) or not isinstance(source, Mapping):
+        raise SkillPatternRiskReviewError(f"{_LABEL} cited audit is missing its summary or its source")
+    return {
+        "schema_version": PLUGIN_RISK_AUDIT_SCHEMA_VERSION,
+        "audit_digest": policy_decision_digest(dict(audit)),
+        "manifest_status": _closed(
+            source.get("manifest_status"),
+            allowed=AUDIT_MANIFEST_STATUSES,
+            field=f"{_LABEL} audit_evidence.manifest_status",
+        ),
+        "risk_categories": _vocabulary_list(
+            summary.get("risk_categories") or (),
+            allowed=AUDITED_RISK_CATEGORIES,
+            field=f"{_LABEL} audit_evidence.risk_categories",
+        ),
+        "scanned_file_count": _count(
+            summary.get("scanned_file_count"), field=f"{_LABEL} audit_evidence.scanned_file_count"
+        ),
+        "scanned_byte_count": _count(
+            summary.get("scanned_byte_count"), field=f"{_LABEL} audit_evidence.scanned_byte_count"
+        ),
+    }
+
+
+def record_reviewer_decision(
+    review: Mapping[str, Any], *, decided_by: str, decision: str
+) -> dict[str, Any]:
+    """Bind one reviewer's decision to the content that reviewer saw.
+
+    The only way an approving status is reached. The digest of the material
+    content in front of the reviewer is stamped onto the decision, so content
+    that moves afterwards leaves the review superseded rather than quietly
+    carrying an approval it outgrew.
+    """
+    errors = validate_skill_pattern_risk_review(review)
+    if errors:
+        raise SkillPatternRiskReviewError("; ".join(errors))
+    decided = dict(review)
+    decided["reviewer_decision"] = _reviewer_decision(
+        {"decided_by": decided_by, "decision": decision},
+        current_digest=skill_pattern_risk_review_digest(review),
+    )
+    decided["review_status"] = derive_review_status(decided)
+    remaining = validate_skill_pattern_risk_review(decided)
+    if remaining:
+        raise SkillPatternRiskReviewError("; ".join(remaining))
+    return decided
+
+
+# ---------------------------------------------------------------------------
+# Derived state
+# ---------------------------------------------------------------------------
+
+
+def skill_pattern_risk_review_digest(review: Mapping[str, Any]) -> str:
+    """Content hash of the material part of a review.
+
+    Reuses `quality.skill_governance.policy_decision_digest`: it is already this
+    repository's stable, order-independent content hash over a metadata mapping,
+    and a second encoding rule here would be a second thing to keep correct.
+    """
+    return policy_decision_digest(material_review_content(review))
+
+
+def material_review_content(review: Mapping[str, Any]) -> dict[str, Any]:
+    """The part of a review the digest covers.
+
+    A missing key projects as `None` rather than raising, so a malformed review
+    still has a digest and the validator -- not the hash -- reports the fault.
+    """
+    return {key: review.get(key) for key in MATERIAL_REVIEW_KEYS}
+
+
+def reviewer_decision_state(review: Mapping[str, Any]) -> str:
+    """Whether a decision exists and still covers the content now in the review."""
+    decision = review.get("reviewer_decision")
+    if not isinstance(decision, Mapping) or not decision:
+        return "absent"
+    reviewed = str(decision.get("reviewed_digest", "") or "")
+    return "current" if reviewed and reviewed == skill_pattern_risk_review_digest(review) else "stale"
+
+
+def derive_review_status(review: Mapping[str, Any]) -> str:
+    """The only definition of a review's status.
+
+    Read it as the AC2 rule in code: with no decision the status is
+    `awaiting_reviewer_decision` and there is no branch that reaches an
+    approving value, whatever the scan found.
+    """
+    state = reviewer_decision_state(review)
+    if state == "absent":
+        return "awaiting_reviewer_decision"
+    if state == "stale":
+        return "superseded_by_content_change"
+    decision = review.get("reviewer_decision")
+    verdict = decision.get("decision") if isinstance(decision, Mapping) else ""
+    if verdict == "approve_native_reproduction":
+        return "approved_for_native_reproduction"
+    return "rejected_for_native_reproduction"
+
+
+def review_reads_as_approved(review: Mapping[str, Any]) -> bool:
+    """Whether anything in this review approves anything.
+
+    The one question a surface should ask. True only for a review whose status
+    is the single approving member and whose recorded decision still covers the
+    content, so no amount of clean scanner evidence moves it.
+    """
+    return (
+        str(review.get("review_status", "")) == "approved_for_native_reproduction"
+        and reviewer_decision_state(review) == "current"
+    )
+
+
+def review_status_claim(status: str) -> str:
+    """The one sentence a status may be rendered with."""
+    text = str(status or "")
+    if text not in REVIEW_STATUS_CLAIMS:
+        raise SkillPatternRiskReviewError(f"{_LABEL} review_status is unsupported: {text!r}")
+    return REVIEW_STATUS_CLAIMS[text]
+
+
+def audited_risk_categories(review: Mapping[str, Any]) -> tuple[str, ...]:
+    """The risk categories the cited audit reported, in vocabulary order."""
+    evidence = review.get("audit_evidence")
+    named = set(evidence.get("risk_categories") or ()) if isinstance(evidence, Mapping) else set()
+    return tuple(category for category in AUDITED_RISK_CATEGORIES if category in named)
+
+
+def resolved_risk_categories(review: Mapping[str, Any]) -> tuple[str, ...]:
+    """The risk categories the review answered, in vocabulary order."""
+    risk = review.get("risk")
+    rows = risk.get("resolutions") if isinstance(risk, Mapping) else ()
+    if not _is_row_sequence(rows):
+        return ()
+    named = {str(row.get("category", "")) for row in rows}
+    return tuple(category for category in AUDITED_RISK_CATEGORIES if category in named)
+
+
+def unresolved_risk_categories(review: Mapping[str, Any]) -> tuple[str, ...]:
+    """Audited categories the review left without a constraint or a rejection."""
+    resolved = set(resolved_risk_categories(review))
+    return tuple(category for category in audited_risk_categories(review) if category not in resolved)
+
+
+# ---------------------------------------------------------------------------
+# Validate
+# ---------------------------------------------------------------------------
+
+
+def validate_skill_pattern_risk_review(review: Any) -> list[str]:
+    """Every reason a payload is not a valid review. Both directions on keys."""
+    if not isinstance(review, Mapping):
+        return [f"{_LABEL} must be an object"]
+    errors: list[str] = []
+    claims_execution = sorted(key for key in review if str(key).lower() in EXECUTION_CLAIM_KEYS)
+    if claims_execution:
+        errors.append(
+            f"{_LABEL} must not carry execution-claim keys: {claims_execution}; OMH reads about the "
+            "reviewed skill and never imports, installs, registers, enables, or runs it"
+        )
+    forbidden = sorted(key for key in review if str(key).lower() in RAW_OR_HIDDEN_KEYS)
+    if forbidden:
+        errors.append(f"{_LABEL} must not carry raw or hidden keys: {forbidden}")
+    present = {str(key) for key in review}
+    missing = sorted(set(SKILL_PATTERN_RISK_REVIEW_KEYS) - present)
+    if missing:
+        errors.append(f"{_LABEL} is missing keys: {missing}")
+    unexpected = sorted(
+        present - set(SKILL_PATTERN_RISK_REVIEW_KEYS) - set(claims_execution) - set(forbidden)
+    )
+    if unexpected:
+        errors.append(f"{_LABEL} has unsupported keys: {unexpected}")
+    if review.get("schema_version") != SKILL_PATTERN_RISK_REVIEW_SCHEMA_VERSION:
+        errors.append(f"{_LABEL} schema_version must be {SKILL_PATTERN_RISK_REVIEW_SCHEMA_VERSION}")
+    if review.get("privacy") != REVIEW_PRIVACY:
+        errors.append(f"{_LABEL} privacy must be {REVIEW_PRIVACY}")
+    if review.get("claim_boundary") != SKILL_PATTERN_RISK_REVIEW_CLAIM_BOUNDARY:
+        errors.append(
+            f"{_LABEL} claim_boundary must state that OMH never imports, installs, or executes the "
+            "reviewed skill and that a clean scan is not an approval"
+        )
+    if review.get("not_observed") != {
+        surface: {"status": "not_observed"} for surface in NOT_OBSERVED_SURFACES
+    }:
+        errors.append(
+            f"{_LABEL} not_observed must mark every one of {list(NOT_OBSERVED_SURFACES)} as not_observed"
+        )
+    errors.extend(_line_errors(review.get("prepared_at"), field="prepared_at", limit=_MAX_STAMP_CHARS))
+    errors.extend(reference_errors(review.get("skill_ref"), field="skill_ref", label=_LABEL, required=True))
+    errors.extend(_audit_evidence_errors(review.get("audit_evidence")))
+    errors.extend(_usefulness_errors(review.get("usefulness")))
+    errors.extend(_risk_errors(review))
+    errors.extend(_confidence_errors(review.get("confidence")))
+    errors.extend(_native_reproduction_errors(review.get("native_reproduction")))
+    errors.extend(_decision_errors(review))
+    errors.extend(_digest_errors(review))
+    return errors
+
+
+def _audit_evidence_errors(evidence: Any) -> list[str]:
+    """A review with no cited audit is not a review."""
+    field = "audit_evidence"
+    if not isinstance(evidence, Mapping):
+        return [
+            f"{_LABEL} {field} must cite one {PLUGIN_RISK_AUDIT_SCHEMA_VERSION} payload; a review without "
+            "scanner evidence is an opinion"
+        ]
+    errors = _block_key_errors(evidence, keys=AUDIT_EVIDENCE_KEYS, field=field)
+    if evidence.get("schema_version") != PLUGIN_RISK_AUDIT_SCHEMA_VERSION:
+        errors.append(
+            f"{_LABEL} {field}.schema_version must be {PLUGIN_RISK_AUDIT_SCHEMA_VERSION}, not "
+            f"{evidence.get('schema_version')!r}"
+        )
+    digest = str(evidence.get("audit_digest", "") or "")
+    if not _is_sha256(digest):
+        errors.append(f"{_LABEL} {field}.audit_digest must be a sha256 hex digest of the cited audit")
+    if evidence.get("manifest_status") not in AUDIT_MANIFEST_STATUSES:
+        errors.append(
+            f"{_LABEL} {field}.manifest_status is unsupported: {evidence.get('manifest_status')!r}"
+        )
+    errors.extend(
+        _vocabulary_errors(
+            evidence.get("risk_categories"),
+            allowed=AUDITED_RISK_CATEGORIES,
+            field=f"{field}.risk_categories",
+            minimum=0,
+        )
+    )
+    for name in ("scanned_file_count", "scanned_byte_count"):
+        errors.extend(_count_errors(evidence.get(name), field=f"{field}.{name}"))
+    return errors
+
+
+def _usefulness_errors(usefulness: Any) -> list[str]:
+    """#793 AC1's first block: the outcome, the procedure, and what it needs."""
+    field = "usefulness"
+    if not isinstance(usefulness, Mapping):
+        return [f"{_LABEL} {field} must be an object naming the outcome the skill is worth having"]
+    errors = _block_key_errors(usefulness, keys=USEFULNESS_KEYS, field=field)
+    errors.extend(
+        _line_errors(
+            usefulness.get("intended_outcome"),
+            field=f"{field}.intended_outcome",
+            limit=_MAX_NARRATIVE_CHARS,
+            required=True,
+        )
+    )
+    errors.extend(
+        _line_list_errors(
+            usefulness.get("procedure_steps"),
+            field=f"{field}.procedure_steps",
+            limit=_MAX_STEP_CHARS,
+            minimum=1,
+            maximum=_MAX_PROCEDURE_STEPS,
+        )
+    )
+    errors.extend(
+        _vocabulary_errors(
+            usefulness.get("required_authority"),
+            allowed=REQUIRED_AUTHORITY,
+            field=f"{field}.required_authority",
+            minimum=1,
+        )
+    )
+    errors.extend(
+        _vocabulary_errors(
+            usefulness.get("required_data"), allowed=REQUIRED_DATA, field=f"{field}.required_data", minimum=1
+        )
+    )
+    return errors
+
+
+def _risk_errors(review: Mapping[str, Any]) -> list[str]:
+    """#793 AC1's second block, and AC3 in its enforcing form."""
+    field = "risk"
+    risk = review.get(field)
+    if not isinstance(risk, Mapping):
+        return [
+            f"{_LABEL} {field} must be an object naming the side effects and how each audited category "
+            "resolves"
+        ]
+    errors = _block_key_errors(risk, keys=RISK_KEYS, field=field)
+    effects = risk.get("side_effects")
+    errors.extend(
+        _vocabulary_errors(
+            effects, allowed=OBSERVABLE_SIDE_EFFECTS, field=f"{field}.side_effects", minimum=1
+        )
+    )
+    if isinstance(effects, list) and "no_side_effects_identified" in effects:
+        if len(effects) > 1:
+            errors.append(
+                f"{_LABEL} {field}.side_effects may not name no_side_effects_identified alongside an "
+                f"identified effect: {sorted(set(effects) - {'no_side_effects_identified'})}"
+            )
+        if audited_risk_categories(review):
+            errors.append(
+                f"{_LABEL} {field}.side_effects claims none while the cited audit reports "
+                f"{list(audited_risk_categories(review))}; the reviewer may disagree with the scan, but "
+                "not by asserting the scan found nothing"
+            )
+    errors.extend(_resolution_errors(review))
+    return errors
+
+
+def _resolution_errors(review: Mapping[str, Any]) -> list[str]:
+    """Every audited category resolves, and only audited categories resolve."""
+    field = "risk.resolutions"
+    risk = review.get("risk")
+    rows = risk.get("resolutions") if isinstance(risk, Mapping) else None
+    if not _is_row_sequence(rows):
+        return [f"{_LABEL} {field} must be a list of objects"]
+    errors: list[str] = []
+    native = review.get("native_reproduction")
+    declared_constraints = set(native.get("native_constraints") or ()) if isinstance(native, Mapping) else set()
+    declared_prohibitions = (
+        set(native.get("prohibited_behaviors") or ()) if isinstance(native, Mapping) else set()
+    )
+    named: list[str] = []
+    for row in rows:
+        errors.extend(_block_key_errors(row, keys=RESOLUTION_KEYS, field=field))
+        category = str(row.get("category", ""))
+        named.append(category)
+        if category not in AUDITED_RISK_CATEGORIES:
+            errors.append(f"{_LABEL} {field} names an unknown risk category: {category!r}")
+        resolution = row.get("resolution")
+        constraint = str(row.get("native_constraint", "") or "")
+        prohibition = str(row.get("prohibited_behavior", "") or "")
+        if resolution == "native_constraint":
+            errors.extend(
+                _resolution_target_errors(
+                    category,
+                    value=constraint,
+                    other=prohibition,
+                    allowed=NATIVE_CONSTRAINTS,
+                    declared=declared_constraints,
+                    field=f"{field} native_constraint",
+                    other_field="prohibited_behavior",
+                    declared_field="native_reproduction.native_constraints",
+                )
+            )
+        elif resolution == "rejected":
+            errors.extend(
+                _resolution_target_errors(
+                    category,
+                    value=prohibition,
+                    other=constraint,
+                    allowed=PROHIBITED_BEHAVIORS,
+                    declared=declared_prohibitions,
+                    field=f"{field} prohibited_behavior",
+                    other_field="native_constraint",
+                    declared_field="native_reproduction.prohibited_behaviors",
+                )
+            )
+        else:
+            errors.append(
+                f"{_LABEL} {field} resolution for {category!r} is unsupported: {resolution!r}; a risk "
+                f"resolves to one of {list(RISK_RESOLUTIONS)}"
+            )
+    repeated = sorted({category for category in named if named.count(category) > 1})
+    if repeated:
+        errors.append(f"{_LABEL} {field} resolves the same risk category more than once: {repeated}")
+    audited = audited_risk_categories(review)
+    unresolved = [category for category in audited if category not in set(named)]
+    if unresolved:
+        errors.append(
+            f"{_LABEL} leaves audited risk categories unresolved: {unresolved}; every category the cited "
+            "audit reports must resolve to a named native constraint or an explicit rejection"
+        )
+    unaudited = sorted({category for category in named if category in AUDITED_RISK_CATEGORIES} - set(audited))
+    if unaudited:
+        errors.append(
+            f"{_LABEL} {field} resolves risk categories the cited audit never reported: {unaudited}; a "
+            "review answers the evidence it cites"
+        )
+    return errors
+
+
+def _resolution_target_errors(
+    category: str,
+    *,
+    value: str,
+    other: str,
+    allowed: tuple[str, ...],
+    declared: set[str],
+    field: str,
+    other_field: str,
+    declared_field: str,
+) -> list[str]:
+    errors: list[str] = []
+    if not value:
+        errors.append(f"{_LABEL} {field} is required for {category!r}")
+    elif value not in allowed:
+        errors.append(f"{_LABEL} {field} for {category!r} is unsupported: {value!r}; allowed: {list(allowed)}")
+    elif value not in declared:
+        errors.append(
+            f"{_LABEL} {field} for {category!r} names {value!r}, which {declared_field} does not carry; a "
+            "risk cannot resolve to a constraint the native design never adopted"
+        )
+    if other:
+        errors.append(f"{_LABEL} risk.resolutions must leave {other_field} empty for {category!r}")
+    return errors
+
+
+def _confidence_errors(confidence: Any) -> list[str]:
+    """#793 AC1's third block: how far the evidence goes."""
+    field = "confidence"
+    if not isinstance(confidence, Mapping):
+        return [f"{_LABEL} {field} must be an object stating how far the cited evidence goes"]
+    errors = _block_key_errors(confidence, keys=CONFIDENCE_KEYS, field=field)
+    if confidence.get("level") not in CONFIDENCE_LEVELS:
+        errors.append(f"{_LABEL} {field}.level is unsupported: {confidence.get('level')!r}")
+    errors.extend(
+        _vocabulary_errors(confidence.get("basis"), allowed=CONFIDENCE_BASES, field=f"{field}.basis", minimum=1)
+    )
+    errors.extend(
+        _vocabulary_errors(
+            confidence.get("evidence_limits"),
+            allowed=EVIDENCE_LIMITS,
+            field=f"{field}.evidence_limits",
+            minimum=1,
+        )
+    )
+    return errors
+
+
+def _native_reproduction_errors(native: Any) -> list[str]:
+    """#793 AC1's fourth block: what OMH may build and what it must not copy."""
+    field = "native_reproduction"
+    if not isinstance(native, Mapping):
+        return [f"{_LABEL} {field} must be an object naming the safe pattern OMH may build"]
+    errors = _block_key_errors(native, keys=NATIVE_REPRODUCTION_KEYS, field=field)
+    errors.extend(
+        _line_errors(
+            native.get("safe_pattern"),
+            field=f"{field}.safe_pattern",
+            limit=_MAX_NARRATIVE_CHARS,
+            required=True,
+        )
+    )
+    errors.extend(
+        _vocabulary_errors(
+            native.get("native_constraints"),
+            allowed=NATIVE_CONSTRAINTS,
+            field=f"{field}.native_constraints",
+            minimum=1,
+        )
+    )
+    errors.extend(
+        _vocabulary_errors(
+            native.get("prohibited_behaviors"),
+            allowed=PROHIBITED_BEHAVIORS,
+            field=f"{field}.prohibited_behaviors",
+            minimum=0,
+        )
+    )
+    return errors
+
+
+def _decision_errors(review: Mapping[str, Any]) -> list[str]:
+    """#793 AC2: the reviewer's decision, and the status it alone can reach."""
+    decision = review.get("reviewer_decision")
+    if not isinstance(decision, Mapping):
+        return [f"{_LABEL} reviewer_decision must be an object, empty when nobody has decided"]
+    errors: list[str] = []
+    if decision:
+        errors.extend(_block_key_errors(decision, keys=REVIEWER_DECISION_KEYS, field="reviewer_decision"))
+        errors.extend(
+            reference_errors(
+                decision.get("decided_by"), field="reviewer_decision.decided_by", label=_LABEL, required=True
+            )
+        )
+        if decision.get("decision") not in REVIEWER_DECISIONS:
+            errors.append(f"{_LABEL} reviewer_decision.decision is unsupported: {decision.get('decision')!r}")
+        if not _is_sha256(str(decision.get("reviewed_digest", "") or "")):
+            errors.append(
+                f"{_LABEL} reviewer_decision.reviewed_digest must be the sha256 digest of the content that "
+                "was reviewed"
+            )
+    status = review.get("review_status")
+    if str(status).strip().lower() in REFUSED_REVIEW_STATUSES:
+        errors.append(
+            f"{_LABEL} review_status may not describe the source as {status!r}; OMH approves a native "
+            f"pattern it will build and never the reviewed skill, so one of {list(REVIEW_STATUSES)} is "
+            "required"
+        )
+    elif status not in REVIEW_STATUSES:
+        errors.append(f"{_LABEL} review_status is unsupported: {status!r}")
+    else:
+        derived = derive_review_status(review)
+        if status != derived:
+            errors.append(
+                f"{_LABEL} review_status is {status!r} but the recorded decision derives {derived!r}; the "
+                "status of a review is what its reviewer decision makes it, never what a payload asserts"
+            )
+    return errors
+
+
+def _digest_errors(review: Mapping[str, Any]) -> list[str]:
+    digest = review.get("review_digest")
+    if not isinstance(digest, str) or not _is_sha256(digest):
+        return [f"{_LABEL} review_digest must be a sha256 hex digest"]
+    if digest != skill_pattern_risk_review_digest(review):
+        return [
+            f"{_LABEL} review_digest does not match the content it seals; the review was edited after it "
+            "was minted"
+        ]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolution_rows(resolutions: Any) -> list[dict[str, Any]]:
+    if not _is_row_sequence(resolutions):
+        raise SkillPatternRiskReviewError(f"{_LABEL} risk.resolutions must be a list of objects")
+    rows: list[dict[str, Any]] = []
+    for row in resolutions:
+        unknown = sorted({str(key) for key in row} - set(RESOLUTION_KEYS))
+        if unknown:
+            raise SkillPatternRiskReviewError(f"{_LABEL} risk.resolutions has unsupported keys: {unknown}")
+        category = _closed(
+            row.get("category"), allowed=AUDITED_RISK_CATEGORIES, field=f"{_LABEL} risk.resolutions.category"
+        )
+        resolution = _closed(
+            row.get("resolution"), allowed=RISK_RESOLUTIONS, field=f"{_LABEL} risk.resolutions.resolution"
+        )
+        rows.append(
+            {
+                "category": category,
+                "resolution": resolution,
+                "native_constraint": str(row.get("native_constraint", "") or ""),
+                "prohibited_behavior": str(row.get("prohibited_behavior", "") or ""),
+            }
+        )
+    return sorted(rows, key=lambda row: AUDITED_RISK_CATEGORIES.index(row["category"]))
+
+
+def _reviewer_decision(value: Any, *, current_digest: str) -> dict[str, Any]:
+    if value is None or value == {}:
+        return {}
+    if not isinstance(value, Mapping):
+        raise SkillPatternRiskReviewError(f"{_LABEL} reviewer_decision must be an object")
+    unknown = sorted({str(key) for key in value} - set(REVIEWER_DECISION_KEYS))
+    if unknown:
+        raise SkillPatternRiskReviewError(f"{_LABEL} reviewer_decision has unsupported keys: {unknown}")
+    return {
+        "decided_by": _opaque(value.get("decided_by"), field=f"{_LABEL} reviewer_decision.decided_by"),
+        "decision": _closed(
+            value.get("decision"), allowed=REVIEWER_DECISIONS, field=f"{_LABEL} reviewer_decision.decision"
+        ),
+        "reviewed_digest": str(value.get("reviewed_digest", "") or current_digest),
+    }
+
+
+def _block_key_errors(block: Any, *, keys: tuple[str, ...], field: str) -> list[str]:
+    if not isinstance(block, Mapping):
+        return [f"{_LABEL} {field} must be an object"]
+    errors: list[str] = []
+    present = {str(key) for key in block}
+    missing = sorted(set(keys) - present)
+    if missing:
+        errors.append(f"{_LABEL} {field} is missing keys: {missing}")
+    unexpected = sorted(present - set(keys))
+    if unexpected:
+        errors.append(f"{_LABEL} {field} has unsupported keys: {unexpected}")
+    return errors
+
+
+def _is_row_sequence(value: Any) -> bool:
+    return (
+        isinstance(value, Sequence)
+        and not isinstance(value, (str, bytes, bytearray))
+        and all(isinstance(row, Mapping) for row in value)
+    )
+
+
+def _closed(value: Any, *, allowed: tuple[str, ...], field: str) -> str:
+    text = str(value or "")
+    if text not in allowed:
+        raise SkillPatternRiskReviewError(f"{field} is unsupported: {value!r}; allowed: {list(allowed)}")
+    return text
+
+
+def _vocabulary_list(values: Any, *, allowed: tuple[str, ...], field: str) -> list[str]:
+    """Closed-vocabulary members in declared order, deduplicated.
+
+    Normalizing the order here is what lets two reviewers who named the same
+    members in different orders produce the same `review_digest`. An
+    unrecognised member is refused rather than dropped: silently discarding one
+    would turn a typo into a review that validates and says something else.
+    """
+    if isinstance(values, (str, bytes, bytearray)) or not isinstance(values, Sequence):
+        raise SkillPatternRiskReviewError(f"{field} must be a list")
+    named = [str(value).strip() for value in values if str(value).strip()]
+    unsupported = sorted(set(named) - set(allowed))
+    if unsupported:
+        raise SkillPatternRiskReviewError(
+            f"{field} has unsupported entries: {unsupported}; allowed: {list(allowed)}"
+        )
+    if len(set(named)) != len(named):
+        raise SkillPatternRiskReviewError(f"{field} must not repeat an entry")
+    if len(named) > _MAX_VOCABULARY_ITEMS:
+        raise SkillPatternRiskReviewError(f"{field} must name at most {_MAX_VOCABULARY_ITEMS} entries")
+    return [item for item in allowed if item in set(named)]
+
+
+def _vocabulary_errors(value: Any, *, allowed: tuple[str, ...], field: str, minimum: int) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        return [f"{_LABEL} {field} must be a list of strings"]
+    errors: list[str] = []
+    if len(value) < minimum:
+        errors.append(f"{_LABEL} {field} must name at least {minimum}")
+    if len(value) > _MAX_VOCABULARY_ITEMS:
+        errors.append(f"{_LABEL} {field} must name at most {_MAX_VOCABULARY_ITEMS} entries")
+    if len(set(value)) != len(value):
+        errors.append(f"{_LABEL} {field} must not repeat an entry")
+    unsupported = sorted(set(value) - set(allowed))
+    if unsupported:
+        errors.append(f"{_LABEL} {field} has unsupported entries: {unsupported}; allowed: {list(allowed)}")
+    return errors
+
+
+def _line_list(values: Any, *, field: str, limit: int) -> list[str]:
+    if isinstance(values, (str, bytes, bytearray)) or not isinstance(values, Sequence):
+        raise SkillPatternRiskReviewError(f"{field} must be a list")
+    lines = [_bounded_line(value, field=field, limit=limit) for value in values]
+    if len(set(lines)) != len(lines):
+        raise SkillPatternRiskReviewError(f"{field} must not repeat an entry")
+    if not lines:
+        raise SkillPatternRiskReviewError(f"{field} must name at least 1")
+    if len(lines) > _MAX_PROCEDURE_STEPS:
+        raise SkillPatternRiskReviewError(f"{field} must name at most {_MAX_PROCEDURE_STEPS} entries")
+    return lines
+
+
+def _line_list_errors(value: Any, *, field: str, limit: int, minimum: int, maximum: int) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        return [f"{_LABEL} {field} must be a list of strings"]
+    errors: list[str] = []
+    if len(value) < minimum:
+        errors.append(f"{_LABEL} {field} must name at least {minimum}")
+    if len(value) > maximum:
+        errors.append(f"{_LABEL} {field} must name at most {maximum} entries")
+    if len(set(value)) != len(value):
+        errors.append(f"{_LABEL} {field} must not repeat an entry")
+    for item in value:
+        errors.extend(_line_errors(item, field=field, limit=limit, required=True))
+    return errors
+
+
+def _opaque(value: Any, *, field: str) -> str:
+    return opaque_ref(str(value or ""), field=field, error=SkillPatternRiskReviewError)
+
+
+def _bounded_line(value: Any, *, field: str, limit: int) -> str:
+    text = " ".join(str(value or "").split())
+    if not text:
+        raise SkillPatternRiskReviewError(f"{field} is required")
+    if len(text) > limit:
+        raise SkillPatternRiskReviewError(f"{field} must be at most {limit} characters")
+    if is_unsafe_metadata_line(text):
+        raise SkillPatternRiskReviewError(
+            f"{field} must be one bounded metadata line without secrets, links, or paths"
+        )
+    return text
+
+
+def _optional_line(value: Any, *, field: str, limit: int) -> str:
+    text = " ".join(str(value or "").split())
+    return _bounded_line(text, field=field, limit=limit) if text else ""
+
+
+def _line_errors(value: Any, *, field: str, limit: int, required: bool = False) -> list[str]:
+    if not isinstance(value, str):
+        return [f"{_LABEL} {field} must be a string"]
+    if not value.strip():
+        return [f"{_LABEL} {field} is required"] if required else []
+    if len(value) > limit:
+        return [f"{_LABEL} {field} must be at most {limit} characters"]
+    if is_unsafe_metadata_line(value):
+        return [f"{_LABEL} {field} must not carry secrets, links, paths, or raw text"]
+    return []
+
+
+def _count(value: Any, *, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise SkillPatternRiskReviewError(f"{field} must be a non-negative integer")
+    return value
+
+
+def _count_errors(value: Any, *, field: str) -> list[str]:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return [f"{_LABEL} {field} must be a non-negative integer"]
+    return []
+
+
+def _is_sha256(value: str) -> bool:
+    if len(value) != _SHA256_LENGTH or value != value.lower():
+        return False
+    try:
+        int(value, 16)
+    except ValueError:
+        return False
+    return True

--- a/tests/test_skill_pattern_risk_review.py
+++ b/tests/test_skill_pattern_risk_review.py
@@ -1,0 +1,795 @@
+"""Contracts for `skill_pattern_risk_review/v1` (issue #793).
+
+Grouped by acceptance criterion:
+
+- AC1: every review separates usefulness, risk, confidence, and native
+  reproduction guidance. Four required blocks, each independently variable, and
+  a review missing one is a validation error naming it.
+- AC2: a clean scan cannot mark the source approved or active. Asserted across
+  the whole status vocabulary and against the builder's own signature, because
+  the claim is that approval is unreachable rather than merely discouraged.
+- AC3: every risk category the cited audit reports resolves to a named native
+  constraint or an explicit rejection, and an unresolved category is a
+  validation error naming the category.
+
+Plus the guards the family exists for: the review never reads as having
+executed, imported, or installed the reviewed skill, and a review citing no
+audit is refused.
+
+The one test that puts real files on disk writes them with
+`omh.local_store.atomic_write_text` rather than `Path.write_text`. The audit it
+then cites carries `scanned_byte_count`, that count is inside `review_digest`,
+and `Path.write_text` rewrites "\\n" as CRLF on Windows -- so a fixture written
+that way would produce a different digest on the Windows job than on this one.
+Every digest comparison in this file is between two payloads built in the same
+run for the same reason.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from typing import Any
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.local_store import atomic_write_text  # noqa: E402
+from omh.workflows.plugin_risk_audit import (  # noqa: E402
+    PLUGIN_RISK_AUDIT_SCHEMA_VERSION,
+    audit_plugin_risk,
+)
+from omh.workflows.skill_pattern_risk_review import (  # noqa: E402
+    AUDIT_EVIDENCE_KEYS,
+    AUDITED_RISK_CATEGORIES,
+    CONFIDENCE_KEYS,
+    EXECUTION_CLAIM_KEYS,
+    MATERIAL_REVIEW_KEYS,
+    NATIVE_CONSTRAINTS,
+    NATIVE_REPRODUCTION_KEYS,
+    NOT_OBSERVED_SURFACES,
+    PROHIBITED_BEHAVIORS,
+    REFUSED_REVIEW_STATUSES,
+    RESOLUTION_KEYS,
+    REVIEW_STATUS_CLAIMS,
+    REVIEW_STATUSES,
+    REVIEWER_DECISIONS,
+    RISK_KEYS,
+    RISK_RESOLUTIONS,
+    SKILL_PATTERN_RISK_REVIEW_CLAIM_BOUNDARY,
+    SKILL_PATTERN_RISK_REVIEW_KEYS,
+    SKILL_PATTERN_RISK_REVIEW_SCHEMA_VERSION,
+    USEFULNESS_KEYS,
+    SkillPatternRiskReviewError,
+    audited_risk_categories,
+    build_skill_pattern_risk_review,
+    cite_plugin_risk_audit,
+    derive_review_status,
+    record_reviewer_decision,
+    review_reads_as_approved,
+    review_status_claim,
+    reviewer_decision_state,
+    skill_pattern_risk_review_digest,
+    unresolved_risk_categories,
+    validate_skill_pattern_risk_review,
+)
+
+from _platform_support import requires_secure_dir_io  # noqa: E402
+
+
+def audit_payload(*, categories: tuple[str, ...] = ("network_request", "process_execution")) -> dict[str, Any]:
+    """A `plugin_risk_audit/v1` payload in the shape `audit_plugin_risk` returns."""
+    return {
+        "schema_version": PLUGIN_RISK_AUDIT_SCHEMA_VERSION,
+        "source": {"explicit_root": True, "manifest_status": "present"},
+        "summary": {
+            "scanned_file_count": 3,
+            "scanned_byte_count": 912,
+            "risk_categories": sorted(categories),
+            "risk_category_count": len(categories),
+        },
+        "not_observed": {"plugin_execution": {"status": "not_observed"}},
+        "claim_boundary": "The audit statically reads bounded text and proves nothing about safety.",
+    }
+
+
+def review_kwargs(**overrides: Any) -> dict[str, Any]:
+    """A complete, valid review's arguments, minimally overridable."""
+    base: dict[str, Any] = {
+        "skill_ref": "third-party-review-digest",
+        "audit": audit_payload(),
+        "intended_outcome": (
+            "Turn a repository's open pull requests into one reviewable status summary a maintainer can "
+            "read in a single pass."
+        ),
+        "procedure_steps": [
+            "Collect the open pull requests for one repository.",
+            "Group them by review state and age.",
+            "Render one bounded summary line for each group.",
+        ],
+        "required_authority": ["network_access", "filesystem_read"],
+        "required_data": ["repository_source"],
+        "side_effects": ["sends_network_requests", "spawns_processes"],
+        "risk_resolutions": [
+            {
+                "category": "network_request",
+                "resolution": "rejected",
+                "prohibited_behavior": "reach_a_remote_endpoint",
+            },
+            {
+                "category": "process_execution",
+                "resolution": "native_constraint",
+                "native_constraint": "no_subprocess_execution",
+            },
+        ],
+        "confidence_level": "medium",
+        "confidence_basis": ["cited_static_scan"],
+        "evidence_limits": ["static_scan_only_no_execution_observed", "runtime_behavior_unknown"],
+        "safe_pattern": (
+            "Group locally supplied work items by review state and render one bounded summary line per "
+            "group."
+        ),
+        "native_constraints": ["no_subprocess_execution", "no_network_access"],
+        "prohibited_behaviors": ["reach_a_remote_endpoint"],
+    }
+    base.update(overrides)
+    return base
+
+
+def clean_review_kwargs(**overrides: Any) -> dict[str, Any]:
+    """A review over a scan that matched no risk category at all."""
+    base = review_kwargs(
+        audit=audit_payload(categories=()),
+        side_effects=["no_side_effects_identified"],
+        risk_resolutions=[],
+        native_constraints=["deterministic_offline_behavior"],
+        prohibited_behaviors=[],
+    )
+    base.update(overrides)
+    return base
+
+
+class SkillPatternRiskReviewUsefulnessAndRiskTests(unittest.TestCase):
+    """AC1: four separated blocks, none of them derived from another."""
+
+    def test_a_review_carries_all_four_blocks_as_separate_fields(self) -> None:
+        review = build_skill_pattern_risk_review(**review_kwargs())
+
+        self.assertEqual(review["schema_version"], SKILL_PATTERN_RISK_REVIEW_SCHEMA_VERSION)
+        self.assertEqual(sorted(review), sorted(SKILL_PATTERN_RISK_REVIEW_KEYS))
+        for block, keys in (
+            ("usefulness", USEFULNESS_KEYS),
+            ("risk", RISK_KEYS),
+            ("confidence", CONFIDENCE_KEYS),
+            ("native_reproduction", NATIVE_REPRODUCTION_KEYS),
+        ):
+            with self.subTest(block=block):
+                self.assertEqual(sorted(review[block]), sorted(keys))
+        self.assertEqual(validate_skill_pattern_risk_review(review), [])
+
+    def test_a_review_missing_any_one_block_fails_validation_naming_it(self) -> None:
+        review = build_skill_pattern_risk_review(**review_kwargs())
+
+        for block in ("usefulness", "risk", "confidence", "native_reproduction"):
+            with self.subTest(block=block):
+                incomplete = {key: value for key, value in review.items() if key != block}
+                errors = validate_skill_pattern_risk_review(incomplete)
+                self.assertTrue(any("is missing keys" in error and block in error for error in errors), errors)
+
+    def test_each_block_varies_without_the_others_so_none_is_derived(self) -> None:
+        """Four one-block edits, four different digests, four valid reviews."""
+        baseline = build_skill_pattern_risk_review(**review_kwargs())
+        variants = {
+            "usefulness": review_kwargs(required_data=["repository_source", "local_configuration"]),
+            "risk": review_kwargs(side_effects=["sends_network_requests"]),
+            "confidence": review_kwargs(confidence_level="low"),
+            "native_reproduction": review_kwargs(
+                native_constraints=["no_subprocess_execution", "no_network_access", "metadata_only_artifacts"]
+            ),
+        }
+        digests = {baseline["review_digest"]}
+        for block, kwargs in variants.items():
+            with self.subTest(block=block):
+                variant = build_skill_pattern_risk_review(**kwargs)
+                self.assertEqual(validate_skill_pattern_risk_review(variant), [])
+                unchanged = [name for name in variants if name != block]
+                for name in unchanged:
+                    self.assertEqual(variant[name], baseline[name])
+                self.assertNotEqual(variant[block], baseline[block])
+                digests.add(variant["review_digest"])
+        self.assertEqual(len(digests), len(variants) + 1)
+
+    def test_usefulness_names_the_outcome_the_procedure_and_what_it_needs(self) -> None:
+        review = build_skill_pattern_risk_review(**review_kwargs())
+        usefulness = review["usefulness"]
+
+        self.assertIn("status summary", usefulness["intended_outcome"])
+        self.assertEqual(len(usefulness["procedure_steps"]), 3)
+        self.assertEqual(usefulness["required_authority"], ["filesystem_read", "network_access"])
+        self.assertEqual(usefulness["required_data"], ["repository_source"])
+
+    def test_usefulness_refuses_an_empty_procedure_or_an_unnamed_authority(self) -> None:
+        with self.assertRaisesRegex(SkillPatternRiskReviewError, "procedure_steps must name at least 1"):
+            build_skill_pattern_risk_review(**review_kwargs(procedure_steps=[]))
+        with self.assertRaisesRegex(SkillPatternRiskReviewError, "required_authority has unsupported"):
+            build_skill_pattern_risk_review(**review_kwargs(required_authority=["root"]))
+        review = build_skill_pattern_risk_review(**review_kwargs())
+        review["usefulness"] = {**review["usefulness"], "required_authority": []}
+        self.assertIn(
+            "skill pattern risk review usefulness.required_authority must name at least 1",
+            validate_skill_pattern_risk_review(review),
+        )
+
+    def test_confidence_states_a_level_a_basis_and_what_the_evidence_cannot_show(self) -> None:
+        review = build_skill_pattern_risk_review(**review_kwargs())
+
+        self.assertEqual(review["confidence"]["level"], "medium")
+        self.assertEqual(review["confidence"]["basis"], ["cited_static_scan"])
+        self.assertIn("static_scan_only_no_execution_observed", review["confidence"]["evidence_limits"])
+        with self.assertRaisesRegex(SkillPatternRiskReviewError, "confidence.level is unsupported"):
+            build_skill_pattern_risk_review(**review_kwargs(confidence_level="certain"))
+        with self.assertRaisesRegex(SkillPatternRiskReviewError, "evidence_limits has unsupported"):
+            build_skill_pattern_risk_review(**review_kwargs(evidence_limits=["looks_fine"]))
+
+    def test_a_reviewer_may_not_assert_no_side_effects_against_a_dirty_scan(self) -> None:
+        with self.assertRaisesRegex(SkillPatternRiskReviewError, "side_effects claims none while"):
+            build_skill_pattern_risk_review(**review_kwargs(side_effects=["no_side_effects_identified"]))
+        with self.assertRaisesRegex(SkillPatternRiskReviewError, "alongside an identified effect"):
+            build_skill_pattern_risk_review(
+                **clean_review_kwargs(side_effects=["no_side_effects_identified", "writes_local_files"])
+            )
+        self.assertEqual(
+            build_skill_pattern_risk_review(**clean_review_kwargs())["risk"]["side_effects"],
+            ["no_side_effects_identified"],
+        )
+
+    def test_side_effects_are_the_reviewers_account_not_the_scanners_categories(self) -> None:
+        review = build_skill_pattern_risk_review(**review_kwargs())
+
+        self.assertEqual(review["audit_evidence"]["risk_categories"], ["network_request", "process_execution"])
+        self.assertEqual(review["risk"]["side_effects"], ["spawns_processes", "sends_network_requests"])
+        self.assertEqual(
+            set(review["risk"]["side_effects"]) & set(review["audit_evidence"]["risk_categories"]), set()
+        )
+
+
+class SkillPatternRiskReviewApprovalBoundaryTests(unittest.TestCase):
+    """AC2: a clean scan is evidence, and evidence never approves anything."""
+
+    def test_a_clean_scan_with_no_decision_reads_as_awaiting_and_never_as_approved(self) -> None:
+        review = build_skill_pattern_risk_review(**clean_review_kwargs())
+
+        self.assertEqual(review["audit_evidence"]["risk_categories"], [])
+        self.assertEqual(review["reviewer_decision"], {})
+        self.assertEqual(reviewer_decision_state(review), "absent")
+        self.assertEqual(review["review_status"], "awaiting_reviewer_decision")
+        self.assertFalse(review_reads_as_approved(review))
+        self.assertEqual(validate_skill_pattern_risk_review(review), [])
+
+    def test_no_status_in_the_vocabulary_is_reachable_from_a_clean_scan_alone(self) -> None:
+        """AC2 across the whole vocabulary, not just against the word 'approved'."""
+        review = build_skill_pattern_risk_review(**clean_review_kwargs())
+
+        for status in REVIEW_STATUSES:
+            with self.subTest(status=status):
+                asserted = {**review, "review_status": status}
+                errors = validate_skill_pattern_risk_review(asserted)
+                if status == "awaiting_reviewer_decision":
+                    self.assertEqual(errors, [])
+                    self.assertFalse(review_reads_as_approved(asserted))
+                    continue
+                self.assertTrue(
+                    any("the recorded decision derives" in error for error in errors), (status, errors)
+                )
+                self.assertFalse(review_reads_as_approved(asserted))
+
+    def test_the_builder_exposes_no_status_argument_at_all(self) -> None:
+        """The structural half of AC2: there is nothing to pass."""
+        parameters = set(inspect.signature(build_skill_pattern_risk_review).parameters)
+
+        self.assertNotIn("review_status", parameters)
+        self.assertNotIn("status", parameters)
+        self.assertIn("reviewer_decision", parameters)
+        self.assertEqual(
+            inspect.signature(build_skill_pattern_risk_review).parameters["reviewer_decision"].default, None
+        )
+
+    def test_only_a_recorded_reviewer_decision_reaches_the_approving_status(self) -> None:
+        review = build_skill_pattern_risk_review(**review_kwargs())
+        decided = record_reviewer_decision(
+            review, decided_by="maintainer-01", decision="approve_native_reproduction"
+        )
+
+        self.assertEqual(decided["review_status"], "approved_for_native_reproduction")
+        self.assertEqual(decided["reviewer_decision"]["decided_by"], "maintainer-01")
+        self.assertEqual(decided["reviewer_decision"]["reviewed_digest"], review["review_digest"])
+        self.assertEqual(reviewer_decision_state(decided), "current")
+        self.assertTrue(review_reads_as_approved(decided))
+        self.assertEqual(validate_skill_pattern_risk_review(decided), [])
+
+    def test_a_recorded_rejection_reaches_the_rejecting_status_and_never_approves(self) -> None:
+        review = build_skill_pattern_risk_review(**review_kwargs())
+        decided = record_reviewer_decision(
+            review, decided_by="maintainer-01", decision="reject_native_reproduction"
+        )
+
+        self.assertEqual(decided["review_status"], "rejected_for_native_reproduction")
+        self.assertFalse(review_reads_as_approved(decided))
+
+    def test_a_decision_that_names_nobody_is_refused(self) -> None:
+        review = build_skill_pattern_risk_review(**review_kwargs())
+
+        with self.assertRaisesRegex(SkillPatternRiskReviewError, "decided_by is required"):
+            record_reviewer_decision(review, decided_by="", decision="approve_native_reproduction")
+        with self.assertRaisesRegex(SkillPatternRiskReviewError, "decision is unsupported"):
+            record_reviewer_decision(review, decided_by="maintainer-01", decision="looks_good")
+
+    def test_an_approval_does_not_survive_a_change_to_the_content_it_reviewed(self) -> None:
+        review = build_skill_pattern_risk_review(**review_kwargs())
+        decided = record_reviewer_decision(
+            review, decided_by="maintainer-01", decision="approve_native_reproduction"
+        )
+
+        widened = build_skill_pattern_risk_review(
+            **review_kwargs(
+                native_constraints=["no_subprocess_execution", "no_network_access", "metadata_only_artifacts"],
+                reviewer_decision=decided["reviewer_decision"],
+            )
+        )
+
+        self.assertEqual(reviewer_decision_state(widened), "stale")
+        self.assertEqual(widened["review_status"], "superseded_by_content_change")
+        self.assertFalse(review_reads_as_approved(widened))
+        self.assertEqual(validate_skill_pattern_risk_review(widened), [])
+
+    def test_the_status_vocabulary_refuses_the_words_that_would_approve_the_source(self) -> None:
+        review = build_skill_pattern_risk_review(**clean_review_kwargs())
+
+        for word in REFUSED_REVIEW_STATUSES:
+            with self.subTest(word=word):
+                self.assertNotIn(word, REVIEW_STATUSES)
+                errors = validate_skill_pattern_risk_review({**review, "review_status": word})
+                self.assertTrue(
+                    any("may not describe the source as" in error for error in errors), (word, errors)
+                )
+                self.assertFalse(review_reads_as_approved({**review, "review_status": word}))
+
+    def test_every_status_sentence_says_the_source_is_not_installed_or_trusted(self) -> None:
+        self.assertEqual(sorted(REVIEW_STATUS_CLAIMS), sorted(REVIEW_STATUSES))
+        for status in REVIEW_STATUSES:
+            with self.subTest(status=status):
+                claim = review_status_claim(status)
+                self.assertIn("not installed, enabled, or trusted", claim)
+        self.assertIn("A clean scan is not an approval", review_status_claim("awaiting_reviewer_decision"))
+        self.assertIn("native", review_status_claim("approved_for_native_reproduction"))
+        with self.assertRaisesRegex(SkillPatternRiskReviewError, "review_status is unsupported"):
+            review_status_claim("approved")
+
+    def test_exactly_one_status_approves_and_it_approves_a_native_pattern(self) -> None:
+        approving = [status for status in REVIEW_STATUSES if status.startswith("approved")]
+
+        self.assertEqual(approving, ["approved_for_native_reproduction"])
+        self.assertEqual(sorted(REVIEWER_DECISIONS), ["approve_native_reproduction", "reject_native_reproduction"])
+
+    def test_derived_status_is_the_only_definition_of_a_reviews_status(self) -> None:
+        review = build_skill_pattern_risk_review(**review_kwargs())
+        forged = {
+            **review,
+            "reviewer_decision": {},
+            "review_status": "approved_for_native_reproduction",
+        }
+
+        self.assertEqual(derive_review_status(forged), "awaiting_reviewer_decision")
+        self.assertFalse(review_reads_as_approved(forged))
+        self.assertTrue(
+            any("the recorded decision derives" in error for error in validate_skill_pattern_risk_review(forged))
+        )
+
+
+class SkillPatternRiskReviewRiskResolutionTests(unittest.TestCase):
+    """AC3: audited risk becomes a named constraint or an explicit rejection."""
+
+    def test_every_audited_category_resolves_to_a_constraint_or_a_rejection(self) -> None:
+        review = build_skill_pattern_risk_review(
+            **review_kwargs(
+                audit=audit_payload(categories=AUDITED_RISK_CATEGORIES),
+                side_effects=["sends_network_requests", "spawns_processes", "installs_dependencies"],
+                risk_resolutions=[
+                    {
+                        "category": "declared_dependency",
+                        "resolution": "native_constraint",
+                        "native_constraint": "no_runtime_dependencies",
+                    },
+                    {
+                        "category": "dynamic_code_execution",
+                        "resolution": "rejected",
+                        "prohibited_behavior": "execute_evaluated_source",
+                    },
+                    {
+                        "category": "hermes_hook_capability",
+                        "resolution": "native_constraint",
+                        "native_constraint": "explicit_user_invocation_only",
+                    },
+                    {
+                        "category": "network_request",
+                        "resolution": "rejected",
+                        "prohibited_behavior": "reach_a_remote_endpoint",
+                    },
+                    {
+                        "category": "potential_committed_secret",
+                        "resolution": "native_constraint",
+                        "native_constraint": "no_credential_material_retained",
+                    },
+                    {
+                        "category": "process_execution",
+                        "resolution": "rejected",
+                        "prohibited_behavior": "spawn_a_host_process",
+                    },
+                ],
+                native_constraints=[
+                    "no_runtime_dependencies",
+                    "explicit_user_invocation_only",
+                    "no_credential_material_retained",
+                ],
+                prohibited_behaviors=[
+                    "execute_evaluated_source",
+                    "reach_a_remote_endpoint",
+                    "spawn_a_host_process",
+                ],
+            )
+        )
+
+        self.assertEqual(audited_risk_categories(review), AUDITED_RISK_CATEGORIES)
+        self.assertEqual(unresolved_risk_categories(review), ())
+        self.assertEqual(
+            [row["category"] for row in review["risk"]["resolutions"]], list(AUDITED_RISK_CATEGORIES)
+        )
+        for row in review["risk"]["resolutions"]:
+            with self.subTest(category=row["category"]):
+                self.assertEqual(sorted(row), sorted(RESOLUTION_KEYS))
+                self.assertIn(row["resolution"], RISK_RESOLUTIONS)
+                self.assertEqual(bool(row["native_constraint"]), row["resolution"] == "native_constraint")
+                self.assertEqual(bool(row["prohibited_behavior"]), row["resolution"] == "rejected")
+
+    def test_an_unresolved_audited_category_fails_validation_naming_the_category(self) -> None:
+        with self.assertRaisesRegex(SkillPatternRiskReviewError, r"unresolved: \['process_execution'\]"):
+            build_skill_pattern_risk_review(
+                **review_kwargs(
+                    risk_resolutions=[
+                        {
+                            "category": "network_request",
+                            "resolution": "rejected",
+                            "prohibited_behavior": "reach_a_remote_endpoint",
+                        }
+                    ],
+                    native_constraints=["no_network_access"],
+                )
+            )
+
+        review = build_skill_pattern_risk_review(**review_kwargs())
+        stripped = {**review, "risk": {**review["risk"], "resolutions": []}}
+        errors = validate_skill_pattern_risk_review(stripped)
+
+        self.assertEqual(unresolved_risk_categories(stripped), ("network_request", "process_execution"))
+        self.assertTrue(
+            any("network_request" in error and "process_execution" in error for error in errors), errors
+        )
+
+    def test_a_resolution_may_not_name_a_constraint_the_native_design_never_adopted(self) -> None:
+        with self.assertRaisesRegex(SkillPatternRiskReviewError, "native_reproduction.native_constraints does not carry"):
+            build_skill_pattern_risk_review(
+                **review_kwargs(native_constraints=["no_network_access", "metadata_only_artifacts"])
+            )
+        with self.assertRaisesRegex(
+            SkillPatternRiskReviewError, "native_reproduction.prohibited_behaviors does not carry"
+        ):
+            build_skill_pattern_risk_review(**review_kwargs(prohibited_behaviors=[]))
+
+    def test_a_review_may_not_resolve_a_category_the_cited_audit_never_reported(self) -> None:
+        with self.assertRaisesRegex(
+            SkillPatternRiskReviewError, r"never reported: \['dynamic_code_execution'\]"
+        ):
+            build_skill_pattern_risk_review(
+                **review_kwargs(
+                    risk_resolutions=[
+                        *review_kwargs()["risk_resolutions"],
+                        {
+                            "category": "dynamic_code_execution",
+                            "resolution": "rejected",
+                            "prohibited_behavior": "execute_evaluated_source",
+                        },
+                    ],
+                    prohibited_behaviors=["reach_a_remote_endpoint", "execute_evaluated_source"],
+                )
+            )
+
+    def test_a_resolution_carries_one_answer_and_not_both(self) -> None:
+        review = build_skill_pattern_risk_review(**review_kwargs())
+        both = {
+            **review,
+            "risk": {
+                **review["risk"],
+                "resolutions": [
+                    {
+                        "category": "network_request",
+                        "resolution": "rejected",
+                        "native_constraint": "no_network_access",
+                        "prohibited_behavior": "reach_a_remote_endpoint",
+                    },
+                    review["risk"]["resolutions"][1],
+                ],
+            },
+        }
+        errors = validate_skill_pattern_risk_review(both)
+
+        self.assertTrue(any("must leave native_constraint empty" in error for error in errors), errors)
+
+    def test_the_same_category_may_not_be_resolved_twice(self) -> None:
+        review = build_skill_pattern_risk_review(**review_kwargs())
+        doubled = {
+            **review,
+            "risk": {
+                **review["risk"],
+                "resolutions": [*review["risk"]["resolutions"], review["risk"]["resolutions"][0]],
+            },
+        }
+        errors = validate_skill_pattern_risk_review(doubled)
+
+        self.assertTrue(
+            any("resolves the same risk category more than once" in error for error in errors), errors
+        )
+
+    def test_an_unsupported_resolution_kind_is_refused_by_name(self) -> None:
+        with self.assertRaisesRegex(SkillPatternRiskReviewError, "resolution is unsupported: 'noted'"):
+            build_skill_pattern_risk_review(
+                **review_kwargs(
+                    risk_resolutions=[
+                        {"category": "network_request", "resolution": "noted"},
+                        review_kwargs()["risk_resolutions"][1],
+                    ]
+                )
+            )
+
+    def test_a_clean_scan_resolves_nothing_and_is_still_a_valid_review(self) -> None:
+        review = build_skill_pattern_risk_review(**clean_review_kwargs())
+
+        self.assertEqual(review["risk"]["resolutions"], [])
+        self.assertEqual(audited_risk_categories(review), ())
+        self.assertEqual(unresolved_risk_categories(review), ())
+        self.assertEqual(validate_skill_pattern_risk_review(review), [])
+
+
+class SkillPatternRiskReviewCitationTests(unittest.TestCase):
+    """The review cites the scanner rather than becoming a second one."""
+
+    def test_a_review_citing_no_audit_is_refused(self) -> None:
+        for absent in (None, {}, [], "plugin_risk_audit/v1", {"schema_version": "something_else/v1"}):
+            with self.subTest(absent=absent):
+                with self.assertRaisesRegex(SkillPatternRiskReviewError, "scanner evidence"):
+                    build_skill_pattern_risk_review(**review_kwargs(audit=absent))
+
+    def test_a_cited_audit_missing_its_summary_is_refused(self) -> None:
+        broken = {"schema_version": PLUGIN_RISK_AUDIT_SCHEMA_VERSION, "source": {"manifest_status": "present"}}
+
+        with self.assertRaisesRegex(SkillPatternRiskReviewError, "missing its summary or its source"):
+            build_skill_pattern_risk_review(**review_kwargs(audit=broken))
+
+    def test_a_review_whose_audit_evidence_is_removed_fails_validation(self) -> None:
+        review = build_skill_pattern_risk_review(**review_kwargs())
+        errors = validate_skill_pattern_risk_review({**review, "audit_evidence": {}})
+
+        self.assertTrue(any("audit_evidence is missing keys" in error for error in errors), errors)
+        self.assertTrue(any("schema_version must be plugin_risk_audit/v1" in error for error in errors), errors)
+
+    def test_the_risk_category_vocabulary_is_the_scanners_own(self) -> None:
+        """Derived, not restated: the review cannot drift from the audit."""
+        self.assertEqual(
+            AUDITED_RISK_CATEGORIES,
+            (
+                "declared_dependency",
+                "dynamic_code_execution",
+                "hermes_hook_capability",
+                "network_request",
+                "potential_committed_secret",
+                "process_execution",
+            ),
+        )
+        self.assertEqual(sorted(AUDIT_EVIDENCE_KEYS), sorted(cite_plugin_risk_audit(audit_payload())))
+
+    def test_the_cited_evidence_binds_the_review_to_one_scan(self) -> None:
+        cited = cite_plugin_risk_audit(audit_payload())
+        other = cite_plugin_risk_audit(audit_payload(categories=("network_request",)))
+
+        self.assertEqual(len(cited["audit_digest"]), 64)
+        self.assertNotEqual(cited["audit_digest"], other["audit_digest"])
+        self.assertEqual(cited["scanned_file_count"], 3)
+        self.assertEqual(cited["manifest_status"], "present")
+
+    @requires_secure_dir_io
+    def test_a_review_cites_a_real_scan_without_reading_the_skill_itself(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            marker = "PRIVATE_REVIEWED_SKILL_MARKER"
+            # atomic_write_text, not Path.write_text: these bytes are counted by
+            # the audit and the count lands inside review_digest.
+            atomic_write_text(root / "plugin.json", '{"name": "reviewed-example"}\n')
+            atomic_write_text(
+                root / "plugin.py",
+                "import requests\n"
+                "def run() -> None:\n"
+                "    requests.get('https://example.invalid')\n"
+                f"    marker = '{marker}'\n",
+            )
+
+            audit = audit_plugin_risk(root)
+            review = build_skill_pattern_risk_review(
+                **review_kwargs(
+                    audit=audit,
+                    side_effects=["sends_network_requests"],
+                    risk_resolutions=[
+                        {
+                            "category": "network_request",
+                            "resolution": "rejected",
+                            "prohibited_behavior": "reach_a_remote_endpoint",
+                        }
+                    ],
+                    native_constraints=["no_network_access"],
+                )
+            )
+
+        rendered = json.dumps(review)
+
+        self.assertEqual(review["audit_evidence"]["risk_categories"], ["network_request"])
+        self.assertEqual(review["audit_evidence"]["scanned_file_count"], 2)
+        self.assertEqual(review["review_status"], "awaiting_reviewer_decision")
+        self.assertNotIn(marker, rendered)
+        self.assertNotIn(str(root), rendered)
+        self.assertNotIn(root.name, rendered)
+
+
+class SkillPatternRiskReviewBoundaryTests(unittest.TestCase):
+    """OMH read about a skill. It did not import, install, or run one."""
+
+    def test_the_review_records_every_surface_it_did_not_touch(self) -> None:
+        review = build_skill_pattern_risk_review(**review_kwargs())
+
+        self.assertEqual(
+            review["not_observed"], {surface: {"status": "not_observed"} for surface in NOT_OBSERVED_SURFACES}
+        )
+        for surface in ("skill_import", "skill_installation", "skill_registration", "skill_execution"):
+            with self.subTest(surface=surface):
+                self.assertIn(surface, NOT_OBSERVED_SURFACES)
+        errors = validate_skill_pattern_risk_review({**review, "not_observed": {}})
+        self.assertTrue(any("must mark every one of" in error for error in errors), errors)
+
+    def test_the_claim_boundary_states_that_omh_never_runs_the_reviewed_skill(self) -> None:
+        review = build_skill_pattern_risk_review(**review_kwargs())
+        boundary = review["claim_boundary"]
+
+        self.assertEqual(boundary, SKILL_PATTERN_RISK_REVIEW_CLAIM_BOUNDARY)
+        self.assertIn("never imports, installs, registers, enables, or executes", boundary)
+        self.assertIn("A clean scan is scanner evidence and never an approval", boundary)
+        self.assertIn("merge evidence", boundary)
+        errors = validate_skill_pattern_risk_review({**review, "claim_boundary": "Looks fine."})
+        self.assertTrue(any("claim_boundary must state" in error for error in errors), errors)
+
+    def test_a_payload_shaped_to_claim_execution_is_refused_by_key_name(self) -> None:
+        review = build_skill_pattern_risk_review(**review_kwargs())
+
+        for key in ("executed", "installed", "ran", "exit_code", "trusted", "verified"):
+            with self.subTest(key=key):
+                self.assertIn(key, EXECUTION_CLAIM_KEYS)
+                errors = validate_skill_pattern_risk_review({**review, key: True})
+                self.assertTrue(
+                    any("must not carry execution-claim keys" in error for error in errors), (key, errors)
+                )
+
+    def test_the_review_refuses_raw_or_hidden_content_and_unsupported_keys(self) -> None:
+        review = build_skill_pattern_risk_review(**review_kwargs())
+
+        raw_errors = validate_skill_pattern_risk_review({**review, "transcript": "..."})
+        self.assertTrue(any("raw or hidden keys" in error for error in raw_errors), raw_errors)
+        unsupported = validate_skill_pattern_risk_review({**review, "vibes": "good"})
+        self.assertTrue(any("has unsupported keys: ['vibes']" in error for error in unsupported), unsupported)
+
+    def test_free_text_fields_stay_bounded_metadata_lines(self) -> None:
+        with self.assertRaisesRegex(SkillPatternRiskReviewError, "at most 400 characters"):
+            build_skill_pattern_risk_review(**review_kwargs(intended_outcome="a" * 401))
+        with self.assertRaisesRegex(SkillPatternRiskReviewError, "without secrets, links, or paths"):
+            build_skill_pattern_risk_review(
+                **review_kwargs(safe_pattern="See https://example.invalid for the pattern.")
+            )
+
+    def test_the_skill_ref_is_an_opaque_identifier_and_never_a_location(self) -> None:
+        with self.assertRaisesRegex(SkillPatternRiskReviewError, "must be an opaque identifier, not a URL"):
+            build_skill_pattern_risk_review(**review_kwargs(skill_ref="https://example.invalid/skill"))
+        with self.assertRaisesRegex(SkillPatternRiskReviewError, "skill_ref is required"):
+            build_skill_pattern_risk_review(**review_kwargs(skill_ref=""))
+
+
+class SkillPatternRiskReviewDeterminismTests(unittest.TestCase):
+    """Same inputs, same review. No clock anywhere near the digest."""
+
+    def test_two_reviews_of_the_same_material_are_identical(self) -> None:
+        first = build_skill_pattern_risk_review(**review_kwargs())
+        second = build_skill_pattern_risk_review(**review_kwargs())
+
+        self.assertEqual(first, second)
+        self.assertEqual(first["review_digest"], skill_pattern_risk_review_digest(second))
+
+    def test_prepared_at_is_a_parameter_and_stays_outside_the_digest(self) -> None:
+        early = build_skill_pattern_risk_review(**review_kwargs(prepared_at="2026-01-01T00:00:00Z"))
+        late = build_skill_pattern_risk_review(**review_kwargs(prepared_at="2026-08-09T12:00:00Z"))
+
+        self.assertNotIn("prepared_at", MATERIAL_REVIEW_KEYS)
+        self.assertNotEqual(early["prepared_at"], late["prepared_at"])
+        self.assertEqual(early["review_digest"], late["review_digest"])
+        self.assertEqual(build_skill_pattern_risk_review(**review_kwargs())["prepared_at"], "")
+
+    def test_vocabulary_order_does_not_change_the_digest(self) -> None:
+        forward = build_skill_pattern_risk_review(**review_kwargs())
+        reversed_input = build_skill_pattern_risk_review(
+            **review_kwargs(
+                required_authority=["filesystem_read", "network_access"],
+                native_constraints=["no_network_access", "no_subprocess_execution"],
+                evidence_limits=["runtime_behavior_unknown", "static_scan_only_no_execution_observed"],
+            )
+        )
+
+        self.assertEqual(forward, reversed_input)
+
+    def test_the_digest_seals_the_material_content_and_notices_an_edit(self) -> None:
+        review = build_skill_pattern_risk_review(**review_kwargs())
+        edited = {**review, "confidence": {**review["confidence"], "level": "high"}}
+        errors = validate_skill_pattern_risk_review(edited)
+
+        self.assertTrue(any("does not match the content it seals" in error for error in errors), errors)
+
+    def test_the_material_key_set_covers_the_review_minus_its_own_state(self) -> None:
+        self.assertEqual(
+            sorted(MATERIAL_REVIEW_KEYS),
+            sorted(
+                {
+                    "schema_version",
+                    "skill_ref",
+                    "audit_evidence",
+                    "usefulness",
+                    "risk",
+                    "confidence",
+                    "native_reproduction",
+                    "not_observed",
+                }
+            ),
+        )
+        self.assertEqual(set(MATERIAL_REVIEW_KEYS) - set(SKILL_PATTERN_RISK_REVIEW_KEYS), set())
+
+    def test_the_constraint_and_prohibition_vocabularies_cover_every_audited_category(self) -> None:
+        """AC3 is only satisfiable if every category has an answer available."""
+        self.assertTrue(set(NATIVE_CONSTRAINTS))
+        self.assertTrue(set(PROHIBITED_BEHAVIORS))
+        self.assertEqual(set(NATIVE_CONSTRAINTS) & set(PROHIBITED_BEHAVIORS), set())
+        for category in AUDITED_RISK_CATEGORIES:
+            with self.subTest(category=category):
+                review = build_skill_pattern_risk_review(
+                    **review_kwargs(
+                        audit=audit_payload(categories=(category,)),
+                        side_effects=["side_effects_unclear"],
+                        risk_resolutions=[
+                            {
+                                "category": category,
+                                "resolution": "native_constraint",
+                                "native_constraint": "deterministic_offline_behavior",
+                            }
+                        ],
+                        native_constraints=["deterministic_offline_behavior"],
+                        prohibited_behaviors=[],
+                    )
+                )
+                self.assertEqual(unresolved_risk_categories(review), ())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- Adds `skill_pattern_risk_review/v1`: one deterministic artifact that explains what a third-party skill is
  useful for, what it costs, how far the evidence goes, and what an OMH-native version may and may not copy.
- The review **cites** a `plugin_risk_audit/v1` payload rather than scanning anything itself. There is no
  second reader, no second risk-category vocabulary, and no filesystem access in the new module at all.
- Four separated blocks per review, each a required key and none computed from another: `usefulness`,
  `risk`, `confidence`, `native_reproduction`.
- The scanner/reviewer split is enforced by construction: `review_status` is derived, the builder has no
  status parameter, and exactly one status approves anything — reachable only from a recorded reviewer
  decision, and it approves *building a native pattern*, never the source.
- Every risk category the cited audit reports must resolve to a named native constraint or an explicit
  rejection, and the name must also appear in the review's own `native_reproduction` lists.

### Why This Exists

Closes #793.

`plugin_risk_audit/v1` answers half the question a user actually asks. It statically reads one explicitly
named local directory and reports which of six risk categories it matched — `dynamic_code_execution`,
`network_request`, `process_execution`, `potential_committed_secret`, `hermes_hook_capability`,
`declared_dependency`. That is evidence, not advice. It does not say what the skill is *for*, what authority
the procedure needs, how much the scan's word is worth, which part of the pattern OMH may safely reimplement,
or which part the native version must refuse to copy.

So a user who asks "what is useful and risky about this skill?" got a list of regex hits, and the two failure
modes that follow are both bad: either the useful procedure is discarded along with the risk, or it is copied
along with its permissions and trust assumptions. #793's third acceptance criterion — risky behavior becomes
an explicit native constraint or rejection — is the part that turns a description into something actionable.

### User / Operator Impact

Nothing in the shipped CLI or chat surface changes yet, and the PR does not claim otherwise. What exists after
this change that did not before is a **representable, validated contract**: a review of a third-party skill
can now be written down in a form where

- usefulness, risk, confidence, and native-reproduction guidance cannot be collapsed into one another;
- "the scan came back clean" is structurally incapable of reading as "the source is approved"; and
- an audited risk that nobody answered is a validation error naming the category, instead of a paragraph a
  reader has to notice is missing.

This follows the same delivery shape as the two sibling artifacts already on `main`,
`native_capability_blueprint/v1` (#791, PR #886) and `native_capability_change_preview/v1` (#794, PR #888):
the contract and its tests land first, and the surfaces that mint one join later.

### How It Works

**Citing, not re-scanning.** `cite_plugin_risk_audit(audit)` refuses anything that is not a
`plugin_risk_audit/v1` payload before a single reviewer field is read, so there is no path that produces a
review without evidence. It copies only the aggregate — manifest status, risk categories, file and byte
counts — plus a `policy_decision_digest` of the whole cited audit, which binds the review to one specific
scan. The audit deliberately exposes no plugin source and no root path; copying only its summary keeps that
true of the review.

**The category vocabulary is derived, not restated.**
`AUDITED_RISK_CATEGORIES = tuple(get_args(RiskCategory))` reads `plugin_risk_audit`'s own `RiskCategory`
literal. Widening the scanner widens the set of categories a review has to resolve, and the two cannot drift
into disagreeing about what a category is.

**AC1 — four blocks.** `USEFULNESS_KEYS`, `RISK_KEYS`, `CONFIDENCE_KEYS`, `NATIVE_REPRODUCTION_KEYS` are four
closed key sets under four required top-level keys. The top-level key set is checked in both directions, so a
review missing a block fails with `is missing keys: ['confidence']` rather than silently validating.
Independence is tested rather than asserted: four one-block edits produce four valid reviews, four distinct
digests, and three unchanged blocks each time.

**AC2 — a clean scan is not an approval.** This is the boundary the rest rests on, so it is structural at four
layers:

1. `audit_evidence` and `reviewer_decision` are different keys. A review nobody has decided carries `{}`.
2. `build_skill_pattern_risk_review` **has no `status` parameter** — there is no argument through which a
   clean scan can assert approval. `derive_review_status` is the only definition, and its `absent` branch
   returns `awaiting_reviewer_decision` with no path to an approving value whatever the scan found.
3. `validate_skill_pattern_risk_review` re-derives the status and refuses a payload that disagrees, so a
   hand-written dict cannot lie either.
4. `REFUSED_REVIEW_STATUSES` holds the bare words — `approved`, `active`, `trusted`, `clean`, `safe`,
   `verified` — by name, so the refusal reads as a rule instead of as an unrecognised value. Approval in this
   schema is always `approved_for_native_reproduction`: OMH approves what it will build, never the skill it
   read about. Every sentence in `REVIEW_STATUS_CLAIMS` ends by saying the source is not installed, enabled,
   or trusted.

A decision is stamped with `reviewed_digest` = the digest of the content the reviewer saw. Material content
that moves afterwards lands the review on `superseded_by_content_change`, not on a carried-forward approval.

**AC3 — risk becomes a constraint or a rejection.** Every audited category appears exactly once in
`risk.resolutions`, resolving to either a member of `NATIVE_CONSTRAINTS` or a member of
`PROHIBITED_BEHAVIORS`. The named value must *also* appear in the review's own `native_reproduction` lists —
a risk cannot resolve to a constraint the native design never adopted. An unresolved category is an error
naming the category; a resolution for a category the audit never reported is refused too, so a reviewer
cannot manufacture findings the evidence does not carry.

Those two vocabularies are closed rather than free text for two reasons. A sentence somebody wrote is not
something a later gate can join on; and the security nouns this domain needs ("secret", "credential",
"token") are exactly what `is_unsafe_metadata_line` refuses in a stored metadata line, so putting the
load-bearing fields in vocabularies keeps them clear of a check that would otherwise force euphemisms. The
three remaining free-text fields — `intended_outcome`, `procedure_steps`, `safe_pattern` — describe what the
skill achieves and what OMH may build, and need none of those nouns.

**Boundary and determinism.** Nothing imports, installs, registers, enables, or executes the reviewed skill.
`not_observed` says so per surface (`skill_import`, `skill_installation`, `skill_registration`,
`skill_execution`, `dependency_installation`, `network_access`), the `claim_boundary` says so in a sentence,
and `EXECUTION_CLAIM_KEYS` refuses a payload shaped to say otherwise by key name before the closed key set
refuses it as unsupported. No clock is read: `prepared_at` is a caller parameter and is excluded from
`review_digest`. The hash is `quality.skill_governance.policy_decision_digest`, reused rather than reinvented,
exactly as `native_capability_change_preview` reuses it.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/workflows/skill_pattern_risk_review.py` | New. 1244 lines (a ~130-line design docstring and ~280 lines of documented closed vocabularies, then the builder, validator, digest, derived status, and accessors). |
| `tests/test_skill_pattern_risk_review.py` | New. 795 lines, 45 tests in six classes grouped by acceptance criterion. |

No other file is touched. In particular `src/workflows/plugin_risk_audit.py` and
`src/workflows/plugin_audit_source_io.py` are read-only dependencies — the risk categories are imported from
the first, and the second is not imported at all, because this module never touches a filesystem. No catalog
entry, no generated doc, no capability family, no exact-count fixture moved, which is why every byte gate
below passes unchanged.

Public surface: `SKILL_PATTERN_RISK_REVIEW_SCHEMA_VERSION`, `build_skill_pattern_risk_review`,
`validate_skill_pattern_risk_review`, `cite_plugin_risk_audit`, `record_reviewer_decision`,
`derive_review_status`, `review_reads_as_approved`, `review_status_claim`, `reviewer_decision_state`,
`audited_risk_categories`, `resolved_risk_categories`, `unresolved_risk_categories`,
`skill_pattern_risk_review_digest`, `material_review_content`, plus the closed vocabularies and key sets.

## Validation

All commands run on `agent/issue-793` at `a22debe5`, rebased on `origin/main` at `1215d065` (the merge of
#888). Every box below was ticked only after the command was run and its output read.

- [x] `uv run --group lint ruff check src tests` — `All checks passed!` (one pre-existing warning about an
      invalid `# noqa` directive on `src/commands/main.py:1`, untouched by this PR)
- [x] `python3 -m unittest discover -s tests` — run as `PYTHONPATH=tests uv run python -m unittest discover -s tests`
      per `CLAUDE.md`: **Ran 5240 tests in 173.752s — OK**. 5195 before this branch, +45 new.
- [x] `python3 -m compileall src` — run as `uv run python -m compileall -q src tests`, silent, exit 0
- [x] `python3 -m omh.cli docs workflows --check` —
      `{"checked":".../docs/WORKFLOWS.md","ok":true,"tap_skills":{"checked":115,"expected":115,"extra":[],"missing":[],"ok":true,"stale":[]}}`
- [x] `python3 -m omh.cli harness validate` —
      `{"counts":{"harnesses":72,"skills":104},"errors":[],"ok":true,"schema_version":"catalog_validation/v1","warnings":[]}`
- [x] `python3 -m omh.cli release checklist --json` — emitted the checklist JSON, exit 0
- [x] `python3 -m omh.cli release hermes-smoke` — `Status: ok`, `Mode: plan; observed evidence: no`
- [x] `omh --help` — exit 0, usage printed
- [x] `omh --omh-home <tmp> --hermes-home <tmp> release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
      — `Status: ok`; installed-command check `Mode: live; observed: yes`, `PATH: ok`; the Hermes profile
      portion stayed `Mode: plan; observed: no`, which is `prepared_not_observed` and not Hermes evidence.
      Temp homes were used, so no profile was touched.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: **not run — no learning
      contract changed.** `learning_candidate.py` was read for its card shape and left untouched.
- [x] Relevant dry-run or smoke command: two additional gates beyond the template —
      `uv run python -m omh.cli docs roles --check` → `{"checked":".../docs/ROLES.md","ok":true}` and
      `uv run python -m omh.cli docs capability-families --check` →
      `{"checked":".../src/plugin_bundle/omh/tools/capability_families.json","ok":true}`.
      Also `git diff --check` → clean.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: **not run, and it would prove nothing.** No
      Hermes-visible surface changed: no skill, no router trigger, no chat card, no wrapper action, no CLI
      command. There is no chat sentence that reaches this module today.

**Mutation evidence.** A green suite on first run is weak evidence that tests bite, so four targeted mutations
were applied to the committed module and reverted:

| Mutation | Result |
| --- | --- |
| `derive_review_status` returns the approving status when no decision exists | **5 failures** |
| the unresolved-audited-category error is dropped | **1 failure** (the AC3 test) |
| the closed key set stops reporting missing keys | **4 failures** |
| the "constraint must be adopted by `native_reproduction`" join is dropped | **1 failure** |

The tree was clean and the work committed before the first mutation, and `git status` was clean after the
last revert.

## Risk

- **Low blast radius.** Two new files, nothing else touched, no import of this module anywhere in `src/`. If
  the contract is wrong, nothing in the product is wrong yet — which is also the honest reading of its current
  value.
- **The vocabularies are the design decision worth arguing about.** `NATIVE_CONSTRAINTS` (10 members) and
  `PROHIBITED_BEHAVIORS` (8) are closed, and a reviewer who needs a constraint outside them is stuck until the
  tuple is widened in a reviewed diff. That is deliberate — the same trade `native_capability_blueprint` makes
  with `OMH_RUNTIME_REQUIREMENTS` — but it is a real constraint on authors, not a free win. A test asserts
  every audited category is answerable under the current vocabularies.
- **One consistency rule could be argued as overreach**: a reviewer may not claim
  `no_side_effects_identified` while the cited audit reports categories. The reviewer may still disagree with
  the scan — by naming `side_effects_unclear` or any identified effect — just not by asserting the scan found
  nothing.
- **Windows.** `scanned_byte_count` is inside `review_digest`, so a fixture written with `Path.write_text`
  would hash differently on the Windows job (CRLF). The one on-disk test writes with
  `omh.local_store.atomic_write_text`, and every digest comparison in the file is between two payloads built
  in the same run. Not observed on a Windows runner locally; CI will be the first Windows execution.

## Compatibility / Rollout

- Purely additive. No schema, catalog, generated artifact, count fixture, or public CLI surface changed, so
  there is nothing to migrate and nothing to roll back beyond deleting two files.
- Release channel: `local` / no impact. No installable skill, no packaging change — `omh.workflows` already
  maps to `src/workflows` in `pyproject.toml`, so no `[tool.setuptools]` edit was needed.
- Built in parallel with #796 (`reusable_behavior_map/v1`) on the same scan substrate. This module is
  self-contained, builds no behavior inventory, and edits no shared file, so the two should not conflict.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`) — `local`; no installable surface
      changed
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — the module's own
      docstring states that no production surface mints a review and that its test file is the only caller;
      the `hermes-smoke` run above is explicitly `prepared_not_observed`
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap — `--live`
      was not run; the plan-mode output says so itself, and no Hermes-visible surface changed to make it
      meaningful

## Follow-Up

- No surface mints a review. The natural readers are the native-capability artifacts (#791, #794): a review
  says which parts of a borrowed pattern a blueprint or change preview is allowed to describe. Wiring one to
  the other is a separate goal with its own routing, card, and coverage work — see `docs/ADDING-A-SKILL.md`
  for the full surface list that would come with it.
- `AUDITED_RISK_CATEGORIES` derives from `plugin_risk_audit.RiskCategory`. Widening the scanner is now also a
  widening of what a review must resolve; that is the intended coupling, but a scanner change should expect
  this test file to move with it.
- `review_status` must stay derived. The moment a caller can pass a status, AC2 stops being a property of the
  constructor and becomes a rule someone has to remember.
