### PR TITLE
feat(coding): add shared last-resort model fallback

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -802,13 +802,17 @@ no network request.
 `coding/model_recommendations.py` owns secret-free editorial candidate order.
 The categories reuse the closed `MODEL_CATEGORIES` vocabulary; `main` is a
 separate Hermes role suggestion and `x_platform_data` is a separate domain
-affinity. User override documents can replace only those named chains and
-cannot extend the vocabularies or contain secret/provider configuration.
-Resolution filters order against caller-confirmed active models. A missing head
-falls through to the next eligible candidate; no eligible candidate returns
-`owner_default` without blocking setup or preparing a model-config write. An
-unavailable explicit model instead returns `choice_required` and freezes
-fallthrough.
+affinity. `last_resort.any` is one shared final chain outside those selectors;
+it is considered only after every selected category, role-slot, and domain
+chain is exhausted. Version 2 user override documents can replace only those
+named chains and the shared `any` slot; legacy v1 documents remain accepted but
+cannot define the new slot. Overrides cannot extend the vocabularies or contain
+secret/provider configuration. Resolution filters order against
+caller-confirmed active models. A missing head falls through to the next
+eligible candidate, then the shared final order tries Claude Opus 5 followed by
+GPT-5.6 Sol. No eligible candidate anywhere returns `owner_default` without
+blocking setup or preparing a model-config write. An unavailable explicit model
+instead returns `choice_required` and freezes fallthrough.
 
 The shipped Kimi, Claude, GPT, GLM, Grok, and Gemini order is editorial, not
 benchmarked. Qwen is a valid confirmed user alternative through an override or

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -225,9 +225,14 @@ falls through. A missing recommended model is different: setup remains usable
 and ordered recommendation chains skip missing entries in favor of a confirmed
 compatible alternative. Qwen and Gemini therefore remain valid user-selected
 alternatives even when they are not shipped category heads. If no candidate is
-confirmed for a selector, the resolver records `owner_default`; Hermes or the
-selected external owner keeps its native default model, setup completes with
-`status: defaulted`, and no model-config write is prepared or applied.
+confirmed for the selected category, role-slot, and domain chains, the resolver
+consults one shared final order: Claude Opus 5, then GPT-5.6 Sol. These names
+remain editorial candidates filtered through caller-confirmed metadata; they
+do not prove subscription, entitlement, authentication, or runtime readiness.
+If no candidate is confirmed anywhere, the resolver records `owner_default`;
+Hermes or the selected external owner keeps its native default model, setup
+completes with `status: defaulted`, and no model-config write is prepared or
+applied.
 
 ### Editable recommendation categories
 
@@ -245,6 +250,7 @@ The shipped catalog is editorial policy, not benchmark output:
 | `writing` | Kimi K3, Qwen3-Coder, Gemini 3.1 Pro |
 | `artistry` | Gemini 3.1 Pro, Claude Fable 5, Kimi K3 |
 | `x_platform_data` affinity | Grok, Kimi K3, Gemini |
+| Shared final order (`last_resort.any`) | Claude Opus 5, GPT-5.6 Sol |
 
 The X/Grok row is a static, editable affinity for work explicitly declaring X
 platform data. It is not a measured capability, performance, or availability
@@ -255,13 +261,14 @@ only when the user declares the corresponding local route active. OMH never
 copies their tokens or keys.
 
 Agents and maintainers can replace named chains with a secret-free
-`model_recommendation_overrides/v1` JSON file. Only the existing category,
-`main` role, and `x_platform_data` domain keys are accepted; named chains
-replace rather than merge with shipped order. For example:
+`model_recommendation_overrides/v2` JSON file. Only the existing category,
+`main` role, `x_platform_data` domain, and shared `last_resort.any` keys are
+accepted; named chains replace rather than merge with shipped order. Legacy v1
+documents remain accepted but cannot define `last_resort`. For example:
 
 ```json
 {
-  "schema_version": "model_recommendation_overrides/v1",
+  "schema_version": "model_recommendation_overrides/v2",
   "categories": {
     "deep": [
       {
@@ -270,6 +277,16 @@ replace rather than merge with shipped order. For example:
         "preferred_provider_families": ["openrouter"],
         "reasoning_effort": "high",
         "reasoning": "Local editorial choice for this installation."
+      }
+    ]
+  },
+  "last_resort": {
+    "any": [
+      {
+        "model_alias": "claude-opus-5",
+        "model_family": "claude",
+        "preferred_provider_families": ["anthropic"],
+        "reasoning": "Local final metadata selection."
       }
     ]
   }

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -4469,7 +4469,7 @@ These surfaces are generated command references, not installed Hermes workflow s
   - Treat each Hermes role slot (main, realtime-search, design), semantic category, and external owner as an independent prerequisite/diagnose/recommend/apply unit instead of one combined change.
   - Explain the shipped recommendations as editable editorial defaults, not benchmarks or allowlists: ultrabrain uses GPT-5.6 Sol; deep uses GPT-5.6 Terra; unspecified-high prefers Kimi K3 then Claude Opus 5; unspecified-low prefers GLM-5.2 then GLM-5.2 Ultrafast; quick prefers GLM-5.2 Ultrafast then Kimi K3; writing prefers Kimi K3, Qwen3-Coder, then Gemini 3.1 Pro; visual-engineering prefers Claude Fable 5 then Kimi K3; and artistry prefers Gemini 3.1 Pro, Claude Fable 5, then Kimi K3.
   - For X/Twitter scraping or trend analysis, keep x_platform_data as a domain affinity rather than a role alias: prefer confirmed-active Grok, then Kimi K3, then Gemini, without removing the rest of the route or overriding an explicit model.
-  - When a recommendation head is missing, choose the first confirmed-active owner-compatible fallback; when no candidate is active, keep that selector on its owner's native default model and let the rest of OMH setup finish without a model-config write.
+  - When a recommendation head is missing, choose the first confirmed-active owner-compatible candidate in that chain. Only after every selected category, role-slot, and domain chain is exhausted, consult the shared final order Claude Opus 5 then GPT-5.6 Sol. If no candidate is confirmed active anywhere, keep the selector on its owner's native default model and let the rest of OMH setup finish without a model-config write.
   - Give provider-specific native next actions without claiming provider readiness: use installed Hermes flows for OpenAI OAuth/OpenAI Codex, Anthropic or an existing Claude provider, Qwen OAuth or Alibaba, Gemini/Google/Vertex, Grok/xAI, Kimi, GLM/Z.AI, or an already-working custom provider; preserve working alternatives.
 - Completion checklist:
   - If a prerequisite is unmet, mark that item "not applicable" and continue with the rest of the guide instead of blocking or guessing.
@@ -4494,7 +4494,7 @@ These surfaces are generated command references, not installed Hermes workflow s
   - verification checklist or an incomplete non-blocking setup advisory with exact next actions
 - Artifact expectations:
   - model_discovery/v1 metadata-only report when local discovery runs
-  - model_recommendation_resolution/v2 recommendation result when a chain is resolved
+  - model_recommendation_resolution/v3 recommendation result when a chain is resolved
   - omh_model_activation/v1 setup receipt when the setup surface captures it
 - Safety rules:
   - Treat session and config stores as untrusted metadata sources. Read only allowlisted provider, model, variant, timestamp, and source identifiers; never read or emit transcript prose, prompts, tool results, credentials, token values, entitlement, or quota.

--- a/site/docs/model-routing/index.html
+++ b/site/docs/model-routing/index.html
@@ -109,7 +109,7 @@
           <p>
             A category names the kind of work, never a vendor. Each category
             holds an ordered list of candidate models. OMH ships an editorial
-            order; a <code>model_recommendation_overrides/v1</code> document
+            order; a <code>model_recommendation_overrides/v2</code> document
             replaces the chains it names and leaves the rest untouched.
           </p>
           <div class="reference-grid">
@@ -124,14 +124,16 @@
           </div>
           <p>
             Setup skips unavailable candidates, selects the first active model,
-            and preserves the remaining active candidates as fallbacks. A
-            category with no active candidate keeps the selected owner's default
-            model instead of blocking installation. An override cannot add a
-            category, invent a role slot, or carry provider configuration, and
-            secret-looking fields are rejected.
+            and preserves the remaining active candidates as fallbacks. Only
+            after every selected category, role-slot, and domain chain is
+            exhausted does OMH consult one shared final order: Claude Opus 5,
+            then GPT-5.6 Sol. If neither is confirmed active, the selected owner
+            keeps its default model. An override cannot add a category, invent
+            a role slot, or carry provider configuration, and secret-looking
+            fields are rejected.
           </p>
           <div class="command" role="region" aria-label="Model recommendation override example" tabindex="0"><code>{
-  "schema_version": "model_recommendation_overrides/v1",
+  "schema_version": "model_recommendation_overrides/v2",
   "categories": {
     "quick": [
       {
@@ -139,6 +141,16 @@
         "model_family": "qwen",
         "preferred_provider_families": ["openrouter"],
         "reasoning": "Local preference for short tasks."
+      }
+    ]
+  },
+  "last_resort": {
+    "any": [
+      {
+        "model_alias": "claude-opus-5",
+        "model_family": "claude",
+        "preferred_provider_families": ["anthropic"],
+        "reasoning": "Local final metadata selection."
       }
     ]
   }
@@ -158,10 +170,11 @@ Do not replace the resolved SHA with main. Execute the pinned protocol's OS-appr
             <p>
               You are not expected to hold every model. Resolution walks the
               chain, skips candidates that are not confirmed active, and selects
-              the next eligible one. When no candidate in a chain is eligible,
-              the result is <code>owner_default</code> &mdash; the selected
-              owner keeps its native default without blocking the surrounding
-              installation.
+              the next eligible one. When all selected chains are exhausted,
+              resolution checks the shared Claude Opus 5 then GPT-5.6 Sol final
+              order. When no candidate is confirmed anywhere, the result is
+              <code>owner_default</code> &mdash; the selected owner keeps its
+              native default without blocking the surrounding installation.
             </p>
             <p>
               An explicitly requested model behaves differently on purpose: it

--- a/skills/omh-model-setup/SKILL.md
+++ b/skills/omh-model-setup/SKILL.md
@@ -83,7 +83,7 @@ Quality bar:
 - Treat each Hermes role slot (main, realtime-search, design), semantic category, and external owner as an independent prerequisite/diagnose/recommend/apply unit instead of one combined change.
 - Explain the shipped recommendations as editable editorial defaults, not benchmarks or allowlists: ultrabrain uses GPT-5.6 Sol; deep uses GPT-5.6 Terra; unspecified-high prefers Kimi K3 then Claude Opus 5; unspecified-low prefers GLM-5.2 then GLM-5.2 Ultrafast; quick prefers GLM-5.2 Ultrafast then Kimi K3; writing prefers Kimi K3, Qwen3-Coder, then Gemini 3.1 Pro; visual-engineering prefers Claude Fable 5 then Kimi K3; and artistry prefers Gemini 3.1 Pro, Claude Fable 5, then Kimi K3.
 - For X/Twitter scraping or trend analysis, keep x_platform_data as a domain affinity rather than a role alias: prefer confirmed-active Grok, then Kimi K3, then Gemini, without removing the rest of the route or overriding an explicit model.
-- When a recommendation head is missing, choose the first confirmed-active owner-compatible fallback; when no candidate is active, keep that selector on its owner's native default model and let the rest of OMH setup finish without a model-config write.
+- When a recommendation head is missing, choose the first confirmed-active owner-compatible candidate in that chain. Only after every selected category, role-slot, and domain chain is exhausted, consult the shared final order Claude Opus 5 then GPT-5.6 Sol. If no candidate is confirmed active anywhere, keep the selector on its owner's native default model and let the rest of OMH setup finish without a model-config write.
 - Give provider-specific native next actions without claiming provider readiness: use installed Hermes flows for OpenAI OAuth/OpenAI Codex, Anthropic or an existing Claude provider, Qwen OAuth or Alibaba, Gemini/Google/Vertex, Grok/xAI, Kimi, GLM/Z.AI, or an already-working custom provider; preserve working alternatives.
 
 Handoff policy:
@@ -107,7 +107,7 @@ Expected outputs:
 Artifact expectations:
 
 - model_discovery/v1 metadata-only report when local discovery runs
-- model_recommendation_resolution/v2 recommendation result when a chain is resolved
+- model_recommendation_resolution/v3 recommendation result when a chain is resolved
 - omh_model_activation/v1 setup receipt when the setup surface captures it
 
 Safety rules:

--- a/src/coding/coding_delegation.py
+++ b/src/coding/coding_delegation.py
@@ -869,6 +869,12 @@ def _hermes_native_model_binding(recommendation: dict[str, object]) -> dict[str,
     binding = str(projection.get("binding", "")).strip()
     if not alias or not provider or not model_id or binding != f"{provider}/{model_id}":
         raise ValueError("Hermes native binding projection is incomplete")
+    resolution_source = str(recommendation.get("source", ""))
+    provenance = (
+        resolution_source
+        if resolution_source == "last_resort_chain"
+        else str(selected.get("recommendation_source", resolution_source))
+    )
     return {
         "schema_version": "hermes_native_model_handoff_binding/v1",
         "status": "prepared_not_observed",
@@ -876,7 +882,7 @@ def _hermes_native_model_binding(recommendation: dict[str, object]) -> dict[str,
         "provider": provider,
         "model_id": model_id,
         "binding": binding,
-        "provenance": str(selected.get("recommendation_source", recommendation.get("source", ""))),
+        "provenance": provenance,
         "kanban_task_override": {
             "command": f"set-model {binding}",
             "model": binding,

--- a/src/coding/model_recommendations.py
+++ b/src/coding/model_recommendations.py
@@ -28,6 +28,7 @@ MODEL_RECOMMENDATION_STATUSES: Final[tuple[str, ...]] = (
 MODEL_RECOMMENDATION_OWNERS: Final[tuple[str, ...]] = ("hermes", "maestro")
 HERMES_MODEL_SETUP_ROLE_SLOTS: Final[tuple[str, ...]] = ("main",)
 MODEL_RECOMMENDATION_DOMAINS: Final[tuple[str, ...]] = ("x_platform_data",)
+MODEL_RECOMMENDATION_LAST_RESORT_SLOTS: Final[tuple[str, ...]] = ("any",)
 
 _CANDIDATE_FIELDS: Final[frozenset[str]] = frozenset(
     {
@@ -165,6 +166,15 @@ SHIPPED_MODEL_RECOMMENDATIONS: Final[dict[str, object]] = {
     "domain_affinities": {
         "x_platform_data": [deepcopy(_GROK), deepcopy(_KIMI_K3), deepcopy(_GEMINI)],
     },
+    # One shared final attempt, consulted only after every candidate of the
+    # selected chain is unavailable. A profile whose chains concentrate in one
+    # provider ecosystem otherwise drops straight to the owner default when
+    # that ecosystem is not confirmed active. This is not a per-category
+    # anchor: it never outranks a category, role, or domain candidate, and it
+    # never rescues an unavailable explicit model.
+    "last_resort": {
+        "any": [deepcopy(_OPUS_5), deepcopy(_SOL)],
+    },
 }
 
 
@@ -203,6 +213,7 @@ def load_recommendation_overrides(
         "categories",
         "role_suggestions",
         "domain_affinities",
+        "last_resort",
     }
     if unknown_top:
         raise ValueError(f"unsupported model recommendation override fields: {sorted(unknown_top)}")
@@ -222,6 +233,11 @@ def load_recommendation_overrides(
             allowed=MODEL_RECOMMENDATION_DOMAINS,
             section="domain_affinities",
         ),
+        "last_resort": _normalize_section(
+            raw.get("last_resort", {}),
+            allowed=MODEL_RECOMMENDATION_LAST_RESORT_SLOTS,
+            section="last_resort",
+        ),
     }
     return normalized
 
@@ -234,13 +250,17 @@ def merge_recommendation_catalog(
     if catalog.get("schema_version") != MODEL_RECOMMENDATION_CATALOG_SCHEMA_VERSION:
         raise ValueError("unsupported model recommendation catalog schema")
     merged = deepcopy(dict(catalog))
+    # A caller-supplied catalog predating the shared final attempt stays
+    # meaningful: an absent section means "no last resort", not a malformed
+    # catalog, so resolution keeps dropping straight to the owner default.
+    merged.setdefault("last_resort", {})
     if overrides is None:
         return merged
     # Revalidate even a payload returned by the loader. Callers may mutate a
     # normal-looking dict before reuse; no alternate path may bypass the same
     # closed-surface and secret-field checks as a file-loaded override.
     normalized = load_recommendation_overrides(overrides)
-    for section in ("categories", "role_suggestions", "domain_affinities"):
+    for section in ("categories", "role_suggestions", "domain_affinities", "last_resort"):
         destination = merged.get(section)
         replacements = normalized.get(section)
         if not isinstance(destination, dict) or not isinstance(replacements, Mapping):
@@ -266,9 +286,11 @@ def resolve_model_recommendation(
     Explicit models are fail-closed: an unavailable explicit request returns
     ``choice_required`` and never falls through to an editorial candidate.
     Recommendation chains skip unavailable heads and select the next confirmed,
-    owner-compatible candidate. With no eligible candidate, ``owner_default``
-    keeps the selected owner's native default model in effect without blocking
-    the surrounding installation.
+    owner-compatible candidate. When the whole selected chain is unavailable,
+    the shared ``last_resort`` chain is tried as one final attempt and, when it
+    resolves, is reported with source ``last_resort_chain``. With no eligible
+    candidate anywhere, ``owner_default`` keeps the selected owner's native
+    default model in effect without blocking the surrounding installation.
     """
     normalized_owner = str(owner or "").strip().casefold()
     if normalized_owner not in MODEL_RECOMMENDATION_OWNERS:
@@ -318,6 +340,28 @@ def resolve_model_recommendation(
         )
 
     if not eligible_chain:
+        for candidate in _last_resort_chain(merged):
+            active = _active_for_candidate(candidate, normalized_active)
+            if active is None:
+                alias = str(candidate["model_alias"])
+                if alias not in inactive_candidates:
+                    inactive_candidates.append(alias)
+                continue
+            eligible_chain.append(_resolved_candidate(candidate, active))
+        if eligible_chain:
+            selected = eligible_chain[0]
+            return _resolution_payload(
+                owner=normalized_owner,
+                selector_section=selector_section,
+                selector_name=selector_name,
+                status="resolved",
+                source="last_resort_chain",
+                selected=selected,
+                projection=_projection(normalized_owner, selector_name, eligible_chain),
+                requested_model="",
+                available_chain=[str(entry["model_alias"]) for entry in eligible_chain],
+                inactive_candidates=inactive_candidates,
+            )
         return _resolution_payload(
             owner=normalized_owner,
             selector_section=selector_section,
@@ -461,6 +505,14 @@ def _catalog_chain(
     if not all(isinstance(candidate, Mapping) for candidate in chain):
         raise ValueError(f"malformed model recommendation candidate: {section}.{name}")
     return list(chain)
+
+
+def _last_resort_chain(catalog: Mapping[str, object]) -> list[Mapping[str, object]]:
+    """Return the shared final-attempt chain, or empty when none is configured."""
+    table = catalog.get("last_resort")
+    if not isinstance(table, Mapping) or "any" not in table:
+        return []
+    return _catalog_chain(catalog, "last_resort", "any")
 
 
 def _normalized_active_models(

--- a/src/coding/model_recommendations.py
+++ b/src/coding/model_recommendations.py
@@ -281,7 +281,9 @@ def merge_recommendation_catalog(
         replacements = normalized.get(section)
         if replacements is None:
             continue
-        if section == "last_resort" and destination is None and replacements:
+        if section == "last_resort" and destination is None:
+            if not replacements:
+                continue
             merged[section] = {}
             destination = merged[section]
         if not isinstance(destination, dict) or not isinstance(replacements, Mapping):

--- a/src/coding/model_recommendations.py
+++ b/src/coding/model_recommendations.py
@@ -270,10 +270,6 @@ def merge_recommendation_catalog(
     ):
         raise ValueError("model_recommendation_catalog/v1 cannot define last_resort")
     merged = deepcopy(dict(catalog))
-    # A caller-supplied catalog predating the shared final attempt stays
-    # meaningful: an absent section means "no last resort", not a malformed
-    # catalog, so resolution keeps dropping straight to the owner default.
-    merged.setdefault("last_resort", {})
     if overrides is None:
         return merged
     # Revalidate even a payload returned by the loader. Callers may mutate a
@@ -283,6 +279,11 @@ def merge_recommendation_catalog(
     for section in ("categories", "role_suggestions", "domain_affinities", "last_resort"):
         destination = merged.get(section)
         replacements = normalized.get(section)
+        if replacements is None:
+            continue
+        if section == "last_resort" and destination is None and replacements:
+            merged[section] = {}
+            destination = merged[section]
         if not isinstance(destination, dict) or not isinstance(replacements, Mapping):
             raise ValueError(f"malformed model recommendation catalog section: {section}")
         for name, chain in replacements.items():

--- a/src/coding/model_recommendations.py
+++ b/src/coding/model_recommendations.py
@@ -17,9 +17,11 @@ from typing import Final, Iterable, Mapping
 from .model_routing import MODEL_CATEGORIES, MODEL_ROLES
 
 
-MODEL_RECOMMENDATION_CATALOG_SCHEMA_VERSION: Final[str] = "model_recommendation_catalog/v1"
-MODEL_RECOMMENDATION_OVERRIDE_SCHEMA_VERSION: Final[str] = "model_recommendation_overrides/v1"
-MODEL_RECOMMENDATION_RESOLUTION_SCHEMA_VERSION: Final[str] = "model_recommendation_resolution/v2"
+MODEL_RECOMMENDATION_CATALOG_SCHEMA_VERSION: Final[str] = "model_recommendation_catalog/v2"
+MODEL_RECOMMENDATION_OVERRIDE_SCHEMA_VERSION: Final[str] = "model_recommendation_overrides/v2"
+MODEL_RECOMMENDATION_RESOLUTION_SCHEMA_VERSION: Final[str] = "model_recommendation_resolution/v3"
+_LEGACY_MODEL_RECOMMENDATION_CATALOG_SCHEMA_VERSION: Final[str] = "model_recommendation_catalog/v1"
+_LEGACY_MODEL_RECOMMENDATION_OVERRIDE_SCHEMA_VERSION: Final[str] = "model_recommendation_overrides/v1"
 MODEL_RECOMMENDATION_STATUSES: Final[tuple[str, ...]] = (
     "resolved",
     "choice_required",
@@ -204,22 +206,29 @@ def load_recommendation_overrides(
     if not isinstance(raw, Mapping):
         raise ValueError("model recommendation override must be a JSON object")
     _reject_secret_keys(raw)
-    if raw.get("schema_version") != MODEL_RECOMMENDATION_OVERRIDE_SCHEMA_VERSION:
+    schema_version = str(raw.get("schema_version", ""))
+    supported_versions = (
+        _LEGACY_MODEL_RECOMMENDATION_OVERRIDE_SCHEMA_VERSION,
+        MODEL_RECOMMENDATION_OVERRIDE_SCHEMA_VERSION,
+    )
+    if schema_version not in supported_versions:
         raise ValueError(
-            f"model recommendation override must use {MODEL_RECOMMENDATION_OVERRIDE_SCHEMA_VERSION}"
+            f"model recommendation override must use one of {supported_versions}"
         )
-    unknown_top = set(raw) - {
+    allowed_top = {
         "schema_version",
         "categories",
         "role_suggestions",
         "domain_affinities",
-        "last_resort",
     }
+    if schema_version == MODEL_RECOMMENDATION_OVERRIDE_SCHEMA_VERSION:
+        allowed_top.add("last_resort")
+    unknown_top = set(raw) - allowed_top
     if unknown_top:
         raise ValueError(f"unsupported model recommendation override fields: {sorted(unknown_top)}")
 
     normalized: dict[str, object] = {
-        "schema_version": MODEL_RECOMMENDATION_OVERRIDE_SCHEMA_VERSION,
+        "schema_version": schema_version,
         "categories": _normalize_section(
             raw.get("categories", {}), allowed=MODEL_CATEGORIES, section="categories"
         ),
@@ -233,12 +242,13 @@ def load_recommendation_overrides(
             allowed=MODEL_RECOMMENDATION_DOMAINS,
             section="domain_affinities",
         ),
-        "last_resort": _normalize_section(
+    }
+    if schema_version == MODEL_RECOMMENDATION_OVERRIDE_SCHEMA_VERSION:
+        normalized["last_resort"] = _normalize_section(
             raw.get("last_resort", {}),
             allowed=MODEL_RECOMMENDATION_LAST_RESORT_SLOTS,
             section="last_resort",
-        ),
-    }
+        )
     return normalized
 
 
@@ -247,8 +257,18 @@ def merge_recommendation_catalog(
     overrides: Mapping[str, object] | None,
 ) -> dict[str, object]:
     """Return a new catalog with named user chains replacing editorial ones."""
-    if catalog.get("schema_version") != MODEL_RECOMMENDATION_CATALOG_SCHEMA_VERSION:
+    schema_version = str(catalog.get("schema_version", ""))
+    supported_versions = (
+        _LEGACY_MODEL_RECOMMENDATION_CATALOG_SCHEMA_VERSION,
+        MODEL_RECOMMENDATION_CATALOG_SCHEMA_VERSION,
+    )
+    if schema_version not in supported_versions:
         raise ValueError("unsupported model recommendation catalog schema")
+    if (
+        schema_version == _LEGACY_MODEL_RECOMMENDATION_CATALOG_SCHEMA_VERSION
+        and "last_resort" in catalog
+    ):
+        raise ValueError("model_recommendation_catalog/v1 cannot define last_resort")
     merged = deepcopy(dict(catalog))
     # A caller-supplied catalog predating the shared final attempt stays
     # meaningful: an absent section means "no last resort", not a malformed
@@ -267,6 +287,11 @@ def merge_recommendation_catalog(
             raise ValueError(f"malformed model recommendation catalog section: {section}")
         for name, chain in replacements.items():
             destination[str(name)] = deepcopy(chain)
+    if (
+        schema_version == _LEGACY_MODEL_RECOMMENDATION_CATALOG_SCHEMA_VERSION
+        and normalized.get("last_resort")
+    ):
+        merged["schema_version"] = MODEL_RECOMMENDATION_CATALOG_SCHEMA_VERSION
     return merged
 
 

--- a/src/coding/model_routing.py
+++ b/src/coding/model_routing.py
@@ -938,11 +938,17 @@ def _resolve_hermes_recommendation_route(
         )
     selected = str(chain[0]["model_id"])
     selected_effort = requested_effort or str(chain[0].get("reasoning_effort", ""))
+    last_resort = str(recommendation.get("source", "")) == "last_resort_chain"
     attempted.append(
         {
             "stage": "recommendation_chain",
-            "outcome": "selected",
-            "reason": f"confirmed-active recommendation chain head `{selected}` selected",
+            "outcome": "last_resort" if last_resort else "selected",
+            "reason": (
+                f"no confirmed-active candidate in the `{category}` chain; "
+                f"shared last-resort head `{selected}` selected"
+                if last_resort
+                else f"confirmed-active recommendation chain head `{selected}` selected"
+            ),
         }
     )
     payload = _route_payload(

--- a/src/coding/model_routing.py
+++ b/src/coding/model_routing.py
@@ -890,7 +890,21 @@ def _resolve_hermes_recommendation_route(
         overrides=recommendation_overrides,
         **selector,
     )
-    if recommendation["status"] != "resolved":
+    chain = (
+        _hermes_recommendation_chain(recommendation, active_models=active)
+        if recommendation["status"] == "resolved"
+        else []
+    )
+    if requested_domain:
+        chain, recommendation = _stable_domain_recommendation_chain(
+            requested_domain,
+            chain,
+            attempted,
+            base_resolution=recommendation,
+            active_models=active,
+            recommendation_overrides=recommendation_overrides,
+        )
+    if not chain:
         attempted.append(
             {
                 "stage": "recommendation_chain",
@@ -927,15 +941,6 @@ def _resolve_hermes_recommendation_route(
         payload["recommendation"] = recommendation
         return payload
 
-    chain = _hermes_recommendation_chain(recommendation, active_models=active)
-    if requested_domain:
-        chain = _stable_domain_recommendation_chain(
-            requested_domain,
-            chain,
-            attempted,
-            active_models=active,
-            recommendation_overrides=recommendation_overrides,
-        )
     selected = str(chain[0]["model_id"])
     selected_effort = requested_effort or str(chain[0].get("reasoning_effort", ""))
     last_resort = str(recommendation.get("source", "")) == "last_resort_chain"
@@ -944,7 +949,7 @@ def _resolve_hermes_recommendation_route(
             "stage": "recommendation_chain",
             "outcome": "last_resort" if last_resort else "selected",
             "reason": (
-                f"no confirmed-active candidate in the `{category}` chain; "
+                "no confirmed-active candidate in the selected recommendation chains; "
                 f"shared last-resort head `{selected}` selected"
                 if last_resort
                 else f"confirmed-active recommendation chain head `{selected}` selected"
@@ -1063,9 +1068,10 @@ def _stable_domain_recommendation_chain(
     base_chain: list[dict[str, object]],
     attempted: list[dict[str, str]],
     *,
+    base_resolution: dict[str, object],
     active_models: Iterable[str | Mapping[str, object]],
     recommendation_overrides: Mapping[str, object] | None,
-) -> list[dict[str, object]]:
+) -> tuple[list[dict[str, object]], dict[str, object]]:
     from .model_recommendations import resolve_model_recommendation
 
     domain_resolution = resolve_model_recommendation(
@@ -1078,20 +1084,7 @@ def _stable_domain_recommendation_chain(
         domain_resolution,
         active_models=active_models,
     )
-    seen = {str(entry["model_id"]) for entry in promoted}
-    reordered = promoted + [entry for entry in base_chain if str(entry["model_id"]) not in seen]
-    if promoted:
-        attempted.append(
-            {
-                "stage": "domain_affinity",
-                "outcome": "reordered" if reordered != base_chain else "already_ordered",
-                "reason": (
-                    f"domain `{domain}` promoted its confirmed-active editorial chain in stable order; "
-                    "no entry removed"
-                ),
-            }
-        )
-    else:
+    if not promoted:
         attempted.append(
             {
                 "stage": "domain_affinity",
@@ -1099,7 +1092,39 @@ def _stable_domain_recommendation_chain(
                 "reason": f"domain `{domain}` has no confirmed-active editorial candidate; role chain kept",
             }
         )
-    return reordered
+        return base_chain, base_resolution
+
+    if str(domain_resolution.get("source", "")) == "last_resort_chain" and base_chain:
+        base_is_last_resort = str(base_resolution.get("source", "")) == "last_resort_chain"
+        attempted.append(
+            {
+                "stage": "domain_affinity",
+                "outcome": (
+                    "shared_last_resort_already_selected"
+                    if base_is_last_resort
+                    else "last_resort_deferred"
+                ),
+                "reason": (
+                    f"domain `{domain}` exhausted its affine chain; the shared last resort "
+                    "cannot outrank an already resolved category or role chain"
+                ),
+            }
+        )
+        return base_chain, base_resolution
+
+    seen = {str(entry["model_id"]) for entry in promoted}
+    reordered = promoted + [entry for entry in base_chain if str(entry["model_id"]) not in seen]
+    attempted.append(
+        {
+            "stage": "domain_affinity",
+            "outcome": "reordered" if reordered != base_chain else "already_ordered",
+            "reason": (
+                f"domain `{domain}` promoted its confirmed-active editorial chain in stable order; "
+                "no entry removed"
+            ),
+        }
+    )
+    return reordered, domain_resolution
 
 
 def route_provenance(route: Mapping[str, object] | object) -> tuple[str, str]:

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -1980,7 +1980,7 @@ def _add_coding_commands(sub) -> None:
     model_route.add_argument(
         "--recommendations",
         default=None,
-        help="Optional model_recommendation_overrides/v1 JSON file for editable routing order.",
+        help="Optional model_recommendation_overrides/v2 JSON file for editable routing order.",
     )
     model_route.add_argument("--json", action="store_true", help="Emit the machine payload instead of plain text.")
     model_route.set_defaults(func=cmd_coding_model_route)

--- a/src/skills/catalog_definitions.py
+++ b/src/skills/catalog_definitions.py
@@ -5178,7 +5178,7 @@ _DEFINITIONS = [
         ),
         artifact_expectations=(
             "model_discovery/v1 metadata-only report when local discovery runs",
-            "model_recommendation_resolution/v2 recommendation result when a chain is resolved",
+            "model_recommendation_resolution/v3 recommendation result when a chain is resolved",
             "omh_model_activation/v1 setup receipt when the setup surface captures it",
         ),
         safety_rules=(
@@ -5195,7 +5195,7 @@ _DEFINITIONS = [
             "Treat each Hermes role slot (main, realtime-search, design), semantic category, and external owner as an independent prerequisite/diagnose/recommend/apply unit instead of one combined change.",
             "Explain the shipped recommendations as editable editorial defaults, not benchmarks or allowlists: ultrabrain uses GPT-5.6 Sol; deep uses GPT-5.6 Terra; unspecified-high prefers Kimi K3 then Claude Opus 5; unspecified-low prefers GLM-5.2 then GLM-5.2 Ultrafast; quick prefers GLM-5.2 Ultrafast then Kimi K3; writing prefers Kimi K3, Qwen3-Coder, then Gemini 3.1 Pro; visual-engineering prefers Claude Fable 5 then Kimi K3; and artistry prefers Gemini 3.1 Pro, Claude Fable 5, then Kimi K3.",
             "For X/Twitter scraping or trend analysis, keep x_platform_data as a domain affinity rather than a role alias: prefer confirmed-active Grok, then Kimi K3, then Gemini, without removing the rest of the route or overriding an explicit model.",
-            "When a recommendation head is missing, choose the first confirmed-active owner-compatible fallback; when no candidate is active, keep that selector on its owner's native default model and let the rest of OMH setup finish without a model-config write.",
+            "When a recommendation head is missing, choose the first confirmed-active owner-compatible candidate in that chain. Only after every selected category, role-slot, and domain chain is exhausted, consult the shared final order Claude Opus 5 then GPT-5.6 Sol. If no candidate is confirmed active anywhere, keep the selector on its owner's native default model and let the rest of OMH setup finish without a model-config write.",
             "Give provider-specific native next actions without claiming provider readiness: use installed Hermes flows for OpenAI OAuth/OpenAI Codex, Anthropic or an existing Claude provider, Qwen OAuth or Alibaba, Gemini/Google/Vertex, Grok/xAI, Kimi, GLM/Z.AI, or an already-working custom provider; preserve working alternatives.",
         ),
         why_this_exists=(

--- a/tests/test_candidate_handoff.py
+++ b/tests/test_candidate_handoff.py
@@ -251,6 +251,16 @@ class WrapperPathParityTests(unittest.TestCase):
             )
         )
 
+    @staticmethod
+    def _without_catalog_candidates(interaction: dict[str, Any]) -> dict[str, Any]:
+        """Remove shipped skipped candidates before checking live-model leakage."""
+        import copy
+
+        stripped = copy.deepcopy(interaction)
+        binding = stripped["delegation"]["runtime_handoff"]["hermes_native_model_binding"]
+        binding.pop("inactive_candidates")
+        return stripped
+
     def test_plugin_ultrawork_uses_active_gpt_model_overlay(self) -> None:
         import os
         from pathlib import Path
@@ -265,7 +275,16 @@ class WrapperPathParityTests(unittest.TestCase):
         self.assertEqual(interaction["route"]["selected_skill"], "ultrawork")
         overlay = interaction["delegation"]["runtime_handoff"]["executor_prompting_contract"]["throughput_overlay"]
         self.assertEqual(overlay["mode"], "gpt_hermes_ulw")
-        self.assertNotIn("gpt-5.6-sol", json.dumps(interaction, sort_keys=True))
+        self.assertEqual(
+            interaction["delegation"]["runtime_handoff"]["hermes_native_model_binding"][
+                "inactive_candidates"
+            ],
+            ["kimi-k3", "claude-opus-5", "gpt-5.6-sol"],
+        )
+        self.assertNotIn(
+            "gpt-5.6-sol",
+            json.dumps(self._without_catalog_candidates(interaction), sort_keys=True),
+        )
 
     def test_plugin_ultraprocess_uses_active_gpt_model_overlay(self) -> None:
         import os
@@ -314,7 +333,11 @@ class WrapperPathParityTests(unittest.TestCase):
         self.assertNotIn("eval_strategy", claude_overlay)
         self.assertNotIn("eval_strategy", empty_overlay)
         serialized = json.dumps(
-            [gpt_interaction, claude_interaction, empty_interaction],
+            [
+                self._without_catalog_candidates(gpt_interaction),
+                self._without_catalog_candidates(claude_interaction),
+                self._without_catalog_candidates(empty_interaction),
+            ],
             sort_keys=True,
         )
         self.assertNotIn("gpt-5.6-sol", serialized)

--- a/tests/test_candidate_handoff.py
+++ b/tests/test_candidate_handoff.py
@@ -332,6 +332,14 @@ class WrapperPathParityTests(unittest.TestCase):
         self.assertEqual(empty_overlay["mode"], "parallel_handoff")
         self.assertNotIn("eval_strategy", claude_overlay)
         self.assertNotIn("eval_strategy", empty_overlay)
+        expected_inactive = ["kimi-k3", "claude-opus-5", "gpt-5.6-sol"]
+        for interaction in (gpt_interaction, claude_interaction, empty_interaction):
+            self.assertEqual(
+                interaction["delegation"]["runtime_handoff"]["hermes_native_model_binding"][
+                    "inactive_candidates"
+                ],
+                expected_inactive,
+            )
         serialized = json.dumps(
             [
                 self._without_catalog_candidates(gpt_interaction),

--- a/tests/test_coding_delegation.py
+++ b/tests/test_coding_delegation.py
@@ -130,6 +130,36 @@ class HermesNativeModelBindingTests(unittest.TestCase):
         self.assertNotIn("maestro", str(payload).casefold())
         self.assertIn("runtime observation", binding["claim_boundary"].casefold())
 
+    def test_last_resort_resolution_provenance_reaches_native_handoff(self) -> None:
+        recommendation = {
+            "schema_version": "model_recommendation_resolution/v3",
+            "owner": "hermes",
+            "status": "resolved",
+            "source": "last_resort_chain",
+            "selected": {
+                "model_alias": "claude-opus-5",
+                "provider": "ccapi",
+                "model_id": "claude-opus-5",
+                "recommendation_source": "shipped_editorial",
+            },
+            "projection": {
+                "kind": "hermes_native_binding",
+                "alias": "quick",
+                "provider": "ccapi",
+                "model_id": "claude-opus-5",
+                "binding": "ccapi/claude-opus-5",
+                "apply_state": "approval_required",
+            },
+        }
+
+        payload = build_coding_delegation_payload(
+            "implement a risky refactor with Hermes",
+            executor_target="hermes",
+            model_recommendation=recommendation,
+        )
+        binding = payload["runtime_handoff"]["hermes_native_model_binding"]
+        self.assertEqual(binding["provenance"], "last_resort_chain")
+
     def test_owner_default_recommendation_keeps_native_default_without_model_pin(self) -> None:
         recommendation = {
             "schema_version": "model_recommendation_resolution/v2",

--- a/tests/test_model_recommendation_routing.py
+++ b/tests/test_model_recommendation_routing.py
@@ -151,6 +151,41 @@ class HermesRecommendationRoutingTests(unittest.TestCase):
         outcomes = {entry["stage"]: entry["outcome"] for entry in route["attempted"]}
         self.assertEqual(outcomes["recommendation_chain"], "last_resort")
 
+    def test_domain_candidate_replaces_category_last_resort_and_projection(self) -> None:
+        route = resolve_model_route(
+            "hermes",
+            role="implementation",
+            requested_category="quick",
+            requested_domain="x_platform_data",
+            active_models=[_OPUS, _GROK],
+        )
+
+        self.assertEqual(route["selected_model"], "xai/grok-code-fast")
+        self.assertEqual(route["recommendation"]["source"], "recommendation_chain")
+        self.assertEqual(route["recommendation"]["projection"]["binding"], "xai/grok-code-fast")
+        outcomes = {entry["stage"]: entry["outcome"] for entry in route["attempted"]}
+        self.assertEqual(outcomes["domain_affinity"], "reordered")
+        self.assertEqual(outcomes["recommendation_chain"], "selected")
+
+    def test_domain_last_resort_never_outranks_an_active_category_candidate(self) -> None:
+        route = resolve_model_route(
+            "hermes",
+            role="implementation",
+            requested_category="quick",
+            requested_domain="x_platform_data",
+            active_models=[_GLM_FAST, _OPUS],
+        )
+
+        self.assertEqual(route["selected_model"], "zai/glm-5.2-ultrafast")
+        self.assertEqual(
+            route["recommendation"]["projection"]["binding"],
+            "zai/glm-5.2-ultrafast",
+        )
+        affinity = next(
+            entry for entry in route["attempted"] if entry["stage"] == "domain_affinity"
+        )
+        self.assertEqual(affinity["outcome"], "last_resort_deferred")
+
     def test_x_platform_domain_stably_promotes_grok_kimi_gemini_without_removal(self) -> None:
         route = resolve_model_route(
             "hermes",

--- a/tests/test_model_recommendation_routing.py
+++ b/tests/test_model_recommendation_routing.py
@@ -136,6 +136,21 @@ class HermesRecommendationRoutingTests(unittest.TestCase):
         self.assertEqual(outcomes["recommendation_chain"], "owner_default")
         self.assertEqual(outcomes["executor_default"], "selected")
 
+    def test_dead_category_chain_routes_hermes_through_the_shared_last_resort(self) -> None:
+        route = resolve_model_route(
+            "hermes",
+            role="implementation",
+            requested_category="quick",
+            active_models=[_OPUS],
+        )
+
+        self.assertEqual(route["status"], "routed")
+        self.assertEqual(route["provenance"], "recommendation_chain_head")
+        self.assertEqual(route["selected_model"], "ccapi/claude-opus-5")
+        self.assertEqual(route["recommendation"]["source"], "last_resort_chain")
+        outcomes = {entry["stage"]: entry["outcome"] for entry in route["attempted"]}
+        self.assertEqual(outcomes["recommendation_chain"], "last_resort")
+
     def test_x_platform_domain_stably_promotes_grok_kimi_gemini_without_removal(self) -> None:
         route = resolve_model_route(
             "hermes",

--- a/tests/test_model_recommendations.py
+++ b/tests/test_model_recommendations.py
@@ -416,6 +416,12 @@ class LastResortFallbackTests(unittest.TestCase):
         })
         self.assertEqual(legacy["schema_version"], "model_recommendation_overrides/v1")
         self.assertNotIn("last_resort", legacy)
+        merged = merge_recommendation_catalog(SHIPPED_MODEL_RECOMMENDATIONS, legacy)
+        self.assertEqual(merged["categories"]["quick"][0]["model_alias"], "gemini-3.1-pro")
+        self.assertEqual(
+            merged["last_resort"]["any"][0]["model_alias"],
+            "claude-opus-5",
+        )
         with self.assertRaises(ValueError):
             load_recommendation_overrides({
                 "schema_version": "model_recommendation_overrides/v1",
@@ -429,6 +435,12 @@ class LastResortFallbackTests(unittest.TestCase):
             "role_suggestions": SHIPPED_MODEL_RECOMMENDATIONS["role_suggestions"],
             "domain_affinities": SHIPPED_MODEL_RECOMMENDATIONS["domain_affinities"],
         }
+        untouched = merge_recommendation_catalog(legacy_catalog, None)
+        self.assertNotIn("last_resort", untouched)
+        self.assertEqual(
+            merge_recommendation_catalog(untouched, None)["schema_version"],
+            "model_recommendation_catalog/v1",
+        )
         route = resolve_model_recommendation(
             owner="hermes",
             category="quick",

--- a/tests/test_model_recommendations.py
+++ b/tests/test_model_recommendations.py
@@ -400,6 +400,58 @@ class LastResortFallbackTests(unittest.TestCase):
     _OPUS_ONLY = (_active("claude-opus-5", provider="ccapi", family="claude"),)
     _SOL_ONLY = (_active("gpt-5.6-sol", provider="openai-codex", family="gpt"),)
 
+    def test_schema_versions_advance_and_legacy_override_remains_supported(self) -> None:
+        self.assertEqual(MODEL_RECOMMENDATION_CATALOG_SCHEMA_VERSION, "model_recommendation_catalog/v2")
+        self.assertEqual(MODEL_RECOMMENDATION_OVERRIDE_SCHEMA_VERSION, "model_recommendation_overrides/v2")
+        self.assertEqual(MODEL_RECOMMENDATION_RESOLUTION_SCHEMA_VERSION, "model_recommendation_resolution/v3")
+
+        legacy = load_recommendation_overrides({
+            "schema_version": "model_recommendation_overrides/v1",
+            "categories": {"quick": [{
+                "model_alias": "gemini-3.1-pro",
+                "model_family": "gemini",
+                "preferred_provider_families": ["google"],
+                "reasoning": "Legacy category override.",
+            }]},
+        })
+        self.assertEqual(legacy["schema_version"], "model_recommendation_overrides/v1")
+        self.assertNotIn("last_resort", legacy)
+        with self.assertRaises(ValueError):
+            load_recommendation_overrides({
+                "schema_version": "model_recommendation_overrides/v1",
+                "last_resort": {"any": []},
+            })
+
+    def test_legacy_catalog_without_last_resort_keeps_owner_default_behavior(self) -> None:
+        legacy_catalog = {
+            "schema_version": "model_recommendation_catalog/v1",
+            "categories": SHIPPED_MODEL_RECOMMENDATIONS["categories"],
+            "role_suggestions": SHIPPED_MODEL_RECOMMENDATIONS["role_suggestions"],
+            "domain_affinities": SHIPPED_MODEL_RECOMMENDATIONS["domain_affinities"],
+        }
+        route = resolve_model_recommendation(
+            owner="hermes",
+            category="quick",
+            active_models=self._OPUS_ONLY,
+            catalog=legacy_catalog,
+        )
+        self.assertEqual(route["status"], "owner_default")
+        self.assertEqual(route["source"], "owner_default")
+
+        upgraded = merge_recommendation_catalog(
+            legacy_catalog,
+            load_recommendation_overrides({
+                "schema_version": MODEL_RECOMMENDATION_OVERRIDE_SCHEMA_VERSION,
+                "last_resort": {"any": [{
+                    "model_alias": "claude-opus-5",
+                    "model_family": "claude",
+                    "preferred_provider_families": ["ccapi"],
+                    "reasoning": "Upgrade the legacy catalog with an explicit final chain.",
+                }]},
+            }),
+        )
+        self.assertEqual(upgraded["schema_version"], MODEL_RECOMMENDATION_CATALOG_SCHEMA_VERSION)
+
     def test_dead_category_chain_falls_back_to_the_shared_subscription_chain(self) -> None:
         route = resolve_model_recommendation(
             owner="hermes", category="quick", active_models=self._OPUS_ONLY

--- a/tests/test_model_recommendations.py
+++ b/tests/test_model_recommendations.py
@@ -450,6 +450,22 @@ class LastResortFallbackTests(unittest.TestCase):
         self.assertEqual(route["status"], "owner_default")
         self.assertEqual(route["source"], "owner_default")
 
+        v2_category_only = merge_recommendation_catalog(
+            legacy_catalog,
+            load_recommendation_overrides({
+                "schema_version": MODEL_RECOMMENDATION_OVERRIDE_SCHEMA_VERSION,
+                "categories": {"quick": [{
+                    "model_alias": "gemini-3.1-pro",
+                    "model_family": "gemini",
+                    "preferred_provider_families": ["google"],
+                    "reasoning": "Version 2 override using only a legacy-compatible section.",
+                }]},
+            }),
+        )
+        self.assertEqual(v2_category_only["schema_version"], "model_recommendation_catalog/v1")
+        self.assertNotIn("last_resort", v2_category_only)
+        self.assertEqual(v2_category_only["categories"]["quick"][0]["model_alias"], "gemini-3.1-pro")
+
         upgraded = merge_recommendation_catalog(
             legacy_catalog,
             load_recommendation_overrides({

--- a/tests/test_model_recommendations.py
+++ b/tests/test_model_recommendations.py
@@ -394,5 +394,122 @@ class RecommendationResolverTests(unittest.TestCase):
         self.assertEqual(serialize_recommendation_payload(first), serialize_recommendation_payload(second))
 
 
+class LastResortFallbackTests(unittest.TestCase):
+    """The shared final attempt used only after a selected chain is exhausted."""
+
+    _OPUS_ONLY = (_active("claude-opus-5", provider="ccapi", family="claude"),)
+    _SOL_ONLY = (_active("gpt-5.6-sol", provider="openai-codex", family="gpt"),)
+
+    def test_dead_category_chain_falls_back_to_the_shared_subscription_chain(self) -> None:
+        route = resolve_model_recommendation(
+            owner="hermes", category="quick", active_models=self._OPUS_ONLY
+        )
+        self.assertEqual(route["status"], "resolved")
+        self.assertEqual(route["source"], "last_resort_chain")
+        self.assertEqual(route["selected"]["model_alias"], "claude-opus-5")
+        self.assertEqual(route["available_chain"], ["claude-opus-5"])
+        self.assertEqual(
+            route["inactive_candidates"], ["glm-5.2-ultrafast", "kimi-k3", "gpt-5.6-sol"]
+        )
+        self.assertEqual(route["projection"]["kind"], "hermes_native_binding")
+        self.assertEqual(route["projection"]["apply_state"], "approval_required")
+
+    def test_last_resort_never_outranks_an_eligible_selected_chain_candidate(self) -> None:
+        route = resolve_model_recommendation(
+            owner="hermes",
+            category="quick",
+            active_models=(
+                _active("glm-5.2-ultrafast", provider="zai", family="glm"),
+                *self._OPUS_ONLY,
+            ),
+        )
+        self.assertEqual(route["source"], "recommendation_chain")
+        self.assertEqual(route["selected"]["model_alias"], "glm-5.2-ultrafast")
+
+    def test_last_resort_also_serves_role_slot_and_domain_selectors(self) -> None:
+        route = resolve_model_recommendation(
+            owner="hermes", domain="x_platform_data", active_models=self._SOL_ONLY
+        )
+        self.assertEqual(route["source"], "last_resort_chain")
+        self.assertEqual(route["selected"]["model_alias"], "gpt-5.6-sol")
+        self.assertEqual(
+            route["inactive_candidates"],
+            ["grok-code-fast", "kimi-k3", "gemini-3.1-pro", "claude-opus-5"],
+        )
+
+    def test_unavailable_explicit_model_stays_fail_closed_against_last_resort(self) -> None:
+        route = resolve_model_recommendation(
+            owner="hermes",
+            category="quick",
+            explicit_model="glm-5.2-ultrafast",
+            active_models=self._OPUS_ONLY,
+        )
+        self.assertEqual(route["status"], "choice_required")
+        self.assertIsNone(route["selected"])
+
+    def test_no_active_model_at_all_still_reaches_owner_default(self) -> None:
+        route = resolve_model_recommendation(owner="hermes", category="quick", active_models=[])
+        self.assertEqual(route["status"], "owner_default")
+        self.assertEqual(
+            route["inactive_candidates"],
+            ["glm-5.2-ultrafast", "kimi-k3", "claude-opus-5", "gpt-5.6-sol"],
+        )
+
+    def test_maestro_projection_carries_the_whole_last_resort_order(self) -> None:
+        route = resolve_model_recommendation(
+            owner="maestro",
+            category="quick",
+            active_models=(*self._OPUS_ONLY, *self._SOL_ONLY),
+        )
+        self.assertEqual(
+            [entry["model_alias"] for entry in route["projection"]["chain"]],
+            ["claude-opus-5", "gpt-5.6-sol"],
+        )
+
+    def test_last_resort_chain_is_user_overridable_through_the_same_closed_surface(self) -> None:
+        override = load_recommendation_overrides({
+            "schema_version": MODEL_RECOMMENDATION_OVERRIDE_SCHEMA_VERSION,
+            "last_resort": {"any": [{
+                "model_alias": "gemini-3.1-pro",
+                "model_family": "gemini",
+                "preferred_provider_families": ["google"],
+                "reasoning": "Operator-selected final attempt.",
+            }]},
+        })
+        route = resolve_model_recommendation(
+            owner="hermes",
+            category="quick",
+            active_models=[_active("gemini-3.1-pro", provider="google", family="gemini")],
+            overrides=override,
+        )
+        self.assertEqual(route["source"], "last_resort_chain")
+        self.assertEqual(route["selected"]["model_alias"], "gemini-3.1-pro")
+        self.assertEqual(route["selected"]["recommendation_source"], "user_override")
+        self.assertEqual(
+            SHIPPED_MODEL_RECOMMENDATIONS["last_resort"]["any"][0]["model_alias"],
+            "claude-opus-5",
+        )
+
+    def test_override_rejects_unknown_last_resort_slots_and_secret_fields(self) -> None:
+        bad_payloads = (
+            {
+                "schema_version": MODEL_RECOMMENDATION_OVERRIDE_SCHEMA_VERSION,
+                "last_resort": {"quick": []},
+            },
+            {
+                "schema_version": MODEL_RECOMMENDATION_OVERRIDE_SCHEMA_VERSION,
+                "last_resort": {"any": [{
+                    "model_alias": "gemini-3.1-pro", "model_family": "gemini",
+                    "preferred_provider_families": ["google"],
+                    "reasoning": "x", "api_key": "must-not-be-stored",
+                }]},
+            },
+        )
+        for payload in bad_payloads:
+            with self.subTest(payload=payload):
+                with self.assertRaises(ValueError):
+                    load_recommendation_overrides(payload)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_model_routing_journey.py
+++ b/tests/test_model_routing_journey.py
@@ -81,7 +81,7 @@ class ModelRoutingJourneyTests(unittest.TestCase):
 
         self.assertEqual(missing["status"], "owner_default")
         self.assertTrue(missing["setup_can_continue"])
-        self.assertEqual(missing["inactive_candidates"], ["gpt-5.6-sol"])
+        self.assertEqual(missing["inactive_candidates"], ["gpt-5.6-sol", "claude-opus-5"])
         self.assertEqual(unavailable["status"], "choice_required")
         self.assertTrue(unavailable["setup_can_continue"])
         self.assertEqual(unavailable["requested_model"], "gpt-5.6-sol")


### PR DESCRIPTION
## Feature Report

### What Changed

- Added one shared, configurable last-resort model chain (`claude-opus-5`, then `gpt-5.6-sol`).
- The shared chain is evaluated only after every candidate in the selected category, role-slot, or domain chain is unavailable.
- Preserved fail-closed explicit model requests and the final `owner_default` outcome when no confirmed-active model exists anywhere.
- Added a distinct `last_resort_chain` resolution source and Hermes route narration so operators can see why the fallback was selected.

### Why This Exists

OMH's recommended category chains may primarily contain models from one provider ecosystem. A Hermes Agent user can configure those chains exactly as recommended while having none of that ecosystem's models in caller-confirmed active metadata. Previously, exhausting such a chain dropped directly to the owner default even when a confirmed-active Claude or GPT model was available. This metadata does not prove authentication, entitlement, subscription, or runtime availability.

The fallback belongs outside each category chain so user-authored prompt order remains unchanged and policy is not duplicated across every category.

### User / Operator Impact

- Users may keep their existing category prompt/configuration unchanged.
- If that selected chain has no confirmed-active candidate, OMH makes one final shared metadata selection from confirmed-active Claude/GPT candidates.
- If neither final candidate is confirmed active, Hermes keeps its native default as before.
- An unavailable explicit `--model` still requires user choice; OMH never substitutes a different model behind an explicit request.

### How It Works

- `resolve_model_recommendation()` first evaluates the selected chain exactly as before.
- Only when that eligible chain is empty does it evaluate `last_resort.any`.
- Successful final selection returns `status: resolved`, `source: last_resort_chain`, and the existing owner projection.
- Hermes Agent consumes that normal resolved projection through `_resolve_hermes_recommendation_route`; it becomes a `hermes_native_binding` with `apply_state: approval_required` rather than a hidden invocation.
- `model_recommendation_overrides/v2` may replace only the closed `last_resort.any` slot using the same secret rejection and candidate validation as other recommendation chains; legacy v1 documents remain accepted without that slot.
- The catalog and resolution contracts advance to v2 and v3 respectively; legacy v1 catalogs without `last_resort` preserve direct `owner_default` behavior.
- Domain affinity is composed before the shared final selection: a real domain candidate can replace a category fallback, while a domain fallback can never outrank an active category candidate.

### Files And Contracts Touched

- `src/coding/model_recommendations.py`: catalog, override normalization, resolution contract.
- `src/coding/model_routing.py`: domain/fallback composition and observable Hermes attempted-stage narration.
- `src/coding/coding_delegation.py`: last-resort provenance in Hermes-native prepared handoffs.
- Canonical/generated setup documentation and the model-routing site.
- Recommendation, Hermes routing, wrapper handoff, and journey fixtures.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [x] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [ ] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: actual `omh coding model-route --executor hermes --role implementation --category quick --from-inventory --json`
- [x] Manual Hermes/TUI check, or explicit reason it was not run: CLI metadata surface was exercised; no TUI changed.

### Observed Evidence

- RED: new recommendation/routing tests failed because the old implementation returned `owner_default`, rejected `last_resort`, and produced `model_unrouted`.
- GREEN: `PYTHONPATH=tests uv run python -m unittest tests.test_model_recommendations tests.test_model_recommendation_routing` — 37 passed.
- Three adjacent wrapper/journey regressions were isolated and fixed; their focused rerun passed.
- Real CLI: with only `ccapi/claude-opus-5` confirmed active, `coding model-route` returned `status: routed`, `selected_model: ccapi/claude-opus-5`, `source: last_resort_chain`, and `projection.kind: hermes_native_binding` with `apply_state: approval_required`.
- Full suite ran 6,554 tests; 16 setup/plugin/doctor/distribution failures remain. The same 16 failures reproduce on clean `main`; no feature-caused failure remained.
- Ruff, compileall, all three generated byte gates, and `git diff --check` passed.

### Not Tested / Not Applicable

- The full-suite checkbox is intentionally unchecked because the observed run has 16 failures reproduced unchanged on clean `main`.
- Live provider authentication failure and model invocation were not tested: OMH core does no provider/network calls and this change consumes caller-confirmed local metadata only.
- Release/harness/package checks are unrelated to the model recommendation contract.

## Risk

- Moderate contract risk: consumers move to `model_recommendation_catalog/v2`, `model_recommendation_overrides/v2`, and `model_recommendation_resolution/v3`; legacy override/catalog inputs remain supported as documented.
- No dependency, network, secret, auth mutation, or hidden execution was added.

## Compatibility / Rollout

- Existing v1 catalogs without a `last_resort` section retain old behavior and proceed directly to `owner_default`; adding a v2 final-chain override upgrades the merged catalog version.
- Existing override documents remain valid; `last_resort` is optional.
- Category/role/domain chain contents and order are unchanged.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- None required for this user goal.

