### PR TITLE
feat: say how to obtain a review, not only what one must contain

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -3576,6 +3576,8 @@ These surfaces are generated command references, not installed Hermes workflow s
   - If no diff, file set, PR, or artifact is available, inspect the requested target or ask one target question before reviewing.
   - If tests fail or are missing, cite the exact command gap and do not approve the change as verified.
   - If independent review evidence is unavailable, say so directly instead of implying a second reviewer passed it.
+  - To dispatch a reviewer rather than write the findings yourself, load `omh-code-review/references/review-dispatch.md`; it carries the base-SHA rule and the implementer status contract.
+  - When findings arrive for work you own, load `omh-code-review/references/review-response.md` before changing anything.
 - Required inputs:
   - diff or files
   - expected behavior

--- a/skills/omh-code-review/SKILL.md
+++ b/skills/omh-code-review/SKILL.md
@@ -50,6 +50,8 @@ Bad example:
 - If no diff, file set, PR, or artifact is available, inspect the requested target or ask one target question before reviewing.
 - If tests fail or are missing, cite the exact command gap and do not approve the change as verified.
 - If independent review evidence is unavailable, say so directly instead of implying a second reviewer passed it.
+- To dispatch a reviewer rather than write the findings yourself, load `omh-code-review/references/review-dispatch.md`; it carries the base-SHA rule and the implementer status contract.
+- When findings arrive for work you own, load `omh-code-review/references/review-response.md` before changing anything.
 
 ## Workflow Lane
 

--- a/skills/omh-code-review/references/review-dispatch.md
+++ b/skills/omh-code-review/references/review-dispatch.md
@@ -1,0 +1,71 @@
+# Requesting a Review
+
+`code-review` states what a review must contain. This states how to obtain one.
+Load it when dispatching a reviewer, not when reading a finding.
+
+## Name the range before dispatching
+
+A reviewer handed the wrong range reviews a fraction of the change and returns
+a clean verdict on code nobody read. That is a manufactured pass, and it is the
+exact failure the evidence boundary exists to prevent.
+
+```sh
+BASE_SHA=$(git merge-base origin/main HEAD)   # or the commit recorded before the work began
+HEAD_SHA=$(git rev-parse HEAD)
+```
+
+**Never `HEAD~1`.** It silently drops every commit of a multi-commit task except
+the last. Record BASE before the work starts; deriving it afterwards from the
+log is guesswork the moment a merge or a fixup lands.
+
+State both SHAs in the request. A review whose range is unstated cannot be
+re-run, and cannot be shown to have covered anything.
+
+## Hand over artifacts, not bodies
+
+Everything pasted into a dispatch stays resident for the rest of the session and
+is re-read on every later turn. Write the diff, the plan section, and the failing
+output to files under `.omh/artifacts/` or `.omh/handoffs/` and pass the paths.
+
+A dispatch describes one unit of work. Do not paste accumulated prior-task
+summaries into later dispatches - a fresh reviewer needs the range, the
+requirements, and the constraints, and nothing else.
+
+## What the request must carry
+
+- **Range** - BASE_SHA and HEAD_SHA, both spelled out.
+- **Claim** - what the author says this does. The review is against this claim.
+- **Requirements** - a path to the plan or spec section, not its pasted text.
+- **Constraints** - anything project-wide the diff must satisfy.
+- **Return contract** - findings first, severity per finding, and the file, line,
+  and command output each one rests on.
+
+## Reading the report
+
+A reviewer's report is a claim, not evidence. Two rules keep it honest:
+
+- **Do not trust the report.** A stated rationale never downgrades a finding's
+  severity. "I checked and it is fine" is not a check; the command output is.
+- **"Attempted" is not "addressed."** A fix is done when the specific defect no
+  longer reproduces, shown by the same command that showed it. A commit message
+  saying it was fixed is not that command.
+
+## The four statuses an implementer may return
+
+Anything dispatched to change code returns exactly one of these, so the
+coordinator can act without re-reading the work:
+
+| Status | Meaning | What the coordinator does |
+| --- | --- | --- |
+| `DONE` | Complete and verified | Generate the review range, dispatch the reviewer |
+| `DONE_WITH_CONCERNS` | Complete, with doubts stated | Read the concerns first; address correctness or scope before review |
+| `NEEDS_CONTEXT` | Missing information it could not derive | Supply exactly what is missing, re-dispatch |
+| `BLOCKED` | Cannot complete | Change something - more context, a stronger model, a smaller task, or escalate |
+
+Never re-dispatch a `BLOCKED` unit unchanged. If it said it was stuck, repeating
+the request repeats the outcome.
+
+## Boundary
+
+A prepared review request is not a review. A returned report is not a fix, and a
+fix is not verification. Each step is observed only from its own fresh output.

--- a/skills/omh-code-review/references/review-response.md
+++ b/skills/omh-code-review/references/review-response.md
@@ -1,0 +1,61 @@
+# Receiving a Review
+
+Review feedback is a technical claim to evaluate, not a verdict to perform
+agreement with. Load this when findings arrive, before changing anything.
+
+## Verify before implementing
+
+1. **Read** the whole set without reacting.
+2. **Restate** each item in your own words. If you cannot, you do not understand it yet.
+3. **Verify** it against the codebase as it actually is.
+4. **Evaluate** whether it is correct *for this project*, not in general.
+5. **Respond** with a technical acknowledgement or reasoned push-back.
+6. **Implement** one item at a time, checking each.
+
+## The clarification gate is all-or-nothing
+
+If any item is unclear, ask about it **before implementing any of them**.
+
+Findings are frequently related. Implementing the four you understood can make
+the two you did not understand harder to fix, or can implement them wrongly by
+implication. Partial understanding produces a partial-fix diff that then needs
+its own review round.
+
+## Push-back is part of the contract
+
+A reviewer working from a diff has less context than you do. When a finding is
+wrong, say so with the technical reason and the evidence - the test that covers
+it, the constraint that forbids the suggested shape, the platform it breaks.
+
+Do not implement a change you believe is wrong in order to close a finding. That
+trades a review round for a defect.
+
+What is not push-back: silence, partial implementation, or implementing
+something adjacent and calling the finding addressed.
+
+## Order the work
+
+1. Anything that blocks other items.
+2. Correctness, highest severity first.
+3. Everything mechanical.
+
+Re-run the verifying command after each, not once at the end. A batch of fixes
+verified together cannot tell you which one regressed.
+
+## What not to say
+
+Performative agreement wastes a turn and hides whether the item was understood.
+Skip "you're absolutely right", "great catch", and "let me implement that now" -
+restate the requirement, or start working.
+
+## Convergence
+
+From round two, the review is a ratchet: new findings on ground the previous
+round already settled need a stated reason they were not visible earlier, and a
+finding carried forward keeps the severity it was raised at. See `REVIEW.md` for
+the full rule set; this file only covers the reviewee's side.
+
+## Boundary
+
+Reading a finding is not fixing it. A fix is observed only when the command that
+demonstrated the defect no longer does.

--- a/src/skills/catalog_definitions.py
+++ b/src/skills/catalog_definitions.py
@@ -4360,6 +4360,8 @@ _DEFINITIONS = [
             "If no diff, file set, PR, or artifact is available, inspect the requested target or ask one target question before reviewing.",
             "If tests fail or are missing, cite the exact command gap and do not approve the change as verified.",
             "If independent review evidence is unavailable, say so directly instead of implying a second reviewer passed it.",
+            "To dispatch a reviewer rather than write the findings yourself, load `omh-code-review/references/review-dispatch.md`; it carries the base-SHA rule and the implementer status contract.",
+            "When findings arrive for work you own, load `omh-code-review/references/review-response.md` before changing anything.",
         ),
     ),
     SkillDefinition(

--- a/src/skills/packaging.py
+++ b/src/skills/packaging.py
@@ -6,6 +6,7 @@ from .catalog import installable_skill_definitions
 from .render import (
     SkillReferenceTemplate,
     SkillTemplate,
+    code_review_reference_templates,
     deep_interview_skill,
     memory_new_skill,
     memory_sync_skill,
@@ -22,7 +23,7 @@ def builtin_skill_templates() -> list[SkillTemplate]:
 
 
 def builtin_skill_reference_templates() -> list[SkillReferenceTemplate]:
-    return [*router_reference_templates(), *wiki_reference_templates()]
+    return [*router_reference_templates(), *wiki_reference_templates(), *code_review_reference_templates()]
 
 
 def _skill_template_for(name: str) -> SkillTemplate:

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -1648,3 +1648,155 @@ def _harness_payload(harness: HarnessDefinition) -> dict[str, object]:
         "fallback": harness.fallback,
         "harness_quality": harness_quality_contract(harness.name),
     }
+
+
+def code_review_reference_templates() -> list[SkillReferenceTemplate]:
+    return list(_code_review_reference_templates_cached())
+
+
+@lru_cache(maxsize=1)
+def _code_review_reference_templates_cached() -> tuple[SkillReferenceTemplate, ...]:
+    return (
+        SkillReferenceTemplate("code-review", "references/review-dispatch.md", _review_dispatch_reference()),
+        SkillReferenceTemplate("code-review", "references/review-response.md", _review_response_reference()),
+    )
+
+
+def _review_dispatch_reference() -> str:
+    return """# Requesting a Review
+
+`code-review` states what a review must contain. This states how to obtain one.
+Load it when dispatching a reviewer, not when reading a finding.
+
+## Name the range before dispatching
+
+A reviewer handed the wrong range reviews a fraction of the change and returns
+a clean verdict on code nobody read. That is a manufactured pass, and it is the
+exact failure the evidence boundary exists to prevent.
+
+```sh
+BASE_SHA=$(git merge-base origin/main HEAD)   # or the commit recorded before the work began
+HEAD_SHA=$(git rev-parse HEAD)
+```
+
+**Never `HEAD~1`.** It silently drops every commit of a multi-commit task except
+the last. Record BASE before the work starts; deriving it afterwards from the
+log is guesswork the moment a merge or a fixup lands.
+
+State both SHAs in the request. A review whose range is unstated cannot be
+re-run, and cannot be shown to have covered anything.
+
+## Hand over artifacts, not bodies
+
+Everything pasted into a dispatch stays resident for the rest of the session and
+is re-read on every later turn. Write the diff, the plan section, and the failing
+output to files under `.omh/artifacts/` or `.omh/handoffs/` and pass the paths.
+
+A dispatch describes one unit of work. Do not paste accumulated prior-task
+summaries into later dispatches - a fresh reviewer needs the range, the
+requirements, and the constraints, and nothing else.
+
+## What the request must carry
+
+- **Range** - BASE_SHA and HEAD_SHA, both spelled out.
+- **Claim** - what the author says this does. The review is against this claim.
+- **Requirements** - a path to the plan or spec section, not its pasted text.
+- **Constraints** - anything project-wide the diff must satisfy.
+- **Return contract** - findings first, severity per finding, and the file, line,
+  and command output each one rests on.
+
+## Reading the report
+
+A reviewer's report is a claim, not evidence. Two rules keep it honest:
+
+- **Do not trust the report.** A stated rationale never downgrades a finding's
+  severity. "I checked and it is fine" is not a check; the command output is.
+- **"Attempted" is not "addressed."** A fix is done when the specific defect no
+  longer reproduces, shown by the same command that showed it. A commit message
+  saying it was fixed is not that command.
+
+## The four statuses an implementer may return
+
+Anything dispatched to change code returns exactly one of these, so the
+coordinator can act without re-reading the work:
+
+| Status | Meaning | What the coordinator does |
+| --- | --- | --- |
+| `DONE` | Complete and verified | Generate the review range, dispatch the reviewer |
+| `DONE_WITH_CONCERNS` | Complete, with doubts stated | Read the concerns first; address correctness or scope before review |
+| `NEEDS_CONTEXT` | Missing information it could not derive | Supply exactly what is missing, re-dispatch |
+| `BLOCKED` | Cannot complete | Change something - more context, a stronger model, a smaller task, or escalate |
+
+Never re-dispatch a `BLOCKED` unit unchanged. If it said it was stuck, repeating
+the request repeats the outcome.
+
+## Boundary
+
+A prepared review request is not a review. A returned report is not a fix, and a
+fix is not verification. Each step is observed only from its own fresh output.
+"""
+
+
+def _review_response_reference() -> str:
+    return """# Receiving a Review
+
+Review feedback is a technical claim to evaluate, not a verdict to perform
+agreement with. Load this when findings arrive, before changing anything.
+
+## Verify before implementing
+
+1. **Read** the whole set without reacting.
+2. **Restate** each item in your own words. If you cannot, you do not understand it yet.
+3. **Verify** it against the codebase as it actually is.
+4. **Evaluate** whether it is correct *for this project*, not in general.
+5. **Respond** with a technical acknowledgement or reasoned push-back.
+6. **Implement** one item at a time, checking each.
+
+## The clarification gate is all-or-nothing
+
+If any item is unclear, ask about it **before implementing any of them**.
+
+Findings are frequently related. Implementing the four you understood can make
+the two you did not understand harder to fix, or can implement them wrongly by
+implication. Partial understanding produces a partial-fix diff that then needs
+its own review round.
+
+## Push-back is part of the contract
+
+A reviewer working from a diff has less context than you do. When a finding is
+wrong, say so with the technical reason and the evidence - the test that covers
+it, the constraint that forbids the suggested shape, the platform it breaks.
+
+Do not implement a change you believe is wrong in order to close a finding. That
+trades a review round for a defect.
+
+What is not push-back: silence, partial implementation, or implementing
+something adjacent and calling the finding addressed.
+
+## Order the work
+
+1. Anything that blocks other items.
+2. Correctness, highest severity first.
+3. Everything mechanical.
+
+Re-run the verifying command after each, not once at the end. A batch of fixes
+verified together cannot tell you which one regressed.
+
+## What not to say
+
+Performative agreement wastes a turn and hides whether the item was understood.
+Skip "you're absolutely right", "great catch", and "let me implement that now" -
+restate the requirement, or start working.
+
+## Convergence
+
+From round two, the review is a ratchet: new findings on ground the previous
+round already settled need a stated reason they were not visible earlier, and a
+finding carried forward keeps the severity it was raised at. See `REVIEW.md` for
+the full rule set; this file only covers the reviewee's side.
+
+## Boundary
+
+Reading a finding is not fixing it. A fix is observed only when the command that
+demonstrated the defect no longer does.
+"""

--- a/tests/test_code_review_references.py
+++ b/tests/test_code_review_references.py
@@ -1,0 +1,66 @@
+"""The code-review reference files carry clauses that prevent a wrong answer.
+
+These are not style assertions. Each locked string below is the one sentence in
+its section that stops a specific failure: a review that covered a fraction of
+the change, a fix that was attempted rather than made, or a partial
+implementation of a finding set that was not understood. A rewrite that drops
+one of them should fail here rather than ship quietly.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from omh.skills.packaging import builtin_skill_reference_templates
+from omh.skills.render import code_review_reference_templates
+
+
+class CodeReviewReferenceTests(unittest.TestCase):
+    def _content(self, relative_path: str) -> str:
+        for template in code_review_reference_templates():
+            if template.relative_path == relative_path:
+                return template.content
+        self.fail(f"no code-review reference at {relative_path}")
+
+    def test_both_references_ship_under_the_code_review_skill(self) -> None:
+        paths = {template.relative_path for template in code_review_reference_templates()}
+        self.assertEqual(paths, {"references/review-dispatch.md", "references/review-response.md"})
+        for template in code_review_reference_templates():
+            self.assertEqual(template.skill_name, "code-review")
+
+    def test_the_packaged_set_includes_them(self) -> None:
+        # packaging.py splices three producers by hand; a fourth is a one-line
+        # edit and an omitted one is silent until the byte gate runs.
+        packaged = {(t.skill_name, t.relative_path) for t in builtin_skill_reference_templates()}
+        self.assertIn(("code-review", "references/review-dispatch.md"), packaged)
+        self.assertIn(("code-review", "references/review-response.md"), packaged)
+
+    def test_the_base_sha_rule_states_the_defect_not_just_the_preference(self) -> None:
+        content = self._content("references/review-dispatch.md")
+        # Handing a reviewer HEAD~1 on a multi-commit task yields a clean
+        # verdict on code nobody read - a manufactured pass.
+        self.assertIn("Never `HEAD~1`", content)
+        self.assertIn("BASE_SHA", content)
+        self.assertIn("HEAD_SHA", content)
+
+    def test_the_four_implementer_statuses_are_all_present(self) -> None:
+        content = self._content("references/review-dispatch.md")
+        for status in ("DONE", "DONE_WITH_CONCERNS", "NEEDS_CONTEXT", "BLOCKED"):
+            with self.subTest(status=status):
+                self.assertIn(status, content)
+
+    def test_attempted_is_not_addressed_survives(self) -> None:
+        self.assertIn('"Attempted" is not "addressed."', self._content("references/review-dispatch.md"))
+
+    def test_the_clarification_gate_is_all_or_nothing(self) -> None:
+        content = self._content("references/review-response.md")
+        self.assertIn("before implementing any of them", content)
+
+    def test_both_references_end_at_a_boundary(self) -> None:
+        for relative_path in ("references/review-dispatch.md", "references/review-response.md"):
+            with self.subTest(relative_path=relative_path):
+                self.assertIn("## Boundary", self._content(relative_path))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

Two generated reference files under `omh-code-review`: `references/review-dispatch.md` (how to obtain a review) and `references/review-response.md` (what to do when findings arrive).

### Why This Exists

`code-review` is precise about the *product* of a review — findings first, ranked by severity, each citing file, diff, command output, or artifact. It is silent on how to get one:

- no base-SHA convention,
- no reviewer request contract,
- no statement of what a dispatched implementer returns,
- and no stated reason to dispatch a reviewer at all rather than read the diff inline.

That gap has a concrete cost. **A reviewer handed the wrong range reviews a fraction of the change and returns a clean verdict on code nobody read.** That is a manufactured pass — precisely the failure OMH's whole evidence doctrine exists to prevent, arriving through the one door the doctrine never covered.

### User / Operator Impact

An agent about to request a review now has the range convention, the request contract, and the four statuses an implementer may return. An agent *receiving* findings has the reviewee side, which OMH had nothing for at all.

The cost is zero per turn: `src/skills/context_cost.py` counts reference bytes **outside** the always-loaded skill body. `docs skill-context-cost` confirms the on-demand ledger moved from 12 files to 14; the skill body is unchanged.

### How It Works

`SkillReferenceTemplate` → the hardcoded producer splice in `packaging.py` → byte-gated on disk by the tap-skills staleness check inside `docs workflows --check` and the ≤24,500-byte per-reference ceiling in `tests/test_router_content.py`. The mechanism already existed; it was used by 2 of 103 skills.

**`review-dispatch.md`** carries:

| Clause | What it prevents |
| --- | --- |
| **Never `HEAD~1`** | On a multi-commit task it drops every commit but the last — a clean verdict on unread code |
| Artifact-over-context handover | A dispatch that pastes bodies stays resident and is re-read every later turn |
| Four-status contract — `DONE` / `DONE_WITH_CONCERNS` / `NEEDS_CONTEXT` / `BLOCKED` | A coordinator having to re-read the work to learn what happened |
| A stated rationale never downgrades severity | "I checked and it's fine" standing in for the command output |
| "Attempted" is not "addressed" | A commit message closing a finding the defect still reproduces |

**`review-response.md`** carries the all-or-nothing clarification gate — if any finding is unclear, ask before implementing *any* of them, because findings are frequently related and a partial-understanding diff needs its own round — plus an explicit push-back license, an implementation order (blocking → correctness → mechanical, re-verifying after each), and the note that performative agreement hides whether an item was understood.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/skills/render.py` | `code_review_reference_templates()` + the two builders, following `_wiki_reference_templates_cached` |
| `src/skills/packaging.py` | third producer spliced into `builtin_skill_reference_templates()` |
| `src/skills/catalog_definitions.py` | two `recovery_notes` pointers on `code-review` |
| `skills/omh-code-review/references/*.md`, `skills/omh-code-review/SKILL.md`, `docs/WORKFLOWS.md` | generated |
| `tests/test_code_review_references.py` | **new** — 7 tests |

### Review

**The tests lock clauses, not prose.** Each asserted string is the one sentence in its section that stops a specific failure, so a rewrite that guts one fails here instead of shipping quietly. Nothing asserts wording elsewhere in the files.

**Two alternatives were rejected**, both from the analysis that produced this change:

- *A new `review-response` skill.* It competes directly with `github-event-ops` for the same phrasings (measured: "the reviewer left comments on my PR" → github-event-ops at 46) and spends one of a small number of remaining skill slots on text with no reader of its own.
- *`iron_law` / `red_flags` fields on `SkillDefinition`.* Every entry would be authored from imagination. The source project's own head-to-head evidence reports that under a competing incentive, an invented prohibition list produced *more* of the unwanted content than a positive recipe, and trended worse than no guidance. OMH cannot capture the baseline that makes such a list real, because it makes no LLM calls — which is the product definition, not a gap.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` — **5717 tests OK**
- [x] `tests/test_code_review_references.py` — 7/7
- [x] `docs workflows --check`, `docs roles --check`, `docs capability-families --check` — exit 0
- [x] `ruff check src tests` — All checks passed; `compileall`, `git diff --check` — exit 0
- [x] `harness validate`, `release checklist --json` — exit 0
- [x] All four generated artifact families regenerated together
- [x] `docs skill-context-cost` — on-demand references 12 → 14 files; **always-loaded skill body unchanged**
- [ ] Any evidence that a dispatched reviewer reads these — **not observed.** See Risk.

## Risk

- **Nothing enforces that these are read.** They sit behind a soft `recovery_notes` pointer, so they reach an agent already inclined to comply. This is the honest limit of the change and it should not be oversold: it makes the contract *available and precise*, not *enforced*.
- **The four-status contract has no machine consumer in OMH today.** `fanout_contract/v1` records spawns and exits, not these statuses. It is a convention for agents to follow, not a schema anything validates.
- The base-SHA guidance assumes `origin/main` is the fork point; the file says to record BASE before work starts precisely because deriving it later is guesswork.

## Compatibility / Rollout

- Purely additive. No schema, no scoring, no route, no exact-count fixture moved. Reverting removes two files and one splice line.
- Release channel: `local`.

## Release / Claims

- [x] Release-channel impact considered — none
- [x] Runtime capability claims backed by evidence or marked not observed — no capability claimed; the enforcement gap is stated
- [x] Known manual Hermes checks listed — no Hermes surface touched

## Follow-Up

- `REVIEW.md`'s re-review ratchet and `docs/REVIEW-SWEEP.md` are the natural next things to cross-reference from `review-response.md`; it currently points at `REVIEW.md` by name only.
