### PR TITLE
refactor: move per-skill routing preconditions out of the shared scorer

### DIFF
--- a/src/routing/recommend.py
+++ b/src/routing/recommend.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, replace
 from functools import lru_cache
 import re
@@ -1588,51 +1589,16 @@ def _score_definition(
         _ecosystem_identity_connector_explicit_match(normalized_query)
     )
 
+    # Some skills belong in the shortlist only when their own precondition
+    # holds. That was seven copies of this same conditional, so adding an
+    # eighth meant editing the function every skill is scored by. The rules
+    # live in `_SKILL_OFFERS_ITSELF` at the foot of this module now: same
+    # predicates, same evaluation order, one row per skill.
+    offers_itself = _SKILL_OFFERS_ITSELF.get(definition.name)
     if (
-        definition.name == "ops-observability-card"
-        and explicit_skill != "ops-observability-card"
-        and (
-            ops_observability_external_blocked(normalized_query)
-            or ops_observability_generic_metrics_blocked(normalized_query, query_tokens)
-            or _public_plugin_connector_readiness_match(normalized_query)
-            or _skill_scout_candidate_alias_intent_match(normalized_query)
-        )
-    ):
-        return None
-    if (
-        definition.name == "harness-session-inventory"
-        and explicit_skill != "harness-session-inventory"
-        and not _harness_session_inventory_recommendation_applies(normalized_query, query_tokens)
-    ):
-        return None
-    if (
-        definition.name == "build-failure-triage"
-        and explicit_skill != "build-failure-triage"
-        and _build_failure_triage_fixed_or_pass_verification_context(normalized_query)
-    ):
-        return None
-    if (
-        definition.name == "media-input-operator"
-        and explicit_skill != "media-input-operator"
-        and not media_input_operator_guard_applies(normalized_query, query_tokens)
-    ):
-        return None
-    if (
-        definition.name == "external-connector-readiness"
-        and explicit_skill != "external-connector-readiness"
-        and not _external_connector_readiness_recommendation_applies(normalized_query, query_tokens)
-    ):
-        return None
-    if (
-        definition.name == "prompt-import-readiness"
-        and explicit_skill != "prompt-import-readiness"
-        and not _prompt_import_readiness_recommendation_applies(normalized_query, query_tokens)
-    ):
-        return None
-    if (
-        definition.name == "physical-device-readiness"
-        and explicit_skill != "physical-device-readiness"
-        and not _physical_device_readiness_recommendation_applies(normalized_query, query_tokens)
+        offers_itself is not None
+        and explicit_skill != definition.name
+        and not offers_itself(normalized_query, query_tokens)
     ):
         return None
 
@@ -2371,3 +2337,36 @@ def _evidence_boundary(definition: SkillDefinition) -> str:
 
 def _wrapper_guidance(definition: SkillDefinition) -> str:
     return _policy_for(definition).wrapper_guidance
+
+
+def _ops_observability_card_offers_itself(normalized_query: str, query_tokens: set[str]) -> bool:
+    return not (
+        ops_observability_external_blocked(normalized_query)
+        or ops_observability_generic_metrics_blocked(normalized_query, query_tokens)
+        or _public_plugin_connector_readiness_match(normalized_query)
+        or _skill_scout_candidate_alias_intent_match(normalized_query)
+    )
+
+
+def _build_failure_triage_offers_itself(normalized_query: str, query_tokens: set[str]) -> bool:
+    return not _build_failure_triage_fixed_or_pass_verification_context(normalized_query)
+
+
+# Skills that withdraw from the shortlist unless their own precondition holds,
+# checked in `_score_definition`. An explicit invocation always overrides this:
+# naming a skill outright is the user overruling its self-assessment.
+#
+# This is a table because it was a table already - seven hand-written copies of
+# one conditional inside the function that scores every skill, which is where
+# `docs/ADDING-A-SKILL.md` did not think to send anyone. Two entries are phrased
+# as blockers upstream and keep that phrasing in the wrappers above rather than
+# being rewritten, so the predicates here are the same ones as before.
+_SKILL_OFFERS_ITSELF: dict[str, Callable[[str, set[str]], bool]] = {
+    "ops-observability-card": _ops_observability_card_offers_itself,
+    "harness-session-inventory": _harness_session_inventory_recommendation_applies,
+    "build-failure-triage": _build_failure_triage_offers_itself,
+    "media-input-operator": media_input_operator_guard_applies,
+    "external-connector-readiness": _external_connector_readiness_recommendation_applies,
+    "prompt-import-readiness": _prompt_import_readiness_recommendation_applies,
+    "physical-device-readiness": _physical_device_readiness_recommendation_applies,
+}


### PR DESCRIPTION
## Feature Report

### What Changed

Seven per-skill routing preconditions moved out of `_score_definition` — the function that scores **every** skill in the catalog — into one table, `_SKILL_OFFERS_ITSELF`.

**No routing behaviour changes. That is the acceptance test, not a side note.**

### Why This Exists

`_score_definition` carried seven copies of one conditional:

```python
if (definition.name == "physical-device-readiness"
    and explicit_skill != "physical-device-readiness"
    and not _physical_device_readiness_recommendation_applies(...)):
    return None
```

Two consequences, both paid on every skill added:

- **Adding an eighth meant editing the function every other skill is scored by.** `docs/ADDING-A-SKILL.md` lists ten registration surfaces and does not mention this one, because it is not a registration surface — it is surgery inside shared code.
- **Finding which skills carry a precondition meant grepping the scorer for their names.** The rule lived nowhere near the skill it belonged to.

This is one instance of a wider pattern. A count across `recommend.py` finds **15 hardcoded `definition.name == "<skill>"` rules** in three families: 7 preconditions (this PR), 7 `direct:` score bonuses, and 2 trigger-token subtractions. All three are tables written as code.

### How It Works

The predicates are unchanged and still live where they were defined; only the dispatch moves. Two entries were phrased upstream as *blockers* rather than preconditions, and they keep that phrasing inside a named wrapper (`_ops_observability_card_offers_itself`, `_build_failure_triage_offers_itself`) rather than being inverted — inverting a predicate while moving it makes the diff unreviewable and the equivalence unprovable.

An explicit invocation still overrides the precondition: naming a skill outright is the user overruling its self-assessment. That was true before and is preserved in the single conditional.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/routing/recommend.py` | 7 conditionals (48 lines) → 1 lookup (12 lines) + 2 wrappers + a 7-row table |

Net **+43 / −44**. No catalog data, no trigger, no weight, no guard, no threshold.

## Validation

The bar for a behaviour-preserving change is that nothing moves, so that is what was measured:

- [x] **239-message main-vs-branch differential**, run in separate processes per checkout — **0 workflow changes, 0 rescores, 0 action changes, 0 confidence changes**
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` — **5710 tests OK** (unchanged from main)
- [x] `tests/test_routing_accuracy.py` — the ratchet whose floors must *never* be lowered to make a change pass — holds at **ko 6/6, en 5/6, overall 13/36**
- [x] `ruff check src tests` — All checks passed

The differential runs in separate processes deliberately: `_recommend_skills_cached` is `lru_cache(maxsize=2048)`, so monkeypatching a scorer in-process and re-routing returns cached results and reports zero change whether or not the change did anything.

## Risk

- **Low, and bounded by the zero-diff evidence.** The remaining risk is a predicate whose behaviour depends on evaluation *order* relative to the other six. The table preserves the original order, and the original conditionals were independent `return None` guards, so order was never load-bearing.
- **This does not reduce the number of per-skill rules, only where they live.** Seven skills still have preconditions; they are now declared instead of embedded. The maintenance win is that the eighth is a row, not an edit to shared code.
- **Two families are untouched**, so two thirds of the pattern remains. See below.

## Compatibility / Rollout

- Pure refactor. Reverting restores the seven conditionals exactly.
- Release channel: `local`. No version file, changelog, generated artifact, or schema touched.

## Release / Claims

- [x] Release-channel impact considered — none
- [x] Runtime capability claims backed by evidence or marked not observed — no capability claimed; this is behaviour-preserving
- [x] Known manual Hermes checks listed — none; no Hermes surface touched

## Follow-Up

The two sibling families are deliberately out of scope and need a tuple table rather than a dict, because a skill can own more than one row in each:

- **7 name-gated `direct:` bonuses** — `failure-signal-audit` (+34), `external-connector-readiness` (+36), `skill-scout` (+36), `source-finder` (+36), `accessibility-audit` (+30), `build-failure-triage` (+32), `verification-gate`
- **2 name-gated trigger-token subtractions** — `codegraph-refresh`, `external-connector-readiness`

Each needs its own zero-diff run before it lands.
