### PR TITLE
feat: measure what a failed fanout unit left behind before calling it a loss

### DIFF
--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -223,17 +223,33 @@ goal to Hermes in chat; these commands are the backend surface.
   dispatch base and attaches a `recovery` record to the unit result:
   `outcome` (`recovery_available`, `no_changes`, or `capture_failed`),
   the changed path count and names (capped, with `paths_truncated`),
-  `lines_changed`, `diff_bytes`, `diff_sha256`, and a `recover_with`
-  command. Units whose outcome is `recovery_available` are rolled up in
-  the summary's `recovery_available_units`, the counterpart to
-  `merge_ready_units`, and the record also persists to
-  `~/.omh/coding/fanout/<id>/recovery/<unit>.json`. The probe runs
-  `git add -N` in that unit's worktree first so files the unit *created*
-  are measured too, and so the printed `recover_with` command produces a
-  complete patch; it stages no content and makes no commit. The record is
-  metadata only — the diff is hashed for size and digest, then dropped,
-  and never leaves the worktree. Successful units are never probed: their
-  work is reached by merging their branch, not by salvage. A failed probe
+  `lines_changed`, `diff_bytes`, `diff_sha256`, `recovery_ref`, and a
+  `recover_with` command. Units whose outcome is `recovery_available` are
+  rolled up in the summary's `recovery_available_units`, the counterpart
+  to `merge_ready_units`, and `omh coding fanout brief` carries a compact
+  `recovery` line per unit so the signal survives after the dispatch JSON
+  scrolls past. The record also persists to
+  `~/.omh/coding/fanout/<id>/recovery/<unit>.json`, byte-for-byte the same
+  keys as the summary's copy.
+  The probe runs `git add -N` in that unit's worktree first so files the
+  unit *created* are measured too, and so the printed `recover_with`
+  command produces a complete patch; it stages no content and makes no
+  commit, and a `rev-parse --show-toplevel` check first proves the probe
+  is standing in the unit's own worktree. If `add -N` fails, the outcome
+  is `capture_failed` with `tracked_paths_seen` — never
+  `recovery_available`, because a patch missing the created files is not
+  the complete one the record advertises. Paths and the patch are both
+  read as raw bytes, so a non-ASCII filename is recorded as written
+  rather than mangled through the host locale. The record is metadata
+  only — the diff is hashed for size and digest, then dropped, and never
+  leaves the worktree.
+  Lifecycle: any stored record is cleared before a unit re-runs, so one
+  cannot outlive the worktree it points at; a unit that re-runs and
+  succeeds ends with no record and drops out of the rollup; and a unit
+  that could not re-run at all (`worktree_failed`) keeps the earlier
+  record, because failing to start says nothing about what the last
+  attempt left behind. Successful units are never probed: their work is
+  reached by merging their branch, not by salvage. A failed probe
   degrades to `capture_failed` and never changes the unit's own result.
 - **Limit signals.** A failed spawn whose bounded output matches a fixed,
   context-anchored limit-shape pattern (rate limit, usage limit, quota

--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -216,6 +216,25 @@ goal to Hermes in chat; these commands are the backend surface.
   and `duration_seconds`, and the full dispatch summary persists to
   `~/.omh/coding/fanout/<id>/dispatch_summary.json` (latest wins,
   metadata only, skipped on `--dry-run`).
+- **Failed-unit recovery.** A unit that exits non-zero — including a
+  timeout — still owns its worktree, and whatever it wrote is the only
+  thing between the operator and redoing the work. Before the summary
+  reports the failure, dispatch measures that worktree against the
+  dispatch base and attaches a `recovery` record to the unit result:
+  `outcome` (`recovery_available`, `no_changes`, or `capture_failed`),
+  the changed path count and names (capped, with `paths_truncated`),
+  `lines_changed`, `diff_bytes`, `diff_sha256`, and a `recover_with`
+  command. Units whose outcome is `recovery_available` are rolled up in
+  the summary's `recovery_available_units`, the counterpart to
+  `merge_ready_units`, and the record also persists to
+  `~/.omh/coding/fanout/<id>/recovery/<unit>.json`. The probe runs
+  `git add -N` in that unit's worktree first so files the unit *created*
+  are measured too, and so the printed `recover_with` command produces a
+  complete patch; it stages no content and makes no commit. The record is
+  metadata only — the diff is hashed for size and digest, then dropped,
+  and never leaves the worktree. Successful units are never probed: their
+  work is reached by merging their branch, not by salvage. A failed probe
+  degrades to `capture_failed` and never changes the unit's own result.
 - **Limit signals.** A failed spawn whose bounded output matches a fixed,
   context-anchored limit-shape pattern (rate limit, usage limit, quota
   exceeded, HTTP 429, credits) is flagged `limit_shaped` with a pattern

--- a/src/coding/fanout_artifacts.py
+++ b/src/coding/fanout_artifacts.py
@@ -10,6 +10,9 @@ from ..system.paths import OmhPaths
 from .fanout_contracts import FANOUT_ID_PATTERN
 
 _FANOUT_ID_RE = re.compile(FANOUT_ID_PATTERN)
+# The same slug shape `fanout._UNIT_ID_RE` accepts, restated here rather than
+# imported so the path validator does not depend on the contract builder.
+_UNIT_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
 
 
 def write_fanout_contract(paths: OmhPaths, contract: dict[str, object]) -> dict[str, object]:
@@ -28,6 +31,35 @@ def write_fanout_contract(paths: OmhPaths, contract: dict[str, object]) -> dict[
 def fanout_dispatch_summary_path(paths: OmhPaths, fanout_id: str) -> Path:
     """Validated dispatch-summary path for one fanout (id pattern + containment)."""
     return _managed_fanout_dir(paths, _validated_fanout_id(fanout_id)) / "dispatch_summary.json"
+
+
+def fanout_unit_recovery_path(paths: OmhPaths, fanout_id: str, unit_id: str) -> Path:
+    """Validated recovery-record path for one unit of one fanout.
+
+    The unit id rides through the same slug check the contract builder applies,
+    so a crafted id cannot walk out of the fanout directory.
+    """
+    if not _UNIT_ID_RE.match(str(unit_id or "")):
+        raise ValueError(f"invalid unit_id: {unit_id!r}")
+    recovery_dir = _managed_fanout_dir(paths, _validated_fanout_id(fanout_id)) / "recovery"
+    if recovery_dir.is_symlink():
+        raise ValueError("fanout recovery directory must not be a symlink")
+    return recovery_dir / f"{unit_id}.json"
+
+
+def write_fanout_unit_recovery(
+    paths: OmhPaths,
+    fanout_id: str,
+    unit_id: str,
+    record: dict[str, object],
+) -> Path:
+    """Persist one unit's metadata-only recovery record and return its path."""
+    recovery_path = fanout_unit_recovery_path(paths, fanout_id, unit_id)
+    ensure_dir(paths.fanout_contracts_dir, private=True)
+    ensure_dir(recovery_path.parent.parent, private=True)
+    ensure_dir(recovery_path.parent, private=True)
+    atomic_write_json(recovery_path, record, private=True)
+    return recovery_path
 
 
 def read_fanout_contract(paths: OmhPaths, fanout_id: str) -> dict[str, object]:

--- a/src/coding/fanout_artifacts.py
+++ b/src/coding/fanout_artifacts.py
@@ -62,6 +62,19 @@ def write_fanout_unit_recovery(
     return recovery_path
 
 
+def clear_fanout_unit_recovery(paths: OmhPaths, fanout_id: str, unit_id: str) -> None:
+    """Drop a unit's stored recovery record, if it has one.
+
+    Called before a unit re-runs, so a record describing an earlier attempt
+    cannot outlive the worktree it points at. Same posture as the in-flight
+    marker: best effort, never blocks a dispatch.
+    """
+    try:
+        fanout_unit_recovery_path(paths, fanout_id, unit_id).unlink(missing_ok=True)
+    except (OSError, ValueError):
+        return
+
+
 def read_fanout_contract(paths: OmhPaths, fanout_id: str) -> dict[str, object]:
     import json
 

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -461,12 +461,7 @@ def dispatch_fanout(
         "merge_ready_units": [entry["unit_id"] for entry in summary_units if entry.get("merge_ready")],
         # The counterpart to merge_ready: units that failed but left work worth
         # looking at before anyone re-runs them from scratch.
-        "recovery_available_units": [
-            entry["unit_id"]
-            for entry in summary_units
-            if isinstance(entry.get("recovery"), Mapping)
-            and entry["recovery"].get("outcome") == "recovery_available"
-        ],
+        "recovery_available_units": _recovery_available(summary_units),
         "auto_merge": False,
         "dependency_bar": (
             "A satisfied dependency means only that the owner agent process exited 0. "
@@ -488,7 +483,41 @@ def dispatch_fanout(
         summary_path = fanout_dispatch_summary_path(paths, fanout_id)
         stored = _merged_dispatch_summary(summary_path, summary)
         atomic_write_json(summary_path, stored, private=True)
+        # The CLI prints what this returns, so the rollups it carries have to
+        # agree with the file just written — an operator who re-ran one unit
+        # was being told nothing was salvageable while the stored summary said
+        # otherwise. Only the rollups and the carried-forward `recovery` are
+        # taken from the merged view: per-unit `status` stays THIS run's answer,
+        # so `already_completed` still means "I did not re-run this".
+        summary["units"] = _with_carried_recovery(summary["units"], stored.get("units", []))
+        summary["recovery_available_units"] = _recovery_available(summary["units"])
     return summary
+
+
+def _with_carried_recovery(
+    units: list[dict[str, Any]],
+    merged_units: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """This run's entries, plus the recovery a unit that did not re-run still has."""
+    merged_by_id = {str(entry.get("unit_id", "")): entry for entry in merged_units if isinstance(entry, Mapping)}
+    carried: list[dict[str, Any]] = []
+    for entry in units:
+        merged = merged_by_id.get(str(entry.get("unit_id", "")))
+        if "recovery" not in entry and isinstance(merged, Mapping) and isinstance(merged.get("recovery"), Mapping):
+            carried.append({**entry, "recovery": dict(merged["recovery"])})
+        else:
+            carried.append(entry)
+    return carried
+
+
+def _recovery_available(units: Sequence[Mapping[str, Any]]) -> list[str]:
+    return [
+        str(entry.get("unit_id"))
+        for entry in units
+        if isinstance(entry, Mapping)
+        and isinstance(entry.get("recovery"), Mapping)
+        and entry["recovery"].get("outcome") == "recovery_available"
+    ]
 
 
 _DISPATCH_SKIP_STATUSES = frozenset({"already_completed", "not_selected"})
@@ -513,6 +542,20 @@ def _merged_dispatch_summary(summary_path: Path, summary: dict[str, Any]) -> dic
             # A skipped unit carries no telemetry; the earlier observed entry
             # is the richer record and stays.
             merged_units.append(earlier)
+        elif (
+            isinstance(earlier, dict)
+            and "recovery" in earlier
+            and "recovery" not in entry
+            and "exit_code" not in entry
+        ):
+            # The unit did not actually re-run: no exit code means no spawn, so
+            # statuses like `worktree_failed` or `executor_not_ready` say
+            # nothing about what the earlier attempt left behind. Carrying the
+            # earlier recovery forward keeps a salvageable unit from vanishing
+            # from the rollup while its record is still on disk. A unit that
+            # DID run replaces the answer, which is how a later success clears
+            # a stale one.
+            merged_units.append({**entry, "recovery": earlier["recovery"]})
         else:
             merged_units.append(entry)
     merged = dict(summary)
@@ -525,13 +568,7 @@ def _merged_dispatch_summary(summary_path: Path, summary: dict[str, Any]) -> dic
     # would erase an earlier run's salvageable unit from the one field an
     # operator reads first — while that unit's own `recovery` record, merged
     # just above, still says otherwise.
-    merged["recovery_available_units"] = [
-        str(entry.get("unit_id"))
-        for entry in merged_units
-        if isinstance(entry, dict)
-        and isinstance(entry.get("recovery"), Mapping)
-        and entry["recovery"].get("outcome") == "recovery_available"
-    ]
+    merged["recovery_available_units"] = _recovery_available(merged_units)
     return merged
 
 
@@ -724,6 +761,15 @@ def _dispatch_unit(
             "merge_ready": False,
         }
     worktree = Path(str(worktree_record["worktree_path"]))
+    if fanout_id:
+        # Before the spawn, like the in-flight marker below. A record from an
+        # earlier attempt describes a worktree that has just been rebuilt from
+        # base, so leaving it would advertise a stale digest and a recover_with
+        # pointing at work that no longer exists. If this run also fails, the
+        # probe writes a fresh one.
+        from .fanout_artifacts import clear_fanout_unit_recovery
+
+        clear_fanout_unit_recovery(paths, fanout_id, unit_id)
     _ensure_unit_run(paths, unit, owner)
     append_journal_observation(
         paths,
@@ -903,7 +949,12 @@ def _capture_unit_recovery(
     # makes the `recover_with` command below actually produce a full patch.
     # It respects .gitignore, so build output stays out of the report.
     untracked_measured = _git_text(runner, worktree, ["git", "add", "-N", "--", "."]) is not None
-    numstat = _git_text(runner, worktree, ["git", "diff", "--numstat", "-z", base_sha])
+    # Bytes, not text. `-z` deliberately disables git's C-quoting so paths are
+    # emitted raw, and decoding them through the host locale (cp1252 on the
+    # enforcing Windows job) silently rewrites a non-ASCII filename into
+    # mojibake the operator then cannot find. Decoded strictly as UTF-8 below,
+    # which is what git records paths as.
+    numstat_bytes = _git_bytes(runner, worktree, ["git", "diff", "--numstat", "-z", base_sha])
     # Captured as BYTES, never decoded. A partial file in a non-UTF-8 encoding
     # is ordinary debris in a failed unit, and `text=True` would raise
     # UnicodeDecodeError straight through this function and abort the whole
@@ -911,15 +962,23 @@ def _capture_unit_recovery(
     # actually emits, rather than a decode/re-encode round trip through
     # whatever the host locale happens to be.
     patch_bytes = _git_bytes(runner, worktree, ["git", "diff", base_sha])
-    if numstat is None or patch_bytes is None:
+    if numstat_bytes is None or patch_bytes is None:
         return _capture_failed("git refused to diff the unit worktree against the dispatch base")
-    paths_changed, lines_changed = _parse_numstat(numstat)
+    paths_changed, lines_changed = _parse_numstat(numstat_bytes.decode("utf-8", "surrogateescape"))
+    if not untracked_measured:
+        # `add -N` failed, so anything the unit CREATED is invisible to
+        # `git diff`. Whatever the tracked diff shows, this record cannot make
+        # the completeness promise its `recover_with` command advertises, and a
+        # partial answer an operator acts on is worse than an honest refusal.
+        # `tracked_paths_seen` says the worktree is not empty so nobody deletes
+        # it on the strength of this record.
+        failed = _capture_failed(
+            "git add -N failed, so files the unit created could not be measured; "
+            "the tracked diff alone is not a complete patch"
+        )
+        failed["tracked_paths_seen"] = len(paths_changed)
+        return failed
     if not paths_changed and not patch_bytes:
-        if not untracked_measured:
-            # `add -N` failed, so files the unit created are invisible to
-            # `git diff`. "Nothing here" and "nothing I could see" are
-            # different answers, and only one of them is safe to act on.
-            return _capture_failed("git add -N failed, so files the unit created could not be measured")
         return {
             "schema_version": RECOVERY_SCHEMA_VERSION,
             "outcome": "no_changes",
@@ -935,17 +994,22 @@ def _capture_unit_recovery(
         "lines_changed": lines_changed,
         "paths": paths_changed[:_MAX_RECOVERY_PATHS],
         "paths_truncated": len(paths_changed) > _MAX_RECOVERY_PATHS,
-        "untracked_measured": untracked_measured,
         "diff_bytes": len(patch_bytes),
         "diff_sha256": sha256(patch_bytes).hexdigest(),
         "recover_with": f"git -C {shlex.quote(str(worktree))} diff {shlex.quote(base_sha)}",
         "claim_boundary": RECOVERY_CLAIM_BOUNDARY,
     }
     if fanout_id:
-        from .fanout_artifacts import write_fanout_unit_recovery
+        from .fanout_artifacts import fanout_unit_recovery_path, write_fanout_unit_recovery
 
         try:
-            record["recovery_ref"] = str(write_fanout_unit_recovery(paths, fanout_id, unit_id, record))
+            # The ref goes INTO the record before it is serialized. Writing
+            # first and assigning after left the on-disk file missing a key the
+            # summary's copy carried, so two shapes advertised the same
+            # schema_version and a consumer reading the documented path got a
+            # KeyError.
+            record["recovery_ref"] = str(fanout_unit_recovery_path(paths, fanout_id, unit_id))
+            write_fanout_unit_recovery(paths, fanout_id, unit_id, record)
         except (OSError, ValueError):
             # Same posture as the in-flight marker: a persistence failure is
             # reported by omission, never by losing the unit result.
@@ -988,11 +1052,14 @@ def _git_text(runner: Callable[..., Any], worktree: Path, argv: list[str]) -> st
         completed = runner(
             argv, cwd=str(worktree), text=True, errors="replace", capture_output=True, timeout=60
         )
-    except (OSError, subprocess.SubprocessError, ValueError):
+        # Inside the try: a runner that reports a non-numeric returncode makes
+        # `int(...)` raise TypeError, which would escape this "never raises"
+        # helper exactly the way UnicodeDecodeError used to.
+        if int(getattr(completed, "returncode", 1)) != 0:
+            return None
+        stdout = getattr(completed, "stdout", "") or ""
+    except (OSError, subprocess.SubprocessError, ValueError, TypeError):
         return None
-    if int(getattr(completed, "returncode", 1)) != 0:
-        return None
-    stdout = getattr(completed, "stdout", "") or ""
     return stdout if isinstance(stdout, str) else stdout.decode("utf-8", "replace")
 
 
@@ -1005,12 +1072,12 @@ def _git_bytes(runner: Callable[..., Any], worktree: Path, argv: list[str]) -> b
     """
     try:
         completed = runner(argv, cwd=str(worktree), capture_output=True, timeout=60)
-    except (OSError, subprocess.SubprocessError, ValueError):
+        if int(getattr(completed, "returncode", 1)) != 0:
+            return None
+        stdout = getattr(completed, "stdout", b"") or b""
+    except (OSError, subprocess.SubprocessError, ValueError, TypeError):
         return None
-    if int(getattr(completed, "returncode", 1)) != 0:
-        return None
-    stdout = getattr(completed, "stdout", b"") or b""
-    return stdout if isinstance(stdout, bytes) else str(stdout).encode("utf-8", "replace")
+    return stdout if isinstance(stdout, bytes) else str(stdout).encode("utf-8", "surrogateescape")
 
 
 def _parse_numstat(numstat: str) -> tuple[list[str], int]:

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from concurrent.futures import ThreadPoolExecutor
 from hashlib import sha256
 from pathlib import Path
+import shlex
 import shutil
 import subprocess
 import time
@@ -519,6 +520,18 @@ def _merged_dispatch_summary(summary_path: Path, summary: dict[str, Any]) -> dic
     merged["merge_ready_units"] = [
         str(entry.get("unit_id")) for entry in merged_units if isinstance(entry, dict) and entry.get("merge_ready")
     ]
+    # Recomputed for the same reason merge_ready_units is: the current run's
+    # rollup only names units it dispatched, so carrying it through unchanged
+    # would erase an earlier run's salvageable unit from the one field an
+    # operator reads first — while that unit's own `recovery` record, merged
+    # just above, still says otherwise.
+    merged["recovery_available_units"] = [
+        str(entry.get("unit_id"))
+        for entry in merged_units
+        if isinstance(entry, dict)
+        and isinstance(entry.get("recovery"), Mapping)
+        and entry["recovery"].get("outcome") == "recovery_available"
+    ]
     return merged
 
 
@@ -871,27 +884,42 @@ def _capture_unit_recovery(
     Capture never raises. A unit that failed must not fail differently because
     the salvage probe did.
     """
+    # Each argv is spelled with a literal subcommand, never `["git", verb]`:
+    # INVARIANT 3 in tests/test_handoff_safety_contract_enforcement.py resolves
+    # git verbs statically and fails closed on a runtime one.
+    #
+    # Git discovery walks UP from cwd, and a unit worktree is a sibling of the
+    # repo root. If the unit destroyed its own `.git` link, an unguarded write
+    # here would land in whatever repository encloses the parent directory —
+    # possibly the operator's. Confirm the worktree is its own toplevel before
+    # writing anything, so the allowlist's "never the operator's repository"
+    # claim is checked rather than asserted.
+    toplevel = _git_text(runner, worktree, ["git", "rev-parse", "--show-toplevel"])
+    if toplevel is None or not _same_directory(toplevel.strip(), worktree):
+        return _capture_failed("the unit worktree no longer resolves as its own git toplevel")
     # `git diff` does not see untracked files, and a failed unit's brand-new
     # files are the most common thing worth salvaging. `add -N` records the
     # paths without staging content, which both completes the measurement and
     # makes the `recover_with` command below actually produce a full patch.
     # It respects .gitignore, so build output stays out of the report.
-    # Each argv is spelled with a literal subcommand, never `["git", verb]`:
-    # INVARIANT 3 in tests/test_handoff_safety_contract_enforcement.py resolves
-    # git verbs statically and fails closed on a runtime one.
-    _git_text(runner, worktree, ["git", "add", "-N", "--", "."])
-    numstat = _git_text(runner, worktree, ["git", "diff", "--numstat", base_sha])
-    patch = _git_text(runner, worktree, ["git", "diff", base_sha])
-    if numstat is None or patch is None:
-        return {
-            "schema_version": RECOVERY_SCHEMA_VERSION,
-            "outcome": "capture_failed",
-            "reason": "git refused to diff the unit worktree against the dispatch base",
-            "claim_boundary": RECOVERY_CLAIM_BOUNDARY,
-        }
+    untracked_measured = _git_text(runner, worktree, ["git", "add", "-N", "--", "."]) is not None
+    numstat = _git_text(runner, worktree, ["git", "diff", "--numstat", "-z", base_sha])
+    # Captured as BYTES, never decoded. A partial file in a non-UTF-8 encoding
+    # is ordinary debris in a failed unit, and `text=True` would raise
+    # UnicodeDecodeError straight through this function and abort the whole
+    # dispatch. Hashing raw bytes also makes the digest describe what git
+    # actually emits, rather than a decode/re-encode round trip through
+    # whatever the host locale happens to be.
+    patch_bytes = _git_bytes(runner, worktree, ["git", "diff", base_sha])
+    if numstat is None or patch_bytes is None:
+        return _capture_failed("git refused to diff the unit worktree against the dispatch base")
     paths_changed, lines_changed = _parse_numstat(numstat)
-    patch_bytes = patch.encode("utf-8")
     if not paths_changed and not patch_bytes:
+        if not untracked_measured:
+            # `add -N` failed, so files the unit created are invisible to
+            # `git diff`. "Nothing here" and "nothing I could see" are
+            # different answers, and only one of them is safe to act on.
+            return _capture_failed("git add -N failed, so files the unit created could not be measured")
         return {
             "schema_version": RECOVERY_SCHEMA_VERSION,
             "outcome": "no_changes",
@@ -907,9 +935,10 @@ def _capture_unit_recovery(
         "lines_changed": lines_changed,
         "paths": paths_changed[:_MAX_RECOVERY_PATHS],
         "paths_truncated": len(paths_changed) > _MAX_RECOVERY_PATHS,
+        "untracked_measured": untracked_measured,
         "diff_bytes": len(patch_bytes),
         "diff_sha256": sha256(patch_bytes).hexdigest(),
-        "recover_with": f"git -C {worktree} diff {base_sha}",
+        "recover_with": f"git -C {shlex.quote(str(worktree))} diff {shlex.quote(base_sha)}",
         "claim_boundary": RECOVERY_CLAIM_BOUNDARY,
     }
     if fanout_id:
@@ -924,40 +953,102 @@ def _capture_unit_recovery(
     return record
 
 
+def _capture_failed(reason: str) -> dict[str, Any]:
+    """A recovery record that reports the probe could not answer.
+
+    Distinct from `no_changes` on purpose: "the unit left nothing" and "I could
+    not tell" lead an operator to opposite actions.
+    """
+    return {
+        "schema_version": RECOVERY_SCHEMA_VERSION,
+        "outcome": "capture_failed",
+        "reason": reason,
+        "claim_boundary": RECOVERY_CLAIM_BOUNDARY,
+    }
+
+
+def _same_directory(reported: str, worktree: Path) -> bool:
+    if not reported:
+        return False
+    try:
+        return Path(reported).resolve(strict=False) == worktree.resolve(strict=False)
+    except OSError:
+        return False
+
+
 def _git_text(runner: Callable[..., Any], worktree: Path, argv: list[str]) -> str | None:
-    """Stdout of one git command in the unit worktree, or None on any failure.
+    """Decoded stdout of one git command in the unit worktree, or None on failure.
 
     Callers pass the complete argv, subcommand included, so the verb stays a
-    literal at every construction site.
+    literal at every construction site. Decoding is lenient: this is used for
+    git's own structured output (paths, refs), where an undecodable byte
+    should degrade one field rather than abort a dispatch.
     """
     try:
-        completed = runner(argv, cwd=str(worktree), text=True, capture_output=True, timeout=60)
-    except (OSError, subprocess.SubprocessError):
+        completed = runner(
+            argv, cwd=str(worktree), text=True, errors="replace", capture_output=True, timeout=60
+        )
+    except (OSError, subprocess.SubprocessError, ValueError):
         return None
     if int(getattr(completed, "returncode", 1)) != 0:
         return None
-    return str(getattr(completed, "stdout", "") or "")
+    stdout = getattr(completed, "stdout", "") or ""
+    return stdout if isinstance(stdout, str) else stdout.decode("utf-8", "replace")
+
+
+def _git_bytes(runner: Callable[..., Any], worktree: Path, argv: list[str]) -> bytes | None:
+    """Raw stdout of one git command, undecoded, or None on failure.
+
+    Used for the patch: it may contain any byte sequence a failed unit wrote,
+    and decoding it would both risk raising and make any digest describe the
+    round trip rather than git's actual output.
+    """
+    try:
+        completed = runner(argv, cwd=str(worktree), capture_output=True, timeout=60)
+    except (OSError, subprocess.SubprocessError, ValueError):
+        return None
+    if int(getattr(completed, "returncode", 1)) != 0:
+        return None
+    stdout = getattr(completed, "stdout", b"") or b""
+    return stdout if isinstance(stdout, bytes) else str(stdout).encode("utf-8", "replace")
 
 
 def _parse_numstat(numstat: str) -> tuple[list[str], int]:
-    """Sorted changed paths and total moved lines from `git diff --numstat`.
+    """Sorted changed paths and total moved lines from `git diff --numstat -z`.
 
-    Binary files report `-` for both counts; they still count as a changed
-    path and contribute no lines.
+    `-z` is what makes this parseable: it NUL-terminates records and turns off
+    the C-quoting that would otherwise mangle a path containing a tab or a
+    quote. Binary files report `-` for both counts; they still count as a
+    changed path and contribute no lines.
+
+    A rename or copy emits an empty path field followed by two more records —
+    the old path then the new one. Both are counted, because both are things
+    the operator has to reconcile.
     """
+    tokens = numstat.split("\0")
     paths_changed: list[str] = []
     lines_changed = 0
-    for line in numstat.splitlines():
-        fields = line.split("\t")
+    index = 0
+    while index < len(tokens):
+        record = tokens[index]
+        index += 1
+        # Split on the first two tabs only. `-z` emits the path raw, so a
+        # filename containing a tab would otherwise be truncated at it.
+        fields = record.split("\t", 2)
         if len(fields) < 3:
             continue
-        added, removed, path = fields[0], fields[1], fields[-1]
-        if not path.strip():
-            continue
-        paths_changed.append(path.strip())
+        added, removed, path = fields[0], fields[1], fields[2]
         for count in (added, removed):
             if count.isdigit():
                 lines_changed += int(count)
+        if path:
+            paths_changed.append(path)
+            continue
+        # Rename/copy: the next two tokens are the old and new paths.
+        for offset in (0, 1):
+            if index + offset < len(tokens) and tokens[index + offset]:
+                paths_changed.append(tokens[index + offset])
+        index += 2
     return sorted(set(paths_changed)), lines_changed
 
 

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
+from hashlib import sha256
 from pathlib import Path
 import shutil
 import subprocess
@@ -457,6 +458,14 @@ def dispatch_fanout(
         "merge_order": order,
         "units": summary_units,
         "merge_ready_units": [entry["unit_id"] for entry in summary_units if entry.get("merge_ready")],
+        # The counterpart to merge_ready: units that failed but left work worth
+        # looking at before anyone re-runs them from scratch.
+        "recovery_available_units": [
+            entry["unit_id"]
+            for entry in summary_units
+            if isinstance(entry.get("recovery"), Mapping)
+            and entry["recovery"].get("outcome") == "recovery_available"
+        ],
         "auto_merge": False,
         "dependency_bar": (
             "A satisfied dependency means only that the owner agent process exited 0. "
@@ -815,7 +824,141 @@ def _dispatch_unit(
     if limit_label:
         result["limit_shaped"] = True
         result["limit_pattern"] = limit_label
+    if exit_code != 0:
+        # A failed unit still owns its worktree, and whatever it managed to
+        # write is the only thing standing between the operator and redoing
+        # the work. Capture what survived before the summary claims the unit
+        # produced nothing.
+        recovery = _capture_unit_recovery(
+            paths,
+            fanout_id=fanout_id,
+            unit_id=unit_id,
+            worktree=worktree,
+            base_sha=base_sha,
+            runner=runner,
+        )
+        if recovery is not None:
+            result["recovery"] = recovery
     return result
+
+
+# One unit's salvage report is a few dozen paths at most; past that the list
+# stops being a recovery aid and starts being a second copy of the diff.
+_MAX_RECOVERY_PATHS = 50
+RECOVERY_SCHEMA_VERSION = "fanout_unit_recovery/v1"
+RECOVERY_CLAIM_BOUNDARY = (
+    "A recovery record measures what a failed unit left in its worktree. It is not verification, review, "
+    "or evidence that the captured work is correct, complete, or safe to merge."
+)
+
+
+def _capture_unit_recovery(
+    paths: OmhPaths,
+    *,
+    fanout_id: str,
+    unit_id: str,
+    worktree: Path,
+    base_sha: str,
+    runner: Callable[..., Any],
+) -> dict[str, Any] | None:
+    """Metadata for whatever a failed unit left behind, or None when unmeasurable.
+
+    Metadata only, on purpose: the changed paths, how many lines moved, and the
+    size and SHA-256 of the diff that carries them. The diff itself is hashed
+    and dropped — it stays in the unit worktree, which is the one place it is
+    already allowed to live.
+
+    Capture never raises. A unit that failed must not fail differently because
+    the salvage probe did.
+    """
+    # `git diff` does not see untracked files, and a failed unit's brand-new
+    # files are the most common thing worth salvaging. `add -N` records the
+    # paths without staging content, which both completes the measurement and
+    # makes the `recover_with` command below actually produce a full patch.
+    # It respects .gitignore, so build output stays out of the report.
+    # Each argv is spelled with a literal subcommand, never `["git", verb]`:
+    # INVARIANT 3 in tests/test_handoff_safety_contract_enforcement.py resolves
+    # git verbs statically and fails closed on a runtime one.
+    _git_text(runner, worktree, ["git", "add", "-N", "--", "."])
+    numstat = _git_text(runner, worktree, ["git", "diff", "--numstat", base_sha])
+    patch = _git_text(runner, worktree, ["git", "diff", base_sha])
+    if numstat is None or patch is None:
+        return {
+            "schema_version": RECOVERY_SCHEMA_VERSION,
+            "outcome": "capture_failed",
+            "reason": "git refused to diff the unit worktree against the dispatch base",
+            "claim_boundary": RECOVERY_CLAIM_BOUNDARY,
+        }
+    paths_changed, lines_changed = _parse_numstat(numstat)
+    patch_bytes = patch.encode("utf-8")
+    if not paths_changed and not patch_bytes:
+        return {
+            "schema_version": RECOVERY_SCHEMA_VERSION,
+            "outcome": "no_changes",
+            "claim_boundary": RECOVERY_CLAIM_BOUNDARY,
+        }
+    record: dict[str, Any] = {
+        "schema_version": RECOVERY_SCHEMA_VERSION,
+        "outcome": "recovery_available",
+        "unit_id": unit_id,
+        "base_sha": base_sha,
+        "worktree_path": str(worktree),
+        "paths_changed": len(paths_changed),
+        "lines_changed": lines_changed,
+        "paths": paths_changed[:_MAX_RECOVERY_PATHS],
+        "paths_truncated": len(paths_changed) > _MAX_RECOVERY_PATHS,
+        "diff_bytes": len(patch_bytes),
+        "diff_sha256": sha256(patch_bytes).hexdigest(),
+        "recover_with": f"git -C {worktree} diff {base_sha}",
+        "claim_boundary": RECOVERY_CLAIM_BOUNDARY,
+    }
+    if fanout_id:
+        from .fanout_artifacts import write_fanout_unit_recovery
+
+        try:
+            record["recovery_ref"] = str(write_fanout_unit_recovery(paths, fanout_id, unit_id, record))
+        except (OSError, ValueError):
+            # Same posture as the in-flight marker: a persistence failure is
+            # reported by omission, never by losing the unit result.
+            record["recovery_ref"] = ""
+    return record
+
+
+def _git_text(runner: Callable[..., Any], worktree: Path, argv: list[str]) -> str | None:
+    """Stdout of one git command in the unit worktree, or None on any failure.
+
+    Callers pass the complete argv, subcommand included, so the verb stays a
+    literal at every construction site.
+    """
+    try:
+        completed = runner(argv, cwd=str(worktree), text=True, capture_output=True, timeout=60)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if int(getattr(completed, "returncode", 1)) != 0:
+        return None
+    return str(getattr(completed, "stdout", "") or "")
+
+
+def _parse_numstat(numstat: str) -> tuple[list[str], int]:
+    """Sorted changed paths and total moved lines from `git diff --numstat`.
+
+    Binary files report `-` for both counts; they still count as a changed
+    path and contribute no lines.
+    """
+    paths_changed: list[str] = []
+    lines_changed = 0
+    for line in numstat.splitlines():
+        fields = line.split("\t")
+        if len(fields) < 3:
+            continue
+        added, removed, path = fields[0], fields[1], fields[-1]
+        if not path.strip():
+            continue
+        paths_changed.append(path.strip())
+        for count in (added, removed):
+            if count.isdigit():
+                lines_changed += int(count)
+    return sorted(set(paths_changed)), lines_changed
 
 
 def _ensure_unit_run(paths: OmhPaths, unit: Mapping[str, Any], owner: str) -> None:

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -1068,6 +1068,25 @@ _FANOUT_BRIEF_CLAIM_BOUNDARY = (
 )
 
 
+def _brief_recovery(dispatched: dict) -> dict[str, object]:
+    """The salvage line for one unit: outcome, size, and how to get the patch.
+
+    `unknown` when the unit was never dispatched, matching how every other
+    field in this view reports an absent observation rather than inferring one.
+    A successful unit is never probed, so it reports `not_applicable`.
+    """
+    record = dispatched.get("recovery")
+    if not isinstance(record, dict):
+        if not dispatched:
+            return {"outcome": "unknown"}
+        return {"outcome": "not_applicable"}
+    brief: dict[str, object] = {"outcome": str(record.get("outcome", "unknown"))}
+    for key in ("paths_changed", "lines_changed", "diff_bytes", "recover_with", "recovery_ref", "reason"):
+        if key in record:
+            brief[key] = record[key]
+    return brief
+
+
 def cmd_coding_fanout_brief(args: argparse.Namespace) -> int:
     from ..coding.fanout_artifacts import fanout_dispatch_summary_path, read_fanout_contract
     from ..coding.fanout_contracts import PREPARED_NOT_OBSERVED
@@ -1158,6 +1177,12 @@ def cmd_coding_fanout_brief(args: argparse.Namespace) -> int:
                 "elapsed_seconds": dispatched.get("duration_seconds", "unknown"),
                 "tokens_total": dispatched.get("tokens_total", "unknown"),
                 "limit_shaped": bool(dispatched.get("limit_shaped", False)),
+                # The salvage signal, beside the other failure annotation this
+                # view already carries. Without it the operator reads
+                # `status: failed`, deletes the unit worktree so a re-dispatch
+                # can recreate it, and destroys the work the recovery record
+                # exists to preserve.
+                "recovery": _brief_recovery(dispatched),
                 "summary": latest_summary,
             }
         )

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 from pathlib import Path
 import shlex
+import shutil
 import subprocess
 from tempfile import TemporaryDirectory
 import unittest
@@ -105,6 +106,7 @@ def _writing_runner(
     break_git_diff: bool = False,
     break_git_add: bool = False,
     latin1_units: set[str] | None = None,
+    unicode_units: set[str] | None = None,
     wide_units: set[str] | None = None,
     rename_units: set[str] | None = None,
 ):
@@ -143,6 +145,9 @@ def _writing_runner(
                 # (binary detection needs a NUL in the first 8000 bytes). This
                 # is what used to abort the whole dispatch.
                 (cwd / f"{unit_id}_latin1.txt").write_bytes("caf\xe9 partial work\n".encode("latin-1"))
+        for unit_id in unicode_units or set():
+            if owns(prompt, unit_id):
+                (cwd / "análisis_你好.py").write_text("value = 1\n", encoding="utf-8")
         for unit_id in wide_units or set():
             if owns(prompt, unit_id):
                 for index in range(_MAX_RECOVERY_PATHS + 3):
@@ -823,6 +828,139 @@ class FanoutUnitRecoveryTests(unittest.TestCase):
             by_unit = {entry["unit_id"]: entry for entry in stored["units"]}
             self.assertEqual(by_unit["docs"]["recovery"]["outcome"], "recovery_available")
             self.assertEqual(stored["recovery_available_units"], ["docs"])
+
+    def test_a_partial_measurement_is_never_reported_as_recoverable(self) -> None:
+        # `git add -N` failing plus ANY tracked change used to yield
+        # `recovery_available` whose paths and recover_with omitted every file
+        # the unit created -- a patch that deletes a file and salvages nothing.
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+
+            summary = self._dispatch(
+                paths, repo, sha, contract,
+                _writing_runner(
+                    fail_units={"docs"}, write_units={"docs"}, rename_units={"docs"}, break_git_add=True
+                ),
+            )
+
+            recovery = {entry["unit_id"]: entry for entry in summary["units"]}["docs"]["recovery"]
+            self.assertEqual(recovery["outcome"], "capture_failed")
+            self.assertIn("not a complete patch", recovery["reason"])
+            # The worktree is not empty, and the record says so, so nobody
+            # deletes it on the strength of a "nothing here" answer.
+            self.assertGreater(recovery["tracked_paths_seen"], 0)
+            self.assertNotIn("recover_with", recovery)
+            self.assertEqual(summary["recovery_available_units"], [])
+
+    def test_a_non_utf8_path_survives_the_probe_intact(self) -> None:
+        # `-z` disables git's C-quoting, so paths arrive as raw bytes. Decoding
+        # them through the host locale silently renamed them in the record.
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+
+            summary = self._dispatch(
+                paths, repo, sha, contract,
+                _writing_runner(fail_units={"docs"}, unicode_units={"docs"}),
+            )
+
+            recovery = {entry["unit_id"]: entry for entry in summary["units"]}["docs"]["recovery"]
+            self.assertEqual(recovery["outcome"], "recovery_available")
+            self.assertEqual(recovery["paths"], ["análisis_你好.py"])
+
+    def test_the_persisted_record_carries_the_same_keys_as_the_summary_copy(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+
+            summary = self._dispatch(
+                paths, repo, sha, contract,
+                _writing_runner(fail_units={"docs"}, write_units={"docs"}),
+            )
+
+            recovery = {entry["unit_id"]: entry for entry in summary["units"]}["docs"]["recovery"]
+            stored = json.loads(Path(recovery["recovery_ref"]).read_text(encoding="utf-8"))
+            # One schema_version must mean one shape. The ref used to be
+            # assigned after the file was already written.
+            self.assertEqual(sorted(stored), sorted(recovery))
+            self.assertEqual(stored["recovery_ref"], recovery["recovery_ref"])
+
+    def test_a_unit_that_could_not_rerun_keeps_its_earlier_recovery(self) -> None:
+        # `worktree_failed` says nothing about what the earlier attempt left,
+        # so the rollup must not drop the unit -- its record is still on disk.
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            first = self._dispatch(
+                paths, repo, sha, contract,
+                _writing_runner(fail_units={"docs"}, write_units={"docs"}),
+            )
+            self.assertEqual(first["recovery_available_units"], ["docs"])
+
+            # The worktree still exists, so re-dispatch cannot create it.
+            second = dispatch_fanout(
+                paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                runner=_writing_runner(), readiness=_ready, only_units=["docs"],
+            )
+
+            by_unit = {entry["unit_id"]: entry for entry in second["units"]}
+            self.assertEqual(by_unit["docs"]["status"], "worktree_failed")
+            self.assertEqual(by_unit["docs"]["recovery"]["outcome"], "recovery_available")
+            self.assertEqual(second["recovery_available_units"], ["docs"])
+            stored = json.loads(
+                fanout_dispatch_summary_path(paths, contract["fanout_id"]).read_text(encoding="utf-8")
+            )
+            self.assertEqual(stored["recovery_available_units"], ["docs"])
+
+    def test_a_later_success_clears_the_stale_recovery_record(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            first = self._dispatch(
+                paths, repo, sha, contract,
+                _writing_runner(fail_units={"docs"}, write_units={"docs"}),
+            )
+            record_path = Path({e["unit_id"]: e for e in first["units"]}["docs"]["recovery"]["recovery_ref"])
+            self.assertTrue(record_path.is_file())
+
+            # Operator salvages, then clears the worktree AND its branch so a
+            # re-dispatch can create both (the creator refuses to reuse either).
+            shutil.rmtree(Path(repo).parent / "repo-fanout-docs")
+            _git(repo, "worktree", "prune")
+            _git(repo, "branch", "-D", "agent/docs")
+            second = dispatch_fanout(
+                paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                runner=_writing_runner(), readiness=_ready, only_units=["docs"],
+            )
+
+            by_unit = {entry["unit_id"]: entry for entry in second["units"]}
+            self.assertEqual(by_unit["docs"]["status"], "completed")
+            self.assertNotIn("recovery", by_unit["docs"])
+            self.assertEqual(second["recovery_available_units"], [])
+            # The stale file is gone, not left advertising a dead worktree.
+            self.assertFalse(record_path.is_file())
+
+    def test_a_runner_with_a_non_numeric_returncode_does_not_abort_the_dispatch(self) -> None:
+        # Same failure family as the UnicodeDecodeError fixed earlier: an
+        # exception escaping the probe takes the whole batch down.
+        class _NoReturnCode:
+            returncode = None
+            stdout = ""
+            stderr = ""
+
+        def runner(argv, **kwargs):
+            # argv[:2], so `git worktree add` (which creates the unit worktree)
+            # is not caught by the `add` arm and the probe is actually reached.
+            if argv[:2] in (["git", "diff"], ["git", "add"], ["git", "rev-parse"]):
+                return _NoReturnCode()
+            if argv[0] == "git":
+                return subprocess.run(argv, **kwargs)
+            return _FakeCompleted(1, "boom")
+
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+
+            summary = self._dispatch(paths, repo, sha, contract, runner)
+
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            self.assertEqual(by_unit["docs"]["recovery"]["outcome"], "capture_failed")
+            self.assertEqual(by_unit["docs"]["status"], "failed")
 
     def test_recovery_paths_reject_ids_that_would_escape_the_fanout_directory(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -20,6 +20,7 @@ from omh.coding.executor_readiness import (  # noqa: E402
 from omh.coding.fanout import build_fanout_contract  # noqa: E402
 from omh.coding.fanout_artifacts import write_fanout_contract  # noqa: E402
 from omh.coding.fanout_artifacts import fanout_dispatch_summary_path  # noqa: E402
+from omh.coding.fanout_artifacts import fanout_unit_recovery_path  # noqa: E402
 from omh.coding.fanout_dispatch import (  # noqa: E402
     _owner_skill_discoveries,
     dispatch_fanout,
@@ -83,6 +84,52 @@ def _agent_runner(*, fail_units: set[str] | None = None, timeout_units: set[str]
 
 def _ready(paths, profile, **kwargs):
     return {"status": "ready", "profile": profile}
+
+
+_SECRET = "s3cret-source-line-that-must-never-leave-the-worktree"
+
+
+def _writing_runner(
+    *,
+    fail_units: set[str] | None = None,
+    write_units: set[str] | None = None,
+    timeout_units: set[str] | None = None,
+    break_git_diff: bool = False,
+):
+    """Like `_agent_runner`, but the fake agent leaves real files behind.
+
+    Units named in `write_units` write a file into their worktree before the
+    spawn returns, which is what gives the recovery probe something to measure.
+    """
+    spawned: list[list[str]] = []
+
+    def owns(prompt: str, unit_id: str) -> bool:
+        # The branch line is the only unit-unique string in the prompt: every
+        # unit's do_not_touch list names its siblings' paths, so a bare
+        # substring match on the id fires for the wrong unit.
+        return f"agent/{unit_id} in the current worktree" in prompt
+
+    def runner(argv, **kwargs):
+        if argv[0] == "git":
+            if break_git_diff and "diff" in argv:
+                return _FakeCompleted(128, "")
+            return subprocess.run(argv, **kwargs)
+        spawned.append(list(argv))
+        prompt = " ".join(argv)
+        cwd = Path(str(kwargs.get("cwd", ".")))
+        for unit_id in write_units or set():
+            if owns(prompt, unit_id):
+                (cwd / f"{unit_id}_partial.py").write_text(f"# {_SECRET}\nvalue = 1\n", encoding="utf-8")
+        for unit_id in timeout_units or set():
+            if owns(prompt, unit_id):
+                raise subprocess.TimeoutExpired(argv, kwargs.get("timeout", 0))
+        for unit_id in fail_units or set():
+            if owns(prompt, unit_id):
+                return _FakeCompleted(1, f"unit {unit_id} failed")
+        return _FakeCompleted(0, "done")
+
+    runner.spawned = spawned
+    return runner
 
 
 class FanoutDispatchEngineTests(unittest.TestCase):
@@ -461,6 +508,139 @@ class FanoutDispatchEngineTests(unittest.TestCase):
             by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
             self.assertEqual(by_unit["core"]["status"], "worktree_failed")
             self.assertIn("already exists", by_unit["core"]["reason"])
+
+
+class FanoutUnitRecoveryTests(unittest.TestCase):
+    """A failed unit still owns its worktree; the summary must say what survived."""
+
+    def _setup(self, tmp: str):
+        root = Path(tmp)
+        paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+        repo, sha = _make_repo(root)
+        contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, _UNITS))
+        return paths, repo, sha, contract
+
+    def _dispatch(self, paths, repo, sha, contract, runner):
+        return dispatch_fanout(
+            paths,
+            contract,
+            goal_text=_GOAL,
+            repo_root=repo,
+            base_sha=sha,
+            runner=runner,
+            readiness=_ready,
+        )
+
+    def test_a_failed_unit_that_wrote_files_reports_recoverable_work(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+
+            summary = self._dispatch(
+                paths, repo, sha, contract,
+                _writing_runner(fail_units={"docs"}, write_units={"docs"}),
+            )
+
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            recovery = by_unit["docs"]["recovery"]
+            self.assertEqual(by_unit["docs"]["status"], "failed")
+            self.assertFalse(by_unit["docs"]["merge_ready"])
+            self.assertEqual(recovery["outcome"], "recovery_available")
+            self.assertEqual(recovery["schema_version"], "fanout_unit_recovery/v1")
+            self.assertEqual(recovery["paths"], ["docs_partial.py"])
+            self.assertEqual(recovery["paths_changed"], 1)
+            self.assertFalse(recovery["paths_truncated"])
+            self.assertGreater(recovery["diff_bytes"], 0)
+            self.assertEqual(len(recovery["diff_sha256"]), 64)
+            self.assertIn("git -C", recovery["recover_with"])
+            self.assertIn("not verification", recovery["claim_boundary"])
+            self.assertEqual(summary["recovery_available_units"], ["docs"])
+
+    def test_the_recovery_record_carries_metadata_and_never_content(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+
+            summary = self._dispatch(
+                paths, repo, sha, contract,
+                _writing_runner(fail_units={"docs"}, write_units={"docs"}),
+            )
+
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            recovery = by_unit["docs"]["recovery"]
+            # The whole point of hashing the diff instead of storing it.
+            self.assertNotIn(_SECRET, json.dumps(summary))
+            stored = Path(recovery["recovery_ref"])
+            self.assertTrue(stored.is_file())
+            stored_text = stored.read_text(encoding="utf-8")
+            self.assertNotIn(_SECRET, stored_text)
+            self.assertIn(recovery["diff_sha256"], stored_text)
+            # Persisted under the fanout's own directory, nowhere else.
+            self.assertEqual(
+                stored,
+                fanout_unit_recovery_path(paths, contract["fanout_id"], "docs"),
+            )
+
+    def test_a_failed_unit_that_wrote_nothing_reports_no_changes(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+
+            summary = self._dispatch(paths, repo, sha, contract, _writing_runner(fail_units={"docs"}))
+
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            self.assertEqual(by_unit["docs"]["recovery"]["outcome"], "no_changes")
+            self.assertNotIn("recovery_ref", by_unit["docs"]["recovery"])
+            self.assertEqual(summary["recovery_available_units"], [])
+
+    def test_a_completed_unit_is_never_probed_for_recovery(self) -> None:
+        # Negative guard: a successful unit's work is reached by merging its
+        # branch, not by salvage. Capturing there would imply the opposite.
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+
+            summary = self._dispatch(paths, repo, sha, contract, _writing_runner(write_units={"docs"}))
+
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            self.assertEqual(by_unit["docs"]["status"], "completed")
+            self.assertNotIn("recovery", by_unit["docs"])
+            self.assertEqual(summary["recovery_available_units"], [])
+
+    def test_a_timed_out_unit_still_gets_its_partial_work_measured(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+
+            summary = self._dispatch(
+                paths, repo, sha, contract,
+                _writing_runner(timeout_units={"docs"}, write_units={"docs"}),
+            )
+
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            self.assertEqual(by_unit["docs"]["exit_code"], 124)
+            self.assertEqual(by_unit["docs"]["recovery"]["outcome"], "recovery_available")
+            self.assertEqual(summary["recovery_available_units"], ["docs"])
+
+    def test_a_broken_git_probe_degrades_instead_of_failing_the_unit(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+
+            summary = self._dispatch(
+                paths, repo, sha, contract,
+                _writing_runner(fail_units={"docs"}, write_units={"docs"}, break_git_diff=True),
+            )
+
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            # The unit result survives; only the salvage report degrades.
+            self.assertEqual(by_unit["docs"]["status"], "failed")
+            self.assertEqual(by_unit["docs"]["exit_code"], 1)
+            self.assertEqual(by_unit["docs"]["recovery"]["outcome"], "capture_failed")
+            self.assertEqual(summary["recovery_available_units"], [])
+
+    def test_recovery_paths_reject_ids_that_would_escape_the_fanout_directory(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            for bad in ("../escape", "a/b", "", "UPPER", "-leading"):
+                with self.subTest(unit_id=bad):
+                    with self.assertRaises(ValueError):
+                        fanout_unit_recovery_path(paths, "fanout-0123456789ab", bad)
 
 
 class FanoutDispatchCliTests(unittest.TestCase):

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
+import shlex
 import subprocess
 from tempfile import TemporaryDirectory
 import unittest
@@ -22,7 +24,9 @@ from omh.coding.fanout_artifacts import write_fanout_contract  # noqa: E402
 from omh.coding.fanout_artifacts import fanout_dispatch_summary_path  # noqa: E402
 from omh.coding.fanout_artifacts import fanout_unit_recovery_path  # noqa: E402
 from omh.coding.fanout_dispatch import (  # noqa: E402
+    _MAX_RECOVERY_PATHS,
     _owner_skill_discoveries,
+    _parse_numstat,
     dispatch_fanout,
     verify_goal_matches_contract,
 )
@@ -46,7 +50,11 @@ def _make_repo(root: Path) -> tuple[Path, str]:
     repo = root / "repo"
     repo.mkdir()
     _git(repo, "init", "-q")
-    _git(repo, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "--allow-empty", "-q", "-m", "init")
+    # One tracked file at the base commit, so a unit that MOVES it produces a
+    # rename git actually detects rather than an add/delete pair.
+    (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+    _git(repo, "add", "seed.txt")
+    _git(repo, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "init")
     sha = subprocess.run(
         ["git", "rev-parse", "HEAD"], cwd=str(repo), capture_output=True, text=True, check=True
     ).stdout.strip()
@@ -95,6 +103,10 @@ def _writing_runner(
     write_units: set[str] | None = None,
     timeout_units: set[str] | None = None,
     break_git_diff: bool = False,
+    break_git_add: bool = False,
+    latin1_units: set[str] | None = None,
+    wide_units: set[str] | None = None,
+    rename_units: set[str] | None = None,
 ):
     """Like `_agent_runner`, but the fake agent leaves real files behind.
 
@@ -113,6 +125,11 @@ def _writing_runner(
         if argv[0] == "git":
             if break_git_diff and "diff" in argv:
                 return _FakeCompleted(128, "")
+            # `argv[:2]`, not `"add" in argv`: `git worktree add` creates the
+            # unit worktree, and faulting that would fail the unit before the
+            # recovery probe is ever reached.
+            if break_git_add and argv[:2] == ["git", "add"]:
+                return _FakeCompleted(128, "")
             return subprocess.run(argv, **kwargs)
         spawned.append(list(argv))
         prompt = " ".join(argv)
@@ -120,6 +137,22 @@ def _writing_runner(
         for unit_id in write_units or set():
             if owns(prompt, unit_id):
                 (cwd / f"{unit_id}_partial.py").write_text(f"# {_SECRET}\nvalue = 1\n", encoding="utf-8")
+        for unit_id in latin1_units or set():
+            if owns(prompt, unit_id):
+                # Bytes that are not valid UTF-8, in a file git treats as TEXT
+                # (binary detection needs a NUL in the first 8000 bytes). This
+                # is what used to abort the whole dispatch.
+                (cwd / f"{unit_id}_latin1.txt").write_bytes("caf\xe9 partial work\n".encode("latin-1"))
+        for unit_id in wide_units or set():
+            if owns(prompt, unit_id):
+                for index in range(_MAX_RECOVERY_PATHS + 3):
+                    (cwd / f"{unit_id}_{index:03d}.py").write_text(f"value = {index}\n", encoding="utf-8")
+        for unit_id in rename_units or set():
+            if owns(prompt, unit_id):
+                # `seed.txt` is committed at base, so moving it is a rename
+                # git detects rather than an add/delete pair.
+                (cwd / "seed_moved.txt").write_text((cwd / "seed.txt").read_text(encoding="utf-8"), encoding="utf-8")
+                (cwd / "seed.txt").unlink()
         for unit_id in timeout_units or set():
             if owns(prompt, unit_id):
                 raise subprocess.TimeoutExpired(argv, kwargs.get("timeout", 0))
@@ -632,6 +665,164 @@ class FanoutUnitRecoveryTests(unittest.TestCase):
             self.assertEqual(by_unit["docs"]["exit_code"], 1)
             self.assertEqual(by_unit["docs"]["recovery"]["outcome"], "capture_failed")
             self.assertEqual(summary["recovery_available_units"], [])
+
+    def test_non_utf8_partial_work_is_measured_instead_of_aborting_the_dispatch(self) -> None:
+        # Regression: the probe decoded the patch with text=True, which raises
+        # UnicodeDecodeError (a ValueError, caught by neither except arm) on a
+        # latin-1 partial file. It escaped _dispatch_unit through future.result()
+        # and killed the whole run before the summary was ever written.
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+
+            summary = self._dispatch(
+                paths, repo, sha, contract,
+                _writing_runner(fail_units={"docs"}, latin1_units={"docs"}),
+            )
+
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            recovery = by_unit["docs"]["recovery"]
+            self.assertEqual(recovery["outcome"], "recovery_available")
+            self.assertEqual(recovery["paths"], ["docs_latin1.txt"])
+            self.assertEqual(len(recovery["diff_sha256"]), 64)
+            # Every other unit's telemetry survived, and the summary was written.
+            self.assertEqual(by_unit["core"]["status"], "completed")
+            self.assertTrue(fanout_dispatch_summary_path(paths, contract["fanout_id"]).is_file())
+
+    def test_the_digest_matches_the_bytes_git_actually_emits(self) -> None:
+        # The digest is the only thing that makes the record verifiable, so it
+        # has to describe git's raw output -- not a decode/re-encode round trip
+        # through whatever the host locale happens to be.
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+
+            summary = self._dispatch(
+                paths, repo, sha, contract,
+                _writing_runner(fail_units={"docs"}, latin1_units={"docs"}),
+            )
+
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            recovery = by_unit["docs"]["recovery"]
+            worktree = Path(recovery["worktree_path"])
+            emitted = subprocess.run(
+                ["git", "diff", sha], cwd=str(worktree), capture_output=True, check=True
+            ).stdout
+            self.assertEqual(recovery["diff_bytes"], len(emitted))
+            self.assertEqual(recovery["diff_sha256"], hashlib.sha256(emitted).hexdigest())
+
+    def test_an_unmeasurable_worktree_is_not_reported_as_empty(self) -> None:
+        # `git add -N` failing (a stale index.lock is the plausible aftermath of
+        # the timeout path) leaves `git diff` exit-0 and empty, which used to be
+        # indistinguishable from a unit that genuinely wrote nothing. The
+        # operator would be told there is nothing to salvage and re-run.
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+
+            summary = self._dispatch(
+                paths, repo, sha, contract,
+                _writing_runner(fail_units={"docs"}, write_units={"docs"}, break_git_add=True),
+            )
+
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            recovery = by_unit["docs"]["recovery"]
+            self.assertEqual(recovery["outcome"], "capture_failed")
+            self.assertIn("could not be measured", recovery["reason"])
+            self.assertEqual(summary["recovery_available_units"], [])
+            # The work really is on disk; the probe just could not prove it.
+            self.assertTrue((Path(repo).parent / "repo-fanout-docs" / "docs_partial.py").is_file())
+
+    def test_a_wide_failure_caps_its_path_list_and_says_so(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+
+            summary = self._dispatch(
+                paths, repo, sha, contract,
+                _writing_runner(fail_units={"docs"}, wide_units={"docs"}),
+            )
+
+            recovery = {entry["unit_id"]: entry for entry in summary["units"]}["docs"]["recovery"]
+            self.assertEqual(recovery["paths_changed"], _MAX_RECOVERY_PATHS + 3)
+            self.assertEqual(len(recovery["paths"]), _MAX_RECOVERY_PATHS)
+            self.assertTrue(recovery["paths_truncated"])
+
+    def test_a_renamed_file_is_measured_as_both_of_its_paths(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+
+            summary = self._dispatch(
+                paths, repo, sha, contract,
+                _writing_runner(fail_units={"docs"}, rename_units={"docs"}),
+            )
+
+            recovery = {entry["unit_id"]: entry for entry in summary["units"]}["docs"]["recovery"]
+            self.assertEqual(recovery["paths"], ["seed.txt", "seed_moved.txt"])
+            self.assertEqual(recovery["paths_changed"], 2)
+
+    def test_numstat_parsing_handles_renames_binaries_and_awkward_paths(self) -> None:
+        # `-z` framing: normal records end at NUL; a rename emits an empty path
+        # field followed by two more NUL-separated tokens.
+        self.assertEqual(_parse_numstat("1\t0\ta.py\0"), (["a.py"], 1))
+        self.assertEqual(_parse_numstat("3\t2\tsrc/a.py\0004\t0\tsrc/b.py\0"), (["src/a.py", "src/b.py"], 9))
+        self.assertEqual(_parse_numstat("1\t1\t\0old.py\0new.py\0"), (["new.py", "old.py"], 2))
+        # Binary files report `-` for both counts and contribute no lines.
+        self.assertEqual(_parse_numstat("-\t-\timg.png\0"), (["img.png"], 0))
+        # `-z` turns off C-quoting, so a tab or a trailing space survives intact.
+        self.assertEqual(_parse_numstat("1\t0\thas\ttab.txt\0"), (["has\ttab.txt"], 1))
+        self.assertEqual(_parse_numstat("1\t0\ttrailing \0"), (["trailing "], 1))
+        self.assertEqual(_parse_numstat(""), ([], 0))
+
+    def test_recover_with_survives_a_worktree_path_containing_spaces(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp) / "My Projects"
+            root.mkdir()
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            repo, sha = _make_repo(root)
+            contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, _UNITS))
+
+            summary = self._dispatch(
+                paths, repo, sha, contract,
+                _writing_runner(fail_units={"docs"}, write_units={"docs"}),
+            )
+
+            recovery = {entry["unit_id"]: entry for entry in summary["units"]}["docs"]["recovery"]
+            self.assertIn(" ", recovery["worktree_path"])
+            # Quoted, so the printed command is actually paste-able.
+            self.assertIn(shlex.quote(recovery["worktree_path"]), recovery["recover_with"])
+            argv = shlex.split(recovery["recover_with"])
+            self.assertEqual(argv[:3], ["git", "-C", recovery["worktree_path"]])
+
+    def test_a_partial_redispatch_keeps_an_earlier_units_recovery_rollup(self) -> None:
+        # `_merged_dispatch_summary` exists so re-dispatching one unit does not
+        # erase another's telemetry. It recomputed merge_ready_units but not
+        # recovery_available_units, so the stored summary contradicted the very
+        # recovery record it had just merged.
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            self._dispatch(
+                paths, repo, sha, contract,
+                _writing_runner(fail_units={"docs"}, write_units={"docs"}),
+            )
+            stored = json.loads(
+                fanout_dispatch_summary_path(paths, contract["fanout_id"]).read_text(encoding="utf-8")
+            )
+            self.assertEqual(stored["recovery_available_units"], ["docs"])
+
+            dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                runner=_writing_runner(),
+                readiness=_ready,
+                only_units=["tests"],
+            )
+
+            stored = json.loads(
+                fanout_dispatch_summary_path(paths, contract["fanout_id"]).read_text(encoding="utf-8")
+            )
+            by_unit = {entry["unit_id"]: entry for entry in stored["units"]}
+            self.assertEqual(by_unit["docs"]["recovery"]["outcome"], "recovery_available")
+            self.assertEqual(stored["recovery_available_units"], ["docs"])
 
     def test_recovery_paths_reject_ids_that_would_escape_the_fanout_directory(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_handoff_safety_contract_enforcement.py
+++ b/tests/test_handoff_safety_contract_enforcement.py
@@ -444,8 +444,13 @@ GIT_ARGV_ALLOWLIST: dict[tuple[str, tuple[str, ...]], str] = {
         "against the operator's repository or a unit that succeeded"
     ),
     ("src/coding/fanout_dispatch.py", ("diff",)): (
-        "measures what a failed unit left in its own worktree -- `--numstat` for paths, then the "
+        "measures what a failed unit left in its own worktree -- `--numstat -z` for paths, then the "
         "patch that is hashed for size/sha256 and dropped; read-only"
+    ),
+    ("src/coding/fanout_dispatch.py", ("rev-parse",)): (
+        "`rev-parse --show-toplevel`, run BEFORE the `add -N` above, to prove the recovery probe is "
+        "standing in the unit's own worktree and not in whatever repository encloses it; read-only, "
+        "and the reason the `add` entry's containment claim is checked rather than asserted"
     ),
 }
 

--- a/tests/test_handoff_safety_contract_enforcement.py
+++ b/tests/test_handoff_safety_contract_enforcement.py
@@ -429,13 +429,23 @@ FORBIDDEN_GIT_VERBS = frozenset({"push", "merge", "rebase", "remote", "fetch", "
 FORGE_PROGRAMS = frozenset({"gh", "hub", "glab", "tea"})
 
 # The complete set of git argv literals in `src/`, keyed by file and by the run
-# of literal words that follow `git`. Both are read-only local operations.
+# of literal words that follow `git`. Every one is local; none names a remote.
 GIT_ARGV_ALLOWLIST: dict[tuple[str, tuple[str, ...]], str] = {
     ("src/coding/worktree_creator.py", ("worktree", "add")): (
         "creates a local isolated workspace for an executor; touches no remote"
     ),
     ("src/commands/coding.py", ("rev-parse",)): (
         "resolves --base-ref to a commit sha inside `coding fanout dispatch`; read-only"
+    ),
+    ("src/coding/fanout_dispatch.py", ("add", ".")): (
+        "`git add -N -- .` inside a FAILED unit's own isolated worktree, so the recovery probe can "
+        "measure files that unit created. Not read-only: it writes intent-to-add entries to that "
+        "worktree's index. It stages no content, makes no commit, names no remote, and never runs "
+        "against the operator's repository or a unit that succeeded"
+    ),
+    ("src/coding/fanout_dispatch.py", ("diff",)): (
+        "measures what a failed unit left in its own worktree -- `--numstat` for paths, then the "
+        "patch that is hashed for size/sha256 and dropped; read-only"
     ),
 }
 


### PR DESCRIPTION
## Feature Report

### What Changed

- When a fanout unit's spawned agent CLI exits non-zero — including a timeout — dispatch now measures that unit's worktree against the dispatch base before reporting the failure.
- The unit result gains a `recovery` record: `outcome`, changed paths (capped, with `paths_truncated`), `lines_changed`, `diff_bytes`, `diff_sha256`, and a `recover_with` command.
- The dispatch summary gains `recovery_available_units`, the counterpart to `merge_ready_units`.
- The record persists to `~/.omh/coding/fanout/<id>/recovery/<unit>.json`.
- `docs/FANOUT.md` documents the lane.

### Why This Exists

A unit that exited non-zero reported `status: failed` and nothing else.

Its worktree was still on disk with whatever the agent had managed to write, but the summary gave the operator no way to tell a unit that died on its first tool call from one that got most of the way through and then hit a rate limit. Both read as `failed`, so both got re-run from scratch — paying for the same agent work twice and throwing away the part that had succeeded.

Adapted from the Gajae-Code harness, which always writes a recovery artifact before tearing down an isolated task workspace, for failed and aborted tasks as much as successful ones.

### User / Operator Impact

After a partial fanout failure, the operator can see which failed units left work worth looking at, how much, and the exact command that reproduces the patch — instead of inferring it by hand from N worktree paths.

`recovery_available_units` is the field to read: it is to salvage what `merge_ready_units` is to merging.

### How It Works

The probe runs three git commands in the failed unit's own worktree:

```
git add -N -- .            # so files the unit CREATED are measured
git diff --numstat <base>  # paths and line counts
git diff <base>            # hashed for size + digest, then dropped
```

preceded by a `git rev-parse --show-toplevel` check that the worktree really is its own git toplevel — git discovery walks *up* from cwd, and a unit worktree is a sibling of the repo root, so if a unit destroyed its own `.git` link an unguarded write would land in whatever repository encloses the parent.

**`git add -N` is load-bearing, and it is why this is not simply `git diff`.** `git diff` cannot see untracked files, and a failed unit's brand-new files are the most common thing worth salvaging — without the intent-to-add pass, the common case reports `no_changes` and the `recover_with` command the record prints silently omits those files. `-N` records paths without staging content, respects `.gitignore`, makes no commit, and makes the advertised recovery command actually complete. Its exit status is **checked**: when it fails, "the unit left nothing" and "I could not see what it left" become different answers (`capture_failed`, not `no_changes`).

**The patch is never decoded.** It is captured as raw bytes and hashed. Decoding it would risk raising on a failed unit's non-UTF-8 debris, and would make the digest describe a decode/re-encode round trip through the host locale rather than what git actually emits — which would leave `diff_sha256` unverifiable against `recover_with` on any non-UTF-8 machine.

**Metadata only.** The patch is hashed for `diff_bytes` and `diff_sha256`, then dropped; it stays in the unit worktree, the one place it is already allowed to live. A test writes a marked line into a failing unit and asserts that line appears in neither the summary nor the persisted artifact.

**Failure-only.** A successful unit is never probed — its work is reached by merging its branch, and capturing there would imply the branch is not enough. A negative test pins this.

**Never raises.** Every git call degrades to `None` on any failure and the outcome becomes `capture_failed`. A unit that failed must not fail *differently* because the salvage probe did. Same posture as the existing in-flight marker.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/coding/fanout_dispatch.py` | `_capture_unit_recovery`, `_git_text`, `_parse_numstat`; wired into the non-zero-exit path; `recovery_available_units` in the summary |
| `src/coding/fanout_artifacts.py` | `fanout_unit_recovery_path` (id + slug + symlink validated), `write_fanout_unit_recovery` |
| `tests/test_fanout_dispatch.py` | `FanoutUnitRecoveryTests` + a file-writing fake runner |
| `tests/test_handoff_safety_contract_enforcement.py` | two `GIT_ARGV_ALLOWLIST` entries |
| `docs/FANOUT.md` | **Failed-unit recovery** bullet |

**INVARIANT 3 (no remote mutation).** That gate resolves git verbs statically and fails closed on a runtime one, so both new argv are spelled with a literal subcommand and enumerated in `GIT_ARGV_ALLOWLIST` with a justification. The `add -N` entry records it as what it is — a local index write, **not** a read-only call — because the surrounding allowlist comment previously claimed every entry was read-only and that would no longer have been true.

New schema: `fanout_unit_recovery/v1`, metadata-only, carrying its own claim boundary stating it is not verification, review, or evidence the captured work is correct.

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `python3 -m unittest discover -s tests` — **5679 tests OK**
- [x] `python3 -m compileall src` — exit 0
- [x] `python3 -m omh.cli docs workflows --check` — exit 0
- [x] `python3 -m omh.cli harness validate` — exit 0
- [x] `python3 -m omh.cli release checklist --json` — exit 0
- [x] `python3 -m omh.cli release hermes-smoke` — exit 0
- [x] `omh --help` — exit 0
- [x] Also `docs roles --check`, `docs capability-families --check` — exit 0; `git diff --check` clean
- [x] `tests/test_fanout_dispatch.py` — 50/50, including a content-leak guard, a path-traversal guard, a non-UTF-8 fixture, and a digest compared against git's actual bytes
- [x] Merged against `claude/fanout-spawn-plan-receipt` in a scratch worktree — **5697 tests OK**, byte gates and ruff clean. Both PRs touch `docs/FANOUT.md`; they merge without conflict.
- [ ] Manual Hermes/TUI check — **not run.** Backend dispatch surface; no chat or TUI copy changed.

**Independent code review found 1 CRITICAL and 3 HIGH on the first commit; all are fixed in `48f5d580`.** Naming them, because three produced the same operator-visible lie — "this unit left nothing behind", the one claim this feature exists to make trustworthy:

| Severity | Defect |
| --- | --- |
| CRITICAL | `text=True` decodes strictly, so a latin-1 partial file raised `UnicodeDecodeError` — a `ValueError`, caught by neither except arm — which escaped through `future.result()` and aborted the **whole dispatch** before the summary was written |
| HIGH | `patch.encode("utf-8")` hashed a decode/re-encode round trip, so `diff_sha256` was unverifiable against `recover_with` on any non-UTF-8 host (i.e. Windows, where this repo has enforcing CI) |
| HIGH | the `git add -N` exit status was discarded, so a stale `index.lock` produced `no_changes` while the work sat on disk |
| HIGH | `_merged_dispatch_summary` did not recompute `recovery_available_units`, so a partial re-dispatch erased an earlier unit from the rollup while its own merged record still said otherwise |

Plus three MEDIUM/LOW: rename paths rendered as the pseudo-path `old => new`, an unquoted `recover_with`, and the enclosing-repository exposure now closed by the `rev-parse` check. Writing the tests surfaced one more — splitting a `-z` record on every tab truncates a filename containing one.

Development also hit two earlier defects worth naming: the first implementation used plain `git diff` and reported `no_changes` for every unit that only created files, and the first `_git_text` built `["git", *args]`, which INVARIANT 3 correctly refused because the verb was not statically resolvable.

## Risk

- **`git add -N` mutates the failed unit's index.** It is that unit's own isolated worktree, created by this dispatch and never the operator's repository (`worktree` comes from `ensure_fanout_unit_worktree`, after the `worktree_failed` early return), and the probe now proves `rev-parse --show-toplevel` matches before writing. It stages no content and makes no commit. Still, it is the one non-read-only thing this change does, and it is the line to scrutinize.
- **The probe costs a full `git diff` per failed unit, buffered whole.** For a unit that created a very large tracked file this makes the probe cost proportional to the artifact it is only trying to measure, while other units may still be running. Capturing bytes removed the previous encode-doubling, but there is no size ceiling and the digest is not streamed. Named as a follow-up rather than fixed.
- The 50-path cap means a very wide failure lists a subset; `paths_truncated` says so, and `paths_changed` keeps the true count.

## Compatibility / Rollout

- Additive: `recovery` appears only on failed units, `recovery_available_units` is a new summary key. Nothing is removed or renamed.
- The persisted summary merge path is unchanged, so partial re-dispatch still preserves prior units' telemetry.
- No schema version bump on `fanout_dispatch_summary/v1`; the new key is additive, consistent with how this surface has grown before.

## Release / Claims

- [x] Release-channel impact considered — `local`; no version file or release artifact touched
- [x] Runtime/native capability claims backed by evidence or marked not observed — the recovery record carries an explicit claim boundary; `capture_failed` is reported rather than hidden
- [x] Known manual Hermes checks listed — TUI gap stated above; `release hermes-smoke` ran non-`--live`

## Follow-Up

- **No live dispatch was run against a real agent CLI.** Every spawn in these tests is a fake runner. The git interaction is real (the harness routes `git` to the real subprocess against real worktrees), but the end-to-end path with a real failing agent stays unobserved.
- The enclosing-repository guard is proven by construction, not by a test that removes a worktree's `.git` link mid-dispatch.
- The patch is still buffered whole with no size ceiling. Streaming the digest, or reporting size-only above a bound, is the obvious next step.
- `omh coding fanout brief` does not yet surface the recovery lane; it currently joins contract, summary, and journal tail only.
