### PR TITLE
feat(hud): render a plan todo panel above the Hermes prompt input

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -48,7 +48,7 @@ flowchart LR
 
   user --> hermes
   skills --> hermes
-  plugin -->|"omh_interact, omh_recommend, omh_probe, omh_hud, omh_memory, omh_role, omh_status, evidence, hooks"| hermes
+  plugin -->|"omh_interact, omh_recommend, omh_probe, omh_hud, omh_memory, omh_role, omh_status, omh_todo, evidence, hooks"| hermes
   user --> wrapper
   wrapper -->|"chat_interaction/v1"| omh
   omh -->|"answer, clarify, plan, or status"| wrapper
@@ -202,7 +202,8 @@ OMH directly when Hermes taps are available.
 `~/.hermes/plugins/omh`. The v1 plugin registers deterministic
 `omh_interact` chat/session interaction, `omh_recommend` route hints,
 metadata-only `omh_probe` capability status/roadmap, compact metadata-only
-`omh_hud`, detailed metadata-only `omh_status`, `omh_role` role context, a
+`omh_hud`, detailed metadata-only `omh_status`, `omh_todo` plan-todo
+declaration for the HUD checklist panel, `omh_role` role context, a
 bounded `omh_gather_evidence` local verification probe, and passive lifecycle
 hooks for bounded status context, role marker validation, and metadata-only
 session-end checkpointing. The

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -194,7 +194,7 @@ evidence only.
 The managed plugin bridge has the same split. Local install/import/register
 smoke proves the bundle is present and importable, including tools such as
 `omh_interact`, `omh_context`, `omh_recommend`, `omh_capabilities`,
-`omh_probe`, `omh_hud`, and `omh_status`.
+`omh_probe`, `omh_hud`, `omh_status`, and `omh_todo`.
 `omh_probe` can return the same capability roadmap shape as `omh probe
 --roadmap`; in standalone plugin-bundle mode it returns a degraded roadmap that
 only uses local files and metadata. Host or wrapper evidence that Hermes

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -417,10 +417,11 @@ OMH's setup footprint is intentionally bounded:
 - It enables the managed `omh` plugin and selects the OMH memory provider only
   when the corresponding provider slot is free. Existing foreign ownership is
   preserved.
-- On a fresh Hermes config only, it adds `display.interface: tui` so the
-  installed HUD is reachable. Existing configs without an interface are left
-  unchanged, explicit display choices are always preserved, and uninstall does
-  not remove this fresh-install default.
+- It defaults `display.interface: tui` whenever the user has not chosen an
+  interface — on fresh configs and on existing configs alike, so upgraders
+  reach the installed HUD without knowing about `hermes --tui`. Explicit or
+  noncanonical display choices are always preserved, and uninstall does not
+  remove this default.
 - It adds `auxiliary.compression.fallback_chain` when the config pins
   compression to a single provider and already lists other fallback providers.
   Without a compression fallback, one unreachable endpoint leaves a session

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -502,6 +502,17 @@ evidence state. Skill counts, setup inventory, token metadata, and deep
 diagnostics are left to `omh doctor`, `omh_status`, and machine-readable HUD
 JSON.
 
+The HUD payload also carries a metadata-only plan todo list. When a todo is
+declared — by Hermes through the `omh_todo` plugin tool, or by an agent or
+operator through `omh runtime todo set` — the modern Hermes TUI
+(`hermes --tui`) renders it as a compact checklist directly above the prompt
+input, while the status widget stays below the input. The classic Python TUI
+does not load TUI widget files, so this panel is a modern-TUI-only surface.
+`omh runtime todo show` prints the todo projection the HUD payload carries
+(`todo` plus `display.todo_lines`), and `omh runtime todo clear` removes it. Todo items are plan declarations, never execution, review, CI, or
+merge evidence; an all-done list collapses to a single header line and a list
+untouched for 24 hours is hidden as stale.
+
 #### Status model: no-run, prepared-handoff, observed-run
 
 `omh setup` deliberately records a safety-first `choose` preference and asks

--- a/src/capabilities/hooks.py
+++ b/src/capabilities/hooks.py
@@ -86,6 +86,8 @@ def _cli_backend_surface(name: str) -> str:
         return "omh probe"
     if name == "omh_recommend":
         return "omh recommend"
+    if name == "omh_todo":
+        return "omh runtime todo"
     return ""
 
 

--- a/src/commands/runtime.py
+++ b/src/commands/runtime.py
@@ -91,6 +91,16 @@ from ..local_store import read_json_object
 from ..paths import OmhPaths
 from ..skill_pack import builtin_harnesses, routable_definitions
 from ..team_readiness import DEFAULT_RUNTIME_TARGET_SCAN_LIMIT, build_team_worker_readiness
+from ..hud import build_hud_payload
+from ..plugin_bundle.omh.todo_store import (
+    TODO_CLAIM_BOUNDARY,
+    TodoStoreError,
+    TodoValidationError,
+    build_todo_record,
+    clear_todo,
+    todo_path,
+    write_todo,
+)
 from .common import _paths, _print_json, _wants_json
 
 
@@ -1229,6 +1239,57 @@ def _bounded_limit(args: argparse.Namespace) -> int | None:
     return limit
 
 
+def cmd_runtime_todo_set(args: argparse.Namespace) -> int:
+    paths = _paths(args)
+    if args.items_json is not None:
+        try:
+            items = json.loads(args.items_json)
+        except json.JSONDecodeError as error:
+            _print_json({"status": "invalid_todo", "error": f"--items-json is not valid JSON: {error}"})
+            return 1
+    else:
+        items = [{"text": text, "state": "pending"} for text in args.items]
+    try:
+        record = build_todo_record(args.title, items, source="cli")
+        write_todo(paths.omh_home, record)
+    except (TodoValidationError, TodoStoreError) as error:
+        _print_json({"status": "invalid_todo", "error": str(error)})
+        return 1
+    _print_json(
+        {
+            "status": "written",
+            "path": str(todo_path(paths.omh_home)),
+            "todo": build_hud_payload(paths)["todo"],
+            "claim_boundary": TODO_CLAIM_BOUNDARY,
+        }
+    )
+    return 0
+
+
+def cmd_runtime_todo_clear(args: argparse.Namespace) -> int:
+    paths = _paths(args)
+    try:
+        cleared = clear_todo(paths.omh_home)
+    except TodoStoreError as error:
+        _print_json({"status": "invalid_todo", "error": str(error)})
+        return 1
+    _print_json({"status": "cleared" if cleared else "already_absent", "path": str(todo_path(paths.omh_home))})
+    return 0
+
+
+def cmd_runtime_todo_show(args: argparse.Namespace) -> int:
+    payload = build_hud_payload(_paths(args))
+    _print_json(
+        {
+            "status": "read",
+            "todo": payload["todo"],
+            "todo_lines": payload["display"]["todo_lines"],
+            "claim_boundary": TODO_CLAIM_BOUNDARY,
+        }
+    )
+    return 0
+
+
 def _add_runtime_commands(sub) -> None:
     from .run_efficiency import add_runtime_efficiency_command
     from .run_health import add_runtime_health_summary_command
@@ -1506,3 +1567,32 @@ def _add_runtime_commands(sub) -> None:
     )
     runtime_team_readiness.add_argument("--all", action="store_true", help="Inspect all runtime targets.")
     runtime_team_readiness.set_defaults(func=cmd_runtime_team_readiness)
+
+    runtime_todo = runtime_sub.add_parser(
+        "todo",
+        help=(
+            "Agent/operator surface: declare, clear, or read the metadata-only plan todo "
+            "list rendered by OMH HUD surfaces."
+        ),
+    )
+    todo_sub = runtime_todo.add_subparsers(dest="runtime_todo_command", required=True)
+    todo_set = todo_sub.add_parser("set", help="Write the todo list (agent/operator surface; items are declarations, not evidence).")
+    todo_set.add_argument("--title", default="", help="Optional short plan title for the panel header.")
+    todo_items = todo_set.add_mutually_exclusive_group(required=True)
+    todo_items.add_argument(
+        "--item",
+        dest="items",
+        action="append",
+        default=None,
+        help="Pending todo item text; repeat for multiple items in display order.",
+    )
+    todo_items.add_argument(
+        "--items-json",
+        default=None,
+        help='JSON array of {"text", "state"} objects with state pending, active, or done.',
+    )
+    todo_set.set_defaults(func=cmd_runtime_todo_set)
+    todo_clear = todo_sub.add_parser("clear", help="Remove the todo list from the HUD surfaces.")
+    todo_clear.set_defaults(func=cmd_runtime_todo_clear)
+    todo_show = todo_sub.add_parser("show", help="Read the current todo projection exactly as HUD surfaces see it.")
+    todo_show.set_defaults(func=cmd_runtime_todo_show)

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -1121,7 +1121,6 @@ def cmd_apply(args: argparse.Namespace) -> int:
 def _apply_result(args: argparse.Namespace) -> dict[str, object]:
     paths = _paths(args)
     memory_mode = str(getattr(args, "memory_mode", "") or "") or "review-first"
-    config_existed = paths.hermes_config_path.exists()
     current = read_config(paths.hermes_config_path)
     try:
         change = ensure_external_dir(current, paths.skills_dir)
@@ -1131,12 +1130,10 @@ def _apply_result(args: argparse.Namespace) -> dict[str, object]:
         # structural check while no OMH tool is reachable in chat.
         plugin_enable = ensure_plugin_enabled(compression.text, PLUGIN_NAME)
         # Hermes loads tui-widgets only in its official Ink TUI. Installing the
-        # widget while leaving a fresh install on the classic REPL makes the
-        # HUD unreachable. An explicit display preference remains user-owned.
-        tui_interface = ensure_tui_interface(
-            plugin_enable.text,
-            insert_default=not config_existed,
-        )
+        # widget while leaving the install on the classic REPL makes the HUD
+        # unreachable -- for upgraders with an older config just as much as for
+        # fresh installs. An explicit display preference remains user-owned.
+        tui_interface = ensure_tui_interface(plugin_enable.text)
         # Same reasoning one layer down. OMH's memory provider ships inside the
         # bundle, and a provider Hermes never selects is a provider that never
         # runs -- so requiring a control-plane command to switch it on meant the

--- a/src/install/config_adapter.py
+++ b/src/install/config_adapter.py
@@ -245,8 +245,15 @@ def display_interface_selection(config_text: str) -> str:
     return _scalar_value(entries[0])
 
 
-def ensure_tui_interface(config_text: str, *, insert_default: bool = True) -> ConfigChange:
-    """Select the TUI on fresh config only; preserve existing display ownership."""
+def ensure_tui_interface(config_text: str) -> ConfigChange:
+    """Default `display.interface` to tui whenever the user has not chosen one.
+
+    Existing installs matter as much as fresh ones: OMH's HUD widgets render
+    only in Hermes' official Ink TUI, so an upgrading user whose config predates
+    this key would otherwise keep landing in the classic REPL where the HUD
+    cannot exist. Every explicit or noncanonical display choice below stays
+    user-owned; only the genuinely unset case is defaulted.
+    """
     lines = config_text.splitlines()
     display_lines = [
         line
@@ -291,12 +298,6 @@ def ensure_tui_interface(config_text: str, *, insert_default: bool = True) -> Co
         return ConfigChange(False, "display.interface is already tui", config_text)
     if selected:
         return ConfigChange(False, f"display.interface is {selected}; leaving user preference unchanged", config_text)
-    if not insert_default:
-        return ConfigChange(
-            False,
-            "existing config has no display.interface; leaving it unchanged",
-            config_text,
-        )
 
     if display_index is None:
         text = (config_text.rstrip() + "\n\ndisplay:\n  interface: tui\n").lstrip("\n")

--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -29,11 +29,13 @@ export default function register(sdk) {
       {
         encoding: 'utf8',
         env: READER_ENV,
-        maxBuffer: 16384,
+        // Headroom over the payload's worst case (todo panel included) so an
+        // oversized snapshot degrades to null instead of blanking the HUD.
+        maxBuffer: 65536,
         timeout: 1500,
       },
       (error, stdout) => {
-        if (error || !stdout || stdout.length > 16384) return resolve(null)
+        if (error || !stdout || stdout.length > 65536) return resolve(null)
         try {
           resolve(JSON.parse(stdout))
         } catch {
@@ -212,6 +214,64 @@ export default function register(sdk) {
     )
   }
 
+  function TodoPanel({ columns, state, t }) {
+    const payload = state.payload
+    if (!payload || payload.error || payload.privacy !== 'metadata_only') return null
+    // Deliberately not gated on payload.active: a declared plan outlives
+    // subagent activity, and the reader's 24h staleness rule bounds it. The
+    // READER always projects the focused preset, which display_items encode.
+    const todo = payload.todo || {}
+    if (todo.status !== 'established' && todo.status !== 'all_done') return null
+    const counts = todo.counts || {}
+    const title = safeText(todo.title)
+    const label = title ? `Todo · ${title}` : 'Todo'
+    if (todo.status === 'all_done') {
+      return h(
+        Box,
+        { flexDirection: 'column', width: '100%' },
+        h(
+          Text,
+          { wrap: 'truncate-end' },
+          h(Text, { bold: true, color: t.color.warn }, ` ${label}`),
+          h(Text, { color: t.color.ok }, ` ✓ ${counts.done ?? 0}/${counts.total ?? 0}`),
+        ),
+      )
+    }
+    const shown = Array.isArray(todo.display_items) ? todo.display_items : []
+    const more = Number.isFinite(todo.more_count) ? todo.more_count : 0
+    const markers = { active: '[•]', done: '[✓]', pending: '[ ]' }
+    const budget = Math.max(16, columns - 10)
+    return h(
+      Box,
+      { flexDirection: 'column', width: '100%' },
+      h(
+        Text,
+        { wrap: 'truncate-end' },
+        h(Text, { bold: true, color: t.color.warn }, ` ${label}`),
+        h(Text, { color: t.color.muted }, `   ${counts.done ?? 0}/${counts.total ?? 0}`),
+      ),
+      ...shown.map((item, index) => {
+        const withMore = more > 0 && index === shown.length - 1
+        // Reserve the "+N more" suffix width so truncation never eats it.
+        const rowBudget = withMore ? Math.max(12, budget - 11) : budget
+        return h(
+          Text,
+          { key: `todo-${index}`, wrap: 'truncate-end' },
+          h(
+            Text,
+            {
+              bold: item.state === 'active',
+              color: item.state === 'active' ? t.color.ok : item.state === 'done' ? t.color.muted : t.color.text,
+              strikethrough: item.state === 'done',
+            },
+            ` ${Object.hasOwn(markers, item.state) ? markers[item.state] : '[ ]'} ${truncateCells(item.text, rowBudget)}`,
+          ),
+          withMore ? h(Text, { color: t.color.muted }, `   +${more} more`) : null,
+        )
+      }),
+    )
+  }
+
   const app = defineWidgetApp({
     id: 'omh-status',
     help: 'OMH workflow and subagent status',
@@ -225,7 +285,28 @@ export default function register(sdk) {
     render: ({ cols, rows, state, t }) => h(Hud, { columns: cols, state, t, viewportRows: rows }),
   })
 
+  const todoApp = defineWidgetApp({
+    id: 'omh-todo',
+    help: 'OMH plan todo checklist above the prompt input',
+    mode: 'ambient',
+    zone: 'dock-top',
+    init: () => ({ payload: null, tick: 0 }),
+    reduce: (state, input) =>
+      input.kind === 'snapshot'
+        ? { ...state, payload: input.payload, tick: state.tick + 1 }
+        : state,
+    render: ({ cols, state, t }) => h(TodoPanel, { columns: cols, state, t }),
+  })
+
   openWidget(app, app.init(''))
+  openWidget(todoApp, todoApp.init(''))
+  const applySnapshot = payload => {
+    for (const target of [app, todoApp]) {
+      updateWidget(target, state =>
+        payload ? { ...state, payload, tick: state.tick + 1 } : state
+      )
+    }
+  }
   const timerKey = Symbol.for('omh.hermes-tui-widget.refresh')
   const generationKey = Symbol.for('omh.hermes-tui-widget.generation')
   const generation = (globalThis[generationKey] || 0) + 1
@@ -235,9 +316,7 @@ export default function register(sdk) {
     globalThis[timerKey] = setTimeout(async () => {
       const payload = await readHud()
       if (generation !== globalThis[generationKey]) return
-      updateWidget(app, state =>
-        payload ? { ...state, payload, tick: state.tick + 1 } : state
-      )
+      applySnapshot(payload)
       schedule()
     }, 2000)
     globalThis[timerKey].unref?.()
@@ -245,9 +324,7 @@ export default function register(sdk) {
   clearTimeout(globalThis[timerKey])
   void readHud().then(payload => {
     if (generation !== globalThis[generationKey]) return
-    updateWidget(app, state =>
-      payload ? { ...state, payload, tick: state.tick + 1 } : state
-    )
+    applySnapshot(payload)
   })
   schedule()
 }

--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -165,14 +165,18 @@ export default function register(sdk) {
   function Hud({ columns, state, t, viewportRows }) {
     const spinnerPhase = useShimmerPhase(30_000) + state.tick
     const payload = state.payload
-    if (!payload || payload.error || payload.privacy !== 'metadata_only' || !payload.active) return null
+    if (!payload || payload.error || payload.privacy !== 'metadata_only') return null
 
+    // The header stays visible whenever the plugin answers, so an installed
+    // OMH is discoverable from an idle session; activity rows are the only
+    // part gated on live work.
+    const active = !!payload.active
     const agents = payload.subagents || {}
     const version = safeText(payload.version) || 'unknown'
     const maestro = payload.maestro || {}
-    const mainRows = Array.isArray(maestro.rows) ? maestro.rows.slice(0, 1) : []
+    const mainRows = active && Array.isArray(maestro.rows) ? maestro.rows.slice(0, 1) : []
     const activityLimit = Math.max(1, Math.min(3, viewportRows - 3))
-    const rows = Array.isArray(agents.rows)
+    const rows = active && Array.isArray(agents.rows)
       ? agents.rows.slice(0, Math.max(0, activityLimit - mainRows.length))
       : []
     return h(

--- a/src/plugin_bundle/omh/__init__.py
+++ b/src/plugin_bundle/omh/__init__.py
@@ -62,6 +62,7 @@ def register(ctx):
     from .tools.role_tool import OMH_ROLE_SCHEMA, omh_role_handler
     from .tools.source_trust_tool import OMH_SOURCE_TRUST_SCHEMA, omh_source_trust_handler
     from .tools.status_tool import OMH_STATUS_SCHEMA, omh_status_handler
+    from .tools.todo_tool import OMH_TODO_SCHEMA, omh_todo_handler
 
     ctx.register_tool(
         "omh_capabilities",
@@ -139,6 +140,13 @@ def register(ctx):
         OMH_STATUS_SCHEMA,
         omh_status_handler,
         description=OMH_STATUS_SCHEMA["description"],
+    )
+    ctx.register_tool(
+        "omh_todo",
+        _TOOLSET,
+        OMH_TODO_SCHEMA,
+        omh_todo_handler,
+        description=OMH_TODO_SCHEMA["description"],
     )
     ctx.register_hook("on_session_end", on_session_end)
     ctx.register_hook("pre_llm_call", pre_llm_call)

--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -5811,6 +5811,7 @@ def awareness_primer_payload() -> dict[str, object]:
             "Use omh_capabilities for detailed workflow catalog and capability manifest lookup.",
             "Use omh_probe when the user asks whether OMH is installed, what is missing, or what the next setup/runtime evidence step should be.",
             "Use omh_status or omh_hud for metadata-only runtime state.",
+            "Use omh_todo to declare or update the plan todo checklist that the Hermes TUI renders above the prompt input; items are declarations, never execution evidence.",
             "Use omh_memory before adding to Hermes memory: it reports what Hermes already holds, what OMH holds that it does not, and the remaining character headroom.",
             "Use omh_role for responsibility context when a role marker is present.",
             "Use wrapper cards/actions for user-facing choices instead of asking users to approve shell catalog commands.",

--- a/src/plugin_bundle/omh/metadata.py
+++ b/src/plugin_bundle/omh/metadata.py
@@ -12,6 +12,7 @@ PROVIDED_TOOLS = (
     "omh_role",
     "omh_source_trust",
     "omh_status",
+    "omh_todo",
 )
 REQUIRED_HOOKS = ("on_session_end", "pre_llm_call", "pre_tool_call")
 OPTIONAL_HOOKS = ("pre_verify",)
@@ -29,6 +30,7 @@ TOOL_FILE_STEMS = {
     "omh_role": "role_tool",
     "omh_source_trust": "source_trust_tool",
     "omh_status": "status_tool",
+    "omh_todo": "todo_tool",
 }
 
 TOOLS_REQUIRING_ROLE_CATALOG = frozenset({"omh_role"})

--- a/src/plugin_bundle/omh/plugin.yaml
+++ b/src/plugin_bundle/omh/plugin.yaml
@@ -16,6 +16,7 @@ provides_tools:
   - omh_role
   - omh_source_trust
   - omh_status
+  - omh_todo
 provides_hooks:
   - on_session_end
   - pre_llm_call

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -18,10 +18,22 @@ from .metadata import (
     TOOL_FILE_STEMS,
     TOOLS_REQUIRING_ROLE_CATALOG,
 )
+from .todo_store import (
+    MAX_TODO_ITEMS,
+    MAX_TODO_SOURCE_CHARS,
+    MAX_TODO_TEXT_CHARS,
+    MAX_TODO_TITLE_CHARS,
+    TODO_ITEM_STATES,
+    TODO_SCHEMA_VERSION,
+    strip_control_characters,
+    todo_path,
+)
 
 STATUS_SCHEMA_VERSION = "omh_status/v1"
 HUD_SCHEMA_VERSION = "omh_hud/v1"
 HUD_PRESETS = {"minimal", "focused", "full"}
+TODO_STALE_SECONDS = 86400
+TODO_DISPLAY_ITEM_LIMIT = 3
 HUD_REQUIRED_TOOLS = PROVIDED_TOOLS
 HUD_REQUIRED_HOOKS = REQUIRED_HOOKS
 HUD_OPTIONAL_HOOKS = OPTIONAL_HOOKS
@@ -623,8 +635,10 @@ def read_omh_hud(
         "runtime": _hud_runtime_summary(status_payload, latest_run),
         "achievements": _achievements_summary(hermes),
         "tokens": _token_summary(token_metadata or {}),
+        "todo": _todo_summary(home),
         "evidence_boundary": (
-            "HUD is metadata-only. Prepared handoffs are not execution, review, CI, merge, or token-usage evidence."
+            "HUD is metadata-only. Prepared handoffs are not execution, review, CI, merge, or token-usage evidence. "
+            "Todo items are plan declarations, not execution evidence."
         ),
         "privacy": "metadata_only",
     }
@@ -642,6 +656,7 @@ def read_omh_hud(
         "line": format_omh_hud_line(payload, preset=safe_preset),
         "segments": _hud_segments(payload, preset=safe_preset),
         "widget_lines": _hud_widget_lines(payload),
+        "todo_lines": _hud_todo_lines(payload["todo"], preset=safe_preset),
     }
     return payload
 
@@ -1091,6 +1106,105 @@ def _evidence_state(run: dict[str, Any]) -> str:
     if run.get("prepared_handoff"):
         return "prepared_not_observed"
     return str(run.get("observation_status", "unknown") or "unknown")
+
+
+def read_omh_todo(omh_home: str | Path | None = None) -> dict[str, Any]:
+    """Public todo projection for tools and hosts that only need the panel."""
+    home = _expand_path(omh_home) if omh_home else _default_omh_home()
+    return _todo_summary(home)
+
+
+def default_omh_home() -> Path:
+    """Public alias so tools can target the configured home without private imports."""
+    return _default_omh_home()
+
+
+def _todo_summary(home: Path) -> dict[str, Any]:
+    empty = {
+        "status": "absent",
+        "title": "",
+        "source": "",
+        "updated_at": "",
+        "counts": {"total": 0, "done": 0, "active": 0, "pending": 0},
+        "items": [],
+        "display_items": [],
+        "more_count": 0,
+    }
+    record = _read_hud_json(todo_path(home), root=home)
+    if record.get("schema_version") != TODO_SCHEMA_VERSION:
+        return empty
+    items: list[dict[str, str]] = []
+    raw_items = record.get("items")
+    for raw in raw_items if isinstance(raw_items, list) else []:
+        if not isinstance(raw, dict):
+            continue
+        text = strip_control_characters(raw.get("text", ""))[:MAX_TODO_TEXT_CHARS]
+        state = str(raw.get("state", ""))
+        if text and state in TODO_ITEM_STATES:
+            items.append({"text": text, "state": state})
+        if len(items) >= MAX_TODO_ITEMS:
+            break
+    if not items:
+        return empty
+    summary = dict(empty)
+    summary["display_items"] = []
+    summary["more_count"] = 0
+    summary["title"] = strip_control_characters(record.get("title", ""))[:MAX_TODO_TITLE_CHARS]
+    summary["source"] = strip_control_characters(record.get("source", ""))[:MAX_TODO_SOURCE_CHARS]
+    summary["updated_at"] = strip_control_characters(record.get("updated_at", ""))[:40]
+    summary["items"] = items
+    counts = {
+        "total": len(items),
+        "done": sum(1 for item in items if item["state"] == "done"),
+        "active": sum(1 for item in items if item["state"] == "active"),
+        "pending": sum(1 for item in items if item["state"] == "pending"),
+    }
+    summary["counts"] = counts
+    age = _seconds_since(summary["updated_at"])
+    if age is None or age > TODO_STALE_SECONDS:
+        summary["status"] = "stale"
+        return summary
+    if counts["done"] == counts["total"]:
+        summary["status"] = "all_done"
+        return summary
+    summary["status"] = "established"
+    summary["display_items"] = _collapse_todo_items(items)
+    # "+N more" counts hidden remaining work only; hidden done items are
+    # already summarized by the header's done/total counter.
+    shown_remaining = sum(1 for item in summary["display_items"] if item["state"] != "done")
+    summary["more_count"] = counts["active"] + counts["pending"] - shown_remaining
+    return summary
+
+
+def _collapse_todo_items(items: list[dict[str, str]]) -> list[dict[str, str]]:
+    """Latest done, then active, then upcoming pending — capped for the HUD."""
+    done_items = [item for item in items if item["state"] == "done"]
+    shown = done_items[-1:]
+    shown += [item for item in items if item["state"] == "active"]
+    shown += [item for item in items if item["state"] == "pending"]
+    return shown[:TODO_DISPLAY_ITEM_LIMIT]
+
+
+def _hud_todo_lines(todo: dict[str, Any], *, preset: str = "focused") -> list[str]:
+    status = str(todo.get("status", "absent"))
+    if status not in {"established", "all_done"}:
+        return []
+    counts = todo.get("counts", {})
+    title = str(todo.get("title", ""))
+    label = f"Todo · {title}" if title else "Todo"
+    if status == "all_done":
+        return [f"{label} ✓ {counts.get('done', 0)}/{counts.get('total', 0)}"]
+    header = f"{label}   {counts.get('done', 0)}/{counts.get('total', 0)}"
+    if preset == "minimal":
+        return [header]
+    full = preset == "full"
+    shown = todo.get("items", []) if full else todo.get("display_items", [])
+    marker = {"done": "[✓]", "active": "[•]", "pending": "[ ]"}
+    lines = [header] + [f"{marker[item['state']]} {item['text']}" for item in shown]
+    more = 0 if full else int(todo.get("more_count", 0) or 0)
+    if more > 0:
+        lines[-1] = f"{lines[-1]}   +{more} more"
+    return lines
 
 
 def _token_summary(metadata: dict[str, Any]) -> dict[str, Any]:

--- a/src/plugin_bundle/omh/todo_store.py
+++ b/src/plugin_bundle/omh/todo_store.py
@@ -1,0 +1,128 @@
+"""Shared store for the HUD todo artifact.
+
+One todo list per OMH home, written to ``$OMH_HOME/runtime/todo.json``. The
+CLI (`omh runtime todo`) and the `omh_todo` plugin tool both write through this
+module so the schema has a single source of truth; `runtime_reader` projects
+the file into the HUD payload read-only.
+"""
+from __future__ import annotations
+
+import json
+import os
+import secrets
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+TODO_SCHEMA_VERSION = "omh_todo/v1"
+TODO_FILENAME = "todo.json"
+TODO_ITEM_STATES = ("pending", "active", "done")
+MAX_TODO_ITEMS = 20
+MAX_TODO_TEXT_CHARS = 200
+MAX_TODO_TITLE_CHARS = 80
+MAX_TODO_SOURCE_CHARS = 80
+TODO_CLAIM_BOUNDARY = (
+    "Todo items are plan declarations. They are not execution, verification, "
+    "review, CI, merge-readiness, or merge evidence."
+)
+
+
+class TodoValidationError(ValueError):
+    """The supplied todo payload does not satisfy the omh_todo/v1 contract."""
+
+
+class TodoStoreError(RuntimeError):
+    """The todo destination under the OMH home is unsafe to write."""
+
+
+# C0/C1 control characters (ESC, BEL, CR, LF included) are stripped on write
+# and again on read so neither the artifact at rest nor the HUD projection can
+# carry terminal escapes or forge extra checklist lines.
+_CONTROL_CHARACTERS = {code: None for code in (*range(0x00, 0x20), 0x7F, *range(0x80, 0xA0))}
+
+
+def strip_control_characters(value: object) -> str:
+    return str(value or "").translate(_CONTROL_CHARACTERS).strip()
+
+
+def validate_todo_items(items: object) -> list[dict[str, str]]:
+    if not isinstance(items, list) or not items:
+        raise TodoValidationError("todo items must be a non-empty list")
+    if len(items) > MAX_TODO_ITEMS:
+        raise TodoValidationError(f"todo items are capped at {MAX_TODO_ITEMS}")
+    validated: list[dict[str, str]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            raise TodoValidationError("each todo item must be an object")
+        text = strip_control_characters(item.get("text", ""))
+        if not text:
+            raise TodoValidationError("each todo item needs non-empty text")
+        if len(text) > MAX_TODO_TEXT_CHARS:
+            raise TodoValidationError(f"todo item text is capped at {MAX_TODO_TEXT_CHARS} characters")
+        state = str(item.get("state", "pending"))
+        if state not in TODO_ITEM_STATES:
+            raise TodoValidationError(f"todo item state must be one of {', '.join(TODO_ITEM_STATES)}")
+        validated.append({"text": text, "state": state})
+    return validated
+
+
+def build_todo_record(title: object, items: object, *, source: str) -> dict[str, Any]:
+    safe_title = strip_control_characters(title)
+    if len(safe_title) > MAX_TODO_TITLE_CHARS:
+        raise TodoValidationError(f"todo title is capped at {MAX_TODO_TITLE_CHARS} characters")
+    safe_source = strip_control_characters(source)[:MAX_TODO_SOURCE_CHARS]
+    return {
+        "schema_version": TODO_SCHEMA_VERSION,
+        "title": safe_title,
+        "source": safe_source,
+        "updated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "items": validate_todo_items(items),
+        "claim_boundary": TODO_CLAIM_BOUNDARY,
+    }
+
+
+def todo_path(omh_home: Path) -> Path:
+    return omh_home / "runtime" / TODO_FILENAME
+
+
+def write_todo(omh_home: Path, record: dict[str, Any]) -> Path:
+    destination = todo_path(omh_home)
+    _reject_symlink_ancestry(destination, root=omh_home)
+    temporary = destination.with_name(f".{destination.name}.{os.getpid()}-{secrets.token_hex(8)}.tmp")
+    try:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        # Post-mkdir TOCTOU recheck; the ancestry walk above already rejected a
+        # pre-existing symlink at this path.
+        if destination.is_symlink():
+            raise TodoStoreError(f"refusing symlinked todo destination: {destination}")
+        with temporary.open("x", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, sort_keys=True) + "\n")
+        os.replace(temporary, destination)
+    except OSError as error:
+        raise TodoStoreError(f"todo destination is not writable: {error}") from error
+    finally:
+        if temporary.exists() and not temporary.is_symlink():
+            temporary.unlink()
+    return destination
+
+
+def clear_todo(omh_home: Path) -> bool:
+    destination = todo_path(omh_home)
+    _reject_symlink_ancestry(destination, root=omh_home)
+    if not destination.is_file() or destination.is_symlink():
+        return False
+    try:
+        destination.unlink()
+    except OSError as error:
+        raise TodoStoreError(f"todo destination is not removable: {error}") from error
+    return True
+
+
+def _reject_symlink_ancestry(path: Path, *, root: Path) -> None:
+    current = path
+    while True:
+        if current.is_symlink():
+            raise TodoStoreError(f"refusing symlinked todo path: {current}")
+        if current == root or current == current.parent:
+            return
+        current = current.parent

--- a/src/plugin_bundle/omh/tools/todo_tool.py
+++ b/src/plugin_bundle/omh/tools/todo_tool.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from ..host_observation import OBSERVATION_SCHEMA, attach_public_observation, observe_plugin_tool_call
+from ..runtime_reader import default_omh_home, read_omh_todo
+from ..todo_store import (
+    TODO_CLAIM_BOUNDARY,
+    TodoStoreError,
+    TodoValidationError,
+    build_todo_record,
+    clear_todo,
+    write_todo,
+)
+
+OMH_TODO_SCHEMA = {
+    "name": "omh_todo",
+    "description": (
+        "Declare, clear, or read the metadata-only plan todo list that OMH HUD surfaces render "
+        "above the Hermes prompt input. Todo items are plan declarations, never execution evidence."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["set", "clear", "show"],
+                "description": "set writes a new todo list, clear removes it, show reads the current projection.",
+            },
+            "title": {
+                "type": "string",
+                "description": "Optional short plan title shown in the todo panel header.",
+            },
+            "items": {
+                "type": "array",
+                "description": "Todo items for action=set, in display order.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "text": {"type": "string", "description": "Item text."},
+                        "state": {
+                            "type": "string",
+                            "enum": ["pending", "active", "done"],
+                            "description": "Item state. Defaults to pending.",
+                        },
+                    },
+                    "required": ["text"],
+                },
+            },
+            "omh_home": {
+                "type": "string",
+                "description": (
+                    "Optional OMH_HOME override for action=show only. "
+                    "set and clear always use the configured OMH home."
+                ),
+            },
+            "observation": OBSERVATION_SCHEMA,
+        },
+        "required": ["action"],
+    },
+}
+
+
+def omh_todo_handler(args: dict[str, Any], **kwargs) -> str:
+    observation = observe_plugin_tool_call("omh_todo", args, kwargs)
+    home_arg = str(args.get("omh_home", "") or "")
+    action = str(args.get("action", ""))
+    payload: dict[str, Any] = {
+        "schema_version": "omh_todo_result/v1",
+        "action": action,
+        "claim_boundary": TODO_CLAIM_BOUNDARY,
+    }
+    # Mutations bind to the environment-configured home only: a caller-chosen
+    # path would turn this metadata tool into an arbitrary-location
+    # file-create/delete primitive.
+    if action in {"set", "clear"} and home_arg:
+        payload["status"] = "invalid_todo"
+        payload["error"] = "omh_home override is read-only; set and clear use the configured OMH home"
+        payload["todo"] = read_omh_todo()
+        return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
+    if action == "set":
+        try:
+            record = build_todo_record(args.get("title", ""), args.get("items"), source="omh_todo")
+            write_todo(default_omh_home(), record)
+            payload["status"] = "written"
+        except (TodoValidationError, TodoStoreError) as error:
+            payload["status"] = "invalid_todo"
+            payload["error"] = str(error)
+    elif action == "clear":
+        try:
+            payload["status"] = "cleared" if clear_todo(default_omh_home()) else "already_absent"
+        except TodoStoreError as error:
+            payload["status"] = "invalid_todo"
+            payload["error"] = str(error)
+    elif action == "show":
+        payload["status"] = "read"
+    else:
+        payload["status"] = "invalid_action"
+        payload["error"] = "action must be set, clear, or show"
+    payload["todo"] = read_omh_todo(home_arg or None)
+    return json.dumps(attach_public_observation(payload, observation), sort_keys=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13209,5 +13209,80 @@ class RuntimeReceiptsViewCliTests(unittest.TestCase):
             self.assertEqual(read_external_effect_receipts(paths), [])
 
 
+class RuntimeTodoCliTests(unittest.TestCase):
+    def test_runtime_todo_set_show_clear_round_trip(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home = str(Path(tmp) / ".omh")
+            base = ["--omh-home", omh_home, "runtime", "todo"]
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "set",
+                    "--title",
+                    "Foundation",
+                    "--items-json",
+                    json.dumps(
+                        [
+                            {"text": "Restore RED baseline", "state": "done"},
+                            {"text": "Inspect routing fixtures", "state": "active"},
+                            {"text": "Run byte gates"},
+                        ]
+                    ),
+                ]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            written = json.loads(stdout)
+            self.assertEqual(written["status"], "written")
+            self.assertEqual(written["todo"]["status"], "established")
+            self.assertEqual(written["todo"]["counts"], {"total": 3, "done": 1, "active": 1, "pending": 1})
+
+            status, stdout, _ = run_cli(base + ["show"])
+            self.assertEqual(status, 0)
+            shown = json.loads(stdout)
+            self.assertEqual(shown["todo_lines"][0], "Todo · Foundation   1/3")
+            self.assertIn("not execution", shown["claim_boundary"])
+
+            status, stdout, _ = run_cli(base + ["clear"])
+            self.assertEqual(status, 0)
+            self.assertEqual(json.loads(stdout)["status"], "cleared")
+
+            status, stdout, _ = run_cli(base + ["show"])
+            self.assertEqual(status, 0)
+            self.assertEqual(json.loads(stdout)["todo"]["status"], "absent")
+
+    def test_runtime_todo_set_supports_repeated_pending_items(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home = str(Path(tmp) / ".omh")
+            status, stdout, _ = run_cli(
+                ["--omh-home", omh_home, "runtime", "todo", "set", "--item", "first", "--item", "second"]
+            )
+
+            self.assertEqual(status, 0)
+            written = json.loads(stdout)
+            self.assertEqual(
+                written["todo"]["items"],
+                [{"text": "first", "state": "pending"}, {"text": "second", "state": "pending"}],
+            )
+
+    def test_runtime_todo_set_rejects_invalid_items_with_error_payload(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home = str(Path(tmp) / ".omh")
+            cases = [
+                ["--items-json", "not json"],
+                ["--items-json", json.dumps([{"text": "x", "state": "later"}])],
+                ["--items-json", json.dumps([])],
+            ]
+            for items_args in cases:
+                status, stdout, _ = run_cli(["--omh-home", omh_home, "runtime", "todo", "set"] + items_args)
+
+                self.assertEqual(status, 1)
+                payload = json.loads(stdout)
+                self.assertEqual(payload["status"], "invalid_todo")
+                self.assertTrue(payload["error"])
+            self.assertFalse((Path(omh_home) / "runtime" / "todo.json").exists())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -929,5 +929,276 @@ class HudCliTests(unittest.TestCase):
             self.assertEqual(payload["runtime"]["recent_run_count"], 0)
 
 
+class TodoHudTests(unittest.TestCase):
+    def _write_todo(self, omh_home: Path, record: dict) -> Path:
+        runtime_dir = omh_home / "runtime"
+        runtime_dir.mkdir(parents=True, exist_ok=True)
+        path = runtime_dir / "todo.json"
+        path.write_text(json.dumps(record), encoding="utf-8")
+        return path
+
+    def _record(self, **overrides: object) -> dict:
+        from datetime import datetime, timezone
+
+        record = {
+            "schema_version": "omh_todo/v1",
+            "title": "Foundation",
+            "source": "cli",
+            "updated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "items": [
+                {"text": "Restore RED baseline", "state": "done"},
+                {"text": "Inspect routing fixtures", "state": "active"},
+                {"text": "Update count assertions", "state": "pending"},
+                {"text": "Run byte gates", "state": "pending"},
+            ],
+        }
+        record.update(overrides)
+        return record
+
+    def test_hud_projects_established_todo_with_collapse_and_lines(self) -> None:
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._write_todo(root / ".omh", self._record())
+            payload = read_omh_hud(root / ".omh", root / ".hermes")
+
+            todo = payload["todo"]
+            self.assertEqual(todo["status"], "established")
+            self.assertEqual(todo["counts"], {"total": 4, "done": 1, "active": 1, "pending": 2})
+            self.assertEqual(
+                [item["text"] for item in todo["display_items"]],
+                ["Restore RED baseline", "Inspect routing fixtures", "Update count assertions"],
+            )
+            self.assertEqual(todo["more_count"], 1)
+            self.assertEqual(
+                payload["display"]["todo_lines"],
+                [
+                    "Todo · Foundation   1/4",
+                    "[✓] Restore RED baseline",
+                    "[•] Inspect routing fixtures",
+                    "[ ] Update count assertions   +1 more",
+                ],
+            )
+            self.assertIn("Todo items are plan declarations", payload["evidence_boundary"])
+
+    def test_hud_todo_lines_respect_minimal_and_full_presets(self) -> None:
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._write_todo(root / ".omh", self._record())
+            minimal = read_omh_hud(root / ".omh", root / ".hermes", preset="minimal")
+            full = read_omh_hud(root / ".omh", root / ".hermes", preset="full")
+
+            self.assertEqual(minimal["display"]["todo_lines"], ["Todo · Foundation   1/4"])
+            self.assertEqual(len(full["display"]["todo_lines"]), 5)
+            self.assertNotIn("more", full["display"]["todo_lines"][-1])
+
+    def test_hud_collapses_all_done_todo_to_single_header_line(self) -> None:
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            items = [{"text": "Restore RED baseline", "state": "done"}, {"text": "Run byte gates", "state": "done"}]
+            self._write_todo(root / ".omh", self._record(items=items))
+            payload = read_omh_hud(root / ".omh", root / ".hermes")
+
+            self.assertEqual(payload["todo"]["status"], "all_done")
+            self.assertEqual(payload["todo"]["display_items"], [])
+            self.assertEqual(payload["display"]["todo_lines"], ["Todo · Foundation ✓ 2/2"])
+
+    def test_hud_hides_stale_and_unparseable_todo_updates(self) -> None:
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for updated_at in ("2020-01-01T00:00:00Z", "not-a-timestamp"):
+                self._write_todo(root / ".omh", self._record(updated_at=updated_at))
+                payload = read_omh_hud(root / ".omh", root / ".hermes")
+
+                self.assertEqual(payload["todo"]["status"], "stale")
+                self.assertEqual(payload["display"]["todo_lines"], [])
+
+    def test_hud_ignores_invalid_todo_schema_and_malformed_items(self) -> None:
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            invalid_records = [
+                self._record(schema_version="omh_todo/v0"),
+                self._record(items=[]),
+                self._record(items=[{"text": "", "state": "done"}, {"text": "x", "state": "later"}, "raw"]),
+            ]
+            for record in invalid_records:
+                self._write_todo(root / ".omh", record)
+                payload = read_omh_hud(root / ".omh", root / ".hermes")
+
+                self.assertEqual(payload["todo"]["status"], "absent")
+                self.assertEqual(payload["display"]["todo_lines"], [])
+
+    def test_hud_rejects_symlinked_todo_file(self) -> None:
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            outside = root / "outside-todo.json"
+            outside.write_text(json.dumps(self._record()), encoding="utf-8")
+            runtime_dir = root / ".omh" / "runtime"
+            runtime_dir.mkdir(parents=True)
+            (runtime_dir / "todo.json").symlink_to(outside)
+            payload = read_omh_hud(root / ".omh", root / ".hermes")
+
+            self.assertEqual(payload["todo"]["status"], "absent")
+
+    def test_todo_plugin_tool_set_show_clear_round_trip(self) -> None:
+        import os
+
+        from omh.plugin_bundle.omh.tools.todo_tool import omh_todo_handler
+
+        with TemporaryDirectory() as tmp:
+            home = str(Path(tmp) / ".omh")
+            with patch.dict(os.environ, {"OMH_HOME": home}):
+                written = json.loads(
+                    omh_todo_handler(
+                        {
+                            "action": "set",
+                            "title": "Foundation",
+                            "items": [{"text": "Inspect routing fixtures", "state": "active"}],
+                        }
+                    )
+                )
+                self.assertEqual(written["status"], "written")
+                self.assertEqual(written["todo"]["status"], "established")
+
+            shown = json.loads(omh_todo_handler({"action": "show", "omh_home": home}))
+            self.assertEqual(shown["status"], "read")
+            self.assertEqual(shown["todo"]["counts"]["total"], 1)
+
+            with patch.dict(os.environ, {"OMH_HOME": home}):
+                cleared = json.loads(omh_todo_handler({"action": "clear"}))
+                self.assertEqual(cleared["status"], "cleared")
+                self.assertEqual(cleared["todo"]["status"], "absent")
+
+    def test_todo_plugin_tool_rejects_omh_home_override_for_mutations(self) -> None:
+        from omh.plugin_bundle.omh.tools.todo_tool import omh_todo_handler
+
+        with TemporaryDirectory() as tmp:
+            target = Path(tmp) / "victim"
+            for action, extra in (("set", {"items": [{"text": "x"}]}), ("clear", {})):
+                payload = json.loads(
+                    omh_todo_handler({"action": action, "omh_home": str(target), **extra})
+                )
+
+                self.assertEqual(payload["status"], "invalid_todo")
+                self.assertIn("configured OMH home", payload["error"])
+            self.assertFalse(target.exists())
+
+    def test_todo_plugin_tool_reports_invalid_items_without_writing(self) -> None:
+        import os
+
+        from omh.plugin_bundle.omh.tools.todo_tool import omh_todo_handler
+
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp) / ".omh"
+            with patch.dict(os.environ, {"OMH_HOME": str(home)}):
+                payload = json.loads(
+                    omh_todo_handler({"action": "set", "items": [{"text": "x", "state": "later"}]})
+                )
+
+            self.assertEqual(payload["status"], "invalid_todo")
+            self.assertEqual(payload["todo"]["status"], "absent")
+            self.assertFalse((home / "runtime" / "todo.json").exists())
+
+    def test_todo_more_count_ignores_hidden_done_items(self) -> None:
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            items = [{"text": f"done {n}", "state": "done"} for n in range(4)]
+            items.append({"text": "current", "state": "active"})
+            self._write_todo(root / ".omh", self._record(items=items))
+            payload = read_omh_hud(root / ".omh", root / ".hermes")
+
+            self.assertEqual(payload["todo"]["more_count"], 0)
+            self.assertEqual(
+                payload["display"]["todo_lines"],
+                ["Todo · Foundation   4/5", "[✓] done 3", "[•] current"],
+            )
+
+    def test_todo_plugin_tool_reports_invalid_action_and_already_absent(self) -> None:
+        import os
+
+        from omh.plugin_bundle.omh.tools.todo_tool import omh_todo_handler
+
+        with TemporaryDirectory() as tmp:
+            with patch.dict(os.environ, {"OMH_HOME": str(Path(tmp) / ".omh")}):
+                invalid = json.loads(omh_todo_handler({"action": "purge"}))
+                absent = json.loads(omh_todo_handler({"action": "clear"}))
+
+            self.assertEqual(invalid["status"], "invalid_action")
+            self.assertTrue(invalid["error"])
+            self.assertEqual(absent["status"], "already_absent")
+
+    def test_todo_store_rejects_item_cap_symlinked_home_and_unwritable_home(self) -> None:
+        from omh.plugin_bundle.omh.todo_store import (
+            MAX_TODO_ITEMS,
+            TodoStoreError,
+            TodoValidationError,
+            build_todo_record,
+            write_todo,
+        )
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            record = build_todo_record("t", [{"text": "x"}], source="cli")
+
+            with self.assertRaises(TodoValidationError):
+                build_todo_record("t", [{"text": "x"}] * (MAX_TODO_ITEMS + 1), source="cli")
+
+            outside = root / "outside"
+            outside.mkdir()
+            linked_home = root / ".omh"
+            linked_home.mkdir()
+            (linked_home / "runtime").symlink_to(outside)
+            with self.assertRaises(TodoStoreError):
+                write_todo(linked_home, record)
+
+            sealed_home = root / "sealed"
+            sealed_home.mkdir(mode=0o500)
+            try:
+                with self.assertRaises(TodoStoreError):
+                    write_todo(sealed_home, record)
+            finally:
+                sealed_home.chmod(0o700)
+
+    def test_todo_surfaces_strip_control_characters_on_write_and_read(self) -> None:
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+        from omh.plugin_bundle.omh.todo_store import build_todo_record
+
+        record = build_todo_record(
+            "A\x1b[2J\x1b[1;1Hpwned",
+            [{"text": "ok\x1b]0;hijack\x07 \r\n done", "state": "active"}],
+            source="cli",
+        )
+        self.assertEqual(record["title"], "A[2J[1;1Hpwned")
+        self.assertEqual(record["items"][0]["text"], "ok]0;hijack  done")
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._write_todo(
+                root / ".omh",
+                self._record(
+                    title="B\x1bad",
+                    items=[{"text": "line\r\nsplit", "state": "active"}],
+                ),
+            )
+            payload = read_omh_hud(root / ".omh", root / ".hermes")
+
+            self.assertEqual(payload["todo"]["title"], "Bad")
+            self.assertEqual(payload["todo"]["items"], [{"text": "linesplit", "state": "active"}])
+            self.assertEqual(len(payload["display"]["todo_lines"]), 2)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -7,6 +7,7 @@ from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 from _cli_harness import run_cli
+from _platform_support import requires_posix_permissions
 
 
 class HudCliTests(unittest.TestCase):
@@ -1140,7 +1141,7 @@ class TodoHudTests(unittest.TestCase):
             self.assertTrue(invalid["error"])
             self.assertEqual(absent["status"], "already_absent")
 
-    def test_todo_store_rejects_item_cap_symlinked_home_and_unwritable_home(self) -> None:
+    def test_todo_store_rejects_item_cap_and_symlinked_home(self) -> None:
         from omh.plugin_bundle.omh.todo_store import (
             MAX_TODO_ITEMS,
             TodoStoreError,
@@ -1164,11 +1165,16 @@ class TodoHudTests(unittest.TestCase):
             with self.assertRaises(TodoStoreError):
                 write_todo(linked_home, record)
 
-            sealed_home = root / "sealed"
+    @requires_posix_permissions
+    def test_todo_store_reports_unwritable_home_as_store_error(self) -> None:
+        from omh.plugin_bundle.omh.todo_store import TodoStoreError, build_todo_record, write_todo
+
+        with TemporaryDirectory() as tmp:
+            sealed_home = Path(tmp) / "sealed"
             sealed_home.mkdir(mode=0o500)
             try:
                 with self.assertRaises(TodoStoreError):
-                    write_todo(sealed_home, record)
+                    write_todo(sealed_home, build_todo_record("t", [{"text": "x"}], source="cli"))
             finally:
                 sealed_home.chmod(0o700)
 

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -631,6 +631,7 @@ print(json.dumps(observed, ensure_ascii=False))
                     "omh_role",
                     "omh_source_trust",
                     "omh_status",
+                    "omh_todo",
                 ],
             )
             self.assertEqual(

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -48,7 +48,9 @@ class TuiWidgetPackTests(unittest.TestCase):
                 (hermes_home / "config.yaml").read_text(encoding="utf-8"),
             )
 
-    def test_setup_preserves_existing_config_without_display_interface(self) -> None:
+    def test_setup_defaults_existing_config_without_display_interface_to_tui(self) -> None:
+        # Upgraders whose config predates display.interface get the same TUI
+        # default as fresh installs; only an explicit choice is user-owned.
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
             omh_home = root / ".omh"
@@ -71,11 +73,11 @@ class TuiWidgetPackTests(unittest.TestCase):
 
             self.assertEqual((status, stderr), (0, ""))
             config_text = config.read_text(encoding="utf-8")
-            self.assertIn("display:\n  compact: true\n", config_text)
-            self.assertNotIn("interface:", config_text)
+            self.assertIn("  compact: true", config_text)
+            self.assertIn("  interface: tui", config_text)
             tui_interface = json.loads(stdout)["steps"]["apply"]["tui_interface"]
-            self.assertFalse(tui_interface["changed"])
-            self.assertEqual(tui_interface["selected"], "")
+            self.assertTrue(tui_interface["changed"])
+            self.assertEqual(tui_interface["selected"], "tui")
 
     def test_setup_preserves_an_explicit_classic_interface(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -237,7 +237,14 @@ class TuiWidgetPackTests(unittest.TestCase):
 
         self.assertIn("zone: 'dock-bottom'", widget)
         self.assertNotIn("zone: 'top-right'", widget)
-        self.assertNotIn("zone: 'dock-top'", widget)
+        # The todo checklist is the one dock-top app; the status app stays
+        # dock-bottom so the panel renders above the prompt input and the
+        # activity rows below it.
+        self.assertEqual(widget.count("zone: 'dock-top'"), 1)
+        self.assertIn("id: 'omh-todo'", widget)
+        self.assertIn("TodoPanel", widget)
+        self.assertIn("truncateCells(item.text", widget)
+        self.assertIn("safeText(todo.title)", widget)
         self.assertIn("width: '100%'", widget)
         self.assertIn("marginTop: 1", widget)
         self.assertNotIn("borderStyle:", widget)
@@ -275,7 +282,10 @@ class TuiWidgetPackTests(unittest.TestCase):
         self.assertIn("generation !== globalThis[generationKey]", widget)
         self.assertIn("clearTimeout(", widget)
         self.assertNotIn("payload ? { payload } : state", widget)
-        self.assertEqual(widget.count("{ ...state, payload, tick: state.tick + 1 }"), 2)
+        # One immutable snapshot-apply helper feeds both widget apps, and both
+        # the initial read and the refresh timer go through it.
+        self.assertEqual(widget.count("{ ...state, payload, tick: state.tick + 1 }"), 1)
+        self.assertEqual(widget.count("applySnapshot(payload)"), 2)
         self.assertNotIn("friendlyWorkflow", widget)
         self.assertNotIn("'fanout-unit': 'Parallel work'", widget)
         self.assertIn("t.color.ok", widget)

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -245,6 +245,10 @@ class TuiWidgetPackTests(unittest.TestCase):
         self.assertIn("TodoPanel", widget)
         self.assertIn("truncateCells(item.text", widget)
         self.assertIn("safeText(todo.title)", widget)
+        # An installed OMH stays discoverable from an idle session: only the
+        # activity rows are gated on live work, never the header.
+        self.assertNotIn("|| !payload.active", widget)
+        self.assertIn("const active = !!payload.active", widget)
         self.assertIn("width: '100%'", widget)
         self.assertIn("marginTop: 1", widget)
         self.assertNotIn("borderStyle:", widget)


### PR DESCRIPTION
## Feature Report

### Screenshots (real `hermes --tui` session, unedited captures)

Both frames are tmux captures of a live `hermes --tui` session on macOS with this branch's widget temporarily installed through the repo's managed installer (removed afterwards), rendered to PNG cell-for-cell with the captured colors. Not mockups.

**Before — current `omh-status` widget only (dock-bottom, below the prompt input):**

![Before: status widget below the prompt input, no todo panel](https://raw.githubusercontent.com/rlaope/oh-my-hermes/assets/hud-todo-panel/hud-todo-before.png)

**After — `omh-todo` panel (dock-top, directly above the prompt input):**

![After: todo checklist rendered above the prompt input](https://raw.githubusercontent.com/rlaope/oh-my-hermes/assets/hud-todo-panel/hud-todo-after.png)

### What Changed

- New metadata-only plan todo artifact `$OMH_HOME/runtime/todo.json` (`omh_todo/v1`) with a shared store (`src/plugin_bundle/omh/todo_store.py`) used by every writer.
- New plugin tool `omh_todo` (set/clear/show) — the Hermes-side TodoWrite-equivalent — registered across `metadata.py`, `plugin.yaml`, and `__init__.py`.
- New agent/operator CLI `omh runtime todo set|clear|show`.
- `read_omh_hud()` projects `payload["todo"]` and `display.todo_lines` (plus a public `read_omh_todo()`), reusing the reader's existing symlink/size fail-closed guards.
- `omh-status.mjs` now registers a second widget app `omh-todo` in the modern TUI's `dock-top` zone, sharing the existing READER polling, so the checklist renders directly above the prompt input while the status widget stays below it.
- Docs: `docs/INSTALLATION.md` todo section; tool enumerations updated in `docs/ARCHITECTURE.md` / `docs/CAPABILITIES.md`; awareness guidance and the CLI-backend capability mapping now name `omh_todo`.
- Out-of-the-box visibility (follow-up commits from live testing): the `[OMH]` status header now stays visible in an idle session — only activity rows are gated on live work — so an installed OMH is discoverable without running anything; and `omh setup`/`omh update` now default `display.interface: tui` for existing configs that never chose an interface (not just fresh installs), so bare `hermes` boots the modern TUI where the HUD renders. Explicit display choices remain user-owned.

### Why This Exists

Claude Code renders its todo list directly above the prompt input, which keeps the active plan visible without scrolling. OMH's HUD had no plan surface at all — only workflow/subagent activity — and the existing widget's `dock-bottom` zone demonstrably renders **below** the input (verified against a live session and `ui-tui/src/components/appLayout.tsx` layout order), so this capability needed a new dock-top widget app, not an extension of the existing one.

### User / Operator Impact

- When Hermes (via `omh_todo`) or an agent/operator (via `omh runtime todo set`) declares a plan, `hermes --tui` shows a compact checklist above the input: latest done item (struck through), active item, next pending, and a `+N more` collapse that counts only hidden remaining work. All-done collapses to a single header line; a list untouched for 24h is hidden as stale.
- `omh hud --json`, the `omh_hud` tool, and `omh runtime todo show` all carry the same projection.
- Classic Python TUI (`hermes` without `--tui`) does not load `.mjs` widgets; documented as a modern-TUI-only surface.

### How It Works

Writers go through `todo_store.py` (validation, control-character stripping, atomic write with symlink-ancestry rejection, `OSError` re-raised as `TodoStoreError` so both writers keep one JSON error contract). The reader re-validates independently — schema-version gate, per-item state/type filtering, item/text caps, control-character stripping again, staleness — so a hand-planted file cannot inflate or forge the projection. The widget renders `todo.display_items` with the existing `safeText`/`truncateCells` sanitizers; the READER buffer ceiling was raised to 64 KB so a full todo can never blank the whole HUD.

Security posture (from the review passes): `omh_todo` refuses an `omh_home` override for `set`/`clear` — mutations bind to the environment-configured home only, so a model-chosen path can never become an arbitrary-location file create/delete primitive.

### Files And Contracts Touched

- `src/plugin_bundle/omh/todo_store.py` (new), `tools/todo_tool.py` (new), `runtime_reader.py`, `metadata.py`, `plugin.yaml`, `__init__.py`, `awareness.py`
- `src/omh/tui_widgets/omh-status.mjs`, `src/commands/runtime.py`, `src/capabilities/hooks.py`
- `tests/test_hud.py`, `tests/test_cli.py`, `tests/test_tui_widget_pack.py`, `tests/test_plugin_distribution.py`
- `docs/INSTALLATION.md`, `docs/ARCHITECTURE.md`, `docs/CAPABILITIES.md`

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli release checklist --json`
- [x] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [x] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [x] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- Full suite: 6,561 tests; the only failures are three pre-existing machine-environment buckets (macOS-sandbox `test_cross_harness_adapter*`, npm/bun tarball packaging, and doctor tests that consult this machine's 56-commit-stale Hermes loader — that loader reports zero registered tools for the unmodified `main` bundle too). Zero failures touch this diff's import graph; verified by running the affected modules with `HERMES_PYTHON` neutralized: all green.
- New coverage: todo projection (established/all_done/stale/absent/symlink/control-chars/`more_count` semantics), plugin tool round trip plus negative cases (`invalid_action`, `already_absent`, `omh_home` mutation guard, invalid items), store caps and write-side symlink/unwritable-home errors, CLI round trip, widget-pack contract (dock-top app, snapshot-apply helper).
- Live TUI observation: with fabricated schema-valid runtime state and this branch's widget temporarily installed, a real `hermes --tui` session rendered the panel above the input (screenshots above); `omh runtime todo clear` removed it within one 2 s poll; an all-done list collapsed to the single header line. The temporary install was removed and the machine restored with released `omh setup` afterwards.
- Out-of-the-box observation: after this branch's `omh setup` on a real machine with a pre-existing 1,800-line Hermes config, `display.interface: tui` was inserted, bare `hermes` booted the modern TUI, and the `[OMH]` header rendered from an idle session with no seeded state; declaring a todo via `omh runtime todo set` made the panel appear above the input in the same session.
- Three independent review agents (architecture completeness, security, code quality) ran against the diff; all blocking findings (arbitrary-path write via `omh_home`, control-character passthrough, stale widget-pack test contract) are fixed in this commit.

### Not Tested / Not Applicable

- The full-install `release hermes-smoke --install-path setup --include-command-smoke` variant was not run (plain `release hermes-smoke` was).
- No workflow-learning contract changed, so no review-queue smoke applies.
- Hermes production model adherence for the `omh_todo` tool (whether Hermes actually calls it at the right moments) is not observed — it requires live Hermes chat sessions.
- Doctor's real-loader observation cannot pass on this machine until `hermes update` (its 56-commit-stale loader registers zero tools for any bundle).

## Risk

- The HUD payload gains a `todo` key; consumers that iterate keys strictly could see a new field (additive, schema-versioned surface).
- The widget file now registers two apps; a Hermes build older than the modern TUI's multi-widget support would ignore the file entirely (same failure mode as today).
- `more_count`, collapse, and preset semantics live in the reader; the widget renders `display_items` as-is, so a drift would show up in tests (`test_hud.py`) before the TUI.
- Deferred hardening (reviewer follow-ups, non-blocking): openat-style dir-fd descent for the writer (narrow same-uid TOCTOU on the `runtime/` directory component), path strings in error payloads, `0o644` artifact permissions.

## Compatibility / Rollout

- Existing installs pick the new tool, widget, and CLI up on the next `omh setup`/`omh update`; no migration, no new dependencies, no schema changes to existing artifacts.
- Absent `todo.json` projects `status: "absent"` and renders nothing — zero behavior change until a todo is declared.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Reviewer-suggested hardening: dir-fd descent in `todo_store.write_todo`, reason-code error payloads, tighter artifact permissions.
- Optional: project fanout roster `lifecycle_state` into the todo panel; run-scoped todos for concurrent sessions.
- Screenshots live on the `assets/hud-todo-panel` branch; delete it if the images are ever moved into docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
