### PR TITLE
docs: stop the routing-test guidance sending contributors to dead strings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,12 +75,20 @@ Rules:
   raw substring checks. Phrase triggers for multi-word intents; token triggers
   only when a single token is unambiguous.
 - Guard patterns: routing and policy changes ship with negative cases
-  (overroute guards) alongside positive cases. Adding a trigger without a
-  negative case is incomplete.
-- Tests are contracts. Many fixtures assert exact counts
-  (`case_count == 51`, `intervention_case_count == 105`, etc.). When you add a
+  alongside positive cases. Adding a trigger without a negative case is
+  incomplete. Both corpora live in `src/quality/routing_precision.py` and each
+  has a name worth searching for: `ROUTING_PRECISION_CASES` is the
+  negative-control corpus and its failure metric is `overroute_count`;
+  `ROUTING_INTERVENTION_CASES` is the positive-intervention corpus and its
+  failure metric is `missed_intervention_count`. Grepping for "underroute"
+  finds nothing — the guard exists under the intervention name.
+- Tests are contracts. Many fixtures assert exact counts. When you add a
   routing case, skill, or demo card, update the exact-count assertions in the
-  same commit — they are the point, not noise.
+  same commit — they are the point, not noise. To find them, grep the current
+  value read off `tests/test_routing_precision.py` (or the drift registry in
+  `src/maintenance/drift.py`), not a number quoted here; per the rule above,
+  counts written into prose drift and then send you looking for a string that
+  no longer exists.
 - English for code, docs, commits, and PR text — and for all user-facing CLI
   output by default. Localized output (ko/ja/zh) is explicit opt-in via
   `--language` or `OMH_LANG` only; never auto-detect the OS locale. Korean-only


### PR DESCRIPTION
## Feature Report

### What Changed

- `CLAUDE.md` Code Conventions: the exact-count bullet no longer quotes count literals, and the guard-patterns bullet now names **both** routing corpora and both failure metrics.
- Documentation only. No code, test, fixture, count, or generated artifact touched.

### Why This Exists

Two lines were actively sending contributors to strings that are not in the repo.

**1. The counts were stale.** The bullet quoted `case_count == 51` and `intervention_case_count == 105`. Live values are **57** and **157** (`tests/test_routing_precision.py:18,27`). That sentence exists specifically to tell you what to grep for when a count changes, so a stale number there is worse than no number — it sends you hunting a string that does not exist and implies the fixtures live somewhere else.

`CLAUDE.md` already states the rule this violates, forty lines earlier, in the broad-exception section:

> do not record hit counts or line numbers in prose, they drift.

So the fix is not to refresh 51/105 → 57/157 and wait for the next drift. It is to apply the file's own rule and point at where the counts are actually read from.

**2. The positive corpus had no searchable name.** The guard-patterns bullet named only "overroute guards". Grepping this repo for `underroute`, `must_route`, or `should_route` returns **nothing** — which reads as "OMH has no positive-routing guards".

It has 157 of them. They are called *intervention cases*, a nonzero `missed_intervention_count` is a hard error, and `src/quality/routing_precision.py:1960` already names the pair explicitly as "over-intervention and missed-intervention guards". The vocabulary was fine; only the contributor-facing doc was missing half of it.

This is not hypothetical. It misled an agent working in this repo this week into reporting "OMH has no underroute guards" as a finding, when the guards were there under the other name.

### User / Operator Impact

A contributor adding a routing case can now find:

- which corpus their case belongs in, by constant name;
- which metric fails if they get it wrong;
- where the live counts are, without trusting a number in prose.

And someone searching for the concept under the wrong word gets told, in the doc, that the word is wrong and what the right one is.

### How It Works

Guard-patterns bullet now carries the mapping:

| Corpus | Constant | Failure metric |
| --- | --- | --- |
| Negative control | `ROUTING_PRECISION_CASES` (`src/quality/routing_precision.py:38`) | `overroute_count` (`:1913`) |
| Positive intervention | `ROUTING_INTERVENTION_CASES` (`:454`) | `missed_intervention_count` (`:1916`) |

plus an explicit negative result for the term people reach for first ("grepping for *underroute* finds nothing — the guard exists under the intervention name").

Exact-count bullet keeps the rule that counts are contracts and must move in the same commit, but directs you to read the current value off `tests/test_routing_precision.py` or the drift registry in `src/maintenance/drift.py` rather than from a literal quoted in CLAUDE.md.

Every name and line reference above was verified by reading `src/quality/routing_precision.py` directly, not carried over from the previous prose.

### Files And Contracts Touched

- `CLAUDE.md` — +13 / −5, two bullets in Code Conventions.

## Validation

- [ ] `uv run --group lint ruff check src tests` — not run; no Python touched
- [x] `python3 -m unittest discover -s tests` — **5815 tests OK** on this branch
- [ ] `python3 -m compileall src` — not run; no Python touched
- [ ] `python3 -m omh.cli docs workflows --check` — not run; `CLAUDE.md` is not a generated artifact and no catalog data changed
- [ ] `python3 -m omh.cli harness validate` — not applicable
- [ ] `python3 -m omh.cli release checklist --json` — not applicable
- [ ] `python3 -m omh.cli release hermes-smoke` — not applicable
- [ ] `omh --help` — not applicable
- [ ] installed-command smoke — not applicable
- [ ] Relevant workflow-learning review queue smoke — not applicable
- [x] Relevant dry-run or smoke command: the four tests that actually read `CLAUDE.md` (`test_project_governance`, `test_broad_exception_policy`, `test_handoff_safety_contract_enforcement`, `test_cli`) pass — 36 tests in the first three, full suite covers the fourth. `git diff --check` clean.
- [ ] Manual Hermes/TUI check — **not run, and would prove nothing**: `CLAUDE.md` is agent-facing repo guidance with no runtime surface.

## Risk

- Effectively none for behavior. The only real risk is the doc going stale again in a different way: if `ROUTING_PRECISION_CASES` or `ROUTING_INTERVENTION_CASES` is ever renamed, this bullet becomes wrong. Nothing enforces that, and I deliberately did not add a test that greps `CLAUDE.md` for live constant names — gating prose against code that is free to change trades one maintenance burden for another. The commit records a `Directive:` trailer instead: name the corpus constant and its failure metric, never the count.

## Compatibility / Rollout

- Documentation only. No migration, no version impact, no channel impact.

## Release / Claims

- [x] Release-channel impact considered — none
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — no runtime claim is made; the only claims are constant names and line numbers read from source in this session
- [x] Known manual Hermes checks are listed — none apply

## Follow-Up

- None required. Related but separate: PR #921 adds the `source_trust/v1` axis; the two share no files.
