### PR TITLE
feat: load only the capabilities a request needs

### DIFF
--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -34,6 +34,7 @@ omh capabilities list
 omh capabilities inspect ultragoal --json
 omh capabilities inspect handoff-guide --section roles --json
 omh capabilities inspect request-to-handoff --section playbooks --json
+omh capabilities project "prepare a coding handoff for this issue"
 omh context brief "make an image card for this PR" --json
 ```
 
@@ -71,6 +72,66 @@ Capability families are the public, user-facing front door. The older lanes and
 groups remain in the manifest as compatibility context for wrappers, tests, and
 existing plugin surfaces; they should not be introduced to normal users before
 the family layer.
+
+## Task-Scoped Projection
+
+Every payload above is a whole-catalog snapshot. That is the right answer to
+"what can this install do?" and the wrong answer to "what does this request
+need": a request that needs two capabilities was still handed all of them, so
+the inventory ate context, diluted the routing signal, and put authority the
+task never asked for in front of the model.
+
+`omh capabilities project "<request>"` answers the second question as a view
+over the same catalog. It emits `omh_capability_projection/v1`:
+
+```sh
+omh capabilities project "prepare a coding handoff for this issue"
+omh capabilities project "prepare a coding handoff for this issue" --json
+omh capabilities project "prepare a coding handoff for this issue" --expand plan
+omh capabilities project "<request>" --task-id task-a --authority-digest <digest>
+```
+
+How it behaves:
+
+- **Selection reuses the router.** The shortlist comes from `omh recommend`'s
+  scorer and the family mapping, not from a second ranking, so a projection can
+  never disagree with the route the user is about to be offered.
+- **Two levels.** The projection carries a compact summary per relevant
+  capability: id, family, one-line description, next action, why it matched,
+  and score. Exact detail requires an explicit `--expand <capability>`, and a
+  capability the projection did not include cannot be expanded.
+- **Budgeted.** Content size is measured against `omh_run_context_budget/v1` --
+  the same per-task ledger the runtime observe surfaces spend from, keyed by
+  `--task-id`. Over budget, the lowest-ranked capabilities are dropped and
+  named; past the floor the payload degrades to
+  `omh_capability_projection_summary_only/v1` with `budget_drop` carrying the
+  dropped ids and the byte numbers. A drop is never silent.
+- **Closed exclusion vocabulary.** Every offered capability that is not
+  included is accounted for by exactly one of `beyond_context_budget`,
+  `not_granted_by_authority`, `not_relevant_to_request`, or
+  `outranked_by_shortlist`. Only capabilities the router actually considered are
+  itemized by name; the rest are counted. Naming ninety irrelevant workflows to
+  explain their absence would restore the dump this surface removes.
+
+### Approved Authority Is Frozen
+
+`omh_capability_authority/v1` records what a task's approval covered. A
+projection is a VIEW over it and can only intersect, which is enforced by the
+shape of the API rather than by a rule a caller must remember: the grant is a
+frozen record holding a frozen set, one function builds it, and the refresh
+entry point takes no authority parameter at all. Re-projecting against a
+catalog that grew since approval therefore cannot widen anything -- the new
+capability appears as an exclusion carrying `not_granted_by_authority`.
+
+The grant is re-derived from this install's capability policy on every
+invocation and identified by a digest. Pass `--authority-digest` with the value
+you approved and the command refuses with exit code 2 and an
+`omh_capability_authority_change/v1` report when the local policy has moved,
+instead of quietly serving a different view.
+
+The projection reads no clock and touches no network. The context budget is a
+parameter, so the same request against the same grant and budget projects byte
+for byte the same payload.
 
 ## Sections
 

--- a/src/capabilities/projection.py
+++ b/src/capabilities/projection.py
@@ -1,0 +1,550 @@
+"""Task-scoped capability projection (`omh_capability_projection/v1`).
+
+Every capability payload OMH had before this module was a whole-catalog
+snapshot: `capability_snapshot()` and `capability_summary()` answer "what can
+this install do at all?", which is the right answer to a discovery question and
+the wrong answer to a request. A request that needs two capabilities was still
+handed all of them, so the inventory ate context, diluted the routing signal,
+and put authority the task never asked for in front of the model.
+
+This module answers the other question -- "what does THIS request need?" -- as
+a view over the same catalog:
+
+- Selection reuses the router. `recommend_skills` already ranks the catalog
+  against a message; this module takes that shortlist and the capability-family
+  mapping rather than inventing a second ranking, so a projection can never
+  disagree with the route the user is about to be offered.
+- Two levels. The projection carries a compact summary per relevant capability.
+  Exact detail is a separate `expand_capability` call, never produced as a side
+  effect of projecting.
+- Budgeted. Content size is measured against `omh_run_context_budget/v1`, the
+  same ledger the runtime observe surfaces spend from. Over budget, the
+  projection degrades through `degrade_capability_projection_payload` and names
+  every capability it dropped.
+- Closed exclusion vocabulary. Every offered capability that is not included is
+  accounted for by one of `EXCLUSION_REASON_CODES`, and an unrecognized reason
+  is refused rather than passed through.
+
+Authority is a frozen input, never an output. `CapabilityAuthority` is what an
+approval covered; a projection is a VIEW over it and can only intersect. The
+structural guarantee is in the shape of the API, not in a rule a caller must
+remember:
+
+- `CapabilityAuthority` is a frozen dataclass holding a `frozenset`, so the
+  granted set cannot be edited in place.
+- `approve_capability_authority` is the only function that builds one.
+- `refresh_capability_projection` takes no authority parameter at all. It reads
+  the frozen grant off the projection it is refreshing, so a refresh against a
+  larger catalog has no seam through which a new capability could enter the
+  grant -- it appears as an exclusion carrying `not_granted_by_authority`.
+
+Determinism: nothing here reads a clock, the environment, or the filesystem.
+The context budget arrives as a parameter, exactly like a time would. Note also
+that none of this work belongs behind the `@lru_cache` on
+`registry._capability_summary_template()`: that cache advertises
+`"determinism": "static_projection_no_runtime_clock"` and is keyed on nothing,
+so a per-request result cached there would be served to the next, different
+request. Per-request work stays in this module, outside that cache; the only
+cache it relies on is `recommend_skills`, which is keyed on the query itself.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from copy import deepcopy
+import hashlib
+import json
+from typing import Any, Iterable
+
+from ..routing.recommend import recommend_skills
+from ..runtime.context_budget import degrade_capability_projection_payload, public_budget
+from ..skills.catalog import installable_skill_names
+from .families import capability_family_projection
+from .registry import inspect_capability
+
+CAPABILITY_AUTHORITY_SCHEMA_VERSION = "omh_capability_authority/v1"
+CAPABILITY_PROJECTION_SCHEMA_VERSION = "omh_capability_projection/v1"
+CAPABILITY_EXPANSION_SCHEMA_VERSION = "omh_capability_expansion/v1"
+
+# Closed vocabulary. A projection that cannot name why a capability is absent
+# is a projection that hides authority, so there is no "other" member and
+# `capability_exclusion` refuses anything outside this tuple.
+EXCLUSION_REASON_CODES = (
+    "beyond_context_budget",
+    "not_granted_by_authority",
+    "not_relevant_to_request",
+    "outranked_by_shortlist",
+)
+
+_EXCLUSION_EXPLANATIONS = {
+    "beyond_context_budget": (
+        "Relevant and granted, but dropped so the projection stays inside the declared context budget."
+    ),
+    "not_granted_by_authority": (
+        "Offered by the catalog but outside the approved authority for this task; approving it again is "
+        "the only way in."
+    ),
+    "not_relevant_to_request": "The router scored no trigger, phrase, or metadata match against this request.",
+    "outranked_by_shortlist": "Matched the request, but ranked below the capabilities that were included.",
+}
+
+# How far down the router's ranking a capability still counts as "considered".
+# Only considered capabilities are itemized in `exclusions`; everything below is
+# counted in `exclusion_summary` and never named. That split is the whole point
+# of the feature: naming ninety irrelevant workflows to explain why they were
+# excluded is the tool-list dump the projection exists to avoid.
+CONSIDERED_LIMIT = 12
+DEFAULT_PROJECTION_LIMIT = 5
+
+PROJECTION_CLAIM_BOUNDARY = (
+    "A capability projection is a task-scoped view over the approved authority. It grants nothing, "
+    "widens nothing, and is not execution, review, CI, merge-readiness, or merge evidence."
+)
+AUTHORITY_CLAIM_BOUNDARY = (
+    "An approved capability authority records what a task was allowed to see. Re-projecting it can only "
+    "intersect; a projection never writes authority."
+)
+EXPANSION_CLAIM_BOUNDARY = (
+    "Expanded capability detail is catalog metadata returned because it was explicitly requested. It is "
+    "not execution, review, CI, merge-readiness, or merge evidence."
+)
+
+EXPANSION_POLICY = "explicit_request_only"
+
+
+class CapabilityProjectionError(ValueError):
+    """Raised for an unknown exclusion reason, an unapproved expansion, or a changed grant."""
+
+
+@dataclass(frozen=True)
+class CapabilityAuthority:
+    """What one task's approval covered, frozen at approval time.
+
+    Frozen dataclass plus a `frozenset` on purpose: neither the record nor the
+    granted set can be edited after approval, so "the projection widened the
+    grant" is not a bug that can be written, only a constructor call that would
+    have to be added.
+    """
+
+    task_id: str
+    permission_profile: str
+    envelope_digest: str
+    granted: frozenset[str]
+    granted_families: tuple[str, ...]
+
+    def permits(self, capability: str) -> bool:
+        return str(capability) in self.granted
+
+    def granted_capabilities(self) -> tuple[str, ...]:
+        return tuple(sorted(self.granted))
+
+    @property
+    def digest(self) -> str:
+        """Stable identity for this grant; the value a caller re-approves against."""
+        encoded = "\x1f".join(
+            [
+                CAPABILITY_AUTHORITY_SCHEMA_VERSION,
+                self.task_id,
+                self.permission_profile,
+                self.envelope_digest,
+                *self.granted_capabilities(),
+            ]
+        )
+        return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Emit the grant identity, never the grant contents.
+
+        The full granted list is the whole-catalog inventory this feature exists
+        to keep out of context. A reader gets the count, the families, and the
+        digest to compare against; `omh capabilities list` still returns the
+        inventory when someone actually wants it.
+        """
+        return {
+            "schema_version": CAPABILITY_AUTHORITY_SCHEMA_VERSION,
+            "task_id": self.task_id,
+            "permission_profile": self.permission_profile,
+            "envelope_digest": self.envelope_digest,
+            "digest": self.digest,
+            "granted_capability_count": len(self.granted),
+            "granted_families": list(self.granted_families),
+            "frozen": True,
+            "claim_boundary": AUTHORITY_CLAIM_BOUNDARY,
+        }
+
+
+@dataclass(frozen=True)
+class CapabilityProjection:
+    """One task-scoped view. `authority` is the approval it was built against."""
+
+    authority: CapabilityAuthority
+    request: str
+    payload: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return deepcopy(self.payload)
+
+    def included_capabilities(self) -> tuple[str, ...]:
+        included = self.payload.get("included")
+        if not isinstance(included, list):
+            return ()
+        return tuple(str(entry.get("capability", "")) for entry in included if isinstance(entry, dict))
+
+
+def capability_exclusion(capability: str, reason_code: str, explanation: str = "") -> dict[str, str]:
+    """Build one exclusion entry, refusing any reason outside the closed vocabulary."""
+    if reason_code not in EXCLUSION_REASON_CODES:
+        raise CapabilityProjectionError(
+            f"unsupported capability exclusion reason: {reason_code}; "
+            f"expected one of {', '.join(EXCLUSION_REASON_CODES)}"
+        )
+    return {
+        "capability": str(capability),
+        "reason_code": reason_code,
+        "explanation": str(explanation or _EXCLUSION_EXPLANATIONS[reason_code]),
+    }
+
+
+def approve_capability_authority(
+    *,
+    task_id: str,
+    granted_capabilities: Iterable[str],
+    permission_profile: str = "",
+    authority_envelope: dict[str, Any] | None = None,
+) -> CapabilityAuthority:
+    """Freeze one task's approved capability grant.
+
+    The only constructor of `CapabilityAuthority`. When an approved
+    `task_authority_envelope/v1` is supplied its permission profile wins and its
+    digest is recorded, so a later envelope change shows up as a different
+    authority digest instead of being absorbed silently.
+    """
+    resolved_profile = str(permission_profile or "")
+    envelope_digest = ""
+    if authority_envelope is not None:
+        envelope_profile, envelope_digest = _envelope_identity(authority_envelope)
+        if resolved_profile and resolved_profile != envelope_profile:
+            raise CapabilityProjectionError(
+                "permission_profile disagrees with the supplied task_authority_envelope; "
+                f"envelope says {envelope_profile!r} and the caller says {resolved_profile!r}"
+            )
+        resolved_profile = envelope_profile
+    if resolved_profile and resolved_profile not in _permission_profiles():
+        raise CapabilityProjectionError(
+            f"unsupported permission profile: {resolved_profile}; "
+            f"expected one of {', '.join(_permission_profiles())}"
+        )
+    granted = frozenset(str(item) for item in granted_capabilities if str(item))
+    mapping = _workflow_to_family()
+    families = tuple(sorted({mapping[name] for name in granted if name in mapping}))
+    return CapabilityAuthority(
+        task_id=str(task_id),
+        permission_profile=resolved_profile,
+        envelope_digest=envelope_digest,
+        granted=granted,
+        granted_families=families,
+    )
+
+
+def project_capabilities(
+    request: str,
+    *,
+    authority: CapabilityAuthority,
+    budget: dict[str, Any],
+    offered_capabilities: Iterable[str] | None = None,
+    limit: int = DEFAULT_PROJECTION_LIMIT,
+) -> CapabilityProjection:
+    """Build the task-scoped view of `offered_capabilities` for one request.
+
+    `budget` is an `omh_run_context_budget/v1` payload supplied by the caller --
+    a parameter for the same reason a clock reading would be, so the projection
+    stays reproducible and testable without a filesystem.
+    """
+    if limit < 1:
+        raise CapabilityProjectionError("capability projection limit must be at least 1")
+
+    offered = _offered_set(offered_capabilities)
+    ranked = _ranked_candidates(request, offered)
+    considered = tuple(name for name, _score, _entry in ranked)
+    granted_candidates = [item for item in ranked if authority.permits(item[0])]
+
+    families = _workflow_to_family()
+    included = [_compact_summary(entry, families) for _name, _score, entry in granted_candidates[:limit]]
+    dropped: list[dict[str, str]] = []
+
+    payload = _projection_payload(
+        request=request,
+        authority=authority,
+        offered=offered,
+        considered=considered,
+        included=included,
+        dropped=dropped,
+        budget=budget,
+    )
+    remaining = max(0, int(budget.get("remaining_bytes", 0) or 0))
+    content_bytes = int(payload["projected_bytes"])
+
+    # Trim the lowest-ranked capability at a time, recording each drop, until
+    # the content fits. A drop is never silent: it is itemized with
+    # `beyond_context_budget` and counted in `budget_drop`.
+    while included and content_bytes > remaining:
+        removed = included.pop()
+        dropped.append(capability_exclusion(str(removed["capability"]), "beyond_context_budget"))
+        payload = _projection_payload(
+            request=request,
+            authority=authority,
+            offered=offered,
+            considered=considered,
+            included=included,
+            dropped=dropped,
+            budget=budget,
+        )
+        content_bytes = int(payload["projected_bytes"])
+
+    if content_bytes > remaining:
+        # Nothing fits, so fall through to the same degrade contract the runtime
+        # observe surfaces use: summary only, named drops, pointer to the
+        # command that returns the full view.
+        payload = degrade_capability_projection_payload(
+            payload,
+            budget,
+            dropped=dropped,
+            content_bytes=content_bytes,
+        )
+
+    return CapabilityProjection(authority=authority, request=str(request), payload=payload)
+
+
+def refresh_capability_projection(
+    projection: CapabilityProjection,
+    *,
+    budget: dict[str, Any],
+    offered_capabilities: Iterable[str] | None = None,
+    limit: int = DEFAULT_PROJECTION_LIMIT,
+    request: str | None = None,
+) -> CapabilityProjection:
+    """Re-project against a possibly-changed catalog, reusing the frozen grant.
+
+    There is deliberately no authority parameter. The grant comes off the
+    projection being refreshed and is passed through by identity, so a catalog
+    that grew since approval cannot widen what the task may see -- the new
+    capability is reported as an exclusion carrying `not_granted_by_authority`.
+    """
+    return project_capabilities(
+        projection.request if request is None else str(request),
+        authority=projection.authority,
+        budget=budget,
+        offered_capabilities=offered_capabilities,
+        limit=limit,
+    )
+
+
+def expand_capability(projection: CapabilityProjection, capability: str) -> dict[str, Any]:
+    """Return exact detail for one projected capability, on explicit request only.
+
+    Nothing in `project_capabilities` calls this. Expansion is a second, opt-in
+    round trip; that is what keeps the compact level compact.
+    """
+    name = str(capability or "").strip()
+    if not name:
+        raise CapabilityProjectionError("capability expansion requires a capability id")
+    if not projection.authority.permits(name):
+        raise CapabilityProjectionError(
+            f"capability {name} is outside the approved authority for task {projection.authority.task_id}"
+        )
+    if name not in projection.included_capabilities():
+        raise CapabilityProjectionError(
+            f"capability {name} is not in this projection; project a request that needs it before expanding"
+        )
+    inspected = inspect_capability(name, section="skills")
+    return {
+        "schema_version": CAPABILITY_EXPANSION_SCHEMA_VERSION,
+        "task_id": projection.authority.task_id,
+        "authority_digest": projection.authority.digest,
+        "capability": name,
+        "family": _workflow_to_family().get(name, ""),
+        "requested": True,
+        "automatic": False,
+        "detail": inspected["capability"],
+        "claim_boundary": EXPANSION_CLAIM_BOUNDARY,
+    }
+
+
+def authority_change_report(approved_digest: str, current: CapabilityAuthority) -> dict[str, Any]:
+    """Compare a re-derived grant against the digest a caller approved.
+
+    The digest is the whole point: an install whose capability policy changed
+    between two projections produces a different grant, and this makes that
+    visible as a refusal instead of a quietly different view. It deliberately
+    does not name what changed -- a digest is all the caller held, and naming
+    the delta would re-emit the grant contents this feature keeps out of
+    context. `omh capability-policy status` is where that question belongs.
+    """
+    expected = str(approved_digest or "")
+    matches = expected == current.digest
+    return {
+        "schema_version": "omh_capability_authority_change/v1",
+        "task_id": current.task_id,
+        "approved_digest": expected,
+        "current_digest": current.digest,
+        "unchanged": matches,
+        "next_action": "reuse_projection" if matches else "re_approve_capability_authority",
+        "compare_command": "omh capability-policy status",
+        "claim_boundary": AUTHORITY_CLAIM_BOUNDARY,
+    }
+
+
+def _projection_payload(
+    *,
+    request: str,
+    authority: CapabilityAuthority,
+    offered: frozenset[str],
+    considered: tuple[str, ...],
+    included: list[dict[str, Any]],
+    dropped: list[dict[str, str]],
+    budget: dict[str, Any],
+) -> dict[str, Any]:
+    included_names = {str(entry["capability"]) for entry in included}
+    dropped_names = {str(entry["capability"]) for entry in dropped}
+    considered_set = set(considered)
+
+    summary: dict[str, int] = {code: 0 for code in EXCLUSION_REASON_CODES}
+    itemized: list[dict[str, str]] = list(dropped)
+    for name in sorted(offered - included_names):
+        reason = _exclusion_reason(
+            name,
+            authority=authority,
+            dropped_names=dropped_names,
+            considered=considered_set,
+        )
+        summary[reason] += 1
+        if reason != "beyond_context_budget" and name in considered_set:
+            itemized.append(capability_exclusion(name, reason))
+
+    content = {
+        "included": included,
+        "exclusions": itemized,
+        "exclusion_summary": summary,
+    }
+    payload: dict[str, Any] = {
+        "schema_version": CAPABILITY_PROJECTION_SCHEMA_VERSION,
+        "determinism": "static_projection_no_runtime_clock",
+        "task_id": authority.task_id,
+        "request_digest": request_digest(request),
+        "authority": authority.to_dict(),
+        "included": included,
+        "included_count": len(included),
+        "offered_count": len(offered),
+        "excluded_count": len(offered) - len(included),
+        "exclusions": itemized,
+        "exclusion_summary": summary,
+        "exclusion_reason_vocabulary": list(EXCLUSION_REASON_CODES),
+        "expansion": {
+            "policy": EXPANSION_POLICY,
+            "automatic": False,
+            "expandable": sorted(included_names),
+            "command_template": "omh capabilities project <request> --expand <capability>",
+        },
+        # Measured over the content block only. Including the envelope would
+        # make the number self-referential: writing it into the payload would
+        # change the payload it measures.
+        "projected_bytes": _content_bytes(content),
+        "context_budget": public_budget(budget),
+        "degraded": False,
+        "claim_boundary": PROJECTION_CLAIM_BOUNDARY,
+    }
+    if dropped:
+        payload["budget_drop"] = {
+            "dropped_capabilities": [str(entry["capability"]) for entry in dropped],
+            "dropped_count": len(dropped),
+            "projected_bytes": payload["projected_bytes"],
+            "budget_bytes": int(budget.get("budget_bytes", 0) or 0),
+            "remaining_bytes": max(0, int(budget.get("remaining_bytes", 0) or 0)),
+        }
+    return payload
+
+
+def _exclusion_reason(
+    name: str,
+    *,
+    authority: CapabilityAuthority,
+    dropped_names: set[str],
+    considered: set[str],
+) -> str:
+    if name in dropped_names:
+        return "beyond_context_budget"
+    if not authority.permits(name):
+        return "not_granted_by_authority"
+    if name in considered:
+        return "outranked_by_shortlist"
+    return "not_relevant_to_request"
+
+
+def _ranked_candidates(request: str, offered: frozenset[str]) -> list[tuple[str, int, dict[str, Any]]]:
+    """The router's own shortlist, filtered to what this install offers.
+
+    `recommend_skills` is the selection algorithm. This module adds no ranking
+    of its own so a projection and a route cannot disagree.
+    """
+    ranked: list[tuple[str, int, dict[str, Any]]] = []
+    for entry in recommend_skills(str(request), limit=CONSIDERED_LIMIT):
+        name = str(entry.get("skill", ""))
+        if name not in offered:
+            continue
+        ranked.append((name, int(entry.get("score", 0) or 0), entry))
+    return ranked
+
+
+def _compact_summary(entry: dict[str, Any], families: dict[str, str]) -> dict[str, Any]:
+    """One capability at the discovery level: enough to choose, not to execute."""
+    name = str(entry.get("skill", ""))
+    return {
+        "capability": name,
+        "family": families.get(name, ""),
+        "summary": str(entry.get("description", "")),
+        "next_action": str(entry.get("next_action", "")),
+        "match_reason": str(entry.get("why", "")),
+        "score": int(entry.get("score", 0) or 0),
+    }
+
+
+def request_digest(request: str) -> str:
+    """Reproducible identity for one request; also the default task-id source."""
+    return hashlib.sha256(str(request).encode("utf-8")).hexdigest()
+
+
+def _content_bytes(content: dict[str, Any]) -> int:
+    return len(json.dumps(content, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8"))
+
+
+def _offered_set(offered_capabilities: Iterable[str] | None) -> frozenset[str]:
+    if offered_capabilities is None:
+        return frozenset(installable_skill_names())
+    return frozenset(str(item) for item in offered_capabilities if str(item))
+
+
+def _workflow_to_family() -> dict[str, str]:
+    mapping = capability_family_projection().get("workflow_to_family", {})
+    if not isinstance(mapping, dict):
+        return {}
+    return {str(key): str(value) for key, value in mapping.items()}
+
+
+def _envelope_identity(envelope: dict[str, Any]) -> tuple[str, str]:
+    """Read the permission profile and a stable digest off an approved envelope."""
+    if not isinstance(envelope, dict):
+        raise CapabilityProjectionError("authority_envelope must be a task_authority_envelope/v1 object")
+    if str(envelope.get("schema_version", "")) != "task_authority_envelope/v1":
+        raise CapabilityProjectionError("authority_envelope must be a task_authority_envelope/v1 object")
+    profile = str(envelope.get("permission_profile", ""))
+    digest = hashlib.sha256(
+        json.dumps(envelope, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    ).hexdigest()
+    return profile, digest
+
+
+def _permission_profiles() -> tuple[str, ...]:
+    """Imported lazily, matching `action_gate`, to keep this module import-light."""
+    from ..workflows.goal_loop import PERMISSION_PROFILES
+
+    return PERMISSION_PROFILES

--- a/src/commands/capabilities.py
+++ b/src/commands/capabilities.py
@@ -1,12 +1,28 @@
 from __future__ import annotations
 
 import argparse
+import json
 
+from ..capabilities.projection import (
+    CapabilityProjectionError,
+    DEFAULT_PROJECTION_LIMIT,
+    approve_capability_authority,
+    authority_change_report,
+    expand_capability,
+    project_capabilities,
+    request_digest,
+)
 from ..capabilities.registry import capability_summary, filtered_capability_snapshot, inspect_capability, list_capabilities
 from ..capabilities.schema import CAPABILITY_SECTION_CHOICES
+from ..capabilities.toggles import enabled_workflow_names, read_capability_policy
 from ..installer import OmhError
 from ..quality.capability_impact import build_capability_impact_report, format_capability_impact_summary
-from .common import _print_json, _wants_json
+from ..runtime.context_budget import (
+    CAPABILITY_PROJECTION_SURFACE,
+    record_context_emission,
+    run_context_budget,
+)
+from .common import _paths, _print_json, _wants_json
 
 
 def cmd_capabilities_export(args: argparse.Namespace) -> int:
@@ -98,6 +114,111 @@ def cmd_capabilities_impact(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_capabilities_project(args: argparse.Namespace) -> int:
+    """Project only the capabilities one request needs, inside the task budget.
+
+    The grant is re-derived from this install's capability policy on every call.
+    `--authority-digest` is how a caller pins the grant it approved: a policy
+    change between two projections produces a different digest and this command
+    refuses rather than quietly serving a different view.
+    """
+    paths = _paths(args)
+    request = str(getattr(args, "request", "") or "")
+    task_id = str(getattr(args, "task_id", "") or "") or f"task-{request_digest(request)[:12]}"
+    offered = enabled_workflow_names(read_capability_policy(paths))
+
+    try:
+        authority = approve_capability_authority(task_id=task_id, granted_capabilities=offered)
+    except CapabilityProjectionError as exc:
+        raise OmhError(str(exc)) from exc
+
+    approved_digest = str(getattr(args, "authority_digest", "") or "")
+    if approved_digest:
+        change = authority_change_report(approved_digest, authority)
+        if not change["unchanged"]:
+            if _wants_json(args):
+                _print_json(change)
+            else:
+                print(f"OMH capability authority changed for {task_id}")
+                print(f"  Approved digest: {change['approved_digest']}")
+                print(f"  Current digest:  {change['current_digest']}")
+                print("  Re-approve the capability authority before reusing this projection.")
+            return 2
+
+    budget = run_context_budget(paths, task_id, surface=CAPABILITY_PROJECTION_SURFACE)
+    try:
+        projection = project_capabilities(
+            request,
+            authority=authority,
+            budget=budget,
+            offered_capabilities=offered,
+            limit=int(getattr(args, "limit", DEFAULT_PROJECTION_LIMIT)),
+        )
+        expand = str(getattr(args, "expand", "") or "")
+        payload = expand_capability(projection, expand) if expand else projection.to_dict()
+    except CapabilityProjectionError as exc:
+        raise OmhError(str(exc)) from exc
+    except ValueError as exc:
+        raise OmhError(str(exc)) from exc
+
+    record_context_emission(
+        paths,
+        task_id,
+        surface=CAPABILITY_PROJECTION_SURFACE,
+        byte_count=len(json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)),
+    )
+
+    if _wants_json(args):
+        _print_json(payload)
+        return 0
+    if expand:
+        _print_capability_expansion(payload)
+    else:
+        _print_capability_projection(payload)
+    return 0
+
+
+def _print_capability_projection(payload: dict[str, object]) -> None:
+    authority = payload.get("authority", {})
+    authority = authority if isinstance(authority, dict) else {}
+    print(f"OMH capability projection for task {payload.get('task_id', '')}")
+    if payload.get("degraded"):
+        drop = payload.get("budget_drop", {})
+        drop = drop if isinstance(drop, dict) else {}
+        print("  Degraded: this task exhausted its context budget; no capability detail was emitted.")
+        print(f"  Dropped: {', '.join(str(item) for item in drop.get('dropped_capabilities', []))}")
+        print(f"  Bytes: {drop.get('projected_bytes', 0)} needed, {drop.get('remaining_bytes', 0)} remaining.")
+    included = payload.get("included", [])
+    if isinstance(included, list) and included:
+        print("Relevant capabilities")
+        for entry in included:
+            if not isinstance(entry, dict):
+                continue
+            print(f"- {entry.get('capability', '')} ({entry.get('family', '')})")
+            print(f"  {entry.get('summary', '')}")
+            print(f"  Why: {entry.get('match_reason', '')}")
+    summary = payload.get("exclusion_summary", {})
+    if isinstance(summary, dict) and summary:
+        print("Excluded")
+        for reason, count in sorted(summary.items()):
+            print(f"  {reason}: {count}")
+    print(f"Offered: {payload.get('offered_count', 0)}; included: {payload.get('included_count', 0)}.")
+    print("Expansion is explicit: rerun with `--expand <capability>` for exact detail.")
+    print("For machine-readable output, rerun with `--json`.")
+
+
+def _print_capability_expansion(payload: dict[str, object]) -> None:
+    detail = payload.get("detail", {})
+    detail = detail if isinstance(detail, dict) else {}
+    print(f"OMH capability detail: {payload.get('capability', '')}")
+    print(f"Family: {payload.get('family', '')}")
+    for key in ("description", "category", "phase", "hermes_role", "primary_harness"):
+        if detail.get(key):
+            print(f"{key.replace('_', ' ').title()}: {detail[key]}")
+    print("Boundary: expanded detail is catalog metadata, not execution evidence.")
+    print("For machine-readable output, rerun with `--json`.")
+
+
 def _add_capabilities_commands(sub) -> None:
     capabilities = sub.add_parser("capabilities", help="Inspect OMH capability manifests for Hermes/plugin/wrapper use.")
     capabilities.add_argument("--json", action="store_true", help="Print the default machine-readable capability summary.")
@@ -124,6 +245,22 @@ def _add_capabilities_commands(sub) -> None:
     )
     impact.add_argument("--json", action="store_true", help="Print the machine-readable impact report.")
     impact.set_defaults(func=cmd_capabilities_impact)
+
+    project = capabilities_sub.add_parser(
+        "project",
+        help="Project only the capabilities one request needs, inside the declared context budget.",
+    )
+    project.add_argument("request", nargs="?", default="", help="The outcome the user asked for.")
+    project.add_argument("--limit", type=int, default=DEFAULT_PROJECTION_LIMIT, help="Maximum capabilities to include.")
+    project.add_argument("--task-id", default="", help="Ledger and authority id; defaults to a digest of the request.")
+    project.add_argument("--expand", default="", help="Return exact detail for one already-projected capability.")
+    project.add_argument(
+        "--authority-digest",
+        default="",
+        help="Refuse the projection when the re-derived authority no longer matches this approved digest.",
+    )
+    project.add_argument("--json", action="store_true", help="Print the machine-readable projection payload.")
+    project.set_defaults(func=cmd_capabilities_project)
 
     inspect = capabilities_sub.add_parser("inspect", help="Inspect one capability by id.")
     inspect.add_argument("identifier")

--- a/src/runtime/context_budget.py
+++ b/src/runtime/context_budget.py
@@ -26,7 +26,13 @@ from ..paths import OmhPaths
 RUN_CONTEXT_BUDGET_SCHEMA_VERSION = "omh_run_context_budget/v1"
 RUN_UNCHANGED_SCHEMA_VERSION = "omh_run_show_unchanged/v1"
 PROGRESS_STATUS_UNCHANGED_SCHEMA_VERSION = "omh_progress_status_unchanged/v1"
+CAPABILITY_PROJECTION_SUMMARY_ONLY_SCHEMA_VERSION = "omh_capability_projection_summary_only/v1"
 CONTEXT_BUDGET_LEDGER_NAME = "context_budget.json"
+
+# The ledger bucket a task-scoped capability projection spends from. A
+# projection is emitted per task, not per run, so the ledger key is the task id
+# the caller supplies rather than a run id.
+CAPABILITY_PROJECTION_SURFACE = "capability_projection"
 
 # `progress-status` spans every binding rather than one run, so it needs a
 # ledger bucket that is not a run id. The double underscores keep it from
@@ -300,5 +306,56 @@ def degrade_run_payload(shown: dict[str, Any], budget: dict[str, Any]) -> dict[s
             "Summary-only projection emitted after this run exhausted its observe-context budget. "
             "It is not execution, review, CI, merge-readiness, or merge evidence; read the listed "
             "artifacts for the full record."
+        ),
+    }
+
+
+def degrade_capability_projection_payload(
+    projected: dict[str, Any],
+    budget: dict[str, Any],
+    *,
+    dropped: list[dict[str, Any]],
+    content_bytes: int,
+) -> dict[str, Any]:
+    """Summary-only replacement for a task-scoped capability projection.
+
+    Same contract as `degrade_run_payload`: keep the position, drop the
+    material, name what was removed, and point at the command that returns it.
+    A capability projection has no journal history to shorten, so what it drops
+    is capability detail -- which is exactly what a reader must be told, or the
+    projection becomes a silent truncation of the authority view.
+
+    The authority block is carried through unchanged. Degrading is a context
+    decision; it never narrows or widens what the approved authority granted.
+    """
+    authority = projected.get("authority") if isinstance(projected.get("authority"), dict) else {}
+    task_id = str(projected.get("task_id", ""))
+    return {
+        "schema_version": CAPABILITY_PROJECTION_SUMMARY_ONLY_SCHEMA_VERSION,
+        "task_id": task_id,
+        "request_digest": str(projected.get("request_digest", "")),
+        "authority": authority,
+        "included": [],
+        "included_count": 0,
+        "offered_count": int(projected.get("offered_count", 0) or 0),
+        "exclusions": dropped,
+        "exclusion_summary": projected.get("exclusion_summary", {}),
+        "exclusion_reason_vocabulary": projected.get("exclusion_reason_vocabulary", []),
+        "budget_drop": {
+            "dropped_capabilities": [str(entry.get("capability", "")) for entry in dropped],
+            "dropped_count": len(dropped),
+            "projected_bytes": content_bytes,
+            "budget_bytes": int(budget.get("budget_bytes", 0) or 0),
+            "remaining_bytes": int(budget.get("remaining_bytes", 0) or 0),
+        },
+        "context_budget": public_budget(budget),
+        "degraded": True,
+        "degraded_reason": "capability_projection_context_budget_exhausted",
+        "next_action": "widen_the_request_or_start_a_new_task_budget_instead_of_repeating_this_command",
+        "full_output_command": f"omh capabilities project --task-id {task_id} --json",
+        "claim_boundary": (
+            "Summary-only capability projection emitted after this task exhausted its context "
+            "budget. Every capability it dropped is named above; nothing was silently withheld. "
+            "It is not execution, review, CI, merge-readiness, or merge evidence."
         ),
     }

--- a/tests/test_capability_projection.py
+++ b/tests/test_capability_projection.py
@@ -1,0 +1,615 @@
+"""Contract tests for the task-scoped capability projection (issue #814).
+
+Three acceptance criteria drive this file, and each one is locked at the level
+it can actually fail at:
+
+- AC1 is arithmetic. A projection either fits the declared budget or degrades
+  through the same path the runtime observe surfaces use, and the degraded
+  payload names every capability it dropped with the byte numbers that caused
+  it.
+- AC2 is structural, not behavioural. A projection is a VIEW; the test that
+  matters is not "this refresh happened to keep the grant" but "there is no
+  seam through which a refresh could change it" -- a frozen grant, one
+  constructor, and a refresh entry point with no authority parameter at all.
+- AC3 is about what the payload does NOT contain. Naming ninety irrelevant
+  workflows to explain their absence is the inventory dump the feature exists
+  to remove, so exclusions are itemized only for what the router considered and
+  counted for everything else.
+"""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+import inspect
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+from omh.capabilities import projection as projection_module
+from omh.capabilities.projection import (
+    CAPABILITY_AUTHORITY_SCHEMA_VERSION,
+    CAPABILITY_EXPANSION_SCHEMA_VERSION,
+    CAPABILITY_PROJECTION_SCHEMA_VERSION,
+    CONSIDERED_LIMIT,
+    EXCLUSION_REASON_CODES,
+    CapabilityAuthority,
+    CapabilityProjectionError,
+    approve_capability_authority,
+    authority_change_report,
+    capability_exclusion,
+    expand_capability,
+    project_capabilities,
+    refresh_capability_projection,
+)
+from omh.capabilities.registry import capability_summary
+from omh.paths import resolve_paths
+from omh.runtime.context_budget import (
+    CAPABILITY_PROJECTION_SUMMARY_ONLY_SCHEMA_VERSION,
+    CAPABILITY_PROJECTION_SURFACE,
+    RUN_CONTEXT_BUDGET_SCHEMA_VERSION,
+    context_budget_ledger_path,
+    record_context_emission,
+    run_context_budget,
+)
+from omh.skills.catalog import installable_skill_names
+
+CODING_REQUEST = "prepare a coding handoff for this issue"
+PROJECTION_SOURCE = Path(projection_module.__file__)
+
+
+def _budget(remaining: int, *, total: int = 200_000, task_id: str = "task-1") -> dict[str, object]:
+    """An `omh_run_context_budget/v1` payload with a chosen remaining allowance.
+
+    Handed in as a parameter exactly like a clock reading would be, so these
+    tests never depend on a filesystem ledger to reach a budget state.
+    """
+    emitted = max(0, total - remaining)
+    return {
+        "schema_version": RUN_CONTEXT_BUDGET_SCHEMA_VERSION,
+        "run_id": task_id,
+        "surface": CAPABILITY_PROJECTION_SURFACE,
+        "budget_bytes": total,
+        "emitted_bytes": emitted,
+        "remaining_bytes": max(0, remaining),
+        "observe_call_count": 0,
+        "surfaces": {},
+        "last_payload_fingerprint": "",
+        "exhausted": remaining <= 0,
+        "enforcement": "degrade_to_summary_only_with_artifact_pointers",
+        "policy": "timed_polling_rejected; raw_log_dumping_rejected",
+    }
+
+
+def _full_authority(task_id: str = "task-1") -> CapabilityAuthority:
+    return approve_capability_authority(
+        task_id=task_id,
+        granted_capabilities=sorted(installable_skill_names()),
+    )
+
+
+def _function_calls(source: Path, callee: str) -> set[str]:
+    """Names of the module-level functions that call `callee`."""
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+    callers: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for inner in ast.walk(node):
+            if isinstance(inner, ast.Call) and isinstance(inner.func, ast.Name) and inner.func.id == callee:
+                callers.add(node.name)
+    return callers
+
+
+class BudgetedProjectionTests(unittest.TestCase):
+    """AC1: context and handoffs stay inside declared budgets."""
+
+    def test_a_projection_stays_inside_the_declared_budget(self) -> None:
+        projection = project_capabilities(CODING_REQUEST, authority=_full_authority(), budget=_budget(200_000))
+
+        payload = projection.to_dict()
+        self.assertEqual(payload["schema_version"], CAPABILITY_PROJECTION_SCHEMA_VERSION)
+        self.assertFalse(payload["degraded"])
+        self.assertNotIn("budget_drop", payload)
+        self.assertLessEqual(payload["projected_bytes"], payload["context_budget"]["remaining_bytes"])
+        self.assertEqual(payload["context_budget"]["schema_version"], RUN_CONTEXT_BUDGET_SCHEMA_VERSION)
+        # Internal bookkeeping stays internal, the same way `public_budget`
+        # keeps it out of every other budgeted surface.
+        self.assertNotIn("last_payload_fingerprint", payload["context_budget"])
+
+    def test_a_task_projection_is_a_fraction_of_the_whole_catalog_summary(self) -> None:
+        projection = project_capabilities(CODING_REQUEST, authority=_full_authority(), budget=_budget(200_000))
+
+        projected = len(json.dumps(projection.to_dict(), sort_keys=True, separators=(",", ":")))
+        whole_catalog = len(json.dumps(capability_summary(), sort_keys=True, separators=(",", ":")))
+        self.assertLess(projected * 4, whole_catalog)
+
+    def test_a_trimmed_projection_names_every_capability_it_dropped(self) -> None:
+        roomy = project_capabilities(CODING_REQUEST, authority=_full_authority(), budget=_budget(200_000))
+        tight = project_capabilities(CODING_REQUEST, authority=_full_authority(), budget=_budget(3_000))
+
+        payload = tight.to_dict()
+        self.assertFalse(payload["degraded"])
+        self.assertLess(payload["included_count"], roomy.to_dict()["included_count"])
+        self.assertLessEqual(payload["projected_bytes"], 3_000)
+
+        drop = payload["budget_drop"]
+        dropped = set(roomy.included_capabilities()) - set(tight.included_capabilities())
+        self.assertEqual(set(drop["dropped_capabilities"]), dropped)
+        self.assertEqual(drop["dropped_count"], len(dropped))
+        self.assertEqual(drop["remaining_bytes"], 3_000)
+        self.assertEqual(drop["budget_bytes"], 200_000)
+
+        budget_exclusions = {
+            entry["capability"]
+            for entry in payload["exclusions"]
+            if entry["reason_code"] == "beyond_context_budget"
+        }
+        self.assertEqual(budget_exclusions, dropped)
+
+    def test_an_over_budget_projection_degrades_through_the_existing_path(self) -> None:
+        roomy = project_capabilities(CODING_REQUEST, authority=_full_authority(), budget=_budget(200_000))
+        starved = project_capabilities(CODING_REQUEST, authority=_full_authority(), budget=_budget(10))
+
+        payload = starved.to_dict()
+        self.assertEqual(payload["schema_version"], CAPABILITY_PROJECTION_SUMMARY_ONLY_SCHEMA_VERSION)
+        self.assertTrue(payload["degraded"])
+        self.assertEqual(payload["degraded_reason"], "capability_projection_context_budget_exhausted")
+        self.assertEqual(payload["included"], [])
+        self.assertEqual(payload["included_count"], 0)
+
+        drop = payload["budget_drop"]
+        self.assertEqual(set(drop["dropped_capabilities"]), set(roomy.included_capabilities()))
+        self.assertEqual(drop["dropped_count"], len(roomy.included_capabilities()))
+        self.assertGreater(drop["projected_bytes"], drop["remaining_bytes"])
+        self.assertEqual(drop["remaining_bytes"], 10)
+        self.assertEqual(drop["budget_bytes"], 200_000)
+        self.assertIn("nothing was silently withheld", payload["claim_boundary"])
+        self.assertEqual(
+            {entry["reason_code"] for entry in payload["exclusions"]},
+            {"beyond_context_budget"},
+        )
+
+    def test_a_degraded_projection_still_reports_the_unchanged_authority(self) -> None:
+        authority = _full_authority()
+        starved = project_capabilities(CODING_REQUEST, authority=authority, budget=_budget(10))
+
+        self.assertEqual(starved.to_dict()["authority"]["digest"], authority.digest)
+
+    def test_the_cli_spends_the_task_budget_through_the_shared_ledger(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+            status, stdout, stderr = run_cli([*base, "capabilities", "project", CODING_REQUEST, "--task-id", "task-a"])
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            self.assertEqual(payload["schema_version"], CAPABILITY_PROJECTION_SCHEMA_VERSION)
+            self.assertTrue(context_budget_ledger_path(paths).exists())
+
+            spent = run_context_budget(paths, "task-a", surface=CAPABILITY_PROJECTION_SURFACE)
+            self.assertGreater(spent["emitted_bytes"], 0)
+            self.assertEqual(spent["surfaces"], {CAPABILITY_PROJECTION_SURFACE: 1})
+            self.assertEqual(run_context_budget(paths, "task-b")["emitted_bytes"], 0)
+
+    def test_an_exhausted_task_budget_degrades_the_cli_projection(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            record_context_emission(
+                paths,
+                "task-a",
+                surface=CAPABILITY_PROJECTION_SURFACE,
+                byte_count=run_context_budget(paths, "task-a")["budget_bytes"],
+            )
+
+            status, stdout, _ = run_cli([*base, "capabilities", "project", CODING_REQUEST, "--task-id", "task-a"])
+
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            self.assertEqual(payload["schema_version"], CAPABILITY_PROJECTION_SUMMARY_ONLY_SCHEMA_VERSION)
+            self.assertTrue(payload["degraded"])
+            self.assertGreater(payload["budget_drop"]["dropped_count"], 0)
+
+
+class ApprovedAuthorityTests(unittest.TestCase):
+    """AC2: a refresh cannot silently alter approved authority."""
+
+    def _narrow_grant(self) -> tuple[CapabilityAuthority, list[str], list[str]]:
+        offered = sorted(installable_skill_names())
+        granted = offered[:20]
+        return approve_capability_authority(task_id="task-1", granted_capabilities=granted), granted, offered
+
+    def test_refreshing_with_a_larger_catalog_leaves_the_grant_untouched(self) -> None:
+        authority, granted, offered = self._narrow_grant()
+        original = project_capabilities(
+            CODING_REQUEST, authority=authority, budget=_budget(200_000), offered_capabilities=granted
+        )
+
+        refreshed = refresh_capability_projection(
+            original, budget=_budget(200_000), offered_capabilities=offered
+        )
+
+        self.assertIs(refreshed.authority, original.authority)
+        self.assertEqual(refreshed.authority.digest, original.authority.digest)
+        self.assertEqual(refreshed.authority.granted_capabilities(), tuple(sorted(granted)))
+        self.assertTrue(set(refreshed.included_capabilities()) <= set(granted))
+
+        payload = refreshed.to_dict()
+        self.assertEqual(payload["offered_count"], len(offered))
+        self.assertEqual(
+            payload["exclusion_summary"]["not_granted_by_authority"],
+            len(offered) - len(granted),
+        )
+
+    def test_a_capability_the_catalog_gained_is_reported_not_absorbed(self) -> None:
+        authority, granted, offered = self._narrow_grant()
+        original = project_capabilities(
+            CODING_REQUEST, authority=authority, budget=_budget(200_000), offered_capabilities=granted
+        )
+        newcomer = next(name for name in offered if name not in granted and name in _shortlisted(CODING_REQUEST))
+
+        refreshed = refresh_capability_projection(
+            original, budget=_budget(200_000), offered_capabilities=offered
+        )
+
+        payload = refreshed.to_dict()
+        self.assertNotIn(newcomer, refreshed.included_capabilities())
+        entry = next(item for item in payload["exclusions"] if item["capability"] == newcomer)
+        self.assertEqual(entry["reason_code"], "not_granted_by_authority")
+        self.assertIn("approving it again", entry["explanation"])
+
+    def test_the_refresh_entry_point_has_no_authority_seam(self) -> None:
+        parameters = inspect.signature(refresh_capability_projection).parameters
+
+        self.assertNotIn("authority", parameters)
+        self.assertFalse([name for name in parameters if "authority" in name])
+
+    def test_the_grant_record_cannot_be_edited_after_approval(self) -> None:
+        authority = _full_authority()
+
+        self.assertTrue(dataclasses.is_dataclass(authority))
+        self.assertTrue(getattr(CapabilityAuthority, "__dataclass_params__").frozen)
+        self.assertIsInstance(authority.granted, frozenset)
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            authority.task_id = "other"  # type: ignore[misc]
+        with self.assertRaises(AttributeError):
+            authority.granted.add("smuggled")  # type: ignore[attr-defined]
+
+    def test_the_emitted_authority_block_is_a_copy_and_carries_no_inventory(self) -> None:
+        authority = _full_authority()
+        payload = project_capabilities(
+            CODING_REQUEST, authority=authority, budget=_budget(200_000)
+        ).to_dict()
+
+        emitted = payload["authority"]
+        emitted["granted_families"].append("smuggled_family")
+        emitted["granted_capability_count"] = 9_999
+
+        self.assertEqual(authority.to_dict()["granted_capability_count"], len(authority.granted))
+        self.assertNotIn("smuggled_family", authority.granted_families)
+        self.assertEqual(emitted["schema_version"], CAPABILITY_AUTHORITY_SCHEMA_VERSION)
+        # The grant identity travels; the grant contents do not. Emitting the
+        # granted list would restore the whole-catalog dump the projection
+        # exists to remove.
+        self.assertNotIn("granted", payload["authority"])
+        self.assertNotIn("granted_capabilities", payload["authority"])
+
+    def test_only_the_approval_constructor_builds_a_grant(self) -> None:
+        callers = _function_calls(PROJECTION_SOURCE, "CapabilityAuthority")
+
+        self.assertEqual(callers, {"approve_capability_authority"})
+
+    def test_no_projection_code_path_mutates_a_frozen_grant(self) -> None:
+        source = PROJECTION_SOURCE.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        attribute_writes = {
+            target.attr
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Assign)
+            for target in node.targets
+            if isinstance(target, ast.Attribute)
+        }
+
+        self.assertEqual(attribute_writes, set())
+        # The two documented escape hatches out of a frozen dataclass.
+        self.assertNotIn("object.__setattr__", source)
+        self.assertNotIn("dataclasses.replace", source)
+        self.assertNotIn("__dict__", source)
+
+    def test_no_other_module_constructs_a_grant(self) -> None:
+        src_root = PROJECTION_SOURCE.parents[1]
+        builders = sorted(
+            path.relative_to(src_root).as_posix()
+            for path in src_root.rglob("*.py")
+            if "CapabilityAuthority(" in path.read_text(encoding="utf-8")
+        )
+
+        self.assertEqual(builders, ["capabilities/projection.py"])
+
+    def test_a_changed_grant_is_refused_instead_of_silently_reprojected(self) -> None:
+        authority = _full_authority()
+
+        unchanged = authority_change_report(authority.digest, authority)
+        changed = authority_change_report("stale-digest", authority)
+
+        self.assertTrue(unchanged["unchanged"])
+        self.assertEqual(unchanged["next_action"], "reuse_projection")
+        self.assertFalse(changed["unchanged"])
+        self.assertEqual(changed["next_action"], "re_approve_capability_authority")
+        self.assertEqual(changed["current_digest"], authority.digest)
+        # A digest is all the caller held, so the refusal points at the policy
+        # surface instead of re-emitting the grant it is protecting.
+        self.assertEqual(changed["compare_command"], "omh capability-policy status")
+        self.assertNotIn("granted", json.dumps(changed))
+
+    def test_the_cli_refuses_a_projection_whose_grant_no_longer_matches(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+            status, stdout, _ = run_cli(
+                [*base, "capabilities", "project", CODING_REQUEST, "--authority-digest", "stale-digest"]
+            )
+
+            self.assertEqual(status, 2)
+            payload = json.loads(stdout)
+            self.assertEqual(payload["schema_version"], "omh_capability_authority_change/v1")
+            self.assertFalse(payload["unchanged"])
+            self.assertEqual(payload["approved_digest"], "stale-digest")
+
+    def test_the_grant_digest_moves_only_when_the_grant_moves(self) -> None:
+        offered = sorted(installable_skill_names())
+        first = approve_capability_authority(task_id="task-1", granted_capabilities=offered)
+        same = approve_capability_authority(task_id="task-1", granted_capabilities=reversed(offered))
+        wider = approve_capability_authority(task_id="task-1", granted_capabilities=[*offered, "invented"])
+
+        self.assertEqual(first.digest, same.digest)
+        self.assertNotEqual(first.digest, wider.digest)
+
+    def test_an_approved_envelope_pins_the_permission_profile_and_its_digest(self) -> None:
+        envelope = {"schema_version": "task_authority_envelope/v1", "permission_profile": "handoff_only"}
+
+        authority = approve_capability_authority(
+            task_id="task-1",
+            granted_capabilities=["plan"],
+            authority_envelope=envelope,
+        )
+
+        self.assertEqual(authority.permission_profile, "handoff_only")
+        self.assertNotEqual(authority.envelope_digest, "")
+        with self.assertRaises(CapabilityProjectionError):
+            approve_capability_authority(
+                task_id="task-1",
+                granted_capabilities=["plan"],
+                permission_profile="full_loop",
+                authority_envelope=envelope,
+            )
+
+    def test_an_unsupported_permission_profile_is_refused(self) -> None:
+        with self.assertRaises(CapabilityProjectionError) as caught:
+            approve_capability_authority(
+                task_id="task-1", granted_capabilities=["plan"], permission_profile="do_anything"
+            )
+
+        self.assertIn("full_loop", str(caught.exception))
+
+
+class ExplainedExclusionTests(unittest.TestCase):
+    """AC3: relevant inclusion and exclusion, without a tool-list dump."""
+
+    def test_every_offered_capability_is_accounted_for_by_the_closed_vocabulary(self) -> None:
+        payload = project_capabilities(
+            CODING_REQUEST, authority=_full_authority(), budget=_budget(200_000)
+        ).to_dict()
+
+        summary = payload["exclusion_summary"]
+        self.assertEqual(set(summary), set(EXCLUSION_REASON_CODES))
+        self.assertEqual(payload["included_count"] + sum(summary.values()), payload["offered_count"])
+        self.assertEqual(payload["excluded_count"], sum(summary.values()))
+        for entry in payload["exclusions"]:
+            self.assertIn(entry["reason_code"], EXCLUSION_REASON_CODES)
+            self.assertTrue(entry["explanation"].strip())
+        self.assertEqual(payload["exclusion_reason_vocabulary"], list(EXCLUSION_REASON_CODES))
+
+    def test_an_unknown_exclusion_reason_is_refused(self) -> None:
+        with self.assertRaises(CapabilityProjectionError) as caught:
+            capability_exclusion("plan", "because_the_model_felt_like_it")
+
+        message = str(caught.exception)
+        self.assertIn("because_the_model_felt_like_it", message)
+        for reason in EXCLUSION_REASON_CODES:
+            self.assertIn(reason, message)
+
+    def test_the_payload_carries_no_full_tool_inventory(self) -> None:
+        payload = project_capabilities(
+            CODING_REQUEST, authority=_full_authority(), budget=_budget(200_000)
+        ).to_dict()
+
+        named = {entry["capability"] for entry in payload["included"]}
+        named |= {entry["capability"] for entry in payload["exclusions"]}
+        self.assertLessEqual(len(named), CONSIDERED_LIMIT)
+        self.assertLess(len(named) * 4, payload["offered_count"])
+        for section in ("skills", "hooks", "plugin_tools", "tool_requirements", "orchestration_patterns"):
+            self.assertNotIn(section, payload)
+
+    def test_an_irrelevant_capability_is_counted_but_never_named(self) -> None:
+        payload = project_capabilities(
+            CODING_REQUEST, authority=_full_authority(), budget=_budget(200_000)
+        ).to_dict()
+
+        named = {entry["capability"] for entry in payload["included"]}
+        named |= {entry["capability"] for entry in payload["exclusions"]}
+        unnamed = set(installable_skill_names()) - named
+
+        self.assertGreater(len(unnamed), 80)
+        self.assertEqual(payload["exclusion_summary"]["not_relevant_to_request"], len(unnamed))
+
+    def test_included_capabilities_explain_why_they_matched(self) -> None:
+        payload = project_capabilities(
+            CODING_REQUEST, authority=_full_authority(), budget=_budget(200_000)
+        ).to_dict()
+
+        self.assertTrue(payload["included"])
+        for entry in payload["included"]:
+            self.assertEqual(
+                set(entry),
+                {"capability", "family", "summary", "next_action", "match_reason", "score"},
+            )
+            self.assertTrue(entry["match_reason"].strip())
+            self.assertTrue(entry["family"].strip())
+
+    def test_selection_reuses_the_router_shortlist_rather_than_a_second_ranking(self) -> None:
+        projection = project_capabilities(
+            CODING_REQUEST, authority=_full_authority(), budget=_budget(200_000)
+        )
+
+        shortlist = _shortlisted(CODING_REQUEST)
+        self.assertTrue(set(projection.included_capabilities()) <= set(shortlist))
+        scores = [entry["score"] for entry in projection.to_dict()["included"]]
+        self.assertEqual(scores, sorted(scores, reverse=True))
+
+
+class ExpansionGuardTests(unittest.TestCase):
+    def test_expansion_is_never_automatic(self) -> None:
+        payload = project_capabilities(
+            CODING_REQUEST, authority=_full_authority(), budget=_budget(200_000)
+        ).to_dict()
+
+        self.assertFalse(payload["expansion"]["automatic"])
+        self.assertEqual(payload["expansion"]["policy"], "explicit_request_only")
+        self.assertEqual(sorted(payload["expansion"]["expandable"]), sorted(payload["expansion"]["expandable"]))
+        for entry in payload["included"]:
+            for detail_only in ("triggers", "quality_bar", "safety_rules", "expected_outputs"):
+                self.assertNotIn(detail_only, entry)
+
+    def test_no_projection_code_path_expands_a_capability(self) -> None:
+        callers = _function_calls(PROJECTION_SOURCE, "expand_capability")
+
+        self.assertEqual(callers, set())
+
+    def test_an_explicit_expansion_returns_the_exact_detail(self) -> None:
+        projection = project_capabilities(CODING_REQUEST, authority=_full_authority(), budget=_budget(200_000))
+        target = projection.included_capabilities()[0]
+
+        expanded = expand_capability(projection, target)
+
+        self.assertEqual(expanded["schema_version"], CAPABILITY_EXPANSION_SCHEMA_VERSION)
+        self.assertEqual(expanded["capability"], target)
+        self.assertTrue(expanded["requested"])
+        self.assertFalse(expanded["automatic"])
+        self.assertEqual(expanded["detail"]["id"], target)
+        self.assertEqual(expanded["authority_digest"], projection.authority.digest)
+        self.assertIn("triggers", expanded["detail"])
+
+    def test_expanding_something_the_projection_did_not_include_is_refused(self) -> None:
+        projection = project_capabilities(CODING_REQUEST, authority=_full_authority(), budget=_budget(200_000))
+        absent = next(
+            name for name in sorted(installable_skill_names()) if name not in projection.included_capabilities()
+        )
+
+        with self.assertRaises(CapabilityProjectionError) as caught:
+            expand_capability(projection, absent)
+
+        self.assertIn("not in this projection", str(caught.exception))
+
+    def test_expanding_outside_the_grant_is_refused(self) -> None:
+        offered = sorted(installable_skill_names())
+        authority = approve_capability_authority(task_id="task-1", granted_capabilities=offered[:20])
+        projection = project_capabilities(
+            CODING_REQUEST, authority=authority, budget=_budget(200_000), offered_capabilities=offered
+        )
+        ungranted = next(name for name in offered if name not in offered[:20])
+
+        with self.assertRaises(CapabilityProjectionError) as caught:
+            expand_capability(projection, ungranted)
+
+        self.assertIn("outside the approved authority", str(caught.exception))
+
+    def test_the_cli_expands_only_on_request(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            _status, stdout, _ = run_cli([*base, "capabilities", "project", CODING_REQUEST])
+            target = json.loads(stdout)["included"][0]["capability"]
+
+            status, expanded_out, stderr = run_cli(
+                [*base, "capabilities", "project", CODING_REQUEST, "--expand", target]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            expanded = json.loads(expanded_out)
+            self.assertEqual(expanded["schema_version"], CAPABILITY_EXPANSION_SCHEMA_VERSION)
+            self.assertEqual(expanded["capability"], target)
+
+
+class ProjectionSurfaceTests(unittest.TestCase):
+    def test_the_whole_catalog_summary_is_unchanged_for_existing_callers(self) -> None:
+        before = capability_summary()
+
+        project_capabilities(CODING_REQUEST, authority=_full_authority(), budget=_budget(200_000))
+        project_capabilities("find papers about this", authority=_full_authority(), budget=_budget(200_000))
+
+        after = capability_summary()
+        self.assertEqual(before, after)
+        self.assertEqual(after["schema_version"], "omh_capability_summary/v1")
+        self.assertEqual(after["determinism"], "static_projection_no_runtime_clock")
+        self.assertNotIn("projection", after)
+        self.assertNotIn("included", after)
+
+    def test_the_same_request_projects_byte_identically(self) -> None:
+        first = project_capabilities(CODING_REQUEST, authority=_full_authority(), budget=_budget(200_000))
+        second = project_capabilities(CODING_REQUEST, authority=_full_authority(), budget=_budget(200_000))
+
+        self.assertEqual(first.to_dict(), second.to_dict())
+
+    def test_the_projection_payload_carries_no_wall_clock_field(self) -> None:
+        payload = project_capabilities(
+            CODING_REQUEST, authority=_full_authority(), budget=_budget(200_000)
+        ).to_dict()
+
+        serialized = json.dumps(payload, sort_keys=True)
+        for clock_field in ("updated_at", "observed_at", "generated_at", "timestamp"):
+            self.assertNotIn(clock_field, serialized)
+        self.assertEqual(payload["determinism"], "static_projection_no_runtime_clock")
+
+    def test_a_projection_limit_below_one_is_refused(self) -> None:
+        with self.assertRaises(CapabilityProjectionError):
+            project_capabilities(CODING_REQUEST, authority=_full_authority(), budget=_budget(200_000), limit=0)
+
+    def test_the_cli_defaults_to_plain_text_and_opts_into_json(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+            _status, text, _ = run_cli([*base, "capabilities", "project", CODING_REQUEST], output_json=False)
+            _status, machine, _ = run_cli(
+                [*base, "capabilities", "project", CODING_REQUEST, "--json"], output_json=False
+            )
+
+            self.assertTrue(text.startswith("OMH capability projection for task "))
+            self.assertIn("Expansion is explicit", text)
+            self.assertIn("Excluded", text)
+            self.assertEqual(
+                json.loads(machine)["schema_version"], CAPABILITY_PROJECTION_SCHEMA_VERSION
+            )
+
+
+def _shortlisted(request: str) -> list[str]:
+    from omh.routing.recommend import recommend_skills
+
+    return [str(entry["skill"]) for entry in recommend_skills(request, limit=CONSIDERED_LIMIT)]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New task-scoped capability projection: `omh capabilities project "<request>"`, emitting `omh_capability_projection/v1` — a compact, budgeted view of only the capabilities one request needs, instead of the whole catalog.
- New frozen approval record `omh_capability_authority/v1`. A projection is a VIEW over it and can only intersect; re-projecting cannot widen it.
- New explicit detail level: `--expand <capability>` returns `omh_capability_expansion/v1`. Expansion never happens as a side effect of projecting.
- New degrade path `degrade_capability_projection_payload` in `src/runtime/context_budget.py`, sibling to the existing `degrade_run_payload`, producing `omh_capability_projection_summary_only/v1`.
- New refusal report `omh_capability_authority_change/v1` behind `--authority-digest`, exit code 2.
- `docs/CAPABILITIES.md` gains a "Task-Scoped Projection" section under its existing agent/wrapper/maintainer audience label.

### Why This Exists

Every capability payload OMH had was a whole-catalog snapshot. `capability_snapshot()` and `capability_summary()` answer "what can this install do at all?", which is the right answer to a discovery question and the wrong answer to a request. A request that needs two capabilities was still handed all 103.

Measured in this checkout:

| Payload | Bytes (compact JSON) |
| --- | --- |
| `capability_snapshot()` — full manifest | 674,052 |
| `capability_summary()` — whole-catalog summary | 39,484 |
| `omh capabilities project "prepare a coding handoff for this issue"` | 4,925 |

That inventory ate context, diluted the routing signal, and put authority the task never asked for in front of the model — issue #814.

### User / Operator Impact

A wrapper or coding agent can now ask "what does this request need?" and get five capabilities with a one-line summary, family, next action, and the reason each one matched — plus a counted, reasoned account of everything left out. Before this, the only options were a 39 KB summary or a 674 KB manifest.

Concretely, for `"prepare a coding handoff for this issue"` against a default install (103 offered capabilities):

- 5 included: `connector-operator`, `plan`, `executor-runtime-readiness`, `github-event-ops`, `codegraph-refresh`.
- 98 excluded: 7 `outranked_by_shortlist` (named), 91 `not_relevant_to_request` (counted, deliberately not named).
- `included_count + sum(exclusion_summary.values()) == offered_count` holds by construction and is asserted.

Normal chat users are unaffected — this is a control-plane surface for Hermes, wrappers, and agents, documented under the existing audience label per `docs/DIRECTION.md` "Command Audience".

### How It Works

**Selection reuses the router.** `_ranked_candidates` calls `recommend_skills(request, limit=12)` and filters to what the install offers. No new ranking exists, so a projection cannot disagree with the route the user is about to be offered. `test_selection_reuses_the_router_shortlist_rather_than_a_second_ranking` locks the shortlist containment and the score ordering.

**Two levels.** The compact entry is exactly `{capability, family, summary, next_action, match_reason, score}` — asserted as an exact key set so detail cannot leak into the discovery level. Exact detail comes from `expand_capability`, which refuses a capability the projection did not include and refuses anything outside the grant.

**Budgeted through the existing ledger.** `project_capabilities` takes an `omh_run_context_budget/v1` payload as a parameter — the same way a clock reading would be, keeping the projection reproducible without a filesystem. The CLI reads and writes the real ledger via `run_context_budget` / `record_context_emission` under a new `capability_projection` surface keyed by `--task-id`. Content bytes are measured over the `{included, exclusions, exclusion_summary}` block only, so the number is not self-referential.

Over budget, the lowest-ranked capability is dropped one at a time and each drop is itemized as `beyond_context_budget` with a `budget_drop` block carrying names and numbers. Past the floor the payload degrades through `degrade_capability_projection_payload` to summary-only. There is no silent truncation on either path.

**AC2 is structural, not procedural.** This was the sharp one, so the guarantee is in the shape of the API:

- `CapabilityAuthority` is `@dataclass(frozen=True)` holding a `frozenset`, so neither the record nor the granted set can be edited in place.
- `approve_capability_authority` is the only function that constructs one — verified by an AST walk over `src/capabilities/projection.py`, and by a scan of all 514 files under `src/` confirming no other module constructs it.
- `refresh_capability_projection` **has no authority parameter at all**. It reads the grant off the projection it is refreshing and passes it by identity, so a refresh against a larger catalog has no seam through which a new capability could enter the grant.
- The module contains no attribute assignment, no `object.__setattr__`, no `dataclasses.replace`, and no `__dict__` — the documented escape hatches out of a frozen dataclass — asserted by source scan.
- `to_dict()` emits the grant's identity (digest, count, families) and never its contents, so the authority block cannot itself become the inventory dump.

Behaviourally: approving 20 capabilities, then refreshing against all 103, leaves `refreshed.authority is original.authority`, an identical digest, and reports the 83 newcomers as `not_granted_by_authority` — visible, never absorbed.

`--authority-digest` closes the operator-side loop: the grant is re-derived from the local capability policy on every call, and a policy that moved since approval exits 2 with `omh_capability_authority_change/v1` rather than quietly serving a different view. The refusal deliberately does not name the delta — a digest is all the caller held, and naming it would re-emit the grant contents this feature keeps out of context; it points at `omh capability-policy status` instead.

**Closed exclusion vocabulary.** `beyond_context_budget`, `not_granted_by_authority`, `not_relevant_to_request`, `outranked_by_shortlist`. `capability_exclusion()` is the single constructor and refuses anything else, naming every valid code. Only capabilities the router actually considered are itemized; the rest are counted. Naming ninety irrelevant workflows to explain their absence would restore the dump this surface removes.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/capabilities/projection.py` | New. `CapabilityAuthority`, `CapabilityProjection`, `approve_capability_authority`, `project_capabilities`, `refresh_capability_projection`, `expand_capability`, `capability_exclusion`, `authority_change_report`. |
| `src/runtime/context_budget.py` | Adds `CAPABILITY_PROJECTION_SURFACE`, `CAPABILITY_PROJECTION_SUMMARY_ONLY_SCHEMA_VERSION`, and `degrade_capability_projection_payload` beside the existing degrade/unchanged payloads. Existing behaviour untouched. |
| `src/commands/capabilities.py` | Adds the `project` subcommand with plain-text default and `--json` opt-in, matching the group's existing convention. |
| `tests/test_capability_projection.py` | New. 37 tests across AC1 budget, AC2 authority, AC3 exclusions, expansion guards, and surface/determinism. |
| `docs/CAPABILITIES.md` | New "Task-Scoped Projection" section. |

New schema versions: `omh_capability_projection/v1`, `omh_capability_authority/v1`, `omh_capability_expansion/v1`, `omh_capability_projection_summary_only/v1`, `omh_capability_authority_change/v1`. No generated artifact changed — no catalog, skill, routing case, or demo card was touched, so no exact-count assertion moved.

## Validation

- [x] `uv run --group lint ruff check src tests` — `All checks passed!`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` — `Ran 5558 tests in 160.850s / OK` (5521 on `origin/main` before this branch, 37 new)
- [x] `uv run python -m compileall -q src tests` — exit 0
- [x] `uv run python -m omh.cli docs workflows --check` — `"ok":true`, `tap_skills` 115/115, no missing/stale/extra
- [x] `uv run python -m omh.cli docs roles --check` — `"ok":true`
- [x] `uv run python -m omh.cli docs capability-families --check` — `"ok":true`
- [x] `uv run python -m omh.cli harness validate` — `"ok":true`, 72 harnesses / 104 skills, no errors or warnings
- [x] `git diff --check` — clean
- [x] `uv run python -m omh.cli release checklist --json` — `"ok":true`, 35 required items, mode `plan`
- [x] `uv run python -m omh.cli release hermes-smoke` — plan renders, plan-only boundary printed
- [x] `omh --help` — installed console script resolves (`/Users/…/.local/bin/omh`) and prints help
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — **not run.** The installed `omh` on this machine is an older build without `capabilities project`, so this would smoke a different package than the branch, not this change.
- [ ] Workflow-learning review queue smoke — not applicable; no learning contract changed.
- [x] Relevant dry-run / smoke command: `omh capabilities project` exercised end to end against a temp home for the plain-text, `--json`, `--expand`, exhausted-budget, and `--authority-digest` refusal paths.
- [ ] Manual Hermes/TUI check — **not run.** No Hermes profile was mutated and no wrapper rendered this payload; the projection is exercised only through the CLI and unit tests.

### Mutation evidence

Green tests that cannot fail are not evidence, so the three sharpest guards were mutation-checked against a file backup and then restored byte-identically (`cmp` verified):

| Mutation | Guard that turned red |
| --- | --- |
| Add an `authority=` parameter to `refresh_capability_projection` | `test_the_refresh_entry_point_has_no_authority_seam` |
| Itemize every exclusion instead of only the considered ones | `test_the_payload_carries_no_full_tool_inventory` (103 named, limit 12), `test_an_irrelevant_capability_is_counted_but_never_named`, `test_a_task_projection_is_a_fraction_of_the_whole_catalog_summary` |
| Skip the degrade path when content exceeds the budget | `test_an_over_budget_projection_degrades_through_the_existing_path`, `test_an_exhausted_task_budget_degrades_the_cli_projection`, `test_a_trimmed_projection_names_every_capability_it_dropped` |

## Risk

- **Low blast radius on existing surfaces.** `capability_summary()`, `capability_snapshot()`, `list_capabilities()`, and `inspect_capability()` are unchanged and byte-identical for existing callers; `test_the_whole_catalog_summary_is_unchanged_for_existing_callers` asserts the summary is deep-equal before and after projections are built. The additions to `src/runtime/context_budget.py` are new symbols only.
- **The task budget is spent per invocation.** Repeatedly projecting the same request under the same `--task-id` accrues against the 200,000-byte ledger and will eventually degrade. That is the intended mechanism — it is the same one `omh runtime show` uses — but an automation that loops on one task id will see summary-only output after roughly forty calls. A fresh `--task-id` starts a fresh budget.
- **`--task-id` lands in the local ledger.** The default is `task-<sha256(request)[:12]>`, so no request text is persisted. A caller that passes free text as `--task-id` puts that text in the local ledger, the same as any other run id.
- **Determinism.** No clock, environment, or filesystem read inside the projection; `test_the_same_request_projects_byte_identically` and a no-wall-clock-field assertion lock it. Nothing was added behind the `@lru_cache` that advertises `static_projection_no_runtime_clock`.

## Compatibility / Rollout

- Purely additive. No existing schema, CLI flag, generated artifact, or catalog entry changed, so an older wrapper keeps working unchanged.
- The standalone plugin-bundle capability tool (`omh_capabilities`) is **not** extended. It cannot import omh core, so a projection action there would mean a second, divergent implementation; it still exposes the whole-catalog actions only. This is a stated capability boundary, not an oversight.
- Release-channel impact: `stable`, behind no flag. Nothing runs unless `omh capabilities project` is invoked.
- Runtime claims: everything this PR adds is prepared local metadata. The payload's `claim_boundary` states it is not execution, review, CI, merge-readiness, or merge evidence, and the degraded payload repeats it.

## Follow-Up

- Wiring the projection into `chat_interaction/v1` wrapper context, so Hermes carries the compact projection without an explicit command, is the natural next step and was left out to keep this PR to one coherent goal.
- If the plugin bundle should serve projections in standalone mode, that needs a vendored sidecar in the shape of `capability_families.json` plus a drift gate — a separate, deliberate piece of work.
