### PR TITLE
feat: retarget accepted coding work to another owner without replanning

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -119,6 +119,7 @@ src/
     executors.py
     isolation.py
     owner_fit.py
+    owner_retarget.py
     pre_handoff_readiness.py
     team_readiness.py
     worktree_creator.py
@@ -687,6 +688,59 @@ Classification reads the snapshot and never the owner id.
 `owner_fit_without_owner_identity` drops the only two owner-identity fields
 (`owner`, `label`), and two owners holding equal evidence produce equal
 projections — the executor-neutrality property in code rather than in prose.
+
+### Coding Owner Retarget
+
+`coding/owner_retarget.py` moves an accepted coding plan to a different owner
+without planning it again. A plan is accepted once, and the accepted reading —
+routed workflow, intent, acceptance criteria, verification expectations — is
+computed before `build_coding_delegation_payload` looks at `executor_target` at
+all. What used to depend on the owner was the only way to change one:
+`prepare_wrapper_session_handoff` refused every executor change on a follow-up
+handoff and offered a single escape, "start a new session". A new session has no
+accepted plan, so changing owner meant replanning approved work.
+
+Retargeting is therefore a re-projection, not a decision:
+
+- `coding_task_contract/v1` is the owner-neutral half of one accepted plan,
+  projected from `payload["delegation"]` plus a digest of the equally
+  owner-neutral `specialist_work_quality` bar. `work_role` is
+  `delegation.executor_profile` renamed on projection, because it names the role
+  the work is scoped to and never the coding owner.
+- `coding_owner_retarget/v1` records one move: both owners, the preserved
+  contract and its digest, the enumerated owner-specific delta
+  (`OWNER_SPECIFIC_FIELDS`, plus the observed-evidence events and wrapper
+  actions gained and lost), and the capability delta.
+- `build_owner_retarget` compares the two contracts field by field and raises
+  when any of them moved. A move that would change the task contract is refused
+  as a replan, so preservation is enforced by the builder rather than only
+  asserted by a test.
+
+The capability delta reuses `owner_fit`'s matcher instead of growing a second
+one. Both owners are classified against the target plan's requirement set,
+because "what changed" is only meaningful on one yardstick; the yardstick's own
+movement is reported separately as `required_by_owner_change` and
+`dropped_by_owner_change`. That movement is the point — retargeting from an
+external-executor owner to a runtime owner turns the routed workflow into
+something the new owner must carry locally, adding a `local_workflow`
+requirement the source plan never had. `next_action` follows from the delta:
+`confirm_owner_capability_gap` when something is recorded unavailable,
+`record_capability_evidence` when something is unproven, otherwise
+`prepare_handoff_for_new_owner`.
+
+Capability snapshots arrive as a parameter and nothing here reads a clock, a
+network, a credential, or a host configuration file, so retargeting stays a pure
+local re-projection.
+
+On the wrapper surface the guard was relaxed into a named operation rather than
+a silent allow. `omh chat session prepare-handoff --executor <owner> --retarget`
+moves a session that already has a prepared handoff; without `--retarget` a
+follow-up still keeps its executor, exactly as before. The retarget only applies
+to a prepared session, refuses a move to the owner already selected, refuses an
+unknown owner, and journals `coding_owner_retarget/v1` as a
+`coding_owner_retargeted` session event once the new handoff exists. A retarget
+is `prepared_not_observed`: it is not dispatch evidence and not proof the new
+owner accepted or started the work.
 
 ## Hermes Capability Boundary
 

--- a/src/coding/owner_retarget.py
+++ b/src/coding/owner_retarget.py
@@ -1,0 +1,712 @@
+"""Move accepted coding work to another owner without replanning it (#812).
+
+The gap this closes. A coding plan is accepted once. The accepted plan decides
+the routed workflow, the intent, the acceptance criteria, and the verification
+expectations, and none of those four readings depend on who ends up doing the
+work --- `build_coding_delegation_payload` computes `payload["delegation"]`
+before it ever looks at `executor_target`. What DID depend on the owner was the
+only way to change one: `prepare_wrapper_session_handoff` refused every
+executor change on a follow-up handoff and offered exactly one escape, "start a
+new session". A new session has no accepted plan, so changing owner meant
+replanning work the person had already approved and re-deriving criteria they
+had already agreed to.
+
+So retargeting is a **re-projection, not a decision**. The same owner-neutral
+task contract is rendered through a different owner's handoff projection, and
+the only thing Hermes has to explain is the part that genuinely moved.
+
+Three artifacts, all pure and all deterministic (`now` is a parameter, and
+nothing here reads a clock, a network, a credential, or a host configuration
+file):
+
+* `coding_task_contract/v1` --- the owner-neutral half of one accepted plan.
+  Projected from `payload["delegation"]`, whose ten fields are computed with no
+  reading of the owner, plus a digest of the equally owner-neutral
+  `specialist_work_quality` bar. This is what AC1 protects: the task's scope
+  (`intent`, `recommended_workflow`, `recommended_harness`, `work_role`), its
+  non-goals and review boundary (`review_required`, `review_workflow`, and the
+  `delegation_prompt_template` that states them to the owner), its
+  `acceptance_criteria`, and its `verification`.
+
+* `coding_owner_retarget/v1` --- the record of one move. It carries the two
+  owners, the preserved contract and its digest, the enumerated owner-specific
+  delta, and the capability delta.
+
+* The refusal. `build_owner_retarget` compares the two contracts field by field
+  and raises when any of them moved. **A retarget that would change the task
+  contract is refused as a replan**, so AC1 is enforced by the builder rather
+  than asserted by a test alone.
+
+AC2 --- "enumerate unsupported or changed owner capability before handoff" ---
+reuses #810's matcher rather than growing a second one. Requirements come from
+`derive_plan_capability_requirements(accepted_plan_from_delegation(...))` and
+each owner is classified by `evaluate_owner_fit`. Both owners are judged
+against the TARGET plan's requirement set, because "what changed" is only
+meaningful on one yardstick; the yardstick's own movement is reported
+separately as `required_by_owner_change` / `dropped_by_owner_change`. That
+movement is real and is the whole point of the field: retargeting from an
+external-executor owner to a runtime owner turns the routed workflow into
+something the new owner has to carry locally, which adds a `local_workflow`
+requirement that the source plan never had.
+
+AC3 --- no source-host configuration or credential is read. Capability
+snapshots arrive as a parameter; absent snapshots classify every requirement
+`unknown` (an unproven owner), never a guess. Retargeting is a local
+re-projection of two values the caller already holds.
+
+Nothing here is execution. A retarget is not dispatch and not evidence that the
+new owner accepted or started anything.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any, Final
+
+from ..system.hashutil import sha256_text
+from .executors import EXECUTOR_PROFILES, executor_label
+from .owner_fit import (
+    OWNER_FIT_CLASSIFICATIONS,
+    OWNER_FIT_VERDICTS,
+    accepted_plan_from_delegation,
+    derive_plan_capability_requirements,
+    evaluate_owner_fit,
+)
+
+
+CODING_TASK_CONTRACT_SCHEMA_VERSION: Final = "coding_task_contract/v1"
+OWNER_RETARGET_SCHEMA_VERSION: Final = "coding_owner_retarget/v1"
+OWNER_RETARGET_STATUS: Final = "prepared_not_observed"
+
+# The three fields a built payload can carry a prepared handoff under. Exactly
+# one is present per owner, and which one it is is itself part of the delta.
+HANDOFF_PAYLOAD_FIELDS: Final = ("executor_handoff", "prompt_handoff", "runtime_handoff")
+
+# The preserved half. `work_role` is `delegation.executor_profile` renamed on
+# projection: it is the ROLE the work is scoped to (coding-agent, reviewer,
+# planner, docs-writer), never the coding owner, and in a record whose subject
+# is "the owner changed" the source name would read as the opposite of what it
+# means.
+TASK_CONTRACT_KEYS: Final = (
+    "schema_version",
+    "status",
+    "task_source_sha256",
+    "action",
+    "intent",
+    "recommended_workflow",
+    "recommended_harness",
+    "work_role",
+    "acceptance_criteria",
+    "verification",
+    "review_required",
+    "review_workflow",
+    "delegation_prompt_template",
+    "work_quality_sha256",
+    "claim_boundary",
+)
+
+# The moved half. A closed list, compared field by field, so the delta names
+# what changed instead of diffing two whole handoffs and reporting noise.
+OWNER_SPECIFIC_FIELDS: Final = (
+    "work_owner_mode",
+    "handoff_field",
+    "dispatch_policy",
+    "dispatchable",
+    "dispatch_contract",
+    "recording_contract",
+    "invocation_mode",
+    "isolation_strategy",
+)
+
+OWNER_RETARGET_KEYS: Final = (
+    "schema_version",
+    "status",
+    "from_owner",
+    "from_owner_label",
+    "to_owner",
+    "to_owner_label",
+    "preserved",
+    "preserved_digest",
+    "owner_delta",
+    "capability_delta",
+    "next_action",
+    "reason",
+    "claim_boundary",
+)
+OWNER_DELTA_KEYS: Final = (
+    "changed",
+    "unchanged",
+    "observed_evidence_gained",
+    "observed_evidence_lost",
+    "wrapper_actions_gained",
+    "wrapper_actions_lost",
+)
+OWNER_DELTA_CHANGE_KEYS: Final = ("field", "from", "to")
+CAPABILITY_DELTA_KEYS: Final = (
+    "requirements",
+    "required_by_owner_change",
+    "dropped_by_owner_change",
+    "unsupported",
+    "unproven",
+    "changed",
+    "from_verdict",
+    "to_verdict",
+    "statement",
+)
+CAPABILITY_CHANGE_KEYS: Final = ("capability", "from_classification", "to_classification")
+
+OWNER_RETARGET_NEXT_ACTIONS: Final = (
+    "prepare_handoff_for_new_owner",
+    "confirm_owner_capability_gap",
+    "record_capability_evidence",
+)
+
+TASK_CONTRACT_CLAIM_BOUNDARY: Final = (
+    "This is the owner-neutral half of one accepted coding plan: what the work is, what it has to "
+    "satisfy, and how it has to be verified. It is prepared context, not dispatch, execution, "
+    "verification, review, CI, or merge evidence."
+)
+OWNER_RETARGET_CLAIM_BOUNDARY: Final = (
+    "A retarget re-projects one already-accepted task contract onto another coding owner. It is not "
+    "dispatch, execution, verification, review, CI, or merge evidence, it is not proof that the new "
+    "owner accepted or started the work, and it never replans the task."
+)
+
+_MAX_TEXT_LENGTH: Final = 240
+_MAX_REASON_LENGTH: Final = 400
+_MAX_LIST_ITEMS: Final = 16
+_MAX_CAPABILITIES: Final = 12
+
+
+class OwnerRetargetError(ValueError):
+    pass
+
+
+def coding_task_contract(payload: Mapping[str, Any], *, task_source_sha256: str = "") -> dict[str, Any]:
+    """The owner-neutral projection of one built coding-delegation payload.
+
+    A projection rather than a second derivation: every value is read back from
+    where the delegation build already wrote it, so the contract and the
+    handoff can never describe different work. `task_source_sha256` is the
+    caller's binding to the task text --- the payload never carries the raw
+    message, and OMH does not persist it.
+    """
+    delegation = payload.get("delegation")
+    if not isinstance(delegation, Mapping):
+        raise OwnerRetargetError("a built coding delegation payload is required to project a task contract")
+    work_quality = payload.get("specialist_work_quality")
+    review_workflow = delegation.get("review_workflow")
+    return {
+        "schema_version": CODING_TASK_CONTRACT_SCHEMA_VERSION,
+        "status": OWNER_RETARGET_STATUS,
+        "task_source_sha256": str(task_source_sha256 or ""),
+        "action": str(delegation.get("action", "")),
+        "intent": str(delegation.get("intent", "")),
+        "recommended_workflow": str(delegation.get("recommended_workflow", "")),
+        "recommended_harness": str(delegation.get("recommended_harness", "")),
+        "work_role": str(delegation.get("executor_profile", "")),
+        "acceptance_criteria": _text_list(delegation.get("acceptance_criteria")),
+        "verification": _text_list(delegation.get("verification")),
+        "review_required": bool(delegation.get("review_required", False)),
+        "review_workflow": "" if review_workflow is None else str(review_workflow),
+        "delegation_prompt_template": str(delegation.get("delegation_prompt_template", "")),
+        # The work-quality bar is owner-neutral too, but it is a nested contract
+        # rather than a sentence. Digesting it keeps it inside `preserved_digest`
+        # without turning a session event into a copy of the whole payload.
+        "work_quality_sha256": _canonical_digest(work_quality if isinstance(work_quality, Mapping) else {}),
+        "claim_boundary": TASK_CONTRACT_CLAIM_BOUNDARY,
+    }
+
+
+def coding_task_contract_digest(contract: Mapping[str, Any]) -> str:
+    """sha256 over the canonical JSON of one task contract."""
+    return _canonical_digest(dict(contract))
+
+
+def build_owner_retarget(
+    *,
+    from_payload: Mapping[str, Any],
+    to_payload: Mapping[str, Any],
+    task_source_sha256: str = "",
+    capability_snapshots: Mapping[str, Mapping[str, Any] | None] | None = None,
+    now: str = "",
+) -> dict[str, Any]:
+    """Record one accepted plan moving from one coding owner to another.
+
+    Both arguments are built coding-delegation payloads for the SAME task, one
+    per owner. The builder refuses rather than repairs: an owner-neutral field
+    that differs between them is a replan, not a retarget, and the caller is
+    told which field moved.
+
+    `capability_snapshots` maps an owner to its recorded
+    `executor_capability_snapshot/v1`, or to `None`. It is a parameter and not
+    a read so that retargeting stays a pure local re-projection (AC3); an owner
+    with no snapshot classifies `unknown` and reads as unproven, never as fit.
+    """
+    from_owner = _accepted_owner(from_payload, "source")
+    to_owner = _accepted_owner(to_payload, "target")
+    if from_owner == to_owner:
+        raise OwnerRetargetError(f"retargeting requires a different coding owner; both sides are {to_owner}")
+
+    from_contract = coding_task_contract(from_payload, task_source_sha256=task_source_sha256)
+    to_contract = coding_task_contract(to_payload, task_source_sha256=task_source_sha256)
+    moved = [key for key in TASK_CONTRACT_KEYS if from_contract[key] != to_contract[key]]
+    if moved:
+        raise OwnerRetargetError(
+            "retargeting must preserve the accepted task contract, and these owner-neutral fields moved, "
+            f"which is a replan rather than a retarget: {', '.join(moved)}"
+        )
+
+    owner_delta = _owner_delta(from_payload, to_payload)
+    capability_delta = _capability_delta(
+        from_payload=from_payload,
+        to_payload=to_payload,
+        from_owner=from_owner,
+        to_owner=to_owner,
+        capability_snapshots=dict(capability_snapshots or {}),
+        now=now,
+    )
+    record = {
+        "schema_version": OWNER_RETARGET_SCHEMA_VERSION,
+        "status": OWNER_RETARGET_STATUS,
+        "from_owner": from_owner,
+        "from_owner_label": executor_label(from_owner),
+        "to_owner": to_owner,
+        "to_owner_label": executor_label(to_owner),
+        "preserved": to_contract,
+        "preserved_digest": coding_task_contract_digest(to_contract),
+        "owner_delta": owner_delta,
+        "capability_delta": capability_delta,
+        "next_action": _next_action(capability_delta),
+        "reason": _retarget_reason(from_owner, to_owner, owner_delta, capability_delta),
+        "claim_boundary": OWNER_RETARGET_CLAIM_BOUNDARY,
+    }
+    errors = validate_owner_retarget(record)
+    if errors:
+        raise OwnerRetargetError("; ".join(errors))
+    return record
+
+
+def validate_coding_task_contract(contract: Mapping[str, Any]) -> list[str]:
+    """Both directions: no key of the closed set missing, no key outside it."""
+    errors = _closed_key_errors("task contract", contract, TASK_CONTRACT_KEYS)
+    if contract.get("schema_version") != CODING_TASK_CONTRACT_SCHEMA_VERSION:
+        errors.append(f"task contract schema_version must be {CODING_TASK_CONTRACT_SCHEMA_VERSION}")
+    if contract.get("status") != OWNER_RETARGET_STATUS:
+        errors.append("task contract status must be prepared_not_observed; a contract is never an observation")
+    if contract.get("claim_boundary") != TASK_CONTRACT_CLAIM_BOUNDARY:
+        errors.append("task contract claim_boundary must be the task contract claim boundary")
+    for field in ("action", "intent", "recommended_workflow", "recommended_harness", "work_role"):
+        value = contract.get(field)
+        if not isinstance(value, str) or not value.strip() or len(value) > _MAX_TEXT_LENGTH:
+            errors.append(f"task contract {field} must be a nonempty string of at most {_MAX_TEXT_LENGTH} characters")
+    for field in ("task_source_sha256", "review_workflow"):
+        value = contract.get(field)
+        if not isinstance(value, str) or len(value) > _MAX_TEXT_LENGTH:
+            errors.append(f"task contract {field} must be a string, empty when the plan declares none")
+    template = contract.get("delegation_prompt_template")
+    if not isinstance(template, str) or not template.strip():
+        errors.append("task contract delegation_prompt_template must be a nonempty string")
+    digest = contract.get("work_quality_sha256")
+    if not _is_sha256(digest):
+        errors.append("task contract work_quality_sha256 must be a sha256 hex digest")
+    if not isinstance(contract.get("review_required"), bool):
+        errors.append("task contract review_required must be a boolean")
+    for field in ("acceptance_criteria", "verification"):
+        errors.extend(_text_list_errors(f"task contract {field}", contract.get(field), required=True))
+    return errors
+
+
+def validate_owner_retarget(record: Mapping[str, Any]) -> list[str]:
+    """Both directions, plus the three properties the record exists to carry.
+
+    AC1 has teeth here: `preserved_digest` must be recomputable from the stored
+    contract, so a record cannot claim a preserved contract it does not hold.
+    AC2 has teeth here: `unsupported` and `unproven` must be subsets of the
+    declared requirements, and `next_action` must follow from them, so a gap
+    cannot be enumerated and then quietly dropped from the recommendation.
+    """
+    errors = _closed_key_errors("owner retarget", record, OWNER_RETARGET_KEYS)
+    if record.get("schema_version") != OWNER_RETARGET_SCHEMA_VERSION:
+        errors.append(f"owner retarget schema_version must be {OWNER_RETARGET_SCHEMA_VERSION}")
+    if record.get("status") != OWNER_RETARGET_STATUS:
+        errors.append("owner retarget status must be prepared_not_observed; a retarget is never an observation")
+    if record.get("claim_boundary") != OWNER_RETARGET_CLAIM_BOUNDARY:
+        errors.append("owner retarget claim_boundary must be the owner retarget claim boundary")
+    errors.extend(_owner_identity_errors(record))
+    reason = record.get("reason")
+    if not isinstance(reason, str) or not reason.strip() or len(reason) > _MAX_REASON_LENGTH:
+        errors.append(f"owner retarget reason must be a nonempty string of at most {_MAX_REASON_LENGTH} characters")
+
+    preserved = record.get("preserved")
+    if not isinstance(preserved, Mapping):
+        errors.append("owner retarget preserved must be the preserved task contract")
+    else:
+        errors.extend(validate_coding_task_contract(preserved))
+        if record.get("preserved_digest") != coding_task_contract_digest(preserved):
+            errors.append("owner retarget preserved_digest must be the digest of the preserved task contract")
+    if not _is_sha256(record.get("preserved_digest")):
+        errors.append("owner retarget preserved_digest must be a sha256 hex digest")
+
+    errors.extend(_owner_delta_errors(record.get("owner_delta")))
+    capability_errors, capability_delta = _capability_delta_errors(record.get("capability_delta"))
+    errors.extend(capability_errors)
+    next_action = record.get("next_action")
+    if next_action not in OWNER_RETARGET_NEXT_ACTIONS:
+        errors.append(f"owner retarget next_action must be one of {', '.join(OWNER_RETARGET_NEXT_ACTIONS)}")
+    elif capability_delta is not None and next_action != _next_action(capability_delta):
+        errors.append("owner retarget next_action must follow from the enumerated capability delta")
+    return errors
+
+
+def _accepted_owner(payload: Mapping[str, Any], side: str) -> str:
+    delegation = payload.get("delegation")
+    if not isinstance(delegation, Mapping) or str(delegation.get("action", "")) != "delegate":
+        raise OwnerRetargetError(f"the {side} payload carries no accepted coding delegation to retarget")
+    owner = str(payload.get("selected_executor_profile") or "")
+    if owner not in EXECUTOR_PROFILES:
+        raise OwnerRetargetError(
+            f"unsupported coding owner on the {side} side of a retarget: {owner or '<none selected>'}"
+        )
+    if not _handoff_field(payload):
+        raise OwnerRetargetError(f"the {side} payload carries no prepared handoff to retarget")
+    return owner
+
+
+def _handoff_field(payload: Mapping[str, Any]) -> str:
+    return next((name for name in HANDOFF_PAYLOAD_FIELDS if isinstance(payload.get(name), Mapping)), "")
+
+
+def _handoff(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    handoff = payload.get(_handoff_field(payload))
+    return handoff if isinstance(handoff, Mapping) else {}
+
+
+def _owner_facts(payload: Mapping[str, Any]) -> dict[str, str]:
+    handoff = _handoff(payload)
+    invocation = handoff.get("invocation")
+    invocation = invocation if isinstance(invocation, Mapping) else {}
+    isolation = payload.get("isolation_plan")
+    isolation = isolation if isinstance(isolation, Mapping) else {}
+    return {
+        "work_owner_mode": _scalar_text(payload.get("work_owner_mode", "")),
+        "handoff_field": _handoff_field(payload),
+        "dispatch_policy": _scalar_text(payload.get("dispatch_policy", "")),
+        "dispatchable": _scalar_text(bool(payload.get("dispatchable", False))),
+        "dispatch_contract": _scalar_text(handoff.get("dispatch_contract", "")),
+        "recording_contract": _scalar_text(handoff.get("recording_contract", "")),
+        # The codex projection names its invocation shape `handoff_mode` and the
+        # prompt/runtime projections name it `invocation.mode`; both answer the
+        # same question, so the delta reads one field rather than two.
+        "invocation_mode": _scalar_text(invocation.get("mode", "") or handoff.get("handoff_mode", "")),
+        "isolation_strategy": _scalar_text(isolation.get("strategy", "")),
+    }
+
+
+def _owner_delta(from_payload: Mapping[str, Any], to_payload: Mapping[str, Any]) -> dict[str, Any]:
+    from_facts = _owner_facts(from_payload)
+    to_facts = _owner_facts(to_payload)
+    from_evidence = _observed_evidence(from_payload)
+    to_evidence = _observed_evidence(to_payload)
+    from_actions = _wrapper_actions(from_payload)
+    to_actions = _wrapper_actions(to_payload)
+    return {
+        "changed": [
+            {"field": field, "from": from_facts[field], "to": to_facts[field]}
+            for field in OWNER_SPECIFIC_FIELDS
+            if from_facts[field] != to_facts[field]
+        ],
+        "unchanged": [field for field in OWNER_SPECIFIC_FIELDS if from_facts[field] == to_facts[field]],
+        "observed_evidence_gained": _missing_from(to_evidence, from_evidence),
+        "observed_evidence_lost": _missing_from(from_evidence, to_evidence),
+        "wrapper_actions_gained": _missing_from(to_actions, from_actions),
+        "wrapper_actions_lost": _missing_from(from_actions, to_actions),
+    }
+
+
+def _observed_evidence(payload: Mapping[str, Any]) -> list[str]:
+    contract = _handoff(payload).get("evidence_contract")
+    contract = contract if isinstance(contract, Mapping) else {}
+    return _text_list(contract.get("observed_required_for"))
+
+
+def _wrapper_actions(payload: Mapping[str, Any]) -> list[str]:
+    # The payload-level harness quality, not the handoff's own copy: only the
+    # payload-level one is narrowed per owner by `_public_harness_quality`, so
+    # only it answers "which actions does this owner's handoff actually offer".
+    harness = payload.get("harness_quality")
+    harness = harness if isinstance(harness, Mapping) else {}
+    return _text_list(harness.get("wrapper_actions"))
+
+
+def _capability_delta(
+    *,
+    from_payload: Mapping[str, Any],
+    to_payload: Mapping[str, Any],
+    from_owner: str,
+    to_owner: str,
+    capability_snapshots: Mapping[str, Mapping[str, Any] | None],
+    now: str,
+) -> dict[str, Any]:
+    to_requirements = derive_plan_capability_requirements(accepted_plan_from_delegation(to_payload))
+    from_requirements = derive_plan_capability_requirements(accepted_plan_from_delegation(from_payload))
+    to_names = [str(requirement["capability"]) for requirement in to_requirements]
+    from_names = [str(requirement["capability"]) for requirement in from_requirements]
+    from_fit = evaluate_owner_fit(
+        owner=from_owner,
+        requirements=to_requirements,
+        capability_snapshot=capability_snapshots.get(from_owner),
+        now=now,
+    )
+    to_fit = evaluate_owner_fit(
+        owner=to_owner,
+        requirements=to_requirements,
+        capability_snapshot=capability_snapshots.get(to_owner),
+        now=now,
+    )
+    from_classification = _classifications(from_fit)
+    to_classification = _classifications(to_fit)
+    changed = [
+        {
+            "capability": name,
+            "from_classification": from_classification[name],
+            "to_classification": to_classification[name],
+        }
+        for name in to_names
+        if from_classification[name] != to_classification[name]
+    ]
+    required_by_change = _missing_from(to_names, from_names)
+    dropped_by_change = _missing_from(from_names, to_names)
+    unsupported = [str(name) for name in to_fit["unmet"]]
+    unproven = [str(name) for name in to_fit["unknown"]]
+    return {
+        "requirements": to_names,
+        "required_by_owner_change": required_by_change,
+        "dropped_by_owner_change": dropped_by_change,
+        "unsupported": unsupported,
+        "unproven": unproven,
+        "changed": changed,
+        "from_verdict": str(from_fit["verdict"]),
+        "to_verdict": str(to_fit["verdict"]),
+        "statement": _capability_statement(unsupported, unproven, required_by_change, changed),
+    }
+
+
+def _classifications(fit: Mapping[str, Any]) -> dict[str, str]:
+    entries = fit.get("capabilities")
+    entries = entries if isinstance(entries, Sequence) else ()
+    return {
+        str(entry["capability"]): str(entry["classification"])
+        for entry in entries
+        if isinstance(entry, Mapping)
+    }
+
+
+def _capability_statement(
+    unsupported: Sequence[str],
+    unproven: Sequence[str],
+    required_by_change: Sequence[str],
+    changed: Sequence[Mapping[str, Any]],
+) -> str:
+    if unsupported:
+        statement = (
+            f"Fresh host observation records {_capability_count(unsupported)} as unavailable for the new owner: "
+            f"{', '.join(unsupported)}. Name this before the new handoff is used."
+        )
+    elif unproven:
+        statement = (
+            f"{_capability_count(unproven)} {_has_have(unproven)} no fresh host observation for the new owner: "
+            f"{', '.join(unproven)}. Nothing is known to be missing, and nothing is proven present."
+        )
+    elif required_by_change:
+        statement = (
+            f"The owner change adds {_capability_count(required_by_change)} that the previous owner's plan did "
+            f"not need: {', '.join(required_by_change)}. Fresh host observation answers all of them."
+        )
+    elif changed:
+        names = ", ".join(str(entry["capability"]) for entry in changed)
+        statement = f"No required capability is unsupported, and the evidence behind these moved: {names}."
+    else:
+        statement = "No required capability is unsupported, unproven, or changed by this owner change."
+    return statement[:_MAX_REASON_LENGTH]
+
+
+def _capability_count(names: Sequence[str]) -> str:
+    return f"{len(names)} required {'capability' if len(names) == 1 else 'capabilities'}"
+
+
+def _has_have(names: Sequence[str]) -> str:
+    return "has" if len(names) == 1 else "have"
+
+
+def _next_action(capability_delta: Mapping[str, Any]) -> str:
+    if capability_delta.get("unsupported"):
+        return "confirm_owner_capability_gap"
+    if capability_delta.get("unproven"):
+        return "record_capability_evidence"
+    return "prepare_handoff_for_new_owner"
+
+
+def _retarget_reason(
+    from_owner: str,
+    to_owner: str,
+    owner_delta: Mapping[str, Any],
+    capability_delta: Mapping[str, Any],
+) -> str:
+    changed = owner_delta.get("changed")
+    moved = len(changed) if isinstance(changed, Sequence) else 0
+    reason = (
+        f"The accepted plan moved from {executor_label(from_owner)} to {executor_label(to_owner)} without "
+        f"replanning: every owner-neutral field of the task contract is unchanged and "
+        f"{moved} owner-specific {'field was' if moved == 1 else 'fields were'} re-projected. "
+        f"{capability_delta.get('statement', '')}"
+    )
+    return reason[:_MAX_REASON_LENGTH]
+
+
+def _owner_identity_errors(record: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    owners: dict[str, str] = {}
+    for field, label_field in (("from_owner", "from_owner_label"), ("to_owner", "to_owner_label")):
+        owner = record.get(field)
+        if owner not in EXECUTOR_PROFILES:
+            errors.append(f"owner retarget {field} must be a known coding owner profile")
+            continue
+        owners[field] = str(owner)
+        if record.get(label_field) != executor_label(str(owner)):
+            errors.append(f"owner retarget {label_field} must be the label of {field}")
+    if len(owners) == 2 and owners["from_owner"] == owners["to_owner"]:
+        errors.append("owner retarget from_owner and to_owner must differ; a retarget moves the work")
+    return errors
+
+
+def _owner_delta_errors(delta: Any) -> list[str]:
+    if not isinstance(delta, Mapping):
+        return ["owner retarget owner_delta must be a mapping"]
+    errors = _closed_key_errors("owner delta", delta, OWNER_DELTA_KEYS)
+    for field in ("observed_evidence_gained", "observed_evidence_lost", "wrapper_actions_gained", "wrapper_actions_lost"):
+        errors.extend(_text_list_errors(f"owner delta {field}", delta.get(field), required=False))
+    changed = delta.get("changed")
+    unchanged = delta.get("unchanged")
+    if not isinstance(changed, list) or not isinstance(unchanged, list):
+        errors.append("owner delta changed and unchanged must be lists")
+        return errors
+    changed_fields: list[str] = []
+    for entry in changed:
+        if not isinstance(entry, Mapping):
+            errors.append("each owner delta change must be a mapping")
+            continue
+        entry_errors = _closed_key_errors("owner delta change", entry, OWNER_DELTA_CHANGE_KEYS)
+        field = entry.get("field")
+        if field not in OWNER_SPECIFIC_FIELDS:
+            entry_errors.append(f"owner delta change field must be one of {', '.join(OWNER_SPECIFIC_FIELDS)}")
+        for side in ("from", "to"):
+            value = entry.get(side)
+            if not isinstance(value, str) or len(value) > _MAX_TEXT_LENGTH:
+                entry_errors.append(f"owner delta change {side} must be a string of at most {_MAX_TEXT_LENGTH} characters")
+        if not entry_errors and entry["from"] == entry["to"]:
+            entry_errors.append("owner delta change must record a field that actually moved")
+        errors.extend(entry_errors)
+        if not entry_errors:
+            changed_fields.append(str(field))
+    # Every owner-specific field lands on exactly one side. A field that is
+    # neither changed nor unchanged would be a difference nobody was told about.
+    partition = sorted([*changed_fields, *(str(field) for field in unchanged)])
+    if partition != sorted(OWNER_SPECIFIC_FIELDS):
+        errors.append("owner delta must place every owner-specific field in exactly one of changed or unchanged")
+    return errors
+
+
+def _capability_delta_errors(delta: Any) -> tuple[list[str], Mapping[str, Any] | None]:
+    if not isinstance(delta, Mapping):
+        return ["owner retarget capability_delta must be a mapping"], None
+    errors = _closed_key_errors("capability delta", delta, CAPABILITY_DELTA_KEYS)
+    for field in ("requirements", "required_by_owner_change", "dropped_by_owner_change", "unsupported", "unproven"):
+        errors.extend(_text_list_errors(f"capability delta {field}", delta.get(field), required=False))
+    for field in ("from_verdict", "to_verdict"):
+        if delta.get(field) not in OWNER_FIT_VERDICTS:
+            errors.append(f"capability delta {field} must be one of {', '.join(OWNER_FIT_VERDICTS)}")
+    statement = delta.get("statement")
+    if not isinstance(statement, str) or not statement.strip() or len(statement) > _MAX_REASON_LENGTH:
+        errors.append("capability delta statement must be a nonempty string naming the gap or its absence")
+    requirements = delta.get("requirements")
+    declared = {str(name) for name in requirements} if isinstance(requirements, list) else set()
+    for field in ("required_by_owner_change", "unsupported", "unproven"):
+        values = delta.get(field)
+        if isinstance(values, list) and not {str(name) for name in values} <= declared:
+            errors.append(f"capability delta {field} must only name declared required capabilities")
+    changed = delta.get("changed")
+    if not isinstance(changed, list):
+        errors.append("capability delta changed must be a list")
+        return errors, delta
+    if len(changed) > _MAX_CAPABILITIES:
+        errors.append(f"capability delta changed must hold at most {_MAX_CAPABILITIES} entries")
+    for entry in changed:
+        if not isinstance(entry, Mapping):
+            errors.append("each capability change must be a mapping")
+            continue
+        entry_errors = _closed_key_errors("capability change", entry, CAPABILITY_CHANGE_KEYS)
+        if str(entry.get("capability", "")) not in declared:
+            entry_errors.append("capability change must name a declared required capability")
+        for side in ("from_classification", "to_classification"):
+            if entry.get(side) not in OWNER_FIT_CLASSIFICATIONS:
+                entry_errors.append(f"capability change {side} must be one of {', '.join(OWNER_FIT_CLASSIFICATIONS)}")
+        if not entry_errors and entry["from_classification"] == entry["to_classification"]:
+            entry_errors.append("capability change must record a classification that actually moved")
+        errors.extend(entry_errors)
+    return errors, delta
+
+
+def _closed_key_errors(label: str, value: Mapping[str, Any], keys: Sequence[str]) -> list[str]:
+    expected = set(keys)
+    present = {str(key) for key in value}
+    errors: list[str] = []
+    missing = expected - present
+    if missing:
+        errors.append(f"{label} is missing required keys: {', '.join(sorted(missing))}")
+    unexpected = present - expected
+    if unexpected:
+        errors.append(f"{label} contains unsupported keys: {', '.join(sorted(unexpected))}")
+    return errors
+
+
+def _text_list_errors(label: str, value: Any, *, required: bool) -> list[str]:
+    if not isinstance(value, list):
+        return [f"{label} must be a list"]
+    if required and not value:
+        return [f"{label} must not be empty"]
+    if len(value) > _MAX_LIST_ITEMS:
+        return [f"{label} must hold at most {_MAX_LIST_ITEMS} entries"]
+    if any(not isinstance(item, str) or not item.strip() or len(item) > _MAX_TEXT_LENGTH for item in value):
+        return [f"{label} entries must be nonempty strings of at most {_MAX_TEXT_LENGTH} characters"]
+    return []
+
+
+def _text_list(value: Any) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return []
+    return [str(item) for item in value]
+
+
+def _missing_from(values: Sequence[str], other: Sequence[str]) -> list[str]:
+    absent = set(other)
+    return [value for value in values if value not in absent]
+
+
+def _scalar_text(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _canonical_digest(value: Any) -> str:
+    return sha256_text(_canonical_json(value))
+
+
+def _is_sha256(value: Any) -> bool:
+    return isinstance(value, str) and len(value) == 64 and all(char in "0123456789abcdef" for char in value)

--- a/src/commands/chat.py
+++ b/src/commands/chat.py
@@ -248,6 +248,7 @@ def cmd_chat_session_prepare_handoff(args: argparse.Namespace) -> int:
             source_metadata=source_metadata,
             executor_target=args.executor,
             context_pack=_context_pack(args),
+            retarget=bool(getattr(args, "retarget", False)),
             **_revision_guard(args),
         )
     except FileNotFoundError as exc:
@@ -1229,6 +1230,14 @@ def _add_chat_commands(sub) -> None:
         "--context-pack",
         default=None,
         help="Optional handoff_context_pack/v1 JSON to attach to the prepared executor prompt when conflict-free.",
+    )
+    session_prepare.add_argument(
+        "--retarget",
+        action="store_true",
+        help=(
+            "Move the already-accepted plan to the --executor owner without replanning it. Preserves scope, "
+            "criteria, and verification, and reports the owner-specific and capability differences."
+        ),
     )
     add_revision_guard_arguments(session_prepare)
     session_prepare.set_defaults(func=cmd_chat_session_prepare_handoff)

--- a/src/wrapper/sessions.py
+++ b/src/wrapper/sessions.py
@@ -63,9 +63,15 @@ from .executor_sessions import (
     read_executor_session_result,
 )
 from ..coding_delegation import build_coding_delegation_payload
+from ..coding.owner_fit import owner_capability_snapshots
+from ..coding.owner_retarget import build_owner_retarget
 
 
 WRAPPER_SESSION_RESULT_SCHEMA_VERSION = "wrapper_session_result/v1"
+# The statuses that mean "this session already has a prepared handoff", and so
+# the only ones an explicit retarget can move: there is nothing to re-project
+# before one exists.
+PREPARED_HANDOFF_STATUSES = ("handoff_prepared", "prompt_handoff_prepared", "runtime_handoff_prepared")
 PLAN_DECISION_TRANSITIONS = {
     "plan_presented": {"accept", "revise", "cancel"},
     "plan_accepted": {"accept", "revise", "cancel"},
@@ -304,6 +310,7 @@ def prepare_wrapper_session_handoff(
     source_metadata: dict[str, str] | None = None,
     executor_target: str | None = None,
     context_pack: dict[str, object] | None = None,
+    retarget: bool = False,
     expected_revision: int | None = None,
     mutation_id: str | None = None,
 ) -> dict[str, object]:
@@ -329,7 +336,23 @@ def prepare_wrapper_session_handoff(
     follow_up_sha = hashlib.sha256(extract_message_text(event_or_message).encode("utf-8")).hexdigest()
     follow_up_message = bool(extract_message_text(event_or_message))
     follow_up = False
-    if session.get("current_run_id"):
+    retarget_from = _retarget_source_owner(session, executor_target or "", retarget=retarget)
+    if retarget_from:
+        # An explicit retarget must not take any of the re-serve short-circuits
+        # below. Retargeting normally repeats the ORIGINAL task text, which
+        # matches the prepared message, and re-serving would hand back the OLD
+        # owner's handoff with exit 0 while silently ignoring the owner the
+        # person just asked for.
+        #
+        # The run-integrity invariants that branch enforces still apply while a
+        # run is linked: a retarget detaches this session from its Codex run,
+        # so it must not detach from an inconsistent one.
+        if session.get("current_run_id"):
+            if session["status"] != "handoff_prepared":
+                raise WrapperSessionError("wrapper session current_run_id is only valid after handoff preparation")
+            if _run_owned_by_other_session(paths, str(session["current_run_id"]), str(session["session_id"])):
+                raise WrapperSessionError("wrapper session current_run_id is already linked to another wrapper session")
+    elif session.get("current_run_id"):
         if session["status"] != "handoff_prepared":
             raise WrapperSessionError("wrapper session current_run_id is only valid after handoff preparation")
         run_id = str(session["current_run_id"])
@@ -369,8 +392,11 @@ def prepare_wrapper_session_handoff(
         raise WrapperSessionError("wrapper session requires executor selection before preparing a handoff")
     if executor_target and follow_up:
         if executor_target != str(session.get("selected_executor_profile") or ""):
-            raise WrapperSessionError("a follow-up handoff keeps the selected executor; start a new session to switch executors")
-    elif executor_target:
+            raise WrapperSessionError(
+                "a follow-up handoff keeps the selected executor; retarget the accepted plan explicitly to move "
+                "it to another executor, or start a new session to replan"
+            )
+    elif executor_target and not retarget_from:
         selected = select_wrapper_session_executor(
             paths,
             session_id,
@@ -384,36 +410,74 @@ def prepare_wrapper_session_handoff(
             # that follows must compare against the revision that write
             # produced, not the one the wrapper originally rendered.
             guard_revision = record_revision_of(session)
-    if not follow_up and session["status"] not in {"plan_accepted", "executor_selected"}:
+    if not follow_up and not retarget_from and session["status"] not in {"plan_accepted", "executor_selected"}:
         raise WrapperSessionError("wrapper session plan must be accepted before preparing a handoff")
-    selected_executor = str(session.get("selected_executor_profile") or "codex")
-    if session.get("work_owner_mode") == "runtime_handoff" and selected_executor:
-        return _prepare_runtime_session_handoff(
+    if retarget_from:
+        # The accepted plan is already bound to this session; only the owner
+        # moves. The selection write `select_wrapper_session_executor` performs
+        # is skipped because it refuses a session that already has a prepared
+        # handoff, and the prepare below rewrites owner, mode, and status in the
+        # same guarded transaction that stores the new handoff.
+        selected_executor = str(executor_target)
+        work_owner_mode = executor_selection_for_target(selected_executor, action="delegate").work_owner_mode
+        # Named before the new handoff exists (AC2): building it here means a
+        # move that would silently replan the task raises instead of preparing.
+        #
+        # `follow_up` stays false, so the prepare below does NOT inherit the
+        # session's route preference. A follow-up is new text that has to be
+        # pulled back onto the accepted lane; a retarget repeats the accepted
+        # task itself, and routing it exactly as the prepare it replaces did is
+        # what keeps the re-projection faithful to that handoff.
+        retarget_record: dict[str, object] | None = _owner_retarget_record(
             paths,
             session,
-            event_or_message,
+            extract_message_text(event_or_message),
             limit=limit,
-            include_message=include_message,
-            source_metadata=source_metadata,
-            executor_target=selected_executor,
             context_pack=context_pack,
-            follow_up=follow_up,
-            expected_revision=guard_revision,
-            mutation_id=mutation_id,
+            from_owner=retarget_from,
+            to_owner=selected_executor,
+        )
+    else:
+        selected_executor = str(session.get("selected_executor_profile") or "codex")
+        work_owner_mode = str(session.get("work_owner_mode") or "")
+        retarget_record = None
+    if work_owner_mode == "runtime_handoff" and selected_executor:
+        return _with_owner_retarget(
+            _prepare_runtime_session_handoff(
+                paths,
+                session,
+                event_or_message,
+                limit=limit,
+                include_message=include_message,
+                source_metadata=source_metadata,
+                executor_target=selected_executor,
+                context_pack=context_pack,
+                follow_up=follow_up,
+                expected_revision=guard_revision,
+                mutation_id=mutation_id,
+            ),
+            retarget_record,
+            paths,
+            session_id,
         )
     if selected_executor and selected_executor != "codex":
-        return _prepare_prompt_only_session_handoff(
+        return _with_owner_retarget(
+            _prepare_prompt_only_session_handoff(
+                paths,
+                session,
+                event_or_message,
+                limit=limit,
+                include_message=include_message,
+                source_metadata=source_metadata,
+                executor_target=selected_executor,
+                context_pack=context_pack,
+                follow_up=follow_up,
+                expected_revision=guard_revision,
+                mutation_id=mutation_id,
+            ),
+            retarget_record,
             paths,
-            session,
-            event_or_message,
-            limit=limit,
-            include_message=include_message,
-            source_metadata=source_metadata,
-            executor_target=selected_executor,
-            context_pack=context_pack,
-            follow_up=follow_up,
-            expected_revision=guard_revision,
-            mutation_id=mutation_id,
+            session_id,
         )
     message = extract_message_text(event_or_message)
     metadata = _source_metadata(event_or_message)
@@ -424,14 +488,19 @@ def prepare_wrapper_session_handoff(
     digest = _mutation_digest("link_prepared_handoff_run", message_sha256, "codex", metadata)
     recovered_run_id = _find_recoverable_prepared_handoff_run(paths, session, message_sha256, metadata)
     if recovered_run_id:
-        return _link_prepared_handoff_run(
+        return _with_owner_retarget(
+            _link_prepared_handoff_run(
+                paths,
+                session,
+                recovered_run_id,
+                recovered=True,
+                expected_revision=guard_revision,
+                mutation_id=mutation_id,
+                mutation_digest=digest,
+            ),
+            retarget_record,
             paths,
-            session,
-            recovered_run_id,
-            recovered=True,
-            expected_revision=guard_revision,
-            mutation_id=mutation_id,
-            mutation_digest=digest,
+            session_id,
         )
     follow_up_workflow, follow_up_score = _session_route_preference(session) if follow_up else (None, None)
     lifecycle: dict[str, object] = {}
@@ -479,7 +548,125 @@ def prepare_wrapper_session_handoff(
         run = lifecycle["run"]
         lifecycle["status"] = report_codex_delegation_lifecycle(paths, str(run["run_id"]) if isinstance(run, dict) else "")
         linked["handoff"] = lifecycle
-    return linked
+    return _with_owner_retarget(linked, retarget_record, paths, session_id)
+
+
+def _retarget_source_owner(session: dict[str, Any], executor_target: str, *, retarget: bool) -> str:
+    """The owner an explicit retarget moves away from, or "" when this is not one.
+
+    The guard this relaxes refused EVERY executor change on a follow-up handoff,
+    and that intent survives untouched: a follow-up is a delta on an accepted
+    plan, silently swapping its owner would hand the next instruction to
+    somebody the user never chose, and this returns "" for a follow-up so the
+    refusal still fires. What no longer holds is the only escape the old message
+    offered --- "start a new session to switch executors". A new session has no
+    accepted plan, so that escape charged the user a full replan for a change
+    that alters nothing about the work (#812).
+
+    Retargeting is therefore a distinct, named operation rather than a silent
+    allow. The caller has to ask for it by name, it only applies to a session
+    that already has a prepared handoff, it refuses a move to the owner already
+    selected, and it records what it did in `coding_owner_retarget/v1`.
+    """
+    if not retarget:
+        return ""
+    if not executor_target:
+        raise WrapperSessionError("retargeting requires the coding owner to move the accepted plan to")
+    # `select_wrapper_session_executor` is skipped on this path, so the target
+    # validation it normally performs has to happen here instead.
+    if executor_target == "choose" or executor_target not in CODING_EXECUTOR_TARGETS:
+        raise WrapperSessionError(f"unsupported wrapper session executor: {executor_target}")
+    status = str(session.get("status", ""))
+    if status not in PREPARED_HANDOFF_STATUSES:
+        raise WrapperSessionError(
+            f"cannot retarget a wrapper session while status is {status}; there is no prepared handoff to re-project"
+        )
+    current = str(session.get("selected_executor_profile") or "")
+    if not current:
+        raise WrapperSessionError("cannot retarget a wrapper session that has no selected executor")
+    if executor_target == current:
+        raise WrapperSessionError(
+            f"the accepted plan is already targeted at {executor_target}; retargeting requires a different executor"
+        )
+    return current
+
+
+def _owner_retarget_record(
+    paths: OmhPaths,
+    session: dict[str, Any],
+    message: str,
+    *,
+    limit: int,
+    context_pack: dict[str, object] | None,
+    from_owner: str,
+    to_owner: str,
+) -> dict[str, object]:
+    """The `coding_owner_retarget/v1` record for one accepted plan changing owner.
+
+    Both sides are re-projections of the same accepted plan, built here from
+    identical owner-neutral inputs and differing only in `executor_target`.
+    `build_owner_retarget` then compares the two owner-neutral task contracts
+    and refuses when any field moved, so a "retarget" that would quietly replan
+    the task raises instead of being recorded as one.
+
+    The routing arguments deliberately match the prepare this record describes,
+    down to NOT inheriting the session's route preference: a projection routed
+    differently from the handoff it accompanies would report a contract that
+    handoff does not carry.
+
+    Neither projection reads a memory recall pack or carries source metadata:
+    both are owner-specific handoff context that never enters the task
+    contract, so reading them here would cost I/O to produce values the
+    comparison ignores.
+    """
+    snapshot_directory = _capability_snapshot_directory(paths)
+
+    def projection(owner: str) -> dict[str, object]:
+        return build_coding_delegation_payload(
+            message,
+            source=str(session["source"]),
+            limit=limit,
+            executor_target=owner,
+            context_pack=context_pack,
+            capability_snapshot_directory=snapshot_directory,
+        )
+
+    return build_owner_retarget(
+        from_payload=projection(from_owner),
+        to_payload=projection(to_owner),
+        task_source_sha256=hashlib.sha256(message.encode("utf-8")).hexdigest(),
+        capability_snapshots=dict(owner_capability_snapshots(snapshot_directory, (from_owner, to_owner))),
+    )
+
+
+def _with_owner_retarget(
+    result: dict[str, object],
+    retarget_record: dict[str, object] | None,
+    paths: OmhPaths,
+    session_id: str,
+) -> dict[str, object]:
+    """Attach and journal the retarget once the new handoff actually exists.
+
+    The record is built before the prepare so a refused move never writes; the
+    event is appended after it so the journal never claims a retarget that did
+    not finish (issue #828 AC1, applied to this operation).
+    """
+    if retarget_record is None:
+        return result
+    append_wrapper_session_event(
+        _session_dir(paths, session_id),
+        {
+            "event": "coding_owner_retargeted",
+            "message": "wrapper session retargeted accepted coding work to another owner",
+            "data": retarget_record,
+        },
+    )
+    result["coding_owner_retarget"] = retarget_record
+    return result
+
+
+def _capability_snapshot_directory(paths: OmhPaths) -> Path:
+    return paths.omh_home / "coding" / "executor-capability-snapshots"
 
 
 def _session_route_preference(session: dict[str, Any]) -> tuple[str | None, int | None]:
@@ -537,7 +724,7 @@ def _prepare_prompt_only_session_handoff(
             executor_target=executor_target,
             session_id=str(session["session_id"]),
         ),
-        capability_snapshot_directory=paths.omh_home / "coding" / "executor-capability-snapshots",
+        capability_snapshot_directory=_capability_snapshot_directory(paths),
     )
     prompt_handoff = payload.get("prompt_handoff")
     if not isinstance(prompt_handoff, dict):
@@ -563,6 +750,12 @@ def _prepare_prompt_only_session_handoff(
                 "selected_executor_profile": executor_target,
                 "dispatch_policy": "prepare_only",
                 "prompt_handoff": prompt_handoff,
+                # Cleared for the same reason the runtime prepare clears
+                # `prompt_handoff`: retargeting (#812) makes a runtime-prepared
+                # session reachable from here, and a stale runtime handoff left
+                # beside a prompt handoff is a second answer to "what is
+                # prepared".
+                "runtime_handoff": {},
                 "current_run_id": "",
                 "updated_at": utc_now(),
             }
@@ -651,7 +844,7 @@ def _prepare_runtime_session_handoff(
             executor_target=executor_target,
             session_id=str(session["session_id"]),
         ),
-        capability_snapshot_directory=paths.omh_home / "coding" / "executor-capability-snapshots",
+        capability_snapshot_directory=_capability_snapshot_directory(paths),
     )
     runtime_handoff = payload.get("runtime_handoff")
     if not isinstance(runtime_handoff, dict):

--- a/tests/test_coding_retarget.py
+++ b/tests/test_coding_retarget.py
@@ -1,0 +1,678 @@
+"""An accepted coding plan can change owner without being planned again (#812).
+
+The gap. `prepare_wrapper_session_handoff` refused every executor change on a
+follow-up handoff and offered one escape: "start a new session to switch
+executors". A new session carries no accepted plan, so the only supported way
+to move work from one coding owner to another was to replan work the user had
+already approved and re-derive criteria they had already agreed to.
+
+What these pin:
+
+* **AC1 -- preservation, proved by equality rather than by inspection.** The
+  owner-neutral task contract is asserted byte-identical across retargets
+  spanning all three handoff kinds (executor-handoff `codex`, prompt-handoff
+  `claude-code`, runtime-handoff `hermes`/`omx-runtime`), on the pure projection
+  AND through the real wrapper session. The teeth are in the builder, not only
+  here: `build_owner_retarget` compares the two contracts field by field and
+  refuses a move that would change one, so a replan cannot be recorded as a
+  retarget.
+
+* **AC2 -- the capability difference is named before the new handoff.** With a
+  recorded snapshot saying the new owner cannot run the routed workflow
+  locally, the retarget reports it as `unsupported` and asks for confirmation;
+  with a snapshot saying it can, nothing is invented. The report is produced by
+  a pure function over two projections, so it exists before anything is
+  prepared or written.
+
+* **AC3 -- no source-host configuration or credential is read.** The host
+  credential and config readers (`~/.codex/auth.json`, `~/.claude.json`, the
+  OMO host marker, the live readiness binding, and `Path.home()` itself) are
+  patched to raise, and a full session-level retarget still completes.
+
+Guards: an unknown owner is refused on both surfaces; the original handoff's
+stored artifact is byte-identical after the move; and the old guard's intent
+survives --- a follow-up handoff with a different executor and no explicit
+retarget is still refused.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+from unittest import mock
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.coding.coding_delegation import build_coding_delegation_payload  # noqa: E402
+from omh.coding.executor_capability_snapshots import (  # noqa: E402
+    build_executor_capability_snapshot,
+    executor_capability_snapshot_path,
+    write_executor_capability_snapshot,
+)
+from omh.coding.executors import EXECUTOR_PROFILES, executor_label  # noqa: E402
+from omh.coding.owner_retarget import (  # noqa: E402
+    CAPABILITY_DELTA_KEYS,
+    CODING_TASK_CONTRACT_SCHEMA_VERSION,
+    OWNER_DELTA_KEYS,
+    OWNER_RETARGET_CLAIM_BOUNDARY,
+    OWNER_RETARGET_KEYS,
+    OWNER_RETARGET_NEXT_ACTIONS,
+    OWNER_RETARGET_SCHEMA_VERSION,
+    OWNER_SPECIFIC_FIELDS,
+    TASK_CONTRACT_KEYS,
+    OwnerRetargetError,
+    build_owner_retarget,
+    coding_task_contract,
+    coding_task_contract_digest,
+    validate_coding_task_contract,
+    validate_owner_retarget,
+)
+from omh.paths import resolve_paths  # noqa: E402
+from omh.system.local_store import utc_now  # noqa: E402
+from omh.wrapper.sessions import (  # noqa: E402
+    WrapperSessionError,
+    create_or_resume_wrapper_session,
+    prepare_wrapper_session_handoff,
+    read_wrapper_session_events,
+    record_plan_decision,
+)
+
+
+# One accepted coding task, routed to `ai-slop-cleaner`. The workflow matters:
+# it is routable (so it can be named in a `local_workflow` snapshot scope) and
+# it declares no workflow-level capability requirement of its own, so the only
+# requirement in play is the one the OWNER CHANGE introduces.
+MESSAGE = "risky refactor of src/coding/executors.py with tests"
+ROUTED_WORKFLOW = "ai-slop-cleaner"
+
+# A different accepted coding task. Also `delegate`, and deliberately a
+# different intent and workflow, so retargeting between the two is a replan.
+OTHER_MESSAGE = "review the diff in src/api/list.py for correctness"
+
+TASK_SHA = "b" * 64
+
+# One owner per handoff kind, so "at least three owner kinds" is exercised by
+# construction rather than by comment.
+OWNER_KINDS = {
+    "codex": "executor_handoff",
+    "claude-code": "prompt_handoff",
+    "hermes": "runtime_handoff",
+    "omx-runtime": "runtime_handoff",
+}
+
+# `build_coding_delegation_payload` takes no clock, so evidence written for the
+# surface tests is recorded at the real current time. The freshness window is 24
+# hours, so drift inside one test run cannot move a verdict.
+RECORDED_NOW = utc_now()
+
+
+def _payload(owner: str, message: str = MESSAGE, **kwargs: Any) -> dict[str, Any]:
+    return build_coding_delegation_payload(message, executor_target=owner, **kwargs)
+
+
+def _canonical(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _local_workflow_snapshot(owner: str, *, status: str, recorded_at: str = RECORDED_NOW) -> dict[str, Any]:
+    return build_executor_capability_snapshot(
+        executor=owner,
+        recorded_at=recorded_at,
+        capabilities={
+            "local_workflow": {
+                "status": status,
+                "scope": {"profile": owner, "skill_id": ROUTED_WORKFLOW, "environment": "test-host"},
+                "evidence_ref": "operator:retarget-fixture",
+                "observed_at": recorded_at,
+            }
+        },
+    )
+
+
+def _paths(root: Path):
+    return resolve_paths(root / ".omh", root / ".hermes")
+
+
+def _snapshot_directory(paths) -> Path:
+    return paths.omh_home / "coding" / "executor-capability-snapshots"
+
+
+def _write_snapshot(paths, snapshot: dict[str, Any]) -> None:
+    directory = _snapshot_directory(paths)
+    write_executor_capability_snapshot(
+        executor_capability_snapshot_path(directory, str(snapshot["executor"])),
+        snapshot,
+    )
+
+
+def _accepted_session(paths, owner: str) -> str:
+    started = create_or_resume_wrapper_session(
+        paths,
+        MESSAGE,
+        source="discord",
+        source_metadata={"source_event_id": "m1", "channel_ref": "c1"},
+        executor_target=owner,
+    )
+    session_id = str(started["session"]["session_id"])
+    record_plan_decision(paths, session_id, "accept")
+    prepare_wrapper_session_handoff(paths, session_id, MESSAGE, executor_target=owner)
+    return session_id
+
+
+def _session_events(paths, session_id: str) -> list[dict[str, Any]]:
+    return read_wrapper_session_events(paths.runtime_wrapper_sessions_dir / session_id)
+
+
+class TaskContractPreservationTests(unittest.TestCase):
+    """AC1: the owner-neutral half of an accepted plan does not move."""
+
+    def test_the_task_contract_is_byte_identical_across_every_owner_kind(self) -> None:
+        contracts = {
+            owner: coding_task_contract(_payload(owner), task_source_sha256=TASK_SHA)
+            for owner in OWNER_KINDS
+        }
+        rendered = {owner: _canonical(contract) for owner, contract in contracts.items()}
+        self.assertEqual(len(set(rendered.values())), 1, rendered)
+        self.assertEqual(len({coding_task_contract_digest(c) for c in contracts.values()}), 1)
+        for owner, contract in contracts.items():
+            with self.subTest(owner=owner):
+                self.assertEqual(validate_coding_task_contract(contract), [])
+                self.assertEqual(sorted(contract), sorted(TASK_CONTRACT_KEYS))
+                self.assertEqual(contract["schema_version"], CODING_TASK_CONTRACT_SCHEMA_VERSION)
+
+    def test_retargeting_across_the_three_handoff_kinds_preserves_the_contract(self) -> None:
+        moves = (
+            ("codex", "claude-code"),
+            ("codex", "hermes"),
+            ("claude-code", "codex"),
+            ("claude-code", "omx-runtime"),
+            ("hermes", "codex"),
+            ("hermes", "claude-code"),
+        )
+        digests: set[str] = set()
+        for source, target in moves:
+            with self.subTest(source=source, target=target):
+                from_payload = _payload(source)
+                to_payload = _payload(target)
+                record = build_owner_retarget(
+                    from_payload=from_payload,
+                    to_payload=to_payload,
+                    task_source_sha256=TASK_SHA,
+                )
+                self.assertEqual(validate_owner_retarget(record), [])
+                self.assertEqual(sorted(record), sorted(OWNER_RETARGET_KEYS))
+                # The preserved contract is byte-identical to BOTH sides'
+                # projections, not merely to the target's.
+                self.assertEqual(
+                    _canonical(record["preserved"]),
+                    _canonical(coding_task_contract(from_payload, task_source_sha256=TASK_SHA)),
+                )
+                self.assertEqual(
+                    _canonical(record["preserved"]),
+                    _canonical(coding_task_contract(to_payload, task_source_sha256=TASK_SHA)),
+                )
+                # And the four things AC1 names by hand.
+                for field in ("acceptance_criteria", "verification"):
+                    self.assertEqual(
+                        record["preserved"][field],
+                        from_payload["delegation"][field],
+                    )
+                    self.assertEqual(record["preserved"][field], to_payload["delegation"][field])
+                self.assertEqual(record["preserved"]["recommended_workflow"], ROUTED_WORKFLOW)
+                self.assertEqual(record["preserved"]["review_required"], from_payload["delegation"]["review_required"])
+                self.assertEqual(record["from_owner"], source)
+                self.assertEqual(record["to_owner"], target)
+                self.assertEqual(record["from_owner_label"], executor_label(source))
+                self.assertEqual(record["to_owner_label"], executor_label(target))
+                self.assertEqual(record["claim_boundary"], OWNER_RETARGET_CLAIM_BOUNDARY)
+                digests.add(str(record["preserved_digest"]))
+        self.assertEqual(len(digests), 1, "one accepted task must have one preserved digest")
+
+    def test_a_move_that_would_change_the_task_contract_is_refused_as_a_replan(self) -> None:
+        replanned = _payload("claude-code", OTHER_MESSAGE)
+        self.assertEqual(replanned["delegation"]["action"], "delegate")
+        with self.assertRaises(OwnerRetargetError) as caught:
+            build_owner_retarget(from_payload=_payload("codex"), to_payload=replanned)
+        message = str(caught.exception)
+        self.assertIn("replan rather than a retarget", message)
+        self.assertIn("intent", message)
+        self.assertIn("recommended_workflow", message)
+        self.assertIn("acceptance_criteria", message)
+
+    def test_a_retarget_is_deterministic_and_carries_no_wall_clock(self) -> None:
+        first = build_owner_retarget(
+            from_payload=_payload("codex"),
+            to_payload=_payload("hermes"),
+            task_source_sha256=TASK_SHA,
+        )
+        second = build_owner_retarget(
+            from_payload=_payload("codex"),
+            to_payload=_payload("hermes"),
+            task_source_sha256=TASK_SHA,
+        )
+        self.assertEqual(_canonical(first), _canonical(second))
+
+
+class OwnerDeltaTests(unittest.TestCase):
+    """Only the owner-specific half moves, and all of it is named."""
+
+    def test_every_owner_specific_field_lands_in_exactly_one_side_of_the_delta(self) -> None:
+        record = build_owner_retarget(from_payload=_payload("codex"), to_payload=_payload("hermes"))
+        delta = record["owner_delta"]
+        self.assertEqual(sorted(delta), sorted(OWNER_DELTA_KEYS))
+        named = [str(entry["field"]) for entry in delta["changed"]] + [str(f) for f in delta["unchanged"]]
+        self.assertEqual(sorted(named), sorted(OWNER_SPECIFIC_FIELDS))
+        changed = {str(entry["field"]): entry for entry in delta["changed"]}
+        self.assertEqual(changed["work_owner_mode"]["from"], "external_executor")
+        self.assertEqual(changed["work_owner_mode"]["to"], "runtime_handoff")
+        self.assertEqual(changed["handoff_field"]["from"], "executor_handoff")
+        self.assertEqual(changed["handoff_field"]["to"], "runtime_handoff")
+        self.assertEqual(changed["dispatchable"]["from"], "true")
+        self.assertEqual(changed["dispatchable"]["to"], "false")
+
+    def test_changed_execution_primitives_are_reported_in_both_directions(self) -> None:
+        record = build_owner_retarget(from_payload=_payload("codex"), to_payload=_payload("hermes"))
+        delta = record["owner_delta"]
+        self.assertEqual(
+            delta["observed_evidence_gained"],
+            ["runtime_start", "worktree_creation", "worker_dispatch", "worker_result"],
+        )
+        self.assertEqual(delta["observed_evidence_lost"], ["executor_dispatch", "executor_result"])
+        self.assertIn("send_to_codex", delta["wrapper_actions_lost"])
+        self.assertIn("start_team", delta["wrapper_actions_gained"])
+
+        back = build_owner_retarget(from_payload=_payload("hermes"), to_payload=_payload("codex"))
+        self.assertEqual(back["owner_delta"]["observed_evidence_lost"], delta["observed_evidence_gained"])
+        self.assertEqual(back["owner_delta"]["observed_evidence_gained"], delta["observed_evidence_lost"])
+
+
+class CapabilityDeltaTests(unittest.TestCase):
+    """AC2: unsupported or changed owner capability is named before the handoff."""
+
+    def _retarget(self, *, from_owner: str, to_owner: str, snapshots: dict[str, Any]) -> dict[str, Any]:
+        return build_owner_retarget(
+            from_payload=_payload(from_owner),
+            to_payload=_payload(to_owner),
+            task_source_sha256=TASK_SHA,
+            capability_snapshots=snapshots,
+            now=RECORDED_NOW,
+        )
+
+    def test_a_capability_gap_on_the_new_owner_is_named_and_gates_the_next_action(self) -> None:
+        record = self._retarget(
+            from_owner="codex",
+            to_owner="hermes",
+            snapshots={"hermes": _local_workflow_snapshot("hermes", status="unavailable"), "codex": None},
+        )
+        delta = record["capability_delta"]
+        self.assertEqual(sorted(delta), sorted(CAPABILITY_DELTA_KEYS))
+        self.assertEqual(delta["requirements"], ["local_workflow"])
+        # The requirement itself is created by the owner change: an
+        # external-executor owner never had to carry the workflow locally.
+        self.assertEqual(delta["required_by_owner_change"], ["local_workflow"])
+        self.assertEqual(delta["unsupported"], ["local_workflow"])
+        self.assertEqual(delta["to_verdict"], "blocked")
+        self.assertIn("local_workflow", delta["statement"])
+        self.assertEqual(record["next_action"], "confirm_owner_capability_gap")
+        self.assertIn("local_workflow", record["reason"])
+
+    def test_a_fit_new_owner_does_not_have_a_gap_invented_for_it(self) -> None:
+        record = self._retarget(
+            from_owner="codex",
+            to_owner="hermes",
+            snapshots={"hermes": _local_workflow_snapshot("hermes", status="host_observed"), "codex": None},
+        )
+        delta = record["capability_delta"]
+        self.assertEqual(delta["requirements"], ["local_workflow"])
+        self.assertEqual(delta["unsupported"], [])
+        self.assertEqual(delta["unproven"], [])
+        self.assertEqual(delta["to_verdict"], "ready")
+        self.assertEqual(record["next_action"], "prepare_handoff_for_new_owner")
+        self.assertNotIn("unavailable", delta["statement"])
+
+    def test_absent_evidence_reads_unproven_rather_than_fit_or_blocked(self) -> None:
+        record = self._retarget(from_owner="codex", to_owner="hermes", snapshots={})
+        delta = record["capability_delta"]
+        self.assertEqual(delta["unsupported"], [])
+        self.assertEqual(delta["unproven"], ["local_workflow"])
+        self.assertEqual(delta["to_verdict"], "unproven")
+        self.assertEqual(record["next_action"], "record_capability_evidence")
+
+    def test_evidence_that_moved_between_the_two_owners_is_reported_as_changed(self) -> None:
+        record = self._retarget(
+            from_owner="omx-runtime",
+            to_owner="hermes",
+            snapshots={
+                "omx-runtime": _local_workflow_snapshot("omx-runtime", status="host_observed"),
+                "hermes": _local_workflow_snapshot("hermes", status="unavailable"),
+            },
+        )
+        delta = record["capability_delta"]
+        # Both owners are runtime owners, so the requirement set does not move
+        # and only the evidence behind it does.
+        self.assertEqual(delta["required_by_owner_change"], [])
+        self.assertEqual(delta["dropped_by_owner_change"], [])
+        self.assertEqual(
+            delta["changed"],
+            [{"capability": "local_workflow", "from_classification": "met", "to_classification": "unmet"}],
+        )
+        self.assertEqual(delta["from_verdict"], "ready")
+        self.assertEqual(delta["to_verdict"], "blocked")
+
+    def test_a_requirement_dropped_by_the_owner_change_is_reported(self) -> None:
+        record = self._retarget(
+            from_owner="hermes",
+            to_owner="codex",
+            snapshots={"hermes": _local_workflow_snapshot("hermes", status="host_observed")},
+        )
+        delta = record["capability_delta"]
+        self.assertEqual(delta["requirements"], [])
+        self.assertEqual(delta["dropped_by_owner_change"], ["local_workflow"])
+        self.assertEqual(delta["to_verdict"], "ready")
+        self.assertEqual(record["next_action"], "prepare_handoff_for_new_owner")
+
+    def test_the_gap_is_available_before_anything_is_prepared_or_written(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            record = self._retarget(
+                from_owner="codex",
+                to_owner="hermes",
+                snapshots={"hermes": _local_workflow_snapshot("hermes", status="unavailable")},
+            )
+            self.assertEqual(record["capability_delta"]["unsupported"], ["local_workflow"])
+            # A pure projection: enumerating the gap creates no artifact, so it
+            # cannot be something a person only discovers after accepting the
+            # new handoff.
+            self.assertEqual(sorted(path.name for path in root.iterdir()), [])
+
+
+class OwnerRetargetValidatorTests(unittest.TestCase):
+    """The closed key set is enforced in both directions."""
+
+    def _record(self) -> dict[str, Any]:
+        return build_owner_retarget(
+            from_payload=_payload("codex"),
+            to_payload=_payload("claude-code"),
+            task_source_sha256=TASK_SHA,
+        )
+
+    def test_a_missing_key_and_an_extra_key_both_fail(self) -> None:
+        for key in OWNER_RETARGET_KEYS:
+            with self.subTest(missing=key):
+                record = self._record()
+                record.pop(key)
+                self.assertTrue(
+                    any("missing required keys" in error for error in validate_owner_retarget(record)),
+                    key,
+                )
+        record = self._record()
+        record["surprise"] = "extra"
+        self.assertIn(
+            "owner retarget contains unsupported keys: surprise",
+            validate_owner_retarget(record),
+        )
+
+    def test_the_preserved_digest_must_be_recomputable_from_the_preserved_contract(self) -> None:
+        record = self._record()
+        record["preserved"] = {**record["preserved"], "intent": "something-else"}
+        self.assertIn(
+            "owner retarget preserved_digest must be the digest of the preserved task contract",
+            validate_owner_retarget(record),
+        )
+
+    def test_the_next_action_must_follow_from_the_enumerated_gap(self) -> None:
+        record = self._record()
+        self.assertEqual(record["next_action"], "prepare_handoff_for_new_owner")
+        record["next_action"] = "confirm_owner_capability_gap"
+        self.assertIn("confirm_owner_capability_gap", OWNER_RETARGET_NEXT_ACTIONS)
+        self.assertIn(
+            "owner retarget next_action must follow from the enumerated capability delta",
+            validate_owner_retarget(record),
+        )
+
+    def test_an_unmoved_field_cannot_be_reported_as_a_change(self) -> None:
+        record = self._record()
+        record["owner_delta"] = {
+            **record["owner_delta"],
+            "changed": [
+                *record["owner_delta"]["changed"],
+                {"field": "isolation_strategy", "from": "same", "to": "same"},
+            ],
+            "unchanged": [],
+        }
+        errors = validate_owner_retarget(record)
+        self.assertIn("owner delta change must record a field that actually moved", errors)
+
+    def test_the_schema_version_status_and_claim_boundary_are_pinned(self) -> None:
+        record = self._record()
+        self.assertEqual(record["schema_version"], OWNER_RETARGET_SCHEMA_VERSION)
+        self.assertEqual(record["status"], "prepared_not_observed")
+        for field, value in (
+            ("schema_version", "coding_owner_retarget/v2"),
+            ("status", "observed"),
+            ("claim_boundary", "retargeting proves the new owner started the work"),
+        ):
+            with self.subTest(field=field):
+                tampered = {**self._record(), field: value}
+                self.assertTrue(validate_owner_retarget(tampered))
+
+    def test_the_claim_boundary_denies_dispatch_and_execution(self) -> None:
+        boundary = OWNER_RETARGET_CLAIM_BOUNDARY.lower()
+        for denied in ("dispatch", "execution", "verification", "review", "ci", "merge"):
+            with self.subTest(denied=denied):
+                self.assertIn(denied, boundary)
+        self.assertIn("never replans", boundary)
+
+
+class OwnerRetargetGuardTests(unittest.TestCase):
+    """What a retarget refuses, and what it must leave alone."""
+
+    def test_an_unknown_owner_is_refused(self) -> None:
+        unknown = {**_payload("claude-code"), "selected_executor_profile": "mystery-agent"}
+        with self.assertRaises(OwnerRetargetError) as caught:
+            build_owner_retarget(from_payload=_payload("codex"), to_payload=unknown)
+        self.assertIn("unsupported coding owner", str(caught.exception))
+        self.assertIn("mystery-agent", str(caught.exception))
+        self.assertNotIn("mystery-agent", EXECUTOR_PROFILES)
+
+    def test_retargeting_to_the_same_owner_is_refused(self) -> None:
+        with self.assertRaises(OwnerRetargetError) as caught:
+            build_owner_retarget(from_payload=_payload("codex"), to_payload=_payload("codex"))
+        self.assertIn("requires a different coding owner", str(caught.exception))
+
+    def test_a_payload_with_no_prepared_handoff_is_refused(self) -> None:
+        without_handoff = {key: value for key, value in _payload("codex").items() if key != "executor_handoff"}
+        with self.assertRaises(OwnerRetargetError) as caught:
+            build_owner_retarget(from_payload=without_handoff, to_payload=_payload("claude-code"))
+        self.assertIn("no prepared handoff", str(caught.exception))
+
+    def test_building_a_retarget_does_not_mutate_either_payload(self) -> None:
+        from_payload = _payload("codex")
+        to_payload = _payload("hermes")
+        before = (_canonical(from_payload), _canonical(to_payload))
+        build_owner_retarget(from_payload=from_payload, to_payload=to_payload, task_source_sha256=TASK_SHA)
+        self.assertEqual((_canonical(from_payload), _canonical(to_payload)), before)
+
+
+class WrapperSessionRetargetTests(unittest.TestCase):
+    """The wrapper surface: the guard relaxed into a named operation."""
+
+    def test_a_follow_up_handoff_without_an_explicit_retarget_still_keeps_its_executor(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            session_id = _accepted_session(paths, "codex")
+            with self.assertRaises(WrapperSessionError) as caught:
+                prepare_wrapper_session_handoff(
+                    paths,
+                    session_id,
+                    "also add a changelog entry",
+                    executor_target="claude-code",
+                )
+            self.assertIn("a follow-up handoff keeps the selected executor", str(caught.exception))
+            session = json.loads(
+                (paths.runtime_wrapper_sessions_dir / session_id / "session.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(session["selected_executor_profile"], "codex")
+            self.assertEqual(session["status"], "handoff_prepared")
+
+    def test_an_explicit_retarget_moves_the_owner_and_preserves_the_contract(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            session_id = _accepted_session(paths, "codex")
+            digests: list[str] = []
+            preserved: list[str] = []
+            for target, expected_status in (
+                ("claude-code", "prompt_handoff_prepared"),
+                ("hermes", "runtime_handoff_prepared"),
+                ("codex", "handoff_prepared"),
+            ):
+                with self.subTest(target=target):
+                    result = prepare_wrapper_session_handoff(
+                        paths,
+                        session_id,
+                        MESSAGE,
+                        executor_target=target,
+                        retarget=True,
+                    )
+                    record = result["coding_owner_retarget"]
+                    self.assertEqual(validate_owner_retarget(record), [])
+                    self.assertEqual(record["to_owner"], target)
+                    # The same routed workflow the pure projection derives: a
+                    # retarget routes the accepted task exactly as the prepare
+                    # it replaces did.
+                    self.assertEqual(record["preserved"]["recommended_workflow"], ROUTED_WORKFLOW)
+                    self.assertEqual(result["session"]["selected_executor_profile"], target)
+                    self.assertEqual(result["session"]["status"], expected_status)
+                    digests.append(str(record["preserved_digest"]))
+                    preserved.append(_canonical(record["preserved"]))
+            # AC1 through the real session, by equality: three owner kinds, one
+            # unchanged accepted contract.
+            self.assertEqual(len(set(digests)), 1, digests)
+            self.assertEqual(len(set(preserved)), 1)
+
+    def test_the_retarget_is_journalled_with_its_gap_and_its_boundary(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            session_id = _accepted_session(paths, "codex")
+            _write_snapshot(paths, _local_workflow_snapshot("hermes", status="unavailable"))
+            result = prepare_wrapper_session_handoff(
+                paths, session_id, MESSAGE, executor_target="hermes", retarget=True
+            )
+            self.assertEqual(result["coding_owner_retarget"]["capability_delta"]["unsupported"], ["local_workflow"])
+            self.assertEqual(result["coding_owner_retarget"]["next_action"], "confirm_owner_capability_gap")
+            journalled = [event for event in _session_events(paths, session_id) if event["event"] == "coding_owner_retargeted"]
+            self.assertEqual(len(journalled), 1)
+            recorded = journalled[0]["data"]
+            self.assertEqual(validate_owner_retarget(recorded), [])
+            self.assertEqual(recorded["from_owner"], "codex")
+            self.assertEqual(recorded["to_owner"], "hermes")
+            self.assertEqual(recorded["claim_boundary"], OWNER_RETARGET_CLAIM_BOUNDARY)
+            self.assertEqual(_canonical(recorded), _canonical(result["coding_owner_retarget"]))
+
+    def test_the_original_prepared_handoff_artifact_is_unchanged_byte_for_byte(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            session_id = _accepted_session(paths, "codex")
+            session = json.loads(
+                (paths.runtime_wrapper_sessions_dir / session_id / "session.json").read_text(encoding="utf-8")
+            )
+            original = paths.runtime_runs_dir / str(session["current_run_id"]) / "coding_delegation.json"
+            before = original.read_bytes()
+
+            result = prepare_wrapper_session_handoff(
+                paths, session_id, MESSAGE, executor_target="claude-code", retarget=True
+            )
+
+            self.assertEqual(original.read_bytes(), before)
+            # And what the retarget calls "preserved" is what the original
+            # handoff actually recorded, not a freshly re-derived plan that
+            # merely agrees with itself.
+            recorded = json.loads(before.decode("utf-8"))
+            preserved = result["coding_owner_retarget"]["preserved"]
+            for stored_field, contract_field in (
+                ("action", "action"),
+                ("intent", "intent"),
+                ("recommended_workflow", "recommended_workflow"),
+                ("recommended_harness", "recommended_harness"),
+                ("executor_profile", "work_role"),
+                ("acceptance_criteria", "acceptance_criteria"),
+                ("verification", "verification"),
+                ("review_required", "review_required"),
+            ):
+                with self.subTest(field=stored_field):
+                    self.assertEqual(recorded[stored_field], preserved[contract_field])
+
+    def test_the_wrapper_refuses_a_retarget_it_cannot_honour(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            session_id = _accepted_session(paths, "codex")
+            for kwargs, expected in (
+                ({"executor_target": "codex", "retarget": True}, "already targeted at codex"),
+                ({"retarget": True}, "retargeting requires the coding owner"),
+                ({"executor_target": "mystery-agent", "retarget": True}, "unsupported wrapper session executor"),
+                ({"executor_target": "choose", "retarget": True}, "unsupported wrapper session executor"),
+            ):
+                with self.subTest(kwargs=kwargs):
+                    with self.assertRaises(WrapperSessionError) as caught:
+                        prepare_wrapper_session_handoff(paths, session_id, MESSAGE, **kwargs)
+                    self.assertIn(expected, str(caught.exception))
+
+    def test_a_session_with_no_prepared_handoff_cannot_be_retargeted(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            started = create_or_resume_wrapper_session(
+                paths,
+                MESSAGE,
+                source="discord",
+                source_metadata={"source_event_id": "m1", "channel_ref": "c1"},
+                executor_target="codex",
+            )
+            session_id = str(started["session"]["session_id"])
+            record_plan_decision(paths, session_id, "accept")
+            with self.assertRaises(WrapperSessionError) as caught:
+                prepare_wrapper_session_handoff(
+                    paths, session_id, MESSAGE, executor_target="claude-code", retarget=True
+                )
+            self.assertIn("there is no prepared handoff to re-project", str(caught.exception))
+
+
+class RetargetNeedsNoHostCredentialTests(unittest.TestCase):
+    """AC3: retargeting is a local re-projection, not a host-config read."""
+
+    def test_a_retarget_completes_with_every_credential_and_config_reader_raising(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            session_id = _accepted_session(paths, "codex")
+
+            def _refuse(*args: Any, **kwargs: Any) -> Any:
+                raise AssertionError("retargeting must not read source-host configuration or credentials")
+
+            patches = (
+                mock.patch("omh.coding.executor_auth_signals.executor_auth_signals", _refuse),
+                mock.patch("omh.coding.executor_auth_signals.auth_signal_for_profile", _refuse),
+                mock.patch("omh.coding.executor_auth_signals.last_limit_signal_for_profile", _refuse),
+                mock.patch("omh.coding.executor_readiness.live_readiness_binding", _refuse),
+                mock.patch.object(Path, "home", staticmethod(_refuse)),
+            )
+            with patches[0], patches[1], patches[2], patches[3], patches[4]:
+                # The patches really do refuse, so a pass below is the retarget
+                # never reaching them rather than the patch never applying.
+                with self.assertRaises(AssertionError):
+                    Path.home()
+                result = prepare_wrapper_session_handoff(
+                    paths, session_id, MESSAGE, executor_target="claude-code", retarget=True
+                )
+
+            record = result["coding_owner_retarget"]
+            self.assertEqual(validate_owner_retarget(record), [])
+            self.assertEqual(record["from_owner"], "codex")
+            self.assertEqual(record["to_owner"], "claude-code")
+            self.assertEqual(result["session"]["status"], "prompt_handoff_prepared")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- An accepted coding plan can now change owner without being planned again. `omh chat session prepare-handoff <session> --executor <owner> --retarget` re-projects the already-accepted task onto a different coding owner, preserves scope, non-goals, acceptance criteria, and verification expectations, and reports only what genuinely moved.
- New `coding_task_contract/v1`: the owner-neutral half of one accepted plan (routed workflow, harness, intent, work role, acceptance criteria, verification, review boundary, delegation prompt template, and a digest of the owner-neutral work-quality bar), plus `coding_task_contract_digest`.
- New `coding_owner_retarget/v1`: both owners and their labels, the preserved contract and its digest, the enumerated owner-specific delta, the capability delta, a derived `next_action`, and a claim boundary denying dispatch and execution.
- The `sessions.py` guard that refused every executor change on a follow-up handoff became an explicit, named operation instead of a silent allow. Without `--retarget`, a follow-up still keeps its executor and still gets refused.
- `docs/ARCHITECTURE.md` gains a "Coding Owner Retarget" section beside the existing "Coding Owner Fit" section.

### Why This Exists

Closes #812.

Before this change, `src/wrapper/sessions.py` raised:

```
a follow-up handoff keeps the selected executor; start a new session to switch executors
```

That guard exists for a real reason — a follow-up is a delta on an accepted plan, and silently swapping its owner would hand the next instruction to somebody the user never chose. But the only escape it offered was to start a new session, and a new session carries no accepted plan. So the only supported way to say "continue this in Claude Code instead" was to replan work the user had already approved and re-derive criteria they had already agreed to.

The accepted reading of a task never depended on the owner in the first place: `build_coding_delegation_payload` computes `payload["delegation"]` before it looks at `executor_target` at all. Retargeting is therefore a re-projection, not a decision — and the fix is to name that operation rather than to weaken the guard.

### User / Operator Impact

A user who says "continue this in Claude Code instead" keeps the plan they accepted. Hermes moves the owner, states that the task contract did not move, and explains only the owner-specific differences: which handoff kind is now prepared, whether it is dispatchable, which observed-evidence events and wrapper actions the new owner gains and loses, and which required capabilities the new owner cannot prove.

Concretely, observed from a real `omh` invocation (`codex` → `claude-code`):

```
schema: coding_owner_retarget/v1 | status: prepared_not_observed
from: codex -> to: claude-code | next_action: prepare_handoff_for_new_owner
preserved_digest: acec47ea2318913b96f384b1b8c83c873b9fc028c8fcd41349f763ee7227c146
preserved workflow: ai-slop-cleaner
acceptance_criteria: ['Implement only the requested coding change within the discovered scope.',
                      'Preserve existing behavior outside the requested change.']
verification: ['Run targeted tests for the changed behavior.',
               'Run static or compile checks when available.']
changed owner fields: ['work_owner_mode', 'handoff_field', 'dispatch_policy', 'dispatchable',
                       'dispatch_contract', 'recording_contract', 'invocation_mode']
capability statement: No required capability is unsupported, unproven, or changed by this owner change.
session: prompt_handoff_prepared claude-code
```

Nothing about the operator's normal path changed: `--retarget` is an agent/wrapper-facing flag on an agent/wrapper-facing command, and a follow-up handoff without it behaves exactly as before.

### How It Works

**AC1 — preservation is enforced, not just asserted.** `build_owner_retarget` takes two built delegation payloads for the same task, one per owner, projects each to a `coding_task_contract/v1`, and compares them field by field. Any difference raises:

```
retargeting must preserve the accepted task contract, and these owner-neutral fields moved,
which is a replan rather than a retarget: intent, recommended_workflow, acceptance_criteria, ...
```

So a move that would silently replan the task cannot be recorded as a retarget. The validator adds a second lock: `preserved_digest` must be recomputable from the stored `preserved` contract, so a record cannot claim a contract it does not hold.

**AC2 — the capability difference is named before the handoff.** The delta reuses #810's matcher rather than growing a second one: requirements come from `derive_plan_capability_requirements(accepted_plan_from_delegation(...))` and each owner is classified by `evaluate_owner_fit`. Both owners are judged against the *target* plan's requirement set, because "what changed" is only meaningful on one yardstick; the yardstick's own movement is reported separately as `required_by_owner_change` / `dropped_by_owner_change`. That movement is the interesting case — retargeting from an external-executor owner to a runtime owner turns the routed workflow into something the new owner must carry locally, adding a `local_workflow` requirement the source plan never had. `next_action` follows from the delta: `confirm_owner_capability_gap` when something is recorded unavailable, `record_capability_evidence` when something is unproven, otherwise `prepare_handoff_for_new_owner`. In the wrapper path the record is built *before* the new handoff is prepared, so a refused move writes nothing.

**AC3 — no source-host configuration or credential.** `build_owner_retarget` performs no I/O at all; capability snapshots arrive as a parameter and absent snapshots classify `unknown` (an unproven owner), never a guess. `now` is a parameter and no wall-clock value enters the hashed payload, so the record is byte-deterministic.

**The relaxed guard.** `_retarget_source_owner` returns `""` for a follow-up, so the original refusal still fires with its intent intact; the only change to that message is that it now names retargeting alongside "start a new session". A retarget requires the caller to ask by name, requires a session that already has a prepared handoff, refuses the owner already selected, refuses an unknown owner or `choose`, and preserves the run-integrity invariants of the branch it bypasses. It also skips the same-message re-serve short-circuits, which would otherwise hand back the old owner's handoff with exit 0 while ignoring the requested owner. The record is journalled as a `coding_owner_retargeted` session event *after* the new handoff exists, so the journal never claims a retarget that did not finish.

One adjacent consistency fix the feature made reachable: `_prepare_prompt_only_session_handoff` now clears `runtime_handoff`, exactly as the runtime prepare already clears `prompt_handoff`. Without it, retargeting a runtime-prepared session to a prompt owner would leave two answers to "what is prepared".

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/coding/owner_retarget.py` | New. `coding_task_contract/v1`, `coding_owner_retarget/v1`, `build_owner_retarget`, both validators, closed key sets, claim boundaries. 712 lines. |
| `src/wrapper/sessions.py` | Guard relaxed into `_retarget_source_owner`; `retarget=` parameter on `prepare_wrapper_session_handoff`; `_owner_retarget_record`, `_with_owner_retarget`, `_capability_snapshot_directory`; `PREPARED_HANDOFF_STATUSES`; prompt prepare clears a stale runtime handoff. |
| `src/commands/chat.py` | `--retarget` flag on `omh chat session prepare-handoff`, threaded to the session call. |
| `tests/test_coding_retarget.py` | New. 29 tests across AC1/AC2/AC3, validator both-directions, and guards. |
| `docs/ARCHITECTURE.md` | `coding/owner_retarget.py` in the module tree, plus a "Coding Owner Retarget" section. |

No generated artifact changed, so no regeneration was needed; the byte gates were still rerun. No new dependency, no network or LLM call, no Hermes patching. New wrapper result key: `coding_owner_retarget`, present only on a retarget. New session event: `coding_owner_retargeted`. The `wrapper_session/v1` record shape is unchanged.

## Validation

- [x] `uv run --group lint ruff check src tests` — `All checks passed!` (the `# noqa` warning on `src/commands/main.py:1` is pre-existing and unrelated)
- [x] `python3 -m unittest discover -s tests` — run as `PYTHONPATH=tests uv run python -m unittest discover -s tests`: **Ran 5276 tests in 163.832s, OK**, on the tree rebased onto `origin/main` (`b2bafb62`)
- [x] `python3 -m compileall src` — run as `uv run python -m compileall -q src tests`, exit 0
- [x] `python3 -m omh.cli docs workflows --check` — `{"ok":true,"tap_skills":{"checked":115,"expected":115,"extra":[],"missing":[],"ok":true,"stale":[]}}`
- [x] `python3 -m omh.cli harness validate` — `{"counts":{"harnesses":72,"skills":104},"errors":[],"ok":true,"warnings":[]}`
- [x] `python3 -m omh.cli release checklist --json` — `"ok":true`, `"required_item_count":35`, mode `plan`
- [x] `python3 -m omh.cli release hermes-smoke` — plan rendered with plan-only evidence boundaries
- [x] `omh --help` — run as `uv run python -m omh.cli --help`, exit 0
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — **not run.** It needs an installed `omh` console script on PATH; this branch was verified from the source checkout only, and it changes no install, packaging, or skill-content surface.
- [x] Relevant workflow-learning review queue smoke, when learning contracts changed: **n/a** — no learning contract changed.
- [x] Relevant dry-run or smoke command: a spawned `omh chat session prepare-handoff --retarget` run in a temp `--omh-home`/`--hermes-home`, covering prepare-for-codex, the follow-up refusal (exit 2, correct message), and the `codex → claude-code` retarget (exit 0, output quoted above).
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: **not run.** No Hermes profile was available in this environment. The change is confined to the OMH control plane; nothing in the Hermes skill catalog, generated skill content, or plugin bundle moved.

Additional gates from `CLAUDE.md`:

- [x] `uv run python -m omh.cli docs roles --check` — `{"ok":true}`
- [x] `uv run python -m omh.cli docs capability-families --check` — `{"ok":true}`
- [x] `git diff --check` — clean
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_coding_retarget.py` — **Ran 29 tests, OK**

## Risk

- **The relaxed guard is the main risk surface.** It is mitigated by keeping the refusal path intact and unreachable-by-accident: `retarget` defaults to `False`, and a follow-up with a different executor and no `retarget` still raises. `tests/test_coding_retarget.py::WrapperSessionRetargetTests::test_a_follow_up_handoff_without_an_explicit_retarget_still_keeps_its_executor` asserts both the refusal and that the persisted session still names the original owner.
- **Cost.** A retarget builds two extra delegation payloads in-process to compare the two projections. This is CPU and two small local snapshot reads; it happens only on an explicit retarget.
- **Route inheritance was a real trap and is now pinned by a directive.** A retarget deliberately does *not* inherit the session's route preference the way a follow-up does. Inheriting it made the recorded contract describe a different workflow (`ralplan`) from the handoff being replaced (`ai-slop-cleaner`), which would have made "preserved" a false claim. `test_the_original_prepared_handoff_artifact_is_unchanged_byte_for_byte` now compares the preserved contract against the *stored* original delegation record, so this cannot regress silently.
- **Not covered.** No natural-language chat trigger for retargeting was added; the capability is reachable from the CLI flag and the Python entry point only. Wiring a phrase like "continue this in Claude Code instead" into `src/routing/` is a separate, additive change with its own overroute guards.

## Compatibility / Rollout

- Backward compatible. `retarget` and `--retarget` both default to off, and every existing `prepare-handoff` path behaves exactly as before. The only visible change on an untouched path is the wording of the follow-up refusal, which now names retargeting as an alternative to starting a new session.
- No schema version was bumped and no persisted record shape changed. `coding_owner_retarget` appears in the wrapper result and in the session journal only when a retarget actually happened, so existing readers that ignore unknown keys are unaffected.
- Executor-neutral by construction: the retarget is exercised across `codex`, `claude-code`, `hermes`, and `omx-runtime`, and the only owner-identity fields in the record are the two owners and their labels. Nothing makes Codex the default.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`) — control-plane only; no install, packaging, version, or generated-artifact surface moved, so no release-channel action is implied.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — the record's `status` is `prepared_not_observed` and its `claim_boundary` states that a retarget is not dispatch, execution, verification, review, CI, or merge evidence and is not proof the new owner accepted or started the work. `test_the_claim_boundary_denies_dispatch_and_execution` pins that wording.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap — no live Hermes smoke was run; `release hermes-smoke` was run in plan mode only, and the `--live` gap is stated above.

## Follow-Up

- Route a natural-language retarget phrase ("continue this in Claude Code instead") through `src/routing/` with the paired overroute guards this repo requires, so the capability is reachable from chat and not only from the wrapper-facing flag.
- Consider surfacing the capability delta in the wrapper chat card, so a blocked new owner reads as a visible confirmation prompt rather than as a `next_action` a wrapper has to interpret.
