### PR TITLE
fix(release): use tap-scoped deploy key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: rlaope/homebrew-tap
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          ssh-key: ${{ secrets.HOMEBREW_TAP_SSH_KEY }}
           path: dist/release/homebrew-tap
 
       - name: Preflight npm and Homebrew destinations

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -33,8 +33,9 @@ Before advertising the package-manager commands:
    `rlaope/oh-my-hermes`, workflow `.github/workflows/release.yml`, and
    environment `npm`.
 3. Create the public repository `rlaope/homebrew-tap` with a default branch.
-4. Add a least-privilege `HOMEBREW_TAP_TOKEN` repository secret that can update
-   only that tap.
+4. Add a write-enabled deploy key to `rlaope/homebrew-tap` and store its
+   private key as the `HOMEBREW_TAP_SSH_KEY` repository secret. The key must
+   grant access only to that tap.
 5. Keep the GitHub `npm` environment protected according to the release policy.
 
 The workflow uses GitHub OIDC for npm provenance. It does not require a

--- a/tests/test_homebrew_distribution.py
+++ b/tests/test_homebrew_distribution.py
@@ -434,7 +434,11 @@ class DistributionReleaseContractTests(unittest.TestCase):
         self.assertIn("npm publish", content)
         self.assertIn("--provenance", content)
         self.assertIn("id-token: write", content)
-        self.assertIn("HOMEBREW_TAP_TOKEN", content)
+        self.assertIn(
+            "ssh-key: ${{ secrets.HOMEBREW_TAP_SSH_KEY }}",
+            content,
+        )
+        self.assertNotIn("HOMEBREW_TAP_TOKEN", content)
         self.assertIn("render_homebrew.py", content)
         self.assertLess(
             content.index("npm publish"),


### PR DESCRIPTION
## Feature Report

### What Changed

- Replaced the Homebrew tap PAT checkout credential with a repository-scoped write deploy key.
- Updated the release contract test and maintainer setup documentation.

### Why This Exists

- The v1.0.6 release reached destination preflight, but the supplied `sionic-khope` PAT could read `rlaope/homebrew-tap` and could not perform `git push --dry-run`; GitHub returned HTTP 403.
- npm publication was not attempted because destination preflight correctly failed first.

### User / Operator Impact

- The release workflow can push only to the Homebrew tap through a dedicated deploy key.
- Broad account OAuth credentials are not stored in Actions secrets.

### How It Works

- A verified, write-enabled deploy key is installed only on `rlaope/homebrew-tap`.
- Its private key is stored as `HOMEBREW_TAP_SSH_KEY` in `rlaope/oh-my-hermes`.
- `actions/checkout` uses `ssh-key` for the cross-repository checkout and push.

### Files And Contracts Touched

- `.github/workflows/release.yml`: tap checkout credential.
- `docs/DISTRIBUTION.md`: one-time credential setup.
- `tests/test_homebrew_distribution.py`: requires SSH deploy-key wiring and rejects the old token.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [ ] `uv run --group lint ruff check src tests`
- [ ] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [ ] `uv run python -m compileall -q src tests`
- [ ] `uv run python -m omh.cli docs workflows --check`
- [ ] `uv run python -m omh.cli docs roles --check`
- [ ] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: deploy-key metadata verified as write-enabled and tap-scoped
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- The new contract test failed against PAT wiring and passed after SSH migration.
- Related release distribution suites passed.
- Ruff, compileall, workflow YAML parse, LSP diagnostics, and diff check passed.
- Deploy key `oh-my-hermes release publisher` is verified and `read_only=false` on the tap; the Actions secret exists.

### Not Tested / Not Applicable

- Full suite and matrix CI are pending this PR.
- The live SSH push is intentionally deferred to the guarded release preflight after merge.
- Hermes/TUI checks do not apply to publication credentials.

## Risk

- Narrow. The deploy key can write only to `rlaope/homebrew-tap`; npm OIDC and artifact generation are unchanged.

## Compatibility / Rollout

- The obsolete PAT secret remains until the first SSH-backed release succeeds, then it will be removed.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Merge on green CI, resume v1.0.6, verify npm/Homebrew publication, then run isolated package-manager QA.