### PR TITLE
Fix Windows benchmark integrity key handling

### DIFF
--- a/benchmarks/live-model-tools/v1/README.md
+++ b/benchmarks/live-model-tools/v1/README.md
@@ -68,3 +68,29 @@ version-aware:
 
 Provider parameters are not claimed unless Hermes actually exposes them and the
 observation records them.
+
+## Latest measured status
+
+The 2026-08-13 evaluation run completed the full offline fake matrix:
+
+| Harness | Condition | Passed | Scheduled | Delta |
+| --- | --- | ---: | ---: | ---: |
+| `fake` | baseline | 30 | 30 | |
+| `fake` | optimized | 30 | 30 | `0.0` |
+
+This proves the pinned corpus, controller validators, pairing, analysis, and
+audit pipeline execute end to end. It is not model-performance evidence. The
+audit correctly returned `claim_permitted: false` and requires the public
+statement: "A reproducible benchmark is available; current results are
+preliminary and are not a superiority claim."
+
+Live baseline smoke runs were attempted for Kimi K3, GPT-5.6 Sol, Claude Fable
+5, and GLM 5. All four isolated Hermes dispatches exited before producing a run
+record, so there is no live baseline-versus-optimized number to publish.
+The local model inventory confirms those families in OMO/Senpi, and Hermes has
+Kimi and GPT aliases, but the isolated child deliberately cannot read Hermes'
+`auth.json` or OMO/Senpi credentials. It accepts only provider-specific
+credential environment variables, and no matching variables were available to
+these runs. Do not present OMO/Senpi availability as Hermes child execution
+evidence or infer cost, token, quality, or superiority metrics from the failed
+smokes.

--- a/src/commands/hermes_child.py
+++ b/src/commands/hermes_child.py
@@ -467,7 +467,7 @@ def _observation_key(args: argparse.Namespace) -> bytes:
     try:
         descriptor = os.open(
             key_path,
-            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            _observation_key_open_flags(),
             0o600,
         )
     except FileExistsError:
@@ -481,6 +481,10 @@ def _observation_key(args: argparse.Namespace) -> bytes:
     if len(key) != 32 or key_path.is_symlink():
         raise OmhError("Hermes child observation integrity key is invalid")
     return key
+
+
+def _observation_key_open_flags() -> int:
+    return os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0)
 
 
 def _canonical_observation(observation: dict[str, object]) -> bytes:

--- a/tests/test_hermes_child_cli.py
+++ b/tests/test_hermes_child_cli.py
@@ -10,6 +10,7 @@ import unittest
 from unittest.mock import patch
 
 from _cli_harness import run_cli
+from omh.commands import hermes_child as hermes_child_command
 
 
 _FAKE_HERMES = r"""
@@ -59,6 +60,12 @@ class HermesChildCliTests(unittest.TestCase):
             "--reasoning", "high", "--parent-run-id", "parent-123",
             "--run-id", "child-456",
         ]
+
+    def test_observation_key_uses_binary_mode_when_platform_requires_it(self) -> None:
+        with patch.object(hermes_child_command.os, "O_BINARY", 0x8000, create=True):
+            flags = hermes_child_command._observation_key_open_flags()
+
+        self.assertEqual(flags & 0x8000, 0x8000)
 
     def test_prepare_is_default_safe_action_and_writes_no_prompt(self) -> None:
         secret = "SECRET_PREPARE_PROMPT_91"


### PR DESCRIPTION
## What changed

Fix the post-merge Windows CI failure in the OMH-native live benchmark integration path. Isolated Hermes child observation HMAC keys now use binary descriptors on platforms that distinguish text and binary file I/O, preserving all 32 random bytes without weakening key length or symlink validation.

The benchmark reference also records what was actually measured on 2026-08-13:

- full offline evaluation matrix: baseline 30/30, optimized 30/30, delta 0.0;
- audit result: reproducible pipeline, no model-performance or superiority claim permitted;
- attempted live baseline smokes for Kimi K3, GPT-5.6 Sol, Claude Fable 5, and GLM 5;
- all four stopped at isolated Hermes dispatch because the child intentionally cannot read Hermes `auth.json` or OMO/Senpi credentials and matching provider environment credentials were unavailable.

## Why

PR #948 passed its pull-request checks but the merged `main` push exposed a Windows-only text-mode translation issue. A random 32-byte integrity key containing byte `0x1A` could be truncated when read back, causing `Hermes child observation integrity key is invalid` in `test_omh_live_model_benchmark`.

## User/operator outcome

- Windows uses the same authenticated observation contract as Unix platforms.
- The benchmark documentation distinguishes completed offline pipeline evidence from unavailable live model evidence.
- Failed live dispatches are not reported as scores, costs, token counts, or model comparisons.

## Boundary-level implementation

- `src/commands/hermes_child.py`: include `os.O_BINARY` when the platform provides it.
- `tests/test_hermes_child_cli.py`: regression-lock binary descriptor selection.
- `benchmarks/live-model-tools/v1/README.md`: report measured fake results and live-smoke limits.

## Verification

- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 6,301 passed.
- Focused Hermes child and benchmark suites — passed.
- Ruff, compileall, generated workflows/roles/capability-family checks, and `git diff --check` — passed.
- Fake evaluation baseline — 30/30.
- Fake evaluation optimized — 30/30.
- Analysis delta — 0.0; exact McNemar p=1.0.
- Audit — `ok: true`, `claim_permitted: false`.

## Risks and follow-up

A live baseline-versus-optimized model result still requires explicit provider credentials at the isolated Hermes child boundary. OMO/Senpi model availability alone is not Hermes execution evidence and was not treated as such.
