### PR TITLE
feat(update): refresh the owning package-manager install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes will be documented here.
 
 ## 1.0.6 - 2026-08-13
 
+- Made `omh update` installation-aware: Homebrew, Bun, npm, curl, and PowerShell installs now update their owning command package first, re-enter the updated CLI, and then refresh managed skills, the installed plugin bundle, and existing Hermes registration.
 - Added the Hermes dock-bottom OMH activity HUD, fresh-install TUI selection, and an all-in-one agent install protocol with approval-gated model aliases; recommendation resolution now reports `owner_default` through `model_recommendation_resolution/v2` and completes setup without a model-config write when no confirmed candidate matches.
 - Added typed unit-result sidecars for fan-out dispatch: `fanout_unit_result/v1` schema with structured process status, command evidence, and reporter-vs-observer provenance marks out exactly what was dispatched, what it reported, and what the dispatcher verified independently — replacing the exit-0 overclaim with a four-state vocabulary (`process_succeeded`, `result_schema_valid`, `unit_verification_observed`, `integration_ready`) that reflects the actual evidence ladder.
 - Hardened worktree creation with runtime base-SHA validation, unique-branch enforcement, and crash-cleanup receipts logged to the observation journal.

--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -150,18 +150,23 @@ loaded the plugin bridge, executed code, reviewed a PR, passed CI, or merged.
 
 ## Package-Manager Lifecycle
 
-`omh update` refreshes managed skills and state. It does not replace a
-Homebrew, Bun, or npm command package. Report and use the owning manager:
+`omh update` is the normal update command for every supported install path. It
+detects Homebrew, Bun, npm, curl, or PowerShell provenance, upgrades the command
+package through that owner, re-enters the updated command, then refreshes
+managed skills, the installed plugin bundle, and existing Hermes registration.
+Use the owning manager directly only as a reported repair fallback:
 
 | Installed with | Upgrade | Remove |
 | --- | --- | --- |
 | Homebrew | `brew upgrade rlaope/tap/omh` | `brew uninstall omh` |
-| Bun | `bun update -g oh-my-hermes` | `bun remove -g oh-my-hermes` |
+| Bun | `bun update -g --latest oh-my-hermes` | `bun remove -g oh-my-hermes` |
 | npm | `npm update -g oh-my-hermes` | `npm uninstall -g oh-my-hermes` |
 
 Removing the command package preserves OMH state. For full cleanup, run
 `omh uninstall --all` before the manager's remove command. Never run the curl
-installer over a package-manager command to update it.
+installer over a package-manager command to update it. An explicit
+`omh update --source ...` refreshes workflow content only and does not replace
+the command package.
 
 For release-candidate verification, add the Hermes CLI smoke. Plan mode is safe
 and non-mutating:

--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -166,7 +166,10 @@ Removing the command package preserves OMH state. For full cleanup, run
 `omh uninstall --all` before the manager's remove command. Never run the curl
 installer over a package-manager command to update it. An explicit
 `omh update --source ...` refreshes workflow content only and does not replace
-the command package.
+the command package, plugin bundle, or Hermes registration. Package-manager
+installs reject explicit release metadata such as `--version`, `--package-url`,
+or `--source-ref`; use the owning manager directly for an intentional CLI
+rollback.
 
 For release-candidate verification, add the Hermes CLI smoke. Plan mode is safe
 and non-mutating:

--- a/README.ja.md
+++ b/README.ja.md
@@ -126,6 +126,9 @@ Do not replace the resolved SHA with main. Execute the pinned protocol's OS-appr
 ```sh
 omh update
 ```
+`omh update` はインストール経路を検出し、Homebrew、Bun、npm、curl、
+または PowerShell のコマンドパッケージを先に更新してから、新しいコマンドで
+再実行し、管理スキル、プラグインバンドル、既存の Hermes 登録も更新します。
 
 **インストールの確認またはトラブルシューティング:**
 ```sh

--- a/README.ko.md
+++ b/README.ko.md
@@ -128,6 +128,9 @@ Do not replace the resolved SHA with main. Execute the pinned protocol's OS-appr
 ```sh
 omh update
 ```
+`omh update`는 설치 경로를 감지해 Homebrew, Bun, npm, curl 또는 PowerShell
+명령 패키지를 먼저 갱신한 뒤, 새 명령으로 다시 진입해 관리 스킬, 플러그인
+번들, 기존 Hermes 등록까지 함께 갱신합니다.
 
 **설치를 확인하거나 문제를 해결합니다:**
 ```sh

--- a/README.md
+++ b/README.md
@@ -183,24 +183,28 @@ Do not replace the resolved SHA with main. Execute the pinned protocol's OS-appr
 omh update
 ```
 
+`omh update` detects how the command was installed. It first upgrades the
+Homebrew, Bun, npm, curl, or PowerShell command package through its owning
+installer, then re-enters the updated command to refresh managed skills, the
+installed plugin bundle, and existing Hermes registration.
+
 **Verify or troubleshoot the installation:**
 
 ```sh
 omh doctor
 ```
 
-**Update or remove the command package with the manager that installed it:**
+**Manual package-manager fallback or removal:**
 
 | Installed with | Upgrade the CLI | Remove the CLI |
 | --- | --- | --- |
 | Homebrew | `brew upgrade rlaope/tap/omh` | `brew uninstall omh` |
-| Bun | `bun update -g oh-my-hermes` | `bun remove -g oh-my-hermes` |
+| Bun | `bun update -g --latest oh-my-hermes` | `bun remove -g oh-my-hermes` |
 | npm | `npm update -g oh-my-hermes` | `npm uninstall -g oh-my-hermes` |
 
-`omh update` refreshes OMH-managed skills and state; it does not replace a
-Homebrew, Bun, or npm package. Removing the command package preserves OMH state.
-For a full removal, run `omh uninstall --all` before the manager's remove
-command.
+Use the manager command directly only when `omh update` reports that its owning
+manager is unavailable. Removing the command package preserves OMH state. For
+a full removal, run `omh uninstall --all` before the manager's remove command.
 
 Maintenance paths such as reconciling a `--full` install back to core live in
 [Installation](docs/INSTALLATION.md#reconciling-an-existing-full-install-back-to-core).

--- a/README.zh.md
+++ b/README.zh.md
@@ -130,6 +130,9 @@ Do not replace the resolved SHA with main. Execute the pinned protocol's OS-appr
 ```sh
 omh update
 ```
+`omh update` 会检测安装来源，先通过 Homebrew、Bun、npm、curl 或
+PowerShell 更新命令包，再重新进入新命令，同时刷新托管技能、插件包和现有
+Hermes 注册。
 
 **验证安装或排查问题：**
 ```sh

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -76,6 +76,26 @@ Hermes:
 omh setup
 ```
 
+### Keep every installed layer current
+
+The same command updates every supported installation path:
+
+```sh
+omh update
+```
+
+For Homebrew, Bun, and npm installs, the launcher records the owning package
+manager. `omh update` runs that manager's native upgrade first, then re-enters
+the newly installed `omh` command. The curl and PowerShell installers use the
+same flow through their isolated managed virtual environment. After the command
+package succeeds, the re-entered command refreshes managed skills, an already
+installed plugin bundle, and existing Hermes registration.
+
+An explicit `--source` or `--from-skills-dir` remains a workflow-content-only
+operation, and `--dry-run` never changes the command package. A source checkout
+or other unmanaged Python environment is not rewritten implicitly; the result
+reports the supported installer command instead.
+
 ### Verify or troubleshoot the installation
 
 Run doctor separately after setup:
@@ -1417,12 +1437,14 @@ omh update
 omh doctor
 ```
 
-Most users should run only `omh update`. When `omh` is running from the default
-install.sh-managed venv, the command first updates the command package from the
-recorded preview/stable package source, re-enters the updated CLI, refreshes the
-managed skills, and records a concise update log. If `omh` is running from a
-pip, pipx, distro, or custom Python install that OMH cannot safely mutate, the
-update still refreshes workflows but prints
+Most users should run only `omh update`. Homebrew, Bun, and npm launchers record
+their package-manager provenance; the update runs that manager's native
+upgrade, re-enters the updated CLI, refreshes the managed skills, and records a
+concise update log. The curl and PowerShell installers follow the same sequence
+through their managed virtual environment and recorded preview/stable source.
+If `omh` is running from a pip, pipx, distro, source checkout, or custom Python
+install that OMH cannot safely mutate, the update still refreshes workflows but
+prints
 `OMH command: not updated (workflows only)` plus the installer command needed to
 update the CLI itself. Successful command package updates print a compact line
 such as `OMH command: 1.0.1 -> 1.0.4 (updated)` or
@@ -1430,18 +1452,18 @@ such as `OMH command: 1.0.1 -> 1.0.4 (updated)` or
 
 ### Package-manager command updates
 
-When Homebrew, Bun, or npm installed the command, `omh update` refreshes
-OMH-managed skills and state but intentionally does not mutate the package
-manager's CLI files. Upgrade that command package first, then run `omh update`:
+When Homebrew, Bun, or npm installed the command, `omh update` uses the matching
+native command automatically:
 
 | Installed with | Upgrade command |
 | --- | --- |
 | Homebrew | `brew upgrade rlaope/tap/omh` |
-| Bun | `bun update -g oh-my-hermes` |
+| Bun | `bun update -g --latest oh-my-hermes` |
 | npm | `npm update -g oh-my-hermes` |
 
-Do not run the curl installer over a package-manager installation; that creates
-a second independently managed `omh` command.
+If the manager update fails, OMH stops before refreshing content and reports the
+manager error. Do not run the curl installer over a package-manager
+installation; that creates a second independently managed `omh` command.
 
 Advanced operators can still pin or test a different source with
 `omh update --channel stable --version <version>` or
@@ -1449,13 +1471,14 @@ Advanced operators can still pin or test a different source with
 release validation, fixtures, or intentional rollback testing. Local
 modifications block updates unless `--force` is supplied.
 
-Run `omh doctor` after an update. Use `omh setup` only when doctor reports that
-Hermes registration needs repair, then restart Hermes Agent. Rerun the installer
-manually only when `omh update` says the command package was not updated, or
-when you intentionally want a one-shot reinstall from a specific source ref. The
-installer passes command-package update evidence into OMH so the state log can
-show version/ref movement such as `1.0.1 -> 1.0.4` or `main@old -> main@new`
-when `OMH_SOURCE_REF` is provided:
+Run `omh doctor` after an update, then restart Hermes Agent. `omh update`
+refreshes existing Hermes registration along with the plugin bundle; use
+`omh setup` only when doctor reports that first-time setup or a repair is still
+needed. Rerun the installer manually only when `omh update` says the command
+package was not updated, or when you intentionally want a one-shot reinstall
+from a specific source ref. The installer passes command-package update
+evidence into OMH so the state log can show version/ref movement such as
+`1.0.1 -> 1.0.4` or `main@old -> main@new` when `OMH_SOURCE_REF` is provided:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | sh

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1465,11 +1465,15 @@ If the manager update fails, OMH stops before refreshing content and reports the
 manager error. Do not run the curl installer over a package-manager
 installation; that creates a second independently managed `omh` command.
 
-Advanced operators can still pin or test a different source with
-`omh update --channel stable --version <version>` or
-`omh update --channel local --from-skills-dir ./skills`, but those flags are for
-release validation, fixtures, or intentional rollback testing. Local
-modifications block updates unless `--force` is supplied.
+Installer-managed commands can still pin or test a different command package
+with `omh update --channel stable --version <version>`. Package-manager installs
+reject `--version`, `--package-url`, and `--source-ref` rather than silently
+installing a different release; use that manager directly for an intentional
+CLI rollback. `omh update --channel local --from-skills-dir ./skills` refreshes
+workflow content only and does not replace the command package, plugin bundle,
+or Hermes registration. These flags are for release validation, fixtures, or
+intentional rollback testing. Local modifications block updates unless
+`--force` is supplied.
 
 Run `omh doctor` after an update, then restart Hermes Agent. `omh update`
 refreshes existing Hermes registration along with the plugin bundle; use

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1465,8 +1465,9 @@ If the manager update fails, OMH stops before refreshing content and reports the
 manager error. Do not run the curl installer over a package-manager
 installation; that creates a second independently managed `omh` command.
 
-Installer-managed commands can still pin or test a different command package
-with `omh update --channel stable --version <version>`. Package-manager installs
+Advanced operators using installer-managed commands can still pin or test a
+different command package with
+`omh update --channel stable --version <version>`. Package-manager installs
 reject `--version`, `--package-url`, and `--source-ref` rather than silently
 installing a different release; use that manager directly for an intentional
 CLI rollback. `omh update --channel local --from-skills-dir ./skills` refreshes

--- a/packaging/npm/README.md
+++ b/packaging/npm/README.md
@@ -18,18 +18,26 @@ omh setup
 
 Use `omh doctor` later to verify or troubleshoot the installation.
 
-Update or remove the command with the manager that installed it:
+Use the same OMH command after either installation:
 
 ```sh
-bun update -g oh-my-hermes
+omh update
+```
+
+It detects npm or Bun, updates the global command package through that manager,
+then re-enters the updated command to refresh managed skills, the installed
+plugin bundle, and existing Hermes registration. Manual fallback and removal:
+
+```sh
+bun update -g --latest oh-my-hermes
 bun remove -g oh-my-hermes
 npm update -g oh-my-hermes
 npm uninstall -g oh-my-hermes
 ```
 
-These commands change only the CLI package. They preserve `~/.omh`, installed
-skills, memory, and Hermes registration. Run `omh uninstall --all` before the
-manager's remove command when you want a complete removal.
+Removal preserves `~/.omh`, installed skills, memory, and Hermes registration.
+Run `omh uninstall --all` before the manager's remove command when you want a
+complete removal.
 
 ## Launcher cache
 

--- a/packaging/npm/lib/launcher.js
+++ b/packaging/npm/lib/launcher.js
@@ -123,6 +123,13 @@ function runPython(
         env: {
           ...env,
           OMH_COMMAND_PACKAGE_MANAGER: packageManager(env),
+          OMH_COMMAND_PACKAGE_ROOT: PACKAGE_ROOT,
+          OMH_COMMAND_PACKAGE_RUNTIME: process.execPath,
+          OMH_COMMAND_PACKAGE_ENTRYPOINT: join(
+            PACKAGE_ROOT,
+            "bin",
+            "omh.js",
+          ),
         },
       },
     );

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -9,6 +9,7 @@ import shutil
 import subprocess
 import sys
 import time
+from typing import cast
 import unicodedata
 
 try:
@@ -392,16 +393,23 @@ def _command_package_self_update_plan(args: argparse.Namespace) -> dict[str, obj
                     "its launcher is missing"
                 ),
             }
+        try:
+            update_command = _package_manager_update_command(
+                package_manager,
+                manager_executable,
+                runtime=runtime,
+            )
+        except OmhError as exc:
+            return {
+                "should_update": False,
+                "reason": str(exc),
+            }
         return {
             "should_update": True,
             "method": "package_manager",
             "package_manager": package_manager,
             "update_instruction": update_instruction,
-            "update_command": _package_manager_update_command(
-                package_manager,
-                manager_executable,
-                runtime=runtime,
-            ),
+            "update_command": update_command,
             "reentry_command": reentry_command,
             "reason": f"running from the {package_manager} command package",
         }
@@ -456,7 +464,9 @@ def _run_command_package_self_update(args: argparse.Namespace, plan: dict[str, o
         stderr=subprocess.PIPE,
     )
     if completed.returncode != 0:
-        detail = (completed.stderr or completed.stdout or "pip install failed").strip()
+        detail = _bounded_command_error(
+            completed.stderr or completed.stdout or "pip install failed"
+        )
         raise OmhError(f"command package update failed: {detail}")
     progress.done("command package updated")
     if not wants_json:
@@ -474,8 +484,8 @@ def _run_package_manager_self_update(
 ) -> int:
     package_manager = str(plan["package_manager"])
     update_instruction = str(plan["update_instruction"])
-    update_command = [str(part) for part in plan["update_command"]]
-    reentry_command = [str(part) for part in plan["reentry_command"]]
+    update_command = list(cast(list[str], plan["update_command"]))
+    reentry_command = list(cast(list[str], plan["reentry_command"]))
     wants_json = _wants_json(args)
     progress = _HumanProgress(enabled=not wants_json, use_color=_use_color())
     progress.header("OMH update", "Refresh the OMH command package and workflow pack.")

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -263,9 +263,11 @@ def cmd_update(args: argparse.Namespace) -> int:
     if self_update.get("should_update"):
         return _run_command_package_self_update(args, self_update)
     code = cmd_install(args)
-    if code == 0 and not (args.from_skills_dir or args.source):
-        _refresh_installed_plugin_bundle(args)
-        _refresh_hermes_registration(args)
+    if code == 0:
+        if not (args.from_skills_dir or args.source):
+            _refresh_installed_plugin_bundle(args)
+            _refresh_hermes_registration(args)
+        _refresh_installed_tui_widget(args)
     return code
 
 
@@ -312,7 +314,6 @@ def _refresh_installed_plugin_bundle(args: argparse.Namespace) -> dict[str, obje
         return None
     try:
         result = install_plugin_bundle(paths, force=args.force, dry_run=args.dry_run)
-        install_tui_widget(paths.hermes_home, dry_run=bool(args.dry_run))
     except PluginPackError:
         # An update must not fail over a bundle a later `omh setup --force` can
         # repair; `omh doctor` reports the drift with the instruction to run it.
@@ -320,6 +321,13 @@ def _refresh_installed_plugin_bundle(args: argparse.Namespace) -> dict[str, obje
     if not args.dry_run:
         update_state(paths, {"last_plugin_distribution": result})
     return result
+
+
+def _refresh_installed_tui_widget(args: argparse.Namespace) -> dict[str, object] | None:
+    paths = _paths(args)
+    if not paths.hermes_plugin_dir.is_dir():
+        return None
+    return install_tui_widget(paths.hermes_home, dry_run=bool(args.dry_run))
 
 
 def _command_package_self_update_plan(args: argparse.Namespace) -> dict[str, object]:

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -101,8 +101,18 @@ WINDOWS_INSTALLER_COMMAND = "irm https://raw.githubusercontent.com/rlaope/oh-my-
 COMMAND_PACKAGE_MANAGER_ENV = "OMH_COMMAND_PACKAGE_MANAGER"
 COMMAND_PACKAGE_UPDATE_COMMANDS = {
     "npm": "npm update -g oh-my-hermes",
-    "bun": "bun update -g oh-my-hermes",
+    "bun": "bun update -g --latest oh-my-hermes",
     "homebrew": "brew upgrade rlaope/tap/omh",
+}
+COMMAND_PACKAGE_UPDATE_ARGUMENTS = {
+    "npm": ("update", "-g", "oh-my-hermes"),
+    "bun": ("update", "-g", "--latest", "oh-my-hermes"),
+    "homebrew": ("upgrade", "rlaope/tap/omh"),
+}
+COMMAND_PACKAGE_EXECUTABLES = {
+    "npm": "npm",
+    "bun": "bun",
+    "homebrew": "brew",
 }
 
 
@@ -320,11 +330,35 @@ def _command_package_self_update_plan(args: argparse.Namespace) -> dict[str, obj
         raise OmhError(str(exc)) from exc
     if release.channel == "local" and release.package_url == "local":
         return {"should_update": False, "reason": "local updates require an explicit package source"}
+    package_manager, update_instruction = _command_package_update_guidance()
+    update_arguments = COMMAND_PACKAGE_UPDATE_ARGUMENTS.get(package_manager)
+    if update_arguments is not None:
+        manager_command = COMMAND_PACKAGE_EXECUTABLES[package_manager]
+        manager_executable = shutil.which(manager_command)
+        if manager_executable is None:
+            raise OmhError(
+                f"cannot update command package because `{manager_command}` is not available on PATH"
+            )
+        omh_executable = shutil.which("omh")
+        if omh_executable is None:
+            raise OmhError(
+                "cannot re-enter the updated command package because `omh` is not available on PATH"
+            )
+        return {
+            "should_update": True,
+            "method": "package_manager",
+            "package_manager": package_manager,
+            "update_instruction": update_instruction,
+            "update_command": _platform_command(manager_executable, *update_arguments),
+            "reentry_command": _platform_command(omh_executable),
+            "reason": f"running from the {package_manager} command package",
+        }
     managed = _managed_command_runtime()
     if not managed["managed"]:
         return {"should_update": False, "reason": managed["reason"]}
     return {
         "should_update": True,
+        "method": "installer",
         "release": release,
         "python": managed["python"],
         "venv_dir": managed["venv_dir"],
@@ -333,6 +367,8 @@ def _command_package_self_update_plan(args: argparse.Namespace) -> dict[str, obj
 
 
 def _run_command_package_self_update(args: argparse.Namespace, plan: dict[str, object]) -> int:
+    if plan.get("method") == "package_manager":
+        return _run_package_manager_self_update(args, plan)
     release = plan.get("release")
     package_url = str(getattr(release, "package_url", "") or "")
     if not package_url:
@@ -378,6 +414,63 @@ def _run_command_package_self_update(args: argparse.Namespace, plan: dict[str, o
     env[SELF_UPDATE_REENTRY_ENV] = "1"
     rerun = subprocess.run([python, "-m", "omh.cli", *argv], env=env)
     return int(rerun.returncode)
+
+
+def _run_package_manager_self_update(
+    args: argparse.Namespace,
+    plan: dict[str, object],
+) -> int:
+    package_manager = str(plan["package_manager"])
+    update_instruction = str(plan["update_instruction"])
+    update_command = [str(part) for part in plan["update_command"]]
+    reentry_command = [str(part) for part in plan["reentry_command"]]
+    wants_json = _wants_json(args)
+    progress = _HumanProgress(enabled=not wants_json, use_color=_use_color())
+    progress.header("OMH update", "Refresh the OMH command package and workflow pack.")
+    progress.step(
+        1,
+        2,
+        "Updating omh command package",
+        detail=update_instruction,
+    )
+    completed = subprocess.run(
+        update_command,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if completed.returncode != 0:
+        detail = (
+            completed.stderr
+            or completed.stdout
+            or f"{package_manager} update failed"
+        ).strip()
+        raise OmhError(f"command package update failed: {detail}")
+    progress.done("command package updated")
+    if not wants_json:
+        progress.step(2, 2, "Refreshing OMH workflows with the updated command")
+    argv = _reentry_argv_with_command_package_updated()
+    env = dict(os.environ)
+    env[SELF_UPDATE_REENTRY_ENV] = "1"
+    rerun = subprocess.run([*reentry_command, *argv], env=env)
+    return int(rerun.returncode)
+
+
+def _platform_command(
+    executable: str,
+    *arguments: str,
+    platform: str = os.name,
+) -> list[str]:
+    if platform == "nt" and Path(executable).suffix.casefold() in {".bat", ".cmd"}:
+        command_processor = os.environ.get("COMSPEC", "cmd.exe")
+        return [
+            command_processor,
+            "/d",
+            "/c",
+            executable,
+            *arguments,
+        ]
+    return [executable, *arguments]
 
 
 def _reentry_argv_with_command_package_updated() -> list[str]:
@@ -446,7 +539,10 @@ def _command_package_status_for_install(
     if command_package_updated:
         status = "would_update" if dry_run else "updated"
         updated = not dry_run
-        reason = "the installer reported that it refreshed the OMH command package before running this command"
+        reason = (
+            f"{package_manager} refreshed the OMH command package before "
+            "running this command"
+        )
     elif dry_run:
         status = "would_remain_unchanged"
         reason = "dry run previews managed skill changes without changing the command package"
@@ -469,7 +565,7 @@ def _command_package_status_for_install(
 
 def _command_package_source(*, command_package_updated: bool, source: str) -> str:
     if command_package_updated:
-        return "installer"
+        return _command_package_update_guidance()[0]
     if source == "builtin":
         return "installed_command_package"
     return "explicit_skill_source"

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -99,6 +99,9 @@ from .model_setup_rendering import (
 POSIX_INSTALLER_COMMAND = "curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | sh"
 WINDOWS_INSTALLER_COMMAND = "irm https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.ps1 | iex"
 COMMAND_PACKAGE_MANAGER_ENV = "OMH_COMMAND_PACKAGE_MANAGER"
+COMMAND_PACKAGE_ROOT_ENV = "OMH_COMMAND_PACKAGE_ROOT"
+COMMAND_PACKAGE_RUNTIME_ENV = "OMH_COMMAND_PACKAGE_RUNTIME"
+COMMAND_PACKAGE_ENTRYPOINT_ENV = "OMH_COMMAND_PACKAGE_ENTRYPOINT"
 COMMAND_PACKAGE_UPDATE_COMMANDS = {
     "npm": "npm update -g oh-my-hermes",
     "bun": "bun update -g --latest oh-my-hermes",
@@ -130,13 +133,18 @@ def _command_package_update_guidance() -> tuple[str, str]:
     explicit = os.environ.get(COMMAND_PACKAGE_MANAGER_ENV, "").strip().lower()
     if explicit in COMMAND_PACKAGE_UPDATE_COMMANDS:
         return explicit, COMMAND_PACKAGE_UPDATE_COMMANDS[explicit]
-    prefix_parts = tuple(part.casefold() for part in Path(sys.prefix).parts)
-    if any(
-        part == "cellar" and prefix_parts[index + 1 : index + 2] == ("omh",)
-        for index, part in enumerate(prefix_parts)
-    ):
+    if _homebrew_prefix_root() is not None:
         return "homebrew", COMMAND_PACKAGE_UPDATE_COMMANDS["homebrew"]
     return "installer", installer_command()
+
+
+def _homebrew_prefix_root() -> Path | None:
+    prefix = Path(sys.prefix)
+    folded_parts = tuple(part.casefold() for part in prefix.parts)
+    for index, part in enumerate(folded_parts):
+        if part == "cellar" and folded_parts[index + 1 : index + 2] == ("omh",):
+            return Path(*prefix.parts[:index])
+    return None
 
 
 COMMAND_PACKAGE_STATUS_SCHEMA_VERSION = "command_package_status/v1"
@@ -254,7 +262,7 @@ def cmd_update(args: argparse.Namespace) -> int:
     if self_update.get("should_update"):
         return _run_command_package_self_update(args, self_update)
     code = cmd_install(args)
-    if code == 0:
+    if code == 0 and not (args.from_skills_dir or args.source):
         _refresh_installed_plugin_bundle(args)
         _refresh_hermes_registration(args)
     return code
@@ -332,25 +340,69 @@ def _command_package_self_update_plan(args: argparse.Namespace) -> dict[str, obj
         return {"should_update": False, "reason": "local updates require an explicit package source"}
     package_manager, update_instruction = _command_package_update_guidance()
     update_arguments = COMMAND_PACKAGE_UPDATE_ARGUMENTS.get(package_manager)
-    if update_arguments is not None:
-        manager_command = COMMAND_PACKAGE_EXECUTABLES[package_manager]
-        manager_executable = shutil.which(manager_command)
+    launcher = _validated_command_package_launcher(package_manager)
+    homebrew_commands = (
+        _validated_homebrew_commands()
+        if package_manager == "homebrew"
+        else None
+    )
+    if update_arguments is not None and (
+        launcher is not None or homebrew_commands is not None
+    ):
+        if _explicit_release_metadata_supplied(args):
+            raise OmhError(
+                "package-manager installs accept the default published update only; "
+                "use the owning manager directly for an explicit version or package URL"
+            )
+        if launcher is not None:
+            manager_command = COMMAND_PACKAGE_EXECUTABLES[package_manager]
+            manager_executable = shutil.which(manager_command)
+            runtime = str(launcher["runtime"])
+            reentry_command = [
+                runtime,
+                str(launcher["entrypoint"]),
+            ]
+        else:
+            assert homebrew_commands is not None
+            manager_command = "brew"
+            manager_executable = str(homebrew_commands["brew"])
+            runtime = ""
+            reentry_command = [str(homebrew_commands["omh"])]
         if manager_executable is None:
-            raise OmhError(
-                f"cannot update command package because `{manager_command}` is not available on PATH"
-            )
-        omh_executable = shutil.which("omh")
-        if omh_executable is None:
-            raise OmhError(
-                "cannot re-enter the updated command package because `omh` is not available on PATH"
-            )
+            return {
+                "should_update": False,
+                "reason": (
+                    f"cannot update command package because `{manager_command}` "
+                    "is not available on PATH"
+                ),
+            }
+        if not Path(manager_executable).is_file():
+            return {
+                "should_update": False,
+                "reason": (
+                    "cannot update command package because "
+                    f"`{manager_executable}` is not a file"
+                ),
+            }
+        if not Path(reentry_command[-1]).is_file():
+            return {
+                "should_update": False,
+                "reason": (
+                    "cannot re-enter the updated command package because "
+                    "its launcher is missing"
+                ),
+            }
         return {
             "should_update": True,
             "method": "package_manager",
             "package_manager": package_manager,
             "update_instruction": update_instruction,
-            "update_command": _platform_command(manager_executable, *update_arguments),
-            "reentry_command": _platform_command(omh_executable),
+            "update_command": _package_manager_update_command(
+                package_manager,
+                manager_executable,
+                runtime=runtime,
+            ),
+            "reentry_command": reentry_command,
             "reason": f"running from the {package_manager} command package",
         }
     managed = _managed_command_runtime()
@@ -440,11 +492,11 @@ def _run_package_manager_self_update(
         stderr=subprocess.PIPE,
     )
     if completed.returncode != 0:
-        detail = (
+        detail = _bounded_command_error(
             completed.stderr
             or completed.stdout
             or f"{package_manager} update failed"
-        ).strip()
+        )
         raise OmhError(f"command package update failed: {detail}")
     progress.done("command package updated")
     if not wants_json:
@@ -456,21 +508,105 @@ def _run_package_manager_self_update(
     return int(rerun.returncode)
 
 
-def _platform_command(
+def _validated_command_package_launcher(
+    package_manager: str,
+) -> dict[str, Path] | None:
+    if package_manager not in {"npm", "bun"}:
+        return None
+    raw_root = os.environ.get(COMMAND_PACKAGE_ROOT_ENV, "")
+    raw_runtime = os.environ.get(COMMAND_PACKAGE_RUNTIME_ENV, "")
+    raw_entrypoint = os.environ.get(COMMAND_PACKAGE_ENTRYPOINT_ENV, "")
+    if not raw_root or not raw_runtime or not raw_entrypoint:
+        return None
+    try:
+        package_root = Path(raw_root).resolve(strict=True)
+        runtime = Path(raw_runtime).resolve(strict=True)
+        entrypoint = Path(raw_entrypoint).resolve(strict=True)
+        expected_entrypoint = (package_root / "bin" / "omh.js").resolve(
+            strict=True
+        )
+        package_manifest = json.loads(
+            (package_root / "package.json").read_text(encoding="utf-8")
+        )
+    except (OSError, json.JSONDecodeError):
+        return None
+    if (
+        not package_root.is_dir()
+        or not runtime.is_file()
+        or not entrypoint.is_file()
+        or entrypoint != expected_entrypoint
+        or package_manifest.get("name") != "oh-my-hermes"
+        or package_manifest.get("version") != __version__
+        or package_manifest.get("bin", {}).get("omh") != "bin/omh.js"
+    ):
+        return None
+    return {
+        "package_root": package_root,
+        "runtime": runtime,
+        "entrypoint": entrypoint,
+    }
+
+
+def _validated_homebrew_commands() -> dict[str, Path] | None:
+    homebrew_root = _homebrew_prefix_root()
+    if homebrew_root is None:
+        return None
+    brew = homebrew_root / "bin" / "brew"
+    omh = homebrew_root / "bin" / "omh"
+    try:
+        cellar_omh = (homebrew_root / "Cellar" / "omh").resolve(strict=True)
+        installed_omh = omh.resolve(strict=True)
+    except OSError:
+        return None
+    if (
+        not brew.is_file()
+        or not installed_omh.is_file()
+        or not installed_omh.is_relative_to(cellar_omh)
+    ):
+        return None
+    return {"brew": brew, "omh": omh}
+
+
+def _package_manager_update_command(
+    package_manager: str,
     executable: str,
-    *arguments: str,
+    *,
+    runtime: str,
     platform: str = os.name,
 ) -> list[str]:
-    if platform == "nt" and Path(executable).suffix.casefold() in {".bat", ".cmd"}:
-        command_processor = os.environ.get("COMSPEC", "cmd.exe")
-        return [
-            command_processor,
-            "/d",
-            "/c",
-            executable,
-            *arguments,
-        ]
-    return [executable, *arguments]
+    arguments = COMMAND_PACKAGE_UPDATE_ARGUMENTS[package_manager]
+    executable_path = Path(executable)
+    if platform != "nt" or executable_path.suffix.casefold() not in {
+        ".bat",
+        ".cmd",
+    }:
+        return [str(executable_path), *arguments]
+    if package_manager != "npm" or not runtime:
+        raise OmhError(
+            f"cannot safely execute the Windows `{package_manager}` command shim"
+        )
+    npm_cli = (
+        executable_path.parent
+        / "node_modules"
+        / "npm"
+        / "bin"
+        / "npm-cli.js"
+    )
+    if not npm_cli.is_file():
+        raise OmhError("cannot locate npm-cli.js beside the Windows npm shim")
+    return [runtime, str(npm_cli), *arguments]
+
+
+def _bounded_command_error(value: str, *, limit: int = 2_000) -> str:
+    sanitized = ANSI_ESCAPE_RE.sub("", value)
+    sanitized = "".join(
+        character
+        for character in sanitized
+        if character in {"\n", "\t"} or ord(character) >= 32
+    ).strip()
+    if len(sanitized) <= limit:
+        return sanitized
+    return f"{sanitized[:limit]}…"
 
 
 def _reentry_argv_with_command_package_updated() -> list[str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2991,7 +2991,10 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             base = ["--omh-home", str(root / ".omh")]
             with patch.dict(
                 os.environ,
-                {"OMH_COMMAND_PACKAGE_MANAGER": "npm"},
+                {
+                    "OMH_COMMAND_PACKAGE_MANAGER": "npm",
+                    setup_commands.SELF_UPDATE_SKIP_ENV: "1",
+                },
             ):
                 status, stdout, stderr = run_cli(
                     base + ["update"],
@@ -3001,9 +3004,19 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
                     base + ["update", "--json"],
                     output_json=False,
                 )
+                updated_status, updated_stdout, updated_stderr = run_cli(
+                    base
+                    + [
+                        "update",
+                        "--command-package-updated",
+                        "--json",
+                    ],
+                    output_json=False,
+                )
 
         self.assertEqual(status, 0, stderr)
         self.assertEqual(json_status, 0, json_stderr)
+        self.assertEqual(updated_status, 0, updated_stderr)
         self.assertIn("npm update -g oh-my-hermes", stdout)
         self.assertNotIn("install.sh", stdout)
         payload = json.loads(json_stdout)
@@ -3015,8 +3028,182 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             payload["command_package"]["update_instruction"],
             "npm update -g oh-my-hermes",
         )
+        updated = json.loads(updated_stdout)
+        self.assertEqual(updated["command_package"]["status"], "updated")
+        self.assertTrue(updated["command_package"]["updated"])
+        self.assertEqual(updated["command_package"]["source"], "npm")
+
+    def test_package_manager_update_plans_native_self_update(self) -> None:
+        args = Namespace(
+            command_package_updated=False,
+            dry_run=False,
+            from_skills_dir=None,
+            source=None,
+            channel="preview",
+            version="",
+            package_url="",
+        )
+        cases = (
+            (
+                "npm",
+                "/usr/local/bin/npm",
+                [
+                    "/usr/local/bin/npm",
+                    "update",
+                    "-g",
+                    "oh-my-hermes",
+                ],
+            ),
+            (
+                "bun",
+                "/usr/local/bin/bun",
+                [
+                    "/usr/local/bin/bun",
+                    "update",
+                    "-g",
+                    "--latest",
+                    "oh-my-hermes",
+                ],
+            ),
+        )
+        for manager, executable, expected_command in cases:
+            with self.subTest(manager=manager):
+                with (
+                    patch.dict(
+                        os.environ,
+                        {
+                            setup_commands.COMMAND_PACKAGE_MANAGER_ENV: manager,
+                            setup_commands.SELF_UPDATE_SKIP_ENV: "",
+                        },
+                    ),
+                    patch.object(
+                        setup_commands.shutil,
+                        "which",
+                        side_effect=lambda command: {
+                            manager: executable,
+                            "omh": "/usr/local/bin/omh",
+                        }.get(command),
+                    ),
+                ):
+                    plan = setup_commands._command_package_self_update_plan(
+                        args
+                    )
+
+                self.assertTrue(plan["should_update"])
+                self.assertEqual(plan["method"], "package_manager")
+                self.assertEqual(plan["package_manager"], manager)
+                self.assertEqual(plan["update_command"], expected_command)
+                self.assertEqual(
+                    plan["reentry_command"],
+                    ["/usr/local/bin/omh"],
+                )
+
+    def test_package_manager_self_update_runs_native_command_and_reenters_omh(
+        self,
+    ) -> None:
+        args = Namespace(json=True)
+        plan = {
+            "method": "package_manager",
+            "package_manager": "npm",
+            "update_instruction": "npm update -g oh-my-hermes",
+            "update_command": [
+                "/usr/local/bin/npm",
+                "update",
+                "-g",
+                "oh-my-hermes",
+            ],
+            "reentry_command": ["/usr/local/bin/omh"],
+        }
+        updated = subprocess.CompletedProcess(
+            args=["npm"],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+        reentered = subprocess.CompletedProcess(
+            args=["omh"],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+        with patch.object(
+            setup_commands.subprocess,
+            "run",
+            side_effect=[updated, reentered],
+        ) as run:
+            with patch.object(
+                setup_commands.sys,
+                "argv",
+                ["omh", "update", "--json"],
+            ):
+                status = setup_commands._run_command_package_self_update(
+                    args,
+                    plan,
+                )
+
+        self.assertEqual(status, 0)
+        self.assertEqual(
+            run.call_args_list[0].args[0],
+            plan["update_command"],
+        )
+        reentry_args = run.call_args_list[1].args[0]
+        self.assertEqual(reentry_args[:1], ["/usr/local/bin/omh"])
+        self.assertIn("update", reentry_args)
+        self.assertIn("--json", reentry_args)
+        self.assertIn("--command-package-updated", reentry_args)
+        self.assertEqual(
+            run.call_args_list[1].kwargs["env"][
+                setup_commands.SELF_UPDATE_REENTRY_ENV
+            ],
+            "1",
+        )
+
+    def test_package_manager_update_failure_stops_before_reentry(self) -> None:
+        args = Namespace(json=True)
+        plan = {
+            "method": "package_manager",
+            "package_manager": "bun",
+            "update_instruction": "bun update -g --latest oh-my-hermes",
+            "update_command": [
+                "/usr/local/bin/bun",
+                "update",
+                "-g",
+                "--latest",
+                "oh-my-hermes",
+            ],
+            "reentry_command": ["/usr/local/bin/omh"],
+        }
+        failed = subprocess.CompletedProcess(
+            args=["bun"],
+            returncode=1,
+            stdout="",
+            stderr="registry unavailable",
+        )
+
+        with patch.object(
+            setup_commands.subprocess,
+            "run",
+            return_value=failed,
+        ) as run:
+            with self.assertRaisesRegex(
+                OmhError,
+                "registry unavailable",
+            ):
+                setup_commands._run_command_package_self_update(args, plan)
+
+        run.assert_called_once()
 
     def test_homebrew_runtime_uses_native_update_guidance(self) -> None:
+        args = Namespace(
+            command_package_updated=False,
+            dry_run=False,
+            from_skills_dir=None,
+            source=None,
+            channel="preview",
+            version="",
+            package_url="",
+        )
         with (
             patch.dict(os.environ, {}, clear=False),
             patch.object(
@@ -3024,14 +3211,53 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
                 "prefix",
                 "/opt/homebrew/Cellar/omh/1.0.5/libexec",
             ),
+            patch.object(
+                setup_commands.shutil,
+                "which",
+                side_effect=lambda command: {
+                    "brew": "/opt/homebrew/bin/brew",
+                    "omh": "/opt/homebrew/bin/omh",
+                }.get(command),
+            ),
         ):
             os.environ.pop("OMH_COMMAND_PACKAGE_MANAGER", None)
             package_manager, instruction = (
                 setup_commands._command_package_update_guidance()
             )
+            plan = setup_commands._command_package_self_update_plan(args)
 
         self.assertEqual(package_manager, "homebrew")
         self.assertEqual(instruction, "brew upgrade rlaope/tap/omh")
+        self.assertTrue(plan["should_update"])
+        self.assertEqual(plan["package_manager"], "homebrew")
+        self.assertEqual(
+            plan["update_command"],
+            [
+                "/opt/homebrew/bin/brew",
+                "upgrade",
+                "rlaope/tap/omh",
+            ],
+        )
+
+    def test_windows_command_shims_run_through_command_processor(self) -> None:
+        self.assertEqual(
+            setup_commands._platform_command(
+                r"C:\npm\npm.cmd",
+                "update",
+                "-g",
+                "oh-my-hermes",
+                platform="nt",
+            ),
+            [
+                "cmd.exe",
+                "/d",
+                "/c",
+                r"C:\npm\npm.cmd",
+                "update",
+                "-g",
+                "oh-my-hermes",
+            ],
+        )
 
     def test_update_self_update_reenters_with_command_package_marker(self) -> None:
         args = Namespace(json=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3225,6 +3225,65 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
         self.assertIn("npm", str(plan["reason"]))
         self.assertIn("not available", str(plan["reason"]))
 
+    def test_unsafe_package_manager_shim_keeps_workflow_update(self) -> None:
+        args = Namespace(
+            command_package_updated=False,
+            dry_run=False,
+            from_skills_dir=None,
+            source=None,
+            channel="preview",
+            version="",
+            package_url="",
+        )
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package_root = root / "oh-my-hermes"
+            entrypoint = package_root / "bin" / "omh.js"
+            entrypoint.parent.mkdir(parents=True)
+            entrypoint.write_text("export {};\n", encoding="utf-8")
+            (package_root / "package.json").write_text(
+                json.dumps(
+                    {
+                        "name": "oh-my-hermes",
+                        "version": setup_commands.__version__,
+                        "bin": {"omh": "bin/omh.js"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            runtime = root / "node"
+            runtime.touch()
+            manager = root / "npm.cmd"
+            manager.touch()
+            env = {
+                setup_commands.COMMAND_PACKAGE_MANAGER_ENV: "npm",
+                setup_commands.COMMAND_PACKAGE_ROOT_ENV: str(package_root),
+                setup_commands.COMMAND_PACKAGE_RUNTIME_ENV: str(runtime),
+                setup_commands.COMMAND_PACKAGE_ENTRYPOINT_ENV: str(
+                    entrypoint
+                ),
+                setup_commands.SELF_UPDATE_SKIP_ENV: "",
+            }
+            with (
+                patch.dict(os.environ, env),
+                patch.object(
+                    setup_commands.shutil,
+                    "which",
+                    return_value=str(manager),
+                ),
+                patch.object(
+                    setup_commands,
+                    "_package_manager_update_command",
+                    side_effect=OmhError("unsafe manager shim"),
+                ),
+            ):
+                plan = setup_commands._command_package_self_update_plan(
+                    args
+                )
+
+        self.assertFalse(plan["should_update"])
+        self.assertEqual(plan["reason"], "unsafe manager shim")
+
     def test_package_manager_rejects_explicit_release_metadata(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3043,60 +3043,241 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             version="",
             package_url="",
         )
-        cases = (
-            (
-                "npm",
-                "/usr/local/bin/npm",
-                [
-                    "/usr/local/bin/npm",
-                    "update",
-                    "-g",
-                    "oh-my-hermes",
-                ],
-            ),
-            (
-                "bun",
-                "/usr/local/bin/bun",
-                [
-                    "/usr/local/bin/bun",
-                    "update",
-                    "-g",
-                    "--latest",
-                    "oh-my-hermes",
-                ],
-            ),
-        )
-        for manager, executable, expected_command in cases:
-            with self.subTest(manager=manager):
-                with (
-                    patch.dict(
-                        os.environ,
-                        {
-                            setup_commands.COMMAND_PACKAGE_MANAGER_ENV: manager,
-                            setup_commands.SELF_UPDATE_SKIP_ENV: "",
-                        },
-                    ),
-                    patch.object(
-                        setup_commands.shutil,
-                        "which",
-                        side_effect=lambda command: {
-                            manager: executable,
-                            "omh": "/usr/local/bin/omh",
-                        }.get(command),
-                    ),
-                ):
-                    plan = setup_commands._command_package_self_update_plan(
-                        args
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package_root = root / "oh-my-hermes"
+            entrypoint = package_root / "bin" / "omh.js"
+            entrypoint.parent.mkdir(parents=True)
+            entrypoint.write_text("export {};\n", encoding="utf-8")
+            (package_root / "package.json").write_text(
+                json.dumps(
+                    {
+                        "name": "oh-my-hermes",
+                        "version": setup_commands.__version__,
+                        "bin": {"omh": "bin/omh.js"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            runtime = root / "node"
+            runtime.touch()
+
+            cases = (
+                (
+                    "npm",
+                    root / "npm",
+                    [
+                        str(root / "npm"),
+                        "update",
+                        "-g",
+                        "oh-my-hermes",
+                    ],
+                ),
+                (
+                    "bun",
+                    root / "bun",
+                    [
+                        str(root / "bun"),
+                        "update",
+                        "-g",
+                        "--latest",
+                        "oh-my-hermes",
+                    ],
+                ),
+            )
+            for manager, executable, expected_command in cases:
+                executable.touch()
+                with self.subTest(manager=manager):
+                    launcher_env = {
+                        setup_commands.COMMAND_PACKAGE_MANAGER_ENV: manager,
+                        setup_commands.COMMAND_PACKAGE_ROOT_ENV: str(
+                            package_root
+                        ),
+                        setup_commands.COMMAND_PACKAGE_RUNTIME_ENV: str(
+                            runtime
+                        ),
+                        setup_commands.COMMAND_PACKAGE_ENTRYPOINT_ENV: str(
+                            entrypoint
+                        ),
+                        setup_commands.SELF_UPDATE_SKIP_ENV: "",
+                    }
+                    with (
+                        patch.dict(os.environ, launcher_env),
+                        patch.object(
+                            setup_commands.shutil,
+                            "which",
+                            return_value=str(executable),
+                        ),
+                    ):
+                        plan = (
+                            setup_commands._command_package_self_update_plan(
+                                args
+                            )
+                        )
+
+                    self.assertTrue(plan["should_update"])
+                    self.assertEqual(plan["method"], "package_manager")
+                    self.assertEqual(plan["package_manager"], manager)
+                    self.assertEqual(
+                        plan["update_command"],
+                        expected_command,
+                    )
+                    self.assertEqual(
+                        plan["reentry_command"],
+                        [
+                            str(runtime.resolve()),
+                            str(entrypoint.resolve()),
+                        ],
                     )
 
-                self.assertTrue(plan["should_update"])
-                self.assertEqual(plan["method"], "package_manager")
-                self.assertEqual(plan["package_manager"], manager)
-                self.assertEqual(plan["update_command"], expected_command)
-                self.assertEqual(
-                    plan["reentry_command"],
-                    ["/usr/local/bin/omh"],
+    def test_package_manager_env_without_launcher_contract_is_guidance_only(
+        self,
+    ) -> None:
+        args = Namespace(
+            command_package_updated=False,
+            dry_run=False,
+            from_skills_dir=None,
+            source=None,
+            channel="preview",
+            version="",
+            package_url="",
+        )
+        env = {
+            setup_commands.COMMAND_PACKAGE_MANAGER_ENV: "npm",
+            setup_commands.COMMAND_PACKAGE_ROOT_ENV: "",
+            setup_commands.COMMAND_PACKAGE_RUNTIME_ENV: "",
+            setup_commands.COMMAND_PACKAGE_ENTRYPOINT_ENV: "",
+            setup_commands.SELF_UPDATE_SKIP_ENV: "",
+        }
+        with (
+            patch.dict(os.environ, env),
+            patch.object(
+                setup_commands,
+                "_managed_command_runtime",
+                return_value={
+                    "managed": False,
+                    "reason": "not installer-managed",
+                },
+            ),
+            patch.object(
+                setup_commands.shutil,
+                "which",
+                return_value="/usr/local/bin/npm",
+            ),
+        ):
+            plan = setup_commands._command_package_self_update_plan(args)
+
+        self.assertFalse(plan["should_update"])
+        self.assertEqual(plan["reason"], "not installer-managed")
+
+    def test_package_manager_missing_executable_keeps_workflow_update(
+        self,
+    ) -> None:
+        args = Namespace(
+            command_package_updated=False,
+            dry_run=False,
+            from_skills_dir=None,
+            source=None,
+            channel="preview",
+            version="",
+            package_url="",
+        )
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package_root = root / "oh-my-hermes"
+            entrypoint = package_root / "bin" / "omh.js"
+            entrypoint.parent.mkdir(parents=True)
+            entrypoint.write_text("export {};\n", encoding="utf-8")
+            (package_root / "package.json").write_text(
+                json.dumps(
+                    {
+                        "name": "oh-my-hermes",
+                        "version": setup_commands.__version__,
+                        "bin": {"omh": "bin/omh.js"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            runtime = root / "node"
+            runtime.touch()
+            env = {
+                setup_commands.COMMAND_PACKAGE_MANAGER_ENV: "npm",
+                setup_commands.COMMAND_PACKAGE_ROOT_ENV: str(package_root),
+                setup_commands.COMMAND_PACKAGE_RUNTIME_ENV: str(runtime),
+                setup_commands.COMMAND_PACKAGE_ENTRYPOINT_ENV: str(
+                    entrypoint
+                ),
+                setup_commands.SELF_UPDATE_SKIP_ENV: "",
+            }
+            with (
+                patch.dict(os.environ, env),
+                patch.object(
+                    setup_commands.shutil,
+                    "which",
+                    return_value=None,
+                ),
+            ):
+                plan = setup_commands._command_package_self_update_plan(
+                    args
                 )
+
+        self.assertFalse(plan["should_update"])
+        self.assertIn("npm", str(plan["reason"]))
+        self.assertIn("not available", str(plan["reason"]))
+
+    def test_package_manager_rejects_explicit_release_metadata(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package_root = root / "oh-my-hermes"
+            entrypoint = package_root / "bin" / "omh.js"
+            entrypoint.parent.mkdir(parents=True)
+            entrypoint.write_text("export {};\n", encoding="utf-8")
+            (package_root / "package.json").write_text(
+                json.dumps(
+                    {
+                        "name": "oh-my-hermes",
+                        "version": setup_commands.__version__,
+                        "bin": {"omh": "bin/omh.js"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            runtime = root / "node"
+            runtime.touch()
+            manager = root / "npm"
+            manager.touch()
+            env = {
+                setup_commands.COMMAND_PACKAGE_MANAGER_ENV: "npm",
+                setup_commands.COMMAND_PACKAGE_ROOT_ENV: str(package_root),
+                setup_commands.COMMAND_PACKAGE_RUNTIME_ENV: str(runtime),
+                setup_commands.COMMAND_PACKAGE_ENTRYPOINT_ENV: str(
+                    entrypoint
+                ),
+                setup_commands.SELF_UPDATE_SKIP_ENV: "",
+            }
+            args = Namespace(
+                command_package_updated=False,
+                dry_run=False,
+                from_skills_dir=None,
+                source=None,
+                channel="stable",
+                version="1.0.5",
+                package_url="",
+                source_ref="",
+            )
+            with (
+                patch.dict(os.environ, env),
+                patch.object(
+                    setup_commands.shutil,
+                    "which",
+                    return_value=str(manager),
+                ),
+                self.assertRaisesRegex(
+                    OmhError,
+                    "default published update only",
+                ),
+            ):
+                setup_commands._command_package_self_update_plan(args)
 
     def test_package_manager_self_update_runs_native_command_and_reenters_omh(
         self,
@@ -3135,7 +3316,13 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             with patch.object(
                 setup_commands.sys,
                 "argv",
-                ["omh", "update", "--json"],
+                [
+                    "omh",
+                    "--omh-home",
+                    r"C:\safe&sound\omh",
+                    "update",
+                    "--json",
+                ],
             ):
                 status = setup_commands._run_command_package_self_update(
                     args,
@@ -3152,6 +3339,7 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
         self.assertIn("update", reentry_args)
         self.assertIn("--json", reentry_args)
         self.assertIn("--command-package-updated", reentry_args)
+        self.assertIn(r"C:\safe&sound\omh", reentry_args)
         self.assertEqual(
             run.call_args_list[1].kwargs["env"][
                 setup_commands.SELF_UPDATE_REENTRY_ENV
@@ -3178,7 +3366,7 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             args=["bun"],
             returncode=1,
             stdout="",
-            stderr="registry unavailable",
+            stderr="\x1b[31mregistry unavailable\x1b[0m" + ("x" * 3_000),
         )
 
         with patch.object(
@@ -3189,11 +3377,14 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             with self.assertRaisesRegex(
                 OmhError,
                 "registry unavailable",
-            ):
+            ) as raised:
                 setup_commands._run_command_package_self_update(args, plan)
 
         run.assert_called_once()
+        self.assertNotIn("\x1b", str(raised.exception))
+        self.assertLess(len(str(raised.exception)), 2_100)
 
+    @requires_posix
     def test_homebrew_runtime_uses_native_update_guidance(self) -> None:
         args = Namespace(
             command_package_updated=False,
@@ -3204,27 +3395,33 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             version="",
             package_url="",
         )
-        with (
-            patch.dict(os.environ, {}, clear=False),
-            patch.object(
-                setup_commands.sys,
-                "prefix",
-                "/opt/homebrew/Cellar/omh/1.0.5/libexec",
-            ),
-            patch.object(
-                setup_commands.shutil,
-                "which",
-                side_effect=lambda command: {
-                    "brew": "/opt/homebrew/bin/brew",
-                    "omh": "/opt/homebrew/bin/omh",
-                }.get(command),
-            ),
-        ):
-            os.environ.pop("OMH_COMMAND_PACKAGE_MANAGER", None)
-            package_manager, instruction = (
-                setup_commands._command_package_update_guidance()
-            )
-            plan = setup_commands._command_package_self_update_plan(args)
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            prefix = root / "Cellar" / "omh" / "1.0.5" / "libexec"
+            prefix.mkdir(parents=True)
+            brew = root / "bin" / "brew"
+            omh = root / "bin" / "omh"
+            brew.parent.mkdir()
+            brew.touch()
+            installed_omh = prefix / "bin" / "omh"
+            installed_omh.parent.mkdir()
+            installed_omh.touch()
+            omh.symlink_to(installed_omh)
+            with (
+                patch.dict(os.environ, {}, clear=False),
+                patch.object(
+                    setup_commands.sys,
+                    "prefix",
+                    str(prefix),
+                ),
+            ):
+                os.environ.pop("OMH_COMMAND_PACKAGE_MANAGER", None)
+                package_manager, instruction = (
+                    setup_commands._command_package_update_guidance()
+                )
+                plan = setup_commands._command_package_self_update_plan(
+                    args
+                )
 
         self.assertEqual(package_manager, "homebrew")
         self.assertEqual(instruction, "brew upgrade rlaope/tap/omh")
@@ -3233,31 +3430,83 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
         self.assertEqual(
             plan["update_command"],
             [
-                "/opt/homebrew/bin/brew",
+                str(brew),
                 "upgrade",
                 "rlaope/tap/omh",
             ],
         )
+        self.assertEqual(plan["reentry_command"], [str(omh)])
 
-    def test_windows_command_shims_run_through_command_processor(self) -> None:
-        self.assertEqual(
-            setup_commands._platform_command(
-                r"C:\npm\npm.cmd",
-                "update",
-                "-g",
-                "oh-my-hermes",
+    @requires_posix
+    def test_homebrew_like_prefix_without_linked_formula_is_guidance_only(
+        self,
+    ) -> None:
+        args = Namespace(
+            command_package_updated=False,
+            dry_run=False,
+            from_skills_dir=None,
+            source=None,
+            channel="preview",
+            version="",
+            package_url="",
+        )
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            prefix = root / "Cellar" / "omh" / "1.0.5" / "libexec"
+            prefix.mkdir(parents=True)
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            (bin_dir / "brew").touch()
+            (bin_dir / "omh").touch()
+            with (
+                patch.dict(os.environ, {}, clear=False),
+                patch.object(setup_commands.sys, "prefix", str(prefix)),
+                patch.object(
+                    setup_commands,
+                    "_managed_command_runtime",
+                    return_value={
+                        "managed": False,
+                        "reason": "not installer-managed",
+                    },
+                ),
+            ):
+                os.environ.pop("OMH_COMMAND_PACKAGE_MANAGER", None)
+                plan = setup_commands._command_package_self_update_plan(
+                    args
+                )
+
+        self.assertFalse(plan["should_update"])
+        self.assertEqual(plan["reason"], "not installer-managed")
+
+    def test_windows_npm_cmd_uses_node_cli_without_command_shell(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            runtime = root / "node.exe"
+            runtime.touch()
+            npm_cmd = root / "npm.cmd"
+            npm_cmd.touch()
+            npm_cli = root / "node_modules" / "npm" / "bin" / "npm-cli.js"
+            npm_cli.parent.mkdir(parents=True)
+            npm_cli.touch()
+
+            command = setup_commands._package_manager_update_command(
+                "npm",
+                str(npm_cmd),
+                runtime=str(runtime),
                 platform="nt",
-            ),
+            )
+
+        self.assertEqual(
+            command,
             [
-                "cmd.exe",
-                "/d",
-                "/c",
-                r"C:\npm\npm.cmd",
+                str(runtime),
+                str(npm_cli),
                 "update",
                 "-g",
                 "oh-my-hermes",
             ],
         )
+        self.assertNotIn("cmd.exe", command)
 
     def test_update_self_update_reenters_with_command_package_marker(self) -> None:
         args = Namespace(json=True)
@@ -3305,6 +3554,39 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
 
         self.assertFalse(plan["should_update"])
         self.assertIn("local updates require", plan["reason"])
+
+    def test_update_explicit_skill_source_skips_other_managed_layers(
+        self,
+    ) -> None:
+        args = Namespace(
+            from_skills_dir="/tmp/local-skills",
+            source=None,
+        )
+        with (
+            patch.object(
+                setup_commands,
+                "_command_package_self_update_plan",
+                return_value={"should_update": False},
+            ),
+            patch.object(
+                setup_commands,
+                "cmd_install",
+                return_value=0,
+            ),
+            patch.object(
+                setup_commands,
+                "_refresh_installed_plugin_bundle",
+            ) as plugin_refresh,
+            patch.object(
+                setup_commands,
+                "_refresh_hermes_registration",
+            ) as registration_refresh,
+        ):
+            status = setup_commands.cmd_update(args)
+
+        self.assertEqual(status, 0)
+        plugin_refresh.assert_not_called()
+        registration_refresh.assert_not_called()
 
     def test_update_self_update_recognizes_venv_python_symlink_path(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3640,12 +3640,17 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
                 setup_commands,
                 "_refresh_hermes_registration",
             ) as registration_refresh,
+            patch.object(
+                setup_commands,
+                "_refresh_installed_tui_widget",
+            ) as widget_refresh,
         ):
             status = setup_commands.cmd_update(args)
 
         self.assertEqual(status, 0)
         plugin_refresh.assert_not_called()
         registration_refresh.assert_not_called()
+        widget_refresh.assert_called_once_with(args)
 
     def test_update_self_update_recognizes_venv_python_symlink_path(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_distribution_packages.py
+++ b/tests/test_distribution_packages.py
@@ -363,6 +363,30 @@ class NpmBunDistributionTests(unittest.TestCase):
             update_payload["command_package"]["update_instruction"],
             expected_update,
         )
+        manager_update_env = dict(env)
+        manager_update_env.pop("OMH_SKIP_COMMAND_PACKAGE_UPDATE")
+        pinned = run(
+            command_for(
+                binary,
+                "--omh-home",
+                str(doctor_root / "omh"),
+                "--hermes-home",
+                str(doctor_root / "hermes"),
+                "update",
+                "--channel",
+                "stable",
+                "--version",
+                PROJECT_VERSION,
+                "--json",
+            ),
+            env=manager_update_env,
+            check=False,
+        )
+        self.assertEqual(pinned.returncode, 2)
+        self.assertIn(
+            "default published update only",
+            pinned.stderr,
+        )
 
     def test_global_tarball_launchers(self) -> None:
         tarball = self._tarball()

--- a/tests/test_distribution_packages.py
+++ b/tests/test_distribution_packages.py
@@ -309,6 +309,11 @@ class NpmBunDistributionTests(unittest.TestCase):
             "OMH_PYTHON": sys.executable,
             "PYTHONPATH": "must-not-be-inherited",
             "PIP_NO_INDEX": "1",
+            # This fixture installs an unpublished local tarball with network
+            # access disabled. Package-manager self-update is covered by the
+            # update routing tests and the public-release QA; this assertion
+            # verifies the staged artifact's own CLI and provenance.
+            "OMH_SKIP_COMMAND_PACKAGE_UPDATE": "1",
         }
         for arguments in (("--version",), ("--help",), ("setup", "--help")):
             result = run(command_for(binary, *arguments), env=env)
@@ -352,7 +357,7 @@ class NpmBunDistributionTests(unittest.TestCase):
         )
         expected_update = {
             "npm": "npm update -g oh-my-hermes",
-            "bun": "bun update -g oh-my-hermes",
+            "bun": "bun update -g --latest oh-my-hermes",
         }[package_manager]
         self.assertEqual(
             update_payload["command_package"]["update_instruction"],

--- a/tests/test_distribution_surfaces.py
+++ b/tests/test_distribution_surfaces.py
@@ -20,7 +20,7 @@ DOCTOR_COMMAND = "omh doctor"
 LIFECYCLE_COMMANDS = (
     "brew upgrade rlaope/tap/omh",
     "brew uninstall omh",
-    "bun update -g oh-my-hermes",
+    "bun update -g --latest oh-my-hermes",
     "bun remove -g oh-my-hermes",
     "npm update -g oh-my-hermes",
     "npm uninstall -g oh-my-hermes",


### PR DESCRIPTION
## Feature Report

### What Changed

- `omh update` now upgrades the command package through the package manager that installed it: Homebrew, Bun, npm, or the existing curl/PowerShell-managed virtual environment.
- After a successful command-package upgrade, the updated CLI re-enters once to refresh managed workflows, plugin content, registration state, and the update log.
- Unsafe or unproven install provenance degrades to workflows-only refresh instead of mutating an unrelated command.

### Why This Exists

- Package-manager users previously refreshed OMH workflows without upgrading the globally installed `omh` command, leaving the command and workflow pack at different versions.
- Users should need one normal action, `omh update`, regardless of the supported installation method.

### User / Operator Impact

- Homebrew, Bun, npm, curl, and PowerShell users can use the same `omh update` command.
- Package-manager updates use native manager commands and shell-free argument arrays.
- Unsupported pip, pipx, distro, source-checkout, custom Python, missing-manager, and unsafe-shim cases remain non-destructive and print workflows-only guidance.
- Explicit installer version or package URL selection is rejected for package-manager installs instead of being silently ignored.

### How It Works

- npm and Bun launchers bind package root, runtime, entrypoint, and manager provenance into the process environment.
- Python validates package identity, version, declared binary, resolved entrypoint, Homebrew linked Cellar provenance, and manager availability before planning mutation.
- npm, Bun, and Homebrew dispatch their native global upgrade command, then re-enter through the validated updated entrypoint with a bounded one-level marker.
- Manager and installer failures stop before workflow mutation and return sanitized, bounded diagnostics.

### Files And Contracts Touched

- `src/commands/setup.py`: update planning, provenance validation, manager dispatch, fallback, reentry, and error boundaries.
- `packaging/npm/lib/launcher.js`: npm/Bun launcher provenance contract.
- `tests/test_cli.py`, `tests/test_distribution_packages.py`, `tests/test_distribution_surfaces.py`: routing, security, staged package, and public-surface contracts.
- `README*`, `INSTALL_FOR_AGENTS.md`, `docs/INSTALLATION.md`, `packaging/npm/README.md`, `CHANGELOG.md`: one-command update guidance and capability boundaries.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [ ] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [x] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: dry-run, bad input, manager-failure, explicit-source, and reentry scenarios
- [x] Manual Hermes/TUI check, or explicit reason it was not run: not applicable; this is a CLI/package-manager surface

### Observed Evidence

- 362 update and distribution tests passed at the final executable head; 440 CLI, router-content, package, and distribution-surface smoke tests passed after the documentation-only fix.
- Staged npm and Bun tarballs installed globally and exposed validated launcher contracts.
- Positive and negative scenarios passed for manager provenance, missing managers, Homebrew linked-formula detection, nonstandard Windows shims, explicit release metadata, explicit skill sources, shell metacharacters, dry-run, manager failure, and one-level reentry.
- Five independent review lanes passed: goal/constraints, code quality, security, hands-on QA, and repository context.
- Generated docs checks, Ruff, compileall, Node syntax, and diff checks passed.

### Not Tested / Not Applicable

- Full discovery is left to CI because the review environment reproduced unrelated baseline failures in cross-harness filesystem-fault modules; affected and adjacent suites are green.
- No public npm, Bun, or Homebrew mutation was possible before v1.0.6 publication.
- Windows behavior was simulated through the platform-injected command builder; a native Windows host remains release QA.
- Hermes runtime, handoff, and workflow-learning checks do not apply to this package-manager CLI change.

## Risk

- The update command can mutate a global package-manager install. Mutation is gated by validated launcher or linked-formula provenance, uses no shell, and stops before workflow refresh on manager failure.
- An unsupported or ambiguous installation intentionally receives workflows-only refresh and explicit manager guidance rather than a guessed upgrade.

## Compatibility / Rollout

- Existing curl and PowerShell installer-managed updates remain supported.
- Existing `--command-package-updated` reentry remains bounded and internal.
- Package-manager update publication depends on the separate canonical v1.0.6 version PR, npm namespace, Homebrew tap, and release workflow.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Rebase and merge the canonical v1.0.6 version PR after this feature lands.
- Publish the npm package and Homebrew tap, then verify real npm, Bun, Homebrew, curl, PowerShell, and native Windows update paths against the public release.