### PR TITLE
perf: stop stamping three information-free fields into every skill capability

### DIFF
--- a/src/capabilities/skills.py
+++ b/src/capabilities/skills.py
@@ -38,14 +38,12 @@ def _skill_capability(
     return {
         "schema_version": SKILL_CAPABILITY_SCHEMA_VERSION,
         "id": definition.name,
-        "display_name": definition.name,
         "description": definition.description,
         "category": definition.category,
         "phase": definition.phase,
         "hermes_role": definition.hermes_role,
         "primary_harness": harness,
         "surface_exposure": exposure["exposure"],
-        "exposure": exposure["exposure"],
         "install_visibility": exposure["install_visibility"],
         "docs_visibility": exposure["docs_visibility"],
         "preferred_usage": exposure["preferred_usage"],
@@ -70,11 +68,6 @@ def _skill_capability(
         "cross_lane_examples": _capability_lane_examples(lane_id, definition.name),
         "do_not_use_when": _bounded_list(definition.do_not_use_when, 1),
         "orchestration_eligibility": _orchestration_eligibility(definition),
-        "tool_requirements": {
-            "derivation_status": "partial",
-            "required_tools": [],
-            "fallback": "none",
-        },
         "evidence_boundary": _skill_evidence_boundary(definition),
     }
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -13,6 +13,7 @@ load_local_package()
 from omh.capabilities.families import capability_family_projection, family_for_workflow
 from omh.capabilities.registry import capability_snapshot, capability_summary, inspect_capability, list_capabilities
 from omh.capabilities.schema import normalize_capability_section
+from omh.capabilities.skills import skill_capabilities
 from omh.skills.catalog import builtin_definitions, installable_skill_names
 
 
@@ -340,6 +341,28 @@ class CapabilityManifestTests(unittest.TestCase):
         self.assertIn("build-failure-triage", context_cards["coding_handoff"]["representative_workflows"])
         self.assertIn("implementation", context_cards["coding_handoff"]["not_evidence_until_observed"])
 
+    def test_the_skill_payload_carries_no_field_that_restates_another(self) -> None:
+        """Every skill item is stamped 103 times into a budgeted payload.
+
+        `display_name` was `id`, `exposure` was `surface_exposure`, and
+        `tool_requirements` was a constant stub superseded by the real manifest
+        one key away in the same snapshot. None of them carried information, and
+        together they cost about 16.5k characters of a shared budget that had
+        under 2k left. Re-adding any of them is the regression this catches; the
+        surviving twin is named so the fix is obvious.
+        """
+        skills = skill_capabilities()
+        self.assertTrue(skills)
+        twin = {
+            "display_name": "id",
+            "exposure": "surface_exposure",
+            "tool_requirements": "the snapshot's own tool_requirements section",
+        }
+        for item in skills:
+            for removed, survivor in twin.items():
+                with self.subTest(skill=item["id"], field=removed):
+                    self.assertNotIn(removed, item, f"use {survivor} instead of {removed}")
+
     def test_capability_inspect_finds_skill_and_role_without_runtime_claim(self) -> None:
         skill = inspect_capability("ultragoal", section="skills")["capability"]
         wiki_skill = inspect_capability("wiki", section="skills")["capability"]
@@ -353,7 +376,6 @@ class CapabilityManifestTests(unittest.TestCase):
         legacy_role = inspect_capability("coding-handoff", section="agent_roles")
 
         self.assertEqual(skill["schema_version"], "skill_capability/v1")
-        self.assertEqual(skill["tool_requirements"]["derivation_status"], "partial")
         self.assertIn("prepared_not_observed", skill["evidence_boundary"])
         self.assertEqual(skill["awareness_lane"], "intent_to_plan")
         self.assertIn("Use `ultragoal`", skill["workflow_routing_hint"])
@@ -366,7 +388,7 @@ class CapabilityManifestTests(unittest.TestCase):
         self.assertIn("omh_context", awareness["tool_hints"][0])
         self.assertIn("omh_capabilities", " ".join(awareness["tool_hints"]))
         self.assertIn("ambitious goal -> loopability check", " ".join(skill["cross_lane_examples"]))
-        self.assertEqual(ops_surface["exposure"], "workflow_skill")
+        self.assertEqual(ops_surface["surface_exposure"], "workflow_skill")
         self.assertEqual(awareness["schema_version"], "omh_awareness/v1")
         # The rule discriminates by the shape of the result, not by a list of
         # subjects. It used to enumerate planning/research/knowledge/ops/


### PR DESCRIPTION
## Feature Report

### What Changed

- Removed three per-skill fields from the capability projection (`src/capabilities/skills.py`) that restated another field in the same object: `display_name`, `exposure`, and a constant `tool_requirements` stub.
- Added a regression guard so they cannot silently return.
- **16,533 characters saved.** Full capability skill section: 338,179 → **321,646** of 340,000. Headroom 1,821 → **18,354**.

### Why This Exists

The budget was not "getting tight" — it was **already blocking**. The smallest skill item in the catalog is 2,403 characters and there were 1,821 left, so the next skill addition could not fit. Adding one catalog rule in #926 cost 75 characters of that remainder.

Three fields were paid 103 times each and carried nothing:

| Field | What it actually was | Duplicated in |
| --- | --- | --- |
| `display_name` | `definition.name` — byte-identical to `id`, 103/103 | `id`, same object |
| `exposure` | `exposure["exposure"]` — byte-identical to `surface_exposure`, 103/103 | `surface_exposure`, same object |
| `tool_requirements` | hardcoded stub: `derivation_status: partial`, `required_tools: []`, `fallback: none` — identical for every skill | `capability_snapshot()["tool_requirements"]`, one key away |

The stub is the sharpest case: it is **strictly less informative** than the real manifest sitting beside it in the same snapshot. Verified live — that manifest holds 103 rows, each carrying those same three fields *plus* `required_mcps`, `source_refs`, `skill`, and the full exposure set.

### User / Operator Impact

Room for roughly six more skills instead of zero. No behavior change: the payload's readers see the same information, with the duplicates gone.

### How It Works

**Nothing reads the removed fields.** The only code consumer of `skill_capabilities()` is `_list_skill_catalog_fields` (`src/commands/setup.py:1101-1114`), which names eleven fields — none of these three — and reads each through `.get(..., "")` regardless. Beyond that the reader is Hermes, and a field whose value is character-for-character another field in the same object cannot be carrying understanding.

**`schema_version` was the fourth candidate and is deliberately kept.** It is also constant across all 103 items, so it looks like the same kind of waste (4,223 characters). It is not: it is how a reader identifies what kind of record it holds, and unlike the other three it has **no surviving twin**. Removing it is the one change here that could actually cost a consumer something.

**Routing is untouched, provably.** `src/routing/` never imports `capabilities.skills`; the scorer reads `name`, `triggers`, `description`, `use_when`, `category`, and `phase` off `SkillDefinition` directly. No `SkillDefinition` field, catalog string, or generated artifact is modified in this PR — `docs workflows/roles/capability-families --check` all pass untouched.

**On the contract question.** This is a field-set change to `skill_capability/v1`, and `docs/CONTRACT_SUNSET_CANDIDATES.md` sets the bar for that class of change: consumer re-verification, and ship a successor first if replacing. No successor is shipped here because **nothing is dropped** — every removed value stays readable in the same payload under the surviving twin, which the new test names in its failure message (`use id instead of display_name`). Flagging it rather than burying it, since it is the one judgement call in this PR.

### Files And Contracts Touched

- `src/capabilities/skills.py` — −9 lines, three fields
- `tests/test_capabilities.py` — +24/−2: one new guard, two assertions repointed to the surviving twins

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `python3 -m unittest discover -s tests` — **5866 tests OK** (5865 on main + 1 new guard)
- [x] `python3 -m compileall src` — OK
- [x] `python3 -m omh.cli docs workflows --check` — `ok: true`, tap-skills 117/117
- [ ] `python3 -m omh.cli harness validate` — not rerun; no skill or harness changed
- [ ] `python3 -m omh.cli release checklist --json` — not rerun; plan-mode renderer
- [ ] `python3 -m omh.cli release hermes-smoke` — not rerun; no installed surface changed
- [ ] `omh --help` / installed-command smoke — not applicable; no CLI change
- [ ] Relevant workflow-learning review queue smoke — not applicable
- [x] Relevant dry-run or smoke command: `docs roles --check` ok, `docs capability-families --check` ok, `release drift` → **No drift, 12 checks passed**, `git diff --check` clean. `release skill-content-smoke` measured before and after, **zero budget failures** both times.
- [x] **Manual QA — executed.** Confirmed a live skill item no longer carries any of the three fields, that `surface_exposure` still reports `workflow_skill`, and that `capability_snapshot()["tool_requirements"]["items"]` still holds 103 rows with the superset of the removed stub's fields.
- [ ] Manual Hermes/TUI check — **not run.** The claim that these fields carried no understanding rests on their values being identical to surviving fields, not on observed model behavior. That is the honest limit of this evidence.

### Measured

| Budget | Before | After | Limit |
| --- | --- | --- | --- |
| full capability skill section | 338,179 | **321,646** | 340,000 |
| max full capability skill item | 4,115 | 3,958 | 9,000 |
| standalone capability section | 98,935 | 98,935 | 100,000 |
| awareness primer markdown | 3,192 | 3,192 | 3,210 |
| awareness primer context | 897 | 897 | 900 |

## Risk

- **The payload is a versioned tool output**, so a consumer outside this repo doing `item["display_name"]` would get a `KeyError`. I cannot enumerate external consumers; what I can say is that every removed value is still present under a documented twin, so any migration is a one-word rename rather than a data loss.
- The other two budgets remain untouched and tight: the **awareness primer context has 3 characters of headroom** and is genuinely always-loaded on every LLM call — unlike this section, which is an on-demand tool projection. That is the more urgent budget and this PR does not address it. See Follow-Up.

## Compatibility / Rollout

- No migration. No persisted format, no CLI, no routing behavior, no catalog or generated artifact.
- Existing installs pick the smaller payload up through the normal `omh update` path; nothing breaks for anyone who does not update.

## Release / Claims

- [x] Release-channel impact considered — none; no version file or packaging change
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — every number above was measured in this session; the unobserved part is stated in Validation
- [x] Known manual Hermes checks are listed

## Follow-Up

- **The awareness primer context (900 chars, 3 left) is the budget that actually costs per turn**, and it was deliberately *tightened* from 2200 with a recorded rationale rather than ratcheted up. Roughly 120 characters of it is a collision-handling sentence that no test asserts. Worth its own look; not bundled here because it is a different surface with a different justification.
- The standalone capability section (`src/plugin_bundle/omh/tools/capability_tool.py`) has the same shape of duplication, proportionally worse — about 57% of its 98,935 characters are four constants stamped 103 times. Same technique applies.
- `FULL_CAPABILITY_SKILL_SECTION_CHAR_LIMIT` has been raised roughly ten times, each bump justified by the previous one, and no external constraint is recorded anywhere for it. Now that a third of the payload is gone, it would be a good moment to set it from the cleaned baseline **with the derivation written down** — the way `src/wrapper/contract.py:8567-8583` documents Discord's real 2000-character cap.
