### PR TITLE
feat(identity): ship the OH-MY-HERMES skin and make bare omh the door

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -199,10 +199,11 @@ _Avoid_: opening a PR for it, reaching for `hermes update`
 **Hermes user-config fault**:
 A key that the user or `hermes setup` owns, and that OMH must never write, is
 set inconsistently with what the reporter expects — `model.default`,
-`model.provider`, `model.base_url`, anything under `display.`, the active
+`model.provider`, `model.base_url`, `display.interface`, an explicitly chosen
 skin. Reading the key proves it. OMH reports the inconsistency and stops
 there; it only ever writes the managed keys it installed (see Managed
-artifact). Check it alongside the install fault, before reproducing anything.
+artifact) — `display.skin` counts as managed only in its unset-default case.
+Check it alongside the install fault, before reproducing anything.
 _Avoid_: writing the key from OMH, filing it as a product fault
 
 **OMH product fault**:
@@ -243,7 +244,11 @@ _Avoid_: underroute (that name matches nothing in the code)
 
 **Managed artifact**:
 A file OMH installs and refreshes under a host-owned root and may safely
-overwrite on setup/update — the plugin bundle, the widget file, managed
-skills, and the config keys OMH inserted. Everything else under a host root is
-user-owned and preserved.
-_Avoid_: overwriting anything OMH did not write
+overwrite on setup/update — the plugin bundle, the widget file, the identity
+skin (`skins/omh.yaml`), managed skills, and the config keys OMH inserted.
+`display.skin` is the one identity default OMH sets, and only when the user
+has not chosen a skin; an explicit choice — including `hermes skin use` over
+OMH's default — is user-owned from then on. Everything else under a host root
+is user-owned and preserved.
+_Avoid_: overwriting anything OMH did not write, rewriting an explicit skin
+choice back to `omh`

--- a/README.ja.md
+++ b/README.ja.md
@@ -138,6 +138,26 @@ omh doctor
 [Installation](docs/INSTALLATION.md#reconciling-an-existing-full-install-back-to-core)
 にあります。
 
+## OH-MY-HERMES ターミナル
+
+`omh` と入力するだけで、OMH のアイデンティティをまとった Hermes のモダン TUI が
+開きます:
+
+```sh
+omh
+```
+
+setup は管理された `omh` スキンをインストールします — 上のバッジ色を基準とした
+スカイターコイズのパレットで、バナー・ウェルカム行・レスポンスラベルが
+OH-MY-HERMES にリブランドされます。スキンが未選択の場合にのみデフォルトとして
+有効化されます。`hermes skin use <name>`(`default` を含む)は恒久的に優先され、
+OMH が明示的な選択を書き換えることはありません。TUI 内では OMH HUD がテーマ
+パネルとして描画されます: 作業中はコスト・ターン・キャッシュ指標付きの
+サブエージェント活動行、プロンプトの上にはプラン todo チェックリストが
+表示されます。
+
+<br>
+
 ## 推奨モデル
 
 OMH には次の編集可能な順序付き recommendation chain が含まれています。guided model setup は、ユーザーが active と確認した candidate だけを基準に chain を解決します。その結果は準備済み routing config であり、provider availability、credential、dispatch、execution の証拠ではありません。

--- a/README.ko.md
+++ b/README.ko.md
@@ -139,6 +139,24 @@ omh doctor
 [Installation](docs/INSTALLATION.md#reconciling-an-existing-full-install-back-to-core)에
 있습니다.
 
+## OH-MY-HERMES 터미널
+
+`omh`만 입력하면 OMH 정체성을 입은 Hermes 모던 TUI가 열립니다:
+
+```sh
+omh
+```
+
+setup은 관리형 `omh` 스킨을 설치합니다 — 위 배지 색을 기준으로 한 하늘색
+터쿼이즈 팔레트에, 배너·환영 문구·응답 라벨이 OH-MY-HERMES로 리브랜딩됩니다.
+스킨은 아무것도 선택되지 않았을 때만 기본으로 활성화됩니다. `hermes skin use
+<name>`(`default` 포함)은 영구히 우선하며, OMH는 명시적 선택을 절대 다시 쓰지
+않습니다. TUI 안에서 OMH HUD는 테마 패널로 렌더됩니다: 작업 중에는 비용·턴·캐시
+지표가 붙은 서브에이전트 활동 행이, 프롬프트 위에는 플랜 todo 체크리스트가
+표시됩니다.
+
+<br>
+
 ## 권장 모델
 
 OMH에는 다음과 같이 편집 가능한 순서형 recommendation chain이 포함되어 있습니다. guided model setup은 사용자가 active라고 확인한 candidate만 기준으로 chain을 해석합니다. 그 결과는 준비된 routing config이며 provider availability, credential, dispatch, execution evidence가 아닙니다.

--- a/README.md
+++ b/README.md
@@ -211,6 +211,24 @@ Maintenance paths such as reconciling a `--full` install back to core live in
 
 <br>
 
+## The OH-MY-HERMES terminal
+
+Bare `omh` opens Hermes' modern TUI wearing the OMH identity:
+
+```sh
+omh
+```
+
+Setup installs a managed `omh` skin — sky turquoise anchored on the badge
+colour above, with the banner, welcome line, and response label rebranded to
+OH-MY-HERMES — and selects it only when no skin is chosen. `hermes skin use
+<name>` (including `default`) overrides it permanently; OMH never rewrites an
+explicit choice. Inside the TUI, the OMH HUD renders as a themed panel:
+subagent activity rows with cost, turn, and cache metrics while work runs, and
+the plan todo checklist above the prompt.
+
+<br>
+
 ## Recommended models
 
 OMH ships with these editable, ordered recommendation chains. Guided model

--- a/README.zh.md
+++ b/README.zh.md
@@ -141,6 +141,22 @@ omh doctor
 把 `--full` 安装收敛回 core 这类维护路径，见
 [Installation](docs/INSTALLATION.md#reconciling-an-existing-full-install-back-to-core)。
 
+## OH-MY-HERMES 终端
+
+只需输入 `omh`,即可打开带有 OMH 标识的 Hermes 现代 TUI:
+
+```sh
+omh
+```
+
+setup 会安装受管理的 `omh` 皮肤 — 以上方徽章颜色为基准的天空绿松石配色,
+横幅、欢迎语和响应标签均重塑为 OH-MY-HERMES。仅当未选择任何皮肤时才会默认
+激活。`hermes skin use <name>`(包括 `default`)将永久优先,OMH 绝不改写
+显式选择。在 TUI 中,OMH HUD 以主题面板呈现:工作进行时显示带成本、轮次和
+缓存指标的子代理活动行,提示符上方显示计划 todo 清单。
+
+<br>
+
 ## 推荐模型
 
 OMH 随附以下可编辑的有序 recommendation chain。guided model setup 只会依据用户确认 active 的 candidate 来解析 chain。结果是已准备的 routing config，不是 provider availability、credential、dispatch 或 execution 证据。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ packages = [
   "omh.plugin_bundle.omh.hooks",
   "omh.plugin_bundle.omh.references",
   "omh.plugin_bundle.omh.tools",
+  "omh.skins",
   "omh.tui_widgets",
   "omh.profiles",
   "omh.quality",
@@ -91,6 +92,7 @@ packages = [
 "omh.wrapper" = "src/wrapper"
 
 [tool.setuptools.package-data]
+"omh.skins" = ["*.yaml"]
 "omh.tui_widgets" = ["*.mjs"]
 "omh.catalogs" = ["*.json"]
 "omh.plugin_bundle.omh" = ["plugin.yaml", "config.yaml"]

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -369,6 +369,31 @@ Run `omh --help` for the full command list."""
     )
 
 
+def _launch_hermes_tui() -> int | None:
+    """Open the OH-MY-HERMES terminal: bare `omh` boots Hermes' Ink TUI.
+
+    The oh-my-zsh contract, applied here: the wrapper's bare name IS the
+    styled experience. This execs the user's own `hermes` binary with
+    `--tui` -- a user-invoked local launch, not background dispatch, and the
+    one flag Hermes documents for opening the Ink TUI for a single session
+    without touching `display.interface`. No terminal or no Hermes install
+    means there is nothing to launch, and the caller falls back to the
+    welcome text.
+    """
+    import shutil
+    import subprocess
+
+    if not sys.stdin.isatty() or not sys.stdout.isatty():
+        return None
+    hermes = shutil.which("hermes")
+    if not hermes:
+        return None
+    try:
+        return int(subprocess.run([hermes, "--tui"]).returncode)
+    except (OSError, KeyboardInterrupt):
+        return None
+
+
 def main(argv: list[str] | None = None) -> int:
     raw_argv = list(sys.argv[1:] if argv is None else argv)
     if raw_argv in (["--version"], ["-V"]):
@@ -378,6 +403,9 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(raw_argv)
     set_json_output_pretty(bool(getattr(args, "pretty", False)))
     if not getattr(args, "command", None):
+        launched = _launch_hermes_tui()
+        if launched is not None:
+            return launched
         _print_welcome()
         return 0
     try:

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -33,7 +33,9 @@ from ..coding.model_recommendations import resolve_model_recommendation
 from ..config_adapter import (
     ConfigChange,
     display_interface_selection,
+    display_skin_selection,
     ensure_external_dir,
+    ensure_omh_skin,
     ensure_plugin_enabled,
     external_dirs,
     maybe_set_memory_provider,
@@ -72,6 +74,7 @@ from ..release import (
     package_url_for,
     release_artifact_note,
 )
+from ..skin_pack import SKIN_NAME, install_skin, uninstall_skin
 from ..tui_widget_pack import install_tui_widget, uninstall_tui_widget
 from ..routing.recommend import recommend_skills
 from ..routing.route_plan import build_workflow_route_plan, compact_workflow_route_plan
@@ -368,6 +371,7 @@ def _refresh_installed_tui_widget(args: argparse.Namespace) -> dict[str, object]
     if not paths.hermes_plugin_dir.is_dir():
         return None
     result = install_tui_widget(paths.hermes_home, dry_run=bool(args.dry_run))
+    install_skin(paths.hermes_home, dry_run=bool(args.dry_run))
     # A refreshed widget that the Hermes side cannot load is a success that
     # behaves like a failure; say so at update time (same note as setup).
     _hermes_tui_preflight_step(paths, quiet=_wants_json(args), dry_run=bool(args.dry_run))
@@ -1209,16 +1213,22 @@ def _apply_result(args: argparse.Namespace) -> dict[str, object]:
         # non-default value the user had not chosen, which is exactly what
         # Managed artifact forbids.
         # OMH now reads the interface and adapts to it instead: the widget
-        # still renders when the user runs the Ink TUI, and the plugin's
-        # `on_session_start` line carries the same status in the classic REPL.
+        # renders when the user runs the Ink TUI, and doctor names the
+        # trade-off for the classic REPL.
         tui_interface = ConfigChange(False, "display.interface is Hermes-owned; OMH reads it and never writes it", plugin_enable.text)
+        # Identity is different from terminal choice. The managed skin themes
+        # whichever surface the user already runs -- classic CLI, Ink TUI, and
+        # desktop all read the same YAML -- so defaulting `display.skin` to it
+        # costs no chrome and changes no behaviour, and an explicit skin
+        # choice is never rewritten (see `ensure_omh_skin`).
+        skin_active = ensure_omh_skin(tui_interface.text, SKIN_NAME)
         # Same reasoning one layer down. OMH's memory provider ships inside the
         # bundle, and a provider Hermes never selects is a provider that never
         # runs -- so requiring a control-plane command to switch it on meant the
         # people AGENTS.md says should only need setup/update/doctor would never
         # have it. Claims the slot only when it is free; `set_memory_provider`
         # refuses when another product holds it, because Hermes runs exactly one.
-        memory_provider = maybe_set_memory_provider(tui_interface.text, MEMORY_PROVIDER_NAME, memory_mode)
+        memory_provider = maybe_set_memory_provider(skin_active.text, MEMORY_PROVIDER_NAME, memory_mode)
     except ValueError as exc:
         raise OmhError(str(exc)) from exc
     if not args.dry_run and (
@@ -1226,6 +1236,7 @@ def _apply_result(args: argparse.Namespace) -> dict[str, object]:
         or compression.changed
         or plugin_enable.changed
         or tui_interface.changed
+        or skin_active.changed
         or memory_provider.changed
     ):
         write_config(paths.hermes_config_path, memory_provider.text)
@@ -1244,6 +1255,7 @@ def _apply_result(args: argparse.Namespace) -> dict[str, object]:
             or compression.changed
             or plugin_enable.changed
             or tui_interface.changed
+            or skin_active.changed
             or memory_provider.changed
         ),
         "message": change.message,
@@ -1256,6 +1268,11 @@ def _apply_result(args: argparse.Namespace) -> dict[str, object]:
             "changed": tui_interface.changed,
             "message": tui_interface.message,
             "selected": display_interface_selection(memory_provider.text),
+        },
+        "skin": {
+            "changed": skin_active.changed,
+            "message": skin_active.message,
+            "selected": display_skin_selection(memory_provider.text),
         },
         "memory_provider": {
             "changed": memory_provider.changed,
@@ -1296,6 +1313,11 @@ def cmd_uninstall(args: argparse.Namespace) -> int:
         if remove_all
         else {"status": "not_requested"}
     )
+    skin_result = (
+        uninstall_skin(paths.hermes_home, dry_run=bool(args.dry_run))
+        if remove_all
+        else {"status": "not_requested"}
+    )
     scope = (
         tr(language, "uninstall_scope_all")
         if remove_all
@@ -1313,6 +1335,7 @@ def cmd_uninstall(args: argparse.Namespace) -> int:
             "dry_run": args.dry_run,
             "menubar_app": menubar_result,
             "tui_widget": tui_widget_result,
+            "skin": skin_result,
             "language": language,
         }
     )
@@ -1635,6 +1658,10 @@ def cmd_setup(args: argparse.Namespace) -> int:
     progress.step(step_index, total_steps, tr(language, "step_plugin"), detail=str(paths.hermes_plugin_dir))
     steps["plugin"] = _plugin_setup_result(args, paths)
     steps["tui_widget"] = install_tui_widget(paths.hermes_home, dry_run=bool(args.dry_run))
+    # The OMH identity skin ships next to the widget: same managed-artifact
+    # discipline, same refresh cadence. Activation happens in the config
+    # apply step (`ensure_omh_skin`), never here.
+    steps["skin"] = install_skin(paths.hermes_home, dry_run=bool(args.dry_run))
     steps["hermes_tui_preflight"] = _hermes_tui_preflight_step(
         paths, quiet=_wants_json(args), dry_run=bool(args.dry_run)
     )

--- a/src/install/config_adapter.py
+++ b/src/install/config_adapter.py
@@ -227,10 +227,42 @@ def memory_provider_selection(config_text: str) -> str:
 def display_skin_selection(config_text: str) -> str:
     """The name in `display.skin`, or "" when Hermes resolves its built-in default.
 
-    Read-only: OMH never writes this key. The active skin is what colours the
-    OMH widget's panel border, so doctor names it when reporting the chrome.
+    The active skin is what colours the OMH widget's panel border, so doctor
+    names it when reporting the chrome. `ensure_omh_skin` is the one writer,
+    and only for the unset case.
     """
     return _section_scalar(config_text, "display", "skin")
+
+
+def ensure_omh_skin(config_text: str, name: str) -> ConfigChange:
+    """Default `display.skin` to the managed OMH skin when no skin is chosen.
+
+    This is the owner-directed identity default: installing OMH is opting into
+    the OH-MY-HERMES look, the way installing oh-my-zsh restyles the shell it
+    wraps. It is deliberately narrower than the retired `display.interface`
+    write that #986 removed — that write moved users off Hermes' default
+    terminal and cost them chrome; this one selects a palette on the terminal
+    they already use, only when `display.skin` is unset, and `hermes skin use
+    <anything>` immediately and permanently overrides it because an explicit
+    value is never rewritten.
+    """
+    selected = display_skin_selection(config_text)
+    if selected == name:
+        return ConfigChange(False, f"display.skin is already {name}", config_text)
+    if selected:
+        return ConfigChange(False, f"display.skin is {selected}; leaving user preference unchanged", config_text)
+
+    lines = config_text.splitlines()
+    if any(line.startswith("display.skin:") for line in lines):
+        return ConfigChange(False, "dotted display.skin is user-owned; leaving it alone", config_text)
+    display_indices = [index for index, line in enumerate(lines) if line == "display:"]
+    if len(display_indices) > 1:
+        return ConfigChange(False, "duplicate display sections are ambiguous; leaving them alone", config_text)
+    if not display_indices:
+        text = (config_text.rstrip() + f"\n\ndisplay:\n  skin: {name}\n").lstrip("\n")
+        return ConfigChange(True, "appended display.skin", text)
+    lines.insert(display_indices[0] + 1, f"  skin: {name}")
+    return ConfigChange(True, f"set display.skin to {name}", "\n".join(lines) + "\n")
 
 
 def model_scalar_selection(config_text: str, key: str) -> str:

--- a/src/omh/skin_pack.py
+++ b/src/omh/skin_pack.py
@@ -1,0 +1,122 @@
+"""Managed OMH identity skin for Hermes.
+
+Mirrors ``tui_widget_pack``: the skin is a managed artifact OMH installs into
+``$HERMES_HOME/skins/`` and may safely refresh because a manifest proves OMH
+wrote it. Hermes' own skin engine is the only consumer — a YAML dropped in
+that directory themes the classic CLI, the Ink TUI, and the desktop GUI at
+once, with no Hermes patching involved. A file at the destination without a
+matching manifest is user-owned and never touched.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from importlib import resources
+import json
+import os
+from pathlib import Path
+import secrets
+
+SKIN_NAME = "omh"
+SKIN_FILENAME = "omh.yaml"
+MANIFEST_FILENAME = ".omh-skin.manifest.json"
+_MANIFEST_SCHEMA = "omh_skin_manifest/v1"
+
+
+class SkinInstallError(RuntimeError):
+    """The managed Hermes skin destination is unsafe."""
+
+
+def skin_payload() -> bytes:
+    return resources.files("omh.skins").joinpath(SKIN_FILENAME).read_text(encoding="utf-8").encode()
+
+
+def _reject_symlink_path(path: Path) -> None:
+    current = path
+    while True:
+        if current.is_symlink():
+            raise SkinInstallError(f"refusing symlinked skin path: {current}")
+        if current == current.parent:
+            return
+        current = current.parent
+
+
+def _atomic_write_bytes(path: Path, payload: bytes) -> None:
+    temporary = path.with_name(f".{path.name}.{os.getpid()}-{secrets.token_hex(8)}.tmp")
+    try:
+        with temporary.open("xb") as handle:
+            handle.write(payload)
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists() and not temporary.is_symlink():
+            temporary.unlink()
+
+
+def _sha256(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _is_managed_skin(destination: Path, manifest: Path) -> bool:
+    try:
+        if manifest.is_symlink() or not manifest.is_file():
+            return False
+        record = json.loads(manifest.read_text(encoding="utf-8"))
+        return (
+            record.get("schema_version") == _MANIFEST_SCHEMA
+            and record.get("filename") == SKIN_FILENAME
+            and record.get("sha256") == _sha256(destination.read_bytes())
+        )
+    except (OSError, json.JSONDecodeError, AttributeError):
+        return False
+
+
+def install_skin(hermes_home: Path, *, dry_run: bool = False) -> dict[str, str]:
+    destination_dir = hermes_home / "skins"
+    destination = destination_dir / SKIN_FILENAME
+    manifest = destination_dir / MANIFEST_FILENAME
+    _reject_symlink_path(hermes_home)
+    _reject_symlink_path(destination_dir)
+    _reject_symlink_path(destination)
+    if destination.exists() and not destination.is_file():
+        raise SkinInstallError(f"skin destination is not a regular file: {destination}")
+    payload = skin_payload()
+    if destination.exists() and not _is_managed_skin(destination, manifest):
+        # A user-authored omh.yaml wins over ours forever; identity is theirs
+        # to override and update must not undo that.
+        return {"status": "kept_unmanaged", "path": str(destination)}
+    status = "unchanged" if destination.exists() and destination.read_bytes() == payload else "installed"
+    if dry_run and status == "installed":
+        status = "would_install"
+    elif status == "installed":
+        destination_dir.mkdir(parents=True, exist_ok=True)
+        _reject_symlink_path(destination_dir)
+        _atomic_write_bytes(destination, payload)
+        _atomic_write_bytes(
+            manifest,
+            json.dumps(
+                {
+                    "schema_version": _MANIFEST_SCHEMA,
+                    "filename": SKIN_FILENAME,
+                    "sha256": _sha256(payload),
+                },
+                sort_keys=True,
+            ).encode(),
+        )
+    return {"status": status, "path": str(destination), "skin": SKIN_NAME}
+
+
+def uninstall_skin(hermes_home: Path, *, dry_run: bool = False) -> dict[str, str]:
+    destination_dir = hermes_home / "skins"
+    destination = destination_dir / SKIN_FILENAME
+    manifest = destination_dir / MANIFEST_FILENAME
+    _reject_symlink_path(destination_dir)
+    _reject_symlink_path(destination)
+    _reject_symlink_path(manifest)
+    if not destination.exists() and not manifest.exists():
+        return {"status": "absent", "path": str(destination)}
+    if not _is_managed_skin(destination, manifest):
+        return {"status": "kept_unmanaged", "path": str(destination)}
+    if not dry_run:
+        destination.unlink()
+        manifest.unlink()
+    return {"status": "would_remove" if dry_run else "removed", "path": str(destination)}

--- a/src/omh/skins/__init__.py
+++ b/src/omh/skins/__init__.py
@@ -1,0 +1,1 @@
+"""Packaged Hermes skins."""

--- a/src/omh/skins/omh.yaml
+++ b/src/omh/skins/omh.yaml
@@ -1,0 +1,86 @@
+# OMH identity skin for Hermes Agent.
+#
+# Managed artifact: `omh setup` installs this file into $HERMES_HOME/skins/
+# and refreshes it on update; edits here are overwritten. The palette anchors
+# on the README badge turquoise (#00CED1) with a sky gradient above it, and
+# `branding` renames the surfaces Hermes lets a skin own — the banner title,
+# welcome line, and response label — to OH-MY-HERMES. Hermes' skin engine is
+# the only consumer; OMH never patches Hermes to apply any of this.
+name: omh
+description: OH-MY-HERMES — sky turquoise orchestration identity
+
+colors:
+  background: "#081C22"
+  banner_border: "#1E8A99"
+  banner_title: "#7FDBFF"
+  banner_accent: "#00CED1"
+  banner_dim: "#3E7C8A"
+  banner_text: "#E4FAFF"
+  ui_accent: "#00CED1"
+  ui_label: "#7FDBFF"
+  ui_ok: "#4caf50"
+  ui_error: "#ef5350"
+  ui_warn: "#ffa726"
+  ui_tool: "#00CED1"
+  ui_thinking: "#3E7C8A"
+  prompt: "#E4FAFF"
+  input_rule: "#1E8A99"
+  response_border: "#00CED1"
+  status_bar_bg: "#0A2229"
+  status_bar_text: "#CFF3F8"
+  status_bar_strong: "#7FDBFF"
+  status_bar_dim: "#4A7580"
+  status_bar_good: "#6ED7B0"
+  status_bar_warn: "#00CED1"
+  status_bar_bad: "#3E9FB0"
+  status_bar_critical: "#D94F4F"
+  session_label: "#7FDBFF"
+  session_border: "#4A7580"
+  completion_menu_bg: "#0A2229"
+  completion_menu_current_bg: "#14444F"
+  selection_bg: "#155E6B"
+  voice_status_bg: "#0A2229"
+  syntax_string: "#00CED1"
+  syntax_number: "#E4FAFF"
+  syntax_keyword: "#7FDBFF"
+  syntax_comment: "#3E7C8A"
+
+spinner:
+  waiting_faces:
+    - "(◆)"
+    - "(≋)"
+    - "(∿)"
+    - "(◇)"
+  thinking_faces:
+    - "(◆)"
+    - "(◇)"
+    - "(≋)"
+    - "(⌁)"
+  thinking_verbs:
+    - "orchestrating"
+    - "routing skills"
+    - "weighing evidence"
+    - "preparing handoffs"
+    - "sequencing agents"
+    - "charting workflows"
+  wings:
+    - ["⟪◆", "◆⟫"]
+    - ["⟪≋", "≋⟫"]
+
+branding:
+  agent_name: "OH-MY-HERMES"
+  welcome: "Welcome to OH-MY-HERMES! Type your message or /help for commands."
+  goodbye: "Goodbye! ◆"
+  response_label: " ◆ OMH "
+  prompt_symbol: "❯"
+  help_header: "(◆) Commands"
+
+tool_prefix: "│"
+
+banner_logo: |-
+  [bold #B8F4FF] ██████╗ ██╗  ██╗      ███╗   ███╗██╗   ██╗      ██╗  ██╗███████╗██████╗ ███╗   ███╗███████╗███████╗[/]
+  [bold #7FDBFF]██╔═══██╗██║  ██║      ████╗ ████║╚██╗ ██╔╝      ██║  ██║██╔════╝██╔══██╗████╗ ████║██╔════╝██╔════╝[/]
+  [#40D6DE]██║   ██║███████║█████╗██╔████╔██║ ╚████╔╝ █████╗███████║█████╗  ██████╔╝██╔████╔██║█████╗  ███████╗[/]
+  [#00CED1]██║   ██║██╔══██║╚════╝██║╚██╔╝██║  ╚██╔╝  ╚════╝██╔══██║██╔══╝  ██╔══██╗██║╚██╔╝██║██╔══╝  ╚════██║[/]
+  [#0FA3AF]╚██████╔╝██║  ██║      ██║ ╚═╝ ██║   ██║         ██║  ██║███████╗██║  ██║██║ ╚═╝ ██║███████╗███████║[/]
+  [#0B7E8A] ╚═════╝ ╚═╝  ╚═╝      ╚═╝     ╚═╝   ╚═╝         ╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚═╝     ╚═╝╚══════╝╚══════╝[/]

--- a/tests/test_handoff_safety_contract_enforcement.py
+++ b/tests/test_handoff_safety_contract_enforcement.py
@@ -154,6 +154,10 @@ PROCESS_SPAWN_ALLOWLIST: dict[str, str] = {
         "`git rev-parse <base-ref>` inside the operator-invoked `coding fanout dispatch` command, "
         "to resolve the base commit before the fanout bridge above runs."
     ),
+    "src/commands/main.py": (
+        "bare `omh` with a tty -- the operator's own launch of `hermes --tui`, the "
+        "OH-MY-HERMES terminal; never reached from any prepared-handoff path."
+    ),
     "src/commands/setup.py": (
         "`omh setup` / `omh update` -- pip self-update, CLI re-entry after update, and the "
         "opt-in GitHub star (see GH_INVOCATION_EXCEPTIONS in INVARIANT 3)."

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -3821,6 +3821,14 @@ class RouterContentTests(unittest.TestCase):
         readme_section_translations = (
             ("## Quick Start", {"ko": "## 빠른 시작", "ja": "## クイックスタート", "zh": "## 快速开始"}),
             (
+                "## The OH-MY-HERMES terminal",
+                {
+                    "ko": "## OH-MY-HERMES 터미널",
+                    "ja": "## OH-MY-HERMES ターミナル",
+                    "zh": "## OH-MY-HERMES 终端",
+                },
+            ),
+            (
                 "## Recommended models",
                 {
                     "ko": "## 권장 모델",

--- a/tests/test_skin_pack.py
+++ b/tests/test_skin_pack.py
@@ -1,0 +1,133 @@
+"""The managed OMH identity skin: install discipline and activation rules.
+
+The skin is the owner-directed identity default — installing OMH opts into the
+OH-MY-HERMES look the way installing oh-my-zsh restyles the shell — so these
+tests pin the two edges that keep it honest: the file is only ever overwritten
+when a manifest proves OMH wrote it, and `display.skin` is only ever written
+in the unset case. An explicit user skin wins forever, in both places.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from omh.install.config_adapter import display_skin_selection, ensure_omh_skin
+from omh.skin_pack import (
+    SKIN_FILENAME,
+    SKIN_NAME,
+    install_skin,
+    skin_payload,
+    uninstall_skin,
+)
+
+
+class SkinPayloadTests(unittest.TestCase):
+    def test_the_shipped_skin_carries_the_identity_contract(self) -> None:
+        text = skin_payload().decode("utf-8")
+        self.assertIn("name: omh", text)
+        # The rename is the point: Hermes' banner title and welcome line read
+        # OH-MY-HERMES through skin branding alone, never through a patch.
+        self.assertIn('agent_name: "OH-MY-HERMES"', text)
+        self.assertIn("banner_logo:", text)
+        # The palette anchors on the README badge turquoise.
+        self.assertIn('"#00CED1"', text)
+
+    def test_the_logo_rows_are_equally_wide(self) -> None:
+        # A block logo with ragged rows renders as visible corruption in the
+        # banner; alignment is a contract, not cosmetics.
+        import re
+
+        text = skin_payload().decode("utf-8")
+        # No strip: the O and the closing S rows legitimately begin with a
+        # space, and eating it is exactly the misalignment this test exists
+        # to catch. Only the rich markup and the uniform YAML block indent go.
+        rows = [
+            re.sub(r"\[[^\]]*\]", "", line).removeprefix("  ")
+            for line in text.splitlines()
+            if "██" in line or "╚" in line
+        ]
+        self.assertTrue(rows)
+        self.assertEqual(len({len(row) for row in rows}), 1)
+
+
+class SkinInstallTests(unittest.TestCase):
+    def test_install_writes_skin_and_manifest(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp).resolve()
+            result = install_skin(home)
+            self.assertEqual(result["status"], "installed")
+            destination = home / "skins" / SKIN_FILENAME
+            self.assertEqual(destination.read_bytes(), skin_payload())
+            manifest = json.loads((home / "skins" / ".omh-skin.manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(manifest["filename"], SKIN_FILENAME)
+
+    def test_reinstall_is_idempotent(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp).resolve()
+            install_skin(home)
+            self.assertEqual(install_skin(home)["status"], "unchanged")
+
+    def test_a_user_authored_skin_file_is_never_replaced(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp).resolve()
+            destination = home / "skins" / SKIN_FILENAME
+            destination.parent.mkdir(parents=True)
+            destination.write_text("name: omh\n# mine\n", encoding="utf-8")
+            self.assertEqual(install_skin(home)["status"], "kept_unmanaged")
+            self.assertEqual(destination.read_text(encoding="utf-8"), "name: omh\n# mine\n")
+
+    def test_uninstall_removes_only_the_managed_file(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp).resolve()
+            install_skin(home)
+            self.assertEqual(uninstall_skin(home)["status"], "removed")
+            self.assertFalse((home / "skins" / SKIN_FILENAME).exists())
+
+    def test_uninstall_keeps_a_user_authored_file(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp).resolve()
+            destination = home / "skins" / SKIN_FILENAME
+            destination.parent.mkdir(parents=True)
+            destination.write_text("name: omh\n", encoding="utf-8")
+            self.assertEqual(uninstall_skin(home)["status"], "kept_unmanaged")
+            self.assertTrue(destination.exists())
+
+
+class EnsureOmhSkinTests(unittest.TestCase):
+    def test_unset_skin_defaults_to_omh(self) -> None:
+        change = ensure_omh_skin("display:\n  compact: true\n", SKIN_NAME)
+        self.assertTrue(change.changed)
+        self.assertEqual(display_skin_selection(change.text), SKIN_NAME)
+        self.assertIn("  compact: true", change.text)
+
+    def test_missing_display_section_is_appended(self) -> None:
+        change = ensure_omh_skin("plugins:\n  enabled:\n    - omh\n", SKIN_NAME)
+        self.assertTrue(change.changed)
+        self.assertEqual(display_skin_selection(change.text), SKIN_NAME)
+
+    def test_an_explicit_skin_choice_is_never_rewritten(self) -> None:
+        # `hermes skin use ares` after setup must stick across every future
+        # update; rewriting it would repeat the display.interface mistake.
+        text = "display:\n  skin: ares\n"
+        change = ensure_omh_skin(text, SKIN_NAME)
+        self.assertFalse(change.changed)
+        self.assertEqual(change.text, text)
+
+    def test_already_omh_is_unchanged(self) -> None:
+        change = ensure_omh_skin("display:\n  skin: omh\n", SKIN_NAME)
+        self.assertFalse(change.changed)
+
+    def test_dotted_key_is_user_owned(self) -> None:
+        change = ensure_omh_skin("display.skin: ares\n", SKIN_NAME)
+        self.assertFalse(change.changed)
+
+    def test_duplicate_display_sections_are_left_alone(self) -> None:
+        change = ensure_omh_skin("display:\n  compact: true\ndisplay:\n  streaming: true\n", SKIN_NAME)
+        self.assertFalse(change.changed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -107,7 +107,11 @@ class TuiWidgetPackTests(unittest.TestCase):
 
             self.assertEqual((status, stderr), (0, ""))
             config_text = config.read_text(encoding="utf-8")
-            self.assertIn("display:\n  interface: classic\n", config_text)
+            # The identity skin default lands in the same display section, so
+            # the interface line is no longer adjacent to the header; what this
+            # test protects is that the explicit classic choice SURVIVES setup.
+            self.assertIn("  interface: classic\n", config_text)
+            self.assertIn("  skin: omh\n", config_text)
             self.assertEqual(config_text.count("interface:"), 1)
             self.assertEqual(json.loads(stdout)["steps"]["apply"]["tui_interface"]["selected"], "classic")
 


### PR DESCRIPTION
## Capability

Installing OMH now installs an identity: a managed `omh` skin that rebrands
Hermes' banner, welcome line, and response label to OH-MY-HERMES under a sky
turquoise palette, activated as the default whenever the user has not chosen a
skin — and bare `omh` on a terminal opens the Ink TUI, so the wrapper's own
name is the door to the styled experience.

## What it looks like (observed, throwaway HERMES_HOME)

```
 ██████╗ ██╗  ██╗      ███╗   ███╗██╗   ██╗      ██╗  ██╗███████╗██████╗ ███╗   ███╗███████╗███████╗
██╔═══██╗██║  ██║      ████╗ ████║╚██╗ ██╔╝      ██║  ██║██╔════╝██╔══██╗████╗ ████║██╔════╝██╔════╝
██║   ██║███████║█████╗██╔████╔██║ ╚████╔╝ █████╗███████║█████╗  ██████╔╝██╔████╔██║█████╗  ███████╗
██║   ██║██╔══██║╚════╝██║╚██╔╝██║  ╚██╔╝  ╚════╝██╔══██║██╔══╝  ██╔══██╗██║╚██╔╝██║██╔══╝  ╚════██║
╚██████╔╝██║  ██║      ██║ ╚═╝ ██║   ██║         ██║  ██║███████╗██║  ██║██║ ╚═╝ ██║███████╗███████║
 ╚═════╝ ╚═╝  ╚═╝      ╚═╝     ╚═╝   ╚═╝         ╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚═╝     ╚═╝╚══════╝╚══════╝

Welcome to OH-MY-HERMES! Type your message or /help for commands.
```

Sky gradient confirmed in truecolor from the captured pane (`38;2;184;244;255`
= #B8F4FF, `38;2;127;219;255` = #7FDBFF), anchored on the README badge
turquoise #00CED1 across ui accents, status bar, response border, and prompt.

## Implementation, at the boundary level

- **`src/omh/skins/omh.yaml`** — full skin: palette, spinner (orchestration
  verbs), branding (`agent_name`, `welcome`, `response_label`, `goodbye`),
  6-row block logo with a width-alignment test. Everything rides Hermes' own
  skin engine; zero patching.
- **`src/omh/skin_pack.py`** — install/uninstall mirroring `tui_widget_pack`:
  manifest-proven overwrites only, user-authored `omh.yaml` wins forever,
  symlink refusal, atomic writes.
- **`ensure_omh_skin`** (config adapter) — writes `display.skin: omh` only
  when the key is unset. Explicit choices — including an explicit
  `skin: default` — are never rewritten. This is deliberately narrower than
  the `display.interface` write #986 removed: that changed which terminal
  opens and cost users chrome; this selects a palette on the terminal they
  already run, and `hermes skin use <anything>` overrides it permanently.
- **Bare `omh`** — with a tty and a `hermes` on PATH, launches `hermes --tui`
  and returns its exit code. Non-tty or no Hermes keeps the existing welcome
  text, so scripts and CI are byte-identical. The `subprocess` import is
  registered in `PROCESS_SPAWN_ALLOWLIST` with the operator-launch reason,
  following INVARIANT 1's own procedure.
- **CONTEXT.md** — Managed artifact and Hermes user-config fault entries
  updated in the same commit: `display.skin` is managed only in its
  unset-default case.

## A real config taught the activation rule

During verification, a config carrying an explicit `skin: default` swallowed
the inserted default via YAML last-key-wins. That is the correct outcome, not
a bug: an explicit `default` is the user choosing Hermes classic, and
`ensure_omh_skin` honours it the same as any other explicit skin. The test
suite pins this (`test_an_explicit_skin_choice_is_never_rewritten`).

## Known limit

The banner box's version line (`Hermes Agent v0.20.1 …`) is hardcoded by
Hermes outside the skin surface and keeps saying Hermes Agent. The logo,
welcome, response label, and suspend messages all rebrand.

## Observed verification

- Full suite: **6747 tests, 1 failure** — the pre-existing missing-`bun`
  distribution gap. Zero added.
- 13 new tests: payload contract, logo alignment, install/uninstall
  discipline, activation rules (explicit-choice negative controls included).
- Five `docs --check` byte gates, `compileall`, `ruff`, `git diff --check` — clean.
- Throwaway-home boot captures above; bare `omh` in tmux launched the Ink TUI.

## Risks

- Desktop GUI surface of the skin unobserved (same YAML feeds it per Hermes'
  skin engine docs, but not captured).
- Windows tty detection for the bare-`omh` launch untested; CI's
  test-windows covers the non-tty fallback path only.