### PR TITLE
fix(coding): propagate parallel guidance through messenger handoffs

### DIFF
--- a/src/coding/coding_delegation.py
+++ b/src/coding/coding_delegation.py
@@ -323,6 +323,7 @@ def build_coding_delegation_payload(
     limit: int = 3,
     include_message: bool = False,
     source_metadata: dict[str, str] | None = None,
+    main_agent_model: str = "",
     executor_target: str = "generic",
     context_pack: dict[str, object] | None = None,
     input_manifest: dict[str, object] | None = None,
@@ -331,6 +332,7 @@ def build_coding_delegation_payload(
     preferred_workflow: str | None = None,
     preferred_workflow_score: int | None = None,
     prefer_direct_coding_handoff: bool = True,
+    preserve_preferred_workflow: bool = False,
     force_coding_handoff: bool = False,
     capability_snapshot_directory: Path | None = None,
     project_root: str | Path | None = None,
@@ -352,6 +354,9 @@ def build_coding_delegation_payload(
         raise ValueError(f"unsupported coding delegate executor: {executor_target}")
     if limit < 1:
         raise ValueError("coding delegate --limit must be at least 1")
+    resolved_main_agent_model = str(
+        main_agent_model or (source_metadata or {}).get("main_agent_model", "")
+    ).strip()
     governance = discover_project_governance(project_root, decision=governance_default) if project_root else None
     family_template = product_family_template(product_family) if product_family else None
     quality_harness = product_quality_harness(product_family) if product_family else None
@@ -369,6 +374,7 @@ def build_coding_delegation_payload(
     intent = _intent_for(message, workflow, score)
     if (
         prefer_direct_coding_handoff
+        and not preserve_preferred_workflow
         and score >= 4
         and workflow in _RETAINED_HERMES_WORKFLOWS
         and intent == "coding"
@@ -557,6 +563,7 @@ def build_coding_delegation_payload(
             isolation_plan=isolation_plan,
             has_plan_artifact=bool(plan_artifact),
             plan_artifact_status=str(plan_artifact.get("status", "")) if plan_artifact else "",
+            main_agent_model=resolved_main_agent_model,
         )
         payload["executor_handoff"] = _executor_handoff(
             executor_target,
@@ -577,6 +584,7 @@ def build_coding_delegation_payload(
             isolation_plan=isolation_plan,
             has_plan_artifact=bool(plan_artifact),
             plan_artifact_status=str(plan_artifact.get("status", "")) if plan_artifact else "",
+            main_agent_model=resolved_main_agent_model,
         )
         payload["runtime_handoff"] = _runtime_handoff(
             selection.selected_executor_profile,
@@ -597,6 +605,7 @@ def build_coding_delegation_payload(
             isolation_plan=isolation_plan,
             has_plan_artifact=bool(plan_artifact),
             plan_artifact_status=str(plan_artifact.get("status", "")) if plan_artifact else "",
+            main_agent_model=resolved_main_agent_model,
         )
         payload["prompt_handoff"] = _prompt_handoff(
             selection.selected_executor_profile,
@@ -1865,6 +1874,7 @@ def _executor_prompting_contract(
     isolation_plan: dict[str, object],
     has_plan_artifact: bool,
     plan_artifact_status: str,
+    main_agent_model: str,
 ) -> dict[str, object]:
     return build_executor_prompting_contract(
         profile,
@@ -1873,6 +1883,8 @@ def _executor_prompting_contract(
         has_plan_artifact=has_plan_artifact,
         plan_artifact_status=plan_artifact_status,
         isolation_plan=isolation_plan,
+        recommended_workflow=delegation.recommended_workflow,
+        main_agent_model=main_agent_model,
     )
 
 

--- a/src/coding/prompting.py
+++ b/src/coding/prompting.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterable, Mapping
+from typing import Iterable, Mapping, cast
 
 from ..coding_contracts import (
     EXECUTOR_PROMPTING_CONTRACT_SCHEMA_VERSION,
@@ -8,6 +8,7 @@ from ..coding_contracts import (
     EXECUTOR_PROMPTING_STRATEGIES,
     EXECUTOR_STEERING_DELTA_CONTRACT_SCHEMA_VERSION,
 )
+from .throughput_prompting import build_throughput_overlay
 
 
 _RISK_AWARE_CUES = (
@@ -37,6 +38,8 @@ def build_executor_prompting_contract(
     has_plan_artifact: bool,
     plan_artifact_status: str = "",
     isolation_plan: Mapping[str, object] | None = None,
+    recommended_workflow: str = "",
+    main_agent_model: str = "",
 ) -> dict[str, object]:
     """Describe a deterministic executor prompt without storing the task itself."""
     strategy = select_executor_prompting_strategy(
@@ -45,7 +48,7 @@ def build_executor_prompting_contract(
         has_plan_artifact=has_plan_artifact,
         isolation_plan=isolation_plan,
     )
-    return {
+    contract: dict[str, object] = {
         "schema_version": EXECUTOR_PROMPTING_CONTRACT_SCHEMA_VERSION,
         "profile": profile,
         "status": "prepared_not_observed",
@@ -77,6 +80,14 @@ def build_executor_prompting_contract(
             "This is prepared executor-prompt guidance only; it is not dispatch, execution, verification, review, CI, or merge evidence."
         ),
     }
+    throughput_overlay = build_throughput_overlay(
+        profile,
+        main_agent_model=main_agent_model,
+        recommended_workflow=recommended_workflow,
+    )
+    if throughput_overlay:
+        contract["throughput_overlay"] = throughput_overlay
+    return contract
 
 
 def select_executor_prompting_strategy(
@@ -117,6 +128,13 @@ def render_executor_prompt_sections(
         _strategy_instruction(strategy),
         "Implement only the requested scope after repository facts confirm it.",
     ]
+    throughput_overlay = contract.get("throughput_overlay")
+    if isinstance(throughput_overlay, Mapping) and throughput_overlay.get("status") == "enabled":
+        overlay = cast(Mapping[str, object], throughput_overlay)
+        rules = overlay.get("rules")
+        if isinstance(rules, list):
+            typed_rules = cast(list[object], rules)
+            do_items.extend(rule for rule in typed_rules if isinstance(rule, str) and rule.strip())
     if review_required:
         do_items.append("Treat review findings as a separate gate and report unresolved risks explicitly.")
     known_context = [

--- a/src/coding/throughput_prompting.py
+++ b/src/coding/throughput_prompting.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from .model_routing import model_family
+
+
+_ULW_THROUGHPUT_WORKFLOWS = frozenset({"ultragoal", "ultraprocess", "ultrawork"})
+_BASE_THROUGHPUT_RULES = (
+    "Parallel independent tool calls, repository reads, searches, and reasoning lanes in one batch whenever their inputs do not depend on each other.",
+    "Keep dependency-bound work sequential; collect the upstream result before starting work that consumes it.",
+)
+_ADVANCED_THROUGHPUT_RULES = (
+    "While delegated lanes run, continue only non-overlapping work and merge their evidence after completion is observed.",
+    "For delegated work, declare one goal, an observable stop condition, and required evidence; judge completion from that evidence.",
+    "Stop as soon as decisive evidence satisfies the stated criteria; do not reopen settled work without contradictory output.",
+)
+_EVAL_BATCHING_RULE = (
+    "When an eval or code-execution surface can batch independent operations, use one eval cell and run them concurrently "
+    "inside it instead of emitting separate eval calls."
+)
+
+
+def build_throughput_overlay(
+    profile: str,
+    *,
+    main_agent_model: str,
+    recommended_workflow: str,
+) -> dict[str, object]:
+    family = model_family(main_agent_model) or "unknown"
+    mode = "parallel_handoff"
+    rules: list[str] = list(_BASE_THROUGHPUT_RULES)
+    eval_strategy = ""
+    if profile == "codex" and _is_gpt_sol_model(main_agent_model):
+        mode = "gpt_sol_codex_handoff"
+        rules.extend(_ADVANCED_THROUGHPUT_RULES)
+        rules.append(_EVAL_BATCHING_RULE)
+        eval_strategy = "single_cell_internal_parallel"
+    elif (
+        profile == "hermes"
+        and family == "gpt"
+        and recommended_workflow in _ULW_THROUGHPUT_WORKFLOWS
+    ):
+        mode = "gpt_hermes_ulw"
+        rules.extend(_ADVANCED_THROUGHPUT_RULES)
+    overlay: dict[str, object] = {
+        "schema_version": "executor_throughput_overlay/v1",
+        "status": "enabled",
+        "mode": mode,
+        "model_family": family,
+        "rules": rules,
+        "claim_boundary": "This overlay is prepared execution guidance only; it is not proof of parallel work, dispatch, verification, or completion.",
+    }
+    if eval_strategy:
+        overlay["eval_strategy"] = eval_strategy
+    return overlay
+
+
+def _is_gpt_sol_model(model_id: str) -> bool:
+    normalized = str(model_id or "").strip().casefold().rsplit("/", 1)[-1]
+    if not normalized:
+        return False
+    normalized = normalized.split(":", 1)[0].split(None, 1)[0]
+    return model_family(normalized) == "gpt" and normalized.endswith("-sol")
+
+
+__all__ = ["build_throughput_overlay"]

--- a/src/plugin_bundle/omh/hooks/llm_hooks.py
+++ b/src/plugin_bundle/omh/hooks/llm_hooks.py
@@ -17,6 +17,7 @@ from ..degradation import (
     safe_error_type,
 )
 from ..awareness_delivery import record_awareness_delivery
+from ..host_context import record_active_main_agent_model
 from ..host_observation import observe_plugin_hook_call
 from ..omh_roles import extract_role_marker, role_context_payload
 from ..runtime_reader import read_omh_hud, read_omh_status
@@ -56,6 +57,7 @@ def _record_delivery(*, delivered: bool, route_hint: bool, context_chars: int, o
 
 def pre_llm_call(**kwargs) -> dict[str, object] | None:
     """Inject bounded OMH role/status context without storing prompts."""
+    record_active_main_agent_model(kwargs.get("model"))
     observe_plugin_hook_call("pre_llm_call", kwargs)
     context_parts: list[str] = []
     payload: dict[str, object] = {}

--- a/src/plugin_bundle/omh/host_context.py
+++ b/src/plugin_bundle/omh/host_context.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from contextvars import ContextVar
+
+
+_ACTIVE_MAIN_AGENT_MODEL: ContextVar[str] = ContextVar(
+    "omh_active_main_agent_model",
+    default="",
+)
+
+
+def record_active_main_agent_model(model: object) -> None:
+    normalized = " ".join(str(model or "").split())
+    _ = _ACTIVE_MAIN_AGENT_MODEL.set(normalized[:180])
+
+
+def active_main_agent_model() -> str:
+    return _ACTIVE_MAIN_AGENT_MODEL.get()
+
+
+__all__ = ["active_main_agent_model", "record_active_main_agent_model"]

--- a/src/plugin_bundle/omh/tools/chat_tool.py
+++ b/src/plugin_bundle/omh/tools/chat_tool.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from ..awareness import awareness_route_hint
 from ..degradation import safe_error_type as _safe_error_type
+from ..host_context import active_main_agent_model
 from ..host_observation import OBSERVATION_SCHEMA, attach_public_observation, observe_plugin_tool_call
 
 OMH_INTERACT_SCHEMA = {
@@ -148,6 +149,7 @@ def _package_interaction(
     min_confidence = _min_confidence(args)
     executor_target = str(args.get("executor_target") or "choose")
     source_metadata = _source_metadata(args)
+    main_agent_model = active_main_agent_model()
     host_values = host_kwargs or {}
     if bool(args.get("record_session", True)):
         result = create_or_resume_wrapper_session(
@@ -159,6 +161,7 @@ def _package_interaction(
             min_confidence=min_confidence,
             source_metadata=source_metadata,
             executor_target=executor_target,
+            main_agent_model=main_agent_model,
             record_provenance={
                 "producer": "plugin_tool",
                 "producer_detail": "omh_interact plugin tool",
@@ -191,6 +194,7 @@ def _package_interaction(
         include_message=False,
         executor_target=executor_target,
         source_metadata=source_metadata,
+        main_agent_model=main_agent_model,
         paths=paths,
         _host_project_binding_factory=lambda: bind_plugin_project(host_values),
     )

--- a/src/runtime/records.py
+++ b/src/runtime/records.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from copy import deepcopy
 from dataclasses import dataclass
 import hashlib
-from typing import Any, Literal, assert_never
+from typing import Any, Literal, assert_never, cast
 
 from ..coding_contracts import (
     CLAUDE_CODE_SESSION_OBSERVATION_CONTRACT_SCHEMA_VERSION,
@@ -457,6 +457,16 @@ CODING_EXECUTOR_PROMPTING_CONTRACT_KEYS = (
     "steering_delta_template",
     "claim_boundary",
 )
+CODING_EXECUTOR_PROMPTING_CONTRACT_OPTIONAL_KEYS = ("throughput_overlay",)
+CODING_EXECUTOR_THROUGHPUT_OVERLAY_KEYS = (
+    "schema_version",
+    "status",
+    "mode",
+    "model_family",
+    "rules",
+    "claim_boundary",
+)
+CODING_EXECUTOR_THROUGHPUT_OVERLAY_OPTIONAL_KEYS = ("eval_strategy",)
 CODING_EXECUTOR_STEERING_DELTA_CONTRACT_KEYS = (
     "schema_version",
     "status",
@@ -1609,7 +1619,7 @@ def _compact_task_prompt_contract(value: Any) -> dict[str, Any]:
 def _compact_executor_prompting_contract(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict) or not value:
         return {}
-    return {
+    compacted = {
         "schema_version": str(value.get("schema_version", "")),
         "profile": str(value.get("profile", "")),
         "status": str(value.get("status", "")),
@@ -1627,6 +1637,20 @@ def _compact_executor_prompting_contract(value: Any) -> dict[str, Any]:
         "steering_delta_template": str(value.get("steering_delta_template", "")),
         "claim_boundary": str(value.get("claim_boundary", "")),
     }
+    throughput_overlay = value.get("throughput_overlay")
+    if isinstance(throughput_overlay, dict):
+        overlay = cast(dict[str, Any], throughput_overlay)
+        compacted["throughput_overlay"] = {
+            "schema_version": str(overlay.get("schema_version", "")),
+            "status": str(overlay.get("status", "")),
+            "mode": str(overlay.get("mode", "")),
+            "model_family": str(overlay.get("model_family", "")),
+            "rules": _compact_string_list(overlay.get("rules", [])),
+            "claim_boundary": str(overlay.get("claim_boundary", "")),
+        }
+        if "eval_strategy" in overlay:
+            compacted["throughput_overlay"]["eval_strategy"] = str(overlay.get("eval_strategy", ""))
+    return compacted
 
 
 def _compact_executor_steering_delta_contract(value: Any) -> dict[str, Any]:
@@ -2733,7 +2757,11 @@ def validate_executor_prompting_contract(contract: Any, label: str, *, expected_
     _require(isinstance(contract, dict), errors, f"{label} must be an object")
     if not isinstance(contract, dict):
         return errors
-    extra_keys = sorted(set(contract) - set(CODING_EXECUTOR_PROMPTING_CONTRACT_KEYS))
+    extra_keys = sorted(
+        set(contract)
+        - set(CODING_EXECUTOR_PROMPTING_CONTRACT_KEYS)
+        - set(CODING_EXECUTOR_PROMPTING_CONTRACT_OPTIONAL_KEYS)
+    )
     missing_keys = sorted(set(CODING_EXECUTOR_PROMPTING_CONTRACT_KEYS) - set(contract))
     _require(not extra_keys, errors, f"{label} has unsupported keys: {extra_keys}")
     _require(not missing_keys, errors, f"{label} is missing keys: {missing_keys}")
@@ -2803,6 +2831,76 @@ def validate_executor_prompting_contract(contract: Any, label: str, *, expected_
             _require(isinstance(steering.get(key), str) and bool(str(steering.get(key))), errors, f"{label} steering_delta_contract {key} must be a non-empty string")
     boundary = str(contract.get("claim_boundary", "")).lower()
     _require("not dispatch" in boundary and "evidence" in boundary, errors, f"{label} claim_boundary must preserve prepared-only evidence boundary")
+    if "throughput_overlay" in contract:
+        errors.extend(
+            _validate_executor_throughput_overlay(
+                contract["throughput_overlay"],
+                f"{label} throughput_overlay",
+                expected_profile=expected_profile,
+            )
+        )
+    return errors
+
+
+def _validate_executor_throughput_overlay(
+    overlay: Any,
+    label: str,
+    *,
+    expected_profile: str,
+) -> list[str]:
+    errors: list[str] = []
+    _require(isinstance(overlay, dict), errors, f"{label} must be an object")
+    if not isinstance(overlay, dict):
+        return errors
+    overlay_contract = cast(dict[str, Any], overlay)
+    extra_keys = sorted(
+        set(overlay_contract)
+        - set(CODING_EXECUTOR_THROUGHPUT_OVERLAY_KEYS)
+        - set(CODING_EXECUTOR_THROUGHPUT_OVERLAY_OPTIONAL_KEYS)
+    )
+    missing_keys = sorted(set(CODING_EXECUTOR_THROUGHPUT_OVERLAY_KEYS) - set(overlay_contract))
+    _require(not extra_keys, errors, f"{label} has unsupported keys: {extra_keys}")
+    _require(not missing_keys, errors, f"{label} is missing keys: {missing_keys}")
+    _require(
+        overlay_contract.get("schema_version") == "executor_throughput_overlay/v1",
+        errors,
+        f"{label} schema_version is invalid",
+    )
+    _require(overlay_contract.get("status") == "enabled", errors, f"{label} status must be enabled")
+    mode = str(overlay_contract.get("mode", ""))
+    specialized_mode = {
+        "gpt_sol_codex_handoff": "codex",
+        "gpt_hermes_ulw": "hermes",
+    }.get(mode)
+    _require(
+        mode == "parallel_handoff" or specialized_mode == expected_profile,
+        errors,
+        f"{label} mode does not match selected executor",
+    )
+    family = str(overlay_contract.get("model_family", ""))
+    _require(bool(family), errors, f"{label} model_family must be non-empty")
+    if specialized_mode:
+        _require(family == "gpt", errors, f"{label} specialized mode requires gpt model_family")
+    eval_strategy = overlay_contract.get("eval_strategy")
+    if mode == "gpt_sol_codex_handoff":
+        _require(
+            eval_strategy == "single_cell_internal_parallel",
+            errors,
+            f"{label} GPT-Sol Codex mode requires single-cell eval strategy",
+        )
+    else:
+        _require(eval_strategy is None, errors, f"{label} eval_strategy is only valid for GPT-Sol Codex mode")
+    rules = overlay_contract.get("rules")
+    _require(isinstance(rules, list) and bool(rules), errors, f"{label} rules must be a non-empty list")
+    if isinstance(rules, list):
+        for index, rule in enumerate(rules):
+            _require(isinstance(rule, str) and bool(rule.strip()), errors, f"{label} rules[{index}] must be a non-empty string")
+    boundary = str(overlay_contract.get("claim_boundary", "")).casefold()
+    _require(
+        "not proof" in boundary and "completion" in boundary,
+        errors,
+        f"{label} claim_boundary must preserve prepared-only completion evidence",
+    )
     return errors
 
 

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -3272,6 +3272,7 @@ def build_chat_interaction_payload(
     include_message: bool = False,
     executor_target: str = "choose",
     source_metadata: dict[str, str] | None = None,
+    main_agent_model: str = "",
     target_notice: dict[str, object] | None = None,
     paths: OmhPaths | None = None,
     skill_policy: dict[str, object] | None = None,
@@ -3289,6 +3290,7 @@ def build_chat_interaction_payload(
         event_or_message,
         include_message=include_message,
         source_metadata=source_metadata,
+        main_agent_model=main_agent_model,
         target_notice=target_notice,
         paths=paths,
         skill_policy=skill_policy,
@@ -3314,6 +3316,7 @@ def build_chat_interaction_payload(
         include_message=include_message,
         executor_target=executor_target,
         source_metadata=source_metadata,
+        main_agent_model=main_agent_model,
         target_notice=target_notice,
         paths=paths,
         skill_policy=skill_policy,
@@ -3334,6 +3337,7 @@ def _can_use_chat_interaction_cache(
     *,
     include_message: bool,
     source_metadata: dict[str, str] | None,
+    main_agent_model: str,
     target_notice: dict[str, object] | None,
     paths: OmhPaths | None,
     skill_policy: dict[str, object] | None,
@@ -3343,6 +3347,7 @@ def _can_use_chat_interaction_cache(
         isinstance(event_or_message, str)
         and not include_message
         and source_metadata is None
+        and not main_agent_model
         and target_notice is None
         and paths is None
         and skill_policy is None
@@ -3808,6 +3813,7 @@ def _build_chat_interaction_payload_cached(
         include_message=False,
         executor_target=executor_target,
         source_metadata=None,
+        main_agent_model="",
         target_notice=None,
         paths=None,
         skill_policy=None,
@@ -3825,6 +3831,7 @@ def _build_chat_interaction_payload_uncached(
     include_message: bool,
     executor_target: str,
     source_metadata: dict[str, str] | None,
+    main_agent_model: str,
     target_notice: dict[str, object] | None,
     paths: OmhPaths | None,
     skill_policy: dict[str, object] | None,
@@ -3940,6 +3947,7 @@ def _build_chat_interaction_payload_uncached(
             include_message=include_message,
             source_metadata=metadata,
             executor_target=resolved_executor_target,
+            main_agent_model=main_agent_model,
             memory_recall_pack=memory_recall_pack_for_handoff(
                 paths,
                 message,
@@ -4007,6 +4015,7 @@ def _build_chat_interaction_payload_uncached(
                     limit=limit,
                     include_message=include_message,
                     source_metadata=metadata,
+                    main_agent_model=main_agent_model,
                     resolved_executor_target=resolved_executor_target,
                     executor_resolution=executor_resolution,
                     route_payload=route_payload,
@@ -4106,6 +4115,7 @@ def _attach_coding_owner_handoff(
     limit: int,
     include_message: bool,
     source_metadata: dict[str, str],
+    main_agent_model: str,
     resolved_executor_target: str,
     executor_resolution: dict[str, object],
     route_payload: dict[str, object],
@@ -4118,9 +4128,11 @@ def _attach_coding_owner_handoff(
         include_message=include_message,
         source_metadata=source_metadata,
         executor_target=resolved_executor_target,
+        main_agent_model=main_agent_model,
         force_coding_handoff=True,
         preferred_workflow=str(route_payload.get("selected_skill", "")),
         preferred_workflow_score=_intish(route_payload.get("score", 0)),
+        preserve_preferred_workflow=resolved_executor_target == "hermes",
         memory_recall_pack=memory_recall_pack_for_handoff(
             paths,
             message,

--- a/src/wrapper/sessions.py
+++ b/src/wrapper/sessions.py
@@ -118,6 +118,7 @@ def create_or_resume_wrapper_session(
     min_confidence: str = "high",
     source_metadata: dict[str, str] | None = None,
     executor_target: str = "choose",
+    main_agent_model: str = "",
     target_notice: dict[str, object] | None = None,
     record_provenance: dict[str, object] | None = None,
     _host_project_binding_factory: HostProjectBindingFactory | None = None,
@@ -137,6 +138,7 @@ def create_or_resume_wrapper_session(
         include_message=False,
         source_metadata=source_metadata,
         executor_target=executor_target,
+        main_agent_model=main_agent_model,
         target_notice=target_notice,
         paths=paths,
         _host_project_binding_factory=build_session_project_binding_factory(

--- a/tests/test_candidate_handoff.py
+++ b/tests/test_candidate_handoff.py
@@ -8,7 +8,9 @@ picker or a bare fallback.
 
 from __future__ import annotations
 
+import json
 import unittest
+from typing import Any
 
 from omh.routing.candidate_handoff import (
     CANDIDATE_HANDOFF_SCHEMA_VERSION,
@@ -215,6 +217,108 @@ class WrapperPathParityTests(unittest.TestCase):
         tool_lane = [c["skill"] for c in (tool_route.get("candidate_handoff") or {}).get("candidates", [])]
         self.assertEqual(tool_lane, direct_lane)
         self.assertIn("input_language", tool_route)
+
+    def _plugin_ulw_interaction(
+        self,
+        root,
+        *,
+        model: str,
+        workflow: str = "ultrawork",
+    ) -> dict[str, Any]:
+        from omh.plugin_bundle.omh.hooks.llm_hooks import pre_llm_call
+        from omh.plugin_bundle.omh.tools.chat_tool import omh_interact_handler
+
+        message = f"${workflow} implement src/example.py end to end"
+        pre_llm_call(
+            user_message=message,
+            is_first_turn=False,
+            model=model,
+            source="discord",
+            omh_home=str(root / ".omh"),
+            hermes_home=str(root / ".hermes"),
+        )
+        return json.loads(
+            omh_interact_handler(
+                {
+                    "message": message,
+                    "source": "discord",
+                    "mode": "route",
+                    "executor_target": "hermes",
+                    "record_session": False,
+                    "omh_home": str(root / ".omh"),
+                    "hermes_home": str(root / ".hermes"),
+                }
+            )
+        )
+
+    def test_plugin_ultrawork_uses_active_gpt_model_overlay(self) -> None:
+        import os
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        from unittest.mock import patch
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            with patch.dict(os.environ, {"OMH_HOME": str(root / ".omh"), "HERMES_HOME": str(root / ".hermes")}):
+                interaction = self._plugin_ulw_interaction(root, model="gpt-5.6-sol")
+
+        self.assertEqual(interaction["route"]["selected_skill"], "ultrawork")
+        overlay = interaction["delegation"]["runtime_handoff"]["executor_prompting_contract"]["throughput_overlay"]
+        self.assertEqual(overlay["mode"], "gpt_hermes_ulw")
+        self.assertNotIn("gpt-5.6-sol", json.dumps(interaction, sort_keys=True))
+
+    def test_plugin_ultraprocess_uses_active_gpt_model_overlay(self) -> None:
+        import os
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        from unittest.mock import patch
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            with patch.dict(os.environ, {"OMH_HOME": str(root / ".omh"), "HERMES_HOME": str(root / ".hermes")}):
+                interaction = self._plugin_ulw_interaction(
+                    root,
+                    model="gpt-5.6-sol",
+                    workflow="ultraprocess",
+                )
+
+        self.assertEqual(interaction["route"]["selected_skill"], "ultraprocess")
+        overlay = interaction["delegation"]["runtime_handoff"]["executor_prompting_contract"]["throughput_overlay"]
+        self.assertEqual(overlay["mode"], "gpt_hermes_ulw")
+
+    def test_plugin_model_context_resets_between_messenger_turns(self) -> None:
+        import os
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        from unittest.mock import patch
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            with patch.dict(os.environ, {"OMH_HOME": str(root / ".omh"), "HERMES_HOME": str(root / ".hermes")}):
+                gpt_interaction = self._plugin_ulw_interaction(root, model="gpt-5.6-sol")
+                claude_interaction = self._plugin_ulw_interaction(root, model="claude-sonnet-4-5")
+                empty_interaction = self._plugin_ulw_interaction(root, model="")
+
+        gpt_overlay = gpt_interaction["delegation"]["runtime_handoff"]["executor_prompting_contract"][
+            "throughput_overlay"
+        ]
+        claude_overlay = claude_interaction["delegation"]["runtime_handoff"]["executor_prompting_contract"][
+            "throughput_overlay"
+        ]
+        empty_overlay = empty_interaction["delegation"]["runtime_handoff"]["executor_prompting_contract"][
+            "throughput_overlay"
+        ]
+        self.assertEqual(gpt_overlay["mode"], "gpt_hermes_ulw")
+        self.assertEqual(claude_overlay["mode"], "parallel_handoff")
+        self.assertEqual(empty_overlay["mode"], "parallel_handoff")
+        self.assertNotIn("eval_strategy", claude_overlay)
+        self.assertNotIn("eval_strategy", empty_overlay)
+        serialized = json.dumps(
+            [gpt_interaction, claude_interaction, empty_interaction],
+            sort_keys=True,
+        )
+        self.assertNotIn("gpt-5.6-sol", serialized)
+        self.assertNotIn("claude-sonnet-4-5", serialized)
 
 
 if __name__ == "__main__":

--- a/tests/test_executor_prompting.py
+++ b/tests/test_executor_prompting.py
@@ -173,6 +173,120 @@ class ExecutorPromptingTests(unittest.TestCase):
                 self.assertIn(payload["delegation"]["acceptance_criteria"][0], handoff["prompt_template"])
                 self.assertIn(payload["delegation"]["verification"][0], handoff["prompt_template"])
 
+    def test_gpt_sol_codex_handoff_adds_parallel_execution_overlay(self) -> None:
+        payload = build_coding_delegation_payload(
+            "Implement src/example.py",
+            executor_target="codex",
+            main_agent_model="gpt-5.6-sol",
+        )
+        handoff = payload["executor_handoff"]
+
+        self.assertEqual(
+            handoff["executor_prompting_contract"]["throughput_overlay"]["mode"],
+            "gpt_sol_codex_handoff",
+        )
+        for rule in handoff["executor_prompting_contract"]["throughput_overlay"]["rules"]:
+            self.assertIn(rule, handoff["prompt_template"])
+        self.assertEqual(validate_coding_executor_handoff(handoff), [])
+
+    def test_gpt_sol_codex_handoff_adds_eval_batching_guidance(self) -> None:
+        payload = build_coding_delegation_payload(
+            "Implement src/example.py",
+            executor_target="codex",
+            main_agent_model="gpt-5.6-sol",
+        )
+        overlay = payload["executor_handoff"]["executor_prompting_contract"]["throughput_overlay"]
+
+        self.assertEqual(overlay["mode"], "gpt_sol_codex_handoff")
+        self.assertEqual(overlay["eval_strategy"], "single_cell_internal_parallel")
+
+    def test_gpt_sol_hermes_ulw_handoff_adds_parallel_execution_overlay(self) -> None:
+        payload = build_coding_delegation_payload(
+            "Run this goal to completion.",
+            executor_target="hermes",
+            preferred_workflow="ultrawork",
+            preferred_workflow_score=10,
+            force_coding_handoff=True,
+            main_agent_model="openai/gpt-5.6-sol",
+        )
+        handoff = payload["runtime_handoff"]
+
+        self.assertEqual(payload["delegation"]["recommended_workflow"], "ultrawork")
+        self.assertEqual(
+            handoff["executor_prompting_contract"]["throughput_overlay"]["mode"],
+            "gpt_hermes_ulw",
+        )
+        for rule in handoff["executor_prompting_contract"]["throughput_overlay"]["rules"]:
+            self.assertIn(rule, handoff["prompt_template"])
+        self.assertEqual(validate_coding_runtime_handoff(handoff), [])
+
+    def test_parallel_execution_overlay_is_scoped_to_gpt_sol_routes(self) -> None:
+        cases = (
+            (
+                build_coding_delegation_payload(
+                    "Implement src/example.py",
+                    executor_target="codex",
+                    main_agent_model="claude-fable-5",
+                )["executor_handoff"],
+                "claude Codex handoff",
+            ),
+            (
+                build_coding_delegation_payload(
+                    "Review src/example.py.",
+                    executor_target="hermes",
+                    preferred_workflow="code-review",
+                    preferred_workflow_score=10,
+                    force_coding_handoff=True,
+                    main_agent_model="gpt-5.6-sol",
+                )["runtime_handoff"],
+                "GPT Hermes non-ULW handoff",
+            ),
+            (
+                build_coding_delegation_payload(
+                    "Run this goal to completion.",
+                    executor_target="hermes",
+                    preferred_workflow="ultrawork",
+                    preferred_workflow_score=10,
+                    force_coding_handoff=True,
+                    main_agent_model="claude-fable-5",
+                )["runtime_handoff"],
+                "Claude Hermes ULW handoff",
+            ),
+        )
+
+        for handoff, label in cases:
+            with self.subTest(label=label):
+                overlay = handoff["executor_prompting_contract"]["throughput_overlay"]
+                self.assertEqual(overlay["mode"], "parallel_handoff")
+                self.assertNotIn("eval_strategy", overlay)
+                for rule in overlay["rules"]:
+                    self.assertIn(rule, handoff["prompt_template"])
+
+    def test_parallel_guidance_reaches_non_gpt_handoffs(self) -> None:
+        cases = (
+            (
+                build_coding_delegation_payload(
+                    "Implement src/example.py",
+                    executor_target="claude-code",
+                    main_agent_model="claude-fable-5",
+                )["prompt_handoff"],
+                "claude-code",
+            ),
+            (
+                build_coding_delegation_payload(
+                    "Implement src/example.py",
+                    executor_target="generic",
+                )["prompt_handoff"],
+                "generic",
+            ),
+        )
+
+        for handoff, profile in cases:
+            with self.subTest(profile=profile):
+                overlay = handoff["executor_prompting_contract"]["throughput_overlay"]
+                self.assertEqual(overlay["mode"], "parallel_handoff")
+                self.assertNotIn("eval_strategy", overlay)
+
     def test_strategy_selection_distinguishes_plan_risk_and_repair(self) -> None:
         self.assertEqual(
             select_executor_prompting_strategy(


### PR DESCRIPTION
## Summary

- capture the active Hermes model from `pre_llm_call` in request-scoped context and pass it ephemerally through `omh_interact` wrapper paths
- give every prepared handoff executor-neutral independent/dependent call guidance, while GPT-Sol Codex alone receives one-eval-cell internal concurrency guidance
- preserve explicit Hermes `$ultrawork`, `$ultraprocess`, and `$ultragoal` messenger routes without changing the existing direct Hermes authority path
- compact and validate the optional eval strategy without persisting raw model identifiers

Closes #927.

## Problem reproduced

Before this change, an agent/web-messenger request could select an ULW workflow but generated:

```json
{
  "overlay": null,
  "parallel_text": false
}
```

`main_agent_model` was accepted only by direct Python callers. Hermes provides the live model to `pre_llm_call`, but plugin tool kwargs and bounded source metadata do not carry it.

## Verification

Failing-first coverage:

- messenger GPT-Sol `$ultrawork`: `KeyError: throughput_overlay`
- stale model-context boundary: `KeyError: throughput_overlay`
- GPT-Sol Codex eval strategy: missing `eval_strategy`
- Claude/generic handoffs: missing universal `throughput_overlay`
- messenger `$ultraprocess`: `parallel_handoff != gpt_hermes_ulw`

GREEN:

- focused RED→GREEN tests: 7 passed
- authority regression suite plus `$ultraprocess`: 60 passed
- related plugin/wrapper/delegation suite: 447 passed
- final full suite: **5,851 passed** in 173.601s
- ruff: passed
- compileall: passed
- `git diff --check`: passed
- new modules basedpyright: 0 errors, 0 warnings

Real plugin/data surfaces:

- Discord-style `$ultrawork` through `pre_llm_call` + `omh_interact`: selected `ultrawork`, emitted `gpt_hermes_ulw`, validated cleanly, persisted no raw model
- Codex/Claude Code/generic matrix: all receive base batching/dependency guidance; GPT-Sol Codex alone receives `single_cell_internal_parallel`
- Slack-style trigger matrix: `ultrawork`, `ultraprocess`, and `ultragoal` all emit `gpt_hermes_ulw`; later Claude/empty turns emit only `parallel_handoff`

## Boundaries

- prepared guidance remains explicitly non-evidence of execution
- raw model ids remain outside source metadata and durable record allowlists
- no live third-party Discord/Slack network delivery was performed; the production `omh_interact` plugin surface was exercised locally
