### PR TITLE
fix(release): accept npm owner CLI output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,14 +112,9 @@ jobs:
           test -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
           package_name="$(npm view oh-my-hermes name --json | tr -d '"')"
           test "$package_name" = "oh-my-hermes"
-          owners="$(npm owner ls oh-my-hermes --json)"
-          node -e '
-            const value = JSON.parse(process.argv[1]);
-            const owners = Array.isArray(value)
-              ? value.map((item) => item.name ?? item)
-              : Object.keys(value);
-            if (!owners.includes("rlaope")) process.exit(1);
-          ' "$owners"
+          npm owner ls oh-my-hermes --json |
+            uv run tools/package_manager/metadata.py \
+              --require-npm-owner rlaope
           tap="$PWD/dist/release/homebrew-tap"
           test -d "$tap/.git"
           git -C "$tap" push --dry-run origin HEAD:refs/heads/main

--- a/tests/test_homebrew_distribution.py
+++ b/tests/test_homebrew_distribution.py
@@ -5,6 +5,7 @@ import json
 import os
 from pathlib import Path
 import re
+import subprocess
 import sys
 from tempfile import TemporaryDirectory
 import unittest
@@ -125,6 +126,47 @@ class HomebrewDistributionTests(unittest.TestCase):
 
 
 class DistributionReleaseContractTests(unittest.TestCase):
+    def test_npm_owner_preflight_accepts_cli_text_and_json(self) -> None:
+        metadata = PROJECT_ROOT / "tools" / "package_manager" / "metadata.py"
+        accepted = (
+            "rlaope <piyrw9754@gmail.com>\n",
+            '["rlaope"]\n',
+            '{"rlaope":"piyrw9754@gmail.com"}\n',
+            '[{"name":"rlaope","email":"piyrw9754@gmail.com"}]\n',
+        )
+        for owner_output in accepted:
+            with self.subTest(owner_output=owner_output):
+                result = subprocess.run(
+                    [
+                        sys.executable,
+                        str(metadata),
+                        "--require-npm-owner",
+                        "rlaope",
+                    ],
+                    cwd=PROJECT_ROOT,
+                    input=owner_output,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+        rejected = subprocess.run(
+            [
+                sys.executable,
+                str(metadata),
+                "--require-npm-owner",
+                "rlaope",
+            ],
+            cwd=PROJECT_ROOT,
+            input="other-owner <owner@example.test>\n",
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(rejected.returncode, 2)
+        self.assertIn("required npm owner is missing", rejected.stderr)
+
     def test_version_comparison_cli_guards_tap_monotonicity(self) -> None:
         metadata = (
             PROJECT_ROOT / "tools" / "package_manager" / "metadata.py"
@@ -291,6 +333,7 @@ class DistributionReleaseContractTests(unittest.TestCase):
         for contract in (
             "npm view oh-my-hermes name",
             "npm owner ls oh-my-hermes",
+            "--require-npm-owner rlaope",
             "ACTIONS_ID_TOKEN_REQUEST_URL",
             "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
             "git -C \"$tap\" push --dry-run origin HEAD:refs/heads/main",

--- a/tools/package_manager/metadata.py
+++ b/tools/package_manager/metadata.py
@@ -198,6 +198,47 @@ def inspect_wheel(
     )
 
 
+def npm_owner_names(raw: str) -> tuple[str, ...]:
+    """Parse the JSON and plain-text formats emitted by ``npm owner ls``."""
+
+    text = raw.strip()
+    if not text:
+        raise DistributionError("npm owner output is empty")
+
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError:
+        names = [
+            line.split(maxsplit=1)[0]
+            for line in text.splitlines()
+            if line.strip()
+        ]
+    else:
+        if isinstance(value, dict):
+            names = [name for name in value if isinstance(name, str)]
+        elif isinstance(value, list):
+            names = []
+            for item in value:
+                if isinstance(item, str):
+                    names.append(item)
+                elif (
+                    isinstance(item, dict)
+                    and isinstance(item.get("name"), str)
+                ):
+                    names.append(item["name"])
+                else:
+                    raise DistributionError(
+                        "npm owner JSON contains an unsupported entry"
+                    )
+        else:
+            raise DistributionError("npm owner output has an unsupported shape")
+
+    normalized = tuple(dict.fromkeys(name.strip() for name in names if name.strip()))
+    if not normalized:
+        raise DistributionError("npm owner output contains no owners")
+    return normalized
+
+
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Verify OMH distribution identity.")
     parser.add_argument("--wheel", type=Path)
@@ -207,6 +248,7 @@ def _parser() -> argparse.ArgumentParser:
         nargs=2,
         metavar=("EXISTING", "CANDIDATE"),
     )
+    parser.add_argument("--require-npm-owner")
     parser.add_argument("--json", action="store_true")
     return parser
 
@@ -221,6 +263,13 @@ def main(argv: list[str] | None = None) -> int:
             return 0
         if args.compare_versions is not None:
             print(version_order(*args.compare_versions))
+            return 0
+        if args.require_npm_owner is not None:
+            owners = npm_owner_names(sys.stdin.read())
+            if args.require_npm_owner not in owners:
+                raise DistributionError(
+                    f"required npm owner is missing: {args.require_npm_owner}"
+                )
             return 0
         if args.wheel is None:
             raise DistributionError(


### PR DESCRIPTION
## Feature Report

### What Changed

- Replaced the release workflow inline JSON-only npm owner parser with the tested distribution metadata verifier.
- Added support for the plain text emitted by pinned npm 11.5.1 plus JSON array and object shapes.

### Why This Exists

- The v1.0.6 tag run failed before its first publication write because `npm owner ls oh-my-hermes --json` returned `rlaope <email>` and the workflow passed that text to `JSON.parse`.

### User / Operator Impact

- Maintainers can resume the existing v1.0.6 tag run without weakening npm owner or Homebrew destination preflight.
- No package, GitHub release asset, or tap formula was written by the failed run.

### How It Works

- `tools/package_manager/metadata.py --require-npm-owner rlaope` reads stdin, normalizes npm CLI text or JSON owner records, and exits 2 when the required owner is absent.
- `release.yml` pipes the pinned npm CLI output to that verifier before any release write.

### Files And Contracts Touched

- `.github/workflows/release.yml`: npm destination preflight.
- `tools/package_manager/metadata.py`: owner-output normalization CLI.
- `tests/test_homebrew_distribution.py`: positive shapes, negative control, and workflow wiring.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [ ] `uv run --group lint ruff check src tests`
- [ ] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [ ] `uv run python -m compileall -q src tests`
- [ ] `uv run python -m omh.cli docs workflows --check`
- [ ] `uv run python -m omh.cli docs roles --check`
- [ ] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: real `npm owner ls oh-my-hermes --json` piped into the new verifier
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- The exact parser test failed on the missing CLI before implementation and passed afterward.
- Related Homebrew/distribution suites passed.
- Real npm 11 owner output passed; a different owner exited 2.
- Changed-file Ruff, Python compileall, YAML parse, LSP diagnostics, and diff check passed.

### Not Tested / Not Applicable

- Full suite and GitHub matrix CI are pending this PR.
- Hermes/TUI checks do not apply to a release destination parser.

## Risk

- Narrow: only the pre-write npm owner assertion changes. Exact owner equality remains mandatory.

## Compatibility / Rollout

- Compatible with observed npm 11 plain text and prior JSON owner output. The existing tag is resumed only after this PR is green and merged.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Merge on green CI, then dispatch `Distribution Release` with input `v1.0.6` and observe all publication boundaries.