### PR TITLE
chore(release): prepare 1.0.6 distribution

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -72,8 +72,8 @@ python3 -m omh.cli docs workflows --check
 python3 -m omh.cli harness validate
 python3 -m omh.cli release checklist --json
 python3 -m omh.cli release skill-content-smoke --json
-python3 -m omh.cli release product-readiness --version 1.0.5 --json
-python3 -m omh.cli release evidence-bundle --version 1.0.5 --write --json
+python3 -m omh.cli release product-readiness --version 1.0.6 --json
+python3 -m omh.cli release evidence-bundle --version 1.0.6 --write --json
 python3 -m omh.cli cases demo --all --json
 python3 -m omh.cli cases artifact --all --json
 python3 -m omh.cli cases replay --json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "oh-my-hermes"
-version = "1.0.5"
+version = "1.0.6"
 description = "Install a Hermes-native skill workflow pack."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/omh/version.py
+++ b/src/omh/version.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "1.0.5"
+__version__ = "1.0.6"

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -664,7 +664,7 @@ class HudCliTests(unittest.TestCase):
 
             self.assertEqual(stderr, "")
             self.assertEqual(status, 0)
-            self.assertIn("[omh] v1.0.5", stdout)
+            self.assertIn("[omh] v1.0.6", stdout)
             self.assertIn("plugin:not-installed", stdout)
             # No run and no recorded coding-agent preference: the segment is
             # executor-neutral, not an idle agent named "ask". See
@@ -755,7 +755,7 @@ class HudCliTests(unittest.TestCase):
             self.assertEqual(status, 0)
             payload = json.loads(stdout)
             self.assertEqual(payload["schema_version"], "omh_hud/v1")
-            self.assertEqual(payload["version"], "1.0.5")
+            self.assertEqual(payload["version"], "1.0.6")
             self.assertEqual(payload["plugin"]["status"], "ready")
             self.assertNotIn("skills", payload)
             self.assertEqual(payload["target_topology"]["mode"], "single_agent_target")

--- a/tests/test_menubar_status.py
+++ b/tests/test_menubar_status.py
@@ -53,7 +53,7 @@ class MenubarStatusTests(unittest.TestCase):
             payload = json.loads(stdout)
             self.assertEqual(payload["schema_version"], "menubar_status/v1")
             self.assertEqual(payload["display"]["menu_title"], "omh")
-            self.assertEqual(payload["versions"]["omh"]["value"], "1.0.5")
+            self.assertEqual(payload["versions"]["omh"]["value"], "1.0.6")
             self.assertEqual(payload["versions"]["hermes"]["value"], "unknown")
             self.assertFalse(payload["versions"]["hermes"]["observed"])
             self.assertEqual(payload["settings"]["omh_connection"]["label"], "OMH connection: Ready")


### PR DESCRIPTION
## Feature Report

### What Changed

- Advances the canonical Python package and runtime version from `1.0.5` to `1.0.6`.
- Updates release-readiness commands to produce `1.0.6` evidence.

### Why This Exists

- Follow-up to #958. The immutable `v1.0.5` tag and GitHub release already point to the prior release, so the newly merged npm/Bun/Homebrew distribution cannot safely reuse that version.

### User / Operator Impact

- Maintainers can tag the merged protected-main commit as `v1.0.6` and publish one synchronized wheel, npm package, and Homebrew formula.

### How It Works

- `tools/package_manager/metadata.py` continues to derive and enforce exact agreement between `pyproject.toml`, `src/omh/version.py`, wheel metadata, npm staging, tag input, and formula rendering.

### Files And Contracts Touched

- `pyproject.toml`
- `src/omh/version.py`
- `docs/RELEASE.md`

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [ ] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [ ] `uv run python -m omh.cli docs workflows --check`
- [ ] `uv run python -m omh.cli docs roles --check`
- [ ] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: distribution metadata and release workflow contract suites
- [x] Manual Hermes/TUI check, or explicit reason it was not run: version-only release preparation; no Hermes/TUI behavior changed

### Observed Evidence

- Canonical metadata reports `1.0.6`.
- Distribution metadata and release contract tests pass, including reproducible wheel/tarball checks.
- Release checklist, product-readiness `1.0.6`, and evidence-bundle `1.0.6` commands exited successfully.
- Ruff, compileall, and `git diff --check` pass.

### Not Tested / Not Applicable

- The full multi-platform suite is delegated to required PR CI.
- Public npm/Homebrew publication occurs only after this commit is merged and tagged.

## Risk

- Narrow version-synchronization change. The primary risk is tag/version drift, which the release workflow fails closed.

## Compatibility / Rollout

- Existing `v1.0.5` remains immutable. `v1.0.6` becomes the first package-manager distribution release.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [ ] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Merge on green CI, create `v1.0.6`, run the distribution workflow, and verify public npm, Bun, and Homebrew installs.
