### PR TITLE
fix(setup): stop moving the user off Hermes' own terminal

### DIFF
--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -31,10 +31,10 @@ from ..coding.hermes_model_config import (
 from ..coding.model_discovery import discover_local_models
 from ..coding.model_recommendations import resolve_model_recommendation
 from ..config_adapter import (
+    ConfigChange,
     display_interface_selection,
     ensure_external_dir,
     ensure_plugin_enabled,
-    ensure_tui_interface,
     external_dirs,
     maybe_set_memory_provider,
     memory_provider_selection,
@@ -1165,11 +1165,19 @@ def _apply_result(args: argparse.Namespace) -> dict[str, object]:
         # Hermes. Doing only the first leaves an install that passes every
         # structural check while no OMH tool is reachable in chat.
         plugin_enable = ensure_plugin_enabled(compression.text, PLUGIN_NAME)
-        # Hermes loads tui-widgets only in its official Ink TUI. Installing the
-        # widget while leaving the install on the classic REPL makes the HUD
-        # unreachable -- for upgraders with an older config just as much as for
-        # fresh installs. An explicit display preference remains user-owned.
-        tui_interface = ensure_tui_interface(plugin_enable.text)
+        # `display.interface` is Hermes' own, and its default is the classic
+        # REPL. OMH used to write `tui` here so its widget would be reachable,
+        # because Hermes loads tui-widgets only in the Ink TUI. That traded the
+        # user's terminal for OMH's convenience: the classic REPL draws the
+        # banner, the status line, and the rules framing the prompt, and the
+        # Ink TUI does not, so installing OMH visibly stripped chrome the user
+        # never asked to lose -- and it wrote a Hermes-owned key to a
+        # non-default value the user had not chosen, which is exactly what
+        # Managed artifact forbids.
+        # OMH now reads the interface and adapts to it instead: the widget
+        # still renders when the user runs the Ink TUI, and the plugin's
+        # `on_session_start` line carries the same status in the classic REPL.
+        tui_interface = ConfigChange(False, "display.interface is Hermes-owned; OMH reads it and never writes it", plugin_enable.text)
         # Same reasoning one layer down. OMH's memory provider ships inside the
         # bundle, and a provider Hermes never selects is a provider that never
         # runs -- so requiring a control-plane command to switch it on meant the

--- a/src/maintenance/doctor.py
+++ b/src/maintenance/doctor.py
@@ -419,29 +419,32 @@ def _hermes_tui_checks(paths: OmhPaths) -> list[Check]:
                 next_action=sdk_action,
             )
         )
+    # `display.interface` is Hermes-owned and OMH never writes it. Which
+    # terminal the user runs is a real trade-off and theirs to make: the modern
+    # TUI is the only surface that loads `tui-widgets/`, so it is where the OMH
+    # HUD renders, while the classic REPL draws the banner, status line, and
+    # the rules framing the prompt that the modern TUI does not. Naming the
+    # trade-off is the whole job here; picking a side for the user was the bug.
     interface = preflight["display_interface"]
+    hud_hint = "`hermes --tui` opens the modern TUI for one session without changing any setting"
     if interface["explicit"] and interface["value"] not in ("", "tui"):
         message = (
-            f"display.interface is set to {interface['value']!r} (user-owned); the OMH HUD renders only in the "
-            "modern TUI (`hermes --tui` still reaches it)"
+            f"display.interface is {interface['value']!r} (Hermes-owned) — bare `hermes` opens the classic REPL, "
+            "which keeps its banner and prompt rules but loads no OMH HUD widget"
         )
-        interface_severity = "warning"
-        interface_action = "set display.interface to tui (or use `hermes --tui`) to see the OMH HUD"
+        interface_severity = "ok"
+        interface_action = hud_hint
     elif interface["explicit"]:
-        message = "display.interface defaults bare `hermes` to the modern TUI"
+        message = "display.interface is 'tui' (Hermes-owned) — bare `hermes` opens the modern TUI, where the OMH HUD renders"
         interface_severity = "ok"
         interface_action = ""
-    elif interface["settable"]:
-        message = "display.interface is unset — bare `hermes` opens the classic REPL where the HUD cannot render"
-        interface_severity = "warning"
-        interface_action = "run `omh setup` to default display.interface to the TUI"
     else:
         message = (
-            "display configuration is user-owned in a shape this check cannot read; the OMH HUD needs the "
-            "modern TUI either way"
+            "display.interface is unset, so bare `hermes` opens Hermes' default classic REPL — it keeps its banner "
+            "and prompt rules, and loads no OMH HUD widget"
         )
         interface_severity = "ok"
-        interface_action = ""
+        interface_action = hud_hint
     checks.append(
         Check(
             "hermes_tui_interface_default",

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -43,14 +43,20 @@ class TuiWidgetPackTests(unittest.TestCase):
             self.assertEqual((widget_dir / "omh-status.mjs").read_bytes(), expected)
             self.assertEqual(unrelated.read_bytes(), unrelated_bytes)
             self.assertEqual(payload["steps"]["tui_widget"]["status"], "installed")
-            self.assertIn(
-                "display:\n  interface: tui\n",
+            # `display.interface` is Hermes-owned. Installing the widget must
+            # not move the user's terminal to make that widget reachable.
+            self.assertNotIn(
+                "interface:",
                 (hermes_home / "config.yaml").read_text(encoding="utf-8"),
             )
 
-    def test_setup_defaults_existing_config_without_display_interface_to_tui(self) -> None:
-        # Upgraders whose config predates display.interface get the same TUI
-        # default as fresh installs; only an explicit choice is user-owned.
+    def test_setup_never_writes_display_interface(self) -> None:
+        # Inverted deliberately. OMH used to write `display.interface: tui`
+        # here so its widget -- which Hermes loads only in the Ink TUI -- would
+        # be reachable. That moved the user off Hermes' own default classic
+        # REPL, and with it the banner, status line, and the rules framing the
+        # prompt, to serve an OMH surface. `display.interface` is Hermes-owned:
+        # OMH reads it and adapts, and never writes it.
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
             omh_home = root / ".omh"
@@ -74,10 +80,9 @@ class TuiWidgetPackTests(unittest.TestCase):
             self.assertEqual((status, stderr), (0, ""))
             config_text = config.read_text(encoding="utf-8")
             self.assertIn("  compact: true", config_text)
-            self.assertIn("  interface: tui", config_text)
+            self.assertNotIn("interface:", config_text)
             tui_interface = json.loads(stdout)["steps"]["apply"]["tui_interface"]
-            self.assertTrue(tui_interface["changed"])
-            self.assertEqual(tui_interface["selected"], "tui")
+            self.assertFalse(tui_interface["changed"])
 
     def test_setup_preserves_an_explicit_classic_interface(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -122,8 +127,11 @@ class TuiWidgetPackTests(unittest.TestCase):
             widget = hermes_home / "tui-widgets" / "omh-status.mjs"
             widget.unlink()
             config = hermes_home / "config.yaml"
+            # Authored here rather than derived from a value OMH wrote: OMH no
+            # longer writes display.interface at all, so the explicit classic
+            # preference this test protects has to come from the user.
             config.write_text(
-                config.read_text(encoding="utf-8").replace("interface: tui", "interface: cli"),
+                config.read_text(encoding="utf-8") + "\ndisplay:\n  interface: cli\n",
                 encoding="utf-8",
             )
 


### PR DESCRIPTION
## Capability

`omh setup` no longer writes `display.interface: tui`. Installing OMH stops
changing which terminal Hermes opens, so users keep Hermes' own default classic
REPL — and its banner, status line, and prompt rules — unless they choose
otherwise themselves.

## Motivation

A user reported that after installing OMH a "barer" TUI kept appearing, and
that plain `hermes` without OMH looked richer. Three earlier hypotheses were
wrong and were measured away: Hermes was at its `origin/main` HEAD (v0.20.1)
with a freshly rebuilt Ink bundle, and the installed OMH widget matched its
shipped source byte for byte apart from the interpreter substitution.

The cause was OMH's own setup step. `ensure_tui_interface` wrote
`display.interface: tui` whenever the user had not set it, and the code comment
said why: Hermes loads `tui-widgets/*.mjs` only in the Ink TUI, so leaving the
install on the classic REPL made the OMH HUD unreachable.

Hermes' default is the classic REPL, and the two surfaces are not equivalent.
Captured from a real boot of each, same terminal size:

classic REPL — banner box, status line, and the rules framing the prompt:

```
 ⚕ claude-opus-4.6 │ ctx -- │ [░░░░░░░░░░] -- │ 2s │ ⏲ 0s
────────────────────────────────────────────────────────────
❯
────────────────────────────────────────────────────────────
```

The Ink TUI draws none of those around the composer. So OMH moved every user
who had not made an explicit choice onto the sparser surface, to make its own
widget reachable.

It also broke OMH's own rule: `display.interface` is Hermes-owned, and
CONTEXT.md's **Managed artifact** entry limits OMH to artifacts it installed and
keys it inserted. Writing a Hermes key to a non-default value the user never
chose is precisely what that forbids.

## Implementation, at the boundary level

- `omh setup` no longer writes `display.interface`; it reads it and adapts. The
  apply step still reports the key so the JSON shape is unchanged, now always
  as unchanged.
- `omh doctor` names the trade-off in **both** directions instead of prescribing
  one. It no longer tells the user to run `omh setup` to have OMH set the key.
  Every branch is `severity="ok"`: which terminal to run is a preference, not a
  defect. Where the HUD is wanted, it points at `hermes --tui`, which reaches it
  for one session without changing a setting.
- Two widget-pack tests encoded the old behaviour and are inverted deliberately,
  each with a comment saying why. A third authored its explicit `interface: cli`
  preference by rewriting a value OMH had written; it now writes that preference
  itself, since OMH writes nothing to derive it from.

## Rejected alternative, with evidence

Registering an `on_session_start` hook so OMH could print its status line in the
classic REPL. Implemented, then removed: Hermes fires `on_session_start` only in
its own tests and in a raft platform adapter, never in the interactive boot
path. Booting the classic REPL with the hook installed printed nothing. It would
have shipped as code that never runs.

The classic REPL therefore has no plugin surface for a persistent OMH HUD in
this Hermes version. That is stated plainly rather than papered over: OMH tools
and skills work there (the banner already lists them), the HUD widget does not.

## Observed verification

- Full suite: **6690 tests, 16 failures**. Baseline on `main` in the same
  environment: **6690 tests, 17 failures**. Zero added.
- `docs workflows|roles|capability-families|ulw-inventory|ulw-site --check` — all pass.
- `compileall`, `ruff check src tests`, `git diff --check` — clean.
- Classic REPL and Ink TUI each booted under tmux in throwaway `HERMES_HOME`s to
  confirm which chrome each draws. The reporter's real `~/.hermes` was not
  modified.

## Risks

- **Existing installs keep the key OMH already wrote.** OMH will not rewrite a
  key it no longer owns, so anyone whose config already carries
  `display.interface: tui` stays on the Ink TUI until they unset it. That is
  deliberate — silently reverting a live config would repeat the original
  mistake in the opposite direction — but it means the fix reaches existing
  users only through doctor's guidance.
- **Fresh installs no longer see the HUD by default**, because Hermes' default
  is the classic REPL and the widget cannot render there. Doctor names it and
  points at `hermes --tui`.
- No automated test asserts what the classic REPL renders; that difference was
  confirmed by hand from tmux captures.