### PR TITLE
fix(update): slim the install/update artifact and publish to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,6 +200,33 @@ jobs:
             npm publish "$OMH_TARBALL" --access public --provenance
           fi
 
+      - name: Publish or verify PyPI package
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The same immutable wheel that became the GitHub release asset also
+          # goes to PyPI, so `pip install --upgrade oh-my-hermes` resolves the
+          # newest version itself. That is what lets `omh update` leave the
+          # ~44 MB on-demand branch archive behind WITHOUT omh's own process
+          # ever opening a socket to ask which version is newest -- the
+          # no-network boundary in AGENTS.md stays intact because the index
+          # does the resolving.
+          # Idempotent across re-runs, and it re-verifies rather than trusting
+          # a previous run: a version already on PyPI must carry this exact
+          # wheel, byte for byte.
+          published_sha256=""
+          if response="$(curl -fsS "https://pypi.org/pypi/oh-my-hermes/$OMH_VERSION/json" 2>/dev/null)"; then
+            published_sha256="$(
+              printf '%s' "$response" \
+                | python3 -c 'import json,sys; print(next((u["digests"]["sha256"] for u in json.load(sys.stdin)["urls"] if u["packagetype"] == "bdist_wheel"), ""))'
+            )"
+          fi
+          if [ -n "$published_sha256" ]; then
+            test "$published_sha256" = "$OMH_WHEEL_SHA256"
+          else
+            uv publish --trusted-publishing always "$OMH_WHEEL"
+          fi
+
       - name: Render verified Homebrew formula
         shell: bash
         run: |

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -351,9 +351,12 @@ equivalent — this is what the installer automates:
 ```powershell
 py -m venv $env:LOCALAPPDATA\omh\venv
 & $env:LOCALAPPDATA\omh\venv\Scripts\python.exe -m pip install --upgrade `
-    https://github.com/rlaope/oh-my-hermes/archive/refs/heads/main.zip
+    https://github.com/rlaope/oh-my-hermes/releases/download/v<version>/oh_my_hermes-<version>-py3-none-any.whl
 & $env:LOCALAPPDATA\omh\venv\Scripts\omh.exe setup
 ```
+
+The installer resolves `<version>` for you from the `releases/latest` redirect.
+Doing it by hand means naming the release you want.
 
 Where it differs from `install.sh`, it differs because the platform does:
 
@@ -835,26 +838,53 @@ Run the installer:
 curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | sh
 ```
 
-By default this installs the preview channel from the `main` branch archive.
-For pinned stable installs, pass a release version after the matching
-`v<version>` tag exists:
+By default this installs the `stable` channel: the newest published release,
+as a wheel. To pin a specific release instead, pass its version — the channel
+is already the default, so naming it is optional but harmless:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | OMH_CHANNEL=stable OMH_VERSION=<version> sh
 ```
 
+To track the unreleased `main` branch instead, ask for `preview` explicitly:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | OMH_CHANNEL=preview sh
+```
+
 The two channels download different artifacts, and the difference is large
 enough to plan around:
 
-| Channel | Artifact | Measured size |
-| --- | --- | --- |
-| `stable` | `oh_my_hermes-<version>-py3-none-any.whl` release asset | 2,714,885 bytes at v1.0.6 |
-| `preview` | `main` branch repository archive | 46,012,605 bytes on 2026-08-15 |
+| Channel | Artifact | Measured size | Measured time |
+| --- | --- | --- | --- |
+| `stable` (default) | `oh_my_hermes-<version>-py3-none-any.whl` release asset | 2,714,885 bytes at v1.0.6 | 0.55s |
+| `preview` | `main` branch repository archive | 46,012,605 bytes on 2026-08-15 | 5.71s |
 
-The preview archive is the whole repository, including `assets/`, `tests/`,
-and `site/`, none of which is needed to run `omh`. It stays an archive because
-GitHub publishes release assets per tag and there is no per-branch wheel to
-point at. Prefer `stable` unless you specifically need unreleased `main`.
+Sizes and times measured 2026-08-15 with `curl`. Two things make the gap
+bigger than the byte ratio suggests. The preview archive is the whole
+repository, including `assets/`, `tests/`, and `site/`, none of which is
+needed to run `omh`. And GitHub *generates* `archive/refs/heads/<branch>.zip`
+on demand for every request rather than serving a cached object, so preview
+pays generation latency each time — on an ordinary connection that download
+has been observed to take over five minutes. Release assets are static objects
+served from a CDN.
+
+Preview stays an archive because GitHub publishes release assets per tag and
+there is no per-branch wheel to point at. Use it only when you specifically
+need unreleased `main`.
+
+A version-less `stable` install asks GitHub which release is newest by reading
+a single redirect (`releases/latest`), which costs about 0.25s. If that lookup
+fails, the installer says so and tells you to pass `OMH_VERSION` or switch to
+`OMH_CHANNEL=preview`; it never guesses a URL. The installer does this lookup
+itself and passes the resolved version to `omh setup`, because `omh` makes no
+network calls of its own.
+
+> **`omh update` still defaults to `preview`.** Only the installer default
+> moved. Until the release-version lookup has a home inside `omh` that does not
+> break its no-network boundary, a plain `omh update` keeps fetching the branch
+> archive. To get the slim path from `omh update` today, name the release:
+> `omh update --channel stable --version <version>`.
 
 Releases published before the wheel-publishing workflow existed carry no
 asset. If a stable install reports a 404 for the wheel, install that tag from

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -843,8 +843,30 @@ For pinned stable installs, pass a release version after the matching
 curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | OMH_CHANNEL=stable OMH_VERSION=<version> sh
 ```
 
+The two channels download different artifacts, and the difference is large
+enough to plan around:
+
+| Channel | Artifact | Measured size |
+| --- | --- | --- |
+| `stable` | `oh_my_hermes-<version>-py3-none-any.whl` release asset | 2,714,885 bytes at v1.0.6 |
+| `preview` | `main` branch repository archive | 46,012,605 bytes on 2026-08-15 |
+
+The preview archive is the whole repository, including `assets/`, `tests/`,
+and `site/`, none of which is needed to run `omh`. It stays an archive because
+GitHub publishes release assets per tag and there is no per-branch wheel to
+point at. Prefer `stable` unless you specifically need unreleased `main`.
+
+Releases published before the wheel-publishing workflow existed carry no
+asset. If a stable install reports a 404 for the wheel, install that tag from
+the repository archive instead:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | OMH_PACKAGE_URL=https://github.com/rlaope/oh-my-hermes/archive/refs/tags/v<version>.zip sh
+```
+
 For custom release archives or local package sources accepted by `pip`, pass
-`OMH_PACKAGE_URL`.
+`OMH_PACKAGE_URL`. To install from a fork or mirror, override
+`OMH_REPO_ASSET_ROOT` and `OMH_REPO_ARCHIVE_ROOT`.
 
 The installer creates an isolated OMH virtual environment and links the `omh`
 command into `~/.local/bin` when possible. It does not run `omh setup`, register

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -31,30 +31,41 @@ hermes skills tap add rlaope/oh-my-hermes
 hermes skills install rlaope/oh-my-hermes/skills/omh-routing --yes
 ```
 
-Pinned stable install, which resolves to the published
-`oh_my_hermes-<version>-py3-none-any.whl` release asset:
-
-```sh
-curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | OMH_CHANNEL=stable OMH_VERSION=<version> sh
-```
-
-Because the stable channel names that asset by convention, a release that
-publishes no wheel leaves `OMH_CHANNEL=stable` with nothing to fetch. The
-"Required Checks" wheel steps below are what keep the asset present; do not
-tag a release that skips them.
-
-Preview install, which downloads the full `main` repository archive (measured
-46,012,605 bytes on 2026-08-15) because GitHub publishes release assets per
-tag only:
+Default install, which resolves the newest release through the
+`releases/latest` redirect *in the installer script* and fetches its published
+`oh_my_hermes-<version>-py3-none-any.whl` asset. The lookup lives in
+`install.sh`/`install.ps1` rather than in `omh` because core `omh` makes no
+network calls:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | sh
 ```
 
+Pinned stable install:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | OMH_VERSION=<version> sh
+```
+
+Because the stable channel names that asset by convention, **a release that
+publishes no wheel breaks the default install path for everyone**, not just
+for people who pinned that version. The "Required Checks" wheel steps below are
+what keep the asset present; do not tag a release that skips them. The same
+applies to the `latest` pointer: whatever GitHub marks as the latest release
+must carry a wheel.
+
+Preview install, now explicit opt-in, which downloads the full `main`
+repository archive (measured 46,012,605 bytes on 2026-08-15) because GitHub
+publishes release assets per tag only:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | OMH_CHANNEL=preview sh
+```
+
 Preview update with an auditable source ref:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | OMH_SOURCE_REF=main@<sha> sh
+curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | OMH_CHANNEL=preview OMH_SOURCE_REF=main@<sha> sh
 ```
 
 Custom archive, and the documented fallback for a tag with no published wheel

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -14,10 +14,44 @@ public claims are all checked.
 
 ## Package-manager distribution
 
-The tag-driven npm/Bun, GitHub wheel, and Homebrew tap release is defined by
-`.github/workflows/release.yml`. Its release order, one-time external setup,
+The tag-driven npm/Bun, PyPI, GitHub wheel, and Homebrew tap release is defined
+by `.github/workflows/release.yml`. Its release order, one-time external setup,
 resume rules, rollback matrix, immutable artifact checks, and pending-first-
 release status are the single contract in [Distribution](DISTRIBUTION.md).
+
+### PyPI, and why it exists
+
+The workflow publishes the same immutable wheel to PyPI that it uploads as the
+GitHub release asset. This is not a convenience mirror -- it is what lets a
+version-less update stay fast without breaking a product boundary.
+
+`omh update` has to answer "which version is newest". Core `omh` may not ask
+that question itself: `AGENTS.md` forbids network calls inside core features
+without an owner-approved scoped integration, and `plugin_risk_audit.py` flags
+the pattern. Having pip resolve the version against an index moves the network
+call to the package manager, where it already lives, so the boundary stays
+true.
+
+The alternative was rejected on evidence, not taste: pip cannot resolve
+"latest" from GitHub releases at all. `pip install --no-index --find-links
+https://github.com/rlaope/oh-my-hermes/releases oh-my-hermes` fails with
+"from versions: none", because that page carries no `.whl` hrefs -- the assets
+are lazy-loaded.
+
+**One-time owner setup, required before this step can succeed.** Configure PyPI
+Trusted Publishing for the `oh-my-hermes` project against this repository, the
+`release.yml` workflow, and the `npm` environment the job already declares. The
+job needs no token: it publishes through the `id-token: write` permission the
+workflow already grants. Until that is configured, the step fails and the
+release stops there -- deliberately, rather than shipping a release whose
+artifacts disagree across indexes.
+
+**Sequencing.** The installer scripts already default to the newest release and
+resolve it through the `releases/latest` redirect in shell, so fresh installs
+are slim today. Switching `omh update`'s own default to a name-based
+`pip install --upgrade oh-my-hermes` is a follow-up, and it must not land until
+at least one release has actually been published to PyPI; otherwise every
+existing install's update path breaks on a package the index does not carry.
 
 Those package-manager artifacts extend the stable channel; they do not replace
 the installer, Hermes skill tap, generated-document, or evidence checks below.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -31,13 +31,21 @@ hermes skills tap add rlaope/oh-my-hermes
 hermes skills install rlaope/oh-my-hermes/skills/omh-routing --yes
 ```
 
-Pinned stable install:
+Pinned stable install, which resolves to the published
+`oh_my_hermes-<version>-py3-none-any.whl` release asset:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | OMH_CHANNEL=stable OMH_VERSION=<version> sh
 ```
 
-Preview install:
+Because the stable channel names that asset by convention, a release that
+publishes no wheel leaves `OMH_CHANNEL=stable` with nothing to fetch. The
+"Required Checks" wheel steps below are what keep the asset present; do not
+tag a release that skips them.
+
+Preview install, which downloads the full `main` repository archive (measured
+46,012,605 bytes on 2026-08-15) because GitHub publishes release assets per
+tag only:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | sh
@@ -49,7 +57,8 @@ Preview update with an auditable source ref:
 curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | OMH_SOURCE_REF=main@<sha> sh
 ```
 
-Custom archive:
+Custom archive, and the documented fallback for a tag with no published wheel
+asset:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | OMH_PACKAGE_URL=https://github.com/rlaope/oh-my-hermes/archive/refs/tags/v<version>.zip sh

--- a/install.ps1
+++ b/install.ps1
@@ -77,6 +77,7 @@ function Test-OmhEnvSet {
 }
 
 $OmhRepoArchiveRoot = Get-OmhEnv 'OMH_REPO_ARCHIVE_ROOT' 'https://github.com/rlaope/oh-my-hermes/archive/refs'
+$OmhRepoAssetRoot   = Get-OmhEnv 'OMH_REPO_ASSET_ROOT' 'https://github.com/rlaope/oh-my-hermes/releases/download'
 $OmhChannel         = Get-OmhEnv 'OMH_CHANNEL' 'preview'
 $OmhVersion         = Get-OmhEnv 'OMH_VERSION'
 $OmhPackageUrl      = Get-OmhEnv 'OMH_PACKAGE_URL'
@@ -620,7 +621,18 @@ try {
                     Stop-OmhInstall @('omh installer: OMH_CHANNEL=stable requires OMH_VERSION, for example OMH_VERSION=1.0.1.')
                 }
                 $OmhTag = Get-OmhNormalizedTag $OmhVersion
-                $OmhPackageUrl = "$OmhRepoArchiveRoot/tags/$OmhTag.zip"
+                # The release workflow only accepts a vX.Y.Z tag and uploads a
+                # wheel named from that version, so the asset URL is
+                # predictable. It is ~2.7 MB against ~44 MB for the tag
+                # archive, which carries assets, tests, and site that nothing
+                # needs to run omh. A version outside that shape has no
+                # published asset to name, so it keeps the archive.
+                $OmhReleaseVersion = $OmhTag.Substring(1)
+                if ($OmhReleaseVersion -match '^[0-9]+\.[0-9]+\.[0-9]+$') {
+                    $OmhPackageUrl = "$OmhRepoAssetRoot/$OmhTag/oh_my_hermes-$OmhReleaseVersion-py3-none-any.whl"
+                } else {
+                    $OmhPackageUrl = "$OmhRepoArchiveRoot/tags/$OmhTag.zip"
+                }
                 if (-not $OmhSourceRef) { $OmhSourceRef = $OmhTag }
             }
             'local' {

--- a/install.ps1
+++ b/install.ps1
@@ -78,7 +78,10 @@ function Test-OmhEnvSet {
 
 $OmhRepoArchiveRoot = Get-OmhEnv 'OMH_REPO_ARCHIVE_ROOT' 'https://github.com/rlaope/oh-my-hermes/archive/refs'
 $OmhRepoAssetRoot   = Get-OmhEnv 'OMH_REPO_ASSET_ROOT' 'https://github.com/rlaope/oh-my-hermes/releases/download'
-$OmhChannel         = Get-OmhEnv 'OMH_CHANNEL' 'preview'
+$OmhRepoLatestUrl   = Get-OmhEnv 'OMH_REPO_LATEST_URL' 'https://github.com/rlaope/oh-my-hermes/releases/latest'
+# Stable installs the ~2.7 MB release wheel; preview installs the ~44 MB branch
+# archive, which GitHub generates per request rather than serving from a CDN.
+$OmhChannel         = Get-OmhEnv 'OMH_CHANNEL' 'stable'
 $OmhVersion         = Get-OmhEnv 'OMH_VERSION'
 $OmhPackageUrl      = Get-OmhEnv 'OMH_PACKAGE_URL'
 $OmhSourceRef       = Get-OmhEnv 'OMH_SOURCE_REF'
@@ -618,7 +621,25 @@ try {
             }
             'stable' {
                 if (-not $OmhVersion) {
-                    Stop-OmhInstall @('omh installer: OMH_CHANNEL=stable requires OMH_VERSION, for example OMH_VERSION=1.0.1.')
+                    # GitHub answers /releases/latest with a 302 whose Location
+                    # carries the newest tag, so "latest" costs one header read
+                    # and no API token. Only the redirect target is fetched.
+                    $OmhLatestLocation = ''
+                    try {
+                        $OmhLatestResponse = Invoke-WebRequest -Uri $OmhRepoLatestUrl -Method Head -MaximumRedirection 0 -ErrorAction Stop
+                        $OmhLatestLocation = [string]$OmhLatestResponse.Headers['Location']
+                    } catch {
+                        $OmhLatestError = $_.Exception.Response
+                        if ($OmhLatestError) { $OmhLatestLocation = [string]$OmhLatestError.Headers['Location'] }
+                    }
+                    if ($OmhLatestLocation -match '/releases/tag/v([0-9]+\.[0-9]+\.[0-9]+)/?$') {
+                        $OmhVersion = $Matches[1]
+                    } else {
+                        Stop-OmhInstall @(
+                            "omh installer: could not resolve the latest release from $OmhRepoLatestUrl.",
+                            'omh installer: set OMH_VERSION to pin one, or OMH_CHANNEL=preview to track main.'
+                        )
+                    }
                 }
                 $OmhTag = Get-OmhNormalizedTag $OmhVersion
                 # The release workflow only accepts a vX.Y.Z tag and uploads a

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,12 @@ set -eu
 
 OMH_REPO_ARCHIVE_ROOT="${OMH_REPO_ARCHIVE_ROOT:-https://github.com/rlaope/oh-my-hermes/archive/refs}"
 OMH_REPO_ASSET_ROOT="${OMH_REPO_ASSET_ROOT:-https://github.com/rlaope/oh-my-hermes/releases/download}"
-OMH_CHANNEL="${OMH_CHANNEL:-preview}"
+OMH_REPO_LATEST_URL="${OMH_REPO_LATEST_URL:-https://github.com/rlaope/oh-my-hermes/releases/latest}"
+# Stable installs the ~2.7 MB release wheel; preview installs the ~44 MB branch
+# archive, which GitHub generates per request rather than serving from a CDN.
+# Defaulting to the newest release is the contract every package manager
+# honours; preview stays available for tracking main.
+OMH_CHANNEL="${OMH_CHANNEL:-stable}"
 OMH_VERSION="${OMH_VERSION:-}"
 OMH_PACKAGE_URL="${OMH_PACKAGE_URL:-}"
 OMH_SOURCE_REF="${OMH_SOURCE_REF:-}"
@@ -346,8 +351,23 @@ if [ -z "$OMH_PACKAGE_URL" ]; then
       ;;
     stable)
       if [ -z "$OMH_VERSION" ]; then
-        say "omh installer: OMH_CHANNEL=stable requires OMH_VERSION, for example OMH_VERSION=1.0.1."
-        exit 1
+        # GitHub answers /releases/latest with a 302 whose Location carries the
+        # newest tag, so "latest" costs one header read and no API token. Only
+        # the redirect target is fetched, never the release page.
+        OMH_LATEST_LOCATION=""
+        if command -v curl >/dev/null 2>&1; then
+          OMH_LATEST_LOCATION="$(curl -sSI "$OMH_REPO_LATEST_URL" 2>/dev/null | tr -d '\r' | awk 'tolower($1) == "location:" { print $2 }' | tail -1)"
+        elif command -v wget >/dev/null 2>&1; then
+          OMH_LATEST_LOCATION="$(wget -qS --max-redirect=0 -O /dev/null "$OMH_REPO_LATEST_URL" 2>&1 | tr -d '\r' | awk 'tolower($1) == "location:" { print $2 }' | tail -1)"
+        fi
+        case "$OMH_LATEST_LOCATION" in
+          */releases/tag/v*) OMH_VERSION="${OMH_LATEST_LOCATION##*/releases/tag/v}" ;;
+          *)
+            say "omh installer: could not resolve the latest release from $OMH_REPO_LATEST_URL."
+            say "omh installer: set OMH_VERSION=1.0.6 to pin one, or OMH_CHANNEL=preview to track main."
+            exit 1
+            ;;
+        esac
       fi
       case "$OMH_VERSION" in
         v*) OMH_TAG="$OMH_VERSION" ;;

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,7 @@
 set -eu
 
 OMH_REPO_ARCHIVE_ROOT="${OMH_REPO_ARCHIVE_ROOT:-https://github.com/rlaope/oh-my-hermes/archive/refs}"
+OMH_REPO_ASSET_ROOT="${OMH_REPO_ASSET_ROOT:-https://github.com/rlaope/oh-my-hermes/releases/download}"
 OMH_CHANNEL="${OMH_CHANNEL:-preview}"
 OMH_VERSION="${OMH_VERSION:-}"
 OMH_PACKAGE_URL="${OMH_PACKAGE_URL:-}"
@@ -352,7 +353,17 @@ if [ -z "$OMH_PACKAGE_URL" ]; then
         v*) OMH_TAG="$OMH_VERSION" ;;
         *) OMH_TAG="v$OMH_VERSION" ;;
       esac
-      OMH_PACKAGE_URL="$OMH_REPO_ARCHIVE_ROOT/tags/$OMH_TAG.zip"
+      # The release workflow only accepts a vX.Y.Z tag and uploads a wheel
+      # named from that version, so the asset URL is predictable. It is ~2.7 MB
+      # against ~44 MB for the tag archive, which carries assets, tests, and
+      # site that nothing needs to run omh. A version outside that shape has no
+      # published asset to name, so it keeps the archive.
+      OMH_RELEASE_VERSION="${OMH_TAG#v}"
+      if printf '%s' "$OMH_RELEASE_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+        OMH_PACKAGE_URL="$OMH_REPO_ASSET_ROOT/$OMH_TAG/oh_my_hermes-$OMH_RELEASE_VERSION-py3-none-any.whl"
+      else
+        OMH_PACKAGE_URL="$OMH_REPO_ARCHIVE_ROOT/tags/$OMH_TAG.zip"
+      fi
       if [ -z "$OMH_SOURCE_REF" ]; then
         OMH_SOURCE_REF="$OMH_TAG"
       fi

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -65,7 +65,13 @@ from ..paths import OmhPaths, managed_command_venv_dir
 from ..plugin_bundle.omh.metadata import MEMORY_PROVIDER_NAME
 from ..plugin_pack import PLUGIN_NAME, PluginPackError, install_plugin_bundle
 from ..probe import probe_capabilities
-from ..release import RELEASE_CHANNELS, package_url_for
+from ..release import (
+    RELEASE_CHANNELS,
+    ReleaseSelection,
+    missing_release_asset_hint,
+    package_url_for,
+    release_artifact_note,
+)
 from ..tui_widget_pack import install_tui_widget, uninstall_tui_widget
 from ..routing.recommend import recommend_skills
 from ..routing.route_plan import build_workflow_route_plan, compact_workflow_route_plan
@@ -206,6 +212,8 @@ def _install_result(args: argparse.Namespace) -> dict[str, object]:
             "release_channel": release.channel,
             "release_version": release.version,
             "release_package_url": release.package_url,
+            "release_artifact_kind": release.artifact_kind,
+            "release_artifact_note": release_artifact_note(release),
             "release_source_ref": source_ref,
             "language": language,
         }
@@ -481,7 +489,16 @@ def _run_command_package_self_update(args: argparse.Namespace, plan: dict[str, o
     wants_json = _wants_json(args)
     progress = _HumanProgress(enabled=not wants_json, use_color=_use_color())
     progress.header("OMH update", "Refresh the OMH command package and workflow pack.")
-    progress.step(1, 2, "Updating omh command package", detail=package_url)
+    # The size goes on the line printed before pip starts, not after it
+    # finishes: a stable wheel is a second, and the repository archive is the
+    # multi-minute wait people were left staring at with no explanation.
+    note = release_artifact_note(release) if isinstance(release, ReleaseSelection) else ""
+    progress.step(
+        1,
+        2,
+        "Updating omh command package",
+        detail=f"{package_url} ({note})" if note else package_url,
+    )
     completed = subprocess.run(
         [
             python,
@@ -511,7 +528,9 @@ def _run_command_package_self_update(args: argparse.Namespace, plan: dict[str, o
         detail = _bounded_command_error(
             completed.stderr or completed.stdout or "pip install failed"
         )
-        raise OmhError(f"command package update failed: {detail}")
+        hint = missing_release_asset_hint(release) if isinstance(release, ReleaseSelection) else ""
+        message = f"command package update failed: {detail}"
+        raise OmhError(f"{message}; {hint}" if hint else message)
     progress.done("command package updated")
     if not wants_json:
         progress.step(2, 2, "Refreshing OMH workflows with the updated command")

--- a/src/maintenance/release.py
+++ b/src/maintenance/release.py
@@ -60,7 +60,20 @@ from ..use_cases import (
 )
 
 REPOSITORY_ARCHIVE_ROOT = "https://github.com/rlaope/oh-my-hermes/archive/refs"
+RELEASE_ASSET_ROOT = "https://github.com/rlaope/oh-my-hermes/releases/download"
 RELEASE_CHANNELS = ("stable", "preview", "local")
+# `.github/workflows/release.yml` refuses any tag that is not `vX.Y.Z` and
+# names the wheel it uploads after that version, so a stable version of this
+# shape has a predictable release-asset URL. Anything else does not, and falls
+# back to the repository archive rather than pointing pip at a guess.
+RELEASE_WHEEL_VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+# Measured 2026-08-15 with `curl -sL -o /dev/null -w '%{size_download}'`: the
+# v1.0.6 tag archive is 45,921,555 bytes and the main branch archive is
+# 46,012,605 bytes, against 2,714,885 bytes for the published v1.0.6 wheel.
+# The archive carries assets/, tests/, and site/; none of the three is needed
+# to run omh, and downloading them is what made `omh update` take minutes.
+RELEASE_ARCHIVE_APPROX_SIZE = "~44 MB"
+RELEASE_WHEEL_APPROX_SIZE = "~2.7 MB"
 HERMES_SMOKE_SCHEMA = "hermes_release_smoke/v1"
 RELEASE_CHECKLIST_SCHEMA = "release_readiness_checklist/v1"
 INSTALLED_COMMAND_SMOKE_SCHEMA = "installed_omh_command_smoke/v1"
@@ -122,21 +135,71 @@ class ReleaseSelection:
     version: str
     package_url: str
     source_label: str
+    artifact_kind: str = "repository-archive"
+
+
+def release_tag_for(version: str) -> str:
+    return version if version.startswith("v") else f"v{version}"
+
+
+def release_wheel_name(release_version: str) -> str:
+    return f"oh_my_hermes-{release_version}-py3-none-any.whl"
+
+
+def repository_archive_url(tag: str) -> str:
+    return f"{REPOSITORY_ARCHIVE_ROOT}/tags/{tag}.zip"
 
 
 def package_url_for(channel: str, version: str = "", package_url: str = "") -> ReleaseSelection:
     if channel not in RELEASE_CHANNELS:
         raise ValueError(f"unsupported release channel: {channel}")
     if package_url:
-        return ReleaseSelection(channel, version, package_url, "custom-url")
+        return ReleaseSelection(channel, version, package_url, "custom-url", "custom-url")
     if channel == "stable":
         if not version:
             raise ValueError("stable channel requires --version or OMH_VERSION")
-        tag = version if version.startswith("v") else f"v{version}"
-        return ReleaseSelection(channel, version, f"{REPOSITORY_ARCHIVE_ROOT}/tags/{tag}.zip", tag)
+        tag = release_tag_for(version)
+        release_version = tag[1:]
+        if RELEASE_WHEEL_VERSION_RE.fullmatch(release_version):
+            wheel_url = f"{RELEASE_ASSET_ROOT}/{tag}/{release_wheel_name(release_version)}"
+            return ReleaseSelection(channel, version, wheel_url, tag, "release-wheel")
+        return ReleaseSelection(channel, version, repository_archive_url(tag), tag, "repository-archive")
     if channel == "preview":
-        return ReleaseSelection(channel, version, f"{REPOSITORY_ARCHIVE_ROOT}/heads/main.zip", "main")
-    return ReleaseSelection(channel, version, "local", "local")
+        # Preview tracks branch `main`, and GitHub publishes release assets per
+        # tag only, so there is no slim artifact to point at here. The branch
+        # archive stays, labelled with what it costs, rather than inventing an
+        # endpoint the release workflow does not produce.
+        return ReleaseSelection(channel, version, f"{REPOSITORY_ARCHIVE_ROOT}/heads/main.zip", "main", "repository-archive")
+    return ReleaseSelection(channel, version, "local", "local", "local")
+
+
+def release_artifact_note(selection: ReleaseSelection) -> str:
+    """Say what the resolved artifact is and what downloading it costs."""
+    if selection.artifact_kind == "release-wheel":
+        return f"release wheel, {RELEASE_WHEEL_APPROX_SIZE}"
+    if selection.artifact_kind == "repository-archive":
+        return (
+            f"full repository archive, {RELEASE_ARCHIVE_APPROX_SIZE} "
+            "including assets, tests, and site; this download can take minutes"
+        )
+    return ""
+
+
+def missing_release_asset_hint(selection: ReleaseSelection) -> str:
+    """Name the fallback when a stable version has no published wheel asset.
+
+    Releases before the wheel-publishing workflow existed carry no asset, and
+    v1.0.3 through v1.0.5 carry none either. pip reports those as a bare 404
+    against a URL nobody typed, so the failure has to name the archive that
+    does exist for the same tag.
+    """
+    if selection.artifact_kind != "release-wheel":
+        return ""
+    tag = selection.source_label
+    return (
+        f"if {tag} has no published wheel asset, install from the full repository archive instead: "
+        f"--package-url {repository_archive_url(tag)}"
+    )
 
 
 @dataclass(frozen=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3593,6 +3593,51 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
         self.assertIn("--command-package-updated", reentry_args)
         self.assertEqual(run.call_args_list[1].kwargs["env"][setup_commands.SELF_UPDATE_REENTRY_ENV], "1")
 
+    def test_stable_self_update_downloads_the_release_wheel(self) -> None:
+        # The tag archive is ~44 MB of assets, tests, and site; the wheel is
+        # ~2.7 MB. This is the URL `omh update --channel stable` hands pip.
+        args = Namespace(json=True)
+        release = setup_commands.package_url_for("stable", "1.0.6")
+        plan = {"release": release, "python": sys.executable}
+        first = subprocess.CompletedProcess(args=["pip"], returncode=0, stdout="", stderr="")
+        second = subprocess.CompletedProcess(args=["omh"], returncode=0, stdout="", stderr="")
+
+        with patch.object(setup_commands.subprocess, "run", side_effect=[first, second]):
+            with patch.object(setup_commands.sys, "argv", ["omh", "update", "--json"]):
+                status = setup_commands._run_command_package_self_update(args, plan)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(
+            release.package_url,
+            "https://github.com/rlaope/oh-my-hermes/releases/download/v1.0.6/"
+            "oh_my_hermes-1.0.6-py3-none-any.whl",
+        )
+
+    def test_a_failed_wheel_update_names_the_archive_fallback(self) -> None:
+        # v1.0.3 through v1.0.5 published no wheel asset, so pip answers with a
+        # bare 404 against a URL the user never typed. The failure has to name
+        # the archive that does exist for the same tag.
+        args = Namespace(json=True)
+        plan = {
+            "release": setup_commands.package_url_for("stable", "1.0.4"),
+            "python": sys.executable,
+        }
+        failed = subprocess.CompletedProcess(
+            args=["pip"], returncode=1, stdout="", stderr="ERROR: HTTP error 404"
+        )
+
+        with patch.object(setup_commands.subprocess, "run", side_effect=[failed]):
+            with self.assertRaises(OmhError) as raised:
+                setup_commands._run_command_package_self_update(args, plan)
+
+        message = str(raised.exception)
+        self.assertIn("404", message)
+        self.assertIn("--package-url", message)
+        self.assertIn(
+            "https://github.com/rlaope/oh-my-hermes/archive/refs/tags/v1.0.4.zip",
+            message,
+        )
+
     def test_update_self_update_skips_local_channel_without_package_source(self) -> None:
         args = Namespace(
             command_package_updated=False,
@@ -11746,7 +11791,15 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             dry_run = json.loads(stdout)
             self.assertEqual(dry_run["release_channel"], "stable")
             self.assertEqual(dry_run["release_source_ref"], "v1.0.0")
-            self.assertIn("/tags/v1.0.0.zip", dry_run["release_package_url"])
+            # Stable resolves the published wheel asset, not the tag archive:
+            # the archive is ~44 MB of assets/tests/site against ~2.7 MB for
+            # the wheel, and downloading it is what made `omh update` slow.
+            self.assertEqual(
+                dry_run["release_package_url"],
+                "https://github.com/rlaope/oh-my-hermes/releases/download/v1.0.0/"
+                "oh_my_hermes-1.0.0-py3-none-any.whl",
+            )
+            self.assertEqual(dry_run["release_artifact_kind"], "release-wheel")
 
             status, _, stderr = run_cli(["--omh-home", str(omh_home), "install", "--dry-run", "--channel", "stable"])
             self.assertEqual(status, 2)

--- a/tests/test_release_artifact.py
+++ b/tests/test_release_artifact.py
@@ -149,6 +149,37 @@ class InstallerParityTests(unittest.TestCase):
         self.assertIn('OMH_PACKAGE_URL="$OMH_REPO_ARCHIVE_ROOT/tags/$OMH_TAG.zip"', self.shell)
         self.assertIn('$OmhPackageUrl = "$OmhRepoArchiveRoot/tags/$OmhTag.zip"', self.powershell)
 
+    def test_both_installers_default_to_stable(self) -> None:
+        # A fresh install used to default to the `main` branch archive, which
+        # GitHub generates per request rather than serving from a CDN: 46,012,605
+        # bytes measured, and over five minutes on an ordinary connection. The
+        # default is now the newest release wheel; tracking main is opt-in.
+        self.assertIn('OMH_CHANNEL="${OMH_CHANNEL:-stable}"', self.shell)
+        self.assertIn("Get-OmhEnv 'OMH_CHANNEL' 'stable'", self.powershell)
+
+    def test_both_installers_resolve_latest_from_the_releases_redirect(self) -> None:
+        # The installers are download scripts, so resolving "newest release" is
+        # theirs to do -- `src/` stays offline, which INVARIANT 2 in
+        # tests/test_handoff_safety_contract_enforcement.py enforces.
+        for name, source in (("install.sh", self.shell), ("install.ps1", self.powershell)):
+            with self.subTest(installer=name):
+                self.assertIn("releases/latest", source)
+                self.assertIn("/releases/tag/v", source)
+
+    def test_a_failed_latest_lookup_names_both_ways_out(self) -> None:
+        # An unresolvable redirect must not become a guessed URL.
+        for name, source in (("install.sh", self.shell), ("install.ps1", self.powershell)):
+            with self.subTest(installer=name):
+                self.assertIn("could not resolve the latest release", source)
+                self.assertIn("OMH_CHANNEL=preview", source)
+
+    def test_the_installers_never_hand_omh_a_version_less_stable_channel(self) -> None:
+        # `src/` refuses a version-less stable selection rather than reaching
+        # the network, so the installer must always resolve a concrete version
+        # before it forwards --channel stable to `omh setup`.
+        self.assertIn('set -- setup --channel "$OMH_CHANNEL"', self.shell)
+        self.assertIn('set -- "$@" --version "$OMH_VERSION"', self.shell)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_release_artifact.py
+++ b/tests/test_release_artifact.py
@@ -1,0 +1,154 @@
+"""What `omh update` actually downloads, per channel.
+
+The stable channel used to resolve the tag's repository archive. Measured on
+2026-08-15 with `curl -sL -o /dev/null -w '%{size_download} %{time_total}'`:
+the v1.0.6 tag archive is 45,921,555 bytes, the `main` branch archive is
+46,012,605 bytes, and the published v1.0.6 wheel is 2,714,885 bytes. The
+archive carries `assets/`, `tests/`, and `site/`; none of the three is needed
+to run `omh`, and downloading them is the whole reason `omh update` took
+minutes. These tests pin which artifact each channel names, and pin that the
+heavy one still says so out loud.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+from omh.release import (
+    RELEASE_ARCHIVE_APPROX_SIZE,
+    RELEASE_WHEEL_APPROX_SIZE,
+    missing_release_asset_hint,
+    package_url_for,
+    release_artifact_note,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WHEEL_URL = (
+    "https://github.com/rlaope/oh-my-hermes/releases/download/v1.0.6/"
+    "oh_my_hermes-1.0.6-py3-none-any.whl"
+)
+ARCHIVE_URL = "https://github.com/rlaope/oh-my-hermes/archive/refs/tags/v1.0.6.zip"
+PREVIEW_URL = "https://github.com/rlaope/oh-my-hermes/archive/refs/heads/main.zip"
+
+
+class StableChannelArtifactTests(unittest.TestCase):
+    def test_stable_resolves_the_published_wheel_asset(self) -> None:
+        selection = package_url_for("stable", "1.0.6")
+
+        self.assertEqual(selection.package_url, WHEEL_URL)
+        self.assertEqual(selection.artifact_kind, "release-wheel")
+        self.assertEqual(selection.source_label, "v1.0.6")
+
+    def test_a_v_prefixed_version_resolves_to_the_same_asset(self) -> None:
+        # `--version v1.0.6` and `--version 1.0.6` were interchangeable before
+        # the wheel name entered the URL, and the wheel name carries no `v`.
+        self.assertEqual(package_url_for("stable", "v1.0.6").package_url, WHEEL_URL)
+
+    def test_a_version_outside_the_release_tag_shape_keeps_the_archive(self) -> None:
+        # release.yml refuses to publish anything but `vX.Y.Z`, so there is no
+        # asset name to predict here; guessing one would 404 on every install.
+        selection = package_url_for("stable", "1.0.6rc1")
+
+        self.assertEqual(
+            selection.package_url,
+            "https://github.com/rlaope/oh-my-hermes/archive/refs/tags/v1.0.6rc1.zip",
+        )
+        self.assertEqual(selection.artifact_kind, "repository-archive")
+
+    def test_stable_still_requires_a_version(self) -> None:
+        with self.assertRaises(ValueError) as raised:
+            package_url_for("stable")
+
+        self.assertIn("stable channel requires", str(raised.exception))
+
+
+class PreviewAndLocalChannelTests(unittest.TestCase):
+    def test_preview_still_tracks_the_branch_archive(self) -> None:
+        # Preview tracks `main`, and GitHub publishes release assets per tag
+        # only. There is no per-branch wheel to point at, so this stays the
+        # heavy path rather than becoming an invented endpoint.
+        selection = package_url_for("preview")
+
+        self.assertEqual(selection.package_url, PREVIEW_URL)
+        self.assertEqual(selection.artifact_kind, "repository-archive")
+        self.assertEqual(selection.source_label, "main")
+
+    def test_local_channel_is_unchanged(self) -> None:
+        selection = package_url_for("local")
+
+        self.assertEqual(selection.package_url, "local")
+        self.assertEqual(selection.source_label, "local")
+        self.assertEqual(selection.artifact_kind, "local")
+
+    def test_an_explicit_package_url_still_wins_on_every_channel(self) -> None:
+        for channel in ("stable", "preview", "local"):
+            selection = package_url_for(channel, "1.0.6", "https://example.invalid/omh.whl")
+
+            self.assertEqual(selection.package_url, "https://example.invalid/omh.whl")
+            self.assertEqual(selection.artifact_kind, "custom-url")
+
+
+class ArtifactCostDisclosureTests(unittest.TestCase):
+    def test_the_heavy_path_names_its_size_before_the_download(self) -> None:
+        note = release_artifact_note(package_url_for("preview"))
+
+        self.assertIn(RELEASE_ARCHIVE_APPROX_SIZE, note)
+        self.assertIn("minutes", note)
+
+    def test_the_slim_path_names_its_size_too(self) -> None:
+        note = release_artifact_note(package_url_for("stable", "1.0.6"))
+
+        self.assertIn(RELEASE_WHEEL_APPROX_SIZE, note)
+        self.assertNotIn("minutes", note)
+
+    def test_local_and_custom_sources_have_nothing_to_disclose(self) -> None:
+        self.assertEqual(release_artifact_note(package_url_for("local")), "")
+        self.assertEqual(
+            release_artifact_note(package_url_for("stable", "1.0.6", "https://example.invalid/x.whl")),
+            "",
+        )
+
+
+class MissingAssetFallbackTests(unittest.TestCase):
+    def test_a_wheel_failure_names_the_archive_that_does_exist(self) -> None:
+        # v1.0.3 through v1.0.5 published no asset at all, so this is a real
+        # state a user can reach, and pip reports it as a bare 404 against a
+        # URL nobody typed.
+        hint = missing_release_asset_hint(package_url_for("stable", "1.0.6"))
+
+        self.assertIn("v1.0.6", hint)
+        self.assertIn("--package-url", hint)
+        self.assertIn(ARCHIVE_URL, hint)
+
+    def test_paths_that_are_already_archives_offer_no_fallback(self) -> None:
+        self.assertEqual(missing_release_asset_hint(package_url_for("preview")), "")
+        self.assertEqual(missing_release_asset_hint(package_url_for("local")), "")
+
+
+class InstallerParityTests(unittest.TestCase):
+    """The installers resolve the same channels and must not fork from omh."""
+
+    def setUp(self) -> None:
+        self.shell = (REPO_ROOT / "install.sh").read_text(encoding="utf-8")
+        self.powershell = (REPO_ROOT / "install.ps1").read_text(encoding="utf-8")
+
+    def test_both_installers_build_the_stable_wheel_asset_name(self) -> None:
+        for name, source in (("install.sh", self.shell), ("install.ps1", self.powershell)):
+            with self.subTest(installer=name):
+                self.assertIn("releases/download", source)
+                self.assertIn("-py3-none-any.whl", source)
+                self.assertRegex(
+                    source,
+                    re.compile(r"\^\[0-9\]\+\\\.\[0-9\]\+\\\.\[0-9\]\+\$"),
+                    "the installer must gate the wheel name on the vX.Y.Z release-tag shape",
+                )
+
+    def test_both_installers_keep_the_archive_as_the_stable_fallback(self) -> None:
+        self.assertIn('OMH_PACKAGE_URL="$OMH_REPO_ARCHIVE_ROOT/tags/$OMH_TAG.zip"', self.shell)
+        self.assertIn('$OmhPackageUrl = "$OmhRepoArchiveRoot/tags/$OmhTag.zip"', self.powershell)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_windows_install_path.py
+++ b/tests/test_windows_install_path.py
@@ -123,7 +123,18 @@ class WindowsInstallerContractParityTests(unittest.TestCase):
         self.assertEqual(sorted(powershell_flags - shell_flags), [], "install.ps1 forwards setup flags install.sh does not")
 
     def test_package_source_resolution_matches(self) -> None:
-        for fragment in ("/heads/main.zip", "/tags/", "custom-url", "preview", "stable", "local"):
+        for fragment in (
+            "/heads/main.zip",
+            "/tags/",
+            # Stable resolves the slim release wheel; the tag archive stays
+            # only as the fallback for a tag that published no asset.
+            "releases/download",
+            "-py3-none-any.whl",
+            "custom-url",
+            "preview",
+            "stable",
+            "local",
+        ):
             self.assertIn(fragment, self.powershell, f"channel resolution lost {fragment!r}")
 
     def test_windows_installer_uses_the_windows_virtualenv_layout(self) -> None:


### PR DESCRIPTION
## Capability

`omh update` and fresh installs stop pulling the whole repository. The stable
channel names the published ~2.7 MB release wheel, fresh installs default to
the newest release and resolve it in the installer shell, and the release
workflow now publishes that same wheel to PyPI so a future version-less update
can let pip resolve "latest" without omh making a network call.

## Motivation

Measured before this change:

| artifact | size | wall clock |
| --- | --- | --- |
| `archive/refs/heads/main.zip` (preview default) | 44 MB, 1485 files | **5m 05s** |
| `archive/refs/tags/v1.0.6.zip` | 45,921,555 B | — |
| `releases/download/v1.0.6/oh_my_hermes-1.0.6-py3-none-any.whl` | 2,714,885 B | **0.57s** |
| `releases/latest` redirect (tag resolution) | header only | **0.26s** |

Two independent causes, not one:

1. **Size.** `assets/` (31M), `tests/` (20M) and `site/` (8.3M) ride along in the
   archive and none of it is needed to run `omh`.
2. **Serving path.** GitHub *generates* `archive/refs/heads/<branch>.zip` per
   request; it is not a cached static object. Release assets are static CDN
   objects. That is why 44 MB took five minutes instead of the ~10s a 44 MB CDN
   download costs — and it means shrinking the archive would not have been
   enough. The fix has to leave the on-demand endpoint.

## Implementation, at the boundary level

- **Stable channel → release wheel.** `package_url_for` resolves the published
  wheel asset for any `vX.Y.Z` tag, and falls back to the tag archive for any
  version outside the shape the release workflow accepts, rather than pointing
  pip at a guessed URL. A missing asset names the archive that does exist.
- **Installers default to the newest release.** `install.sh` / `install.ps1`
  default `OMH_CHANNEL` to `stable` and resolve the newest tag from the
  `releases/latest` 302, in `curl`/`wget`/`Invoke-WebRequest`. This lives in the
  installer scripts on purpose: they are shell, not core `omh`, so the
  no-network boundary is untouched. An unresolvable redirect stops with a
  message naming both escapes (`OMH_VERSION`, `OMH_CHANNEL=preview`).
- **Release workflow publishes to PyPI.** The same immutable wheel that becomes
  the GitHub asset is published to PyPI, publish-or-verify like the existing npm
  step, through the `id-token: write` permission the job already holds.
- **Preview is unchanged and still honest.** It tracks `main`, where no per-tag
  asset can exist, and it says what the download costs.

## Why PyPI rather than resolving in omh

An earlier revision of this branch resolved `releases/latest` with `urllib`
inside `omh` itself. It worked and measured 0.3s, but `AGENTS.md` forbids
network calls in core features absent an owner-approved scoped integration, the
no-network claim is stated as fact in `CLAUDE.md`, `CONTEXT.md` and
`docs/DIRECTION.md`, and `plugin_risk_audit.py` flags exactly that pattern.
Shipping it would have made four documents false. The owner chose PyPI instead;
that revision is fully reverted and `src/` contains no `urlopen`.

Letting pip resolve against an index was verified as the only workable
alternative: `pip install --no-index --find-links
https://github.com/rlaope/oh-my-hermes/releases oh-my-hermes` fails with
"from versions: none" because the page's asset hrefs are lazy-loaded.

## Observed verification

- Full suite: **6710 tests, 16 failures**. Baseline on `main` in the same
  environment: **6690 tests, 17 failures**. Zero failures added. The failures
  are pre-existing and environment-dependent (`omh doctor` exits 1 on this
  machine); CI is green.
- `uv run python -m compileall -q src tests` — clean.
- `docs workflows|roles|capability-families|ulw-inventory|ulw-site --check` — all pass.
- `uv run --group lint ruff check src tests` — All checks passed.
- `git diff --check` — clean.
- Wheel and redirect timings above measured with `curl -w '%{size_download} %{time_total}'`.

## Risks

- **The PyPI step has never run.** It requires Trusted Publishing configured for
  this repo, `release.yml`, and the `npm` environment — owner-only setup. Until
  then the step fails and the release stops there. No observed publish evidence
  exists and none is claimed.
- **Installers now default to `stable`.** A fresh install without `OMH_VERSION`
  depends on the `releases/latest` redirect and on the tag carrying a wheel
  asset. A release that publishes no wheel breaks the default install path for
  everyone, not only for people who pinned that version.
- **`omh update`'s own default is still `preview`** and still pays the 44 MB
  on-demand archive. Flipping it to a name-based `pip install --upgrade
  oh-my-hermes` is deliberately left for a follow-up, because it must not land
  before a release has actually reached PyPI.