### PR TITLE
feat: find high-value OMH capability gaps from trusted evidence

### DIFF
--- a/src/quality/capability_gap_scout.py
+++ b/src/quality/capability_gap_scout.py
@@ -1,0 +1,1195 @@
+"""Ranked OMH-native opportunities for one user goal, from evidence already on disk.
+
+Somebody knows the outcome they want and does not know which public agent
+projects have already solved something like it. The raw form of that question --
+search the ecosystem, read what comes back -- answers with implementation names,
+and an answer made of implementation names is a shopping list. This module
+answers the same question with OMH capability statements instead: what could
+Hermes do better for this goal, which OMH capability family covers it today, and
+which frozen evidence supports saying so.
+
+What is already here, and what this adds
+----------------------------------------
+
+Two rankers exist. `capability_roadmap` ranks missing setup and missing runtime
+evidence from a probe payload -- an installation question, the same answer for
+every user. `popular_plugin_coverage` weighs request families against OMH case
+ids -- a breadth heuristic, again the same answer for every user. Neither is
+scoped to a goal, neither applies a source policy, and neither knows whether the
+material behind its verdict was read last week or last year.
+
+This module is the goal-scoped one. The same catalog and the same observed
+material, asked about a different outcome, returns a different ranking, because
+the ranking is a function of the goal.
+
+Coverage is read, never invented
+--------------------------------
+
+Every opportunity names a `coverage_family_id` from
+`capabilities.families.capability_family_projection`, the projection that
+already defines OMH's user-facing capability surface. An id outside it is
+refused, and the family's label is copied from the live projection rather than
+retyped. There is no second inventory of what OMH can do, so there is nothing to
+drift out of sync.
+
+Which family a goal belongs to and how much of it that family already delivers
+are two different questions, and only the first has a mechanical answer. The
+family and its label are OMH's fact, read from the projection; `coverage_state`
+is the caller's judgement about their own goal, and is recorded as such.
+
+The product boundary, enforced rather than requested
+----------------------------------------------------
+
+An opportunity's own prose may not name a distributable artifact as the answer.
+"Install the review plugin" is a validation error here, not a style note: the
+whole point of the workflow is that the user asked how Hermes should improve,
+and a package name does not answer that. `PACKAGE_ACQUISITION_CUES` refuses on
+its own -- an OMH capability statement never needs the word "install" --  while
+`DISTRIBUTABLE_ARTIFACT_CUES` refuses only alongside `ARTIFACT_ADOPTION_CUES`,
+because this repository's own boundary language ("must not require a plugin at
+runtime") says the word without recommending the thing.
+
+Findings are scanned by exactly the opposite rule: not at all. A finding
+describes what an observer read in somebody else's project and naming that
+project is the honest thing to do. The prohibition is on the answer, not on the
+evidence.
+
+Three evidence states, and none of them reads as another
+--------------------------------------------------------
+
+`fresh` means an approved source whose cited snapshot was observed inside the
+horizon. `stale` means an approved source whose observation is older than the
+horizon or whose age cannot be established at all -- an unparseable or missing
+observation time is never fresh. `denied` means the source policy does not admit
+one of the cited sources, and nothing about its age is even considered.
+
+Only `fresh` supports an opportunity. An opportunity with no fresh evidence is
+not dropped, because silently dropping it would hide the denial that caused it;
+it moves to `withheld_opportunities` carrying the reason, so widening the policy
+or re-observing the source is a visible next step rather than a guess.
+
+Freshness is derived at read time
+---------------------------------
+
+No record here stores an expiry. A cited `capability_inspiration_snapshot/v1`
+reports when it was observed; this module subtracts that from the `now` it was
+handed and compares against a horizon supplied by the same call. Two callers
+with different horizons get different verdicts from the same snapshot, which is
+correct -- how long evidence stays good is a policy, not a property of the
+evidence -- and a snapshot never has to be rewritten because time passed.
+
+`now` is a parameter and this module reads no clock. It lands in `evaluated_at`
+for a reader, and it is excluded from `report_id`, so two scouts of the same
+material at different moments agree unless a verdict actually moved. A timestamp
+inside a compared value would make every comparison a race.
+
+OMH does not search
+-------------------
+
+Every byte of observed material arrives from the caller, frozen in snapshots
+somebody else already wrote. This module imports nothing that can open a socket
+and calls nothing that can. The `claim_boundary` on the report says so, because
+the failure this guards against is a reader treating a ranked opportunity as
+proof that OMH just surveyed the ecosystem. It did not, and it cannot.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from typing import Any, Final
+
+from ..capabilities.families import capability_family_projection
+from ..routing.executor_cues import contains_boundary_phrase
+from ..routing.localization import normalized_phrase, routing_tokens
+from .capability_inspiration_snapshot import validate_capability_inspiration_snapshot
+from .skill_governance import _stable_encode
+
+
+CAPABILITY_GAP_SCOUT_SCHEMA_VERSION: Final = "capability_gap_scout/v1"
+
+# How much of the goal an existing OMH capability family already delivers, as
+# the caller judged it. Ordered weakest-coverage-first because that is the
+# ranking order too: the biggest opportunity is where nothing covers the goal.
+COVERAGE_STATES: Final[tuple[str, ...]] = ("absent", "partial", "covered")
+
+_COVERAGE_WEIGHTS: Final[dict[str, int]] = {"absent": 3, "partial": 2, "covered": 1}
+
+# What a cited snapshot is worth right now. `denied` is a policy verdict and
+# `stale` is a time verdict; they are never collapsed, because the maintainer
+# action they ask for is different -- widen the policy, or go and re-read the
+# source.
+EVIDENCE_STATES: Final[tuple[str, ...]] = ("denied", "fresh", "stale")
+
+# How much fresh evidence stands behind an opportunity, weakest first. This
+# counts distinct fresh snapshots and nothing else -- two findings drawn from
+# one frozen snapshot are one piece of evidence, not two -- and it is never a
+# judgement about whether the idea is good. OMH cannot have one of those.
+OPPORTUNITY_CONFIDENCE_LEVELS: Final[tuple[str, ...]] = (
+    "unsupported",
+    "low",
+    "medium",
+    "high",
+)
+
+# Why an opportunity carries no fresh support. Three values rather than one so
+# the reason survives to the reader: an opportunity held back by an unapproved
+# source is a different problem from one held back by an old reading.
+WITHHELD_REASONS: Final[tuple[str, ...]] = (
+    "evidence_denied",
+    "evidence_stale",
+    "evidence_stale_and_denied",
+)
+
+# The single next step the report asks for. Derived, never supplied.
+SCOUT_NEXT_ACTIONS: Final[tuple[str, ...]] = (
+    "refresh_stale_evidence",
+    "review_ranked_opportunities",
+    "supply_observed_evidence",
+    "widen_source_policy",
+)
+
+# Acquiring a distributable artifact. Any one of these refuses an opportunity on
+# its own: an OMH capability statement has no legitimate use for them, so a
+# false positive costs a rephrase while a false negative ships a shopping list.
+PACKAGE_ACQUISITION_CUES: Final[tuple[str, ...]] = (
+    "install",
+    "installs",
+    "installed",
+    "installing",
+    "installation",
+    "installer",
+    "reinstall",
+    "uninstall",
+    "npx",
+    "uv add",
+    "cargo add",
+    "go get",
+    "docker pull",
+)
+
+# Names for a distributable artifact. Refused only together with an adoption cue
+# below, because this repository's own boundary language says these words
+# without recommending anything: "must not require the source plugin at runtime"
+# is the boundary, not a violation of it. Bare "package" is deliberately absent
+# -- `materials-package`, `report-package`, and `deliverable-package` are OMH
+# capabilities, and a rule that refuses OMH's own vocabulary is a broken rule.
+DISTRIBUTABLE_ARTIFACT_CUES: Final[tuple[str, ...]] = (
+    "plugin",
+    "plugins",
+    "extension",
+    "extensions",
+    "add-on",
+    "add-ons",
+    "addon",
+    "addons",
+    "marketplace",
+    "registry entry",
+    "mcp server",
+    "npm package",
+    "pip package",
+    "third-party package",
+)
+
+# Choosing to take a named artifact on. "require" is deliberately absent: saying
+# OMH must not require a plugin is the boundary this repo already states.
+ARTIFACT_ADOPTION_CUES: Final[tuple[str, ...]] = (
+    "adopt",
+    "adopts",
+    "adopting",
+    "add",
+    "adds",
+    "adding",
+    "enable",
+    "enables",
+    "enabling",
+    "use",
+    "uses",
+    "using",
+    "switch to",
+    "integrate",
+    "integrates",
+    "integrating",
+    "bundle",
+    "bundles",
+    "bundling",
+    "wire in",
+    "wire up",
+    "bring in",
+    "pull in",
+    "depend on",
+    "depends on",
+)
+
+# Every claim this report does not make, named so a consumer can check the list
+# instead of inferring the boundary from prose.
+CAPABILITY_GAP_SCOUT_NOT_OBSERVED: Final[tuple[str, ...]] = (
+    "source_search_execution",
+    "source_availability",
+    "source_content_re_observation",
+    "opportunity_acceptance",
+    "capability_implementation",
+    "coverage_verification",
+)
+
+CAPABILITY_GAP_SCOUT_CLAIM_BOUNDARY: Final = (
+    "A gap scout ranks OMH-native opportunities against evidence a caller already supplied. OMH ran "
+    "no search, fetch, download, or network call to produce it and cannot run one. Freshness is "
+    "derived from the observation time the cited snapshot reports, not from re-reading the source. A "
+    "ranked opportunity is work OMH could do, never an instruction to install a plugin, extension, "
+    "add-on, or registry entry, and it is not maintainer acceptance, implementation, review, CI, or "
+    "merge evidence."
+)
+
+CAPABILITY_GAP_SCOUT_KEYS: Final[tuple[str, ...]] = (
+    "claim_boundary",
+    "evaluated_at",
+    "freshness_horizon_days",
+    "goal",
+    "goal_terms",
+    "next_action",
+    "not_evidence_until_observed",
+    "ranked_opportunities",
+    "report_id",
+    "schema_version",
+    "source_policy",
+    "summary",
+    "withheld_opportunities",
+)
+
+CAPABILITY_GAP_SOURCE_POLICY_KEYS: Final[tuple[str, ...]] = (
+    "approved_source_count",
+    "approved_sources",
+    "policy_id",
+)
+
+CAPABILITY_GAP_SUMMARY_KEYS: Final[tuple[str, ...]] = (
+    "denied_evidence_count",
+    "distinct_coverage_family_count",
+    "fresh_evidence_count",
+    "opportunity_count",
+    "stale_evidence_count",
+    "withheld_count",
+)
+
+CAPABILITY_GAP_OPPORTUNITY_KEYS: Final[tuple[str, ...]] = (
+    "confidence",
+    "coverage_family_id",
+    "coverage_label",
+    "coverage_note",
+    "coverage_state",
+    "denied_evidence_count",
+    "evidence",
+    "fresh_evidence_count",
+    "goal_alignment",
+    "opportunity_id",
+    "outcome_statement",
+    "priority_score",
+    "rank",
+    "stale_evidence_count",
+    "user_value",
+    "withheld_reason",
+)
+
+CAPABILITY_GAP_EVIDENCE_KEYS: Final[tuple[str, ...]] = (
+    "cited_source_count",
+    "denied_sources",
+    "evidence_digest",
+    "evidence_state",
+    "finding",
+    "finding_id",
+    "observed_age_days",
+    "observed_at",
+    "snapshot_id",
+)
+
+# The shapes a caller hands in, closed on the way in as well as on the way out.
+# An unsupported key is refused rather than ignored: a caller who passes
+# `priority` expecting it to be honoured is better served by an error than by a
+# ranking that silently ignored it.
+CAPABILITY_GAP_OPPORTUNITY_INPUT_KEYS: Final[tuple[str, ...]] = (
+    "coverage_family_id",
+    "coverage_note",
+    "coverage_state",
+    "evidence",
+    "outcome_statement",
+    "user_value",
+)
+
+CAPABILITY_GAP_EVIDENCE_INPUT_KEYS: Final[tuple[str, ...]] = ("finding", "snapshot")
+
+# How much each signal moves a ranking. Goal alignment dominates by design: this
+# report exists to answer one goal, and a large gap nobody asked about must not
+# outrank a smaller one that is exactly what the user wants.
+GOAL_ALIGNMENT_WEIGHT: Final = 10
+COVERAGE_STATE_WEIGHT: Final = 5
+FRESH_EVIDENCE_WEIGHT: Final = 2
+
+# Bounded because a ranked answer nobody can read is not an answer, and because
+# an unbounded list turns a metadata report into a document store. Over the cap
+# is refused rather than truncated: dropping the twenty-first opportunity would
+# change the ranking without telling anyone why.
+MAX_OPPORTUNITIES: Final = 20
+MAX_EVIDENCE_PER_OPPORTUNITY: Final = 10
+MAX_APPROVED_SOURCES: Final = 40
+MAX_LINE_LENGTH: Final = 200
+MAX_URI_LENGTH: Final = 512
+
+DEFAULT_FRESHNESS_HORIZON_DAYS: Final = 90
+MIN_FRESHNESS_HORIZON_DAYS: Final = 1
+MAX_FRESHNESS_HORIZON_DAYS: Final = 3650
+
+# `observed_age_days` when the cited snapshot's observation time could not be
+# read at all. Never `fresh`: an age nobody could establish is not a young one.
+AGE_NOT_ESTABLISHED: Final = -1
+
+
+class CapabilityGapScoutError(ValueError):
+    """A scout report that cannot be built without asserting something untrue."""
+
+
+def package_recommendation_refusals(text: str) -> list[str]:
+    """Every reason a line reads as "acquire this" instead of "Hermes could".
+
+    Returned rather than raised so both the builder and the validator can use
+    the same judgement, and so the message names the cue that tripped instead of
+    leaving an author to guess which word to change.
+    """
+    folded = normalized_phrase(str(text or ""))
+    if not folded:
+        return []
+    refusals = [
+        f"names a package acquisition: {cue!r}"
+        for cue in PACKAGE_ACQUISITION_CUES
+        if contains_boundary_phrase(folded, (normalized_phrase(cue),))
+    ]
+    artifacts = [
+        cue
+        for cue in DISTRIBUTABLE_ARTIFACT_CUES
+        if contains_boundary_phrase(folded, (normalized_phrase(cue),))
+    ]
+    adoptions = [
+        cue
+        for cue in ARTIFACT_ADOPTION_CUES
+        if contains_boundary_phrase(folded, (normalized_phrase(cue),))
+    ]
+    if artifacts and adoptions:
+        refusals.append(
+            f"recommends adopting a distributable artifact: {artifacts[0]!r} with {adoptions[0]!r}"
+        )
+    return refusals
+
+
+def build_capability_gap_scout(
+    *,
+    goal: str,
+    now: str,
+    opportunities: Sequence[Mapping[str, Any]] = (),
+    approved_sources: Sequence[str] = (),
+    freshness_horizon_days: int = DEFAULT_FRESHNESS_HORIZON_DAYS,
+) -> dict[str, Any]:
+    """Rank what OMH could do better for one goal against the evidence supplied.
+
+    `now` is a parameter and never a clock read here, so a caller can reproduce
+    a report exactly. It is required and must parse: a freshness verdict reached
+    against an unreadable clock would be a guess wearing a state name.
+
+    Each entry of `opportunities` carries `CAPABILITY_GAP_OPPORTUNITY_INPUT_KEYS`
+    and each of its `evidence` entries carries
+    `CAPABILITY_GAP_EVIDENCE_INPUT_KEYS`, whose `snapshot` is a
+    `capability_inspiration_snapshot/v1` that must validate. Two entries naming
+    the same family and the same outcome are one opportunity; the first
+    occurrence's wording stands and the later one contributes its evidence.
+    """
+    safe_goal = _bounded_line(goal, field="goal")
+    if not safe_goal:
+        raise CapabilityGapScoutError("capability_gap_scout goal is required")
+    goal_terms = sorted(routing_tokens(safe_goal))
+    if not goal_terms:
+        raise CapabilityGapScoutError(
+            "capability_gap_scout goal must carry at least one term the ranking can score"
+        )
+    evaluated_at = _bounded_line(now, field="now")
+    now_moment = _parse_timestamp(evaluated_at)
+    if now_moment is None:
+        raise CapabilityGapScoutError(
+            "capability_gap_scout now must be an ISO 8601 timestamp so freshness can be derived"
+        )
+    horizon = _validated_horizon(freshness_horizon_days)
+    policy = _source_policy(approved_sources)
+    approved = set(policy["approved_sources"])
+
+    collapsed: dict[str, dict[str, Any]] = {}
+    for entry in _input_sequence(opportunities, field="opportunities"):
+        built = _opportunity(
+            entry,
+            goal_terms=goal_terms,
+            approved=approved,
+            now_moment=now_moment,
+            horizon=horizon,
+        )
+        existing = collapsed.get(str(built["opportunity_id"]))
+        if existing is None:
+            collapsed[str(built["opportunity_id"])] = built
+            continue
+        _merge_evidence(existing, built)
+    if len(collapsed) > MAX_OPPORTUNITIES:
+        raise CapabilityGapScoutError(
+            f"capability_gap_scout opportunities exceeds {MAX_OPPORTUNITIES} distinct entries"
+        )
+
+    ranked = sorted(
+        (row for row in collapsed.values() if not row["withheld_reason"]), key=_ranking_key
+    )
+    for position, row in enumerate(ranked, start=1):
+        row["rank"] = position
+    withheld = sorted(
+        (row for row in collapsed.values() if row["withheld_reason"]), key=_ranking_key
+    )
+    summary = _summary(ranked, withheld)
+    return {
+        "schema_version": CAPABILITY_GAP_SCOUT_SCHEMA_VERSION,
+        "report_id": _report_id(
+            goal=safe_goal,
+            horizon=horizon,
+            policy_id=str(policy["policy_id"]),
+            ranked=ranked,
+            withheld=withheld,
+        ),
+        "goal": safe_goal,
+        "goal_terms": goal_terms,
+        "evaluated_at": evaluated_at,
+        "freshness_horizon_days": horizon,
+        "source_policy": policy,
+        "ranked_opportunities": ranked,
+        "withheld_opportunities": withheld,
+        "summary": summary,
+        "next_action": _next_action(ranked, summary),
+        "claim_boundary": CAPABILITY_GAP_SCOUT_CLAIM_BOUNDARY,
+        "not_evidence_until_observed": list(CAPABILITY_GAP_SCOUT_NOT_OBSERVED),
+    }
+
+
+def validate_capability_gap_scout(report: Any) -> list[str]:
+    """Every reason a payload is not a `capability_gap_scout/v1`."""
+    label = "capability_gap_scout"
+    if not isinstance(report, Mapping):
+        return [f"{label} must be an object"]
+    errors = _key_set_errors(report, CAPABILITY_GAP_SCOUT_KEYS, label)
+    if report.get("schema_version") != CAPABILITY_GAP_SCOUT_SCHEMA_VERSION:
+        errors.append(f"{label} schema_version must be {CAPABILITY_GAP_SCOUT_SCHEMA_VERSION}")
+    for key in ("goal", "report_id", "evaluated_at"):
+        if not _non_empty_text(report.get(key)):
+            errors.append(f"{label} {key} must be a non-empty string")
+    goal_terms = report.get("goal_terms")
+    if not isinstance(goal_terms, list) or not all(isinstance(term, str) for term in goal_terms):
+        errors.append(f"{label} goal_terms must be a list of strings")
+        goal_terms = []
+    elif not goal_terms or goal_terms != sorted(set(goal_terms)):
+        errors.append(f"{label} goal_terms must be non-empty, sorted, and distinct")
+    horizon = report.get("freshness_horizon_days")
+    if not _is_int(horizon) or not (
+        MIN_FRESHNESS_HORIZON_DAYS <= int(str(horizon)) <= MAX_FRESHNESS_HORIZON_DAYS
+    ):
+        errors.append(
+            f"{label} freshness_horizon_days must be an integer between "
+            f"{MIN_FRESHNESS_HORIZON_DAYS} and {MAX_FRESHNESS_HORIZON_DAYS}"
+        )
+        horizon = MAX_FRESHNESS_HORIZON_DAYS
+    if report.get("next_action") not in SCOUT_NEXT_ACTIONS:
+        errors.append(f"{label} next_action must be one of {list(SCOUT_NEXT_ACTIONS)}")
+    if report.get("claim_boundary") != CAPABILITY_GAP_SCOUT_CLAIM_BOUNDARY:
+        errors.append(f"{label} claim_boundary must state that OMH searched nothing itself")
+    declared = report.get("not_evidence_until_observed")
+    if not isinstance(declared, list) or list(declared) != list(CAPABILITY_GAP_SCOUT_NOT_OBSERVED):
+        errors.append(
+            f"{label} not_evidence_until_observed must be {list(CAPABILITY_GAP_SCOUT_NOT_OBSERVED)}"
+        )
+    errors.extend(_source_policy_errors(report.get("source_policy"), label))
+    errors.extend(
+        _opportunity_list_errors(
+            report.get("ranked_opportunities"),
+            label=label,
+            field="ranked_opportunities",
+            goal_terms=[str(term) for term in goal_terms],
+            horizon=int(str(horizon)),
+            ranked=True,
+        )
+    )
+    errors.extend(
+        _opportunity_list_errors(
+            report.get("withheld_opportunities"),
+            label=label,
+            field="withheld_opportunities",
+            goal_terms=[str(term) for term in goal_terms],
+            horizon=int(str(horizon)),
+            ranked=False,
+        )
+    )
+    errors.extend(_cross_list_errors(report, label))
+    if not errors:
+        errors.extend(_derived_value_errors(report, label))
+    return errors
+
+
+def _opportunity(
+    entry: Mapping[str, Any],
+    *,
+    goal_terms: list[str],
+    approved: set[str],
+    now_moment: datetime,
+    horizon: int,
+) -> dict[str, Any]:
+    unsupported = sorted(set(entry) - set(CAPABILITY_GAP_OPPORTUNITY_INPUT_KEYS))
+    if unsupported:
+        raise CapabilityGapScoutError(
+            f"capability_gap_scout opportunity has unsupported keys: {unsupported}"
+        )
+    outcome = _bounded_line(entry.get("outcome_statement", ""), field="outcome_statement")
+    if not outcome:
+        raise CapabilityGapScoutError("capability_gap_scout opportunity outcome_statement is required")
+    user_value = _bounded_line(entry.get("user_value", ""), field="user_value")
+    if not user_value:
+        raise CapabilityGapScoutError("capability_gap_scout opportunity user_value is required")
+    coverage_note = _bounded_line(entry.get("coverage_note", ""), field="coverage_note")
+    for field, text in (
+        ("outcome_statement", outcome),
+        ("user_value", user_value),
+        ("coverage_note", coverage_note),
+    ):
+        refusals = package_recommendation_refusals(text)
+        if refusals:
+            raise CapabilityGapScoutError(
+                f"capability_gap_scout opportunity {field} recommends an installable package "
+                f"instead of user value: {refusals[0]}"
+            )
+    family_id = _bounded_line(entry.get("coverage_family_id", ""), field="coverage_family_id")
+    labels = _coverage_labels()
+    if family_id not in labels:
+        raise CapabilityGapScoutError(
+            f"capability_gap_scout opportunity coverage_family_id must be one of {sorted(labels)}"
+        )
+    coverage_state = str(entry.get("coverage_state", ""))
+    if coverage_state not in COVERAGE_STATES:
+        raise CapabilityGapScoutError(
+            f"capability_gap_scout opportunity coverage_state must be one of {list(COVERAGE_STATES)}"
+        )
+    evidence = _evidence_list(
+        entry.get("evidence", ()), approved=approved, now_moment=now_moment, horizon=horizon
+    )
+    counts = _evidence_counts(evidence)
+    alignment = _goal_alignment(goal_terms, outcome, user_value)
+    return {
+        "opportunity_id": _opportunity_id(family_id, outcome),
+        "outcome_statement": outcome,
+        "user_value": user_value,
+        "coverage_family_id": family_id,
+        "coverage_label": labels[family_id],
+        "coverage_state": coverage_state,
+        "coverage_note": coverage_note,
+        "evidence": evidence,
+        "fresh_evidence_count": counts["fresh"],
+        "stale_evidence_count": counts["stale"],
+        "denied_evidence_count": counts["denied"],
+        "confidence": _confidence(evidence),
+        "goal_alignment": alignment,
+        "priority_score": _priority_score(alignment, coverage_state, counts["fresh"]),
+        "rank": 0,
+        "withheld_reason": _withheld_reason(counts),
+    }
+
+
+def _merge_evidence(existing: dict[str, Any], duplicate: dict[str, Any]) -> None:
+    """Fold a repeated opportunity into the one already held.
+
+    The wording of the first occurrence stands -- two authors describing the
+    same gap differently is not two gaps -- but its evidence is the union, since
+    dropping a citation because somebody said the same thing twice would lose
+    support the report is meant to carry.
+    """
+    merged = {str(item["finding_id"]): item for item in existing["evidence"]}
+    for item in duplicate["evidence"]:
+        merged.setdefault(str(item["finding_id"]), item)
+    evidence = sorted(merged.values(), key=lambda item: str(item["finding_id"]))
+    if len(evidence) > MAX_EVIDENCE_PER_OPPORTUNITY:
+        raise CapabilityGapScoutError(
+            f"capability_gap_scout opportunity evidence exceeds "
+            f"{MAX_EVIDENCE_PER_OPPORTUNITY} entries after collapsing duplicates"
+        )
+    counts = _evidence_counts(evidence)
+    existing["evidence"] = evidence
+    existing["fresh_evidence_count"] = counts["fresh"]
+    existing["stale_evidence_count"] = counts["stale"]
+    existing["denied_evidence_count"] = counts["denied"]
+    existing["confidence"] = _confidence(evidence)
+    existing["priority_score"] = _priority_score(
+        int(existing["goal_alignment"]), str(existing["coverage_state"]), counts["fresh"]
+    )
+    existing["withheld_reason"] = _withheld_reason(counts)
+
+
+def _evidence_list(
+    entries: Any, *, approved: set[str], now_moment: datetime, horizon: int
+) -> list[dict[str, Any]]:
+    rows = _input_sequence(entries, field="opportunity evidence")
+    if not rows:
+        raise CapabilityGapScoutError(
+            "capability_gap_scout opportunity requires at least one cited snapshot"
+        )
+    if len(rows) > MAX_EVIDENCE_PER_OPPORTUNITY:
+        raise CapabilityGapScoutError(
+            f"capability_gap_scout opportunity evidence exceeds {MAX_EVIDENCE_PER_OPPORTUNITY} entries"
+        )
+    built: dict[str, dict[str, Any]] = {}
+    for entry in rows:
+        item = _evidence(entry, approved=approved, now_moment=now_moment, horizon=horizon)
+        built.setdefault(str(item["finding_id"]), item)
+    return sorted(built.values(), key=lambda item: str(item["finding_id"]))
+
+
+def _evidence(
+    entry: Mapping[str, Any], *, approved: set[str], now_moment: datetime, horizon: int
+) -> dict[str, Any]:
+    unsupported = sorted(set(entry) - set(CAPABILITY_GAP_EVIDENCE_INPUT_KEYS))
+    if unsupported:
+        raise CapabilityGapScoutError(
+            f"capability_gap_scout evidence has unsupported keys: {unsupported}"
+        )
+    snapshot = entry.get("snapshot")
+    if not isinstance(snapshot, Mapping):
+        raise CapabilityGapScoutError(
+            "capability_gap_scout evidence snapshot must be a capability_inspiration_snapshot/v1 object"
+        )
+    snapshot_errors = validate_capability_inspiration_snapshot(snapshot)
+    if snapshot_errors:
+        raise CapabilityGapScoutError(
+            f"capability_gap_scout evidence cites an invalid snapshot: {snapshot_errors[0]}"
+        )
+    finding = _bounded_line(entry.get("finding", ""), field="evidence finding")
+    if not finding:
+        raise CapabilityGapScoutError("capability_gap_scout evidence finding is required")
+    sources = [source for source in snapshot["observed_sources"] if isinstance(source, Mapping)]
+    uris = sorted({str(source.get("uri", "")) for source in sources})
+    denied = [uri for uri in uris if uri not in approved]
+    observed_at = str(snapshot.get("observed_at", ""))
+    age = _age_days(observed_at, now_moment)
+    snapshot_id = str(snapshot.get("snapshot_id", ""))
+    return {
+        "finding_id": _finding_id(snapshot_id, finding),
+        "snapshot_id": snapshot_id,
+        "evidence_digest": str(snapshot.get("evidence_digest", "")),
+        "finding": finding,
+        "observed_at": observed_at,
+        "observed_age_days": age,
+        "cited_source_count": len(uris),
+        "denied_sources": denied,
+        "evidence_state": _evidence_state(denied, age, horizon),
+    }
+
+
+def _evidence_state(denied: list[str], age: int, horizon: int) -> str:
+    if denied:
+        return "denied"
+    if age == AGE_NOT_ESTABLISHED or age > horizon:
+        return "stale"
+    return "fresh"
+
+
+def _evidence_counts(evidence: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    return {
+        state: sum(1 for item in evidence if item.get("evidence_state") == state)
+        for state in EVIDENCE_STATES
+    }
+
+
+def _confidence(evidence: Sequence[Mapping[str, Any]]) -> str:
+    """How many separate frozen snapshots back this, capped at the vocabulary.
+
+    Distinct snapshots rather than findings: an author who draws three findings
+    from one reading has read one thing, and a count that rose with the number
+    of sentences would reward paraphrase.
+    """
+    sources = {
+        str(item.get("snapshot_id", ""))
+        for item in evidence
+        if item.get("evidence_state") == "fresh"
+    }
+    return OPPORTUNITY_CONFIDENCE_LEVELS[min(len(sources), len(OPPORTUNITY_CONFIDENCE_LEVELS) - 1)]
+
+
+def _withheld_reason(counts: Mapping[str, int]) -> str:
+    if counts["fresh"]:
+        return ""
+    if counts["denied"] and counts["stale"]:
+        return "evidence_stale_and_denied"
+    if counts["denied"]:
+        return "evidence_denied"
+    return "evidence_stale"
+
+
+def _priority_score(alignment: int, coverage_state: str, fresh_count: int) -> int:
+    return (
+        alignment * GOAL_ALIGNMENT_WEIGHT
+        + _COVERAGE_WEIGHTS.get(coverage_state, 0) * COVERAGE_STATE_WEIGHT
+        + fresh_count * FRESH_EVIDENCE_WEIGHT
+    )
+
+
+def _goal_alignment(goal_terms: Sequence[str], outcome: str, user_value: str) -> int:
+    """How many distinct goal terms the opportunity says in its own words.
+
+    Only the two fields a user reads as the answer count. Findings are excluded
+    on purpose: a ranking that rose with the volume of quoted evidence would
+    reward padding the citation list rather than answering the goal.
+    """
+    spoken = routing_tokens(f"{outcome} {user_value}")
+    return len(set(goal_terms) & spoken)
+
+
+def _ranking_key(row: Mapping[str, Any]) -> tuple[int, str]:
+    return (-int(row["priority_score"]), str(row["opportunity_id"]))
+
+
+def _summary(
+    ranked: Sequence[Mapping[str, Any]], withheld: Sequence[Mapping[str, Any]]
+) -> dict[str, int]:
+    rows = [*ranked, *withheld]
+    return {
+        "opportunity_count": len(ranked),
+        "withheld_count": len(withheld),
+        "distinct_coverage_family_count": len({str(row["coverage_family_id"]) for row in ranked}),
+        "fresh_evidence_count": sum(int(row["fresh_evidence_count"]) for row in rows),
+        "stale_evidence_count": sum(int(row["stale_evidence_count"]) for row in rows),
+        "denied_evidence_count": sum(int(row["denied_evidence_count"]) for row in rows),
+    }
+
+
+def _next_action(ranked: Sequence[Mapping[str, Any]], summary: Mapping[str, int]) -> str:
+    """The one step worth taking next, in the order that unblocks the most.
+
+    A denial outranks a stale reading: approving a source costs a policy edit,
+    while re-observing one costs somebody going and reading it again.
+    """
+    if ranked:
+        return "review_ranked_opportunities"
+    if summary["denied_evidence_count"]:
+        return "widen_source_policy"
+    if summary["stale_evidence_count"]:
+        return "refresh_stale_evidence"
+    return "supply_observed_evidence"
+
+
+def _source_policy(approved_sources: Sequence[str]) -> dict[str, Any]:
+    if isinstance(approved_sources, (str, bytes)) or not isinstance(approved_sources, Sequence):
+        raise CapabilityGapScoutError(
+            "capability_gap_scout approved_sources must be a sequence of source uris"
+        )
+    if len(approved_sources) > MAX_APPROVED_SOURCES:
+        raise CapabilityGapScoutError(
+            f"capability_gap_scout approved_sources exceeds {MAX_APPROVED_SOURCES} entries"
+        )
+    approved: set[str] = set()
+    for value in approved_sources:
+        uri = str(value or "").strip()
+        if not uri:
+            continue
+        if len(uri) > MAX_URI_LENGTH:
+            raise CapabilityGapScoutError(
+                f"capability_gap_scout approved source uri exceeds {MAX_URI_LENGTH} characters"
+            )
+        approved.add(uri)
+    ordered = sorted(approved)
+    return {
+        "policy_id": _policy_id(ordered),
+        "approved_sources": ordered,
+        "approved_source_count": len(ordered),
+    }
+
+
+def _coverage_labels() -> dict[str, str]:
+    """The live capability-family inventory, read rather than restated."""
+    projection = capability_family_projection()
+    families = projection.get("families")
+    if not isinstance(families, list):
+        return {}
+    return {
+        str(family.get("id", "")): str(family.get("label", ""))
+        for family in families
+        if isinstance(family, Mapping) and str(family.get("id", ""))
+    }
+
+
+def _validated_horizon(freshness_horizon_days: Any) -> int:
+    if not _is_int(freshness_horizon_days):
+        raise CapabilityGapScoutError("capability_gap_scout freshness_horizon_days must be an integer")
+    horizon = int(freshness_horizon_days)
+    if not MIN_FRESHNESS_HORIZON_DAYS <= horizon <= MAX_FRESHNESS_HORIZON_DAYS:
+        raise CapabilityGapScoutError(
+            f"capability_gap_scout freshness_horizon_days must be between "
+            f"{MIN_FRESHNESS_HORIZON_DAYS} and {MAX_FRESHNESS_HORIZON_DAYS}"
+        )
+    return horizon
+
+
+def _age_days(observed_at: str, now_moment: datetime) -> int:
+    """Whole days between an observation and `now`, or `AGE_NOT_ESTABLISHED`.
+
+    An observation dated ahead of `now` is clamped to zero rather than refused.
+    Both values are caller-supplied metadata, so a few seconds of clock skew is
+    the likely cause and refusing it would turn an ordinary skew into a stale
+    verdict.
+    """
+    observed = _parse_timestamp(observed_at)
+    if observed is None:
+        return AGE_NOT_ESTABLISHED
+    return max(0, (now_moment - observed).days)
+
+
+def _parse_timestamp(value: str) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _input_sequence(value: Any, *, field: str) -> list[Mapping[str, Any]]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise CapabilityGapScoutError(
+            f"capability_gap_scout {field} must be a sequence of objects"
+        )
+    rows: list[Mapping[str, Any]] = []
+    for item in value:
+        if not isinstance(item, Mapping):
+            raise CapabilityGapScoutError(f"capability_gap_scout {field} entry must be an object")
+        rows.append(item)
+    return rows
+
+
+def _bounded_line(value: Any, *, field: str) -> str:
+    """One metadata line: whitespace collapsed, length capped, never wrapped.
+
+    Collapsing whitespace also removes a pasted newline, which is what keeps a
+    supplied value from arriving as `\\r\\n` on one platform and `\\n` on another
+    and producing two different ids for the same text.
+    """
+    text = " ".join(str(value or "").split())
+    if len(text) > MAX_LINE_LENGTH:
+        raise CapabilityGapScoutError(
+            f"capability_gap_scout {field} exceeds {MAX_LINE_LENGTH} characters"
+        )
+    return text
+
+
+def _opportunity_id(family_id: str, outcome: str) -> str:
+    seed = _stable_encode({"coverage_family_id": family_id, "outcome": normalized_phrase(outcome)})
+    return f"gap-opportunity-{hashlib.sha256(seed.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _finding_id(snapshot_id: str, finding: str) -> str:
+    seed = _stable_encode({"finding": normalized_phrase(finding), "snapshot_id": snapshot_id})
+    return f"gap-finding-{hashlib.sha256(seed.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _policy_id(approved: Sequence[str]) -> str:
+    seed = _stable_encode({"approved_sources": list(approved)})
+    return f"gap-source-policy-{hashlib.sha256(seed.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _report_id(
+    *,
+    goal: str,
+    horizon: int,
+    policy_id: str,
+    ranked: Sequence[Mapping[str, Any]],
+    withheld: Sequence[Mapping[str, Any]],
+) -> str:
+    """Identity over the answer, never over the moment it was produced.
+
+    Every clock reading is excluded: `evaluated_at` at the top, and
+    `observed_age_days` inside each finding, which counts up by one every day
+    and would otherwise mint a new id each morning while the answer stood still.
+    The freshness verdicts themselves stay in, which is the point -- when
+    evidence crosses the horizon the answer changed, and the id should say so.
+    """
+    seed = _stable_encode(
+        {
+            "freshness_horizon_days": horizon,
+            "goal": goal,
+            "ranked": [_identity_projection(row) for row in ranked],
+            "source_policy_id": policy_id,
+            "withheld": [_identity_projection(row) for row in withheld],
+        }
+    )
+    return f"capability-gap-scout-{hashlib.sha256(seed.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _identity_projection(row: Mapping[str, Any]) -> dict[str, Any]:
+    """One opportunity with the ticking parts of its findings removed."""
+    projected = dict(row)
+    evidence = row.get("evidence")
+    if isinstance(evidence, list):
+        projected["evidence"] = [
+            {key: value for key, value in item.items() if key != "observed_age_days"}
+            for item in evidence
+            if isinstance(item, Mapping)
+        ]
+    return projected
+
+
+def _source_policy_errors(policy: Any, label: str) -> list[str]:
+    if not isinstance(policy, Mapping):
+        return [f"{label} source_policy must be an object"]
+    errors = _key_set_errors(policy, CAPABILITY_GAP_SOURCE_POLICY_KEYS, f"{label} source_policy")
+    if not _non_empty_text(policy.get("policy_id")):
+        errors.append(f"{label} source_policy policy_id must be a non-empty string")
+    sources = policy.get("approved_sources")
+    if not isinstance(sources, list) or not all(isinstance(uri, str) for uri in sources):
+        return [*errors, f"{label} source_policy approved_sources must be a list of strings"]
+    if sources != sorted(set(sources)):
+        errors.append(f"{label} source_policy approved_sources must be sorted and distinct")
+    if policy.get("approved_source_count") != len(sources):
+        errors.append(f"{label} source_policy approved_source_count does not match approved_sources")
+    if policy.get("policy_id") != _policy_id(sources):
+        errors.append(f"{label} source_policy policy_id does not match its approved sources")
+    return errors
+
+
+def _opportunity_list_errors(
+    rows: Any, *, label: str, field: str, goal_terms: list[str], horizon: int, ranked: bool
+) -> list[str]:
+    if not isinstance(rows, list):
+        return [f"{label} {field} must be a list"]
+    if len(rows) > MAX_OPPORTUNITIES:
+        return [f"{label} {field} exceeds {MAX_OPPORTUNITIES} entries"]
+    errors: list[str] = []
+    keys: list[tuple[int, str]] = []
+    for index, row in enumerate(rows):
+        if not isinstance(row, Mapping):
+            errors.append(f"{label} {field}[{index}] must be an object")
+            continue
+        errors.extend(
+            _opportunity_errors(
+                row,
+                label=f"{label} {field}[{index}]",
+                goal_terms=goal_terms,
+                horizon=horizon,
+                ranked=ranked,
+                expected_rank=index + 1 if ranked else 0,
+            )
+        )
+        if _is_int(row.get("priority_score")) and isinstance(row.get("opportunity_id"), str):
+            keys.append((-int(str(row["priority_score"])), str(row["opportunity_id"])))
+    if keys != sorted(keys):
+        errors.append(f"{label} {field} must be sorted by descending priority then opportunity_id")
+    return errors
+
+
+def _opportunity_errors(
+    row: Mapping[str, Any],
+    *,
+    label: str,
+    goal_terms: list[str],
+    horizon: int,
+    ranked: bool,
+    expected_rank: int,
+) -> list[str]:
+    errors = _key_set_errors(row, CAPABILITY_GAP_OPPORTUNITY_KEYS, label)
+    outcome = row.get("outcome_statement")
+    user_value = row.get("user_value")
+    for key in ("opportunity_id", "outcome_statement", "user_value", "coverage_label"):
+        if not _non_empty_text(row.get(key)):
+            errors.append(f"{label} {key} must be a non-empty string")
+    if not isinstance(row.get("coverage_note"), str):
+        errors.append(f"{label} coverage_note must be a string")
+    for key in ("outcome_statement", "user_value", "coverage_note"):
+        refusals = package_recommendation_refusals(str(row.get(key, "")))
+        if refusals:
+            errors.append(
+                f"{label} {key} recommends an installable package instead of user value: {refusals[0]}"
+            )
+    labels = _coverage_labels()
+    family_id = row.get("coverage_family_id")
+    if family_id not in labels:
+        errors.append(f"{label} coverage_family_id must be one of {sorted(labels)}")
+    elif row.get("coverage_label") != labels[str(family_id)]:
+        errors.append(f"{label} coverage_label does not match the current capability family")
+    if row.get("coverage_state") not in COVERAGE_STATES:
+        errors.append(f"{label} coverage_state must be one of {list(COVERAGE_STATES)}")
+    if row.get("confidence") not in OPPORTUNITY_CONFIDENCE_LEVELS:
+        errors.append(f"{label} confidence must be one of {list(OPPORTUNITY_CONFIDENCE_LEVELS)}")
+    withheld_reason = row.get("withheld_reason")
+    if ranked and withheld_reason != "":
+        errors.append(f"{label} a ranked opportunity must carry no withheld_reason")
+    if not ranked and withheld_reason not in WITHHELD_REASONS:
+        errors.append(f"{label} withheld_reason must be one of {list(WITHHELD_REASONS)}")
+    if row.get("rank") != expected_rank:
+        errors.append(f"{label} rank must be {expected_rank}")
+    evidence_errors, counts = _evidence_errors(row.get("evidence"), label=label, horizon=horizon)
+    errors.extend(evidence_errors)
+    if not evidence_errors:
+        for state in EVIDENCE_STATES:
+            key = f"{state}_evidence_count"
+            if row.get(key) != counts[state]:
+                errors.append(f"{label} {key} does not match its evidence")
+        if _withheld_reason(counts) != (withheld_reason if isinstance(withheld_reason, str) else ""):
+            errors.append(f"{label} withheld_reason does not follow from its evidence states")
+        evidence = [item for item in row["evidence"] if isinstance(item, Mapping)]
+        if row.get("confidence") != _confidence(evidence):
+            errors.append(f"{label} confidence does not match its distinct fresh snapshots")
+        if ranked and not counts["fresh"]:
+            errors.append(f"{label} a ranked opportunity must cite at least one fresh finding")
+        if not ranked and counts["fresh"]:
+            errors.append(f"{label} a withheld opportunity must cite no fresh finding")
+    if isinstance(outcome, str) and isinstance(user_value, str):
+        alignment = _goal_alignment(goal_terms, outcome, user_value)
+        if row.get("goal_alignment") != alignment:
+            errors.append(f"{label} goal_alignment does not match the report goal terms")
+        elif not evidence_errors and row.get("priority_score") != _priority_score(
+            alignment, str(row.get("coverage_state", "")), counts["fresh"]
+        ):
+            errors.append(f"{label} priority_score does not follow from its own signals")
+    if isinstance(family_id, str) and isinstance(outcome, str):
+        if row.get("opportunity_id") != _opportunity_id(family_id, outcome):
+            errors.append(f"{label} opportunity_id does not match its family and outcome")
+    return errors
+
+
+def _evidence_errors(
+    evidence: Any, *, label: str, horizon: int
+) -> tuple[list[str], dict[str, int]]:
+    empty = dict.fromkeys(EVIDENCE_STATES, 0)
+    if not isinstance(evidence, list) or not evidence:
+        return [f"{label} evidence must be a non-empty list"], empty
+    if len(evidence) > MAX_EVIDENCE_PER_OPPORTUNITY:
+        return [f"{label} evidence exceeds {MAX_EVIDENCE_PER_OPPORTUNITY} entries"], empty
+    errors: list[str] = []
+    order: list[str] = []
+    for index, item in enumerate(evidence):
+        item_label = f"{label} evidence[{index}]"
+        if not isinstance(item, Mapping):
+            errors.append(f"{item_label} must be an object")
+            continue
+        errors.extend(_single_evidence_errors(item, label=item_label, horizon=horizon))
+        order.append(str(item.get("finding_id", "")))
+    if order != sorted(order):
+        errors.append(f"{label} evidence must be sorted by finding_id")
+    if len(set(order)) != len(order):
+        errors.append(f"{label} evidence must not repeat a finding_id")
+    if errors:
+        return errors, empty
+    return errors, _evidence_counts(evidence)
+
+
+def _single_evidence_errors(item: Mapping[str, Any], *, label: str, horizon: int) -> list[str]:
+    errors = _key_set_errors(item, CAPABILITY_GAP_EVIDENCE_KEYS, label)
+    for key in ("finding_id", "snapshot_id", "evidence_digest", "finding"):
+        if not _non_empty_text(item.get(key)):
+            errors.append(f"{label} {key} must be a non-empty string")
+    if not isinstance(item.get("observed_at"), str):
+        errors.append(f"{label} observed_at must be a string")
+    state = item.get("evidence_state")
+    if state not in EVIDENCE_STATES:
+        errors.append(f"{label} evidence_state must be one of {list(EVIDENCE_STATES)}")
+    denied = item.get("denied_sources")
+    if not isinstance(denied, list) or not all(isinstance(uri, str) for uri in denied):
+        errors.append(f"{label} denied_sources must be a list of strings")
+        denied = []
+    elif denied != sorted(set(denied)):
+        errors.append(f"{label} denied_sources must be sorted and distinct")
+    count = item.get("cited_source_count")
+    if not _is_int(count) or int(str(count)) < 1:
+        errors.append(f"{label} cited_source_count must be a positive integer")
+    elif len(denied) > int(str(count)):
+        errors.append(f"{label} denied_sources cannot outnumber the cited sources")
+    age = item.get("observed_age_days")
+    if not _is_int(age) or int(str(age)) < AGE_NOT_ESTABLISHED:
+        errors.append(f"{label} observed_age_days must be an integer of at least {AGE_NOT_ESTABLISHED}")
+        return errors
+    if state != _evidence_state([str(uri) for uri in denied], int(str(age)), horizon):
+        errors.append(
+            f"{label} evidence_state does not follow from its denied sources, age, and the report horizon"
+        )
+    if isinstance(item.get("snapshot_id"), str) and isinstance(item.get("finding"), str):
+        if item.get("finding_id") != _finding_id(str(item["snapshot_id"]), str(item["finding"])):
+            errors.append(f"{label} finding_id does not match its snapshot and finding")
+    return errors
+
+
+def _cross_list_errors(report: Mapping[str, Any], label: str) -> list[str]:
+    ranked = report.get("ranked_opportunities")
+    withheld = report.get("withheld_opportunities")
+    if not isinstance(ranked, list) or not isinstance(withheld, list):
+        return []
+    rows = [row for row in [*ranked, *withheld] if isinstance(row, Mapping)]
+    ids = [str(row.get("opportunity_id", "")) for row in rows]
+    errors: list[str] = []
+    if len(set(ids)) != len(ids):
+        errors.append(f"{label} an opportunity_id must not appear twice")
+    summary = report.get("summary")
+    if not isinstance(summary, Mapping):
+        return [*errors, f"{label} summary must be an object"]
+    errors.extend(_key_set_errors(summary, CAPABILITY_GAP_SUMMARY_KEYS, f"{label} summary"))
+    if not all(_is_int(summary.get(key)) for key in CAPABILITY_GAP_SUMMARY_KEYS):
+        return [*errors, f"{label} summary counts must be integers"]
+    countable = all(
+        _is_int(row.get(f"{state}_evidence_count")) and isinstance(row.get("coverage_family_id"), str)
+        for row in rows
+        for state in EVIDENCE_STATES
+    )
+    if not countable:
+        # The per-opportunity pass already reported the malformed rows; totalling
+        # them here would raise instead of adding a reason worth reading.
+        return errors
+    expected = _summary(
+        [row for row in ranked if isinstance(row, Mapping)],
+        [row for row in withheld if isinstance(row, Mapping)],
+    )
+    for key, value in expected.items():
+        if summary.get(key) != value:
+            errors.append(f"{label} summary {key} does not match the reported opportunities")
+    return errors
+
+
+def _derived_value_errors(report: Mapping[str, Any], label: str) -> list[str]:
+    """Re-derive the report's own identity and next step from its own material."""
+    errors: list[str] = []
+    ranked = [row for row in report["ranked_opportunities"] if isinstance(row, Mapping)]
+    summary = report["summary"]
+    if report.get("next_action") != _next_action(ranked, summary):
+        errors.append(f"{label} next_action does not follow from its opportunities and evidence")
+    report_id = _report_id(
+        goal=str(report["goal"]),
+        horizon=int(str(report["freshness_horizon_days"])),
+        policy_id=str(report["source_policy"]["policy_id"]),
+        ranked=ranked,
+        withheld=[row for row in report["withheld_opportunities"] if isinstance(row, Mapping)],
+    )
+    if report.get("report_id") != report_id:
+        errors.append(f"{label} report_id does not match its ranked material")
+    return errors
+
+
+def _key_set_errors(payload: Mapping[str, Any], keys: tuple[str, ...], label: str) -> list[str]:
+    errors: list[str] = []
+    extra = sorted(set(payload) - set(keys))
+    if extra:
+        errors.append(f"{label} has unsupported keys: {extra}")
+    missing = sorted(set(keys) - set(payload))
+    if missing:
+        errors.append(f"{label} is missing keys: {missing}")
+    return errors
+
+
+def _is_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _non_empty_text(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())

--- a/tests/test_capability_gap_scout.py
+++ b/tests/test_capability_gap_scout.py
@@ -1,0 +1,1066 @@
+"""Contracts for `capability_gap_scout/v1`.
+
+Three properties are load-bearing and each has its own section below.
+
+Goal scoping. The report is an answer to one goal, so the same opportunities and
+the same catalog asked about a different outcome must come back in a different
+order. A ranking that ignored the goal would be the coverage report this repo
+already has twice.
+
+The product boundary. An opportunity's own prose may not name a distributable
+artifact as the answer, and that is enforced in both directions: the phrasing
+"install X" is refused, the same capability phrased as user value is accepted,
+and a finding is free to name the project it was read from. The prohibition is
+on the answer, never on the evidence.
+
+Evidence states. Fresh, stale, and denied are three separate answers with three
+separate consequences, and only fresh supports an opportunity. The staleness
+verdict is derived from the cited snapshot at read time, so the same frozen
+snapshot reads fresh under one `now` and stale under another while staying
+byte-identical -- there is no expiry written anywhere to go out of date.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import unittest
+from pathlib import Path
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.capabilities.families import capability_family_projection
+from omh.quality.capability_gap_scout import (
+    AGE_NOT_ESTABLISHED,
+    CAPABILITY_GAP_EVIDENCE_KEYS,
+    CAPABILITY_GAP_OPPORTUNITY_KEYS,
+    CAPABILITY_GAP_SCOUT_CLAIM_BOUNDARY,
+    CAPABILITY_GAP_SCOUT_KEYS,
+    CAPABILITY_GAP_SCOUT_NOT_OBSERVED,
+    CAPABILITY_GAP_SCOUT_SCHEMA_VERSION,
+    CAPABILITY_GAP_SOURCE_POLICY_KEYS,
+    CAPABILITY_GAP_SUMMARY_KEYS,
+    COVERAGE_STATES,
+    DEFAULT_FRESHNESS_HORIZON_DAYS,
+    EVIDENCE_STATES,
+    MAX_APPROVED_SOURCES,
+    MAX_EVIDENCE_PER_OPPORTUNITY,
+    MAX_FRESHNESS_HORIZON_DAYS,
+    MAX_LINE_LENGTH,
+    MAX_OPPORTUNITIES,
+    OPPORTUNITY_CONFIDENCE_LEVELS,
+    SCOUT_NEXT_ACTIONS,
+    WITHHELD_REASONS,
+    CapabilityGapScoutError,
+    build_capability_gap_scout,
+    package_recommendation_refusals,
+    validate_capability_gap_scout,
+)
+from omh.quality.capability_inspiration_snapshot import (
+    build_capability_inspiration_snapshot,
+    build_capability_inspiration_source,
+)
+
+
+_APPROVED_DOCS = "https://docs.openclaw.ai/plugins/community"
+_APPROVED_REGISTRY = "https://registry.modelcontextprotocol.io/docs"
+_UNAPPROVED = "https://example.invalid/somebodys-blog-post"
+
+_NOW = "2026-08-09T00:00:00Z"
+_RECENT = "2026-07-01T00:00:00Z"
+_LONG_AGO = "2024-01-01T00:00:00Z"
+
+_REVIEW_GOAL = "catch risky changes before review"
+_CITATION_GOAL = "explain which research source backs a claim"
+
+# Words that would make a ranked opportunity read as a survey OMH just ran. None
+# of them appears in this family's field names or closed vocabularies, which is
+# the property the "OMH does not search" boundary asks for.
+_ASSERTED_SEARCH = (
+    "reachable",
+    "online",
+    "verified",
+    "fetched",
+    "downloaded",
+    "crawled",
+    "searched",
+    "up to date",
+)
+
+# Every module that could turn this into a searcher. The scout ranks evidence a
+# caller supplied; a network import here would make that claim unenforceable.
+_NETWORK_MODULES = (
+    "http",
+    "httpx",
+    "requests",
+    "socket",
+    "ssl",
+    "subprocess",
+    "urllib",
+)
+
+
+def _snapshot(
+    uri: str = _APPROVED_DOCS,
+    *,
+    observed_at: str = _RECENT,
+    content: str = "community plugin index, hooks section",
+    extra_uri: str = "",
+) -> dict[str, object]:
+    sources = [
+        build_capability_inspiration_source(
+            uri=uri, revision="a" * 40, content=content, observation_provenance="user"
+        )
+    ]
+    if extra_uri:
+        sources.append(
+            build_capability_inspiration_source(
+                uri=extra_uri,
+                revision="b" * 40,
+                content=f"{content} second reading",
+                observation_provenance="user",
+            )
+        )
+    return build_capability_inspiration_snapshot(
+        capability_id="capability-gap-scout",
+        observed_sources=sources,
+        observer="maintainer reading the published docs",
+        observed_at=observed_at,
+        findings=("Hook manifests are declared per lane.",),
+    )
+
+
+def _evidence(
+    finding: str = "Risk lanes are ordered before a reviewer opens anything.",
+    **snapshot_kwargs: object,
+) -> dict[str, object]:
+    return {"snapshot": _snapshot(**snapshot_kwargs), "finding": finding}  # type: ignore[arg-type]
+
+
+def _review_opportunity(**overrides: object) -> dict[str, object]:
+    opportunity: dict[str, object] = {
+        "outcome_statement": "Hermes flags a risky change before a reviewer opens the diff",
+        "user_value": "A reviewer sees which change is risky without reading everything first.",
+        "coverage_family_id": "delegate_coding_and_ship",
+        "coverage_state": "partial",
+        "coverage_note": "Code review is covered; ordering by risk is not.",
+        "evidence": [_evidence()],
+    }
+    opportunity.update(overrides)
+    return opportunity
+
+
+def _citation_opportunity(**overrides: object) -> dict[str, object]:
+    opportunity: dict[str, object] = {
+        "outcome_statement": "Hermes names the research source behind every claim it makes",
+        "user_value": "A reader can check a claim against the research source it came from.",
+        "coverage_family_id": "learn_and_gather",
+        "coverage_state": "covered",
+        "coverage_note": "Source finding and research already retrieve material.",
+        "evidence": [_evidence(finding="Each claim carries the id of the source it came from.")],
+    }
+    opportunity.update(overrides)
+    return opportunity
+
+
+def _scout(
+    *,
+    goal: str = _REVIEW_GOAL,
+    now: str = _NOW,
+    opportunities: list[dict[str, object]] | None = None,
+    approved_sources: tuple[str, ...] = (_APPROVED_DOCS, _APPROVED_REGISTRY),
+    freshness_horizon_days: int = DEFAULT_FRESHNESS_HORIZON_DAYS,
+) -> dict[str, object]:
+    return build_capability_gap_scout(
+        goal=goal,
+        now=now,
+        opportunities=opportunities if opportunities is not None else [_review_opportunity()],
+        approved_sources=approved_sources,
+        freshness_horizon_days=freshness_horizon_days,
+    )
+
+
+def _first(report: dict[str, object]) -> dict[str, object]:
+    return report["ranked_opportunities"][0]  # type: ignore[index,return-value]
+
+
+def _only_withheld(report: dict[str, object]) -> dict[str, object]:
+    return report["withheld_opportunities"][0]  # type: ignore[index,return-value]
+
+
+class GoalScopedOpportunitiesTests(unittest.TestCase):
+    """AC1: distinct opportunities tied to coverage, reordered by the goal."""
+
+    def test_a_goal_returns_distinct_opportunities_tied_to_current_coverage(self) -> None:
+        report = _scout(opportunities=[_review_opportunity(), _citation_opportunity()])
+        ranked = report["ranked_opportunities"]
+
+        self.assertEqual(validate_capability_gap_scout(report), [])
+        self.assertEqual(report["schema_version"], CAPABILITY_GAP_SCOUT_SCHEMA_VERSION)
+        self.assertEqual(len(ranked), 2)
+        self.assertEqual(len({row["opportunity_id"] for row in ranked}), 2)
+        self.assertEqual([row["rank"] for row in ranked], [1, 2])
+        self.assertEqual(report["summary"]["distinct_coverage_family_count"], 2)
+        for row in ranked:
+            with self.subTest(opportunity=row["opportunity_id"]):
+                self.assertIn(row["coverage_state"], COVERAGE_STATES)
+                self.assertTrue(row["coverage_label"])
+                self.assertEqual(row["withheld_reason"], "")
+
+    def test_coverage_is_read_from_the_live_capability_families(self) -> None:
+        families = {
+            str(family["id"]): str(family["label"])
+            for family in capability_family_projection()["families"]
+        }
+        report = _scout(opportunities=[_review_opportunity(), _citation_opportunity()])
+
+        for row in report["ranked_opportunities"]:
+            with self.subTest(family=row["coverage_family_id"]):
+                self.assertIn(row["coverage_family_id"], families)
+                self.assertEqual(row["coverage_label"], families[str(row["coverage_family_id"])])
+
+    def test_a_different_goal_reorders_the_same_catalog(self) -> None:
+        opportunities = [_review_opportunity(), _citation_opportunity()]
+
+        for_review = _scout(goal=_REVIEW_GOAL, opportunities=opportunities)
+        for_citations = _scout(goal=_CITATION_GOAL, opportunities=opportunities)
+
+        self.assertEqual(validate_capability_gap_scout(for_citations), [])
+        self.assertEqual(_first(for_review)["coverage_family_id"], "delegate_coding_and_ship")
+        self.assertEqual(_first(for_citations)["coverage_family_id"], "learn_and_gather")
+        self.assertNotEqual(
+            [row["opportunity_id"] for row in for_review["ranked_opportunities"]],
+            [row["opportunity_id"] for row in for_citations["ranked_opportunities"]],
+        )
+
+    def test_the_goal_outranks_the_size_of_the_gap(self) -> None:
+        # The citation opportunity is `covered` and the review one is `partial`,
+        # so coverage weight alone would rank review first under either goal.
+        # Under the citation goal it does not, which is what "goal-scoped" buys.
+        for_citations = _scout(
+            goal=_CITATION_GOAL, opportunities=[_review_opportunity(), _citation_opportunity()]
+        )
+        winner, runner_up = for_citations["ranked_opportunities"]
+
+        self.assertEqual(winner["coverage_state"], "covered")
+        self.assertEqual(runner_up["coverage_state"], "partial")
+        self.assertGreater(winner["goal_alignment"], runner_up["goal_alignment"])
+        self.assertGreater(winner["priority_score"], runner_up["priority_score"])
+
+    def test_a_coverage_family_outside_the_projection_is_refused(self) -> None:
+        with self.assertRaises(CapabilityGapScoutError) as caught:
+            _scout(opportunities=[_review_opportunity(coverage_family_id="ship_it_faster")])
+
+        self.assertIn("coverage_family_id must be one of", str(caught.exception))
+
+    def test_the_same_request_reproduces_the_same_report(self) -> None:
+        opportunities = [_review_opportunity(), _citation_opportunity()]
+
+        first = _scout(opportunities=opportunities)
+        second = _scout(opportunities=opportunities)
+
+        self.assertEqual(first, second)
+
+    def test_the_report_id_ignores_the_moment_it_was_evaluated(self) -> None:
+        early = _scout(now="2026-08-09T00:00:00Z")
+        later = _scout(now="2026-08-19T00:00:00Z")
+
+        # The clock really did move -- the recorded age says so -- and the
+        # identity of the answer did not follow it.
+        self.assertNotEqual(early["evaluated_at"], later["evaluated_at"])
+        self.assertEqual(
+            _first(later)["evidence"][0]["observed_age_days"]
+            - _first(early)["evidence"][0]["observed_age_days"],
+            10,
+        )
+        self.assertEqual(early["report_id"], later["report_id"])
+
+    def test_a_moved_verdict_moves_the_report_id(self) -> None:
+        fresh = _scout(now=_NOW)
+        aged = _scout(now="2027-08-09T00:00:00Z")
+
+        self.assertNotEqual(fresh["report_id"], aged["report_id"])
+
+    def test_a_goal_the_ranker_cannot_score_is_refused(self) -> None:
+        for goal in ("", "   ", "the and or of to"):
+            with self.subTest(goal=goal):
+                with self.assertRaises(CapabilityGapScoutError) as caught:
+                    _scout(goal=goal)
+                self.assertIn("goal", str(caught.exception))
+
+
+class UserValueNotAShoppingListTests(unittest.TestCase):
+    """AC2: the answer explains value; naming an installable package is refused."""
+
+    def test_an_opportunity_phrased_as_an_installation_is_refused(self) -> None:
+        with self.assertRaises(CapabilityGapScoutError) as caught:
+            _scout(
+                opportunities=[
+                    _review_opportunity(
+                        outcome_statement="Install the openclaw diff-risk plugin so Hermes flags changes"
+                    )
+                ]
+            )
+
+        message = str(caught.exception)
+        self.assertIn("recommends an installable package instead of user value", message)
+        self.assertIn("'install'", message)
+
+    def test_the_same_capability_phrased_as_user_value_is_accepted(self) -> None:
+        report = _scout(
+            opportunities=[
+                _review_opportunity(
+                    outcome_statement="Hermes flags a risky change before a reviewer opens the diff"
+                )
+            ]
+        )
+
+        self.assertEqual(validate_capability_gap_scout(report), [])
+        self.assertEqual(_first(report)["rank"], 1)
+        self.assertTrue(_first(report)["user_value"])
+
+    def test_adopting_a_named_artifact_is_refused_without_the_word_install(self) -> None:
+        with self.assertRaises(CapabilityGapScoutError) as caught:
+            _scout(
+                opportunities=[
+                    _review_opportunity(
+                        outcome_statement="Adopt the community review plugin for risky changes"
+                    )
+                ]
+            )
+
+        self.assertIn("recommends adopting a distributable artifact", str(caught.exception))
+
+    def test_every_prose_field_of_an_opportunity_is_held_to_the_boundary(self) -> None:
+        shopping_list = "Enable the diff-risk extension for reviewers"
+        for field in ("outcome_statement", "user_value", "coverage_note"):
+            with self.subTest(field=field):
+                with self.assertRaises(CapabilityGapScoutError) as caught:
+                    _scout(opportunities=[_review_opportunity(**{field: shopping_list})])
+                self.assertIn(field, str(caught.exception))
+
+    def test_a_finding_may_name_the_project_it_was_read_from(self) -> None:
+        observed = "The openclaw community plugin page documents a per-hook risk manifest."
+        report = _scout(opportunities=[_review_opportunity(evidence=[_evidence(finding=observed)])])
+
+        self.assertEqual(validate_capability_gap_scout(report), [])
+        self.assertEqual(_first(report)["evidence"][0]["finding"], observed)
+
+    def test_the_answer_may_not_recommend_what_a_finding_is_allowed_to_name(self) -> None:
+        # The sharp edge of AC2: the very same sentence is admissible evidence
+        # and an inadmissible answer. The prohibition is on what OMH proposes,
+        # never on what an observer read.
+        recommendation = "Use the openclaw community plugin to get a per-hook risk manifest"
+
+        as_evidence = _scout(
+            opportunities=[_review_opportunity(evidence=[_evidence(finding=recommendation)])]
+        )
+
+        self.assertEqual(validate_capability_gap_scout(as_evidence), [])
+        self.assertEqual(_first(as_evidence)["evidence"][0]["finding"], recommendation)
+        with self.assertRaises(CapabilityGapScoutError) as caught:
+            _scout(opportunities=[_review_opportunity(outcome_statement=recommendation)])
+        self.assertIn("recommends adopting a distributable artifact", str(caught.exception))
+
+    def test_the_boundary_language_this_repo_already_uses_is_not_refused(self) -> None:
+        # "must not require the source plugin at runtime" is the inspiration
+        # boundary every issue in this batch states. A blanket word ban would
+        # refuse OMH's own contract language, so the artifact vocabulary only
+        # refuses alongside an adoption cue.
+        self.assertEqual(
+            package_recommendation_refusals(
+                "Hermes answers this natively and must not require the source plugin at runtime"
+            ),
+            [],
+        )
+
+    def test_an_omh_package_workflow_is_not_read_as_a_distributable(self) -> None:
+        # `materials-package`, `report-package`, and `deliverable-package` are
+        # OMH capabilities. A rule that refuses its own product vocabulary is a
+        # broken rule, so bare "package" is deliberately not a cue.
+        self.assertEqual(
+            package_recommendation_refusals(
+                "Hermes prepares a materials package a reviewer can read in one pass"
+            ),
+            [],
+        )
+
+    def test_a_hand_written_report_cannot_smuggle_a_recommendation_past_the_validator(self) -> None:
+        report = _scout()
+        _first(report)["user_value"] = "Install the diff-risk plugin and the reviewer is done"
+
+        errors = validate_capability_gap_scout(report)
+
+        self.assertTrue(
+            any("recommends an installable package instead of user value" in error for error in errors),
+            errors,
+        )
+
+    def test_user_value_is_required(self) -> None:
+        for field in ("outcome_statement", "user_value"):
+            with self.subTest(field=field):
+                with self.assertRaises(CapabilityGapScoutError) as caught:
+                    _scout(opportunities=[_review_opportunity(**{field: "   "})])
+                self.assertIn(f"{field} is required", str(caught.exception))
+
+
+class ThreeEvidenceStatesTests(unittest.TestCase):
+    """AC3: fresh, stale, and denied stay three answers with three consequences."""
+
+    def test_the_three_states_are_distinguishable_in_one_report(self) -> None:
+        report = _scout(
+            opportunities=[
+                _review_opportunity(
+                    evidence=[
+                        _evidence(finding="A recent reading of the approved docs."),
+                        _evidence(finding="An old reading of the approved docs.", observed_at=_LONG_AGO),
+                        _evidence(finding="A reading of a source nobody approved.", uri=_UNAPPROVED),
+                    ]
+                )
+            ]
+        )
+        row = _first(report)
+        states = {str(item["evidence_state"]) for item in row["evidence"]}
+
+        self.assertEqual(validate_capability_gap_scout(report), [])
+        self.assertEqual(states, set(EVIDENCE_STATES))
+        self.assertEqual(
+            (row["fresh_evidence_count"], row["stale_evidence_count"], row["denied_evidence_count"]),
+            (1, 1, 1),
+        )
+
+    def test_a_ranked_opportunity_still_shows_what_did_not_support_it(self) -> None:
+        report = _scout(
+            opportunities=[
+                _review_opportunity(
+                    evidence=[
+                        _evidence(finding="A recent reading of the approved docs."),
+                        _evidence(finding="An old reading of the approved docs.", observed_at=_LONG_AGO),
+                    ]
+                )
+            ]
+        )
+        row = _first(report)
+
+        self.assertEqual(row["rank"], 1)
+        self.assertEqual(row["fresh_evidence_count"], 1)
+        self.assertEqual(row["stale_evidence_count"], 1)
+        self.assertEqual(report["summary"]["stale_evidence_count"], 1)
+
+    def test_confidence_counts_distinct_fresh_snapshots(self) -> None:
+        cases = {
+            "low": [_evidence(finding="One reading.")],
+            "medium": [
+                _evidence(finding="One reading.", content="first page"),
+                _evidence(finding="Another reading.", content="second page"),
+            ],
+            "high": [
+                _evidence(finding=f"Reading {index}.", content=f"page {index}")
+                for index in range(3)
+            ],
+        }
+        for expected, evidence in cases.items():
+            with self.subTest(confidence=expected):
+                report = _scout(opportunities=[_review_opportunity(evidence=evidence)])
+                self.assertEqual(_first(report)["confidence"], expected)
+                self.assertIn(expected, OPPORTUNITY_CONFIDENCE_LEVELS)
+
+    def test_paraphrasing_one_reading_does_not_raise_confidence(self) -> None:
+        # Two findings drawn from the same frozen snapshot are one piece of
+        # evidence. A count over findings would reward saying it twice.
+        snapshot = _snapshot()
+        report = _scout(
+            opportunities=[
+                _review_opportunity(
+                    evidence=[
+                        {"snapshot": snapshot, "finding": "Risk lanes are ordered."},
+                        {"snapshot": snapshot, "finding": "Ordering happens before review."},
+                    ]
+                )
+            ]
+        )
+
+        self.assertEqual(_first(report)["fresh_evidence_count"], 2)
+        self.assertEqual(_first(report)["confidence"], "low")
+
+    def test_evidence_that_cannot_support_leaves_confidence_unsupported(self) -> None:
+        for evidence in (
+            [_evidence(observed_at=_LONG_AGO)],
+            [_evidence(uri=_UNAPPROVED)],
+        ):
+            with self.subTest(state=evidence[0]["snapshot"]["observed_at"]):
+                report = _scout(opportunities=[_review_opportunity(evidence=evidence)])
+                self.assertEqual(_only_withheld(report)["confidence"], "unsupported")
+                self.assertEqual(OPPORTUNITY_CONFIDENCE_LEVELS[0], "unsupported")
+
+    def test_a_confidence_that_outruns_its_evidence_is_refused(self) -> None:
+        report = _scout()
+        _first(report)["confidence"] = "high"
+
+        self.assertIn(
+            "capability_gap_scout ranked_opportunities[0] confidence does not match its distinct "
+            "fresh snapshots",
+            validate_capability_gap_scout(report),
+        )
+
+    def test_stale_evidence_cannot_support_an_opportunity(self) -> None:
+        report = _scout(
+            opportunities=[
+                _review_opportunity(evidence=[_evidence(observed_at=_LONG_AGO)]),
+            ]
+        )
+        withheld = _only_withheld(report)
+
+        self.assertEqual(validate_capability_gap_scout(report), [])
+        self.assertEqual(report["ranked_opportunities"], [])
+        self.assertEqual(withheld["withheld_reason"], "evidence_stale")
+        self.assertEqual(withheld["fresh_evidence_count"], 0)
+        self.assertEqual(withheld["rank"], 0)
+        self.assertEqual(report["next_action"], "refresh_stale_evidence")
+
+    def test_denied_evidence_cannot_support_an_opportunity(self) -> None:
+        report = _scout(
+            opportunities=[_review_opportunity(evidence=[_evidence(uri=_UNAPPROVED)])],
+        )
+        withheld = _only_withheld(report)
+
+        self.assertEqual(validate_capability_gap_scout(report), [])
+        self.assertEqual(report["ranked_opportunities"], [])
+        self.assertEqual(withheld["withheld_reason"], "evidence_denied")
+        self.assertEqual(withheld["evidence"][0]["denied_sources"], [_UNAPPROVED])
+        self.assertEqual(report["next_action"], "widen_source_policy")
+
+    def test_a_denial_is_never_reported_as_staleness(self) -> None:
+        # An unapproved source read years ago is `denied`, not `stale`: the
+        # policy verdict comes first and its age was never even considered.
+        report = _scout(
+            opportunities=[_review_opportunity(evidence=[_evidence(uri=_UNAPPROVED, observed_at=_LONG_AGO)])],
+        )
+        item = _only_withheld(report)["evidence"][0]
+
+        self.assertEqual(item["evidence_state"], "denied")
+        self.assertEqual(_only_withheld(report)["withheld_reason"], "evidence_denied")
+        self.assertEqual(report["summary"]["stale_evidence_count"], 0)
+
+    def test_stale_and_denied_together_keep_both_reasons(self) -> None:
+        report = _scout(
+            opportunities=[
+                _review_opportunity(
+                    evidence=[
+                        _evidence(finding="An old reading of the approved docs.", observed_at=_LONG_AGO),
+                        _evidence(finding="A reading of a source nobody approved.", uri=_UNAPPROVED),
+                    ]
+                )
+            ]
+        )
+
+        self.assertEqual(validate_capability_gap_scout(report), [])
+        self.assertEqual(_only_withheld(report)["withheld_reason"], "evidence_stale_and_denied")
+        self.assertEqual(sorted(WITHHELD_REASONS)[-1], "evidence_stale_and_denied")
+
+    def test_one_denied_source_denies_a_snapshot_that_also_cites_an_approved_one(self) -> None:
+        # A finding cannot say which of its sources it came from, so a snapshot
+        # is only as admissible as its least admissible source.
+        report = _scout(
+            opportunities=[_review_opportunity(evidence=[_evidence(extra_uri=_UNAPPROVED)])],
+        )
+        item = _only_withheld(report)["evidence"][0]
+
+        self.assertEqual(item["cited_source_count"], 2)
+        self.assertEqual(item["denied_sources"], [_UNAPPROVED])
+        self.assertEqual(item["evidence_state"], "denied")
+
+    def test_an_empty_policy_admits_nothing(self) -> None:
+        report = _scout(opportunities=[_review_opportunity()], approved_sources=())
+
+        self.assertEqual(validate_capability_gap_scout(report), [])
+        self.assertEqual(report["source_policy"]["approved_source_count"], 0)
+        self.assertEqual(report["next_action"], "widen_source_policy")
+
+    def test_staleness_is_derived_at_read_time_and_never_written_down(self) -> None:
+        snapshot = _snapshot(observed_at=_RECENT)
+        frozen = json.dumps(snapshot, sort_keys=True)
+        opportunities = [_review_opportunity(evidence=[{"snapshot": snapshot, "finding": "One reading."}])]
+
+        inside = _scout(now="2026-08-09T00:00:00Z", opportunities=opportunities)
+        outside = _scout(now="2027-08-09T00:00:00Z", opportunities=opportunities)
+
+        self.assertEqual(_first(inside)["evidence"][0]["evidence_state"], "fresh")
+        self.assertEqual(_only_withheld(outside)["evidence"][0]["evidence_state"], "stale")
+        self.assertEqual(json.dumps(snapshot, sort_keys=True), frozen)
+        self.assertNotIn("expires", frozen)
+        self.assertNotIn("expiry", frozen)
+
+    def test_the_horizon_is_the_callers_policy_not_the_snapshots(self) -> None:
+        opportunities = [_review_opportunity(evidence=[_evidence(observed_at=_RECENT)])]
+
+        generous = _scout(opportunities=opportunities, freshness_horizon_days=90)
+        strict = _scout(opportunities=opportunities, freshness_horizon_days=7)
+
+        self.assertEqual(_first(generous)["evidence"][0]["evidence_state"], "fresh")
+        self.assertEqual(_only_withheld(strict)["evidence"][0]["evidence_state"], "stale")
+        self.assertEqual(
+            _first(generous)["evidence"][0]["observed_age_days"],
+            _only_withheld(strict)["evidence"][0]["observed_age_days"],
+        )
+
+    def test_an_observation_time_that_cannot_be_read_is_never_fresh(self) -> None:
+        report = _scout(
+            opportunities=[_review_opportunity(evidence=[_evidence(observed_at="sometime last spring")])],
+        )
+        item = _only_withheld(report)["evidence"][0]
+
+        self.assertEqual(validate_capability_gap_scout(report), [])
+        self.assertEqual(item["observed_age_days"], AGE_NOT_ESTABLISHED)
+        self.assertEqual(item["evidence_state"], "stale")
+
+    def test_a_now_that_cannot_be_read_is_refused(self) -> None:
+        for now in ("", "yesterday"):
+            with self.subTest(now=now):
+                with self.assertRaises(CapabilityGapScoutError) as caught:
+                    _scout(now=now)
+                self.assertIn("now must be an ISO 8601 timestamp", str(caught.exception))
+
+    def test_an_observation_dated_ahead_of_now_is_clamped_rather_than_refused(self) -> None:
+        report = _scout(
+            opportunities=[_review_opportunity(evidence=[_evidence(observed_at="2026-08-09T00:00:01Z")])],
+            now="2026-08-09T00:00:00Z",
+        )
+        item = _first(report)["evidence"][0]
+
+        self.assertEqual(item["observed_age_days"], 0)
+        self.assertEqual(item["evidence_state"], "fresh")
+
+    def test_a_naive_observation_time_is_read_as_utc(self) -> None:
+        report = _scout(opportunities=[_review_opportunity(evidence=[_evidence(observed_at="2026-07-01")])])
+
+        self.assertEqual(_first(report)["evidence"][0]["observed_age_days"], 39)
+
+
+class CollapsingAndRefusalTests(unittest.TestCase):
+    """The guards that keep a ranking from double-counting or floating free."""
+
+    def test_duplicate_opportunities_are_collapsed_into_one(self) -> None:
+        report = _scout(
+            opportunities=[
+                _review_opportunity(evidence=[_evidence(finding="First reading of the docs.")]),
+                _review_opportunity(evidence=[_evidence(finding="Second reading of the docs.")]),
+            ]
+        )
+        row = _first(report)
+
+        self.assertEqual(validate_capability_gap_scout(report), [])
+        self.assertEqual(len(report["ranked_opportunities"]), 1)
+        self.assertEqual(report["summary"]["opportunity_count"], 1)
+        self.assertEqual(len(row["evidence"]), 2)
+        self.assertEqual(row["fresh_evidence_count"], 2)
+
+    def test_a_repeated_wording_is_the_same_opportunity(self) -> None:
+        spaced = _review_opportunity(
+            outcome_statement="  Hermes flags a RISKY change before a reviewer   opens the diff ",
+            user_value="A different author said the same thing in different words.",
+        )
+        report = _scout(opportunities=[_review_opportunity(), spaced])
+
+        self.assertEqual(len(report["ranked_opportunities"]), 1)
+        self.assertEqual(
+            _first(report)["user_value"],
+            "A reviewer sees which change is risky without reading everything first.",
+        )
+
+    def test_a_repeated_citation_is_counted_once(self) -> None:
+        report = _scout(
+            opportunities=[
+                _review_opportunity(evidence=[_evidence(finding="One reading."), _evidence(finding="One reading.")])
+            ]
+        )
+
+        self.assertEqual(len(_first(report)["evidence"]), 1)
+        self.assertEqual(_first(report)["fresh_evidence_count"], 1)
+
+    def test_an_opportunity_citing_no_evidence_is_refused(self) -> None:
+        with self.assertRaises(CapabilityGapScoutError) as caught:
+            _scout(opportunities=[_review_opportunity(evidence=[])])
+
+        self.assertIn("requires at least one cited snapshot", str(caught.exception))
+
+    def test_an_invalid_snapshot_citation_is_refused(self) -> None:
+        broken = _snapshot()
+        broken["evidence_digest"] = "0" * 64
+
+        with self.assertRaises(CapabilityGapScoutError) as caught:
+            _scout(
+                opportunities=[
+                    _review_opportunity(evidence=[{"snapshot": broken, "finding": "A reading."}])
+                ]
+            )
+
+        self.assertIn("cites an invalid snapshot", str(caught.exception))
+
+    def test_a_citation_that_is_not_a_snapshot_is_refused(self) -> None:
+        with self.assertRaises(CapabilityGapScoutError) as caught:
+            _scout(
+                opportunities=[
+                    _review_opportunity(evidence=[{"snapshot": "the openclaw docs", "finding": "A reading."}])
+                ]
+            )
+
+        self.assertIn("must be a capability_inspiration_snapshot/v1 object", str(caught.exception))
+
+    def test_a_finding_is_required(self) -> None:
+        with self.assertRaises(CapabilityGapScoutError) as caught:
+            _scout(opportunities=[_review_opportunity(evidence=[{"snapshot": _snapshot(), "finding": " "}])])
+
+        self.assertIn("evidence finding is required", str(caught.exception))
+
+    def test_unsupported_input_keys_are_refused(self) -> None:
+        with self.assertRaises(CapabilityGapScoutError) as caught:
+            _scout(opportunities=[_review_opportunity(**{"priority_score": 999})])
+        self.assertIn("opportunity has unsupported keys: ['priority_score']", str(caught.exception))
+
+        with self.assertRaises(CapabilityGapScoutError) as caught:
+            _scout(
+                opportunities=[
+                    _review_opportunity(
+                        evidence=[{"snapshot": _snapshot(), "finding": "A reading.", "state": "fresh"}]
+                    )
+                ]
+            )
+        self.assertIn("evidence has unsupported keys: ['state']", str(caught.exception))
+
+    def test_opportunities_stay_bounded(self) -> None:
+        crowd = [
+            _review_opportunity(
+                outcome_statement=f"Hermes narrows the review lane by rule number {index}",
+                evidence=[_evidence(finding=f"Reading number {index}.")],
+            )
+            for index in range(MAX_OPPORTUNITIES + 1)
+        ]
+
+        with self.assertRaises(CapabilityGapScoutError) as caught:
+            _scout(opportunities=crowd)
+
+        self.assertIn(f"exceeds {MAX_OPPORTUNITIES} distinct entries", str(caught.exception))
+
+    def test_evidence_stays_bounded_on_the_way_in(self) -> None:
+        with self.assertRaises(CapabilityGapScoutError) as caught:
+            _scout(
+                opportunities=[
+                    _review_opportunity(
+                        evidence=[
+                            _evidence(finding=f"Reading number {index}.")
+                            for index in range(MAX_EVIDENCE_PER_OPPORTUNITY + 1)
+                        ]
+                    )
+                ]
+            )
+
+        self.assertIn(f"evidence exceeds {MAX_EVIDENCE_PER_OPPORTUNITY} entries", str(caught.exception))
+
+    def test_evidence_stays_bounded_after_collapsing(self) -> None:
+        half = MAX_EVIDENCE_PER_OPPORTUNITY // 2 + 1
+        with self.assertRaises(CapabilityGapScoutError) as caught:
+            _scout(
+                opportunities=[
+                    _review_opportunity(
+                        evidence=[_evidence(finding=f"Left reading {index}.") for index in range(half)]
+                    ),
+                    _review_opportunity(
+                        evidence=[_evidence(finding=f"Right reading {index}.") for index in range(half)]
+                    ),
+                ]
+            )
+
+        self.assertIn("after collapsing duplicates", str(caught.exception))
+
+    def test_an_overlong_line_is_refused(self) -> None:
+        with self.assertRaises(CapabilityGapScoutError) as caught:
+            _scout(opportunities=[_review_opportunity(outcome_statement="x" * (MAX_LINE_LENGTH + 1))])
+
+        self.assertIn(f"exceeds {MAX_LINE_LENGTH} characters", str(caught.exception))
+
+    def test_the_source_policy_stays_bounded(self) -> None:
+        with self.assertRaises(CapabilityGapScoutError) as caught:
+            _scout(
+                approved_sources=tuple(
+                    f"https://example.test/source-{index}" for index in range(MAX_APPROVED_SOURCES + 1)
+                )
+            )
+
+        self.assertIn(f"approved_sources exceeds {MAX_APPROVED_SOURCES} entries", str(caught.exception))
+
+    def test_a_policy_that_is_not_a_list_of_uris_is_refused(self) -> None:
+        with self.assertRaises(CapabilityGapScoutError) as caught:
+            _scout(approved_sources=_APPROVED_DOCS)  # type: ignore[arg-type]
+
+        self.assertIn("approved_sources must be a sequence of source uris", str(caught.exception))
+
+    def test_an_unusable_horizon_is_refused(self) -> None:
+        for horizon in (0, -1, MAX_FRESHNESS_HORIZON_DAYS + 1):
+            with self.subTest(horizon=horizon):
+                with self.assertRaises(CapabilityGapScoutError) as caught:
+                    _scout(freshness_horizon_days=horizon)
+                self.assertIn("freshness_horizon_days must be between", str(caught.exception))
+
+    def test_a_report_with_nothing_to_rank_asks_for_evidence(self) -> None:
+        report = _scout(opportunities=[])
+
+        self.assertEqual(validate_capability_gap_scout(report), [])
+        self.assertEqual(report["ranked_opportunities"], [])
+        self.assertEqual(report["next_action"], "supply_observed_evidence")
+        self.assertIn(report["next_action"], SCOUT_NEXT_ACTIONS)
+
+
+class ValidatorTests(unittest.TestCase):
+    """The key sets are closed both ways and every derived value is re-derived."""
+
+    def test_the_built_report_carries_exactly_the_declared_keys(self) -> None:
+        report = _scout(opportunities=[_review_opportunity()])
+
+        self.assertEqual(sorted(report), sorted(CAPABILITY_GAP_SCOUT_KEYS))
+        self.assertEqual(sorted(report["source_policy"]), sorted(CAPABILITY_GAP_SOURCE_POLICY_KEYS))
+        self.assertEqual(sorted(report["summary"]), sorted(CAPABILITY_GAP_SUMMARY_KEYS))
+        self.assertEqual(sorted(_first(report)), sorted(CAPABILITY_GAP_OPPORTUNITY_KEYS))
+        self.assertEqual(sorted(_first(report)["evidence"][0]), sorted(CAPABILITY_GAP_EVIDENCE_KEYS))
+
+    def test_an_extra_key_is_refused(self) -> None:
+        report = _scout()
+        report["source_freshness_verified"] = True
+
+        self.assertIn(
+            "capability_gap_scout has unsupported keys: ['source_freshness_verified']",
+            validate_capability_gap_scout(report),
+        )
+
+    def test_a_missing_key_is_refused(self) -> None:
+        report = _scout()
+        del report["summary"]
+
+        self.assertIn(
+            "capability_gap_scout is missing keys: ['summary']",
+            validate_capability_gap_scout(report),
+        )
+
+    def test_an_extra_key_on_a_nested_shape_is_refused(self) -> None:
+        report = _scout()
+        _first(report)["evidence"][0]["source_reachable"] = True
+
+        self.assertIn(
+            "capability_gap_scout ranked_opportunities[0] evidence[0] has unsupported keys: "
+            "['source_reachable']",
+            validate_capability_gap_scout(report),
+        )
+
+    def test_a_priority_that_does_not_follow_from_its_signals_is_refused(self) -> None:
+        report = _scout(opportunities=[_review_opportunity(), _citation_opportunity()])
+        _first(report)["priority_score"] = 9999
+
+        self.assertIn(
+            "capability_gap_scout ranked_opportunities[0] priority_score does not follow from its own signals",
+            validate_capability_gap_scout(report),
+        )
+
+    def test_a_reordered_ranking_is_refused(self) -> None:
+        report = _scout(opportunities=[_review_opportunity(), _citation_opportunity()])
+        report["ranked_opportunities"] = list(reversed(report["ranked_opportunities"]))
+
+        errors = validate_capability_gap_scout(report)
+
+        self.assertIn(
+            "capability_gap_scout ranked_opportunities must be sorted by descending priority "
+            "then opportunity_id",
+            errors,
+        )
+
+    def test_a_rank_out_of_sequence_is_refused(self) -> None:
+        report = _scout()
+        _first(report)["rank"] = 7
+
+        self.assertIn(
+            "capability_gap_scout ranked_opportunities[0] rank must be 1",
+            validate_capability_gap_scout(report),
+        )
+
+    def test_a_stale_finding_promoted_to_fresh_is_refused(self) -> None:
+        report = _scout(opportunities=[_review_opportunity(evidence=[_evidence(observed_at=_LONG_AGO)])])
+        _only_withheld(report)["evidence"][0]["evidence_state"] = "fresh"
+
+        errors = validate_capability_gap_scout(report)
+
+        self.assertIn(
+            "capability_gap_scout withheld_opportunities[0] evidence[0] evidence_state does not "
+            "follow from its denied sources, age, and the report horizon",
+            errors,
+        )
+
+    def test_a_denied_finding_promoted_to_fresh_is_refused(self) -> None:
+        report = _scout(opportunities=[_review_opportunity(evidence=[_evidence(uri=_UNAPPROVED)])])
+        _only_withheld(report)["evidence"][0]["evidence_state"] = "fresh"
+
+        self.assertTrue(
+            any("evidence_state does not follow" in error for error in validate_capability_gap_scout(report))
+        )
+
+    def test_a_withheld_opportunity_moved_into_the_ranking_is_refused(self) -> None:
+        report = _scout(opportunities=[_review_opportunity(evidence=[_evidence(observed_at=_LONG_AGO)])])
+        report["ranked_opportunities"] = report["withheld_opportunities"]
+        report["withheld_opportunities"] = []
+
+        errors = validate_capability_gap_scout(report)
+
+        self.assertIn(
+            "capability_gap_scout ranked_opportunities[0] a ranked opportunity must carry no withheld_reason",
+            errors,
+        )
+        self.assertIn(
+            "capability_gap_scout ranked_opportunities[0] a ranked opportunity must cite at least "
+            "one fresh finding",
+            errors,
+        )
+
+    def test_a_ranked_opportunity_moved_into_the_withheld_list_is_refused(self) -> None:
+        report = _scout()
+        report["withheld_opportunities"] = report["ranked_opportunities"]
+        report["ranked_opportunities"] = []
+
+        errors = validate_capability_gap_scout(report)
+
+        self.assertIn(
+            "capability_gap_scout withheld_opportunities[0] withheld_reason must be one of "
+            f"{list(WITHHELD_REASONS)}",
+            errors,
+        )
+        self.assertIn(
+            "capability_gap_scout withheld_opportunities[0] a withheld opportunity must cite no fresh finding",
+            errors,
+        )
+
+    def test_an_opportunity_repeated_across_both_lists_is_refused(self) -> None:
+        report = _scout()
+        report["withheld_opportunities"] = [dict(_first(report))]
+
+        self.assertIn(
+            "capability_gap_scout an opportunity_id must not appear twice",
+            validate_capability_gap_scout(report),
+        )
+
+    def test_a_summary_that_does_not_total_the_lists_is_refused(self) -> None:
+        report = _scout()
+        report["summary"]["fresh_evidence_count"] = 42
+
+        self.assertIn(
+            "capability_gap_scout summary fresh_evidence_count does not match the reported opportunities",
+            validate_capability_gap_scout(report),
+        )
+
+    def test_a_next_action_that_does_not_follow_is_refused(self) -> None:
+        report = _scout()
+        report["next_action"] = "widen_source_policy"
+
+        self.assertIn(
+            "capability_gap_scout next_action does not follow from its opportunities and evidence",
+            validate_capability_gap_scout(report),
+        )
+
+    def test_a_report_id_that_does_not_match_its_material_is_refused(self) -> None:
+        report = _scout()
+        report["report_id"] = "capability-gap-scout-0000000000000000"
+
+        self.assertIn(
+            "capability_gap_scout report_id does not match its ranked material",
+            validate_capability_gap_scout(report),
+        )
+
+    def test_a_rewritten_source_policy_is_refused(self) -> None:
+        report = _scout()
+        report["source_policy"]["approved_sources"] = [_UNAPPROVED]
+
+        errors = validate_capability_gap_scout(report)
+
+        self.assertIn(
+            "capability_gap_scout source_policy approved_source_count does not match approved_sources",
+            errors,
+        )
+        self.assertIn(
+            "capability_gap_scout source_policy policy_id does not match its approved sources", errors
+        )
+
+    def test_a_weakened_claim_boundary_is_refused(self) -> None:
+        report = _scout()
+        report["claim_boundary"] = "OMH searched the ecosystem for you."
+
+        self.assertIn(
+            "capability_gap_scout claim_boundary must state that OMH searched nothing itself",
+            validate_capability_gap_scout(report),
+        )
+
+    def test_a_dropped_boundary_declaration_is_refused(self) -> None:
+        report = _scout()
+        report["not_evidence_until_observed"] = ["source_availability"]
+
+        self.assertIn(
+            "capability_gap_scout not_evidence_until_observed must be "
+            f"{list(CAPABILITY_GAP_SCOUT_NOT_OBSERVED)}",
+            validate_capability_gap_scout(report),
+        )
+
+    def test_a_relabelled_coverage_family_is_refused(self) -> None:
+        report = _scout()
+        _first(report)["coverage_label"] = "Ship whatever is popular"
+
+        self.assertIn(
+            "capability_gap_scout ranked_opportunities[0] coverage_label does not match the current "
+            "capability family",
+            validate_capability_gap_scout(report),
+        )
+
+    def test_a_non_object_is_refused(self) -> None:
+        self.assertEqual(validate_capability_gap_scout("not an object"), ["capability_gap_scout must be an object"])
+
+
+class NoSearchHappenedTests(unittest.TestCase):
+    """The report is a ranking over supplied evidence, and says so."""
+
+    def test_the_module_cannot_search(self) -> None:
+        # Parsed rather than string-matched: this module's docstring explains
+        # what it does not import, and a prefix scan would read those sentences
+        # as imports.
+        module_path = (
+            Path(__file__).resolve().parents[1] / "src" / "quality" / "capability_gap_scout.py"
+        )
+        tree = ast.parse(module_path.read_text(encoding="utf-8"))
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                imported.add((node.module or "").split(".")[0])
+
+        for module in _NETWORK_MODULES:
+            with self.subTest(module=module):
+                self.assertNotIn(module, imported)
+
+    def test_nothing_in_the_report_reads_as_a_survey_omh_just_ran(self) -> None:
+        report = _scout(opportunities=[_review_opportunity(), _citation_opportunity()])
+        scanned = dict(report)
+        scanned.pop("claim_boundary")
+        rendered = json.dumps(scanned, sort_keys=True).lower()
+
+        for phrase in _ASSERTED_SEARCH:
+            with self.subTest(phrase=phrase):
+                self.assertNotIn(phrase, rendered)
+
+    def test_the_boundary_states_the_negations_it_owes(self) -> None:
+        report = _scout()
+
+        self.assertEqual(report["claim_boundary"], CAPABILITY_GAP_SCOUT_CLAIM_BOUNDARY)
+        self.assertIn("no search, fetch, download, or network call", report["claim_boundary"])
+        self.assertIn("never an instruction to install", report["claim_boundary"])
+        self.assertEqual(
+            report["not_evidence_until_observed"], list(CAPABILITY_GAP_SCOUT_NOT_OBSERVED)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- Adds `capability_gap_scout/v1` (`src/quality/capability_gap_scout.py`): a goal-scoped ranker that turns "what could Hermes do better at this?" into ranked OMH-native opportunities, each tied to the capability family that covers it today and each backed by frozen evidence with an explicit freshness verdict.
- Adds `build_capability_gap_scout(...)` and `validate_capability_gap_scout(...)`, plus `package_recommendation_refusals(...)` — the shared judgement the builder and the validator both use to refuse an opportunity phrased as an installation instruction.
- Adds `tests/test_capability_gap_scout.py`: 76 tests covering the three acceptance criteria, the collapse/refusal guards, the closed key sets in both directions, and the no-search boundary.
- No generated artifact, catalog entry, doc, or CLI surface changed. The module is library-only, matching how `capability_inspiration_snapshot/v1` (#790) landed.

### Why This Exists

Issue #792. A user knows the outcome they want and does not know which public agent projects have already tried something like it. The raw form of that question — search the ecosystem, read what comes back — answers with implementation names, and an answer made of implementation names is a shopping list rather than a product direction.

Two rankers already exist and neither answers this:

- `src/quality/capability_roadmap.py` (`omh_capability_gap_roadmap/v1`) ranks missing setup and missing runtime evidence from a probe payload. That is an installation question, and it returns the same answer for every user.
- `src/quality/popular_plugin_coverage.py` (`popular_plugin_coverage/v1`) weighs request families against OMH case ids. That is a breadth heuristic, and it also returns the same answer for every user.

Neither is goal-scoped, neither applies a source policy, and neither knows whether the material behind its verdict was read last week or two years ago. That gap is what this adds.

### User / Operator Impact

A caller can now ask the question with a goal attached and get an answer that changes with the goal. Concretely, from `tests/test_capability_gap_scout.py`, the same two opportunities and the same catalog:

| Goal | Rank 1 | Rank 2 |
| --- | --- | --- |
| `catch risky changes before review` | `delegate_coding_and_ship` (alignment 2, score 32) | `learn_and_gather` (alignment 0, score 7) |
| `explain which research source backs a claim` | `learn_and_gather` (alignment 3, score 37) | `delegate_coding_and_ship` (alignment 1, score 22) |

The second row is the interesting one: the citation opportunity is marked `covered` and the review opportunity `partial`, so gap size alone would rank review first under either goal. Under the citation goal it does not. That is the whole point of goal scoping.

Three things a reader of the report can now tell apart that were previously indistinguishable:

- An opportunity supported by an approved source read inside the horizon (`fresh`) from one supported only by an old reading (`stale`) or by a source the policy does not admit (`denied`). Only `fresh` supports an opportunity.
- An opportunity that was held back because of a policy denial (`evidence_denied` → `next_action: widen_source_policy`) from one held back because the reading aged out (`evidence_stale` → `next_action: refresh_stale_evidence`). Those ask a maintainer for different work.
- A proposal for OMH to build from an instruction to acquire something. The second is a validation error, not a style note.

### How It Works

**Goal scoping.** The goal is reduced to scoring terms with the existing `routing_tokens` helper (`src/routing/localization.py`), so the tokenizer, stopword list, and unicode folding are the ones the router already uses rather than a second one. `goal_alignment` counts distinct goal terms an opportunity says in its own `outcome_statement` and `user_value`. Findings are deliberately excluded from that corpus: a ranking that rose with the volume of quoted evidence would reward padding the citation list. `priority_score = alignment*10 + coverage_weight*5 + fresh_count*2`, so alignment dominates gap size; ties break on `opportunity_id`.

**Coverage is read, not invented.** Every opportunity names a `coverage_family_id` from `capabilities.families.capability_family_projection()`. An id outside the live projection is refused, and `coverage_label` is copied from the projection rather than retyped, so there is no second inventory of what OMH can do. `coverage_state` (`absent` / `partial` / `covered`) is recorded as the caller's judgement about their own goal — the family is OMH's fact, the state is not, and the module docstring says which is which.

**The product boundary (AC2), enforced in both directions.** `PACKAGE_ACQUISITION_CUES` ("install", "npx", "uv add", …) refuses an opportunity on its own. `DISTRIBUTABLE_ARTIFACT_CUES` ("plugin", "extension", "add-on", …) refuses only alongside `ARTIFACT_ADOPTION_CUES` ("adopt", "use", "enable", …), because this repository's own boundary language — "must not require the source plugin at runtime" — says the word without recommending the thing. Bare "package" is deliberately not a cue: `materials-package`, `report-package`, and `deliverable-package` are OMH capabilities, and a rule that refuses its own product vocabulary is a broken rule. Matching goes through `normalized_phrase` + `contains_boundary_phrase` (`src/routing/executor_cues.py`), so it is word-boundary matching and not raw containment.

Findings are scanned by the opposite rule: not at all. `test_the_answer_may_not_recommend_what_a_finding_is_allowed_to_name` pins the sharp edge — the sentence "Use the openclaw community plugin to get a per-hook risk manifest" is admissible as a finding and refused as an `outcome_statement`. The prohibition is on what OMH proposes, never on what an observer read.

**Freshness (AC3), derived at read time.** Each finding cites a `capability_inspiration_snapshot/v1` from #790, which must pass `validate_capability_inspiration_snapshot` or the build is refused. Freshness is `now - snapshot.observed_at` against a caller-supplied `freshness_horizon_days` (default 90). Nothing writes an expiry anywhere: `test_the_horizon_is_the_callers_policy_not_the_snapshots` shows the same snapshot reading `fresh` at a 90-day horizon and `stale` at a 7-day one, and `test_staleness_is_derived_at_read_time_and_never_written_down` asserts the snapshot is byte-identical afterwards. An unreadable or missing observation time is `AGE_NOT_ESTABLISHED` and never `fresh`. A denied source is `denied` regardless of age — the policy verdict comes first and the age is never considered.

**Determinism.** `now` is a required parameter and the module reads no clock. It lands in `evaluated_at` for the reader and is excluded from `report_id`, along with `observed_age_days` inside every finding — that field counts up daily and would otherwise mint a new id each morning while the answer stood still. The freshness *verdicts* stay inside the seed on purpose, so a report whose evidence crossed the horizon does get a new id. Both halves are pinned: `test_the_report_id_ignores_the_moment_it_was_evaluated` moves the clock ten days (asserting the recorded age really moved by 10) and requires the id to hold; `test_a_moved_verdict_moves_the_report_id` requires it to change when a verdict flips.

**Validator.** Closed exact key sets in both directions (unsupported keys and missing keys) on the report, `source_policy`, `summary`, every opportunity, and every finding. Beyond shape, it re-derives `opportunity_id`, `finding_id`, `policy_id`, `report_id`, `goal_alignment`, `priority_score`, `confidence`, every evidence state, the withheld reason, the summary totals, the rank sequence, and the sort order from the payload's own material — so a hand-edited report whose numbers disagree with its content is refused, not just one with a missing field.

**No search.** The module imports nothing that can open a socket; `test_the_module_cannot_search` re-derives the import set with `ast` (rather than a string-prefix scan, which would read the docstring's prose as imports) and asserts the network modules are absent. `test_nothing_in_the_report_reads_as_a_survey_omh_just_ran` renders the whole report minus `claim_boundary` and asserts no "reachable"/"verified"/"fetched"/"searched"-class word appears anywhere in it.

### Files And Contracts Touched

| File | What |
| --- | --- |
| `src/quality/capability_gap_scout.py` | New. `capability_gap_scout/v1` builder, validator, closed key sets, five closed vocabularies, `claim_boundary`, `not_evidence_until_observed`. |
| `tests/test_capability_gap_scout.py` | New. 76 tests in five classes: goal scoping, the product boundary, the three evidence states, collapse/refusal guards, validator, no-search boundary. |

Contracts consumed, none changed: `capability_inspiration_snapshot/v1` (`src/quality/capability_inspiration_snapshot.py`), `capability_family_projection()` (`src/capabilities/families.py`), `routing_tokens` / `normalized_phrase` (`src/routing/localization.py`), `contains_boundary_phrase` (`src/routing/executor_cues.py`), `_stable_encode` (`src/quality/skill_governance.py`).

No generated artifact is touched: `skills/*/SKILL.md`, `docs/WORKFLOWS.md`, `docs/ROLES.md`, the capability-family sidecar, and the demo-cards JSON are all unmodified, and their `--check` gates confirm it below.

## Validation

Observed on `agent/issue-792` at `9cc21643`, rebased on `origin/main` `1215d065` (rebase was a no-op — the branch was already at that commit).

- [x] `uv run --group lint ruff check src tests` — `All checks passed!`
- [x] `python3 -m unittest discover -s tests` — ran as `PYTHONPATH=tests uv run python -m unittest discover -s tests`: **Ran 5271 tests in 175.747s — OK**
- [x] `python3 -m compileall src` — ran as `uv run python -m compileall -q src tests`: exit 0, no output
- [x] `python3 -m omh.cli docs workflows --check` — `{"checked":".../docs/WORKFLOWS.md","ok":true,"tap_skills":{"checked":115,"expected":115,"extra":[],"missing":[],"ok":true,"stale":[]}}`
- [x] `python3 -m omh.cli harness validate` — `{"counts":{"harnesses":72,"skills":104},"errors":[],"ok":true,"schema_version":"catalog_validation/v1","warnings":[]}`
- [x] `python3 -m omh.cli release checklist --json` — exit 0, emitted the checklist payload (every item `"observed": false`, which is the checklist's own prepared-not-observed default and not a claim about this PR)
- [x] `python3 -m omh.cli release hermes-smoke` — exit 0, **`Mode: plan; observed evidence: no`**. This is a printed plan, not an install; it is not evidence that Hermes loaded anything.
- [x] `omh --help` — exit 0
- [x] `omh --omh-home <tmp> --hermes-home <tmp> release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — exit 0, `Status: ok`, again `Mode: plan; observed evidence: no`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: **not applicable** — no learning contract changed.
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli docs roles --check` → `ok:true`; `uv run python -m omh.cli docs capability-families --check` → `ok:true`; `git diff --check` → clean
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: **not run.** Nothing in this PR reaches a Hermes-visible surface — no skill, no router trigger, no CLI command, no generated file — so there is no Hermes behaviour to check. When a later change wires the scout to a chat or CLI surface, that is where the manual check belongs.

Targeted run of the new file: `PYTHONPATH=tests uv run python -m unittest tests/test_capability_gap_scout.py` → **Ran 76 tests in 0.025s — OK**.

## Risk

- **Low blast radius.** Two new files, nothing imports the module in production, so no existing code path changes behaviour. The failure mode of a bug here is a wrong ranking in a caller that does not exist yet, not a regression in a shipping surface.
- **The refusal vocabulary is conservative and will over-refuse.** "Add a plugin-free path to X" trips the artifact+adoption rule. That is the chosen direction: AC2 makes naming an installable package a validation error, the cost of a false positive is a rephrase, and the cost of a false negative is shipping a shopping list. Three tests pin the cases where it must *not* fire — this repo's own "must not require the source plugin at runtime" boundary language, OMH's `materials package` vocabulary, and any finding.
- **`coverage_state` is caller-supplied and unverifiable.** OMH cannot mechanically judge how much of a goal a family already delivers. The family id and label are read from the live projection and refused when unknown; the state is recorded as a judgement and the docstring says so. A caller who marks everything `absent` inflates its own ranking, which is a garbage-in property, not a contract hole.
- **Confidence counts citations, not quality.** `confidence` is the number of *distinct fresh snapshots* capped at the vocabulary — deliberately snapshots, not findings, so paraphrasing one reading three times does not raise it (`test_paraphrasing_one_reading_does_not_raise_confidence`). It is not a judgement about whether the idea is good; OMH cannot have one of those, and both the constant's comment and the helper's docstring say so.
- **Clock handling.** An observation dated ahead of `now` is clamped to age 0 rather than refused, on the reasoning that both values are caller-supplied metadata and a few seconds of skew should not read as staleness. A caller who fabricates a future timestamp could equally fabricate a current one, so this is not the place that guard belongs.

## Compatibility / Rollout

- Additive only. No existing schema, key set, vocabulary, count assertion, or generated file changed, so nothing needs to be regenerated and no consumer needs to migrate.
- The four exact-count fixtures the repo warns about (`tests/test_routing_precision.py`, `tests/test_cli.py`, `tests/test_hermes_ux_quality.py`, `tests/test_release_smoke.py`) are untouched, because no routing case, skill, or demo card was added. Skill count stays 104 and harness count stays 72, as `harness validate` shows above.
- No new dependency. The module's imports are `hashlib`, `datetime`, `collections.abc`, `typing`, and four in-tree modules.
- Nothing is user-reachable yet, so there is no rollout step and nothing to roll back beyond reverting the commit.

## Release / Claims

- [x] Release-channel impact considered — none. No installed surface, no packaged artifact, no version file changes; this rides the next ordinary release with no channel-specific behaviour.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — the report's `claim_boundary` states that OMH ran no search, fetch, download, or network call and cannot run one, that freshness comes from the snapshot's *reported* observation time rather than a re-read, and that a ranked opportunity is neither an installation instruction nor maintainer acceptance, implementation, review, CI, or merge evidence. `not_evidence_until_observed` names all six unobserved claims, and the validator refuses a payload that weakens either.
- [x] Known manual Hermes checks are listed — see the unticked Validation line above. `omh release hermes-smoke` was run and reported `Mode: plan; observed evidence: no`; it was not run `--live`, and neither run is evidence that Hermes loaded anything.

## Follow-Up

- Wire the scout to a surface. It is library-only today, exactly as `capability_inspiration_snapshot/v1` landed in #790, and nothing produces or consumes a report in a real flow yet. A follow-up that adds a skill, router trigger, or CLI command needs the full `docs/ADDING-A-SKILL.md` treatment (awareness lane, context card, ack/label/card coverage, the capability-family sidecar) plus updates to the exact-count fixtures.
- Give accepted opportunities somewhere to go. The issue's "How it blends into OMH" says an accepted opportunity becomes a native capability request and may enter reviewed memory or an implementation handoff after review. Acceptance is deliberately out of scope here — scouting stays read-only until a maintainer acts — and `opportunity_acceptance` is already named in `not_evidence_until_observed` so the boundary is stated before the feature exists.
- The goal ranker is English-token overlap, consistent with the Routing Language Policy in `docs/DIRECTION.md` (English is the primary trigger surface; non-English intent resolution belongs to model selection). A non-English goal will score zero alignment and fall back to coverage weight and evidence count. That is the documented policy rather than a defect, but it is worth naming if a localized surface ever calls this.
