### PR TITLE
feat(doctor): report Hermes model-routing inconsistency

### DIFF
--- a/src/install/config_adapter.py
+++ b/src/install/config_adapter.py
@@ -224,6 +224,16 @@ def memory_provider_selection(config_text: str) -> str:
     return _section_scalar(config_text, "memory", "provider")
 
 
+def model_scalar_selection(config_text: str, key: str) -> str:
+    """The scalar `model.<key>` (`default`, `provider`, `base_url`), or "".
+
+    Read-only: OMH writes `model.aliases.*` through Hermes' own `config set`
+    and never touches these keys. `maintenance.hermes_model_routing` reads them
+    to report when they disagree.
+    """
+    return _section_scalar(config_text, "model", key)
+
+
 def display_interface_selection(config_text: str) -> str:
     """The unambiguous scalar `display.interface`, or "" for other shapes."""
     lines = config_text.splitlines()

--- a/src/maintenance/doctor.py
+++ b/src/maintenance/doctor.py
@@ -319,6 +319,7 @@ def run_doctor(paths: OmhPaths) -> list[Check]:
     checks.append(_retired_skill_install_check(paths))
     checks.append(_plugin_ulw_lifecycle_check(paths))
     checks.extend(_hermes_tui_checks(paths))
+    checks.append(_hermes_model_routing_check(paths))
     profile_installs = state.get("last_team_profile_install") if isinstance(state, dict) else None
     if not profile_installs:
         checks.append(Check("team_profile_packs", True, f"optional OMH team profile packs are not installed at {paths.hermes_agents_dir}"))
@@ -471,6 +472,51 @@ def _hermes_tui_checks(paths: OmhPaths) -> list[Check]:
         )
     )
     return checks
+
+
+def _hermes_model_routing_check(paths: OmhPaths) -> Check:
+    """Does Hermes' config name the provider that serves `model.default`?
+
+    Users read a mismatch here as OMH hardcoding a model: they authenticate as
+    one provider, the picker keeps showing the family pinned in
+    `model.default`, and nothing says why. OMH writes only `model.aliases.*`,
+    so this is a Hermes user-config fault — doctor names the observed
+    disagreement and leaves the repair to the user.
+
+    ok stays True like the sibling `hermes_tui_*` checks: an inconsistent
+    Hermes model config is not an OMH install failure and must not flip the
+    doctor exit code. `severity="warning"` plus a next action carries it.
+    """
+    from .hermes_model_routing import (
+        hermes_model_routing_preflight,
+        model_routing_consistent_summary,
+        model_routing_disagreements,
+        model_routing_next_action,
+    )
+
+    preflight = hermes_model_routing_preflight(paths)
+    config = preflight["config"]
+    if not config["readable"]:
+        return Check(
+            "hermes_model_routing",
+            True,
+            (
+                f"Hermes config not found at {config['path']}; model routing consistency not checked"
+                if not config["found"]
+                else f"the `model:` block in {config['path']} is user-owned in a shape this check cannot read"
+            ),
+            observed=False,
+        )
+    disagreements = model_routing_disagreements(preflight)
+    if not disagreements:
+        return Check("hermes_model_routing", True, model_routing_consistent_summary(preflight))
+    return Check(
+        "hermes_model_routing",
+        True,
+        "; ".join(disagreements),
+        severity="warning",
+        next_action=model_routing_next_action(preflight),
+    )
 
 
 def _retired_skill_install_check(paths: OmhPaths) -> Check:

--- a/src/maintenance/hermes_model_routing.py
+++ b/src/maintenance/hermes_model_routing.py
@@ -1,0 +1,255 @@
+"""Hermes-side model-routing preflight: does the config name one provider?
+
+Hermes resolves a request from three independent ``config.yaml`` keys —
+``model.default`` (often written as ``<family>/<model>``), ``model.provider``,
+and ``model.base_url`` — plus whichever provider the user is authenticated as.
+Nothing forces those to agree, and Hermes' model picker changes the *active
+provider*, never ``model.default``. A user who is logged in to one provider and
+has a different family pinned in ``model.default`` therefore keeps seeing that
+pinned model in the picker and reads it as the wrapper hardcoding a model.
+
+This module inspects the Hermes side read-only — no subprocess, no network, no
+writes — and reports when the config does not name the provider that serves
+``model.default``. Per the repo's fault-domain model this is a Hermes
+USER-CONFIG fault: OMH reports it and never repairs it.
+
+Scope, deliberately: a finding requires ``model.provider`` to be *unpinned*
+(``auto``/unset, the merged Hermes default). An explicit pin is authoritative —
+Hermes' own ``split_model_config_default`` treats it as such — and it also makes
+a ``<family>/`` prefix a gateway namespace rather than a provider claim
+(``provider: openrouter`` with ``model: anthropic/claude-sonnet-4`` is the shape
+Hermes' own config comments document). Reporting a pinned config would flag
+those correct setups, so a pin means there is no ambiguity left to report.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+from ..config_adapter import model_scalar_selection
+from ..paths import OmhPaths
+from ..system.local_store import read_json_object_result
+from ..system.metadata_safety import require_opaque_metadata_ref
+
+HERMES_MODEL_ROUTING_SCHEMA_VERSION = "omh_hermes_model_routing/v1"
+
+# Values that mean "no explicit provider pin"; mirrors the advisory lane's
+# reading of the same key so the two surfaces cannot disagree about `auto`.
+_UNPINNED_PROVIDER_MARKERS = frozenset({"", "auto", "null", "~", "default", "none"})
+
+# Reading caps: config.yaml is tens of KB and auth.json a few KB today.
+_MAX_INSPECT_BYTES = 512_000
+# A credential pool has one entry per provider; a file claiming hundreds is not
+# a pool this check understands, so it is reported as unobserved instead.
+_MAX_CREDENTIAL_PROVIDERS = 32
+
+_HOST_SHAPE = re.compile(r"^[A-Za-z0-9._:-]{1,253}$")
+
+
+def _read_text_bounded(path: Path) -> str | None:
+    try:
+        if not path.is_file() or path.stat().st_size > _MAX_INSPECT_BYTES:
+            return None
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+
+def _model_section_is_unambiguous(config_text: str) -> bool:
+    """False when the ``model:`` block cannot be read by one canonical rule.
+
+    Tab indentation and duplicate top-level ``model:`` blocks both make the
+    tolerant scalar reader pick one shape out of several plausible ones. A
+    guess here would produce a named finding about values the user never wrote,
+    so an unreadable shape reports nothing at all.
+    """
+    if "\t" in config_text or "\x00" in config_text:
+        return False
+    return sum(1 for line in config_text.splitlines() if line.rstrip() == "model:") <= 1
+
+
+def _safe_scalar(value: str) -> str:
+    """The value when it is a safe opaque reference to echo back, else ""."""
+    try:
+        return require_opaque_metadata_ref(value, field="hermes model config value")
+    except ValueError:
+        return ""
+
+
+def _model_family(default_model: str) -> str:
+    """The ``<family>/`` prefix of a model pin, or "" when it carries none."""
+    family, separator, rest = default_model.partition("/")
+    if not separator or not rest:
+        return ""
+    return family.casefold()
+
+
+def _base_url_host(base_url: str) -> str:
+    """The host of ``model.base_url``, or "" when it cannot be read.
+
+    Only the host leaves this module. A base URL can carry userinfo, and the
+    rest of the URL is not needed to say which host serves the default model.
+    """
+    if not base_url:
+        return ""
+    candidate = base_url if "://" in base_url else f"//{base_url}"
+    try:
+        host = urlsplit(candidate).hostname or ""
+    except ValueError:
+        return ""
+    return host if _HOST_SHAPE.fullmatch(host) else ""
+
+
+def _host_core(host: str) -> str:
+    """The host without its public suffix label, casefolded.
+
+    ``openrouter.ai`` -> ``openrouter``; ``api.anthropic.com`` ->
+    ``api.anthropic``. Dropping the last label is what keeps a two-letter TLD
+    such as ``.ai`` from matching family names that merely contain those
+    letters.
+    """
+    labels = host.casefold().rstrip(".").split(".")
+    if len(labels) > 1:
+        labels = labels[:-1]
+    return ".".join(labels)
+
+
+def _host_names_family(host: str, family: str) -> bool:
+    return bool(host) and bool(family) and family in _host_core(host)
+
+
+def _credential_providers(paths: OmhPaths) -> dict[str, Any]:
+    """Which providers Hermes has stored credentials for. Names only.
+
+    Reads the top-level ``credential_pool`` keys and ``active_provider`` from
+    ``auth.json`` — provider ids, which Hermes also writes in the clear to
+    ``provider_models_cache.json``. No nested value is read, so no issued
+    credential material can reach a doctor message.
+    """
+    path = paths.hermes_home / "auth.json"
+    try:
+        if not path.is_file() or path.stat().st_size > _MAX_INSPECT_BYTES:
+            return {"observed": False, "providers": [], "active": ""}
+    except OSError:
+        return {"observed": False, "providers": [], "active": ""}
+    payload, error = read_json_object_result(path)
+    if error or payload is None:
+        return {"observed": False, "providers": [], "active": ""}
+    pool = payload.get("credential_pool")
+    if not isinstance(pool, dict) or len(pool) > _MAX_CREDENTIAL_PROVIDERS:
+        return {"observed": False, "providers": [], "active": ""}
+    providers = sorted({name for name in (_safe_scalar(str(key)) for key in pool) if name})
+    active = _safe_scalar(str(payload.get("active_provider") or ""))
+    return {"observed": True, "providers": providers, "active": active}
+
+
+def hermes_model_routing_preflight(paths: OmhPaths) -> dict[str, Any]:
+    """Inspect how Hermes' config names the provider for its default model."""
+    config_path = paths.hermes_config_path
+    config_text = _read_text_bounded(config_path)
+    if config_text is None or not _model_section_is_unambiguous(config_text):
+        return {
+            "schema_version": HERMES_MODEL_ROUTING_SCHEMA_VERSION,
+            "config": {
+                "found": config_text is not None,
+                "readable": False,
+                "path": str(config_path),
+            },
+            "default_model": {"value": "", "family": ""},
+            "provider": {"value": "", "pinned": False},
+            "base_url": {"set": False, "host": ""},
+            "credentials": {"observed": False, "providers": [], "active": ""},
+        }
+    default_model = _safe_scalar(model_scalar_selection(config_text, "default"))
+    provider = _safe_scalar(model_scalar_selection(config_text, "provider")).casefold()
+    base_url = model_scalar_selection(config_text, "base_url")
+    return {
+        "schema_version": HERMES_MODEL_ROUTING_SCHEMA_VERSION,
+        "config": {"found": True, "readable": True, "path": str(config_path)},
+        "default_model": {"value": default_model, "family": _model_family(default_model)},
+        "provider": {
+            "value": provider,
+            "pinned": provider not in _UNPINNED_PROVIDER_MARKERS,
+        },
+        "base_url": {"set": bool(base_url), "host": _base_url_host(base_url)},
+        "credentials": _credential_providers(paths),
+    }
+
+
+def model_routing_disagreements(preflight: dict[str, Any]) -> list[str]:
+    """Plain-English clauses naming the observed disagreement, empty when none.
+
+    The first clause is the finding; any further clause corroborates it. The
+    credential clause never stands alone: a provider authenticated by
+    environment variable is invisible to ``auth.json``, so an absent family
+    there is evidence about an already-inconsistent config and never a claim
+    on its own.
+    """
+    config = preflight.get("config", {})
+    if not config.get("readable"):
+        return []
+    default_model = preflight.get("default_model", {})
+    provider = preflight.get("provider", {})
+    base_url = preflight.get("base_url", {})
+    family = str(default_model.get("family") or "")
+    host = str(base_url.get("host") or "")
+    if not family or not host or provider.get("pinned"):
+        return []
+    if _host_names_family(host, family):
+        return []
+
+    provider_value = str(provider.get("value") or "")
+    clauses = [
+        f"`model.default` is `{default_model['value']}`, whose `{family}/` prefix names one provider family, "
+        f"but `model.base_url` sends every request to `{host}`, and `model.provider` is "
+        f"{f'`{provider_value}`' if provider_value else 'unset'}, which names no provider — so the provider you "
+        f"pick in Hermes' model picker does not change `model.default`"
+    ]
+    credentials = preflight.get("credentials", {})
+    stored = [str(name) for name in credentials.get("providers", [])]
+    if credentials.get("observed") and stored and family not in stored:
+        active = str(credentials.get("active") or "")
+        suffix = f" (active: `{active}`)" if active else ""
+        clauses.append(
+            f"stored Hermes credentials cover {', '.join(f'`{name}`' for name in stored)}{suffix}, "
+            f"not `{family}`"
+        )
+    return clauses
+
+
+def model_routing_consistent_summary(preflight: dict[str, Any]) -> str:
+    """Why there is nothing to reconcile, naming the reason that applies.
+
+    A single "config looks consistent" line would over-claim: most of these
+    states are "no ambiguity exists", not "all three keys were compared and
+    agreed". The reader is told which one they are in.
+    """
+    default_model = str(preflight.get("default_model", {}).get("value") or "")
+    family = str(preflight.get("default_model", {}).get("family") or "")
+    provider = preflight.get("provider", {})
+    host = str(preflight.get("base_url", {}).get("host") or "")
+    if not default_model:
+        return "no `model.default` is pinned in the Hermes config; nothing overrides the provider you select"
+    if provider.get("pinned"):
+        return (
+            f"`model.provider` is pinned to `{provider['value']}`, which is authoritative for "
+            f"`model.default` (`{default_model}`)"
+        )
+    if not family:
+        return f"`model.default` is `{default_model}`, which names no provider family to disagree with"
+    if not host:
+        return f"`model.default` is `{default_model}` and no `model.base_url` redirects where it is served"
+    return f"`model.default` is `{default_model}` and `model.base_url` (`{host}`) name the same provider family"
+
+
+def model_routing_next_action(preflight: dict[str, Any]) -> str:
+    """The user-owned repair for a disagreement; OMH never applies it."""
+    host = str(preflight.get("base_url", {}).get("host") or "")
+    return (
+        f"Reconcile these in Hermes yourself — OMH never writes Hermes model configuration. Either pin the "
+        f"provider that serves {host} (`hermes config set model.provider <name>`) or set `model.default` to a "
+        f"model the provider you actually use serves. Then rerun `omh doctor`."
+    )

--- a/tests/test_hermes_model_routing.py
+++ b/tests/test_hermes_model_routing.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from omh.maintenance.doctor import doctor_ok, run_doctor
+from omh.maintenance.hermes_model_routing import (
+    HERMES_MODEL_ROUTING_SCHEMA_VERSION,
+    hermes_model_routing_preflight,
+    model_routing_consistent_summary,
+    model_routing_disagreements,
+    model_routing_next_action,
+)
+from omh.paths import OmhPaths
+
+
+def _make_paths(root: Path) -> OmhPaths:
+    resolved = root.resolve()
+    return OmhPaths(resolved / ".omh", resolved / ".hermes")
+
+
+def _write_config(paths: OmhPaths, body: str) -> None:
+    paths.hermes_home.mkdir(parents=True, exist_ok=True)
+    paths.hermes_config_path.write_text(body, encoding="utf-8")
+
+
+def _write_auth(paths: OmhPaths, providers: list[str], active: str = "") -> None:
+    paths.hermes_home.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": 1,
+        # Values mirror the real file's shape so a regression that starts
+        # reading them would surface the marker instead of a provider id.
+        "credential_pool": {name: [{"token": f"secret-{name}"}] for name in providers},
+    }
+    if active:
+        payload["active_provider"] = active
+    (paths.hermes_home / "auth.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+# The reported config: the default names one family, the base URL routes to a
+# second host, and the provider names neither.
+_INCONSISTENT = """model:
+  default: anthropic/claude-opus-4.6
+  provider: auto
+  base_url: https://openrouter.ai/api/v1
+"""
+
+
+class ModelRoutingDetectionTests(unittest.TestCase):
+    def test_reported_three_way_inconsistency_is_named_from_observed_values(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _make_paths(Path(tmp))
+            _write_config(paths, _INCONSISTENT)
+            _write_auth(paths, ["copilot", "openai-codex"], active="openai-codex")
+
+            preflight = hermes_model_routing_preflight(paths)
+            clauses = model_routing_disagreements(preflight)
+
+            self.assertEqual(preflight["schema_version"], HERMES_MODEL_ROUTING_SCHEMA_VERSION)
+            self.assertEqual(preflight["default_model"]["family"], "anthropic")
+            self.assertFalse(preflight["provider"]["pinned"])
+            self.assertEqual(preflight["base_url"]["host"], "openrouter.ai")
+            self.assertEqual(len(clauses), 2)
+            self.assertIn("anthropic/claude-opus-4.6", clauses[0])
+            self.assertIn("openrouter.ai", clauses[0])
+            self.assertIn("`auto`", clauses[0])
+            self.assertIn("does not change `model.default`", clauses[0])
+            self.assertIn("`copilot`, `openai-codex`", clauses[1])
+            self.assertIn("active: `openai-codex`", clauses[1])
+            self.assertIn("openrouter.ai", model_routing_next_action(preflight))
+
+    def test_credential_clause_is_omitted_when_the_family_is_credentialed(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _make_paths(Path(tmp))
+            _write_config(paths, _INCONSISTENT)
+            _write_auth(paths, ["anthropic", "openai-codex"], active="anthropic")
+
+            clauses = model_routing_disagreements(hermes_model_routing_preflight(paths))
+
+            self.assertEqual(len(clauses), 1)
+            self.assertIn("openrouter.ai", clauses[0])
+
+    def test_base_url_userinfo_never_reaches_the_finding(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _make_paths(Path(tmp))
+            _write_config(
+                paths,
+                "model:\n"
+                "  default: anthropic/claude-opus-4.6\n"
+                "  provider: auto\n"
+                "  base_url: https://user:hunter2@gateway.example.net/v1\n",
+            )
+
+            preflight = hermes_model_routing_preflight(paths)
+            clauses = model_routing_disagreements(preflight)
+
+            self.assertEqual(preflight["base_url"]["host"], "gateway.example.net")
+            self.assertEqual(len(clauses), 1)
+            self.assertNotIn("hunter2", clauses[0])
+
+    def test_credential_reader_returns_provider_names_only(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _make_paths(Path(tmp))
+            _write_config(paths, _INCONSISTENT)
+            _write_auth(paths, ["copilot"], active="copilot")
+
+            credentials = hermes_model_routing_preflight(paths)["credentials"]
+
+            self.assertEqual(credentials["providers"], ["copilot"])
+            self.assertNotIn("secret-copilot", json.dumps(credentials))
+
+
+class ModelRoutingNegativeControlTests(unittest.TestCase):
+    """Consistent, unpinnable, and unreadable configs must report nothing."""
+
+    def _clauses(self, body: str) -> list[str]:
+        with TemporaryDirectory() as tmp:
+            paths = _make_paths(Path(tmp))
+            _write_config(paths, body)
+            return model_routing_disagreements(hermes_model_routing_preflight(paths))
+
+    def test_base_url_on_the_same_family_is_consistent(self) -> None:
+        self.assertEqual(
+            self._clauses(
+                "model:\n"
+                "  default: anthropic/claude-opus-4.6\n"
+                "  provider: auto\n"
+                "  base_url: https://api.anthropic.com/v1\n"
+            ),
+            [],
+        )
+
+    def test_pinned_gateway_provider_makes_the_prefix_a_namespace(self) -> None:
+        # `provider: openrouter` with an `anthropic/` model is the shape Hermes'
+        # own config comments document; flagging it would be a false positive.
+        self.assertEqual(
+            self._clauses(
+                "model:\n"
+                "  default: anthropic/claude-sonnet-4\n"
+                "  provider: openrouter\n"
+                "  base_url: https://openrouter.ai/api/v1\n"
+            ),
+            [],
+        )
+
+    def test_custom_provider_pin_with_any_endpoint_is_not_a_finding(self) -> None:
+        self.assertEqual(
+            self._clauses(
+                "model:\n"
+                "  default: anthropic/claude-opus-4.6\n"
+                "  provider: custom\n"
+                "  base_url: https://gateway.internal.example/v1\n"
+            ),
+            [],
+        )
+
+    def test_no_base_url_is_not_a_finding(self) -> None:
+        self.assertEqual(
+            self._clauses("model:\n  default: anthropic/claude-opus-4.6\n  provider: auto\n"),
+            [],
+        )
+
+    def test_model_default_without_a_family_prefix_is_not_a_finding(self) -> None:
+        self.assertEqual(
+            self._clauses(
+                "model:\n  default: gpt-5.5\n  provider: auto\n  base_url: https://openrouter.ai/api/v1\n"
+            ),
+            [],
+        )
+
+    def test_missing_model_block_is_not_a_finding(self) -> None:
+        self.assertEqual(self._clauses("display:\n  interface: tui\n"), [])
+
+    def test_two_letter_tld_never_matches_a_family_by_accident(self) -> None:
+        # `.ai` is a substring of "anthropic"; dropping the suffix label is what
+        # keeps `openrouter.ai` from reading as an anthropic host.
+        clauses = self._clauses(_INCONSISTENT)
+        self.assertEqual(len(clauses), 1)
+
+    def test_duplicate_model_blocks_report_nothing(self) -> None:
+        self.assertEqual(
+            self._clauses(
+                "model:\n  default: anthropic/claude-opus-4.6\n"
+                "model:\n  provider: auto\n  base_url: https://openrouter.ai/api/v1\n"
+            ),
+            [],
+        )
+
+    def test_tab_indented_config_reports_nothing(self) -> None:
+        self.assertEqual(
+            self._clauses("model:\n\tdefault: anthropic/claude-opus-4.6\n\tbase_url: https://openrouter.ai/v1\n"),
+            [],
+        )
+
+    def test_missing_config_reports_nothing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _make_paths(Path(tmp))
+            preflight = hermes_model_routing_preflight(paths)
+            self.assertFalse(preflight["config"]["found"])
+            self.assertEqual(model_routing_disagreements(preflight), [])
+
+    def test_unreadable_auth_file_degrades_to_no_credential_clause(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _make_paths(Path(tmp))
+            _write_config(paths, _INCONSISTENT)
+            paths.hermes_home.joinpath("auth.json").write_text("not json {", encoding="utf-8")
+
+            preflight = hermes_model_routing_preflight(paths)
+
+            self.assertFalse(preflight["credentials"]["observed"])
+            self.assertEqual(len(model_routing_disagreements(preflight)), 1)
+
+    def test_consistent_summary_names_the_reason_that_applies(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _make_paths(Path(tmp))
+            _write_config(paths, "model:\n  default: anthropic/claude-opus-4.6\n  provider: anthropic\n")
+            summary = model_routing_consistent_summary(hermes_model_routing_preflight(paths))
+            self.assertIn("pinned to `anthropic`", summary)
+
+        with TemporaryDirectory() as tmp:
+            paths = _make_paths(Path(tmp))
+            _write_config(paths, "display:\n  interface: tui\n")
+            summary = model_routing_consistent_summary(hermes_model_routing_preflight(paths))
+            self.assertIn("no `model.default` is pinned", summary)
+
+
+class DoctorModelRoutingCheckTests(unittest.TestCase):
+    def _check(self, paths: OmhPaths):
+        return next(item for item in run_doctor(paths) if item.name == "hermes_model_routing")
+
+    def test_doctor_warns_without_flipping_the_exit_code(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _make_paths(Path(tmp))
+            _write_config(paths, _INCONSISTENT)
+            _write_auth(paths, ["copilot", "openai-codex"], active="openai-codex")
+
+            checks = run_doctor(paths)
+            check = next(item for item in checks if item.name == "hermes_model_routing")
+
+            # A Hermes user-config fault is not an OMH install failure.
+            self.assertTrue(check.ok)
+            self.assertEqual(check.severity, "warning")
+            self.assertIn("anthropic/claude-opus-4.6", check.message)
+            self.assertIn("openrouter.ai", check.message)
+            self.assertIn("openai-codex", check.message)
+            self.assertIn("hermes config set model.provider", check.next_action)
+            self.assertEqual(
+                doctor_ok(checks),
+                doctor_ok([item for item in checks if item.name != "hermes_model_routing"]),
+            )
+
+    def test_doctor_reports_ok_for_a_consistent_config(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _make_paths(Path(tmp))
+            _write_config(
+                paths,
+                "model:\n  default: anthropic/claude-opus-4.6\n"
+                "  provider: auto\n  base_url: https://api.anthropic.com/v1\n",
+            )
+
+            check = self._check(paths)
+
+            self.assertTrue(check.ok)
+            self.assertEqual(check.severity, "ok")
+            self.assertTrue(check.observed)
+
+    def test_doctor_skips_quietly_when_the_hermes_config_is_absent(self) -> None:
+        with TemporaryDirectory() as tmp:
+            check = self._check(_make_paths(Path(tmp)))
+            self.assertTrue(check.ok)
+            self.assertFalse(check.observed)
+            self.assertEqual(check.severity, "ok")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New read-only preflight `src/maintenance/hermes_model_routing.py` (`omh_hermes_model_routing/v1`) that inspects how Hermes' `config.yaml` names the provider serving `model.default`.
- New `omh doctor` check `hermes_model_routing` that reports a three-way disagreement between `model.default`'s family prefix, `model.provider`, `model.base_url`'s host, and the providers Hermes actually holds credentials for.
- New public `model_scalar_selection(config_text, key)` in `src/install/config_adapter.py`, reusing the repo's existing tolerant indentation-based `_section_scalar` reader.

### Why This Exists

- A user reported: "I'm connected to ChatGPT/Codex but `opus 4.6` shows up in the model selection," and suspected OMH hardcoded a model name.
- OMH does not. It writes only `model.aliases.<alias>` keys through Hermes' own `config set` (`src/coding/hermes_model_config.py`) and never `model.default`, `model.provider`, or `model.base_url`. Hermes' own `provider_models_cache.json` is correctly partitioned too.
- The real cause was a three-way inconsistency in the user's own Hermes config: `model.default: anthropic/claude-opus-4.6` names one provider family, `model.base_url: https://openrouter.ai/api/v1` routes to a second host, and `model.provider: auto` names neither. Hermes' model picker changes the *active provider*, never `model.default`, so the pinned model keeps showing regardless of which provider is selected.
- Nothing anywhere told the user this. Per the repo's fault-domain model this is a Hermes USER-CONFIG fault, so OMH must report it and must never patch it. Absent that report, OMH wears the blame for a fault it does not own.

### User / Operator Impact

- `omh doctor` now names the actual disagreement in plain English, derived entirely from observed values, and hands back a user-owned repair. Against the reporting user's real config:

```
- hermes_model_routing: `model.default` is `anthropic/claude-opus-4.6`, whose `anthropic/` prefix
  names one provider family, but `model.base_url` sends every request to `openrouter.ai`, and
  `model.provider` is `auto`, which names no provider — so the provider you pick in Hermes' model
  picker does not change `model.default`; stored Hermes credentials cover `copilot`, `openai-codex`
  (active: `openai-codex`), not `anthropic`
    Fix: Reconcile these in Hermes yourself — OMH never writes Hermes model configuration. Either
    pin the provider that serves openrouter.ai (`hermes config set model.provider <name>`) or set
    `model.default` to a model the provider you actually use serves. Then rerun `omh doctor`.
```

- Exit code is unchanged. The check is always `ok=True` with `severity="warning"`, mirroring the sibling `hermes_tui_*` checks: a Hermes user-config fault is not an OMH install failure.

### How It Works

- **Sibling module, not an extension of `hermes_tui.py`.** Same established pattern — schema-versioned, bounded reads, no fail-open, no subprocess, no network, no writes — but a different fault domain (provider routing vs. HUD render surface). A separate schema version lets each preflight evolve without forcing a version bump on the other.
- **No YAML dependency.** `model.default`, `model.provider`, and `model.base_url` are read through the repo's existing tolerant indentation-based reader, exposed as `model_scalar_selection()` next to `memory_provider_selection()` / `display_interface_selection()`.
- **A finding requires `model.provider` to be unpinned** (`auto`/unset/null/default). An explicit pin is authoritative — Hermes' own `split_model_config_default` docstring says runtime resolution treats it so — and it also makes a `<family>/` prefix a gateway namespace rather than a provider claim. `provider: openrouter` with `model: anthropic/claude-sonnet-4` is the shape Hermes' *own* `config.yaml` comments document. Flagging a pinned config would false-positive on correct setups, so a pin means there is no ambiguity left to report.
- **Credential reading is names-only.** Only the top-level `credential_pool` keys and `active_provider` scalar are read from `auth.json` — provider ids, which Hermes also writes in the clear to `provider_models_cache.json`. No nested value is ever touched, and each id passes `require_opaque_metadata_ref` before it can reach a message.
- **The credential clause never stands alone.** A provider authenticated by environment variable is invisible to `auth.json`, so an absent family there corroborates an already-inconsistent config but is never a standalone claim.
- **Only the host of `model.base_url` leaves the module** — a base URL can carry userinfo, and the host is all that is needed to say who serves the default.
- **Host/family matching drops the public-suffix label** before comparing. `.ai` is a substring of "anthropic"; without this, `openrouter.ai` would read as an anthropic host and the reported case would be silently missed.
- **Every degradation is silent.** Missing config, missing Hermes install, unparseable values, tab indentation, duplicate `model:` blocks, or an unreadable `auth.json` all produce "nothing to report" — never a crash, never a false positive.

### Files And Contracts Touched

- `src/maintenance/hermes_model_routing.py` (new) — contract `omh_hermes_model_routing/v1`.
- `src/maintenance/doctor.py` — new `_hermes_model_routing_check()`, appended after `_hermes_tui_checks`. Check name `hermes_model_routing`.
- `src/install/config_adapter.py` — new public `model_scalar_selection()`; read-only, no writer counterpart.
- `tests/test_hermes_model_routing.py` (new) — 19 tests.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke ...`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [x] Manual Hermes/TUI check: ran `omh doctor` against the reporting user's real inconsistent `~/.hermes/config.yaml`; output quoted above.

Also run and passing, beyond the template list:

- [x] `uv run python -m omh.cli docs ulw-inventory --check`
- [x] `uv run python -m omh.cli docs ulw-site --check`

### Observed Evidence

- `tests/test_hermes_model_routing.py`: 19 tests, all passing. Positive detection of the reported config; credential-clause suppression when the family *is* credentialed; userinfo in `base_url` never reaching the finding; credential reader returning provider names only. Negative controls: same-family `base_url`, pinned gateway provider (`openrouter` + `anthropic/…`), pinned `custom` provider, absent `base_url`, prefix-less `model.default`, absent `model:` block, duplicate `model:` blocks, tab indentation, missing config file, unreadable `auth.json`, and a dedicated guard that a two-letter TLD never matches a family by accident.
- Full suite: `Ran 6709 tests` with 16 failures. Those 16 are **pre-existing on the branch base** — I captured the sorted `FAIL:`/`ERROR:` list with and without this change and they are byte-identical. The failures are `omh doctor` exit-code assertions caused by the pre-existing blocking `plugin_loader_observed` check, unrelated to this change. This branch adds zero failures.
- Doctor exit code is unchanged by this check. `tests/test_hermes_model_routing.py` asserts `doctor_ok(checks) == doctor_ok(checks without hermes_model_routing)` on the inconsistent fixture.
- `uv run --group lint ruff check src tests` → `All checks passed!` (with one pre-existing unrelated warning about an invalid `# noqa` directive on `src/commands/main.py:1`).
- No test asserts a total doctor check count; every existing doctor test looks checks up by name, so no exact-count assertion needed updating. I grepped `run_doctor` across `tests/` to confirm this rather than assuming it.

### Not Tested / Not Applicable

- `harness validate`, `release checklist`, `release hermes-smoke`, and the tarball smoke: no harness, release, packaging, or distribution surface is touched — this adds one doctor check and one read-only module.
- `omh --help`: no CLI surface, flag, or command was added or changed.
- No live Hermes run: the check never invokes Hermes, makes no subprocess call, and makes no network call.
- Host matching drops exactly one suffix label, so a multi-label public suffix such as `example.co.uk` is compared including `co`. No observed Hermes config uses one, and the failure mode is a missed finding, not a false one.

## Risk

- Low. The check is additive, always `ok=True`, and cannot change `omh doctor`'s exit code or persisted `last_doctor.ok`.
- The residual risk is a false-positive warning on an unusual-but-correct config. It is bounded by requiring `model.provider` to be unpinned before anything is reported, and by the negative-control corpus above, which pins the two correct-config shapes (gateway pin, custom pin) that a looser rule would have flagged.
- Reading `auth.json` is new for this lane. It is confined to top-level key names and one scalar, each validated as a safe opaque metadata reference; a test asserts no credential material appears in the returned payload.

## Compatibility / Rollout

- No config migration, no new dependency, no schema change to any existing contract. Pure Python 3.11+.
- Older Hermes installs, absent installs, and configs without a `model:` block report `observed=False` and stay silent.

## Release / Claims

- [x] Release-channel impact considered (`local`; no packaging or release surface touched)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data — the quoted doctor output contains provider ids only
- [x] Known manual Hermes checks are listed

## Follow-Up

- If Hermes gains a first-class "provider that serves this default" resolution, this check should read that instead of inferring from the prefix and host.
- The pinned-provider case is deliberately out of scope. If a real pinned-config fault is reported, revisit it with the gateway-vs-family distinction handled explicitly rather than by skipping.
