### PR TITLE
fix(plugin): register every OMH tool and hook again

### DIFF
--- a/src/plugin_bundle/omh/__init__.py
+++ b/src/plugin_bundle/omh/__init__.py
@@ -18,6 +18,22 @@ def _host_supports_hook(hook_name: str) -> bool:
     return hook_name in valid_hooks
 
 
+def _register_optional_surface(ctx, method_name: str, *args: object) -> None:
+    """Call a host registration method when this host offers one.
+
+    OMH must not assume a Hermes context shape: assuming one is what silently
+    unregistered every tool and hook. A host without the method is a host that
+    does not want that surface, not an error.
+    """
+    method = getattr(ctx, method_name, None)
+    if not callable(method):
+        return
+    try:
+        method(*args)
+    except (TypeError, ValueError):
+        return
+
+
 def _register_optional_hook(ctx, hook_name: str, callback: object) -> None:
     if not _host_supports_hook(hook_name):
         return
@@ -30,22 +46,35 @@ def _register_optional_hook(ctx, hook_name: str, callback: object) -> None:
 def register(ctx):
     """Register the OMH thin native bridge with Hermes.
 
-    Two different loaders call this with two different contexts. The plugin
-    loader passes a context that registers tools and hooks. The *memory
-    provider* loader in ``plugins/memory/__init__.py`` passes a collector whose
-    only real method is ``register_memory_provider`` -- it no-ops the rest -- so
-    running the tool wiring for it would import ten modules to no effect.
+    Two different loaders call this with two different contexts: the plugin
+    loader, and the *memory provider* loader in ``plugins/memory/__init__.py``.
+    Both now get the full registration, deliberately.
 
-    The real plugin context has no ``register_memory_provider``, which is what
-    makes the two safely distinguishable. Mentioning the name here is also what
-    makes this directory visible to Hermes' provider discovery, which text-scans
-    ``__init__.py`` for it.
+    This used to branch on ``hasattr(ctx, "register_memory_provider")`` and
+    return early, assuming only the memory collector had that attribute. Hermes
+    made both halves of the assumption false, and the failure was silent.
+    ``PluginContext`` gained ``register_memory_provider`` -- recorded and inert
+    unless ``memory.provider`` selects the plugin, added so a plugin's
+    ``register()`` would stop dying on a missing attribute -- so OMH took the
+    memory branch on the plugin path and returned. Meanwhile the collector's
+    ``__getattr__`` began delegating every other ``register_*`` call to a real
+    ``PluginContext``, so a provider "has the same registration surface as any
+    other plugin". Result: every OMH tool and hook registered nowhere, while
+    the plugin still reported ``enabled`` with no error. The only symptom was
+    `omh_*` tools quietly absent from Hermes.
+
+    Nothing is left to discriminate on, and nothing needs discriminating.
+    Registering the provider on the plugin path is inert, and running the tool
+    wiring on the memory path reaches the same registry. The early return only
+    ever saved importing the tool modules on the memory path; that is the price
+    of not silently registering nothing.
+
+    Naming ``register_memory_provider`` here is also what makes this directory
+    visible to Hermes' provider discovery, which text-scans ``__init__.py``.
     """
-    if hasattr(ctx, "register_memory_provider"):
-        from .memory_provider import OmhMemoryProvider
+    from .memory_provider import OmhMemoryProvider
 
-        ctx.register_memory_provider(OmhMemoryProvider())
-        return
+    _register_optional_surface(ctx, "register_memory_provider", OmhMemoryProvider())
 
     from .hooks.llm_hooks import pre_llm_call
     from .hooks.session_hooks import on_session_end

--- a/tests/test_memory_provider.py
+++ b/tests/test_memory_provider.py
@@ -377,13 +377,31 @@ class ProviderRegistrationTests(unittest.TestCase):
         def register_hook(self, name, callback) -> None:
             self.hooks.append(name)
 
-    def test_the_memory_loader_gets_a_provider_and_no_tools(self) -> None:
+    def test_the_memory_loader_gets_a_provider_and_every_tool(self) -> None:
+        # Inverted deliberately. This used to assert the memory path registered
+        # NO tools, which was true only while `register()` returned early on
+        # `hasattr(ctx, "register_memory_provider")`. Hermes broke both halves
+        # of that: `PluginContext` gained the attribute, so the PLUGIN path
+        # took the memory branch and registered nothing at all, and the memory
+        # collector began delegating every other `register_*` to a real
+        # `PluginContext` so "a memory provider has the same registration
+        # surface as any other plugin". Skipping tools here is no longer a
+        # saving -- it is the shape that silently unregistered the whole
+        # bridge. Observed against the real Hermes loader: 0 tools and 0 hooks
+        # before, 12 and 4 after.
         collector = self._Collector()
         register(collector)
         self.assertIsInstance(collector.provider, OmhMemoryProvider)
-        # Registering every tool into a collector that discards them is work the
-        # provider load should never do.
-        self.assertEqual(collector.tools, [])
+        self.assertEqual(sorted(collector.tools), sorted(PROVIDED_TOOLS))
+
+    def test_registration_survives_a_host_without_a_memory_surface(self) -> None:
+        # The guard that replaced the branch: a host that offers no
+        # `register_memory_provider` must still get every tool and hook, rather
+        # than dying on a missing attribute the way Hermes' own note describes.
+        ctx = self._PluginCtx()
+        self.assertFalse(hasattr(ctx, "register_memory_provider"))
+        register(ctx)
+        self.assertEqual(sorted(ctx.tools), sorted(PROVIDED_TOOLS))
 
     def test_the_plugin_loader_still_gets_every_tool_and_hook(self) -> None:
         ctx = self._PluginCtx()


### PR DESCRIPTION
## Capability

OMH's Hermes plugin registers its 12 tools and 4 hooks again. On current Hermes
it was registering **none of them**, silently.

## Motivation

`register(ctx)` discriminated between the two loaders that call it:

```python
if hasattr(ctx, "register_memory_provider"):
    ctx.register_memory_provider(OmhMemoryProvider())
    return
```

with a docstring asserting *"The real plugin context has no
`register_memory_provider`, which is what makes the two safely
distinguishable."* Hermes falsified both halves of that:

- `PluginContext` **gained** `register_memory_provider` — recorded and inert
  unless `memory.provider` selects the plugin, added so a plugin's `register()`
  would stop dying on a missing attribute. So on the **plugin** path OMH took
  the memory branch and returned.
- The memory collector's `__getattr__` began **delegating** every other
  `register_*` call to a real `PluginContext`, so that a provider "has the same
  registration surface as any other plugin". The work the early return saved no
  longer existed.

Observed against the real Hermes loader (v0.20.1) in an isolated `HERMES_HOME`:

```
enabled: True | error: None
tools registered: 0
hooks registered: 0
```

Every `omh_*` tool — `omh_recommend`, `omh_hud`, `omh_todo`, all of them — was
absent from Hermes, with `enabled: True` and no error. Nothing surfaced it.

## Implementation, at the boundary level

The discrimination is **removed**, not repaired. Nothing is left to
discriminate on, and nothing needs it: registering the provider on the plugin
path is inert, and the tool wiring on the memory path reaches the same registry.

`_register_optional_surface(ctx, name, *args)` replaces the branch — a host that
offers a registration method gets that surface; a host that does not is a host
that does not want it, never an error. OMH stops modelling *which loader* is
calling and models *what the host accepts*.

Double registration across both paths was checked explicitly: it raises nothing
and does not duplicate (still exactly 12 tools).

## Observed verification

Real Hermes loader, isolated `HERMES_HOME`, before → after:

```
tools registered: 0  ->  12   (omh_capabilities, omh_context, omh_gather_evidence,
                               omh_hud, omh_interact, omh_memory, omh_probe,
                               omh_recommend, omh_role, omh_source_trust,
                               omh_status, omh_todo)
hooks registered: 0  ->   4   (on_session_end, pre_llm_call, pre_tool_call, pre_verify)
```

Memory-collector path still yields `OmhMemoryProvider`, now plus the same 12
tools and 4 hooks.

Full suite: **6734 tests, 1 failure** — `test_global_tarball_launchers`, the
pre-existing missing-`bun` gap. The `main` baseline in the same environment is
**16 failures**; this change fixes 14 of them, because they were all this bug.

`compileall`, five `docs --check` byte gates, `ruff check src tests`,
`git diff --check` — all clean.

## Contract tests updated deliberately

`test_the_memory_loader_gets_a_provider_and_no_tools` asserted the early-return
design by name. It is inverted to
`test_the_memory_loader_gets_a_provider_and_every_tool`, with a comment
recording why, plus a new
`test_registration_survives_a_host_without_a_memory_surface` covering the guard
that replaced the branch.

## Risks

- **No test exercises Hermes' real `PluginManager`.** The loader evidence comes
  from `omh doctor`'s `plugin_loader_observed` probe, which cannot run in CI
  because CI has no Hermes install. That is exactly why this shipped broken and
  stayed green.
- **This class of bug can recur.** Any future attribute-shape assumption about a
  Hermes context will degrade silently the same way. The trailer carries the
  directive; the real guard is the doctor check, which was reporting
  `registration_mismatch` correctly the whole time and was dismissed as
  environmental noise.
- Registering tools on the memory path costs importing the tool modules there.
  That is the accepted price of not silently registering nothing.