### PR TITLE
fix(plugin): add kind: standalone so omh tools/hooks register in live Hermes

### DIFF
--- a/src/plugin_bundle/omh/plugin.yaml
+++ b/src/plugin_bundle/omh/plugin.yaml
@@ -1,4 +1,5 @@
 name: omh
+kind: standalone
 version: "1.0.5"
 description: "Oh My Hermes native bridge for metadata-only runtime status, HUD, role context, bounded evidence probes, evidence-boundary context, and a deterministic file-backed memory provider."
 author: oh-my-hermes maintainers


### PR DESCRIPTION
## Summary

The omh plugin bundle ships a `plugin.yaml` with no `kind` field. Since April 2026 Hermes auto-coerces any user plugin whose `__init__.py` mentions `register_memory_provider` to **kind: exclusive** (hermes-agent #14005). The general PluginManager skips exclusive plugins entirely, so omh's `register()` only ever runs through the memory provider loader, which passes a collector whose only real method is `register_memory_provider` — the provider registers and returns before reaching the tool/hook wiring.

**Net result:** the 10 `omh_*` tools and 4 hooks declared in `plugin.yaml` never register in a live Hermes session. The memory provider works; `omh doctor` stays green because its smoke tests call the module directly.

## Fix

Adding `kind: standalone` to `plugin.yaml` resolves it — all 10 tools and 4 hooks register in a live session, and the memory provider still slots through the separate `plugins/memory` text scan.

```yaml
name: omh
kind: standalone
version: "1.0.5"
```

## Verification

- Reproduced on Hermes 0.20.0 with the real PluginManager against the installed bundle: `kind: exclusive | enabled: False`, tools registered: 0, hooks registered: 0.
- After the change: `kind: standalone | enabled: True`, all 10 `omh_*` tools and 4 hooks registered.
- `tests/test_plugin_distribution.py`: **29 passed** (12 subtests).
- Distribution tests confirm the bundle still packages the yaml and advertises the full tool/hook set.

## Scope / Risk

One-line YAML manifest fix, no runtime code path touched. The memory provider's activation is unchanged (still via `plugins/memory` scan).

Fixes #922