### PR TITLE
feat: enforce a definition of done for every native capability

### DIFF
--- a/src/workflows/native_capability_blueprint.py
+++ b/src/workflows/native_capability_blueprint.py
@@ -90,10 +90,13 @@ What reads these today
 
 Stated because the vocabulary here is wider than the wiring. No production
 surface mints a blueprint yet; this module is the contract and
-`tests/test_native_capability_blueprint.py` is its only caller. Issue #795's
-quality gate is the intended reader, and `blueprint_expected_surfaces` is the
-accessor it joins on: it refuses an invalid blueprint rather than returning a
-partial surface list a gate would silently pass.
+`tests/test_native_capability_blueprint.py` is its only minting caller.
+
+`native_capability_quality_gate` (#795) reads it: the surface vocabulary and the
+anchors are the expected set it gates a capability against, and
+`blueprint_expected_surfaces` is the accessor it joins on, which refuses an
+invalid blueprint rather than returning a partial surface list a gate would
+silently pass.
 """
 
 from __future__ import annotations
@@ -380,6 +383,17 @@ class NativeCapabilityBlueprintError(ValueError):
 # ---------------------------------------------------------------------------
 
 
+def is_canonical_capability_id(value: Any) -> bool:
+    """Whether one value is the canonical skill-name slug a capability is keyed by.
+
+    Exposed because a capability is keyed by the same identifier wherever it is
+    described -- a blueprint here, a quality gate in #795 -- and two modules
+    deciding separately what that identifier looks like is how they end up
+    disagreeing about which capability a payload is about.
+    """
+    return isinstance(value, str) and bool(_CAPABILITY_ID.match(value))
+
+
 def blueprint_surface_anchor(surface: str) -> str:
     """The file and structure one surface name refers to, or an empty string."""
     return NATIVE_CAPABILITY_SURFACE_ANCHORS.get(str(surface), "")
@@ -530,7 +544,7 @@ def validate_native_capability_blueprint(blueprint: Mapping[str, Any]) -> list[s
 def _identity_errors(blueprint: Mapping[str, Any]) -> list[str]:
     errors: list[str] = []
     capability_id = blueprint.get("capability_id")
-    if not isinstance(capability_id, str) or not _CAPABILITY_ID.match(capability_id):
+    if not is_canonical_capability_id(capability_id):
         errors.append(
             f"{_LABEL} capability_id must be the canonical skill name as a lowercase slug: {capability_id!r}"
         )

--- a/src/workflows/native_capability_quality_gate.py
+++ b/src/workflows/native_capability_quality_gate.py
@@ -1,0 +1,747 @@
+"""Definition of done for one native capability: `native_capability_quality_gate/v1` (issue #795).
+
+What was missing
+----------------
+
+A capability looks present as soon as a route fires or a skill name resolves.
+The chat copy, the memory rules, the handoff behavior, the evidence ladder, the
+tests, and the documentation are each enforced by their own gate, and every one
+of those gates answers a question about the repository rather than a question
+about one capability. Nobody could ask "is this capability genuinely complete?"
+and get an answer, because the answer was scattered across a dozen suites that
+each pass happily while a capability is half-built.
+
+What this is
+------------
+
+One capability, checked against the surfaces #791 says an installable capability
+moves, with three verdicts a maintainer can act on:
+
+    pass     every expected surface is answered, and generated guidance reproduces
+    revise   a surface this capability needs is absent
+    blocked  the repository's own checks do not reproduce, so completeness is unknowable
+
+`blocked` is not a worse `revise`. It says the question could not be answered:
+while the catalog does not validate or a generated file is stale, "this
+capability is missing an awareness lane" is a statement nobody should act on,
+because the surfaces are being read out of a tree that no longer agrees with
+itself. Telling an author to add a lane in that state is worse than telling them
+nothing.
+
+The surface vocabulary is #791's, imported
+------------------------------------------
+
+This module names no surface of its own. `REQUIRED_NATIVE_CAPABILITY_SURFACES`,
+the wider vocabulary, and the per-surface anchors all come from
+`native_capability_blueprint`, and `tests/test_native_capability_quality_gate.py`
+fails if a surface name is ever written as a literal here. Two lists of native
+surfaces that drift apart would be worse than one list nobody enforces.
+
+When a blueprint is supplied, `blueprint_expected_surfaces` -- the accessor #791
+built for this reader -- widens the expected set with whatever conditional
+surfaces the design promised. A capability whose blueprint promised a memory
+policy has to answer for one; a capability whose blueprint did not, does not.
+An invalid blueprint raises out of that accessor and is deliberately not
+re-wrapped: the fault is in the blueprint, and the sentence that names it is
+#791's, not this module's.
+
+Absent, or exempt with a reason. Never silent
+---------------------------------------------
+
+AC1's two halves are one rule. Every expected surface carries a row, and a
+surface with no row at all is refused by name and by the file it lives in --
+silence is not an available answer. A row is `present`, `missing`, or `exempt`,
+and an exemption carries the reason it is one. An exemption with no reason is a
+validation error, because "this surface does not apply here" is an argument
+somebody has to actually make; without it, `exempt` is just `missing` spelled in
+a way that passes.
+
+The reason is bounded to one metadata line for the same reason every other
+free-text field in this repository is: it is a place a transcript would
+otherwise get parked.
+
+A required surface can be exempted, and that is deliberate even though #791
+calls the required set the one no installable capability can avoid. The required
+set is what a capability must *answer for*; the exemption is the answer that
+says why this one does not need it, written down where a reviewer reads it.
+Refusing the exemption outright would not make the surface appear -- it would
+make an author write `present` and move on, which is the failure with the
+evidence removed.
+
+Reproducibility is reported, never recomputed
+----------------------------------------------
+
+AC2 asks whether generated guidance still reproduces. This repository already
+answers that twice -- `catalog_validation/v1` for the catalog the guidance is
+rendered from, and the generated-artifact half of `omh_drift_report/v1` for the
+committed files, which is the same byte comparison `omh docs workflows --check`,
+`omh docs roles --check`, and `omh docs capability-families --check` make.
+`generated_guidance_reproducibility` projects those two and adds nothing. It
+regenerates nothing either; the regenerate commands stay where they already are.
+
+Count and budget metrics are deliberately left out of that projection: they are
+exact-count fixtures, not generated guidance, and a capability's completeness
+should not hinge on a number in a test file that a different change moved.
+
+The verdict is derived on the way in and on the way out
+-------------------------------------------------------
+
+`build_native_capability_quality_gate` has no verdict parameter, so a caller
+cannot state one. That alone would only move the problem to whoever hands a
+payload around, so `validate_native_capability_quality_gate` re-derives the
+verdict from the findings the payload carries and refuses one that disagrees.
+The same rule runs one level down on the reproducibility block: its
+`reproducible` flag is re-derived from its own parts, and a reasonless exemption
+counts as unanswered inside the derivation itself rather than only in the key
+checks. Between them there is no arrangement of a payload where `pass` sits on
+top of an incomplete gate.
+
+Deliberately no digest. A digest seals content against edits made after a
+reviewer agreed to it, and this schema carries no review to bind one to. The
+property it would buy -- a payload that cannot be quietly rearranged -- is
+already bought by re-deriving the verdict, and a second hashing rule in this
+repository is a second thing to keep in agreement with the first.
+
+Structure is not evidence
+-------------------------
+
+A `pass` says the structure is complete. It does not say the capability was
+exercised, that a test ran, that anyone reviewed it, that CI is green, or that
+anything shipped. `NATIVE_CAPABILITY_QUALITY_GATE_CLAIM_BOUNDARY` says so on
+every payload, every verdict's one permitted sentence repeats the denial,
+`REFUSED_QUALITY_GATE_VERDICTS` refuses the words that would blur it by name,
+and #791's `IMPLEMENTATION_CLAIM_KEYS` refuses a payload reshaped to say
+otherwise.
+
+What this does not check
+------------------------
+
+That an answer is true. A row saying a surface is `present` is the author's
+statement, and this gate makes it impossible to leave one out, not impossible to
+get one wrong. The coverage gates in `tests/test_capabilities.py`,
+`tests/test_wrapper_contract.py`, and the routing suites are what fail on a
+false `present`, and duplicating them here would be a second set of rules to
+keep in agreement with the first.
+
+Determinism
+-----------
+
+No clock is read. `prepared_at` is a parameter and defaults to empty; it is the
+caller's stamp for when the reproducibility block -- which is a point-in-time
+read of a working tree -- was taken.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from ..maintenance.drift import drift_report
+from ..skills.validation import validate_catalog_contract
+from ..system.append_only_store import RAW_OR_HIDDEN_KEYS, is_unsafe_metadata_line
+from .native_capability_blueprint import (
+    IMPLEMENTATION_CLAIM_KEYS,
+    NATIVE_CAPABILITY_SURFACES,
+    REQUIRED_NATIVE_CAPABILITY_SURFACES,
+    blueprint_expected_surfaces,
+    blueprint_surface_anchor,
+    is_canonical_capability_id,
+    missing_required_surfaces,
+    unknown_surfaces,
+)
+
+
+NATIVE_CAPABILITY_QUALITY_GATE_SCHEMA_VERSION: Final[str] = "native_capability_quality_gate/v1"
+
+QUALITY_GATE_PRIVACY: Final[str] = "metadata_only"
+
+# Three, and they are not a severity scale. `revise` is about the capability;
+# `blocked` is about whether the question can be answered at all.
+QUALITY_GATE_VERDICTS: Final[tuple[str, ...]] = ("pass", "revise", "blocked")
+
+# Words a verdict will not be. Held by name so the refusal reads as a rule
+# rather than as an unrecognised value, and so AC3 is testable as data.
+REFUSED_QUALITY_GATE_VERDICTS: Final[tuple[str, ...]] = (
+    "approved",
+    "certified",
+    "ci_green",
+    "complete",
+    "delivered",
+    "deployed",
+    "done",
+    "green",
+    "merged",
+    "observed",
+    "passing",
+    "released",
+    "reviewed",
+    "shipped",
+    "tested",
+    "validated",
+    "verified",
+    "working",
+)
+
+# Repeated verbatim in every verdict's sentence. One string so no rendering of
+# any verdict can exist that forgets it.
+VERDICT_CLAIM_DENIAL: Final[str] = "Nothing here was run, reviewed, checked by CI, merged, or released."
+
+# The one sentence each verdict may be described with.
+QUALITY_GATE_VERDICT_CLAIMS: Final[dict[str, str]] = {
+    "pass": (
+        "Every expected native surface is answered and the repository's generated guidance reproduces. "
+        f"{VERDICT_CLAIM_DENIAL}"
+    ),
+    "revise": (
+        "A native surface this capability needs is absent or unanswered, so the capability is not complete. "
+        f"{VERDICT_CLAIM_DENIAL}"
+    ),
+    "blocked": (
+        "The repository's own catalog and generated-output checks do not reproduce, so this capability's "
+        f"completeness cannot be judged from this tree yet. {VERDICT_CLAIM_DENIAL}"
+    ),
+}
+
+# What one surface row may say. `exempt` is the recorded not-applicable, and it
+# is the only state that carries a reason.
+SURFACE_STATES: Final[tuple[str, ...]] = ("present", "missing", "exempt")
+
+SURFACE_FINDING_KEYS: Final[tuple[str, ...]] = ("surface", "state", "reason")
+
+GENERATED_GUIDANCE_KEYS: Final[tuple[str, ...]] = (
+    "catalog_validation_errors",
+    "catalog_validation_ok",
+    "checked",
+    "reproducible",
+    "stale_artifacts",
+)
+
+NATIVE_CAPABILITY_QUALITY_GATE_KEYS: Final[tuple[str, ...]] = (
+    "capability_id",
+    "claim_boundary",
+    "expected_surfaces",
+    "generated_guidance",
+    "prepared_at",
+    "privacy",
+    "schema_version",
+    "surfaces",
+    "unmet_surfaces",
+    "verdict",
+    "verdict_claim",
+)
+
+NATIVE_CAPABILITY_QUALITY_GATE_CLAIM_BOUNDARY: Final[str] = (
+    "A native capability quality gate is an OMH-local structural check of one capability against the "
+    "required native surfaces of native_capability_blueprint/v1 and this repository's own catalog and "
+    "generated-output checks. A pass means the structure is complete and nothing more: it is never "
+    "execution, runtime, test, code-review, CI, merge-readiness, merge, or release evidence, and it never "
+    "certifies, ranks, or admits an external package."
+)
+
+_LABEL: Final[str] = "native_capability_quality_gate"
+
+# An exemption is an argument. Long enough that `n/a`, `none`, `-`, and `skip`
+# are not one.
+_MIN_REASON_CHARS: Final[int] = 12
+_MAX_REASON_CHARS: Final[int] = 240
+
+
+class NativeCapabilityQualityGateError(ValueError):
+    """Raised when a set of findings cannot become a quality gate."""
+
+
+# ---------------------------------------------------------------------------
+# Expected surfaces
+# ---------------------------------------------------------------------------
+
+
+def expected_gate_surfaces(
+    *,
+    blueprint: Mapping[str, Any] | None = None,
+    answered: Iterable[str] = (),
+) -> tuple[str, ...]:
+    """The surfaces one capability has to answer for, in #791's declared order.
+
+    Always every required surface. Plus every surface a supplied blueprint
+    promised, so a design that named a conditional surface cannot then skip it.
+    Plus every surface the caller answered anyway, because answering more than
+    was asked is not an error and dropping the extra answer silently would be.
+
+    A supplied blueprint is read through `blueprint_expected_surfaces`, which
+    refuses an invalid blueprint rather than handing back a partial list.
+    """
+    named = set(REQUIRED_NATIVE_CAPABILITY_SURFACES)
+    if blueprint is not None:
+        named |= set(blueprint_expected_surfaces(blueprint))
+    answered_names = [str(surface) for surface in answered]
+    unknown = unknown_surfaces(answered_names)
+    if unknown:
+        raise NativeCapabilityQualityGateError(
+            f"{_LABEL} names surfaces that do not exist in this repository: {list(unknown)}; "
+            f"the vocabulary is {list(NATIVE_CAPABILITY_SURFACES)}"
+        )
+    named |= set(answered_names)
+    return tuple(surface for surface in NATIVE_CAPABILITY_SURFACES if surface in named)
+
+
+def unmet_surface_anchors(gate: Mapping[str, Any]) -> tuple[str, ...]:
+    """Every unanswered surface with the file and structure #791 says it lives in.
+
+    Derived on demand rather than stored: the anchor text belongs to
+    `native_capability_blueprint/v1`, and a copy of it inside a report is a copy
+    that can disagree with the original.
+    """
+    return tuple(
+        f"{surface} ({blueprint_surface_anchor(surface)})"
+        for surface in quality_gate_unmet_surfaces(gate)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reproducibility of generated guidance
+# ---------------------------------------------------------------------------
+
+
+def generated_guidance_reproducibility(*, repo_root: Path | None = None) -> dict[str, Any]:
+    """Whether generated guidance reproduces, as this repository already checks it.
+
+    Two existing checks, projected and nothing else: `catalog_validation/v1`
+    for the catalog every generated file is rendered from, and the
+    generated-artifact half of `omh_drift_report/v1` for the committed files,
+    which is the byte comparison the `--check` gates already make.
+
+    Nothing is regenerated here. When something is stale, the fix is the
+    regenerate command the drift report already names.
+    """
+    validation = validate_catalog_contract()
+    report = drift_report(repo_root=repo_root, counts=(), budgets=())
+    stale = sorted(
+        {
+            str(item.get("name", ""))
+            for item in report.get("drift", [])
+            if isinstance(item, Mapping) and str(item.get("name", ""))
+        }
+    )
+    block: dict[str, Any] = {
+        "catalog_validation_errors": [str(error) for error in _string_list(validation.get("errors"))],
+        "catalog_validation_ok": validation.get("ok") is True,
+        "checked": ["catalog_validation", *(str(name) for name in _string_list(report.get("checked")))],
+        "reproducible": False,
+        "stale_artifacts": stale,
+    }
+    block["reproducible"] = generated_guidance_reproduces(block)
+    return block
+
+
+def generated_guidance_reproduces(block: Mapping[str, Any]) -> bool:
+    """Re-derived from the block's own parts, never read off its stored flag.
+
+    An empty `checked` list is not reproducible: nothing having been checked is
+    not the same answer as everything having reproduced.
+    """
+    return (
+        block.get("catalog_validation_ok") is True
+        and not _string_list(block.get("catalog_validation_errors"))
+        and not _string_list(block.get("stale_artifacts"))
+        and bool(_string_list(block.get("checked")))
+    )
+
+
+# ---------------------------------------------------------------------------
+# Verdict
+# ---------------------------------------------------------------------------
+
+
+def quality_gate_unmet_surfaces(gate: Mapping[str, Any]) -> tuple[str, ...]:
+    """Every expected surface this capability has not answered for.
+
+    A surface is answered when it is `present`, or `exempt` with a reason. A
+    required surface with no row at all is unanswered by the same rule that
+    makes a `missing` row unanswered -- an omission cannot be quieter than a
+    stated absence.
+    """
+    answered: dict[str, Mapping[str, Any]] = {}
+    for row in _mapping_rows(gate.get("surfaces")):
+        surface = str(row.get("surface", ""))
+        if surface and surface not in answered:
+            answered[surface] = row
+    expected = {
+        str(surface) for surface in _string_list(gate.get("expected_surfaces"))
+    } | set(REQUIRED_NATIVE_CAPABILITY_SURFACES)
+    return tuple(
+        surface
+        for surface in NATIVE_CAPABILITY_SURFACES
+        if surface in expected and not _surface_is_answered(answered.get(surface))
+    )
+
+
+def derive_quality_gate_verdict(gate: Mapping[str, Any]) -> str:
+    """The verdict the findings produce. `blocked` outranks `revise` outranks `pass`.
+
+    The only place a verdict is ever decided. The builder calls it because it
+    accepts no verdict, and the validator calls it because a payload that
+    arrived from somewhere else must not be taken at its word.
+    """
+    guidance = gate.get("generated_guidance")
+    if not isinstance(guidance, Mapping) or not generated_guidance_reproduces(guidance):
+        return "blocked"
+    if quality_gate_unmet_surfaces(gate):
+        return "revise"
+    return "pass"
+
+
+def quality_gate_verdict_claim(verdict: str) -> str:
+    """The one sentence a verdict may be described with."""
+    text = str(verdict or "")
+    if text not in QUALITY_GATE_VERDICT_CLAIMS:
+        raise NativeCapabilityQualityGateError(f"{_LABEL} verdict is unsupported: {verdict!r}")
+    return QUALITY_GATE_VERDICT_CLAIMS[text]
+
+
+# ---------------------------------------------------------------------------
+# Build and validate
+# ---------------------------------------------------------------------------
+
+
+def build_native_capability_quality_gate(
+    *,
+    capability_id: str,
+    surfaces: Sequence[Mapping[str, Any]],
+    blueprint: Mapping[str, Any] | None = None,
+    repo_root: Path | None = None,
+    prepared_at: str = "",
+) -> dict[str, Any]:
+    """Gate one capability, or refuse.
+
+    There is no verdict parameter and there will not be one. The verdict is a
+    conclusion about the findings, and a caller who could state it could state
+    `pass` over an incomplete gate, which is the entire failure this artifact
+    exists to prevent.
+
+    `repo_root` selects the tree whose generated guidance is read; the default
+    is this installation's own repository.
+    """
+    rows = _finding_rows(surfaces)
+    expected = expected_gate_surfaces(
+        blueprint=blueprint, answered=[str(row["surface"]) for row in rows]
+    )
+    gate: dict[str, Any] = {
+        "schema_version": NATIVE_CAPABILITY_QUALITY_GATE_SCHEMA_VERSION,
+        "capability_id": str(capability_id).strip().casefold(),
+        "expected_surfaces": list(expected),
+        "surfaces": rows,
+        "generated_guidance": generated_guidance_reproducibility(repo_root=repo_root),
+        "unmet_surfaces": [],
+        "verdict": "",
+        "verdict_claim": "",
+        "prepared_at": str(prepared_at).strip(),
+        "privacy": QUALITY_GATE_PRIVACY,
+        "claim_boundary": NATIVE_CAPABILITY_QUALITY_GATE_CLAIM_BOUNDARY,
+    }
+    gate["unmet_surfaces"] = list(quality_gate_unmet_surfaces(gate))
+    gate["verdict"] = derive_quality_gate_verdict(gate)
+    gate["verdict_claim"] = quality_gate_verdict_claim(gate["verdict"])
+    errors = validate_native_capability_quality_gate(gate)
+    if errors:
+        raise NativeCapabilityQualityGateError("; ".join(errors))
+    return gate
+
+
+def validate_native_capability_quality_gate(gate: Any) -> list[str]:
+    """Every reason one payload is not a native capability quality gate."""
+    if not isinstance(gate, Mapping):
+        return [f"{_LABEL} must be an object"]
+    errors: list[str] = []
+    claims_implementation = sorted(key for key in gate if str(key).lower() in IMPLEMENTATION_CLAIM_KEYS)
+    if claims_implementation:
+        errors.append(
+            f"{_LABEL} must not carry implementation-claim keys: {claims_implementation}; a structural "
+            "gate reports what exists in this tree and never reports that something ran"
+        )
+    forbidden = sorted(key for key in gate if str(key).lower() in RAW_OR_HIDDEN_KEYS)
+    if forbidden:
+        errors.append(f"{_LABEL} must not carry raw or hidden keys: {forbidden}")
+    unexpected = sorted(
+        set(gate) - set(NATIVE_CAPABILITY_QUALITY_GATE_KEYS) - set(claims_implementation) - set(forbidden)
+    )
+    if unexpected:
+        errors.append(f"{_LABEL} has unsupported keys: {unexpected}")
+    missing = sorted(set(NATIVE_CAPABILITY_QUALITY_GATE_KEYS) - set(gate))
+    if missing:
+        errors.append(f"{_LABEL} is missing keys: {missing}")
+    if gate.get("schema_version") != NATIVE_CAPABILITY_QUALITY_GATE_SCHEMA_VERSION:
+        errors.append(f"{_LABEL} schema_version must be {NATIVE_CAPABILITY_QUALITY_GATE_SCHEMA_VERSION}")
+    if gate.get("privacy") != QUALITY_GATE_PRIVACY:
+        errors.append(f"{_LABEL} privacy must be {QUALITY_GATE_PRIVACY}")
+    if gate.get("claim_boundary") != NATIVE_CAPABILITY_QUALITY_GATE_CLAIM_BOUNDARY:
+        errors.append(
+            f"{_LABEL} claim_boundary must state the structural boundary: a complete structure is not "
+            "execution, review, CI, merge, or release evidence"
+        )
+    if not isinstance(gate.get("prepared_at"), str):
+        errors.append(f"{_LABEL} prepared_at must be a string")
+    if not is_canonical_capability_id(gate.get("capability_id")):
+        errors.append(
+            f"{_LABEL} capability_id must be the canonical skill name as a lowercase slug: "
+            f"{gate.get('capability_id')!r}"
+        )
+    errors.extend(_expected_surface_errors(gate))
+    errors.extend(_finding_errors(gate))
+    errors.extend(_generated_guidance_errors(gate.get("generated_guidance")))
+    errors.extend(_verdict_errors(gate))
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Validation parts
+# ---------------------------------------------------------------------------
+
+
+def _expected_surface_errors(gate: Mapping[str, Any]) -> list[str]:
+    """AC1's first half: the expected set is #791's, and it is complete."""
+    expected = gate.get("expected_surfaces")
+    if not isinstance(expected, list) or not all(isinstance(item, str) for item in expected):
+        return [f"{_LABEL} expected_surfaces must be a list of strings"]
+    errors: list[str] = []
+    if len(set(expected)) != len(expected):
+        errors.append(f"{_LABEL} expected_surfaces must not repeat a surface")
+    unknown = unknown_surfaces(expected)
+    if unknown:
+        errors.append(
+            f"{_LABEL} expected_surfaces names surfaces that do not exist in this repository: "
+            f"{list(unknown)}; the vocabulary is {list(NATIVE_CAPABILITY_SURFACES)}"
+        )
+    absent = missing_required_surfaces(expected)
+    if absent:
+        described = [f"{surface} ({blueprint_surface_anchor(surface)})" for surface in absent]
+        errors.append(
+            f"{_LABEL} expected_surfaces is missing required surfaces: {described}; every installable "
+            "capability moves all of them, so a gate that does not expect one cannot report on it"
+        )
+    canonical = [surface for surface in NATIVE_CAPABILITY_SURFACES if surface in set(expected)]
+    if not unknown and expected != canonical:
+        errors.append(f"{_LABEL} expected_surfaces must be listed in the declared surface order")
+    return errors
+
+
+def _finding_errors(gate: Mapping[str, Any]) -> list[str]:
+    """AC1's second half: absent, or exempt with a reason, and never silent."""
+    rows = gate.get("surfaces")
+    if not isinstance(rows, list) or not all(isinstance(row, Mapping) for row in rows):
+        return [f"{_LABEL} surfaces must be a list of objects"]
+    errors: list[str] = []
+    seen: list[str] = []
+    for row in rows:
+        unknown_keys = sorted({str(key) for key in row} - set(SURFACE_FINDING_KEYS))
+        if unknown_keys:
+            errors.append(f"{_LABEL} surface finding has unsupported keys: {unknown_keys}")
+        absent_keys = sorted(set(SURFACE_FINDING_KEYS) - {str(key) for key in row})
+        if absent_keys:
+            errors.append(f"{_LABEL} surface finding is missing keys: {absent_keys}")
+        surface = str(row.get("surface", ""))
+        if surface not in set(NATIVE_CAPABILITY_SURFACES):
+            errors.append(
+                f"{_LABEL} surface finding names a surface that does not exist in this repository: "
+                f"{row.get('surface')!r}; the vocabulary is {list(NATIVE_CAPABILITY_SURFACES)}"
+            )
+            continue
+        if surface in seen:
+            errors.append(f"{_LABEL} answers for surface {surface} more than once")
+        seen.append(surface)
+        errors.extend(_state_errors(surface, row))
+    ordered = [surface for surface in NATIVE_CAPABILITY_SURFACES if surface in set(seen)]
+    if sorted(seen) == sorted(set(seen)) and seen != ordered:
+        errors.append(f"{_LABEL} surfaces must be listed in the declared surface order")
+    expected = [str(item) for item in _string_list(gate.get("expected_surfaces"))]
+    unanswered = [surface for surface in expected if surface not in set(seen)]
+    if unanswered:
+        described = [f"{surface} ({blueprint_surface_anchor(surface)})" for surface in unanswered]
+        errors.append(
+            f"{_LABEL} does not answer for every expected surface: {described}; a surface is present, "
+            "absent, or exempt with a reason, and never unmentioned"
+        )
+    derived = list(quality_gate_unmet_surfaces(gate))
+    if gate.get("unmet_surfaces") != derived:
+        errors.append(
+            f"{_LABEL} unmet_surfaces must be derived from the findings: {derived}, "
+            f"not {gate.get('unmet_surfaces')!r}"
+        )
+    return errors
+
+
+def _state_errors(surface: str, row: Mapping[str, Any]) -> list[str]:
+    """One row's state and the reason rule that goes with it, both directions."""
+    state = row.get("state")
+    if state not in SURFACE_STATES:
+        return [
+            f"{_LABEL} surface {surface} has an unsupported state: {state!r}; "
+            f"one of {list(SURFACE_STATES)} is required"
+        ]
+    reason = row.get("reason")
+    if not isinstance(reason, str):
+        return [f"{_LABEL} surface {surface} reason must be a string"]
+    text = " ".join(reason.split())
+    if state != "exempt":
+        if text:
+            return [
+                f"{_LABEL} surface {surface} is marked {state} and must not carry a reason; a reason "
+                "records why an exemption is one"
+            ]
+        return []
+    if not text:
+        return [
+            f"{_LABEL} surface {surface} is exempt and must record why it does not apply to this "
+            "capability; an exemption without a reason is an omission"
+        ]
+    errors: list[str] = []
+    if len(text) < _MIN_REASON_CHARS:
+        errors.append(
+            f"{_LABEL} surface {surface} exemption reason must be at least {_MIN_REASON_CHARS} "
+            "characters; an exemption is an argument, not a shrug"
+        )
+    if len(text) > _MAX_REASON_CHARS:
+        errors.append(
+            f"{_LABEL} surface {surface} exemption reason must be at most {_MAX_REASON_CHARS} characters"
+        )
+    if is_unsafe_metadata_line(text):
+        errors.append(
+            f"{_LABEL} surface {surface} exemption reason must be one bounded metadata line without "
+            "secrets, links, or paths"
+        )
+    return errors
+
+
+def _generated_guidance_errors(block: Any) -> list[str]:
+    """AC2: reported from the repository's own checks, and never stapled on."""
+    if not isinstance(block, Mapping):
+        return [f"{_LABEL} generated_guidance must be an object"]
+    errors: list[str] = []
+    unknown_keys = sorted({str(key) for key in block} - set(GENERATED_GUIDANCE_KEYS))
+    if unknown_keys:
+        errors.append(f"{_LABEL} generated_guidance has unsupported keys: {unknown_keys}")
+    absent_keys = sorted(set(GENERATED_GUIDANCE_KEYS) - {str(key) for key in block})
+    if absent_keys:
+        errors.append(f"{_LABEL} generated_guidance is missing keys: {absent_keys}")
+    if not isinstance(block.get("catalog_validation_ok"), bool):
+        errors.append(f"{_LABEL} generated_guidance catalog_validation_ok must be a boolean")
+    for field in ("catalog_validation_errors", "checked", "stale_artifacts"):
+        value = block.get(field)
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            errors.append(f"{_LABEL} generated_guidance {field} must be a list of strings")
+    if errors:
+        return errors
+    if block.get("catalog_validation_ok") is True and block.get("catalog_validation_errors"):
+        errors.append(
+            f"{_LABEL} generated_guidance cannot report a passing catalog validation alongside "
+            f"{len(block['catalog_validation_errors'])} validation error(s)"
+        )
+    unchecked = sorted(set(block["stale_artifacts"]) - set(block["checked"]))
+    if unchecked:
+        errors.append(f"{_LABEL} generated_guidance reports stale artifacts it did not check: {unchecked}")
+    reproducible = block.get("reproducible")
+    if not isinstance(reproducible, bool):
+        errors.append(f"{_LABEL} generated_guidance reproducible must be a boolean")
+    elif reproducible != generated_guidance_reproduces(block):
+        errors.append(
+            f"{_LABEL} generated_guidance reproducible must be derived from the checks it reports, "
+            f"not {reproducible!r}"
+        )
+    return errors
+
+
+def _verdict_errors(gate: Mapping[str, Any]) -> list[str]:
+    """AC3, and the rule that makes the verdict a conclusion rather than a claim."""
+    errors: list[str] = []
+    verdict = gate.get("verdict")
+    if isinstance(verdict, str) and verdict.strip().casefold() in REFUSED_QUALITY_GATE_VERDICTS:
+        errors.append(
+            f"{_LABEL} verdict may not claim the capability was run, reviewed, or released: {verdict!r}; "
+            f"a gate reports structure, and one of {list(QUALITY_GATE_VERDICTS)} is required"
+        )
+    elif verdict not in QUALITY_GATE_VERDICTS:
+        errors.append(f"{_LABEL} verdict is unsupported: {verdict!r}")
+    derived = derive_quality_gate_verdict(gate)
+    if verdict != derived:
+        errors.append(
+            f"{_LABEL} verdict must be derived from the findings; these findings are {derived}, "
+            f"not {verdict!r}"
+        )
+    claim = gate.get("verdict_claim")
+    expected_claim = QUALITY_GATE_VERDICT_CLAIMS.get(derived, "")
+    if claim != expected_claim:
+        errors.append(
+            f"{_LABEL} verdict_claim must be the one sentence the {derived} verdict is described with"
+        )
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _finding_rows(surfaces: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Normalize authored rows into declared surface order, or refuse."""
+    if isinstance(surfaces, (str, bytes, bytearray)) or not isinstance(surfaces, Sequence):
+        raise NativeCapabilityQualityGateError(f"{_LABEL} surfaces must be a list of objects")
+    if not all(isinstance(row, Mapping) for row in surfaces):
+        raise NativeCapabilityQualityGateError(f"{_LABEL} surfaces must be a list of objects")
+    seen: dict[str, dict[str, Any]] = {}
+    for row in surfaces:
+        unknown_keys = sorted({str(key) for key in row} - set(SURFACE_FINDING_KEYS))
+        if unknown_keys:
+            raise NativeCapabilityQualityGateError(
+                f"{_LABEL} surface finding has unsupported keys: {unknown_keys}"
+            )
+        surface = str(row.get("surface", ""))
+        if surface not in set(NATIVE_CAPABILITY_SURFACES):
+            raise NativeCapabilityQualityGateError(
+                f"{_LABEL} surface finding names a surface that does not exist in this repository: "
+                f"{row.get('surface')!r}; the vocabulary is {list(NATIVE_CAPABILITY_SURFACES)}"
+            )
+        if surface in seen:
+            raise NativeCapabilityQualityGateError(f"{_LABEL} answers for surface {surface} more than once")
+        state = row.get("state")
+        if state not in SURFACE_STATES:
+            raise NativeCapabilityQualityGateError(
+                f"{_LABEL} surface {surface} has an unsupported state: {state!r}; "
+                f"one of {list(SURFACE_STATES)} is required"
+            )
+        built = {
+            "surface": surface,
+            "state": str(state),
+            "reason": " ".join(str(row.get("reason", "") or "").split()),
+        }
+        state_errors = _state_errors(surface, built)
+        if state_errors:
+            raise NativeCapabilityQualityGateError("; ".join(state_errors))
+        seen[surface] = built
+    return [seen[surface] for surface in NATIVE_CAPABILITY_SURFACES if surface in seen]
+
+
+def _surface_is_answered(row: Mapping[str, Any] | None) -> bool:
+    """Present, or exempt with a reason. Nothing else counts as answered.
+
+    The reason is read here rather than only in the key checks so that a
+    hand-written payload carrying a reasonless exemption cannot derive `pass`.
+    """
+    if not isinstance(row, Mapping):
+        return False
+    state = str(row.get("state", ""))
+    if state == "present":
+        return True
+    reason = row.get("reason")
+    return state == "exempt" and isinstance(reason, str) and bool(reason.strip())
+
+
+def _mapping_rows(value: Any) -> list[Mapping[str, Any]]:
+    if isinstance(value, (str, bytes, bytearray)) or not isinstance(value, Sequence):
+        return []
+    return [row for row in value if isinstance(row, Mapping)]
+
+
+def _string_list(value: Any) -> list[str]:
+    if isinstance(value, (str, bytes, bytearray)) or not isinstance(value, Sequence):
+        return []
+    return [item for item in value if isinstance(item, str) and item]

--- a/tests/test_native_capability_quality_gate.py
+++ b/tests/test_native_capability_quality_gate.py
@@ -1,0 +1,716 @@
+"""Contracts for `native_capability_quality_gate/v1` (issue #795).
+
+Grouped by acceptance criterion:
+
+- AC1: a missing native surface fails and names itself, or carries an explicit
+  exemption with a reason. An exemption without a reason is a validation error.
+- AC2: generated guidance is reported as reproducible for a clean tree and as
+  non-reproducible for a tampered one, through the repository's own checks.
+- AC3: structural success never reads as runtime, review, CI, or release
+  evidence, and a caller cannot staple `pass` onto an incomplete gate.
+
+Plus the binding this gate exists on top of: the expected surface set is #791's
+vocabulary, imported rather than restated.
+
+Two file-writing rules this file follows. Nothing under the repository is ever
+written: the AC2 tamper happens in a copy under a temporary directory, so the
+byte gates cannot be left failing for the next run. And the one write it does
+make goes through `atomic_write_text`, which pins "\\n" on Windows -- the bytes
+it writes are compared against rendered template bytes moments later, and
+`Path.write_text` would rewrite them as CRLF and make the comparison decide the
+platform rather than the tamper.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.local_store import atomic_write_text  # noqa: E402
+from omh.maintenance.drift import drift_report, generated_artifacts  # noqa: E402
+from omh.skills.validation import validate_catalog_contract  # noqa: E402
+from omh.workflows.native_capability_blueprint import (  # noqa: E402
+    IMPLEMENTATION_CLAIM_KEYS,
+    NATIVE_CAPABILITY_SURFACES,
+    OPTIONAL_NATIVE_CAPABILITY_SURFACES,
+    REQUIRED_NATIVE_CAPABILITY_SURFACES,
+    NativeCapabilityBlueprintError,
+    blueprint_surface_anchor,
+    build_native_capability_blueprint,
+)
+from omh.workflows.native_capability_quality_gate import (  # noqa: E402
+    GENERATED_GUIDANCE_KEYS,
+    NATIVE_CAPABILITY_QUALITY_GATE_CLAIM_BOUNDARY,
+    NATIVE_CAPABILITY_QUALITY_GATE_KEYS,
+    NATIVE_CAPABILITY_QUALITY_GATE_SCHEMA_VERSION,
+    QUALITY_GATE_PRIVACY,
+    QUALITY_GATE_VERDICT_CLAIMS,
+    QUALITY_GATE_VERDICTS,
+    REFUSED_QUALITY_GATE_VERDICTS,
+    SURFACE_FINDING_KEYS,
+    SURFACE_STATES,
+    VERDICT_CLAIM_DENIAL,
+    NativeCapabilityQualityGateError,
+    build_native_capability_quality_gate,
+    derive_quality_gate_verdict,
+    expected_gate_surfaces,
+    generated_guidance_reproducibility,
+    quality_gate_unmet_surfaces,
+    quality_gate_verdict_claim,
+    unmet_surface_anchors,
+    validate_native_capability_quality_gate,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "src" / "workflows" / "native_capability_quality_gate.py"
+
+CAPABILITY_ID = "native-capability-quality-gate"
+PREPARED_AT = "2026-08-09T00:00:00Z"
+REASON = "This capability mints no local artifact, so there is nothing to version."
+
+# The four families the copied tree needs for the drift probe to see the same
+# thing it sees in the checkout.
+COPIED_TREE_DIRECTORIES = ("skills",)
+
+
+def finding(surface: str, state: str = "present", reason: str = "") -> dict[str, Any]:
+    return {"surface": surface, "state": state, "reason": reason}
+
+
+def findings(*, states: dict[str, tuple[str, str]] | None = None, drop: str = "") -> list[dict[str, Any]]:
+    """One row per required surface, `present` unless overridden."""
+    overrides = states or {}
+    rows = []
+    for surface in REQUIRED_NATIVE_CAPABILITY_SURFACES:
+        if surface == drop:
+            continue
+        state, reason = overrides.get(surface, ("present", ""))
+        rows.append(finding(surface, state, reason))
+    return rows
+
+
+def gate(**overrides: Any) -> dict[str, Any]:
+    arguments: dict[str, Any] = {
+        "capability_id": CAPABILITY_ID,
+        "surfaces": findings(),
+        "repo_root": REPO_ROOT,
+        "prepared_at": PREPARED_AT,
+    }
+    arguments.update(overrides)
+    return build_native_capability_quality_gate(**arguments)
+
+
+def edited(payload: dict[str, Any], **overrides: Any) -> dict[str, Any]:
+    """A payload changed after minting, with nothing re-derived.
+
+    The shape a hand-written or forwarded payload arrives in, and the only way
+    to hand the validator a verdict that does not follow from its findings.
+    """
+    return {**payload, **overrides}
+
+
+def blueprint_naming(surfaces: tuple[str, ...]) -> dict[str, Any]:
+    return build_native_capability_blueprint(
+        capability_id=CAPABILITY_ID,
+        intent_summary="Report whether one native capability is genuinely complete across OMH.",
+        example_requests=(
+            "Is the memory sync capability actually finished?",
+            "Check whether that new workflow is complete everywhere.",
+        ),
+        clarification_policy="clarify_then_answer",
+        clarifying_questions=("Which capability should Hermes gate?",),
+        hermes_retained_work=("chat_intake", "clarification"),
+        expected_outputs=("native_capability_quality_gate/v1", "the unanswered surfaces"),
+        affected_surfaces=surfaces,
+        omh_runtime_requirements=("local_catalog_metadata", "local_deterministic_contract"),
+        evidence_steps=("surfaces_answered", "generated_guidance_checked", "verdict_derived"),
+        degradation_behavior="explain_gap_and_stop",
+        non_goals=("Certifying, ranking, or admitting an external package.",),
+        prepared_at=PREPARED_AT,
+    )
+
+
+def copied_tree(root: Path) -> Path:
+    """A byte-for-byte copy of every tree the generated-output checks read."""
+    for name in COPIED_TREE_DIRECTORIES:
+        shutil.copytree(REPO_ROOT / name, root / name)
+    for artifact in generated_artifacts():
+        source = REPO_ROOT / artifact.path
+        target = root / artifact.path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+    return root
+
+
+class SurfaceVocabularyBindingTests(unittest.TestCase):
+    """The expected set is #791's vocabulary, not a second copy of it."""
+
+    def test_the_vocabulary_is_imported_from_the_blueprint_module(self) -> None:
+        tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+        imported = {
+            alias.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom)
+            and node.module
+            and node.module.endswith("native_capability_blueprint")
+            for alias in node.names
+        }
+
+        self.assertLessEqual(
+            {
+                "NATIVE_CAPABILITY_SURFACES",
+                "REQUIRED_NATIVE_CAPABILITY_SURFACES",
+                "blueprint_expected_surfaces",
+                "blueprint_surface_anchor",
+            },
+            imported,
+        )
+
+    def test_the_module_writes_no_surface_name_of_its_own(self) -> None:
+        source = MODULE_PATH.read_text(encoding="utf-8")
+        for surface in NATIVE_CAPABILITY_SURFACES:
+            with self.subTest(surface=surface):
+                self.assertNotIn(f'"{surface}"', source)
+                self.assertNotIn(f"'{surface}'", source)
+
+    def test_the_default_expected_set_is_the_required_surfaces(self) -> None:
+        self.assertEqual(expected_gate_surfaces(), tuple(REQUIRED_NATIVE_CAPABILITY_SURFACES))
+
+    def test_a_blueprint_widens_the_expected_set_with_what_it_promised(self) -> None:
+        promised = blueprint_naming(NATIVE_CAPABILITY_SURFACES)
+
+        self.assertEqual(expected_gate_surfaces(blueprint=promised), NATIVE_CAPABILITY_SURFACES)
+
+        with self.assertRaises(NativeCapabilityQualityGateError) as raised:
+            gate(blueprint=promised)
+        message = str(raised.exception)
+        for surface in OPTIONAL_NATIVE_CAPABILITY_SURFACES:
+            self.assertIn(surface, message)
+            self.assertIn(blueprint_surface_anchor(surface), message)
+
+    def test_a_blueprint_that_promised_nothing_extra_leaves_the_expected_set_alone(self) -> None:
+        promised = blueprint_naming(REQUIRED_NATIVE_CAPABILITY_SURFACES)
+        payload = gate(blueprint=promised)
+
+        self.assertEqual(payload["expected_surfaces"], list(REQUIRED_NATIVE_CAPABILITY_SURFACES))
+        self.assertEqual(payload["verdict"], "pass")
+
+    def test_an_invalid_blueprint_is_refused_by_the_791_accessor(self) -> None:
+        broken = {**blueprint_naming(REQUIRED_NATIVE_CAPABILITY_SURFACES), "intent_summary": ""}
+
+        with self.assertRaises(NativeCapabilityBlueprintError):
+            expected_gate_surfaces(blueprint=broken)
+
+    def test_answering_a_conditional_surface_without_a_blueprint_is_allowed(self) -> None:
+        extra = OPTIONAL_NATIVE_CAPABILITY_SURFACES[0]
+        payload = gate(surfaces=[*findings(), finding(extra)])
+
+        self.assertIn(extra, payload["expected_surfaces"])
+        self.assertEqual(payload["verdict"], "pass")
+
+
+class MissingSurfaceTests(unittest.TestCase):
+    """AC1: absent surfaces fail and name themselves, or carry an exemption."""
+
+    def test_a_capability_answering_every_required_surface_passes(self) -> None:
+        payload = gate()
+
+        self.assertEqual(validate_native_capability_quality_gate(payload), [])
+        self.assertEqual(payload["verdict"], "pass")
+        self.assertEqual(payload["unmet_surfaces"], [])
+
+    def test_a_missing_surface_fails_and_names_the_surface(self) -> None:
+        for surface in REQUIRED_NATIVE_CAPABILITY_SURFACES:
+            with self.subTest(surface=surface):
+                payload = gate(surfaces=findings(states={surface: ("missing", "")}))
+
+                self.assertEqual(payload["verdict"], "revise")
+                self.assertEqual(payload["unmet_surfaces"], [surface])
+                self.assertIn(
+                    f"{surface} ({blueprint_surface_anchor(surface)})", unmet_surface_anchors(payload)
+                )
+                self.assertEqual(validate_native_capability_quality_gate(payload), [])
+
+    def test_omitting_a_required_surface_entirely_is_refused_by_name(self) -> None:
+        for surface in REQUIRED_NATIVE_CAPABILITY_SURFACES:
+            with self.subTest(surface=surface):
+                with self.assertRaises(NativeCapabilityQualityGateError) as raised:
+                    gate(surfaces=findings(drop=surface))
+                message = str(raised.exception)
+                self.assertIn("does not answer for every expected surface", message)
+                self.assertIn(surface, message)
+                self.assertIn(blueprint_surface_anchor(surface), message)
+
+    def test_the_same_surface_with_a_recorded_exemption_passes(self) -> None:
+        for surface in REQUIRED_NATIVE_CAPABILITY_SURFACES:
+            with self.subTest(surface=surface):
+                payload = gate(surfaces=findings(states={surface: ("exempt", REASON)}))
+
+                self.assertEqual(payload["verdict"], "pass")
+                self.assertEqual(payload["unmet_surfaces"], [])
+                self.assertEqual(validate_native_capability_quality_gate(payload), [])
+
+    def test_an_exemption_without_a_reason_is_refused(self) -> None:
+        surface = REQUIRED_NATIVE_CAPABILITY_SURFACES[0]
+
+        with self.assertRaises(NativeCapabilityQualityGateError) as raised:
+            gate(surfaces=findings(states={surface: ("exempt", "")}))
+        message = str(raised.exception)
+        self.assertIn("must record why it does not apply", message)
+        self.assertIn("an exemption without a reason is an omission", message)
+
+        forwarded = edited(gate(), surfaces=findings(states={surface: ("exempt", "")}))
+        errors = validate_native_capability_quality_gate(forwarded)
+        self.assertTrue(any("must record why it does not apply" in error for error in errors), errors)
+
+    def test_a_shrug_is_not_a_reason(self) -> None:
+        surface = REQUIRED_NATIVE_CAPABILITY_SURFACES[0]
+        for shrug in ("n/a", "none", "-", "skip", "no"):
+            with self.subTest(shrug=shrug):
+                with self.assertRaises(NativeCapabilityQualityGateError) as raised:
+                    gate(surfaces=findings(states={surface: ("exempt", shrug)}))
+                self.assertIn("exemption reason must be", str(raised.exception))
+
+    def test_a_reason_carrying_a_path_or_a_link_is_refused(self) -> None:
+        surface = REQUIRED_NATIVE_CAPABILITY_SURFACES[0]
+        for unsafe in (
+            "Covered by src/quality/chat_card_coverage.py instead",
+            "Explained at https://example.invalid/decision",
+        ):
+            with self.subTest(unsafe=unsafe):
+                with self.assertRaises(NativeCapabilityQualityGateError) as raised:
+                    gate(surfaces=findings(states={surface: ("exempt", unsafe)}))
+                self.assertIn("one bounded metadata line", str(raised.exception))
+
+    def test_a_reason_on_a_surface_that_is_not_exempt_is_refused(self) -> None:
+        surface = REQUIRED_NATIVE_CAPABILITY_SURFACES[0]
+        for state in ("present", "missing"):
+            with self.subTest(state=state):
+                with self.assertRaises(NativeCapabilityQualityGateError) as raised:
+                    gate(surfaces=findings(states={surface: (state, REASON)}))
+                self.assertIn("must not carry a reason", str(raised.exception))
+
+    def test_an_unknown_surface_is_refused(self) -> None:
+        with self.assertRaises(NativeCapabilityQualityGateError) as raised:
+            gate(surfaces=[*findings(), finding("vscode_agent_plugin")])
+        message = str(raised.exception)
+        self.assertIn("does not exist in this repository", message)
+        self.assertIn("vscode_agent_plugin", message)
+
+        forwarded = edited(gate(), surfaces=[*findings(), finding("vscode_agent_plugin")])
+        errors = validate_native_capability_quality_gate(forwarded)
+        self.assertTrue(any("vscode_agent_plugin" in error for error in errors), errors)
+
+    def test_an_unknown_surface_state_is_refused(self) -> None:
+        surface = REQUIRED_NATIVE_CAPABILITY_SURFACES[0]
+
+        with self.assertRaises(NativeCapabilityQualityGateError) as raised:
+            gate(surfaces=findings(states={surface: ("partial", "")}))
+        message = str(raised.exception)
+        self.assertIn("unsupported state", message)
+        self.assertIn(str(list(SURFACE_STATES)), message)
+
+    def test_answering_for_one_surface_twice_is_refused(self) -> None:
+        surface = REQUIRED_NATIVE_CAPABILITY_SURFACES[0]
+
+        with self.assertRaises(NativeCapabilityQualityGateError) as raised:
+            gate(surfaces=[*findings(), finding(surface)])
+        self.assertIn("more than once", str(raised.exception))
+
+    def test_rows_are_normalized_into_the_declared_surface_order(self) -> None:
+        payload = gate(surfaces=list(reversed(findings())))
+
+        self.assertEqual(
+            [row["surface"] for row in payload["surfaces"]], list(REQUIRED_NATIVE_CAPABILITY_SURFACES)
+        )
+        self.assertEqual(sorted(payload["surfaces"][0]), sorted(SURFACE_FINDING_KEYS))
+
+
+class GeneratedGuidanceTests(unittest.TestCase):
+    """AC2: reproducibility is reported through the repository's own checks."""
+
+    def test_the_probe_reuses_the_catalog_and_drift_checks_and_adds_nothing(self) -> None:
+        block = generated_guidance_reproducibility(repo_root=REPO_ROOT)
+        validation = validate_catalog_contract()
+        report = drift_report(repo_root=REPO_ROOT, counts=(), budgets=())
+
+        self.assertEqual(sorted(block), sorted(GENERATED_GUIDANCE_KEYS))
+        self.assertEqual(block["catalog_validation_ok"], validation["ok"] is True)
+        self.assertEqual(block["catalog_validation_errors"], list(validation["errors"]))
+        self.assertEqual(block["checked"], ["catalog_validation", *report["checked"]])
+        self.assertEqual(len(block["stale_artifacts"]), report["drift_count"])
+
+    def test_the_committed_tree_reports_reproducible_generated_guidance(self) -> None:
+        block = generated_guidance_reproducibility(repo_root=REPO_ROOT)
+
+        self.assertTrue(
+            block["reproducible"],
+            f"regenerate the stale artifacts before running this suite: {block['stale_artifacts']}",
+        )
+        self.assertEqual(block["stale_artifacts"], [])
+        self.assertEqual(gate()["verdict"], "pass")
+
+    def test_a_tampered_generated_file_reports_non_reproducible_and_blocks(self) -> None:
+        artifact = generated_artifacts()[0]
+        with tempfile.TemporaryDirectory(prefix="omh-quality-gate-") as raw_root:
+            root = copied_tree(Path(raw_root))
+
+            clean = gate(repo_root=root)
+            self.assertTrue(clean["generated_guidance"]["reproducible"])
+            self.assertEqual(clean["verdict"], "pass")
+
+            target = root / artifact.path
+            atomic_write_text(target, target.read_text(encoding="utf-8") + "\ndrifted\n")
+            tampered = gate(repo_root=root)
+
+        self.assertFalse(tampered["generated_guidance"]["reproducible"])
+        self.assertEqual(tampered["generated_guidance"]["stale_artifacts"], [artifact.name])
+        self.assertEqual(tampered["verdict"], "blocked")
+        self.assertEqual(validate_native_capability_quality_gate(tampered), [])
+        self.assertEqual(tampered["unmet_surfaces"], [])
+
+    def test_a_stapled_reproducible_flag_is_refused(self) -> None:
+        payload = gate()
+        block = {**payload["generated_guidance"], "stale_artifacts": ["workflows_doc"]}
+
+        errors = validate_native_capability_quality_gate(edited(payload, generated_guidance=block))
+        self.assertTrue(
+            any("reproducible must be derived from the checks it reports" in error for error in errors),
+            errors,
+        )
+
+    def test_a_failed_catalog_validation_blocks_rather_than_revises(self) -> None:
+        payload = gate()
+        block = {
+            **payload["generated_guidance"],
+            "catalog_validation_ok": False,
+            "catalog_validation_errors": ["skill demo description must be a non-empty string"],
+            "reproducible": False,
+        }
+
+        blocked = edited(payload, generated_guidance=block)
+        self.assertEqual(derive_quality_gate_verdict(blocked), "blocked")
+
+    def test_a_report_that_checked_nothing_is_not_reproducible(self) -> None:
+        payload = gate()
+        block = {**payload["generated_guidance"], "checked": [], "reproducible": False}
+
+        self.assertEqual(derive_quality_gate_verdict(edited(payload, generated_guidance=block)), "blocked")
+
+    def test_a_stale_artifact_that_was_never_checked_is_refused(self) -> None:
+        payload = gate()
+        block = {**payload["generated_guidance"], "stale_artifacts": ["a_file_nobody_checked"], "reproducible": False}
+
+        errors = validate_native_capability_quality_gate(edited(payload, generated_guidance=block))
+        self.assertTrue(
+            any("reports stale artifacts it did not check" in error for error in errors), errors
+        )
+
+
+class VerdictTests(unittest.TestCase):
+    """AC3: the verdict is derived, and none of it reads as evidence."""
+
+    def test_all_three_verdicts_are_reachable_and_distinguishable(self) -> None:
+        passing = gate()
+        revising = gate(surfaces=findings(states={REQUIRED_NATIVE_CAPABILITY_SURFACES[0]: ("missing", "")}))
+        blocked = edited(
+            passing,
+            generated_guidance={**passing["generated_guidance"], "reproducible": False, "checked": []},
+        )
+
+        self.assertEqual(passing["verdict"], "pass")
+        self.assertEqual(revising["verdict"], "revise")
+        self.assertEqual(derive_quality_gate_verdict(blocked), "blocked")
+        self.assertEqual(sorted({"pass", "revise", "blocked"}), sorted(QUALITY_GATE_VERDICTS))
+
+    def test_the_builder_accepts_no_verdict_from_the_caller(self) -> None:
+        parameters = inspect.signature(build_native_capability_quality_gate).parameters
+
+        self.assertNotIn("verdict", parameters)
+        self.assertNotIn("verdict_claim", parameters)
+        self.assertNotIn("unmet_surfaces", parameters)
+        with self.assertRaises(TypeError):
+            build_native_capability_quality_gate(  # type: ignore[call-arg]
+                capability_id=CAPABILITY_ID,
+                surfaces=findings(),
+                repo_root=REPO_ROOT,
+                verdict="pass",
+            )
+
+    def test_a_caller_supplied_pass_on_an_incomplete_gate_is_refused(self) -> None:
+        surface = REQUIRED_NATIVE_CAPABILITY_SURFACES[0]
+        incomplete = gate(surfaces=findings(states={surface: ("missing", "")}))
+        stapled = edited(incomplete, verdict="pass", unmet_surfaces=[], verdict_claim=QUALITY_GATE_VERDICT_CLAIMS["pass"])
+
+        errors = validate_native_capability_quality_gate(stapled)
+        self.assertTrue(
+            any("verdict must be derived from the findings" in error and "revise" in error for error in errors),
+            errors,
+        )
+        self.assertTrue(any("unmet_surfaces must be derived" in error for error in errors), errors)
+        self.assertEqual(derive_quality_gate_verdict(stapled), "revise")
+
+    def test_a_caller_supplied_pass_over_a_dropped_surface_is_refused(self) -> None:
+        surface = REQUIRED_NATIVE_CAPABILITY_SURFACES[-1]
+        passing = gate()
+        stapled = edited(
+            passing, surfaces=[row for row in passing["surfaces"] if row["surface"] != surface]
+        )
+
+        errors = validate_native_capability_quality_gate(stapled)
+        self.assertTrue(any("does not answer for every expected surface" in error for error in errors), errors)
+        self.assertTrue(any("verdict must be derived from the findings" in error for error in errors), errors)
+        self.assertEqual(quality_gate_unmet_surfaces(stapled), (surface,))
+
+    def test_a_caller_supplied_pass_over_a_reasonless_exemption_is_refused(self) -> None:
+        surface = REQUIRED_NATIVE_CAPABILITY_SURFACES[0]
+        passing = gate()
+        stapled = edited(
+            passing,
+            surfaces=[
+                {**row, "state": "exempt"} if row["surface"] == surface else row
+                for row in passing["surfaces"]
+            ],
+        )
+
+        self.assertEqual(derive_quality_gate_verdict(stapled), "revise")
+        errors = validate_native_capability_quality_gate(stapled)
+        self.assertTrue(any("must record why it does not apply" in error for error in errors), errors)
+
+    def test_a_caller_supplied_pass_over_a_blocked_tree_is_refused(self) -> None:
+        passing = gate()
+        stapled = edited(
+            passing,
+            generated_guidance={
+                **passing["generated_guidance"],
+                "stale_artifacts": ["workflows_doc"],
+                "reproducible": False,
+            },
+        )
+
+        errors = validate_native_capability_quality_gate(stapled)
+        self.assertTrue(
+            any("verdict must be derived from the findings" in error and "blocked" in error for error in errors),
+            errors,
+        )
+
+    def test_an_unknown_verdict_is_refused(self) -> None:
+        errors = validate_native_capability_quality_gate(edited(gate(), verdict="mostly_fine"))
+
+        self.assertTrue(any("verdict is unsupported" in error for error in errors), errors)
+        with self.assertRaises(NativeCapabilityQualityGateError):
+            quality_gate_verdict_claim("mostly_fine")
+
+    def test_a_verdict_claiming_evidence_is_refused_by_name(self) -> None:
+        for refused in REFUSED_QUALITY_GATE_VERDICTS:
+            with self.subTest(refused=refused):
+                errors = validate_native_capability_quality_gate(edited(gate(), verdict=refused))
+                self.assertTrue(
+                    any("may not claim the capability was run, reviewed, or released" in error for error in errors),
+                    errors,
+                )
+
+    def test_a_mismatched_verdict_claim_is_refused(self) -> None:
+        errors = validate_native_capability_quality_gate(
+            edited(gate(), verdict_claim="This capability is complete and shipped.")
+        )
+
+        self.assertTrue(any("verdict_claim must be the one sentence" in error for error in errors), errors)
+
+
+class StructureIsNotEvidenceTests(unittest.TestCase):
+    """AC3: nothing in the vocabulary reads as runtime, review, CI, or release."""
+
+    def test_every_verdict_claim_denies_run_review_ci_and_release(self) -> None:
+        self.assertEqual(sorted(QUALITY_GATE_VERDICT_CLAIMS), sorted(QUALITY_GATE_VERDICTS))
+        for verdict in QUALITY_GATE_VERDICTS:
+            with self.subTest(verdict=verdict):
+                claim = quality_gate_verdict_claim(verdict)
+                self.assertIn(VERDICT_CLAIM_DENIAL, claim)
+                for denied in ("run", "reviewed", "CI", "merged", "released"):
+                    self.assertIn(denied, claim)
+
+    def test_no_verdict_word_reads_as_evidence(self) -> None:
+        self.assertEqual(set(QUALITY_GATE_VERDICTS) & set(REFUSED_QUALITY_GATE_VERDICTS), set())
+        for verdict in QUALITY_GATE_VERDICTS:
+            with self.subTest(verdict=verdict):
+                self.assertNotIn(verdict, ("verified", "tested", "passing", "green", "approved"))
+
+    def test_the_claim_boundary_denies_execution_review_ci_merge_and_release(self) -> None:
+        for phrase in (
+            "never execution, runtime, test, code-review, CI, merge-readiness, merge, or release evidence",
+            "A pass means the structure is complete and nothing more",
+            "never certifies, ranks, or admits an external package",
+        ):
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, NATIVE_CAPABILITY_QUALITY_GATE_CLAIM_BOUNDARY)
+
+    def test_a_softened_claim_boundary_is_refused(self) -> None:
+        for boundary in ("", "This capability passed its quality gate."):
+            with self.subTest(boundary=boundary):
+                errors = validate_native_capability_quality_gate(edited(gate(), claim_boundary=boundary))
+                self.assertTrue(any("claim_boundary" in error for error in errors), errors)
+
+    def test_an_implementation_claim_key_is_refused_by_name(self) -> None:
+        for key in sorted(IMPLEMENTATION_CLAIM_KEYS):
+            with self.subTest(key=key):
+                errors = validate_native_capability_quality_gate({**gate(), key: True})
+                self.assertTrue(
+                    any("implementation-claim keys" in error and key in error for error in errors), errors
+                )
+
+    def test_a_raw_or_hidden_key_is_refused(self) -> None:
+        errors = validate_native_capability_quality_gate({**gate(), "transcript": "..."})
+
+        self.assertTrue(any("raw or hidden keys" in error for error in errors), errors)
+
+    def test_the_key_set_is_closed_in_both_directions(self) -> None:
+        payload = gate()
+        self.assertEqual(sorted(payload), sorted(NATIVE_CAPABILITY_QUALITY_GATE_KEYS))
+
+        extra = validate_native_capability_quality_gate({**payload, "ci_run_url": "x"})
+        self.assertTrue(any("unsupported keys" in error for error in extra), extra)
+
+        for key in NATIVE_CAPABILITY_QUALITY_GATE_KEYS:
+            with self.subTest(key=key):
+                short = {name: value for name, value in payload.items() if name != key}
+                errors = validate_native_capability_quality_gate(short)
+                self.assertTrue(any("is missing keys" in error and key in error for error in errors), errors)
+
+    def test_the_payload_is_metadata_only_and_schema_versioned(self) -> None:
+        payload = gate()
+
+        self.assertEqual(payload["schema_version"], NATIVE_CAPABILITY_QUALITY_GATE_SCHEMA_VERSION)
+        self.assertEqual(NATIVE_CAPABILITY_QUALITY_GATE_SCHEMA_VERSION, "native_capability_quality_gate/v1")
+        self.assertEqual(payload["privacy"], QUALITY_GATE_PRIVACY)
+        self.assertEqual(QUALITY_GATE_PRIVACY, "metadata_only")
+        errors = validate_native_capability_quality_gate(edited(payload, privacy="raw"))
+        self.assertTrue(any("privacy" in error for error in errors), errors)
+
+    def test_a_non_mapping_is_refused_rather_than_crashing(self) -> None:
+        self.assertEqual(
+            validate_native_capability_quality_gate(["not", "a", "gate"]),
+            ["native_capability_quality_gate must be an object"],
+        )
+
+    def test_a_capability_id_that_is_not_the_canonical_slug_is_refused(self) -> None:
+        for identifier in ("", "Native Capability Quality Gate", "x"):
+            with self.subTest(identifier=identifier):
+                errors = validate_native_capability_quality_gate(edited(gate(), capability_id=identifier))
+                self.assertTrue(any("capability_id" in error for error in errors), errors)
+
+
+class ForwardedPayloadTests(unittest.TestCase):
+    """A payload the builder did not mint still has to hold together."""
+
+    def test_an_expected_set_that_drops_a_required_surface_is_refused(self) -> None:
+        surface = REQUIRED_NATIVE_CAPABILITY_SURFACES[0]
+        payload = gate()
+        narrowed = edited(
+            payload, expected_surfaces=[item for item in payload["expected_surfaces"] if item != surface]
+        )
+
+        errors = validate_native_capability_quality_gate(narrowed)
+        self.assertTrue(
+            any("expected_surfaces is missing required surfaces" in error for error in errors), errors
+        )
+        self.assertTrue(any(blueprint_surface_anchor(surface) in error for error in errors), errors)
+
+    def test_an_expected_set_out_of_declared_order_is_refused(self) -> None:
+        payload = gate()
+
+        errors = validate_native_capability_quality_gate(
+            edited(payload, expected_surfaces=list(reversed(payload["expected_surfaces"])))
+        )
+        self.assertTrue(
+            any("expected_surfaces must be listed in the declared surface order" in error for error in errors),
+            errors,
+        )
+
+    def test_findings_out_of_declared_order_are_refused(self) -> None:
+        payload = gate()
+
+        errors = validate_native_capability_quality_gate(
+            edited(payload, surfaces=list(reversed(payload["surfaces"])))
+        )
+        self.assertTrue(
+            any("surfaces must be listed in the declared surface order" in error for error in errors), errors
+        )
+
+    def test_a_passing_catalog_validation_alongside_errors_is_refused(self) -> None:
+        payload = gate()
+        block = {
+            **payload["generated_guidance"],
+            "catalog_validation_ok": True,
+            "catalog_validation_errors": ["harness planning evidence_ladder is missing gate steps"],
+        }
+
+        errors = validate_native_capability_quality_gate(edited(payload, generated_guidance=block))
+        self.assertTrue(
+            any("passing catalog validation alongside" in error for error in errors), errors
+        )
+
+    def test_a_malformed_generated_guidance_block_is_refused_rather_than_crashing(self) -> None:
+        payload = gate()
+
+        for block in ("not an object", {}, {**payload["generated_guidance"], "checked": "everything"}):
+            with self.subTest(block=block):
+                errors = validate_native_capability_quality_gate(edited(payload, generated_guidance=block))
+                self.assertTrue(any("generated_guidance" in error for error in errors), errors)
+
+    def test_a_malformed_surface_row_is_refused_rather_than_crashing(self) -> None:
+        payload = gate()
+
+        for rows in ("not a list", [{"surface": REQUIRED_NATIVE_CAPABILITY_SURFACES[0]}], [{}]):
+            with self.subTest(rows=rows):
+                errors = validate_native_capability_quality_gate(edited(payload, surfaces=rows))
+                self.assertTrue(errors)
+
+
+class DeterminismTests(unittest.TestCase):
+    """No clock reaches a compared value."""
+
+    def test_the_module_reads_no_clock(self) -> None:
+        tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+        imported = {
+            node.module.split(".")[0]
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom) and node.module
+        } | {
+            alias.name.split(".")[0]
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Import)
+            for alias in node.names
+        }
+        called = {
+            node.func.id
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+
+        self.assertEqual(imported & {"time", "datetime", "random", "secrets"}, set())
+        self.assertNotIn("utc_now", called)
+
+    def test_two_gates_over_one_set_of_findings_are_identical(self) -> None:
+        self.assertEqual(gate(), gate())
+
+    def test_prepared_at_is_a_parameter_and_defaults_to_empty(self) -> None:
+        payload = build_native_capability_quality_gate(
+            capability_id=CAPABILITY_ID, surfaces=findings(), repo_root=REPO_ROOT
+        )
+
+        self.assertEqual(payload["prepared_at"], "")
+        self.assertEqual(validate_native_capability_quality_gate(payload), [])
+        self.assertEqual(payload["surfaces"], gate()["surfaces"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

Closes #795.

### What Changed

- New contract `native_capability_quality_gate/v1` in
  `src/workflows/native_capability_quality_gate.py`: gate one native capability
  against the surface vocabulary #791 established and report **pass**,
  **revise**, or **blocked** across the whole native experience.
- Every expected surface carries a row that is `present`, `missing`, or
  `exempt` with the reason it is exempt. A surface with no row at all is refused
  by name and by the file `native_capability_blueprint/v1` says it lives in, and
  an exemption with no reason is a validation error rather than a quiet
  `missing`.
- The verdict is never supplied by a caller.
  `build_native_capability_quality_gate` has no verdict parameter, and
  `validate_native_capability_quality_gate` re-derives the verdict from the
  findings a payload carries and refuses one that disagrees.
- Generated-guidance reproducibility is a projection of two checks this
  repository already runs, not a third one:
  `catalog_validation/v1` and the generated-artifact half of
  `omh_drift_report/v1`.
- One small public accessor added to the merged #791 module,
  `is_canonical_capability_id()`, so both artifacts key a capability by the same
  identifier rule instead of two regexes that can drift.
- 54 new tests in `tests/test_native_capability_quality_gate.py`.

### Why This Exists

A capability looks present the moment a route fires or a skill name resolves.
Its chat copy, memory rules, handoff behavior, evidence ladder, tests, and
documentation can all still be half-built, and every gate that would catch that
answers a question about the *repository* rather than about *one capability*:
`tests/test_capabilities.py` proves lanes are covered, the routing suites prove
routes land, the byte gates prove the docs regenerate. All of them pass happily
while one capability is incomplete. So "is this capability genuinely complete?"
had no answer anybody could produce on demand.

#791 shipped the missing half of that answer: a checkable vocabulary of the
native surfaces an installable capability moves, each anchored to the file and
structure a real gate fails on. This PR is the reader that vocabulary was built
for.

### User / Operator Impact

A maintainer (or Hermes, on a maintainer's behalf) can now ask whether a
capability is finished and get one of three answers that mean different things:

- `pass` — every expected surface is answered and generated guidance reproduces.
- `revise` — a surface this capability needs is absent or unanswered; the report
  names it, and `unmet_surface_anchors()` names the file to edit.
- `blocked` — the repository's own catalog or generated-output checks do not
  reproduce, so completeness cannot be judged from this tree yet.

`blocked` is deliberately not a worse `revise`. While the catalog does not
validate or a generated file is stale, "this capability is missing an awareness
lane" is a statement nobody should act on, because the surfaces are being read
out of a tree that no longer agrees with itself.

What a maintainer could not do before: get a per-capability answer at all.

### How It Works

**AC1 — missing surfaces fail, or carry an explicit exemption.**
`expected_gate_surfaces()` starts from `REQUIRED_NATIVE_CAPABILITY_SURFACES`
(imported from #791, never restated), widens it with whatever conditional
surfaces a supplied blueprint promised — through `blueprint_expected_surfaces()`,
the accessor #791 built for this reader, which refuses an invalid blueprint
rather than handing back a partial list — and widens it again with anything the
author answered anyway. Every surface in that set needs a row. An unanswered one
is reported with its #791 anchor. `exempt` requires a reason that is a bounded
metadata line of at least 12 characters, so `n/a` and `-` are refused; a reason
on a non-exempt row is refused too, in the other direction.

A required surface *can* be exempted. That is deliberate even though #791 calls
the required set the one no installable capability can avoid: the required set
is what a capability must *answer for*, and the exemption is the answer that
says why this one does not need it, written where a reviewer reads it. Refusing
the exemption outright would not make the surface appear — it would make an
author write `present` and move on.

**AC2 — generated guidance stays reproducible under repository checks.**
`generated_guidance_reproducibility()` calls `validate_catalog_contract()`
(`catalog_validation/v1`) and `drift_report(counts=(), budgets=())`, which is the
same byte comparison `omh docs workflows --check`, `omh docs roles --check`, and
`omh docs capability-families --check` make, plus the tap-skills staleness check.
It regenerates nothing and adds no comparison of its own. Count and budget
metrics are deliberately excluded from the projection: they are exact-count
fixtures, not generated guidance, and a capability's completeness should not
hinge on a number a different change moved.

**AC3 — structural success is never runtime, review, CI, or release evidence.**
The verdict is derived in exactly one function, `derive_quality_gate_verdict()`,
which the builder calls because it accepts no verdict and the validator calls
because a forwarded payload must not be taken at its word. The same re-derivation
runs one level down on the reproducibility block's own `reproducible` flag, and a
reasonless exemption counts as unanswered inside the derivation itself rather
than only in the key checks — so there is no arrangement of a payload where
`pass` sits on top of an incomplete gate. Alongside that:
`NATIVE_CAPABILITY_QUALITY_GATE_CLAIM_BOUNDARY` on every payload,
`VERDICT_CLAIM_DENIAL` repeated verbatim inside all three verdict sentences,
`REFUSED_QUALITY_GATE_VERDICTS` refusing 18 words like `verified`, `green`, and
`released` by name, and #791's `IMPLEMENTATION_CLAIM_KEYS` refusing a payload
reshaped to say otherwise.

**Determinism.** No clock is read (asserted by AST in the test module).
`prepared_at` is a caller parameter defaulting to empty. No digest: this schema
carries no review to bind one to, and the property a digest would buy is already
bought by re-deriving the verdict.

**What it does not check:** that an answer is *true*. A `present` row is the
author's statement. This gate makes it impossible to leave a surface out, not
impossible to get one wrong — the coverage gates that already own each surface
are what fail on a false `present`, and duplicating them here would give the
repository two sets of rules to keep in agreement.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/workflows/native_capability_quality_gate.py` | New. `native_capability_quality_gate/v1`: closed 11-key payload, three verdicts, surface findings, reproducibility projection, validator in both directions. |
| `src/workflows/native_capability_blueprint.py` | +`is_canonical_capability_id()` (used by its own `_identity_errors` and by the gate); "what reads these today" note updated now that #795 reads it. No behavior change. |
| `tests/test_native_capability_quality_gate.py` | New. 54 tests grouped by AC. |

No CLI surface, no routing trigger, no skill, no generated artifact, and no
count fixture moved — so no regeneration was required and none of the byte gates
changed. This matches how #791 and #794 landed: the contract first, the wiring
when a surface mints one.

## Validation

- [x] `uv run --group lint ruff check src tests` — `All checks passed!`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` — `Ran 5249 tests in 171.708s / OK`
- [x] `uv run python -m compileall -q src tests` — exit 0, no output
- [x] `uv run python -m omh.cli docs workflows --check` — `ok:true`, tap_skills `checked:115 expected:115`, no missing/stale/extra
- [x] `uv run python -m omh.cli harness validate` — `ok:true`, `{"harnesses":72,"skills":104}`, 0 errors
- [x] `uv run python -m omh.cli release checklist --json` — renders
- [x] `uv run python -m omh.cli release hermes-smoke` — plan mode, status ok, not observed
- [x] `omh --help` — renders
- [x] `omh --omh-home <tmp> --hermes-home <tmp> release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — installed-command smoke `ok` (observed), first-use status `ok` (plan mode, **not** observed). Run against a scratch home, not `/tmp/omh-smoke`.
- [x] Also run, not in the template: `uv run python -m omh.cli docs roles --check` (`ok:true`), `uv run python -m omh.cli docs capability-families --check` (`ok:true`), `git diff --check` (clean)
- [ ] Workflow-learning review queue smoke — not applicable; no learning contract changed
- [x] Targeted suites: `tests/test_native_capability_quality_gate.py` (54 tests, OK), `tests/test_native_capability_blueprint.py` (39 tests, OK, unchanged by the accessor extraction)
- [ ] Manual Hermes/TUI check — **not run, and not applicable**: nothing user-facing was added. No CLI command, chat route, wrapper action, or skill mints a gate, so there is no surface a person could reach in Hermes.

**Mutation evidence for the new tests.** Nine mutations were applied to the new
module one at a time, with the suite run after each and the file restored:

| Mutation | Caught |
| --- | --- |
| verdict returns the payload's own value instead of deriving | yes (100 failures) |
| a reasonless exemption validates | yes (2) |
| stale artifacts stop affecting reproducibility | yes (3) |
| the exemption reason has no minimum length | yes (4) |
| an unanswered expected surface stops being reported | yes (14) |
| `unmet_surfaces` is trusted instead of derived | yes (1) |
| the expected set drops the required surfaces | yes (13) |
| a `missing` row counts as answered | yes (14) |
| the verdict claim is not checked against the verdict | yes (1) |

A tenth mutation initially survived — a redundant pre-check inside the builder
that the validator already enforced with the identical message. It was removed
rather than tested around, and the validator path is covered by the 14-failure
row above.

## Risk

- **Low blast radius.** One new module with no production caller and one
  additive accessor on a module whose only current caller is its own test. The
  full suite is green, and `tests/test_native_capability_blueprint.py` (39 tests)
  passes unchanged after the accessor extraction.
- **The honest limitation, stated in the module docstring and locked by a test:**
  this gate proves every surface was *answered*, not that each answer is true.
  An author who writes `present` everywhere passes. That is a deliberate boundary
  — deriving presence here would re-implement the coverage gates — but a reviewer
  should know the gate is an anti-omission device, not a lie detector.
- `generated_guidance_reproducibility()` reads the filesystem and is therefore
  point-in-time. `prepared_at` is the caller's stamp for when; the module itself
  reads no clock, so nothing wall-clock enters a compared value.
- The AC2 tamper test copies `skills/` and the three generated single files into
  a temporary directory and tampers only there. Nothing under the repository is
  written, so the byte gates cannot be left failing for the next run. The one
  write it makes goes through `atomic_write_text` (`newline=""`), because the
  bytes it writes are compared against rendered template bytes moments later and
  `Path.write_text` would rewrite them as CRLF on the Windows job.

## Compatibility / Rollout

- Purely additive. No existing payload, schema, command, or generated file
  changed; nothing to migrate, and no release-channel behavior moves.
- `is_canonical_capability_id()` is a new public name on an existing module; the
  private regex it wraps is unchanged, and the blueprint's error message for a
  bad `capability_id` is byte-identical to before.

## Release / Claims

- [x] Release-channel impact considered — none. No user-reachable surface, no
      packaging change, no version bump.
- [x] Runtime/native capability claims are backed by evidence or marked as not
      observed — the only claim this PR makes is that the contract exists and its
      tests pass, both shown above. The artifact it produces says on every
      payload that a `pass` is structural and not execution, review, CI, or
      release evidence.
- [x] Known manual Hermes checks listed — `omh release hermes-smoke` ran in plan
      mode only (`observed: no`). No `--live` run was made; there is nothing
      user-facing in this change for a live profile to exercise.

## Follow-Up

- Nothing mints a gate yet. The natural next step is a surface that does — an
  `omh` control-plane command for maintainers, or a chat route so a maintainer
  can ask Hermes in words — which is a separate user goal with its own routing
  triggers, overroute guards, chat card, and exact-count fixture updates.
- Joining the gate to a real capability's actual surfaces (deriving `present`
  from catalog, awareness, and wrapper data instead of recording it) is a
  deliberate non-goal here. If it is ever wanted, the right move is to have the
  existing coverage gates expose a per-capability answer that this module reads,
  not to re-derive them inside it.
