### PR TITLE
feat: let the caller state recall recency intent instead of guessing at it

### DIFF
--- a/src/commands/memory.py
+++ b/src/commands/memory.py
@@ -183,6 +183,7 @@ def cmd_memory_recall(args: argparse.Namespace) -> int:
             include_archived=args.include_archived,
             observer=args.observer,
             observed=args.observed,
+            query_intent=args.intent,
         )
     except (OSError, ValueError) as exc:
         raise OmhError(str(exc)) from exc

--- a/src/commands/memory_parser.py
+++ b/src/commands/memory_parser.py
@@ -80,6 +80,16 @@ def add_memory_commands(sub: argparse._SubParsersAction[argparse.ArgumentParser]
         action="store_true",
         help="Also recall archive-tier records. They are excluded by default as archived_tier, never deleted.",
     )
+    recall.add_argument(
+        "--intent",
+        choices=("auto", "default", "temporal"),
+        default="auto",
+        help=(
+            "State whether the query asks for the most recent, instead of leaving it to the English cue table. "
+            "temporal doubles the recency weight inside rank fusion; it never changes which records match. "
+            "auto keeps the existing English-cue derivation."
+        ),
+    )
     recall.add_argument("--observer", default=None, help="Perspective lens: only unscoped records and records with this observer pass.")
     recall.add_argument("--observed", default=None, help="Perspective lens: only unscoped records and records about this actor pass.")
     recall.set_defaults(func=memory.cmd_memory_recall)

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -720,6 +720,7 @@ def build_project_memory_recall_pack(
     run_id: str | None = None,
     observer: str | None = None,
     observed: str | None = None,
+    query_intent: str | None = None,
 ) -> dict[str, object]:
     policy = read_project_memory_policy(paths)
     # Lens labels normalize exactly like capture labels: capture lowercases
@@ -817,7 +818,7 @@ def build_project_memory_recall_pack(
             excluded.append(_recall_exclusion(record, evaluation, staleness=staleness, reason="no_query_overlap"))
             continue
         included.append(_recall_item(record, score=score, staleness=staleness, evaluation=evaluation, attention_tier=attention_tier))
-    query_intent = _recall_query_intent(query)
+    query_intent = _resolve_query_intent(query, query_intent)
     _attach_recall_ranking(
         included,
         read_recall_usage(paths),
@@ -1371,6 +1372,36 @@ def _recall_query_intent(query: str) -> str:
         return "temporal"
     normalized = f" {' '.join(query.lower().split())} "
     return "temporal" if any(f" {phrase} " in normalized for phrase in _TEMPORAL_QUERY_PHRASES) else "default"
+
+
+def _resolve_query_intent(query: str, supplied: str | None) -> str:
+    """The caller's stated intent when there is one, else the English cues.
+
+    The cue table is English-only and stays that way. Per the routing-language
+    policy (`tests/test_routing_language_policy.py`, `src/routing/input_language.py`)
+    per-language trigger tables do not scale to a global product, and non-English
+    intent resolution belongs to model selection over supplied candidates rather
+    than to more tokens. Measured before this existed: every Korean and Japanese
+    phrasing of "recently" -- `어제 뭐 정했지`, `최근 배포 결정`, `3일 전에 정한 거`,
+    `最近の変更` -- resolved to `default`, so recency weighting never engaged for
+    them while `recent changes` got it.
+
+    Adding those words to the table would have fixed five languages and left the
+    rest, which is the habit the policy exists to stop. So the caller states it
+    instead: Hermes read the message and already knows whether the user asked
+    for the latest, in any language, and now has somewhere to say so.
+
+    An unrecognized value is refused rather than ignored. A caller that
+    misspells its intent should learn that, not silently get the default.
+    """
+    if supplied is None:
+        return _recall_query_intent(query)
+    normalized = str(supplied).strip().lower()
+    if normalized in {"", "auto"}:
+        return _recall_query_intent(query)
+    if normalized not in {"default", "temporal"}:
+        raise ValueError(f"query_intent must be one of auto, default, temporal; got {supplied!r}")
+    return normalized
 
 
 def _memory_pins_path(paths: OmhPaths) -> Path:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1270,5 +1270,78 @@ class UnreadableRecordVisibilityTests(unittest.TestCase):
             self.assertIn("not admitted by this build", check.message)
 
 
+class CallerSuppliedQueryIntentTests(unittest.TestCase):
+    """Recency intent a non-English speaker can actually reach.
+
+    `_TEMPORAL_QUERY_CUES` is English-only, so every non-English phrasing of
+    "recently" resolved to `default` and never got the doubled recency weight:
+    `어제 뭐 정했지`, `최근 배포 결정`, `3일 전에 정한 거`, `最近の変更`.
+
+    Growing the cue table is the fix the routing-language policy exists to stop
+    (`tests/test_routing_language_policy.py`): per-language trigger tables do
+    not scale, and non-English intent resolution belongs to model selection
+    over supplied candidates. So the caller states the intent instead -- Hermes
+    read the message and knows, in any language.
+    """
+
+    def _store(self, root: Path):
+        paths = resolve_paths(root / ".omh", root / ".hermes")
+        write_setup_profile(paths, memory_mode="auto-safe")
+        capture_project_memory_candidate(paths, "배포는 블루그린 방식으로 적용한다", tags=["deploy"])
+        return paths
+
+    def test_a_stated_intent_reaches_the_pack_in_any_language(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = self._store(Path(tmp))
+            for query in ("어제 뭐 정했지", "最近の変更", "3일 전에 정한 거", ""):
+                with self.subTest(query):
+                    derived = build_project_memory_recall_pack(paths, query)
+                    self.assertEqual(derived["query_intent"], "default")
+                    stated = build_project_memory_recall_pack(paths, query, query_intent="temporal")
+                    self.assertEqual(stated["query_intent"], "temporal")
+                    self.assertEqual(validate_project_memory_recall_pack(stated), [])
+
+    def test_the_english_cue_table_still_answers_when_nothing_is_stated(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = self._store(Path(tmp))
+            for query, expected in (("recent changes", "temporal"), ("the most recent deploy", "temporal"),
+                                    ("deploy strategy", "default"), ("배포 방식", "default")):
+                with self.subTest(query):
+                    self.assertEqual(build_project_memory_recall_pack(paths, query)["query_intent"], expected)
+                    # `auto` is the same thing said out loud.
+                    self.assertEqual(
+                        build_project_memory_recall_pack(paths, query, query_intent="auto")["query_intent"], expected
+                    )
+
+    def test_a_stated_default_overrides_an_english_cue(self) -> None:
+        # The caller read the message; a cue word inside it does not outrank
+        # that. "recent" appears here and the caller says it is not the point.
+        with TemporaryDirectory() as tmp:
+            paths = self._store(Path(tmp))
+            pack = build_project_memory_recall_pack(paths, "recent deploy strategy", query_intent="default")
+            self.assertEqual(pack["query_intent"], "default")
+
+    def test_an_unrecognized_intent_is_refused_not_ignored(self) -> None:
+        # A caller that misspells its intent should learn that, rather than
+        # silently receive the default ranking it did not ask for.
+        with TemporaryDirectory() as tmp:
+            paths = self._store(Path(tmp))
+            with self.assertRaises(ValueError):
+                build_project_memory_recall_pack(paths, "배포", query_intent="recent")
+
+    def test_intent_reorders_peers_and_never_changes_what_matches(self) -> None:
+        # The whole reason this is safe: intent only weights recency inside
+        # rank fusion. If it could change the matched set it would be a
+        # second, undeclared, retrieval policy.
+        with TemporaryDirectory() as tmp:
+            paths = self._store(Path(tmp))
+            capture_project_memory_candidate(paths, "결제 실패가 나면 즉시 롤백한다", tags=["payment"])
+            default = build_project_memory_recall_pack(paths, "배포")
+            temporal = build_project_memory_recall_pack(paths, "배포", query_intent="temporal")
+            self.assertEqual(
+                {item["record_id"] for item in default["included_records"]},
+                {item["record_id"] for item in temporal["included_records"]},
+            )
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

`build_project_memory_recall_pack` takes an optional `query_intent`, exposed as `omh memory recall --intent {auto,temporal,default}`. The English cue table is unchanged and stays the `auto` fallback.

Closes #910.

## Why

Recency weighting engaged for `recent changes` and never for the same request in any other language:

```
intent('recent changes')   = temporal
intent('어제 뭐 정했지')     = default
intent('최근 배포 결정')     = default
intent('3일 전에 정한 거')   = default
intent('最近の変更')         = default
```

The obvious fix is to add those words to `_TEMPORAL_QUERY_CUES`. That is the habit the routing-language policy exists to stop. `tests/test_routing_language_policy.py` freezes each skill's Hangul trigger count so growing one is a deliberate act, and states the rule directly:

> per-language trigger tables do not scale to a global product, so non-English intent resolution belongs to model selection over supplied candidates, not to more tokens

Five more languages in the cue set leaves the sixth exactly where Korean was.

So the caller states it. Hermes read the message and already knows whether the user asked for the latest, in any language — until now it had nowhere to say so.

## Implementation

- `_resolve_query_intent(query, supplied)` — `None`/`auto` keeps the existing English-cue derivation; `temporal`/`default` are taken as stated; anything else **raises**, because a caller that misspells its intent should learn that rather than silently receive a ranking it did not ask for.
- A stated `default` beats a cue word in the text. The caller read the message; a keyword inside it did not.
- No schema change: `query_intent` was already a pack field and its validator already admitted exactly these two values.

## Verification observed

```
어제 뭐 정했지     auto              -> default
recent changes   auto              -> temporal
어제 뭐 정했지     --intent temporal -> temporal
x                --intent nonsense -> omh memory recall: error: invalid choice
```

```
PYTHONPATH=tests uv run python -m unittest discover -s tests     5793 tests OK
docs workflows / roles / capability-families --check             exit 0
harness validate                                                 exit 0
ruff check src tests                                             All checks passed
git diff --check                                                 clean
```

The Hangul trigger freeze is untouched — the cue table did not grow by one character.

## Test changes

New `CallerSuppliedQueryIntentTests` (5 tests, +5 total, 5788 → 5793):

- a stated intent reaches the pack for `어제 뭐 정했지`, `最近の変更`, `3일 전에 정한 거`, and an empty query
- the English cue table still answers when nothing is stated, and `auto` says the same thing out loud
- a stated `default` overrides an English cue in the text
- an unrecognized intent raises rather than falling back
- **intent reorders peers and never changes what matches** — the property that makes this safe; if intent could move the matched set it would be a second, undeclared retrieval policy

## Risks and follow-ups

- Nothing in the wrapper sets `--intent` yet, so today it is reachable from the CLI and the workflow API. That is deliberate: the flag exists so the component that can read intent has somewhere to put it, and wiring a specific Hermes path is a separate change with its own evidence.
- The second half of #910 — relative dates captured with no absolute anchor ("we decided yesterday…") — is **not** in this PR. Detecting them needs vocabulary, which runs into the same policy, and it deserves its own decision rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)