### PR TITLE
feat: offer design directions as a choice, and render one a person can look at

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -2008,6 +2008,7 @@ These surfaces are generated command references, not installed Hermes workflow s
   - executor selection and observed visual evidence remain pending
 - Expected outputs:
   - design_orchestration/v1
+  - design_direction_set/v1 when the direction is still open
   - design intent and opaque context-reference boundary
   - prepared direction vocabulary
   - downstream composition: design-quality-gate, frontend, accessibility-audit, visual-qa
@@ -2015,6 +2016,8 @@ These surfaces are generated command references, not installed Hermes workflow s
   - visual evidence requirements with visual_verdict not_observed
 - Artifact expectations:
   - design_orchestration/v1 with prepared_not_observed status
+  - design_direction_set/v1 offers two to four directions with chosen_option empty until the user picks
+  - a static self-contained preview file when one is written; no server, port, or browser launch
   - no raw project source, prompt, asset, path, or URL retention
   - no executor target, dispatch, implementation, render, QA PASS, review, CI, deployment, or merge claim
 - Safety rules:
@@ -9031,6 +9034,7 @@ Direction.
   - context
 - Outputs:
   - design_orchestration/v1
+  - design_direction_set/v1
 - Stop conditions:
   - card is prepared or a missing decision is surfaced
   - observed evidence is separated from prepared guidance

--- a/skills/omh-design-orchestration/SKILL.md
+++ b/skills/omh-design-orchestration/SKILL.md
@@ -90,6 +90,7 @@ Required inputs:
 Expected outputs:
 
 - design_orchestration/v1
+- design_direction_set/v1 when the direction is still open
 - design intent and opaque context-reference boundary
 - prepared direction vocabulary
 - downstream composition: design-quality-gate, frontend, accessibility-audit, visual-qa
@@ -99,6 +100,8 @@ Expected outputs:
 Artifact expectations:
 
 - design_orchestration/v1 with prepared_not_observed status
+- design_direction_set/v1 offers two to four directions with chosen_option empty until the user picks
+- a static self-contained preview file when one is written; no server, port, or browser launch
 - no raw project source, prompt, asset, path, or URL retention
 - no executor target, dispatch, implementation, render, QA PASS, review, CI, deployment, or merge claim
 

--- a/src/commands/ops.py
+++ b/src/commands/ops.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
 
 from ..installer import OmhError
 from ..operator_productivity import (
@@ -55,6 +56,11 @@ from ..design_orchestration import (
     DESIGN_SURFACES,
     DESIGN_TYPOGRAPHIES,
     build_design_orchestration,
+)
+from ..design_directions import (
+    DESIGN_DIRECTION_OPTION_IDS,
+    build_design_direction_set,
+    render_design_direction_set_html,
 )
 from ..research_department import (
     build_research_department_plan,
@@ -213,6 +219,66 @@ def cmd_ops_design_orchestration(args: argparse.Namespace) -> int:
         )
     except ValueError as exc:
         raise OmhError(str(exc)) from exc
+    return 0
+
+
+def _direction_option_descriptor(value: str) -> tuple[str, str, str, str, str, str, tuple[str, ...]]:
+    parts = value.split(":")
+    if len(parts) != 7:
+        raise ValueError(
+            "option must be id:hierarchy:palette:typography:layout:signature_element:avoid1|avoid2"
+        )
+    avoid_patterns = tuple(pattern for pattern in parts[6].split("|") if pattern)
+    if not avoid_patterns:
+        raise ValueError("option must name at least one avoid pattern")
+    return (parts[0], parts[1], parts[2], parts[3], parts[4], parts[5], avoid_patterns)
+
+
+def cmd_ops_design_directions(args: argparse.Namespace) -> int:
+    try:
+        directions = build_design_direction_set(
+            surface=args.surface,
+            audience=args.audience,
+            primary_task=args.primary_task,
+            platform=args.platform,
+            mode=args.mode,
+            context_references=tuple(_context_reference_descriptor(value) for value in args.context_reference),
+            options=tuple(_direction_option_descriptor(value) for value in args.option),
+            chosen_option=args.choose or "",
+        )
+        preview_path = ""
+        if args.html:
+            document = render_design_direction_set_html(directions)
+            target = Path(args.html)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            # newline="" so the document is byte-identical on Windows; a
+            # rendered artifact that differs by platform cannot be compared.
+            with target.open("w", encoding="utf-8", newline="") as handle:
+                handle.write(document)
+            preview_path = str(target)
+    except (OSError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    if _wants_json(args):
+        payload = dict(directions)
+        if preview_path:
+            payload["preview_path"] = preview_path
+        _print_json(payload)
+        return 0
+    offered = ", ".join(str(option["option_id"]) for option in directions["options"])
+    print(f"Design directions for {directions['intent']['surface']}: option {offered}")
+    for option in directions["options"]:
+        marker = " (chosen)" if option["option_id"] == directions["chosen_option"] else ""
+        print(
+            f"  {option['option_id']}{marker}: {option['hierarchy']} / {option['palette']} / "
+            f"{option['typography']} / {option['layout']} / {option['signature_element']}"
+        )
+    if preview_path:
+        print(f"Preview written to {preview_path} - open it yourself; nothing was served or launched.")
+    if directions["chosen_option"]:
+        print(f"Choice recorded: {directions['chosen_option']}.")
+    else:
+        print("No choice recorded yet. Re-run with --choose <id> once you have looked.")
+    print("Prepared only. This is not implementation, visual QA, or evidence that anyone looked at the preview.")
     return 0
 
 
@@ -893,6 +959,34 @@ def _add_ops_commands(sub) -> None:
     design_orchestration.add_argument("--signature-element", choices=DESIGN_SIGNATURE_ELEMENTS, required=True)
     design_orchestration.add_argument("--avoid-pattern", action="append", choices=DESIGN_AVOID_PATTERNS, required=True)
     design_orchestration.set_defaults(func=cmd_ops_design_orchestration)
+
+    design_directions = ops_sub.add_parser(
+        "design-directions",
+        help="Offer two to four design directions and record which one was chosen.",
+    )
+    design_directions.add_argument("--surface", choices=DESIGN_SURFACES, required=True)
+    design_directions.add_argument("--audience", choices=DESIGN_AUDIENCES, required=True)
+    design_directions.add_argument("--primary-task", choices=DESIGN_PRIMARY_TASKS, required=True)
+    design_directions.add_argument("--platform", choices=DESIGN_PLATFORMS, required=True)
+    design_directions.add_argument("--mode", choices=DESIGN_MODES, required=True)
+    design_directions.add_argument("--context-reference", action="append", required=True)
+    design_directions.add_argument(
+        "--option",
+        action="append",
+        required=True,
+        metavar="ID:HIERARCHY:PALETTE:TYPOGRAPHY:LAYOUT:SIGNATURE:AVOID|AVOID",
+        help="A direction to offer. Repeat two to four times, ids a, b, c, d in order.",
+    )
+    design_directions.add_argument(
+        "--choose",
+        choices=DESIGN_DIRECTION_OPTION_IDS,
+        help="Record this option as chosen. Omit while the choice is still open.",
+    )
+    design_directions.add_argument(
+        "--html",
+        help="Write the self-contained static preview here. No server is started and no browser is opened.",
+    )
+    design_directions.set_defaults(func=cmd_ops_design_directions)
 
     rhythm = ops_sub.add_parser("rhythm", help="Create an operating rhythm artifact such as a meeting or retro record.")
     _add_artifact_args(rhythm, surface="operating-rhythm", default_kind="meeting")

--- a/src/omh/design_directions.py
+++ b/src/omh/design_directions.py
@@ -1,0 +1,1 @@
+from .workflows.design_directions import *  # noqa: F401,F403

--- a/src/skills/catalog_definitions.py
+++ b/src/skills/catalog_definitions.py
@@ -2290,6 +2290,7 @@ _DEFINITIONS = [
         ),
         expected_outputs=(
             "design_orchestration/v1",
+            "design_direction_set/v1 when the direction is still open",
             "design intent and opaque context-reference boundary",
             "prepared direction vocabulary",
             "downstream composition: design-quality-gate, frontend, accessibility-audit, visual-qa",
@@ -2298,6 +2299,8 @@ _DEFINITIONS = [
         ),
         artifact_expectations=(
             "design_orchestration/v1 with prepared_not_observed status",
+            "design_direction_set/v1 offers two to four directions with chosen_option empty until the user picks",
+            "a static self-contained preview file when one is written; no server, port, or browser launch",
             "no raw project source, prompt, asset, path, or URL retention",
             "no executor target, dispatch, implementation, render, QA PASS, review, CI, deployment, or merge claim",
         ),

--- a/src/skills/catalog_harnesses.py
+++ b/src/skills/catalog_harnesses.py
@@ -2203,7 +2203,7 @@ _FEATURE_SURFACE_HARNESSES = (
         "Direction.",
         "Use for design.",
         ("intent", "context"),
-        ("design_orchestration/v1",),
+        ("design_orchestration/v1", "design_direction_set/v1"),
         quality_tier="design-gated",
         evidence_ladder=("intent", "direction", "visual_when_available"),
         wrapper_actions=("prepare_design_orchestration", "choose_executor", "prepare_visual_qa"),

--- a/src/workflows/design_directions.py
+++ b/src/workflows/design_directions.py
@@ -1,0 +1,429 @@
+"""Plural design directions, and a static preview a person can actually look at.
+
+`design_orchestration/v1` can hold exactly one hierarchy, one palette, one
+typography, one layout, and one signature element, and its validator re-derives
+the whole object and rejects anything not byte-identical - so it is closed
+against extension by construction. Every CLI flag behind it is required, which
+means the command cannot be invoked until the answer is already known. It can
+record a decision; it can never be the thing that elicits one.
+
+This module is the plural sibling: 2-4 directions offered together with a
+`chosen_option` slot that starts empty. `render_design_direction_set_html`
+turns that into one self-contained HTML file with the options side by side.
+
+On the boundary: this writes a file, and nothing else. No socket is bound, no
+port is opened, no browser is launched, no network call is made - the operator
+opens the file themselves. That is the same shape as every other artifact OMH
+writes, and it is deliberately not the shape of the brainstorm server this idea
+came from, which binds a port and shells out to `open`.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from html import escape
+from typing import Any, Final
+
+from .design_orchestration import (
+    DESIGN_AUDIENCES,
+    DESIGN_AVOID_PATTERNS,
+    DESIGN_HIERARCHIES,
+    DESIGN_LAYOUTS,
+    DESIGN_MODES,
+    DESIGN_PALETTES,
+    DESIGN_PLATFORMS,
+    DESIGN_PRIMARY_TASKS,
+    DESIGN_SIGNATURE_ELEMENTS,
+    DESIGN_SURFACES,
+    DESIGN_TYPOGRAPHIES,
+    _build_context_reference,
+    _context_descriptors,
+    _require_choice,
+)
+
+DESIGN_DIRECTION_SET_SCHEMA_VERSION: Final = "design_direction_set/v1"
+# Four is the ceiling because a person comparing options holds about that many
+# at once, and every option past the fourth is picked less often than the noise
+# in the first three. Two is the floor because one option is not a choice - it
+# is `design_orchestration/v1`, which already exists.
+DESIGN_DIRECTION_OPTION_IDS: Final = ("a", "b", "c", "d")
+_UNCHOSEN: Final = ""
+
+
+def _build_direction_option(descriptor: tuple[str, str, str, str, str, str, tuple[str, ...]]) -> dict[str, object]:
+    option_id, hierarchy, palette, typography, layout, signature_element, avoid_patterns = descriptor
+    _require_choice(option_id, DESIGN_DIRECTION_OPTION_IDS, "option id")
+    _require_choice(hierarchy, DESIGN_HIERARCHIES, "hierarchy")
+    _require_choice(palette, DESIGN_PALETTES, "palette")
+    _require_choice(typography, DESIGN_TYPOGRAPHIES, "typography")
+    _require_choice(layout, DESIGN_LAYOUTS, "layout")
+    _require_choice(signature_element, DESIGN_SIGNATURE_ELEMENTS, "signature_element")
+    if not 1 <= len(avoid_patterns) <= len(DESIGN_AVOID_PATTERNS):
+        raise ValueError("avoid_patterns must contain between one and six values")
+    for pattern in avoid_patterns:
+        _require_choice(pattern, DESIGN_AVOID_PATTERNS, "avoid_pattern")
+    if len(set(avoid_patterns)) != len(avoid_patterns):
+        raise ValueError("avoid_patterns must be unique")
+    return {
+        "option_id": option_id,
+        "hierarchy": hierarchy,
+        "palette": palette,
+        "typography": typography,
+        "layout": layout,
+        "signature_element": signature_element,
+        "avoid_patterns": list(avoid_patterns),
+    }
+
+
+def build_design_direction_set(
+    *,
+    surface: str,
+    audience: str,
+    primary_task: str,
+    platform: str,
+    mode: str,
+    context_references: tuple[tuple[str, str, str], ...],
+    options: tuple[tuple[str, str, str, str, str, str, tuple[str, ...]], ...],
+    chosen_option: str = _UNCHOSEN,
+) -> dict[str, object]:
+    _require_choice(surface, DESIGN_SURFACES, "surface")
+    _require_choice(audience, DESIGN_AUDIENCES, "audience")
+    _require_choice(primary_task, DESIGN_PRIMARY_TASKS, "primary_task")
+    _require_choice(platform, DESIGN_PLATFORMS, "platform")
+    _require_choice(mode, DESIGN_MODES, "mode")
+    if not 1 <= len(context_references) <= 5:
+        raise ValueError("context_references must contain between one and five descriptors")
+    references = [_build_context_reference(descriptor) for descriptor in context_references]
+    reference_ids = [str(reference["reference_id"]) for reference in references]
+    if len(set(reference_ids)) != len(reference_ids):
+        raise ValueError("context reference_id values must be unique")
+    if not 2 <= len(options) <= len(DESIGN_DIRECTION_OPTION_IDS):
+        raise ValueError("options must contain between two and four directions")
+    built = [_build_direction_option(descriptor) for descriptor in options]
+    option_ids = [str(option["option_id"]) for option in built]
+    if len(set(option_ids)) != len(option_ids):
+        raise ValueError("option_id values must be unique")
+    if option_ids != list(DESIGN_DIRECTION_OPTION_IDS[: len(option_ids)]):
+        raise ValueError("option_id values must be the leading ids in order, starting at a")
+    # Two directions that differ in nothing are one direction presented twice,
+    # which makes the choice a coin flip and the record of it meaningless.
+    comparable = {tuple(sorted((key, str(value)) for key, value in option.items() if key != "option_id"))
+                  for option in built}
+    if len(comparable) != len(built):
+        raise ValueError("options must differ from each other in at least one direction value")
+    if chosen_option != _UNCHOSEN and chosen_option not in option_ids:
+        raise ValueError("chosen_option must be empty or name one of the offered options")
+    return {
+        "schema_version": DESIGN_DIRECTION_SET_SCHEMA_VERSION,
+        "status": "prepared_not_observed",
+        "intent": {
+            "surface": surface,
+            "audience": audience,
+            "primary_task": primary_task,
+            "platform": platform,
+            "mode": mode,
+        },
+        "context_references": references,
+        "options": built,
+        "chosen_option": chosen_option,
+        "choice_status": "chosen" if chosen_option else "awaiting_choice",
+        "preview": {
+            "format": "static_html",
+            "self_contained": True,
+            "server_bound": False,
+            "browser_launched": False,
+            "rendered_observed": False,
+        },
+        "stop_conditions": [
+            "No opaque project, user, or Hermes context reference is available.",
+            "Fewer than two materially different directions can be described for this surface.",
+            "The choice needs rendered evidence of the real product rather than a vocabulary preview.",
+        ],
+        "claim_boundary": (
+            "This prepared design direction set records only bounded design intent, opaque context references, two to four "
+            "direction vocabularies, and which one was chosen. The static preview is a rendering of that vocabulary, not of the "
+            "product: it is not implementation, browser verification, accessibility or visual QA, review, CI, deployment, or "
+            "merge evidence, and a recorded choice is not evidence that anyone looked at it."
+        ),
+    }
+
+
+def _option_descriptors(value: object) -> tuple[tuple[str, str, str, str, str, str, tuple[str, ...]], ...] | None:
+    if not isinstance(value, list):
+        return None
+    descriptors: list[tuple[str, str, str, str, str, str, tuple[str, ...]]] = []
+    for option in value:
+        if not isinstance(option, dict) or set(option) != {
+            "option_id", "hierarchy", "palette", "typography", "layout", "signature_element", "avoid_patterns"
+        }:
+            return None
+        avoid_patterns = option.get("avoid_patterns")
+        if not isinstance(avoid_patterns, list) or not all(isinstance(item, str) for item in avoid_patterns):
+            return None
+        scalars = [option.get(key) for key in
+                   ("option_id", "hierarchy", "palette", "typography", "layout", "signature_element")]
+        if not all(isinstance(item, str) for item in scalars):
+            return None
+        descriptors.append((*scalars, tuple(avoid_patterns)))  # type: ignore[arg-type]
+    return tuple(descriptors)
+
+
+def validate_design_direction_set(value: Any) -> list[str]:
+    if not isinstance(value, dict):
+        return ["design direction set must be an object"]
+    required = {
+        "schema_version",
+        "status",
+        "intent",
+        "context_references",
+        "options",
+        "chosen_option",
+        "choice_status",
+        "preview",
+        "stop_conditions",
+        "claim_boundary",
+    }
+    if set(value) != required:
+        return ["design direction set keys are invalid"]
+    intent = value.get("intent")
+    if not isinstance(intent, dict) or set(intent) != {"surface", "audience", "primary_task", "platform", "mode"}:
+        return ["design direction set intent is invalid"]
+    if not all(isinstance(item, str) for item in intent.values()):
+        return ["design direction set intent is invalid"]
+    descriptors = _context_descriptors(value.get("context_references"))
+    if descriptors is None:
+        return ["design direction set context references are invalid"]
+    options = _option_descriptors(value.get("options"))
+    if options is None:
+        return ["design direction set options are invalid"]
+    chosen_option = value.get("chosen_option")
+    if not isinstance(chosen_option, str):
+        return ["design direction set chosen_option is invalid"]
+    try:
+        expected = build_design_direction_set(
+            surface=intent["surface"],
+            audience=intent["audience"],
+            primary_task=intent["primary_task"],
+            platform=intent["platform"],
+            mode=intent["mode"],
+            context_references=descriptors,
+            options=options,
+            chosen_option=chosen_option,
+        )
+    except ValueError as exc:
+        return [str(exc)]
+    return [] if value == expected else ["design direction set values are invalid"]
+
+
+def compact_design_direction_set(value: Any) -> dict[str, object]:
+    if not isinstance(value, dict) or validate_design_direction_set(value):
+        return {}
+    return deepcopy(value)
+
+
+def choose_design_direction(value: Any, option_id: str) -> dict[str, object]:
+    """Record a choice against an existing set, leaving the offer untouched.
+
+    Rebuilds rather than mutating so the result goes through the same validator
+    as a fresh set: a stored artifact that has drifted cannot be laundered into
+    a valid one by writing a choice onto it.
+    """
+    issues = validate_design_direction_set(value)
+    if issues:
+        raise ValueError(issues[0])
+    intent = value["intent"]
+    descriptors = _context_descriptors(value["context_references"])
+    options = _option_descriptors(value["options"])
+    if descriptors is None or options is None:  # pragma: no cover - validator already proved these
+        raise ValueError("design direction set is invalid")
+    return build_design_direction_set(
+        surface=intent["surface"],
+        audience=intent["audience"],
+        primary_task=intent["primary_task"],
+        platform=intent["platform"],
+        mode=intent["mode"],
+        context_references=descriptors,
+        options=options,
+        chosen_option=option_id,
+    )
+
+
+# --- static preview -------------------------------------------------------
+#
+# The vocabulary is rendered as the thing it names, not as a table of the words.
+# A person choosing between `editorial_serif` and `utilitarian_mono` is choosing
+# between two typefaces, so the preview has to set them.
+
+_PALETTE_TOKENS: Final = {
+    "restrained_neutral": ("#f7f7f5", "#1b1b19", "#6b6b63", "#e2e2dc", "#3d5a4c"),
+    "contextual_accent": ("#fbfaf8", "#191821", "#6a6780", "#e6e3ee", "#4b3fa7"),
+    "high_contrast": ("#ffffff", "#000000", "#3a3a3a", "#d0d0d0", "#b4001f"),
+}
+_TYPE_STACKS: Final = {
+    "editorial_serif": ("'Iowan Old Style','Palatino Linotype',Palatino,Georgia,serif", "0"),
+    "system_sans": ("system-ui,-apple-system,'Segoe UI',Roboto,'Helvetica Neue',sans-serif", "-0.011em"),
+    "utilitarian_mono": ("ui-monospace,SFMono-Regular,Menlo,Consolas,'Liberation Mono',monospace", "-0.02em"),
+}
+_HIERARCHY_ORDER: Final = {
+    "task_first": ("action", "evidence", "content"),
+    "evidence_first": ("evidence", "action", "content"),
+    "content_first": ("content", "action", "evidence"),
+}
+_BLOCK_LABELS: Final = {
+    "action": "Primary action",
+    "evidence": "Evidence",
+    "content": "Content",
+}
+_SIGNATURE_LABELS: Final = {
+    "evidence_rail": "Evidence rail",
+    "decision_map": "Decision map",
+    "progress_trace": "Progress trace",
+    "none": "",
+}
+
+
+def _block_html(kind: str) -> str:
+    label = escape(_BLOCK_LABELS[kind])
+    if kind == "action":
+        return f'<div class="blk act"><span>{label}</span><em class="btn">Continue</em></div>'
+    if kind == "evidence":
+        return (
+            f'<div class="blk ev"><span>{label}</span>'
+            '<i class="bar w80"></i><i class="bar w55"></i><i class="bar w66"></i></div>'
+        )
+    return (
+        f'<div class="blk ct"><span>{label}</span>'
+        '<i class="line w90"></i><i class="line w75"></i><i class="line w84"></i><i class="line w40"></i></div>'
+    )
+
+
+def _mockup_html(option: dict[str, object]) -> str:
+    order = _HIERARCHY_ORDER[str(option["hierarchy"])]
+    blocks = "".join(_block_html(kind) for kind in order)
+    signature = _SIGNATURE_LABELS[str(option["signature_element"])]
+    rail = f'<div class="rail"><span>{escape(signature)}</span></div>' if signature else ""
+    layout = str(option["layout"])
+    if layout == "split_panel":
+        return f'<div class="mock split">{rail}<div class="col">{blocks}</div></div>'
+    if layout == "editorial_grid":
+        return f'<div class="mock grid">{blocks}{rail}</div>'
+    return f'<div class="mock single">{blocks}{rail}</div>'
+
+
+def _option_card_html(option: dict[str, object], chosen: str) -> str:
+    option_id = str(option["option_id"])
+    background, ink, muted, hairline, accent = _PALETTE_TOKENS[str(option["palette"])]
+    family, tracking = _TYPE_STACKS[str(option["typography"])]
+    is_chosen = option_id == chosen
+    avoided = ", ".join(escape(str(pattern)) for pattern in option["avoid_patterns"])  # type: ignore[union-attr]
+    facts = "".join(
+        f"<dt>{escape(key)}</dt><dd>{escape(str(option[key]))}</dd>"
+        for key in ("hierarchy", "palette", "typography", "layout", "signature_element")
+    )
+    return f"""
+  <section class="opt{' chosen' if is_chosen else ''}" style="
+      --bg:{background}; --ink:{ink}; --muted:{muted}; --hair:{hairline}; --accent:{accent};
+      --family:{family}; --tracking:{tracking};">
+    <header class="opt-head">
+      <span class="tag">Option {escape(option_id.upper())}</span>
+      {'<span class="chosen-mark">chosen</span>' if is_chosen else ''}
+    </header>
+    <div class="canvas">{_mockup_html(option)}</div>
+    <dl class="facts">{facts}</dl>
+    <p class="avoid"><span>avoids</span> {avoided}</p>
+  </section>"""
+
+
+def render_design_direction_set_html(value: Any) -> str:
+    """One self-contained HTML document. No external request of any kind."""
+    issues = validate_design_direction_set(value)
+    if issues:
+        raise ValueError(issues[0])
+    intent = value["intent"]
+    chosen = str(value["chosen_option"])
+    cards = "".join(_option_card_html(option, chosen) for option in value["options"])
+    summary = " &middot; ".join(
+        escape(f"{key.replace('_', ' ')}: {intent[key]}")
+        for key in ("surface", "audience", "primary_task", "platform", "mode")
+    )
+    choice_line = (
+        f"Option {escape(chosen.upper())} is recorded as chosen."
+        if chosen
+        else "No option is chosen yet. Record one with "
+        "<code>omh ops design-directions … --choose &lt;id&gt;</code>."
+    )
+    reference_count = len(value["context_references"])
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Design directions &mdash; {escape(str(intent['surface']))}</title>
+<style>
+  :root {{
+    --page: #fdfdfc; --page-ink: #17170f; --page-muted: #6f6f64; --page-hair: #e4e4dd;
+    font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  }}
+  @media (prefers-color-scheme: dark) {{
+    :root {{ --page: #131312; --page-ink: #f2f2ec; --page-muted: #9b9b90; --page-hair: #2e2e2a; }}
+  }}
+  * {{ box-sizing: border-box; }}
+  body {{ margin: 0; padding: 2.5rem 1.5rem 4rem; background: var(--page); color: var(--page-ink); }}
+  .wrap {{ max-width: 1180px; margin: 0 auto; }}
+  h1 {{ font-size: 1.5rem; margin: 0 0 .4rem; letter-spacing: -.02em; }}
+  .meta {{ color: var(--page-muted); font-size: .8125rem; margin: 0 0 .35rem; }}
+  .choice {{ font-size: .8125rem; margin: 0 0 2rem; }}
+  code {{ font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .95em; }}
+  .opts {{ display: grid; gap: 1.25rem; grid-template-columns: repeat(auto-fit, minmax(255px, 1fr)); }}
+  /* Column + growing canvas so the fact lists bottom-align across options.
+     Without it a shorter mockup pulls its own facts up and the eye compares
+     rows that are not the same row. */
+  .opt {{ border: 1px solid var(--page-hair); border-radius: 10px; overflow: hidden; background: var(--bg);
+          color: var(--ink); font-family: var(--family); letter-spacing: var(--tracking);
+          display: flex; flex-direction: column; }}
+  .opt > .canvas {{ flex: 1; }}
+  .opt.chosen {{ outline: 2px solid var(--accent); outline-offset: -1px; }}
+  .opt-head {{ display: flex; justify-content: space-between; align-items: center;
+               padding: .6rem .85rem; border-bottom: 1px solid var(--hair); }}
+  .tag {{ font-size: .6875rem; text-transform: uppercase; letter-spacing: .09em; color: var(--muted); }}
+  .chosen-mark {{ font-size: .6875rem; text-transform: uppercase; letter-spacing: .09em; color: var(--accent); }}
+  .canvas {{ padding: 1rem .85rem; min-height: 250px; }}
+  .mock {{ display: flex; flex-direction: column; gap: .6rem; }}
+  .mock.split {{ flex-direction: row-reverse; align-items: stretch; gap: .55rem; }}
+  .mock.split .col {{ display: flex; flex-direction: column; gap: .6rem; flex: 1; }}
+  .mock.grid {{ display: grid; grid-template-columns: 1fr 1fr; gap: .55rem; }}
+  .blk {{ border: 1px solid var(--hair); border-radius: 6px; padding: .55rem .6rem; }}
+  .blk span {{ display: block; font-size: .625rem; text-transform: uppercase;
+               letter-spacing: .08em; color: var(--muted); margin-bottom: .4rem; }}
+  .btn {{ display: inline-block; font-style: normal; font-size: .75rem; padding: .3rem .8rem;
+          border-radius: 5px; background: var(--accent); color: var(--bg); }}
+  .bar {{ display: block; height: .5rem; border-radius: 2px; background: var(--accent); opacity: .28; margin-bottom: .28rem; }}
+  .line {{ display: block; height: .3rem; border-radius: 2px; background: var(--ink); opacity: .17; margin-bottom: .3rem; }}
+  .w90 {{ width: 90%; }} .w84 {{ width: 84%; }} .w80 {{ width: 80%; }}
+  .w75 {{ width: 75%; }} .w66 {{ width: 66%; }} .w55 {{ width: 55%; }} .w40 {{ width: 40%; }}
+  .rail {{ border: 1px dashed var(--accent); border-radius: 6px; padding: .5rem .45rem;
+           min-width: 4.6rem; display: flex; align-items: center; justify-content: center; }}
+  .rail span {{ font-size: .625rem; text-transform: uppercase; letter-spacing: .07em;
+                color: var(--accent); text-align: center; line-height: 1.35; }}
+  .facts {{ display: grid; grid-template-columns: auto 1fr; gap: .12rem .6rem; margin: 0;
+            padding: .7rem .85rem; border-top: 1px solid var(--hair); font-size: .6875rem; }}
+  .facts dt {{ color: var(--muted); }}
+  .facts dd {{ margin: 0; }}
+  .avoid {{ margin: 0; padding: .55rem .85rem .8rem; font-size: .6875rem; color: var(--muted); }}
+  .avoid span {{ text-transform: uppercase; letter-spacing: .08em; }}
+  footer {{ margin-top: 2.25rem; padding-top: 1rem; border-top: 1px solid var(--page-hair);
+            color: var(--page-muted); font-size: .75rem; line-height: 1.6; max-width: 62ch; }}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Design directions</h1>
+  <p class="meta">{summary} &middot; {reference_count} opaque context reference(s)</p>
+  <p class="choice">{choice_line}</p>
+  <div class="opts">{cards}
+  </div>
+  <footer>{escape(str(value['claim_boundary']))}</footer>
+</div>
+</body>
+</html>
+"""

--- a/tests/test_design_directions.py
+++ b/tests/test_design_directions.py
@@ -1,0 +1,184 @@
+"""Contract for the plural design direction set and its static preview.
+
+The point of this family is that OMH can offer a choice rather than record one
+that was already made, so the tests that matter are the ones about plurality:
+how many options, that they differ, that the choice slot starts empty, and that
+the preview a person opens is a file and only a file.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from _cli_harness import run_cli
+
+from omh.workflows.design_directions import (
+    DESIGN_DIRECTION_SET_SCHEMA_VERSION,
+    build_design_direction_set,
+    choose_design_direction,
+    compact_design_direction_set,
+    render_design_direction_set_html,
+    validate_design_direction_set,
+)
+
+_REFERENCE = ("design_system", "design_ref_a1b2c3d4e5f60718", "project_local")
+_A = ("a", "task_first", "restrained_neutral", "system_sans", "single_column", "progress_trace",
+      ("placeholder_copy", "weak_hierarchy"))
+_B = ("b", "evidence_first", "contextual_accent", "editorial_serif", "split_panel", "evidence_rail",
+      ("generic_glass", "card_wall"))
+_C = ("c", "content_first", "high_contrast", "utilitarian_mono", "editorial_grid", "decision_map",
+      ("decorative_gradient", "tiny_text"))
+
+
+def _set(*options, chosen: str = ""):
+    return build_design_direction_set(
+        surface="workflow_screen",
+        audience="operator",
+        primary_task="decide",
+        platform="web",
+        mode="new",
+        context_references=(_REFERENCE,),
+        options=options or (_A, _B),
+        chosen_option=chosen,
+    )
+
+
+class DesignDirectionSetShapeTests(unittest.TestCase):
+    def test_a_prepared_set_validates_and_starts_with_no_choice(self) -> None:
+        directions = _set()
+        self.assertEqual(directions["schema_version"], DESIGN_DIRECTION_SET_SCHEMA_VERSION)
+        self.assertEqual(directions["status"], "prepared_not_observed")
+        self.assertEqual(directions["chosen_option"], "")
+        self.assertEqual(directions["choice_status"], "awaiting_choice")
+        self.assertEqual(validate_design_direction_set(directions), [])
+
+    def test_one_option_is_not_a_choice_and_five_is_not_a_comparison(self) -> None:
+        with self.assertRaises(ValueError):
+            _set(_A)
+        with self.assertRaises(ValueError):
+            _set(_A, _B, _C, ("d", *_A[1:]), ("a", *_B[1:]))
+
+    def test_option_ids_must_be_the_leading_ids_in_order(self) -> None:
+        with self.assertRaises(ValueError):
+            _set(_B, _C)
+        with self.assertRaises(ValueError):
+            _set(_B, _A)
+
+    def test_two_identical_directions_are_refused(self) -> None:
+        # Presenting the same direction twice makes the choice a coin flip and
+        # the recorded answer meaningless.
+        with self.assertRaises(ValueError):
+            _set(_A, ("b", *_A[1:]))
+
+    def test_a_choice_must_name_an_offered_option(self) -> None:
+        with self.assertRaises(ValueError):
+            _set(_A, _B, chosen="c")
+        self.assertEqual(_set(_A, _B, chosen="b")["choice_status"], "chosen")
+
+    def test_the_preview_block_states_what_was_not_done(self) -> None:
+        preview = _set()["preview"]
+        self.assertFalse(preview["server_bound"])
+        self.assertFalse(preview["browser_launched"])
+        self.assertFalse(preview["rendered_observed"])
+        self.assertTrue(preview["self_contained"])
+
+
+class DesignDirectionChoiceTests(unittest.TestCase):
+    def test_choosing_records_the_pick_and_leaves_the_offer_intact(self) -> None:
+        offered = _set(_A, _B, _C)
+        chosen = choose_design_direction(offered, "c")
+        self.assertEqual(chosen["chosen_option"], "c")
+        self.assertEqual(chosen["options"], offered["options"])
+        self.assertEqual(validate_design_direction_set(chosen), [])
+
+    def test_a_drifted_artifact_cannot_be_laundered_by_writing_a_choice_on_it(self) -> None:
+        drifted = _set()
+        drifted["options"][0]["palette"] = "not_a_palette"
+        with self.assertRaises(ValueError):
+            choose_design_direction(drifted, "a")
+
+    def test_compact_returns_nothing_for_an_invalid_set(self) -> None:
+        self.assertEqual(compact_design_direction_set({"schema_version": "wrong"}), {})
+        self.assertEqual(compact_design_direction_set(_set()), _set())
+
+
+class DesignDirectionPreviewTests(unittest.TestCase):
+    def test_the_preview_makes_no_external_request_of_any_kind(self) -> None:
+        document = render_design_direction_set_html(_set(_A, _B, _C))
+        for forbidden in ("http://", "https://", "<script", "<iframe", "src=", "@import", "url("):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, document.lower())
+
+    def test_each_direction_is_rendered_as_the_thing_it_names(self) -> None:
+        document = render_design_direction_set_html(_set(_A, _B, _C))
+        # The palettes and typefaces are applied, not merely listed.
+        self.assertIn("#f7f7f5", document)
+        self.assertIn("#4b3fa7", document)
+        self.assertIn("Iowan Old Style", document)
+        self.assertIn("ui-monospace", document)
+        # Hierarchy reorders the blocks rather than relabelling them.
+        self.assertLess(document.index("Primary action"), document.index("Evidence"))
+
+    def test_the_chosen_option_is_marked_and_an_open_choice_says_so(self) -> None:
+        self.assertIn("chosen", render_design_direction_set_html(_set(_A, _B, chosen="b")))
+        self.assertIn("No option is chosen yet", render_design_direction_set_html(_set()))
+
+    def test_the_claim_boundary_travels_with_the_document(self) -> None:
+        self.assertIn("not evidence that anyone looked at it", render_design_direction_set_html(_set()))
+
+    def test_an_invalid_set_is_refused_rather_than_half_rendered(self) -> None:
+        with self.assertRaises(ValueError):
+            render_design_direction_set_html({"schema_version": "design_direction_set/v1"})
+
+
+class DesignDirectionsCliTests(unittest.TestCase):
+    ARGS = [
+        "ops", "design-directions",
+        "--surface", "workflow_screen", "--audience", "operator", "--primary-task", "decide",
+        "--platform", "web", "--mode", "new",
+        "--context-reference", "design_system:design_ref_a1b2c3d4e5f60718:project_local",
+        "--option", "a:task_first:restrained_neutral:system_sans:single_column:progress_trace:placeholder_copy|weak_hierarchy",
+        "--option", "b:evidence_first:contextual_accent:editorial_serif:split_panel:evidence_rail:generic_glass|card_wall",
+    ]
+
+    def test_plain_text_is_the_default_and_names_the_open_choice(self) -> None:
+        code, stdout, _ = run_cli(self.ARGS, output_json=False)
+        self.assertEqual(code, 0)
+        self.assertIn("option a, b", stdout)
+        self.assertIn("No choice recorded yet", stdout)
+        self.assertNotIn("schema_version", stdout)
+
+    def test_json_carries_the_artifact(self) -> None:
+        code, stdout, _ = run_cli(self.ARGS)
+        self.assertEqual(code, 0)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["schema_version"], DESIGN_DIRECTION_SET_SCHEMA_VERSION)
+        self.assertEqual(validate_design_direction_set(
+            {key: value for key, value in payload.items() if key != "preview_path"}), [])
+
+    def test_html_writes_a_file_and_says_nothing_was_launched(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "nested" / "directions.html"
+            code, stdout, _ = run_cli([*self.ARGS, "--html", str(target)], output_json=False)
+            self.assertEqual(code, 0)
+            self.assertTrue(target.is_file())
+            self.assertIn("nothing was served or launched", stdout)
+            self.assertIn("<!DOCTYPE html>", target.read_text(encoding="utf-8"))
+
+    def test_a_malformed_option_fails_with_a_usable_message_and_a_nonzero_code(self) -> None:
+        code, _, stderr = run_cli([*self.ARGS[:-1], "b:evidence_first"], output_json=False)
+        self.assertNotEqual(code, 0)
+        self.assertIn("id:hierarchy:palette", stderr)
+
+    def test_choosing_records_the_option(self) -> None:
+        code, stdout, _ = run_cli([*self.ARGS, "--choose", "b"], output_json=False)
+        self.assertEqual(code, 0)
+        self.assertIn("b (chosen)", stdout)
+        self.assertIn("Choice recorded: b.", stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

A new artifact family, `design_direction_set/v1`, that holds **two to four** design directions with a `chosen_option` slot that starts empty — plus `omh ops design-directions`, which can write a **self-contained static HTML preview** of those directions that a person opens themselves.

### Why This Exists

OMH could record a design decision. It could not offer one.

`design_orchestration/v1` holds exactly one hierarchy, one palette, one typography, one layout, one signature element. Its validator re-derives the entire object and rejects anything not byte-identical (`src/workflows/design_orchestration.py:220`), so the schema is closed against extension by construction. And every CLI flag behind it is `required=True` — the command cannot be invoked until the answer is already known.

Verified across the whole catalog before building anything:

- `mockup`, `wireframe`, `prototype` — **zero** occurrences in `src/skills/catalog_definitions.py`, across all 103 skill definitions.
- `http.server`, `socketserver`, `HTTPServer`, `webbrowser` — **zero** occurrences anywhere in `src/`.

So there was no way to show a design, and no way to hold more than one.

### User / Operator Impact

```sh
omh ops design-directions \
  --surface workflow_screen --audience operator --primary-task decide \
  --platform web --mode new \
  --context-reference design_system:design_ref_a1b2c3d4e5f60718:project_local \
  --option "a:task_first:restrained_neutral:system_sans:single_column:progress_trace:placeholder_copy|weak_hierarchy" \
  --option "b:evidence_first:contextual_accent:editorial_serif:split_panel:evidence_rail:generic_glass|card_wall" \
  --html .omh/artifacts/directions.html
```
```
Design directions for workflow_screen: option a, b
  a: task_first / restrained_neutral / system_sans / single_column / progress_trace
  b: evidence_first / contextual_accent / editorial_serif / split_panel / evidence_rail
Preview written to .omh/artifacts/directions.html - open it yourself; nothing was served or launched.
No choice recorded yet. Re-run with --choose <id> once you have looked.
```

You open the file, look, then re-run with `--choose b`.

### How It Works

**The bounds are arguments, not round numbers.** One option is not a choice — that is `design_orchestration/v1`, which already exists. Four is the ceiling because a person comparing directions holds about that many at once. And two options that differ in *nothing* are refused outright: that makes the choice a coin flip and the recorded answer meaningless.

**The preview renders the vocabulary as the thing it names, not as a table of the words.** `editorial_serif` sets a serif stack; `high_contrast` sets its actual palette; `split_panel` lays out a split panel; `hierarchy` *reorders* the mockup blocks rather than relabelling them. Someone choosing between two typefaces is choosing between two typefaces.

**`choose_design_direction` rebuilds through the validator rather than mutating**, so an artifact that has drifted on disk cannot be laundered into a valid one by writing a choice onto it.

### The boundary, and why this is a file

The idea comes from Superpowers' brainstorm companion, which binds a port, speaks RFC 6455 WebSocket, and shells out to `open`. `AGENTS.md` names **"network service"** in the list of what OMH is not — a statement about *shape*, not about reachability. Loopback does not escape a shape rule, and that project's own server ships a `--host 0.0.0.0` flag, which proves localhost-only is a runtime option rather than a guarantee.

So this writes a file and stops. **No socket bound, no port opened, no browser launched, no network call, no subprocess.** The zero-dependency rule was never the blocker here — a stdlib `http.server` would satisfy it. The architecture rule is.

The artifact says so in machine-readable form, so a downstream reader cannot infer more than happened:

```json
"preview": {"format": "static_html", "self_contained": true,
            "server_bound": false, "browser_launched": false,
            "rendered_observed": false}
```

`rendered_observed: false` is the important one: a recorded choice is not evidence that anyone looked.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/workflows/design_directions.py` | **new** — build / validate / compact / choose + the HTML renderer |
| `src/omh/design_directions.py` | **new** — flat re-export shim, matching the existing layout |
| `src/commands/ops.py` | `design-directions` subcommand; plain text by default, `--json` for the artifact |
| `src/skills/catalog_definitions.py` | `design-orchestration` advertises the new family in `expected_outputs` + `artifact_expectations` |
| `src/skills/catalog_harnesses.py` | harness expected artifacts gains `design_direction_set/v1` |
| `skills/omh-design-orchestration/SKILL.md`, `docs/WORKFLOWS.md` | regenerated |
| `tests/test_design_directions.py` | **new** — 19 tests |

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` — **5729 tests OK**
- [x] `tests/test_design_directions.py` — 19/19
- [x] `docs workflows --check`, `docs roles --check`, `docs capability-families --check` — exit 0
- [x] `ruff check src tests` — All checks passed; `compileall`, `git diff --check` — exit 0
- [x] `harness validate`, `release checklist --json`, `release hermes-smoke` — exit 0
- [x] All four generated artifact families regenerated together
- [x] **Preview rendered in a real browser at 1180px and inspected.** Three options showed three distinct palettes, three distinct typefaces, three distinct layouts, with B carrying the chosen outline. One defect found and fixed that way: the option cards did not bottom-align because the canvases differ in height, so the eye compared rows that were not the same row.
- [x] Asserted mechanically that the document contains no `http://`, `https://`, `<script`, `<iframe`, `src=`, `@import`, or `url(`
- [ ] Hermes chat surface — **not applicable.** CLI and catalog only; no chat card offers this yet.

## Risk

- **The preview renders the vocabulary, never the product.** It is a comparison aid for a closed vocabulary, not a mockup of anyone's real screen. The claim boundary travels inside the HTML footer so the file cannot be forwarded without it.
- **No chat surface offers this yet**, so it is reachable only by an operator or agent running the CLI. `design-orchestration` advertises the family in its expected outputs, but nothing routes a user to the command.
- **The vocabulary→CSS mapping is a judgement call.** `restrained_neutral` is one designer's restrained neutral. It is deterministic and reviewable, but it is not derived from anything.
- **Windows:** the file is written with `newline=""` so it is byte-identical across platforms; a rendered artifact that differs by platform cannot be compared. Not exercised on Windows CI in this PR beyond the existing suite.

## Compatibility / Rollout

- Purely additive. `design_orchestration/v1` is untouched — deliberately, since its validator is a byte-identical re-derivation and *any* additive change to it is a breaking change.
- Release channel: `local`. No version file or changelog touched.

## Release / Claims

- [x] Release-channel impact considered — none
- [x] Runtime capability claims backed by evidence or marked not observed — the preview block records `rendered_observed: false`
- [x] Known manual Hermes checks listed — no Hermes surface touched

## Follow-Up

- A chat card that offers directions and accepts a pick would make this reachable without the CLI; that needs a `*_CHAT_CARDS` entry and a coverage case, and is its own goal.
