### PR TITLE
docs: keep Ultra-Skills commands on one line

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Maintenance paths such as reconciling a `--full` install back to core live in
 Twelve `ulw-` workflows. Say the trigger in chat — Hermes routes the
 rest. Full catalog: [Workflow Reference](docs/WORKFLOWS.md).
 
-| Skill | What it does |
+| Workflow&nbsp;command | What it does |
 | --- | --- |
 | ⚡ `ulw-context` | Aligns reviewed project terms, captures confirmed candidates, and interviews the next decision frontier without giving terminology routing authority. |
 | ⚡ `ulw-interview` | Asks one question at a time until it knows exactly what you want. |


### PR DESCRIPTION
## Feature Report

### What Changed

- Renamed the Ultra-Skills table's first header from `Skill` to `Workflow command`.
- Kept the two header words together with a nonbreaking space so GitHub allocates enough width for the longest `ulw-*` label.

### Why This Exists

The narrow `Skill` header allowed the first table column to collapse until labels could wrap immediately after `ulw-`, making the command list look uneven and harder to scan.

### User / Operator Impact

README readers now see each `ulw-*` workflow command on one line with a consistently sized command column.

### How It Works

The Markdown table remains otherwise unchanged. `Workflow&nbsp;command` widens the column through normal table layout while preserving every exact backtick-wrapped installable label and all existing descriptions.

### Files And Contracts Touched

- `README.md`: Ultra-Skills table header only.
- Existing exact-label contract in `tests/test_readme_highlights.py` remains unchanged and passing.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [ ] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [ ] `uv run python -m compileall -q src tests`
- [ ] `uv run python -m omh.cli docs workflows --check`
- [ ] `uv run python -m omh.cli docs roles --check`
- [ ] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: GitHub Markdown API rendered the updated table header as one nonbreaking `Workflow command` cell.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- Full suite: 6,136 tests passed in 188.401 seconds.
- Targeted README contract: 3 tests passed.
- GitHub's Markdown API preserved the nonbreaking space and rendered all labels as code.
- `git diff --check` passed.

### Not Tested / Not Applicable

- Lint, compile, generated-doc, harness, release, and CLI checks are not applicable to a one-line prose-only README table-header change.
- Manual Hermes/TUI testing is not applicable because no runtime or wrapper behavior changed.
- Third-party Markdown renderers were not manually inspected; the public GitHub README surface was rendered through GitHub's API.

## Risk

Low. The only change is display text in one table header; commands, descriptions, links, and generated artifacts are untouched.

## Compatibility / Rollout

GitHub supports `&nbsp;` in GFM table cells. Other Markdown renderers commonly preserve it as a normal nonbreaking space; if one does not, the fallback remains readable header text.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- None.
