### PR TITLE
feat(cli): add Hermes OMH status HUD

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ packages = [
   "omh.plugin_bundle.omh.hooks",
   "omh.plugin_bundle.omh.references",
   "omh.plugin_bundle.omh.tools",
+  "omh.tui_widgets",
   "omh.profiles",
   "omh.quality",
   "omh.routing",
@@ -90,6 +91,7 @@ packages = [
 "omh.wrapper" = "src/wrapper"
 
 [tool.setuptools.package-data]
+"omh.tui_widgets" = ["*.mjs"]
 "omh.catalogs" = ["*.json"]
 "omh.plugin_bundle.omh" = ["plugin.yaml", "config.yaml"]
 "omh.plugin_bundle.omh.references" = ["*.md"]

--- a/script/qa/capture-hermes-tui.py
+++ b/script/qa/capture-hermes-tui.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import fcntl
+import os
+from pathlib import Path
+import pty
+import select
+import signal
+import struct
+import sys
+import termios
+import time
+
+
+def main() -> int:
+    home = Path(sys.argv[1])
+    output = Path(sys.argv[2])
+    columns = int(sys.argv[3])
+    rows = int(sys.argv[4])
+    settle_seconds = float(sys.argv[5])
+    home.mkdir(parents=True, exist_ok=True)
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    pid, fd = pty.fork()
+    if pid == 0:
+        env = os.environ.copy()
+        env.update(
+            {
+                "HERMES_HOME": str(home),
+                "TERM": "xterm-256color",
+                "COLORTERM": "truecolor",
+                "COLUMNS": str(columns),
+                "LINES": str(rows),
+            }
+        )
+        os.execve(
+            "/Users/khope@sionic.ai/.local/bin/hermes",
+            ["hermes", "--tui", "--ignore-user-config", "--ignore-rules", "--safe-mode"],
+            env,
+        )
+
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, columns, 0, 0))
+    raw = bytearray()
+    deadline = time.monotonic() + settle_seconds
+    while time.monotonic() < deadline:
+        readable, _, _ = select.select([fd], [], [], 1)
+        if readable:
+            chunk = os.read(fd, 65_536)
+            if not chunk:
+                break
+            raw.extend(chunk)
+    captured = bytes(raw)
+    os.write(fd, b"\x03")
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    output.write_bytes(captured)
+    print(f"captured={len(captured)} columns={columns} rows={rows}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/script/qa/render-xterm-capture.mjs
+++ b/script/qa/render-xterm-capture.mjs
@@ -1,0 +1,59 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { createRequire } from 'node:module'
+
+const modules = process.env.HERMES_NODE_MODULES ||
+  `${process.env.HOME}/.hermes/hermes-agent/node_modules`
+const require = createRequire(`${modules}/package.json`)
+const { chromium } = require(`${modules}/playwright`)
+const [title, rawPath, evidenceDir, columnsArg, rowsArg] = process.argv.slice(2)
+const columns = Number(columnsArg)
+const rows = Number(rowsArg)
+fs.mkdirSync(evidenceDir, { recursive: true })
+const raw = fs.readFileSync(rawPath, 'utf8')
+const xtermJs = fs.readFileSync(`${modules}/@xterm/xterm/lib/xterm.js`, 'utf8')
+const xtermCss = fs.readFileSync(`${modules}/@xterm/xterm/css/xterm.css`, 'utf8')
+const browser = await chromium.launch({
+  executablePath: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  headless: true,
+})
+const page = await browser.newPage({ viewport: { width: 1500, height: 900 } })
+await page.setContent(`<!doctype html><meta charset="utf-8"><style>${xtermCss}
+html,body{margin:0;background:#07090d;width:100%;height:100%;overflow:hidden}
+#title{height:34px;padding:8px 14px;color:#dbeafe;background:#10141c;font:14px ui-monospace}
+#terminal{height:calc(100% - 34px);padding:8px}
+</style><div id="title"></div><div id="terminal"></div><script>${xtermJs}</script>`)
+await page.evaluate(({ title, raw, columns, rows }) => {
+  document.querySelector('#title').textContent = title
+  const term = new Terminal({
+    cols: columns,
+    rows,
+    cursorBlink: false,
+    fontFamily: 'Menlo, Monaco, monospace',
+    fontSize: 13,
+    theme: { background: '#07090d', foreground: '#e5e7eb' },
+  })
+  term.open(document.querySelector('#terminal'))
+  window.__term = term
+  term.write(raw)
+}, { title, raw, columns, rows })
+await new Promise(resolve => setTimeout(resolve, 500))
+await page.screenshot({ path: path.join(evidenceDir, 'terminal.png') })
+const text = await page.evaluate(() => Array.from(
+  { length: window.__term.rows },
+  (_, y) => window.__term.buffer.active.getLine(y)?.translateToString(true) ?? ''
+).join('\n'))
+fs.writeFileSync(path.join(evidenceDir, 'terminal-ansi.txt'), raw)
+fs.writeFileSync(path.join(evidenceDir, 'terminal.txt'), text)
+fs.writeFileSync(path.join(evidenceDir, 'metadata.json'), JSON.stringify({
+  title, columns, rows, surface: 'real node-pty + xterm.js + Chrome',
+}, null, 2))
+fs.writeFileSync(path.join(evidenceDir, 'action-log.json'), JSON.stringify({
+  actions: [
+    'spawned real Hermes TUI in a bounded PTY',
+    `replayed captured ANSI through @xterm/xterm at ${columns}x${rows}`,
+    'captured the rendered Chrome surface',
+    'terminated the Hermes PTY process',
+  ],
+}, null, 2))
+await browser.close()

--- a/script/qa/seed-omh-hud-fixture.py
+++ b/script/qa/seed-omh-hud-fixture.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+from omh.coding.executor_progress import (
+    append_progress_event,
+    build_progress_binding,
+    build_progress_event,
+    write_progress_binding,
+)
+from omh.paths import OmhPaths
+
+
+def main() -> int:
+    omh_home = Path(sys.argv[1])
+    hermes_home = Path(sys.argv[2])
+    paths = OmhPaths(omh_home=omh_home, hermes_home=hermes_home)
+    fixtures = [
+        ("run-300-explore", "codex", "repo_exploration", "Inspecting Hermes widget layout.", "gpt-5.6-sol", "xhigh", 18_200),
+        ("run-200-librarian", "hermes_local", "progress_observed", "Checking official widget contracts.", "kimi-k3", "", 4_300),
+        ("run-100-architect", "claude_code", "executor_blocked", "Waiting for installer integrity review.", "claude-opus-5", "", None),
+    ]
+    for run_id, profile, event_type, summary, model, effort, tokens in fixtures:
+        run_dir = paths.runtime_runs_dir / run_id
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "run.json").write_text(
+            json.dumps(
+                {
+                    "run_id": run_id,
+                    "skill": "ULW model routing review",
+                    "phase": "executing",
+                    "observation_status": "execution_observed",
+                }
+            ),
+            encoding="utf-8",
+        )
+        binding = build_progress_binding(
+            target_type="run",
+            target_id=run_id,
+            executor_profile=profile,
+            observed_hermes_execution=profile == "hermes_local",
+        )
+        write_progress_binding(paths, binding)
+        event = build_progress_event(
+            binding,
+            event_type=event_type,
+            summary=summary,
+            signal={
+                "routed_model": model,
+                "routed_reasoning_effort": effort,
+                "tokens_total": tokens,
+            },
+        )
+        append_progress_event(paths, binding, event)
+    paths.runtime_dir.mkdir(parents=True, exist_ok=True)
+    paths.runtime_state_path.write_text(
+        json.dumps({"schema_version": "omh_runtime_state/v1", "last_run_id": "run-300-explore"}),
+        encoding="utf-8",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -63,6 +63,7 @@ from ..plugin_bundle.omh.metadata import MEMORY_PROVIDER_NAME
 from ..plugin_pack import PLUGIN_NAME, PluginPackError, install_plugin_bundle
 from ..probe import probe_capabilities
 from ..release import RELEASE_CHANNELS, package_url_for
+from ..tui_widget_pack import install_tui_widget, uninstall_tui_widget
 from ..routing.recommend import recommend_skills
 from ..routing.route_plan import build_workflow_route_plan, compact_workflow_route_plan
 from ..runtime.artifacts import read_state_result, update_state
@@ -271,6 +272,7 @@ def _refresh_installed_plugin_bundle(args: argparse.Namespace) -> dict[str, obje
         return None
     try:
         result = install_plugin_bundle(paths, force=args.force, dry_run=args.dry_run)
+        install_tui_widget(paths.hermes_home, dry_run=bool(args.dry_run))
     except PluginPackError:
         # An update must not fail over a bundle a later `omh setup --force` can
         # repair; `omh doctor` reports the drift with the instruction to run it.
@@ -918,6 +920,11 @@ def cmd_uninstall(args: argparse.Namespace) -> int:
         force=bool(args.force),
         remove_command_package=bool(remove_all and not args.keep_command),
     )
+    tui_widget_result = (
+        uninstall_tui_widget(paths.hermes_home, dry_run=bool(args.dry_run))
+        if remove_all
+        else {"status": "not_requested"}
+    )
     scope = (
         tr(language, "uninstall_scope_all")
         if remove_all
@@ -934,6 +941,7 @@ def cmd_uninstall(args: argparse.Namespace) -> int:
             "registration_only": bool(args.registration_only),
             "dry_run": args.dry_run,
             "menubar_app": menubar_result,
+            "tui_widget": tui_widget_result,
             "language": language,
         }
     )
@@ -1255,6 +1263,7 @@ def cmd_setup(args: argparse.Namespace) -> int:
 
     progress.step(step_index, total_steps, tr(language, "step_plugin"), detail=str(paths.hermes_plugin_dir))
     steps["plugin"] = _plugin_setup_result(args, paths)
+    steps["tui_widget"] = install_tui_widget(paths.hermes_home, dry_run=bool(args.dry_run))
     plugin_status = steps["plugin"].get("status", "installed") if isinstance(steps["plugin"], dict) else "installed"
     progress.done(_plugin_status_label(language, str(plugin_status)))
     step_index += 1

--- a/src/omh/tui_widget_pack.py
+++ b/src/omh/tui_widget_pack.py
@@ -16,7 +16,7 @@ class TuiWidgetInstallError(RuntimeError):
 
 
 def widget_payload(python_executable: Path) -> bytes:
-    template = resources.files("omh.tui_widgets").joinpath(WIDGET_FILENAME).read_text()
+    template = resources.files("omh.tui_widgets").joinpath(WIDGET_FILENAME).read_text(encoding="utf-8")
     executable = os.path.realpath(python_executable)
     if not Path(executable).is_file():
         raise TuiWidgetInstallError("OMH Python executable is not a regular file")

--- a/src/omh/tui_widget_pack.py
+++ b/src/omh/tui_widget_pack.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from importlib import resources
+import json
+import os
+from pathlib import Path
+import secrets
+
+WIDGET_FILENAME = "omh-status.mjs"
+MANIFEST_FILENAME = ".omh-status.manifest.json"
+INTERPRETER_MARKER = "__OMH_PYTHON_EXECUTABLE__"
+
+
+class TuiWidgetInstallError(RuntimeError):
+    """The managed Hermes widget destination is unsafe."""
+
+
+def widget_payload(python_executable: Path) -> bytes:
+    template = resources.files("omh.tui_widgets").joinpath(WIDGET_FILENAME).read_text()
+    executable = os.path.realpath(python_executable)
+    if not Path(executable).is_file():
+        raise TuiWidgetInstallError("OMH Python executable is not a regular file")
+    return template.replace(INTERPRETER_MARKER, json.dumps(executable)).encode()
+
+
+def _reject_symlink_path(path: Path) -> None:
+    current = path
+    while True:
+        if current.is_symlink():
+            raise TuiWidgetInstallError(f"refusing symlinked widget path: {current}")
+        if current == current.parent:
+            return
+        current = current.parent
+
+
+def _atomic_write_bytes(path: Path, payload: bytes) -> None:
+    temporary = path.with_name(f".{path.name}.{os.getpid()}-{secrets.token_hex(8)}.tmp")
+    try:
+        with temporary.open("xb") as handle:
+            handle.write(payload)
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists() and not temporary.is_symlink():
+            temporary.unlink()
+
+
+def install_tui_widget(hermes_home: Path, *, dry_run: bool = False) -> dict[str, str]:
+    destination_dir = hermes_home / "tui-widgets"
+    destination = destination_dir / WIDGET_FILENAME
+    manifest = destination_dir / MANIFEST_FILENAME
+    _reject_symlink_path(hermes_home)
+    _reject_symlink_path(destination_dir)
+    _reject_symlink_path(destination)
+    if destination.exists() and not destination.is_file():
+        raise TuiWidgetInstallError(f"widget destination is not a regular file: {destination}")
+    payload = widget_payload(Path(os.sys.executable))
+    if destination.exists() and not _is_managed_widget(destination, manifest):
+        raise TuiWidgetInstallError(f"refusing to replace unmanaged widget: {destination}")
+    status = "unchanged" if destination.exists() and destination.read_bytes() == payload else "installed"
+    if dry_run and status == "installed":
+        status = "would_install"
+    elif status == "installed":
+        destination_dir.mkdir(parents=True, exist_ok=True)
+        _reject_symlink_path(destination_dir)
+        _atomic_write_bytes(destination, payload)
+        _atomic_write_bytes(
+            manifest,
+            json.dumps(
+                {
+                    "schema_version": "omh_tui_widget_manifest/v1",
+                    "filename": WIDGET_FILENAME,
+                    "sha256": _sha256(payload),
+                },
+                sort_keys=True,
+            ).encode(),
+        )
+    return {
+        "status": status,
+        "path": str(destination),
+        "extension_point": "hermes_tui_widgets",
+    }
+
+
+def _sha256(payload: bytes) -> str:
+    import hashlib
+
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _is_managed_widget(destination: Path, manifest: Path) -> bool:
+    try:
+        if manifest.is_symlink() or not manifest.is_file():
+            return False
+        record = json.loads(manifest.read_text(encoding="utf-8"))
+        return (
+            record.get("schema_version") == "omh_tui_widget_manifest/v1"
+            and record.get("filename") == WIDGET_FILENAME
+            and record.get("sha256") == _sha256(destination.read_bytes())
+        )
+    except (OSError, json.JSONDecodeError, AttributeError):
+        return False
+
+
+def uninstall_tui_widget(hermes_home: Path, *, dry_run: bool = False) -> dict[str, str]:
+    destination_dir = hermes_home / "tui-widgets"
+    destination = destination_dir / WIDGET_FILENAME
+    manifest = destination_dir / MANIFEST_FILENAME
+    _reject_symlink_path(destination_dir)
+    _reject_symlink_path(destination)
+    _reject_symlink_path(manifest)
+    if not destination.exists() and not manifest.exists():
+        return {"status": "absent", "path": str(destination)}
+    if not _is_managed_widget(destination, manifest):
+        return {"status": "kept_unmanaged", "path": str(destination)}
+    if not dry_run:
+        destination.unlink()
+        manifest.unlink()
+    return {"status": "would_remove" if dry_run else "removed", "path": str(destination)}

--- a/src/omh/tui_widgets/__init__.py
+++ b/src/omh/tui_widgets/__init__.py
@@ -1,0 +1,1 @@
+"""Packaged Hermes TUI widgets."""

--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -1,0 +1,135 @@
+import { execFile } from 'node:child_process'
+
+export default function register(sdk) {
+  const { Box, Text, defineWidgetApp, h, openWidget, updateWidget } = sdk
+  const HOME = process.env.OMH_HOME || `${process.env.HOME}/.omh`
+  const HERMES_HOME = process.env.HERMES_HOME || `${process.env.HOME}/.hermes`
+  const READER = [
+    'import json,os,sys',
+    "sys.path.insert(0, os.path.join(os.environ['HERMES_HOME'], 'plugins'))",
+    'from omh.runtime_reader import read_omh_hud',
+    "print(json.dumps(read_omh_hud(os.environ.get('OMH_HOME'), os.environ.get('HERMES_HOME'))))",
+  ].join(';')
+
+  const safeText = value => String(value ?? '').replace(/[^\p{L}\p{N} .:/_·|+\-]/gu, '').slice(0, 96)
+
+  const readHud = () => new Promise(resolve => {
+    execFile(
+      __OMH_PYTHON_EXECUTABLE__,
+      ['-c', READER],
+      {
+        encoding: 'utf8',
+        env: { ...process.env, HERMES_HOME, OMH_HOME: HOME },
+        maxBuffer: 16384,
+        timeout: 1500,
+      },
+      (error, stdout) => {
+        if (error || !stdout || stdout.length > 16384) return resolve(null)
+        try {
+          resolve(JSON.parse(stdout))
+        } catch {
+          resolve(null)
+        }
+      }
+    )
+  })
+
+  const compactTokens = value => {
+    if (!Number.isInteger(value)) return ''
+    if (value >= 1000) return `${(value / 1000).toFixed(1)}k`
+    return String(value)
+  }
+
+  const metricText = row => {
+    const routed = [safeText(row.model), safeText(row.effort)].filter(Boolean).join(':')
+    const tokens = compactTokens(row.tokens)
+    return [routed, tokens ? `${tokens} tok` : ''].filter(Boolean).join(' · ')
+  }
+
+  function AgentRow({ row, t }) {
+    const state = safeText(row.state)
+    const color = state === 'blocked' ? t.color.error : t.color.ok
+    return h(
+      Box,
+      { columnGap: 1, flexDirection: 'row' },
+      h(Text, { color }, `${state === 'blocked' ? '▲' : '●'} ${state}`.padEnd(11)),
+      h(Text, { bold: true, color: t.color.label }, safeText(row.role).padEnd(11)),
+      h(Text, { color: t.color.text }, safeText(row.action)),
+      metricText(row) ? h(Text, { color: t.color.muted }, ` ${metricText(row)}`) : null
+    )
+  }
+
+  function Hud({ state, t }) {
+    const payload = state.payload
+    if (!payload || payload.error || payload.privacy !== 'metadata_only' || !payload.active) return null
+
+    const runtime = payload.runtime || {}
+    const agents = payload.subagents || {}
+    const version = safeText(payload.plugin?.version || payload.version)
+    const workflow = safeText(runtime.workflow)
+    const phase = safeText(runtime.phase)
+    const latest = safeText(agents.latest_action)
+    const rows = Array.isArray(agents.rows) ? agents.rows.slice(0, 4) : []
+    const maestro = payload.maestro || {}
+    const maestroRows = Array.isArray(maestro.rows) ? maestro.rows.slice(0, 2) : []
+    return h(
+      Box,
+      { flexDirection: 'column', width: '100%' },
+      h(
+        Box,
+        { columnGap: 1, flexDirection: 'row' },
+        h(Text, { bold: true, color: t.color.primary }, `[OMH] ${version}`),
+        h(Text, { color: t.color.muted }, '|'),
+        h(Text, { bold: true, color: t.color.label }, workflow),
+        h(Text, { color: t.color.primary }, phase),
+        h(
+          Text,
+          { color: t.color.muted },
+          `agents ${agents.active || 0} · run ${agents.running || 0} · block ${agents.blocked || 0} · done ${agents.completed || 0}`
+        )
+      ),
+      ...rows.map((row, index) => h(AgentRow, { key: `subagent-${index}`, row, t })),
+      ...maestroRows.map((row, index) =>
+        h(
+          Box,
+          { key: `maestro-${index}`, columnGap: 1, flexDirection: 'row' },
+          h(Text, { bold: true, color: t.color.primary }, 'MAESTRO'),
+          h(AgentRow, { row, t })
+        )
+      ),
+      latest ? h(Text, { color: t.color.muted }, `latest ${latest}`) : null
+    )
+  }
+
+  const app = defineWidgetApp({
+    id: 'omh-status',
+    help: 'OMH workflow and subagent status',
+    mode: 'ambient',
+    zone: 'dock-bottom',
+    init: () => ({ payload: null }),
+    reduce: (state, input) => input.kind === 'snapshot' ? { payload: input.payload } : state,
+    render: ({ state, t }) => h(Hud, { state, t }),
+  })
+
+  openWidget(app, app.init(''))
+  const timerKey = Symbol.for('omh.hermes-tui-widget.refresh')
+  const generationKey = Symbol.for('omh.hermes-tui-widget.generation')
+  const generation = (globalThis[generationKey] || 0) + 1
+  globalThis[generationKey] = generation
+  const schedule = () => {
+    if (generation !== globalThis[generationKey]) return
+    globalThis[timerKey] = setTimeout(async () => {
+      const payload = await readHud()
+      if (generation !== globalThis[generationKey]) return
+      updateWidget(app, state => payload ? { payload } : state)
+      schedule()
+    }, 2000)
+    globalThis[timerKey].unref?.()
+  }
+  clearTimeout(globalThis[timerKey])
+  void readHud().then(payload => {
+    if (generation !== globalThis[generationKey]) return
+    updateWidget(app, state => payload ? { payload } : state)
+  })
+  schedule()
+}

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from .metadata import (
     OPTIONAL_HOOKS,
@@ -104,10 +105,16 @@ RAW_OR_HIDDEN_KEYS = {
     "thinking",
     "transcript",
 }
+MAX_HUD_METADATA_BYTES = 262_144
+MAX_HUD_TEXT_CHARS = 120
 
 
 def _expand_path(value: str | Path) -> Path:
     return Path(os.path.expandvars(str(value))).expanduser().resolve()
+
+
+def _hud_text(value: Any, *, limit: int = MAX_HUD_TEXT_CHARS) -> str:
+    return str(value or "").strip()[:limit]
 
 
 def _default_omh_home() -> Path:
@@ -124,6 +131,47 @@ def _read_json(path: Path) -> dict[str, Any]:
     except (OSError, json.JSONDecodeError):
         return {}
     return data if isinstance(data, dict) else {}
+
+
+def _read_hud_json(path: Path) -> dict[str, Any]:
+    try:
+        if path.is_symlink() or path.stat().st_size > MAX_HUD_METADATA_BYTES:
+            return {}
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) and not _has_raw_or_hidden_content(data) else {}
+
+
+def _read_hud_coding_projection(path: Path) -> dict[str, Any]:
+    try:
+        if path.is_symlink() or path.stat().st_size > MAX_HUD_METADATA_BYTES:
+            return {}
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    projected: dict[str, Any] = {
+        key: data[key]
+        for key in (
+            "recommended_workflow",
+            "recommended_harness",
+            "selected_executor_profile",
+            "executor_profile",
+            "status",
+        )
+        if isinstance(data.get(key), (str, int, float, bool))
+    }
+    for key in ("executor_handoff", "prompt_handoff"):
+        value = data.get(key)
+        if isinstance(value, dict):
+            projected[key] = {
+                nested: value[nested]
+                for nested in ("executor_target", "selected_executor_profile")
+                if isinstance(value.get(nested), str)
+            }
+    return projected
 
 
 def _read_jsonl(path: Path) -> list[dict[str, Any]]:
@@ -144,6 +192,26 @@ def _read_jsonl(path: Path) -> list[dict[str, Any]]:
     return records
 
 
+def _read_hud_jsonl(path: Path) -> list[dict[str, Any]]:
+    try:
+        if path.is_symlink() or path.stat().st_size > MAX_HUD_METADATA_BYTES:
+            return []
+    except OSError:
+        return []
+    return _read_jsonl(path)
+
+
+def _contains_symlink(path: Path, *, root: Path) -> bool:
+    current = path
+    while current != root:
+        if current.is_symlink():
+            return True
+        if current == current.parent:
+            return True
+        current = current.parent
+    return root.is_symlink()
+
+
 def _child_files(directory: Path, *relative: str) -> list[Path]:
     """Return every existing `directory/<child>/*relative` file.
 
@@ -162,11 +230,28 @@ def _child_files(directory: Path, *relative: str) -> list[Path]:
     """
     try:
         with os.scandir(directory) as entries:
-            names = [entry.name for entry in entries]
+            names = [entry.name for entry in entries if not entry.is_symlink()]
     except (FileNotFoundError, NotADirectoryError):
         return []
     candidates = [directory.joinpath(name, *relative) for name in names]
-    return [candidate for candidate in candidates if candidate.is_file()]
+    return [
+        candidate
+        for candidate in candidates
+        if not _contains_symlink(candidate, root=directory)
+        and candidate.is_file()
+    ]
+
+
+def _hud_child_files(directory: Path, *relative: str) -> list[Path]:
+    files = _child_files(directory, *relative)
+    safe: list[Path] = []
+    for path in files:
+        try:
+            if path.stat().st_size <= MAX_HUD_METADATA_BYTES:
+                safe.append(path)
+        except OSError:
+            continue
+    return safe
 
 
 def _bool_from_record(record: dict[str, Any], key: str = "observed") -> bool:
@@ -179,13 +264,15 @@ def _summarize_run(
     run: dict[str, Any],
     journal_events: list[dict[str, Any]],
     external_effect_receipts: list[dict[str, Any]],
+    json_reader: Callable[[Path], dict[str, Any]] = _read_json,
+    coding_reader: Callable[[Path], dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
-    coding = _read_json(run_dir / "coding_delegation.json")
-    delegation = _read_json(run_dir / "delegation.json")
-    wrapper = _read_json(run_dir / "wrapper.json")
-    review = _read_json(run_dir / "review.json")
-    ci = _read_json(run_dir / "ci.json")
-    merge = _read_json(run_dir / "merge.json")
+    coding = (coding_reader or json_reader)(run_dir / "coding_delegation.json")
+    delegation = json_reader(run_dir / "delegation.json")
+    wrapper = json_reader(run_dir / "wrapper.json")
+    review = json_reader(run_dir / "review.json")
+    ci = json_reader(run_dir / "ci.json")
+    merge = json_reader(run_dir / "merge.json")
     legacy = {
         "run_id": str(run.get("run_id", run_dir.name)),
         "workflow": str(coding.get("recommended_workflow") or run.get("skill", "unknown")),
@@ -446,10 +533,10 @@ def read_omh_hud(
     home = _expand_path(omh_home) if omh_home else _default_omh_home()
     hermes = _expand_path(hermes_home) if hermes_home else _default_hermes_home()
     safe_limit = _safe_limit(limit, default=3)
-    status_payload = status if status is not None else read_omh_status(home, limit=safe_limit)
-    state = _read_json(home / "runtime" / "state.json")
-    profile = _read_json(home / "setup-profile.json")
-    target_registry = _read_json(home / "targets.json")
+    status_payload = status if status is not None else _read_omh_hud_status(home, limit=safe_limit)
+    state = _read_hud_json(home / "runtime" / "state.json")
+    profile = _read_hud_json(home / "setup-profile.json")
+    target_registry = _read_hud_json(home / "targets.json")
     runs = status_payload.get("runs", [])
     latest_run = runs[0] if runs else {}
     payload: dict[str, Any] = {
@@ -470,9 +557,20 @@ def read_omh_hud(
         ),
         "privacy": "metadata_only",
     }
+    payload["subagents"] = _hud_subagent_summary(status_payload)
+    payload["maestro"] = {
+        "status": "observed" if payload["subagents"]["maestro_rows"] else "idle",
+        "rows": payload["subagents"].pop("maestro_rows"),
+    }
+    payload["active"] = bool(
+        payload["runtime"]["workflow"] != "idle"
+        or payload["subagents"]["active"]
+        or payload["maestro"]["rows"]
+    )
     payload["display"] = {
         "line": format_omh_hud_line(payload, preset=safe_preset),
         "segments": _hud_segments(payload, preset=safe_preset),
+        "widget_lines": _hud_widget_lines(payload),
     }
     return payload
 
@@ -512,6 +610,7 @@ def _plugin_summary(hermes_home: Path, state: dict[str, Any]) -> dict[str, Any]:
         status = "missing"
     return {
         "status": status,
+        "version": _plugin_version(plugin_dir),
         "plugin_dir": str(plugin_dir),
         "distribution_observed": observed,
         "runtime_observed": False,
@@ -521,6 +620,18 @@ def _plugin_summary(hermes_home: Path, state: dict[str, Any]) -> dict[str, Any]:
         "capabilities": capabilities,
         "stale": status == "stale",
     }
+
+
+def _plugin_version(plugin_dir: Path) -> str:
+    plugin_yaml = plugin_dir / "plugin.yaml"
+    try:
+        if plugin_yaml.is_symlink() or plugin_yaml.stat().st_size > 16_384:
+            return ""
+        text = plugin_yaml.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    match = re.search(r'(?m)^version:\s*["\']?([A-Za-z0-9._+-]+)', text)
+    return match.group(1) if match else ""
 
 
 def _plugin_capabilities(plugin_dir: Path, last_distribution: dict[str, Any]) -> dict[str, Any]:
@@ -686,13 +797,109 @@ def _hud_runtime_summary(status: dict[str, Any], latest_run: dict[str, Any]) -> 
     return {
         "state_present": bool(status.get("runtime_state_present", False)),
         "recent_run_count": run_count,
-        "latest_run_id": str(latest_run.get("run_id", "")),
-        "executor_target": str(latest_run.get("executor_target", "")),
-        "workflow": str(latest_run.get("workflow", "unknown")),
-        "phase": str(latest_run.get("phase", "unknown")),
-        "observation_status": str(latest_run.get("observation_status", "unknown")),
+        "latest_run_id": _hud_text(latest_run.get("run_id", ""), limit=80),
+        "executor_target": _hud_text(latest_run.get("executor_target", ""), limit=80),
+        "workflow": _hud_text(latest_run.get("workflow", "unknown")),
+        "phase": _hud_text(latest_run.get("phase", "unknown"), limit=40),
+        "observation_status": _hud_text(latest_run.get("observation_status", "unknown"), limit=40),
         "evidence_state": _evidence_state(latest_run),
     }
+
+
+def _hud_subagent_summary(status: dict[str, Any]) -> dict[str, Any]:
+    active_rows = status.get("active_executors", [])
+    active = active_rows if isinstance(active_rows, list) else []
+    stale_rows = status.get("stale_executors", [])
+    stale = stale_rows if isinstance(stale_rows, list) else []
+    progress_rows = status.get("latest_progress_events", [])
+    progress = progress_rows if isinstance(progress_rows, list) else []
+    blocked = 0
+    for row in active:
+        event = row.get("latest_event", {}) if isinstance(row, dict) else {}
+        event_type = str(event.get("event_type", "")) if isinstance(event, dict) else ""
+        event_status = str(event.get("status", "")) if isinstance(event, dict) else ""
+        if event_type in {"executor_blocked", "executor_failed"} or event_status in {"blocked", "failed"}:
+            blocked += 1
+    completed = sum(
+        1
+        for event in progress
+        if isinstance(event, dict) and str(event.get("event_type", "")) == "executor_completed"
+    )
+    latest_action = ""
+    if progress:
+        latest = progress[0]
+        if isinstance(latest, dict):
+            latest_action = _hud_text(latest.get("summary", ""))
+    subagent_rows: list[dict[str, Any]] = []
+    maestro_rows: list[dict[str, Any]] = []
+    maestro_run_ids = {
+        str(run.get("run_id", ""))
+        for run in (status.get("runs", []) if isinstance(status.get("runs"), list) else [])
+        if isinstance(run, dict) and str(run.get("executor_target", "")).casefold() == "maestro"
+    }
+    for row in active[:5]:
+        if not isinstance(row, dict):
+            continue
+        event = row.get("latest_event", {})
+        event = event if isinstance(event, dict) else {}
+        event_type = str(event.get("event_type", ""))
+        event_status = str(event.get("status", ""))
+        state = (
+            "blocked"
+            if event_type in {"executor_blocked", "executor_failed"}
+            or event_status in {"blocked", "failed"}
+            else "running"
+        )
+        projected = {
+            "state": state,
+            "role": _hud_executor_role(row),
+            "action": _hud_text(event.get("summary", "")),
+            "model": _hud_text(row.get("routed_model", "")),
+            "effort": _hud_text(row.get("routed_reasoning_effort", ""), limit=40),
+            "tokens": row.get("tokens_total") if isinstance(row.get("tokens_total"), int) else None,
+        }
+        if (
+            str(row.get("executor_profile", "")).casefold() == "maestro"
+            or str(row.get("target_id", "")) in maestro_run_ids
+        ):
+            maestro_rows.append(projected)
+        else:
+            subagent_rows.append(projected)
+    return {
+        "status": "observed" if active or stale or progress else "idle",
+        "active": len(active),
+        "running": max(0, len(active) - blocked),
+        "blocked": blocked,
+        "completed": completed,
+        "stale": len(stale),
+        "latest_action": latest_action,
+        "rows": subagent_rows,
+        "maestro_rows": maestro_rows,
+    }
+
+
+def _hud_executor_role(row: dict[str, Any]) -> str:
+    target_id = str(row.get("target_id", ""))
+    profile = str(row.get("executor_profile", ""))
+    if target_id.startswith(("run-", "session-")):
+        return profile[:40]
+    return (target_id or profile)[:40]
+
+
+def _hud_widget_lines(payload: dict[str, Any]) -> list[str]:
+    runtime = payload.get("runtime", {})
+    subagents = payload.get("subagents", {})
+    workflow = str(runtime.get("workflow", "idle"))
+    phase = str(runtime.get("phase", "idle"))
+    header = (
+        f"[OMH] {workflow} {phase} "
+        f"agents {subagents.get('active', 0)} · "
+        f"run {subagents.get('running', 0)} · "
+        f"block {subagents.get('blocked', 0)} · "
+        f"done {subagents.get('completed', 0)}"
+    )
+    latest_action = str(subagents.get("latest_action", "")).strip()
+    return [header, f"latest {latest_action}"] if latest_action else [header]
 
 
 def _evidence_state(run: dict[str, Any]) -> str:
@@ -966,6 +1173,37 @@ def read_omh_status(omh_home: str | Path | None = None, limit: int = 5) -> dict[
     }
 
 
+def _read_omh_hud_status(home: Path, *, limit: int) -> dict[str, Any]:
+    runtime_dir = home / "runtime"
+    runs: list[dict[str, Any]] = []
+    for run_json in sorted(
+        _hud_child_files(runtime_dir / "runs", "run.json"),
+        reverse=True,
+    )[:limit]:
+        run = _read_hud_json(run_json)
+        if run:
+            runs.append(
+                _summarize_run(
+                    run_json.parent,
+                    run=run,
+                    journal_events=[],
+                    external_effect_receipts=[],
+                    json_reader=_read_hud_json,
+                    coding_reader=_read_hud_coding_projection,
+                )
+            )
+    progress = _executor_progress_projection(
+        runtime_dir,
+        limit=max(limit * 10, limit),
+        hud_safe=True,
+    )
+    return {
+        "runtime_state_present": bool(_read_hud_json(runtime_dir / "state.json")),
+        "runs": runs,
+        **progress,
+    }
+
+
 def read_omh_activity(omh_home: str | Path | None = None, limit: int = 5) -> dict[str, Any]:
     """Project only live executor state for latency-sensitive hook routing."""
     safe_limit = _safe_limit(limit, default=5)
@@ -983,8 +1221,13 @@ def read_omh_activity(omh_home: str | Path | None = None, limit: int = 5) -> dic
     }
 
 
-def _executor_progress_projection(runtime_dir: Path, *, limit: int) -> dict[str, Any]:
-    bindings = _progress_bindings(runtime_dir, limit=limit)
+def _executor_progress_projection(
+    runtime_dir: Path,
+    *,
+    limit: int,
+    hud_safe: bool = False,
+) -> dict[str, Any]:
+    bindings = _progress_bindings(runtime_dir, limit=limit, hud_safe=hud_safe)
     groups: dict[str, list[dict[str, Any]]] = {}
     for item in bindings:
         binding = item["binding"]
@@ -1020,20 +1263,28 @@ def _executor_progress_projection(runtime_dir: Path, *, limit: int) -> dict[str,
     }
 
 
-def _progress_bindings(runtime_dir: Path, *, limit: int) -> list[dict[str, Any]]:
+def _progress_bindings(
+    runtime_dir: Path,
+    *,
+    limit: int,
+    hud_safe: bool = False,
+) -> list[dict[str, Any]]:
     items: list[dict[str, Any]] = []
     roots = (
         (runtime_dir / "runs", "run"),
         (runtime_dir / "wrapper_sessions", "wrapper_session"),
     )
     for root, target_type in roots:
-        for binding_path in sorted(_child_files(root, "executor_progress", "binding.json"), reverse=True):
-            binding = _read_json(binding_path)
+        child_files = _hud_child_files if hud_safe else _child_files
+        json_reader = _read_hud_json if hud_safe else _read_json
+        jsonl_reader = _read_hud_jsonl if hud_safe else _read_jsonl
+        for binding_path in sorted(child_files(root, "executor_progress", "binding.json"), reverse=True):
+            binding = json_reader(binding_path)
             if not _valid_progress_binding(binding, target_type):
                 continue
             progress_dir = binding_path.parent
-            events = _read_jsonl(progress_dir / "events.jsonl")
-            reports = _read_jsonl(progress_dir / "reports.jsonl")
+            events = jsonl_reader(progress_dir / "events.jsonl")
+            reports = jsonl_reader(progress_dir / "reports.jsonl")
             binding_id = str(binding.get("binding_id", ""))
             instance_id = str(binding.get("instance_id", ""))
             matching_events = [event for event in events if _valid_progress_event(event, binding_id, instance_id)]
@@ -1116,7 +1367,7 @@ def _progress_row(primary: dict[str, Any], group: list[dict[str, Any]], event: d
         for item in group
         if item["binding"].get("binding_id") != binding.get("binding_id")
     ]
-    return {
+    row = {
         "primary_binding_id": binding.get("binding_id", ""),
         "primary_instance_id": binding.get("instance_id", ""),
         "binding_id": binding.get("binding_id", ""),
@@ -1133,6 +1384,13 @@ def _progress_row(primary: dict[str, Any], group: list[dict[str, Any]], event: d
         "linked_bindings": linked,
         "claim_boundary": binding.get("claim_boundary", ""),
     }
+    signal = event.get("signal", {}) if event else {}
+    if isinstance(signal, dict):
+        for key in ("routed_model", "routed_reasoning_effort", "tokens_total"):
+            value = signal.get(key)
+            if value not in (None, ""):
+                row[key] = value
+    return row
 
 
 def _compact_progress_event(event: dict[str, Any], binding: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -4,11 +4,430 @@ import json
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from _cli_harness import run_cli
 
 
 class HudCliTests(unittest.TestCase):
+    def test_hud_projects_active_subagents_without_duplicate_host_fields(self) -> None:
+        status = {
+            "runtime_state_present": True,
+            "runs": [
+                {
+                    "run_id": "run-hud",
+                    "workflow": "ULW model routing review",
+                    "phase": "executing",
+                    "observation_status": "execution_observed",
+                    "execution_observed": True,
+                }
+            ],
+            "active_executors": [
+                {
+                    "binding_id": "binding-running-1",
+                    "target_type": "subagent",
+                    "target_id": "explore",
+                    "executor_profile": "hermes",
+                    "routed_model": "gpt-5.6-sol",
+                    "routed_reasoning_effort": "xhigh",
+                    "tokens_total": 18_200,
+                    "latest_event": {
+                        "event_type": "repo_exploration",
+                        "summary": "Inspecting the routing implementation.",
+                        "observed_at": "2026-08-13T11:00:00Z",
+                    },
+                },
+                {
+                    "binding_id": "binding-running-2",
+                    "target_type": "subagent",
+                    "target_id": "librarian",
+                    "executor_profile": "hermes",
+                    "routed_model": "kimi-k3",
+                    "tokens_total": 4_300,
+                    "latest_event": {
+                        "event_type": "tests_started",
+                        "summary": "Running focused routing tests.",
+                        "observed_at": "2026-08-13T11:01:00Z",
+                    },
+                },
+                {
+                    "binding_id": "binding-blocked",
+                    "target_type": "subagent",
+                    "target_id": "architect",
+                    "executor_profile": "hermes",
+                    "routed_model": "claude-opus-5",
+                    "latest_event": {
+                        "event_type": "executor_blocked",
+                        "summary": "Waiting for the Windows CI result.",
+                        "observed_at": "2026-08-13T11:02:00Z",
+                    },
+                },
+            ],
+            "stale_executors": [],
+            "latest_progress_events": [
+                {
+                    "binding_id": "binding-completed",
+                    "event_type": "executor_completed",
+                    "summary": "Verified the Windows CI integrity fix.",
+                    "observed_at": "2026-08-13T11:03:00Z",
+                }
+            ],
+        }
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            payload = json.loads(
+                run_cli(
+                    [
+                        "--omh-home",
+                        str(root / ".omh"),
+                        "--hermes-home",
+                        str(root / ".hermes"),
+                        "hud",
+                        "--json",
+                    ],
+                    output_json=False,
+                )[1]
+            )
+            # The CLI call proves the public surface still works, while the
+            # injected status below isolates the deterministic projection seam.
+            from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+            payload = read_omh_hud(
+                root / ".omh",
+                root / ".hermes",
+                status=status,
+            )
+
+        self.assertEqual(payload["subagents"]["status"], "observed")
+        self.assertTrue(payload["active"])
+        self.assertEqual(payload["subagents"]["active"], 3)
+        self.assertEqual(payload["subagents"]["running"], 2)
+        self.assertEqual(payload["subagents"]["blocked"], 1)
+        self.assertEqual(payload["subagents"]["completed"], 1)
+        self.assertEqual(payload["subagents"]["stale"], 0)
+        self.assertEqual(
+            payload["subagents"]["latest_action"],
+            "Verified the Windows CI integrity fix.",
+        )
+        self.assertEqual(
+            payload["subagents"]["rows"],
+            [
+                {
+                    "state": "running",
+                    "role": "explore",
+                    "action": "Inspecting the routing implementation.",
+                    "model": "gpt-5.6-sol",
+                    "effort": "xhigh",
+                    "tokens": 18_200,
+                },
+                {
+                    "state": "running",
+                    "role": "librarian",
+                    "action": "Running focused routing tests.",
+                    "model": "kimi-k3",
+                    "effort": "",
+                    "tokens": 4_300,
+                },
+                {
+                    "state": "blocked",
+                    "role": "architect",
+                    "action": "Waiting for the Windows CI result.",
+                    "model": "claude-opus-5",
+                    "effort": "",
+                    "tokens": None,
+                },
+            ],
+        )
+        self.assertEqual(payload["maestro"], {"status": "idle", "rows": []})
+        widget_text = "\n".join(payload["display"]["widget_lines"])
+        self.assertIn("[OMH]", widget_text)
+        self.assertIn("ULW model routing review", widget_text)
+        self.assertIn("executing", widget_text)
+        self.assertIn("agents 3", widget_text)
+        self.assertIn("run 2", widget_text)
+        self.assertIn("block 1", widget_text)
+        self.assertIn("done 1", widget_text)
+        for duplicate in ("cwd", "branch", "context", "cost", "provider", "model:"):
+            self.assertNotIn(duplicate, widget_text.casefold())
+
+    def test_hud_fails_closed_for_unsafe_runtime_state(self) -> None:
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+        sentinel = "INJECTED_RUNTIME_SENTINEL"
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            runtime_dir = omh_home / "runtime"
+            runtime_dir.mkdir(parents=True)
+            external = root / "outside.json"
+            cases = {
+                "absent": None,
+                "malformed": '{"version": "INJECTED_RUNTIME_SENTINEL"',
+                "oversized": json.dumps(
+                    {
+                        "version": sentinel,
+                        "padding": "x" * 300_000,
+                    }
+                ),
+                "symlinked": external,
+            }
+            external.write_text(json.dumps({"version": sentinel}), encoding="utf-8")
+
+            for name, fixture in cases.items():
+                with self.subTest(name=name):
+                    state_path = runtime_dir / "state.json"
+                    state_path.unlink(missing_ok=True)
+                    if isinstance(fixture, Path):
+                        state_path.symlink_to(fixture)
+                    elif isinstance(fixture, str):
+                        state_path.write_text(fixture, encoding="utf-8")
+
+                    payload = read_omh_hud(
+                        omh_home,
+                        root / ".hermes",
+                        package_version="1.0.5",
+                    )
+                    rendered = json.dumps(payload)
+
+                    self.assertEqual(payload["runtime"]["workflow"], "idle")
+                    self.assertFalse(payload["active"])
+                    self.assertEqual(payload["subagents"]["status"], "idle")
+                    self.assertNotIn(sentinel, rendered)
+                    self.assertLessEqual(len(rendered), 16_384)
+
+    def test_hud_rejects_symlinked_run_directories(self) -> None:
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+        sentinel = "EXTERNAL_SECRET_SENTINEL"
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            runs = root / ".omh" / "runtime" / "runs"
+            runs.mkdir(parents=True)
+            external = root / "external-run"
+            external.mkdir()
+            (external / "run.json").write_text(
+                json.dumps(
+                    {
+                        "run_id": "external",
+                        "skill": sentinel,
+                        "phase": "executing",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (runs / "999").symlink_to(external, target_is_directory=True)
+
+            payload = read_omh_hud(root / ".omh", root / ".hermes")
+            rendered = json.dumps(payload)
+
+            self.assertEqual(payload["runtime"]["workflow"], "idle")
+            self.assertNotIn(sentinel, rendered)
+
+    def test_hud_rejects_symlinked_run_auxiliary_metadata(self) -> None:
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+        sentinel = "AUXILIARY_METADATA_SECRET"
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_dir = root / ".omh" / "runtime" / "runs" / "999"
+            run_dir.mkdir(parents=True)
+            (run_dir / "run.json").write_text(
+                json.dumps({"run_id": "999", "skill": "safe workflow", "phase": "executing"}),
+                encoding="utf-8",
+            )
+            external = root / "coding.json"
+            external.write_text(
+                json.dumps({"recommended_workflow": sentinel}),
+                encoding="utf-8",
+            )
+            (run_dir / "coding_delegation.json").symlink_to(external)
+
+            payload = read_omh_hud(root / ".omh", root / ".hermes")
+            rendered = json.dumps(payload)
+
+            self.assertEqual(payload["runtime"]["workflow"], "safe workflow")
+            self.assertNotIn(sentinel, rendered)
+
+    def test_hud_rejects_symlinked_executor_progress_directory(self) -> None:
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+        sentinel = "INTERMEDIATE_SYMLINK_SECRET"
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_dir = root / ".omh" / "runtime" / "runs" / "999"
+            run_dir.mkdir(parents=True)
+            (run_dir / "run.json").write_text(
+                json.dumps({"run_id": "999", "skill": "safe", "phase": "executing"}),
+                encoding="utf-8",
+            )
+            external = root / "external-progress"
+            external.mkdir()
+            binding = {
+                "schema_version": "omh_executor_progress_binding/v1",
+                "binding_id": "run:999:codex",
+                "instance_id": "run:999:codex:instance",
+                "target": {"type": "run", "id": "999"},
+                "target_type": "run",
+                "target_id": "999",
+                "executor": "codex",
+                "executor_profile": "codex",
+                "correlation_root": "run:999",
+                "state": "active",
+                "created_at": "2099-01-01T00:00:00Z",
+                "updated_at": "2099-01-01T00:00:00Z",
+                "last_observed_at": "2099-01-01T00:00:00Z",
+                "freshness_seconds": 900,
+                "expiry_seconds": 86400,
+                "report_count": 0,
+                "last_reported_event_type": "",
+                "evidence_refs": [],
+                "privacy": "metadata_only",
+                "claim_boundary": (
+                    "Executor progress is metadata-only observed activity. It is not result, verification, "
+                    "review, CI, merge-readiness, or merge evidence."
+                ),
+            }
+            (external / "binding.json").write_text(json.dumps(binding), encoding="utf-8")
+            (external / "events.jsonl").write_text(
+                json.dumps(
+                    {
+                        **binding,
+                        "schema_version": "omh_executor_progress_event/v1",
+                        "event_type": "progress_observed",
+                        "status": "running",
+                        "summary": sentinel,
+                        "observed_at": "2099-01-01T00:00:00Z",
+                        "severity": "info",
+                        "signal": {},
+                        "transition_fingerprint": "a" * 64,
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            (run_dir / "executor_progress").symlink_to(external, target_is_directory=True)
+
+            payload = read_omh_hud(root / ".omh", root / ".hermes")
+            rendered = json.dumps(payload)
+
+            self.assertEqual(payload["subagents"]["active"], 0)
+            self.assertNotIn(sentinel, rendered)
+
+    def test_hud_separates_maestro_owned_run_from_subagents(self) -> None:
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+        status = {
+            "runtime_state_present": True,
+            "runs": [
+                {
+                    "run_id": "run-maestro",
+                    "workflow": "coding execution",
+                    "phase": "executing",
+                    "executor_target": "maestro",
+                }
+            ],
+            "active_executors": [
+                {
+                    "target_type": "run",
+                    "target_id": "run-maestro",
+                    "executor_profile": "codex",
+                    "routed_model": "gpt-5.6-sol",
+                    "routed_reasoning_effort": "xhigh",
+                    "tokens_total": 42_100,
+                    "latest_event": {
+                        "event_type": "progress_observed",
+                        "status": "running",
+                        "summary": "Implementing the coding handoff.",
+                    },
+                },
+                {
+                    "target_type": "run",
+                    "target_id": "run-subagent",
+                    "executor_profile": "hermes_local",
+                    "latest_event": {
+                        "event_type": "repo_exploration",
+                        "status": "running",
+                        "summary": "Exploring the repository.",
+                    },
+                },
+            ],
+            "stale_executors": [],
+            "latest_progress_events": [],
+        }
+
+        payload = read_omh_hud(status=status)
+
+        self.assertEqual(payload["maestro"]["status"], "observed")
+        self.assertEqual(payload["maestro"]["rows"][0]["role"], "codex")
+        self.assertEqual(payload["maestro"]["rows"][0]["model"], "gpt-5.6-sol")
+        self.assertEqual(len(payload["subagents"]["rows"]), 1)
+
+    def test_hud_bounds_workflow_within_allowed_file_size(self) -> None:
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+        sentinel = "BOUNDARY_WORKFLOW_SENTINEL"
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_dir = root / ".omh" / "runtime" / "runs" / "999"
+            run_dir.mkdir(parents=True)
+            workflow = sentinel + ("x" * 240_000)
+            (run_dir / "run.json").write_text(
+                json.dumps({"run_id": "999", "skill": workflow, "phase": "executing"}),
+                encoding="utf-8",
+            )
+
+            payload = read_omh_hud(root / ".omh", root / ".hermes")
+            rendered = json.dumps(payload)
+
+            self.assertLessEqual(len(payload["runtime"]["workflow"]), 120)
+            self.assertLessEqual(len(rendered), 16_384)
+            self.assertNotIn("x" * 121, rendered)
+
+    def test_hud_bounds_run_and_jsonl_reads_before_projection(self) -> None:
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+        sentinel = "OVERSIZED_HUD_SENTINEL"
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            runtime = omh_home / "runtime"
+            run_dir = runtime / "runs" / "999"
+            progress_dir = run_dir / "executor_progress"
+            progress_dir.mkdir(parents=True)
+            state_path = runtime / "state.json"
+            state_path.write_text(
+                json.dumps({"version": sentinel, "padding": "x" * 300_000}),
+                encoding="utf-8",
+            )
+            (run_dir / "run.json").write_text(
+                json.dumps(
+                    {
+                        "run_id": "999",
+                        "skill": sentinel + ("y" * 300_000),
+                        "phase": "executing",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (progress_dir / "events.jsonl").write_text(
+                (json.dumps({"summary": sentinel, "padding": "z" * 300_000}) + "\n") * 5,
+                encoding="utf-8",
+            )
+            original_read_text = Path.read_text
+
+            def guarded_read_text(path: Path, *args, **kwargs) -> str:
+                if path in {state_path, run_dir / "run.json", progress_dir / "events.jsonl"}:
+                    raise AssertionError(f"oversized metadata was read: {path}")
+                return original_read_text(path, *args, **kwargs)
+
+            with patch.object(Path, "read_text", guarded_read_text):
+                payload = read_omh_hud(omh_home, root / ".hermes")
+            rendered = json.dumps(payload)
+
+            self.assertLessEqual(len(rendered), 16_384)
+            self.assertNotIn(sentinel, rendered)
+
     def test_status_alias_returns_hud_payload_for_operator_smoke_checks(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -143,7 +143,7 @@ class TuiWidgetPackTests(unittest.TestCase):
             self.assertEqual(json.loads(stdout)["tui_widget"]["status"], "removed")
 
     def test_widget_is_full_width_and_omits_host_status_fields(self) -> None:
-        widget = resources.files("omh.tui_widgets").joinpath("omh-status.mjs").read_text()
+        widget = resources.files("omh.tui_widgets").joinpath("omh-status.mjs").read_text(encoding="utf-8")
 
         self.assertIn("zone: 'dock-bottom'", widget)
         self.assertIn("width: '100%'", widget)

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+from importlib import resources
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _cli_harness import run_cli
+from omh.tui_widget_pack import TuiWidgetInstallError, install_tui_widget, widget_payload
+
+
+class TuiWidgetPackTests(unittest.TestCase):
+    def test_setup_installs_byte_correct_widget_without_overwriting_unrelated_widget(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            widget_dir = hermes_home / "tui-widgets"
+            widget_dir.mkdir(parents=True)
+            unrelated = widget_dir / "personal-dashboard.mjs"
+            unrelated_bytes = b"export default function register() {}\n"
+            unrelated.write_bytes(unrelated_bytes)
+
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(omh_home),
+                    "--hermes-home",
+                    str(hermes_home),
+                    "setup",
+                    "--json",
+                ],
+                output_json=False,
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            expected = widget_payload(Path(sys.executable))
+            self.assertEqual((widget_dir / "omh-status.mjs").read_bytes(), expected)
+            self.assertEqual(unrelated.read_bytes(), unrelated_bytes)
+            self.assertEqual(payload["steps"]["tui_widget"]["status"], "installed")
+
+    def test_update_restores_an_installed_widget(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            common = [
+                "--omh-home",
+                str(omh_home),
+                "--hermes-home",
+                str(hermes_home),
+            ]
+            setup_status, _, setup_stderr = run_cli([*common, "setup", "--json"], output_json=False)
+            self.assertEqual((setup_status, setup_stderr), (0, ""))
+            widget = hermes_home / "tui-widgets" / "omh-status.mjs"
+            widget.unlink()
+
+            status, _, stderr = run_cli(
+                [
+                    *common,
+                    "update",
+                    "--source",
+                    str(Path(__file__).parents[1]),
+                    "--channel",
+                    "local",
+                    "--json",
+                ],
+                output_json=False,
+            )
+
+            self.assertEqual((status, stderr), (0, ""))
+            expected = widget_payload(Path(sys.executable))
+            self.assertEqual(widget.read_bytes(), expected)
+
+    def test_installer_rejects_symlinked_widget_destination_and_parent(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            hermes_home = root / ".hermes"
+            widget_dir = hermes_home / "tui-widgets"
+            widget_dir.mkdir(parents=True)
+            victim = root / "victim.mjs"
+            victim_bytes = b"do not overwrite\n"
+            victim.write_bytes(victim_bytes)
+            destination = widget_dir / "omh-status.mjs"
+            destination.symlink_to(victim)
+
+            with self.assertRaises(TuiWidgetInstallError):
+                install_tui_widget(hermes_home)
+            self.assertEqual(victim.read_bytes(), victim_bytes)
+
+            destination.unlink()
+            widget_dir.rmdir()
+            external_dir = root / "external-widgets"
+            external_dir.mkdir()
+            widget_dir.symlink_to(external_dir, target_is_directory=True)
+            with self.assertRaises(TuiWidgetInstallError):
+                install_tui_widget(hermes_home)
+            self.assertEqual(list(external_dir.iterdir()), [])
+
+    def test_installer_refuses_unmanaged_existing_widget(self) -> None:
+        with TemporaryDirectory() as tmp:
+            hermes_home = Path(tmp) / ".hermes"
+            destination = hermes_home / "tui-widgets" / "omh-status.mjs"
+            destination.parent.mkdir(parents=True)
+            user_bytes = b"export default function userOwned() {}\n"
+            destination.write_bytes(user_bytes)
+
+            with self.assertRaises(TuiWidgetInstallError):
+                install_tui_widget(hermes_home)
+            self.assertEqual(destination.read_bytes(), user_bytes)
+
+    def test_widget_uses_setup_interpreter_not_path_python(self) -> None:
+        payload = widget_payload(Path(sys.executable)).decode()
+
+        self.assertIn(json.dumps(os.path.realpath(sys.executable)), payload)
+        self.assertNotIn("spawnSync('python3'", payload)
+
+    def test_full_uninstall_removes_only_managed_widget(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            common = ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home)]
+            status, _, stderr = run_cli([*common, "setup", "--json"], output_json=False)
+            self.assertEqual((status, stderr), (0, ""))
+            destination = hermes_home / "tui-widgets" / "omh-status.mjs"
+            unrelated = destination.parent / "personal.mjs"
+            unrelated.write_text("personal\n", encoding="utf-8")
+
+            status, stdout, stderr = run_cli(
+                [*common, "uninstall", "--all", "--keep-command", "--json"],
+                output_json=False,
+            )
+
+            self.assertEqual((status, stderr), (0, ""))
+            self.assertFalse(destination.exists())
+            self.assertEqual(unrelated.read_text(encoding="utf-8"), "personal\n")
+            self.assertEqual(json.loads(stdout)["tui_widget"]["status"], "removed")
+
+    def test_widget_is_full_width_and_omits_host_status_fields(self) -> None:
+        widget = resources.files("omh.tui_widgets").joinpath("omh-status.mjs").read_text()
+
+        self.assertIn("zone: 'dock-bottom'", widget)
+        self.assertIn("width: '100%'", widget)
+        self.assertIn("[OMH]", widget)
+        self.assertIn("MAESTRO", widget)
+        self.assertIn("routed", widget)
+        self.assertIn("execFile(", widget)
+        self.assertIn("Symbol.for(", widget)
+        self.assertIn("generationKey", widget)
+        self.assertIn("generation !== globalThis[generationKey]", widget)
+        self.assertIn("clearTimeout(", widget)
+        self.assertNotIn("spawnSync(", widget)
+        self.assertNotIn("setInterval(", widget)
+        for forbidden in ("payload.cwd", "payload.branch", "payload.context", "payload.cost"):
+            self.assertNotIn(forbidden, widget)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds an OMH-owned Hermes TUI status HUD through Hermes' supported `tui-widgets` extension point. The widget is installed by `omh setup`, refreshed by `omh update`, removed by full uninstall, and never patches Hermes core.

## Why

Hermes already exposes model, session, routing, cwd, context, and cost information. OMH lacked a live surface for its own workflow and delegated-worker state, so operators had to leave the TUI or infer progress from prepared artifacts. This change adds a compact metadata-only view without duplicating host-owned fields or implying that preparation is execution.

## User-facing behavior

- Active OMH work shows a left-aligned `[OMH] 1.0.5` row with workflow, phase, and running/blocked/completed counts.
- Each observed executor row may show its role, current action, routed model, reasoning-effort level, and observed token total. Missing observations stay absent.
- Maestro-owned coding runs render under a separate `MAESTRO` label instead of being mixed with Hermes subagents.
- Inactive OMH state stays hidden.
- The 80x24 terminal surface remains usable without duplicating cwd, branch, context, cost, provider, or host current-model fields.

## Implementation

- `src/omh/tui_widgets/omh-status.mjs` is the official Hermes ambient `dock-bottom` widget. It polls asynchronously with a fixed interpreter, retains the last valid state on read failure, and uses generation ownership so hot reload cannot create duplicate polling chains.
- `src/plugin_bundle/omh/runtime_reader.py` adds a bounded, fail-closed HUD projection over local OMH run and executor-progress metadata. HUD-only readers reject symlinks, oversized files, hidden/raw fields, and unbounded projected text without weakening generic append-only history readers.
- `src/omh/tui_widget_pack.py` installs one managed widget plus a digest manifest, refuses unsafe or user-owned destinations, writes atomically, preserves unrelated widgets, and removes only the managed widget.
- Setup, update, package data, and full uninstall are wired to that managed artifact.
- Reproducible PTY/xterm.js/Chrome QA drivers live under `script/qa/`.

## Verification

Observed on the integrated head (`2ef06d1e` on current `main`):

- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — **6,398 tests passed** in 260.138s.
- Integrated HUD/security/install/architecture focused suite — **51 tests passed**.
- `uv run --group lint ruff check src tests` — passed.
- `uv run python -m compileall -q src tests` — passed.
- Generated workflows, roles, and capability-family byte checks — passed.
- `uv build` — passed; wheel widget template is byte-identical to source.
- `git diff --check` — passed.
- Independent security, project-contract, and code-quality re-audits — passed.
- Actual Hermes v0.20.0 PTY → xterm.js → Chrome QA:
  - active 150x38: `.omo/evidence/hermes-cli-omh-hud/final-happy/`
  - active 80x24: `.omo/evidence/hermes-cli-omh-hud/final-80x24/`
  - inactive/hidden 150x38: `.omo/evidence/hermes-cli-omh-hud/final-idle/`
- Temporary Hermes homes, copied auth/config files, browser state, and matching processes were removed after capture.

## Risks and compatibility

- The widget requires a Hermes build that supports user TUI widgets and Node child-process APIs. It does not change Hermes core or configuration schema.
- The HUD reads deterministic local metadata only; it performs no network calls and renders no prompts, transcripts, hidden reasoning, credentials, or raw tool payloads.
- Widget ownership is digest-verified. Existing unmanaged `omh-status.mjs` files are refused rather than overwritten.
- Windows-native TUI rendering was not manually exercised; Python portability, package tests, and the full repository suite are green.

## Rollout

Normal users receive the widget through `omh setup`; existing managed installs refresh through `omh update`. A full `omh uninstall --all` removes the managed widget while preserving unrelated Hermes widgets.