### PR TITLE
fix(release): publish missing npm version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,11 +191,10 @@ jobs:
         run: |
           set -euo pipefail
           local_integrity="sha512-$(openssl dgst -sha512 -binary "$OMH_TARBALL" | openssl base64 -A)"
-          published_integrity="$(
-            npm view "oh-my-hermes@$OMH_VERSION" dist.integrity --json 2>/dev/null |
-              tr -d '"' || true
-          )"
-          if [ -n "$published_integrity" ]; then
+          if published_integrity="$(
+            npm view "oh-my-hermes@$OMH_VERSION" dist.integrity --json 2>/dev/null
+          )"; then
+            published_integrity="${published_integrity//\"/}"
             test "$published_integrity" = "$local_integrity"
           else
             npm publish "$OMH_TARBALL" --access public --provenance

--- a/tests/test_homebrew_distribution.py
+++ b/tests/test_homebrew_distribution.py
@@ -445,6 +445,22 @@ class DistributionReleaseContractTests(unittest.TestCase):
             content.index("render_homebrew.py"),
         )
 
+    def test_missing_npm_version_reaches_publish_instead_of_integrity_check(
+        self,
+    ) -> None:
+        workflow = (
+            PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+        ).read_text()
+        self.assertIn(
+            'if published_integrity="$(\n'
+            '            npm view "oh-my-hermes@$OMH_VERSION" '
+            "dist.integrity --json 2>/dev/null\n"
+            '          )"; then',
+            workflow,
+        )
+        self.assertNotIn("tr -d '\"' || true", workflow)
+        self.assertIn('npm publish "$OMH_TARBALL"', workflow)
+
     def test_npm_template_has_no_published_placeholder_version(self) -> None:
         template = NPM_PACKAGE_SOURCE / "package.template.json"
         self.assertTrue(template.is_file(), "npm package template missing")


### PR DESCRIPTION
## Feature Report

### What Changed

- Makes npm version existence depend on `npm view` exit status instead of non-empty stdout.
- Adds a regression contract proving an unpublished version reaches `npm publish`.

### Why This Exists

- The v1.0.6 run reached the npm step, but npm returned a JSON error body with exit 1 for the missing version. The workflow treated that non-empty error as an integrity value and failed a silent string comparison without invoking publish.

### User / Operator Impact

- A genuinely missing package version now reaches OIDC-backed publication.
- Existing versions still require exact integrity equality before the workflow continues.

### How It Works

- Successful `npm view` enters immutable-integrity verification.
- Non-zero `npm view` enters `npm publish --access public --provenance`.

### Files And Contracts Touched

- `.github/workflows/release.yml`: npm version branch.
- `tests/test_homebrew_distribution.py`: missing-version regression.

### Affected Surfaces

- [x] Not executor-specific

## Validation

- [x] `git diff --check`
- [x] Relevant dry-run or smoke command: live `npm view oh-my-hermes@1.0.6` non-zero branch reached publish path

### Observed Evidence

- Regression test failed before the fix and passed afterward.
- Related release distribution suites, Ruff, compileall, YAML parsing, LSP, and diff check passed.
- The prior run created the immutable GitHub wheel but did not publish npm or update the tap.

### Not Tested / Not Applicable

- Live OIDC publication follows immediately after merge.
- Hermes/TUI checks do not apply.

## Risk

- Narrow: only missing-version detection changes; existing-version integrity remains strict.

## Compatibility / Rollout

- Safe for idempotent reruns with the existing v1.0.6 GitHub release asset.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Evidence contains no credentials or unrelated private data

## Follow-Up

- Merge, resume v1.0.6, observe npm 1.0.6 publicly, then continue Homebrew and isolated install/update QA.