### PR TITLE
fix(update): stream pip output in human mode and bound the self-update

### DIFF
--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -470,6 +470,12 @@ def _command_package_self_update_plan(args: argparse.Namespace) -> dict[str, obj
     }
 
 
+# Bounds the package download + sdist build. A repository archive of this repo
+# builds in well under two minutes on ordinary hardware; fifteen gives slow
+# links headroom while still turning a stalled network into an error.
+SELF_UPDATE_TIMEOUT_SECONDS = 900
+
+
 def _run_command_package_self_update(args: argparse.Namespace, plan: dict[str, object]) -> int:
     if plan.get("method") == "package_manager":
         return _run_package_manager_self_update(args, plan)
@@ -482,34 +488,50 @@ def _run_command_package_self_update(args: argparse.Namespace, plan: dict[str, o
     progress = _HumanProgress(enabled=not wants_json, use_color=_use_color())
     progress.header("OMH update", "Refresh the OMH command package and workflow pack.")
     progress.step(1, 2, "Updating omh command package", detail=package_url)
-    completed = subprocess.run(
-        [
-            python,
-            "-m",
-            "pip",
-            "install",
-            "--disable-pip-version-check",
-            "-q",
-            # A branch archive keeps one URL while its contents change, and pip
-            # caches by URL. Without this, `omh update` reinstalls whatever
-            # `main.zip` was downloaded last - it reports success, the version
-            # string does not move, and the user gets an older tree. Observed:
-            # a fresh venv still printed "Using cached main.zip" and installed
-            # a build from before the merge it was run to pick up.
-            # `--force-reinstall` does not help; it forces the reinstall, not
-            # the download.
-            "--no-cache-dir",
-            "--force-reinstall",
-            "--upgrade",
-            package_url,
-        ],
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
+    pip_command = [
+        python,
+        "-m",
+        "pip",
+        "install",
+        "--disable-pip-version-check",
+        # A branch archive keeps one URL while its contents change, and pip
+        # caches by URL. Without this, `omh update` reinstalls whatever
+        # `main.zip` was downloaded last - it reports success, the version
+        # string does not move, and the user gets an older tree. Observed:
+        # a fresh venv still printed "Using cached main.zip" and installed
+        # a build from before the merge it was run to pick up.
+        # `--force-reinstall` does not help; it forces the reinstall, not
+        # the download.
+        "--no-cache-dir",
+        "--force-reinstall",
+        "--upgrade",
+        package_url,
+    ]
+    # Human mode streams pip's own download/build lines: this step downloads a
+    # repository archive and builds a large sdist, which can take minutes, and
+    # a silent terminal during that window is indistinguishable from a hang —
+    # users kill it and report `omh update` as frozen. JSON mode keeps stdout
+    # parseable by capturing instead. Either way the step is bounded: a stalled
+    # network must become an actionable error, not an indefinite wait.
+    if wants_json:
+        pip_command.insert(pip_command.index("install") + 1, "-q")
+    capture = subprocess.PIPE if wants_json else None
+    try:
+        completed = subprocess.run(
+            pip_command,
+            text=True,
+            stdout=capture,
+            stderr=capture,
+            timeout=SELF_UPDATE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        raise OmhError(
+            f"command package update timed out after {SELF_UPDATE_TIMEOUT_SECONDS}s downloading/building "
+            f"{package_url}; check the network and rerun `omh update`"
+        ) from None
     if completed.returncode != 0:
         detail = _bounded_command_error(
-            completed.stderr or completed.stdout or "pip install failed"
+            completed.stderr or completed.stdout or "pip install failed (see output above)"
         )
         raise OmhError(f"command package update failed: {detail}")
     progress.done("command package updated")
@@ -539,17 +561,25 @@ def _run_package_manager_self_update(
         "Updating omh command package",
         detail=update_instruction,
     )
-    completed = subprocess.run(
-        update_command,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
+    pm_capture = subprocess.PIPE if wants_json else None
+    try:
+        completed = subprocess.run(
+            update_command,
+            text=True,
+            stdout=pm_capture,
+            stderr=pm_capture,
+            timeout=SELF_UPDATE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        raise OmhError(
+            f"command package update timed out after {SELF_UPDATE_TIMEOUT_SECONDS}s running "
+            f"`{' '.join(update_command)}`; check the network and rerun `omh update`"
+        ) from None
     if completed.returncode != 0:
         detail = _bounded_command_error(
             completed.stderr
             or completed.stdout
-            or f"{package_manager} update failed"
+            or f"{package_manager} update failed (see output above)"
         )
         raise OmhError(f"command package update failed: {detail}")
     progress.done("command package updated")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3593,6 +3593,49 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
         self.assertIn("--command-package-updated", reentry_args)
         self.assertEqual(run.call_args_list[1].kwargs["env"][setup_commands.SELF_UPDATE_REENTRY_ENV], "1")
 
+    def test_update_self_update_streams_pip_output_in_human_mode_and_captures_in_json(self) -> None:
+        # A silent multi-minute archive download/build is indistinguishable
+        # from a hang; human mode must inherit stdio so pip's own progress
+        # shows, while JSON mode keeps stdout parseable by capturing.
+        plan = {"release": Namespace(package_url="https://example.invalid/omh.zip"), "python": sys.executable}
+        first = subprocess.CompletedProcess(args=["pip"], returncode=0, stdout="", stderr="")
+        second = subprocess.CompletedProcess(args=["omh"], returncode=0, stdout="", stderr="")
+
+        with patch.object(setup_commands.subprocess, "run", side_effect=[first, second]) as run:
+            with patch.object(setup_commands.sys, "argv", ["omh", "update"]):
+                setup_commands._run_command_package_self_update(Namespace(json=False), plan)
+        human_call = run.call_args_list[0]
+        self.assertNotIn("-q", human_call.args[0])
+        self.assertIsNone(human_call.kwargs["stdout"])
+        self.assertIsNone(human_call.kwargs["stderr"])
+        self.assertEqual(human_call.kwargs["timeout"], setup_commands.SELF_UPDATE_TIMEOUT_SECONDS)
+
+        first_json = subprocess.CompletedProcess(args=["pip"], returncode=0, stdout="", stderr="")
+        second_json = subprocess.CompletedProcess(args=["omh"], returncode=0, stdout="", stderr="")
+        with patch.object(setup_commands.subprocess, "run", side_effect=[first_json, second_json]) as run:
+            with patch.object(setup_commands.sys, "argv", ["omh", "update", "--json"]):
+                setup_commands._run_command_package_self_update(Namespace(json=True), plan)
+        json_call = run.call_args_list[0]
+        self.assertIn("-q", json_call.args[0])
+        self.assertEqual(json_call.kwargs["stdout"], subprocess.PIPE)
+        self.assertEqual(json_call.kwargs["timeout"], setup_commands.SELF_UPDATE_TIMEOUT_SECONDS)
+
+    def test_update_self_update_timeout_becomes_an_actionable_error(self) -> None:
+        plan = {"release": Namespace(package_url="https://example.invalid/omh.zip"), "python": sys.executable}
+
+        with patch.object(
+            setup_commands.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(cmd=["pip"], timeout=900),
+        ):
+            with patch.object(setup_commands.sys, "argv", ["omh", "update"]):
+                with self.assertRaises(OmhError) as raised:
+                    setup_commands._run_command_package_self_update(Namespace(json=False), plan)
+        message = str(raised.exception)
+        self.assertIn("timed out", message)
+        self.assertIn("https://example.invalid/omh.zip", message)
+        self.assertIn("omh update", message)
+
     def test_update_self_update_skips_local_channel_without_package_source(self) -> None:
         args = Namespace(
             command_package_updated=False,


### PR DESCRIPTION
## Feature Report

### What Changed

`omh update`'s command-package self-update no longer runs pip silently or unboundedly. Human mode inherits stdio so pip's own download and build lines stream to the terminal; JSON mode keeps capturing (with `-q`) so machine output stays parseable. Both self-update paths — the pip archive install and the package-manager variant — are bounded by a 900-second timeout that raises an actionable `OmhError` naming the package URL/command and the retry, instead of waiting forever.

### Why This Exists

Observed live: a user ran `omh update`, saw `[1/2] Updating omh command package...` with the archive URL, and nothing else — for minutes. The step downloads a repository archive and builds a large sdist through `pip -q` with stdout/stderr captured, so a working multi-minute install is indistinguishable from a hang, and a genuinely stalled network hangs forever. Users kill it and report `omh update` as frozen; this is the delivery pipeline every other OMH improvement depends on.

### User / Operator Impact

- `omh update` now shows pip's `Collecting… / Downloading… / Building wheel…` progress while the archive installs; a slow link looks slow instead of dead.
- A stalled download fails after 15 minutes with: `command package update timed out after 900s downloading/building <url>; check the network and rerun \`omh update\``.
- `omh update --json` output is byte-for-byte unaffected on success.

### How It Works

The pip argv is built once; `-q` is inserted and stdio captured only when `--json` is set, otherwise stdio is inherited (`stdout=None`). `subprocess.run(..., timeout=SELF_UPDATE_TIMEOUT_SECONDS)` wraps both self-update call sites; `TimeoutExpired` is converted to `OmhError`. The reentry exec that refreshes workflows stays unbounded on purpose — it is the real update work, not a network wait. The load-bearing `--no-cache-dir --force-reinstall` cache-busting flags are unchanged.

### Files And Contracts Touched

- `src/commands/setup.py` — `_run_command_package_self_update`, `_run_package_manager_self_update`, new `SELF_UPDATE_TIMEOUT_SECONDS`
- `tests/test_cli.py` — two regression tests (mode-dependent stdio/`-q`/timeout wiring; timeout→actionable-error conversion)

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

### Verification (observed)

- `PYTHONPATH=tests uv run python -m unittest test_cli.CliTests -k self_update` — 7/7 (5 existing + 2 new).
- `ruff` clean, `compileall` clean, `release drift` 16 checks, `git diff --check` clean.

### Risks

- Installs that legitimately need >15 minutes (extremely slow links) now fail with the retry message instead of eventually succeeding; the message names the exact rerun.
- Human-mode pip output formatting is pip's own and may vary across pip versions; nothing parses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
