### PR TITLE
docs(context): define the four fault domains and their proofs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,9 @@ Rules:
 
 ## Workflow Rules
 
+- A report that something is broken is not yet repo work. Measure which fault
+  domain owns it first — see Fault domains in `CONTEXT.md` for the four domains
+  and the command that proves each. Only one of them produces a PR.
 - One user goal → one PR. Do not frame partial slices; see Delivery Grain in
   `AGENTS.md` for the only valid split reasons.
 - Branch before the first edit: `claude/<topic>` (or `agent/`, `hermes/`).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -184,6 +184,48 @@ during live work) and the plan-todo checklist in `dock-top`.
 _Avoid_: statusline (that is a different, host-owned surface), HUD (the widget
 renders the HUD payload; it is not the payload)
 
+### Fault domains
+
+**OMH install fault**:
+A managed artifact under a host root is missing, stale, or was never refreshed
+on this machine; the repo itself is fine. `omh doctor` proves it — it reports
+plugin, widget, and managed-skill state — and `omh setup` or `omh update`
+fixes it. Measure the domain before assuming one: this and the Hermes
+user-config fault are cheap reads and come first, an OMH product fault needs a
+clean-tree reproduction, and a Hermes-side fault comes last and only with both
+of its proofs in hand.
+_Avoid_: opening a PR for it, reaching for `hermes update`
+
+**Hermes user-config fault**:
+A key that the user or `hermes setup` owns, and that OMH must never write, is
+set inconsistently with what the reporter expects — `model.default`,
+`model.provider`, `model.base_url`, anything under `display.`, the active
+skin. Reading the key proves it. OMH reports the inconsistency and stops
+there; it only ever writes the managed keys it installed (see Managed
+artifact). Check it alongside the install fault, before reproducing anything.
+_Avoid_: writing the key from OMH, filing it as a product fault
+
+**OMH product fault**:
+The behaviour reproduces from a clean install and on the repo dev tree,
+independent of the reporter's machine — prove it by running
+`uv run python -m omh.cli …` in a clean checkout. The fix is a repo change
+with tests, which makes this the only fault domain that produces a PR.
+_Avoid_: claiming it before a clean-tree reproduction
+
+**Hermes-side fault**:
+Hermes Agent's own code or built assets are genuinely behind, which is what
+makes `hermes update` the answer. Two proofs are required together, never
+either one alone: `git -C "$HERMES_HOME/hermes-agent" rev-parse HEAD` behind
+that repo's `origin/main`, and the built Modern-TUI bundle older than its
+TypeScript sources. A visual symptom that reads as "an old TUI" is almost
+always an OMH product fault or a Hermes user-config fault instead — in one
+real session Hermes sat at its `origin/main` HEAD with a freshly built
+Modern-TUI bundle while the visual complaint was entirely valid, and the
+missing chrome turned out to be an OMH product gap. OMH never patches Hermes
+either way.
+_Avoid_: prescribing `hermes update` from a visual symptom alone, treating one
+of the two proofs as sufficient
+
 ### Repo guard vocabulary
 
 **Byte gate**:


### PR DESCRIPTION
## Feature Report

### What Changed

- `CONTEXT.md` gains a `### Fault domains` subsection under `## Language`,
  placed immediately before `### Repo guard vocabulary`, defining four terms in
  the existing glossary style (bold term, definition paragraph, `_Avoid_:`
  line): **OMH install fault**, **Hermes user-config fault**, **OMH product
  fault**, **Hermes-side fault**.
- `CLAUDE.md` gains one pointer bullet under **Workflow Rules** routing an agent
  to that subsection before it treats a breakage report as repo work.

### Why This Exists

An agent handed "X is broken" has no shared vocabulary for which product owns
the fault, so it guesses — and the expensive guess is the Hermes-side one. In a
real session, a visual complaint that read as "an old TUI" was answered with
`hermes update`, while Hermes was already at its `origin/main` HEAD with a
freshly built Modern-TUI bundle. The complaint was entirely valid; the missing
chrome was an OMH product gap. The wrong domain cost the user time and produced
no fix. The glossary now names the domains and, for each, the command that
proves it.

### User / Operator Impact

- An agent or operator diagnosing a breakage now has a measurement order rather
  than an assumption: the two cheap reads (`omh doctor`, and reading the
  user-owned Hermes config key) come first, a clean-tree reproduction second,
  and the Hermes-side domain last and only with both of its proofs in hand.
- Only one domain — **OMH product fault** — produces a PR. That is stated in the
  entry, so install and config faults stop arriving as repo changes.
- No CLI, tool, or runtime behaviour changes.

### How It Works

Each entry carries its proof and its boundary:

- **OMH install fault** — a managed artifact under a host root is missing,
  stale, or never refreshed on this machine. `omh doctor` proves it;
  `omh setup` / `omh update` fixes it; it is never a repo change. This entry
  also carries the ordering rule for the other three.
- **Hermes user-config fault** — a key the user or `hermes setup` owns and OMH
  must never write (`model.default`, `model.provider`, `model.base_url`,
  anything under `display.`, the active skin). Reading the key proves it. OMH
  reports the inconsistency and stops; it only writes the managed keys it
  installed, which the existing **Managed artifact** entry already defines.
- **OMH product fault** — reproduces from a clean install and on the repo dev
  tree, independent of the reporter's machine, against
  `uv run python -m omh.cli …`. The only domain that produces a PR.
- **Hermes-side fault** — requires two proofs together, never either alone:
  `git -C "$HERMES_HOME/hermes-agent" rev-parse HEAD` behind that repo's
  `origin/main`, **and** the built Modern-TUI bundle older than its TypeScript
  sources. This entry carries the "old TUI" warning above, and restates that OMH
  never patches Hermes either way.

The ordering rule is encoded in the entries' prose and in the order the entries
appear, not as a separate essay. Consistent with the repo rule against prose
that drifts, the entries name commands and keys, never counts, line numbers, or
sizes.

### Files And Contracts Touched

- `CONTEXT.md` — glossary addition only; no existing entry reworded.
- `CLAUDE.md` — one bullet under Workflow Rules. It is a pointer, not a copy:
  `CLAUDE.md` states that `CONTEXT.md` is the glossary and that it does not
  repeat what `CONTEXT.md`/`AGENTS.md` define.
- No source, catalog, routing, test, or generated artifact touched.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `uv run python -m omh.cli docs ulw-inventory --check`
- [x] `uv run python -m omh.cli docs ulw-site --check`
- [x] `git diff --check`

### Observed Evidence

- `uv run python -m compileall -q src tests` — exit 0.
- `PYTHONPATH=tests uv run python -m unittest discover -s tests` — `Ran 6690
  tests`, `FAILED (failures=16)`. All 16 are pre-existing on this machine and
  unrelated to this change: re-running `tests/test_cli.py`,
  `tests/test_distribution_packages.py`, `tests/test_plugin_distribution.py`,
  `tests/test_plugin_observations.py`, and
  `tests/test_installer_skill_profile.py` with the two documentation files
  stashed reproduces the identical failure set (10 + 6). Every one asserts
  `doctor` exit 0 after `setup`; reproducing `omh setup` + `omh doctor` against
  throwaway homes shows the blocking check is `plugin_loader_observed` — "real
  Hermes loader registration mismatch: registration_mismatch; tools=[]
  hooks=[]". This matches the same-machine clean-`main` baseline recorded in the
  previous merged commit on `main`.
- `uv run python -m omh.cli docs workflows --check` — `"ok":true`, tap_skills
  `"ok":true` with no missing/stale/extra.
- `uv run python -m omh.cli docs roles --check` — `"ok":true`.
- `uv run python -m omh.cli docs capability-families --check` — `"ok":true`.
- `uv run python -m omh.cli docs ulw-inventory --check` — `"ok":true`
  (`README.md`).
- `uv run python -m omh.cli docs ulw-site --check` — `"ok":true`
  (`site/index.html`).
- `uv run --group lint ruff check src tests` — `All checks passed!`, exit 0. (It
  prints a pre-existing warning about an invalid `# noqa` directive in
  `src/commands/main.py`; that is on `main` and untouched here.)
- `git diff --check` — exit 0, no output.
- Every `CONTEXT.md` line stays within the file's existing wrap width.

### Not Tested / Not Applicable

- `omh release checklist`, `omh release hermes-smoke`, `omh harness validate`,
  `omh --help`, and the Hermes/TUI manual check were not run: this change adds
  no code, command, catalog entry, or generated artifact, so no runtime surface
  is exercised. The five byte gates were still run to prove no generated
  artifact drifted.
- No automated gate asserts on `CONTEXT.md` content, so the new subsection is
  documentation-guarded only. Stated as a gap rather than solved by inventing a
  new gate for it.

## Risk

Low. Documentation only. The realistic failure mode is the guidance going stale
rather than breaking anything: if Hermes renames a user-owned config key or the
Modern-TUI build layout moves, the **Hermes-side fault** proof and the
**Hermes user-config fault** key list would need updating. Neither is enforced
by a test.

## Compatibility / Rollout

No compatibility surface. Nothing is packaged, generated, or installed from
these two files; they take effect the moment an agent reads them.

## Release / Claims

- [x] Release-channel impact considered — none; no packaged or generated
      artifact changes.
- [x] Runtime/native capability claims are backed by evidence or marked as not
      observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as
      execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events,
      transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any
      `omh release hermes-smoke --live` gap

## Follow-Up

- The 16 `doctor`/`setup` failures are a pre-existing local baseline on this
  machine (`plugin_loader_observed` registration mismatch), not introduced here
  and out of scope for this PR.
