### PR TITLE
fix(update): show pip's progress instead of a silent terminal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,33 +200,6 @@ jobs:
             npm publish "$OMH_TARBALL" --access public --provenance
           fi
 
-      - name: Publish or verify PyPI package
-        shell: bash
-        run: |
-          set -euo pipefail
-          # The same immutable wheel that became the GitHub release asset also
-          # goes to PyPI, so `pip install --upgrade oh-my-hermes` resolves the
-          # newest version itself. That is what lets `omh update` leave the
-          # ~44 MB on-demand branch archive behind WITHOUT omh's own process
-          # ever opening a socket to ask which version is newest -- the
-          # no-network boundary in AGENTS.md stays intact because the index
-          # does the resolving.
-          # Idempotent across re-runs, and it re-verifies rather than trusting
-          # a previous run: a version already on PyPI must carry this exact
-          # wheel, byte for byte.
-          published_sha256=""
-          if response="$(curl -fsS "https://pypi.org/pypi/oh-my-hermes/$OMH_VERSION/json" 2>/dev/null)"; then
-            published_sha256="$(
-              printf '%s' "$response" \
-                | python3 -c 'import json,sys; print(next((u["digests"]["sha256"] for u in json.load(sys.stdin)["urls"] if u["packagetype"] == "bdist_wheel"), ""))'
-            )"
-          fi
-          if [ -n "$published_sha256" ]; then
-            test "$published_sha256" = "$OMH_WHEEL_SHA256"
-          else
-            uv publish --trusted-publishing always "$OMH_WHEEL"
-          fi
-
       - name: Render verified Homebrew formula
         shell: bash
         run: |

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -14,44 +14,10 @@ public claims are all checked.
 
 ## Package-manager distribution
 
-The tag-driven npm/Bun, PyPI, GitHub wheel, and Homebrew tap release is defined
-by `.github/workflows/release.yml`. Its release order, one-time external setup,
+The tag-driven npm/Bun, GitHub wheel, and Homebrew tap release is defined by
+`.github/workflows/release.yml`. Its release order, one-time external setup,
 resume rules, rollback matrix, immutable artifact checks, and pending-first-
 release status are the single contract in [Distribution](DISTRIBUTION.md).
-
-### PyPI, and why it exists
-
-The workflow publishes the same immutable wheel to PyPI that it uploads as the
-GitHub release asset. This is not a convenience mirror -- it is what lets a
-version-less update stay fast without breaking a product boundary.
-
-`omh update` has to answer "which version is newest". Core `omh` may not ask
-that question itself: `AGENTS.md` forbids network calls inside core features
-without an owner-approved scoped integration, and `plugin_risk_audit.py` flags
-the pattern. Having pip resolve the version against an index moves the network
-call to the package manager, where it already lives, so the boundary stays
-true.
-
-The alternative was rejected on evidence, not taste: pip cannot resolve
-"latest" from GitHub releases at all. `pip install --no-index --find-links
-https://github.com/rlaope/oh-my-hermes/releases oh-my-hermes` fails with
-"from versions: none", because that page carries no `.whl` hrefs -- the assets
-are lazy-loaded.
-
-**One-time owner setup, required before this step can succeed.** Configure PyPI
-Trusted Publishing for the `oh-my-hermes` project against this repository, the
-`release.yml` workflow, and the `npm` environment the job already declares. The
-job needs no token: it publishes through the `id-token: write` permission the
-workflow already grants. Until that is configured, the step fails and the
-release stops there -- deliberately, rather than shipping a release whose
-artifacts disagree across indexes.
-
-**Sequencing.** The installer scripts already default to the newest release and
-resolve it through the `releases/latest` redirect in shell, so fresh installs
-are slim today. Switching `omh update`'s own default to a name-based
-`pip install --upgrade oh-my-hermes` is a follow-up, and it must not land until
-at least one release has actually been published to PyPI; otherwise every
-existing install's update path breaks on a package the index does not carry.
 
 Those package-manager artifacts extend the stable channel; they do not replace
 the installer, Hermes skill tap, generated-document, or evidence checks below.

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -499,34 +499,49 @@ def _run_command_package_self_update(args: argparse.Namespace, plan: dict[str, o
         "Updating omh command package",
         detail=f"{package_url} ({note})" if note else package_url,
     )
+    pip_command = [
+        python,
+        "-m",
+        "pip",
+        "install",
+        "--disable-pip-version-check",
+        # A branch archive keeps one URL while its contents change, and pip
+        # caches by URL. Without this, `omh update` reinstalls whatever
+        # `main.zip` was downloaded last - it reports success, the version
+        # string does not move, and the user gets an older tree. Observed:
+        # a fresh venv still printed "Using cached main.zip" and installed
+        # a build from before the merge it was run to pick up.
+        # `--force-reinstall` does not help; it forces the reinstall, not
+        # the download.
+        "--no-cache-dir",
+        "--force-reinstall",
+        "--upgrade",
+        package_url,
+    ]
+    # Human mode hands pip the terminal so its own download and build lines
+    # appear as they happen. This step fetches an archive and builds an sdist,
+    # which takes minutes on the preview channel, and a terminal that prints
+    # nothing for that long is indistinguishable from a hang -- the reported
+    # symptom was `omh update` "stuck" on the URL line, from a run that was
+    # working the whole time. The wait is expected and the step line above
+    # already names its size; what was missing was any sign of progress.
+    # JSON mode keeps capturing, because stdout there has to stay parseable.
+    if wants_json:
+        pip_command.insert(pip_command.index("install") + 1, "-q")
+    capture = subprocess.PIPE if wants_json else None
     completed = subprocess.run(
-        [
-            python,
-            "-m",
-            "pip",
-            "install",
-            "--disable-pip-version-check",
-            "-q",
-            # A branch archive keeps one URL while its contents change, and pip
-            # caches by URL. Without this, `omh update` reinstalls whatever
-            # `main.zip` was downloaded last - it reports success, the version
-            # string does not move, and the user gets an older tree. Observed:
-            # a fresh venv still printed "Using cached main.zip" and installed
-            # a build from before the merge it was run to pick up.
-            # `--force-reinstall` does not help; it forces the reinstall, not
-            # the download.
-            "--no-cache-dir",
-            "--force-reinstall",
-            "--upgrade",
-            package_url,
-        ],
+        pip_command,
         text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        stdout=capture,
+        stderr=capture,
     )
     if completed.returncode != 0:
         detail = _bounded_command_error(
-            completed.stderr or completed.stdout or "pip install failed"
+            completed.stderr
+            or completed.stdout
+            # Human mode streamed pip straight to the terminal, so there is
+            # nothing captured to quote back -- the user already saw it.
+            or f"pip install failed with exit code {completed.returncode}"
         )
         hint = missing_release_asset_hint(release) if isinstance(release, ReleaseSelection) else ""
         message = f"command package update failed: {detail}"


### PR DESCRIPTION
## Capability

`omh update` shows pip's own download and build output while it works, and the
release workflow no longer carries a publish step that cannot succeed.

## Motivation

The owner decided against publishing to PyPI. That settles two things at once.

**The wait stays.** Without an index, pip cannot resolve "the newest version",
so a version-less update keeps fetching the repository archive. That is
accepted — the ask was to make the wait legible, not shorter.

**The PyPI step becomes a hazard.** It was merged in #985 on the assumption
Trusted Publishing would be configured. It will not be. Left in place it does
not sit idle: `uv publish --trusted-publishing always` fails on the next `v*`
tag and stops the release before the Homebrew formula step. A step that can
never succeed is worse than no step, so it is reverted along with the
`docs/RELEASE.md` section describing it.

**The actual reported symptom.** `omh update` printed the package URL and then
nothing:

```
[1/2] Updating omh command package...
https://github.com/rlaope/oh-my-hermes/archive/refs/heads/main.zip
```

…and stayed there for minutes. It was working the whole time; it just looked
dead, and got killed for it. Silence is indistinguishable from a hang.

## Implementation, at the boundary level

- Human mode hands pip the terminal (`stdout`/`stderr` inherited, no `-q`), so
  its download and build lines appear as they happen.
- JSON mode is unchanged in behaviour: it keeps `-q` and keeps capturing,
  because stdout there has to stay parseable.
- The failure path accounts for the new case. When output was streamed there is
  nothing captured to quote back, so the error names the exit code instead of
  rendering an empty detail — the user has already seen pip's own message.
- The PyPI publish step and its docs section are removed; the workflow returns
  to npm → GitHub asset → Homebrew.

## Deliberately not a timeout

An earlier revision bounded the subprocess with `SELF_UPDATE_TIMEOUT_SECONDS`
and was rejected by the owner. The reasoning holds: a timeout does not make a
slow download faster, it converts a long working download into a failure
partway through. The wait is expected, the step line already names the artifact
size, and what was missing was any sign of progress. PR #981, which carried
both halves, is superseded by this one.

## Observed verification

- Full suite: **6729 tests, 16 failures** — identical to the `main` baseline in
  the same environment. Zero added.
- `tests.test_cli`: **9 failures**, against **9 on `main`**. Zero added.
- `docs workflows|roles|capability-families|ulw-inventory|ulw-site --check` — all pass.
- `compileall`, `ruff check src`, `git diff --check` — clean.
- The 16 baseline failures are environment-dependent and do not reproduce in
  CI: 14 are `omh doctor` exiting 1 because this host has a real Hermes Agent
  installed, which makes `plugin_loader_observed` report `registration_mismatch`
  even under a temporary `--hermes-home`; 2 are `test_distribution_packages`
  missing `bun`.

## Risks

- **No automated test asserts what a human-mode terminal displays.** The change
  is covered only indirectly, by the JSON-mode capture path staying parseable.
  The streamed output was confirmed by reading the code path, not by asserting
  on a TTY.
- **`omh update` remains slow on the default preview channel** — 44 MB from an
  endpoint GitHub generates per request. That is now a visible wait rather than
  a silent one, which is the accepted outcome, not an oversight.
- The 14-failure `plugin_loader_observed` test-isolation defect is pre-existing
  and untouched here; it deserves its own issue.