### PR TITLE
docs: make re-review a ratchet so a turned-around PR can actually land

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -102,45 +102,81 @@ consistency finding with a concrete `file:line` alternative, not a bug.
 ## Re-review convergence
 
 A review round that can raise anything about anything never converges. From
-the second round on, the review is a ratchet: it can only tighten around what
-is still unresolved, never re-open settled ground. Six rules, in force from
-round two.
+the second round on, the review is a ratchet: it tightens around what is still
+unresolved and does not re-open settled ground.
+
+**Settled ground** is the diff the previous round was posted against, and only
+as far as that round says it looked. A round that reviewed part of a PR — a
+large diff, a partial pass, a skipped module — says so, and settles only what
+it names. A shallow round one must not blind every round after it.
+
+**Verdict** below means this file's tally (`1 important, 3 nits`,
+`No blocking issues`). The `review-sweep` procedure posts `COMMENT` and never
+approves or requests changes, so the tally is the only verdict it has. A
+reviewer who does hold approve / request-changes power reads the same rules
+with their verdict in place of the tally.
+
+Six rules, in force from round two.
 
 **Suppress new Nits.** Post Important findings only. A one-line fix must not
 reach round seven on style.
 
-**Review the delta, not the PR.** Round two and later cover exactly two
-things: what changed since the round you last posted, and whether the findings
-you raised then are resolved. Ground you already approved is closed. If you
-find yourself reading a file the delta does not touch, you have left the
-round.
+**Scope findings to the delta — not your reading.** Round two and later raise
+findings about two things: what changed since the round you last posted, and
+whether the findings you raised then are resolved.
 
-**Justify novelty or demote it.** A new Important finding on ground a previous
-round already passed over must say, in the finding itself, why it was not
-visible then — a fix revealed it, a file arrived, an assumption was disproved.
-Without that sentence it is not Important; record it as a Nit and let it ride.
-This is the rule that stops a reviewer from mining an unchanged file for
-leverage after the author has already turned the PR around once.
+This constrains what you *report*, never what you *read*. Reading outside the
+delta stays mandatory: the two headline Important findings in this repo are
+things that should have changed and did not — a generated artifact whose
+source moved without it, a count assertion three files away. Neither is
+visible in the diff. **A finding whose cause is in the delta is a delta
+finding, whichever file exhibits it.** Run the Step 4 gates every round; they
+catch desync without reading anything.
+
+**Justify novelty, or post it demoted and say why.** A new Important finding
+on ground a previous round settled must say, in the finding itself, why it was
+not visible then. Four reasons count, and the fourth is the honest one: a fix
+revealed it, a file arrived, an assumption was disproved, or **you did not
+examine this last round** — say that plainly. It costs you credibility, which
+is the correct price, and it costs the repository nothing.
+
+Without one of those, the finding is not Important this round: post it as a
+Nit *with* the admission attached. It does not vanish — the nit-suppression
+rule above does not apply to a demoted finding, because a suppressed finding
+and a deleted finding are the same thing.
+
+**Anything on the `What Important means here` list is exempt from demotion.**
+A contract break is Important on discovery, in whatever round it surfaces. A
+network call added to core `omh`, a false evidence claim, a hand-edited
+generated artifact, a positive-only routing trigger: these stay Important
+without a novelty sentence. Convergence pressure is not worth shipping one.
 
 **Carryover blockers stay blocking.** A finding raised in an earlier round and
 still unresolved blocks at its original severity no matter how many rounds
-have passed. Convergence pressure never dissolves a real defect; it only stops
-new ones from appearing on old ground.
+have passed — unless you withdraw it under the last rule, which is the only
+thing that clears one other than a fix. Judge "resolved" to the same bar the
+Verification bar sets for findings: point at the line that resolves it, or say
+the resolution is unverified.
 
-**The verdict cannot worsen once blockers clear.** When every Important
-finding from the previous round is resolved, this round's verdict must be at
-least as good as the last. Going from "changes requested" to "changes
-requested" on entirely new grounds — without a novelty justification — is the
-failure this forbids.
+**A cleared round cannot be made worse.** When the previous round raised at
+least one Important finding and this round finds all of them resolved, this
+round's tally must not report more Important findings *on that same ground*.
+The antecedent needs a non-empty set: a previous round with no Important
+findings settles nothing and locks nothing. And this rule is subordinate to
+the novelty rule above — a properly justified new Important finding stands on
+its own and sets the tally, whatever this rule would otherwise say.
 
 **Withdraw your own over-reach.** Before posting, re-read your previous round
-against the rules above and the Do-not-report list. A demand that turns out to
-have been scope expansion, speculation, or a Nit dressed as Important is your
-defect, not the author's: withdraw it in this round's body and say so. Do not
-convert it into another revision cycle.
+against the Do-not-report list and the `What Important means here` list. A
+demand that turns out to have been scope expansion, speculation, or a Nit
+dressed as Important is your defect, not the author's: withdraw it in this
+round's body and say so. A withdrawn finding stops being a carryover blocker.
+Judge round one against those two lists only — the ratchet did not bind it.
 
-State the round number and the previous review you are ratcheting against at
-the top of the body, so the author can check the ratchet held.
+State the round number and the SHA you are ratcheting against at the top of
+the body, so the author can check the ratchet held. If the same finding is
+disputed across two rounds, it goes to the maintainer rather than into a third
+round; nothing here is a mandate to keep arguing.
 
 ## Summary shape
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -101,8 +101,46 @@ consistency finding with a concrete `file:line` alternative, not a bug.
 
 ## Re-review convergence
 
-After the first review of a PR, suppress new Nits and post Important findings
-only. A one-line fix must not reach round seven on style.
+A review round that can raise anything about anything never converges. From
+the second round on, the review is a ratchet: it can only tighten around what
+is still unresolved, never re-open settled ground. Six rules, in force from
+round two.
+
+**Suppress new Nits.** Post Important findings only. A one-line fix must not
+reach round seven on style.
+
+**Review the delta, not the PR.** Round two and later cover exactly two
+things: what changed since the round you last posted, and whether the findings
+you raised then are resolved. Ground you already approved is closed. If you
+find yourself reading a file the delta does not touch, you have left the
+round.
+
+**Justify novelty or demote it.** A new Important finding on ground a previous
+round already passed over must say, in the finding itself, why it was not
+visible then — a fix revealed it, a file arrived, an assumption was disproved.
+Without that sentence it is not Important; record it as a Nit and let it ride.
+This is the rule that stops a reviewer from mining an unchanged file for
+leverage after the author has already turned the PR around once.
+
+**Carryover blockers stay blocking.** A finding raised in an earlier round and
+still unresolved blocks at its original severity no matter how many rounds
+have passed. Convergence pressure never dissolves a real defect; it only stops
+new ones from appearing on old ground.
+
+**The verdict cannot worsen once blockers clear.** When every Important
+finding from the previous round is resolved, this round's verdict must be at
+least as good as the last. Going from "changes requested" to "changes
+requested" on entirely new grounds — without a novelty justification — is the
+failure this forbids.
+
+**Withdraw your own over-reach.** Before posting, re-read your previous round
+against the rules above and the Do-not-report list. A demand that turns out to
+have been scope expansion, speculation, or a Nit dressed as Important is your
+defect, not the author's: withdraw it in this round's body and say so. Do not
+convert it into another revision cycle.
+
+State the round number and the previous review you are ratcheting against at
+the top of the body, so the author can check the ratchet held.
 
 ## Summary shape
 

--- a/docs/REVIEW-SWEEP.md
+++ b/docs/REVIEW-SWEEP.md
@@ -235,9 +235,30 @@ Non-zero means this exact commit was already reviewed. Skip it.
 
 ### Re-reviews
 
-When a PR already has a `review-sweep` review at an older SHA, follow the
-`REVIEW.md` convergence rule: **Important findings only, no new nits.** Open
-with what changed since the last review.
+When a PR already has a `review-sweep` review at an older SHA, the
+`REVIEW.md` **Re-review convergence** ratchet is in force. Read that section
+before posting; it is six rules, not one, and the sweep cannot satisfy them
+from memory.
+
+Fetch your previous review first — it is the thing you are ratcheting
+against:
+
+```sh
+gh api repos/rlaope/oh-my-hermes/pulls/<number>/reviews \
+  --jq '[.[] | select(.body | contains("review-sweep: head="))] | last'
+```
+
+Then diff the PR against the SHA that review was posted at, so the round
+covers the delta rather than the whole PR:
+
+```sh
+git diff <previous-reviewed-sha>..<headRefOid>
+```
+
+Open the body with the round number and the SHA you are ratcheting against,
+carry every unresolved finding forward at its original severity, justify any
+new Important finding on unchanged ground or demote it, and withdraw anything
+from your previous round that the rules say you should not have raised.
 
 ## Step 8 — report
 

--- a/docs/REVIEW-SWEEP.md
+++ b/docs/REVIEW-SWEEP.md
@@ -105,8 +105,10 @@ uv run python -m omh.cli docs capability-families --check
 git diff --check
 ```
 
-CI only runs `docs workflows --check` of those three byte gates, so
-`docs roles --check` and `docs capability-families --check` are yours to catch.
+CI runs all three of those byte gates unconditionally on every PR
+(`.github/workflows/ci.yml`), so a desync fails there whether or not you catch
+it. Run them anyway: a red gate you name with the source that moved is a
+useful finding, and a red gate the author has to bisect from a CI log is not.
 
 When the diff touches only a few modules, run those first for a fast signal,
 then the full suite before you post:
@@ -240,25 +242,49 @@ When a PR already has a `review-sweep` review at an older SHA, the
 before posting; it is six rules, not one, and the sweep cannot satisfy them
 from memory.
 
-Fetch your previous review first — it is the thing you are ratcheting
-against:
+Fetch the previous review first — it is the thing you are ratcheting against.
+Take the **last review by any author**, not only a sweep-marked one: a human
+review settles ground exactly as a sweep review does, and its blockers carry
+forward the same way. Read the SHA from `.commit_id` rather than parsing the
+marker, since the API field is authoritative and the marker is reviewer-written
+text:
 
 ```sh
 gh api repos/rlaope/oh-my-hermes/pulls/<number>/reviews \
-  --jq '[.[] | select(.body | contains("review-sweep: head="))] | last'
+  --jq '[.[] | {sha: .commit_id, user: .user.login, state, body}] | last'
 ```
 
-Then diff the PR against the SHA that review was posted at, so the round
-covers the delta rather than the whole PR:
+**An empty result means this is round one.** Say so in the body and review the
+whole PR; the ratchet does not apply.
+
+Then scope the delta. A force-push — rebase or squash, the ordinary way an
+author turns a PR around — leaves the previously reviewed SHA unreachable, and
+a merge of `main` into the branch makes a two-dot diff render other people's
+commits as the author's work. Handle both:
 
 ```sh
-git diff <previous-reviewed-sha>..<headRefOid>
+git fetch origin <previous-reviewed-sha> 2>/dev/null || true
+if git merge-base --is-ancestor <previous-reviewed-sha> <headRefOid> 2>/dev/null; then
+  git diff <previous-reviewed-sha>..<headRefOid>
+else
+  git range-diff origin/main...<previous-reviewed-sha> origin/main...<headRefOid>
+fi
 ```
+
+If neither resolves — the previous SHA is gone and `range-diff` cannot pair
+the commits — declare the ratchet broken in the body, carry the previous
+round's unresolved findings forward by hand, and treat the rest as round one.
+
+Run the Step 4 gates on every round, including this one. They are how a
+re-review catches an artifact desync or a broken count without reading outside
+the delta, and `REVIEW.md`'s scope rule constrains what you report, not what
+you run.
 
 Open the body with the round number and the SHA you are ratcheting against,
 carry every unresolved finding forward at its original severity, justify any
-new Important finding on unchanged ground or demote it, and withdraw anything
-from your previous round that the rules say you should not have raised.
+new Important finding on settled ground or post it demoted with the admission
+attached, and withdraw anything from your previous round that the rules say
+you should not have raised.
 
 ## Step 8 — report
 

--- a/docs/REVIEW-SWEEP.md
+++ b/docs/REVIEW-SWEEP.md
@@ -257,22 +257,31 @@ gh api repos/rlaope/oh-my-hermes/pulls/<number>/reviews \
 **An empty result means this is round one.** Say so in the body and review the
 whole PR; the ratchet does not apply.
 
-Then scope the delta. A force-push — rebase or squash, the ordinary way an
-author turns a PR around — leaves the previously reviewed SHA unreachable, and
-a merge of `main` into the branch makes a two-dot diff render other people's
-commits as the author's work. Handle both:
+Then scope the delta. Two ordinary things break the obvious
+`git diff <prev>..<head>`: a force-push — rebase or squash, the usual way an
+author turns a PR around — leaves the previous SHA unreachable, and a merge of
+`main` into the branch leaves it reachable but fills a two-dot diff with every
+commit `main` gained in the interval, rendering other people's already-merged
+work as the author's.
+
+`range-diff` is correct in both cases, because it compares the two series
+*as rebased onto `main`* rather than walking history between them. Use it
+first, not as a fallback:
 
 ```sh
 git fetch origin <previous-reviewed-sha> 2>/dev/null || true
-if git merge-base --is-ancestor <previous-reviewed-sha> <headRefOid> 2>/dev/null; then
-  git diff <previous-reviewed-sha>..<headRefOid>
-else
-  git range-diff origin/main...<previous-reviewed-sha> origin/main...<headRefOid>
-fi
+git range-diff origin/main...<previous-reviewed-sha> origin/main...<headRefOid>
 ```
 
-If neither resolves — the previous SHA is gone and `range-diff` cannot pair
-the commits — declare the ratchet broken in the body, carry the previous
+Reach for a plain diff only to read a specific file's change in full, and
+scope it to the merge base so a merged `main` cannot leak in:
+
+```sh
+git diff "$(git merge-base <previous-reviewed-sha> <headRefOid>)"..<headRefOid> -- <path>
+```
+
+If `range-diff` cannot pair the commits — the previous SHA is gone and was
+never fetched — declare the ratchet broken in the body, carry the previous
 round's unresolved findings forward by hand, and treat the rest as round one.
 
 Run the Step 4 gates on every round, including this one. They are how a


### PR DESCRIPTION
## Feature Report

### What Changed

- `REVIEW.md`'s **Re-review convergence** section grows from one rule to six, all in force from round two: suppress new nits, delta-only scope, novelty justification, carryover blockers keep their severity, verdict monotonicity, and a duty to withdraw your own prior over-reach.
- `docs/REVIEW-SWEEP.md`'s **Re-reviews** step gains the operational half: fetch your previous review, diff against the SHA it was posted at, and state the round number and base SHA in the body.

Docs only. No runtime code, no schema, no generated artifact.

### Why This Exists

`REVIEW.md` asked a re-review to do exactly one thing: suppress new nits. That leaves every other way a review round fails to converge wide open.

A reviewer could pass over a file in round one and then mine that same untouched file for a fresh blocker in round three. A verdict could get *worse* after the author had resolved everything raised against it. And nothing obliged a reviewer to revisit its own earlier demands, so a request that turned out to be scope expansion just stayed on the board.

None of that requires anyone to behave unreasonably in any single round. It is how a one-line fix reaches round seven: the author does the work, and the goalposts move.

### User / Operator Impact

This is maintainer-facing policy, not a product surface. Nothing in `omh` reads `REVIEW.md` — it is loaded by a reviewer, human or agent, and by the `review-sweep` procedure.

Concretely, on the next re-review: the author can check whether the ratchet held, because the round number and base SHA are stated in the body, unresolved findings are carried forward at their original severity, and any new blocker on already-passed ground has to say why it was not visible earlier.

### How It Works

The six rules constrain what a *reviewer* may raise, which is the side of the loop that was unconstrained:

| Rule | What it stops |
| --- | --- |
| Suppress new nits | Style churn on a turned-around PR |
| Scope **findings** to the delta | Re-opening ground already settled |
| Novelty justification | Mining an unchanged file for leverage after round one |
| Carryover blockers keep severity | Convergence pressure dissolving a real defect |
| A cleared round cannot be made worse | A tally worsening after the author resolved everything |
| Withdraw your own over-reach | A bad round-one demand costing another cycle |

Carryover-blocker persistence is what keeps the other five from turning into a rubber stamp: convergence pressure applies to *new findings on settled ground*, never to defects that are still open.

Three definitions do the load-bearing work, and all three exist because the first draft got them wrong:

- **Settled ground** is the diff the previous round was posted against, *and only as far as that round says it looked* — so a shallow round one cannot permanently blind every round after it.
- **Verdict** means this file's tally. The sweep posts `COMMENT` and never approves, so the tally is the only verdict it has.
- **Scope constrains what you report, never what you read.** Reading outside the delta stays mandatory — this repo's two headline Important findings are things that *should have changed and did not*, which no diff can show. A finding whose cause is in the delta is a delta finding, whichever file exhibits it.

`docs/REVIEW-SWEEP.md` carries the mechanics because `REVIEW.md` is policy and the sweep is procedure — the repo already splits them that way, and `.claude/skills/review-sweep/` deliberately holds no rules of its own so there is nothing to drift. The procedure now takes the last review by **any** author (a human review settles ground exactly as a sweep review does) and reads the SHA from the API's `.commit_id` rather than parsing a reviewer-written marker; it handles a force-push with an ancestry check and a `range-diff` fallback; it says explicitly what to do when the previous SHA is unrecoverable; and it states that the Step 4 gates run on every round.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `REVIEW.md` | **Re-review convergence** expanded from 2 lines to 3 definitions + 6 rules |
| `docs/REVIEW-SWEEP.md` | **Re-reviews** step gains previous-review fetch, force-push-safe delta scoping, and body requirements; one pre-existing factual error corrected |

No source module or test reads either file — verified by grep. `.claude/skills/review-sweep/SKILL.md` still defers to `docs/REVIEW-SWEEP.md` and holds no rules, so it needed no change.

**One unrelated correction, in a file already open.** `docs/REVIEW-SWEEP.md` claimed CI runs only `docs workflows --check` and that `docs roles --check` and `docs capability-families --check` were the reviewer's to catch. `.github/workflows/ci.yml` runs all three unconditionally on every PR. The false claim inflated reviewer workload, and it sits in the paragraph this change is already editing around.

### Provenance

Adapted from the Gajae-Code project's `critic` agent re-review contract, which carries five rules of the same shape. Its fifth is a counter-review of a *sibling* agent's output — Critic reviewing Architect for over-engineering.

That has no counterpart in a single-reviewer sweep, so it is replaced by the reviewer auditing its own previous round. **This is a weaker substitute, not an equivalent**: the property that made the original work is that the checker is not the checked, and the substitute drops exactly that. It is recorded as a `Directive:` trailer so a future second reviewer lane restores the real rule rather than inheriting the compromise.

### Review

An adversarial critique of the first commit returned **ITERATE** with six blocking defects, all real, all confirmed against the actual text. `26d01225` fixes them:

| # | Defect |
| --- | --- |
| B1 | Delta-only was written as a **reading** rule, flatly contradicting `docs/REVIEW-SWEEP.md`'s "Never review from the diff text alone" — and making this repo's two headline Important findings structurally unobservable |
| B2 | Novelty-demotion + nit-suppression **composed into deletion**: a demoted finding became a nit, and new nits were suppressed. The three sanctioned novelty reasons were all external-cause, so an honest "I missed it" had no compliant path while a fabricated reason passed unverified |
| B3 | Verdict monotonicity had a **vacuous antecedent** — a previous round with zero Important findings satisfied "all resolved" trivially, pinning the next round to clean whatever the author pushed |
| B4 | Three rules spoke of verdicts and approval, which the sweep is **forbidden to emit**; the illustration also contradicted the rule it illustrated |
| B5 | The review fetch filtered on the sweep's own marker, so a human-reviewed PR returned `null` **silently** and the ratchet did not apply |
| B6 | The delta diff assumed the previous SHA was reachable — false after a **force-push**, the ordinary way an author turns a PR around |

Also adopted from that critique: settled-ground and verdict definitions, "resolved" held to the existing Verification bar, withdrawal named as the one thing other than a fix that clears a carryover blocker, and escalation to the maintainer after two disputed rounds.

The critique's own summary of the failure is the fairest description of what went wrong: *"the new section was written against an idealized reviewer and never reconciled against the file it ships beside."*

## Validation

- [x] `uv run --group lint ruff check src tests` — exit 0
- [x] `python3 -m unittest discover -s tests` — **5664 tests OK**
- [x] `python3 -m compileall src` — exit 0
- [x] `python3 -m omh.cli docs workflows --check` — exit 0
- [x] `python3 -m omh.cli harness validate` — exit 0
- [x] `python3 -m omh.cli release checklist --json` — exit 0
- [x] `python3 -m omh.cli release hermes-smoke` — exit 0
- [x] `docs roles --check`, `docs capability-families --check` — exit 0; `git diff --check` clean
- [x] Confirmed by grep that no test or `src/` module reads `REVIEW.md` or `docs/REVIEW-SWEEP.md`
- [x] Verified against source that `docs/REVIEW-SWEEP.md` forbids diff-only review, that the sweep posts `COMMENT` only, and that `.github/workflows/ci.yml` runs all three byte gates
- [ ] Manual Hermes/TUI check — **not applicable.** No product surface changed.

## Risk

- **The policy is unenforceable by construction.** Nothing reads `REVIEW.md`; adherence cannot be proven by any gate in this repo, only observed on the next re-review that follows it. That is a property of the file, not of this change, but it is the main reason to be skeptical.
- **It constrains the reviewer, and a lazy author benefits from a constrained reviewer.** The counterweights are the carryover-blocker rule, the `What Important means here` exemption from demotion, and the requirement to keep reading outside the delta — but the balance is a judgment call, not a proof.
- **The novelty gate still filters candour more than it filters mining.** A reviewer can assert a sanctioned reason and nothing verifies it. Adding "I did not examine this last round" as an explicit, self-indicting option narrows the gap; it does not close it.
- **The self-audit rule is not independent.** Named above and in the commit trailer, but worth repeating in the risk section: it is the one rule whose mechanism is strictly weaker than the source it was adapted from.
- The fetch path has **never run in production** — no sweep-marked review exists in the current backlog, so `.commit_id` extraction and the `range-diff` fallback are reasoned, not observed.

## Compatibility / Rollout

- Takes effect the next time anyone runs `review-sweep` or reviews a PR by hand. No migration, no state, nothing to roll back but the commit.
- Existing open PRs with a prior review are covered from their next round.

## Release / Claims

- [x] Release-channel impact considered — `local`; no version file, changelog, or release artifact touched
- [x] Runtime/native capability claims backed by evidence or marked not observed — none made; this change adds no capability claim
- [x] Known manual Hermes checks listed — not applicable, no Hermes surface touched

## Follow-Up

- If a second reviewer lane is ever added, the sibling counter-review should be restored as its own rule rather than stretching the self-audit one. The commit message carries that as a `Directive:` trailer.
- A force-pushed PR can make the previously-reviewed SHA unreachable, which leaves the delta diff without a base. The procedure does not yet say what to do in that case.
