### PR TITLE
fix: stop the memory dream status query from consuming the next brief

### DIFF
--- a/src/commands/memory.py
+++ b/src/commands/memory.py
@@ -531,11 +531,26 @@ def cmd_memory_block_remove(args: argparse.Namespace) -> int:
 
 
 def cmd_memory_dream(args: argparse.Namespace) -> int:
-    """Report whether consolidation is due. Never consolidates: that needs a model."""
+    """Report whether consolidation is due. Never consolidates: that needs a model.
+
+    Without `--evaluate` this reads the counters and writes nothing. It used to
+    build a provider and `initialize` it before looking at `args.evaluate`, and
+    `initialize` ends by settling the previous session's unconsolidated turns --
+    so asking the status question raised a brief, stamped its reasons as fired,
+    zeroed the turn counter, and lowered `compaction_pending`. The standing
+    conditions (`headroom_below_floor`, `duplicate_records`, `expiring_records`)
+    are suppressed while their exact string is unchanged, so the next real brief
+    stayed silent about a condition nobody had cleared.
+
+    `--evaluate` no longer initializes either. The evaluation it reports is now
+    its own first one, under the `manual` trigger it actually is, rather than
+    the second reading of a `session_start_recovery` that never happened.
+    """
     paths = _paths(args)
-    provider = OmhMemoryProvider(paths.omh_home)
-    provider.initialize("", hermes_home=str(paths.hermes_home))
-    payload = dict(provider.consolidation_due()) if args.evaluate else {}
+    payload: dict[str, object] = {}
+    if args.evaluate:
+        provider = OmhMemoryProvider(paths.omh_home, hermes_home=paths.hermes_home)
+        payload = dict(provider.consolidation_due())
     payload["state"] = read_dreaming_state(paths.omh_home)
     payload["evaluated"] = bool(args.evaluate)
     _print_json(payload)

--- a/src/plugin_bundle/omh/memory_provider.py
+++ b/src/plugin_bundle/omh/memory_provider.py
@@ -87,9 +87,15 @@ _SESSION_ENDING_TRIGGERS = frozenset({"session_end", "shutdown", "session_start_
 class OmhMemoryProvider(_MemoryProviderBase):
     """Deterministic, file-backed recall for Hermes. No model call, no network."""
 
-    def __init__(self, omh_home: str | Path | None = None) -> None:
+    def __init__(self, omh_home: str | Path | None = None, *, hermes_home: str | Path | None = None) -> None:
+        # `hermes_home` is also settable here, not only through `initialize`,
+        # so a caller that wants one reading -- `omh memory dream --evaluate`
+        # asking whether consolidation is due -- can get a configured provider
+        # without entering the session lifecycle. `initialize` is a session
+        # start: it renders the pack and settles the previous session's
+        # unconsolidated turns. A question is not a session start.
         self._omh_home = Path(omh_home).expanduser() if omh_home else _default_omh_home()
-        self._hermes_home: Path | None = None
+        self._hermes_home = Path(str(hermes_home)).expanduser() if hermes_home else None
         self._session_id = ""
         self._writes_enabled = True
         # prefetch() is called before every API call and the base class asks for

--- a/tests/test_memory_provider.py
+++ b/tests/test_memory_provider.py
@@ -821,30 +821,66 @@ class MemoryCliTests(unittest.TestCase):
             self.assertEqual([block["label"] for block in payload["blocks"]], ["sometimes"])
 
     def test_dream_reports_without_evaluating_unless_asked(self) -> None:
+        # The fixture writes a nearly-full Hermes memory file on purpose. With
+        # an empty one nothing is ever due, the write branch is never taken,
+        # and the assertions below pass for a reason that has nothing to do
+        # with the command being read-only.
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
+            _write_hermes_memory(root / ".hermes", "x" * 2100)
             status, payload, stderr = self._json(run_cli(self._base(root) + ["memory", "dream"]))
             self.assertEqual(status, 0, stderr)
             self.assertFalse(payload["evaluated"])
             self.assertNotIn("due", payload)
             self.assertFalse((root / ".omh" / "memory" / "consolidation.json").exists())
+            self.assertFalse((root / ".omh" / "memory" / "dreaming.json").exists())
 
-    def test_dream_evaluate_weighs_the_triggers_and_never_consolidates(self) -> None:
+    def test_the_status_question_does_not_consume_the_next_brief(self) -> None:
+        # Asking "is consolidation due" must not answer "no" to the next asker
+        # by having silently fired the reason itself. The condition here --
+        # a Hermes memory file with no headroom left -- is standing: it stays
+        # true until somebody consolidates, which OMH cannot do.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_hermes_memory(root / ".hermes", "x" * 2100)
+            run_cli(self._base(root) + ["memory", "dream"])
+            _, payload, stderr = self._json(run_cli(self._base(root) + ["memory", "dream", "--evaluate"]))
+            self.assertTrue(payload["due"], stderr)
+            self.assertTrue(any(reason.startswith("headroom_below_floor") for reason in payload["reasons"]))
+
+    def test_dream_evaluate_reports_its_own_evaluation_under_the_manual_trigger(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
             _write_hermes_memory(root / ".hermes", "x" * 2100)
             status, payload, stderr = self._json(run_cli(self._base(root) + ["memory", "dream", "--evaluate"]))
             self.assertEqual(status, 0, stderr)
             self.assertIn("not evidence that memory was consolidated", payload["claim_boundary"])
-            # The brief lands on disk whether or not this particular call is the
-            # one that weighed the trigger: `initialize` evaluates first, and a
-            # standing condition is not restated once it has been reported.
+            # The trigger names what actually happened. It used to read
+            # `session_start_recovery` -- "a previous session ended without
+            # consolidating" -- because `initialize` ran first and evaluated on
+            # the way past, leaving this payload as the second, always-not-due
+            # reading of a session start that was really a CLI question.
+            self.assertEqual(payload["trigger"], "manual")
+            self.assertTrue(payload["due"])
             self.assertTrue((root / ".omh" / "memory" / "consolidation.json").is_file())
 
             # Asking twice does not write twice, which is the whole point.
             before = (root / ".omh" / "memory" / "consolidation.jsonl").read_text(encoding="utf-8")
             run_cli(self._base(root) + ["memory", "dream", "--evaluate"])
             self.assertEqual((root / ".omh" / "memory" / "consolidation.jsonl").read_text(encoding="utf-8"), before)
+
+    def test_a_pending_compaction_flag_survives_the_status_question(self) -> None:
+        # `compaction_pending` records that Hermes discarded messages. A status
+        # query that lowers it destroys the only trace of a real trigger.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_hermes_memory(root / ".hermes", "x" * 2100)
+            omh_home = root / ".omh"
+            write_dreaming_state(omh_home, record_compaction(record_turn(empty_dreaming_state())))
+            run_cli(self._base(root) + ["memory", "dream"])
+            state = read_dreaming_state(omh_home)
+            self.assertTrue(state["compaction_pending"])
+            self.assertEqual(state["turns_since_consolidation"], 1)
 
     def test_the_provider_slot_can_be_taken_and_handed_back(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## What changed

`omh memory dream` is now actually the report its help text promises. Without `--evaluate` it reads the dreaming counters and writes nothing; with `--evaluate` it reports its own evaluation under the `manual` trigger instead of the second reading of a session start that never happened.

`OmhMemoryProvider.__init__` gains a keyword-only `hermes_home`, so a caller with one question can obtain a configured provider without entering the session lifecycle.

Closes #906.

## Why

The subcommand help says *"Report whether memory consolidation is due, and why. Never consolidates."* and the payload says `evaluated: false`. Both were true about consolidation and false about everything else the command did.

`cmd_memory_dream` built a provider and called `initialize` **before** looking at `args.evaluate`. `initialize` ends with `self._evaluate_if_due("session_start_recovery")` — the recovery path for a session that died without consolidating — and the CLI's empty `agent_context` is in `_WRITING_CONTEXTS`, so writes were enabled. Asking the status question therefore:

- wrote `memory/consolidation.json` and `memory/consolidation.jsonl`
- wrote `memory/dreaming.json` via `clear_after_consolidation`, which zeroes `turns_since_consolidation`, zeroes `memory_writes_observed`, lowers `compaction_pending`, and stamps `last_reasons`

The stamp is what causes user-visible harm. `_has_unfired_reason` withholds a *condition* reason while its exact string is unchanged, which is correct behaviour for a condition only OMH's consumer can clear. So a status query silenced the next real brief:

```
$ omh memory dream                # documented: report only
  evaluated = False
  consolidation.json  YES         # written anyway
  last_reasons = ['headroom_below_floor:98<=300']

$ omh memory dream --evaluate     # condition unchanged, still true
  due = False  reasons = []
```

Lowering `compaction_pending` is the worst of the four: that flag is the only record that Hermes discarded messages, and a read-only question dropped it.

The brief also carried `trigger: "session_start_recovery"` and its instruction text — *"A previous session ended without consolidating -- a closed laptop, a killed process, a lost gateway"* — describing something that did not happen.

## Implementation

`src/plugin_bundle/omh/memory_provider.py` — `__init__` takes `hermes_home` as a keyword. `initialize` is unchanged and remains the session-start path the Hermes runtime calls.

`src/commands/memory.py` — `cmd_memory_dream` constructs a provider only under `--evaluate`, and calls `consolidation_due()` directly. The report path uses `read_dreaming_state`, which was already side-effect free and already used here for `payload["state"]`.

Both surfaces keep their claim boundaries; nothing about what OMH may write to Hermes memory changed.

## Verification observed

```
PYTHONPATH=tests uv run python -m unittest discover -s tests     5790 tests OK
uv run python -m omh.cli docs workflows --check                  exit 0
uv run python -m omh.cli docs roles --check                      exit 0
uv run python -m omh.cli docs capability-families --check        exit 0
uv run python -m omh.cli harness validate                        exit 0
uv run --group lint ruff check src tests                         All checks passed
uv run python -m compileall -q src tests                         exit 0
git diff --check                                                 clean
```

Issue repro re-run against the branch:

```
=== bare 'memory dream' ===
  evaluated = False
  files written:                      (none)
=== then --evaluate ===
  due = True  trigger = manual  reasons = ['headroom_below_floor:98<=300']
```

## Test changes

`test_dream_reports_without_evaluating_unless_asked` already asserted `consolidation.json` does not exist, and passed on main — its fixture wrote no Hermes memory file, so no reason was ever due and the write branch was never reached. It now writes a nearly-full one, which is what makes the assertion mean anything, and also asserts `dreaming.json` stays absent.

Three tests were added or retargeted for the consequences rather than the mechanism:

- `test_the_status_question_does_not_consume_the_next_brief` — the standing condition is still reported after a bare `dream`
- `test_dream_evaluate_reports_its_own_evaluation_under_the_manual_trigger` — replaces the old `--evaluate` test; keeps its "asking twice does not write twice" assertion and adds `trigger == "manual"` and `due`
- `test_a_pending_compaction_flag_survives_the_status_question`

Net +2 tests (5788 → 5790).

## Risks and follow-ups

- Low. One CLI command and one constructor keyword; no schema, no generated artifact, no exact-count fixture touched.
- `initialize` still evaluates on session start, which is correct and is the path the Hermes runtime uses. The trap it sets for a future non-session caller is now avoidable by construction (`OmhMemoryProvider(home, hermes_home=...)`) rather than by remembering not to call `initialize`.
- Not observed: behaviour inside a live Hermes process, where `initialize` is called by the runtime rather than by the CLI. That path is unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
