### PR TITLE
feat(tui): give the OMH widget theme-derived panel chrome

### DIFF
--- a/src/install/config_adapter.py
+++ b/src/install/config_adapter.py
@@ -224,6 +224,15 @@ def memory_provider_selection(config_text: str) -> str:
     return _section_scalar(config_text, "memory", "provider")
 
 
+def display_skin_selection(config_text: str) -> str:
+    """The name in `display.skin`, or "" when Hermes resolves its built-in default.
+
+    Read-only: OMH never writes this key. The active skin is what colours the
+    OMH widget's panel border, so doctor names it when reporting the chrome.
+    """
+    return _section_scalar(config_text, "display", "skin")
+
+
 def display_interface_selection(config_text: str) -> str:
     """The unambiguous scalar `display.interface`, or "" for other shapes."""
     lines = config_text.splitlines()

--- a/src/maintenance/doctor.py
+++ b/src/maintenance/doctor.py
@@ -470,6 +470,32 @@ def _hermes_tui_checks(paths: OmhPaths) -> list[Check]:
             next_action="run `omh setup` to (re)install the managed TUI widget" if widget_degraded else "",
         )
     )
+    if widget["installed"]:
+        # A widget from an OMH that predated panel chrome loads and runs, so
+        # every check above stays green while the HUD renders as borderless
+        # text beside the prompt — the exact "it still looks like the old
+        # version, and has no bright border" report this check exists to name.
+        skin = preflight["display_skin"]
+        checks.append(
+            Check(
+                "hermes_tui_widget_chrome",
+                True,
+                (
+                    f"OMH status widget borders its panel from the active Hermes skin ({skin['value']})"
+                    if widget["themed_panel"]
+                    else (
+                        "installed OMH status widget predates themed panel chrome; it renders as borderless "
+                        f"text instead of a card bordered from the active skin ({skin['value']})"
+                    )
+                ),
+                severity="ok" if widget["themed_panel"] else "warning",
+                next_action=(
+                    ""
+                    if widget["themed_panel"]
+                    else "run `omh setup` to refresh the managed TUI widget with themed panel chrome"
+                ),
+            )
+        )
     return checks
 
 

--- a/src/maintenance/hermes_tui.py
+++ b/src/maintenance/hermes_tui.py
@@ -107,6 +107,32 @@ def _display_interface(config_text: str) -> dict[str, Any]:
     return {"value": "", "explicit": False, "settable": settable}
 
 
+def _display_skin(config_text: str) -> dict[str, Any]:
+    """The skin whose palette colours the OMH panel. User-owned, never written.
+
+    An unset key means Hermes resolves its built-in ``default`` skin, which is
+    a real answer here, not a gap: the widget takes its border colour from
+    whichever skin is active either way.
+    """
+    from ..install.config_adapter import display_skin_selection
+
+    value = display_skin_selection(config_text)
+    return {"value": value or "default", "explicit": bool(value)}
+
+
+def _widget_draws_themed_panel(widget_text: str) -> bool:
+    """Does the INSTALLED widget draw a bordered card coloured by the theme?
+
+    A widget left over from an OMH that predated panel chrome loads and runs
+    fine — it just renders as borderless text beside the prompt, which reads
+    as "the HUD still looks like the old version" with nothing else wrong.
+    Both halves matter: a border alone could be a hardcoded palette that
+    fights the user's skin, so the colour must resolve through the theme
+    object the host hands the app.
+    """
+    return "borderStyle:" in widget_text and re.search(r"borderColor:\s*t\.color\.", widget_text) is not None
+
+
 def _widget_interpreter(widget_text: str) -> str:
     match = re.search(r"execFile\(\s*\n?\s*(\"(?:[^\"\\]|\\.)+\")", widget_text)
     if not match:
@@ -140,6 +166,7 @@ def hermes_tui_preflight(paths: OmhPaths) -> dict[str, Any]:
 
     config_text = _read_text_bounded(paths.hermes_config_path) or ""
     interface = _display_interface(config_text)
+    skin = _display_skin(config_text)
 
     widget_path = paths.hermes_home / "tui-widgets" / WIDGET_FILENAME
     manifest_path = paths.hermes_home / "tui-widgets" / MANIFEST_FILENAME
@@ -164,11 +191,13 @@ def hermes_tui_preflight(paths: OmhPaths) -> dict[str, Any]:
             "missing": missing_keys or [],
         },
         "display_interface": interface,
+        "display_skin": skin,
         "widget": {
             "installed": widget_text is not None,
             "managed": manifest_path.is_file(),
             "interpreter": interpreter,
             "interpreter_ok": interpreter_ok,
+            "themed_panel": widget_text is not None and _widget_draws_themed_panel(widget_text),
         },
     }
 

--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -22,6 +22,24 @@ export default function register(sdk) {
 
   const safeText = value => String(value ?? '').replace(/[^\p{L}\p{N} .:/_·|+\-]/gu, '').slice(0, 96)
 
+  // Panel chrome. Both apps draw their own bordered, padded card so the OMH
+  // surface reads as a piece of the TUI instead of loose text floating around
+  // the prompt. Every colour comes from the active theme the host hands
+  // `render`, never a literal: `primary` is the token Hermes' own Dialog card
+  // borders with, so the panel follows whatever skin is active (default gold,
+  // ares crimson, mono, …) with no OMH-side palette to keep in sync.
+  // The card costs two columns of border plus two of padding, and two rows of
+  // border; the render callsites hand the components the INNER budget.
+  const PANEL_CHROME_COLUMNS = 4
+  const PANEL_CHROME_ROWS = 2
+  const panelProps = t => ({
+    borderColor: t.color.primary,
+    borderStyle: 'round',
+    flexDirection: 'column',
+    paddingX: 1,
+    width: '100%',
+  })
+
   const readHud = () => new Promise(resolve => {
     execFile(
       __OMH_PYTHON_EXECUTABLE__,
@@ -181,11 +199,7 @@ export default function register(sdk) {
       : []
     return h(
       Box,
-      {
-        flexDirection: 'column',
-        marginTop: 1,
-        width: '100%',
-      },
+      { ...panelProps(t), marginTop: 1 },
       h(
         Box,
         { columnGap: 1, flexDirection: 'row' },
@@ -232,11 +246,11 @@ export default function register(sdk) {
     if (todo.status === 'all_done') {
       return h(
         Box,
-        { flexDirection: 'column', width: '100%' },
+        panelProps(t),
         h(
           Text,
           { wrap: 'truncate-end' },
-          h(Text, { bold: true, color: t.color.warn }, ` ${label}`),
+          h(Text, { bold: true, color: t.color.warn }, label),
           h(Text, { color: t.color.ok }, ` ✓ ${counts.done ?? 0}/${counts.total ?? 0}`),
         ),
       )
@@ -247,11 +261,11 @@ export default function register(sdk) {
     const budget = Math.max(16, columns - 10)
     return h(
       Box,
-      { flexDirection: 'column', width: '100%' },
+      panelProps(t),
       h(
         Text,
         { wrap: 'truncate-end' },
-        h(Text, { bold: true, color: t.color.warn }, ` ${label}`),
+        h(Text, { bold: true, color: t.color.warn }, label),
         h(Text, { color: t.color.muted }, `   ${counts.done ?? 0}/${counts.total ?? 0}`),
       ),
       ...shown.map((item, index) => {
@@ -268,7 +282,7 @@ export default function register(sdk) {
               color: item.state === 'active' ? t.color.ok : item.state === 'done' ? t.color.muted : t.color.text,
               strikethrough: item.state === 'done',
             },
-            ` ${Object.hasOwn(markers, item.state) ? markers[item.state] : '[ ]'} ${truncateCells(item.text, rowBudget)}`,
+            `${Object.hasOwn(markers, item.state) ? markers[item.state] : '[ ]'} ${truncateCells(item.text, rowBudget)}`,
           ),
           withMore ? h(Text, { color: t.color.muted }, `   +${more} more`) : null,
         )
@@ -286,7 +300,14 @@ export default function register(sdk) {
       input.kind === 'snapshot'
         ? { ...state, payload: input.payload, tick: state.tick + 1 }
         : state,
-    render: ({ cols, rows, state, t }) => h(Hud, { columns: cols, state, t, viewportRows: rows }),
+    // The panel's own border and padding are not content space, so both
+    // components budget against the INNER card, not the raw terminal.
+    render: ({ cols, rows, state, t }) => h(Hud, {
+      columns: Math.max(20, cols - PANEL_CHROME_COLUMNS),
+      state,
+      t,
+      viewportRows: Math.max(1, rows - PANEL_CHROME_ROWS),
+    }),
   })
 
   const todoApp = defineWidgetApp({
@@ -299,7 +320,7 @@ export default function register(sdk) {
       input.kind === 'snapshot'
         ? { ...state, payload: input.payload, tick: state.tick + 1 }
         : state,
-    render: ({ cols, state, t }) => h(TodoPanel, { columns: cols, state, t }),
+    render: ({ cols, state, t }) => h(TodoPanel, { columns: Math.max(20, cols - PANEL_CHROME_COLUMNS), state, t }),
   })
 
   openWidget(app, app.init(''))

--- a/tests/test_hermes_tui_preflight.py
+++ b/tests/test_hermes_tui_preflight.py
@@ -83,7 +83,49 @@ class HermesTuiPreflightTests(unittest.TestCase):
             self.assertTrue(preflight["widget"]["managed"])
             self.assertEqual(preflight["widget"]["interpreter"], os.path.realpath(sys.executable))
             self.assertTrue(preflight["widget"]["interpreter_ok"])
+            self.assertTrue(preflight["widget"]["themed_panel"])
+            self.assertEqual(preflight["display_skin"], {"value": "default", "explicit": False})
             self.assertEqual(widget_render_blockers(preflight), [])
+
+    def test_preflight_names_an_explicit_skin_and_a_borderless_widget(self) -> None:
+        # A widget that predates panel chrome loads fine, so it is a degraded
+        # look and never a render blocker.
+        with TemporaryDirectory() as tmp:
+            paths = _make_paths(Path(tmp))
+            _make_hermes_install(paths.hermes_home)
+            (paths.hermes_home / "config.yaml").write_text(
+                "display:\n  interface: tui\n  skin: ares\n", encoding="utf-8"
+            )
+            install_tui_widget(paths.hermes_home)
+            widget = paths.hermes_home / "tui-widgets" / "omh-status.mjs"
+            widget.write_text(
+                widget.read_text(encoding="utf-8").replace("borderStyle:", "noBorderStyle:"),
+                encoding="utf-8",
+            )
+
+            preflight = hermes_tui_preflight(paths)
+
+            self.assertFalse(preflight["widget"]["themed_panel"])
+            self.assertEqual(preflight["display_skin"], {"value": "ares", "explicit": True})
+            self.assertEqual(widget_render_blockers(preflight), [])
+
+    def test_preflight_rejects_a_hardcoded_border_colour_as_unthemed(self) -> None:
+        # A border alone is not the contract: a literal palette would fight
+        # whatever skin the user runs, so it reads as unthemed chrome.
+        with TemporaryDirectory() as tmp:
+            paths = _make_paths(Path(tmp))
+            _make_hermes_install(paths.hermes_home)
+            _write_display_interface(paths.hermes_home, "tui")
+            install_tui_widget(paths.hermes_home)
+            widget = paths.hermes_home / "tui-widgets" / "omh-status.mjs"
+            widget.write_text(
+                widget.read_text(encoding="utf-8").replace(
+                    "borderColor: t.color.primary", "borderColor: '#FFD700'"
+                ),
+                encoding="utf-8",
+            )
+
+            self.assertFalse(hermes_tui_preflight(paths)["widget"]["themed_panel"])
 
     def test_old_hermes_without_widget_loader_names_hermes_update(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -232,7 +274,7 @@ class DoctorHermesTuiChecksTests(unittest.TestCase):
     def _checks_by_name(self, paths: OmhPaths) -> dict[str, object]:
         return {check.name: check for check in run_doctor(paths)}
 
-    def test_doctor_reports_all_four_checks_ok_on_modern_install(self) -> None:
+    def test_doctor_reports_all_five_checks_ok_on_modern_install(self) -> None:
         with TemporaryDirectory() as tmp:
             paths = _make_paths(Path(tmp))
             _make_hermes_install(paths.hermes_home)
@@ -246,9 +288,45 @@ class DoctorHermesTuiChecksTests(unittest.TestCase):
                 "hermes_tui_sdk_surface",
                 "hermes_tui_interface_default",
                 "hermes_tui_widget_state",
+                "hermes_tui_widget_chrome",
             ):
                 self.assertIn(name, checks)
                 self.assertTrue(checks[name].ok, name)
+                self.assertEqual(checks[name].severity, "ok", name)
+
+    def test_doctor_warns_on_a_borderless_widget_without_flipping_the_exit_code(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _make_paths(Path(tmp))
+            _make_hermes_install(paths.hermes_home)
+            _write_display_interface(paths.hermes_home, "tui")
+            install_tui_widget(paths.hermes_home)
+            widget = paths.hermes_home / "tui-widgets" / "omh-status.mjs"
+            widget.write_text(
+                widget.read_text(encoding="utf-8").replace("borderStyle:", "noBorderStyle:"),
+                encoding="utf-8",
+            )
+
+            checks = self._checks_by_name(paths)
+            chrome = checks["hermes_tui_widget_chrome"]
+
+            self.assertTrue(chrome.ok)
+            self.assertEqual(chrome.severity, "warning")
+            self.assertIn("borderless", chrome.message)
+            self.assertIn("omh setup", chrome.next_action)
+            # The widget itself is still installed and loadable; only its look
+            # is stale, so the sibling state check stays clean.
+            self.assertEqual(checks["hermes_tui_widget_state"].severity, "ok")
+
+    def test_doctor_omits_the_chrome_check_when_no_widget_is_installed(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _make_paths(Path(tmp))
+            _make_hermes_install(paths.hermes_home)
+            _write_display_interface(paths.hermes_home, "tui")
+
+            checks = self._checks_by_name(paths)
+
+            self.assertNotIn("hermes_tui_widget_chrome", checks)
+            self.assertEqual(checks["hermes_tui_widget_state"].severity, "warning")
 
     def test_doctor_warns_with_hermes_update_next_action_on_old_hermes(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -253,7 +253,24 @@ class TuiWidgetPackTests(unittest.TestCase):
         self.assertIn("const active = !!payload.active", widget)
         self.assertIn("width: '100%'", widget)
         self.assertIn("marginTop: 1", widget)
-        self.assertNotIn("borderStyle:", widget)
+        # Panel chrome, changed on purpose (this used to assert
+        # `assertNotIn("borderStyle:")`). The borderless design rendered the
+        # HUD as loose text floating around the prompt instead of a piece of
+        # the TUI. Both apps now draw a bordered, padded card, and the border
+        # colour must come from the ACTIVE THEME the host hands `render` — a
+        # literal hex would freeze the panel on one palette while the rest of
+        # the TUI followed the user's skin.
+        self.assertIn("borderStyle: 'round'", widget)
+        self.assertIn("borderColor: t.color.primary", widget)
+        self.assertIn("paddingX: 1", widget)
+        self.assertNotIn("color: '#", widget)
+        # One panel definition serves the status HUD and both todo states, so
+        # the chrome can never drift between them.
+        self.assertEqual(widget.count("panelProps(t)"), 3)
+        # Border + padding are chrome, not content: both apps budget against
+        # the inner card, not the raw terminal.
+        self.assertIn("cols - PANEL_CHROME_COLUMNS", widget)
+        self.assertIn("rows - PANEL_CHROME_ROWS", widget)
         self.assertNotIn("metricRow", widget)
         self.assertIn("...rows.map", widget)
         self.assertNotIn("...maestroRows.map", widget)


### PR DESCRIPTION
## Feature Report

### What Changed

- The managed Hermes Modern-TUI widget (`omh-status.mjs`) now renders both of its registered apps — the status HUD in `dock-bottom` and the plan-todo checklist in `dock-top` — as rounded, padded cards instead of borderless text.
- The card's border colour is taken from the active theme (`t.color.primary`), the same token Hermes' own `Dialog` card borders with, so the panel matches whatever skin the user runs.
- `omh doctor` gains a fifth Hermes-TUI check, `hermes_tui_widget_chrome`, which reports whether the *installed* widget draws that themed card, and names the active skin.
- `hermes_tui_preflight()` gains `widget.themed_panel` and `display_skin`; `config_adapter.display_skin_selection()` reads `display.skin` (read-only — OMH never writes that key).

### Why This Exists

A user on a current Hermes (v0.20.1, `display.interface: tui`, freshly built `ui-tui/dist/entry.js`) with a current OMH widget reported that the OMH HUD "still looks like the old version, and has no bright border."

Every existing diagnostic was green, and correctly so. The widget was byte-identical to the repo copy, the SDK surface was intact, and the interface default was right. The gap was purely visual: the OMH apps rendered as bare `Box`/`Text` rows docked around the prompt input while everything else on screen — Hermes' own dialogs and cards — sat inside bordered chrome. Next to those, the OMH rows read as loose output rather than an extension of the TUI.

The gold the reporter remembered is not something OMH removed. Hermes' built-in `default` skin does define `response_border: "#FFD700"` and `input_rule: "#CD7F32"`, but those are largely Classic-TUI tokens; the Modern TUI does not draw a frame around the composer. The fix is therefore for OMH's own widget to draw its own frame — and to colour it from the host theme so it lands as chrome rather than decoration.

### User / Operator Impact

- Any user who installs hermes-agent and then installs OMH gets the bordered panels. Nothing is machine-local: the change is in the widget template that `omh setup` / `omh update` install.
- The panel automatically follows the user's skin. Someone on default gold sees a gold-bordered card; someone on `ares` sees the crimson equivalent; a mono or slate skin gets its own. No OMH-side palette to keep in sync, and no skin is activated on the user's behalf.
- `omh doctor` now names the exact condition behind the report. A widget installed by an older OMH loads and runs fine, so every other check stays green while the HUD renders flat — the new check flags that state and prints `run \`omh setup\` to refresh the managed TUI widget with themed panel chrome`.

### How It Works

- `src/omh/tui_widgets/omh-status.mjs` adds a single `panelProps(t)` factory returning `{ borderColor: t.color.primary, borderStyle: 'round', flexDirection: 'column', paddingX: 1, width: '100%' }`. The status HUD spreads it (plus its existing `marginTop: 1`) and both todo states use it directly, so the three surfaces cannot drift apart.
- Border and padding are chrome, not content. The `render` callsites hand the components the inner budget (`cols - PANEL_CHROME_COLUMNS`, `rows - PANEL_CHROME_ROWS`) so the existing truncation and activity-row-limit math keeps working unchanged against the card's interior. The manual leading spaces in the todo rows are dropped now that `paddingX` supplies the inset.
- The widget still uses only the seven SDK names it already destructures (`Box`, `Text`, `defineWidgetApp`, `h`, `openWidget`, `updateWidget`, `useShimmerPhase`) — `borderStyle`/`borderColor`/`paddingX` are plain `Box` style props, so no new SDK surface is required and `REQUIRED_WIDGET_SDK_KEYS` is unchanged.
- `_widget_draws_themed_panel()` in `src/maintenance/hermes_tui.py` requires *both* a border and a `borderColor: t.color.*` binding. A border alone would pass while a hardcoded hex fought the user's skin, so a literal palette is classified as unthemed.
- The doctor check mirrors `_hermes_tui_checks`' existing style exactly: `ok=True` always, `severity="warning"` for the degraded state so the exit code and persisted `last_doctor.ok` never flip over an optional surface, plus a concrete `next_action`. It is emitted only when a widget is actually installed — the "not installed" case is already `hermes_tui_widget_state`'s to report.

### Files And Contracts Touched

- `src/omh/tui_widgets/omh-status.mjs` — panel chrome for both apps, inner-budget render callsites.
- `src/maintenance/hermes_tui.py` — `_widget_draws_themed_panel()`, `_display_skin()`, new `widget.themed_panel` and `display_skin` fields on `omh_hermes_tui_preflight/v1`. `widget_render_blockers()` is deliberately unchanged: stale chrome still renders, so it is a degraded look, never a render blocker.
- `src/maintenance/doctor.py` — the `hermes_tui_widget_chrome` check.
- `src/install/config_adapter.py` — `display_skin_selection()`, a read-only reader over the existing `_section_scalar` helper.
- `tests/test_tui_widget_pack.py`, `tests/test_hermes_tui_preflight.py` — see below.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Test Contract Change

`tests/test_tui_widget_pack.py` asserted `assertNotIn("borderStyle:", widget)`. That assertion encoded the borderless design and is now wrong on purpose. It is replaced with the new contract — a border is present, its colour resolves through `t.color.*`, no literal hex appears (`assertNotIn("color: '#")`), and one `panelProps(t)` definition serves all three render sites — with an inline comment recording why it changed.

`test_doctor_reports_all_four_checks_ok_on_modern_install` is renamed to `..._all_five_...` and now also asserts `severity == "ok"` per check.

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke ...`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed
- [x] Relevant dry-run or smoke command: `omh setup` into a throwaway `HERMES_HOME`; read-only `omh doctor --json` against the real Hermes home
- [x] Manual Hermes/TUI check

Also run and passing: `uv run python -m omh.cli docs ulw-inventory --check`, `uv run python -m omh.cli docs ulw-site --check`, `node --check src/omh/tui_widgets/omh-status.mjs`.

### Observed Evidence

**Manual Modern-TUI render.** The worktree's widget was installed into a throwaway `HERMES_HOME` under the scratchpad (`omh setup --omh-home <tmp>/oh --hermes-home <tmp>/hh`); the reporter's real `~/.hermes` was never written to. `hermes --tui` was booted in a 120x40 tmux pane against that home. Both panels render as bordered cards:

```
 ─ setup required │ glm 5.2 │ 12s │ voice off │ 1 session            ─ …/oh-my-hermes (main)
 ╭──────────────────────────────────────────────────────────────────────────────────────────╮
 │ Todo · W2 TUI chrome   1/3                                                               │
 │ [✓] Give the OMH widget real panel chrome                                                │
 │ [•] Colour the border from the active skin                                               │
 │ [ ] Add the omh doctor chrome check                                                      │
 ╰──────────────────────────────────────────────────────────────────────────────────────────╯
 ❯

 ╭──────────────────────────────────────────────────────────────────────────────────────────╮
 │ [OMH] 1.0.6 - Oh My Hermes • Ultra Work Ready                                            │
 ╰──────────────────────────────────────────────────────────────────────────────────────────╯
```

**Border colour follows the skin, and matches host chrome.** Reading the ANSI from `tmux capture-pane -e` on the same session:

| Active skin | OMH panel border | Hermes' own Dialog border on screen |
| --- | --- | --- |
| `default` (unset) | `38;5;220` | `38;5;220` |
| `ares` | `38;5;180` | `38;5;180` |

ANSI 220 is `#FFD700` — Hermes gold, the same value `default`'s `banner_title` carries. The two OMH panels and Hermes' own card are byte-identical in both colour and corner glyphs, which is the "coherent piece of chrome" the report asked for. (The 256-colour downgrade is tmux's `screen-256color`; a truecolor terminal gets the exact hex.)

**Doctor check against the real installation.** Run read-only with `--hermes-home ~/.hermes` and a throwaway `--omh-home`, against the stale widget currently installed there:

```
hermes_tui_support           | ok      | Hermes 0.20.1 ships the TUI widget loader (ui-tui-source)
hermes_tui_sdk_surface       | ok      | Hermes widget SDK exposes every API the OMH widget uses
hermes_tui_interface_default | ok      | display.interface defaults bare `hermes` to the modern TUI
hermes_tui_widget_state      | ok      | OMH status widget installed and its embedded interpreter resolves
hermes_tui_widget_chrome     | warning | installed OMH status widget predates themed panel chrome; it renders as
                                         borderless text instead of a card bordered from the active skin (default)
                                         → run `omh setup` to refresh the managed TUI widget with themed panel chrome
```

That is the reporter's machine state reproduced: four green checks and one that names the actual symptom.

**Suites.** `tests/test_tui_widget_pack.py` + `tests/test_hermes_tui_preflight.py`: 26 tests, all passing. Full discovery: 6694 tests, 16 failures — all 16 reproduce identically on the base commit (`3af14618`) with this change stashed, and all trace to `plugin_loader_observed` reporting `registration_mismatch` against the local Hermes install. They are pre-existing and environmental, not introduced here.

### Not Tested / Not Applicable

- Activity rows rendered inside the bordered panel. The panel wraps them and the width budget was adjusted for the card interior, but no live executor progress binding was available in the throwaway home, so only the idle header was observed on screen. The row layout code itself is unchanged apart from receiving the inner column count.
- Light-polarity terminals and light-authored skins. The border resolves through `t.color.primary`, which Hermes already polarity-corrects, so no OMH-side handling exists to break — but it was not observed.
- `harness validate`, `release checklist`, `release hermes-smoke`, and the packaged-install smoke: this change touches no release, packaging, or harness contract.
- No generated artifact is affected — the catalog, docs, demo cards, capability sidecar, and ULW regions are untouched, and all five byte gates confirm it.

## Risk

- The cards cost two extra rows in each dock (four total) versus the borderless layout. On very short terminals that is real vertical budget; the status app's activity-row limit already subtracts the border rows so it degrades by showing fewer rows rather than overflowing.
- If a future skin authors a `primary` that reads poorly as a border, the panel follows it. That is the intended trade: matching the user's skin beats pinning a colour OMH picked.

## Compatibility / Rollout

- Purely a refresh of a managed artifact. `omh setup` and `omh update` overwrite the widget through the existing sha256-manifest path, so upgraders pick the card up on their next run with no migration and no config change.
- A user who has not yet re-run setup keeps the old flat widget; it still loads and works, and `omh doctor` now tells them exactly which command fixes it.
- `omh_hermes_tui_preflight/v1` gains two additive fields; no existing field changed shape.

## Release / Claims

- [x] Release-channel impact considered (`preview`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed

## Follow-Up

An opt-in OMH skin installed into `$HERMES_HOME/skins/` was scoped for this work and deliberately dropped. The widget already derives its colours from whatever skin is active, so an OMH skin would change nothing about the reported symptom; it would only add a second managed-artifact family under a host-owned root — with its own manifest, idempotence, uninstall path, and doctor coverage — for a palette nobody asked for, and which the reporter would have to activate *over* the default gold they said they wanted. If a distinct OMH visual identity is wanted later, it is a standalone goal with its own PR.
