### PR TITLE
feat: make the research lane name the source class it is already reasoning about

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1145,6 +1145,40 @@ is permitted to claim. Judging *which* sources deserve trust is the reader's
 call and stays outside OMH, per the ownership boundary in `docs/DIRECTION.md`
 that puts source-backed research on the Hermes side.
 
+#### How this relates to the vocabularies already in the repo
+
+OMH carries three other trichotomies that sound adjacent and are not. They
+answer different questions about different objects, and conflating any two of
+them is the confusion `source_trust` exists to remove. Read them as four
+independent axes over one claim:
+
+| Axis | Object | Question | Where |
+| --- | --- | --- | --- |
+| Observation | A state of work | Did OMH see it happen? | `evidence/labels.py`, `workflows/operator_productivity.py` |
+| Source trust | A claim | What class of source stands behind it? | `workflows/source_trust.py` |
+| Derivation | A figure | Was it measured, assumed, or derived? | `research` / `research-brief` quality bars |
+| Acquisition provenance | A state transition | Which actor moved this source through its lifecycle? | `SOURCE_FINDER_OBSERVATION_PROVENANCE` in `workflows/source_finder.py` |
+
+The subordination that matters:
+
+- **Derivation is orthogonal to source trust, not a weaker form of it.** A
+  measured figure from a practitioner blog and a measured figure from an
+  upstream spec are both `measured`; only the source-trust axis separates them.
+  A research claim carries a value on both axes, never one standing in for the
+  other.
+- **Acquisition provenance is about a document, source trust is about a
+  claim.** `source_finder` records that a `user` supplied a link or a
+  `runtime_observation` saw a download — facts about how a source entered the
+  workflow. It says nothing about what a claim drawn from that source may
+  assert. A `download_observed` PDF still yields `practitioner_heuristic`
+  claims if a practitioner wrote it.
+- **Observation outranks all three on completion only.** No value on any other
+  axis reaches `completion`; that is the floor `TRUST_CLAIM_CEILING` enforces
+  and it is why the three axes can coexist without competing.
+
+Do not add a fifth vocabulary over claims without stating here which of these
+four it subordinates to or replaces.
+
 ### Approval Receipts
 
 `runtime/journal/approval_receipts.jsonl` is an append-only store of

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -714,6 +714,7 @@ These surfaces are generated command references, not installed Hermes workflow s
   - Assert contested claims only after cross-source verification; keep unresolved and refuted claims in an explicit annex - abstention is a correct outcome.
   - Separate quoted evidence from inference.
   - Separate measured, assumed, and derived figures in any estimate.
+  - Name the source class behind each claim - upstream official, practitioner heuristic, or unattributed - as an axis separate from measured/assumed/derived: a practitioner heuristic may inform approach but never enters as an established finding, and no source class settles completion.
   - Parallel lanes widen coverage, not authority: each lane's findings stay claims until merged and verified, and lane count or wave count never substitutes for the declared depth budget.
   - State retrieval limits, dates, and missing-source gaps for unstable facts.
   - product_evidence_loop/v1 is prepared-only opaque references, not observed evidence or execution.
@@ -820,7 +821,7 @@ These surfaces are generated command references, not installed Hermes workflow s
   - Why: The request lacks the required inputs or would overclaim work that Hermes did not observe.
 - Quality bar:
   - State the research question, source boundaries, and recency assumptions before synthesis.
-  - Record each material claim as a compact evidence row: claim, source, source date, confidence, and unresolved conflict.
+  - Record each material claim as a compact evidence row: claim, source, source class (upstream official, practitioner heuristic, or unattributed), source date, confidence, and unresolved conflict.
   - Keep claims that lack corroboration in an explicit unresolved list instead of asserting or silently dropping them.
   - Separate observed sources, source quality, source diversity, inferred trends, and unresolved uncertainty.
   - Use the brief to feed strategy or meeting work without calling it execution evidence.
@@ -3686,6 +3687,7 @@ These surfaces are generated command references, not installed Hermes workflow s
   - Use official or upstream sources first and name the version/environment assumptions.
   - Map applicability to the user's local context before recommending action.
   - Preserve residual uncertainty instead of overstating best practice.
+  - Upstream guidance is the strongest source class and still not completion evidence: that the docs prescribe something is never that it was done, verified, or is passing here.
 - Completion checklist:
   - The research question, source boundaries, recency assumptions, and confidence level are named.
   - Observed sources, inference, synthesis, and unresolved retrieval gaps are separated.

--- a/skills/omh-best-practice-research/SKILL.md
+++ b/skills/omh-best-practice-research/SKILL.md
@@ -72,6 +72,7 @@ Quality bar:
 - Use official or upstream sources first and name the version/environment assumptions.
 - Map applicability to the user's local context before recommending action.
 - Preserve residual uncertainty instead of overstating best practice.
+- Upstream guidance is the strongest source class and still not completion evidence: that the docs prescribe something is never that it was done, verified, or is passing here.
 
 Handoff policy:
 

--- a/skills/omh-research-brief/SKILL.md
+++ b/skills/omh-research-brief/SKILL.md
@@ -71,7 +71,7 @@ Reasoning demand: `standard`
 Quality bar:
 
 - State the research question, source boundaries, and recency assumptions before synthesis.
-- Record each material claim as a compact evidence row: claim, source, source date, confidence, and unresolved conflict.
+- Record each material claim as a compact evidence row: claim, source, source class (upstream official, practitioner heuristic, or unattributed), source date, confidence, and unresolved conflict.
 - Keep claims that lack corroboration in an explicit unresolved list instead of asserting or silently dropping them.
 - Separate observed sources, source quality, source diversity, inferred trends, and unresolved uncertainty.
 - Use the brief to feed strategy or meeting work without calling it execution evidence.

--- a/skills/ulw-research/SKILL.md
+++ b/skills/ulw-research/SKILL.md
@@ -133,6 +133,7 @@ Safety rules:
 - Assert contested claims only after cross-source verification; keep unresolved and refuted claims in an explicit annex - abstention is a correct outcome.
 - Separate quoted evidence from inference.
 - Separate measured, assumed, and derived figures in any estimate.
+- Name the source class behind each claim - upstream official, practitioner heuristic, or unattributed - as an axis separate from measured/assumed/derived: a practitioner heuristic may inform approach but never enters as an established finding, and no source class settles completion.
 - Parallel lanes widen coverage, not authority: each lane's findings stay claims until merged and verified, and lane count or wave count never substitutes for the declared depth budget.
 - State retrieval limits, dates, and missing-source gaps for unstable facts.
 - product_evidence_loop/v1 is prepared-only opaque references, not observed evidence or execution.

--- a/src/skills/catalog_definitions.py
+++ b/src/skills/catalog_definitions.py
@@ -757,6 +757,7 @@ _DEFINITIONS = [
             "Assert contested claims only after cross-source verification; keep unresolved and refuted claims in an explicit annex - abstention is a correct outcome.",
             "Separate quoted evidence from inference.",
             "Separate measured, assumed, and derived figures in any estimate.",
+            "Name the source class behind each claim - upstream official, practitioner heuristic, or unattributed - as an axis separate from measured/assumed/derived: a practitioner heuristic may inform approach but never enters as an established finding, and no source class settles completion.",
             "Parallel lanes widen coverage, not authority: each lane's findings stay claims until merged and verified, and lane count or wave count never substitutes for the declared depth budget.",
             "State retrieval limits, dates, and missing-source gaps for unstable facts.",
             "product_evidence_loop/v1 is prepared-only opaque references, not observed evidence or execution.",
@@ -959,7 +960,7 @@ _DEFINITIONS = [
         quality_tier="source-gated",
         quality_bar=(
             "State the research question, source boundaries, and recency assumptions before synthesis.",
-            "Record each material claim as a compact evidence row: claim, source, source date, confidence, and unresolved conflict.",
+            "Record each material claim as a compact evidence row: claim, source, source class (upstream official, practitioner heuristic, or unattributed), source date, confidence, and unresolved conflict.",
             "Keep claims that lack corroboration in an explicit unresolved list instead of asserting or silently dropping them.",
             "Separate observed sources, source quality, source diversity, inferred trends, and unresolved uncertainty.",
             "Use the brief to feed strategy or meeting work without calling it execution evidence.",
@@ -4430,6 +4431,7 @@ _DEFINITIONS = [
             "Use official or upstream sources first and name the version/environment assumptions.",
             "Map applicability to the user's local context before recommending action.",
             "Preserve residual uncertainty instead of overstating best practice.",
+            "Upstream guidance is the strongest source class and still not completion evidence: that the docs prescribe something is never that it was done, verified, or is passing here.",
         ),
         do_not_use_when=(
             "The work needs multi-source current evidence, a market or literature comparison, or a business brief rather than one technology's upstream guidance; use `research`.",

--- a/tests/test_source_trust.py
+++ b/tests/test_source_trust.py
@@ -276,5 +276,55 @@ class SummaryTests(unittest.TestCase):
         self.assertTrue(any("frozen boundary sentence" in error for error in errors), errors)
 
 
+class CatalogWiringTests(unittest.TestCase):
+    """The research lane's prose must name the same tiers the module enforces.
+
+    Without this the two drift: the catalog tells Hermes one vocabulary while
+    `TRUST_CLAIM_CEILING` enforces another, and the guidance quietly stops
+    describing the guard. Derived from `SOURCE_TRUST_TIERS` rather than
+    hardcoded, so renaming a tier fails here instead of going unnoticed.
+    """
+
+    @staticmethod
+    def _prose(definition: object) -> str:
+        parts: list[str] = []
+        for field in ("safety_rules", "quality_bar", "expected_outputs"):
+            parts.extend(getattr(definition, field, ()) or ())
+        return " ".join(parts).lower()
+
+    def setUp(self) -> None:
+        from omh.skills.catalog import builtin_definitions
+
+        self.definitions = {definition.name: definition for definition in builtin_definitions()}
+
+    def test_research_names_every_source_trust_tier(self) -> None:
+        prose = self._prose(self.definitions["research"])
+        for tier in SOURCE_TRUST_TIERS:
+            with self.subTest(tier=tier):
+                self.assertIn(tier.replace("_", " "), prose)
+
+    def test_research_brief_claim_row_carries_the_source_class(self) -> None:
+        prose = self._prose(self.definitions["research-brief"])
+        self.assertIn("source class", prose)
+        for tier in SOURCE_TRUST_TIERS:
+            with self.subTest(tier=tier):
+                self.assertIn(tier.replace("_", " "), prose)
+
+    def test_best_practice_research_denies_itself_completion(self) -> None:
+        """The strongest tier is the one most likely to be read as done."""
+        prose = self._prose(self.definitions["best-practice-research"])
+        self.assertIn("not completion evidence", prose)
+
+    def test_no_research_lane_prose_promises_a_completion_claim(self) -> None:
+        """The negative case: no lane may describe a source as settling completion."""
+        for name in ("research", "research-brief", "best-practice-research"):
+            with self.subTest(name=name):
+                prose = self._prose(self.definitions[name])
+                for tier in SOURCE_TRUST_TIERS:
+                    readable = tier.replace("_", " ")
+                    self.assertNotIn(f"{readable} confirms completion", prose)
+                    self.assertNotIn(f"{readable} is completion evidence", prose)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
> **Stacked on #921.** Base is `claude/source-trust-contract`, not `main`, because this wires up the module #921 adds. Retarget to `main` once #921 merges. Review only the top commit (`23e17c77`).

## Feature Report

### What Changed

- `research`, `research-brief`, and `best-practice-research` catalog definitions now name the **source class** behind a claim, using the same three tiers `workflows/source_trust.py` enforces.
- `docs/ARCHITECTURE.md` gains a subordination table putting the four claim-related vocabularies in OMH in explicit relation to each other, so a fifth cannot be added silently.
- `tests/test_source_trust.py` gains `CatalogWiringTests` (4 gates) deriving its expectations from `SOURCE_TRUST_TIERS`.
- All four generated artifact families regenerated together.

### Why This Exists

#921 gave OMH a tier vocabulary with a mechanical ceiling. Nothing in the research lane spoke it — which is where claims from outside actually enter the product.

The lane was already reaching for this idea in four places and getting it half-right each time:

| Existing rule | What it needed |
| --- | --- |
| `research`: "Prefer official or primary sources" | a name for the class it is preferring |
| `research`: "keep unresolved and refuted claims in an explicit annex" | a reason a claim lands there other than being contested |
| `research-brief`: "Record each material claim as a compact evidence row: claim, source, source date, confidence" | the class of the source, not just its identity |
| `best-practice-research`: entire skill deals in upstream docs | the fact that upstream docs still are not completion evidence |

Every one of those needs a word for *what class of source this is*. None had one.

The second half is vocabulary hygiene. OMH now has four trichotomies that sound adjacent, and the risk I flagged in #921's Risk section was adding a fourth without subordinating the others. This PR pays that debt in the same change that creates the exposure.

### User / Operator Impact

Hermes, reading the research skill guidance, is now told:

- to name the source class per claim, as an axis **separate** from measured/assumed/derived;
- that a practitioner heuristic may inform approach and never enters as an established finding;
- that no source class settles completion — including upstream official.

The last one is the trap that most needed naming. `best-practice-research` exists to consult authoritative docs, and "the docs prescribe X" reads as done more easily than any other source class does.

### How It Works

Three catalog edits, all data:

1. **`research`** — one safety rule naming the three tiers, the ceiling, and the axis separation.
2. **`research-brief`** — the existing claim row gains `source class` as a field, so the tier travels with the claim instead of being re-decided by each reader.
3. **`best-practice-research`** — one quality bar: upstream guidance is the strongest source class and still not completion evidence.

**The subordination table went in `docs/ARCHITECTURE.md`, not the catalog**, for a concrete reason: it is reasoning rather than an operative rule, and prompt-context budget is a shared, nearly-exhausted resource. Measured before and after:

| Budget | Before | After | Limit |
| --- | --- | --- | --- |
| full capability skill section | 337927 | **338002** | 340000 |
| standalone capability skill section | 98935 | 98935 | 100000 |
| awareness primer markdown | 3192 | 3192 | 3210 |
| awareness primer context | 897 | 897 | **900** |

The whole catalog change costs **75 characters** of a shared pool with under 2000 left. Putting a four-row table plus three paragraphs of reasoning there was not affordable, and would have been the wrong home regardless.

The four axes, as tabulated in the docs:

| Axis | Object | Question |
| --- | --- | --- |
| Observation | a state of work | did OMH see it happen? |
| Source trust | a claim | what class of source stands behind it? |
| Derivation | a figure | measured, assumed, or derived? |
| Acquisition provenance | a state transition | which actor moved this source through its lifecycle? |

with the two confusions named explicitly: derivation is **orthogonal** to source trust rather than a weaker form of it (a measured figure from a practitioner blog and one from an upstream spec are both `measured`; only source trust separates them), and `source_finder`'s provenance describes a **document's** lifecycle rather than a **claim's** backing.

**The wiring test derives from the enum.** `CatalogWiringTests` reads `SOURCE_TRUST_TIERS` and checks the readable form appears in each lane's prose, rather than hardcoding three strings. If a tier is renamed, the gate fails instead of the catalog quietly continuing to describe a vocabulary the module no longer enforces. That exact drift — prose ceasing to describe the guard behind it — is the defect class this change closes, so the fix should not reintroduce it.

Includes a negative gate: no research lane's prose may say a source class confirms or is completion evidence.

### Files And Contracts Touched

- `src/skills/catalog_definitions.py` — +4/−1, three definitions
- `skills/ulw-research/SKILL.md`, `skills/omh-research-brief/SKILL.md`, `skills/omh-best-practice-research/SKILL.md` — regenerated
- `docs/WORKFLOWS.md` — regenerated
- `docs/ARCHITECTURE.md` — +34, subordination subsection
- `tests/test_source_trust.py` — +50, 4 gates

`docs/ROLES.md` and `capability_families.json` were regenerated and came out byte-identical.

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `python3 -m unittest discover -s tests` — **5816 tests OK** (5812 on the base branch + 4 new gates)
- [x] `python3 -m compileall src` — OK
- [x] `python3 -m omh.cli docs workflows --check` — `ok: true`, tap-skills **117/117**, no missing/stale/extra
- [ ] `python3 -m omh.cli harness validate` — not rerun; no harness or skill added, count unchanged at 72/104
- [ ] `python3 -m omh.cli release checklist --json` — not rerun; plan-mode renderer, unaffected
- [ ] `python3 -m omh.cli release hermes-smoke` — not rerun; no installed surface changed
- [ ] `omh --help` — not applicable
- [ ] installed-command smoke — not applicable; no CLI surface added
- [ ] Relevant workflow-learning review queue smoke — not applicable
- [x] Relevant dry-run or smoke command: `docs roles --check` ok, `docs capability-families --check` ok, `release drift` → **No drift, 12 checks passed**, `release skill-content-smoke` → `ok: true` with **zero** budget failures, `git diff --check` clean
- [ ] Manual Hermes/TUI check — **not run**. This changes generated skill guidance, which is exactly the surface a local check cannot prove: `--check` proves the generated files match the catalog, not that Hermes loaded or followed them. Called out rather than papered over.

**Mutation-checked.** The new gates were verified to actually bite: replacing the three tier names in the catalog with near-synonyms (`official, heuristic, or unknown`) fails **5 assertions** across three lanes. The mutation was reverted and the suite re-run green.

## Risk

- **Moderate, and it is the artifact-regeneration surface, not the logic.** Catalog data feeds four generated families and four character budgets. All were regenerated in this commit and all gates re-run. The failure mode if I had missed one is a byte-gate failure in CI, which is loud rather than silent.
- **Budget pressure is the real ongoing risk, and this PR consumes some of it.** 75 characters of ~2000 remaining in the full capability skill section. The next contributor adding catalog prose has less room than I did. Worth a separate look at whether that section needs trimming before it becomes a blocker.
- The wiring gates assert on prose containment, so they are sensitive to rewording that keeps the meaning. That is deliberate — the tier names are a vocabulary, and paraphrasing them is the drift being prevented — but it does mean a future prose edit must keep the exact tier words.

## Compatibility / Rollout

- Catalog prose and docs only. No schema, no persisted format, no CLI, no routing behavior, no migration.
- Users who reinstall pick up the changed skill guidance through the normal `omh update` path; nothing breaks for anyone who does not.

## Release / Claims

- [x] Release-channel impact considered — none; no version file, no packaging change
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — every number in this PR was measured in this session; the Hermes-side gap is stated explicitly above rather than implied
- [x] Known manual Hermes checks are listed — the generated-guidance gap is called out in Validation

## Follow-Up

- **Retarget this PR to `main` after #921 merges.**
- The `source-finder` lane is deliberately untouched. Its provenance enum answers a different question about a different object, and conflating them is precisely what the new docs table forbids.
- Neither #921 nor this PR exposes the axis through a CLI command or chat route. Whether it should be reachable from chat is a real product question, not an oversight, and belongs in its own goal.
