### PR TITLE
feat: review OMH policy and routing changes before rollout

### DIFF
--- a/src/workflows/policy_change_review.py
+++ b/src/workflows/policy_change_review.py
@@ -1,0 +1,1187 @@
+"""Review one OMH policy or routing change before it becomes the active behavior (#798).
+
+The defect this closes: a change to OMH clarification, routing, handoff, or
+verification policy is a behavior change for every intent that policy touches,
+and the ones it improves are the ones the author was looking at. The ones it
+regresses are the others. Nothing in the tree made a maintainer say, before
+rollout, which intents move, which way each of them moves, which coding owners
+the change re-scopes, or what evidence would show the change landed without
+taking something else down with it.
+
+`policy_change_review/v1` is that statement. One review, for one policy surface,
+bound to the baseline it was measured against.
+
+Why a sibling and not an extension
+----------------------------------
+
+The nearest neighbour is `improvement_patch_proposal/v1` in
+:mod:`workflows.workflow_learning`, and it was the first thing tried. It already
+carries a review gate, a regression gate with a replay status, a
+`patch_scope.mode` of `proposal_only`, and a target type that includes
+`routing`. Extending it was rejected for two reasons that are structural rather
+than stylistic:
+
+* **Its subject is different.** An improvement patch proposal is *derived*: it
+  exists only downstream of a learning trace, an eval result, and a candidate,
+  and its identity keys (`trace_id`, `eval_id`, `candidate_id`) are all
+  required. It answers "one observed workflow went wrong; what should change?".
+  A policy change review is *authored*: a maintainer proposes a change with no
+  trace behind it, and demanding a synthetic trace to record one would make the
+  learning family lie about where the proposal came from.
+* **Its lifecycle is different.** The patch proposal's status ladder is a
+  function of the candidate's decision and a regression replay, and it stops at
+  `ready_for_human_patch` -- by design, since `apply_path_available` is `False`
+  and the change owner is a later human PR. #798 needs the state *after* that
+  handoff: a rollout gated on a matching baseline, observed repository changes,
+  and named regression evidence. Bolting a second, differently-gated ladder onto
+  a frozen v1 schema read by the export bundle, the learning index, and the
+  review queue would change the meaning of a record several surfaces already
+  parse.
+
+What is reused instead of reinvented: the hashing scheme is
+``quality.skill_governance.policy_decision_digest`` for both the baseline digest
+and the review digest, the coding-owner vocabulary is
+``coding.executors.EXECUTOR_PROFILES`` rather than a second list of owners, and
+the derived-status-plus-content-digest shape is the one
+`workflows.skill_pattern_risk_review` established for the same reason.
+
+Not the capability toggle
+-------------------------
+
+`omh_capability_policy_change/v1` in `commands.capability_policy` is a different
+thing that shares a word. It records that one capability *family* was switched
+on or off for one local install: which family, the policy before, the policy
+after, and the reverse command. It says nothing about behavior, has no reviewer,
+no baseline binding, no intents, and no rollout state, and it applies itself the
+moment it is invoked. A review is the opposite: it changes nothing, and it
+exists to be argued with first.
+
+AC1 -- every affected intent, with both sides
+---------------------------------------------
+
+``intents`` is a list of rows, each naming one intent and both of its behaviors.
+A row that states only a before, or only an after, is a validation error naming
+the intent and the side it is missing, because one side of a behavior change is
+not reviewable: "clarification asks a question here" is a fact about the world,
+not a change to it.
+
+An intent whose before and after read the same is deliberately *allowed*. The
+user problem is silent regression, and recording "I checked this one and it does
+not move" is how a review shows the check happened.
+
+AC2 -- a rejected or superseded review is structurally not the active policy
+-----------------------------------------------------------------------------
+
+``review_state`` is **derived**, never passed. :func:`build_policy_change_review`
+has no state parameter, no decision parameter, and no rollout parameter, so
+there is no argument through which a proposal can assert that it is in force,
+and :func:`validate_policy_change_review` re-derives the state and refuses a
+payload that disagrees -- a hand-written dict cannot lie either.
+
+Three separate things keep an inactive review inactive:
+
+* ``superseded_by_review_ref`` is the supersession link, and it dominates every
+  other input in :func:`derive_review_state`. A review a later review replaced
+  reads as ``superseded`` whatever it was decided to be, and
+  :func:`record_policy_change_rollout` refuses to touch it at all.
+* A rejection is a recorded decision like any other, and ``rejected`` has no
+  edge to ``applied``.
+* A decision is bound to the content it covers. ``reviewed_digest`` stamps
+  ``review_digest``, so material content that moves after the decision leaves
+  the review at ``superseded_by_content_change`` rather than carrying the old
+  approval onto text nobody read.
+
+:func:`review_reads_as_active` is the one question a surface asks, and
+:data:`ACTIVE_REVIEW_STATE` is the only member of :data:`REVIEW_STATES` it is
+true for. :data:`REFUSED_REVIEW_STATES` holds the bare words -- ``active``,
+``live``, ``in_effect``, ``rolled_out`` -- by name, so a payload asserting one of
+them is refused as a rule rather than as an unrecognised value.
+
+AC3 -- applied needs all three, or it is not applied
+-----------------------------------------------------
+
+:data:`ROLLOUT_REQUIREMENTS` names them: the observed baseline digest equals the
+baseline the review was bound to, at least one repository change was observed,
+and the named regression evidence is present and passing. All three, together,
+and only from an approved review whose content has not moved. Any one missing
+and :func:`derive_review_state` returns ``approved_not_rolled_out``;
+:func:`unmet_rollout_requirements` says which, and the validator repeats it in
+the error so a refusal is actionable rather than a verdict.
+
+The baseline is the reason the first requirement exists. A review argues about
+one specific policy; if the policy in force at rollout time is not the one that
+was reviewed, the review does not describe the world and its approval covers
+nothing. Both digests come from :func:`policy_change_baseline_digest`.
+
+What OMH did not do
+-------------------
+
+Nothing here reads the repository, edits policy source, regenerates a skill,
+changes a route, or replays a regression. ``not_observed`` says so per surface.
+The rollout block records what a *caller* observed and is only as good as the
+surface that supplied it -- which is why the requirement is that the evidence be
+named and matched, not that this module went and looked.
+
+Determinism
+-----------
+
+No clock is read. ``prepared_at`` is a caller parameter and is excluded from
+``review_digest``, because a wall-clock value inside a compared digest turns an
+equality check into a race that a slow CI worker loses. ``reviewer_decision``,
+``rollout``, ``superseded_by_review_ref``, and ``review_state`` are excluded too:
+recording a decision must not move the digest that decision names, and recording
+rollout evidence must not invalidate the approval it rests on.
+
+What reads this today
+---------------------
+
+Stated because the contract is wider than the wiring. No production surface
+mints a review yet; this module is the contract and
+``tests/test_policy_change_review.py`` is its only caller.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Final
+
+from ..coding.executors import EXECUTOR_PROFILES
+from ..quality.skill_governance import policy_decision_digest
+from ..system.append_only_store import (
+    RAW_OR_HIDDEN_KEYS,
+    is_unsafe_metadata_line,
+    opaque_ref,
+    reference_errors,
+)
+
+
+POLICY_CHANGE_REVIEW_SCHEMA_VERSION: Final = "policy_change_review/v1"
+
+REVIEW_PRIVACY: Final = "metadata_only"
+
+# The four surfaces #798 scopes this family to. Closed, and short on purpose:
+# each one is a place where OMH decides how it will behave toward a user intent,
+# and none of them is a place where content is authored.
+POLICY_SURFACES: Final = ("clarification", "routing", "handoff", "verification")
+
+# Named so the boundary refuses by name instead of as an unrecognised value.
+# Turning an observed user workflow into a reusable skill is the teach-workflow
+# capability's job (#838), and a review of a *policy* surface is not the record
+# for it.
+OUT_OF_SCOPE_SURFACES: Final = ("skill", "skill_creation", "reusable_skill", "teach_workflow")
+
+# Derived from the delegation vocabulary, never restated. A second list of
+# coding owners here would be a second thing to keep in agreement with
+# `coding.executors`, and the first time they disagreed a review would answer
+# for an owner that no longer exists or miss one that does.
+POLICY_CHANGE_OWNERS: Final[tuple[str, ...]] = EXECUTOR_PROFILES
+
+# What a policy change does to one coding owner's boundary. Closed so a later
+# gate can join on a member instead of parsing a sentence.
+# `no_boundary_change` is a real answer rather than an omission, which is what
+# keeps "this owner is unaffected" and "nobody considered this owner" apart.
+OWNER_BOUNDARY_CHANGES: Final = (
+    "handoff_scope_widened",
+    "handoff_scope_narrowed",
+    "clarification_required_earlier",
+    "clarification_no_longer_required",
+    "verification_evidence_required",
+    "verification_evidence_relaxed",
+    "routing_reaches_this_owner",
+    "routing_no_longer_reaches_this_owner",
+    "no_boundary_change",
+)
+
+# A regression case has a result; a repository change is simply a fact that
+# happened. That asymmetry is why only one of the two rollout lists carries
+# rows. There is no `not_run` member: evidence that was not run is not evidence,
+# and leaving it out of the list says so more clearly than naming it.
+REGRESSION_OUTCOMES: Final = ("passed", "failed")
+
+# Both are about the proposed change, and neither is about the source of it.
+REVIEWER_DECISIONS: Final = ("approve_policy_change", "reject_policy_change")
+
+# The lifecycle of a review. Exactly one member says the change is in force.
+REVIEW_STATES: Final = (
+    "awaiting_review",
+    "rejected",
+    "superseded",
+    "superseded_by_content_change",
+    "approved_not_rolled_out",
+    "applied",
+)
+
+# The single member of REVIEW_STATES under which this review's after-behavior is
+# the behavior now in force.
+ACTIVE_REVIEW_STATE: Final = "applied"
+
+# Words a state will not be, held by name so the refusal states a rule. Every
+# one of them asserts that routing or guidance is already live, which is a claim
+# about the running system that a review is not in a position to make.
+REFUSED_REVIEW_STATES: Final = (
+    "active",
+    "current",
+    "deployed",
+    "enabled",
+    "in_effect",
+    "live",
+    "merged",
+    "passed",
+    "released",
+    "rolled_out",
+    "shipped",
+    "verified",
+)
+
+# The one sentence each state may be rendered with. Every one says what did or
+# did not change in active behavior, so no rendering of any state can read as a
+# rollout OMH performed.
+REVIEW_STATE_CLAIMS: Final = {
+    "awaiting_review": (
+        "A policy change is proposed and no reviewer has decided yet. Active routing and guidance are "
+        "unchanged."
+    ),
+    "rejected": (
+        "A reviewer rejected the proposed change. It is not the active policy and must not alter routing "
+        "or guidance."
+    ),
+    "superseded": (
+        "A later review replaced this one. It is not the active policy, whatever it was decided to be."
+    ),
+    "superseded_by_content_change": (
+        "The reviewed content moved after the decision, so the decision no longer covers it. It is not the "
+        "active policy."
+    ),
+    "approved_not_rolled_out": (
+        "A reviewer approved the change and its rollout evidence is incomplete. Active routing and "
+        "guidance are unchanged."
+    ),
+    "applied": (
+        "An approved change was rolled out against the matching baseline, with observed repository changes "
+        "and named passing regression evidence. OMH neither made nor verified those changes; it recorded "
+        "that a caller observed them."
+    ),
+}
+
+# How a recorded decision stands against the content now in the review.
+REVIEWER_DECISION_STATES: Final = ("absent", "current", "stale")
+
+# #798 AC3, as three names a caller can be told it is missing.
+ROLLOUT_REQUIREMENTS: Final = (
+    "baseline_matches",
+    "repository_changes_observed",
+    "regression_evidence_named",
+)
+
+# What OMH did not do to the policy under review, per surface.
+NOT_OBSERVED_SURFACES: Final = (
+    "policy_source_edit",
+    "routing_behavior_change",
+    "clarification_behavior_change",
+    "regression_replay",
+    "test_execution",
+    "repository_write",
+)
+
+BASELINE_KEYS: Final = ("baseline_ref", "baseline_digest")
+INTENT_KEYS: Final = ("intent_ref", "before", "after")
+OWNER_BOUNDARY_KEYS: Final = ("owner", "boundary_change")
+REGRESSION_EVIDENCE_KEYS: Final = ("case_ref", "outcome")
+ROLLOUT_KEYS: Final = (
+    "observed_baseline_digest",
+    "observed_repository_changes",
+    "regression_evidence",
+)
+REVIEWER_DECISION_KEYS: Final = ("decided_by", "decision", "reviewed_digest")
+
+POLICY_CHANGE_REVIEW_KEYS: Final = (
+    "schema_version",
+    "review_ref",
+    "policy_surface",
+    "baseline",
+    "intents",
+    "owner_boundaries",
+    "not_observed",
+    "reviewer_decision",
+    "rollout",
+    "superseded_by_review_ref",
+    "review_state",
+    "prepared_at",
+    "privacy",
+    "review_digest",
+    "claim_boundary",
+)
+
+# The review's own lifecycle: outside the digest, because recording a decision
+# must not move the digest that decision names, and recording the rollout
+# evidence an approval asked for must not invalidate the approval.
+REVIEW_STATE_KEYS: Final = (
+    "reviewer_decision",
+    "rollout",
+    "superseded_by_review_ref",
+    "review_state",
+)
+
+# A value that cannot cover itself, two module constants identical in every
+# review, and the one field that holds a clock.
+DERIVED_REVIEW_KEYS: Final = ("review_digest", "claim_boundary", "privacy", "prepared_at")
+
+# Everything else. Derived rather than listed so a key added to the schema is
+# material by default and has to be argued out, never silently left out.
+MATERIAL_REVIEW_KEYS: Final = tuple(
+    key
+    for key in POLICY_CHANGE_REVIEW_KEYS
+    if key not in set(REVIEW_STATE_KEYS) | set(DERIVED_REVIEW_KEYS)
+)
+
+# Key names under which "the change is already live" arrives. The closed key set
+# already refuses every one of them, but it refuses them as unsupported keys,
+# and the point of this family is that proposing a change is not making one.
+ROLLOUT_CLAIM_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "active",
+        "applied_at",
+        "ci_passed",
+        "deployed",
+        "enabled",
+        "executed",
+        "in_effect",
+        "live",
+        "merged",
+        "passed",
+        "released",
+        "rolled_out",
+        "routing_changed",
+        "shipped",
+        "succeeded",
+        "success",
+        "verified",
+    }
+)
+
+POLICY_CHANGE_REVIEW_CLAIM_BOUNDARY: Final = (
+    "This review records a proposed change to one OMH clarification, routing, handoff, or verification "
+    "policy surface: the intents it moves, both sides of each of those behaviors, the coding-owner "
+    "boundaries it shifts, and a reviewer's decision. OMH does not edit policy source, regenerate skills, "
+    "change routing, read the repository, or replay a regression here. Every observation in the rollout "
+    "block is supplied by the caller and is only as good as the surface that supplied it. A rejected or "
+    "superseded review is never the active policy, and the review is not execution, review, CI, "
+    "merge-readiness, or merge evidence."
+)
+
+_MAX_BEHAVIOR_CHARS: Final = 240
+_MAX_STAMP_CHARS: Final = 64
+_MAX_INTENTS: Final = 24
+_MAX_OBSERVED_CHANGES: Final = 12
+_MAX_REGRESSION_ROWS: Final = 24
+
+_LABEL: Final = "policy change review"
+_SHA256_LENGTH: Final = 64
+
+
+class PolicyChangeReviewError(ValueError):
+    """Raised when a review cannot be built, decided, superseded, or rolled out."""
+
+
+# ---------------------------------------------------------------------------
+# Build
+# ---------------------------------------------------------------------------
+
+
+def build_policy_change_review(
+    *,
+    review_ref: str,
+    policy_surface: str,
+    baseline_ref: str,
+    baseline_policy: Mapping[str, Any],
+    intents: Sequence[Mapping[str, Any]],
+    owner_boundaries: Sequence[Mapping[str, Any]],
+    prepared_at: str = "",
+) -> dict[str, Any]:
+    """Mint one proposed policy change review, or refuse.
+
+    There is no `review_state` parameter, no `reviewer_decision` parameter, and
+    no `rollout` parameter. A freshly minted review is a proposal and nothing
+    else, which is what makes "a proposal cannot read as the active policy" a
+    property of the constructor rather than a rule a caller is asked to respect.
+    The three later transitions each have their own function, and each of them
+    re-derives the state.
+    """
+    review: dict[str, Any] = {
+        "schema_version": POLICY_CHANGE_REVIEW_SCHEMA_VERSION,
+        "review_ref": _opaque(review_ref, field=f"{_LABEL} review_ref"),
+        "policy_surface": _policy_surface(policy_surface),
+        "baseline": {
+            "baseline_ref": _opaque(baseline_ref, field=f"{_LABEL} baseline.baseline_ref"),
+            "baseline_digest": policy_change_baseline_digest(baseline_policy),
+        },
+        "intents": _intent_rows(intents),
+        "owner_boundaries": _owner_boundary_rows(owner_boundaries),
+        "not_observed": {surface: {"status": "not_observed"} for surface in NOT_OBSERVED_SURFACES},
+        "prepared_at": _optional_line(prepared_at, field=f"{_LABEL} prepared_at", limit=_MAX_STAMP_CHARS),
+        "privacy": REVIEW_PRIVACY,
+        "claim_boundary": POLICY_CHANGE_REVIEW_CLAIM_BOUNDARY,
+    }
+    review["review_digest"] = policy_change_review_digest(review)
+    review["reviewer_decision"] = {}
+    review["rollout"] = empty_rollout()
+    review["superseded_by_review_ref"] = ""
+    review["review_state"] = derive_review_state(review)
+    _raise_on(validate_policy_change_review(review))
+    return review
+
+
+def policy_change_baseline_digest(baseline_policy: Mapping[str, Any]) -> str:
+    """The digest that binds a review to the policy it argues about.
+
+    Reuses `quality.skill_governance.policy_decision_digest`: it is already this
+    repository's stable, order-independent content hash over a policy mapping,
+    and a second encoding rule here would be a second thing to keep correct.
+    The same function produces the digest recorded at rollout time, so the
+    baseline comparison is between two values derived the same way.
+    """
+    if not isinstance(baseline_policy, Mapping) or not baseline_policy:
+        raise PolicyChangeReviewError(
+            f"{_LABEL} baseline_policy must be a non-empty object describing the policy in force; a change "
+            "measured against nothing cannot be reviewed"
+        )
+    return policy_decision_digest(dict(baseline_policy))
+
+
+def empty_rollout() -> dict[str, Any]:
+    """The rollout block of a review nobody has rolled out.
+
+    Present with all three keys rather than absent, because #798 AC3 is three
+    independent requirements and each of them has to be individually missing.
+    """
+    return {
+        "observed_baseline_digest": "",
+        "observed_repository_changes": [],
+        "regression_evidence": [],
+    }
+
+
+def record_policy_change_decision(
+    review: Mapping[str, Any], *, decided_by: str, decision: str
+) -> dict[str, Any]:
+    """Bind one reviewer's decision to the content that reviewer saw.
+
+    The digest of the material content in front of the reviewer is stamped onto
+    the decision, so content that moves afterwards leaves the review superseded
+    rather than quietly carrying an approval it outgrew.
+
+    A superseded review is not re-decided: a later review already replaced it,
+    and a decision recorded on it now would be a decision about text nothing
+    reads.
+    """
+    _raise_on(validate_policy_change_review(review))
+    if str(review.get("superseded_by_review_ref", "") or ""):
+        raise PolicyChangeReviewError(
+            f"{_LABEL} cannot record a decision on a review superseded by "
+            f"{review.get('superseded_by_review_ref')!r}; decide the review that replaced it"
+        )
+    decided = dict(review)
+    decided["reviewer_decision"] = {
+        "decided_by": _opaque(decided_by, field=f"{_LABEL} reviewer_decision.decided_by"),
+        "decision": _closed(
+            decision, allowed=REVIEWER_DECISIONS, field=f"{_LABEL} reviewer_decision.decision"
+        ),
+        "reviewed_digest": policy_change_review_digest(review),
+    }
+    decided["review_state"] = derive_review_state(decided)
+    _raise_on(validate_policy_change_review(decided))
+    return decided
+
+
+def record_policy_change_rollout(
+    review: Mapping[str, Any],
+    *,
+    observed_baseline_digest: str = "",
+    observed_repository_changes: Sequence[str] = (),
+    regression_evidence: Sequence[Mapping[str, Any]] = (),
+) -> dict[str, Any]:
+    """Attach the evidence a rollout rests on to an approved review.
+
+    Partial evidence is accepted on purpose: evidence arrives in pieces, and a
+    review holding two of the three requirements is a useful record of exactly
+    what is still outstanding. It simply does not read as `applied` --
+    :func:`derive_review_state` decides that, here and in the validator, from
+    the evidence rather than from having been called.
+
+    What is refused is attaching evidence at all to a review that no current
+    approval covers. That refusal is a convenience, not the safety property:
+    even a hand-written payload carrying complete rollout evidence under a
+    rejection derives `rejected`.
+    """
+    _raise_on(validate_policy_change_review(review))
+    if str(review.get("superseded_by_review_ref", "") or ""):
+        raise PolicyChangeReviewError(
+            f"{_LABEL} cannot roll out a review superseded by "
+            f"{review.get('superseded_by_review_ref')!r}; roll out the review that replaced it"
+        )
+    state = derive_review_state(review)
+    if state not in {"approved_not_rolled_out", ACTIVE_REVIEW_STATE}:
+        raise PolicyChangeReviewError(
+            f"{_LABEL} rollout evidence may only be recorded on a review a reviewer approved and whose "
+            f"content has not moved since; this review reads {state!r}"
+        )
+    rolled = dict(review)
+    rolled["rollout"] = {
+        "observed_baseline_digest": _optional_digest(
+            observed_baseline_digest, field=f"{_LABEL} rollout.observed_baseline_digest"
+        ),
+        "observed_repository_changes": _ref_list(
+            observed_repository_changes,
+            field=f"{_LABEL} rollout.observed_repository_changes",
+            maximum=_MAX_OBSERVED_CHANGES,
+        ),
+        "regression_evidence": _regression_rows(regression_evidence),
+    }
+    rolled["review_state"] = derive_review_state(rolled)
+    _raise_on(validate_policy_change_review(rolled))
+    return rolled
+
+
+def supersede_policy_change_review(
+    review: Mapping[str, Any], *, superseded_by_review_ref: str
+) -> dict[str, Any]:
+    """Link one review to the review that replaced it.
+
+    The link points forward, from the replaced review to its replacement, so
+    whether a review is still the active policy is answerable from that review
+    alone and does not require holding the whole sequence.
+    """
+    _raise_on(validate_policy_change_review(review))
+    successor = _opaque(superseded_by_review_ref, field=f"{_LABEL} superseded_by_review_ref")
+    if successor == str(review.get("review_ref", "") or ""):
+        raise PolicyChangeReviewError(
+            f"{_LABEL} superseded_by_review_ref must not name the review itself: {successor}"
+        )
+    superseded = dict(review)
+    superseded["superseded_by_review_ref"] = successor
+    superseded["review_state"] = derive_review_state(superseded)
+    _raise_on(validate_policy_change_review(superseded))
+    return superseded
+
+
+# ---------------------------------------------------------------------------
+# Derived state
+# ---------------------------------------------------------------------------
+
+
+def policy_change_review_digest(review: Mapping[str, Any]) -> str:
+    """Content hash of the material part of a review."""
+    return policy_decision_digest(material_review_content(review))
+
+
+def material_review_content(review: Mapping[str, Any]) -> dict[str, Any]:
+    """The part of a review the digest covers.
+
+    A missing key projects as `None` rather than raising, so a malformed review
+    still has a digest and the validator -- not the hash -- reports the fault.
+    """
+    return {key: review.get(key) for key in MATERIAL_REVIEW_KEYS}
+
+
+def reviewer_decision_state(review: Mapping[str, Any]) -> str:
+    """Whether a decision exists and still covers the content now in the review."""
+    decision = review.get("reviewer_decision")
+    if not isinstance(decision, Mapping) or not decision:
+        return "absent"
+    reviewed = str(decision.get("reviewed_digest", "") or "")
+    return "current" if reviewed and reviewed == policy_change_review_digest(review) else "stale"
+
+
+def rollout_requirements(review: Mapping[str, Any]) -> dict[str, bool]:
+    """#798 AC3, evaluated: the matching baseline, observed changes, named evidence.
+
+    Named regression evidence means at least one named case whose recorded
+    outcome is `passed` and no named case that failed. A list carrying a failure
+    is evidence, and what it is evidence of is that the change is not ready.
+    """
+    rollout = review.get("rollout")
+    rollout = rollout if isinstance(rollout, Mapping) else {}
+    baseline = review.get("baseline")
+    expected = str(baseline.get("baseline_digest", "") or "") if isinstance(baseline, Mapping) else ""
+    observed = str(rollout.get("observed_baseline_digest", "") or "")
+    changes = rollout.get("observed_repository_changes")
+    evidence = rollout.get("regression_evidence")
+    rows = list(evidence) if _is_row_sequence(evidence) else []
+    return {
+        "baseline_matches": bool(expected) and observed == expected,
+        "repository_changes_observed": isinstance(changes, list) and bool(changes),
+        "regression_evidence_named": bool(rows)
+        and all(str(row.get("outcome", "")) == "passed" for row in rows),
+    }
+
+
+def unmet_rollout_requirements(review: Mapping[str, Any]) -> tuple[str, ...]:
+    """Which of #798 AC3's three requirements this review does not yet meet."""
+    met = rollout_requirements(review)
+    return tuple(name for name in ROLLOUT_REQUIREMENTS if not met.get(name, False))
+
+
+def derive_review_state(review: Mapping[str, Any]) -> str:
+    """The only definition of a review's state.
+
+    Read it as #798 AC2 and AC3 in code. Supersession dominates, because a
+    review something else replaced is not the active policy whatever it holds. A
+    decision that no longer covers the content is treated as superseded by that
+    content, for the same reason. Only an approval that is current reaches the
+    rollout gate, and only a complete gate reaches `applied`.
+    """
+    if str(review.get("superseded_by_review_ref", "") or ""):
+        return "superseded"
+    state = reviewer_decision_state(review)
+    if state == "absent":
+        return "awaiting_review"
+    if state == "stale":
+        return "superseded_by_content_change"
+    decision = review.get("reviewer_decision")
+    verdict = decision.get("decision") if isinstance(decision, Mapping) else ""
+    if verdict != "approve_policy_change":
+        return "rejected"
+    return ACTIVE_REVIEW_STATE if not unmet_rollout_requirements(review) else "approved_not_rolled_out"
+
+
+def review_reads_as_active(review: Mapping[str, Any]) -> bool:
+    """Whether this review's after-behavior is the behavior now in force.
+
+    The one question a surface should ask before letting a review speak for
+    active routing or guidance. Every clause is redundant with `derive_review_state`
+    and every clause is here anyway, because #798 AC2 is the property this
+    function exists to hold and it should be readable at the call site.
+    """
+    return (
+        str(review.get("review_state", "")) == ACTIVE_REVIEW_STATE
+        and derive_review_state(review) == ACTIVE_REVIEW_STATE
+        and not str(review.get("superseded_by_review_ref", "") or "")
+        and reviewer_decision_state(review) == "current"
+    )
+
+
+def review_state_claim(state: str) -> str:
+    """The one sentence a state may be rendered with."""
+    text = str(state or "")
+    if text not in REVIEW_STATE_CLAIMS:
+        raise PolicyChangeReviewError(f"{_LABEL} review_state is unsupported: {text!r}")
+    return REVIEW_STATE_CLAIMS[text]
+
+
+def affected_intents(review: Mapping[str, Any]) -> tuple[str, ...]:
+    """The intents this change moves, in the order the review named them."""
+    intents = review.get("intents")
+    if not _is_row_sequence(intents):
+        return ()
+    return tuple(str(row.get("intent_ref", "")) for row in intents)
+
+
+def owner_boundary_impact(review: Mapping[str, Any]) -> dict[str, str]:
+    """Each coding owner's boundary change, by owner."""
+    rows = review.get("owner_boundaries")
+    if not _is_row_sequence(rows):
+        return {}
+    return {str(row.get("owner", "")): str(row.get("boundary_change", "")) for row in rows}
+
+
+# ---------------------------------------------------------------------------
+# Validate
+# ---------------------------------------------------------------------------
+
+
+def validate_policy_change_review(review: Any) -> list[str]:
+    """Every reason a payload is not a valid review. Both directions on keys."""
+    if not isinstance(review, Mapping):
+        return [f"{_LABEL} must be an object"]
+    errors: list[str] = []
+    claims_rollout = sorted(key for key in review if str(key).lower() in ROLLOUT_CLAIM_KEYS)
+    if claims_rollout:
+        errors.append(
+            f"{_LABEL} must not carry rollout-claim keys: {claims_rollout}; a review proposes a policy "
+            "change and never asserts that routing or guidance is already live"
+        )
+    forbidden = sorted(key for key in review if str(key).lower() in RAW_OR_HIDDEN_KEYS)
+    if forbidden:
+        errors.append(f"{_LABEL} must not carry raw or hidden keys: {forbidden}")
+    present = {str(key) for key in review}
+    missing = sorted(set(POLICY_CHANGE_REVIEW_KEYS) - present)
+    if missing:
+        errors.append(f"{_LABEL} is missing keys: {missing}")
+    unexpected = sorted(present - set(POLICY_CHANGE_REVIEW_KEYS) - set(claims_rollout) - set(forbidden))
+    if unexpected:
+        errors.append(f"{_LABEL} has unsupported keys: {unexpected}")
+    if review.get("schema_version") != POLICY_CHANGE_REVIEW_SCHEMA_VERSION:
+        errors.append(f"{_LABEL} schema_version must be {POLICY_CHANGE_REVIEW_SCHEMA_VERSION}")
+    if review.get("privacy") != REVIEW_PRIVACY:
+        errors.append(f"{_LABEL} privacy must be {REVIEW_PRIVACY}")
+    if review.get("claim_boundary") != POLICY_CHANGE_REVIEW_CLAIM_BOUNDARY:
+        errors.append(
+            f"{_LABEL} claim_boundary must state that OMH changes no policy source or routing here and "
+            "that a rejected or superseded review is never the active policy"
+        )
+    if review.get("not_observed") != {
+        surface: {"status": "not_observed"} for surface in NOT_OBSERVED_SURFACES
+    }:
+        errors.append(
+            f"{_LABEL} not_observed must mark every one of {list(NOT_OBSERVED_SURFACES)} as not_observed"
+        )
+    errors.extend(_line_errors(review.get("prepared_at"), field="prepared_at", limit=_MAX_STAMP_CHARS))
+    errors.extend(reference_errors(review.get("review_ref"), field="review_ref", label=_LABEL, required=True))
+    errors.extend(_surface_errors(review.get("policy_surface")))
+    errors.extend(_baseline_errors(review.get("baseline")))
+    errors.extend(_intent_errors(review.get("intents")))
+    errors.extend(_owner_boundary_errors(review.get("owner_boundaries")))
+    errors.extend(_supersession_errors(review))
+    errors.extend(_decision_errors(review))
+    errors.extend(_rollout_errors(review))
+    errors.extend(_state_errors(review))
+    errors.extend(_digest_errors(review))
+    return errors
+
+
+def _surface_errors(value: Any) -> list[str]:
+    text = str(value or "")
+    if text in POLICY_SURFACES:
+        return []
+    if text.strip().lower() in OUT_OF_SCOPE_SURFACES:
+        return [
+            f"{_LABEL} policy_surface {text!r} is out of scope for this family; it reviews changes to "
+            f"{list(POLICY_SURFACES)} policy, and turning an observed workflow into a reusable skill "
+            "belongs to the teach-workflow capability"
+        ]
+    return [f"{_LABEL} policy_surface is unsupported: {value!r}; allowed: {list(POLICY_SURFACES)}"]
+
+
+def _baseline_errors(baseline: Any) -> list[str]:
+    field = "baseline"
+    if not isinstance(baseline, Mapping):
+        return [
+            f"{_LABEL} {field} must be an object naming the policy this change is measured against; a "
+            "change with no baseline cannot be shown to still describe the world at rollout time"
+        ]
+    errors = _block_key_errors(baseline, keys=BASELINE_KEYS, field=field)
+    errors.extend(
+        reference_errors(
+            baseline.get("baseline_ref"), field=f"{field}.baseline_ref", label=_LABEL, required=True
+        )
+    )
+    if not _is_sha256(str(baseline.get("baseline_digest", "") or "")):
+        errors.append(
+            f"{_LABEL} {field}.baseline_digest must be a sha256 hex digest of the policy in force when the "
+            "change was proposed"
+        )
+    return errors
+
+
+def _intent_errors(intents: Any) -> list[str]:
+    """#798 AC1: every affected intent, each with a before and an after."""
+    field = "intents"
+    if not _is_row_sequence(intents):
+        return [f"{_LABEL} {field} must be a list of objects, one per affected intent"]
+    errors: list[str] = []
+    if not intents:
+        errors.append(
+            f"{_LABEL} {field} must name at least 1 affected intent; a policy change that moves no named "
+            "intent is not reviewable"
+        )
+    if len(intents) > _MAX_INTENTS:
+        errors.append(f"{_LABEL} {field} must name at most {_MAX_INTENTS} intents")
+    named: list[str] = []
+    for index, row in enumerate(intents, start=1):
+        reference = str(row.get("intent_ref", "") or "")
+        where = repr(reference) if reference else f"row {index}"
+        named.append(reference)
+        errors.extend(
+            reference_errors(
+                row.get("intent_ref"), field=f"{field} {where} intent_ref", label=_LABEL, required=True
+            )
+        )
+        unsupported = sorted({str(key) for key in row} - set(INTENT_KEYS))
+        if unsupported:
+            errors.append(f"{_LABEL} {field} entry {where} has unsupported keys: {unsupported}")
+        for side in ("before", "after"):
+            value = row.get(side)
+            if not isinstance(value, str) or not value.strip():
+                errors.append(
+                    f"{_LABEL} {field} entry {where} states no {side} behavior; an affected intent needs "
+                    "both a before and an after, because one side of a behavior change is not reviewable"
+                )
+                continue
+            errors.extend(
+                _line_errors(value, field=f"{field} {where} {side}", limit=_MAX_BEHAVIOR_CHARS, required=True)
+            )
+    repeated = sorted({reference for reference in named if reference and named.count(reference) > 1})
+    if repeated:
+        errors.append(f"{_LABEL} {field} names the same intent more than once: {repeated}")
+    return errors
+
+
+def _owner_boundary_errors(rows: Any) -> list[str]:
+    """The owner-boundary impact, answered for every coding owner rather than some."""
+    field = "owner_boundaries"
+    if not _is_row_sequence(rows):
+        return [f"{_LABEL} {field} must be a list of objects, one per coding owner"]
+    errors: list[str] = []
+    named: list[str] = []
+    for index, row in enumerate(rows, start=1):
+        owner = str(row.get("owner", "") or "")
+        where = repr(owner) if owner else f"row {index}"
+        named.append(owner)
+        errors.extend(_block_key_errors(row, keys=OWNER_BOUNDARY_KEYS, field=f"{field} entry {where}"))
+        if owner not in POLICY_CHANGE_OWNERS:
+            errors.append(
+                f"{_LABEL} {field} names an unknown coding owner: {owner!r}; allowed: "
+                f"{list(POLICY_CHANGE_OWNERS)}"
+            )
+        change = row.get("boundary_change")
+        if change not in OWNER_BOUNDARY_CHANGES:
+            errors.append(
+                f"{_LABEL} {field} boundary_change for {where} is unsupported: {change!r}; allowed: "
+                f"{list(OWNER_BOUNDARY_CHANGES)}"
+            )
+    repeated = sorted({owner for owner in named if owner and named.count(owner) > 1})
+    if repeated:
+        errors.append(f"{_LABEL} {field} answers for the same coding owner more than once: {repeated}")
+    unanswered = [owner for owner in POLICY_CHANGE_OWNERS if owner not in set(named)]
+    if unanswered:
+        errors.append(
+            f"{_LABEL} {field} does not answer for every coding owner: {unanswered}; name "
+            "no_boundary_change for an owner the change does not move, so an unaffected owner and an "
+            "unconsidered one stay different"
+        )
+    return errors
+
+
+def _supersession_errors(review: Mapping[str, Any]) -> list[str]:
+    value = review.get("superseded_by_review_ref")
+    errors = reference_errors(value, field="superseded_by_review_ref", label=_LABEL, required=False)
+    if errors:
+        return errors
+    if isinstance(value, str) and value and value == str(review.get("review_ref", "") or ""):
+        return [f"{_LABEL} superseded_by_review_ref must not name the review itself: {value}"]
+    return []
+
+
+def _decision_errors(review: Mapping[str, Any]) -> list[str]:
+    decision = review.get("reviewer_decision")
+    if not isinstance(decision, Mapping):
+        return [f"{_LABEL} reviewer_decision must be an object, empty when nobody has decided"]
+    if not decision:
+        return []
+    errors = _block_key_errors(decision, keys=REVIEWER_DECISION_KEYS, field="reviewer_decision")
+    errors.extend(
+        reference_errors(
+            decision.get("decided_by"), field="reviewer_decision.decided_by", label=_LABEL, required=True
+        )
+    )
+    if decision.get("decision") not in REVIEWER_DECISIONS:
+        errors.append(f"{_LABEL} reviewer_decision.decision is unsupported: {decision.get('decision')!r}")
+    if not _is_sha256(str(decision.get("reviewed_digest", "") or "")):
+        errors.append(
+            f"{_LABEL} reviewer_decision.reviewed_digest must be the sha256 digest of the content that was "
+            "reviewed"
+        )
+    return errors
+
+
+def _rollout_errors(review: Mapping[str, Any]) -> list[str]:
+    field = "rollout"
+    rollout = review.get(field)
+    if not isinstance(rollout, Mapping):
+        return [f"{_LABEL} {field} must be an object carrying the evidence a rollout rests on"]
+    errors = _block_key_errors(rollout, keys=ROLLOUT_KEYS, field=field)
+    digest = rollout.get("observed_baseline_digest")
+    if not isinstance(digest, str):
+        errors.append(
+            f"{_LABEL} {field}.observed_baseline_digest must be a string, empty when no baseline was observed"
+        )
+    elif digest and not _is_sha256(digest):
+        errors.append(
+            f"{_LABEL} {field}.observed_baseline_digest must be a sha256 hex digest of the policy actually "
+            "in force"
+        )
+    errors.extend(
+        _ref_list_errors(
+            rollout.get("observed_repository_changes"),
+            field=f"{field}.observed_repository_changes",
+            maximum=_MAX_OBSERVED_CHANGES,
+        )
+    )
+    errors.extend(_regression_evidence_errors(rollout.get("regression_evidence")))
+    return errors
+
+
+def _regression_evidence_errors(evidence: Any) -> list[str]:
+    field = "rollout.regression_evidence"
+    if not _is_row_sequence(evidence):
+        return [f"{_LABEL} {field} must be a list of objects naming one regression case each"]
+    errors: list[str] = []
+    if len(evidence) > _MAX_REGRESSION_ROWS:
+        errors.append(f"{_LABEL} {field} must name at most {_MAX_REGRESSION_ROWS} cases")
+    named: list[str] = []
+    for index, row in enumerate(evidence, start=1):
+        case = str(row.get("case_ref", "") or "")
+        where = repr(case) if case else f"row {index}"
+        named.append(case)
+        errors.extend(_block_key_errors(row, keys=REGRESSION_EVIDENCE_KEYS, field=f"{field} entry {where}"))
+        errors.extend(
+            reference_errors(
+                row.get("case_ref"), field=f"{field} {where} case_ref", label=_LABEL, required=True
+            )
+        )
+        if row.get("outcome") not in REGRESSION_OUTCOMES:
+            errors.append(
+                f"{_LABEL} {field} outcome for {where} is unsupported: {row.get('outcome')!r}; allowed: "
+                f"{list(REGRESSION_OUTCOMES)}"
+            )
+    repeated = sorted({case for case in named if case and named.count(case) > 1})
+    if repeated:
+        errors.append(f"{_LABEL} {field} names the same regression case more than once: {repeated}")
+    return errors
+
+
+def _state_errors(review: Mapping[str, Any]) -> list[str]:
+    """#798 AC2 and AC3: the state is what the evidence makes it."""
+    state = review.get("review_state")
+    if str(state).strip().lower() in REFUSED_REVIEW_STATES:
+        return [
+            f"{_LABEL} review_state may not assert that the change is {state!r}; a review records its own "
+            f"lifecycle and never that routing or guidance is live, so one of {list(REVIEW_STATES)} is "
+            "required"
+        ]
+    if state not in REVIEW_STATES:
+        return [f"{_LABEL} review_state is unsupported: {state!r}"]
+    derived = derive_review_state(review)
+    if state == derived:
+        return []
+    unmet = unmet_rollout_requirements(review)
+    detail = f"; unmet rollout requirements: {list(unmet)}" if unmet else ""
+    return [
+        f"{_LABEL} review_state is {state!r} but the supersession link, the recorded decision, and the "
+        f"rollout evidence derive {derived!r}; the state of a review is what its evidence makes it, never "
+        f"what a payload asserts{detail}"
+    ]
+
+
+def _digest_errors(review: Mapping[str, Any]) -> list[str]:
+    digest = review.get("review_digest")
+    if not isinstance(digest, str) or not _is_sha256(digest):
+        return [f"{_LABEL} review_digest must be a sha256 hex digest"]
+    if digest != policy_change_review_digest(review):
+        return [
+            f"{_LABEL} review_digest does not match the content it seals; the review was edited after it "
+            "was minted"
+        ]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _raise_on(errors: list[str]) -> None:
+    if errors:
+        raise PolicyChangeReviewError("; ".join(errors))
+
+
+def _policy_surface(value: Any) -> str:
+    errors = _surface_errors(value)
+    if errors:
+        raise PolicyChangeReviewError(errors[0])
+    return str(value)
+
+
+def _intent_rows(intents: Any) -> list[dict[str, Any]]:
+    if not _is_row_sequence(intents):
+        raise PolicyChangeReviewError(f"{_LABEL} intents must be a list of objects, one per affected intent")
+    rows: list[dict[str, Any]] = []
+    for index, row in enumerate(intents, start=1):
+        reference = str(row.get("intent_ref", "") or "")
+        where = repr(reference) if reference else f"row {index}"
+        unsupported = sorted({str(key) for key in row} - set(INTENT_KEYS))
+        if unsupported:
+            raise PolicyChangeReviewError(
+                f"{_LABEL} intents entry {where} has unsupported keys: {unsupported}"
+            )
+        for side in ("before", "after"):
+            value = row.get(side)
+            if not isinstance(value, str) or not value.strip():
+                raise PolicyChangeReviewError(
+                    f"{_LABEL} intents entry {where} states no {side} behavior; an affected intent needs "
+                    "both a before and an after, because one side of a behavior change is not reviewable"
+                )
+        rows.append(
+            {
+                "intent_ref": _opaque(row.get("intent_ref"), field=f"{_LABEL} intents {where} intent_ref"),
+                "before": _bounded_line(
+                    row.get("before"), field=f"{_LABEL} intents {where} before", limit=_MAX_BEHAVIOR_CHARS
+                ),
+                "after": _bounded_line(
+                    row.get("after"), field=f"{_LABEL} intents {where} after", limit=_MAX_BEHAVIOR_CHARS
+                ),
+            }
+        )
+    return rows
+
+
+def _owner_boundary_rows(boundaries: Any) -> list[dict[str, Any]]:
+    if not _is_row_sequence(boundaries):
+        raise PolicyChangeReviewError(
+            f"{_LABEL} owner_boundaries must be a list of objects, one per coding owner"
+        )
+    rows: list[dict[str, Any]] = []
+    for row in boundaries:
+        unsupported = sorted({str(key) for key in row} - set(OWNER_BOUNDARY_KEYS))
+        if unsupported:
+            raise PolicyChangeReviewError(f"{_LABEL} owner_boundaries has unsupported keys: {unsupported}")
+        owner = _closed(row.get("owner"), allowed=POLICY_CHANGE_OWNERS, field=f"{_LABEL} owner_boundaries.owner")
+        rows.append(
+            {
+                "owner": owner,
+                "boundary_change": _closed(
+                    row.get("boundary_change"),
+                    allowed=OWNER_BOUNDARY_CHANGES,
+                    field=f"{_LABEL} owner_boundaries.boundary_change for {owner!r}",
+                ),
+            }
+        )
+    # Owner order is normalized so two reviews answering the same way in a
+    # different order produce the same `review_digest`.
+    ordered = sorted(rows, key=lambda row: POLICY_CHANGE_OWNERS.index(row["owner"]))
+    errors = _owner_boundary_errors(ordered)
+    if errors:
+        raise PolicyChangeReviewError("; ".join(errors))
+    return ordered
+
+
+def _regression_rows(evidence: Any) -> list[dict[str, Any]]:
+    if not _is_row_sequence(evidence):
+        raise PolicyChangeReviewError(
+            f"{_LABEL} rollout.regression_evidence must be a list of objects naming one regression case each"
+        )
+    rows: list[dict[str, Any]] = []
+    for row in evidence:
+        unsupported = sorted({str(key) for key in row} - set(REGRESSION_EVIDENCE_KEYS))
+        if unsupported:
+            raise PolicyChangeReviewError(
+                f"{_LABEL} rollout.regression_evidence has unsupported keys: {unsupported}"
+            )
+        case = _opaque(row.get("case_ref"), field=f"{_LABEL} rollout.regression_evidence.case_ref")
+        rows.append(
+            {
+                "case_ref": case,
+                "outcome": _closed(
+                    row.get("outcome"),
+                    allowed=REGRESSION_OUTCOMES,
+                    field=f"{_LABEL} rollout.regression_evidence.outcome for {case!r}",
+                ),
+            }
+        )
+    return rows
+
+
+def _ref_list(values: Any, *, field: str, maximum: int) -> list[str]:
+    if isinstance(values, (str, bytes, bytearray)) or not isinstance(values, Sequence):
+        raise PolicyChangeReviewError(f"{field} must be a list")
+    refs = [_opaque(value, field=field) for value in values]
+    if len(set(refs)) != len(refs):
+        raise PolicyChangeReviewError(f"{field} must not repeat an entry")
+    if len(refs) > maximum:
+        raise PolicyChangeReviewError(f"{field} must name at most {maximum} entries")
+    return refs
+
+
+def _ref_list_errors(value: Any, *, field: str, maximum: int) -> list[str]:
+    if not isinstance(value, list):
+        return [f"{_LABEL} {field} must be a list of opaque references"]
+    errors: list[str] = []
+    if len(value) > maximum:
+        errors.append(f"{_LABEL} {field} must name at most {maximum} entries")
+    if len({str(item) for item in value}) != len(value):
+        errors.append(f"{_LABEL} {field} must not repeat an entry")
+    for item in value:
+        errors.extend(reference_errors(item, field=field, label=_LABEL, required=True))
+    return errors
+
+
+def _block_key_errors(block: Any, *, keys: tuple[str, ...], field: str) -> list[str]:
+    if not isinstance(block, Mapping):
+        return [f"{_LABEL} {field} must be an object"]
+    errors: list[str] = []
+    present = {str(key) for key in block}
+    missing = sorted(set(keys) - present)
+    if missing:
+        errors.append(f"{_LABEL} {field} is missing keys: {missing}")
+    unexpected = sorted(present - set(keys))
+    if unexpected:
+        errors.append(f"{_LABEL} {field} has unsupported keys: {unexpected}")
+    return errors
+
+
+def _is_row_sequence(value: Any) -> bool:
+    return (
+        isinstance(value, Sequence)
+        and not isinstance(value, (str, bytes, bytearray))
+        and all(isinstance(row, Mapping) for row in value)
+    )
+
+
+def _closed(value: Any, *, allowed: tuple[str, ...], field: str) -> str:
+    text = str(value or "")
+    if text not in allowed:
+        raise PolicyChangeReviewError(f"{field} is unsupported: {value!r}; allowed: {list(allowed)}")
+    return text
+
+
+def _opaque(value: Any, *, field: str) -> str:
+    return opaque_ref(str(value or ""), field=field, error=PolicyChangeReviewError)
+
+
+def _optional_digest(value: Any, *, field: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    if not _is_sha256(text):
+        raise PolicyChangeReviewError(f"{field} must be a sha256 hex digest")
+    return text
+
+
+def _bounded_line(value: Any, *, field: str, limit: int) -> str:
+    text = " ".join(str(value or "").split())
+    if not text:
+        raise PolicyChangeReviewError(f"{field} is required")
+    if len(text) > limit:
+        raise PolicyChangeReviewError(f"{field} must be at most {limit} characters")
+    if is_unsafe_metadata_line(text):
+        raise PolicyChangeReviewError(
+            f"{field} must be one bounded metadata line without secrets, links, or paths"
+        )
+    return text
+
+
+def _optional_line(value: Any, *, field: str, limit: int) -> str:
+    text = " ".join(str(value or "").split())
+    return _bounded_line(text, field=field, limit=limit) if text else ""
+
+
+def _line_errors(value: Any, *, field: str, limit: int, required: bool = False) -> list[str]:
+    if not isinstance(value, str):
+        return [f"{_LABEL} {field} must be a string"]
+    if not value.strip():
+        return [f"{_LABEL} {field} is required"] if required else []
+    if len(value) > limit:
+        return [f"{_LABEL} {field} must be at most {limit} characters"]
+    if is_unsafe_metadata_line(value):
+        return [f"{_LABEL} {field} must not carry secrets, links, paths, or raw text"]
+    return []
+
+
+def _is_sha256(value: str) -> bool:
+    if len(value) != _SHA256_LENGTH or value != value.lower():
+        return False
+    try:
+        int(value, 16)
+    except ValueError:
+        return False
+    return True

--- a/tests/test_policy_change_review.py
+++ b/tests/test_policy_change_review.py
@@ -1,0 +1,795 @@
+"""Contracts for `policy_change_review/v1` (issue #798).
+
+Grouped by acceptance criterion:
+
+- AC1: a proposed policy change lists every affected intent and both sides of
+  its behavior. An intent carrying only a before, or only an after, is a
+  validation error naming the intent and the missing side.
+- AC2: a rejected or superseded review cannot alter active routing or guidance.
+  Asserted across the whole state vocabulary rather than on one state, because
+  the claim is that being active is unreachable from those two rather than
+  merely discouraged.
+- AC3: `applied` requires the matching baseline, observed repository changes,
+  and named regression evidence. Three tests drop exactly one requirement each
+  and a fourth supplies all three, so no single requirement can be the one
+  carrying the gate.
+
+Plus the guards the family exists for: a caller-supplied `applied` on an
+incomplete review is refused, a baseline mismatch is refused, and a review never
+reads as having changed policy source, routing, or a test run.
+
+No test here writes a file. The digests compared are all between payloads built
+in the same run, and `prepared_at` is a parameter rather than a clock, so
+nothing in this file depends on the newline convention or the wall clock of the
+platform it runs on.
+"""
+
+from __future__ import annotations
+
+import inspect
+import unittest
+from typing import Any
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.coding.executors import EXECUTOR_PROFILES  # noqa: E402
+from omh.quality.skill_governance import policy_decision_digest  # noqa: E402
+from omh.system.append_only_store import RAW_OR_HIDDEN_KEYS  # noqa: E402
+from omh.workflows.policy_change_review import (  # noqa: E402
+    ACTIVE_REVIEW_STATE,
+    BASELINE_KEYS,
+    DERIVED_REVIEW_KEYS,
+    INTENT_KEYS,
+    MATERIAL_REVIEW_KEYS,
+    NOT_OBSERVED_SURFACES,
+    OUT_OF_SCOPE_SURFACES,
+    OWNER_BOUNDARY_CHANGES,
+    OWNER_BOUNDARY_KEYS,
+    POLICY_CHANGE_OWNERS,
+    POLICY_CHANGE_REVIEW_CLAIM_BOUNDARY,
+    POLICY_CHANGE_REVIEW_KEYS,
+    POLICY_CHANGE_REVIEW_SCHEMA_VERSION,
+    POLICY_SURFACES,
+    REFUSED_REVIEW_STATES,
+    REGRESSION_EVIDENCE_KEYS,
+    REGRESSION_OUTCOMES,
+    REVIEW_STATE_CLAIMS,
+    REVIEW_STATE_KEYS,
+    REVIEW_STATES,
+    REVIEWER_DECISION_KEYS,
+    REVIEWER_DECISION_STATES,
+    REVIEWER_DECISIONS,
+    ROLLOUT_CLAIM_KEYS,
+    ROLLOUT_KEYS,
+    ROLLOUT_REQUIREMENTS,
+    PolicyChangeReviewError,
+    affected_intents,
+    build_policy_change_review,
+    derive_review_state,
+    empty_rollout,
+    material_review_content,
+    owner_boundary_impact,
+    policy_change_baseline_digest,
+    policy_change_review_digest,
+    record_policy_change_decision,
+    record_policy_change_rollout,
+    review_reads_as_active,
+    review_state_claim,
+    reviewer_decision_state,
+    rollout_requirements,
+    supersede_policy_change_review,
+    unmet_rollout_requirements,
+    validate_policy_change_review,
+)
+
+
+BASELINE_POLICY = {
+    "clarify_threshold": "ambiguous_only",
+    "max_questions": 2,
+    "runtime_priority": "builtin",
+}
+
+MOVED_BASELINE_POLICY = {
+    "clarify_threshold": "always",
+    "max_questions": 2,
+    "runtime_priority": "builtin",
+}
+
+
+def intent_rows() -> list[dict[str, Any]]:
+    """Two affected intents: one the change moves, one it deliberately does not."""
+    return [
+        {
+            "intent_ref": "ship-a-small-fix",
+            "before": "Hermes asks one scoping question before it prepares the coding handoff.",
+            "after": "Hermes prepares the coding handoff and asks nothing.",
+        },
+        {
+            "intent_ref": "plan-a-release",
+            "before": "Hermes asks two scoping questions before it drafts the plan.",
+            "after": "Hermes asks two scoping questions before it drafts the plan.",
+        },
+    ]
+
+
+def owner_rows(**overrides: str) -> list[dict[str, Any]]:
+    """One row per coding owner, unaffected unless the caller says otherwise."""
+    changes = {owner: "no_boundary_change" for owner in POLICY_CHANGE_OWNERS}
+    changes.update(overrides)
+    return [{"owner": owner, "boundary_change": change} for owner, change in changes.items()]
+
+
+def review_kwargs(**overrides: Any) -> dict[str, Any]:
+    """A complete, valid proposal's arguments, minimally overridable."""
+    base: dict[str, Any] = {
+        "review_ref": "policy-review-clarify-01",
+        "policy_surface": "clarification",
+        "baseline_ref": "clarification-policy-2026-08",
+        "baseline_policy": dict(BASELINE_POLICY),
+        "intents": intent_rows(),
+        "owner_boundaries": owner_rows(**{"codex": "clarification_no_longer_required"}),
+        "prepared_at": "2026-08-09T00:00:00Z",
+    }
+    base.update(overrides)
+    return base
+
+
+def proposed(**overrides: Any) -> dict[str, Any]:
+    return build_policy_change_review(**review_kwargs(**overrides))
+
+
+def approved(**overrides: Any) -> dict[str, Any]:
+    return record_policy_change_decision(
+        proposed(**overrides), decided_by="maintainer-1", decision="approve_policy_change"
+    )
+
+
+def rejected(**overrides: Any) -> dict[str, Any]:
+    return record_policy_change_decision(
+        proposed(**overrides), decided_by="maintainer-1", decision="reject_policy_change"
+    )
+
+
+def rolled_out(
+    review: dict[str, Any] | None = None,
+    *,
+    baseline: str | None = None,
+    changes: tuple[str, ...] = ("repo-change-9f21c4",),
+    evidence: tuple[dict[str, Any], ...] = ({"case_ref": "regression-clarify-01", "outcome": "passed"},),
+) -> dict[str, Any]:
+    """An approved review carrying rollout evidence, complete unless narrowed."""
+    review = review or approved()
+    digest = baseline if baseline is not None else str(review["baseline"]["baseline_digest"])
+    return record_policy_change_rollout(
+        review,
+        observed_baseline_digest=digest,
+        observed_repository_changes=list(changes),
+        regression_evidence=[dict(row) for row in evidence],
+    )
+
+
+def content_moved(review: dict[str, Any]) -> dict[str, Any]:
+    """The same review after its material content changed under a live decision.
+
+    Re-seals the digest the way a rebuild from a store would, so the payload is
+    self-consistent and the only thing the validator can object to is the state.
+    """
+    moved = dict(review)
+    moved["intents"] = [
+        dict(intent_rows()[0], after="Hermes asks two scoping questions and then prepares the handoff."),
+        intent_rows()[1],
+    ]
+    moved["review_digest"] = policy_change_review_digest(moved)
+    moved["review_state"] = derive_review_state(moved)
+    return moved
+
+
+def review_in_state(state: str) -> dict[str, Any]:
+    """One valid review for each member of the state vocabulary."""
+    builders = {
+        "awaiting_review": proposed,
+        "rejected": rejected,
+        "superseded": lambda: supersede_policy_change_review(
+            approved(), superseded_by_review_ref="policy-review-clarify-02"
+        ),
+        "superseded_by_content_change": lambda: content_moved(approved()),
+        "approved_not_rolled_out": approved,
+        "applied": rolled_out,
+    }
+    return builders[state]()
+
+
+class PolicyChangeReviewShapeTests(unittest.TestCase):
+    def test_a_proposal_validates_and_carries_the_closed_key_set(self) -> None:
+        review = proposed()
+
+        self.assertEqual(validate_policy_change_review(review), [])
+        self.assertEqual(sorted(review), sorted(POLICY_CHANGE_REVIEW_KEYS))
+        self.assertEqual(review["schema_version"], POLICY_CHANGE_REVIEW_SCHEMA_VERSION)
+        self.assertEqual(review["privacy"], "metadata_only")
+        self.assertEqual(review["claim_boundary"], POLICY_CHANGE_REVIEW_CLAIM_BOUNDARY)
+        self.assertEqual(sorted(review["baseline"]), sorted(BASELINE_KEYS))
+        self.assertEqual(sorted(review["rollout"]), sorted(ROLLOUT_KEYS))
+        self.assertEqual(review["rollout"], empty_rollout())
+        self.assertEqual(review["reviewer_decision"], {})
+        self.assertEqual(review["superseded_by_review_ref"], "")
+
+    def test_an_unsupported_key_and_a_missing_key_are_both_refused(self) -> None:
+        review = proposed()
+
+        added = dict(review, reviewer_notes="looks fine")
+        self.assertIn(
+            "policy change review has unsupported keys: ['reviewer_notes']",
+            validate_policy_change_review(added),
+        )
+
+        removed = {key: value for key, value in review.items() if key != "owner_boundaries"}
+        self.assertIn(
+            "policy change review is missing keys: ['owner_boundaries']",
+            validate_policy_change_review(removed),
+        )
+
+    def test_a_payload_asserting_the_change_is_live_is_refused_by_key_name(self) -> None:
+        review = dict(proposed(), rolled_out=True)
+
+        errors = validate_policy_change_review(review)
+
+        self.assertTrue(
+            any("must not carry rollout-claim keys: ['rolled_out']" in error for error in errors), errors
+        )
+
+    def test_a_payload_carrying_raw_or_hidden_content_is_refused(self) -> None:
+        review = dict(proposed(), transcript="the whole review call")
+
+        errors = validate_policy_change_review(review)
+
+        self.assertTrue(any("must not carry raw or hidden keys" in error for error in errors), errors)
+
+    def test_rollout_claim_keys_do_not_collide_with_the_schema_or_the_raw_guard(self) -> None:
+        self.assertEqual(ROLLOUT_CLAIM_KEYS & set(POLICY_CHANGE_REVIEW_KEYS), set())
+        self.assertEqual(ROLLOUT_CLAIM_KEYS & RAW_OR_HIDDEN_KEYS, set())
+
+    def test_the_reviewed_surfaces_are_the_four_the_issue_scopes(self) -> None:
+        self.assertEqual(POLICY_SURFACES, ("clarification", "routing", "handoff", "verification"))
+        for surface in POLICY_SURFACES:
+            with self.subTest(surface=surface):
+                self.assertEqual(validate_policy_change_review(proposed(policy_surface=surface)), [])
+
+    def test_reusable_skill_creation_is_refused_as_out_of_scope_by_name(self) -> None:
+        for surface in OUT_OF_SCOPE_SURFACES:
+            with self.subTest(surface=surface):
+                with self.assertRaises(PolicyChangeReviewError) as caught:
+                    proposed(policy_surface=surface)
+                message = str(caught.exception)
+                self.assertIn("out of scope for this family", message)
+                self.assertIn("teach-workflow capability", message)
+
+    def test_not_observed_names_every_surface_omh_did_not_touch(self) -> None:
+        review = proposed()
+
+        self.assertEqual(
+            review["not_observed"],
+            {surface: {"status": "not_observed"} for surface in NOT_OBSERVED_SURFACES},
+        )
+        self.assertIn("policy_source_edit", NOT_OBSERVED_SURFACES)
+        self.assertIn("routing_behavior_change", NOT_OBSERVED_SURFACES)
+        self.assertIn("repository_write", NOT_OBSERVED_SURFACES)
+
+        broken = dict(review, not_observed={"policy_source_edit": {"status": "observed"}})
+        self.assertTrue(
+            any("must mark every one of" in error for error in validate_policy_change_review(broken))
+        )
+
+
+class PolicyChangeReviewIntentTests(unittest.TestCase):
+    """#798 AC1: every affected intent, each with a before and an after."""
+
+    def test_a_review_lists_every_affected_intent_with_both_behaviors(self) -> None:
+        review = proposed()
+
+        self.assertEqual(affected_intents(review), ("ship-a-small-fix", "plan-a-release"))
+        for intent in review["intents"]:
+            with self.subTest(intent=intent["intent_ref"]):
+                self.assertEqual(sorted(intent), sorted(INTENT_KEYS))
+                self.assertTrue(intent["before"].strip())
+                self.assertTrue(intent["after"].strip())
+
+    def test_an_intent_with_only_a_before_is_refused_naming_the_intent(self) -> None:
+        rows = [{"intent_ref": "ship-a-small-fix", "before": "Hermes asks one scoping question."}]
+
+        with self.assertRaises(PolicyChangeReviewError) as caught:
+            proposed(intents=rows)
+
+        message = str(caught.exception)
+        self.assertIn("'ship-a-small-fix'", message)
+        self.assertIn("states no after behavior", message)
+
+        payload = dict(proposed(), intents=rows)
+        errors = validate_policy_change_review(payload)
+        self.assertTrue(
+            any("'ship-a-small-fix' states no after behavior" in error for error in errors), errors
+        )
+
+    def test_an_intent_with_only_an_after_is_refused_naming_the_intent(self) -> None:
+        rows = [{"intent_ref": "plan-a-release", "after": "Hermes asks nothing."}]
+
+        with self.assertRaises(PolicyChangeReviewError) as caught:
+            proposed(intents=rows)
+
+        message = str(caught.exception)
+        self.assertIn("'plan-a-release'", message)
+        self.assertIn("states no before behavior", message)
+
+        payload = dict(proposed(), intents=rows)
+        errors = validate_policy_change_review(payload)
+        self.assertTrue(any("'plan-a-release' states no before behavior" in error for error in errors), errors)
+
+    def test_an_intent_whose_behavior_is_blank_on_one_side_is_refused(self) -> None:
+        rows = [{"intent_ref": "ship-a-small-fix", "before": "Hermes asks one question.", "after": "   "}]
+
+        with self.assertRaises(PolicyChangeReviewError) as caught:
+            proposed(intents=rows)
+
+        self.assertIn("states no after behavior", str(caught.exception))
+
+    def test_an_intent_the_change_does_not_move_may_state_the_same_behavior_twice(self) -> None:
+        # Recording "I checked this one and it does not move" is how a review
+        # shows the check happened, so identical sides are allowed on purpose.
+        rows = [
+            {
+                "intent_ref": "plan-a-release",
+                "before": "Hermes asks two scoping questions.",
+                "after": "Hermes asks two scoping questions.",
+            }
+        ]
+
+        review = proposed(intents=rows)
+
+        self.assertEqual(validate_policy_change_review(review), [])
+
+    def test_a_review_naming_no_intent_is_refused(self) -> None:
+        errors = validate_policy_change_review(dict(proposed(), intents=[]))
+
+        self.assertTrue(any("must name at least 1 affected intent" in error for error in errors), errors)
+
+    def test_the_same_intent_is_not_answered_twice(self) -> None:
+        rows = [intent_rows()[0], dict(intent_rows()[0], after="Hermes asks three questions.")]
+
+        errors = validate_policy_change_review(dict(proposed(), intents=rows))
+
+        self.assertTrue(
+            any("names the same intent more than once: ['ship-a-small-fix']" in error for error in errors),
+            errors,
+        )
+
+    def test_a_behavior_line_carrying_a_path_or_a_secret_is_refused(self) -> None:
+        for bad in ("Hermes reads src/routing/chat.py first.", "Hermes forwards the api_key downstream."):
+            with self.subTest(bad=bad):
+                with self.assertRaises(PolicyChangeReviewError):
+                    proposed(intents=[{"intent_ref": "ship-a-small-fix", "before": bad, "after": "Hermes stops."}])
+
+
+class PolicyChangeReviewOwnerBoundaryTests(unittest.TestCase):
+    def test_owner_boundary_impact_answers_for_every_coding_owner(self) -> None:
+        review = proposed()
+
+        impact = owner_boundary_impact(review)
+
+        self.assertEqual(sorted(impact), sorted(EXECUTOR_PROFILES))
+        self.assertEqual(impact["codex"], "clarification_no_longer_required")
+        self.assertEqual(impact["hermes"], "no_boundary_change")
+        for row in review["owner_boundaries"]:
+            with self.subTest(owner=row["owner"]):
+                self.assertEqual(sorted(row), sorted(OWNER_BOUNDARY_KEYS))
+
+    def test_the_owner_vocabulary_is_the_delegation_one_rather_than_a_second_list(self) -> None:
+        self.assertEqual(POLICY_CHANGE_OWNERS, EXECUTOR_PROFILES)
+        self.assertIn("claude-code", POLICY_CHANGE_OWNERS)
+        self.assertIn("hermes", POLICY_CHANGE_OWNERS)
+        self.assertIn("generic", POLICY_CHANGE_OWNERS)
+
+    def test_a_review_that_skips_a_coding_owner_is_refused_naming_the_owner(self) -> None:
+        rows = [row for row in owner_rows() if row["owner"] != "claude-code"]
+
+        with self.assertRaises(PolicyChangeReviewError) as caught:
+            proposed(owner_boundaries=rows)
+
+        message = str(caught.exception)
+        self.assertIn("does not answer for every coding owner: ['claude-code']", message)
+        self.assertIn("no_boundary_change", message)
+
+    def test_an_unknown_owner_and_an_unknown_boundary_change_are_both_refused(self) -> None:
+        with self.assertRaises(PolicyChangeReviewError):
+            proposed(owner_boundaries=[*owner_rows(), {"owner": "gemini", "boundary_change": "no_boundary_change"}])
+        with self.assertRaises(PolicyChangeReviewError):
+            proposed(owner_boundaries=owner_rows(**{"codex": "everything_changes"}))
+
+    def test_owner_rows_are_ordered_so_two_equal_answers_share_a_digest(self) -> None:
+        forward = proposed()
+        reversed_rows = list(reversed(owner_rows(**{"codex": "clarification_no_longer_required"})))
+        backward = proposed(owner_boundaries=reversed_rows)
+
+        self.assertEqual(forward["owner_boundaries"], backward["owner_boundaries"])
+        self.assertEqual(forward["review_digest"], backward["review_digest"])
+
+    def test_no_boundary_change_is_a_real_answer_and_not_an_omission(self) -> None:
+        self.assertIn("no_boundary_change", OWNER_BOUNDARY_CHANGES)
+
+        unaffected = proposed(owner_boundaries=owner_rows())
+        skipped = [row for row in owner_rows() if row["owner"] != "codex"]
+
+        self.assertEqual(validate_policy_change_review(unaffected), [])
+        self.assertTrue(validate_policy_change_review(dict(unaffected, owner_boundaries=skipped)))
+
+
+class PolicyChangeReviewBaselineTests(unittest.TestCase):
+    def test_the_baseline_digest_reuses_the_repository_policy_digest_scheme(self) -> None:
+        review = proposed()
+
+        self.assertEqual(
+            review["baseline"]["baseline_digest"], policy_decision_digest(dict(BASELINE_POLICY))
+        )
+        self.assertEqual(
+            policy_change_baseline_digest(BASELINE_POLICY), policy_decision_digest(dict(BASELINE_POLICY))
+        )
+
+    def test_a_different_policy_produces_a_different_baseline_digest(self) -> None:
+        self.assertNotEqual(
+            policy_change_baseline_digest(BASELINE_POLICY),
+            policy_change_baseline_digest(MOVED_BASELINE_POLICY),
+        )
+
+    def test_a_review_measured_against_nothing_is_refused(self) -> None:
+        for empty in ({}, None, "clarification-policy"):
+            with self.subTest(empty=empty):
+                with self.assertRaises(PolicyChangeReviewError) as caught:
+                    proposed(baseline_policy=empty)
+                self.assertIn("baseline_policy must be a non-empty object", str(caught.exception))
+
+    def test_a_baseline_digest_that_is_not_a_digest_is_refused(self) -> None:
+        review = proposed()
+        broken = dict(review, baseline=dict(review["baseline"], baseline_digest="not-a-digest"))
+
+        errors = validate_policy_change_review(broken)
+
+        self.assertTrue(any("baseline_digest must be a sha256 hex digest" in error for error in errors), errors)
+
+
+class PolicyChangeReviewInactivityTests(unittest.TestCase):
+    """#798 AC2: a rejected or superseded review is never the active policy."""
+
+    def test_exactly_one_state_reads_as_active_across_the_whole_vocabulary(self) -> None:
+        for state in REVIEW_STATES:
+            with self.subTest(state=state):
+                review = review_in_state(state)
+                self.assertEqual(validate_policy_change_review(review), [])
+                self.assertEqual(review["review_state"], state)
+                self.assertEqual(review_reads_as_active(review), state == ACTIVE_REVIEW_STATE)
+
+    def test_a_rejected_review_cannot_read_as_active_even_with_full_evidence(self) -> None:
+        review = rejected()
+
+        self.assertEqual(review["review_state"], "rejected")
+        self.assertFalse(review_reads_as_active(review))
+
+        # Rollout evidence is refused on a rejected review, and a hand-written
+        # payload that carries it anyway still derives `rejected`.
+        with self.assertRaises(PolicyChangeReviewError) as caught:
+            rolled_out(review)
+        self.assertIn("may only be recorded on a review a reviewer approved", str(caught.exception))
+
+        stapled = dict(review, rollout=rolled_out()["rollout"])
+        self.assertEqual(derive_review_state(stapled), "rejected")
+        self.assertFalse(review_reads_as_active(stapled))
+        self.assertEqual(validate_policy_change_review(stapled), [])
+
+    def test_a_superseded_review_cannot_read_as_active_even_after_being_applied(self) -> None:
+        applied = rolled_out()
+        self.assertTrue(review_reads_as_active(applied))
+
+        superseded = supersede_policy_change_review(
+            applied, superseded_by_review_ref="policy-review-clarify-02"
+        )
+
+        self.assertEqual(superseded["review_state"], "superseded")
+        self.assertFalse(review_reads_as_active(superseded))
+        self.assertEqual(superseded["rollout"], applied["rollout"])
+        self.assertEqual(validate_policy_change_review(superseded), [])
+
+    def test_a_superseded_review_is_neither_re_decided_nor_rolled_out(self) -> None:
+        superseded = supersede_policy_change_review(
+            proposed(), superseded_by_review_ref="policy-review-clarify-02"
+        )
+
+        with self.assertRaises(PolicyChangeReviewError) as decision_error:
+            record_policy_change_decision(
+                superseded, decided_by="maintainer-1", decision="approve_policy_change"
+            )
+        self.assertIn("cannot record a decision on a review superseded by", str(decision_error.exception))
+
+        with self.assertRaises(PolicyChangeReviewError) as rollout_error:
+            rolled_out(superseded)
+        self.assertIn("cannot roll out a review superseded by", str(rollout_error.exception))
+
+    def test_a_review_cannot_supersede_itself(self) -> None:
+        review = proposed()
+
+        with self.assertRaises(PolicyChangeReviewError) as caught:
+            supersede_policy_change_review(review, superseded_by_review_ref=review["review_ref"])
+        self.assertIn("must not name the review itself", str(caught.exception))
+
+        self_linked = dict(review, superseded_by_review_ref=review["review_ref"])
+        self.assertTrue(
+            any("must not name the review itself" in error for error in validate_policy_change_review(self_linked))
+        )
+
+    def test_content_that_moves_after_a_decision_supersedes_the_decision(self) -> None:
+        applied = rolled_out()
+        self.assertEqual(reviewer_decision_state(applied), "current")
+
+        moved = content_moved(applied)
+
+        self.assertEqual(reviewer_decision_state(moved), "stale")
+        self.assertEqual(moved["review_state"], "superseded_by_content_change")
+        self.assertFalse(review_reads_as_active(moved))
+        self.assertEqual(validate_policy_change_review(moved), [])
+
+    def test_the_state_vocabulary_never_borrows_a_word_that_asserts_liveness(self) -> None:
+        self.assertEqual(set(REVIEW_STATES) & set(REFUSED_REVIEW_STATES), set())
+        for word in REFUSED_REVIEW_STATES:
+            with self.subTest(word=word):
+                errors = validate_policy_change_review(dict(proposed(), review_state=word))
+                self.assertTrue(
+                    any("may not assert that the change is" in error for error in errors), errors
+                )
+
+    def test_every_state_renders_one_sentence_and_no_other(self) -> None:
+        self.assertEqual(sorted(REVIEW_STATE_CLAIMS), sorted(REVIEW_STATES))
+        for state in REVIEW_STATES:
+            with self.subTest(state=state):
+                self.assertTrue(review_state_claim(state).strip())
+        with self.assertRaises(PolicyChangeReviewError):
+            review_state_claim("live")
+
+    def test_the_decision_state_vocabulary_is_the_declared_one(self) -> None:
+        self.assertEqual(REVIEWER_DECISION_STATES, ("absent", "current", "stale"))
+        self.assertEqual(reviewer_decision_state(proposed()), "absent")
+        self.assertEqual(reviewer_decision_state(approved()), "current")
+        self.assertEqual(reviewer_decision_state(content_moved(approved())), "stale")
+
+
+class PolicyChangeReviewRolloutTests(unittest.TestCase):
+    """#798 AC3: applied requires the baseline, the changes, and the evidence."""
+
+    def test_a_rollout_missing_the_matching_baseline_cannot_be_applied(self) -> None:
+        review = rolled_out(baseline="")
+
+        self.assertEqual(review["review_state"], "approved_not_rolled_out")
+        self.assertFalse(review_reads_as_active(review))
+        self.assertEqual(unmet_rollout_requirements(review), ("baseline_matches",))
+        self.assertFalse(rollout_requirements(review)["baseline_matches"])
+        self.assertTrue(rollout_requirements(review)["repository_changes_observed"])
+        self.assertTrue(rollout_requirements(review)["regression_evidence_named"])
+
+    def test_a_rollout_missing_observed_repository_changes_cannot_be_applied(self) -> None:
+        review = rolled_out(changes=())
+
+        self.assertEqual(review["review_state"], "approved_not_rolled_out")
+        self.assertFalse(review_reads_as_active(review))
+        self.assertEqual(unmet_rollout_requirements(review), ("repository_changes_observed",))
+        self.assertEqual(review["rollout"]["observed_repository_changes"], [])
+
+    def test_a_rollout_missing_named_regression_evidence_cannot_be_applied(self) -> None:
+        review = rolled_out(evidence=())
+
+        self.assertEqual(review["review_state"], "approved_not_rolled_out")
+        self.assertFalse(review_reads_as_active(review))
+        self.assertEqual(unmet_rollout_requirements(review), ("regression_evidence_named",))
+        self.assertEqual(review["rollout"]["regression_evidence"], [])
+
+    def test_all_three_together_reach_applied(self) -> None:
+        review = rolled_out()
+
+        self.assertEqual(validate_policy_change_review(review), [])
+        self.assertEqual(review["review_state"], ACTIVE_REVIEW_STATE)
+        self.assertTrue(review_reads_as_active(review))
+        self.assertEqual(unmet_rollout_requirements(review), ())
+        self.assertEqual(
+            rollout_requirements(review), {name: True for name in ROLLOUT_REQUIREMENTS}
+        )
+        self.assertEqual(
+            review["rollout"]["observed_baseline_digest"], review["baseline"]["baseline_digest"]
+        )
+        self.assertEqual(
+            review["rollout"]["regression_evidence"],
+            [{"case_ref": "regression-clarify-01", "outcome": "passed"}],
+        )
+
+    def test_a_baseline_observed_from_a_policy_that_moved_is_refused(self) -> None:
+        review = rolled_out(baseline=policy_change_baseline_digest(MOVED_BASELINE_POLICY))
+
+        self.assertEqual(review["review_state"], "approved_not_rolled_out")
+        self.assertFalse(review_reads_as_active(review))
+        self.assertEqual(unmet_rollout_requirements(review), ("baseline_matches",))
+
+        stapled = dict(review, review_state=ACTIVE_REVIEW_STATE)
+        errors = validate_policy_change_review(stapled)
+        self.assertTrue(any("unmet rollout requirements: ['baseline_matches']" in error for error in errors), errors)
+
+    def test_a_failing_named_regression_case_is_not_evidence_for_a_rollout(self) -> None:
+        review = rolled_out(
+            evidence=(
+                {"case_ref": "regression-clarify-01", "outcome": "passed"},
+                {"case_ref": "regression-plan-02", "outcome": "failed"},
+            )
+        )
+
+        self.assertEqual(review["review_state"], "approved_not_rolled_out")
+        self.assertEqual(unmet_rollout_requirements(review), ("regression_evidence_named",))
+        self.assertEqual(REGRESSION_OUTCOMES, ("passed", "failed"))
+
+    def test_a_caller_supplied_applied_on_an_incomplete_review_is_refused(self) -> None:
+        for narrowed, requirement in (
+            (rolled_out(baseline=""), "baseline_matches"),
+            (rolled_out(changes=()), "repository_changes_observed"),
+            (rolled_out(evidence=()), "regression_evidence_named"),
+            (approved(), "baseline_matches"),
+            (proposed(), "baseline_matches"),
+        ):
+            with self.subTest(requirement=requirement):
+                stapled = dict(narrowed, review_state=ACTIVE_REVIEW_STATE)
+                errors = validate_policy_change_review(stapled)
+                self.assertTrue(
+                    any("never what a payload asserts" in error for error in errors), errors
+                )
+                self.assertTrue(any(requirement in error for error in errors), errors)
+                self.assertFalse(review_reads_as_active(stapled))
+
+    def test_rollout_evidence_is_refused_on_a_review_no_current_approval_covers(self) -> None:
+        for review, label in ((proposed(), "awaiting_review"), (content_moved(approved()), "stale")):
+            with self.subTest(label=label):
+                with self.assertRaises(PolicyChangeReviewError) as caught:
+                    rolled_out(review)
+                self.assertIn("may only be recorded on a review a reviewer approved", str(caught.exception))
+
+    def test_partial_rollout_evidence_is_recorded_rather_than_refused(self) -> None:
+        review = record_policy_change_rollout(approved(), observed_repository_changes=["repo-change-9f21c4"])
+
+        self.assertEqual(review["review_state"], "approved_not_rolled_out")
+        self.assertEqual(
+            unmet_rollout_requirements(review), ("baseline_matches", "regression_evidence_named")
+        )
+        self.assertEqual(validate_policy_change_review(review), [])
+
+    def test_more_rollout_evidence_can_be_added_to_an_already_applied_review(self) -> None:
+        review = rolled_out(rolled_out())
+
+        self.assertEqual(review["review_state"], ACTIVE_REVIEW_STATE)
+        self.assertTrue(review_reads_as_active(review))
+
+    def test_rollout_evidence_rows_are_closed_and_named(self) -> None:
+        review = rolled_out()
+        for row in review["rollout"]["regression_evidence"]:
+            with self.subTest(case=row["case_ref"]):
+                self.assertEqual(sorted(row), sorted(REGRESSION_EVIDENCE_KEYS))
+
+        with self.assertRaises(PolicyChangeReviewError):
+            rolled_out(evidence=({"case_ref": "regression-clarify-01", "outcome": "maybe"},))
+        with self.assertRaises(PolicyChangeReviewError):
+            rolled_out(evidence=({"case_ref": "", "outcome": "passed"},))
+        with self.assertRaises(PolicyChangeReviewError):
+            rolled_out(changes=("https://example.invalid?pr=1",))
+
+    def test_the_same_regression_case_is_not_counted_twice(self) -> None:
+        duplicated = [
+            {"case_ref": "regression-clarify-01", "outcome": "passed"},
+            {"case_ref": "regression-clarify-01", "outcome": "passed"},
+        ]
+        review = dict(rolled_out())
+        review["rollout"] = dict(review["rollout"], regression_evidence=duplicated)
+
+        errors = validate_policy_change_review(review)
+
+        self.assertTrue(
+            any("names the same regression case more than once" in error for error in errors), errors
+        )
+
+
+class PolicyChangeReviewDerivationTests(unittest.TestCase):
+    def test_the_builder_exposes_no_state_decision_or_rollout_parameter(self) -> None:
+        parameters = set(inspect.signature(build_policy_change_review).parameters)
+
+        self.assertEqual(parameters & set(REVIEW_STATE_KEYS), set())
+        self.assertNotIn("review_state", parameters)
+        self.assertNotIn("state", parameters)
+        self.assertNotIn("status", parameters)
+
+    def test_every_transition_re_derives_the_state(self) -> None:
+        review = proposed()
+        self.assertEqual(review["review_state"], derive_review_state(review))
+
+        decided = record_policy_change_decision(
+            review, decided_by="maintainer-1", decision="approve_policy_change"
+        )
+        self.assertEqual(decided["review_state"], derive_review_state(decided))
+
+        applied = rolled_out(decided)
+        self.assertEqual(applied["review_state"], derive_review_state(applied))
+
+        superseded = supersede_policy_change_review(applied, superseded_by_review_ref="policy-review-02")
+        self.assertEqual(superseded["review_state"], derive_review_state(superseded))
+
+    def test_an_unsupported_state_is_refused(self) -> None:
+        errors = validate_policy_change_review(dict(proposed(), review_state="under_discussion"))
+
+        self.assertTrue(any("review_state is unsupported" in error for error in errors), errors)
+
+    def test_the_decision_vocabulary_is_the_two_declared_verdicts(self) -> None:
+        self.assertEqual(REVIEWER_DECISIONS, ("approve_policy_change", "reject_policy_change"))
+        with self.assertRaises(PolicyChangeReviewError):
+            record_policy_change_decision(proposed(), decided_by="maintainer-1", decision="looks_fine")
+
+    def test_a_decision_is_bound_to_the_content_it_covers(self) -> None:
+        review = approved()
+
+        self.assertEqual(sorted(review["reviewer_decision"]), sorted(REVIEWER_DECISION_KEYS))
+        self.assertEqual(
+            review["reviewer_decision"]["reviewed_digest"], policy_change_review_digest(review)
+        )
+
+        forged = dict(review)
+        forged["reviewer_decision"] = dict(review["reviewer_decision"], reviewed_digest="short")
+        self.assertTrue(
+            any("reviewed_digest must be the sha256 digest" in error for error in validate_policy_change_review(forged))
+        )
+
+
+class PolicyChangeReviewDeterminismTests(unittest.TestCase):
+    def test_the_digest_covers_the_material_content_and_nothing_else(self) -> None:
+        review = proposed()
+
+        self.assertEqual(sorted(material_review_content(review)), sorted(MATERIAL_REVIEW_KEYS))
+        self.assertEqual(set(MATERIAL_REVIEW_KEYS) & set(REVIEW_STATE_KEYS), set())
+        self.assertEqual(set(MATERIAL_REVIEW_KEYS) & set(DERIVED_REVIEW_KEYS), set())
+        self.assertEqual(
+            set(MATERIAL_REVIEW_KEYS) | set(REVIEW_STATE_KEYS) | set(DERIVED_REVIEW_KEYS),
+            set(POLICY_CHANGE_REVIEW_KEYS),
+        )
+
+    def test_two_reviews_built_from_the_same_content_share_a_digest(self) -> None:
+        self.assertEqual(proposed()["review_digest"], proposed()["review_digest"])
+
+    def test_the_clock_field_is_a_parameter_and_stays_out_of_the_digest(self) -> None:
+        early = proposed(prepared_at="2026-08-09T00:00:00Z")
+        late = proposed(prepared_at="2026-12-31T23:59:59Z")
+        unstamped = proposed(prepared_at="")
+
+        self.assertEqual(early["review_digest"], late["review_digest"])
+        self.assertEqual(early["review_digest"], unstamped["review_digest"])
+        self.assertEqual(unstamped["prepared_at"], "")
+
+    def test_recording_a_decision_or_a_rollout_does_not_move_the_digest(self) -> None:
+        review = proposed()
+        decided = record_policy_change_decision(
+            review, decided_by="maintainer-1", decision="approve_policy_change"
+        )
+        applied = rolled_out(decided)
+        superseded = supersede_policy_change_review(applied, superseded_by_review_ref="policy-review-02")
+
+        for later in (decided, applied, superseded):
+            with self.subTest(state=later["review_state"]):
+                self.assertEqual(later["review_digest"], review["review_digest"])
+                self.assertEqual(reviewer_decision_state(applied), "current")
+
+    def test_a_review_edited_after_it_was_minted_is_refused(self) -> None:
+        review = proposed()
+        edited = dict(review, policy_surface="routing")
+
+        errors = validate_policy_change_review(edited)
+
+        self.assertTrue(any("does not match the content it seals" in error for error in errors), errors)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- Adds `policy_change_review/v1`, a native OMH record for reviewing one proposed change to a **clarification, routing, handoff, or verification** policy surface before it becomes the active behavior. Closes #798.
- One review carries: the policy surface, a digest binding to the baseline policy it argues about, every affected user intent with **both** sides of its behavior, an owner-boundary answer for **every** coding owner, a reviewer decision, and a rollout block holding the evidence a rollout rests on.
- Two new files, both additive. No existing module, schema, CLI command, generated artifact, or stored record changed.

### Why This Exists

- A change to OMH clarification, routing, handoff, or verification policy is a behavior change for every intent that policy touches. The intents it improves are the ones the author was looking at. The ones it regresses are the others, and nothing in the tree made a maintainer name them before rollout.
- The nearest existing record, `improvement_patch_proposal/v1` (`src/workflows/workflow_learning.py:738`), already has a review gate, a regression gate with a replay status, `patch_scope.mode = "proposal_only"`, and a target type that includes `routing`. Extending it was tried first and rejected for two structural reasons, recorded in the new module's docstring:
  - **Different subject.** A patch proposal is *derived* — it requires `trace_id`, `eval_id`, and `candidate_id`, and answers "one observed workflow went wrong, what should change?". A policy change review is *authored*: a maintainer proposes a change with no trace behind it, and minting a synthetic trace to record one would make the learning family lie about where the proposal came from.
  - **Different lifecycle.** The patch proposal's ladder is a function of the candidate decision plus a regression replay and stops at `ready_for_human_patch` by design (`apply_path_available` is `False`). #798 needs the state *after* that handoff. Bolting a second, differently-gated ladder onto a frozen v1 schema that the export bundle, the learning index, and the review queue all parse would change the meaning of a record those surfaces already read.
- `omh_capability_policy_change/v1` (`src/commands/capability_policy.py:119`) is a different thing sharing a word: it records that one capability *family* was toggled on or off for one install, and it applies itself the moment it is invoked. It has no reviewer, no baseline binding, no intents, and no rollout state.

### User / Operator Impact

- A maintainer proposing a policy change can now record a reviewable artifact that names what moves and what does not, per intent and per coding owner, and cannot record one that names only half of a behavior change.
- A reviewer's rejection, or a later review's supersession, is structurally incapable of reading as the active policy. `review_reads_as_active()` is the one question a surface asks.
- `applied` cannot be claimed without the matching baseline digest, at least one observed repository change, and named passing regression evidence — together. `unmet_rollout_requirements()` names which are outstanding.
- **Boundary:** no production surface mints a review yet. This PR ships the contract and its tests; there is no CLI command, chat card, skill surface, or store behind it. That is stated in the module docstring and in the commit's `Not-tested`.

### How It Works

- **AC1 — every affected intent, both sides.** `intents` is a list of `{intent_ref, before, after}`. A row stating only one side is a validation error naming the intent *and* the missing side (`intents entry 'ship-a-small-fix' states no after behavior; ...`). Both the builder and the validator refuse it. A row whose two sides read the same is allowed on purpose: the user problem is silent regression, so "I checked this one and it does not move" must be recordable.
- **AC2 — rejected or superseded is structurally not active.** `review_state` is **derived**. `build_policy_change_review()` exposes no state, decision, or rollout parameter, so no argument can assert that a proposal is in force, and `validate_policy_change_review()` re-derives the state and refuses a payload that disagrees. Three separate mechanisms:
  - `superseded_by_review_ref` is a forward supersession link that dominates every other input in `derive_review_state()`. A superseded review reads `superseded` whatever it was decided to be, and both `record_policy_change_decision()` and `record_policy_change_rollout()` refuse to touch it.
  - `rejected` has no edge to `applied`.
  - A decision is stamped with `reviewed_digest`, so material content that moves afterwards leaves the review at `superseded_by_content_change` rather than carrying an approval onto text nobody read.
  - `REFUSED_REVIEW_STATES` holds the liveness words — `active`, `live`, `in_effect`, `rolled_out`, … — by name, so a payload asserting one is refused as a rule rather than as an unrecognised value. Asserted disjoint from `REVIEW_STATES`.
- **AC3 — applied needs all three.** `ROLLOUT_REQUIREMENTS` names them: `baseline_matches`, `repository_changes_observed`, `regression_evidence_named`. Any one missing derives `approved_not_rolled_out`, and the validator repeats the unmet names in the refusal so it is actionable. `regression_evidence_named` means at least one named case recorded `passed` and none recorded `failed`.
- **Baseline binding.** `policy_change_baseline_digest()` reuses `quality.skill_governance.policy_decision_digest` rather than adding a second hashing scheme, so the digest recorded at proposal time and the one observed at rollout time are derived the same way. A policy that moved under a review is refused instead of rolled out.
- **Owner boundaries.** `POLICY_CHANGE_OWNERS` is `coding.executors.EXECUTOR_PROFILES`, derived rather than restated. A review must answer for **every** owner, with `no_boundary_change` as the honest answer, so an unaffected owner and an unconsidered one stay different — this is AGENTS.md's executor-neutrality rule made structural rather than remembered.
- **Determinism.** No clock is read. `prepared_at` is a caller parameter and is excluded from `review_digest`; so are `reviewer_decision`, `rollout`, `superseded_by_review_ref`, and `review_state`. That exclusion is load-bearing, not cosmetic: if `rollout` were inside the digest, recording the evidence an approval asked for would invalidate that approval and deadlock `applied` permanently.
- **Evidence boundary.** Nothing here reads the repository, edits policy source, regenerates a skill, changes a route, or replays a regression. `not_observed` marks all six surfaces. The rollout block records what a *caller* observed and is only as good as the surface that supplied it; the claim boundary says the record is not execution, review, CI, merge-readiness, or merge evidence. `ROLLOUT_CLAIM_KEYS` refuses a payload shaped to say otherwise (`rolled_out`, `merged`, `deployed`, …) by key name.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/workflows/policy_change_review.py` | New. 1187 lines. The `policy_change_review/v1` contract: builder, three transitions (`record_policy_change_decision`, `record_policy_change_rollout`, `supersede_policy_change_review`), derived state, rollout gate, and a validator closed in both directions. |
| `tests/test_policy_change_review.py` | New. 795 lines, 57 tests, grouped by acceptance criterion. |

Reused rather than reinvented: `quality.skill_governance.policy_decision_digest` (both digests), `coding.executors.EXECUTOR_PROFILES` (owner vocabulary), `system.append_only_store` (`opaque_ref`, `reference_errors`, `is_unsafe_metadata_line`, `RAW_OR_HIDDEN_KEYS`).

No generated artifact regenerated, because no catalog data changed: `skills/*/SKILL.md`, `docs/WORKFLOWS.md`, `docs/ROLES.md`, the demo-cards JSON, and `capability_families.json` are all untouched and all four byte gates pass unchanged. No exact-count assertion moved, because no routing case, skill, or demo card was added.

## Validation

- [x] `uv run --group lint ruff check src tests` — `All checks passed!` (the pre-existing `# noqa` warning on `src/commands/main.py:1` is unrelated and unchanged)
- [x] `python3 -m unittest discover -s tests` — **Ran 5578 tests in 182.064s, OK** (`PYTHONPATH=tests uv run python -m unittest discover -s tests`; 57 of those are new)
- [x] `python3 -m compileall src` — ran as `uv run python -m compileall -q src tests`, exit 0
- [x] `python3 -m omh.cli docs workflows --check` — `{"ok":true,"tap_skills":{"checked":115,"expected":115,"extra":[],"missing":[],"ok":true,"stale":[]}}`
- [x] `python3 -m omh.cli harness validate` — `{"counts":{"harnesses":72,"skills":104},"errors":[],"ok":true,"warnings":[]}`
- [x] `python3 -m omh.cli release checklist --json` — exit 0
- [ ] `python3 -m omh.cli release hermes-smoke` — **not run.** This PR adds no CLI command, no installed skill, and no packaged artifact; nothing in the install or Hermes-load path changed.
- [x] `omh --help` — exit 0 (`uv run python -m omh.cli --help`)
- [ ] `omh --omh-home /tmp/omh-smoke ... release hermes-smoke ...` — **not run**, same reason as above.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: **not applicable.** `improvement_patch_proposal/v1`, `improvement_candidate/v1`, and `workflow_learning_review_queue/v1` are unmodified — the whole point of the sibling record is that they are not touched. `tests/test_workflow_learning.py` passes unchanged inside the full suite above.
- [x] Relevant dry-run or smoke command: two byte gates beyond the template's own — `docs roles --check` → `{"ok":true}` and `docs capability-families --check` → `{"ok":true}`; plus `git diff --check` exit 0.
- [ ] Manual Hermes/TUI check: **not run, and not reachable.** There is no user-facing surface to check — no command, card, or skill mints a review yet.

Additional evidence beyond the checklist — **six mutation probes**, each applied to `src/workflows/policy_change_review.py` in isolation and reverted, to show the new tests bite rather than merely pass:

| Mutation | Result |
| --- | --- |
| supersession link ignored in `derive_review_state` | 2 failures |
| `baseline_matches` forced `True` | 6 failures |
| `repository_changes_observed` forced `True` | 2 failures |
| `regression_evidence_named` forced `True` | 4 failures |
| validator state re-derivation disabled | 6 failures |
| both intent sides made optional | 3 failures |

Source verified byte-identical to its pre-probe backup afterwards, and the 57 tests green again.

## Risk

- **Low blast radius.** Two new files, zero edits to existing code. Nothing imports the new module except its test, so a defect in it cannot reach any running surface today.
- **The one real coupling:** `POLICY_CHANGE_OWNERS` is `EXECUTOR_PROFILES`. Widening the executor vocabulary widens what a review must answer for, which is the intended behavior (a new owner should not be silently unconsidered) but would invalidate any review stored under the old vocabulary. There are no stored reviews, so this is a forward-looking note rather than a migration.
- **The one thing that must not be refactored casually:** `rollout` must stay outside `review_digest`. Moving it into the material content makes recording rollout evidence invalidate the approval that asked for it, which deadlocks `applied` permanently. Recorded as the commit's `Directive:`.

## Compatibility / Rollout

- Purely additive. No schema version bumped, no stored record's shape changed, no CLI surface added or altered, no generated artifact regenerated, no exact-count assertion moved.
- No new dependencies. No network, LLM, or subprocess calls. No file writes: the family is value-semantics only, every transition returns a new dict.
- Platform-neutral by construction — writes no bytes and reads no clock, so there is nothing for a CRLF or wall-clock difference to change between the macOS and Windows jobs.

## Release / Claims

- [x] Release-channel impact considered — none. No installed skill, no packaged artifact, no version file, no CHANGELOG entry; this is `local` in effect until a surface mints a review.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — `not_observed` marks all six surfaces (`policy_source_edit`, `routing_behavior_change`, `clarification_behavior_change`, `regression_replay`, `test_execution`, `repository_write`), and `POLICY_CHANGE_REVIEW_CLAIM_BOUNDARY` states that every rollout observation is caller-supplied and that the record is not execution, review, CI, merge-readiness, or merge evidence.
- [x] Known manual Hermes checks are listed — there are none to run; `omh release hermes-smoke --live` was not run and the reason is stated in Validation.

## Follow-Up

- A minting surface. The contract is representable and validated but not produced: no CLI command, chat card, or skill creates a review, and there is no store, so there is no persistence, no supersede-chain walk across records (`system.append_only_store.supersede_chain_errors` is the walk it would use), and no rendering path. `REVIEW_STATE_CLAIMS` already holds the one sentence each state may be rendered with, for whichever surface goes first.
- Reusable-skill creation from an observed workflow stays out of scope and belongs to #838. This family refuses those surface names by name (`OUT_OF_SCOPE_SURFACES`) with an error pointing at the teach-workflow capability, so the boundary is enforced rather than documented.
