### PR TITLE
fix: name the memory record files this build cannot admit

### DIFF
--- a/src/maintenance/doctor.py
+++ b/src/maintenance/doctor.py
@@ -22,6 +22,7 @@ from ..install.identity_conflicts import build_identity_conflict_report
 from ..manifest import local_modifications, read_manifest
 from ..paths import OmhPaths
 from ..plugin_bundle.omh.memory_dreaming import read_dreaming_state, read_latest_consolidation
+from ..workflows.memory import scan_project_memory_records
 from ..plugin_bundle.omh.metadata import MEMORY_PROVIDER_NAME
 from ..plugin_observations import (
     PLUGIN_HOST_ACTIVE_OBSERVATION_EVENTS,
@@ -143,6 +144,7 @@ def run_doctor(paths: OmhPaths) -> list[Check]:
     checks.append(_identity_conflicts_check(paths, dirs if hermes_config_present else None, manifest))
     checks.append(_memory_provider_check(config_text))
     checks.append(_memory_consolidation_check(paths))
+    checks.append(_memory_record_readability_check(paths))
     checks.append(
         Check(
             "runtime_context",
@@ -335,6 +337,35 @@ def _memory_consolidation_check(paths: OmhPaths) -> Check:
         True,
         f"Memory consolidation is due ({', '.join(reasons)}), raised at {at} by {brief.get('trigger', 'unknown')}. "
         + remedy,
+        severity="warning",
+        observed=True,
+    )
+
+
+def _memory_record_readability_check(paths: OmhPaths) -> Check:
+    """Name the record files this build cannot admit, instead of losing them.
+
+    Refusing an unrecognized record is right; refusing it silently is not. A v1
+    record without an approved review status, and any record written by a newer
+    schema, were dropped by the store reader with no count in `memory status`,
+    no entry in a recall pack's exclusions, and nothing here -- so a store that
+    had quietly shrunk was indistinguishable from a smaller store.
+
+    Never a fault. The records are intact on disk and nothing is lost by
+    reporting them; what is lost is the operator not knowing.
+    """
+    _records, unreadable = scan_project_memory_records(paths)
+    if not unreadable:
+        return Check("memory_records", True, "Every memory record file is readable by this build", observed=True)
+    by_reason: dict[str, list[str]] = {}
+    for item in unreadable:
+        by_reason.setdefault(str(item.get("reason", "")), []).append(str(item.get("path_name", "")))
+    detail = "; ".join(f"{reason}: {', '.join(sorted(names)[:5])}" for reason, names in sorted(by_reason.items()))
+    return Check(
+        "memory_records",
+        True,
+        f"{len(unreadable)} memory record file(s) are on disk but not admitted by this build ({detail}). "
+        "Run `omh memory inventory` for the full ledger; nothing was deleted.",
         severity="warning",
         observed=True,
     )

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -431,7 +431,7 @@ def build_hermes_memory_bridge(paths: OmhPaths) -> dict[str, object]:
 
 def build_project_memory_status(paths: OmhPaths) -> dict[str, object]:
     candidates = _read_project_memory_candidates(paths)
-    records = _read_project_memory_records(paths)
+    records, unreadable_records = scan_project_memory_records(paths)
     reviews = _read_project_memory_reviews(paths)
     now = datetime.now(timezone.utc)
     evaluations = [_evaluate_memory_artifact(record, paths=paths, now=now, review_resolver=_project_memory_review_resolver(paths)) for record in records]
@@ -460,9 +460,14 @@ def build_project_memory_status(paths: OmhPaths) -> dict[str, object]:
             "eligible_records": sum(1 for evaluation in evaluations if evaluation["eligible"]),
             "ineligible_records": sum(1 for evaluation in evaluations if not evaluation["eligible"]),
             "review_required_legacy": sum(1 for evaluation in evaluations if evaluation["reason_code"] == "review_required_legacy"),
+            # Record files on disk that this build cannot admit. They used to be
+            # dropped by the reader with no count anywhere, so a store that had
+            # silently shrunk looked exactly like a smaller store.
+            "unreadable_records": len(unreadable_records),
             "review_records": len(reviews),
             "candidate_statuses": candidate_status_counts,
         },
+        "unreadable_records": unreadable_records,
         "hermes_memory": build_hermes_memory_bridge(paths),
         "redaction_policy": "metadata_only",
         "claim_boundary": "Project memory status is prepared local context only; it is not execution, review, CI, merge, or Hermes internal-memory evidence.",
@@ -3316,16 +3321,68 @@ def _read_project_memory_candidates(paths: OmhPaths) -> list[dict[str, Any]]:
 
 
 def _read_project_memory_records(paths: OmhPaths) -> list[dict[str, Any]]:
+    return scan_project_memory_records(paths)[0]
+
+
+UNREADABLE_RECORD_REASONS = ("unsupported_record_schema", "legacy_review_status_missing", "unreadable_file")
+
+
+def scan_project_memory_records(paths: OmhPaths) -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
+    """Approved records, and the record files this reader cannot answer for.
+
+    Failing closed on an unrecognized record is right. Failing closed *silently*
+    is what this exists to stop: a v1 record without an approved review status
+    and any record from a newer schema were dropped here with no count, no
+    exclusion entry, and nothing in `omh doctor`, so four files on disk read as
+    two and the store simply got smaller. The forward case is the one that will
+    happen -- the record schema has already moved once, and a shared `~/.omh`
+    across two machines on different `omh` versions, a downgrade, or a partly
+    finished migration all produce records this build cannot admit.
+
+    The rest of the module already holds this line: the archive attention tier
+    leaves the working context NAMED, never silently, and retirement reports a
+    corrupt or malformed file per path with its reason. This is the same
+    courtesy for the read every other surface goes through.
+    """
     records: list[dict[str, Any]] = []
-    for record in _read_memory_json_files(paths, _memory_records_dir(paths)):
-        schema_version = record.get("schema_version")
+    unreadable: list[dict[str, str]] = []
+    directory = _memory_records_dir(paths)
+    for record, path_name in _read_memory_record_files(paths, directory):
+        if record is None:
+            unreadable.append({"path_name": path_name, "reason": "unreadable_file", "schema_version": ""})
+            continue
+        schema_version = str(record.get("schema_version", "") or "")
         if schema_version == PROJECT_MEMORY_RECORD_SCHEMA_VERSION:
             records.append(record)
-        elif schema_version == LEGACY_PROJECT_MEMORY_RECORD_SCHEMA_VERSION and record.get("review_status") == "approved":
-            # Legacy records stay review/status visible, but the evaluator will
-            # fail them closed as review_required_legacy before any replay.
-            records.append(record)
-    return records
+        elif schema_version == LEGACY_PROJECT_MEMORY_RECORD_SCHEMA_VERSION:
+            if record.get("review_status") == "approved":
+                # Legacy records stay review/status visible, but the evaluator
+                # will fail them closed as review_required_legacy before replay.
+                records.append(record)
+            else:
+                unreadable.append({"path_name": path_name, "reason": "legacy_review_status_missing", "schema_version": schema_version})
+        else:
+            unreadable.append({"path_name": path_name, "reason": "unsupported_record_schema", "schema_version": schema_version})
+    return records, unreadable
+
+
+def _read_memory_record_files(paths: OmhPaths, directory: Path) -> list[tuple[dict[str, Any] | None, str]]:
+    """Every record file with its name, `None` for the ones that would not parse.
+
+    `_read_memory_json_files` drops an unparseable file and keeps no trace of
+    it, which is correct for a reader that only wants the good rows and wrong
+    for one that has to say what it skipped.
+    """
+    if not directory.exists():
+        return []
+    items: list[tuple[dict[str, Any] | None, str]] = []
+    for path in sorted(directory.glob("*.json")):
+        if path.is_symlink() or not path.is_file():
+            continue
+        _assert_under_memory_root(paths, path)
+        data, _error = read_json_object_result(path)
+        items.append((data if isinstance(data, dict) else None, path.name))
+    return items
 
 
 def _read_project_memory_reviews(paths: OmhPaths) -> list[dict[str, Any]]:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1190,5 +1190,85 @@ def _wrapper_snapshot(items: list[dict[str, object]]) -> dict[str, object]:
     }
 
 
+class UnreadableRecordVisibilityTests(unittest.TestCase):
+    """A record this build cannot admit must be named, not lost.
+
+    Failing closed on an unrecognized record is right. Failing closed silently
+    is the defect: a v1 record without an approved review status and any record
+    from a newer schema were dropped by the store reader with no count in
+    `memory status` and nothing in `omh doctor`, so four files on disk read as
+    two and a store that had quietly shrunk looked exactly like a smaller one.
+    The forward case is the one that will happen -- the record schema has moved
+    once already, and a shared `~/.omh` across two `omh` versions, a downgrade,
+    or a half-finished migration all produce records this build refuses.
+    """
+
+    def _store(self, root: Path):
+        paths = resolve_paths(root / ".omh", root / ".hermes")
+        write_setup_profile(paths, memory_mode="auto-safe")
+        capture_project_memory_candidate(paths, "api gateway timeout is 30 seconds", tags=["api"])
+        records_dir = paths.memory_dir / "records"
+        records_dir.mkdir(parents=True, exist_ok=True)
+        base = {
+            "record_type": "fact",
+            "scope": {"kind": "project", "ref": "default"},
+            "tags": ["api"],
+            "source": "cli",
+            "created_at": "2026-01-01T00:00:00Z",
+            "approved_at": "2026-01-01T00:00:00Z",
+            "ttl": {"ttl_days": None, "expires_at": ""},
+        }
+        for record_id, extra in (
+            ("mem_v1approved", {"schema_version": "project_memory_record/v1", "review_status": "approved"}),
+            ("mem_v1noreview", {"schema_version": "project_memory_record/v1"}),
+            ("mem_futurev3", {"schema_version": "project_memory_record/v3"}),
+        ):
+            payload = {**base, **extra, "record_id": record_id, "summary": f"{record_id} fact"}
+            (records_dir / f"{record_id}.json").write_text(json.dumps(payload), encoding="utf-8")
+        (records_dir / "mem_corrupt.json").write_text("{", encoding="utf-8")
+        return paths
+
+    def test_every_record_file_is_accounted_for_by_status(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = self._store(Path(tmp))
+            status = build_project_memory_status(paths)
+            self.assertEqual(status["counts"]["unreadable_records"], 3)
+            by_name = {item["path_name"]: item["reason"] for item in status["unreadable_records"]}
+            self.assertEqual(by_name["mem_corrupt.json"], "unreadable_file")
+            self.assertEqual(by_name["mem_futurev3.json"], "unsupported_record_schema")
+            self.assertEqual(by_name["mem_v1noreview.json"], "legacy_review_status_missing")
+            # The schema version is reported so an operator can tell a newer
+            # OMH's record from a corrupt file without opening either.
+            versions = {item["path_name"]: item["schema_version"] for item in status["unreadable_records"]}
+            self.assertEqual(versions["mem_futurev3.json"], "project_memory_record/v3")
+
+            # Nothing that used to be admitted stopped being admitted: the
+            # approved v1 record still counts and still fails closed on replay.
+            self.assertEqual(status["counts"]["approved_records"], 1)
+            self.assertEqual(status["counts"]["review_required_legacy"], 1)
+
+    def test_a_healthy_store_reports_nothing_unreadable(self) -> None:
+        # Overroute guard: the count must stay zero for an ordinary store, or
+        # it is noise an operator learns to ignore.
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, memory_mode="auto-safe")
+            capture_project_memory_candidate(paths, "a perfectly ordinary fact", tags=["api"])
+            status = build_project_memory_status(paths)
+            self.assertEqual(status["counts"]["unreadable_records"], 0)
+            self.assertEqual(status["unreadable_records"], [])
+
+    def test_doctor_names_the_files_it_cannot_admit(self) -> None:
+        from omh.maintenance.doctor import run_doctor
+
+        with TemporaryDirectory() as tmp:
+            paths = self._store(Path(tmp))
+            check = next(item for item in run_doctor(paths) if item.name == "memory_records")
+            self.assertTrue(check.ok, "an unadmitted record is a thing to know, never a fault")
+            self.assertEqual(check.severity, "warning")
+            self.assertIn("mem_futurev3.json", check.message)
+            self.assertIn("not admitted by this build", check.message)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

Record files the current build cannot admit are now counted and named — in `omh memory status` and in `omh doctor` — instead of being dropped by the store reader with no trace anywhere.

Closes #911.

## Why

`_read_project_memory_records` admitted exactly two shapes:

```python
if schema_version == PROJECT_MEMORY_RECORD_SCHEMA_VERSION:            # v2
elif schema_version == LEGACY_..._SCHEMA_VERSION and record.get("review_status") == "approved":
```

Everything else vanished. Observed with four fixtures plus one ordinary record:

```
files on disk        5
memory status        approved_records: 1, review_required_legacy: 1     <- 3 unaccounted for
recall excluded      [('mem_v1approved', 'review_required_legacy')]     <- the other 2 absent
omh doctor           (no memory-related line)
```

Failing closed on an unrecognized record is correct. Failing closed *silently* is not, and the module already holds that line elsewhere — the archive attention tier leaves the working context "NAMED, never silently, so the operator can always see what the archive is holding back", and retirement reports a corrupt or malformed file per path with its reason.

**The forward case is the one that will happen.** The record schema has moved once already (`/v1` → `/v2`, with `LEGACY_` constants kept for the transition). The next bump plus a shared `~/.omh` across two machines on different `omh` versions, a downgrade after an upgrade, or a half-finished migration all produce records this build refuses. Recall keeps working, returns fewer records, and reports nothing. A memory system that quietly forgets is worse than one that fails.

## Implementation

`src/workflows/memory.py`:

- `scan_project_memory_records(paths) -> (records, unreadable)` is the new reader; `_read_project_memory_records` is now a one-line wrapper, so every existing caller is unaffected.
- `_read_memory_record_files` keeps the file name and a `None` for anything that would not parse. `_read_memory_json_files` drops unparseable files without a trace, which is right for a reader that only wants the good rows and wrong for one that must say what it skipped.
- Three reasons: `unsupported_record_schema` (newer or unknown schema), `legacy_review_status_missing` (v1 without an approved review), `unreadable_file`.
- `build_project_memory_status` gains `counts.unreadable_records` and a top-level `unreadable_records` list carrying `path_name`, `reason`, and `schema_version`.

`src/maintenance/doctor.py` — new `memory_records` check. It reports as a **warning and never a fault**: the records are intact on disk, so an unadmitted one is a thing to know rather than a thing that is broken, following `_memory_consolidation_check`'s precedent.

**Eligibility is unchanged.** Nothing refused before is admitted now; only the refusal is visible.

## Verification observed

```
files on disk:  mem_<ok>.json  mem_corrupt.json  mem_futurev3.json
                mem_v1approved.json  mem_v1noreview.json

memory status counts:
  approved_records 1, review_required_legacy 1, ineligible_records 1,
  unreadable_records 3

unreadable_records:
  mem_corrupt.json     unreadable_file                ""
  mem_futurev3.json    unsupported_record_schema      project_memory_record/v3
  mem_v1noreview.json  legacy_review_status_missing   project_memory_record/v1

omh doctor:
  - memory_records: 2 memory record file(s) are on disk but not admitted by this
    build (unreadable_file: mem_corrupt.json; unsupported_record_schema: ...)
```

Every file is now accounted for: 1 admitted + 1 legacy-approved-but-ineligible + 3 named.

```
PYTHONPATH=tests uv run python -m unittest discover -s tests     5791 tests OK
uv run python -m omh.cli docs workflows --check                  exit 0
uv run python -m omh.cli docs roles --check                      exit 0
uv run python -m omh.cli docs capability-families --check        exit 0
uv run python -m omh.cli harness validate                        exit 0
uv run --group lint ruff check src tests                         All checks passed
uv run python -m compileall -q src tests                         exit 0
git diff --check                                                 clean
```

## Test changes

New `UnreadableRecordVisibilityTests` (3 tests, +3 total, 5788 → 5791):

- every record file is accounted for by status, with the right reason and schema version per file, and the previously-admitted v1 record still counts and still fails closed on replay
- **a healthy store reports zero** — the overroute guard, because a count that is noisy on an ordinary store is a count operators learn to ignore
- doctor names the files, as a warning rather than a fault

## Risks and follow-ups

- Additive fields on `project_memory_status/v1`; no generated artifact and no eligibility change.
- **Deliberately not included:** listing these in a recall pack's `excluded_records`. That needs a new reason code inside `project_memory_recall_pack/v1` and its validator — a contract change that does not belong in a visibility fix. Status and doctor answer the operator's actual question ("which of my records is being ignored right now") without it.
- Not observed: a real cross-version store. The fixtures hand-write the shapes a newer or older build would leave behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
