### PR TITLE
fix: let a durable record actually be permanent

### DIFF
--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -2578,7 +2578,9 @@ def _build_project_memory_candidate(
     safety = _project_memory_safety(summary, content_text, tags=normalized_tags)
     now = utc_now()
     ttl = _ttl_metadata(ttl_days, record_type=normalized_type, created_at=now)
-    staleness = _staleness_metadata(stale_after_days, record_type=normalized_type, created_at=now)
+    staleness = _staleness_metadata(
+        stale_after_days, record_type=normalized_type, retention_class=retention_class, created_at=now
+    )
     candidate_id = "cand_" + os.urandom(8).hex()
     status = "blocked_review_required" if safety["status"] == "blocked" else "pending_review"
     # Digest the ref exactly as it will be stored, not as it was passed:
@@ -3265,9 +3267,33 @@ def _ttl_metadata(ttl_days: int | None, *, record_type: str, created_at: str) ->
     }
 
 
-def _staleness_metadata(stale_after_days: int | None, *, record_type: str, created_at: str) -> dict[str, object]:
+def _staleness_metadata(
+    stale_after_days: int | None,
+    *,
+    record_type: str,
+    created_at: str,
+    retention_class: str = "standard",
+) -> dict[str, object]:
+    """The review-due deadline, or none for a record declared durable.
+
+    The 90-day default used to key off `record_type` alone, so a `durable`
+    record -- the class that exists to say this does not expire -- still read
+    `stale/review_due` after 90 days and carried a freshness warning into every
+    recall from then on. `build_retention` has always been explicit that the
+    class does not work that way ("durable: no default expiry; revalidation
+    deadline is optional"); the two layers simply never spoke.
+
+    A 90-day re-read is right for a claim that rots -- an API timeout, an
+    on-call rotation, a deploy procedure. It is noise on a founding date, a
+    chosen license, a settled architecture, or a post-mortem lesson, and noise
+    on those trains operators to ignore the warning on the records where it was
+    the point.
+
+    An explicitly supplied deadline is still honoured for a durable record: the
+    class says the deadline is optional, not forbidden.
+    """
     days = _validated_day_count(stale_after_days, field="stale_after_days")
-    if days is None and record_type in {"fact", "decision", "lesson", "procedure"}:
+    if days is None and retention_class != "durable" and record_type in {"fact", "decision", "lesson", "procedure"}:
         days = _REVIEW_DEFAULT_DAYS
     default_days = days
     deadline = _days_after(created_at, days) if days is not None else ""

--- a/tests/test_memory_staleness.py
+++ b/tests/test_memory_staleness.py
@@ -508,5 +508,78 @@ class RetentionDayBoundsTests(unittest.TestCase):
                     self.assertEqual(candidate["ttl"]["ttl_days"], record["ttl"]["ttl_days"])
 
 
+class DurableRecordsAreActuallyPermanentTests(unittest.TestCase):
+    """`durable` is the class for a record that does not expire. It has to mean it.
+
+    The 90-day review default keyed off `record_type` alone, so a durable
+    record read `stale/review_due` after 90 days and carried a freshness
+    warning into every recall from then on -- identical to a standard record,
+    which made declaring one durable buy nothing. `build_retention` had always
+    said otherwise ("durable: no default expiry; revalidation deadline is
+    optional"); the staleness layer never read the class.
+
+    The only escape was to guess a large `stale_after_days`. With zero and
+    negative counts refused and `None` meaning "apply the type default", there
+    was no value that meant *no review deadline*.
+    """
+
+    LATER = timedelta(days=100)
+
+    def _record(self, paths, summary: str, **kwargs):
+        captured = capture_project_memory_candidate(paths, summary, **kwargs)
+        return approve_project_memory_candidate(paths, str(captured["candidate"]["candidate_id"]))["record"]
+
+    def test_a_durable_record_never_falls_due_for_review_on_its_own(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            for record_type in ("fact", "decision", "lesson", "procedure"):
+                with self.subTest(record_type):
+                    record = self._record(paths, f"durable {record_type}", record_type=record_type, retention_class="durable")
+                    self.assertEqual(record["staleness"]["review_due_at"], "")
+                    self.assertEqual(record["staleness"]["stale_after"], "")
+                    state = memory_workflow._record_staleness(record, now=datetime.now(timezone.utc) + self.LATER)
+                    self.assertEqual(state["state"], "fresh")
+
+    def test_a_durable_record_still_honours_a_deadline_it_was_given(self) -> None:
+        # The class says the deadline is optional, not forbidden.
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record = self._record(paths, "durable but worth rereading", retention_class="durable", stale_after_days=30)
+            self.assertTrue(record["staleness"]["review_due_at"])
+            state = memory_workflow._record_staleness(record, now=datetime.now(timezone.utc) + self.LATER)
+            self.assertEqual((state["state"], state["reason"]), ("stale", "review_due"))
+
+    def test_standard_and_volatile_records_keep_their_deadlines(self) -> None:
+        # Overroute guard: the fix must not quietly make everything permanent.
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            for label, kwargs, expected in (
+                ("standard fact", {}, "review_due"),
+                ("standard decision", {"record_type": "decision"}, "review_due"),
+                # Volatile carries a review date too, but a 7-day TTL reaches it
+                # first and expiry outranks review-due in the one verdict.
+                ("volatile fact", {"retention_class": "volatile"}, "retention_expired"),
+            ):
+                with self.subTest(label):
+                    record = self._record(paths, f"{label} keeps its deadline", **kwargs)
+                    self.assertTrue(record["staleness"]["review_due_at"], "a non-durable record keeps its review date")
+                    state = memory_workflow._record_staleness(record, now=datetime.now(timezone.utc) + self.LATER)
+                    self.assertEqual(state["reason"], expected)
+
+    def test_a_durable_record_is_not_an_immortal_one_by_accident(self) -> None:
+        # Durable removes the review prompt, never the other freshness checks:
+        # a moved or unreadable cited source still lowers trust.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            source = root / "cited.md"
+            atomic_write_text(source, "the original claim\n")
+            record = self._record(paths, "durable with a cited source", retention_class="durable", source_ref=str(source))
+            self.assertEqual(memory_workflow._record_staleness(record)["state"], "fresh")
+            atomic_write_text(source, "the claim, edited\n")
+            changed = memory_workflow._record_staleness(record)
+            self.assertEqual((changed["state"], changed["reason"]), ("stale", "source_changed"))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

`_staleness_metadata` reads the retention class. A `durable` record gets no review-due deadline unless one is explicitly supplied — which is what `build_retention` has always documented and the staleness layer never knew.

Closes #918.

## Why

`durable` exists to say a record does not expire, and it only worked on the TTL half. Measured at +100 days:

| capture | review_due_at | state @ +100d |
| --- | --- | --- |
| `retention_class="durable"` | 2026-11-09 | **stale / review_due** |
| default (`standard` fact) | 2026-11-09 | stale / review_due |
| `durable` + `stale_after_days=3650` | 2036-08-08 | fresh |

Rows 1 and 2 were identical, so declaring a record durable bought nothing here. Row 3 was the only escape and it is a workaround, not an expression of intent: pick a number large enough not to come up in your lifetime. With `0` and negatives refused (#908) and `None` meaning "apply the type default", **no value meant *no review deadline***.

The two layers disagreed in plain sight:

```python
# memory_governance.build_retention
elif retention_class == "durable":
    # Durable: no default expiry; revalidation deadline is optional (set separately)
    pass

# memory._staleness_metadata  — never looked at the class
default_days = 90 if record_type in {"fact", "decision", "lesson", "procedure"} and stale_after_days is None else ...
```

A 90-day re-read is right for a claim that rots — an API timeout, an on-call rotation, a deploy procedure. It is noise on a founding date, a chosen license, a settled architecture, a post-mortem lesson. And noise on those is how operators learn to ignore the freshness warning on the records where it was the point.

## What durable does *not* buy

Only the scheduled re-read goes away. A durable record with a cited source still turns `stale/source_changed` when that file changes, so this cannot be used to mint a record nothing can question. An explicitly supplied `stale_after_days` is still honoured — the class says the deadline is optional, not forbidden.

## Verification observed

```
durable fact           review_due=none         @+100d -> fresh
durable + stale 30d    review_due=2026-09-10   @+100d -> stale/review_due
standard fact          review_due=2026-11-09   @+100d -> stale/review_due
durable episode        review_due=none         @+100d -> fresh
```

```
PYTHONPATH=tests uv run python -m unittest discover -s tests     5815 tests OK
docs workflows / roles / capability-families --check             exit 0
harness validate                                                 exit 0
ruff check src tests                                             All checks passed
git diff --check                                                 clean
```

## Test changes

New `DurableRecordsAreActuallyPermanentTests` (4 tests, +4):

- a durable record never falls due for review on its own, across all four affected record types
- a durable record still honours a deadline it was given
- **standard and volatile records keep theirs** — the overroute guard, so the fix cannot quietly make everything permanent
- a durable record is not an immortal one by accident: an edited cited source still turns it stale

One expectation in that guard was wrong on the first run and is worth recording: a volatile record at +100 days reads `retention_expired`, not `review_due`, because its 7-day TTL arrives first and expiry outranks review-due in the single verdict. The test now says so explicitly.

## Risks and follow-ups

- One default; no schema change, no generated artifact.
- Durable records already on disk keep the 90-day date they were minted with. Nothing migrates them, which is the conservative outcome — a re-read prompt on an old record is noise, not damage, and `memory correct` is the path if it matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)