### PR TITLE
fix(site): report the twelve-engine ULW count and gate every count surface

### DIFF
--- a/site/i18n.js
+++ b/site/i18n.js
@@ -153,10 +153,10 @@ window.OMH_I18N = {
     "ulw.kicker": { en: "Flagship workflows", ko: "대표 워크플로", ja: "フラッグシップ", zh: "旗舰工作流" },
     "ulw.title": { en: "The ulw-* family.", ko: "ulw-* 패밀리.", ja: "ulw-* ファミリー。", zh: "ulw-* 家族。" },
     "ulw.lead": {
-      en: "Eleven long-horizon lanes. Say the trigger in normal language — Hermes routes the rest.",
-      ko: "11개의 장기 레인. 평범한 말로 트리거만 말하면 나머지는 Hermes가 라우팅합니다.",
-      ja: "11 の長期レーン。普通の言葉でトリガーを言えば、あとは Hermes がルーティング。",
-      zh: "十一条长周期车道。用日常语言说出触发词，其余交给 Hermes 路由。"
+      en: "Twelve long-horizon lanes. Say the trigger in normal language — Hermes routes the rest.",
+      ko: "12개의 장기 레인. 평범한 말로 트리거만 말하면 나머지는 Hermes가 라우팅합니다.",
+      ja: "12 の長期レーン。普通の言葉でトリガーを言えば、あとは Hermes がルーティング。",
+      zh: "十二条长周期车道。用日常语言说出触发词，其余交给 Hermes 路由。"
     },
     "ulw.trigger": { en: "Say", ko: "이렇게 말하세요", ja: "こう言う", zh: "这样说" },
 

--- a/site/index.html
+++ b/site/index.html
@@ -104,7 +104,7 @@
 
         <ul class="stat-line" aria-label="OMH facts" data-reveal data-reveal-delay="260">
           <li><strong data-count-to="103">103</strong><span data-i18n="stat.skills">installable skills</span></li>
-          <li><strong data-count-to="11">11</strong><span data-i18n="stat.workflows">ulw workflows</span></li>
+          <li><strong data-count-to="12">12</strong><span data-i18n="stat.workflows">ulw workflows</span></li>
           <li><strong data-count-to="7">7</strong><span data-i18n="stat.families">capability families</span></li>
           <li><strong data-count-to="8">8</strong><span data-i18n="stat.langs">languages routed</span></li>
         </ul>
@@ -392,7 +392,7 @@
         <div class="section__head" data-reveal>
           <p class="kicker" data-i18n="ulw.kicker">Flagship workflows</p>
           <h2 id="ulw-title" data-i18n="ulw.title">The ulw-* family.</h2>
-          <p class="section__lead" data-i18n="ulw.lead">Eleven long-horizon lanes.</p>
+          <p class="section__lead" data-i18n="ulw.lead">Twelve long-horizon lanes.</p>
         </div>
 
         <ol class="ulw-list">

--- a/tests/test_ulw_count_gates.py
+++ b/tests/test_ulw_count_gates.py
@@ -1,0 +1,163 @@
+"""Count gates for the ULW engine roster on human-facing surfaces.
+
+The ULW engine roster is owned by ``omh.skills.catalog_types.ULW_ENGINE_SKILL_NAMES``.
+Five surfaces state that count in prose: the site's ``ulw.lead`` sentence
+(``site/index.html`` fallback text plus all four locales of ``site/i18n.js``)
+and the count sentence in each of the four READMEs. Each README also carries a
+ULW table whose row count must match the roster.
+
+These gates read the numeral per locale and compare it to the roster size, so
+the sentence can be reworded freely as long as the number stays true. The row
+gate matches the table-row form (``| ⚡ `ulw-``) rather than a bare ``ulw-``
+substring, because prose lines also mention ``ulw-`` and a bare grep would
+encode an off-by-one that turns into a false failure when prose is reworded.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.skills.catalog_types import ULW_ENGINE_SKILL_NAMES
+
+_ENGLISH_NUMBER_WORDS = {
+    "Ten": 10,
+    "Eleven": 11,
+    "Twelve": 12,
+    "Thirteen": 13,
+    "Fourteen": 14,
+    "Fifteen": 15,
+}
+
+_CHINESE_NUMERALS = {
+    "十": 10,
+    "十一": 11,
+    "十二": 12,
+    "十三": 13,
+    "十四": 14,
+    "十五": 15,
+}
+
+_README_TABLE_ROW = re.compile(r"^\| ⚡ `ulw-", re.MULTILINE)
+
+_README_COUNT_PATTERNS = {
+    "README.md": re.compile(r"\b([A-Z][a-z]+) `ulw-` workflows\."),
+    "README.ko.md": re.compile(r"\b(\d+)개의 `ulw-` workflow\."),
+    "README.ja.md": re.compile(r"\b(\d+) 個の `ulw-` workflow。"),
+    "README.zh.md": re.compile(r"([十一二三四五]+)个 `ulw-` workflow。"),
+}
+
+_SITE_LEAD_PATTERNS = {
+    "en": re.compile(r"^([A-Z][a-z]+) long-horizon lanes\."),
+    "ko": re.compile(r"^(\d+)개의 장기 레인\."),
+    "ja": re.compile(r"^(\d+) の長期レーン。"),
+    "zh": re.compile(r"^([十一二三四五]+)条长周期车道。"),
+}
+
+
+def _numeral_to_int(surface: str, numeral: str) -> int:
+    if numeral.isdigit():
+        return int(numeral)
+    if numeral in _ENGLISH_NUMBER_WORDS:
+        return _ENGLISH_NUMBER_WORDS[numeral]
+    if numeral in _CHINESE_NUMERALS:
+        return _CHINESE_NUMERALS[numeral]
+    raise AssertionError(f"{surface}: unmapped numeral {numeral!r}")
+
+
+def _site_lead_entries() -> dict[str, str]:
+    """Return the ``ulw.lead`` locale strings from ``site/i18n.js``."""
+    source = Path("site/i18n.js").read_text(encoding="utf-8")
+    match = re.search(r'"ulw\.lead":\s*\{(.*?)\}', source, re.DOTALL)
+    if match is None:
+        raise AssertionError('site/i18n.js: no "ulw.lead" entry found')
+    entries = dict(re.findall(r'(\w+):\s*"([^"]*)"', match.group(1)))
+    missing = {"en", "ko", "ja", "zh"} - set(entries)
+    if missing:
+        raise AssertionError(f"site/i18n.js ulw.lead: missing locales {sorted(missing)}")
+    return entries
+
+
+class UlwCountGateTest(unittest.TestCase):
+    def test_site_lead_states_engine_count_in_all_locales(self) -> None:
+        expected = len(ULW_ENGINE_SKILL_NAMES)
+        entries = _site_lead_entries()
+        for locale, pattern in _SITE_LEAD_PATTERNS.items():
+            with self.subTest(locale=locale):
+                match = pattern.search(entries[locale])
+                self.assertIsNotNone(
+                    match,
+                    f"site/i18n.js ulw.lead[{locale}]: count sentence not found "
+                    f"in {entries[locale]!r}",
+                )
+                stated = _numeral_to_int(f"site/i18n.js ulw.lead[{locale}]", match.group(1))
+                self.assertEqual(
+                    stated,
+                    expected,
+                    f"site/i18n.js ulw.lead[{locale}] states {stated} ULW engines; "
+                    f"source has {expected}",
+                )
+
+    def test_site_html_fallback_states_engine_count(self) -> None:
+        expected = len(ULW_ENGINE_SKILL_NAMES)
+        html = Path("site/index.html").read_text(encoding="utf-8")
+        match = re.search(r'data-i18n="ulw\.lead">([A-Z][a-z]+) long-horizon lanes\.', html)
+        self.assertIsNotNone(match, "site/index.html: ulw.lead fallback sentence not found")
+        stated = _numeral_to_int("site/index.html ulw.lead", match.group(1))
+        self.assertEqual(
+            stated,
+            expected,
+            f"site/index.html ulw.lead fallback states {stated} ULW engines; "
+            f"source has {expected}",
+        )
+
+    def test_site_hero_stat_states_engine_count(self) -> None:
+        expected = len(ULW_ENGINE_SKILL_NAMES)
+        html = Path("site/index.html").read_text(encoding="utf-8")
+        match = re.search(
+            r'data-count-to="(\d+)">(\d+)</strong>'
+            r'<span data-i18n="stat\.workflows">',
+            html,
+        )
+        self.assertIsNotNone(match, "site/index.html: ulw workflows hero stat not found")
+        for stated in (int(match.group(1)), int(match.group(2))):
+            self.assertEqual(
+                stated,
+                expected,
+                f"site/index.html hero stat states {stated} ulw workflows; "
+                f"source has {expected}",
+            )
+
+    def test_readme_count_sentences_state_engine_count(self) -> None:
+        expected = len(ULW_ENGINE_SKILL_NAMES)
+        for name, pattern in _README_COUNT_PATTERNS.items():
+            with self.subTest(readme=name):
+                text = Path(name).read_text(encoding="utf-8")
+                match = pattern.search(text)
+                self.assertIsNotNone(match, f"{name}: ULW count sentence not found")
+                stated = _numeral_to_int(name, match.group(1))
+                self.assertEqual(
+                    stated,
+                    expected,
+                    f"{name} states {stated} ULW engines; source has {expected}",
+                )
+
+    def test_readme_ulw_table_row_counts_match_source(self) -> None:
+        expected = len(ULW_ENGINE_SKILL_NAMES)
+        for name in _README_COUNT_PATTERNS:
+            with self.subTest(readme=name):
+                text = Path(name).read_text(encoding="utf-8")
+                rows = len(_README_TABLE_ROW.findall(text))
+                self.assertEqual(
+                    rows,
+                    expected,
+                    f"{name} has {rows} ULW table rows; source has {expected} engines",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- Fixes the shipped ULW count defect on the public site: `site/i18n.js`'s
  `ulw.lead` said "Eleven long-horizon lanes" in all four locales (en/ko/ja/zh)
  and the hero stat in `site/index.html` said "11 ulw workflows", while the
  source roster `ULW_ENGINE_SKILL_NAMES` has twelve members and all four
  READMEs already say twelve. All of those surfaces now say twelve.
- Adds `tests/test_ulw_count_gates.py`, a regression gate that asserts every
  surface stating the ULW engine count against `len(ULW_ENGINE_SKILL_NAMES)`,
  so the count can never silently drift from source again.
- Scope is deliberately narrow per the approved consolidation plan (§11.3 PR B,
  serving #954): no generator, no new CLI subcommand, no producer — the wrong
  numbers plus the gates, nothing else.

### Why This Exists

- #954 (Direction: simplify ULW around ulw-work and retire redundant engine
  surfaces) starts from an audit of every surface that states the ULW engine
  count. That audit found the site publicly reporting eleven engines while the
  catalog ships twelve — a live, user-visible defect.
- The historical cause is the site's card list omitting `ulw-context`. Per the
  plan, the missing card arrives with PR C's *generated* site region; this PR
  fixes only the count copy so the site stops understating the roster now, and
  installs the gates PR C will build on.
- Without a gate, the count lives as hand-maintained literals in five-plus
  places (site lead x4 locales, site HTML fallback, hero stat, four READMEs);
  the eleven/twelve drift proves that arrangement fails.

### User / Operator Impact

- Visitors to the site in any of the four locales now see the correct engine
  count (Twelve / 12개 / 12 個 / 十二条) in the ULW section lead and "12 ulw
  workflows" in the hero stat line.
- Contributors get a failing test naming the exact locale or file whenever any
  count surface disagrees with `ULW_ENGINE_SKILL_NAMES` — adding or retiring a
  ULW engine without updating the copy is now caught pre-merge.

### How It Works

- `site/i18n.js`: the four `ulw.lead` locale strings change their numeral word
  only (Eleven→Twelve, 11개→12개, "11 の"→"12 の", 十一条→十二条). No keys
  added or removed, so i18n key parity is untouched.
- `site/index.html`: the no-JS fallback lead text and the hero stat
  (`data-count-to="11"` → `"12"` plus its visible text) change; no structure.
- `tests/test_ulw_count_gates.py` (`UlwCountGateTest`, five methods, one gate):
  - Site lead per-locale: parses each locale's `ulw.lead` string out of
    `site/i18n.js` and reads the numeral per-locale, comparing to
    `len(ULW_ENGINE_SKILL_NAMES)`; a mismatch fails naming the locale.
  - Site HTML fallback and hero stat: same source-of-truth comparison against
    `site/index.html`.
  - README count sentences: asserts each of `README.md` / `README.ko.md` /
    `README.ja.md` / `README.zh.md` states the count with its locale numeral
    (Twelve / 12개 / 12 個 / 十二个).
  - README table rows: counts rows matching the table-row regex
    `^\| ⚡ `ulw-` (`_README_TABLE_ROW`, `re.MULTILINE`) per README and asserts
    equality with the source count, failing naming the file. The table-row
    pattern is load-bearing: a bare `ulw-` grep returns 13 in every README
    because one prose line also mentions `ulw-` — asserting on that would
    encode an off-by-one that turns into a false failure when the prose is
    reworded.
- Localized row prose is count-gated only, not content-asserted, by plan
  decision (Q4).

### Files And Contracts Touched

- `site/i18n.js` — `ulw.lead` numerals in en/ko/ja/zh (copy only).
- `site/index.html` — hero stat `data-count-to` + text; `ulw.lead` fallback
  text (copy only).
- `tests/test_ulw_count_gates.py` — new; contracts: five count surfaces vs
  `omh.skills.catalog_types.ULW_ENGINE_SKILL_NAMES`.
- Not touched: `src/` (zero lines), all generated artifacts (`skills/*`,
  `docs/WORKFLOWS.md`, `docs/ROLES.md`, demo cards, capability-families
  sidecar), routing corpora, exact-count fixtures.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

Check only commands that completed successfully. Leave non-applicable checks
unchecked and explain why under **Not Tested / Not Applicable**.

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

All of the following was executed and observed on this branch at `582aed63`
(implementer run, then independently re-executed by a separate verifier pass):

- `uv run python -m compileall -q src tests` — exit 0.
- `uv run --group lint ruff check src tests` — "All checks passed!" (one
  pre-existing unused-`noqa` warning at `src/commands/main.py:1`, present on
  `main`, untouched here).
- `uv run python -m omh.cli docs workflows --check` — `ok: true`, tap-skills
  125/125; `docs roles --check` — `ok: true`;
  `docs capability-families --check` — ok. All byte gates prove the generated
  artifacts are byte-identical to `main` (this PR changes none of their
  inputs).
- `uv run python -m omh.cli release drift` — "No drift. 12 checks passed."
- `git diff --check` — clean.
- `PYTHONPATH=tests uv run python -m unittest discover -s tests` — Ran 6564;
  44 failures/errors, all in sandboxed-subprocess/installer suites
  (`test_plugin_distribution`, `test_plugin_observations`,
  `test_cross_harness_*`, `test_distribution_packages`, …). The identical
  44-entry failure set was observed on clean `origin/main` in the same
  sandbox (failure lists diffed: byte-identical), i.e. zero test delta from
  this change; those suites spawn subprocesses the sandbox blocks.
- `tests/test_ulw_count_gates.py` — 5/5 green; every test file that reads the
  changed files (`test_distribution_surfaces`, `test_model_recommendations`,
  `test_router_content`, `test_ulw_count_gates`) passes in isolation.
- Plan mutants executed and restored: (1) `ja` locale set to 11 → gate fails
  naming `locale='ja'` ("site/i18n.js ulw.lead[ja] states 11 … source has
  12"); (2) `ulw-loop` row deleted from `README.ko.md` → row-count gate fails
  "(readme='README.ko.md') 11 != 12".
- Row-pattern off-by-one confirmed by grep: table-row pattern matches 12 rows
  per README; bare `ulw-` matches 13 in all four.
- Routing inertness: `sha256(json.dumps(build_routing_precision_demo(),
  sort_keys=True, ensure_ascii=False).encode()).hexdigest()` ==
  `0f04ef20ff4c43beafbef06e55710bd8c10ee3170e5a456d8a0a9df3f295ae51`, equal to
  the recorded baseline (trivially expected — no Python under `src/` changed —
  retained as the plan's cheap guard).
- No Eleven / 십일 / 11개 / "11 の" / 十一 count copy remains in
  `site/index.html` or `site/i18n.js` (remaining "11" matches are SVG path
  data only).

### Not Tested / Not Applicable

- `harness validate`, `release checklist`, `release hermes-smoke`, `omh
  --help`, the smoke-install run, and the workflow-learning queue smoke: this
  PR changes site copy and adds one test file; no CLI, harness, release, or
  learning contract is touched, and `release drift` (12 checks) was run as the
  release-side guard instead.
- Rendered site appearance in a browser: copy-only numeral change inside
  existing markup; not exercised.
- The 44 sandboxed-subprocess suite entries above were not driven to green
  here: they fail identically on clean `main` in this sandbox and are outside
  this PR's surface.

## Risk

- Very low. Zero `src/` lines; generated artifacts byte-identical; routing
  digest equals baseline. Worst case is the new gate firing on a future
  legitimate roster change — which is its job; it names the exact surface to
  update.
- Scope note (also declared in the commit's `Scope-risk` trailer for reviewer
  veto): the hero-stat fix (`data-count-to` 11→12) and its assertion go one
  step past plan §11.3's literal criteria list. Both stay inside this PR's
  stated defect — the site reporting a wrong ULW count — and touch no producer
  or region PR C will generate.
- The site still shows 11 ULW cards (no `ulw-context` card). Intentional: per
  the plan, the card arrives with PR C's generated site region; this PR fixes
  only what the copy claims.
- New test reads repo files via cwd-relative paths, matching the existing
  idiom (`tests/test_model_recommendations.py` does the same).

## Compatibility / Rollout

- No API, CLI, schema, or installed-skill change; nothing to migrate. The
  static site picks up the copy on its next deploy.
- Parallel-safe with PR C by design: PR C replaces the hand-gated `README.md`
  count assertion with derivation and generates the site region; this PR's
  gates are the baseline it swaps against.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`) — none; site copy + tests only, no packaged artifact changes (release drift green).
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap — no Hermes surface touched; hermes-smoke not applicable (see Not Tested)

## Follow-Up

- PR C (#954 plan §11.3): generate the site's ULW region from
  `ulw_inventory_payload()` (adding the missing `ulw-context` card), derive the
  English README table, and replace this PR's hand-gated `README.md` count
  assertion with derivation; the three localized READMEs keep the count gates
  added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
