### PR TITLE
fix: let recall reach two-letter technical terms (CI, DB, UI, QA)

### DIFF
--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -2984,13 +2984,41 @@ def _memory_recall_score(record: dict[str, Any], query: str) -> int:
 
 
 _MEMORY_ASCII_TOKEN = re.compile(r"[a-z0-9_/-]{3,}")
+# A whole two-character word, never a fragment of a longer one: the lookarounds
+# keep "ru" out of "runs" while letting "ci" out of "ci failures".
+_MEMORY_SHORT_ASCII_TOKEN = re.compile(r"(?<![a-z0-9_/-])[a-z0-9]{2}(?![a-z0-9_/-])")
+# The length floor was doing two jobs: keeping English function words out of the
+# index, and -- as a side effect nobody chose -- keeping every two-letter
+# technical term out with them. Only the first job is wanted, so it is done by
+# naming the function words rather than by measuring length.
+#
+# The list is deliberately short and holds only words that are never a subject.
+# `go`, `id`, `db`, `ci`, `ui`, `qa`, `ml`, `pr`, `js`, `ts`, `vm`, `s3`, `k8`,
+# `ai`, `ux`, and `vs` are all real terms in some project and stay indexable: a
+# stopword that costs a real search is worse than the noise it removes.
+_MEMORY_SHORT_STOPWORDS = frozenset(
+    {
+        "am", "an", "as", "at", "be", "by", "do", "he", "if", "in", "is", "it",
+        "me", "my", "no", "of", "oh", "on", "or", "so", "to", "up", "us", "we",
+    }
+)
 _MEMORY_CJK_RUN = re.compile(r"[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uac00-\ud7a3]+")
 
 
 def _memory_tokens(value: str) -> set[str]:
     """Index tokens for recall scoring, covering ASCII and CJK text.
 
-    ASCII words keep the >=3 length floor. CJK runs are indexed as the whole
+    ASCII words of three characters or more are indexed whole. Two-character
+    words are indexed unless they are one of the named function words. The old
+    >=3 floor made every two-letter technical term unreachable, and the two
+    failure modes it produced were opposites: "CI" tokenized to nothing, so the
+    no-indexable-tokens fallback handed back the whole store with no exclusion
+    reason, while "ci failures" tokenized to {failures}, so every record came
+    back no_query_overlap -- including one whose summary began with "CI" and
+    carried `ci` as a tag, which the tag bonus could not rescue because the
+    query token had already been dropped.
+
+    CJK runs are indexed as the whole
     run plus its character bigrams: Korean particles glue to the noun
     ("배포는"), so whole-word overlap alone would miss "배포" in a query.
     The previous ASCII-only split tokenized any CJK query to the empty set,
@@ -2999,6 +3027,7 @@ def _memory_tokens(value: str) -> set[str]:
     """
     lowered = unicodedata.normalize("NFC", value).lower()
     tokens = set(_MEMORY_ASCII_TOKEN.findall(lowered))
+    tokens.update(token for token in _MEMORY_SHORT_ASCII_TOKEN.findall(lowered) if token not in _MEMORY_SHORT_STOPWORDS)
     for run in _MEMORY_CJK_RUN.findall(lowered):
         if len(run) >= 2:
             tokens.add(run)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -365,6 +365,60 @@ class MemoryContractTests(unittest.TestCase):
             self.assertEqual(miss["record_count"], 0)
             self.assertEqual(miss["excluded_records"][0]["reason"], "no_query_overlap")
 
+    def test_project_memory_recall_reaches_two_letter_technical_terms(self) -> None:
+        """CI, DB, UI, QA and friends must be findable.
+
+        The >=3 ASCII length floor dropped every two-letter word, which produced
+        two opposite failures against the same store. "CI" tokenized to nothing,
+        so the no-indexable-tokens fallback returned every record with no
+        exclusion reason at all; "ci failures" tokenized to {failures}, so the
+        record whose summary began with "CI" and carried `ci` as a tag came back
+        as no_query_overlap. The tag bonus could not save it either -- the query
+        token was dropped before the tag comparison ran.
+        """
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, memory_mode="auto-safe")
+            capture_project_memory_candidate(paths, "CI runs on GitHub Actions for every push", tags=["ci"])
+            capture_project_memory_candidate(paths, "Postgres is the primary DB for the api service", tags=["db"])
+            capture_project_memory_candidate(paths, "Terraform provisions the staging cluster", tags=["infra"])
+
+            recall = build_project_memory_recall_pack(paths, "ci failures")
+            self.assertEqual([item["summary"] for item in recall["included_records"]],
+                             ["CI runs on GitHub Actions for every push"])
+            self.assertEqual(validate_project_memory_recall_pack(recall), [])
+
+            # The bare term used to return the whole store through the fallback.
+            bare = build_project_memory_recall_pack(paths, "CI")
+            self.assertEqual(bare["record_count"], 1)
+
+            natural = build_project_memory_recall_pack(paths, "which DB do we use")
+            self.assertEqual([item["summary"] for item in natural["included_records"]],
+                             ["Postgres is the primary DB for the api service"])
+
+            # Overroute guard: an unrelated query still recalls nothing.
+            miss = build_project_memory_recall_pack(paths, "quantum tunnelling")
+            self.assertEqual(miss["record_count"], 0)
+            self.assertEqual(miss["excluded_records"][0]["reason"], "no_query_overlap")
+
+    def test_two_letter_function_words_stay_out_of_the_recall_index(self) -> None:
+        """The floor kept English filler out; naming it must keep doing that.
+
+        Without the stopword list, "we", "do", "is", "of" would index and a
+        query built only from them would match every record that contains one.
+        """
+        from omh.workflows.memory import _memory_tokens
+
+        self.assertEqual(_memory_tokens("we do it"), set())
+        self.assertEqual(_memory_tokens("is it up to us"), set())
+        # Real two-letter terms are not filler and stay indexable.
+        for term in ("ci", "db", "ui", "qa", "ml", "pr", "js", "go", "s3", "ai", "ux", "vs", "id"):
+            self.assertIn(term, _memory_tokens(f"the {term} thing"), term)
+        # A short token is a whole word, never a fragment of a longer one.
+        self.assertNotIn("ru", _memory_tokens("runs"))
+        self.assertNotIn("ci", _memory_tokens("circular"))
+        self.assertNotIn("db", _memory_tokens("dbname"))
+
     def test_project_memory_recall_treats_nfd_and_nfc_queries_alike(self) -> None:
         """macOS pipelines hand over decomposed Hangul; ranking must not differ."""
         import unicodedata


### PR DESCRIPTION
## What changed

Two-letter technical terms — CI, DB, UI, UX, QA, AI, ML, PR, JS, TS, VM, S3, `go` — are now indexable by memory recall. The `>=3` ASCII length floor in `_memory_tokens` is replaced by a named list of 24 English function words, which is the job the floor was actually there to do.

Closes #909.

## Why

The floor made every two-letter word invisible to the index, and the result was two *opposite* failures against the same store:

```
query 'CI'                 -> 15 records, excluded=[]      (the entire store)
query 'ci failures'        ->  0 records, no_query_overlap on all 15
query 'which DB do we use' ->  0 records
```

- `CI` tokenized to `∅`, so `_memory_recall_score` took its no-indexable-tokens fallback and scored every record `1`. The pack handed the executor Postgres and Terraform as CI context, with `excluded=[]` — nothing in the payload said the query had never been matched.
- `ci failures` tokenized to `{failures}`, so the record whose summary *begins* `CI runs on GitHub Actions` and carries `ci` as a tag came back `no_query_overlap`. The tag bonus could not save it: `tag_overlap` intersects the same query token set the term was already dropped from, so a 2-character tag is unmatchable by construction.

So the most natural phrasing an operator would type returned nothing, and the bare term returned everything.

## Implementation

`src/workflows/memory.py`:

- `_MEMORY_SHORT_ASCII_TOKEN` matches a two-character alphanumeric **whole word**. The lookarounds are the point: `runs` must not yield `ru`, `circular` must not yield `ci`, `dbname` must not yield `db`.
- `_MEMORY_SHORT_STOPWORDS` holds 24 words that are never a subject (`am an as at be by do he if in is it me my no of oh on or so to up us we`). `go`, `id`, `db`, `ci`, `ai`, `vs` and the rest are deliberately **not** in it — each is a real subject in some project, and a stopword that costs a real search is worse than the noise it removes.
- CJK tokenization is untouched.

`_memory_tokens` is also used by `_recall_query_intent`, but every temporal cue is 3+ characters, so no new intent can fire from this change.

## Verification observed

A stopword list trades one failure mode for another, so this was measured rather than argued. 15-record English/Korean corpus, 26 queries, run in separate processes per checkout:

| query | before | after | |
| --- | ---: | ---: | --- |
| `CI` | 15 | **1** | the fallback stopped returning the whole store |
| `DB` | 15 | **1** | same |
| `ci failures` | 0 | **1** | |
| `why did CI fail` | 0 | **1** | |
| `which DB do we use` | 0 | **1** | |
| `UI framework` | 0 | **1** | |
| `QA process` | 1 | **2** | gained the QA record |
| `we do it` | 15 | 15 | function words still tokenize to nothing |
| 17 others | — | — | unchanged |

**9 changed, all improvements, 0 regressions.** The 17 unchanged include every ordinary multi-word English query (`how do we deploy`, `where do secrets live`, `staging cluster provisioning`) and every Korean query, which is the noise check.

```
PYTHONPATH=tests uv run python -m unittest discover -s tests     5790 tests OK
uv run python -m omh.cli docs workflows --check                  exit 0
uv run python -m omh.cli docs roles --check                      exit 0
uv run python -m omh.cli docs capability-families --check        exit 0
uv run python -m omh.cli harness validate                        exit 0
uv run --group lint ruff check src tests                         All checks passed
uv run python -m compileall -q src tests                         exit 0
git diff --check                                                 clean
```

## Test changes

Two tests, following the shape of the existing CJK test (positive case + overroute guard):

- `test_project_memory_recall_reaches_two_letter_technical_terms` — `ci failures` and `which DB do we use` reach exactly the right record, the bare `CI` no longer returns the store, and `quantum tunnelling` still recalls nothing.
- `test_two_letter_function_words_stay_out_of_the_recall_index` — filler-only queries tokenize to nothing, the 13 real terms stay indexable, and short tokens are never fragments of longer words.

Net +2 tests (5788 → 5790).

## Risks and follow-ups

- **The fallback asymmetry is not fixed here.** A query that still tokenizes to nothing (emoji-only, a single CJK character, function words alone) returns the whole store rather than saying it could not read the query. That is now rare rather than routine, but making it explicit means adding a field to `project_memory_recall_pack/v1`, which is a contract change with its own validator and exact-count work; it does not belong in a tokenizer fix.
- **CJK bigram collisions are not fixed here** either — `메모리` and `모리셔스` still share the bigram `모리`. Same function, different remedy (relative weighting of whole-run vs bigram matches), and it needs its own measurement.
- The stopword list is English-only by design; the CJK branch has never had a length floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
