### PR TITLE
docs: synchronize repository guidance templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,6 +11,13 @@ body:
     validations:
       required: true
   - type: textarea
+    id: user_goal
+    attributes:
+      label: Complete user goal
+      description: What complete outcome were you trying to achieve, beyond the failing step?
+    validations:
+      required: true
+  - type: textarea
     id: reproduce
     attributes:
       label: Reproduction
@@ -26,6 +33,37 @@ body:
       label: Expected behavior
     validations:
       required: true
+  - type: dropdown
+    id: affected_surfaces
+    attributes:
+      label: Affected surfaces
+      description: Select every product or coding-owner surface where you observed the problem.
+      multiple: true
+      options:
+        - Hermes chat or wrapper
+        - Codex
+        - Claude Code
+        - Hermes runtime or handoff
+        - Generic executor
+        - Not executor-specific
+    validations:
+      required: true
+  - type: textarea
+    id: observed_evidence
+    attributes:
+      label: Observed evidence
+      description: |
+        Paste or describe results you personally observed. Label prepared handoffs or plans as
+        prepared_not_observed; they are not execution, review, CI, or merge evidence.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: What observable result would prove the complete problem is fixed?
+    validations:
+      required: true
   - type: textarea
     id: environment
     attributes:
@@ -37,5 +75,10 @@ body:
     id: logs
     attributes:
       label: Logs or output
+      description: Remove credentials, raw prompts, raw platform events, transcripts, and unrelated private data.
       render: shell
+  - type: markdown
+    attributes:
+      value: |
+        By submitting this report, you confirm that attached evidence is sanitized and contains no secrets or private transcripts.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -11,6 +11,35 @@ body:
     validations:
       required: true
   - type: textarea
+    id: user_goal
+    attributes:
+      label: Complete user goal
+      description: Describe the full target capability rather than an initial slice.
+    validations:
+      required: true
+  - type: dropdown
+    id: affected_surfaces
+    attributes:
+      label: Intended surfaces
+      description: Select every product or coding-owner surface this capability should cover.
+      multiple: true
+      options:
+        - Hermes chat or wrapper
+        - Codex
+        - Claude Code
+        - Hermes runtime or handoff
+        - Generic executor
+        - All executors (executor-neutral)
+    validations:
+      required: true
+  - type: textarea
+    id: observed_evidence
+    attributes:
+      label: Observed evidence
+      description: |
+        Describe the observed gap, if any. Label prepared handoffs or plans as
+        prepared_not_observed rather than execution, review, CI, or merge evidence.
+  - type: textarea
     id: proposal
     attributes:
       label: Proposal
@@ -25,4 +54,16 @@ body:
     id: validation
     attributes:
       label: Success criteria
+      description: What observable behavior would prove the complete capability works?
+    validations:
+      required: true
+  - type: textarea
+    id: boundaries
+    attributes:
+      label: Boundaries and risks
+      description: Note executor differences, persisted state, generated artifacts, network effects, privacy concerns, or rollout constraints.
+  - type: markdown
+    attributes:
+      value: |
+        Do not include credentials, raw prompts, raw platform events, transcripts, or unrelated private data.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,20 +20,45 @@
 
 -
 
+### Affected Surfaces
+
+- [ ] Hermes chat or wrapper
+- [ ] Codex
+- [ ] Claude Code
+- [ ] Hermes runtime or handoff
+- [ ] Generic executor
+- [ ] Not executor-specific
+
 ## Validation
 
+Check only commands that completed successfully. Leave non-applicable checks
+unchecked and explain why under **Not Tested / Not Applicable**.
+
 - [ ] `uv run --group lint ruff check src tests`
-- [ ] `python3 -m unittest discover -s tests`
-- [ ] `python3 -m compileall src`
-- [ ] `python3 -m omh.cli docs workflows --check`
-- [ ] `python3 -m omh.cli harness validate`
-- [ ] `python3 -m omh.cli release checklist --json`
-- [ ] `python3 -m omh.cli release hermes-smoke`
+- [ ] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
+- [ ] `uv run python -m compileall -q src tests`
+- [ ] `uv run python -m omh.cli docs workflows --check`
+- [ ] `uv run python -m omh.cli docs roles --check`
+- [ ] `uv run python -m omh.cli docs capability-families --check`
+- [ ] `uv run python -m omh.cli harness validate`
+- [ ] `uv run python -m omh.cli release checklist --json`
+- [ ] `uv run python -m omh.cli release hermes-smoke`
+- [ ] `git diff --check`
 - [ ] `omh --help`
 - [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
 - [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
 - [ ] Relevant dry-run or smoke command:
 - [ ] Manual Hermes/TUI check, or explicit reason it was not run:
+
+### Observed Evidence
+
+- Targeted tests, commands, CI checks, and manual behavior actually observed:
+-
+
+### Not Tested / Not Applicable
+
+- Skipped checks and the concrete reason each one does not apply:
+-
 
 ## Risk
 
@@ -47,6 +72,8 @@
 
 - [ ] Release-channel impact considered (`stable`, `preview`, or `local`)
 - [ ] Runtime/native capability claims are backed by evidence or marked as not observed
+- [ ] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
+- [ ] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
 - [ ] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap
 
 ## Follow-Up

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,32 @@ PR without the chat history.
 - Keep public claims conservative and test-backed.
 - Avoid adding dependencies unless the user explicitly approves the dependency
   and its packaging story.
+- Keep routing changes inside the existing normalization helpers
+  (`normalized_phrase`, `routing_tokens`, and `contains_cue_phrase`) rather
+  than adding raw substring checks.
+- Ship routing and policy changes with both positive-intervention and
+  negative-control cases. The source corpora are
+  `ROUTING_INTERVENTION_CASES` and `ROUTING_PRECISION_CASES`.
+- Treat exact-count fixtures as contracts. Update affected assertions in the
+  same change, but do not copy mutable counts or source line numbers into
+  prose.
+
+## Generated Artifact Discipline
+
+Keep source files and generated projections together in the same change:
+
+- `src/skills/catalog.py` and `src/skills/render.py` produce
+  `skills/*/SKILL.md`, `skills/*/references/*.md`, and `docs/WORKFLOWS.md`.
+- `roles_reference_markdown()` in `src/catalogs/roles.py` produces
+  `docs/ROLES.md`.
+- The demo case engine produces
+  `examples/use-cases/g1-g10-demo-cards.json`.
+- `capability_family_projection()` in `src/capabilities/families.py` produces
+  `src/plugin_bundle/omh/tools/capability_families.json`.
+
+Never hand-edit those generated files. Change the source, regenerate every
+affected projection, and commit source plus generated output together. The
+repository checks are byte-exact; a one-character drift is a failure.
 
 ## CodeGraph
 
@@ -185,9 +211,15 @@ PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py -v
 PYTHONPATH=tests uv run python -m unittest discover -s tests -v
 uv run python -m compileall -q src tests
 uv run python -m omh.cli docs workflows --check
+uv run python -m omh.cli docs roles --check
+uv run python -m omh.cli docs capability-families --check
 uv run --group lint ruff check src tests
 git diff --check
 ```
+
+Always set `PYTHONPATH=tests` for unittest because shared test helpers live at
+the tests root. Run the smallest test that proves the claim first, then broaden
+for shared surfaces and run the full suite before claiming completion.
 
 For direction, docs, generated skill, wrapper contract, lifecycle, or runtime
 artifact changes, add or update tests that lock the public contract.


### PR DESCRIPTION
## Feature Report

### What Changed

- synchronized executor-neutral repository rules from `CLAUDE.md` into `AGENTS.md`
- expanded bug and feature issue forms with complete-goal, affected-surface, observed-evidence, acceptance, and privacy fields
- corrected the pull request checklist to use the repository's exact `uv`, `PYTHONPATH=tests`, generated-artifact, and diff gates

### Why This Exists

Repository guidance had drifted across agent instructions and contributor
templates. Generic agents could miss generated-artifact and routing contracts,
while issue and PR authors were not prompted to separate prepared guidance from
observed evidence or state executor/privacy boundaries.

### User / Operator Impact

Contributors and coding agents now receive one consistent contract regardless
of whether they enter through Claude Code, another executor, an issue form, or
the pull request template.

### How It Works

- `AGENTS.md` mirrors the practical routing, generated-artifact provenance, and verification rules already documented in `CLAUDE.md`
- GitHub issue forms collect whole-goal scope, affected Hermes/executor surfaces, sanitized observed evidence, and measurable success criteria
- the PR template distinguishes observed evidence from untested or non-applicable checks and uses exact repository commands

### Files And Contracts Touched

- `AGENTS.md`
- `.github/ISSUE_TEMPLATE/bug_report.yml`
- `.github/ISSUE_TEMPLATE/feature_request.yml`
- `.github/pull_request_template.md`

### Affected Surfaces

- [x] Not executor-specific
- [x] Repository governance and contribution intake

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -q` — 5,851 tests passed in 183.515s after rebase
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_project_governance.py tests/test_router_content.py -q` — 105 tests passed
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check` — 117/117 tap skills current
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `git diff --check`
- [x] Ruby YAML parser verified both issue forms, unique IDs, and valid body structure
- [x] Independent review passed after correcting `docs/ROLES.md` provenance

### Observed Evidence

- rebased branch divergence before push: `0 behind / 1 ahead`
- bug form: 10 body entries, 9 unique field IDs
- feature form: 9 body entries, 8 unique field IDs
- commit carries DCO signoff and all repository Lore trailers

### Not Tested / Not Applicable

- Live GitHub issue-form rendering was not tested because these default-branch templates are not served until merge.
- No Hermes/TUI check was run because this change affects repository governance and GitHub contribution forms only.
- Release smoke commands were not run because no runtime, packaging, generated output, or release behavior changed.

## Risk

Low. The change is limited to repository guidance and GitHub templates. The
main risk is additional reporter effort from required scope/evidence fields,
traded deliberately for reviewable and privacy-safe reports.

## Compatibility / Rollout

No runtime or persisted-data compatibility impact. GitHub uses the updated
templates for newly opened issues and PRs after merge.

## Release / Claims

- [x] No release-channel impact
- [x] Prepared handoffs remain labeled `prepared_not_observed`
- [x] Templates prohibit credentials, raw prompts, raw platform events, transcripts, and unrelated private data

## Follow-Up

- None.
