### PR TITLE
feat: give the source-trust ceiling something that actually mints claims

### DIFF
--- a/src/workflows/source_trust.py
+++ b/src/workflows/source_trust.py
@@ -55,6 +55,7 @@ from ..system.append_only_store import (
     opaque_ref,
     reference_errors,
 )
+from .source_finder import SOURCE_CANDIDATE_SCHEMA_VERSION
 
 
 SOURCE_TRUST_CLAIM_SCHEMA_VERSION: Final = "source_trust_claim/v1"
@@ -328,6 +329,63 @@ def validate_source_trust_summary(summary: Any) -> list[str]:
     if summary.get("claim_boundary") != SOURCE_TRUST_CLAIM_BOUNDARY:
         errors.append(f"{_SUMMARY_LABEL} claim_boundary must be the frozen boundary sentence")
     return errors
+
+
+def claim_from_source_candidate(
+    *,
+    candidate: Mapping[str, Any],
+    tier: str,
+    claim_kind: str,
+    claim: str,
+    recorded_at: str,
+) -> dict[str, Any]:
+    """Bind one claim to a `source_candidate/v1` that `source_finder` already minted.
+
+    This is the producer the ceiling was missing. :func:`build_source_trust_claim`
+    can only refuse a claim someone hands it; until something in OMH actually
+    mints one, the ceiling is a guard with nothing to guard. `source_finder`
+    already produces the one thing a claim needs and a caller usually does not
+    have: an opaque identifier for a source.
+
+    **`candidate_id` is the source reference, and `uri` is never read.** The two
+    fields sit side by side in a candidate (``source_finder.build_source_candidate``
+    keeps the raw ``uri`` verbatim), and passing the wrong one is the mistake this
+    function exists to make impossible. ``source_ref`` goes through
+    ``reference_errors``, which refuses anything URL-shaped, so a ``uri`` would be
+    rejected -- but at the far end of a pipeline, where the failure is hardest to
+    read. Reading only ``candidate_id`` moves that from a late refusal to a
+    structural impossibility.
+
+    The tier is stated by the caller and never inferred from the candidate.
+    Deriving trust from a source's kind -- treating a `docs_spec` as official or a
+    `web_link` as a heuristic -- would make OMH the judge of which sources deserve
+    trust, which `docs/DIRECTION.md` puts on the Hermes side. OMH decides only
+    what a stated tier may claim.
+
+    ``unattributed`` is refused here even though it is a valid tier elsewhere: a
+    candidate is a named, identified source, so claiming there is no identifiable
+    source behind it contradicts the record being cited.
+    """
+    if not isinstance(candidate, Mapping):
+        raise SourceTrustError("source trust claim requires a source candidate object")
+    if candidate.get("schema_version") != SOURCE_CANDIDATE_SCHEMA_VERSION:
+        raise SourceTrustError(
+            f"source trust claim requires a {SOURCE_CANDIDATE_SCHEMA_VERSION} candidate"
+        )
+    candidate_id = str(candidate.get("candidate_id", "") or "").strip()
+    if not candidate_id:
+        raise SourceTrustError("source trust claim requires the candidate's candidate_id")
+    if tier == "unattributed":
+        raise SourceTrustError(
+            "source trust tier unattributed cannot cite a source candidate; the candidate is the attribution"
+        )
+    return build_source_trust_claim(
+        tier=tier,
+        claim_kind=claim_kind,
+        claim=claim,
+        recorded_at=recorded_at,
+        source_ref=candidate_id,
+    )
 
 
 def _bounded_claim(claim: str) -> str:

--- a/tests/test_source_trust.py
+++ b/tests/test_source_trust.py
@@ -36,6 +36,7 @@ from omh.workflows.source_trust import (
     TRUST_CLAIM_CEILING,
     SourceTrustError,
     build_source_trust_claim,
+    claim_from_source_candidate,
     claim_kinds_for_tier,
     completion_is_never_source_backed,
     normalize_source_trust_tier,
@@ -274,6 +275,144 @@ class SummaryTests(unittest.TestCase):
         summary["claim_boundary"] = "checked and verified"
         errors = validate_source_trust_summary(summary)
         self.assertTrue(any("frozen boundary sentence" in error for error in errors), errors)
+
+
+class ProducerTests(unittest.TestCase):
+    """Binding a claim to a source candidate — the link that makes the ceiling reachable.
+
+    Before this, `build_source_trust_claim` could only refuse claims someone else
+    minted, and nothing in OMH minted one: `source_ref` refuses URL-shaped values
+    and a URL is the only form a source arrives in. `source_finder` already mints
+    the opaque id that fits, so these tests pin the binding and — most importantly
+    — that the raw `uri` can never travel into a claim.
+    """
+
+    @staticmethod
+    def _candidate(uri: str = "https://example.invalid/spec") -> dict[str, object]:
+        from omh.workflows.source_finder import build_source_candidate
+
+        return build_source_candidate(
+            title="Runtime handoff spec",
+            kind="docs_spec",
+            uri=uri,
+            summary="Upstream spec for handoff owners.",
+        )
+
+    def test_candidate_id_becomes_the_source_reference(self) -> None:
+        candidate = self._candidate()
+        record = claim_from_source_candidate(
+            candidate=candidate,
+            tier="upstream_official",
+            claim_kind="finding",
+            claim="The runtime rejects a handoff without an owner.",
+            recorded_at=STAMP,
+        )
+        self.assertEqual(record["source_ref"], candidate["candidate_id"])
+        self.assertEqual(source_trust_claim_errors(record), [])
+
+    def test_the_raw_uri_never_reaches_the_claim(self) -> None:
+        """The whole point: a candidate carries `uri` and `candidate_id` side by side."""
+        candidate = self._candidate(uri="https://example.invalid/very-distinctive-path")
+        self.assertEqual(candidate["uri"], "https://example.invalid/very-distinctive-path")
+        record = claim_from_source_candidate(
+            candidate=candidate,
+            tier="practitioner_heuristic",
+            claim_kind="approach",
+            claim="Set the owner before preparing the handoff.",
+            recorded_at=STAMP,
+        )
+        serialized = " ".join(str(value) for value in record.values())
+        self.assertNotIn("example.invalid", serialized)
+        self.assertNotIn("very-distinctive-path", serialized)
+        self.assertNotIn("http", serialized)
+
+    def test_the_ceiling_still_applies_through_the_producer(self) -> None:
+        """The adapter must not become a way around the refusal."""
+        with self.assertRaises(SourceTrustError) as raised:
+            claim_from_source_candidate(
+                candidate=self._candidate(),
+                tier="practitioner_heuristic",
+                claim_kind="finding",
+                claim="Warming the cache halves p99.",
+                recorded_at=STAMP,
+            )
+        self.assertIn("may not back a finding claim", str(raised.exception))
+
+    def test_completion_is_still_unreachable_through_the_producer(self) -> None:
+        for tier in SOURCE_TRUST_TIERS:
+            with self.subTest(tier=tier):
+                with self.assertRaises(SourceTrustError):
+                    claim_from_source_candidate(
+                        candidate=self._candidate(),
+                        tier=tier,
+                        claim_kind="completion",
+                        claim="The migration shipped and the suite is green.",
+                        recorded_at=STAMP,
+                    )
+
+    def test_unattributed_cannot_cite_a_candidate(self) -> None:
+        with self.assertRaises(SourceTrustError) as raised:
+            claim_from_source_candidate(
+                candidate=self._candidate(),
+                tier="unattributed",
+                claim_kind="approach",
+                claim="Somebody said the scheduler retries twice.",
+                recorded_at=STAMP,
+            )
+        self.assertIn("the candidate is the attribution", str(raised.exception))
+
+    def test_a_foreign_record_is_refused(self) -> None:
+        for bad in ({"schema_version": "source_candidate/v2", "candidate_id": "source-abc"},
+                    {"schema_version": "source_trust_claim/v1", "candidate_id": "source-abc"},
+                    ["not", "a", "candidate"]):
+            with self.subTest(bad=bad):
+                with self.assertRaises(SourceTrustError):
+                    claim_from_source_candidate(
+                        candidate=bad,  # type: ignore[arg-type]
+                        tier="upstream_official",
+                        claim_kind="finding",
+                        claim="The runtime rejects a handoff without an owner.",
+                        recorded_at=STAMP,
+                    )
+
+    def test_a_candidate_without_an_id_is_refused(self) -> None:
+        candidate = dict(self._candidate())
+        candidate["candidate_id"] = ""
+        with self.assertRaises(SourceTrustError) as raised:
+            claim_from_source_candidate(
+                candidate=candidate,
+                tier="upstream_official",
+                claim_kind="finding",
+                claim="The runtime rejects a handoff without an owner.",
+                recorded_at=STAMP,
+            )
+        self.assertIn("candidate_id", str(raised.exception))
+
+    def test_produced_claims_flow_into_a_summary(self) -> None:
+        """End to end: candidate -> claim -> summary, with the ceiling holding."""
+        candidate = self._candidate()
+        claims = [
+            claim_from_source_candidate(
+                candidate=candidate,
+                tier="upstream_official",
+                claim_kind="finding",
+                claim="The runtime rejects a handoff without an owner.",
+                recorded_at=STAMP,
+            ),
+            claim_from_source_candidate(
+                candidate=candidate,
+                tier="practitioner_heuristic",
+                claim_kind="approach",
+                claim="Set the owner before preparing the handoff.",
+                recorded_at=STAMP,
+            ),
+        ]
+        summary = summarize_source_trust(topic="handoff owner requirement", claims=claims)
+        self.assertEqual(summary["accepted_count"], 2)
+        self.assertEqual(summary["rejected_count"], 0)
+        self.assertEqual(summary["strongest_claim_kind"], "finding")
+        self.assertNotEqual(summary["strongest_claim_kind"], "completion")
+        self.assertEqual(validate_source_trust_summary(summary), [])
 
 
 class CatalogWiringTests(unittest.TestCase):


### PR DESCRIPTION
## Feature Report

### What Changed

- `claim_from_source_candidate()` in `src/workflows/source_trust.py`: binds a `source_candidate/v1` that `source_finder` already mints to a `source_trust_claim/v1`, using `candidate_id` as the source reference and **never** reading `uri`.
- `ProducerTests` in `tests/test_source_trust.py` — 8 gates, including one that asserts no part of a distinctive URL survives into a produced claim.
- Nothing else. No catalog, skill, routing case, CLI surface, generated artifact, or exact-count fixture is touched.

### Why This Exists

`source_trust/v1` shipped in #921 as a **validator with no producer**. `build_source_trust_claim` could refuse a claim someone handed it, but nothing in OMH handed it one, so the ceiling was a guard with nothing to guard.

The blocker was concrete rather than architectural:

- a claim needs a `source_ref`
- `source_ref` goes through `reference_errors`, which refuses anything URL-shaped
- a URL is the only form a source actually arrives in

So the only possible caller was a human hand-writing JSON that OMH would reject for containing the one identifier they actually had.

`source_finder` already mints the missing piece and has all along. `build_source_candidate` computes `candidate_id` as `source-<12 hex>` (`src/workflows/source_finder.py:411-414`) and keeps the raw `uri` in a separate field (`:220`). That id is opaque, non-navigable, and stable — exactly the shape `source_ref` requires. The two modules were built to fit and nothing joined them.

### User / Operator Impact

The ceiling can now actually refuse something in a real pipeline. Given a source candidate — which the research lane already produces — a caller can mint a claim and have the tier ceiling enforced mechanically instead of by prose.

Concretely, these three now fail at the point of the mistake rather than being written down and believed later:

```
heuristic offered as a finding:
    source trust tier practitioner_heuristic may not back a finding claim; it may back: approach
official offered as completion:
    source trust tier upstream_official may not back a completion claim; it may back: approach, finding
unattributed citing a source:
    source trust tier unattributed cannot cite a source candidate; the candidate is the attribution
```

### How It Works

**`candidate_id` in, `uri` never read.** The two fields sit side by side in every candidate, and passing the wrong one is the mistake this function exists to make impossible. `reference_errors` *would* catch a URL — but at the far end of a pipeline, where the failure is hardest to read. Reading only the id turns a late refusal into a structural impossibility. The test asserts the negative directly: build a candidate with a distinctive URL, produce a claim, and assert no fragment of it appears anywhere in the record.

**The tier is stated, never inferred.** Deriving trust from a candidate's `kind` — reading `docs_spec` as official, `web_link` as heuristic — would make OMH the judge of which sources deserve trust, which `docs/DIRECTION.md` assigns to Hermes. OMH decides only what a *stated* tier may claim. This is the boundary, not an omission.

**`unattributed` is refused when citing a candidate.** A candidate is a named, identified source; claiming there is no identifiable source behind it contradicts the record being cited. The tier remains valid elsewhere.

**The adapter is not a bypass.** It delegates to `build_source_trust_claim`, so every ceiling refusal applies through this path too, and no tier reaches `completion`.

### Files And Contracts Touched

- `src/workflows/source_trust.py` — +58; one function, one import of `SOURCE_CANDIDATE_SCHEMA_VERSION`
- `tests/test_source_trust.py` — +139; `ProducerTests`, 8 gates

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `python3 -m unittest discover -s tests` — **5851 tests OK** (5843 on main + 8 new)
- [x] `python3 -m compileall src` — OK (also confirms the new `source_trust → source_finder` import introduces no cycle)
- [x] `python3 -m omh.cli docs workflows --check` — `ok: true`, tap-skills 117/117
- [ ] `python3 -m omh.cli harness validate` — not rerun; no skill or harness changed
- [ ] `python3 -m omh.cli release checklist --json` — not rerun; plan-mode renderer, unaffected
- [ ] `python3 -m omh.cli release hermes-smoke` — not rerun; no installed surface changed
- [ ] `omh --help` — not applicable; no CLI surface added
- [ ] installed-command smoke — not applicable
- [ ] Relevant workflow-learning review queue smoke — not applicable
- [x] Relevant dry-run or smoke command: `docs roles --check` ok, `docs capability-families --check` ok, `release drift` → **No drift, 12 checks passed**, `git diff --check` clean
- [x] **Manual QA — executed, not inspected.** Ran the full chain against the real package: `build_source_candidate` → `claim_from_source_candidate` → `summarize_source_trust` → `validate_source_trust_summary`.

```
candidate_id : source-aeb851a812b2
uri (kept)   : https://hermes.example.invalid/docs/handoff#owners
source_ref   : source-aeb851a812b2   <- candidate_id, not the URL
uri leaked?  : False

strongest_claim_kind : finding   (can never be 'completion')
tiers_present        : ['upstream_official', 'practitioner_heuristic']
accepted / rejected  : 2 / 0
validates clean      : True
```

All three refusal paths were exercised live and produced the messages quoted under *User / Operator Impact*.

- [ ] Manual Hermes/TUI check — **not run, and it would find nothing**: no chat surface invokes this yet. See Follow-Up; that gap is the point of the next goal, not an oversight here.

**Mutation-checked.** Changing the adapter to read `uri` instead of `candidate_id` fails **1 assertion and errors 3 more**. The URL-leak test is not passing for the wrong reason. Mutation was applied after commit, then reverted, and the suite re-run green.

## Risk

- **Low.** One additive function; the only existing-behavior change is a new import edge `source_trust → source_finder`, verified acyclic by `compileall` and the full suite.
- The `unattributed`-refusal is a judgement call. If a caller ever legitimately needs to record "a claim I found in this candidate but whose actual author is unknown", they will hit this refusal. I think that case should mint an `unattributed` claim with **no** `source_ref` rather than cite the candidate, which the existing builder already supports — but it is worth knowing the refusal exists.
- Nothing consumes the adapter yet, so its ergonomics are unproven against a real caller.

## Compatibility / Rollout

- Purely additive. No schema change, no persisted format, no migration, no CLI, no routing behavior.
- Zero network, unchanged: both modules are pure and the adapter adds no I/O.

## Release / Claims

- [x] Release-channel impact considered — none; no version file, no packaging change
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — the QA block above is observed local execution; no Hermes runtime or chat claim is made
- [x] Known manual Hermes checks are listed — the chat gap is stated explicitly rather than implied

## Follow-Up

**What I found while looking for the chat-reachability path, since it changes the shape of the next goal:**

1. **Wrapper actions are declarative buttons, not execution.** `record_source_candidate` exists only in `VISIBLE_ACTIONS` (`src/wrapper/contract.py:164`) and as a button label (`:5008`). The contract never imports or calls `build_source_candidate`. Adding source-trust actions to the research card would surface a button and run nothing.
2. **The path where Hermes actually executes OMH Python is a plugin tool.** `PROVIDED_TOOLS` (`src/plugin_bundle/omh/metadata.py:3-14`) holds ten. They reach core by lazy import inside a function with a `standalone_plugin_bundle_fallback` path — see `src/plugin_bundle/omh/tools/recommend_tool.py:110-121` for the canonical shape. (Note for anyone who read otherwise: the bundle *can* import `omh.*`; `chat_tool.py:136-139` does it too. No duplication is required.)
3. **There is no cheap slot in an existing tool.** `omh_gather_evidence` is an allowlisted shell-command runner (`evidence_tool.py`, subprocess/workdir/timeout). Source-trust claim classification does not belong there.

So making the ceiling reachable from chat means **an eleventh plugin tool**, with the full tool-registration checklist (`PROVIDED_TOOLS`, `TOOL_FILE_STEMS`, `plugin.yaml`, the tool module, and the distribution/parity gates at `tests/test_plugin_distribution.py:81-92` and `tests/test_plugin_capabilities.py:601-602`).

That is a product-surface decision — whether OMH should expose an eleventh tool for this — not an implementation detail, so it is deliberately not bundled here and is left to the owner.

Also unrelated and pre-existing, found while verifying: `tests/test_efficiency.py` fails when run alone (`test_quality_leakage_checks_avoid_full_payload_json_serialization`) and passes under `unittest discover`. Confirmed present at `b7ca5258`, before any of this work. A test that only passes alongside others is not testing what it claims; worth its own fix.
