### PR TITLE
fix: stop memory-sync asking for the review it was just asked for

### DIFF
--- a/skills/omh-memory-sync/SKILL.md
+++ b/skills/omh-memory-sync/SKILL.md
@@ -57,9 +57,11 @@ Bad example:
 
 ## English-Canonical Interview Protocol
 
-- **Claim extraction (추출)** - Break supplied `USER.md` and `MEMORY.md` material into claims. Quote only observed claims; never invent provenance.
+- **Inventory (목록)** - Nobody hands you the material: call `omh_memory` with `action="status"` to get the entry inventory - per-file entry counts, per-entry index and size, headroom, and which entries have no OMH record. It returns counts and hashes, never entry text, because the text is already yours.
+- **Claim extraction (추출)** - Break the `USER.md` and `MEMORY.md` material into claims. Quote only observed claims; never invent provenance.
 - **Provenance (출처)** - Ask for the source class and distinguish Hermes-native, provider, and vector material as `not_omh_reviewed`.
 - **Target (대상)** - Review existing native-memory claims only. Route a new project/product fact to `memory-new`.
+- **Per-entry confirmation (확인)** - Walk the inventory in order. For each entry, quote it back from your own memory file and state what you take it to mean, then ask the user to keep, revise, or archive it before moving on. Do not summarize the whole file and ask one question about all of it; a review the user cannot correct entry by entry is not a review.
 - **Review (검토)** - Prioritize stale, conflicting, duplicate, and overgeneralized claims. Offer keep, revise, or archive choices; do not describe an archive as removal.
 - **Attention (주의)** - For a reviewed OMH-local record, keep/archive is an attention tier: `active` leads the working context, `reference` stays recallable behind active peers, `archive` leaves default recall. Preview with `omh memory attention <record-id> --tier <tier>`, say which records stay in the working context and which leave it, then apply with `--apply` only after the user agrees. The preview writes nothing.
 - **Diff (차이)** - Prepare one concise native write diff with before/after claims and counts. Keep the caps: MEMORY.md about 2,200 characters and USER.md about 1,375 characters.

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -1011,9 +1011,11 @@ This is a Hermes-native `{name}` workflow skill.
 
 ## English-Canonical Interview Protocol
 
-- **Claim extraction (추출)** - Break supplied `USER.md` and `MEMORY.md` material into claims. Quote only observed claims; never invent provenance.
+- **Inventory (목록)** - Nobody hands you the material: call `omh_memory` with `action="status"` to get the entry inventory - per-file entry counts, per-entry index and size, headroom, and which entries have no OMH record. It returns counts and hashes, never entry text, because the text is already yours.
+- **Claim extraction (추출)** - Break the `USER.md` and `MEMORY.md` material into claims. Quote only observed claims; never invent provenance.
 - **Provenance (출처)** - Ask for the source class and distinguish Hermes-native, provider, and vector material as `not_omh_reviewed`.
 - **Target (대상)** - Review existing native-memory claims only. Route a new project/product fact to `memory-new`.
+- **Per-entry confirmation (확인)** - Walk the inventory in order. For each entry, quote it back from your own memory file and state what you take it to mean, then ask the user to keep, revise, or archive it before moving on. Do not summarize the whole file and ask one question about all of it; a review the user cannot correct entry by entry is not a review.
 - **Review (검토)** - Prioritize stale, conflicting, duplicate, and overgeneralized claims. Offer keep, revise, or archive choices; do not describe an archive as removal.
 - **Attention (주의)** - For a reviewed OMH-local record, keep/archive is an attention tier: `active` leads the working context, `reference` stays recallable behind active peers, `archive` leaves default recall. Preview with `omh memory attention <record-id> --tier <tier>`, say which records stay in the working context and which leave it, then apply with `--apply` only after the user agrees. The preview writes nothing.
 - **Diff (차이)** - Prepare one concise native write diff with before/after claims and counts. Keep the caps: MEMORY.md about 2,200 characters and USER.md about 1,375 characters.

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -6951,6 +6951,21 @@ def _chat_response_with_goal_quality_coaching(
 MEMORY_CONSOLIDATION_NOTICE_SCHEMA_VERSION = "omh_memory_consolidation_notice/v1"
 
 
+# Which routed cards already ask for what the notice is about to ask for.
+# Keyed by the notice's own `next_action`, because the two namespaces never
+# intersect: the notice emits `ask_hermes_to_consolidate_memory`, the card emits
+# `prepare_memory_sync`. Comparing them directly would be a permanent no-op that
+# still looks like a fix.
+#
+# Keyed on `next_action` rather than on the selected skill deliberately. A skill
+# rename would silently re-arm the loop with nothing failing, while these ids are
+# contract identifiers already pinned by the chat-card and common-request
+# coverage fixtures.
+_CONSOLIDATION_REMEDY_ACTIONS: dict[str, frozenset[str]] = {
+    "ask_hermes_to_consolidate_memory": frozenset({"prepare_memory_sync"}),
+}
+
+
 def _with_memory_consolidation_notice(
     payload: dict[str, object], paths: OmhPaths, message: str = ""
 ) -> dict[str, object]:
@@ -6991,6 +7006,8 @@ def _with_memory_consolidation_notice(
         if int(record_expiry.get("expired", 0) or 0) > 0
         else "ask_hermes_to_consolidate_memory"
     )
+    routed_next_action = str(_nested(_nested(payload, "chat_response"), "state").get("next_action", ""))
+    already_asked = routed_next_action in _CONSOLIDATION_REMEDY_ACTIONS.get(next_action, frozenset())
     payload["memory_consolidation_notice"] = {
         "schema_version": MEMORY_CONSOLIDATION_NOTICE_SCHEMA_VERSION,
         "due": True,
@@ -6998,6 +7015,7 @@ def _with_memory_consolidation_notice(
         "reasons": reasons,
         "raised_at": str(brief.get("raised_at", "")),
         "next_action": next_action,
+        "call_to_action_suppressed": already_asked,
         "redaction_policy": "metadata_only",
         "claim_boundary": (
             "A consolidation notice is prepared context. It is not evidence that memory was "
@@ -7016,7 +7034,9 @@ def _with_memory_consolidation_notice(
     # declarative card copy does not contain, so es/fr/de cards read as English
     # and got an English suffix -- the exact glitch this line exists to avoid.
     notice_line = consolidation_notice_line(
-        detect_copy_locale(message or f"{updated.get('headline', '')} {body}"), reasons
+        detect_copy_locale(message or f"{updated.get('headline', '')} {body}"),
+        reasons,
+        suppress_call_to_action=already_asked,
     )
     if notice_line not in body:
         updated["body"] = f"{body} {notice_line}".strip()

--- a/src/wrapper/localized_copy.py
+++ b/src/wrapper/localized_copy.py
@@ -686,14 +686,31 @@ def skill_picker_body(
 # chose, and that card's copy is already in the reader's language. An English
 # suffix on a Korean body reads as a glitch, so the sentence and its reason
 # phrases localize through the same locale the card used.
-_CONSOLIDATION_NOTICE_SENTENCES = {
-    "en": "Memory tidy-up is pending ({summary}). Ask me to review and consolidate memory.",
-    "ko": "기억 정리가 밀려 있습니다 ({summary}). 기억을 검토하고 정리해 달라고 말씀해 주세요.",
-    "ja": "メモリ整理が保留中です（{summary}）。メモリの確認と整理を依頼してください。",
-    "zh": "记忆整理待处理（{summary}）。请让我审查并整理记忆。",
-    "es": "La consolidación de memoria está pendiente ({summary}). Pídeme revisar y consolidar la memoria.",
-    "fr": "Le rangement de la mémoire est en attente ({summary}). Demandez-moi de revoir et consolider la mémoire.",
-    "de": "Das Aufräumen des Gedächtnisses steht aus ({summary}). Bitte mich, das Gedächtnis zu prüfen und zu konsolidieren.",
+# Two clauses, kept apart because only one of them can be wrong. The status
+# clause reports a fact the reader always needs -- consolidation is pending, and
+# why. The call to action asks them to request a review, which is correct on a
+# card about something else and absurd on a card that is already the review: it
+# told a user who just asked for a memory review to ask for a memory review.
+# `consolidation_notice_line` drops the second clause when the routed card
+# already satisfies it.
+_CONSOLIDATION_NOTICE_STATUS = {
+    "en": "Memory tidy-up is pending ({summary}).",
+    "ko": "기억 정리가 밀려 있습니다 ({summary}).",
+    "ja": "メモリ整理が保留中です（{summary}）。",
+    "zh": "记忆整理待处理（{summary}）。",
+    "es": "La consolidación de memoria está pendiente ({summary}).",
+    "fr": "Le rangement de la mémoire est en attente ({summary}).",
+    "de": "Das Aufräumen des Gedächtnisses steht aus ({summary}).",
+}
+
+_CONSOLIDATION_NOTICE_CALL_TO_ACTION = {
+    "en": "Ask me to review and consolidate memory.",
+    "ko": "기억을 검토하고 정리해 달라고 말씀해 주세요.",
+    "ja": "メモリの確認と整理を依頼してください。",
+    "zh": "请让我审查并整理记忆。",
+    "es": "Pídeme revisar y consolidar la memoria.",
+    "fr": "Demandez-moi de revoir et consolider la mémoire.",
+    "de": "Bitte mich, das Gedächtnis zu prüfen und zu konsolidieren.",
 }
 
 _CONSOLIDATION_REASON_PHRASES = {
@@ -764,15 +781,25 @@ _CONSOLIDATION_FALLBACK_SUMMARY = {
 }
 
 
-def consolidation_notice_line(locale: str, reasons: list[str]) -> str:
+def consolidation_notice_line(
+    locale: str,
+    reasons: list[str],
+    *,
+    suppress_call_to_action: bool = False,
+) -> str:
     """The pending-consolidation sentence in the card's language.
 
     ``reasons`` are the scheduler's own strings (``headroom_below_floor:289<=300``);
     the value suffix is detail for wrappers, so only the family selects a phrase
     and an unknown family simply contributes nothing.
+
+    ``suppress_call_to_action`` drops the closing imperative while keeping the
+    status clause. The status clause is never dropped: a card that reviews memory
+    still needs to know consolidation is pending and that headroom is the reason,
+    because that changes what the review has to accomplish.
     """
     resolved = _normalize_locale(locale)
-    if resolved not in _CONSOLIDATION_NOTICE_SENTENCES:
+    if resolved not in _CONSOLIDATION_NOTICE_STATUS:
         resolved = "en"
     phrases: list[str] = []
     for reason in reasons:
@@ -781,4 +808,7 @@ def consolidation_notice_line(locale: str, reasons: list[str]) -> str:
         if phrase and phrase not in phrases:
             phrases.append(phrase)
     summary = "; ".join(phrases) if phrases else _CONSOLIDATION_FALLBACK_SUMMARY[resolved]
-    return _CONSOLIDATION_NOTICE_SENTENCES[resolved].format(summary=summary)
+    status = _CONSOLIDATION_NOTICE_STATUS[resolved].format(summary=summary)
+    if suppress_call_to_action:
+        return status
+    return f"{status} {_CONSOLIDATION_NOTICE_CALL_TO_ACTION[resolved]}"

--- a/tests/test_memory_provider.py
+++ b/tests/test_memory_provider.py
@@ -1194,6 +1194,55 @@ class ChatNoticeOnEveryMessengerTests(unittest.TestCase):
             self.assertEqual(noticed["headline"], control["headline"])
             self.assertTrue(str(noticed["body"]).startswith(str(control["body"])))
 
+    CALL_TO_ACTION_KO = "기억을 검토하고 정리해 달라고 말씀해 주세요"
+    MEMORY_SYNC_MESSAGE = "내 기억 검토하고 정리해줘"
+
+    def test_a_memory_review_card_does_not_ask_for_a_memory_review(self) -> None:
+        """The loop this closes: the notice told a user who had just asked for a
+        memory review to ask for a memory review."""
+        with TemporaryDirectory() as tmp:
+            _, paths = self._due_paths(Path(tmp))
+            payload = self._payload(paths, "generic", self.MEMORY_SYNC_MESSAGE)
+            body = str(payload["chat_response"]["body"])
+            state = payload["chat_response"]["state"]
+
+            self.assertEqual(state["next_action"], "prepare_memory_sync")
+            self.assertNotIn(self.CALL_TO_ACTION_KO, body)
+            self.assertTrue(payload["memory_consolidation_notice"]["call_to_action_suppressed"])
+
+    def test_the_status_clause_survives_suppression(self) -> None:
+        """Only the imperative is wrong on this card. The status clause says
+        headroom is the reason, which changes what the review has to achieve."""
+        with TemporaryDirectory() as tmp:
+            _, paths = self._due_paths(Path(tmp))
+            payload = self._payload(paths, "generic", self.MEMORY_SYNC_MESSAGE)
+
+            self.assertIn(self.NOTICE_KO, str(payload["chat_response"]["body"]))
+            self.assertTrue(payload["memory_consolidation_notice"]["due"])
+            self.assertTrue(payload["chat_response"]["state"]["memory_consolidation"]["due"])
+
+    def test_a_card_that_does_not_review_memory_still_gets_the_imperative(self) -> None:
+        """The negative case: suppression must be scoped to cards that already ask."""
+        with TemporaryDirectory() as tmp:
+            _, paths = self._due_paths(Path(tmp))
+            payload = self._payload(paths, "generic", self.KO_MESSAGE)
+            body = str(payload["chat_response"]["body"])
+
+            self.assertNotEqual(payload["chat_response"]["state"].get("next_action"), "prepare_memory_sync")
+            self.assertIn(self.CALL_TO_ACTION_KO, body)
+            self.assertFalse(payload["memory_consolidation_notice"]["call_to_action_suppressed"])
+
+    def test_suppression_keys_on_the_remedy_map_not_the_skill_name(self) -> None:
+        """A skill rename must not silently re-arm the loop, so the map is keyed
+        on `next_action` ids, which coverage fixtures already pin."""
+        from omh.wrapper.contract import _CONSOLIDATION_REMEDY_ACTIONS
+
+        self.assertIn("prepare_memory_sync", _CONSOLIDATION_REMEDY_ACTIONS["ask_hermes_to_consolidate_memory"])
+        # The two namespaces never intersect; comparing them directly would be a
+        # permanent no-op that still looked like a fix.
+        for notice_action, card_actions in _CONSOLIDATION_REMEDY_ACTIONS.items():
+            self.assertNotIn(notice_action, card_actions)
+
     def test_no_brief_means_no_notice_anywhere(self) -> None:
         with TemporaryDirectory() as tmp:
             from omh.paths import resolve_paths
@@ -1487,13 +1536,18 @@ class NoticeLocaleCoverageTests(unittest.TestCase):
         # regress the notice to English; this is that gate.
         from omh.wrapper.localized_copy import (
             _CONSOLIDATION_FALLBACK_SUMMARY,
-            _CONSOLIDATION_NOTICE_SENTENCES,
+            _CONSOLIDATION_NOTICE_CALL_TO_ACTION,
+            _CONSOLIDATION_NOTICE_STATUS,
             _CONSOLIDATION_REASON_PHRASES,
             SUPPORTED_COPY_LOCALES,
         )
 
         expected = set(SUPPORTED_COPY_LOCALES)
-        self.assertEqual(set(_CONSOLIDATION_NOTICE_SENTENCES), expected)
+        # The notice sentence is two tables since the call to action became
+        # suppressible; both are parallel and both are gated, or a locale could
+        # lose only its imperative and read as a truncated sentence.
+        self.assertEqual(set(_CONSOLIDATION_NOTICE_STATUS), expected)
+        self.assertEqual(set(_CONSOLIDATION_NOTICE_CALL_TO_ACTION), expected)
         self.assertEqual(set(_CONSOLIDATION_FALLBACK_SUMMARY), expected)
         for family, phrases in _CONSOLIDATION_REASON_PHRASES.items():
             self.assertEqual(set(phrases), expected, family)

--- a/tests/test_memory_sync_skill.py
+++ b/tests/test_memory_sync_skill.py
@@ -169,6 +169,34 @@ class MemorySyncSkillTests(unittest.TestCase):
         ):
             self.assertIn(anchor, content, anchor)
 
+    def test_memory_sync_skill_names_who_supplies_the_material(self) -> None:
+        """The protocol said "supplied" material and never named a supplier.
+
+        `omh_memory` with `action="status"` has shipped since PR #672 and returns
+        exactly the entry inventory this review needs, but nothing told Hermes to
+        call it, so the review started from nothing and the card asked the user
+        to ask again. One bullet turns a registered tool into a working loop.
+        """
+        content = _template_content("memory-sync")
+        for anchor in (
+            "Inventory (목록)",
+            "omh_memory",
+            'action="status"',
+            "never entry text",
+        ):
+            self.assertIn(anchor, content, anchor)
+
+    def test_memory_sync_skill_requires_entry_by_entry_confirmation(self) -> None:
+        """A summary of the whole file with one question is not a review."""
+        content = _template_content("memory-sync")
+        for anchor in (
+            "Per-entry confirmation (확인)",
+            "quote it back",
+            "keep, revise, or archive it before moving on",
+            "cannot correct entry by entry is not a review",
+        ):
+            self.assertIn(anchor, content, anchor)
+
     def test_memory_sync_skill_teaches_the_preview_then_apply_attention_tier_flow(self) -> None:
         """Without this guidance the tier is a CLI feature Hermes never reaches,
         and the user is back to typing a control-plane command."""


### PR DESCRIPTION
## Feature Report

### What Changed

- The consolidation notice no longer tells a user who just asked for a memory review to ask for a memory review. Its sentence is split into a status clause (always kept) and a call to action (suppressed when the routed card already is that request).
- The memory-sync interview protocol now **names who supplies the material** — `omh_memory` with `action="status"` — and requires walking the inventory **entry by entry**, quoting each one back and asking keep / revise / archive before moving on.
- Six new tests, including the negative case that non-memory-sync cards keep the imperative.

### Why This Exists

Reported from actual use. `omh chat interact "내 기억 검토하고 정리해줘"` returned:

> …I can prepare a native write diff, but this guidance never invokes, applies, or observes a MEMORY.md or USER.md write. 기억 정리가 밀려 있습니다 (…). **기억을 검토하고 정리해 달라고 말씀해 주세요.**

The last sentence asks the user to make the request they just made. And no remembered claim ever appeared, so the review the card describes never started. The expectation — *"at this point I remember this context this way, is that right?"* back and forth — was not reachable.

### User / Operator Impact

**Before / after on the exact repro:**

```
- …기억 정리가 밀려 있습니다 (정리되지 않은 작업을 남긴 채 세션 종료; 기억이 거의 가득 참).
-   기억을 검토하고 정리해 달라고 말씀해 주세요.
+ …기억 정리가 밀려 있습니다 (정리되지 않은 작업을 남긴 채 세션 종료; 기억이 거의 가득 참).
```

A card about anything else is unchanged and still carries the imperative.

And Hermes is now told, in the installed skill, to fetch the inventory and confirm entries one at a time instead of describing a review in the abstract.

### How It Works

**The loop.** The sentence belongs to `_with_memory_consolidation_notice`, not to memory-sync. It was one string with two clauses. Only the imperative is ever wrong, and only when the routed card already is the request. Now two tables, joined unless suppressed.

**The status clause deliberately survives.** `headroom_below_floor:139<=300` is *why* the notice fired and it changes what the review must accomplish — this is not tidying for its own sake, it has to free space. Suppressing the whole notice would also drop `state.memory_consolidation`, the card's only urgency signal.

**Keyed on `next_action`, not on the skill name.** A rename would silently re-arm the loop with nothing failing; `next_action` ids are contract identifiers the coverage fixtures already pin. Worth noting: the two namespaces never intersect — the notice emits `ask_hermes_to_consolidate_memory`, the card emits `prepare_memory_sync` — so the obvious `notice.next_action == card.next_action` check would have been a **permanent no-op that still looked like a fix**. A test asserts the disjointness so nobody simplifies it into one.

**The review that never started.** The protocol said "supplied `USER.md` and `MEMORY.md` material" and never named a supplier. Nothing supplied it. Meanwhile `omh_memory` `action="status"` has shipped since PR #672 and returns exactly the needed inventory — per-file entry counts, per-entry index and size, headroom, and which entries have no OMH record. Registered, reachable, and unmentioned by any line of guidance. Two bullets close that: `Inventory (목록)` names the producer, `Per-entry confirmation (확인)` requires the entry-by-entry loop.

**No redaction change was needed, and the tempting justification for that is wrong.** OMH *does* read entry text in-process — it cannot hash and char-count otherwise (`hermes_memory.py:146`). `metadata_only` is a property of the **emitted payload**, not of the process. The loop works without touching it for a simpler reason: the text is Hermes' own file, so Hermes quotes its own entry and OMH supplies only the index. Stating it precisely because "content never passes through OMH" would be an overclaim of exactly the kind `AGENTS.md` prohibits.

### Files And Contracts Touched

- `src/wrapper/localized_copy.py` — notice split into `_CONSOLIDATION_NOTICE_STATUS` + `_CONSOLIDATION_NOTICE_CALL_TO_ACTION` (7 locales each); `suppress_call_to_action` on the builder
- `src/wrapper/contract.py` — `_CONSOLIDATION_REMEDY_ACTIONS` map; suppression at the existing seam; new `call_to_action_suppressed` field so the behavior is observable rather than invisible
- `src/skills/render.py` — two protocol bullets
- `skills/omh-memory-sync/SKILL.md` — regenerated
- `tests/test_memory_provider.py`, `tests/test_memory_sync_skill.py` — 6 new tests; the locale-coverage gate extended to both new tables

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `python3 -m unittest discover -s tests` — **5871 tests OK** (5865 + 6 new)
- [x] `python3 -m compileall src` — OK
- [x] `python3 -m omh.cli docs workflows --check` — `ok: true`, tap-skills 117/117
- [ ] `python3 -m omh.cli harness validate` — not rerun; no skill or harness added
- [ ] `python3 -m omh.cli release checklist --json` / `hermes-smoke` / `omh --help` / installed-command smoke — not applicable; no CLI or installed surface changed
- [ ] Relevant workflow-learning review queue smoke — not applicable
- [x] Relevant dry-run or smoke command: `docs roles --check` ok, `docs capability-families --check` ok, `release drift` → **No drift, 12 checks passed**, `git diff --check` clean
- [x] **Manual QA — executed.** Re-ran the original repro: the imperative is gone, the status clause and structured notice remain, `call_to_action_suppressed: true`, `due: true`. Re-ran a non-memory-sync message: imperative present, `call_to_action_suppressed: false`.
- [ ] Manual Hermes/TUI check — **not run, and this is the honest limit.** Whether Hermes actually calls `omh_memory` and runs the per-entry loop is unobservable from OMH. This ships the instruction and names the producer; it is not evidence a model followed either.

**Existing-behavior check.** Eleven tests pin always-append. I resolved every fixture message against the live router — `이 레포에 기능 하나 안전하게 추가하고 싶어` → `oh-my-hermes`, `I want to add a feature safely` → `ralplan`, `PR 하나 올리고 싶은데 도와줘` → `oh-my-hermes`, `hello there` → not memory-sync. None routes here, so the suppression is additive-safe; the new negative-control test covers the direction they do not.

## Risk

- Suppression is gated on a two-entry map and one `next_action` comparison. If a retire-shaped card ever appears, `run_omh_memory_retire` needs its own entry — the map is the single place to add it.
- The protocol bullets are prose in a generated skill. Their effect depends on Hermes following them, which no local gate can prove.

## Compatibility / Rollout

- No schema change, no persisted format, no CLI, no routing behavior, no new action. The notice payload gains one boolean field.
- Existing installs pick up the skill guidance through `omh update`.

## Release / Claims

- [x] Release-channel impact considered — none
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — the before/after is observed local execution; the Hermes-side gap is stated plainly
- [x] Known manual Hermes checks are listed

## Follow-Up

**Two things I attempted and deliberately did not ship:**

1. **Korean per-entry routing triggers — tried, reverted.** `기억 하나씩 확인해줘` and `내 기억을 하나씩 검토해서 맞는지 확인해줘` currently miss memory-sync and fall through to the router. Adding two Hangul triggers fixed both, and then failed `tests/test_routing_language_policy.py`, which freezes per-skill Hangul tables for exactly this reason:

   > *"Raising an entry below means an existing Korean table grew: do it only with a stated reason, and **never to make a routing miss go away** — the fix for that is model selection, not more tokens."*

   That policy is right and my change was the anti-pattern it names, so it is out. The routing gap is real and belongs to model selection over supplied candidates, not to this PR. `review my stored claims one by one` also loses to `code-review`; I chose not to force that either, since taking it would risk stealing genuine code reviews and the phrase is honestly ambiguous.

2. **Entry scaffolding attached to the card payload.** It would save Hermes a tool call, but it duplicates what `omh_memory` already returns, and the bridge payload carries **absolute filesystem paths** (`/Users/…/.hermes/memories/MEMORY.md`) that would leak a home directory into a shared Slack channel. Not worth the round trip it saves.

**Separately found, out of scope, worth its own issue:** the documented exit from `review_required_legacy` is unreachable. All local OMH records sit in that state so `omh memory recall` returns `record_count: 0`. `omh memory reactivate` requires a pre-existing `project_memory_review_record/v2` carrying `review_id`, `artifact_identity`, and `payload_digest` — and no command mints one for a v1 artifact; every v2-review writer produces it only as a byproduct of approving a v2 record. `docs/MEMORY.md:511` reads as though reactivation is a complete path. It is not.
