### PR TITLE
fix: stop storing AWS-key-shaped literals in the test tree

### DIFF
--- a/src/coding/action_gate.py
+++ b/src/coding/action_gate.py
@@ -1772,10 +1772,10 @@ def _is_env_var_name(value: str) -> bool:
 
     Same shape and the same reason: an environment variable *name* is safe to
     carry because it is not the value. The shape alone is not enough — plenty of
-    issued credentials are upper-case alphanumerics too, and
-    `AKIAIOSFODNN7EXAMPLE` satisfies every character rule below — so the value
-    is also screened through the credential boundary's own value detectors
-    before it is accepted as a name.
+    issued credentials are upper-case alphanumerics too, and an `AKIA`-prefixed
+    AWS access key id satisfies every character rule below — so the value is
+    also screened through the credential boundary's own value detectors before
+    it is accepted as a name.
 
     `is_secret_value_shaped` rather than `is_sensitive_metadata_text`: the wider
     predicate flags anything *named* like a secret, and an environment variable

--- a/src/system/metadata_safety.py
+++ b/src/system/metadata_safety.py
@@ -41,7 +41,8 @@ def is_secret_value_shaped(value: str) -> bool:
     is an environment variable *name*, since such a name legitimately contains
     them. These four patterns flag the issued material itself, and a name can
     never match one, so a field that must accept `GITHUB_TOKEN` while refusing
-    `AKIAIOSFODNN7EXAMPLE` reads this predicate instead of the wider one.
+    an issued `AKIA`-prefixed access key id reads this predicate instead of
+    the wider one.
 
     No new pattern is introduced here: these are exactly the detectors this
     module already owned, which also bounds what the screen can catch. A

--- a/tests/_credential_fixtures.py
+++ b/tests/_credential_fixtures.py
@@ -1,0 +1,35 @@
+"""Credential-shaped sample values, assembled rather than written out.
+
+Secret scanners -- GitHub's included -- match literal text in tracked files.
+A test that needs an AWS access key id to prove a redaction path writes one
+out, the scanner sees a live-shaped credential, and the repository collects an
+alert for a value nobody ever issued. That is exactly what happened: an
+`ASIA`-prefixed sample in `tests/test_risky_action_confirmation.py` raised a
+"Amazon AWS Temporary Access Key ID" secret-scanning alert. The value was
+fabricated, so there was nothing to rotate or revoke -- only a literal to stop
+storing.
+
+The constants below are the same strings at runtime that the literals were:
+`_AWS_ACCESS_KEY` in `src/system/metadata_safety.py` matches them, and so does
+every value detector built on it. Joining the prefix to the body at import time
+means no AWS-key-shaped literal exists on disk for a scanner to match, while
+tests keep exercising the real shape rather than a weakened stand-in.
+
+`tests/test_credential_fixture_policy.py` keeps the arrangement honest: it
+fails when an AWS-key-shaped literal reappears anywhere in the tree.
+"""
+
+from __future__ import annotations
+
+# Sixteen upper-case alphanumerics -- the body an AWS access key id carries
+# after its four-character prefix. Alone it matches no scanner pattern, because
+# the prefix is what makes the shape.
+_AWS_ACCESS_KEY_BODY = "IOSFODNN7EXAMPLE"
+
+#: Long-term AWS access key id shape (`AKIA` + sixteen).
+AWS_ACCESS_KEY_ID = "AKIA" + _AWS_ACCESS_KEY_BODY
+
+#: Temporary (STS) AWS access key id shape (`ASIA` + sixteen). The prefix is
+#: the only difference from the long-term form, and the value detectors treat
+#: the two identically.
+AWS_TEMPORARY_ACCESS_KEY_ID = "ASIA" + _AWS_ACCESS_KEY_BODY

--- a/tests/test_append_only_store.py
+++ b/tests/test_append_only_store.py
@@ -23,6 +23,7 @@ import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+from _credential_fixtures import AWS_ACCESS_KEY_ID
 from _local_package import load_local_package
 
 load_local_package()
@@ -353,7 +354,7 @@ class ReferenceGuardTests(unittest.TestCase):
     def test_redacted_ref_keeps_opaque_handles_and_folds_everything_else(self) -> None:
         self.assertEqual(redacted_ref("slack:message-1", field="ref"), "slack:message-1")
         self.assertEqual(redacted_ref("", field="ref"), "")
-        for unsafe in ("https://example.com/x", "AKIAIOSFODNN7EXAMPLE", "bad\x1bref", "a" * 200):
+        for unsafe in ("https://example.com/x", AWS_ACCESS_KEY_ID, "bad\x1bref", "a" * 200):
             with self.subTest(unsafe=unsafe):
                 folded = redacted_ref(unsafe, field="ref")
                 self.assertTrue(folded.startswith("ref-"))
@@ -371,7 +372,7 @@ class BoundedTextTests(unittest.TestCase):
             "erase\x1b[2K\r",
             "C:\\Users\\me",
             "\\\\host\\share",
-            "AKIAIOSFODNN7EXAMPLE",
+            AWS_ACCESS_KEY_ID,
         ):
             with self.subTest(unsafe=unsafe):
                 self.assertTrue(is_unsafe_metadata_line(unsafe))

--- a/tests/test_credential_fixture_policy.py
+++ b/tests/test_credential_fixture_policy.py
@@ -1,0 +1,119 @@
+"""Gate keeping AWS-key-shaped literals out of the tree.
+
+A secret-scanning alert on a fabricated test value costs the same triage as a
+real one: rotate, revoke, check the logs, close. The only way to not pay it
+again is for the literal to not exist, which is what `tests/_credential_fixtures.py`
+arranges -- the sample values are joined from a prefix and a body at import
+time, so the shape is real at runtime and absent from disk.
+
+That arrangement only holds while nobody writes the literal back. This module
+re-derives the answer from the tree on every run: it walks the repository with
+the same pattern the scanner uses, and fails with the offending path when a
+match appears. Adding a fixture is then the obvious move rather than the
+disciplined one.
+
+The pattern is `_AWS_ACCESS_KEY` from `src/system/metadata_safety.py`, quoted
+here rather than imported, so a change that narrows the production detector
+cannot silently narrow this gate too.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+from _credential_fixtures import AWS_ACCESS_KEY_ID, AWS_TEMPORARY_ACCESS_KEY_ID
+from _local_package import load_local_package
+
+
+load_local_package()
+from omh.system.metadata_safety import is_secret_value_shaped
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_MODULE = "tests/_credential_fixtures.py"
+
+# `\b(?:AKIA|ASIA)[A-Z0-9]{16}\b` -- the AWS access key id shape, long-term and
+# temporary. Deliberately a copy of the production detector, not an import.
+AWS_ACCESS_KEY_LITERAL = re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b")
+
+# Text the scanner would read. Binary assets cannot carry a literal a reviewer
+# would paste back, so they are not walked.
+SCANNED_SUFFIXES = frozenset(
+    {".py", ".md", ".txt", ".json", ".yml", ".yaml", ".toml", ".cfg", ".ini", ".sh", ".ps1", ".html", ".css", ".js"}
+)
+
+# Untracked build output and local runtime state. Everything else under the
+# repository root is walked, so a new tracked directory is covered by default.
+IGNORED_DIRECTORY_NAMES = frozenset(
+    {
+        ".git",
+        ".venv",
+        "venv",
+        "build",
+        "dist",
+        "htmlcov",
+        "node_modules",
+        "__pycache__",
+        ".pytest_cache",
+        ".mypy_cache",
+        ".ruff_cache",
+        ".playwright-mcp",
+        ".hermes",
+        ".omh",
+        ".omc",
+        ".omo",
+        ".loop",
+    }
+)
+
+
+def _is_ignored(path: Path) -> bool:
+    return any(
+        part in IGNORED_DIRECTORY_NAMES or part.endswith(".egg-info") for part in path.relative_to(REPO_ROOT).parts
+    )
+
+
+def _scanned_files() -> list[Path]:
+    return sorted(
+        path
+        for path in REPO_ROOT.rglob("*")
+        if path.is_file() and path.suffix in SCANNED_SUFFIXES and not _is_ignored(path)
+    )
+
+
+class CredentialFixturePolicyTests(unittest.TestCase):
+    def test_no_aws_access_key_literal_is_stored_in_the_tree(self) -> None:
+        offenders = []
+        for path in _scanned_files():
+            text = path.read_text(encoding="utf-8", errors="replace")
+            if AWS_ACCESS_KEY_LITERAL.search(text):
+                offenders.append(path.relative_to(REPO_ROOT).as_posix())
+
+        self.assertEqual(
+            offenders,
+            [],
+            "AWS-key-shaped literal stored in the tree; secret scanning will alert on it. "
+            f"Import the sample value from `{FIXTURE_MODULE}` instead of writing it out.",
+        )
+
+    def test_the_scan_reaches_the_files_a_regression_would_land_in(self) -> None:
+        """An empty offender list means nothing if the walk found nothing."""
+        scanned = {path.relative_to(REPO_ROOT).as_posix() for path in _scanned_files()}
+        for expected in (FIXTURE_MODULE, "tests/test_risky_action_confirmation.py", "src/system/metadata_safety.py"):
+            self.assertIn(expected, scanned)
+
+    def test_the_gate_pattern_still_matches_the_shape_it_guards(self) -> None:
+        for value in (AWS_ACCESS_KEY_ID, AWS_TEMPORARY_ACCESS_KEY_ID):
+            with self.subTest(value=value):
+                self.assertTrue(AWS_ACCESS_KEY_LITERAL.fullmatch(value))
+
+    def test_the_fixtures_keep_the_shape_the_production_detector_screens(self) -> None:
+        for value in (AWS_ACCESS_KEY_ID, AWS_TEMPORARY_ACCESS_KEY_ID):
+            with self.subTest(value=value):
+                self.assertEqual(len(value), 20)
+                self.assertTrue(is_secret_value_shaped(value))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cross_harness_adapter_contract.py
+++ b/tests/test_cross_harness_adapter_contract.py
@@ -11,6 +11,7 @@ from tempfile import TemporaryDirectory
 import unittest
 from unittest.mock import patch
 
+from _credential_fixtures import AWS_ACCESS_KEY_ID
 from src.quality.cross_harness_adapter_evidence import (
     adapter_request_payload,
     adapter_result_payload,
@@ -199,7 +200,7 @@ class AdapterBoundaryFailingFirstTests(unittest.TestCase):
     def test_recursive_raw_keys_secret_vectors_and_credential_paths_are_rejected(self) -> None:
         secret_values = (
             "ghp_1234567890abcdefghijklmnopqrstuvwxyz",
-            "AKIAIOSFODNN7EXAMPLE",
+            AWS_ACCESS_KEY_ID,
             "sk-attacker",
             "-----BEGIN EC PRIVATE KEY-----",
             "/home/alice/.aws/credentials",

--- a/tests/test_cross_harness_adapter_security.py
+++ b/tests/test_cross_harness_adapter_security.py
@@ -13,6 +13,7 @@ from threading import Thread
 import unittest
 from unittest.mock import patch
 
+from _credential_fixtures import AWS_ACCESS_KEY_ID
 from src.quality import cross_harness_adapter_io as adapter_io
 from src.quality.cross_harness_adapter_sandbox import ChildContext, ProcessObservation, environment_is_safe, observe_process, preflight, sandbox_command
 from src.quality.cross_harness_adapters import ExecutionSpec, _artifact_result, runner_receipt_payload
@@ -122,7 +123,7 @@ class AdapterSandboxSecurityTests(_RunnerMixin, unittest.TestCase):
     def test_secret_shaped_values_are_rejected_but_numeric_listener_values_are_allowed(self) -> None:
         rejected = (
             "ghp_abcdefghijklmnopqrstuvwxyz1234567890",
-            "AKIAIOSFODNN7EXAMPLE",
+            AWS_ACCESS_KEY_ID,
             "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature",
             "Bearer opaque-credential",
             "-----BEGIN PRIVATE KEY-----",

--- a/tests/test_cross_harness_benchmark_security.py
+++ b/tests/test_cross_harness_benchmark_security.py
@@ -10,6 +10,7 @@ from tempfile import TemporaryDirectory
 import unittest
 from unittest.mock import patch
 
+from _credential_fixtures import AWS_ACCESS_KEY_ID
 from src.quality import cross_harness_benchmark as benchmark
 from src.quality.cross_harness_benchmark import (
     BenchmarkValidationError,
@@ -204,7 +205,7 @@ class CrossHarnessBenchmarkSecurityTests(unittest.TestCase):
         for secret in (
             "person@example.test",
             "ghp_abcdefghijklmnopqrstuvwxyz1234567890",
-            "AKIAIOSFODNN7EXAMPLE",
+            AWS_ACCESS_KEY_ID,
         ):
             with self.subTest(secret_shape=secret[:4]):
                 benchmark_input = _benchmark_input()

--- a/tests/test_data_boundary.py
+++ b/tests/test_data_boundary.py
@@ -17,6 +17,7 @@ import json
 import unittest
 from unittest import mock
 
+from _credential_fixtures import AWS_ACCESS_KEY_ID
 from _local_package import load_local_package
 
 load_local_package()
@@ -189,7 +190,7 @@ class ProhibitedDataClassTests(unittest.TestCase):
 
     def test_credential_material_keeps_naming_the_credential_rule(self) -> None:
         """`secrets_absent` predates #801 and still answers for its own class."""
-        verdict = evaluate_safety_preflight(request(owner="AKIAIOSFODNN7EXAMPLE"))
+        verdict = evaluate_safety_preflight(request(owner=AWS_ACCESS_KEY_ID))
         self.assertEqual(verdict["reason_code"], "secret_shaped_value")
 
     def test_the_prohibited_content_scan_never_reads_a_user_named_path(self) -> None:

--- a/tests/test_project_governance.py
+++ b/tests/test_project_governance.py
@@ -5,6 +5,7 @@ import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+from _credential_fixtures import AWS_ACCESS_KEY_ID
 from _local_package import load_local_package
 
 load_local_package()
@@ -168,7 +169,7 @@ class ProjectGovernanceTests(unittest.TestCase):
         self.assertEqual(discovery["status"], "existing_project_governance")
 
     def test_sensitive_governance_source_is_blocked_before_attachment(self) -> None:
-        for content in ("AWS_SECRET_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE", "secret=topsecret", "-----BEGIN PRIVATE KEY-----"):
+        for content in (f"AWS_SECRET_ACCESS_KEY={AWS_ACCESS_KEY_ID}", "secret=topsecret", "-----BEGIN PRIVATE KEY-----"):
             with self.subTest(content=content), TemporaryDirectory() as tmp:
                 root = Path(tmp)
                 (root / "AGENTS.md").write_text(content, encoding="utf-8")

--- a/tests/test_prompt_compatibility.py
+++ b/tests/test_prompt_compatibility.py
@@ -8,6 +8,7 @@ import unittest
 from unittest.mock import patch
 
 from _cli_harness import run_cli
+from _credential_fixtures import AWS_ACCESS_KEY_ID
 from _local_package import load_local_package
 from _platform_support import requires_posix, requires_secure_dir_io
 
@@ -68,13 +69,13 @@ class PromptCompatibilityAuditTests(unittest.TestCase):
         with TemporaryDirectory() as tmp:
             root = Path(tmp).resolve()
             prompt = root / "secure.md"
-            prompt.write_text("Do not retain AKIAIOSFODNN7EXAMPLE.\n", encoding="utf-8")
+            prompt.write_text(f"Do not retain {AWS_ACCESS_KEY_ID}.\n", encoding="utf-8")
 
             payload = audit_prompt_compatibility((prompt,))
 
             source = payload["sources"]["files"][0]
             self.assertIn("secret_like_text", source["trust_review"]["reasons"])
-            self.assertNotIn("AKIAIOSFODNN7EXAMPLE", json.dumps(payload, sort_keys=True))
+            self.assertNotIn(AWS_ACCESS_KEY_ID, json.dumps(payload, sort_keys=True))
             with self.assertRaisesRegex(ValueError, "regular file"):
                 audit_prompt_compatibility((root,))
 
@@ -94,11 +95,11 @@ class PromptCompatibilityAuditTests(unittest.TestCase):
     def test_audit_rejects_sensitive_metadata_and_symlinks_at_every_path_component(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp).resolve()
-            secret_filename = root / "AKIAIOSFODNN7EXAMPLE.md"
+            secret_filename = root / f"{AWS_ACCESS_KEY_ID}.md"
             secret_filename.write_text("Safe prompt body.\n", encoding="utf-8")
             with self.assertRaisesRegex(ValueError, "safe metadata") as raised:
                 audit_prompt_compatibility((secret_filename,))
-            self.assertNotIn("AKIAIOSFODNN7EXAMPLE", str(raised.exception))
+            self.assertNotIn(AWS_ACCESS_KEY_ID, str(raised.exception))
 
             named_secret = root / "named.md"
             named_secret.write_text("---\nname: secret\n---\nSafe prompt body.\n", encoding="utf-8")
@@ -160,12 +161,12 @@ class PromptCompatibilityAuditTests(unittest.TestCase):
             self.assertEqual(payload["sources"]["files"][0]["proposed_command"], "review")
             self.assertEqual(payload["not_observed"]["slash_command_registration"]["status"], "not_observed")
 
-            secret_named = root / "AKIAIOSFODNN7EXAMPLE.md"
+            secret_named = root / f"{AWS_ACCESS_KEY_ID}.md"
             secret_named.write_text("Safe prompt body.\n", encoding="utf-8")
             status, stdout, stderr = run_cli(["ops", "prompt-compatibility-audit", "--path", str(secret_named)])
             self.assertEqual(status, 2)
             self.assertEqual(stdout, "")
-            self.assertNotIn("AKIAIOSFODNN7EXAMPLE", stderr)
+            self.assertNotIn(AWS_ACCESS_KEY_ID, stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_risky_action_confirmation.py
+++ b/tests/test_risky_action_confirmation.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import mock
 
+from _credential_fixtures import AWS_ACCESS_KEY_ID, AWS_TEMPORARY_ACCESS_KEY_ID
 from _local_package import load_local_package
 
 load_local_package()
@@ -1019,7 +1020,7 @@ class AccountAuthorizationTests(unittest.TestCase):
     def test_a_credential_value_that_matches_the_name_shape_is_still_refused(self) -> None:
         """An AWS key id is upper-case alphanumerics; the shape alone accepted it verbatim."""
         envelope = _envelope()
-        for value in ("AKIAIOSFODNN7EXAMPLE", "ASIAIOSFODNN7EXAMPLE"):
+        for value in (AWS_ACCESS_KEY_ID, AWS_TEMPORARY_ACCESS_KEY_ID):
             with self.subTest(value=value):
                 self.assertTrue(is_secret_value_shaped(value))
                 block = build_account_authorization(

--- a/tests/test_role_context_packs.py
+++ b/tests/test_role_context_packs.py
@@ -21,6 +21,7 @@ from tempfile import TemporaryDirectory
 import unittest
 
 from _cli_harness import run_cli
+from _credential_fixtures import AWS_ACCESS_KEY_ID
 from _local_package import load_local_package
 
 load_local_package()
@@ -372,7 +373,7 @@ class NoMutatingWriterTests(unittest.TestCase):
                 context_pack={
                     "included_context": [
                         {
-                            "item_id": "AKIAIOSFODNN7EXAMPLE",
+                            "item_id": AWS_ACCESS_KEY_ID,
                             "key": "k",
                             "summary": "s",
                             "source": "wrapper_snapshot",

--- a/tests/test_run_efficiency.py
+++ b/tests/test_run_efficiency.py
@@ -6,6 +6,7 @@ from tempfile import TemporaryDirectory
 import unittest
 
 from _cli_harness import run_cli
+from _credential_fixtures import AWS_ACCESS_KEY_ID
 from _local_package import load_local_package
 
 
@@ -70,7 +71,7 @@ class RunEfficiencyReportTests(unittest.TestCase):
             parse_run_efficiency_input(unknown_metric)
 
         for secret_source_value in (
-            "AKIAIOSFODNN7EXAMPLE",
+            AWS_ACCESS_KEY_ID,
             "AIzaSyDUMMYABCDEFGHIJKLMNOPQRSTUVWX123",
             "npm_12345678901234567890",
             "gho_12345678901234567890",

--- a/tests/test_run_health_summary.py
+++ b/tests/test_run_health_summary.py
@@ -23,6 +23,7 @@ from tempfile import TemporaryDirectory
 import unittest
 
 from _cli_harness import run_cli
+from _credential_fixtures import AWS_ACCESS_KEY_ID
 from _local_package import load_local_package
 
 load_local_package()
@@ -459,7 +460,7 @@ class RunHealthInputBoundsTests(unittest.TestCase):
             parse_run_health_input(too_many)
 
     def test_the_parser_refuses_secret_shaped_references(self) -> None:
-        for secret in ("AKIAIOSFODNN7EXAMPLE", "gho_12345678901234567890", "AIzaSyDUMMYABCDEFGHIJKLMNOPQRSTUVWX123"):
+        for secret in (AWS_ACCESS_KEY_ID, "gho_12345678901234567890", "AIzaSyDUMMYABCDEFGHIJKLMNOPQRSTUVWX123"):
             with self.subTest(secret=secret):
                 with self.assertRaisesRegex(ValueError, "safe opaque metadata reference"):
                     parse_run_health_input(

--- a/tests/test_safety_preflight.py
+++ b/tests/test_safety_preflight.py
@@ -15,6 +15,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+from _credential_fixtures import AWS_ACCESS_KEY_ID
 from _local_package import load_local_package
 
 load_local_package()
@@ -233,7 +234,7 @@ class FieldClassTests(unittest.TestCase):
         for field, value in (
             ("owner", "ghp_abcdefghijklmnopqrstuvwxyz"),
             ("approved_scope", "api_key-scope"),
-            ("persisted_content_refs", ["AKIAIOSFODNN7EXAMPLE"]),
+            ("persisted_content_refs", [AWS_ACCESS_KEY_ID]),
             ("observed_record_refs", ["bearer-abc"]),
         ):
             with self.subTest(field=field):
@@ -280,7 +281,7 @@ class FieldClassTests(unittest.TestCase):
         mode = evaluate_safety_preflight(request(message_context_mode="ghp_abcdefghijklmnopqrstuvwxyz"))
         self.assertEqual(mode["status"], "deny")
         self.assertEqual(mode["reason_code"], "raw_context_mode_unknown")
-        claim = evaluate_safety_preflight(request(evidence_claims=["AKIAIOSFODNN7EXAMPLE"]))
+        claim = evaluate_safety_preflight(request(evidence_claims=[AWS_ACCESS_KEY_ID]))
         self.assertEqual(claim["status"], "deny")
         self.assertEqual(claim["reason_code"], "evidence_claim_unknown")
         kind = evaluate_safety_preflight(request(remote_targets=[{"kind": "api_key", "ref": "origin"}]))
@@ -353,7 +354,7 @@ class SafetyPreflightDenialTests(unittest.TestCase):
             ),
             (
                 "credential shaped value",
-                request(owner="AKIAIOSFODNN7EXAMPLE"),
+                request(owner=AWS_ACCESS_KEY_ID),
                 RULE_SECRETS_ABSENT,
                 "owner",
                 "secret_shaped_value",
@@ -732,10 +733,10 @@ class PreExpansionInputTests(unittest.TestCase):
             ("fenced block in a declared field", request(approved_scope="```python```"), "body_shaped_request_value"),
             ("long body in a declared field", request(approved_scope="x" * 500), "body_shaped_request_value"),
             ("credential in a declared field", request(approved_scope="ghp_abcdefghijklmnopqrstuvwxyz"), "secret_shaped_value"),
-            ("credential inside a list", request(persisted_content_refs=["AKIAIOSFODNN7EXAMPLE"]), "secret_shaped_value"),
+            ("credential inside a list", request(persisted_content_refs=[AWS_ACCESS_KEY_ID]), "secret_shaped_value"),
             (
                 "credential inside a nested remote target",
-                request(remote_targets=[{"kind": "git_remote", "ref": "AKIAIOSFODNN7EXAMPLE"}]),
+                request(remote_targets=[{"kind": "git_remote", "ref": AWS_ACCESS_KEY_ID}]),
                 "secret_shaped_value",
             ),
             ("body inside a list", request(target_paths=["src/a.py\nsrc/b.py"]), "body_shaped_request_value"),


### PR DESCRIPTION
## Feature Report

### What Changed

- `tests/_credential_fixtures.py` (new) exports `AWS_ACCESS_KEY_ID` and `AWS_TEMPORARY_ACCESS_KEY_ID`, joined from prefix and body at import time so no AWS-key-shaped literal is stored on disk.
- All 24 call sites across 12 test files now import the fixture instead of writing the literal; four sites that embedded it in a longer string became f-strings.
- The two docstrings in `src/` that quoted a key verbatim (`src/system/metadata_safety.py`, `src/coding/action_gate.py`) now name the `AKIA` prefix, which is the part the prose was actually about.
- `tests/test_credential_fixture_policy.py` (new) walks the tree with the scanner's own pattern and fails with the offending path when a literal reappears.

### Why This Exists

- GitHub secret-scanning alert #1 — "Amazon AWS Temporary Access Key ID", publicly leaked — fired on `ASIAIOSFODNN7EXAMPLE` in `tests/test_risky_action_confirmation.py`. The value was fabricated for a test proving a credential value never reaches an authorization record, so there was nothing to rotate, revoke, or find in an access log.
- The triage cost is the same as for a real leak, and 23 more literals of the same shape sat in the tree. The literal is what the scanner matches, so the durable fix is for the literal to not exist.

### User / Operator Impact

- None at runtime. No production behaviour, CLI surface, schema, or generated artifact changes.
- For contributors: writing an AWS-key-shaped literal now fails a test with a message naming the fixture module to import instead.

### How It Works

- `"AKIA" + "IOSFODNN7EXAMPLE"` is byte-identical at runtime to the literal it replaces. `_AWS_ACCESS_KEY` in `src/system/metadata_safety.py` still matches, and every value detector built on it still fires — no test was weakened to make the scanner quiet.
- The gate quotes `\b(?:AKIA|ASIA)[A-Z0-9]{16}\b` rather than importing the production detector, so a later narrowing of the detector cannot silently narrow the gate.
- A companion test asserts the walk actually reaches the files a regression would land in; an empty offender list means nothing if the walk found nothing.
- Scope is AWS-key-shaped literals only. The other credential-shaped dummies in the tree (`ghp_abcdefghijklmnopqrstuvwxyz`, `sk-SECRET-VALUE-12345`, `AIzaSyDUMMY...`) are non-entropic and do not match GitHub's checksum-bearing patterns; none has alerted, so folding them in would widen the diff without closing an alert.

### Files And Contracts Touched

- New: `tests/_credential_fixtures.py`, `tests/test_credential_fixture_policy.py`.
- Docstring-only: `src/system/metadata_safety.py`, `src/coding/action_gate.py`.
- Fixture import + call sites: `tests/test_append_only_store.py`, `tests/test_cross_harness_adapter_contract.py`, `tests/test_cross_harness_adapter_security.py`, `tests/test_cross_harness_benchmark_security.py`, `tests/test_data_boundary.py`, `tests/test_project_governance.py`, `tests/test_prompt_compatibility.py`, `tests/test_risky_action_confirmation.py`, `tests/test_role_context_packs.py`, `tests/test_run_efficiency.py`, `tests/test_run_health_summary.py`, `tests/test_safety_preflight.py`.
- No catalog, routing, skill, or generated-artifact source was touched; no exact-count assertion changed.

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `python3 -m unittest discover -s tests` — Ran 5668 tests, OK
- [x] `python3 -m compileall src` — clean (ran against `src tests`)
- [x] `python3 -m omh.cli docs workflows --check` — ok=true, tap_skills 115/115, no missing/stale/extra
- [x] `python3 -m omh.cli harness validate` — ok=true, 72 harnesses / 104 skills, no errors or warnings
- [x] `python3 -m omh.cli release checklist --json` — ok=true, 35 required items rendered
- [x] `python3 -m omh.cli release hermes-smoke` — plan rendered with plan-only boundary
- [x] `omh --help` — renders
- [ ] `omh --omh-home /tmp/omh-smoke ... release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; this change touches no install, packaging, or console-script path
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable — no learning contract changed
- [x] Relevant dry-run or smoke command: also ran `docs roles --check` and `docs capability-families --check` (both ok=true), and `git diff --check`
- [ ] Manual Hermes/TUI check: not run — no Hermes-facing surface, card, route, or payload changed

Gate falsification, since a gate that cannot fail proves nothing: planting an `ASIA`-shaped literal in `docs/_guard_probe.md` failed `test_no_aws_access_key_literal_is_stored_in_the_tree` with the offending path in the message; removing the probe restored green.

## Risk

- Low. The fixture values are byte-identical at runtime to the literals they replace, so every assertion exercises the same input as before.
- The gate's reach is bounded by its suffix list and its ignored-directory set. A literal in a file type the repository does not currently contain would not be caught; the ignored set covers only untracked build output and local runtime state, so a new tracked directory is walked by default.
- One environmental note found while validating: `build_plan_handoff_context_pack` rejects a context pack whose text is sensitive-looking, and a git branch named with the word "secret" trips it. The branch was renamed to `claude/credential-fixture-literals` and the suite went green. That is pre-existing behaviour of the sensitive-metadata screen, not a regression from this change, but it is worth knowing before naming a branch.

## Compatibility / Rollout

- No compatibility surface. Test-only plus two docstrings; no schema, no version, no generated artifact.

## Release / Claims

- [x] Release-channel impact considered — none; no packaged behaviour changes
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — no runtime claim is made
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap — no live Hermes smoke was run and none is implied by this change

Not observed: GitHub's scanner has not re-run against this branch, so alert #1 closing is unobserved. Windows CI was not run locally.

## Follow-Up

- After merge, close alert #1 on the secret-scanning page. The correct resolution is "used in tests" / false positive — the value was never an issued credential, so the rotate/revoke/audit-log steps in the alert do not apply.
