### PR TITLE
fix: bound retention day counts at the workflow boundary, not only at argparse

### DIFF
--- a/src/commands/memory.py
+++ b/src/commands/memory.py
@@ -45,6 +45,7 @@ from ..memory import (
     build_project_memory_recall_pack,
     build_project_memory_review,
     build_project_memory_status,
+    MAX_RETENTION_DAYS,
     capture_project_memory_candidate,
     read_memory_snapshot_file,
     reject_project_memory_candidate,
@@ -718,8 +719,8 @@ def _validate_capture_governance_args(args: argparse.Namespace) -> None:
         raise ValueError("unsupported memory source class")
     if args.source_class != "omh_local":
         raise ValueError("memory capture accepts only omh_local source class; external context is not OMH-reviewed")
-    _optional_positive_int(args.ttl_days, "--ttl-days")
-    _optional_positive_int(args.stale_after_days, "--stale-after-days")
+    _optional_positive_int(args.ttl_days, "--ttl-days", maximum=MAX_RETENTION_DAYS)
+    _optional_positive_int(args.stale_after_days, "--stale-after-days", maximum=MAX_RETENTION_DAYS)
     if args.retention_class == "volatile" and args.stale_after_days is not None:
         raise ValueError("volatile memory cannot set --stale-after-days")
     if args.retention_class == "durable" and args.ttl_days is not None:
@@ -756,11 +757,17 @@ def _read_required_json(path: str) -> dict[str, object]:
     return data
 
 
-def _optional_positive_int(value: int | None, flag: str) -> int | None:
+def _optional_positive_int(value: int | None, flag: str, *, maximum: int | None = None) -> int | None:
     if value is None:
         return None
     if value < 1:
         raise ValueError(f"{flag} must be at least 1")
+    # An unbounded day count reached `_days_after`, where
+    # `created_at + timedelta(days=N)` raises OverflowError -- which is not a
+    # ValueError, so it escaped this surface's error handling and printed a raw
+    # Python traceback where every other bad flag prints `omh: ...`.
+    if maximum is not None and value > maximum:
+        raise ValueError(f"{flag} must be at most {maximum}")
     return value
 
 

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -3181,17 +3181,60 @@ def _looks_like_full_transcript(value: str) -> bool:
     return "full transcript" in lowered or "chat transcript" in lowered or speaker_lines >= 4
 
 
+# The longest deadline a retention policy can express. Past this the value is a
+# typo rather than an intent, and `created_at + timedelta(days=N)` starts
+# raising OverflowError out of `_days_after` -- which reached the CLI as a raw
+# Python traceback instead of an `omh:` error.
+MAX_RETENTION_DAYS = 36500
+
+_EPISODE_DEFAULT_TTL_DAYS = 30
+_REVIEW_DEFAULT_DAYS = 90
+
+
+def _validated_day_count(days: int | None, *, field: str) -> int | None:
+    """A day count that can express a deadline, or None for "no deadline".
+
+    The `>= 1` guard used to live only in the argparse layer, so the CLI
+    rejected `--ttl-days 0` and `--ttl-days -5` while the workflow function
+    behind it accepted both from the plugin bundle, the wrapper, or any future
+    caller. `-5` minted a record that was already expired at creation, and `0`
+    made the candidate and its own approved record disagree about the same
+    input: the candidate read `expires_at: ""`, which means never expires, and
+    the record read `expires_at == created_at`, which means expired the instant
+    it was written.
+
+    Zero is rejected rather than reinterpreted. It is not a shorter TTL and it
+    is not the absence of one; it is an input nobody meant.
+    """
+    if days is None:
+        return None
+    if isinstance(days, bool) or not isinstance(days, int):
+        raise ValueError(f"{field} must be a whole number of days")
+    if days < 1 or days > MAX_RETENTION_DAYS:
+        raise ValueError(f"{field} must be between 1 and {MAX_RETENTION_DAYS} days; got {days}")
+    return days
+
+
 def _ttl_metadata(ttl_days: int | None, *, record_type: str, created_at: str) -> dict[str, object]:
-    default_days = 30 if record_type == "episode" and ttl_days is None else ttl_days
+    days = _validated_day_count(ttl_days, field="ttl_days")
+    if days is None and record_type == "episode":
+        days = _EPISODE_DEFAULT_TTL_DAYS
+    # `is None` rather than falsiness: "no deadline" and "zero days" are
+    # different statements, and only the first one may produce an empty
+    # `expires_at`. The falsy test is what let a rejected-at-the-CLI zero
+    # become a candidate that claimed to never expire.
     return {
-        "ttl_days": default_days,
-        "expires_at": _days_after(created_at, default_days) if default_days else "",
+        "ttl_days": days,
+        "expires_at": _days_after(created_at, days) if days is not None else "",
     }
 
 
 def _staleness_metadata(stale_after_days: int | None, *, record_type: str, created_at: str) -> dict[str, object]:
-    default_days = 90 if record_type in {"fact", "decision", "lesson", "procedure"} and stale_after_days is None else stale_after_days
-    deadline = _days_after(created_at, default_days) if default_days else ""
+    days = _validated_day_count(stale_after_days, field="stale_after_days")
+    if days is None and record_type in {"fact", "decision", "lesson", "procedure"}:
+        days = _REVIEW_DEFAULT_DAYS
+    default_days = days
+    deadline = _days_after(created_at, days) if days is not None else ""
     # `review_due_at` is the readable name for the date `stale_after` always
     # held. Both are written so older readers keep working; nothing derives a
     # second deadline from the new spelling.
@@ -3203,7 +3246,7 @@ def _staleness_metadata(stale_after_days: int | None, *, record_type: str, creat
 
 
 def _days_after(created_at: str, days: int | None) -> str:
-    if not days:
+    if days is None:
         return ""
     base = _parse_utc(created_at) or datetime.now(timezone.utc)
     return (base + timedelta(days=int(days))).replace(microsecond=0).isoformat().replace("+00:00", "Z")

--- a/tests/test_memory_staleness.py
+++ b/tests/test_memory_staleness.py
@@ -444,5 +444,69 @@ class DeterministicFreshnessTests(unittest.TestCase):
             self.assertEqual(verdict["review_due_at"], PAST, "the old spelling still supplies the deadline")
 
 
+class RetentionDayBoundsTests(unittest.TestCase):
+    """A deadline nobody meant must be refused, not reinterpreted.
+
+    The `>= 1` guard lived only in the argparse layer, so the CLI rejected
+    `--ttl-days 0` and `--ttl-days -5` while `capture_project_memory_candidate`
+    behind it accepted both from the plugin bundle, the wrapper, or any other
+    caller. There was no upper bound anywhere, and a large value reached
+    `created_at + timedelta(days=N)`, whose OverflowError is not a ValueError
+    and so escaped the CLI's error handling as a raw Python traceback.
+    """
+
+    def _capture(self, paths, **kwargs):
+        return capture_project_memory_candidate(paths, "retention bound probe", **kwargs)
+
+    def test_zero_and_negative_day_counts_are_refused_at_the_workflow_boundary(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            for field, kwargs in (("ttl_days", {"ttl_days": 0}), ("ttl_days", {"ttl_days": -5}),
+                                  ("stale_after_days", {"stale_after_days": 0}),
+                                  ("stale_after_days", {"stale_after_days": -5})):
+                with self.subTest(str(kwargs)):
+                    with self.assertRaises(ValueError) as caught:
+                        self._capture(paths, **kwargs)
+                    self.assertIn(field, str(caught.exception))
+
+    def test_an_unbounded_day_count_is_a_value_error_not_an_overflow(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            for days in (memory_workflow.MAX_RETENTION_DAYS + 1, 10**9, 10**12):
+                with self.subTest(days):
+                    with self.assertRaises(ValueError):
+                        self._capture(paths, ttl_days=days)
+
+    def test_the_longest_expressible_deadline_is_accepted(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            captured = self._capture(paths, ttl_days=memory_workflow.MAX_RETENTION_DAYS)
+            self.assertTrue(captured["candidate"]["ttl"]["expires_at"])
+
+    def test_no_ttl_still_means_a_record_that_never_expires(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            candidate = self._capture(paths, record_type="fact")["candidate"]
+            self.assertEqual(candidate["ttl"], {"ttl_days": None, "expires_at": ""})
+            # An episode keeps its 30-day default rather than inheriting None.
+            episode = capture_project_memory_candidate(paths, "episode bound probe", record_type="episode")
+            self.assertEqual(episode["candidate"]["ttl"]["ttl_days"], 30)
+            self.assertTrue(episode["candidate"]["ttl"]["expires_at"])
+
+    def test_a_candidate_and_its_approved_record_state_the_same_deadline(self) -> None:
+        # `ttl_days=0` used to produce a candidate reading `expires_at: ""`
+        # (never expires) and a record reading `expires_at == created_at`
+        # (expired on arrival). A reviewer approved one and got the other.
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            for kwargs in ({}, {"ttl_days": 7}, {"record_type": "episode"}, {"ttl_days": 1}):
+                with self.subTest(str(kwargs)):
+                    captured = capture_project_memory_candidate(paths, f"parity probe {kwargs}", **kwargs)
+                    candidate = captured["candidate"]
+                    record = approve_project_memory_candidate(paths, str(candidate["candidate_id"]))["record"]
+                    self.assertEqual(candidate["ttl"]["expires_at"], record["ttl"]["expires_at"])
+                    self.assertEqual(candidate["ttl"]["ttl_days"], record["ttl"]["ttl_days"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

Retention day counts are validated where the records are built, not only where the flags are parsed, and the range now has an upper end. `MAX_RETENTION_DAYS` (100 years) is shared by both layers.

Closes #908.

## Why

The `>= 1` guard lived in `_validate_capture_governance_args`, an argparse-layer helper. `capture_project_memory_candidate` — the function the plugin bundle, the wrapper, and any future caller reach — had no guard at all:

```
ttl_days=-5  -> a record already expired at creation, no error, no review reason
ttl_days=0   -> candidate ttl {'ttl_days': 0, 'expires_at': ''}              (never expires)
                record    ttl {'ttl_days': 0, 'expires_at': '<created_at>'}  (expired on arrival)
```

The zero case is the one that does real damage: a reviewer reads a card promising **no deadline** and approves a record that recall excludes **immediately**. `_ttl_metadata` guarded on falsiness (`if default_days else ""`) so it read `0` as *absent*, while `_days_after` read the same `0` as a real offset of zero days. Two readings of one input, one artifact each.

There was also no upper bound anywhere. A large value reached `created_at + timedelta(days=N)`, and `OverflowError` is not a `ValueError`, so it escaped the surface's error handling:

```
$ omh memory capture "probe" --ttl-days 999999999
Traceback (most recent call last):
  ...
OverflowError: date value out of range
```

Every other bad flag on this command prints `omh: ...`.

## Implementation

`src/workflows/memory.py`:

- `MAX_RETENTION_DAYS = 36500`. Past 100 years a day count is a typo rather than an intent, and it is also where the date arithmetic starts failing.
- `_validated_day_count(days, field=...)` guards both `_ttl_metadata` and `_staleness_metadata`. Zero is **rejected, not reinterpreted** — it is neither a shorter TTL nor the absence of one.
- The `expires_at` decision is now `if days is not None`, not `if days`. "No deadline" and "zero days" are different statements and only the first may produce an empty `expires_at`. `_days_after` got the same treatment.
- `_EPISODE_DEFAULT_TTL_DAYS` / `_REVIEW_DEFAULT_DAYS` name the two defaults that were inline literals.

`src/commands/memory.py`:

- `_optional_positive_int` takes an optional `maximum`; the capture validator passes `MAX_RETENTION_DAYS`, imported from the workflow so the two layers cannot drift.

## Verification observed

```
--ttl-days 0           exit=2  omh: --ttl-days must be at least 1
--ttl-days -5          exit=2  omh: --ttl-days must be at least 1
--ttl-days 999999999   exit=2  omh: --ttl-days must be at most 36500
--ttl-days 36501       exit=2  omh: --ttl-days must be at most 36500
--ttl-days 36500       exit=0  captured, expires 2126-07-18
--ttl-days 7           exit=0  captured, expires 2026-08-18
```

The path the CLI guard never covered:

```
ttl_days=0            ValueError: ttl_days must be between 1 and 36500 days; got 0
ttl_days=-5           ValueError: ttl_days must be between 1 and 36500 days; got -5
ttl_days=1000000000   ValueError: ttl_days must be between 1 and 36500 days; got 1000000000
ttl_days=None         {'ttl_days': None, 'expires_at': ''}
ttl_days=7            {'ttl_days': 7, 'expires_at': '2026-08-18T01:32:46Z'}
```

```
PYTHONPATH=tests uv run python -m unittest discover -s tests     5793 tests OK
uv run python -m omh.cli docs workflows --check                  exit 0
uv run python -m omh.cli docs roles --check                      exit 0
uv run python -m omh.cli docs capability-families --check        exit 0
uv run python -m omh.cli harness validate                        exit 0
uv run --group lint ruff check src tests                         All checks passed
uv run python -m compileall -q src tests                         exit 0
git diff --check                                                 clean
```

## Test changes

New `RetentionDayBoundsTests` (5 tests, +5 total, 5788 → 5793):

- zero and negative counts raise at the **workflow** boundary for both fields
- an oversized count is a `ValueError`, not an `OverflowError`
- the longest expressible deadline is still accepted
- `None` still means never-expires, and an episode still gets its 30-day default
- **a candidate and its approved record state the same deadline** across four TTL shapes — the parity `ttl_days=0` used to break

## Risks and follow-ups

- A caller passing `0` or a negative day count now raises where it previously wrote a record. That is the fix, but it is a behaviour change for any out-of-tree caller.
- Not observed: a store already holding a record minted with a non-positive TTL by an older build. Nothing migrates one; it simply reads as expired, which it always did.
- Rejected: clamping an out-of-range value to the bound. That silently stores a deadline the caller did not ask for, which is exactly how the zero case caused harm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
