### PR TITLE
docs(release): announce package-manager availability

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -84,8 +84,8 @@
 >   <img src="assets/friren-agent-omh-callout.png" alt="Friren Agent explaining OMH in Art&Engine" width="720">
 > </p>
 ## クイックスタート
-> **状態:** パッケージマネージャーでのインストールは、最初の配布リリースまで保留中です。
-> npm と Homebrew tap の公開までは curl または PowerShell インストーラーを使用してください。
+> **状態:** Homebrew、Bun、npm のパッケージマネージャー経由のインストールは
+> v1.0.6 から公開されています。
 
 **次のインストール方法から一つ選択します。Bun を推奨します。**
 ```sh

--- a/README.ko.md
+++ b/README.ko.md
@@ -84,8 +84,7 @@
 >   <img src="assets/friren-agent-omh-callout.png" alt="Friren Agent explaining OMH in Art&Engine" width="720">
 > </p>
 ## 빠른 시작
-> **상태:** 패키지 관리자 설치는 첫 배포 릴리스 전까지 대기 상태입니다.
-> npm과 Homebrew tap이 공개되기 전에는 curl 또는 PowerShell 설치 프로그램을 사용하세요.
+> **상태:** Homebrew, Bun, npm 패키지 관리자 설치가 v1.0.6부터 공개되었습니다.
 
 **아래 설치 방법 중 하나를 선택합니다. Bun을 권장합니다.**
 ```sh

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@
 
 ## Quick Start
 
-> **Status:** Package-manager installs are pending the first distribution release.
-> Until npm and the Homebrew tap are public, use the curl or PowerShell installer.
+> **Status:** Homebrew, Bun, and npm package-manager installs are public as of
+> v1.0.6.
 
 **Homebrew:**
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -82,8 +82,7 @@
 >   <img src="assets/friren-agent-omh-callout.png" alt="Friren Agent explaining OMH in Art&Engine" width="720">
 > </p>
 ## 快速开始
-> **状态：** 包管理器安装在首次分发版本发布前暂不可用。
-> 在 npm 与 Homebrew tap 公开前，请使用 curl 或 PowerShell 安装程序。
+> **状态：** Homebrew、Bun 与 npm 包管理器安装方式已随 v1.0.6 正式公开。
 
 **从以下安装方式中选择一种。推荐 Bun。**
 ```sh

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -27,8 +27,9 @@ for using OMH.
 
 ## Quick Start
 
-> **Publication status:** Package-manager installs are pending the first distribution release.
-> Until npm and the Homebrew tap are public, use the curl or PowerShell installer.
+> **Publication status:** Homebrew, Bun, and npm package-manager installs are
+> public as of v1.0.6. Clean installation and `omh update` were observed for
+> each package-manager path in isolated release QA.
 
 Choose one installation path. The package-manager paths install the same `omh`
 command as the platform installers.
@@ -63,9 +64,9 @@ curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh
 irm https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.ps1 | iex
 ```
 
-Windows npm/Bun launcher support is gated by the Windows CI suite. Until the
-first package-manager release passes that gate, use the PowerShell installer
-instead of treating npm or Bun on Windows as published support.
+Windows npm/Bun launcher support is covered by the Windows CI suite, including
+packed-tarball installation and CLI smoke checks. The PowerShell installer
+remains the native Windows alternative.
 
 ### Set up OMH
 
@@ -533,7 +534,7 @@ unselected coding agent never reads as an idle external agent named
    Evidence card carry the same prepared-versus-observed boundary as before.
 
 A quiet no-run line looks like
-`[omh] v1.0.5 | plugin:ready | target:single | coding-agent:not-selected`.
+`[omh] v1.0.6 | plugin:ready | target:single | coding-agent:not-selected`.
 The plugin also exposes `omh_context` for a compact OMH mental model plus
 generic-tool checkpoint, `omh_memory` for a metadata-only comparison of Hermes
 memory against OMH's approved records, `omh_interact` for shell-free chat responses and

--- a/site/home.css
+++ b/site/home.css
@@ -1514,10 +1514,10 @@
 .install-availability {
   margin: 14px 0 0;
   padding: 12px 14px;
-  border: 1px solid rgba(255, 188, 82, 0.36);
+  border: 1px solid rgba(92, 224, 150, 0.38);
   border-radius: 12px;
-  background: rgba(255, 174, 66, 0.08);
-  color: #ffd28a;
+  background: rgba(64, 211, 132, 0.09);
+  color: #9bf2bd;
   font-size: 13px;
   line-height: 1.6;
 }
@@ -1529,9 +1529,9 @@
   transition: border-color var(--transition), color var(--transition);
 }
 
-.section--install[data-package-manager-status="pending"] .install-method--package-manager {
-  border-color: rgba(255, 188, 82, 0.34);
-  box-shadow: inset 0 0 0 1px rgba(255, 174, 66, 0.08);
+.section--install[data-package-manager-status="public"] .install-method--package-manager {
+  border-color: rgba(92, 224, 150, 0.34);
+  box-shadow: inset 0 0 0 1px rgba(64, 211, 132, 0.08);
 }
 
 .install-followup a:hover,

--- a/site/i18n.js
+++ b/site/i18n.js
@@ -24,10 +24,10 @@ window.OMH_I18N = {
 
     /* --------------------------------------------------------------- hero */
     "hero.badge": {
-      en: "For Hermes Agent · v1.0.5",
-      ko: "Hermes Agent 전용 · v1.0.5",
-      ja: "Hermes Agent のための · v1.0.5",
-      zh: "为 Hermes Agent 打造 · v1.0.5"
+      en: "For Hermes Agent · v1.0.6",
+      ko: "Hermes Agent 전용 · v1.0.6",
+      ja: "Hermes Agent のための · v1.0.6",
+      zh: "为 Hermes Agent 打造 · v1.0.6"
     },
     "hero.tagline": {
       en: 'Power intelligence and <em>agentic memory</em> for Hermes Agent.',
@@ -462,10 +462,10 @@ window.OMH_I18N = {
       zh: "选择包管理器或平台安装程序。Doctor 是单独的验证步骤。"
     },
     "install.availability.note": {
-      en: "Package-manager installs are pending the first distribution release. Use curl or PowerShell until npm and the Homebrew tap are public.",
-      ko: "패키지 관리자 설치는 첫 배포 릴리스 전까지 대기 상태입니다. npm과 Homebrew tap 공개 전에는 curl 또는 PowerShell을 사용하세요.",
-      ja: "パッケージマネージャーでのインストールは最初の配布リリースまで保留中です。npm と Homebrew tap の公開までは curl または PowerShell を使用してください。",
-      zh: "包管理器安装在首次分发版本发布前暂不可用。在 npm 与 Homebrew tap 公开前，请使用 curl 或 PowerShell。"
+      en: "Homebrew, Bun, and npm package-manager installs are public as of v1.0.6.",
+      ko: "Homebrew, Bun, npm 패키지 관리자 설치가 v1.0.6부터 공개되었습니다.",
+      ja: "Homebrew、Bun、npm のパッケージマネージャー経由のインストールは v1.0.6 から公開されています。",
+      zh: "Homebrew、Bun 与 npm 包管理器安装方式已随 v1.0.6 正式公开。"
     },
     "install.step1": { en: "Install the command", ko: "명령어 설치", ja: "コマンドをインストール", zh: "安装命令行" },
     "install.method.brew": { en: "Homebrew", ko: "Homebrew", ja: "Homebrew", zh: "Homebrew" },

--- a/site/index.html
+++ b/site/index.html
@@ -88,7 +88,7 @@
           <img src="assets/omh-character-mask.png" alt="" width="768" height="768" fetchpriority="high">
         </figure>
 
-        <span class="pill pill--glass" data-reveal data-reveal-delay="40" data-i18n="hero.badge">For Hermes Agent · v1.0.5</span>
+        <span class="pill pill--glass" data-reveal data-reveal-delay="40" data-i18n="hero.badge">For Hermes Agent · v1.0.6</span>
 
         <h1 id="home-title" class="hero__title" data-reveal data-reveal-delay="90">
           <span class="chrome-word">Oh My Hermes</span>
@@ -709,12 +709,12 @@
       </section>
 
       <!-- ========================================================= INSTALL -->
-      <section class="section section--install" id="install" aria-labelledby="install-title" data-package-manager-status="pending">
+      <section class="section section--install" id="install" aria-labelledby="install-title" data-package-manager-status="public">
         <div class="section__head" data-reveal>
           <p class="kicker" data-i18n="install.kicker">Install</p>
           <h2 id="install-title" data-i18n="install.title">Install your way. Set up once.</h2>
           <p class="section__lead" data-i18n="install.lead">Choose a package manager or platform installer. Doctor stays a separate check.</p>
-          <p class="install-availability" data-i18n="install.availability.note">Package-manager installs are pending the first distribution release. Use curl or PowerShell until npm and the Homebrew tap are public.</p>
+          <p class="install-availability" data-i18n="install.availability.note">Homebrew, Bun, and npm package-manager installs are public as of v1.0.6.</p>
         </div>
 
         <ol class="install-steps">

--- a/tests/test_distribution_surfaces.py
+++ b/tests/test_distribution_surfaces.py
@@ -74,7 +74,7 @@ def _fenced_blocks(markdown: str) -> list[str]:
 
 
 class DistributionInstallSurfaceTests(unittest.TestCase):
-    def test_site_pending_status_drives_unique_styles_and_translations(
+    def test_site_public_status_drives_unique_styles_and_translations(
         self,
     ) -> None:
         page = (PROJECT_ROOT / "site" / "index.html").read_text(
@@ -92,6 +92,10 @@ class DistributionInstallSurfaceTests(unittest.TestCase):
         )
         self.assertEqual(styles.count(".install-availability {"), 1)
         self.assertIn(
+            '[data-package-manager-status="public"]',
+            styles,
+        )
+        self.assertNotIn(
             '[data-package-manager-status="pending"]',
             styles,
         )
@@ -157,11 +161,12 @@ class DistributionInstallSurfaceTests(unittest.TestCase):
         self.assertIn("actions/setup-node@", windows)
         self.assertIn("oven-sh/setup-bun@", windows)
 
-    def test_unpublished_package_manager_commands_are_visibly_caveated(self) -> None:
+    def test_published_package_manager_commands_are_marked_public(self) -> None:
         html = (PROJECT_ROOT / "site" / "index.html").read_text(
             encoding="utf-8"
         )
-        self.assertIn('data-package-manager-status="pending"', html)
+        self.assertIn('data-package-manager-status="public"', html)
+        self.assertNotIn('data-package-manager-status="pending"', html)
 
     def test_site_exposes_ordered_copyable_install_commands(self) -> None:
         html = (PROJECT_ROOT / "site" / "index.html").read_text(


### PR DESCRIPTION
## Feature Report

### What Changed

- Replaced stale pending-release notices across English, Korean, Japanese, and Chinese READMEs and the installation guide.
- Marks the website package-manager surface as public and updates its release badge to v1.0.6.
- Gives public package-manager cards a verified green availability treatment.

### Why This Exists

- v1.0.6 is now public on npm with provenance, in the Homebrew tap, and as an immutable GitHub release.
- Independent clean install and `omh update` QA passed for npm, Bun, and Homebrew, so pending-publication copy became false.

### User / Operator Impact

- Users can follow Homebrew, Bun, or npm commands directly without a stale curl/PowerShell-only caveat.
- Windows npm/Bun support is described conservatively as CI-covered; PowerShell remains the native alternative.

### How It Works

- Public status is represented by `data-package-manager-status="public"` and matching localized copy.
- Site styling distinguishes verified public methods with a green status treatment.

### Files And Contracts Touched

- README variants and `docs/INSTALLATION.md`.
- `site/index.html`, `site/i18n.js`, and `site/home.css`.
- Distribution surface contract tests.

### Affected Surfaces

- [x] Not executor-specific

## Validation

- [x] `git diff --check`
- [x] Relevant dry-run or smoke command: public registry/tap install and update matrix
- [x] Manual Hermes/TUI check, or explicit reason it was not run: browser visual QA used instead

### Observed Evidence

- npm latest is 1.0.6 with SLSA provenance.
- Homebrew tap formula and GitHub wheel share the verified SHA-256.
- Isolated npm, Bun, and Homebrew clean installs and `omh update` passed.
- Distribution surface and site tests, JavaScript syntax, Ruff, compileall, and stale-copy scans passed.
- Playwright rendered English desktop and Korean mobile install sections with three package-manager cards and zero viewport overflow.

### Not Tested / Not Applicable

- Manual Windows-host install was not available on this macOS workstation; packed npm/Bun launcher installation and CLI smoke remain covered by Windows CI.

## Risk

- Narrow documentation and presentation change backed by live publication evidence.

## Compatibility / Rollout

- No runtime contract changes. GitHub Pages updates after merge.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data

## Follow-Up

- Remove isolated QA artifacts after merge and verify the final public documentation state.