### PR TITLE
fix: give one record one expiry deadline across every surface

### DIFF
--- a/src/plugin_bundle/omh/memory_governance.py
+++ b/src/plugin_bundle/omh/memory_governance.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
 
 __all__ = [
@@ -26,6 +27,7 @@ __all__ = [
     "build_retention",
     "canonical_payload_digest",
     "classify_memory_admission",
+    "resolve_record_expiry_deadline",
     "stable_artifact_identity",
     "evaluate_memory_replay",
     "external_context_label",
@@ -258,6 +260,65 @@ def validate_replay_evaluation(result: dict[str, object]) -> list[str]:
     return errors
 
 
+# The two spellings of one record's deadline. `ttl.expires_at` is the one recall,
+# retirement, status, and the dreaming counts read; `retention.expires_at` is the
+# one the lifecycle plans read. Both are written from a single value at approval
+# and nothing enforced that they stay equal, so the two halves of the system
+# could reach opposite verdicts about the same record in the same second:
+# `memory retire` reported `expired: 1` for the record `memory prune` was
+# rejecting as `prune_requires_expired_approved_volatile`.
+#
+# `ttl` wins wherever it speaks, and an empty `expires_at` is it speaking: it
+# says this record never expires, which is not the same as saying nothing. So is
+# an unreadable one, which says the deadline cannot be defended and must not be
+# acted on. `retention.expires_at` is consulted only when the `ttl` mapping
+# carries no `expires_at` key at all.
+DEADLINE_ABSENT = "absent"
+DEADLINE_UNREADABLE = "unreadable"
+DEADLINE_RESOLVED = "resolved"
+
+
+def _parse_deadline(raw: object) -> tuple[datetime | None, str]:
+    text = str(raw or "").strip() if raw else ""
+    if not text:
+        return None, DEADLINE_ABSENT
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None, DEADLINE_UNREADABLE
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc), DEADLINE_RESOLVED
+
+
+def resolve_record_expiry_deadline(record: dict[str, object] | Mapping[str, object]) -> tuple[datetime | None, str]:
+    """One record's deadline, so every caller reads the same date.
+
+    Returns ``(deadline, state)`` where state is ``absent`` (this record does
+    not expire), ``unreadable`` (a deadline is present but cannot be parsed and
+    must not be acted on), or ``resolved``.
+
+    ``ttl.expires_at`` is authoritative whenever the record states it, including
+    when it states it as empty. ``retention.expires_at`` answers only for a
+    record whose ``ttl`` mapping has no ``expires_at`` key at all -- a legacy
+    shape, or one half of a hand edit. Preferring the earlier of the two instead
+    was the first attempt and it is wrong: it lets a retention deadline overrule
+    a record that has explicitly said it never expires, and it turns an
+    unreadable TTL -- which retirement reports as `malformed_expires_at` and
+    refuses to move -- into an expiry somebody acts on.
+
+    Naive timestamps are UTC by definition; the local host's zone would move the
+    verdict by up to 14 hours depending on where the machine happens to be.
+    """
+    ttl = record.get("ttl")
+    if isinstance(ttl, Mapping) and "expires_at" in ttl:
+        return _parse_deadline(ttl.get("expires_at"))
+    retention = record.get("retention")
+    if isinstance(retention, Mapping):
+        return _parse_deadline(retention.get("expires_at"))
+    return None, DEADLINE_ABSENT
+
+
 def classify_record_expiry_v1_compat(
     record: dict[str, object],
     *,
@@ -265,37 +326,27 @@ def classify_record_expiry_v1_compat(
     window_days: int = 7,
 ) -> str:
     """V1 compatibility function for record expiry classification.
-    
+
     N5 integration: Moved from hermes_memory.py. Returns one of:
     - "fresh": not expired, not expiring soon
     - "expiring": approaching deadline within window_days
     - "expired": deadline passed
     - "no_ttl": no deadline set
     - "malformed": deadline present but unparseable
-    
+
+    The deadline comes from `resolve_record_expiry_deadline`, so this and the
+    lifecycle plans read the same date rather than one field each.
+
     Naive timestamps (without tzinfo) are treated as UTC by definition.
     """
-    ttl = record.get("ttl") if isinstance(record.get("ttl"), dict) else {}
-    expires_at_str = ttl.get("expires_at")
-    
-    text = str(expires_at_str or "").strip() if expires_at_str else ""
-    if not text:
+    expires_at, state = resolve_record_expiry_deadline(record)
+    if state == DEADLINE_ABSENT:
         return "no_ttl"
-    
-    try:
-        # Parse ISO timestamp (strip Z if present)
-        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
-        # Naive timestamps are UTC by definition
-        if parsed.tzinfo is None:
-            parsed = parsed.replace(tzinfo=timezone.utc)
-        
-        expires_at = parsed.astimezone(timezone.utc)
-        now_utc = now.astimezone(timezone.utc)
-        
-        if expires_at <= now_utc:
-            return "expired"
-        if expires_at <= now_utc + timedelta(days=max(window_days, 0)):
-            return "expiring"
-        return "fresh"
-    except (ValueError, TypeError):
+    if expires_at is None:
         return "malformed"
+    now_utc = now.astimezone(timezone.utc)
+    if expires_at <= now_utc:
+        return "expired"
+    if expires_at <= now_utc + timedelta(days=max(window_days, 0)):
+        return "expiring"
+    return "fresh"

--- a/src/workflows/_memory_lifecycle_plans.py
+++ b/src/workflows/_memory_lifecycle_plans.py
@@ -12,11 +12,12 @@ from ..plugin_bundle.omh.memory_governance import (
     build_retention,
     canonical_memory_scope,
     canonical_payload_digest,
+    resolve_record_expiry_deadline,
     stable_artifact_identity,
 )
 from ..system.paths import OmhPaths
 from ._memory_lifecycle_model import LifecycleMutation, LifecyclePlan, LifecycleTransactionExecutor
-from ._memory_lifecycle_scan import ScanFinding, journal_findings, linked_to, matching_json_findings, matching_scope_findings, parse_time, read_json, safe_token, stamp
+from ._memory_lifecycle_scan import ScanFinding, journal_findings, linked_to, matching_json_findings, matching_scope_findings, read_json, safe_token, stamp
 from .memory import MEMORY_ATTENTION_SCHEMA_VERSION, MEMORY_ATTENTION_TIERS
 
 
@@ -38,13 +39,27 @@ def _retention_class(value: Mapping[str, object]) -> str:
 
 
 def _expiry_reason(value: Mapping[str, object], now: datetime) -> str:
+    """Whether this revision is past its deadline, on the one deadline there is.
+
+    This used to read `retention.expires_at` alone while recall, retirement,
+    status, and the dreaming counts read `ttl.expires_at`. Both fields are
+    written from a single value at approval and nothing enforced that they stay
+    equal, so one record could be expired for half the system and eligible for
+    the other half at the same moment -- `memory retire` reporting `expired: 1`
+    for the record `memory prune` was rejecting as
+    `prune_requires_expired_approved_volatile`.
+
+    `resolve_record_expiry_deadline` reads both spellings and takes the earlier,
+    which is what `classify_record_expiry` now reads too, so the claim in its
+    docstring -- that recall and retirement "can never disagree" -- is true of
+    the lifecycle plans as well.
+    """
     retention = value.get("retention")
     if not isinstance(retention, Mapping) or _retention_class(value) not in {"volatile", "standard", "durable"}:
         return "retention_invalid"
-    expires_at = retention.get("expires_at")
-    if not expires_at:
+    deadline, state = resolve_record_expiry_deadline(value)
+    if state == "absent":
         return "eligible"
-    deadline = parse_time(expires_at)
     if deadline is None:
         return "retention_parse_error"
     current = now.replace(tzinfo=timezone.utc) if now.tzinfo is None else now.astimezone(timezone.utc)

--- a/tests/test_memory_governance_retention.py
+++ b/tests/test_memory_governance_retention.py
@@ -148,5 +148,94 @@ class RetentionPolicyTests(unittest.TestCase):
         self.assertEqual(_evaluate(artifact, review)["reason_code"], "stale_review_required")
 
 
+class RecordExpiryDeadlineTests(unittest.TestCase):
+    """One record carries its deadline twice; both halves must read one date.
+
+    `ttl.expires_at` is what recall exclusion, `memory retire`, `memory status`,
+    and the dreaming counts read. `retention.expires_at` is what the lifecycle
+    plans (`prune`, `restore`, the standard-retirement guard) read. They are
+    written from a single value at approval and nothing enforced that they stay
+    equal, so `memory retire` could report `expired: 1` for the very record
+    `memory prune` rejected as `prune_requires_expired_approved_volatile`.
+
+    `ttl` is authoritative wherever it speaks -- including when it speaks by
+    being empty, which says this record never expires.
+    """
+
+    PAST = _iso(NOW - timedelta(days=5))
+    FUTURE = _iso(NOW + timedelta(days=30))
+
+    @staticmethod
+    def _record(ttl: dict[str, object] | None, retention_expires: str) -> dict[str, object]:
+        record: dict[str, object] = {"retention": {"class": "volatile", "expires_at": retention_expires}}
+        if ttl is not None:
+            record["ttl"] = ttl
+        return record
+
+    def test_ttl_decides_whenever_the_record_states_it(self) -> None:
+        for label, ttl, retention_expires, expected, state in (
+            ("ttl past, retention future", {"expires_at": self.PAST}, self.FUTURE, self.PAST, "expired"),
+            ("ttl future, retention past", {"expires_at": self.FUTURE}, self.PAST, self.FUTURE, "fresh"),
+            ("both agree", {"expires_at": self.PAST}, self.PAST, self.PAST, "expired"),
+        ):
+            with self.subTest(label):
+                record = self._record(ttl, retention_expires)
+                deadline, resolution = governance.resolve_record_expiry_deadline(record)
+                self.assertEqual(resolution, "resolved")
+                self.assertEqual(_iso(deadline), expected)
+                self.assertEqual(governance.classify_record_expiry_v1_compat(record, now=NOW), state)
+
+    def test_retention_answers_only_when_ttl_has_no_expires_at_key(self) -> None:
+        record = self._record({"ttl_days": 7}, self.PAST)
+        deadline, resolution = governance.resolve_record_expiry_deadline(record)
+        self.assertEqual((resolution, _iso(deadline)), ("resolved", self.PAST))
+        no_ttl_mapping = {"retention": {"class": "volatile", "expires_at": self.PAST}}
+        deadline, resolution = governance.resolve_record_expiry_deadline(no_ttl_mapping)
+        self.assertEqual((resolution, _iso(deadline)), ("resolved", self.PAST))
+
+    def test_an_empty_ttl_says_this_record_never_expires(self) -> None:
+        # Not the same as saying nothing: a retention deadline must not overrule
+        # a record that has explicitly declared it has no deadline.
+        record = self._record({"expires_at": ""}, self.PAST)
+        self.assertEqual(governance.resolve_record_expiry_deadline(record), (None, "absent"))
+        self.assertEqual(governance.classify_record_expiry_v1_compat(record, now=NOW), "no_ttl")
+
+    def test_an_unreadable_ttl_is_never_acted_on(self) -> None:
+        # `build_memory_retirement` reports this as `malformed_expires_at` and
+        # refuses to move the record. A fallback that reached past it to
+        # `retention` would turn a deadline nobody can defend into a deletion.
+        record = self._record({"expires_at": "garbage"}, self.PAST)
+        self.assertEqual(governance.resolve_record_expiry_deadline(record), (None, "unreadable"))
+        self.assertEqual(governance.classify_record_expiry_v1_compat(record, now=NOW), "malformed")
+
+    def test_a_record_with_neither_spelling_has_no_deadline(self) -> None:
+        for record in ({}, {"ttl": {}}, {"retention": {"class": "durable"}}):
+            with self.subTest(repr(record)):
+                self.assertEqual(governance.resolve_record_expiry_deadline(record), (None, "absent"))
+                self.assertEqual(governance.classify_record_expiry_v1_compat(record, now=NOW), "no_ttl")
+
+    def test_the_writer_keeps_both_spellings_equal(self) -> None:
+        # The invariant that made the divergence unreachable through capture,
+        # asserted out loud so a future writer cannot drop it silently.
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+
+        from omh.memory import approve_project_memory_candidate, capture_project_memory_candidate
+        from omh.paths import resolve_paths
+
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            for retention_class, ttl_days in (("volatile", None), ("volatile", 3), ("standard", 7), ("standard", None)):
+                with self.subTest(f"{retention_class}/{ttl_days}"):
+                    captured = capture_project_memory_candidate(
+                        paths,
+                        f"expiry invariant probe {retention_class} {ttl_days}",
+                        retention_class=retention_class,
+                        ttl_days=ttl_days,
+                    )
+                    record = approve_project_memory_candidate(paths, str(captured["candidate"]["candidate_id"]))["record"]
+                    self.assertEqual(record["ttl"]["expires_at"], record["retention"].get("expires_at", ""))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

Every surface that asks "is this record expired?" now reads the deadline through one function, `resolve_record_expiry_deadline`. Recall, retirement, status, and the dreaming counts already shared a classifier; the lifecycle plans (`prune`, `restore`, the standard-retirement guard) read a different field and could reach the opposite verdict.

Closes #907.

## Why

A record carries its deadline twice — `ttl.expires_at` and `retention.expires_at` — and nothing kept them equal. Observed on one record, at one moment, from one CLI:

```
backdate ttl.expires_at only        retire: expired=1   prune: prune_requires_expired_approved_volatile
backdate retention.expires_at only  retire: expired=0   prune: planned
```

The first row is a contradiction an operator hits head-on: `omh memory retire` reports the record as expired and `omh memory prune` refuses it with a reason code asserting it is not.

The second row is the one that could cost data: `prune` was willing to plan a **hard delete** of a record that recall was still serving as fresh.

`classify_record_expiry` already claimed this invariant in its own docstring:

> The single source of truth for what "expired" means. Recall exclusion and retirement both route through this so they can never disagree.

The lifecycle plans never routed through it, so the sentence was true of two surfaces out of four.

## Implementation

`src/plugin_bundle/omh/memory_governance.py` gains `resolve_record_expiry_deadline(record) -> (deadline, state)` with `state` in `{absent, unreadable, resolved}`. It stays stdlib-only because this module is vendored into the Hermes process. `classify_record_expiry_v1_compat` is rewritten on top of it.

`src/workflows/_memory_lifecycle_plans.py` — `_expiry_reason` calls the same resolver instead of reading `retention.expires_at` directly.

**`ttl` is authoritative wherever the record states it, including when it states it as empty.** `retention.expires_at` answers only for a record whose `ttl` mapping has no `expires_at` key at all — a legacy shape, or one half of a hand edit.

That rule is the second attempt. The first took the *earlier* of the two spellings, by analogy with `_earliest_deadline` over the `stale_after` / `review_due_at` pair, and `test_memory_retirement_report_is_fail_closed_and_write_free` refuted it immediately:

- an empty `ttl.expires_at` is not an absent one — it says *this record never expires*, and a retention deadline must not overrule that;
- an unreadable one says *this deadline cannot be defended*, which retirement reports as `malformed_expires_at` and refuses to move — reaching past it to `retention` turns a skip into a deletion.

Both of those are contracts the module already documented; the existing test is what caught the mistake.

## Verification observed

Repro from the issue, before and after:

```
                                     before                                        after
backdate ttl only        retire=1  prune=prune_requires_...     retire=1  prune=planned
backdate retention only  retire=0  prune=planned                retire=0  prune=prune_requires_...
backdate both            retire=1  prune=planned                retire=1  prune=planned
```

All three rows are now internally consistent. Row 2 flipping to a `prune` rejection is the intended narrowing: a deadline that exists only on `retention` no longer authorizes a hard delete.

```
PYTHONPATH=tests uv run python -m unittest discover -s tests     5794 tests OK
uv run python -m omh.cli docs workflows --check                  exit 0
uv run python -m omh.cli docs roles --check                      exit 0
uv run python -m omh.cli docs capability-families --check        exit 0
uv run python -m omh.cli harness validate                        exit 0
uv run --group lint ruff check src tests                         All checks passed
uv run python -m compileall -q src tests                         exit 0
git diff --check                                                 clean
```

## Test changes

New `RecordExpiryDeadlineTests` (6 tests, +6 total, 5788 → 5794):

- `ttl` decides in all three ttl/retention orderings, and the classifier agrees
- `retention` answers only when the `ttl` mapping has no `expires_at` key
- an empty `ttl` means never-expires even when `retention` carries a past date
- an unreadable `ttl` stays `malformed` and is never acted on
- a record with neither spelling has no deadline
- **the writer keeps both fields equal** across four retention-class / TTL combinations — the invariant that made the divergence unreachable through `capture` → `approve`, asserted rather than assumed

## Risks and follow-ups

- `prune` and `restore` now refuse a record whose only deadline lives on `retention`. Deliberate, and in the fail-safe direction, but it is a behaviour change rather than a pure refactor.
- Not observed: a store carrying records written by an older OMH whose `ttl` mapping predates the `expires_at` key. The retention fallback exists precisely for that shape, but no fixture in the repo has one.
- Rejected: asserting equality and failing closed on a mismatch. That converts a recoverable disagreement into a record no surface will touch — including the surfaces that could repair it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
