### PR TITLE
feat(tui): give both HUD panels one quiet header grammar

### DIFF
--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -32,6 +32,26 @@ export default function register(sdk) {
   // border; the render callsites hand the components the INNER budget.
   const PANEL_CHROME_COLUMNS = 4
   const PANEL_CHROME_ROWS = 2
+  // Shared header grammar for both panels: mark, then muted detail, then the
+  // one segment that carries state. Kept as constants so the two headers can
+  // never drift into looking like two different products.
+  const BRAND_MARK = '◆'
+  const SEPARATOR = '  ·  '
+
+  const plural = (count, noun) => `${count} ${noun}${count === 1 ? '' : 's'}`
+
+  function hudStateLabel(active, agents) {
+    // Idle says "ready" and nothing more. Claiming work that is not running is
+    // what made the old fixed "Ultra Work Ready" header meaningless -- it read
+    // identically whether four agents were running or none were.
+    if (!active) return 'ready'
+    const running = Number(agents.running) || 0
+    const blocked = Number(agents.blocked) || 0
+    const parts = [plural(Number(agents.active) || 0, 'agent')]
+    if (running) parts.push(`${running} running`)
+    if (blocked) parts.push(`${blocked} blocked`)
+    return parts.join(' · ')
+  }
   const panelProps = t => ({
     borderColor: t.color.primary,
     borderStyle: 'round',
@@ -201,14 +221,19 @@ export default function register(sdk) {
       Box,
       { ...panelProps(t), marginTop: 1 },
       h(
-        Box,
-        { columnGap: 1, flexDirection: 'row' },
-        h(Text, { bold: true, color: t.color.warn }, `[OMH] ${version}`),
-        h(Text, { color: t.color.border }, '-'),
-        h(Text, { bold: true, color: t.color.label }, 'Oh My Hermes'),
-        h(Text, { color: t.color.border }, '•'),
-        h(Text, { color: t.color.label }, 'Ultra Work'),
-        h(Text, { color: t.color.ok }, 'Ready'),
+        Text,
+        { wrap: 'truncate-end' },
+        // One role per colour, so state is what the eye lands on and the
+        // decoration never competes with it: the mark and name carry the
+        // panel's own border colour, the version recedes into muted, and only
+        // the state segment changes hue. The previous header spent its width
+        // naming the product twice ("[OMH] … Oh My Hermes") and then claimed
+        // "Ultra Work Ready" whether or not anything was actually running.
+        h(Text, { bold: true, color: t.color.primary }, `${BRAND_MARK} OMH`),
+        h(Text, { color: t.color.border }, SEPARATOR),
+        h(Text, { color: t.color.muted }, `v${version}`),
+        h(Text, { color: t.color.border }, SEPARATOR),
+        h(Text, { color: active ? t.color.warn : t.color.ok }, hudStateLabel(active, agents)),
       ),
       ...mainRows.map((row, index) =>
         h(ActivityRow, {
@@ -242,7 +267,6 @@ export default function register(sdk) {
     if (todo.status !== 'established' && todo.status !== 'all_done') return null
     const counts = todo.counts || {}
     const title = safeText(todo.title)
-    const label = title ? `Todo · ${title}` : 'Todo'
     if (todo.status === 'all_done') {
       return h(
         Box,
@@ -250,8 +274,13 @@ export default function register(sdk) {
         h(
           Text,
           { wrap: 'truncate-end' },
-          h(Text, { bold: true, color: t.color.warn }, label),
-          h(Text, { color: t.color.ok }, ` ✓ ${counts.done ?? 0}/${counts.total ?? 0}`),
+          // Same grammar as the status header, so the two panels read as one
+          // surface rather than two widgets that happen to share a border.
+          h(Text, { bold: true, color: t.color.primary }, `${BRAND_MARK} Plan`),
+          title ? h(Text, { color: t.color.border }, SEPARATOR) : null,
+          title ? h(Text, { color: t.color.muted }, title) : null,
+          h(Text, { color: t.color.border }, SEPARATOR),
+          h(Text, { color: t.color.ok }, `✓ ${counts.done ?? 0}/${counts.total ?? 0}`),
         ),
       )
     }
@@ -265,8 +294,11 @@ export default function register(sdk) {
       h(
         Text,
         { wrap: 'truncate-end' },
-        h(Text, { bold: true, color: t.color.warn }, label),
-        h(Text, { color: t.color.muted }, `   ${counts.done ?? 0}/${counts.total ?? 0}`),
+        h(Text, { bold: true, color: t.color.primary }, `${BRAND_MARK} Plan`),
+        title ? h(Text, { color: t.color.border }, SEPARATOR) : null,
+        title ? h(Text, { color: t.color.muted }, title) : null,
+        h(Text, { color: t.color.border }, SEPARATOR),
+        h(Text, { color: t.color.warn }, `${counts.done ?? 0}/${counts.total ?? 0}`),
       ),
       ...shown.map((item, index) => {
         const withMore = more > 0 && index === shown.length - 1

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -284,11 +284,26 @@ class TuiWidgetPackTests(unittest.TestCase):
         self.assertNotIn("...maestroRows.map", widget)
         self.assertNotIn("latest ? h(Text", widget)
         self.assertIn("const version = safeText(payload.version)", widget)
-        self.assertIn("`[OMH] ${version}`", widget)
-        self.assertIn("}, '-'),", widget)
-        self.assertIn("'Oh My Hermes'", widget)
-        self.assertIn("'Ultra Work'", widget)
-        self.assertIn("'Ready'", widget)
+        # Header composition, changed on purpose (this used to assert the
+        # literal "`[OMH] ${version}`"). That header named the product twice
+        # and then claimed "Ultra Work Ready" whether or not anything was
+        # running, so it read identically at four active agents and at zero.
+        # What matters now is the contract, not the wording: the version is
+        # still shown, every colour still resolves through the active theme,
+        # and the state segment is derived rather than fixed.
+        self.assertIn("`v${version}`", widget)
+        self.assertIn("hudStateLabel(active, agents)", widget)
+        self.assertIn("if (!active) return 'ready'", widget)
+        # Both panels share one header grammar so they cannot drift into
+        # looking like two different products.
+        self.assertEqual(widget.count("`${BRAND_MARK} Plan`"), 2)
+        self.assertIn("`${BRAND_MARK} OMH`", widget)
+        # The old header's literal pieces ("-", "Oh My Hermes", "Ultra Work",
+        # "Ready") are gone on purpose; asserting them back would re-pin the
+        # wording this change exists to replace. The separator is now shared
+        # between both panels instead of hand-written per segment.
+        self.assertIn("const SEPARATOR = '  ·  '", widget)
+        self.assertNotIn("'Ultra Work'", widget)
         self.assertIn("SPINNER_FRAMES", widget)
         self.assertIn("useShimmerPhase", widget)
         self.assertNotIn("Number.MAX_SAFE_INTEGER", widget)
@@ -306,7 +321,6 @@ class TuiWidgetPackTests(unittest.TestCase):
         self.assertIn("'MAIN'", widget)
         self.assertIn("maestro.rows", widget)
         self.assertIn("fallback:", widget)
-        self.assertIn("'•'", widget)
         self.assertIn("execFile(", widget)
         self.assertIn("Symbol.for(", widget)
         self.assertIn("generationKey", widget)


### PR DESCRIPTION
## Capability

The OMH status HUD and plan-todo panels share one header grammar — brand mark
and name in the panel's border colour, muted version, and a single derived
state segment — replacing a header that named the product twice and claimed
"Ultra Work Ready" regardless of what was running.

## Before / after (observed, throwaway HERMES_HOME, 120 cols)

```
before: │ [OMH] 1.0.6 - Oh My Hermes • Ultra Work Ready │
after:  │ ◆ OMH  ·  v1.0.6  ·  ready                    │
```

Active state derives from the payload: `◆ OMH · v1.0.6 · 4 agents · 3 running · 1 blocked`.
The todo panel becomes `◆ Plan · <title> · 3/8` under the same grammar.

## Implementation

- `BRAND_MARK` / `SEPARATOR` constants shared by both panels so they cannot
  drift into looking like two products.
- `hudStateLabel(active, agents)`: idle → `ready`; active → counts derived
  from the same payload the activity rows render. A fixed label that reads
  identically at zero and four agents is not status.
- Colour roles: mark/name on `t.color.primary` (the panel's own border token),
  version on muted, state on ok/warn. All through the active theme — no
  literals — so every skin recolours the panel coherently.
- Activity rows (`⠴ task · category:… · turn N (M tools) · $cost · running · 1m`)
  are unchanged; the header now frames them instead of competing with them.

## Contract tests

`tests/test_tui_widget_pack.py` pinned the old header literals
(`[OMH] ${version}`, `'Oh My Hermes'`, `'Ultra Work'`, `'Ready'`, the `'-'`
and `'•'` separators). Inverted deliberately with comments: the new contract
asserts the version is shown, colours resolve through the theme, the state
label is derived (`if (!active) return 'ready'`), and both panels use the
shared grammar.

## Observed verification

- Full suite: 6733 tests, 1 failure — the pre-existing missing-`bun`
  distribution gap (main baseline: same 1). Zero added.
- Five `docs --check` byte gates, `compileall`, `ruff`, `git diff --check` — clean.
- Throwaway-home boot: bordered header rendered with ANSI 220/173/178/72 role
  separation (gold mark, dim separators, muted version, green ready).

## Risks

- The active-state header variant was not observed live (no running agents at
  capture time); covered by the unit contract only.