### PR TITLE
feat: make a wide fanout split justify itself before it freezes

### DIFF
--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -56,30 +56,37 @@ flag, so the justification and the split it justifies live in one file:
     "why_parallel": "Five disjoint subsystems each own their own test lane.",
     "why_not_single_unit": "One executor would serialize five unrelated verification loops.",
     "independence": "No unit reads or writes another unit's file_scope.",
-    "expected_evidence_shape": "Per-unit run record plus the unit's own focused test command.",
-    "max_inline_tokens": 4000
+    "expected_evidence_shape": "Per-unit run record plus the unit's own focused test command."
   }
 }
 ```
 
 Rules:
 
-- The four text fields are collapsed to a single line and bounded at 280
-  characters each. `max_inline_tokens` must be a positive integer.
+- All four fields must be strings. Each is collapsed to a single line and
+  bounded at 280 characters. A list, number, or boolean is refused rather
+  than coerced — its Python repr would pass the blank check while being
+  exactly the answer nobody wrote.
 - A plan supplied at all must be complete, at any width. A half-filled plan
   reads as an answer nobody wrote, so it is refused rather than frozen —
   below the threshold the fix is to complete it or drop the key entirely.
+- The gate runs **last**, after the boundary-overlap and dependency-cycle
+  checks. A split that can never be frozen fails on its structure, so the
+  operator is not asked to justify a decomposition they will have to rewrite.
+- A key that is `spawn_plan` with different punctuation or case (`spawnPlan`,
+  `spawn-plan`) is a hard error naming the intended key, not a silent drop.
 - An accepted plan is frozen into the contract as an optional top-level
-  `spawn_plan` key carrying the four answers, the token budget, the observed
-  `unit_count`, the `threshold` in force, and a claim boundary. A split that
-  needed no plan gains no key, so contracts frozen before this gate existed
-  keep their exact shape.
+  `spawn_plan` key carrying the four answers, the observed `unit_count`, the
+  `threshold` in force, and a claim boundary. A split that needed no plan
+  gains no key, so contracts frozen before this gate existed keep their exact
+  shape.
 - A spawn plan is prepared operator justification. It is not evidence that
   the split is correct, that the units are independent, that the named
   evidence shape was produced, or that any unit ran.
-- `omh coding fanout validate` runs the same gate in the same order and
-  reports `spawn_plan_required` on both its success and its error payload,
-  so a wrapper can ask for a plan before `prepare` refuses the freeze.
+- `omh coding fanout validate` runs the same checks in the same order and
+  reports `unit_count` and `spawn_plan_required` on both its success and its
+  error payload, so a wrapper can ask for a plan before `prepare` refuses the
+  freeze, and can always parse the answer as JSON.
 
 ## Dispatch bridge semantics
 

--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -9,9 +9,10 @@ goal to Hermes in chat; these commands are the backend surface.
    titles, owners, file boundaries, dependencies.
 2. **Freeze** — `omh coding fanout prepare --goal <words> --units units.json
    --record` validates the split deterministically (boundary overlaps without
-   a `depends_on` edge are hard errors; dependency cycles are hard errors) and
-   freezes it as `fanout_contract/v1` under `~/.omh/coding/fanout/<id>/`. The
-   goal is stored as a digest only.
+   a `depends_on` edge are hard errors; dependency cycles are hard errors; a
+   split wider than four units with no spawn plan is a hard error, see
+   **Spawn plan** below) and freezes it as `fanout_contract/v1` under
+   `~/.omh/coding/fanout/<id>/`. The goal is stored as a digest only.
 3. **Dispatch (opt-in bridge)** — `omh coding fanout dispatch <id>
    --goal-file goal.txt` spawns each spawnable unit's local agent CLI in an
    isolated per-unit worktree, dependency-aware, with bounded concurrency.
@@ -37,6 +38,48 @@ goal to Hermes in chat; these commands are the backend surface.
 5. **Merge (human/agent-gated)** — dispatch never merges. The summary lists
    merge-ready units in the contract's `merge_order`; merging and the final
    integration gate remain the operator's or reviewing agent's job.
+
+## Spawn plan
+
+A split into more than four units has to say why. Up to four, the shape is
+small enough to read at a glance; past that the contract stops recording an
+obvious decomposition and starts recording a guess, and the cost of a wrong
+guess is N worktrees of thin work nobody can merge.
+
+The plan rides in the units payload's object form rather than behind its own
+flag, so the justification and the split it justifies live in one file:
+
+```json
+{
+  "units": [ ... ],
+  "spawn_plan": {
+    "why_parallel": "Five disjoint subsystems each own their own test lane.",
+    "why_not_single_unit": "One executor would serialize five unrelated verification loops.",
+    "independence": "No unit reads or writes another unit's file_scope.",
+    "expected_evidence_shape": "Per-unit run record plus the unit's own focused test command.",
+    "max_inline_tokens": 4000
+  }
+}
+```
+
+Rules:
+
+- The four text fields are collapsed to a single line and bounded at 280
+  characters each. `max_inline_tokens` must be a positive integer.
+- A plan supplied at all must be complete, at any width. A half-filled plan
+  reads as an answer nobody wrote, so it is refused rather than frozen —
+  below the threshold the fix is to complete it or drop the key entirely.
+- An accepted plan is frozen into the contract as an optional top-level
+  `spawn_plan` key carrying the four answers, the token budget, the observed
+  `unit_count`, the `threshold` in force, and a claim boundary. A split that
+  needed no plan gains no key, so contracts frozen before this gate existed
+  keep their exact shape.
+- A spawn plan is prepared operator justification. It is not evidence that
+  the split is correct, that the units are independent, that the named
+  evidence shape was produced, or that any unit ran.
+- `omh coding fanout validate` runs the same gate in the same order and
+  reports `spawn_plan_required` on both its success and its error payload,
+  so a wrapper can ask for a plan before `prepare` refuses the freeze.
 
 ## Dispatch bridge semantics
 
@@ -291,8 +334,10 @@ probed source reports a status: `present`, `absent`, `unreadable`, or
 ## Command reference
 
 ```sh
+# units.json is either a JSON list of units, or an object:
+#   {"units": [...], "spawn_plan": {...}}   <- spawn_plan required above 4 units
 omh coding fanout prepare --goal <words...> --units units.json [--record] [--source discord]
-omh coding fanout validate --units units.json
+omh coding fanout validate --units units.json   # also reports spawn_plan_required
 omh coding fanout show <fanout-id> [--limit 20] [--full]
 omh coding fanout brief [<fanout-id>] [--json]
 omh coding fanout dispatch <fanout-id> --goal-file goal.txt \

--- a/src/coding/fanout.py
+++ b/src/coding/fanout.py
@@ -196,7 +196,12 @@ def _normalized_max_inline_tokens(value: object) -> int:
 
 
 def missing_spawn_plan_fields(plan: Mapping[str, object] | None) -> list[str]:
-    """Plan fields still unanswered, in declaration order."""
+    """Plan fields still unanswered, in declaration order.
+
+    Answers the *blank* question only. Over-length fields are a shape failure
+    that `normalized_spawn_plan` raises on, so call this on a normalized plan
+    to get a complete verdict.
+    """
     if plan is None:
         return list(FANOUT_SPAWN_PLAN_FIELDS)
     missing = [field for field in FANOUT_SPAWN_PLAN_TEXT_FIELDS if not str(plan.get(field, "") or "").strip()]
@@ -211,20 +216,34 @@ def require_spawn_plan(
 ) -> dict[str, object] | None:
     """Return the plan to freeze, refusing an unjustified wide split.
 
-    A plan supplied under the threshold is kept rather than rejected: the
-    operator answered a question nobody asked, and dropping that answer would
-    lose the only record of why the split looks the way it does.
+    One rule, so there is no silent path: a plan that is supplied at all must
+    be complete, and above the threshold one must be supplied. A half-filled
+    receipt is worse than none — it reads as an answer — and freezing one
+    would also add a `spawn_plan` key to contracts that used to have none,
+    which is exactly the drift this gate must not cause.
     """
     normalized = normalized_spawn_plan(plan)
-    if not spawn_plan_required(unit_count):
-        return normalized
+    required = spawn_plan_required(unit_count)
+    if normalized is None:
+        if required:
+            raise FanoutContractError(
+                f"a {unit_count}-unit split exceeds the {FANOUT_SPAWN_PLAN_THRESHOLD}-unit spawn-plan "
+                f"threshold; add a spawn_plan to the units payload answering: "
+                f"{', '.join(FANOUT_SPAWN_PLAN_FIELDS)}"
+            )
+        return None
     missing = missing_spawn_plan_fields(normalized)
-    if missing:
+    if not missing:
+        return normalized
+    if required:
         raise FanoutContractError(
             f"a {unit_count}-unit split exceeds the {FANOUT_SPAWN_PLAN_THRESHOLD}-unit spawn-plan threshold; "
             f"add a spawn_plan to the units payload answering: {', '.join(missing)}"
         )
-    return normalized
+    raise FanoutContractError(
+        f"the supplied spawn_plan is incomplete; answer {', '.join(missing)} or remove the spawn_plan "
+        f"entirely (a {unit_count}-unit split does not require one)"
+    )
 
 
 def detect_boundary_overlaps(units: Sequence[Mapping[str, object]]) -> list[dict[str, object]]:

--- a/src/coding/fanout.py
+++ b/src/coding/fanout.py
@@ -9,8 +9,14 @@ from .fanout_contracts import (
     FANOUT_CLAIM_BOUNDARY,
     FANOUT_CONTRACT_SCHEMA_VERSION,
     FANOUT_FINAL_INTEGRATION_GATE,
+    FANOUT_SPAWN_PLAN_CLAIM_BOUNDARY,
+    FANOUT_SPAWN_PLAN_FIELDS,
+    FANOUT_SPAWN_PLAN_SCHEMA_VERSION,
+    FANOUT_SPAWN_PLAN_TEXT_FIELDS,
+    FANOUT_SPAWN_PLAN_THRESHOLD,
     FANOUT_UNIT_OWNERS,
     FanoutContractError,
+    MAX_SPAWN_PLAN_FIELD_CHARS,
     PREPARED_NOT_OBSERVED,
 )
 from .model_routing import model_route_for_unit
@@ -25,12 +31,17 @@ def build_fanout_contract(
     source: str = "generic",
     source_metadata: Mapping[str, object] | None = None,
     local_catalogs: Mapping[str, Mapping[str, object]] | None = None,
+    spawn_plan: Mapping[str, object] | None = None,
 ) -> dict[str, object]:
     normalized_goal = " ".join(goal.split())
     if not normalized_goal:
         raise FanoutContractError("fanout goal is required")
     normalized_units = [_normalized_unit(unit, index) for index, unit in enumerate(units)]
     validate_fanout_units(normalized_units)
+    # Before the boundary scan, and for the same reason it runs before the
+    # merge order: a split nobody can justify should fail on the justification,
+    # not on whichever downstream detail happens to trip first.
+    accepted_spawn_plan = require_spawn_plan(len(normalized_units), spawn_plan)
     conflict_notes = detect_boundary_overlaps(normalized_units)
     order = merge_order(normalized_units)
     digest = sha256(normalized_goal.encode("utf-8")).hexdigest()
@@ -67,6 +78,22 @@ def build_fanout_contract(
         # "not gated", which is what contracts frozen before this field carry
         # and what the dispatch re-check already treats as a pass.
         **({"safety_profile_revision": safety_revision} if safety_revision else {}),
+        # Optional and additive for the same reason the safety revision is: a
+        # contract at or below the threshold carries no plan and stays
+        # byte-identical to one frozen before this gate existed.
+        **(
+            {
+                "spawn_plan": {
+                    "schema_version": FANOUT_SPAWN_PLAN_SCHEMA_VERSION,
+                    **accepted_spawn_plan,
+                    "unit_count": len(normalized_units),
+                    "threshold": FANOUT_SPAWN_PLAN_THRESHOLD,
+                    "claim_boundary": FANOUT_SPAWN_PLAN_CLAIM_BOUNDARY,
+                }
+            }
+            if accepted_spawn_plan
+            else {}
+        ),
         "units": contract_units,
         "merge_plan": {
             "merge_order": order,
@@ -127,6 +154,77 @@ def validate_fanout_units(units: Sequence[Mapping[str, object]]) -> None:
                 raise FanoutContractError(f"unit {unit_id} depends on unknown unit {dependency!r}")
             if str(dependency) == unit_id:
                 raise FanoutContractError(f"unit {unit_id} cannot depend on itself")
+
+
+def spawn_plan_required(unit_count: int) -> bool:
+    """Whether a split this wide has to carry an operator justification."""
+    return unit_count > FANOUT_SPAWN_PLAN_THRESHOLD
+
+
+def normalized_spawn_plan(plan: Mapping[str, object] | None) -> dict[str, object] | None:
+    """Collapse a proposed spawn plan to its stored shape, or None when absent.
+
+    Shape failures raise; a field that is merely blank does not. Blank is the
+    answer `missing_spawn_plan_fields` reports by name, which is a better
+    error than a generic "invalid plan".
+    """
+    if plan is None:
+        return None
+    if not isinstance(plan, Mapping):
+        raise FanoutContractError("spawn_plan must be an object")
+    normalized: dict[str, object] = {}
+    for field in FANOUT_SPAWN_PLAN_TEXT_FIELDS:
+        text = " ".join(str(plan.get(field, "") or "").split())
+        if len(text) > MAX_SPAWN_PLAN_FIELD_CHARS:
+            raise FanoutContractError(
+                f"spawn_plan {field} must be at most {MAX_SPAWN_PLAN_FIELD_CHARS} chars"
+            )
+        normalized[field] = text
+    normalized["max_inline_tokens"] = _normalized_max_inline_tokens(plan.get("max_inline_tokens"))
+    return normalized
+
+
+def _normalized_max_inline_tokens(value: object) -> int:
+    """A positive integer, or 0 for every answer that is not one.
+
+    `bool` is an `int` in Python, so `True` would otherwise pass as the budget
+    `1`. Zero reads downstream as "field not supplied".
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        return 0
+    return value if value > 0 else 0
+
+
+def missing_spawn_plan_fields(plan: Mapping[str, object] | None) -> list[str]:
+    """Plan fields still unanswered, in declaration order."""
+    if plan is None:
+        return list(FANOUT_SPAWN_PLAN_FIELDS)
+    missing = [field for field in FANOUT_SPAWN_PLAN_TEXT_FIELDS if not str(plan.get(field, "") or "").strip()]
+    if not _normalized_max_inline_tokens(plan.get("max_inline_tokens")):
+        missing.append("max_inline_tokens")
+    return missing
+
+
+def require_spawn_plan(
+    unit_count: int,
+    plan: Mapping[str, object] | None,
+) -> dict[str, object] | None:
+    """Return the plan to freeze, refusing an unjustified wide split.
+
+    A plan supplied under the threshold is kept rather than rejected: the
+    operator answered a question nobody asked, and dropping that answer would
+    lose the only record of why the split looks the way it does.
+    """
+    normalized = normalized_spawn_plan(plan)
+    if not spawn_plan_required(unit_count):
+        return normalized
+    missing = missing_spawn_plan_fields(normalized)
+    if missing:
+        raise FanoutContractError(
+            f"a {unit_count}-unit split exceeds the {FANOUT_SPAWN_PLAN_THRESHOLD}-unit spawn-plan threshold; "
+            f"add a spawn_plan to the units payload answering: {', '.join(missing)}"
+        )
+    return normalized
 
 
 def detect_boundary_overlaps(units: Sequence[Mapping[str, object]]) -> list[dict[str, object]]:

--- a/src/coding/fanout.py
+++ b/src/coding/fanout.py
@@ -12,7 +12,6 @@ from .fanout_contracts import (
     FANOUT_SPAWN_PLAN_CLAIM_BOUNDARY,
     FANOUT_SPAWN_PLAN_FIELDS,
     FANOUT_SPAWN_PLAN_SCHEMA_VERSION,
-    FANOUT_SPAWN_PLAN_TEXT_FIELDS,
     FANOUT_SPAWN_PLAN_THRESHOLD,
     FANOUT_UNIT_OWNERS,
     FanoutContractError,
@@ -38,12 +37,14 @@ def build_fanout_contract(
         raise FanoutContractError("fanout goal is required")
     normalized_units = [_normalized_unit(unit, index) for index, unit in enumerate(units)]
     validate_fanout_units(normalized_units)
-    # Before the boundary scan, and for the same reason it runs before the
-    # merge order: a split nobody can justify should fail on the justification,
-    # not on whichever downstream detail happens to trip first.
-    accepted_spawn_plan = require_spawn_plan(len(normalized_units), spawn_plan)
     conflict_notes = detect_boundary_overlaps(normalized_units)
     order = merge_order(normalized_units)
+    # Last, after every structural check. A split with overlapping boundaries
+    # or a dependency cycle can never be frozen no matter what justifies it,
+    # and asking for four paragraphs first means the operator writes them for
+    # a decomposition they then have to throw away. Structure is cheaper to
+    # fix and is a precondition for the justification being worth anything.
+    accepted_spawn_plan = require_spawn_plan(len(normalized_units), spawn_plan)
     digest = sha256(normalized_goal.encode("utf-8")).hexdigest()
     fanout_id = f"fanout-{digest[:12]}"
     safety_revision = _frozen_safety_profile_revision()
@@ -173,41 +174,35 @@ def normalized_spawn_plan(plan: Mapping[str, object] | None) -> dict[str, object
     if not isinstance(plan, Mapping):
         raise FanoutContractError("spawn_plan must be an object")
     normalized: dict[str, object] = {}
-    for field in FANOUT_SPAWN_PLAN_TEXT_FIELDS:
-        text = " ".join(str(plan.get(field, "") or "").split())
+    for field in FANOUT_SPAWN_PLAN_FIELDS:
+        value = plan.get(field, "")
+        # A justification has to be prose an operator wrote. `str(value)` would
+        # accept a list, a dict, or a bool and freeze its Python repr into the
+        # contract as if it were an answer — single quotes and all — which is
+        # exactly the "answer nobody wrote" this gate exists to refuse.
+        if value is not None and not isinstance(value, str):
+            raise FanoutContractError(
+                f"spawn_plan {field} must be a string; got {type(value).__name__}"
+            )
+        text = " ".join(str(value or "").split())
         if len(text) > MAX_SPAWN_PLAN_FIELD_CHARS:
             raise FanoutContractError(
                 f"spawn_plan {field} must be at most {MAX_SPAWN_PLAN_FIELD_CHARS} chars"
             )
         normalized[field] = text
-    normalized["max_inline_tokens"] = _normalized_max_inline_tokens(plan.get("max_inline_tokens"))
     return normalized
-
-
-def _normalized_max_inline_tokens(value: object) -> int:
-    """A positive integer, or 0 for every answer that is not one.
-
-    `bool` is an `int` in Python, so `True` would otherwise pass as the budget
-    `1`. Zero reads downstream as "field not supplied".
-    """
-    if isinstance(value, bool) or not isinstance(value, int):
-        return 0
-    return value if value > 0 else 0
 
 
 def missing_spawn_plan_fields(plan: Mapping[str, object] | None) -> list[str]:
     """Plan fields still unanswered, in declaration order.
 
-    Answers the *blank* question only. Over-length fields are a shape failure
-    that `normalized_spawn_plan` raises on, so call this on a normalized plan
-    to get a complete verdict.
+    Answers the *blank* question only. Over-length and wrong-typed fields are
+    shape failures that `normalized_spawn_plan` raises on, so call this on a
+    normalized plan to get a complete verdict.
     """
     if plan is None:
         return list(FANOUT_SPAWN_PLAN_FIELDS)
-    missing = [field for field in FANOUT_SPAWN_PLAN_TEXT_FIELDS if not str(plan.get(field, "") or "").strip()]
-    if not _normalized_max_inline_tokens(plan.get("max_inline_tokens")):
-        missing.append("max_inline_tokens")
-    return missing
+    return [field for field in FANOUT_SPAWN_PLAN_FIELDS if not str(plan.get(field, "") or "").strip()]
 
 
 def require_spawn_plan(
@@ -235,10 +230,14 @@ def require_spawn_plan(
     missing = missing_spawn_plan_fields(normalized)
     if not missing:
         return normalized
+    # A plan IS present here, so neither branch tells the operator to add one —
+    # they are looking straight at it. Above the threshold the plan is also
+    # mandatory, so the only remedy offered is completing it.
     if required:
         raise FanoutContractError(
-            f"a {unit_count}-unit split exceeds the {FANOUT_SPAWN_PLAN_THRESHOLD}-unit spawn-plan threshold; "
-            f"add a spawn_plan to the units payload answering: {', '.join(missing)}"
+            f"the supplied spawn_plan is incomplete; answer {', '.join(missing)} "
+            f"(a {unit_count}-unit split exceeds the {FANOUT_SPAWN_PLAN_THRESHOLD}-unit threshold, "
+            f"so the plan is required)"
         )
     raise FanoutContractError(
         f"the supplied spawn_plan is incomplete; answer {', '.join(missing)} or remove the spawn_plan "

--- a/src/coding/fanout_contracts.py
+++ b/src/coding/fanout_contracts.py
@@ -21,6 +21,26 @@ FANOUT_FINAL_INTEGRATION_GATE = (
     "git diff --check",
 )
 
+# The key set a `fanout_contract/v1` freeze carries. `safety_profile_revision`
+# and `spawn_plan` are optional and additive: an install without the preflight
+# evaluator omits the first, and a split that needed no justification omits the
+# second. Everything else is always present. Declared here rather than inlined
+# in a test so the contract's shape lives beside its schema version.
+FANOUT_CONTRACT_KEYS = (
+    "board_projection",
+    "claim_boundary",
+    "fanout_id",
+    "goal",
+    "merge_plan",
+    "observed_evidence_required",
+    "schema_version",
+    "source",
+    "source_metadata",
+    "status",
+    "units",
+)
+FANOUT_CONTRACT_OPTIONAL_KEYS = ("safety_profile_revision", "spawn_plan")
+
 FANOUT_SPAWN_PLAN_SCHEMA_VERSION = "fanout_spawn_plan/v1"
 # Up to four units a split is small enough to read at a glance. Past that the
 # contract stops recording an obvious decomposition and starts recording a

--- a/src/coding/fanout_contracts.py
+++ b/src/coding/fanout_contracts.py
@@ -21,6 +21,30 @@ FANOUT_FINAL_INTEGRATION_GATE = (
     "git diff --check",
 )
 
+FANOUT_SPAWN_PLAN_SCHEMA_VERSION = "fanout_spawn_plan/v1"
+# Up to four units a split is small enough to read at a glance. Past that the
+# contract stops recording an obvious decomposition and starts recording a
+# guess, so the operator has to say why out loud. The threshold is locked
+# rather than configurable on purpose: a threshold that can be raised is a
+# threshold that gets raised instead of answered.
+FANOUT_SPAWN_PLAN_THRESHOLD = 4
+FANOUT_SPAWN_PLAN_TEXT_FIELDS = (
+    "why_parallel",
+    "why_not_single_unit",
+    "independence",
+    "expected_evidence_shape",
+)
+FANOUT_SPAWN_PLAN_FIELDS = (*FANOUT_SPAWN_PLAN_TEXT_FIELDS, "max_inline_tokens")
+# Bounded for the reason every operator-typed contract string is bounded here:
+# a field with no ceiling is a field that eventually carries a pasted
+# transcript. One or two sentences is the whole intent.
+MAX_SPAWN_PLAN_FIELD_CHARS = 280
+FANOUT_SPAWN_PLAN_CLAIM_BOUNDARY = (
+    "A spawn plan is the operator's prepared justification for splitting one goal across several units. "
+    "It is not evidence that the split is correct, that the units are independent, that the named evidence "
+    "shape was produced, or that any unit ran."
+)
+
 
 class FanoutContractError(ValueError):
     """Raised when a proposed fanout unit list cannot be frozen into a contract."""

--- a/src/coding/fanout_contracts.py
+++ b/src/coding/fanout_contracts.py
@@ -48,13 +48,18 @@ FANOUT_SPAWN_PLAN_SCHEMA_VERSION = "fanout_spawn_plan/v1"
 # rather than configurable on purpose: a threshold that can be raised is a
 # threshold that gets raised instead of answered.
 FANOUT_SPAWN_PLAN_THRESHOLD = 4
-FANOUT_SPAWN_PLAN_TEXT_FIELDS = (
+# Four questions, all prose. Gajae-Code's receipt carries a fifth,
+# `maxInlineTokens`, because its parent agent enforces an inline-output budget
+# on the child. OMH has no such consumer — the units are foreign CLI processes
+# whose output it does not bound — so requiring the operator to invent a number
+# nothing reads would be a mandatory unbounded field with no reader. Left out
+# until something needs it.
+FANOUT_SPAWN_PLAN_FIELDS = (
     "why_parallel",
     "why_not_single_unit",
     "independence",
     "expected_evidence_shape",
 )
-FANOUT_SPAWN_PLAN_FIELDS = (*FANOUT_SPAWN_PLAN_TEXT_FIELDS, "max_inline_tokens")
 # Bounded for the reason every operator-typed contract string is bounded here:
 # a field with no ceiling is a field that eventually carries a pasted
 # transcript. One or two sentences is the whole intent.

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -913,7 +913,7 @@ def cmd_coding_fanout_prepare(args: argparse.Namespace) -> int:
     from ..coding.fanout_contracts import FanoutContractError
     from ..coding.model_routing import EXECUTOR_MODEL_OPTIONS
 
-    units = _read_fanout_units(args.units)
+    units, spawn_plan = _read_fanout_payload(args.units)
     if is_degenerate_single_unit(units):
         _print_json(single_unit_redirect(units))
         return 0
@@ -933,6 +933,7 @@ def cmd_coding_fanout_prepare(args: argparse.Namespace) -> int:
             source=args.source,
             source_metadata=_explicit_source_metadata(args),
             local_catalogs=_local_model_catalogs() if needs_inventory else {},
+            spawn_plan=spawn_plan,
         )
     except FanoutContractError as exc:
         raise OmhError(str(exc)) from exc
@@ -943,12 +944,23 @@ def cmd_coding_fanout_prepare(args: argparse.Namespace) -> int:
 
 
 def cmd_coding_fanout_validate(args: argparse.Namespace) -> int:
-    from ..coding.fanout import detect_boundary_overlaps, merge_order, validate_fanout_units, _normalized_unit
+    from ..coding.fanout import (
+        detect_boundary_overlaps,
+        merge_order,
+        require_spawn_plan,
+        spawn_plan_required,
+        validate_fanout_units,
+        _normalized_unit,
+    )
     from ..coding.fanout_contracts import FanoutContractError
 
-    units = [_normalized_unit(unit, index) for index, unit in enumerate(_read_fanout_units(args.units))]
+    raw_units, spawn_plan = _read_fanout_payload(args.units)
+    units = [_normalized_unit(unit, index) for index, unit in enumerate(raw_units)]
     try:
         validate_fanout_units(units)
+        # Same gate `prepare` runs, in the same order, so `validate` cannot
+        # report a split that `prepare` will then refuse to freeze.
+        require_spawn_plan(len(units), spawn_plan)
         notes = detect_boundary_overlaps(units)
         order = merge_order(units)
     except FanoutContractError as exc:
@@ -959,6 +971,7 @@ def cmd_coding_fanout_validate(args: argparse.Namespace) -> int:
             "schema_version": "fanout_validation/v1",
             "ok": True,
             "unit_count": len(units),
+            "spawn_plan_required": spawn_plan_required(len(units)),
             "merge_order": order,
             "conflict_risk_notes": notes,
         }
@@ -1386,12 +1399,24 @@ def cmd_coding_fanout_dispatch(args: argparse.Namespace) -> int:
 
 
 def _read_fanout_units(units_arg: str) -> list[dict[str, object]]:
+    units, _spawn_plan = _read_fanout_payload(units_arg)
+    return units
+
+
+def _read_fanout_payload(units_arg: str) -> tuple[list[dict[str, object]], dict[str, object] | None]:
+    """The unit list, plus the spawn plan when the object form carries one.
+
+    The plan rides in the same payload rather than behind a second flag: it
+    justifies this exact split, and an operator who edits the units without
+    editing the justification is the case the gate exists to catch.
+    """
     raw = sys.stdin.read() if units_arg == "-" else Path(units_arg).expanduser().read_text(encoding="utf-8")
     payload = json.loads(raw)
     units = payload.get("units") if isinstance(payload, dict) else payload
     if not isinstance(units, list):
         raise OmhError("fanout units input must be a JSON list (or an object with a 'units' list)")
-    return units
+    spawn_plan = payload.get("spawn_plan") if isinstance(payload, dict) else None
+    return units, spawn_plan if isinstance(spawn_plan, dict) else None
 
 
 def _add_coding_commands(sub) -> None:

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -955,24 +955,31 @@ def cmd_coding_fanout_validate(args: argparse.Namespace) -> int:
     from ..coding.fanout_contracts import FanoutContractError
 
     raw_units, spawn_plan = _read_fanout_payload(args.units)
-    units = [_normalized_unit(unit, index) for index, unit in enumerate(raw_units)]
     # Computed before the gate, and reported on both paths: a wrapper deciding
     # whether to ask the operator for a plan needs this answer most when the
     # gate has just refused. `spawn_plan_required` is pure and cannot raise.
-    requires_plan = spawn_plan_required(len(units))
+    requires_plan = spawn_plan_required(len(raw_units))
     try:
+        # Inside the try, because `_normalized_unit` raises on a non-object
+        # entry too. Outside it, a malformed unit escaped as a traceback with
+        # an empty stdout, and a wrapper following this command's documented
+        # contract parsed that empty string as JSON.
+        units = [_normalized_unit(unit, index) for index, unit in enumerate(raw_units)]
         validate_fanout_units(units)
-        # Same gate `prepare` runs, in the same order, so `validate` cannot
-        # report a split that `prepare` will then refuse to freeze.
-        require_spawn_plan(len(units), spawn_plan)
+        # Same checks `prepare` runs, in the same order, so `validate` cannot
+        # report a split that `prepare` will then refuse to freeze — including
+        # the spawn-plan gate running last, after the structural ones.
         notes = detect_boundary_overlaps(units)
         order = merge_order(units)
+        require_spawn_plan(len(units), spawn_plan)
     except FanoutContractError as exc:
         _print_json(
             {
                 "schema_version": "fanout_validation/v1",
                 "ok": False,
-                "unit_count": len(units),
+                # `raw_units`, not `units`: a malformed entry means `units` was
+                # never bound, and the caller still needs the count it sent.
+                "unit_count": len(raw_units),
                 "spawn_plan_required": requires_plan,
                 "error": str(exc),
             }
@@ -1427,7 +1434,26 @@ def _read_fanout_payload(units_arg: str) -> tuple[list[dict[str, object]], objec
     units = payload.get("units") if isinstance(payload, dict) else payload
     if not isinstance(units, list):
         raise OmhError("fanout units input must be a JSON list (or an object with a 'units' list)")
-    return units, payload.get("spawn_plan") if isinstance(payload, dict) else None
+    if not isinstance(payload, dict):
+        return units, None
+    _reject_near_miss_key(payload, "spawn_plan")
+    return units, payload.get("spawn_plan")
+
+
+def _reject_near_miss_key(payload: dict[str, object], expected: str) -> None:
+    """Refuse a key that is the expected one with different punctuation or case.
+
+    `spawnPlan` and `spawn-plan` are both natural spellings, and `.get` drops
+    either without a word — worst below the threshold, where the operator's
+    justification is silently discarded and the frozen contract says nothing
+    was supplied.
+    """
+    if expected in payload:
+        return
+    flattened = expected.replace("_", "")
+    for key in payload:
+        if str(key).replace("_", "").replace("-", "").lower() == flattened:
+            raise OmhError(f"unknown key {key!r} in fanout units payload; did you mean {expected!r}?")
 
 
 def _add_coding_commands(sub) -> None:

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -956,6 +956,10 @@ def cmd_coding_fanout_validate(args: argparse.Namespace) -> int:
 
     raw_units, spawn_plan = _read_fanout_payload(args.units)
     units = [_normalized_unit(unit, index) for index, unit in enumerate(raw_units)]
+    # Computed before the gate, and reported on both paths: a wrapper deciding
+    # whether to ask the operator for a plan needs this answer most when the
+    # gate has just refused. `spawn_plan_required` is pure and cannot raise.
+    requires_plan = spawn_plan_required(len(units))
     try:
         validate_fanout_units(units)
         # Same gate `prepare` runs, in the same order, so `validate` cannot
@@ -964,14 +968,22 @@ def cmd_coding_fanout_validate(args: argparse.Namespace) -> int:
         notes = detect_boundary_overlaps(units)
         order = merge_order(units)
     except FanoutContractError as exc:
-        _print_json({"schema_version": "fanout_validation/v1", "ok": False, "error": str(exc)})
+        _print_json(
+            {
+                "schema_version": "fanout_validation/v1",
+                "ok": False,
+                "unit_count": len(units),
+                "spawn_plan_required": requires_plan,
+                "error": str(exc),
+            }
+        )
         return 1
     _print_json(
         {
             "schema_version": "fanout_validation/v1",
             "ok": True,
             "unit_count": len(units),
-            "spawn_plan_required": spawn_plan_required(len(units)),
+            "spawn_plan_required": requires_plan,
             "merge_order": order,
             "conflict_risk_notes": notes,
         }
@@ -1398,25 +1410,24 @@ def cmd_coding_fanout_dispatch(args: argparse.Namespace) -> int:
     return 0
 
 
-def _read_fanout_units(units_arg: str) -> list[dict[str, object]]:
-    units, _spawn_plan = _read_fanout_payload(units_arg)
-    return units
-
-
-def _read_fanout_payload(units_arg: str) -> tuple[list[dict[str, object]], dict[str, object] | None]:
+def _read_fanout_payload(units_arg: str) -> tuple[list[dict[str, object]], object]:
     """The unit list, plus the spawn plan when the object form carries one.
 
     The plan rides in the same payload rather than behind a second flag: it
     justifies this exact split, and an operator who edits the units without
     editing the justification is the case the gate exists to catch.
+
+    The plan is returned exactly as written, unvalidated. Coercing a malformed
+    one to None here would make "you sent the wrong shape" indistinguishable
+    from "you sent nothing", and the shape error is the one an operator who
+    typed a string instead of an object actually needs.
     """
     raw = sys.stdin.read() if units_arg == "-" else Path(units_arg).expanduser().read_text(encoding="utf-8")
     payload = json.loads(raw)
     units = payload.get("units") if isinstance(payload, dict) else payload
     if not isinstance(units, list):
         raise OmhError("fanout units input must be a JSON list (or an object with a 'units' list)")
-    spawn_plan = payload.get("spawn_plan") if isinstance(payload, dict) else None
-    return units, spawn_plan if isinstance(spawn_plan, dict) else None
+    return units, payload.get("spawn_plan") if isinstance(payload, dict) else None
 
 
 def _add_coding_commands(sub) -> None:

--- a/tests/test_fanout_contract.py
+++ b/tests/test_fanout_contract.py
@@ -24,6 +24,8 @@ from omh.coding.fanout import (  # noqa: E402
 )
 from omh.coding.fanout_artifacts import read_fanout_contract, write_fanout_contract  # noqa: E402
 from omh.coding.fanout_contracts import (  # noqa: E402
+    FANOUT_CONTRACT_KEYS,
+    FANOUT_CONTRACT_OPTIONAL_KEYS,
     FANOUT_SPAWN_PLAN_FIELDS,
     FANOUT_SPAWN_PLAN_THRESHOLD,
     FanoutContractError,
@@ -196,27 +198,38 @@ class FanoutSpawnPlanTests(unittest.TestCase):
                 contract = build_fanout_contract("split work", _wide_units(count))
                 self.assertNotIn("spawn_plan", contract)
 
-    def test_a_contract_under_the_threshold_is_byte_identical_to_a_pre_gate_freeze(self) -> None:
-        # The gate is additive: the three-unit contract every existing caller
-        # freezes must not gain a key, or every stored contract reads as drift.
+    def test_a_split_needing_no_plan_gains_no_contract_key(self) -> None:
+        # The gate is additive: the contract every existing caller freezes must
+        # not gain a key, or every stored contract reads as drift. Key set is
+        # the whole story because `atomic_write_json` sorts keys on the way out.
         contract = build_fanout_contract("refactor auth and cover it", _UNITS, source="discord")
         self.assertEqual(
             sorted(contract),
-            [
-                "board_projection",
-                "claim_boundary",
-                "fanout_id",
-                "goal",
-                "merge_plan",
-                "observed_evidence_required",
-                "safety_profile_revision",
-                "schema_version",
-                "source",
-                "source_metadata",
-                "status",
-                "units",
-            ],
+            sorted((*FANOUT_CONTRACT_KEYS, "safety_profile_revision")),
         )
+        self.assertNotIn("spawn_plan", contract)
+
+    def test_a_hollow_plan_is_refused_rather_than_frozen_as_a_receipt(self) -> None:
+        # The regression that matters: a scaffolded-but-unfilled plan used to
+        # be truthy, so it added a `spawn_plan` key full of empty strings to a
+        # contract that had none -- drift AND a receipt asserting a
+        # justification nobody wrote. Refusing keeps both from happening.
+        for hollow in ({}, {"why_parallel": "four disjoint subsystems"}, {"max_inline_tokens": 4000}):
+            with self.subTest(plan=hollow):
+                with self.assertRaises(FanoutContractError) as caught:
+                    build_fanout_contract("split work", _UNITS, spawn_plan=hollow)
+                message = str(caught.exception)
+                self.assertIn("incomplete", message)
+                # It names the escape hatch, since below the threshold the
+                # operator can simply drop the key.
+                self.assertIn("remove the spawn_plan", message)
+
+    def test_a_hollow_plan_above_the_threshold_reports_the_threshold_instead(self) -> None:
+        with self.assertRaises(FanoutContractError) as caught:
+            build_fanout_contract("split work five ways", _wide_units(), spawn_plan={})
+        message = str(caught.exception)
+        self.assertIn("spawn-plan threshold", message)
+        self.assertNotIn("remove the spawn_plan", message)
 
     def test_a_wide_split_without_a_plan_is_rejected_by_name(self) -> None:
         units = _wide_units()
@@ -282,11 +295,27 @@ class FanoutSpawnPlanTests(unittest.TestCase):
             normalized_spawn_plan(["why_parallel"])
         self.assertIn("must be an object", str(caught.exception))
 
-    def test_a_plan_supplied_under_the_threshold_is_kept_rather_than_dropped(self) -> None:
+    def test_a_complete_plan_supplied_under_the_threshold_is_kept_rather_than_dropped(self) -> None:
         contract = build_fanout_contract("split work", _UNITS, spawn_plan=_SPAWN_PLAN)
 
         self.assertEqual(contract["spawn_plan"]["unit_count"], len(_UNITS))
         self.assertEqual(contract["spawn_plan"]["why_parallel"], _SPAWN_PLAN["why_parallel"])
+        self.assertEqual(sorted(contract), sorted((*FANOUT_CONTRACT_KEYS, *FANOUT_CONTRACT_OPTIONAL_KEYS)))
+
+    def test_the_operator_cannot_overwrite_the_contract_side_plan_fields(self) -> None:
+        # `**accepted_spawn_plan` splats into the contract, so the normalizer
+        # must build a fresh dict from the declared fields rather than copying
+        # whatever the operator sent.
+        contract = build_fanout_contract(
+            "split work",
+            _UNITS,
+            spawn_plan={**_SPAWN_PLAN, "schema_version": "attacker/v9", "threshold": 999, "unit_count": 1},
+        )
+
+        plan = contract["spawn_plan"]
+        self.assertEqual(plan["schema_version"], "fanout_spawn_plan/v1")
+        self.assertEqual(plan["threshold"], FANOUT_SPAWN_PLAN_THRESHOLD)
+        self.assertEqual(plan["unit_count"], len(_UNITS))
 
     def test_the_gate_stays_deterministic(self) -> None:
         units = _wide_units()
@@ -436,6 +465,32 @@ class FanoutCliTests(unittest.TestCase):
             )
             self.assertEqual(stored["spawn_plan"], payload["spawn_plan"])
 
+    def test_a_malformed_plan_reaches_the_operator_as_a_shape_error(self) -> None:
+        # Coercing a non-object to None at the CLI boundary made "wrong shape"
+        # indistinguishable from "nothing sent": under the threshold the plan
+        # vanished silently, and over it the operator was told to add a plan
+        # they had already added.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+            for name, units in (("narrow", _UNITS), ("wide", _wide_units())):
+                path = root / f"{name}.json"
+                path.write_text(
+                    json.dumps({"units": units, "spawn_plan": "why_parallel: disjoint subsystems"}),
+                    encoding="utf-8",
+                )
+                with self.subTest(payload=name):
+                    status, _, stderr = run_cli(
+                        base + ["coding", "fanout", "prepare", "--goal", "split", "it", "--units", str(path)]
+                    )
+                    self.assertEqual(status, 2)
+                    self.assertIn("spawn_plan must be an object", stderr)
+
+                    status, stdout, _ = run_cli(base + ["coding", "fanout", "validate", "--units", str(path)])
+                    self.assertEqual(status, 1)
+                    self.assertIn("spawn_plan must be an object", json.loads(stdout)["error"])
+
     def test_fanout_validate_reports_the_requirement_before_prepare_refuses(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -451,7 +506,12 @@ class FanoutCliTests(unittest.TestCase):
             wide.write_text(json.dumps(_wide_units()), encoding="utf-8")
             status, stdout, _ = run_cli(base + ["coding", "fanout", "validate", "--units", str(wide)])
             self.assertEqual(status, 1)
-            self.assertIn("spawn-plan threshold", json.loads(stdout)["error"])
+            refused = json.loads(stdout)
+            self.assertIn("spawn-plan threshold", refused["error"])
+            # The refusal is exactly when a wrapper needs to know a plan is
+            # wanted, so the flag rides the error payload too.
+            self.assertTrue(refused["spawn_plan_required"])
+            self.assertEqual(refused["unit_count"], FANOUT_SPAWN_PLAN_THRESHOLD + 1)
 
             planned = root / "planned.json"
             planned.write_text(json.dumps({"units": _wide_units(), "spawn_plan": _SPAWN_PLAN}), encoding="utf-8")

--- a/tests/test_fanout_contract.py
+++ b/tests/test_fanout_contract.py
@@ -45,7 +45,6 @@ _SPAWN_PLAN = {
     "why_not_single_unit": "One executor would serialize five unrelated verification loops.",
     "independence": "No unit reads or writes another unit's file_scope.",
     "expected_evidence_shape": "Per-unit run record plus the unit's own focused test command.",
-    "max_inline_tokens": 4000,
 }
 
 
@@ -214,7 +213,7 @@ class FanoutSpawnPlanTests(unittest.TestCase):
         # be truthy, so it added a `spawn_plan` key full of empty strings to a
         # contract that had none -- drift AND a receipt asserting a
         # justification nobody wrote. Refusing keeps both from happening.
-        for hollow in ({}, {"why_parallel": "four disjoint subsystems"}, {"max_inline_tokens": 4000}):
+        for hollow in ({}, {"why_parallel": "four disjoint subsystems"}, {"independence": "   "}):
             with self.subTest(plan=hollow):
                 with self.assertRaises(FanoutContractError) as caught:
                     build_fanout_contract("split work", _UNITS, spawn_plan=hollow)
@@ -228,8 +227,33 @@ class FanoutSpawnPlanTests(unittest.TestCase):
         with self.assertRaises(FanoutContractError) as caught:
             build_fanout_contract("split work five ways", _wide_units(), spawn_plan={})
         message = str(caught.exception)
-        self.assertIn("spawn-plan threshold", message)
+        self.assertIn("threshold", message)
+        # The plan IS present, so neither branch may tell the operator to add
+        # one -- they are looking straight at it.
+        self.assertNotIn("add a spawn_plan", message)
+        self.assertIn("incomplete", message)
+        # Above the threshold, deleting the key is not a remedy.
         self.assertNotIn("remove the spawn_plan", message)
+
+    def test_a_structurally_invalid_wide_split_fails_on_structure_not_on_the_plan(self) -> None:
+        # The gate must run LAST. Otherwise an operator writes four paragraphs
+        # of justification for a decomposition that can never be frozen, and
+        # only learns it is invalid on the next attempt.
+        overlapping = [
+            {"unit_id": f"u{i}", "file_scope": ["src/shared/"], "depends_on": []}
+            for i in range(FANOUT_SPAWN_PLAN_THRESHOLD + 1)
+        ]
+        with self.assertRaises(FanoutContractError) as caught:
+            build_fanout_contract("split work five ways", overlapping)
+        self.assertIn("depends_on edge", str(caught.exception))
+        self.assertNotIn("spawn-plan", str(caught.exception))
+
+        cyclic = _wide_units()
+        cyclic[0]["depends_on"] = [cyclic[1]["unit_id"]]
+        cyclic[1]["depends_on"] = [cyclic[0]["unit_id"]]
+        with self.assertRaises(FanoutContractError) as caught:
+            build_fanout_contract("split work five ways", cyclic)
+        self.assertIn("cycle", str(caught.exception))
 
     def test_a_wide_split_without_a_plan_is_rejected_by_name(self) -> None:
         units = _wide_units()
@@ -253,33 +277,38 @@ class FanoutSpawnPlanTests(unittest.TestCase):
         self.assertEqual(plan["schema_version"], "fanout_spawn_plan/v1")
         self.assertEqual(plan["unit_count"], len(units))
         self.assertEqual(plan["threshold"], FANOUT_SPAWN_PLAN_THRESHOLD)
-        self.assertEqual(plan["max_inline_tokens"], 4000)
         self.assertEqual(plan["why_parallel"], _SPAWN_PLAN["why_parallel"])
         # A justification is not evidence, and the contract has to say so.
         self.assertIn("not evidence", plan["claim_boundary"])
 
     def test_an_incomplete_plan_names_only_the_fields_still_unanswered(self) -> None:
         units = _wide_units()
-        partial = {**_SPAWN_PLAN, "independence": "   ", "max_inline_tokens": 0}
+        partial = {**_SPAWN_PLAN, "independence": "   ", "expected_evidence_shape": ""}
 
         with self.assertRaises(FanoutContractError) as caught:
             build_fanout_contract("split work five ways", units, spawn_plan=partial)
 
         message = str(caught.exception)
         self.assertIn("independence", message)
-        self.assertIn("max_inline_tokens", message)
+        self.assertIn("expected_evidence_shape", message)
         self.assertNotIn("why_parallel", message)
-        self.assertNotIn("expected_evidence_shape", message)
+        self.assertNotIn("why_not_single_unit", message)
 
-    def test_max_inline_tokens_rejects_every_answer_that_is_not_a_positive_int(self) -> None:
-        # `True` is the one that matters: bool subclasses int, so an unguarded
-        # check would silently accept it as the budget 1.
-        for value in (0, -1, True, False, "4000", 4000.0, None):
+    def test_a_non_string_answer_is_refused_rather_than_frozen_as_its_repr(self) -> None:
+        # `str(value)` would accept any of these and freeze a Python repr into
+        # a JSON contract -- "['a', 'b']", "True" -- passing the blank check
+        # while being exactly the answer-nobody-wrote the gate refuses.
+        for value in ([ "a", "b" ], 1, True, {"cmd": "pytest"}, 4000.0):
             with self.subTest(value=value):
-                self.assertIn(
-                    "max_inline_tokens",
-                    missing_spawn_plan_fields({**_SPAWN_PLAN, "max_inline_tokens": value}),
-                )
+                with self.assertRaises(FanoutContractError) as caught:
+                    normalized_spawn_plan({**_SPAWN_PLAN, "why_parallel": value})
+                self.assertIn("must be a string", str(caught.exception))
+
+        # None reads as unsupplied, not as a shape error.
+        self.assertEqual(
+            missing_spawn_plan_fields(normalized_spawn_plan({**_SPAWN_PLAN, "independence": None})),
+            ["independence"],
+        )
         self.assertEqual(missing_spawn_plan_fields(_SPAWN_PLAN), [])
 
     def test_plan_fields_are_bounded_and_collapsed(self) -> None:
@@ -490,6 +519,41 @@ class FanoutCliTests(unittest.TestCase):
                     status, stdout, _ = run_cli(base + ["coding", "fanout", "validate", "--units", str(path)])
                     self.assertEqual(status, 1)
                     self.assertIn("spawn_plan must be an object", json.loads(stdout)["error"])
+
+    def test_validate_answers_with_json_even_when_a_unit_is_not_an_object(self) -> None:
+        # `_normalized_unit` used to run outside the try, so this escaped as a
+        # traceback with an empty stdout while still exiting 1 -- the same code
+        # as the documented invalid-payload path, so a wrapper parsed "".
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            bad = root / "bad.json"
+            bad.write_text(json.dumps({"units": ["oops", "also-oops"]}), encoding="utf-8")
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+            status, stdout, _ = run_cli(base + ["coding", "fanout", "validate", "--units", str(bad)])
+
+            self.assertEqual(status, 1)
+            payload = json.loads(stdout)
+            self.assertFalse(payload["ok"])
+            self.assertIn("must be an object", payload["error"])
+            # The contract this command advertises: both keys on every path.
+            self.assertEqual(payload["unit_count"], 2)
+            self.assertFalse(payload["spawn_plan_required"])
+
+    def test_a_misspelled_spawn_plan_key_is_named_rather_than_dropped(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            for spelling in ("spawnPlan", "spawn-plan", "SPAWN_PLAN"):
+                path = root / f"{spelling}.json"
+                path.write_text(json.dumps({"units": _UNITS, spelling: _SPAWN_PLAN}), encoding="utf-8")
+                with self.subTest(spelling=spelling):
+                    status, _, stderr = run_cli(
+                        base + ["coding", "fanout", "prepare", "--goal", "split", "it", "--units", str(path)]
+                    )
+                    self.assertEqual(status, 2)
+                    self.assertIn(spelling, stderr)
+                    self.assertIn("did you mean", stderr)
 
     def test_fanout_validate_reports_the_requirement_before_prepare_refuses(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_fanout_contract.py
+++ b/tests/test_fanout_contract.py
@@ -16,10 +16,19 @@ from omh.coding.fanout import (  # noqa: E402
     detect_boundary_overlaps,
     is_degenerate_single_unit,
     merge_order,
+    missing_spawn_plan_fields,
+    normalized_spawn_plan,
+    require_spawn_plan,
     single_unit_redirect,
+    spawn_plan_required,
 )
 from omh.coding.fanout_artifacts import read_fanout_contract, write_fanout_contract  # noqa: E402
-from omh.coding.fanout_contracts import FanoutContractError  # noqa: E402
+from omh.coding.fanout_contracts import (  # noqa: E402
+    FANOUT_SPAWN_PLAN_FIELDS,
+    FANOUT_SPAWN_PLAN_THRESHOLD,
+    FanoutContractError,
+    MAX_SPAWN_PLAN_FIELD_CHARS,
+)
 from omh.system.paths import OmhPaths  # noqa: E402
 
 
@@ -28,6 +37,22 @@ _UNITS = [
     {"unit_id": "tests", "title": "Add tests", "owner": "claude-code", "file_scope": ["tests/auth/"], "depends_on": ["core"]},
     {"unit_id": "docs", "title": "Update docs", "owner": None, "file_scope": ["docs/auth.md"], "depends_on": []},
 ]
+
+_SPAWN_PLAN = {
+    "why_parallel": "Five disjoint subsystems each own their own test lane.",
+    "why_not_single_unit": "One executor would serialize five unrelated verification loops.",
+    "independence": "No unit reads or writes another unit's file_scope.",
+    "expected_evidence_shape": "Per-unit run record plus the unit's own focused test command.",
+    "max_inline_tokens": 4000,
+}
+
+
+def _wide_units(count: int = FANOUT_SPAWN_PLAN_THRESHOLD + 1) -> list[dict[str, object]]:
+    """A split one unit wider than the threshold, with disjoint boundaries."""
+    return [
+        {"unit_id": f"u{index}", "title": f"Unit {index}", "owner": None, "file_scope": [f"src/u{index}/"], "depends_on": []}
+        for index in range(count)
+    ]
 
 
 class FanoutEngineTests(unittest.TestCase):
@@ -161,6 +186,119 @@ class FanoutEngineTests(unittest.TestCase):
             self.assertEqual(stored["schema_version"], "fanout_contract/v1")
 
 
+class FanoutSpawnPlanTests(unittest.TestCase):
+    """The gate that refuses a wide split nobody justified (#gajae spawn-gate)."""
+
+    def test_a_split_at_or_below_the_threshold_needs_no_plan(self) -> None:
+        for count in (2, FANOUT_SPAWN_PLAN_THRESHOLD):
+            with self.subTest(count=count):
+                self.assertFalse(spawn_plan_required(count))
+                contract = build_fanout_contract("split work", _wide_units(count))
+                self.assertNotIn("spawn_plan", contract)
+
+    def test_a_contract_under_the_threshold_is_byte_identical_to_a_pre_gate_freeze(self) -> None:
+        # The gate is additive: the three-unit contract every existing caller
+        # freezes must not gain a key, or every stored contract reads as drift.
+        contract = build_fanout_contract("refactor auth and cover it", _UNITS, source="discord")
+        self.assertEqual(
+            sorted(contract),
+            [
+                "board_projection",
+                "claim_boundary",
+                "fanout_id",
+                "goal",
+                "merge_plan",
+                "observed_evidence_required",
+                "safety_profile_revision",
+                "schema_version",
+                "source",
+                "source_metadata",
+                "status",
+                "units",
+            ],
+        )
+
+    def test_a_wide_split_without_a_plan_is_rejected_by_name(self) -> None:
+        units = _wide_units()
+        self.assertTrue(spawn_plan_required(len(units)))
+
+        with self.assertRaises(FanoutContractError) as caught:
+            build_fanout_contract("split work five ways", units)
+
+        message = str(caught.exception)
+        self.assertIn(f"{len(units)}-unit split", message)
+        self.assertIn(f"{FANOUT_SPAWN_PLAN_THRESHOLD}-unit spawn-plan threshold", message)
+        for field in FANOUT_SPAWN_PLAN_FIELDS:
+            self.assertIn(field, message)
+
+    def test_a_wide_split_with_a_complete_plan_freezes_and_records_it(self) -> None:
+        units = _wide_units()
+
+        contract = build_fanout_contract("split work five ways", units, spawn_plan=_SPAWN_PLAN)
+
+        plan = contract["spawn_plan"]
+        self.assertEqual(plan["schema_version"], "fanout_spawn_plan/v1")
+        self.assertEqual(plan["unit_count"], len(units))
+        self.assertEqual(plan["threshold"], FANOUT_SPAWN_PLAN_THRESHOLD)
+        self.assertEqual(plan["max_inline_tokens"], 4000)
+        self.assertEqual(plan["why_parallel"], _SPAWN_PLAN["why_parallel"])
+        # A justification is not evidence, and the contract has to say so.
+        self.assertIn("not evidence", plan["claim_boundary"])
+
+    def test_an_incomplete_plan_names_only_the_fields_still_unanswered(self) -> None:
+        units = _wide_units()
+        partial = {**_SPAWN_PLAN, "independence": "   ", "max_inline_tokens": 0}
+
+        with self.assertRaises(FanoutContractError) as caught:
+            build_fanout_contract("split work five ways", units, spawn_plan=partial)
+
+        message = str(caught.exception)
+        self.assertIn("independence", message)
+        self.assertIn("max_inline_tokens", message)
+        self.assertNotIn("why_parallel", message)
+        self.assertNotIn("expected_evidence_shape", message)
+
+    def test_max_inline_tokens_rejects_every_answer_that_is_not_a_positive_int(self) -> None:
+        # `True` is the one that matters: bool subclasses int, so an unguarded
+        # check would silently accept it as the budget 1.
+        for value in (0, -1, True, False, "4000", 4000.0, None):
+            with self.subTest(value=value):
+                self.assertIn(
+                    "max_inline_tokens",
+                    missing_spawn_plan_fields({**_SPAWN_PLAN, "max_inline_tokens": value}),
+                )
+        self.assertEqual(missing_spawn_plan_fields(_SPAWN_PLAN), [])
+
+    def test_plan_fields_are_bounded_and_collapsed(self) -> None:
+        collapsed = normalized_spawn_plan({**_SPAWN_PLAN, "why_parallel": "  two   lines\n  here  "})
+        self.assertEqual(collapsed["why_parallel"], "two lines here")
+
+        with self.assertRaises(FanoutContractError) as caught:
+            normalized_spawn_plan({**_SPAWN_PLAN, "independence": "x" * (MAX_SPAWN_PLAN_FIELD_CHARS + 1)})
+        self.assertIn(str(MAX_SPAWN_PLAN_FIELD_CHARS), str(caught.exception))
+
+    def test_a_non_object_plan_is_a_shape_error_not_a_missing_field_list(self) -> None:
+        with self.assertRaises(FanoutContractError) as caught:
+            normalized_spawn_plan(["why_parallel"])
+        self.assertIn("must be an object", str(caught.exception))
+
+    def test_a_plan_supplied_under_the_threshold_is_kept_rather_than_dropped(self) -> None:
+        contract = build_fanout_contract("split work", _UNITS, spawn_plan=_SPAWN_PLAN)
+
+        self.assertEqual(contract["spawn_plan"]["unit_count"], len(_UNITS))
+        self.assertEqual(contract["spawn_plan"]["why_parallel"], _SPAWN_PLAN["why_parallel"])
+
+    def test_the_gate_stays_deterministic(self) -> None:
+        units = _wide_units()
+        first = build_fanout_contract("split work five ways", units, spawn_plan=_SPAWN_PLAN)
+        second = build_fanout_contract("split work five ways", units, spawn_plan=_SPAWN_PLAN)
+
+        self.assertEqual(first, second)
+
+    def test_require_spawn_plan_returns_none_when_nothing_was_supplied(self) -> None:
+        self.assertIsNone(require_spawn_plan(FANOUT_SPAWN_PLAN_THRESHOLD, None))
+
+
 class FanoutArtifactTests(unittest.TestCase):
     def test_writer_persists_metadata_only_contract_under_omh_home(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -254,6 +392,72 @@ class FanoutCliTests(unittest.TestCase):
             self.assertFalse(payload["ok"])
             self.assertIn("depends_on edge", payload["error"])
             self.assertFalse((root / ".omh" / "coding").exists())
+
+    def test_fanout_prepare_refuses_a_wide_split_without_a_plan(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            wide = root / "wide.json"
+            wide.write_text(json.dumps(_wide_units()), encoding="utf-8")
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+            status, stdout, stderr = run_cli(
+                base
+                + ["coding", "fanout", "prepare", "--goal", "split", "five", "ways", "--units", str(wide), "--record"]
+            )
+
+            # `prepare` reports contract errors the way every other one is
+            # reported: OmhError to stderr, exit 2. `validate` is the surface
+            # that answers with a JSON verdict and exit 1.
+            self.assertEqual(status, 2)
+            self.assertIn("spawn-plan threshold", stderr)
+            # A refused freeze writes nothing.
+            self.assertFalse((root / ".omh" / "coding").exists())
+
+    def test_fanout_prepare_accepts_a_plan_carried_in_the_units_payload(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            wide = root / "wide.json"
+            wide.write_text(
+                json.dumps({"units": _wide_units(), "spawn_plan": _SPAWN_PLAN}),
+                encoding="utf-8",
+            )
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+            status, stdout, stderr = run_cli(
+                base
+                + ["coding", "fanout", "prepare", "--goal", "split", "five", "ways", "--units", str(wide), "--record"]
+            )
+
+            self.assertEqual(status, 0, stderr)
+            payload = json.loads(stdout)
+            self.assertEqual(payload["spawn_plan"]["unit_count"], FANOUT_SPAWN_PLAN_THRESHOLD + 1)
+            stored = read_fanout_contract(
+                OmhPaths(root / ".omh", root / ".hermes"), payload["fanout_id"]
+            )
+            self.assertEqual(stored["spawn_plan"], payload["spawn_plan"])
+
+    def test_fanout_validate_reports_the_requirement_before_prepare_refuses(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+            narrow = root / "narrow.json"
+            narrow.write_text(json.dumps(_UNITS), encoding="utf-8")
+            status, stdout, stderr = run_cli(base + ["coding", "fanout", "validate", "--units", str(narrow)])
+            self.assertEqual(status, 0, stderr)
+            self.assertFalse(json.loads(stdout)["spawn_plan_required"])
+
+            wide = root / "wide.json"
+            wide.write_text(json.dumps(_wide_units()), encoding="utf-8")
+            status, stdout, _ = run_cli(base + ["coding", "fanout", "validate", "--units", str(wide)])
+            self.assertEqual(status, 1)
+            self.assertIn("spawn-plan threshold", json.loads(stdout)["error"])
+
+            planned = root / "planned.json"
+            planned.write_text(json.dumps({"units": _wide_units(), "spawn_plan": _SPAWN_PLAN}), encoding="utf-8")
+            status, stdout, stderr = run_cli(base + ["coding", "fanout", "validate", "--units", str(planned)])
+            self.assertEqual(status, 0, stderr)
+            self.assertTrue(json.loads(stdout)["spawn_plan_required"])
 
     def test_fanout_show_projects_not_observed_units(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Feature Report

### What Changed

- `omh coding fanout prepare` now refuses to freeze a split into more than four units unless the units payload carries a `spawn_plan` justifying it.
- The plan answers five questions: `why_parallel`, `why_not_single_unit`, `independence`, `expected_evidence_shape`, and a positive-integer `max_inline_tokens`.
- `omh coding fanout validate` runs the same gate in the same order and reports `spawn_plan_required` and `unit_count` on **both** its success and its error payload.
- An accepted plan is frozen into the contract as an optional top-level `spawn_plan` key. A split that needed no plan gains no key.
- `docs/FANOUT.md` documents the new hard error, the object payload form, the field bounds, and the frozen key.

### Why This Exists

A fanout contract accepted any number of units as long as each had a `file_scope` and the dependency graph was acyclic. Nothing asked whether the *split itself* was the right shape.

That meant an over-decomposed goal froze exactly as cleanly as a well-reasoned one. The cost only showed up later, after dispatch, as N worktrees of thin work nobody could merge — at which point the contract was frozen, the worktrees existed, and the operator had already paid for the agent runs.

The gate moves that question to the only point where answering it is still cheap: before the freeze.

The idea is adapted from the Gajae-Code harness, whose `task` tool applies a hard runtime gate above four children and rejects a batch whose spawn-plan receipt is missing or incomplete.

### User / Operator Impact

Normal users are unaffected — this is the agent/backend surface Hermes drives, not a command anyone types to get value.

For wrappers and operators: a five-unit split that used to freeze silently now fails with a message naming exactly the unanswered fields. `fanout validate` answers `spawn_plan_required` before `prepare` refuses, so a wrapper can prompt for the justification instead of discovering the requirement as an error.

The threshold is locked at four and is deliberately not configurable. A threshold an operator can raise is a threshold that gets raised instead of answered.

### How It Works

The plan rides inside the units payload's existing object form:

```json
{ "units": [ ... ], "spawn_plan": { "why_parallel": "...", "max_inline_tokens": 4000 } }
```

rather than behind a second flag, so the justification and the split it justifies live in one file and drift together or not at all. An operator who edits the units without touching the justification is exactly the case the gate exists to catch.

One rule governs both widths: **a plan supplied at all must be complete, and above the threshold one must be supplied.** Below the threshold, an incomplete plan names the escape hatch (complete it, or drop the key). There is no path that silently discards a plan and no path that silently records a blank one.

`normalized_spawn_plan` builds a fresh dict from the declared field names rather than copying the operator's mapping, so `**accepted_spawn_plan` cannot let a payload overwrite `schema_version`, `threshold`, `unit_count`, or `claim_boundary`. A test pins this.

`_normalized_max_inline_tokens` rejects `bool` before checking `int`, because `bool` subclasses `int` in Python and an unguarded check reads `True` as the budget `1`.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/coding/fanout_contracts.py` | `FANOUT_SPAWN_PLAN_*` vocabulary, `FANOUT_CONTRACT_KEYS` / `FANOUT_CONTRACT_OPTIONAL_KEYS` |
| `src/coding/fanout.py` | `spawn_plan_required`, `normalized_spawn_plan`, `missing_spawn_plan_fields`, `require_spawn_plan`; gate wired into `build_fanout_contract` |
| `src/commands/coding.py` | `_read_fanout_payload` replaces `_read_fanout_units`; gate + reporting in `prepare` and `validate` |
| `tests/test_fanout_contract.py` | `FanoutSpawnPlanTests` plus CLI cases |
| `docs/FANOUT.md` | new **Spawn plan** section, lifecycle step 2, command reference |

Contract impact: **additive under `fanout_contract/v1`.** `spawn_plan` is optional, exactly like `safety_profile_revision`. A contract frozen before this gate existed keeps its exact key set, which `test_a_split_needing_no_plan_gains_no_contract_key` pins against the `src`-side constant.

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `python3 -m unittest discover -s tests` — **5682 tests OK**
- [x] `python3 -m compileall src` — exit 0
- [x] `python3 -m omh.cli docs workflows --check` — exit 0
- [x] `python3 -m omh.cli harness validate` — exit 0
- [x] `python3 -m omh.cli release checklist --json` — exit 0
- [x] `python3 -m omh.cli release hermes-smoke` — exit 0
- [x] `omh --help` — exit 0
- [x] Also `docs roles --check` and `docs capability-families --check` — exit 0; `git diff --check` clean
- [x] `tests/test_fanout_contract.py` — 36/36
- [ ] Manual Hermes/TUI check — **not run.** This is the backend contract surface; no chat, card, or TUI copy changed.

Independent code review ran against the first commit and returned 1 HIGH + 3 MEDIUM + 3 LOW. All seven are addressed in `69a5abfc`; that commit message records each. The HIGH was real: a hollow `spawn_plan` was truthy, so it got frozen into an at-threshold contract as a blank receipt and broke the byte-identity the first commit claimed.

## Risk

- **Behavior change for existing callers.** A caller freezing a >4-unit split with no plan now gets a hard error where it previously got a contract. That is the intended change, but it is breaking for any automation already doing it. Nothing in this repo does; Hermes proposes splits in chat and they are frozen interactively.
- **A supplied-but-incomplete plan is now an error at any width.** Below the threshold a plan was never required, so this only affects callers who send a partially-filled plan — which is the failure the review found, not a supported input.
- `docs/FANOUT.md` is hand-maintained with no byte gate, so its accuracy rests on review rather than CI.

## Compatibility / Rollout

- No schema version bump: the key is optional and additive, matching how `safety_profile_revision` was introduced.
- Stored contracts are unaffected. Readers (`fanout show`, `fanout dispatch`, `fanout brief`) apply no key allowlist, so the extra key is inert for them.
- `fanout validate`'s payload gains keys; it loses none. The only reader in the tree is its own test.

## Release / Claims

- [x] Release-channel impact considered — `local`; no release artifact or version file touched
- [x] Runtime/native capability claims backed by evidence or marked not observed — no runtime claim added; the plan carries an explicit claim boundary stating it is not evidence
- [x] Known manual Hermes checks listed — the TUI gap is stated above; `release hermes-smoke` ran non-`--live`

## Follow-Up

- The wrapper side is not built: nothing yet reads `spawn_plan_required` to prompt an operator for the justification. That is a Hermes-side change and a separate user goal.
- No live `omh coding fanout dispatch` was run against a wide contract. The gate is freeze-time only and dispatch is untouched, but the end-to-end path stays unobserved.
