### PR TITLE
feat: give unobserved knowledge a tier that cannot claim completion

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1087,6 +1087,64 @@ in `coding_progress_policy_enforcement()["bounded_surfaces"]`: its output is one
 verdict, at most eight rejected rows, and at most eight store faults, however
 large the stores grow.
 
+### Source Trust
+
+`workflows/source_trust.py` carries the other half of the evidence question.
+Everything above answers *did OMH observe this*; `evidence/labels.py` renders
+that as Phase × Confidence, and every wire value on it is a statement about
+observation. Knowledge that arrived from outside — an upstream document, a
+practitioner's write-up — has no place on that axis, which left it two ways to be
+handled and both were wrong: drop it, or let it ride into a report beside
+observed facts where a reader cannot tell the two apart. The second is
+laundering, and prose telling an agent not to do it is not a guard.
+
+Two axes, kept apart for the same reason as above:
+
+- **Observation** — did OMH see it. Owned by `evidence/labels.py` and the
+  observed-claim guards in `workflows/operator_productivity.py`. `source_trust`
+  does not touch it.
+- **Source trust** — what class of source stands behind a claim OMH never
+  observed. `upstream_official` is primary or maintainer-published material;
+  `practitioner_heuristic` is a named practitioner's report of what works for
+  them, useful and unverified; `unattributed` is a claim with no identifiable
+  source behind it.
+
+The ceiling is mechanical rather than advisory. `TRUST_CLAIM_CEILING` declares
+which claim kinds each tier may back — `approach` informs a plan, `finding`
+enters a report as established, `completion` says work is done — and
+`build_source_trust_claim()` refuses rather than recording a claim the tier
+cannot support. A `practitioner_heuristic` may back `approach` and nothing
+further, so a tip structurally cannot appear as an established finding. An
+`unattributed` source backs nothing at all; it stays recordable so it is visible
+rather than silently dropped, which is the difference between discarding
+knowledge and refusing to let it vote.
+
+The refusal is a rejection, never a silent downgrade to the nearest kind the
+tier could carry: a downgraded record reads later as though the caller had
+claimed correctly. The same check runs again in `source_trust_claim_errors()`,
+so a hand-written record cannot route around the builder.
+
+The strongest rule falls out of the table instead of sitting on top of it: no
+tier reaches `completion`, not even `upstream_official`. What is done, passing,
+verified, reviewed, or merged is settled by observation alone.
+`completion_is_never_source_backed()` re-derives that from
+`TRUST_CLAIM_CEILING` rather than asserting it, so widening a tier cannot leave
+a stale guarantee behind, and `validate_source_trust_summary()` rejects a
+summary whose `strongest_claim_kind` reads `completion`.
+
+Unrecognised tiers fall closed to `unattributed`, the way
+`source_finder.normalize_observation_provenance` falls back to `unknown` — an
+unreadable tier must lose authority, never borrow it. `summarize_source_trust()`
+rejects invalid claims before deriving anything, so malformed input structurally
+cannot raise what a set of claims supports, and reports the gap through a
+bounded `rejected_claims` list.
+
+The module is pure: OMH fetches nothing, subscribes to nothing, and ranks no
+publisher. A caller states the tier; `source_trust` decides only what that tier
+is permitted to claim. Judging *which* sources deserve trust is the reader's
+call and stays outside OMH, per the ownership boundary in `docs/DIRECTION.md`
+that puts source-backed research on the Hermes side.
+
 ### Approval Receipts
 
 `runtime/journal/approval_receipts.jsonl` is an append-only store of

--- a/src/workflows/source_trust.py
+++ b/src/workflows/source_trust.py
@@ -1,0 +1,394 @@
+"""One mechanical ceiling on what an unobserved source is allowed to claim.
+
+The defect this closes: OMH's evidence vocabulary answers exactly one question --
+did OMH watch this happen. ``src/evidence/labels.py`` renders that as Phase x
+Confidence, and every wire value on it (``prepared_not_observed``,
+``observed_partial``, ...) is a statement about observation. Knowledge that
+arrived from outside -- an upstream document, a practitioner's write-up -- has no
+place on that axis, so it had two ways to be handled and both were wrong: drop it,
+or let it ride into a report next to observed facts where a reader cannot tell
+the two apart. The second is laundering, and prose telling an agent not to do it
+is not a guard.
+
+Two axes, kept apart on purpose, because welding them is the confusion:
+
+* **Observation** -- did OMH see it. Owned by ``evidence.labels`` and the
+  observed-claim guards in ``workflows.operator_productivity``. Nothing here
+  touches it.
+* **Source trust** -- what class of source stands behind a claim OMH never
+  observed. ``upstream_official`` is primary or maintainer-published material.
+  ``practitioner_heuristic`` is a named practitioner's report of what works for
+  them, useful and unverified. ``unattributed`` is a claim with no identifiable
+  source behind it.
+
+The ceiling is mechanical, not advisory: :data:`TRUST_CLAIM_CEILING` says which
+claim kinds each tier may back, and :func:`build_source_trust_claim` refuses the
+record rather than recording a claim the tier cannot support. A
+``practitioner_heuristic`` may back ``approach`` -- it can tell you how to go
+about something -- and nothing further, so a tip structurally cannot appear as an
+established finding. An ``unattributed`` source backs nothing at all; it is
+recordable so that it is visible rather than silently dropped, which is the
+difference between discarding knowledge and refusing to let it vote.
+
+The strongest rule falls out of the table rather than being written on top of it:
+NO tier reaches ``completion``. Not even ``upstream_official``. What is done,
+passing, verified, reviewed, or merged is settled by observation alone, and
+:data:`SOURCE_TRUST_TIERS` has no member that can say otherwise --
+:func:`completion_is_never_source_backed` re-derives that from the table instead
+of trusting the sentence you are reading.
+
+Everything here is pure. OMH fetches nothing, subscribes to nothing, and ranks no
+publisher: a caller states the tier, and this module decides only what that tier
+is permitted to claim. Deciding WHICH sources are trustworthy is the reader's
+judgement and stays outside OMH, per the ownership boundary in
+``docs/DIRECTION.md`` that puts source-backed research on the Hermes side.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Final
+
+from ..system.append_only_store import (
+    RAW_OR_HIDDEN_KEYS,
+    is_unsafe_metadata_line,
+    opaque_ref,
+    reference_errors,
+)
+
+
+SOURCE_TRUST_CLAIM_SCHEMA_VERSION: Final = "source_trust_claim/v1"
+SOURCE_TRUST_SUMMARY_SCHEMA_VERSION: Final = "source_trust_summary/v1"
+
+# The three classes of source a claim can rest on, strongest to weakest. Closed,
+# because the claim kinds a tier may back is the whole mechanism and a free-text
+# tier would route around it.
+SOURCE_TRUST_TIERS: Final = ("upstream_official", "practitioner_heuristic", "unattributed")
+
+# The tier an unreadable or unsupported value falls back to. Fail-closed, the way
+# `source_finder.normalize_observation_provenance` falls back to `unknown`: an
+# unrecognised tier must lose authority, never borrow it.
+SOURCE_TRUST_TIER_FALLBACK: Final = "unattributed"
+
+# What a claim asserts, weakest to strongest.
+#   approach   -- this is a way to go about the work. Informs a plan.
+#   finding    -- this is so. Enters a report as an established fact.
+#   completion -- this work is done, passing, verified, reviewed, or merged.
+CLAIM_KINDS: Final = ("approach", "finding", "completion")
+
+# What a summary reports when no accepted claim backs anything.
+CLAIM_KIND_NONE: Final = "none"
+
+# Which claim kinds each tier may back. `practitioner_heuristic` may back only
+# `approach`, which is what makes "a tip never becomes an established finding" a
+# property of the schema rather than a rule someone remembers. No tier lists
+# `completion`: an outside source cannot settle whether work happened.
+TRUST_CLAIM_CEILING: Final = {
+    "upstream_official": ("approach", "finding"),
+    "practitioner_heuristic": ("approach",),
+    "unattributed": (),
+}
+
+SOURCE_TRUST_CLAIM_KEYS: Final = (
+    "schema_version",
+    "tier",
+    "claim_kind",
+    "claim",
+    "source_ref",
+    "recorded_at",
+)
+
+SOURCE_TRUST_SUMMARY_KEYS: Final = (
+    "schema_version",
+    "topic",
+    "strongest_claim_kind",
+    "tiers_present",
+    "accepted_count",
+    "rejected_count",
+    "rejected_claims",
+    "claim_boundary",
+)
+_REJECTED_CLAIM_KEYS: Final = ("index", "reason")
+
+SOURCE_TRUST_CLAIM_BOUNDARY: Final = (
+    "This summary reports what class of source stands behind each claim, not whether any claim is "
+    "true. OMH fetched nothing, read no source, and verified no statement here; a tier says who "
+    "stands behind a claim, never that OMH checked it, and no claim on this axis is execution, "
+    "verification, review, CI, or merge evidence."
+)
+
+_MAX_TOPIC_CHARS: Final = 160
+_MAX_CLAIM_CHARS: Final = 400
+_MAX_REJECTED_ROWS: Final = 8
+_MAX_REJECTION_REASON_CHARS: Final = 200
+
+_LABEL: Final = "source trust claim"
+_SUMMARY_LABEL: Final = "source trust summary"
+
+_CLAIM_KIND_LEVELS: Final = {kind: level for level, kind in enumerate(CLAIM_KINDS, start=1)}
+
+
+class SourceTrustError(ValueError):
+    """Raised when a claim cannot be accepted at the tier it was offered under."""
+
+
+def normalize_source_trust_tier(tier: str | None) -> str:
+    """The supplied tier, or the fallback when it is not one OMH knows.
+
+    Fail-closed: an unrecognised tier becomes `unattributed`, which backs
+    nothing. Normalising upward would let a typo buy authority.
+    """
+    normalized = " ".join(str(tier or "").strip().lower().split()).replace(" ", "_").replace("-", "_")
+    return normalized if normalized in SOURCE_TRUST_TIERS else SOURCE_TRUST_TIER_FALLBACK
+
+
+def claim_kinds_for_tier(tier: str) -> tuple[str, ...]:
+    """Every claim kind this tier may back, weakest first. Empty when none."""
+    return tuple(TRUST_CLAIM_CEILING.get(normalize_source_trust_tier(tier), ()))
+
+
+def tier_may_claim(tier: str, claim_kind: str) -> bool:
+    """Whether one tier is permitted to back one claim kind."""
+    return claim_kind in claim_kinds_for_tier(tier)
+
+
+def completion_is_never_source_backed() -> bool:
+    """Re-derive from the table that no tier can back a completion claim.
+
+    Stated as a derivation rather than a constant so that widening a tier's
+    ceiling to include `completion` cannot leave a comment claiming otherwise.
+    """
+    return all("completion" not in kinds for kinds in TRUST_CLAIM_CEILING.values())
+
+
+def build_source_trust_claim(
+    *,
+    tier: str,
+    claim_kind: str,
+    claim: str,
+    recorded_at: str,
+    source_ref: str = "",
+) -> dict[str, Any]:
+    """Mint one source-trust claim, or refuse.
+
+    The refusal is the feature. A `practitioner_heuristic` offered as a `finding`
+    does not get downgraded to `approach` and stored, because a silently
+    downgraded record reads later as though the caller had claimed correctly;
+    it is rejected so the caller has to say what they actually mean.
+
+    `source_ref` is required for a tier that names a source and must be empty for
+    `unattributed` -- having no identifiable source is what that tier means, so a
+    reference on it would make the tier a lie.
+    """
+    if tier not in SOURCE_TRUST_TIERS:
+        raise SourceTrustError(f"source trust tier is unsupported: {tier!r}")
+    if claim_kind not in CLAIM_KINDS:
+        raise SourceTrustError(f"source trust claim kind is unsupported: {claim_kind!r}")
+    if not tier_may_claim(tier, claim_kind):
+        allowed = ", ".join(claim_kinds_for_tier(tier)) or "nothing"
+        raise SourceTrustError(
+            f"source trust tier {tier} may not back a {claim_kind} claim; it may back: {allowed}"
+        )
+    has_ref = bool(str(source_ref or "").strip())
+    if tier == "unattributed" and has_ref:
+        raise SourceTrustError("source trust tier unattributed must not name a source")
+    if tier != "unattributed" and not has_ref:
+        raise SourceTrustError(f"source trust tier {tier} must name the source it rests on")
+    record = {
+        "schema_version": SOURCE_TRUST_CLAIM_SCHEMA_VERSION,
+        "tier": tier,
+        "claim_kind": claim_kind,
+        "claim": _bounded_claim(claim),
+        "source_ref": _opaque(source_ref, field="source trust claim source_ref") if has_ref else "",
+        "recorded_at": _opaque(recorded_at, field="source trust claim recorded_at"),
+    }
+    errors = source_trust_claim_errors(record)
+    if errors:
+        raise SourceTrustError(errors[0])
+    return record
+
+
+def source_trust_claim_errors(record: Any) -> list[str]:
+    """Every reason one claim is not usable. Both directions on keys."""
+    if not isinstance(record, Mapping):
+        return [f"{_LABEL} must be an object"]
+    errors: list[str] = []
+    forbidden = sorted(key for key in record if str(key).lower() in RAW_OR_HIDDEN_KEYS)
+    if forbidden:
+        errors.append(f"{_LABEL} must not carry raw or hidden keys: {forbidden}")
+    present = {str(key) for key in record}
+    missing = sorted(set(SOURCE_TRUST_CLAIM_KEYS) - present)
+    if missing:
+        errors.append(f"{_LABEL} is missing keys: {missing}")
+    unexpected = sorted(present - set(SOURCE_TRUST_CLAIM_KEYS) - set(forbidden))
+    if unexpected:
+        errors.append(f"{_LABEL} has unsupported keys: {unexpected}")
+    if record.get("schema_version") != SOURCE_TRUST_CLAIM_SCHEMA_VERSION:
+        errors.append(f"{_LABEL} schema_version must be {SOURCE_TRUST_CLAIM_SCHEMA_VERSION}")
+    tier = record.get("tier")
+    if tier not in SOURCE_TRUST_TIERS:
+        errors.append(f"{_LABEL} tier is unsupported: {tier!r}")
+    claim_kind = record.get("claim_kind")
+    if claim_kind not in CLAIM_KINDS:
+        errors.append(f"{_LABEL} claim kind is unsupported: {claim_kind!r}")
+    elif tier in SOURCE_TRUST_TIERS and not tier_may_claim(str(tier), str(claim_kind)):
+        allowed = ", ".join(claim_kinds_for_tier(str(tier))) or "nothing"
+        errors.append(f"{_LABEL} tier {tier} may not back a {claim_kind} claim; it may back: {allowed}")
+    errors.extend(_bounded_claim_errors(record))
+    source_ref = record.get("source_ref")
+    if tier == "unattributed" and isinstance(source_ref, str) and source_ref:
+        errors.append(f"{_LABEL} tier unattributed must not name a source")
+    if tier in SOURCE_TRUST_TIERS and tier != "unattributed" and not source_ref:
+        errors.append(f"{_LABEL} tier {tier} must name the source it rests on")
+    errors.extend(reference_errors(source_ref, field="source_ref", label=_LABEL, required=False))
+    errors.extend(reference_errors(record.get("recorded_at"), field="recorded_at", label=_LABEL, required=True))
+    return errors
+
+
+def summarize_source_trust(
+    *,
+    topic: str,
+    claims: Sequence[Mapping[str, Any]] = (),
+) -> dict[str, Any]:
+    """What a gathered set of claims is collectively allowed to support.
+
+    Invalid claims are rejected before anything is derived, so a malformed record
+    structurally cannot raise the summary. `strongest_claim_kind` is the
+    strongest kind any accepted claim backs, and because no tier reaches
+    `completion` it can never read as one -- a caller reading this summary to
+    decide whether work is done gets `finding` at most and has to go to the
+    observation axis for the rest.
+    """
+    supplied = list(claims)
+    accepted: list[Mapping[str, Any]] = []
+    rejected: list[dict[str, Any]] = []
+    rejected_count = 0
+    for index, record in enumerate(supplied):
+        errors = source_trust_claim_errors(record)
+        if errors:
+            rejected_count += 1
+            if len(rejected) < _MAX_REJECTED_ROWS:
+                rejected.append({"index": index, "reason": errors[0][:_MAX_REJECTION_REASON_CHARS]})
+            continue
+        accepted.append(record)
+
+    strongest = CLAIM_KIND_NONE
+    best_level = 0
+    tiers: set[str] = set()
+    for record in accepted:
+        tiers.add(str(record["tier"]))
+        level = _CLAIM_KIND_LEVELS.get(str(record["claim_kind"]), 0)
+        if level > best_level:
+            best_level, strongest = level, str(record["claim_kind"])
+
+    return {
+        "schema_version": SOURCE_TRUST_SUMMARY_SCHEMA_VERSION,
+        "topic": _bounded_topic(topic),
+        "strongest_claim_kind": strongest,
+        "tiers_present": [tier for tier in SOURCE_TRUST_TIERS if tier in tiers],
+        "accepted_count": len(accepted),
+        "rejected_count": rejected_count,
+        "rejected_claims": rejected,
+        "claim_boundary": SOURCE_TRUST_CLAIM_BOUNDARY,
+    }
+
+
+def validate_source_trust_summary(summary: Any) -> list[str]:
+    """Every reason one summary is not a well-formed report."""
+    if not isinstance(summary, Mapping):
+        return [f"{_SUMMARY_LABEL} must be an object"]
+    errors: list[str] = []
+    present = {str(key) for key in summary}
+    missing = sorted(set(SOURCE_TRUST_SUMMARY_KEYS) - present)
+    if missing:
+        errors.append(f"{_SUMMARY_LABEL} is missing keys: {missing}")
+    unexpected = sorted(present - set(SOURCE_TRUST_SUMMARY_KEYS))
+    if unexpected:
+        errors.append(f"{_SUMMARY_LABEL} has unsupported keys: {unexpected}")
+    if summary.get("schema_version") != SOURCE_TRUST_SUMMARY_SCHEMA_VERSION:
+        errors.append(f"{_SUMMARY_LABEL} schema_version must be {SOURCE_TRUST_SUMMARY_SCHEMA_VERSION}")
+    topic = summary.get("topic")
+    if not isinstance(topic, str) or not topic.strip() or len(topic) > _MAX_TOPIC_CHARS:
+        errors.append(f"{_SUMMARY_LABEL} topic must be a nonempty string of at most {_MAX_TOPIC_CHARS} characters")
+    elif is_unsafe_metadata_line(topic):
+        errors.append(f"{_SUMMARY_LABEL} topic must not carry secrets, links, paths, or raw text")
+    strongest = summary.get("strongest_claim_kind")
+    if strongest not in (CLAIM_KIND_NONE, *CLAIM_KINDS):
+        errors.append(f"{_SUMMARY_LABEL} strongest_claim_kind is unsupported: {strongest!r}")
+    elif strongest == "completion":
+        errors.append(f"{_SUMMARY_LABEL} strongest_claim_kind must never be completion; no tier backs one")
+    tiers = summary.get("tiers_present")
+    if not isinstance(tiers, list) or any(tier not in SOURCE_TRUST_TIERS for tier in tiers):
+        errors.append(f"{_SUMMARY_LABEL} tiers_present must list known source trust tiers")
+    for field in ("accepted_count", "rejected_count"):
+        value = summary.get(field)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            errors.append(f"{_SUMMARY_LABEL} {field} must be a non-negative integer")
+    errors.extend(_rejected_claim_errors(summary.get("rejected_claims")))
+    if summary.get("claim_boundary") != SOURCE_TRUST_CLAIM_BOUNDARY:
+        errors.append(f"{_SUMMARY_LABEL} claim_boundary must be the frozen boundary sentence")
+    return errors
+
+
+def _bounded_claim(claim: str) -> str:
+    text = " ".join(str(claim or "").split())
+    if not text:
+        raise SourceTrustError(f"{_LABEL} requires the claim it carries")
+    if len(text) > _MAX_CLAIM_CHARS:
+        raise SourceTrustError(f"{_LABEL} claim must be at most {_MAX_CLAIM_CHARS} characters")
+    if is_unsafe_metadata_line(text):
+        raise SourceTrustError(
+            f"{_LABEL} claim must be one bounded metadata line without secrets, links, or paths"
+        )
+    return text
+
+
+def _bounded_topic(topic: str) -> str:
+    text = " ".join(str(topic or "").split())
+    if not text:
+        raise SourceTrustError(f"{_SUMMARY_LABEL} requires the topic it summarizes")
+    if len(text) > _MAX_TOPIC_CHARS:
+        raise SourceTrustError(f"{_SUMMARY_LABEL} topic must be at most {_MAX_TOPIC_CHARS} characters")
+    if is_unsafe_metadata_line(text):
+        raise SourceTrustError(
+            f"{_SUMMARY_LABEL} topic must be one bounded metadata line without secrets, links, or paths"
+        )
+    return text
+
+
+def _bounded_claim_errors(record: Mapping[str, Any]) -> list[str]:
+    value = record.get("claim")
+    if not isinstance(value, str) or not value.strip() or len(value) > _MAX_CLAIM_CHARS:
+        return [f"{_LABEL} claim must be a nonempty string of at most {_MAX_CLAIM_CHARS} characters"]
+    if is_unsafe_metadata_line(value):
+        return [f"{_LABEL} claim must not carry secrets, links, paths, or raw text"]
+    return []
+
+
+def _rejected_claim_errors(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return [f"{_SUMMARY_LABEL} rejected_claims must be a list"]
+    if len(value) > _MAX_REJECTED_ROWS:
+        return [f"{_SUMMARY_LABEL} rejected_claims must hold at most {_MAX_REJECTED_ROWS} rows"]
+    errors: list[str] = []
+    for row in value:
+        if not isinstance(row, Mapping):
+            errors.append(f"{_SUMMARY_LABEL} rejected_claims rows must be objects")
+            continue
+        if sorted(str(key) for key in row) != sorted(_REJECTED_CLAIM_KEYS):
+            errors.append(f"{_SUMMARY_LABEL} rejected_claims rows must carry exactly {list(_REJECTED_CLAIM_KEYS)}")
+            continue
+        index = row.get("index")
+        if not isinstance(index, int) or isinstance(index, bool) or index < 0:
+            errors.append(f"{_SUMMARY_LABEL} rejected_claims index must be a non-negative integer")
+        reason = row.get("reason")
+        if not isinstance(reason, str) or not reason.strip() or len(reason) > _MAX_REJECTION_REASON_CHARS:
+            errors.append(
+                f"{_SUMMARY_LABEL} rejected_claims reason must be a nonempty string of at most "
+                f"{_MAX_REJECTION_REASON_CHARS} characters"
+            )
+    return errors
+
+
+def _opaque(value: str, *, field: str) -> str:
+    return opaque_ref(value, field=field, error=SourceTrustError)

--- a/tests/test_source_trust.py
+++ b/tests/test_source_trust.py
@@ -1,0 +1,280 @@
+"""Contracts for `source_trust_claim/v1` and `source_trust_summary/v1`.
+
+The axis exists so knowledge OMH never observed can be carried without being
+mistaken for something OMH did observe. These group by the guarantee each test
+protects:
+
+- The ceiling: a tier may back only the claim kinds the table gives it, and the
+  refusal is a rejection rather than a silent downgrade.
+- The floor under every tier: no source, however official, backs a completion
+  claim -- that belongs to the observation axis alone.
+- Attribution: a tier that names a source must have one, and the tier that means
+  "nobody in particular" must not.
+- The summary: it cannot be raised by malformed input and cannot report a
+  completion.
+
+Each positive case ships with the negative case that proves the guard is doing
+the work, per the repo's guard-pattern rule.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.workflows.source_trust import (
+    CLAIM_KIND_NONE,
+    CLAIM_KINDS,
+    SOURCE_TRUST_CLAIM_BOUNDARY,
+    SOURCE_TRUST_CLAIM_SCHEMA_VERSION,
+    SOURCE_TRUST_CLAIM_KEYS,
+    SOURCE_TRUST_SUMMARY_SCHEMA_VERSION,
+    SOURCE_TRUST_TIER_FALLBACK,
+    SOURCE_TRUST_TIERS,
+    TRUST_CLAIM_CEILING,
+    SourceTrustError,
+    build_source_trust_claim,
+    claim_kinds_for_tier,
+    completion_is_never_source_backed,
+    normalize_source_trust_tier,
+    source_trust_claim_errors,
+    summarize_source_trust,
+    tier_may_claim,
+    validate_source_trust_summary,
+)
+
+
+STAMP = "2026-08-11T00:00:00Z"
+
+
+def _claim(**overrides: object) -> dict[str, object]:
+    record = build_source_trust_claim(
+        tier="upstream_official",
+        claim_kind="finding",
+        claim="The runtime rejects a handoff without an owner.",
+        recorded_at=STAMP,
+        source_ref="upstream-runtime-spec",
+    )
+    record.update(overrides)
+    return record
+
+
+class CeilingTests(unittest.TestCase):
+    def test_practitioner_heuristic_backs_approach(self) -> None:
+        record = build_source_trust_claim(
+            tier="practitioner_heuristic",
+            claim_kind="approach",
+            claim="Warm the cache before the first batch or the first run skews the timing.",
+            recorded_at=STAMP,
+            source_ref="practitioner-note-cache-warm",
+        )
+        self.assertEqual(record["tier"], "practitioner_heuristic")
+        self.assertEqual(record["claim_kind"], "approach")
+        self.assertEqual(source_trust_claim_errors(record), [])
+
+    def test_practitioner_heuristic_is_refused_as_a_finding(self) -> None:
+        with self.assertRaises(SourceTrustError) as raised:
+            build_source_trust_claim(
+                tier="practitioner_heuristic",
+                claim_kind="finding",
+                claim="Warming the cache halves p99.",
+                recorded_at=STAMP,
+                source_ref="practitioner-note-cache-warm",
+            )
+        self.assertIn("may not back a finding claim", str(raised.exception))
+
+    def test_refusal_is_not_a_silent_downgrade(self) -> None:
+        """A rejected claim must not come back stored one rung lower."""
+        with self.assertRaises(SourceTrustError):
+            build_source_trust_claim(
+                tier="practitioner_heuristic",
+                claim_kind="finding",
+                claim="Warming the cache halves p99.",
+                recorded_at=STAMP,
+                source_ref="practitioner-note-cache-warm",
+            )
+
+    def test_unattributed_backs_nothing(self) -> None:
+        self.assertEqual(claim_kinds_for_tier("unattributed"), ())
+        for kind in CLAIM_KINDS:
+            with self.subTest(kind=kind):
+                with self.assertRaises(SourceTrustError):
+                    build_source_trust_claim(
+                        tier="unattributed",
+                        claim_kind=kind,
+                        claim="Somebody said the scheduler retries twice.",
+                        recorded_at=STAMP,
+                    )
+
+    def test_every_tier_has_an_explicit_ceiling(self) -> None:
+        self.assertEqual(sorted(TRUST_CLAIM_CEILING), sorted(SOURCE_TRUST_TIERS))
+        for tier, kinds in TRUST_CLAIM_CEILING.items():
+            with self.subTest(tier=tier):
+                self.assertTrue(set(kinds) <= set(CLAIM_KINDS), tier)
+
+
+class CompletionFloorTests(unittest.TestCase):
+    def test_no_tier_backs_a_completion_claim(self) -> None:
+        self.assertTrue(completion_is_never_source_backed())
+        for tier in SOURCE_TRUST_TIERS:
+            with self.subTest(tier=tier):
+                self.assertFalse(tier_may_claim(tier, "completion"))
+
+    def test_upstream_official_is_also_refused_a_completion(self) -> None:
+        with self.assertRaises(SourceTrustError) as raised:
+            build_source_trust_claim(
+                tier="upstream_official",
+                claim_kind="completion",
+                claim="The migration shipped and the suite is green.",
+                recorded_at=STAMP,
+                source_ref="upstream-release-notes",
+            )
+        self.assertIn("may not back a completion claim", str(raised.exception))
+
+
+class AttributionTests(unittest.TestCase):
+    def test_named_tier_requires_a_source(self) -> None:
+        with self.assertRaises(SourceTrustError) as raised:
+            build_source_trust_claim(
+                tier="upstream_official",
+                claim_kind="finding",
+                claim="The runtime rejects a handoff without an owner.",
+                recorded_at=STAMP,
+            )
+        self.assertIn("must name the source", str(raised.exception))
+
+    def test_unattributed_must_not_name_a_source(self) -> None:
+        """Only reachable on read: `build` refuses `unattributed` at the ceiling first.
+
+        The ordering is deliberate -- a tier that backs nothing is refused for
+        that reason before anything about its attribution is considered -- so the
+        attribution rule is exercised against a hand-forged record.
+        """
+        errors = source_trust_claim_errors(_claim(tier="unattributed", source_ref="somewhere"))
+        self.assertTrue(any("must not name a source" in error for error in errors), errors)
+
+    def test_source_ref_must_not_be_navigable(self) -> None:
+        with self.assertRaises(SourceTrustError):
+            build_source_trust_claim(
+                tier="upstream_official",
+                claim_kind="finding",
+                claim="The runtime rejects a handoff without an owner.",
+                recorded_at=STAMP,
+                source_ref="https://example.invalid/spec",
+            )
+
+
+class NormalizeTests(unittest.TestCase):
+    def test_known_tiers_survive_normalization(self) -> None:
+        for tier in SOURCE_TRUST_TIERS:
+            with self.subTest(tier=tier):
+                self.assertEqual(normalize_source_trust_tier(tier), tier)
+
+    def test_unknown_tier_falls_closed(self) -> None:
+        for value in ("", None, "trusted", "official-ish", "PRACTITIONER HEURISTICS"):
+            with self.subTest(value=value):
+                self.assertEqual(normalize_source_trust_tier(value), SOURCE_TRUST_TIER_FALLBACK)
+
+    def test_fallback_tier_backs_nothing(self) -> None:
+        """Falling closed is only safe because the fallback has no authority."""
+        self.assertEqual(claim_kinds_for_tier(SOURCE_TRUST_TIER_FALLBACK), ())
+
+
+class ClaimValidationTests(unittest.TestCase):
+    def test_built_claim_validates(self) -> None:
+        self.assertEqual(source_trust_claim_errors(_claim()), [])
+        self.assertEqual(sorted(_claim()), sorted(SOURCE_TRUST_CLAIM_KEYS))
+
+    def test_missing_and_unexpected_keys_are_both_reported(self) -> None:
+        record = _claim()
+        record.pop("recorded_at")
+        record["notes"] = "extra"
+        errors = source_trust_claim_errors(record)
+        self.assertTrue(any("missing keys" in error for error in errors), errors)
+        self.assertTrue(any("unsupported keys" in error for error in errors), errors)
+
+    def test_schema_version_is_pinned(self) -> None:
+        errors = source_trust_claim_errors(_claim(schema_version="source_trust_claim/v2"))
+        self.assertTrue(any(SOURCE_TRUST_CLAIM_SCHEMA_VERSION in error for error in errors), errors)
+
+    def test_hand_forged_ceiling_violation_is_caught_on_read(self) -> None:
+        """The guard cannot be bypassed by writing the record by hand."""
+        errors = source_trust_claim_errors(
+            _claim(tier="practitioner_heuristic", source_ref="practitioner-note")
+        )
+        self.assertTrue(any("may not back a finding claim" in error for error in errors), errors)
+
+    def test_non_mapping_is_rejected(self) -> None:
+        self.assertEqual(source_trust_claim_errors(["not", "a", "record"]), ["source trust claim must be an object"])
+
+
+class SummaryTests(unittest.TestCase):
+    def test_summary_reports_the_strongest_accepted_claim(self) -> None:
+        summary = summarize_source_trust(
+            topic="handoff owner requirement",
+            claims=[
+                build_source_trust_claim(
+                    tier="practitioner_heuristic",
+                    claim_kind="approach",
+                    claim="Set the owner before preparing the handoff.",
+                    recorded_at=STAMP,
+                    source_ref="practitioner-note-owner",
+                ),
+                _claim(),
+            ],
+        )
+        self.assertEqual(summary["strongest_claim_kind"], "finding")
+        self.assertEqual(summary["accepted_count"], 2)
+        self.assertEqual(summary["rejected_count"], 0)
+        self.assertEqual(summary["tiers_present"], ["upstream_official", "practitioner_heuristic"])
+        self.assertEqual(summary["claim_boundary"], SOURCE_TRUST_CLAIM_BOUNDARY)
+        self.assertEqual(validate_source_trust_summary(summary), [])
+
+    def test_empty_summary_backs_nothing(self) -> None:
+        summary = summarize_source_trust(topic="handoff owner requirement")
+        self.assertEqual(summary["strongest_claim_kind"], CLAIM_KIND_NONE)
+        self.assertEqual(summary["tiers_present"], [])
+        self.assertEqual(validate_source_trust_summary(summary), [])
+
+    def test_malformed_claims_cannot_raise_the_summary(self) -> None:
+        summary = summarize_source_trust(
+            topic="handoff owner requirement",
+            claims=[
+                {"tier": "upstream_official", "claim_kind": "finding"},
+                _claim(tier="practitioner_heuristic", source_ref="practitioner-note"),
+                build_source_trust_claim(
+                    tier="practitioner_heuristic",
+                    claim_kind="approach",
+                    claim="Set the owner before preparing the handoff.",
+                    recorded_at=STAMP,
+                    source_ref="practitioner-note-owner",
+                ),
+            ],
+        )
+        self.assertEqual(summary["accepted_count"], 1)
+        self.assertEqual(summary["rejected_count"], 2)
+        self.assertEqual(summary["strongest_claim_kind"], "approach")
+        self.assertEqual([row["index"] for row in summary["rejected_claims"]], [0, 1])
+        self.assertEqual(validate_source_trust_summary(summary), [])
+
+    def test_summary_schema_version_is_pinned(self) -> None:
+        summary = summarize_source_trust(topic="handoff owner requirement")
+        self.assertEqual(summary["schema_version"], SOURCE_TRUST_SUMMARY_SCHEMA_VERSION)
+
+    def test_a_forged_completion_summary_is_rejected(self) -> None:
+        summary = summarize_source_trust(topic="handoff owner requirement")
+        summary["strongest_claim_kind"] = "completion"
+        errors = validate_source_trust_summary(summary)
+        self.assertTrue(any("never be completion" in error for error in errors), errors)
+
+    def test_a_stripped_boundary_is_rejected(self) -> None:
+        summary = summarize_source_trust(topic="handoff owner requirement")
+        summary["claim_boundary"] = "checked and verified"
+        errors = validate_source_trust_summary(summary)
+        self.assertTrue(any("frozen boundary sentence" in error for error in errors), errors)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New contract module `src/workflows/source_trust.py` adding `source_trust_claim/v1` and `source_trust_summary/v1`: a **source-trust axis** for knowledge OMH never observed, with a mechanical ceiling on what each tier is allowed to claim.
- New `tests/test_source_trust.py` (24 tests), grouped by the guarantee each one protects.
- New `### Source Trust` section in `docs/ARCHITECTURE.md`, placed beside `### External Action Readiness` because it is the same two-axis pattern.
- No catalog, skill, routing case, CLI surface, or generated artifact is touched. No exact-count fixture moves and no byte gate is involved.

### Why This Exists

OMH's evidence vocabulary answers exactly one question: *did OMH watch this happen*. `src/evidence/labels.py` renders it as Phase x Confidence, and every wire value on that axis (`prepared_not_observed`, `observed_partial`, ...) is a statement about observation.

Knowledge that arrived from **outside** — an upstream document, a practitioner's write-up, a tip from someone experienced — had nowhere to sit on that axis. That left two options, and both were wrong:

1. **Drop it.** Useful knowledge is discarded because the schema has no slot for it.
2. **Let it ride.** It enters a report next to observed facts, where a reader cannot tell the two apart.

The second is laundering, and until now the only thing standing against it was prose in skill catalog text asking an agent not to do it. `src/skills/catalog_definitions.py:962` already tells `research-brief` to "Record each material claim as a compact evidence row: claim, source, source date, confidence" — the rule was written years of commits ago and has never been enforceable, because nothing parses those rows back.

### User / Operator Impact

A caller can now record an unverified practitioner claim **without** it being able to masquerade as an established finding, and without having to throw it away. Concretely:

- A tip can inform an *approach* and is structurally barred from becoming a *finding*.
- Nothing sourced from outside — not even official upstream documentation — can back a *completion* claim. Whether work is done, passing, verified, reviewed, or merged stays settled by observation alone.
- A claim with no identifiable source stays recordable but backs nothing, so it is visible rather than silently dropped.

This PR establishes the contract. It is not yet reachable from Hermes chat (see Follow-Up).

### How It Works

Two axes, kept apart on purpose:

| Axis | Question | Owner |
| --- | --- | --- |
| Observation | Did OMH see it? | `evidence/labels.py`, `workflows/operator_productivity.py` |
| Source trust | What class of source stands behind a claim OMH never observed? | `workflows/source_trust.py` (new) |

Three tiers and three claim kinds, with the ceiling as data rather than prose:

```python
CLAIM_KINDS = ("approach", "finding", "completion")

TRUST_CLAIM_CEILING = {
    "upstream_official":      ("approach", "finding"),
    "practitioner_heuristic": ("approach",),
    "unattributed":           (),
}
```

Design points that carry the weight:

- **The refusal is a rejection, never a downgrade.** A `practitioner_heuristic` offered as a `finding` is not quietly stored as an `approach`. A downgraded record reads later as though the caller had claimed correctly, which is the exact failure this axis exists to prevent.
- **The builder cannot be routed around.** `source_trust_claim_errors()` re-runs the ceiling check, so a hand-written record fails on read.
- **The completion floor is derived, not asserted.** `completion_is_never_source_backed()` re-derives from `TRUST_CLAIM_CEILING` that no tier lists `completion`, so widening a tier later cannot leave a stale guarantee in a comment. `validate_source_trust_summary()` separately rejects a summary whose `strongest_claim_kind` reads `completion`.
- **Attribution is structural.** A tier that names a source must have one; `unattributed` must not. `source_ref` goes through `reference_errors`, so a navigable URL is refused.
- **Unknown tiers fall closed** to `unattributed`, mirroring `source_finder.normalize_observation_provenance` falling back to `unknown`. An unreadable tier must lose authority, never borrow it.
- **Malformed input cannot raise a summary.** `summarize_source_trust()` rejects invalid claims before deriving anything and reports the gap through a bounded `rejected_claims` list.

Modelled line-for-line on `workflows/external_action_readiness.py`, whose `SOURCE_TIERS` guard does the same job for a different question (`local_configuration` may claim only `installed`, which is what makes "configuration never reaches ready" a property of the schema).

### Files And Contracts Touched

- `src/workflows/source_trust.py` — new, +394. `source_trust_claim/v1`, `source_trust_summary/v1`.
- `tests/test_source_trust.py` — new, +280, 24 tests.
- `docs/ARCHITECTURE.md` — new section, +58.

**Deliberately not touched: `src/evidence/labels.py`.** Framing this as "a third axis on the evidence labels" was the original plan and it is wrong twice over:

1. It breaks on the first test run. `tests/test_evidence_labels_policy.py:136-141` asserts `len(status_label(state)) <= len(state)`. The tightest case is `worktree_failed` (15) rendering as `Setup · failed` (14) — **one character of margin**. The shortest plausible third segment adds ten.
2. More importantly, `labels.py` is a display function with no producer and no validator. An axis added there would have no guard behind it: decorative honesty, which is the same laundering in a new coat.

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed (one pre-existing `# noqa` warning on `src/commands/main.py:1`, untouched here)
- [x] `python3 -m unittest discover -s tests` — **5812 tests OK**, baseline on `main` was 5788, delta is exactly the 24 new tests
- [x] `python3 -m compileall src` — OK
- [x] `python3 -m omh.cli docs workflows --check` — `ok: true`, tap-skills 117/117, no missing/stale/extra
- [x] `python3 -m omh.cli harness validate` — `ok: true`, 72 harnesses / 104 skills, 0 errors, 0 warnings
- [x] `python3 -m omh.cli release checklist --json` — `ok: true` (**plan mode**; every item reports `observed: false`, so this is a rendered plan, not execution evidence)
- [x] `python3 -m omh.cli release hermes-smoke` — plan renders with plan-only boundary
- [x] `omh --help` — exit 0
- [ ] `omh --omh-home /tmp/omh-smoke ... --include-command-smoke` — **not run**; this PR adds no CLI surface and no installed-command behavior
- [ ] Relevant workflow-learning review queue smoke — **not applicable**; no learning contract changed
- [x] Relevant dry-run or smoke command: `docs roles --check` ok, `docs capability-families --check` ok, `release drift` → **No drift, 12 checks passed**, `git diff --check` clean
- [ ] Manual Hermes/TUI check — **not run, and would prove nothing here**: the module is not wired to any chat route, CLI command, or skill, so there is no Hermes-visible behavior to check yet

## Risk

- **Low blast radius.** Nothing imports the module yet. It adds no wire value to the frozen evidence vocabulary, so none of the ~150 test assertions pinning those literals are affected.
- **The real risk is vocabulary overlap, not breakage.** OMH already carries adjacent trichotomies — `source_finder.SOURCE_FINDER_OBSERVATION_PROVENANCE` (attributes a state transition to an actor), and catalog prose telling `research` to "separate measured, assumed, and derived figures". This adds a fourth vocabulary. It is deliberately scoped to a different question (claim-to-source-class, not state-to-actor), but the axes should be explicitly subordinated to each other before more are added.
- The 400-char claim bound and 8-row rejected-claims cap are judgement calls, chosen to match the neighbouring module's bounds rather than derived from a measured need.

## Compatibility / Rollout

- Purely additive. No existing caller changes behavior, no persisted record format changes, no migration.
- Zero network: the module fetches nothing, subscribes to nothing, and ranks no publisher. A caller *states* the tier; the module decides only what that tier may claim. Judging which sources deserve trust stays outside OMH, per the ownership boundary in `docs/DIRECTION.md` that puts source-backed research on the Hermes side.

## Release / Claims

- [x] Release-channel impact considered — none; no installed surface, no version file, no packaging change
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — all verification above is local deterministic evidence; no Hermes runtime, plugin-load, or chat claim is made anywhere in this PR
- [x] Known manual Hermes checks are listed — see the unchecked boxes above; there is no `omh release hermes-smoke --live` gap because this PR touches nothing a live profile would exercise

## Follow-Up

Three follow-ups, deliberately **not** bundled here to keep this one goal:

1. **Wire the axis into the research lane.** `research`, `research-brief`, and `best-practice-research` already carry the claim-row rule as unenforceable prose. Editing that catalog text regenerates four artifact families and spends four char budgets, so it is its own goal.
2. **Subordinate the overlapping vocabularies** (see Risk) before a fifth appears.
3. **Unrelated, found while working:** `CLAUDE.md:81` cites `case_count == 51` and `intervention_case_count == 105`. Live values are **57** and **157** (`tests/test_routing_precision.py:18,27`). That line instructs contributors to grep for those numbers when counts change, so it is actively sending people to the wrong string. Left out of this PR as a different goal; happy to send it as a one-line fix.
