### PR TITLE
fix(release): constrain historical tag recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,25 @@ jobs:
           test "$tag_commit" = "$(git rev-parse HEAD)"
           git fetch --no-tags origin main
           git merge-base --is-ancestor "$tag_commit" origin/main
-          test "$tag_commit" = "$(git rev-parse origin/main)"
+          if [ "$GITHUB_EVENT_NAME" = "push" ]; then
+            test "$tag_commit" = "$(git rev-parse origin/main)"
+          else
+            recovery_changes="$(git diff --name-only "$tag_commit"..origin/main)"
+            while IFS= read -r path; do
+              test -z "$path" && continue
+              case "$path" in
+                .github/workflows/release.yml | \
+                docs/DISTRIBUTION.md | \
+                tests/test_homebrew_distribution.py | \
+                tools/package_manager/metadata.py)
+                  ;;
+                *)
+                  echo "release recovery includes artifact-affecting change: $path" >&2
+                  exit 1
+                  ;;
+              esac
+            done <<< "$recovery_changes"
+          fi
           source_date_epoch="$(git show -s --format=%ct "$tag_commit")"
           echo "SOURCE_DATE_EPOCH=$source_date_epoch" >> "$GITHUB_ENV"
           version="$(uv run tools/package_manager/metadata.py --version)"
@@ -112,9 +130,14 @@ jobs:
           test -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
           package_name="$(npm view oh-my-hermes name --json | tr -d '"')"
           test "$package_name" = "oh-my-hermes"
+          owner_verifier="tools/package_manager/metadata.py"
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            owner_verifier="$RUNNER_TEMP/npm-owner-metadata.py"
+            git show origin/main:tools/package_manager/metadata.py \
+              > "$owner_verifier"
+          fi
           npm owner ls oh-my-hermes --json |
-            uv run tools/package_manager/metadata.py \
-              --require-npm-owner rlaope
+            uv run "$owner_verifier" --require-npm-owner rlaope
           tap="$PWD/dist/release/homebrew-tap"
           test -d "$tap/.git"
           git -C "$tap" push --dry-run origin HEAD:refs/heads/main

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -75,8 +75,10 @@ ruby -c dist/distribution/omh.rb
 
 A `vX.Y.Z` tag runs the distribution workflow in this order:
 
-1. Validate that the tag resolves to the current protected `main` tip and that
-   every version surface matches.
+1. Validate that a newly pushed tag resolves to the current protected `main`
+   tip and that every version surface matches. A manual recovery may use an
+   older tag only when every later `main` change is confined to the
+   release-control allowlist.
 2. Run distribution contract tests.
 3. Build one wheel and stage the npm tarball from it.
 4. Create the GitHub release and upload the wheel.
@@ -94,19 +96,24 @@ downgrade a newer tap formula.
 ## Resume and rollback
 
 The workflow is safe to resume with `workflow_dispatch` and the existing tag
-only while that tag remains the current protected `main` tip. It reuses a
-GitHub asset only when its bytes match the locally rebuilt wheel, accepts an
-existing npm version only when its integrity matches the staged tarball, and
-skips a tap commit when the formula is already identical. If `main` has
-advanced, do not weaken the authority check or rerun the historical tag;
-correct the source and publish a new patch release from the current tip.
+when that tag remains on protected `main` and every later change is confined
+to the explicit release-control allowlist: the release workflow, distribution
+metadata verifier, its contract test, and this recovery documentation. The
+workflow loads the verifier from current `main` while building all published
+artifacts from the immutable tag. Any artifact-affecting change after the tag
+blocks recovery and requires a new patch release.
+
+A resumed run reuses a GitHub asset only when its bytes match the locally
+rebuilt wheel, accepts an existing npm version only when its integrity matches
+the staged tarball, and skips a tap commit when the formula is already
+identical.
 
 Published npm versions and GitHub release assets are immutable. Do not replace
 them. If an identity mismatch occurs, stop the workflow and publish a new patch
 version after correcting the source. If npm succeeds but the tap update fails,
 repair the tap credential or formula and resume the same tag; the workflow
-verifies the existing npm artifact before continuing. If `main` advanced
-before recovery, publish the correcting patch release instead.
+verifies the existing npm artifact before continuing. If artifact-affecting
+source advanced before recovery, publish the correcting patch release instead.
 
 ### GitHub release succeeds, npm fails
 
@@ -114,15 +121,16 @@ Do not delete or replace the release wheel. Repair the npm trusted-publisher
 configuration or environment approval, then resume the same tag. The
 reproducible rebuild must match the existing wheel byte for byte before the
 workflow may retry npm. The tap remains unchanged until npm succeeds.
-If the tag is no longer the current `main` tip, use a new patch release.
+If later `main` changes exceed the release-control allowlist, use a new patch
+release.
 
 ### npm succeeds, Homebrew tap fails
 
 The npm version is immutable. Repair only the tap repository, token, formula,
 or style failure, then resume the same tag. The workflow must verify the
 existing npm integrity before rendering and pushing the formula; it must not
-republish npm. If the tag is no longer the current `main` tip, publish a new
-patch release so the tap advances monotonically.
+republish npm. If later `main` changes exceed the release-control allowlist,
+publish a new patch release so the tap advances monotonically.
 
 ### Release asset is missing
 

--- a/tests/test_homebrew_distribution.py
+++ b/tests/test_homebrew_distribution.py
@@ -360,6 +360,34 @@ class DistributionReleaseContractTests(unittest.TestCase):
             workflow,
         )
 
+    def test_manual_release_resume_is_limited_to_release_control_changes(
+        self,
+    ) -> None:
+        workflow = (
+            PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+        ).read_text()
+        self.assertIn('if [ "$GITHUB_EVENT_NAME" = "push" ]; then', workflow)
+        self.assertIn(
+            'recovery_changes="$(git diff --name-only '
+            '"$tag_commit"..origin/main)"',
+            workflow,
+        )
+        for allowed_path in (
+            ".github/workflows/release.yml",
+            "docs/DISTRIBUTION.md",
+            "tests/test_homebrew_distribution.py",
+            "tools/package_manager/metadata.py",
+        ):
+            self.assertIn(allowed_path, workflow)
+        self.assertIn(
+            'owner_verifier="$RUNNER_TEMP/npm-owner-metadata.py"',
+            workflow,
+        )
+        self.assertIn(
+            "git show origin/main:tools/package_manager/metadata.py",
+            workflow,
+        )
+
     def test_workflow_actions_are_pinned_to_full_commits(self) -> None:
         action_reference = re.compile(
             r"(?:-\s+)?uses:\s+[^@\s]+@[0-9a-f]{40}(?:\s+#.*)?$"


### PR DESCRIPTION
## Feature Report

### What Changed

- Preserves strict tag-equals-main authority for new tag pushes.
- Allows manual recovery of an immutable tag only when every later main change is confined to four release-control files.
- Loads the npm owner verifier from current main during recovery while building every publishable artifact from the tag.
- Documents the constrained recovery boundary.

### Why This Exists

- The corrected v1.0.6 workflow could not resume because the existing contract always required the historical tag to equal the latest main commit.
- Simply allowing any ancestor would be unsafe, and the prior helper fix was unavailable after checkout switched the workspace back to the immutable tag.

### User / Operator Impact

- Maintainers can recover v1.0.6 after reviewed workflow-only fixes without retagging or admitting application/source drift.
- Any artifact-affecting main change still blocks recovery and requires a new patch release.

### How It Works

- Tag push: tag commit must equal protected main.
- Manual dispatch: tag must be an ancestor and the tag-to-main diff may contain only `release.yml`, `metadata.py`, its contract test, and recovery documentation.
- Recovery preflight extracts the reviewed owner verifier from `origin/main`; wheel and npm artifacts remain built from the immutable tag checkout.

### Files And Contracts Touched

- `.github/workflows/release.yml`: event-specific authority and verifier source.
- `tests/test_homebrew_distribution.py`: recovery allowlist and verifier wiring contract.
- `docs/DISTRIBUTION.md`: constrained resume and rollback rules.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [ ] `uv run --group lint ruff check src tests`
- [ ] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [ ] `uv run python -m compileall -q src tests`
- [ ] `uv run python -m omh.cli docs workflows --check`
- [ ] `uv run python -m omh.cli docs roles --check`
- [ ] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: current tag-to-branch allowlist and current-main verifier extraction
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- New recovery contract test failed before implementation and passed afterward.
- Release authority and related distribution suites passed.
- The real v1.0.6-to-branch diff passed the four-file allowlist.
- Owner verification extracted from current main passed against live npm output.
- Ruff, compileall, workflow YAML parse, LSP diagnostics, and diff check passed.

### Not Tested / Not Applicable

- Full suite and GitHub matrix CI are pending this PR.
- Hermes/TUI checks do not apply to release authority.

## Risk

- Moderate release-control risk, bounded by an explicit path allowlist and immutable tag artifact checkout.

## Compatibility / Rollout

- New tag pushes retain the existing strict main-tip rule. Historical recovery is opt-in through `workflow_dispatch` only.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Merge on green CI, rerun v1.0.6, then execute isolated npm, Bun, and Homebrew clean-install plus `omh update` QA lanes.