### PR TITLE
feat: let Hermes actually run the source-trust ceiling, not just read about it

### DIFF
--- a/src/plugin_bundle/omh/__init__.py
+++ b/src/plugin_bundle/omh/__init__.py
@@ -60,6 +60,7 @@ def register(ctx):
     from .tools.probe_tool import OMH_PROBE_SCHEMA, omh_probe_handler
     from .tools.recommend_tool import OMH_RECOMMEND_SCHEMA, omh_recommend_handler
     from .tools.role_tool import OMH_ROLE_SCHEMA, omh_role_handler
+    from .tools.source_trust_tool import OMH_SOURCE_TRUST_SCHEMA, omh_source_trust_handler
     from .tools.status_tool import OMH_STATUS_SCHEMA, omh_status_handler
 
     ctx.register_tool(
@@ -124,6 +125,13 @@ def register(ctx):
         OMH_ROLE_SCHEMA,
         omh_role_handler,
         description=OMH_ROLE_SCHEMA["description"],
+    )
+    ctx.register_tool(
+        "omh_source_trust",
+        _TOOLSET,
+        OMH_SOURCE_TRUST_SCHEMA,
+        omh_source_trust_handler,
+        description=OMH_SOURCE_TRUST_SCHEMA["description"],
     )
     ctx.register_tool(
         "omh_status",

--- a/src/plugin_bundle/omh/metadata.py
+++ b/src/plugin_bundle/omh/metadata.py
@@ -10,6 +10,7 @@ PROVIDED_TOOLS = (
     "omh_probe",
     "omh_recommend",
     "omh_role",
+    "omh_source_trust",
     "omh_status",
 )
 REQUIRED_HOOKS = ("on_session_end", "pre_llm_call", "pre_tool_call")
@@ -26,6 +27,7 @@ TOOL_FILE_STEMS = {
     "omh_probe": "probe_tool",
     "omh_recommend": "recommend_tool",
     "omh_role": "role_tool",
+    "omh_source_trust": "source_trust_tool",
     "omh_status": "status_tool",
 }
 

--- a/src/plugin_bundle/omh/plugin.yaml
+++ b/src/plugin_bundle/omh/plugin.yaml
@@ -14,6 +14,7 @@ provides_tools:
   - omh_probe
   - omh_recommend
   - omh_role
+  - omh_source_trust
   - omh_status
 provides_hooks:
   - on_session_end

--- a/src/plugin_bundle/omh/tools/source_trust_tool.py
+++ b/src/plugin_bundle/omh/tools/source_trust_tool.py
@@ -1,0 +1,169 @@
+"""Hermes-callable surface for the source-trust ceiling.
+
+Hermes learns what OMH *describes* from installed skill prose, but the
+source-trust ceiling is a mechanical guard, and a guard that only exists in
+prose is the thing `omh.workflows.source_trust` was written to replace. This
+tool is the path where Hermes hands over the claims it gathered and OMH actually
+runs the ceiling on them, rather than asking a model to remember a rule.
+
+Fail-closed on degradation, which is the one design decision here worth stating.
+Every other tool in this bundle answers from a standalone fallback when the
+`omh` package is not importable, because a partial answer beats no answer for
+status, routing hints, or capability listings. A ceiling is different: an
+enforcement surface that cannot enforce must not return something a reader can
+mistake for an enforced result. So when the backend is missing this returns
+`degraded: true`, no summary, and says the ceiling did not run.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from ..host_observation import OBSERVATION_SCHEMA, attach_public_observation, observe_plugin_tool_call
+
+# Bounded so one call cannot hand over an unbounded transcript. Matches the
+# spirit of the eight-row rejection cap inside the summary itself.
+_MAX_CLAIMS = 64
+
+_UNAVAILABLE_REASON = (
+    "The OMH package backend is not importable, so the source-trust ceiling did not run. "
+    "No summary is returned: an unenforced answer must not read as an enforced one."
+)
+
+OMH_SOURCE_TRUST_SCHEMA = {
+    "name": "omh_source_trust",
+    "description": (
+        "Apply the OMH source-trust ceiling to gathered claims: report what class of source stands "
+        "behind each claim and what those claims collectively support. A practitioner heuristic may "
+        "inform approach and never becomes an established finding, and no source class settles "
+        "completion. This reports source class, never whether a claim is true; it is not observation, "
+        "execution, verification, review, CI, or merge evidence."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "topic": {
+                "type": "string",
+                "description": "One bounded line naming what these claims are about.",
+            },
+            "claims": {
+                "type": "array",
+                "description": f"Up to {_MAX_CLAIMS} claims to classify.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "tier": {
+                            "type": "string",
+                            "enum": ["upstream_official", "practitioner_heuristic", "unattributed"],
+                            "description": "Stated by the caller. OMH never infers trust from a source.",
+                        },
+                        "claim_kind": {
+                            "type": "string",
+                            "enum": ["approach", "finding", "completion"],
+                            "description": "What the claim asserts. No tier may back completion.",
+                        },
+                        "claim": {"type": "string", "description": "One bounded line, no links or paths."},
+                        "source_id": {
+                            "type": "string",
+                            "description": (
+                                "Opaque source identifier, not a URL - for example a source-finder "
+                                "candidate_id. Omit only for an unattributed claim."
+                            ),
+                        },
+                        "recorded_at": {"type": "string", "description": "Opaque timestamp reference."},
+                    },
+                },
+            },
+            "observation": OBSERVATION_SCHEMA,
+        },
+    },
+}
+
+
+def omh_source_trust_handler(args: dict, **kwargs) -> str:
+    observation = observe_plugin_tool_call("omh_source_trust", args, kwargs)
+    topic = str(args.get("topic", "") or "").strip()
+    rows = args.get("claims")
+    rows = list(rows) if isinstance(rows, list) else []
+    payload = _apply_ceiling(topic=topic, rows=rows[:_MAX_CLAIMS], dropped=max(0, len(rows) - _MAX_CLAIMS))
+    return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
+
+
+def _apply_ceiling(*, topic: str, rows: list[Any], dropped: int) -> dict[str, Any]:
+    try:
+        from omh.workflows.source_trust import (
+            SOURCE_TRUST_CLAIM_BOUNDARY,
+            SourceTrustError,
+            build_source_trust_claim,
+            summarize_source_trust,
+        )
+    except (ImportError, ModuleNotFoundError):
+        return _unavailable()
+
+    minted: list[dict[str, Any]] = []
+    refused: list[dict[str, Any]] = []
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            refused.append({"index": index, "reason": "claim must be an object"})
+            continue
+        try:
+            minted.append(
+                build_source_trust_claim(
+                    tier=str(row.get("tier", "") or ""),
+                    claim_kind=str(row.get("claim_kind", "") or ""),
+                    claim=str(row.get("claim", "") or ""),
+                    recorded_at=str(row.get("recorded_at", "") or ""),
+                    source_ref=str(row.get("source_id", "") or ""),
+                )
+            )
+        except SourceTrustError as exc:
+            # The refusal IS the product here. A claim the ceiling rejects is
+            # reported with its reason rather than dropped, so the caller can
+            # see which tier overreached and restate it.
+            refused.append({"index": index, "reason": str(exc)[:200]})
+
+    try:
+        summary = summarize_source_trust(topic=topic or "unnamed topic", claims=minted)
+    except SourceTrustError as exc:
+        return {
+            "plugin_tool": "omh_source_trust",
+            "source": "package_source_trust_error",
+            "degraded": True,
+            "privacy": "metadata_only",
+            "ceiling_applied": False,
+            "error": "package_backend_error",
+            "error_type": type(exc).__name__,
+            "reason": str(exc)[:200],
+            "claim_boundary": SOURCE_TRUST_CLAIM_BOUNDARY,
+        }
+
+    return {
+        "plugin_tool": "omh_source_trust",
+        "source": "package_source_trust",
+        "degraded": False,
+        "privacy": "metadata_only",
+        "ceiling_applied": True,
+        "summary": summary,
+        "accepted_count": len(minted),
+        "refused_count": len(refused),
+        "refused_claims": refused[:8],
+        "dropped_over_limit": dropped,
+        "claim_boundary": SOURCE_TRUST_CLAIM_BOUNDARY,
+    }
+
+
+def _unavailable() -> dict[str, Any]:
+    return {
+        "plugin_tool": "omh_source_trust",
+        "source": "standalone_plugin_bundle_fallback",
+        "degraded": True,
+        "privacy": "metadata_only",
+        "ceiling_applied": False,
+        "reason": _UNAVAILABLE_REASON,
+        "claim_boundary": (
+            "The source-trust ceiling did not run in this environment. Nothing here reports what a "
+            "claim may support, and no statement is observation, execution, verification, review, "
+            "CI, or merge evidence."
+        ),
+    }

--- a/tests/test_memory_provider.py
+++ b/tests/test_memory_provider.py
@@ -62,7 +62,7 @@ from omh.plugin_bundle.omh.memory_dreaming import (
 )
 from omh.plugin_bundle.omh.memory_eviction import build_eviction_plan, eviction_plan_summary
 from omh.plugin_bundle.omh.memory_provider import PROVIDER_NAME, OmhMemoryProvider
-from omh.plugin_bundle.omh.metadata import MEMORY_PROVIDER_NAME
+from omh.plugin_bundle.omh.metadata import MEMORY_PROVIDER_NAME, PROVIDED_TOOLS
 from omh.plugin_bundle.omh.tools.memory_tool import MEMORY_ACTIONS, OMH_MEMORY_SCHEMA, omh_memory_handler
 
 HERMES_DELIMITER = "§"
@@ -381,7 +381,7 @@ class ProviderRegistrationTests(unittest.TestCase):
         collector = self._Collector()
         register(collector)
         self.assertIsInstance(collector.provider, OmhMemoryProvider)
-        # Registering ten tools into a collector that discards them is work the
+        # Registering every tool into a collector that discards them is work the
         # provider load should never do.
         self.assertEqual(collector.tools, [])
 
@@ -389,7 +389,10 @@ class ProviderRegistrationTests(unittest.TestCase):
         ctx = self._PluginCtx()
         register(ctx)
         self.assertIn("omh_memory", ctx.tools)
-        self.assertEqual(len(ctx.tools), 10)
+        # Derived from the declared set rather than a literal: this assertion
+        # exists to catch a tool that is declared but never registered, and a
+        # hardcoded count turns that into a chore every time a tool is added.
+        self.assertEqual(sorted(ctx.tools), sorted(PROVIDED_TOOLS))
         self.assertIn("on_session_end", ctx.hooks)
 
     def test_the_provider_exposes_no_tool_schemas(self) -> None:

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -343,6 +343,7 @@ print(json.dumps(observed, ensure_ascii=False))
                     "omh_probe",
                     "omh_recommend",
                     "omh_role",
+                    "omh_source_trust",
                     "omh_status",
                 ],
             )

--- a/tests/test_source_trust_tool.py
+++ b/tests/test_source_trust_tool.py
@@ -1,0 +1,170 @@
+"""Contracts for the `omh_source_trust` plugin tool.
+
+This is the surface where Hermes stops being *told* about the source-trust
+ceiling and OMH actually runs it. Two things therefore have to hold, and they
+pull in opposite directions:
+
+- the ceiling must produce the same refusals through the tool as through the
+  Python contract, so the tool cannot become a way around it;
+- when the package backend is missing the tool must refuse to answer at all,
+  rather than degrade to a permissive summary that reads like an enforced one.
+
+The second is the reason this tool does not follow the standalone-fallback
+pattern the rest of the bundle uses, so it is pinned hardest.
+"""
+
+from __future__ import annotations
+
+import builtins
+import json
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.plugin_bundle.omh.metadata import PROVIDED_TOOLS, TOOL_FILE_STEMS
+from omh.plugin_bundle.omh.tools.source_trust_tool import (
+    OMH_SOURCE_TRUST_SCHEMA,
+    omh_source_trust_handler,
+)
+from omh.workflows.source_trust import SOURCE_TRUST_TIERS
+
+
+STAMP = "2026-08-11T00:00:00Z"
+
+
+def _call(**args: object) -> dict:
+    return json.loads(omh_source_trust_handler(dict(args)))
+
+
+def _claim(**overrides: object) -> dict:
+    row = {
+        "tier": "upstream_official",
+        "claim_kind": "finding",
+        "claim": "The runtime rejects a handoff without an owner.",
+        "source_id": "source-aeb851a812b2",
+        "recorded_at": STAMP,
+    }
+    row.update(overrides)
+    return row
+
+
+class RegistrationTests(unittest.TestCase):
+    def test_the_tool_is_registered_under_its_file_stem(self) -> None:
+        self.assertIn("omh_source_trust", PROVIDED_TOOLS)
+        self.assertEqual(TOOL_FILE_STEMS["omh_source_trust"], "source_trust_tool")
+
+    def test_the_schema_names_the_tool_and_bounds_the_claim(self) -> None:
+        self.assertEqual(OMH_SOURCE_TRUST_SCHEMA["name"], "omh_source_trust")
+        props = OMH_SOURCE_TRUST_SCHEMA["parameters"]["properties"]
+        self.assertEqual(
+            props["claims"]["items"]["properties"]["tier"]["enum"],
+            list(SOURCE_TRUST_TIERS),
+        )
+
+    def test_the_description_refuses_to_read_as_verification(self) -> None:
+        description = OMH_SOURCE_TRUST_SCHEMA["description"]
+        self.assertIn("not observation", description)
+        self.assertIn("never whether a claim is true", description.replace("reports source class, ", ""))
+
+
+class CeilingThroughTheToolTests(unittest.TestCase):
+    def test_accepted_claims_reach_a_summary(self) -> None:
+        payload = _call(
+            topic="handoff owner requirement",
+            claims=[_claim(), _claim(tier="practitioner_heuristic", claim_kind="approach", claim="Set the owner first.")],
+        )
+        self.assertTrue(payload["ceiling_applied"])
+        self.assertFalse(payload["degraded"])
+        self.assertEqual(payload["accepted_count"], 2)
+        self.assertEqual(payload["refused_count"], 0)
+        self.assertEqual(payload["summary"]["strongest_claim_kind"], "finding")
+
+    def test_an_overreaching_tier_is_refused_with_its_reason(self) -> None:
+        payload = _call(
+            topic="cache warming",
+            claims=[_claim(tier="practitioner_heuristic", claim_kind="finding", claim="Warming halves p99.")],
+        )
+        self.assertEqual(payload["accepted_count"], 0)
+        self.assertEqual(payload["refused_count"], 1)
+        self.assertEqual(payload["refused_claims"][0]["index"], 0)
+        self.assertIn("may not back a finding claim", payload["refused_claims"][0]["reason"])
+
+    def test_completion_is_unreachable_through_the_tool(self) -> None:
+        for tier in SOURCE_TRUST_TIERS:
+            with self.subTest(tier=tier):
+                payload = _call(
+                    topic="migration",
+                    claims=[_claim(tier=tier, claim_kind="completion", claim="It shipped and is green.")],
+                )
+                self.assertEqual(payload["accepted_count"], 0)
+                self.assertNotEqual(payload["summary"]["strongest_claim_kind"], "completion")
+
+    def test_a_url_source_id_is_refused(self) -> None:
+        payload = _call(topic="spec", claims=[_claim(source_id="https://example.invalid/spec")])
+        self.assertEqual(payload["refused_count"], 1)
+        self.assertIn("opaque identifier", payload["refused_claims"][0]["reason"])
+
+    def test_malformed_rows_are_refused_not_crashed(self) -> None:
+        payload = _call(topic="spec", claims=["not a dict", {}, _claim()])
+        self.assertEqual(payload["accepted_count"], 1)
+        self.assertEqual(payload["refused_count"], 2)
+
+    def test_claims_are_bounded_and_the_drop_is_reported(self) -> None:
+        payload = _call(topic="spec", claims=[_claim() for _ in range(70)])
+        self.assertEqual(payload["dropped_over_limit"], 6)
+        self.assertEqual(payload["accepted_count"], 64)
+        self.assertLessEqual(len(payload["refused_claims"]), 8)
+
+    def test_no_claims_still_answers_and_supports_nothing(self) -> None:
+        payload = _call(topic="spec")
+        self.assertTrue(payload["ceiling_applied"])
+        self.assertEqual(payload["summary"]["strongest_claim_kind"], "none")
+
+    def test_the_boundary_travels_with_every_answer(self) -> None:
+        payload = _call(topic="spec", claims=[_claim()])
+        self.assertIn("not whether any claim is", payload["claim_boundary"])
+        self.assertIn("never that OMH checked it", payload["claim_boundary"])
+
+
+class FailClosedTests(unittest.TestCase):
+    """Without the backend the tool must answer nothing, not answer permissively."""
+
+    def _without_backend(self, **args: object) -> dict:
+        real_import = builtins.__import__
+
+        def fake_import(name, *rest, **kw):
+            if name == "omh.workflows.source_trust":
+                raise ModuleNotFoundError("No module named 'omh'", name="omh")
+            return real_import(name, *rest, **kw)
+
+        builtins.__import__ = fake_import
+        try:
+            return json.loads(omh_source_trust_handler(dict(args)))
+        finally:
+            builtins.__import__ = real_import
+
+    def test_a_missing_backend_returns_no_summary(self) -> None:
+        payload = self._without_backend(topic="spec", claims=[_claim()])
+        self.assertTrue(payload["degraded"])
+        self.assertFalse(payload["ceiling_applied"])
+        self.assertNotIn("summary", payload)
+        self.assertEqual(payload["source"], "standalone_plugin_bundle_fallback")
+
+    def test_the_degraded_answer_says_the_ceiling_did_not_run(self) -> None:
+        payload = self._without_backend(topic="spec", claims=[_claim()])
+        self.assertIn("did not run", payload["reason"])
+        self.assertIn("did not run", payload["claim_boundary"])
+
+    def test_the_degraded_answer_never_reports_acceptance(self) -> None:
+        """The negative case: a permissive fallback would be worse than no tool."""
+        payload = self._without_backend(
+            topic="spec",
+            claims=[_claim(tier="practitioner_heuristic", claim_kind="completion")],
+        )
+        for field in ("accepted_count", "summary", "strongest_claim_kind"):
+            self.assertNotIn(field, payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- **`omh_source_trust`, the eleventh plugin tool.** Hermes hands over gathered claims; OMH runs the source-trust ceiling on them and returns what they collectively support, with every refusal named and indexed.
- Registration across four surfaces: `metadata.py` (`PROVIDED_TOOLS`, `TOOL_FILE_STEMS`), `plugin.yaml`, the tool module, `__init__.py`.
- `tests/test_source_trust_tool.py` — 14 gates, three of them on the fail-closed path.
- One count fixture converted from a literal to a derivation.

### Why This Exists

Three PRs got the axis this far: #921 built the ceiling, #926 taught the research lane its vocabulary, #928 gave it a producer. What remained is the step where Hermes stops being *told* the rule and OMH *applies* it. A ceiling that only a model remembers is precisely what `workflows/source_trust.py` was written to replace — its own docstring says *"prose telling an agent not to do it is not a guard."*

Plugin tools are the only path where Hermes executes OMH Python. Two nearer-looking options were checked against the repo and rejected:

| Option | Why not |
| --- | --- |
| Read-only CLI subcommand | `omh runtime action-readiness` shipped exactly that way and appears in **zero** installed skills. Its own commit trailer: *"reachable through the CLI and the Python contract but not yet through natural language."* |
| Wrapper actions on the research card | `record_source_candidate` exists only in `VISIBLE_ACTIONS` (`src/wrapper/contract.py:164`) and as a button label (`:5008`). The contract never calls `build_source_candidate`. Actions are declarative; the ceiling would still never run. |
| An operation on `omh_gather_evidence` | That tool is an allowlisted shell-command runner (subprocess/workdir/timeout). Claim classification does not belong in it. |

### User / Operator Impact

Hermes can now submit the claims it gathered and get a mechanically enforced answer instead of recalling a rule. Real output from the handler:

```
=== Hermes hands over three gathered claims ===
  ceiling_applied : True   degraded: False
  accepted        : 2      refused: 1
  strongest       : finding
  tiers_present   : ['upstream_official', 'practitioner_heuristic']
  refusal Hermes sees:
      claim[2] -> source trust tier practitioner_heuristic may not back a
                  finding claim; it may back: approach
```

The refusal is the product. A claim the ceiling rejects comes back with its reason and index so the caller can see which tier overreached and restate it, rather than having it silently dropped or silently downgraded.

### How It Works

The tool is a surface and nothing more — `build_source_trust_claim` and `summarize_source_trust` remain the only things that decide anything, so the tool cannot become a bypass. Every ceiling refusal applies through it, and no tier reaches `completion`.

**Fail-closed on degradation, and this is the decision worth arguing about.**

Every other tool in this bundle answers from a standalone fallback when the `omh` package is not importable, because a partial answer beats none for status, route hints, or capability listings. An enforcement surface is different: a permissive fallback returns something a reader cannot distinguish from an enforced result — the exact laundering this axis exists to prevent.

So a missing backend returns:

```
  degraded        : True   ceiling_applied: False
  summary present : False  accepted_count present: False
  reason          : The OMH package backend is not importable, so the
                    source-trust ceiling did not run. No summary is returned...
```

There is no key in that payload to misread. Three tests pin it, including the negative case that a degraded answer never reports acceptance.

**The count fixture moved to a derivation, not a new literal.** `test_memory_provider.py:392` asserted `len(ctx.tools) == 10`; it now asserts `sorted(ctx.tools) == sorted(PROVIDED_TOOLS)`. That assertion exists to catch a tool that is *declared but never registered* — comparing against the declared set tests exactly that, while a hardcoded count tests less and becomes a chore on every tool addition. Consistent with #925, which removed count literals from `CLAUDE.md` for the same reason.

**Mirrors needed no edit.** `hook_manifest()` (`src/capabilities/hooks.py:29`) and the bundle's copy (`capability_tool.py`) both iterate `PROVIDED_TOOLS`. The `supported_by_wrapper_contract` and `supported_by_cli_backend` opt-in sets are deliberately left alone: this tool has neither, and claiming otherwise would be a false capability claim.

### Files And Contracts Touched

- `src/plugin_bundle/omh/tools/source_trust_tool.py` — new, +169
- `src/plugin_bundle/omh/metadata.py` — +2 · `plugin.yaml` — +1 · `__init__.py` — +8
- `tests/test_source_trust_tool.py` — new, +170 · `tests/test_plugin_distribution.py` — +1 · `tests/test_memory_provider.py` — +9/−3

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `python3 -m unittest discover -s tests` — **5865 tests OK** (5851 on main after #928 + 14 new)
- [x] `python3 -m compileall src` — OK
- [x] `python3 -m omh.cli docs workflows --check` — `ok: true`, tap-skills 117/117
- [x] `python3 -m omh.cli harness validate` — `ok: true`, 0 errors, 0 warnings
- [ ] `python3 -m omh.cli release checklist --json` — not rerun; plan-mode renderer, no item enumerates tools
- [ ] `python3 -m omh.cli release hermes-smoke` — not rerun in this pass
- [ ] `omh --help` — not applicable; no CLI command added
- [ ] installed-command smoke — not applicable
- [ ] Relevant workflow-learning review queue smoke — not applicable
- [x] Relevant dry-run or smoke command: `docs capability-families --check` ok, `release drift` → **No drift, 12 checks passed**, `git diff --check` clean. Targeted plugin suites — distribution, capabilities, hook manifest, identity conflicts, memory bridge — **113 tests pass**.
- [x] **Manual QA — executed against the real handler**, four paths: normal accept, ceiling refusal with reason, URL-as-`source_id` refusal, and the fail-closed path with the backend import blocked. Output quoted above.
- [ ] Manual Hermes/TUI check — **not run**. This is the honest gap and it is the important one: registration is *contract* evidence. Nothing here proves a live Hermes loaded the plugin, listed the tool, or called it. See Risk.

## Risk

- **A new tool is a product surface, not just code.** Ten tools became eleven; every install that enables the plugin now advertises one more. That was the owner's call, made explicitly after I recommended waiting — recording it here so the reasoning is visible to a later reader.
- **Registration is not invocation.** All evidence in this PR is local and deterministic. Whether Hermes surfaces and calls the tool in a real conversation is unobserved, and the local gates structurally cannot prove it.
- **Existing installs need `omh update`** before the tool appears; `setup` is first-install only.
- The `_MAX_CLAIMS = 64` bound and the eight-row refusal cap are judgement calls, chosen to match the caps already inside the summary rather than derived from a measured need. `dropped_over_limit` is reported rather than silently truncating.

## Compatibility / Rollout

- Additive. No schema change to any existing tool, no persisted format, no migration, no routing behavior, no catalog or generated artifact.
- Zero network unchanged: the tool computes from its arguments and calls two pure functions.
- Degraded environments get a strictly *less* permissive answer than before, never more.

## Release / Claims

- [x] Release-channel impact considered — no version file or packaging change; the tool ships with the bundle
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — the QA block is observed local execution of the handler; no claim is made that Hermes loaded, listed, or invoked it
- [x] Known manual Hermes checks are listed — the plugin-load gap is stated plainly above rather than implied

## Follow-Up

- **A live Hermes check is the only thing that can close the remaining gap** — enable the plugin in a real profile, confirm `omh_source_trust` is listed, and call it once. Nothing in CI can substitute.
- The axis still has no wrapper card or chat action. Now that a tool exists to back one, a research-card action would have something real behind it — the opposite of the situation this PR found.
- Unrelated, pre-existing, confirmed present at `b7ca5258`: `tests/test_efficiency.py` fails when run alone (`test_quality_leakage_checks_avoid_full_payload_json_serialization`) and passes under `unittest discover`. A test that only passes alongside others is not testing what it claims.
- Also unrelated: the prompt-context budgets are nearly exhausted (full capability section had 1,821 characters of headroom before this PR, which does not touch it). Roughly 20,000 characters of provably information-free duplication sit in `src/capabilities/skills.py` — `display_name` equals `id` for all 103 skills, `exposure` equals `surface_exposure` for all 103, and a constant `tool_requirements` stub is superseded by the real manifest one key away. Routing never reads that module, so trimming it is routing-inert.
