### PR TITLE
feat(menubar): show live Hermes status

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -149,6 +149,9 @@ src/
   surfaces/
     context.py
     demo.py
+    hermes_model_settings.py
+    hermes_processes.py
+    hermes_sessions.py
     hud.py
     menubar_app.py
     menubar_status.py
@@ -232,22 +235,22 @@ context is prompt guidance only; it is not proof
 that a separate role, worker, or executor ran.
 
 `menubar_status.py` owns the platform-neutral macOS menu bar view model exposed
-by `omh menubar status --json`. Its `menubar_status/v1` payload is a UI
-projection over the same local HUD, target registry, and runtime evidence. It is
-intentionally not the source of truth. The payload separates `hermes_agents` from
-`external_coding_executors` so Codex, Claude Code, OMX, OMO, OMC, or generic
-coding tools cannot be rendered as Hermes agents by accident. Compact surfaces
-receive source and model `icon_id` values plus tooltip text rather than Markdown
-tables or prose-only labels. `display.menu_cards` is the human-facing card model
-for the native menu bar helper, grouping the same contract into Agent Status,
-Coding Agent, and Evidence sections so compact UI surfaces do not need to render
-raw JSON-like text. The Agent Status section uses an explicit `Agent | PID |
-Status` row shape.
+by `omh menubar status --json`. Its `menubar_status/v2` payload is a UI
+projection over local HUD, target-registry, runtime, and read-only Hermes
+observations; it is intentionally not the source of truth. The payload retains
+separate `hermes_agents` and `external_coding_executors` metadata so Codex,
+Claude Code, OMX, OMO, OMC, or generic coding tools cannot be rendered as
+Hermes agents by accident. `display.menu_cards` is the human-facing model for
+the native helper: a Sessions table, a Models table, and one compact coding
+metadata footer. Sessions uses the exact columns `Hermes session` / `Count` and
+only the `live` and `total` rows. Session source or TUI breakdown is
+intentionally not exposed. In Models, `current` is the model observed on the
+live Hermes session; `main` and auxiliary aliases are configuration values.
 
 Plain `omh menubar status` renders a short terminal summary from the same
-payload so operators see Summary, Agent Status, Coding Agent, Evidence, and
-Observation sections without reading raw JSON. Machine consumers should request
-`--json` or set `OMH_OUTPUT=json`.
+payload so operators see Summary, Sessions, Models, the compact coding metadata
+footer, and Observation without reading raw JSON. Machine consumers should
+request `--json` or set `OMH_OUTPUT=json`.
 
 `current_external_coding_executor` names the selected row explicitly, preferring
 `runtime/state.json` `last_run_id` when it matches the recent executor list, so
@@ -261,15 +264,27 @@ JSON files. Setup records `project_memory_policy/v1` with `off`,
 prepared context only; they are not execution, review, CI, merge, or Hermes
 internal-memory evidence.
 
+The three observer modules keep these inputs separate.
+`hermes_processes.py` performs the bounded local process-tree scan and reports
+Hermes agent roots and total matching processes. `hermes_sessions.py` opens
+Hermes `state.db` read-only for visible live/total session counts and the newest
+live session's model. `hermes_model_settings.py` reads `config.yaml` for the
+configured `main` and auxiliary model aliases. The status path does not invoke
+Hermes, make network requests, or write any Hermes-owned file.
+
+Session counts are a read-only observation of Hermes' own session store; they are not execution, review, CI, merge, or token-usage evidence.
+
+Model settings are read from Hermes configuration; a configured alias is not evidence that a request used that model.
+
 The menu bar status contract reports configured Hermes targets and prepared
 handoffs without inventing process state. PID, `running`, and `restarting`
 values are applied only from a caller-provided `menubar_process_overlay/v1`
 payload or an explicit `omh menubar status --observe-local-processes --json`
-request from the native macOS helper. That observation is app-local, expires
+request. The native macOS helper makes that explicit request; plain `omh menubar
+status` performs no process scan. Process observation is app-local, expires
 after a short TTL, and applies restarting state only inside its restart window.
-OMH does not turn prepared handoffs into observed execution, review, CI, or merge
-evidence. Plain `omh menubar status` remains metadata-only, even though its
-default terminal output is human-readable.
+OMH does not turn prepared handoffs into observed execution, review, CI, or
+merge evidence.
 
 `cli.py` is a compatibility adapter. `commands/main.py` owns parser assembly,
 top-level error handling, and the public command handler re-export surface.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -536,31 +536,31 @@ untouched for 24 hours is hidden as stale.
 `omh setup` deliberately records a safety-first `choose` preference and asks
 no upfront coding-owner question, so Hermes asks which coding agent to use at
 the first coding request instead of at install time. The HUD line and the
-`menubar_status/v1` payload follow the same three-state model so that an
-unselected coding agent never reads as an idle external agent named
-`choose`/`ask`:
+coding metadata retained by the `menubar_status/v2` payload follow the same
+three-state model so that an unselected coding agent never reads as an idle
+external agent named `choose`/`ask`:
 
 1. **No-run.** No coding request has been routed yet.
    - No preference recorded (the normal safety-first default): the HUD
      `coding-agent` segment is executor-neutral,
-     `coding-agent:not-selected`, and the menu bar's `settings.coding_handoff`
-     reads `Coding agent: Not selected` with `source: "none"`. The Coding
-     Agent card shows `Status: ready` with the detail "Hermes routes the next
-     request to a coding agent" instead of an idle-agent row.
+     `coding-agent:not-selected`, and the menu bar payload's
+     `settings.coding_handoff` reads `Coding agent: Not selected` with
+     `source: "none"`. The menu ends with a compact `coding` metadata footer
+     rather than presenting this as an observed run.
    - A real preference was recorded (for example `omh setup
      --default-executor codex`): the executor name is shown because it is a
      genuine user choice, not a placeholder — `coding-agent:idle(codex)` on
      the HUD line, and `Coding agent: Codex` with `source: "user_preference"`
-     and `Status: preferred` (detail "no request routed yet") in the menu bar.
+     in the menu bar payload.
 2. **Prepared handoff.** `omh coding delegate --record` prepared a handoff for
    a run but execution has not been observed: `coding-agent:prepared(codex)`
-   on the HUD line, and the menu bar shows `source: "prepared_handoff"` with
-   the executor's prepared status.
+   on the HUD line, and the menu bar payload records
+   `source: "prepared_handoff"`.
 3. **Observed run.** A run recorded observed evidence (dispatch, execution,
    verification, review, CI, or merge): the HUD line shows the run's actual
-   phase, for example `coding-agent:runtime(codex)`, and the menu bar shows
-   `source: "observed_runtime"`. The `evidence` HUD segment and the menu bar's
-   Evidence card carry the same prepared-versus-observed boundary as before.
+   phase, for example `coding-agent:runtime(codex)`, and the menu bar payload
+   records `source: "observed_runtime"`. The `evidence` HUD segment keeps the
+   same prepared-versus-observed boundary as before.
 
 A quiet no-run line looks like
 `[omh] v1.0.6 | plugin:ready | target:single | coding-agent:not-selected`.
@@ -588,36 +588,38 @@ human-readable summary:
 omh menubar status
 ```
 
-It prints Summary, Agent Status, Coding Agent, Evidence, and Observation
-sections instead of a raw JSON blob. For native menu bar, status-widget, wrapper,
-or automation integrations, use the platform-neutral view model:
+It prints Summary, Sessions, Models, the compact coding metadata footer, and
+Observation sections instead of a raw JSON blob. For native menu bar,
+status-widget, wrapper, or automation integrations, use the platform-neutral
+view model:
 
 ```sh
 omh menubar status --json
 ```
 
-The `menubar_status/v1` JSON has separate `hermes_agents` and
-`external_coding_executors` sections, friendly labels such as `OMH connection:
-Ready`, `Hermes targets: 2`, `Coding agent: Codex` (or `Coding agent: Not
-selected` in the no-run/no-preference state), and `Open mode: Ask before
-opening Codex`, plus source/model icon IDs with tooltip text. The
-`settings.coding_handoff.source` field distinguishes why an executor name is
-or is not shown — `"none"`, `"user_preference"`, `"prepared_handoff"`, or
-`"observed_runtime"` — per the status model above. It also includes
-`display.menu_cards`, a compact Agent Status/Coding Agent/Evidence card model
-for native menu bar surfaces. The Agent Status card is a small `Agent | PID |
-Status` list. Codex and other coding tools are external executors, not Hermes
-agents. Without an explicit process overlay or local process observation, the
-payload reports configured/prepared state only and shows PID as not observed.
+The `menubar_status/v2` JSON retains the separate `hermes_agents` and
+`external_coding_executors` metadata and adds read-only Hermes process, session,
+and model observations. Its `display.menu_cards` contains Sessions and Models
+tables followed by one compact `coding` metadata footer. The Sessions columns
+are exactly `Hermes session` / `Count`, and its rows are only `live` and
+`total`; source or TUI breakdown is intentionally not shown. Session counts
+come from a read-only read of Hermes' own session store. In Models, `current`
+is the model observed on the live Hermes session, while `main` and any auxiliary
+alias rows are settings read from Hermes configuration. A configured model is
+not evidence that a request used it. The `settings.coding_handoff.source` field
+continues to distinguish `"none"`, `"user_preference"`,
+`"prepared_handoff"`, and `"observed_runtime"` per the status model above.
 
 On macOS, a normal user-scope `omh setup` also attempts to build and start the
 small OMH menu bar helper when `swiftc` is available. The helper lives under
 `~/.omh/menubar`, is started with a user LaunchAgent, and refreshes the same
 `omh menubar status --observe-local-processes --json` payload. The visible menu is
-intentionally grouped as Agent Status, Coding Agent, and Evidence sections
-instead of a raw text list, and it shows process/PID detail only when a fresh
-overlay or explicit local observation saw that process. Use explicit commands
-when you want to manage it yourself:
+grouped as Sessions and Models tables with a compact coding metadata footer
+instead of a raw text list. The helper explicitly requests the bounded local
+process scan so its header can show observed Hermes agent/process counts; plain
+`omh menubar status` does not scan processes unless
+`--observe-local-processes` is supplied. Use explicit commands when you want to
+manage it yourself:
 
 ```sh
 omh menubar install
@@ -643,7 +645,8 @@ omh menubar status --observe-local-processes
 
 The overlay and local observation are app-local and expire by TTL. OMH does not
 infer that a prepared coding-agent action was executed, reviewed, passed CI, or
-merged.
+merged. The session-store and configuration observers are local and read-only:
+the status path makes no network request and does not write Hermes-owned files.
 
 MCP bridge setup is also optional and intentionally conservative:
 

--- a/src/commands/menubar.py
+++ b/src/commands/menubar.py
@@ -99,6 +99,8 @@ def _format_menubar_status(payload: Mapping[str, object]) -> str:
     settings = _as_mapping(payload.get("settings"))
     versions = _as_mapping(payload.get("versions"))
     process_overlay = _as_mapping(payload.get("process_overlay"))
+    hermes_sessions = _as_mapping(payload.get("hermes_sessions"))
+    hermes_processes = _as_mapping(payload.get("hermes_processes"))
 
     lines = ["OMH menu bar status", "Summary"]
     headline = _text(display.get("headline")) or "OMH status"
@@ -106,6 +108,20 @@ def _format_menubar_status(payload: Mapping[str, object]) -> str:
     lines.append(f"  Status: {headline}")
     if summary:
         lines.append(f"  Activity: {summary}")
+    if _truthy(hermes_sessions.get("observed")):
+        lines.append(
+            f"  Sessions: live {_text(hermes_sessions.get('live'))} / "
+            f"total {_text(hermes_sessions.get('total'))}"
+        )
+    else:
+        lines.append("  Sessions: not observed")
+    if _truthy(hermes_processes.get("observed")):
+        lines.append(
+            f"  Processes: {_text(hermes_processes.get('agent_count'))} agent / "
+            f"{_text(hermes_processes.get('process_count'))} processes"
+        )
+    else:
+        lines.append("  Processes: not observed")
     omh_version = _as_mapping(versions.get("omh"))
     if omh_version:
         lines.append(f"  OMH version: {_text(omh_version.get('value')) or 'unknown'}")
@@ -125,16 +141,11 @@ def _format_menubar_status(payload: Mapping[str, object]) -> str:
         lines.extend(["", title])
         columns = [_text(column) for column in _as_sequence(card.get("columns"))]
         rows = [_as_mapping(row) for row in _as_sequence(card.get("rows"))]
-        agent_rows = [row for row in rows if row.get("kind") == "agent_status"]
-        if columns and agent_rows:
-            lines.append(f"  {_pad(columns[0], 20)} {_pad(columns[1], 14)} {columns[2] if len(columns) > 2 else 'Status'}")
-            for row in agent_rows:
-                lines.append(
-                    "  "
-                    f"{_pad(_text(row.get('agent')) or 'unknown', 20)} "
-                    f"{_pad(_text(row.get('pid')) or 'not observed', 14)} "
-                    f"{_text(row.get('status')) or 'unknown'}"
-                )
+        table_rows = [row for row in rows if row.get("kind") == "table_row"]
+        if columns and table_rows:
+            lines.append(f"  {_pad(columns[0], 20)} {columns[1]}")
+            for row in table_rows:
+                lines.append(f"  {_pad(_text(row.get('left')), 20)} {_text(row.get('right'))}")
         else:
             for row in rows:
                 label = _text(row.get("label"))
@@ -142,7 +153,6 @@ def _format_menubar_status(payload: Mapping[str, object]) -> str:
                 detail = _text(row.get("detail"))
                 if not label and not value:
                     continue
-                value = _friendly_row_value(label, value)
                 line = f"  {label}: {value}" if label and value else f"  {label or value}"
                 if detail:
                     line = f"{line} - {detail}"
@@ -228,12 +238,6 @@ def _single_line(value: str) -> str:
 
 def _truthy(value: object) -> bool:
     return bool(value) and str(value).lower() not in {"false", "0", "none", "null"}
-
-
-def _friendly_row_value(label: str, value: str) -> str:
-    if label.lower() == "boundary" and value.lower() == "unknown":
-        return "no active evidence state"
-    return value
 
 
 def _pad(value: str, width: int) -> str:

--- a/src/commands/menubar.py
+++ b/src/commands/menubar.py
@@ -9,6 +9,9 @@ from ..menubar_status import build_menubar_status_payload, read_process_overlay_
 from .common import _paths, _print_json, _wants_json
 
 
+_TABLE_VALUE_DISPLAY_LIMIT = 48
+
+
 def cmd_menubar_status(args: argparse.Namespace) -> int:
     try:
         overlay = read_process_overlay_file(args.overlay) if args.overlay else None
@@ -70,7 +73,7 @@ def _add_menubar_commands(sub) -> None:
         help="Opt in to local Hermes process observation for the native menu bar helper.",
     )
     status.add_argument("--now", default=None, help="Optional ISO timestamp for deterministic overlay TTL evaluation.")
-    status.add_argument("--json", action="store_true", help="Print the full menubar_status/v1 payload.")
+    status.add_argument("--json", action="store_true", help="Print the full menubar_status/v2 payload.")
     status.set_defaults(func=cmd_menubar_status)
 
     install = menubar_sub.add_parser("install", help="Install and start the native macOS OMH menu bar helper when supported.")
@@ -145,7 +148,10 @@ def _format_menubar_status(payload: Mapping[str, object]) -> str:
         if columns and table_rows:
             lines.append(f"  {_pad(columns[0], 20)} {columns[1]}")
             for row in table_rows:
-                lines.append(f"  {_pad(_text(row.get('left')), 20)} {_text(row.get('right'))}")
+                lines.append(
+                    f"  {_pad(_text(row.get('left')), 20)} "
+                    f"{_truncate(_text(row.get('right')), _TABLE_VALUE_DISPLAY_LIMIT)}"
+                )
         else:
             for row in rows:
                 label = _text(row.get("label"))
@@ -240,7 +246,11 @@ def _truthy(value: object) -> bool:
     return bool(value) and str(value).lower() not in {"false", "0", "none", "null"}
 
 
+def _truncate(value: str, limit: int) -> str:
+    if len(value) > limit:
+        return f"{value[: max(0, limit - 3)]}..."
+    return value
+
+
 def _pad(value: str, width: int) -> str:
-    if len(value) > width:
-        return f"{value[: max(0, width - 3)]}..."
-    return value.ljust(width)
+    return _truncate(value, width).ljust(width)

--- a/src/surfaces/hermes_model_settings.py
+++ b/src/surfaces/hermes_model_settings.py
@@ -113,7 +113,7 @@ def _unreadable_result() -> dict[str, Any]:
 def read_hermes_model_settings(paths: OmhPaths) -> dict[str, Any]:
     try:
         config_text = (paths.hermes_home / "config.yaml").read_text(encoding="utf-8")
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return _unreadable_result()
 
     settings, auxiliary = _parse_settings(config_text)

--- a/src/surfaces/hermes_model_settings.py
+++ b/src/surfaces/hermes_model_settings.py
@@ -25,32 +25,42 @@ HERMES_AUX_ALIASES = (
 )
 
 _KEY = re.compile(r"^([a-z_]+):")
+_NULL_SCALARS = {"null", "~"}
+_UNSUPPORTED_SCALAR_PREFIXES = ("|", ">", "[", "{", "&", "*", "!")
 _CLAIM_BOUNDARY = (
     "Model settings are read from Hermes configuration; a configured alias is not evidence "
     "that a request used that model."
 )
 
 
-def _scalar_value(line: str) -> str:
+def _scalar_value(line: str) -> str | None:
     value = line.partition(":")[2].strip()
     if not value:
         return ""
     if value[0] in {'"', "'"}:
         quote = value[0]
+        closing_index = 0
         for index in range(len(value) - 1, 0, -1):
             if value[index] == quote:
                 remainder = value[index + 1 :].strip()
                 if not remainder or remainder.startswith("#"):
+                    closing_index = index
                     value = value[: index + 1]
                     break
+        if not closing_index:
+            return None
     elif " #" in value:
         value = value.split(" #", 1)[0].rstrip()
     if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
         return value[1:-1]
+    if value.lower() in _NULL_SCALARS:
+        return ""
+    if value.startswith(_UNSUPPORTED_SCALAR_PREFIXES):
+        return None
     return value
 
 
-def _parse_settings(config_text: str) -> tuple[dict[str, str], dict[str, dict[str, str]]]:
+def _parse_settings(config_text: str) -> tuple[dict[str, str], dict[str, dict[str, str]]] | None:
     settings: dict[str, str] = {}
     auxiliary: dict[str, dict[str, str]] = {}
     top_level = ""
@@ -58,14 +68,25 @@ def _parse_settings(config_text: str) -> tuple[dict[str, str], dict[str, dict[st
     for line in config_text.splitlines():
         if not line.strip() or line.lstrip().startswith("#"):
             continue
+        indentation = line[: len(line) - len(line.lstrip(" \t"))]
+        if "\t" in indentation:
+            return None
         if not line.startswith(" "):
             match = _KEY.match(line)
             top_level = match.group(1) if match else ""
             auxiliary_task = ""
+            if top_level in {"model", "agent", "auxiliary"}:
+                value = _scalar_value(line)
+                if value is None or value:
+                    return None
             continue
         if top_level == "auxiliary" and line.startswith("  ") and not line.startswith("    "):
             match = _KEY.match(line[2:])
             auxiliary_task = match.group(1) if match else ""
+            if match:
+                value = _scalar_value(line[2:])
+                if value is None or value:
+                    return None
             continue
         if top_level in {"model", "agent"} and line.startswith("  ") and not line.startswith("    "):
             match = _KEY.match(line[2:])
@@ -76,12 +97,18 @@ def _parse_settings(config_text: str) -> tuple[dict[str, str], dict[str, dict[st
                     ("model", "provider"),
                     ("agent", "reasoning_effort"),
                 }:
-                    settings[f"{top_level}.{key}"] = _scalar_value(line)
+                    value = _scalar_value(line)
+                    if value is None:
+                        return None
+                    settings[f"{top_level}.{key}"] = value
             continue
         if top_level == "auxiliary" and auxiliary_task and line.startswith("    ") and not line.startswith("      "):
             match = _KEY.match(line[4:])
             if match and match.group(1) in {"model", "reasoning_effort"}:
-                auxiliary.setdefault(auxiliary_task, {})[match.group(1)] = _scalar_value(line)
+                value = _scalar_value(line)
+                if value is None:
+                    return None
+                auxiliary.setdefault(auxiliary_task, {})[match.group(1)] = value
     return settings, auxiliary
 
 
@@ -116,7 +143,10 @@ def read_hermes_model_settings(paths: OmhPaths) -> dict[str, Any]:
     except (OSError, UnicodeDecodeError):
         return _unreadable_result()
 
-    settings, auxiliary = _parse_settings(config_text)
+    parsed_settings = _parse_settings(config_text)
+    if parsed_settings is None:
+        return _unreadable_result()
+    settings, auxiliary = parsed_settings
     aliases = [
         _alias_entry(
             alias="main",

--- a/src/surfaces/hermes_model_settings.py
+++ b/src/surfaces/hermes_model_settings.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from ..paths import OmhPaths
+
+
+HERMES_MODEL_SETTINGS_SCHEMA_VERSION = "hermes_model_settings/v1"
+HERMES_AUX_ALIASES = (
+    "vision",
+    "web_extract",
+    "compression",
+    "skills_hub",
+    "approval",
+    "mcp",
+    "title_generation",
+    "memory_query_rewrite",
+    "tts_audio_tags",
+    "triage_specifier",
+    "kanban_decomposer",
+    "profile_describer",
+    "goal_judge",
+    "curator",
+)
+
+_KEY = re.compile(r"^([a-z_]+):")
+_CLAIM_BOUNDARY = (
+    "Model settings are read from Hermes configuration; a configured alias is not evidence "
+    "that a request used that model."
+)
+
+
+def _scalar_value(line: str) -> str:
+    value = line.partition(":")[2].strip()
+    if not value:
+        return ""
+    if value[0] in {'"', "'"}:
+        quote = value[0]
+        for index in range(len(value) - 1, 0, -1):
+            if value[index] == quote:
+                remainder = value[index + 1 :].strip()
+                if not remainder or remainder.startswith("#"):
+                    value = value[: index + 1]
+                    break
+    elif " #" in value:
+        value = value.split(" #", 1)[0].rstrip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        return value[1:-1]
+    return value
+
+
+def _parse_settings(config_text: str) -> tuple[dict[str, str], dict[str, dict[str, str]]]:
+    settings: dict[str, str] = {}
+    auxiliary: dict[str, dict[str, str]] = {}
+    top_level = ""
+    auxiliary_task = ""
+    for line in config_text.splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        if not line.startswith(" "):
+            match = _KEY.match(line)
+            top_level = match.group(1) if match else ""
+            auxiliary_task = ""
+            continue
+        if top_level == "auxiliary" and line.startswith("  ") and not line.startswith("    "):
+            match = _KEY.match(line[2:])
+            auxiliary_task = match.group(1) if match else ""
+            continue
+        if top_level in {"model", "agent"} and line.startswith("  ") and not line.startswith("    "):
+            match = _KEY.match(line[2:])
+            if match:
+                key = match.group(1)
+                if (top_level, key) in {
+                    ("model", "default"),
+                    ("model", "provider"),
+                    ("agent", "reasoning_effort"),
+                }:
+                    settings[f"{top_level}.{key}"] = _scalar_value(line)
+            continue
+        if top_level == "auxiliary" and auxiliary_task and line.startswith("    ") and not line.startswith("      "):
+            match = _KEY.match(line[4:])
+            if match and match.group(1) in {"model", "reasoning_effort"}:
+                auxiliary.setdefault(auxiliary_task, {})[match.group(1)] = _scalar_value(line)
+    return settings, auxiliary
+
+
+def _alias_entry(*, alias: str, model: str, effort: str, source: str) -> dict[str, Any]:
+    label = f"{model}:{effort}" if model and effort else model or "inherit"
+    return {
+        "alias": alias,
+        "model": model,
+        "effort": effort,
+        "source": source,
+        "configured": bool(model),
+        "label": label,
+    }
+
+
+def _unreadable_result() -> dict[str, Any]:
+    return {
+        "schema_version": HERMES_MODEL_SETTINGS_SCHEMA_VERSION,
+        "observed": False,
+        "reason": "config_unreadable",
+        "provider": "",
+        "aliases": [],
+        "configured_count": 0,
+        "inherit_count": 0,
+        "claim_boundary": _CLAIM_BOUNDARY,
+    }
+
+
+def read_hermes_model_settings(paths: OmhPaths) -> dict[str, Any]:
+    try:
+        config_text = (paths.hermes_home / "config.yaml").read_text(encoding="utf-8")
+    except OSError:
+        return _unreadable_result()
+
+    settings, auxiliary = _parse_settings(config_text)
+    aliases = [
+        _alias_entry(
+            alias="main",
+            model=settings.get("model.default", ""),
+            effort=settings.get("agent.reasoning_effort", ""),
+            source="config.model.default",
+        )
+    ]
+    for alias in HERMES_AUX_ALIASES:
+        alias_settings = auxiliary.get(alias, {})
+        aliases.append(
+            _alias_entry(
+                alias=alias,
+                model=alias_settings.get("model", ""),
+                effort=alias_settings.get("reasoning_effort", ""),
+                source=f"config.auxiliary.{alias}",
+            )
+        )
+    configured_count = sum(1 for entry in aliases if entry["configured"])
+    return {
+        "schema_version": HERMES_MODEL_SETTINGS_SCHEMA_VERSION,
+        "observed": True,
+        "reason": "",
+        "provider": settings.get("model.provider", ""),
+        "aliases": aliases,
+        "configured_count": configured_count,
+        "inherit_count": len(aliases) - configured_count,
+        "claim_boundary": _CLAIM_BOUNDARY,
+    }

--- a/src/surfaces/hermes_model_settings.py
+++ b/src/surfaces/hermes_model_settings.py
@@ -65,12 +65,18 @@ def _parse_settings(config_text: str) -> tuple[dict[str, str], dict[str, dict[st
     auxiliary: dict[str, dict[str, str]] = {}
     top_level = ""
     auxiliary_task = ""
+    empty_scalar_indent: int | None = None
     for line in config_text.splitlines():
         if not line.strip() or line.lstrip().startswith("#"):
             continue
         indentation = line[: len(line) - len(line.lstrip(" \t"))]
         if "\t" in indentation:
             return None
+        current_indent = len(indentation)
+        if empty_scalar_indent is not None:
+            if current_indent > empty_scalar_indent:
+                return None
+            empty_scalar_indent = None
         if not line.startswith(" "):
             match = _KEY.match(line)
             top_level = match.group(1) if match else ""
@@ -101,6 +107,8 @@ def _parse_settings(config_text: str) -> tuple[dict[str, str], dict[str, dict[st
                     if value is None:
                         return None
                     settings[f"{top_level}.{key}"] = value
+                    if not line.partition(":")[2].strip():
+                        empty_scalar_indent = current_indent
             continue
         if top_level == "auxiliary" and auxiliary_task and line.startswith("    ") and not line.startswith("      "):
             match = _KEY.match(line[4:])
@@ -109,6 +117,8 @@ def _parse_settings(config_text: str) -> tuple[dict[str, str], dict[str, dict[st
                 if value is None:
                     return None
                 auxiliary.setdefault(auxiliary_task, {})[match.group(1)] = value
+                if not line.partition(":")[2].strip():
+                    empty_scalar_indent = current_indent
     return settings, auxiliary
 
 

--- a/src/surfaces/hermes_processes.py
+++ b/src/surfaces/hermes_processes.py
@@ -8,13 +8,6 @@ from typing import Any
 
 
 HERMES_PROCESS_SCHEMA_VERSION = "hermes_process_observation/v1"
-_HERMES_PROCESS_MARKERS = (
-    "hermes-agent/hermes",
-    "hermes_cli.main",
-    "tui_gateway.entry",
-    "ui-tui/dist/entry.js",
-)
-
 _SHELL_NAMES = {"sh", "bash", "zsh", "dash"}
 _CLAIM_BOUNDARY = (
     "Local process observation is bounded, best-effort, and is not execution, review, CI, or merge evidence."
@@ -72,10 +65,36 @@ def _process_rows(ps_output: str) -> list[dict[str, Any]]:
             continue
         if pid in self_pids or _is_filtered_command(command):
             continue
-        if not any(marker in command for marker in _HERMES_PROCESS_MARKERS):
+        if not _is_hermes_command(command):
             continue
         rows.append({"pid": pid, "ppid": ppid, "command": command})
     return rows
+
+
+def _is_hermes_command(command: str) -> bool:
+    argv = command.split()
+    if not argv:
+        return False
+
+    executable = Path(argv[0]).name
+    if _is_python_executable(executable):
+        if len(argv) >= 2 and Path(argv[1]).parts[-2:] == ("hermes-agent", "hermes"):
+            return True
+        return len(argv) >= 3 and argv[1] == "-m" and argv[2] in {
+            "hermes_cli.main",
+            "tui_gateway.entry",
+        }
+
+    if executable == "node":
+        entrypoint = next((argument for argument in argv[1:] if not argument.startswith("-")), "")
+        return Path(entrypoint).parts[-3:] == ("ui-tui", "dist", "entry.js")
+
+    return False
+
+
+def _is_python_executable(executable: str) -> bool:
+    suffix = executable.removeprefix("python")
+    return executable.startswith("python") and (not suffix or all(part.isdigit() for part in suffix.split(".")))
 
 
 def _is_filtered_command(command: str) -> bool:

--- a/src/surfaces/hermes_processes.py
+++ b/src/surfaces/hermes_processes.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+HERMES_PROCESS_SCHEMA_VERSION = "hermes_process_observation/v1"
+_HERMES_PROCESS_MARKERS = (
+    "hermes-agent/hermes",
+    "hermes_cli.main",
+    "tui_gateway.entry",
+    "ui-tui/dist/entry.js",
+)
+
+_SHELL_NAMES = {"sh", "bash", "zsh", "dash"}
+_CLAIM_BOUNDARY = (
+    "Local process observation is bounded, best-effort, and is not execution, review, CI, or merge evidence."
+)
+
+
+def observe_hermes_processes(
+    *,
+    now: datetime | str | None = None,
+    ps_output: str | None = None,
+) -> dict[str, Any]:
+    observed_at = _format_datetime(_coerce_datetime(now) or datetime.now(timezone.utc))
+    if ps_output is None:
+        try:
+            result = subprocess.run(
+                ["ps", "-axo", "pid=,ppid=,command="],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=2,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return _observation(observed=False, reason="ps_unavailable", rows=[], observed_at=observed_at)
+        if result.returncode != 0:
+            return _observation(observed=False, reason="ps_unavailable", rows=[], observed_at=observed_at)
+        ps_output = result.stdout
+
+    kept = _process_rows(ps_output)
+    kept_pids = {row["pid"] for row in kept}
+    rows = [
+        {
+            "pid": row["pid"],
+            "ppid": row["ppid"],
+            "role": "child" if row["ppid"] in kept_pids else "agent",
+            "label": _process_label(row["command"]),
+        }
+        for row in kept
+    ]
+    return _observation(observed=True, reason="", rows=rows, observed_at=observed_at)
+
+
+def _process_rows(ps_output: str) -> list[dict[str, Any]]:
+    self_pids = {os.getpid(), os.getppid()}
+    rows: list[dict[str, Any]] = []
+    for raw_line in ps_output.splitlines():
+        parts = raw_line.strip().split(None, 2)
+        if len(parts) != 3:
+            continue
+        raw_pid, raw_ppid, command = parts
+        try:
+            pid = int(raw_pid)
+            ppid = int(raw_ppid)
+        except ValueError:
+            continue
+        if pid in self_pids or _is_filtered_command(command):
+            continue
+        if not any(marker in command for marker in _HERMES_PROCESS_MARKERS):
+            continue
+        rows.append({"pid": pid, "ppid": ppid, "command": command})
+    return rows
+
+
+def _is_filtered_command(command: str) -> bool:
+    tokens = command.split()
+    if not tokens:
+        return True
+    if Path(tokens[0]).name in _SHELL_NAMES or " -c " in command:
+        return True
+    return "grep " in command or "rg " in command
+
+
+def _process_label(command: str) -> str:
+    tokens = command.split()
+    names = [Path(token).name for token in tokens[:2]]
+    return _short_text(" ".join(names), limit=40)
+
+
+def _short_text(value: str, *, limit: int) -> str:
+    text = " ".join(value.split())
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)].rstrip() + "…"
+
+
+def _coerce_datetime(value: datetime | str | None) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _format_datetime(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _observation(
+    *,
+    observed: bool,
+    reason: str,
+    rows: list[dict[str, Any]],
+    observed_at: str,
+) -> dict[str, Any]:
+    return {
+        "schema_version": HERMES_PROCESS_SCHEMA_VERSION,
+        "observed": observed,
+        "reason": reason,
+        "agent_count": sum(1 for row in rows if row.get("role") == "agent"),
+        "process_count": len(rows),
+        "rows": rows,
+        "source": "local_process_scan",
+        "observed_at": observed_at,
+        "claim_boundary": _CLAIM_BOUNDARY,
+    }
+
+
+__all__ = ["HERMES_PROCESS_SCHEMA_VERSION", "observe_hermes_processes"]

--- a/src/surfaces/hermes_processes.py
+++ b/src/surfaces/hermes_processes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 import shlex
 import subprocess
 from datetime import datetime, timezone
@@ -11,7 +12,10 @@ from typing import Any
 HERMES_PROCESS_SCHEMA_VERSION = "hermes_process_observation/v1"
 _SHELL_NAMES = {"sh", "bash", "zsh", "dash"}
 _PERSISTENT_MAIN_COMMANDS = {"chat", "acp"}
-_PERSISTENT_MAIN_FLAGS = {"--tui", "--classic"}
+_PERSISTENT_MAIN_FLAGS = {"--tui", "--cli"}
+_PYTHON_COMMAND = re.compile(
+    r"^(?P<executable>.*?python(?:\d+(?:\.\d+)*)?)\s+(?P<arguments>.+)$"
+)
 _CLAIM_BOUNDARY = (
     "Local process observation is bounded, best-effort, and is not execution, review, CI, or merge evidence."
 )
@@ -66,9 +70,10 @@ def _process_rows(ps_output: str) -> list[dict[str, Any]]:
             ppid = int(raw_ppid)
         except ValueError:
             continue
-        argv = _command_argv(command)
-        if pid in self_pids or _is_filtered_command(argv):
+        parsed_argv = _command_argv(command)
+        if pid in self_pids or _is_filtered_command(parsed_argv):
             continue
+        argv = parsed_argv if _is_hermes_command(parsed_argv) else _unquoted_hermes_argv(command)
         if not _is_hermes_command(argv):
             continue
         rows.append({"pid": pid, "ppid": ppid, "argv": argv})
@@ -80,6 +85,34 @@ def _command_argv(command: str) -> list[str]:
         return shlex.split(command)
     except ValueError:
         return []
+
+
+def _unquoted_hermes_argv(command: str) -> list[str]:
+    match = _PYTHON_COMMAND.match(command)
+    if not match:
+        return []
+
+    executable = match.group("executable")
+    arguments = match.group("arguments")
+    if arguments.startswith("-m "):
+        try:
+            return [executable, *shlex.split(arguments)]
+        except ValueError:
+            return []
+
+    entrypoint_suffix = "/hermes-agent/hermes"
+    entrypoint_end = arguments.find(entrypoint_suffix)
+    if entrypoint_end < 0:
+        return []
+    entrypoint_end += len(entrypoint_suffix)
+    if len(arguments) > entrypoint_end and not arguments[entrypoint_end].isspace():
+        return []
+    entrypoint = arguments[:entrypoint_end]
+    try:
+        trailing_argv = shlex.split(arguments[entrypoint_end:])
+    except ValueError:
+        return []
+    return [executable, entrypoint, *trailing_argv]
 
 
 def _is_hermes_command(argv: list[str]) -> bool:
@@ -104,6 +137,14 @@ def _is_hermes_command(argv: list[str]) -> bool:
 
 
 def _is_persistent_main_command(arguments: list[str]) -> bool:
+    if arguments and arguments[0] in {"--profile", "-p"}:
+        if len(arguments) < 2 or not arguments[1]:
+            return False
+        arguments = arguments[2:]
+    elif arguments and arguments[0].startswith("--profile="):
+        if not arguments[0].partition("=")[2]:
+            return False
+        arguments = arguments[1:]
     if not arguments:
         return True
     command = arguments[0]

--- a/src/surfaces/hermes_processes.py
+++ b/src/surfaces/hermes_processes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
@@ -9,6 +10,8 @@ from typing import Any
 
 HERMES_PROCESS_SCHEMA_VERSION = "hermes_process_observation/v1"
 _SHELL_NAMES = {"sh", "bash", "zsh", "dash"}
+_PERSISTENT_MAIN_COMMANDS = {"chat", "acp"}
+_PERSISTENT_MAIN_FLAGS = {"--tui", "--classic"}
 _CLAIM_BOUNDARY = (
     "Local process observation is bounded, best-effort, and is not execution, review, CI, or merge evidence."
 )
@@ -43,7 +46,7 @@ def observe_hermes_processes(
             "pid": row["pid"],
             "ppid": row["ppid"],
             "role": "child" if row["ppid"] in kept_pids else "agent",
-            "label": _process_label(row["command"]),
+            "label": _process_label(row["argv"]),
         }
         for row in kept
     ]
@@ -63,27 +66,35 @@ def _process_rows(ps_output: str) -> list[dict[str, Any]]:
             ppid = int(raw_ppid)
         except ValueError:
             continue
-        if pid in self_pids or _is_filtered_command(command):
+        argv = _command_argv(command)
+        if pid in self_pids or _is_filtered_command(argv):
             continue
-        if not _is_hermes_command(command):
+        if not _is_hermes_command(argv):
             continue
-        rows.append({"pid": pid, "ppid": ppid, "command": command})
+        rows.append({"pid": pid, "ppid": ppid, "argv": argv})
     return rows
 
 
-def _is_hermes_command(command: str) -> bool:
-    argv = command.split()
+def _command_argv(command: str) -> list[str]:
+    try:
+        return shlex.split(command)
+    except ValueError:
+        return []
+
+
+def _is_hermes_command(argv: list[str]) -> bool:
     if not argv:
         return False
 
     executable = Path(argv[0]).name
     if _is_python_executable(executable):
         if len(argv) >= 2 and Path(argv[1]).parts[-2:] == ("hermes-agent", "hermes"):
+            return _is_persistent_main_command(argv[2:])
+        if len(argv) < 3 or argv[1] != "-m":
+            return False
+        if argv[2] == "tui_gateway.entry":
             return True
-        return len(argv) >= 3 and argv[1] == "-m" and argv[2] in {
-            "hermes_cli.main",
-            "tui_gateway.entry",
-        }
+        return argv[2] == "hermes_cli.main" and _is_persistent_main_command(argv[3:])
 
     if executable == "node":
         entrypoint = next((argument for argument in argv[1:] if not argument.startswith("-")), "")
@@ -92,23 +103,31 @@ def _is_hermes_command(command: str) -> bool:
     return False
 
 
+def _is_persistent_main_command(arguments: list[str]) -> bool:
+    if not arguments:
+        return True
+    command = arguments[0]
+    if command in _PERSISTENT_MAIN_COMMANDS or command in _PERSISTENT_MAIN_FLAGS:
+        return True
+    return command == "gateway" and (len(arguments) == 1 or arguments[1] == "run")
+
+
 def _is_python_executable(executable: str) -> bool:
     suffix = executable.removeprefix("python")
     return executable.startswith("python") and (not suffix or all(part.isdigit() for part in suffix.split(".")))
 
 
-def _is_filtered_command(command: str) -> bool:
-    tokens = command.split()
-    if not tokens:
+def _is_filtered_command(argv: list[str]) -> bool:
+    if not argv:
         return True
-    if Path(tokens[0]).name in _SHELL_NAMES or " -c " in command:
+    executable = Path(argv[0]).name
+    if executable in _SHELL_NAMES or "-c" in argv:
         return True
-    return "grep " in command or "rg " in command
+    return executable in {"grep", "rg"}
 
 
-def _process_label(command: str) -> str:
-    tokens = command.split()
-    names = [Path(token).name for token in tokens[:2]]
+def _process_label(argv: list[str]) -> str:
+    names = [Path(token).name for token in argv[:2]]
     return _short_text(" ".join(names), limit=40)
 
 

--- a/src/surfaces/hermes_sessions.py
+++ b/src/surfaces/hermes_sessions.py
@@ -21,7 +21,7 @@ def observe_hermes_sessions(paths: OmhPaths) -> dict[str, Any]:
         return _unobserved("state_db_missing")
 
     try:
-        connection = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=1.0)
+        connection = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True, timeout=1.0)
         try:
             cursor = connection.cursor()
             total = int(

--- a/src/surfaces/hermes_sessions.py
+++ b/src/surfaces/hermes_sessions.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from json import JSONDecodeError
+from typing import Any
+
+from ..paths import OmhPaths
+
+
+HERMES_SESSION_SCHEMA_VERSION = "hermes_session_observation/v1"
+_CLAIM_BOUNDARY = (
+    "Session counts are a read-only observation of Hermes' own session store; "
+    "they are not execution, review, CI, merge, or token-usage evidence."
+)
+
+
+def observe_hermes_sessions(paths: OmhPaths) -> dict[str, Any]:
+    db_path = paths.hermes_home / "state.db"
+    if not db_path.exists():
+        return _unobserved("state_db_missing")
+
+    try:
+        connection = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=1.0)
+        try:
+            cursor = connection.cursor()
+            total = int(
+                cursor.execute(
+                    "select count(*) from sessions where archived = 0 and hidden = 0"
+                ).fetchone()[0]
+            )
+            live = int(
+                cursor.execute(
+                    "select count(*) from sessions where archived = 0 and hidden = 0 and ended_at is null"
+                ).fetchone()[0]
+            )
+            current_row = cursor.execute(
+                "select model, model_config from sessions where archived = 0 and hidden = 0 and ended_at is null "
+                "order by coalesce(last_activity_at, started_at) desc limit 1"
+            ).fetchone()
+        finally:
+            connection.close()
+    except sqlite3.Error:
+        return _unobserved("state_db_unreadable")
+
+    return {
+        "schema_version": HERMES_SESSION_SCHEMA_VERSION,
+        "observed": True,
+        "reason": "",
+        "live": live,
+        "total": total,
+        "current_model": _current_model(current_row),
+        "source": "hermes_state_db_readonly",
+        "claim_boundary": _CLAIM_BOUNDARY,
+    }
+
+
+def _current_model(row: tuple[Any, Any] | None) -> dict[str, Any]:
+    if row is None:
+        return _current_model_payload()
+
+    value = row[0] if isinstance(row[0], str) else ""
+    provider = ""
+    effort = ""
+    try:
+        model_config = json.loads(row[1])
+    except (TypeError, ValueError, JSONDecodeError):
+        model_config = {}
+
+    if isinstance(model_config, dict):
+        configured_provider = model_config.get("provider")
+        if isinstance(configured_provider, str):
+            provider = configured_provider
+        reasoning_config = model_config.get("reasoning_config")
+        if isinstance(reasoning_config, dict):
+            configured_effort = reasoning_config.get("effort")
+            if isinstance(configured_effort, str):
+                effort = configured_effort
+
+    return _current_model_payload(value=value, effort=effort, provider=provider)
+
+
+def _current_model_payload(*, value: str = "", effort: str = "", provider: str = "") -> dict[str, Any]:
+    return {
+        "observed": bool(value),
+        "value": value,
+        "effort": effort,
+        "provider": provider,
+        "label": f"{value}:{effort}" if value and effort else value or "not observed",
+    }
+
+
+def _unobserved(reason: str) -> dict[str, Any]:
+    return {
+        "schema_version": HERMES_SESSION_SCHEMA_VERSION,
+        "observed": False,
+        "reason": reason,
+        "live": 0,
+        "total": 0,
+        "current_model": _current_model_payload(),
+        "source": "hermes_state_db_readonly",
+        "claim_boundary": _CLAIM_BOUNDARY,
+    }

--- a/src/surfaces/menubar_app.py
+++ b/src/surfaces/menubar_app.py
@@ -348,7 +348,7 @@ final class OMHMenuBarDelegate: NSObject, NSApplicationDelegate {
                 for row in rows.prefix(6) {
                     let line = rowTitle(row)
                     let item = disabledItem("   \(line)")
-                    item.toolTip = line
+                    item.toolTip = rowToolTip(row)
                     if (row["kind"] as? String) == "table_row" {
                         item.attributedTitle = NSAttributedString(
                             string: "   \(line)",
@@ -382,7 +382,7 @@ final class OMHMenuBarDelegate: NSObject, NSApplicationDelegate {
                 return fixedWidth(value, 18)
             }
             if index == 1 {
-                return fixedWidth(value, 13)
+                return fixedWidth(value, 24)
             }
             return value
         }
@@ -400,7 +400,7 @@ final class OMHMenuBarDelegate: NSObject, NSApplicationDelegate {
     private func rowTitle(_ row: [String: Any]) -> String {
         if (row["kind"] as? String) == "table_row" {
             let left = fixedWidth((row["left"] as? String) ?? "", 18)
-            let right = (row["right"] as? String) ?? ""
+            let right = fixedWidth((row["right"] as? String) ?? "", 24)
             return "\(left)\(right)"
         }
         let label = (row["label"] as? String) ?? ""
@@ -418,6 +418,15 @@ final class OMHMenuBarDelegate: NSObject, NSApplicationDelegate {
             title += " — \(detail)"
         }
         return title.isEmpty ? "Unavailable" : title
+    }
+
+    private func rowToolTip(_ row: [String: Any]) -> String {
+        if (row["kind"] as? String) == "table_row" {
+            let left = (row["left"] as? String) ?? ""
+            let right = (row["right"] as? String) ?? ""
+            return "\(left): \(right)"
+        }
+        return rowTitle(row)
     }
 
     private func menuCards(from payload: [String: Any]) -> [[String: Any]] {

--- a/src/surfaces/menubar_app.py
+++ b/src/surfaces/menubar_app.py
@@ -307,7 +307,8 @@ final class OMHMenuBarDelegate: NSObject, NSApplicationDelegate {
         let summary = (display?["summary_line"] as? String) ?? "OMH ready"
         let connection = ((settings?["omh_connection"] as? [String: Any])?["value"] as? String) ?? "unknown"
         let mark = connection == "ready" ? "✓" : "!"
-        statusItem.button?.title = "\(title) \(mark)"
+        let menuBarTitle = (display?["menu_bar_title"] as? String) ?? ""
+        statusItem.button?.title = menuBarTitle.isEmpty ? "\(title) \(mark)" : menuBarTitle
         statusItem.button?.toolTip = "\(headline) — \(summary)"
         configureMenu(headline: headline, summary: summary, cards: menuCards(from: payload))
     }
@@ -344,11 +345,11 @@ final class OMHMenuBarDelegate: NSObject, NSApplicationDelegate {
                 menu.addItem(item)
             }
             if let rows = card["rows"] as? [[String: Any]] {
-                for row in rows.prefix(5) {
+                for row in rows.prefix(6) {
                     let line = rowTitle(row)
                     let item = disabledItem("   \(line)")
                     item.toolTip = line
-                    if (row["kind"] as? String) == "agent_status" {
+                    if (row["kind"] as? String) == "table_row" {
                         item.attributedTitle = NSAttributedString(
                             string: "   \(line)",
                             attributes: [.font: NSFont.monospacedSystemFont(ofSize: font.pointSize, weight: .regular)]
@@ -397,11 +398,10 @@ final class OMHMenuBarDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func rowTitle(_ row: [String: Any]) -> String {
-        if (row["kind"] as? String) == "agent_status" {
-            let agent = fixedWidth((row["agent"] as? String) ?? "unknown", 18)
-            let pid = fixedWidth((row["pid"] as? String) ?? "not observed", 13)
-            let status = (row["status"] as? String) ?? "unknown"
-            return "\(agent)\(pid)\(status)"
+        if (row["kind"] as? String) == "table_row" {
+            let left = fixedWidth((row["left"] as? String) ?? "", 18)
+            let right = (row["right"] as? String) ?? ""
+            return "\(left)\(right)"
         }
         let label = (row["label"] as? String) ?? ""
         let value = (row["value"] as? String) ?? ""

--- a/src/surfaces/menubar_app.py
+++ b/src/surfaces/menubar_app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import os
 import platform
 import plistlib
@@ -17,6 +18,7 @@ from ..runtime.artifacts import update_state
 MENUBAR_APP_SCHEMA_VERSION = "menubar_app/v1"
 MENUBAR_LABEL = "com.rlaope.omh.menubar"
 DEFAULT_REFRESH_INTERVAL_SECONDS = 8
+MENUBAR_ICON_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAACQAAAAkCAYAAADhAJiYAAAACXBIWXMAAAAAAAAAAQCEeRdzAAANYElEQVR4nKWYCXBUVRaGX3e/dDrpJJ2dAAlhC/sSJGyKbEEEAWeAYVegUDaxHLFAFCxFBasARUsKC0QcBIRSEQZkc0BEwLAFEEKAQDAJWUggobN0d5JO93vznfZlBmarmpmuetWv77vv3v+c85//nNsm5f/8mEwmRdf1//mdf3xf/W8WMpvNisViURoaGv42Jou1bt3a1KVLF2tQUJB8O7xer0/TNJmv+3w+paqqyn/x4kXXhQsX/PHx8cqdO3eUDh06KDdv3lRk3oOg/iMgmdi4aePvkJAQE4ACAwIgMTFRv3LlShfGmzBUf+bMmbK4uDh3bGxs+NGjR6vv3r2rP/vsszaex1+6dMmNQS4Aefv06eOfP3++b9u2bXqjsQLu3wJiAaW2tvYht1qtVpNY3TiHBfSIiAjTwYMH7+bl5d2LiopSn3vuuaLmzZsrTqdT4ZnSr18/2yOPPBKXlpYW2b1792Bes+NFWbj+888/9zBWt2jRIr+AEe//S0CqqgbAxMTEiAeUy5cvCwgTYwLA0rVrVwWv+PkoWK2MGzeu7MH35d3Q0FCz3W7XXS6XaeHCheUYUpacnKz27t3b3rNnTwllA2EL4plSXFxc+/XXX2slJSX/DEhQStxTUlIsuNXy3XffNRgh0ydPnhzbvn17fdeuXU5jTGL6EKMHDBgQx6bqBx98cIc5psOHD9c+8Ni7efNmD+squ3fvjsCrPjFwyZIlNsDVtmvXzvwQIAEjVrOpOmHCBNvy5ctdsrHD4VCwoE90dLT39ddfz7p27Zomc+GJHhYWFsS4ndC0HD9+fNrt27cLpk6derhHjx72Xr16mTdu3FhDqM2EXWOuuaamRs/JydHdbrfWrFkzXcIO54JHjx6t8NunMjkAovFic9PKlSujZs+eXSFgcLPpxIkTY4XATz755C4WDcGi2E6dOiUT/16tWrVKYY2m2BN89erV3e+8886ZF198sW19fb3n008/LREvcq+xjrmoqEiTPeCYZeDAgS5xAkDMb7/9tg0wQRIZtTGFsdjEZP3999+PzczM9JMdGvyxHD9+fHhSUlKbDz/88M/Eu/8TTzzRPTw8PAGOJGO1nVfjuGwVFRW3WSN1/fr1UefPnz915MiRHCxX7t27p8OxONZ2A6w2ODjYJGvDrcC+n332mYaxdS+//LKX/WyqeEGySMAwYJaXcXeuEHvnzp0pLVq0aOPxeEJI0Sl4oqMBQEJdybsqC1cJeUmA7lxpjNWhNX8YNWrU9aVLl95hs9i6urobpPcRvFu8f//+St7RyDrz9evXdfE84Q5t06ZNOOFrCHDIZrMFMmj48OERpK6jvLxcuOIAWAfcmCgZw7SWbBZlgHFgRFMuG5vwZbKIk3nu5z6YMRu/ozGmFvHb98MPP5zcsWMH1LsWCMdTTz1lf/zxx2PZo+CNN96wDxkyRDwdBaAqVQRJYicfkEbKg1mzZkWwWCQe6c2kEMIqKhzBZnXynCuGyyq8EVAAcYsscR/Gt4/fAsjObyfvCqHD5s6dm4pa1/Tt27fdnDlzOhP69bLnxx9/7HrhhRdiDVlxqyJIcsmHePvFsldffbVvWVmZeCWaxSIBk8B9iPzmiuAKMjxSS7aUMqeWsLWVccYEgMiBgIyE/LO5ZnJfLhLF5V+1atUSOObk3swzc9OmTa1wLx9N86rPP/988LfffusVZf3yyy8LJ02alEtGDGaSbB7C2vLtCAiRrgsTo/i24lkJj3DAC1FbiUcCwmQyqb9N1YO498O/s/AxCW+LV6vPnj27cd++fRm8Y0GDhHtSWvLhU0N2drau3rp1SyPGSUyIgDui0uKNULwm4VCNTJKYNuPeYYRJPOujaObDF7vhNTdFtQy31/BdSoaliYfgX1/xJhdJVn/75MmTZ9AvG3JRI6T+/vvvRYR1SB789NNPm9Uff/yxYejQoYUIWNLYsWPTKXw1IusAk7jGGqGysFERG93lUu7fv38EbtS0bNlyGh5qI9mBx6y8E4MnaghfB4NnouIuI5QaRtsQ3JnM+xPlJ5d1QlBnB9XguuAgqcJUw83mSD6gz+A+nHC1Fk9IAoq35F42QxqKUNntWOpNT09fTDp7WfQYXooCSBS/pZrbASde88i7AJFsbJDwCfGRluEvvfRSd+7LmH+ZcK2lvEiyKAUFBboqZYGq2yI/P/8OnuoImF5sYoGsJ9ioMzIQLxbiubMUwQu4ejBKO1SsB2AxdrQAQDReKpS059ssHgZgqGGsYiSAgBKtucn8IDzuQ8m3ZWVliZorM2fOtI4cOdKqogXRCGAxqdiFVO9BSKxiLZvFU5cuiXVsOoJnI7nGsKDf4JSPcEVK2gtX2CSSUDWWRcmmSsleRDBHwo1YpgPqHvMlhDq6tJJsuybiynu+adOmte/WrZtfRbhccCH2sccea4cL7xNnB+EJwjupEHMYAKX+eNhQ0jSWbxLHU0KR9JAlwYYk+CHoVjL1Kjqz1NAmqYVuUWrW6iThZzwEablBmCYzv4ZxS25uro965qDax/CsQrLFunjx4mTqVzaNU7fKyspawpTMuAAIw1uSQcIps3HZpPbgNR3w7US5mevht5XiWXLu3LlltB9rGG8Dn3TpMJW/f0rpDFJWr169DN4cok6egx6VUCWhSZMmSRhgV5ctWxZHhmUh3ymUkDgWzQZ5EpsmCgD6l+lU5rloUz/IfJcNUnnW3VDkCvhSLeJJKku25aAltwDkMwAEGZnmwdM38XwcIGsQwOOE7KJ0FmhgOj2UjXddeN+ikmp5oAuh2oq41dMGtC0tLb0KcZsyIQaQzSDefiw5T7sxDfIvJ1S/w9J+otyAC4XsJ1D2v6AloQBuZwDRDFAmEUk83UIkgPJxFCMsrFP+zTffTAPMo4DNkDZI1Fyl4Cl4KZFYFtBCVNPNpbOoCKCfhXwo9zwh7c986JOmwrmbU6ZM8QwbNqwtCxdhWTT90rqMjIxSuOZ87733tjwQooBk40EruuV86623ZrPGURmn+3S0bdu2iVBDxJhpRcxxixIrHTt2tFDgsiiqXQHkYVIorq0XUBA4DyX/CguC6a3zDx06pDInkxPFa/DNTduQtnbt2gOAaUHPNIMwZAE0mU2Eb/WGHtnJtixAZ0oxpweaNGjQoDgA5PI7VbjFVSF1UZVTAw17JSTz0grIIk7RC8kQgN1C+nuTUbuw7ACiGEwodbrCU3QGOZzHmtCM5bGRQp89i2f1hH7iRx99lMM6iUb5CXAIkK6JEye2x4hzVIQhNHkO7jMRw4sAyUcaPHJEUqlHgaad1AsnZaV9qMPaCrgRxoRwYr2/urpaBUBruPIrnwAvaNLvkx318MsrA6Tsz3j4FNIRw7P58GkCnaZoj8iCG2NyKQ8VNIBd2TPvxo0bl9gnVIQZQ1Iw3MV+ZergwYMtgLFB2Aga+SzUMg6C5pH6btz5K9X59Lx5805SlVXIFzhliNVCDVoIt1E4FUgejJrLeDkiu/fNN990ssZmGv5VUnyRgz3IxK9jxowZj+dqO3fuPICEkZBWiD2StRh3W+UspHNkkX63mhd0iFZy+vTpIsCUSmtRWFjolXYWwvuUhz86vBKQPg4EAyH5VA6Je/CmgiapNF6npXMknKOfeeaZcXJYGDFixAJKT0+OP9kHDhw4yPMq3uuEx8qJRC4ZqKi4UmtMUTmt0vtm0zRFcHLIhg+x6ErdggULkvfs2UNvfrcekGbCI2XDImBSU1NDNmzYsINQfkUCyDIqnvHJuR3ADRRTaUec8GY1SZH5ySefrAZURP/+/VtTCcS7TtEmjl5WuOlW16xZoxJzTSxDsLR169Y5qcYKfLJCznI5BPz0008eADYXdV6xYoV4z0yG+OGIeurUqX0sGo92HTZaYQ2e2JERkYaehHsJY1GbNm1aAXErMHK0tLQQuYBkKYY7TmqZFF4FiVFVYq+jIxrnbzOpaD527JiGu53EWCp04M8FFtIIayEVOYFNovfu3XtfrKNLmE4vc4QDolnCYIRS43AQRw89AkmYC7AMqvpCwjoKOnRgnR2EK5OEiGI/O6Ks4kUNWnhYx6ZOnz7dTNrLeUwjVCZRTGnCCJUf9IE/FBr/bABAKRY2gQsOEqEjXttJyKsoqjXyh4OgeffddxPx7nQkYTRgN2zfvn0T/fJr6FA5B80FzNW2bt3agxBF4iEyv9LJM4+ciqVLUOUvERRUxQsmwiWthQK5A6DkEPnAQTJwst2yZUs5mZLAO6c5ykTj0cWE8lFAXKH7u7Zo0aI/8n5XBHQVbc0uxHIO2eQkzU9iQDKejfviiy+K6d8vwEkf7askgZnUN3MS+a0hp1fRUWudlDeLalMaQklbD8249EJyiNDlECA31DQ/6V6MlUOxWPpl0Zl8Ud6EhIQ0wMTTeW4iVBfZeIFoFgX7MqRvoExVcmy+Ica98sorDoQyBB768VC9JA9cbVDpbUVbtBkzZpgAYiELFEpFHfpkEk/BF2nAVTJLYxONhaIJ7yCwxePVEshZSMizMTyail+H8u7nysYbvycchax1Dhp4CVE4muai1sXKGhhW+8svv7iIRANU0eCUAhbzXwHF+OPCP3lMAQAAAABJRU5ErkJggg=="
 
 
 def setup_menubar_app(
@@ -64,6 +66,7 @@ def setup_menubar_app(
         return payload
 
     app_paths["app_dir"].mkdir(parents=True, exist_ok=True)
+    app_paths["icon"].write_bytes(base64.b64decode(MENUBAR_ICON_BASE64, validate=True))
     atomic_write_text(app_paths["source"], _SWIFT_SOURCE)
     _compile_swift_helper(swiftc, app_paths["source"], app_paths["executable"])
     _write_launch_agent(app_paths["launch_agent"], app_paths["executable"], resolved_command, paths)
@@ -175,6 +178,7 @@ def menubar_app_paths(paths: OmhPaths) -> dict[str, Path]:
         "app_dir": app_dir,
         "source": app_dir / "OMHMenuBar.swift",
         "executable": app_dir / "omh-menubar",
+        "icon": app_dir / "omh-character-mask.png",
         "launch_agent": Path.home() / "Library" / "LaunchAgents" / f"{MENUBAR_LABEL}.plist",
     }
 
@@ -211,6 +215,8 @@ def _write_launch_agent(plist_path: Path, executable: Path, omh_command: str, pa
             str(paths.omh_home),
             "--hermes-home",
             str(paths.hermes_home),
+            "--icon",
+            str(menubar_app_paths(paths)["icon"]),
             "--interval",
             str(DEFAULT_REFRESH_INTERVAL_SECONDS),
         ],
@@ -237,11 +243,14 @@ final class OMHMenuBarDelegate: NSObject, NSApplicationDelegate {
     private var omhCommand = "omh"
     private var omhHome = ""
     private var hermesHome = ""
+    private var iconPath = ""
     private var interval: TimeInterval = 8
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory)
         parseArguments()
+        configureStatusButton()
+        updateStatusDescription(headline: "OMH", summary: "Loading status")
         configureMenu(headline: "OMH", summary: "Loading status", cards: [])
         refresh()
         timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
@@ -265,6 +274,9 @@ final class OMHMenuBarDelegate: NSObject, NSApplicationDelegate {
             case "--hermes-home":
                 hermesHome = value
                 index += 2
+            case "--icon":
+                iconPath = value
+                index += 2
             case "--interval":
                 interval = TimeInterval(value) ?? 8
                 index += 2
@@ -272,6 +284,28 @@ final class OMHMenuBarDelegate: NSObject, NSApplicationDelegate {
                 index += 1
             }
         }
+    }
+
+    private func configureStatusButton() {
+        guard
+            let button = statusItem.button,
+            let image = NSImage(contentsOfFile: iconPath)
+        else {
+            return
+        }
+        image.size = NSSize(width: 18, height: 18)
+        image.isTemplate = true
+        button.image = image
+        button.imagePosition = .imageLeading
+    }
+
+    private func updateStatusDescription(headline: String, summary: String) {
+        guard let button = statusItem.button else {
+            return
+        }
+        let description = "OMH — \(headline) — \(summary)"
+        button.toolTip = description
+        button.setAccessibilityLabel(description)
     }
 
     @objc private func refreshClicked(_ sender: Any?) {
@@ -284,7 +318,8 @@ final class OMHMenuBarDelegate: NSObject, NSApplicationDelegate {
 
     private func refresh() {
         guard let payload = readStatusPayload() else {
-            statusItem.button?.title = "omh !"
+            statusItem.button?.title = "!"
+            updateStatusDescription(headline: "OMH needs attention", summary: "Status unavailable")
             configureMenu(
                 headline: "OMH needs attention",
                 summary: "Status unavailable",
@@ -301,15 +336,11 @@ final class OMHMenuBarDelegate: NSObject, NSApplicationDelegate {
             return
         }
         let display = payload["display"] as? [String: Any]
-        let settings = payload["settings"] as? [String: Any]
-        let title = (display?["menu_title"] as? String) ?? "omh"
         let headline = (display?["headline"] as? String) ?? "OMH ready"
         let summary = (display?["summary_line"] as? String) ?? "OMH ready"
-        let connection = ((settings?["omh_connection"] as? [String: Any])?["value"] as? String) ?? "unknown"
-        let mark = connection == "ready" ? "✓" : "!"
         let menuBarTitle = (display?["menu_bar_title"] as? String) ?? ""
-        statusItem.button?.title = menuBarTitle.isEmpty ? "\(title) \(mark)" : menuBarTitle
-        statusItem.button?.toolTip = "\(headline) — \(summary)"
+        statusItem.button?.title = menuBarTitle
+        updateStatusDescription(headline: headline, summary: summary)
         configureMenu(headline: headline, summary: summary, cards: menuCards(from: payload))
     }
 

--- a/src/surfaces/menubar_status.py
+++ b/src/surfaces/menubar_status.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import subprocess
 from datetime import datetime, timezone
 from json import JSONDecodeError
 from pathlib import Path
@@ -14,11 +13,12 @@ from ..paths import OmhPaths
 from ..runtime.artifacts import summarize_delegated_coding_status
 from ..routing.action_copy import next_action_label
 from ..targets import read_target_registry_result
+from .hermes_model_settings import HERMES_AUX_ALIASES, read_hermes_model_settings
+from .hermes_processes import HERMES_PROCESS_SCHEMA_VERSION, observe_hermes_processes
+from .hermes_sessions import observe_hermes_sessions
 
 
-from ..evidence import status_label
-
-MENUBAR_STATUS_SCHEMA_VERSION = "menubar_status/v1"
+MENUBAR_STATUS_SCHEMA_VERSION = "menubar_status/v2"
 PROCESS_OVERLAY_SCHEMA_VERSION = "menubar_process_overlay/v1"
 DEFAULT_PROCESS_OVERLAY_TTL_SECONDS = 10
 DEFAULT_RESTART_WINDOW_SECONDS = 20
@@ -59,8 +59,13 @@ def build_menubar_status_payload(
     hermes_agents = _hermes_agent_rows(paths)
     external_executors = _external_executor_rows(paths, limit=safe_limit)
     current_executor, current_executor_source = _select_current_external_executor(paths, external_executors)
+    hermes_sessions = observe_hermes_sessions(paths)
+    model_settings = read_hermes_model_settings(paths)
+    hermes_processes = (
+        observe_hermes_processes(now=now) if observe_local_processes else _unrequested_process_observation(now=now)
+    )
     if observe_local_processes and process_overlay is None:
-        process_overlay = _local_process_overlay(hermes_agents, now=now)
+        process_overlay = _local_process_overlay(hermes_agents, hermes_processes, now=now)
     overlay_summary = _apply_process_overlay(
         hermes_agents,
         external_executors,
@@ -73,7 +78,7 @@ def build_menubar_status_payload(
         "package": "oh-my-hermes",
         "omh_home": str(paths.omh_home),
         "hermes_home": str(paths.hermes_home),
-        "display": _display(settings, hermes_agents, current_executor),
+        "display": _display(settings, hermes_processes, hermes_sessions, model_settings, current_executor),
         "sections": {
             "hermes_agents": {
                 "title": "Hermes agents",
@@ -88,6 +93,9 @@ def build_menubar_status_payload(
             },
         },
         "hermes_agents": hermes_agents,
+        "hermes_processes": hermes_processes,
+        "hermes_sessions": hermes_sessions,
+        "model_settings": model_settings,
         "external_coding_executors": external_executors,
         "current_external_coding_executor": _current_external_executor_payload(
             current_executor,
@@ -102,9 +110,9 @@ def build_menubar_status_payload(
             "rendering_rule": "Render source and model as icons in compact surfaces; expose tooltip text on hover or focus.",
         },
         "evidence_boundary": (
-            "menubar_status/v1 is a metadata-only view projection unless a caller overlay or explicit local process "
-            "observation is applied. Configured Hermes targets and prepared coding-agent actions are not execution, "
-            "verification, review, CI, merge, or PID evidence."
+            "menubar_status/v2 combines read-only Hermes state.db session observation and config.yaml model settings "
+            "with metadata unless a caller overlay or explicit local process observation is applied. These sources "
+            "are not execution, verification, review, CI, merge, token-usage, or PID evidence."
         ),
         "privacy": "metadata_only",
     }
@@ -123,9 +131,18 @@ def read_process_overlay_file(path: str) -> dict[str, Any]:
     return data
 
 
-def _local_process_overlay(hermes_agents: list[dict[str, Any]], *, now: datetime | str | None) -> dict[str, Any] | None:
-    observed_at = _coerce_datetime(now) or datetime.now(timezone.utc)
-    processes = _local_hermes_process_rows()
+def _local_process_overlay(
+    hermes_agents: list[dict[str, Any]],
+    hermes_processes: dict[str, Any],
+    *,
+    now: datetime | str | None,
+) -> dict[str, Any]:
+    observed_at = (
+        _parse_datetime(str(hermes_processes.get("observed_at", "") or ""))
+        or _coerce_datetime(now)
+        or datetime.now(timezone.utc)
+    )
+    processes = [row for row in _list(hermes_processes.get("rows")) if row.get("role") == "agent"]
     overlay_agents: list[dict[str, Any]] = []
     if len(hermes_agents) == 1 and processes:
         process = processes[0]
@@ -157,38 +174,21 @@ def _local_process_overlay(hermes_agents: list[dict[str, Any]], *, now: datetime
     }
 
 
-def _local_hermes_process_rows() -> list[dict[str, Any]]:
-    try:
-        result = subprocess.run(
-            ["ps", "-axo", "pid=,stat=,command="],
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            timeout=2,
-            check=False,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return []
-    if result.returncode != 0:
-        return []
-    rows: list[dict[str, Any]] = []
-    for raw_line in result.stdout.splitlines():
-        parts = raw_line.strip().split(None, 2)
-        if len(parts) < 3:
-            continue
-        pid, stat, command = parts
-        if not _looks_like_hermes_runtime_process(command):
-            continue
-        parsed_pid = _positive_int(pid, 0)
-        if not parsed_pid:
-            continue
-        rows.append({"pid": parsed_pid, "stat": stat, "command": command})
-    return rows
-
-
-def _looks_like_hermes_runtime_process(command: str) -> bool:
-    padded = f" {command} "
-    return " -m hermes_cli.main " in padded or "hermes_cli.main gateway run" in command
+def _unrequested_process_observation(*, now: datetime | str | None) -> dict[str, Any]:
+    observed_at = _coerce_datetime(now) or datetime.now(timezone.utc)
+    return {
+        "schema_version": HERMES_PROCESS_SCHEMA_VERSION,
+        "observed": False,
+        "reason": "not_requested",
+        "agent_count": 0,
+        "process_count": 0,
+        "rows": [],
+        "source": "local_process_scan",
+        "observed_at": _format_datetime(observed_at),
+        "claim_boundary": (
+            "Local process observation is bounded, best-effort, and is not execution, review, CI, or merge evidence."
+        ),
+    }
 
 
 def _hermes_agent_rows(paths: OmhPaths) -> list[dict[str, Any]]:
@@ -446,175 +446,119 @@ def _versions(hud: dict[str, Any]) -> dict[str, Any]:
 
 def _display(
     settings: dict[str, Any],
-    hermes_agents: list[dict[str, Any]],
+    hermes_processes: dict[str, Any],
+    hermes_sessions: dict[str, Any],
+    model_settings: dict[str, Any],
     current_executor_row: dict[str, Any],
 ) -> dict[str, Any]:
-    headline = "OMH ready" if settings["omh_connection"]["value"] == "ready" else "OMH needs attention"
-    pieces = [f"{len(hermes_agents)} Hermes target(s)"]
-    if current_executor_row:
-        pieces.append(f"{current_executor_row['name']} {current_executor_row['status_label'].lower()}")
-    elif str(settings["coding_handoff"]["value"]) != "choose":
-        pieces.append(f"{_executor_setting_label(str(settings['coding_handoff']['value']))} preferred, no request routed yet")
+    connection_ready = settings["omh_connection"]["value"] == "ready"
+    processes_observed = bool(hermes_processes.get("observed"))
+    sessions_observed = bool(hermes_sessions.get("observed"))
+    agent_count = _safe_int(hermes_processes.get("agent_count"), 0)
+    process_count = _safe_int(hermes_processes.get("process_count"), 0)
+    live = _safe_int(hermes_sessions.get("live"), 0)
+    if processes_observed and agent_count > 0:
+        headline = "Hermes running"
     else:
-        pieces.append("ready for the next request")
+        headline = "OMH ready" if connection_ready else "OMH needs attention"
+    pieces: list[str] = []
+    if processes_observed:
+        pieces.append(f"{agent_count} agent · {process_count} processes")
+    if sessions_observed:
+        pieces.append(f"sessions live {live} / total {_safe_int(hermes_sessions.get('total'), 0)}")
+    else:
+        pieces.append("sessions not observed")
+    mark = "✓" if connection_ready else "!"
+    menu_bar_title = f"omh {mark} {agent_count}·{live}" if processes_observed and sessions_observed else f"omh {mark}"
     return {
         "menu_title": "omh",
+        "menu_bar_title": menu_bar_title,
         "headline": headline,
         "summary_line": " · ".join(pieces),
-        "menu_cards": _menu_cards(settings, hermes_agents, current_executor_row),
+        "menu_cards": _menu_cards(settings, hermes_sessions, model_settings, current_executor_row),
     }
 
 
 def _menu_cards(
     settings: dict[str, Any],
-    hermes_agents: list[dict[str, Any]],
+    hermes_sessions: dict[str, Any],
+    model_settings: dict[str, Any],
     current_executor_row: dict[str, Any],
 ) -> list[dict[str, Any]]:
     return [
+        _sessions_card(hermes_sessions),
+        _models_card(hermes_sessions, model_settings),
         {
-            "title": "Agent Status",
-            "columns": ["Agent", "PID", "Status"],
-            "rows": _agent_status_menu_rows(hermes_agents),
-            "footer": "PID appears after overlay or explicit local observation.",
-        },
-        {
-            "title": "Coding Agent",
-            "rows": _coding_menu_rows(settings, current_executor_row),
-        },
-        {
-            "title": "Evidence",
+            "title": "",
             "rows": [
-                _menu_row("Boundary", _evidence_menu_value(hermes_agents, current_executor_row)),
-                _menu_row("Next", _evidence_next_action(current_executor_row)),
+                {
+                    "label": "coding",
+                    "value": _coding_agent_menu_value(settings, current_executor_row),
+                    "detail": "metadata only",
+                }
             ],
         },
     ]
 
 
-def _menu_row(label: str, value: str, *, detail: str = "", tone: str = "neutral") -> dict[str, str]:
-    row = {"label": label, "value": value, "tone": tone}
-    if detail:
-        row["detail"] = detail
-    return row
-
-
-def _agent_status_row(agent: str, pid: str, status: str, *, tone: str = "neutral") -> dict[str, str]:
-    return {
-        "kind": "agent_status",
-        "agent": agent,
-        "pid": pid,
-        "status": status,
-        "tone": tone,
-    }
-
-
-def _setting_value(settings: dict[str, Any], key: str, *, default: str = "") -> str:
-    row = _dict(settings.get(key))
-    return str(row.get("value", "") or default)
-
-
 def _coding_agent_menu_value(settings: dict[str, Any], current_executor_row: dict[str, Any]) -> str:
     if current_executor_row:
         return str(current_executor_row.get("name", "") or "selected")
-    return _executor_setting_label(_setting_value(settings, "coding_handoff", default="choose"))
+    coding_handoff = _dict(settings.get("coding_handoff"))
+    return _executor_setting_label(str(coding_handoff.get("value", "") or "choose"))
 
 
-def _agent_status_menu_rows(hermes_agents: list[dict[str, Any]]) -> list[dict[str, str]]:
-    if not hermes_agents:
-        return [_agent_status_row("none", "not observed", "run setup")]
+def _sessions_card(hermes_sessions: dict[str, Any]) -> dict[str, Any]:
+    if not hermes_sessions.get("observed"):
+        return {
+            "title": "Sessions",
+            "columns": ["Hermes session", "Count"],
+            "rows": [{"kind": "table_row", "left": "sessions", "right": "not observed"}],
+            "footer": str(hermes_sessions.get("reason", "") or "not observed"),
+        }
+    live = _safe_int(hermes_sessions.get("live"), 0)
+    total = _safe_int(hermes_sessions.get("total"), 0)
+    return {
+        "title": "Sessions",
+        "columns": ["Hermes session", "Count"],
+        "rows": [
+            {"kind": "table_row", "left": "live", "right": str(live), "tone": "ok" if live else "neutral"},
+            {"kind": "table_row", "left": "total", "right": str(total), "tone": "ok" if total else "neutral"},
+        ],
+        "footer": "Observed from Hermes state.db (read-only).",
+    }
+
+
+def _models_card(hermes_sessions: dict[str, Any], model_settings: dict[str, Any]) -> dict[str, Any]:
     rows: list[dict[str, str]] = []
-    for agent in hermes_agents[:3]:
-        name = _short_text(str(agent.get("name", "") or "Hermes Agent"), limit=28)
-        status = str(agent.get("status_label", "") or agent.get("status", "") or "configured")
-        pid = _pid_menu_value(agent)
+    current_model = _dict(hermes_sessions.get("current_model"))
+    if current_model.get("observed"):
         rows.append(
-            _agent_status_row(
-                name,
-                pid,
-                status,
-                tone="ok" if agent.get("status_observed") or agent.get("pid_observed") else "neutral",
-            )
+            {
+                "kind": "table_row",
+                "left": "current",
+                "right": str(current_model.get("label", "") or "not observed"),
+                "tone": "ok",
+            }
         )
-    if len(hermes_agents) > 3:
-        rows.append(_agent_status_row(f"+{len(hermes_agents) - 3} more", "not shown", "hidden"))
-    return rows
-
-
-def _coding_menu_rows(settings: dict[str, Any], current_executor_row: dict[str, Any]) -> list[dict[str, str]]:
-    if current_executor_row:
-        name = str(current_executor_row.get("name", "") or "Coding agent")
-        status = str(current_executor_row.get("status_label", "") or current_executor_row.get("status", "") or "prepared")
-        rows = [
-            _menu_row("Agent", name),
-            _menu_row("Status", status),
-            _menu_row("PID", _pid_menu_value(current_executor_row)),
-        ]
-        next_action = str(_dict(current_executor_row.get("evidence")).get("next_action", "") or "")
-        if next_action:
-            rows.append(_menu_row("Next", _human_next_action(next_action)))
-        return rows
-    # No-run state: nothing has been routed yet, so this card is led by
-    # Hermes/OMH readiness rather than an idle coding-agent concept. See
-    # docs/INSTALLATION.md "Status model: no-run, prepared-handoff,
-    # observed-run".
-    dispatch = _setting_value(settings, "send_mode", default="ask_before_dispatch")
-    coding_value = _setting_value(settings, "coding_handoff", default="choose")
-    if coding_value == "choose":
-        status_row = _menu_row("Status", "ready", detail="Hermes routes the next request to a coding agent")
-    else:
-        status_row = _menu_row("Status", "preferred", detail="no request routed yet")
-    return [
-        _menu_row("Agent", _coding_agent_menu_value(settings, current_executor_row)),
-        status_row,
-        _menu_row("Open mode", _dispatch_policy_menu_value(dispatch, coding_value)),
-    ]
-
-
-def _dispatch_policy_menu_value(dispatch_policy: str, executor: str) -> str:
-    label = _dispatch_policy_label(dispatch_policy, executor)
-    prefix = "Open mode: "
-    return label[len(prefix) :] if label.startswith(prefix) else label
-
-
-def _pid_menu_value(row: dict[str, Any]) -> str:
-    if row.get("pid_observed") and row.get("pid"):
-        return str(row.get("pid"))
-    return "not observed"
-
-
-def _evidence_menu_value(hermes_agents: list[dict[str, Any]], current_executor_row: dict[str, Any]) -> str:
-    observed_agents = sum(1 for row in hermes_agents if row.get("status_observed") or row.get("pid_observed"))
-    if current_executor_row:
-        evidence = _dict(current_executor_row.get("evidence"))
-        state = str(evidence.get("state", "") or "prepared_not_observed")
-        # `state.replace("_", " ")` spelled the wire value out loud rather than
-        # translating it; the shared label map is what the board and the chat
-        # summary already use.
-        return _short_text(status_label(state), limit=32)
-    if observed_agents:
-        return f"{observed_agents} process observed"
-    return "metadata only"
-
-
-def _evidence_next_action(current_executor_row: dict[str, Any]) -> str:
-    if current_executor_row:
-        evidence = _dict(current_executor_row.get("evidence"))
-        next_action = str(evidence.get("next_action", "") or "")
-        if next_action:
-            return _human_next_action(next_action)
-    return "open Hermes or run omh doctor"
-
-
-def _human_next_action(next_action: str) -> str:
-    label = next_action_label(next_action)
-    return _short_text(label or next_action, limit=48)
-
-
-def _short_text(value: str, *, limit: int) -> str:
-    text = " ".join(str(value or "").split())
-    if len(text) <= limit:
-        return text
-    return text[: max(0, limit - 1)].rstrip() + "…"
+    aliases = {str(row.get("alias", "") or ""): row for row in _list(model_settings.get("aliases"))}
+    main = aliases.get("main")
+    if main is not None and len(rows) < 5:
+        rows.append({"kind": "table_row", "left": "main", "right": str(main.get("label", "") or "inherit")})
+    for alias in HERMES_AUX_ALIASES:
+        entry = aliases.get(alias)
+        if entry is None or not entry.get("configured") or len(rows) >= 5:
+            continue
+        rows.append({"kind": "table_row", "left": alias, "right": str(entry.get("label", "") or "inherit")})
+    inherit_count = _safe_int(model_settings.get("inherit_count"), 0)
+    if inherit_count > 0 and len(rows) < 5:
+        rows.append({"kind": "table_row", "left": f"+{inherit_count} aliases", "right": "inherit default"})
+    return {
+        "title": "Models",
+        "columns": ["Alias", "Model"],
+        "rows": rows,
+        "footer": "current = live session · main/aux = config.yaml",
+    }
 
 
 def _source_icon_id(source: str) -> str:

--- a/src/surfaces/menubar_status.py
+++ b/src/surfaces/menubar_status.py
@@ -545,12 +545,17 @@ def _models_card(hermes_sessions: dict[str, Any], model_settings: dict[str, Any]
     main = aliases.get("main")
     if main is not None and len(rows) < 5:
         rows.append({"kind": "table_row", "left": "main", "right": str(main.get("label", "") or "inherit")})
+    inherit_count = sum(
+        1
+        for alias in HERMES_AUX_ALIASES
+        if (entry := aliases.get(alias)) is not None and not entry.get("configured")
+    )
+    configured_row_limit = 4 if inherit_count > 0 else 5
     for alias in HERMES_AUX_ALIASES:
         entry = aliases.get(alias)
-        if entry is None or not entry.get("configured") or len(rows) >= 5:
+        if entry is None or not entry.get("configured") or len(rows) >= configured_row_limit:
             continue
         rows.append({"kind": "table_row", "left": alias, "right": str(entry.get("label", "") or "inherit")})
-    inherit_count = _safe_int(model_settings.get("inherit_count"), 0)
     if inherit_count > 0 and len(rows) < 5:
         rows.append({"kind": "table_row", "left": f"+{inherit_count} aliases", "right": "inherit default"})
     return {

--- a/src/surfaces/menubar_status.py
+++ b/src/surfaces/menubar_status.py
@@ -468,8 +468,12 @@ def _display(
         pieces.append(f"sessions live {live} / total {_safe_int(hermes_sessions.get('total'), 0)}")
     else:
         pieces.append("sessions not observed")
-    mark = "✓" if connection_ready else "!"
-    menu_bar_title = f"omh {mark} {agent_count}·{live}" if processes_observed and sessions_observed else f"omh {mark}"
+    if not connection_ready:
+        menu_bar_title = "!"
+    elif processes_observed and sessions_observed:
+        menu_bar_title = f"{agent_count}·{live}"
+    else:
+        menu_bar_title = ""
     return {
         "menu_title": "omh",
         "menu_bar_title": menu_bar_title,

--- a/tests/test_handoff_safety_contract_enforcement.py
+++ b/tests/test_handoff_safety_contract_enforcement.py
@@ -177,8 +177,9 @@ PROCESS_SPAWN_ALLOWLIST: dict[str, str] = {
     "src/surfaces/menubar_app.py": (
         "`swiftc` compile plus `launchctl` load for the opt-in macOS menubar helper install."
     ),
-    "src/surfaces/menubar_status.py": (
-        "`ps -axo` local process scan to render menubar status; reads, spawns no agent."
+    "src/surfaces/hermes_processes.py": (
+        "explicit `omh menubar status --observe-local-processes` (also invoked by the opted-in "
+        "native helper); reads local process status, spawns no agent."
     ),
 }
 

--- a/tests/test_hermes_model_settings.py
+++ b/tests/test_hermes_model_settings.py
@@ -91,6 +91,19 @@ class HermesModelSettingsTests(unittest.TestCase):
         self.assertEqual(result["configured_count"], 0)
         self.assertEqual(result["inherit_count"], 0)
 
+    def test_malformed_utf8_config_degrades_to_config_unreadable(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            hermes_home = root / ".hermes"
+            hermes_home.mkdir()
+            (hermes_home / "config.yaml").write_bytes(b"model:\n  default: \xff\n")
+
+            result = read_hermes_model_settings(OmhPaths(root / ".omh", hermes_home))
+
+        self.assertFalse(result["observed"])
+        self.assertEqual(result["reason"], "config_unreadable")
+        self.assertEqual(result["aliases"], [])
+
     def test_alias_order_is_the_exact_hermes_contract(self) -> None:
         result = self._read("model:\n  default:\n")
         self.assertEqual(

--- a/tests/test_hermes_model_settings.py
+++ b/tests/test_hermes_model_settings.py
@@ -104,6 +104,39 @@ class HermesModelSettingsTests(unittest.TestCase):
         self.assertEqual(result["reason"], "config_unreadable")
         self.assertEqual(result["aliases"], [])
 
+    def test_block_scalar_degrades_instead_of_publishing_yaml_syntax(self) -> None:
+        result = self._read("model:\n  default: >-\n    gpt-5.6-sol\n")
+
+        self.assertFalse(result["observed"])
+        self.assertEqual(result["reason"], "config_unreadable")
+        self.assertEqual(result["aliases"], [])
+
+    def test_yaml_null_scalars_mean_inherit(self) -> None:
+        result = self._read(
+            "model:\n  default: null\nauxiliary:\n"
+            "  web_extract:\n    model: ~\n"
+        )
+
+        aliases = {entry["alias"]: entry for entry in result["aliases"]}
+        self.assertTrue(result["observed"])
+        self.assertFalse(aliases["main"]["configured"])
+        self.assertEqual(aliases["main"]["label"], "inherit")
+        self.assertFalse(aliases["web_extract"]["configured"])
+        self.assertEqual(result["configured_count"], 0)
+        self.assertEqual(result["inherit_count"], 15)
+
+    def test_tab_indentation_degrades_as_unreadable(self) -> None:
+        result = self._read("model:\n\tdefault: gpt-5.6-sol\n")
+
+        self.assertFalse(result["observed"])
+        self.assertEqual(result["reason"], "config_unreadable")
+
+    def test_flow_mapping_degrades_as_unreadable(self) -> None:
+        result = self._read("model: {default: gpt-5.6-sol}\n")
+
+        self.assertFalse(result["observed"])
+        self.assertEqual(result["reason"], "config_unreadable")
+
     def test_alias_order_is_the_exact_hermes_contract(self) -> None:
         result = self._read("model:\n  default:\n")
         self.assertEqual(

--- a/tests/test_hermes_model_settings.py
+++ b/tests/test_hermes_model_settings.py
@@ -137,6 +137,18 @@ class HermesModelSettingsTests(unittest.TestCase):
         self.assertFalse(result["observed"])
         self.assertEqual(result["reason"], "config_unreadable")
 
+    def test_nested_tracked_scalar_degrades_as_unreadable(self) -> None:
+        configs = (
+            "model:\n  default:\n    name: gpt-5.6-sol\n",
+            "auxiliary:\n  web_extract:\n    model:\n      name: gpt-5.6-sol\n",
+        )
+        for config_text in configs:
+            with self.subTest(config_text=config_text):
+                result = self._read(config_text)
+
+                self.assertFalse(result["observed"])
+                self.assertEqual(result["reason"], "config_unreadable")
+
     def test_alias_order_is_the_exact_hermes_contract(self) -> None:
         result = self._read("model:\n  default:\n")
         self.assertEqual(

--- a/tests/test_hermes_model_settings.py
+++ b/tests/test_hermes_model_settings.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.paths import OmhPaths
+from omh.surfaces.hermes_model_settings import (
+    HERMES_AUX_ALIASES,
+    HERMES_MODEL_SETTINGS_SCHEMA_VERSION,
+    read_hermes_model_settings,
+)
+
+
+class HermesModelSettingsTests(unittest.TestCase):
+    def _read(self, config_text: str) -> dict[str, object]:
+        temporary = TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        root = Path(temporary.name)
+        hermes_home = root / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(config_text, encoding="utf-8")
+        return read_hermes_model_settings(OmhPaths(root / ".omh", hermes_home))
+
+    def test_reads_live_shaped_default_and_all_inherit_auxiliaries(self) -> None:
+        result = self._read(
+            "model:\n  default: anthropic/claude-opus-4.6\n  provider: auto\n"
+            "  base_url: https://example.invalid\nagent:\n  reasoning_effort: medium\n"
+        )
+        self.assertEqual(result["schema_version"], HERMES_MODEL_SETTINGS_SCHEMA_VERSION)
+        self.assertTrue(result["observed"])
+        self.assertEqual(result["reason"], "")
+        self.assertEqual(result["provider"], "auto")
+        self.assertEqual(
+            result["aliases"][0],
+            {
+                "alias": "main",
+                "model": "anthropic/claude-opus-4.6",
+                "effort": "medium",
+                "source": "config.model.default",
+                "configured": True,
+                "label": "anthropic/claude-opus-4.6:medium",
+            },
+        )
+        self.assertEqual(result["configured_count"], 1)
+        self.assertEqual(result["inherit_count"], 14)
+
+    def test_reads_known_auxiliary_model_and_effort_without_resolving_inheritance(self) -> None:
+        result = self._read(
+            "model:\n  default: main-model\nauxiliary:\n"
+            "  vision:\n    model:\n    reasoning_effort: high\n"
+            "  web_extract:\n    model: google/gemini-2.5-flash\n    reasoning_effort: low\n"
+            "  invented_alias:\n    model: must-not-appear\n"
+        )
+        aliases = {entry["alias"]: entry for entry in result["aliases"]}
+        self.assertEqual(aliases["vision"]["label"], "inherit")
+        self.assertFalse(aliases["vision"]["configured"])
+        self.assertEqual(aliases["vision"]["effort"], "high")
+        self.assertEqual(aliases["web_extract"]["model"], "google/gemini-2.5-flash")
+        self.assertEqual(aliases["web_extract"]["label"], "google/gemini-2.5-flash:low")
+        self.assertTrue(aliases["web_extract"]["configured"])
+        self.assertNotIn("invented_alias", aliases)
+        self.assertEqual(result["configured_count"], 2)
+        self.assertEqual(result["inherit_count"], 13)
+
+    def test_strips_quotes_and_comments_from_configured_scalars(self) -> None:
+        result = self._read(
+            "model:\n  default: 'anthropic/model#revision'  # main note\n"
+            "# top-level comment does not end the model block\n"
+            '  provider: "auto" # provider note\n'
+            "agent:\n  reasoning_effort: medium # effort note\n"
+            "auxiliary:\n  web_extract:\n    # task comment\n"
+            "    model: \"gpt-5.6-sol\"  # inline note\n"
+        )
+        self.assertEqual(result["provider"], "auto")
+        self.assertEqual(result["aliases"][0]["model"], "anthropic/model#revision")
+        self.assertEqual(result["aliases"][0]["effort"], "medium")
+        web_extract = next(entry for entry in result["aliases"] if entry["alias"] == "web_extract")
+        self.assertEqual(web_extract["model"], "gpt-5.6-sol")
+
+    def test_missing_config_degrades_to_config_unreadable(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            result = read_hermes_model_settings(OmhPaths(root / ".omh", root / ".hermes"))
+        self.assertFalse(result["observed"])
+        self.assertEqual(result["reason"], "config_unreadable")
+        self.assertEqual(result["aliases"], [])
+        self.assertEqual(result["configured_count"], 0)
+        self.assertEqual(result["inherit_count"], 0)
+
+    def test_alias_order_is_the_exact_hermes_contract(self) -> None:
+        result = self._read("model:\n  default:\n")
+        self.assertEqual(
+            tuple(entry["alias"] for entry in result["aliases"]),
+            ("main",) + HERMES_AUX_ALIASES,
+        )
+        self.assertEqual(len(HERMES_AUX_ALIASES), 14)
+        self.assertEqual(result["configured_count"], 0)
+        self.assertEqual(result["inherit_count"], 15)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hermes_processes.py
+++ b/tests/test_hermes_processes.py
@@ -55,6 +55,21 @@ class HermesProcessObservationTests(unittest.TestCase):
         self.assertEqual(result["process_count"], 2)
         self.assertEqual({row["role"] for row in result["rows"]}, {"agent"})
 
+    def test_ignores_unrelated_commands_with_hermes_path_arguments(self) -> None:
+        ps_output = """\
+43000 1 /Applications/Electron.app/Contents/MacOS/Electron /Users/u/.hermes/hermes-agent/hermes
+43001 1 /Applications/Visual Studio Code.app/Contents/MacOS/Electron --goto /Users/u/.hermes/hermes-agent/hermes
+43002 1 /usr/bin/printf /Users/u/.hermes/hermes-agent/hermes
+"""
+        with patch("omh.surfaces.hermes_processes.os.getpid", return_value=90001), patch(
+            "omh.surfaces.hermes_processes.os.getppid", return_value=90000
+        ):
+            result = observe_hermes_processes(ps_output=ps_output)
+
+        self.assertEqual(result["agent_count"], 0)
+        self.assertEqual(result["process_count"], 0)
+        self.assertEqual(result["rows"], [])
+
     def test_empty_output_is_a_successful_zero_observation(self) -> None:
         result = observe_hermes_processes(now="2026-08-16T04:30:00Z", ps_output="")
 
@@ -103,18 +118,17 @@ class HermesProcessObservationTests(unittest.TestCase):
 
         self.assertEqual(result["rows"], [])
 
-    def test_labels_use_entrypoint_basenames_and_are_truncated(self) -> None:
-        long_second = "/a/" + "entrypoint-name-that-is-far-too-long-for-the-label.js"
-        ps_output = f"61000 1 /opt/homebrew/bin/node {long_second} ui-tui/dist/entry.js\n"
+    def test_labels_use_entrypoint_basenames(self) -> None:
+        ps_output = (
+            "61000 1 /opt/homebrew/bin/node "
+            "/a/path/that/is/longer/than/the/display/limit/ui-tui/dist/entry.js\n"
+        )
         with patch("omh.surfaces.hermes_processes.os.getpid", return_value=90001), patch(
             "omh.surfaces.hermes_processes.os.getppid", return_value=90000
         ):
             result = observe_hermes_processes(ps_output=ps_output)
 
-        label = result["rows"][0]["label"]
-        self.assertEqual(len(label), 40)
-        self.assertTrue(label.startswith("node "))
-        self.assertTrue(label.endswith("…"))
+        self.assertEqual(result["rows"][0]["label"], "node entry.js")
 
 
 if __name__ == "__main__":

--- a/tests/test_hermes_processes.py
+++ b/tests/test_hermes_processes.py
@@ -70,6 +70,36 @@ class HermesProcessObservationTests(unittest.TestCase):
         self.assertEqual(result["process_count"], 0)
         self.assertEqual(result["rows"], [])
 
+    def test_quoted_paths_with_spaces_preserve_the_hermes_entrypoint(self) -> None:
+        ps_output = (
+            '44000 1 "/Users/Example User/.hermes/hermes-agent/venv/bin/python" '
+            '"/Users/Example User/.hermes/hermes-agent/hermes"\n'
+        )
+        with patch("omh.surfaces.hermes_processes.os.getpid", return_value=90001), patch(
+            "omh.surfaces.hermes_processes.os.getppid", return_value=90000
+        ):
+            result = observe_hermes_processes(ps_output=ps_output)
+
+        self.assertEqual(result["agent_count"], 1)
+        self.assertEqual(result["process_count"], 1)
+        self.assertEqual(result["rows"][0]["label"], "python hermes")
+
+    def test_ignores_one_shot_hermes_cli_commands(self) -> None:
+        ps_output = """\
+45000 1 /usr/bin/python -m hermes_cli.main config check
+45001 1 /usr/bin/python -m hermes_cli.main status
+45002 1 /usr/bin/python /opt/hermes-agent/hermes doctor
+45003 1 /usr/bin/python -m hermes_cli.main gateway status
+"""
+        with patch("omh.surfaces.hermes_processes.os.getpid", return_value=90001), patch(
+            "omh.surfaces.hermes_processes.os.getppid", return_value=90000
+        ):
+            result = observe_hermes_processes(ps_output=ps_output)
+
+        self.assertEqual(result["agent_count"], 0)
+        self.assertEqual(result["process_count"], 0)
+        self.assertEqual(result["rows"], [])
+
     def test_empty_output_is_a_successful_zero_observation(self) -> None:
         result = observe_hermes_processes(now="2026-08-16T04:30:00Z", ps_output="")
 

--- a/tests/test_hermes_processes.py
+++ b/tests/test_hermes_processes.py
@@ -84,12 +84,27 @@ class HermesProcessObservationTests(unittest.TestCase):
         self.assertEqual(result["process_count"], 1)
         self.assertEqual(result["rows"][0]["label"], "python hermes")
 
+    def test_unquoted_ps_paths_with_spaces_preserve_the_hermes_entrypoint(self) -> None:
+        ps_output = (
+            "44500 1 python "
+            "/tmp/Hermes Bare Space/hermes-agent/hermes --cli\n"
+        )
+        with patch("omh.surfaces.hermes_processes.os.getpid", return_value=90001), patch(
+            "omh.surfaces.hermes_processes.os.getppid", return_value=90000
+        ):
+            result = observe_hermes_processes(ps_output=ps_output)
+
+        self.assertEqual(result["agent_count"], 1)
+        self.assertEqual(result["process_count"], 1)
+        self.assertEqual(result["rows"][0]["label"], "python hermes")
+
     def test_ignores_one_shot_hermes_cli_commands(self) -> None:
         ps_output = """\
 45000 1 /usr/bin/python -m hermes_cli.main config check
 45001 1 /usr/bin/python -m hermes_cli.main status
 45002 1 /usr/bin/python /opt/hermes-agent/hermes doctor
 45003 1 /usr/bin/python -m hermes_cli.main gateway status
+45004 1 /usr/bin/python -m hermes_cli.main --profile work status
 """
         with patch("omh.surfaces.hermes_processes.os.getpid", return_value=90001), patch(
             "omh.surfaces.hermes_processes.os.getppid", return_value=90000
@@ -99,6 +114,22 @@ class HermesProcessObservationTests(unittest.TestCase):
         self.assertEqual(result["agent_count"], 0)
         self.assertEqual(result["process_count"], 0)
         self.assertEqual(result["rows"], [])
+
+    def test_profile_selector_before_persistent_command_is_counted(self) -> None:
+        ps_output = """\
+46000 1 /usr/bin/python -m hermes_cli.main --profile work gateway run
+46001 1 /usr/bin/python /opt/hermes-agent/hermes --profile=personal chat
+46002 1 /usr/bin/python -m hermes_cli.main -p work gateway run
+46003 1 /usr/bin/python /opt/hermes-agent/hermes --profile=personal --tui
+46004 1 /usr/bin/python /opt/hermes-agent/hermes --cli
+"""
+        with patch("omh.surfaces.hermes_processes.os.getpid", return_value=90001), patch(
+            "omh.surfaces.hermes_processes.os.getppid", return_value=90000
+        ):
+            result = observe_hermes_processes(ps_output=ps_output)
+
+        self.assertEqual(result["agent_count"], 5)
+        self.assertEqual(result["process_count"], 5)
 
     def test_empty_output_is_a_successful_zero_observation(self) -> None:
         result = observe_hermes_processes(now="2026-08-16T04:30:00Z", ps_output="")

--- a/tests/test_hermes_processes.py
+++ b/tests/test_hermes_processes.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import subprocess
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.surfaces.hermes_processes import HERMES_PROCESS_SCHEMA_VERSION, observe_hermes_processes
+
+
+NOW = datetime(2026, 8, 16, 4, 30, tzinfo=timezone.utc)
+
+
+class HermesProcessObservationTests(unittest.TestCase):
+    def test_real_process_tree_classifies_one_root_and_filters_shell_decoy(self) -> None:
+        ps_output = """\
+31500 1 /Users/example/.hermes/hermes-agent/venv/bin/python /Users/example/.hermes/hermes-agent/hermes
+31548 31500 /opt/homebrew/bin/node --expose-gc /Users/example/.hermes/hermes-agent/ui-tui/dist/entry.js
+31549 31548 /Users/example/.hermes/hermes-agent/venv/bin/python -m tui_gateway.entry
+31599 1 /bin/bash -c python3 /Users/example/.hermes/hermes-agent/hermes
+"""
+        with patch("omh.surfaces.hermes_processes.os.getpid", return_value=90001), patch(
+            "omh.surfaces.hermes_processes.os.getppid", return_value=90000
+        ):
+            result = observe_hermes_processes(now=NOW, ps_output=ps_output)
+
+        self.assertEqual(result["schema_version"], HERMES_PROCESS_SCHEMA_VERSION)
+        self.assertTrue(result["observed"])
+        self.assertEqual(result["reason"], "")
+        self.assertEqual(result["agent_count"], 1)
+        self.assertEqual(result["process_count"], 3)
+        self.assertNotIn(31599, {row["pid"] for row in result["rows"]})
+        self.assertEqual([row["role"] for row in result["rows"]], ["agent", "child", "child"])
+        self.assertEqual(result["observed_at"], "2026-08-16T04:30:00Z")
+        self.assertEqual(result["source"], "local_process_scan")
+        self.assertEqual(
+            result["claim_boundary"],
+            "Local process observation is bounded, best-effort, and is not execution, review, CI, or merge evidence.",
+        )
+
+    def test_two_independent_roots_are_agents(self) -> None:
+        ps_output = """\
+41000 1 /usr/bin/python /opt/hermes-agent/hermes
+42000 2 /usr/bin/python -m hermes_cli.main gateway run
+"""
+        with patch("omh.surfaces.hermes_processes.os.getpid", return_value=90001), patch(
+            "omh.surfaces.hermes_processes.os.getppid", return_value=90000
+        ):
+            result = observe_hermes_processes(ps_output=ps_output)
+
+        self.assertEqual(result["agent_count"], 2)
+        self.assertEqual(result["process_count"], 2)
+        self.assertEqual({row["role"] for row in result["rows"]}, {"agent"})
+
+    def test_empty_output_is_a_successful_zero_observation(self) -> None:
+        result = observe_hermes_processes(now="2026-08-16T04:30:00Z", ps_output="")
+
+        self.assertTrue(result["observed"])
+        self.assertEqual(result["reason"], "")
+        self.assertEqual(result["agent_count"], 0)
+        self.assertEqual(result["process_count"], 0)
+        self.assertEqual(result["rows"], [])
+
+    def test_oserror_from_ps_is_classified_as_unavailable(self) -> None:
+        with patch("omh.surfaces.hermes_processes.subprocess.run", side_effect=OSError("ps missing")) as run:
+            result = observe_hermes_processes(now=NOW)
+
+        run.assert_called_once_with(
+            ["ps", "-axo", "pid=,ppid=,command="],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=2,
+            check=False,
+        )
+        self.assertFalse(result["observed"])
+        self.assertEqual(result["reason"], "ps_unavailable")
+        self.assertEqual(result["agent_count"], 0)
+        self.assertEqual(result["process_count"], 0)
+
+    def test_nonzero_ps_exit_is_classified_as_unavailable(self) -> None:
+        completed = subprocess.CompletedProcess(args=["ps"], returncode=1, stdout="ignored", stderr="denied")
+        with patch("omh.surfaces.hermes_processes.subprocess.run", return_value=completed):
+            result = observe_hermes_processes(now=NOW)
+
+        self.assertFalse(result["observed"])
+        self.assertEqual(result["reason"], "ps_unavailable")
+
+    def test_filters_search_commands_and_observer_processes(self) -> None:
+        ps_output = """\
+51000 1 /usr/bin/grep hermes-agent/hermes
+51001 1 /opt/homebrew/bin/rg hermes_cli.main
+51002 1 /usr/bin/python /opt/hermes-agent/hermes
+51003 1 /usr/bin/python /opt/hermes-agent/hermes
+"""
+        with patch("omh.surfaces.hermes_processes.os.getpid", return_value=51002), patch(
+            "omh.surfaces.hermes_processes.os.getppid", return_value=51003
+        ):
+            result = observe_hermes_processes(ps_output=ps_output)
+
+        self.assertEqual(result["rows"], [])
+
+    def test_labels_use_entrypoint_basenames_and_are_truncated(self) -> None:
+        long_second = "/a/" + "entrypoint-name-that-is-far-too-long-for-the-label.js"
+        ps_output = f"61000 1 /opt/homebrew/bin/node {long_second} ui-tui/dist/entry.js\n"
+        with patch("omh.surfaces.hermes_processes.os.getpid", return_value=90001), patch(
+            "omh.surfaces.hermes_processes.os.getppid", return_value=90000
+        ):
+            result = observe_hermes_processes(ps_output=ps_output)
+
+        label = result["rows"][0]["label"]
+        self.assertEqual(len(label), 40)
+        self.assertTrue(label.startswith("node "))
+        self.assertTrue(label.endswith("…"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hermes_sessions.py
+++ b/tests/test_hermes_sessions.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.paths import OmhPaths
+from omh.surfaces.hermes_sessions import HERMES_SESSION_SCHEMA_VERSION, observe_hermes_sessions
+
+
+CREATE_SESSIONS = """
+create table sessions (
+    source text,
+    model text,
+    model_config text,
+    ended_at text,
+    archived integer not null,
+    hidden integer not null,
+    started_at text,
+    last_activity_at text,
+    title text,
+    token_count integer
+)
+"""
+
+
+class HermesSessionObservationTests(unittest.TestCase):
+    def test_observes_visible_sessions_and_latest_live_model_with_three_selects(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = self._paths(Path(tmp))
+            paths.hermes_home.mkdir()
+            db_path = paths.hermes_home / "state.db"
+            connection = sqlite3.connect(db_path)
+            connection.execute(CREATE_SESSIONS)
+            model_config = json.dumps(
+                {
+                    "model": "gpt-5.6-sol",
+                    "provider": "openai-codex",
+                    "reasoning_config": {"enabled": True, "effort": "medium"},
+                }
+            )
+            rows = [
+                ("tui", "older-model", None, None, 0, 0, "2026-08-01", "2026-08-02", "secret", 11),
+                ("api", "gpt-5.6-sol", model_config, None, 0, 0, "2026-08-03", "2026-08-04", "secret", 22),
+                ("tui", "ended-model", None, "2026-08-05", 0, 0, "2026-08-01", "2026-08-05", "secret", 33),
+                ("tui", "archived-model", None, None, 1, 0, "2026-08-06", "2026-08-06", "secret", 44),
+                ("tui", "hidden-model", None, None, 0, 1, "2026-08-07", "2026-08-07", "secret", 55),
+            ]
+            connection.executemany("insert into sessions values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", rows)
+            connection.commit()
+            connection.close()
+
+            statements: list[str] = []
+            connect_calls: list[tuple[object, dict[str, object]]] = []
+            real_connect = sqlite3.connect
+
+            def recording_connect(database: object, **kwargs: object) -> sqlite3.Connection:
+                connect_calls.append((database, kwargs))
+                observed_connection = real_connect(database, **kwargs)
+                observed_connection.set_trace_callback(statements.append)
+                return observed_connection
+
+            with patch("omh.surfaces.hermes_sessions.sqlite3.connect", side_effect=recording_connect):
+                payload = observe_hermes_sessions(paths)
+
+            self.assertEqual(
+                connect_calls,
+                [(f"file:{db_path}?mode=ro", {"uri": True, "timeout": 1.0})],
+            )
+            self.assertEqual(len(statements), 3)
+            self.assertTrue(all(statement.lower().startswith("select ") for statement in statements))
+            self.assertTrue(all("source" not in statement.lower() for statement in statements))
+            self.assertTrue(all("title" not in statement.lower() for statement in statements))
+            self.assertTrue(all("token" not in statement.lower() for statement in statements))
+            self.assertEqual(payload["schema_version"], HERMES_SESSION_SCHEMA_VERSION)
+            self.assertTrue(payload["observed"])
+            self.assertEqual(payload["reason"], "")
+            self.assertEqual(payload["live"], 2)
+            self.assertEqual(payload["total"], 3)
+            self.assertEqual(
+                payload["current_model"],
+                {
+                    "observed": True,
+                    "value": "gpt-5.6-sol",
+                    "effort": "medium",
+                    "provider": "openai-codex",
+                    "label": "gpt-5.6-sol:medium",
+                },
+            )
+            self.assertNotIn("by_source", payload)
+            self.assertNotIn("source", payload["current_model"])
+            self.assertNotIn("title", payload)
+            self.assertNotIn("token_count", payload)
+
+    def test_missing_database_degrades_without_creating_it(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = self._paths(Path(tmp))
+            paths.hermes_home.mkdir()
+
+            payload = observe_hermes_sessions(paths)
+
+            self.assertFalse(payload["observed"])
+            self.assertEqual(payload["reason"], "state_db_missing")
+            self.assertEqual(payload["live"], 0)
+            self.assertEqual(payload["total"], 0)
+            self.assertFalse(payload["current_model"]["observed"])
+            self.assertFalse((paths.hermes_home / "state.db").exists())
+
+    def test_non_sqlite_database_degrades_as_unreadable(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = self._paths(Path(tmp))
+            paths.hermes_home.mkdir()
+            (paths.hermes_home / "state.db").write_bytes(b"not a sqlite database")
+
+            payload = observe_hermes_sessions(paths)
+
+            self.assertFalse(payload["observed"])
+            self.assertEqual(payload["reason"], "state_db_unreadable")
+            self.assertFalse(payload["current_model"]["observed"])
+
+    def test_missing_or_malformed_model_config_preserves_the_observed_model(self) -> None:
+        for model_config in (None, "not-json", "[]", '{"reasoning_config": []}'):
+            with self.subTest(model_config=model_config), TemporaryDirectory() as tmp:
+                paths = self._paths(Path(tmp))
+                paths.hermes_home.mkdir()
+                connection = sqlite3.connect(paths.hermes_home / "state.db")
+                connection.execute(CREATE_SESSIONS)
+                connection.execute(
+                    "insert into sessions values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    ("tui", "model-only", model_config, None, 0, 0, "2026-08-01", None, "secret", 99),
+                )
+                connection.commit()
+                connection.close()
+
+                payload = observe_hermes_sessions(paths)
+
+                self.assertTrue(payload["observed"])
+                self.assertEqual(
+                    payload["current_model"],
+                    {
+                        "observed": True,
+                        "value": "model-only",
+                        "effort": "",
+                        "provider": "",
+                        "label": "model-only",
+                    },
+                )
+
+    @staticmethod
+    def _paths(root: Path) -> OmhPaths:
+        return OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hermes_sessions.py
+++ b/tests/test_hermes_sessions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 import unittest
 from pathlib import Path
@@ -125,24 +126,40 @@ class HermesSessionObservationTests(unittest.TestCase):
             self.assertFalse(payload["current_model"]["observed"])
 
     def test_special_characters_in_hermes_home_use_a_uri_safe_readonly_path(self) -> None:
-        with TemporaryDirectory() as tmp:
-            paths = self._paths(Path(tmp) / "Hermes ? # Home")
-            paths.hermes_home.mkdir(parents=True)
-            connection = sqlite3.connect(paths.hermes_home / "state.db")
-            connection.execute(CREATE_SESSIONS)
-            connection.execute(
-                "insert into sessions values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                ("api", "gpt-5.6-sol", None, None, 0, 0, "2026-08-01", None, "secret", 1),
-            )
-            connection.commit()
-            connection.close()
+        home_names = ["Hermes % # Home"]
+        if os.name != "nt":
+            home_names.append("Hermes ? # Home")
 
-            payload = observe_hermes_sessions(paths)
+        for home_name in home_names:
+            with self.subTest(home_name=home_name), TemporaryDirectory() as tmp:
+                paths = self._paths(Path(tmp) / home_name)
+                paths.hermes_home.mkdir(parents=True)
+                connection = sqlite3.connect(paths.hermes_home / "state.db")
+                connection.execute(CREATE_SESSIONS)
+                connection.execute(
+                    "insert into sessions values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        "api",
+                        "gpt-5.6-sol",
+                        None,
+                        None,
+                        0,
+                        0,
+                        "2026-08-01",
+                        None,
+                        "secret",
+                        1,
+                    ),
+                )
+                connection.commit()
+                connection.close()
 
-        self.assertTrue(payload["observed"])
-        self.assertEqual(payload["reason"], "")
-        self.assertEqual(payload["live"], 1)
-        self.assertEqual(payload["total"], 1)
+                payload = observe_hermes_sessions(paths)
+
+                self.assertTrue(payload["observed"])
+                self.assertEqual(payload["reason"], "")
+                self.assertEqual(payload["live"], 1)
+                self.assertEqual(payload["total"], 1)
 
     def test_missing_or_malformed_model_config_preserves_the_observed_model(self) -> None:
         for model_config in (None, "not-json", "[]", '{"reasoning_config": []}'):

--- a/tests/test_hermes_sessions.py
+++ b/tests/test_hermes_sessions.py
@@ -71,7 +71,7 @@ class HermesSessionObservationTests(unittest.TestCase):
 
             self.assertEqual(
                 connect_calls,
-                [(f"file:{db_path}?mode=ro", {"uri": True, "timeout": 1.0})],
+                [(f"{db_path.resolve().as_uri()}?mode=ro", {"uri": True, "timeout": 1.0})],
             )
             self.assertEqual(len(statements), 3)
             self.assertTrue(all(statement.lower().startswith("select ") for statement in statements))
@@ -123,6 +123,26 @@ class HermesSessionObservationTests(unittest.TestCase):
             self.assertFalse(payload["observed"])
             self.assertEqual(payload["reason"], "state_db_unreadable")
             self.assertFalse(payload["current_model"]["observed"])
+
+    def test_special_characters_in_hermes_home_use_a_uri_safe_readonly_path(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = self._paths(Path(tmp) / "Hermes ? # Home")
+            paths.hermes_home.mkdir(parents=True)
+            connection = sqlite3.connect(paths.hermes_home / "state.db")
+            connection.execute(CREATE_SESSIONS)
+            connection.execute(
+                "insert into sessions values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                ("api", "gpt-5.6-sol", None, None, 0, 0, "2026-08-01", None, "secret", 1),
+            )
+            connection.commit()
+            connection.close()
+
+            payload = observe_hermes_sessions(paths)
+
+        self.assertTrue(payload["observed"])
+        self.assertEqual(payload["reason"], "")
+        self.assertEqual(payload["live"], 1)
+        self.assertEqual(payload["total"], 1)
 
     def test_missing_or_malformed_model_config_preserves_the_observed_model(self) -> None:
         for model_config in (None, "not-json", "[]", '{"reasoning_config": []}'):

--- a/tests/test_menubar_app.py
+++ b/tests/test_menubar_app.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import base64
 import json
 import platform
+import plistlib
 import shutil
+import struct
 import subprocess
 import unittest
 from pathlib import Path
@@ -19,6 +22,41 @@ from omh.paths import resolve_paths
 
 
 class MenubarAppTests(unittest.TestCase):
+    def test_embedded_character_icon_is_a_non_empty_36_pixel_png(self) -> None:
+        icon_bytes = base64.b64decode(menubar_app_module.MENUBAR_ICON_BASE64, validate=True)
+
+        self.assertGreater(len(icon_bytes), 24)
+        self.assertEqual(icon_bytes[:8], b"\x89PNG\r\n\x1a\n")
+        self.assertEqual(icon_bytes[12:16], b"IHDR")
+        self.assertEqual(struct.unpack(">II", icon_bytes[16:24]), (36, 36))
+
+    def test_install_materializes_exact_icon_bytes_and_passes_icon_path(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            expected_icon = base64.b64decode(menubar_app_module.MENUBAR_ICON_BASE64, validate=True)
+
+            with (
+                patch.object(menubar_app_module.Path, "home", return_value=root),
+                patch("omh.menubar_app.shutil.which", return_value="/usr/bin/swiftc"),
+                patch("omh.menubar_app._compile_swift_helper"),
+            ):
+                payload = setup_menubar_app(
+                    paths,
+                    platform_name="Darwin",
+                    start=False,
+                    command_path="/usr/local/bin/omh",
+                )
+
+            icon_path = paths.omh_home / "menubar" / "omh-character-mask.png"
+            self.assertEqual(payload["icon"], str(icon_path))
+            self.assertEqual(icon_path.read_bytes(), expected_icon)
+            self.assertGreater(len(icon_path.read_bytes()), 0)
+            launch_agent = root / "Library" / "LaunchAgents" / "com.rlaope.omh.menubar.plist"
+            arguments = plistlib.loads(launch_agent.read_bytes())["ProgramArguments"]
+            icon_argument = arguments.index("--icon")
+            self.assertEqual(arguments[icon_argument + 1], str(icon_path))
+
     def test_setup_menubar_app_skips_unsupported_platform(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -95,6 +133,19 @@ class MenubarAppTests(unittest.TestCase):
         self.assertIn('rows.prefix(6)', source)
         self.assertIn('display?["menu_bar_title"]', source)
         self.assertNotIn('agent_status', source)
+
+    def test_native_helper_loads_template_icon_at_18_points_with_accessible_label(self) -> None:
+        source = menubar_app_module._SWIFT_SOURCE
+
+        self.assertIn('case "--icon":', source)
+        self.assertIn('NSImage(contentsOfFile: iconPath)', source)
+        self.assertIn('image.size = NSSize(width: 18, height: 18)', source)
+        self.assertIn('image.isTemplate = true', source)
+        self.assertIn('button.imagePosition = .imageLeading', source)
+        self.assertIn('button.setAccessibilityLabel(', source)
+        self.assertIn('"OMH — \(headline) — \(summary)"', source)
+        self.assertNotIn('statusItem.button?.title = "omh !"', source)
+        self.assertNotIn('? "\(title) \(mark)" : menuBarTitle', source)
 
     def test_native_helper_keeps_sessions_table_header_visible(self) -> None:
         source = menubar_app_module._SWIFT_SOURCE

--- a/tests/test_menubar_app.py
+++ b/tests/test_menubar_app.py
@@ -103,6 +103,59 @@ class MenubarAppTests(unittest.TestCase):
         self.assertIn('return fixedWidth(value, 18)', source)
         self.assertNotIn('fixedWidth(value, 12)', source)
 
+    def test_native_helper_bounds_table_values_without_truncating_tooltips(self) -> None:
+        source = menubar_app_module._SWIFT_SOURCE
+
+        self.assertIn('fixedWidth((row["right"] as? String) ?? "", 24)', source)
+        self.assertIn('item.toolTip = rowToolTip(row)', source)
+        self.assertIn('return fixedWidth(value, 24)', source)
+        tooltip_start = source.index("    private func rowToolTip")
+        tooltip_end = source.index("\n    private func menuCards", tooltip_start)
+        tooltip_source = source[tooltip_start:tooltip_end]
+        self.assertIn('let right = (row["right"] as? String) ?? ""', tooltip_source)
+        self.assertIn('return "\\(left): \\(right)"', tooltip_source)
+        self.assertNotIn("fixedWidth", tooltip_source)
+
+    def test_native_helper_fixed_width_truncates_a_long_value_to_24_characters(self) -> None:
+        swiftc = shutil.which("swiftc")
+        if swiftc is None:
+            self.skipTest("Native fixed-width behavior coverage requires swiftc")
+
+        source = menubar_app_module._SWIFT_SOURCE
+        function_start = source.index("    private func fixedWidth")
+        function_end = source.index("\n    private func rowTitle", function_start)
+        fixed_width_source = source[function_start:function_end].replace(
+            "    private func fixedWidth",
+            "func fixedWidth",
+            1,
+        )
+        long_value = "abcdefghijklmnopqrstuvwxyz0123456789"
+        expected = long_value[:23] + "…"
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            harness = root / "main.swift"
+            executable = root / "fixed-width-test"
+            harness.write_text(
+                f'import Foundation\n{fixed_width_source}\nprint(fixedWidth("{long_value}", 24))\n',
+                encoding="utf-8",
+            )
+            compile_result = subprocess.run(
+                [swiftc, str(harness), "-o", str(executable)],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            self.assertEqual(compile_result.returncode, 0, compile_result.stderr or compile_result.stdout)
+            run_result = subprocess.run(
+                [str(executable)], text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False
+            )
+
+        self.assertEqual(run_result.returncode, 0, run_result.stderr or run_result.stdout)
+        self.assertEqual(run_result.stdout.rstrip("\n"), expected)
+        self.assertEqual(len(expected), 24)
+
     def test_native_helper_swift_source_compiles_on_darwin(self) -> None:
         swiftc = shutil.which("swiftc")
         if platform.system() != "Darwin" or swiftc is None:

--- a/tests/test_menubar_app.py
+++ b/tests/test_menubar_app.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import json
+import platform
+import shutil
+import subprocess
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -82,6 +85,43 @@ class MenubarAppTests(unittest.TestCase):
             '["menubar", "status", "--observe-local-processes", "--json"]',
             menubar_app_module._SWIFT_SOURCE,
         )
+
+    def test_native_helper_renders_v2_table_rows_and_count_title(self) -> None:
+        source = menubar_app_module._SWIFT_SOURCE
+
+        self.assertIn('== "table_row"', source)
+        self.assertIn('fixedWidth((row["left"] as? String) ?? "", 18)', source)
+        self.assertIn('(row["right"] as? String) ?? ""', source)
+        self.assertIn('rows.prefix(6)', source)
+        self.assertIn('display?["menu_bar_title"]', source)
+        self.assertNotIn('agent_status', source)
+
+    def test_native_helper_keeps_sessions_table_header_visible(self) -> None:
+        source = menubar_app_module._SWIFT_SOURCE
+
+        self.assertIn('let line = tableHeaderTitle(columns)', source)
+        self.assertIn('return fixedWidth(value, 18)', source)
+        self.assertNotIn('fixedWidth(value, 12)', source)
+
+    def test_native_helper_swift_source_compiles_on_darwin(self) -> None:
+        swiftc = shutil.which("swiftc")
+        if platform.system() != "Darwin" or swiftc is None:
+            self.skipTest("Swift/AppKit compile coverage requires swiftc on Darwin")
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "OMHMenuBar.swift"
+            executable = root / "omh-menubar"
+            source.write_text(menubar_app_module._SWIFT_SOURCE, encoding="utf-8")
+            result = subprocess.run(
+                [swiftc, "-framework", "AppKit", str(source), "-o", str(executable)],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
 
     def test_menubar_start_defaults_to_human_readable_output(self) -> None:
         payload = {

--- a/tests/test_menubar_status.py
+++ b/tests/test_menubar_status.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 import subprocess
 import unittest
 from pathlib import Path
@@ -44,6 +45,8 @@ class MenubarStatusTests(unittest.TestCase):
             self.assertEqual(stderr, "")
             self.assertEqual(status, 0)
 
+            self._seed_hermes_observers(hermes_home)
+
             status, stdout, stderr = run_cli(
                 ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "menubar", "status"]
             )
@@ -51,7 +54,7 @@ class MenubarStatusTests(unittest.TestCase):
             self.assertEqual(stderr, "")
             self.assertEqual(status, 0)
             payload = json.loads(stdout)
-            self.assertEqual(payload["schema_version"], "menubar_status/v1")
+            self.assertEqual(payload["schema_version"], "menubar_status/v2")
             self.assertEqual(payload["display"]["menu_title"], "omh")
             self.assertEqual(payload["versions"]["omh"]["value"], "1.0.6")
             self.assertEqual(payload["versions"]["hermes"]["value"], "unknown")
@@ -63,20 +66,42 @@ class MenubarStatusTests(unittest.TestCase):
             menu_cards = payload["display"]["menu_cards"]
             self.assertEqual(
                 [card["title"] for card in menu_cards],
-                ["Agent Status", "Coding Agent", "Evidence"],
+                ["Sessions", "Models", ""],
             )
-            self.assertEqual(menu_cards[0]["columns"], ["Agent", "PID", "Status"])
-            self.assertIn("PID appears after overlay or explicit local observation.", menu_cards[0]["footer"])
-            self.assertEqual(menu_cards[0]["rows"][0]["kind"], "agent_status")
-            self.assertEqual(menu_cards[0]["rows"][0]["agent"], ".hermes")
-            self.assertEqual(menu_cards[0]["rows"][0]["pid"], "not observed")
-            self.assertEqual(menu_cards[0]["rows"][0]["status"], "Configured")
-            self.assertNotIn("4312", json.dumps(menu_cards))
-            self.assertEqual(menu_cards[1]["rows"][0]["label"], "Agent")
-            self.assertEqual(menu_cards[1]["rows"][0]["value"], "Codex")
-            self.assertEqual(menu_cards[1]["rows"][3]["label"], "Next")
-            self.assertEqual(menu_cards[1]["rows"][3]["value"], "dispatching to the selected coding agent")
-            self.assertNotIn("dispatch_to_executor", json.dumps(menu_cards))
+            self.assertEqual(menu_cards[0]["columns"], ["Hermes session", "Count"])
+            self.assertEqual(
+                menu_cards[0]["rows"],
+                [
+                    {"kind": "table_row", "left": "live", "right": "1", "tone": "ok"},
+                    {"kind": "table_row", "left": "total", "right": "2", "tone": "ok"},
+                ],
+            )
+            self.assertNotIn("tui", [row["left"] for row in menu_cards[0]["rows"]])
+            self.assertEqual(menu_cards[1]["columns"], ["Alias", "Model"])
+            self.assertEqual(
+                [(row["left"], row["right"]) for row in menu_cards[1]["rows"]],
+                [
+                    ("current", "gpt-5.6-sol:medium"),
+                    ("main", "anthropic/claude-opus-4.6:medium"),
+                    ("vision", "google/gemini-2.5-pro"),
+                    ("web_extract", "google/gemini-2.5-flash"),
+                    ("+12 aliases", "inherit default"),
+                ],
+            )
+            self.assertEqual(
+                menu_cards[2]["rows"],
+                [{"label": "coding", "value": "Codex", "detail": "metadata only"}],
+            )
+            self.assertFalse(any(row.get("kind") == "agent_status" for card in menu_cards for row in card["rows"]))
+            self.assertEqual(payload["hermes_processes"]["reason"], "not_requested")
+            self.assertTrue(payload["hermes_sessions"]["observed"])
+            self.assertTrue(payload["model_settings"]["observed"])
+            self.assertTrue(
+                {
+                    "hermes_agents", "external_coding_executors", "current_external_coding_executor",
+                    "settings", "versions", "process_overlay", "icon_contract", "privacy",
+                }.issubset(payload)
+            )
 
             hermes_agents = payload["hermes_agents"]
             self.assertEqual(len(hermes_agents), 1)
@@ -139,12 +164,9 @@ class MenubarStatusTests(unittest.TestCase):
             self.assertEqual(payload["settings"]["coding_handoff"]["label"], "Coding agent: Not selected")
             self.assertEqual(payload["settings"]["coding_handoff"]["source"], "none")
             self.assertFalse(payload["current_external_coding_executor"]["selected"])
-            self.assertEqual(payload["display"]["summary_line"], "1 Hermes target(s) · ready for the next request")
-            coding_card = next(card for card in payload["display"]["menu_cards"] if card["title"] == "Coding Agent")
-            rows = {row["label"]: row for row in coding_card["rows"]}
-            self.assertEqual(rows["Agent"]["value"], "Not selected")
-            self.assertEqual(rows["Status"]["value"], "ready")
-            self.assertIn("Hermes routes the next request", rows["Status"]["detail"])
+            self.assertEqual(payload["display"]["summary_line"], "sessions not observed")
+            footer = payload["display"]["menu_cards"][2]
+            self.assertEqual(footer["rows"], [{"label": "coding", "value": "Not selected", "detail": "metadata only"}])
 
     def test_menubar_status_shows_recorded_preference_without_a_run(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -176,11 +198,8 @@ class MenubarStatusTests(unittest.TestCase):
             self.assertEqual(payload["settings"]["coding_handoff"]["label"], "Coding agent: Codex")
             self.assertEqual(payload["settings"]["coding_handoff"]["source"], "user_preference")
             self.assertFalse(payload["current_external_coding_executor"]["selected"])
-            coding_card = next(card for card in payload["display"]["menu_cards"] if card["title"] == "Coding Agent")
-            rows = {row["label"]: row for row in coding_card["rows"]}
-            self.assertEqual(rows["Agent"]["value"], "Codex")
-            self.assertEqual(rows["Status"]["value"], "preferred")
-            self.assertIn("no request routed yet", rows["Status"]["detail"])
+            footer = payload["display"]["menu_cards"][2]
+            self.assertEqual(footer["rows"], [{"label": "coding", "value": "Codex", "detail": "metadata only"}])
 
     def test_menubar_status_defaults_to_human_readable_output(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -205,6 +224,7 @@ class MenubarStatusTests(unittest.TestCase):
                 )[0],
                 0,
             )
+            self._seed_hermes_observers(hermes_home)
 
             status, stdout, stderr = run_cli(
                 ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "menubar", "status"],
@@ -215,9 +235,17 @@ class MenubarStatusTests(unittest.TestCase):
             self.assertEqual(status, 0)
             self.assertTrue(stdout.startswith("OMH menu bar status\n"))
             self.assertIn("Summary\n", stdout)
-            self.assertIn("Agent Status\n", stdout)
-            self.assertIn("Coding Agent\n", stdout)
-            self.assertIn("Evidence\n", stdout)
+            self.assertIn("  Sessions: live 1 / total 2\n", stdout)
+            self.assertIn("  Processes: not observed\n", stdout)
+            self.assertIn("Sessions\n  Hermes session       Count\n  live                 1\n  total                2\n", stdout)
+            self.assertIn(
+                "Models\n"
+                "  Alias                Model\n"
+                "  current              gpt-5.6-sol:medium\n"
+                "  main                 anthropic/claude-opus-4.6:medium\n",
+                stdout,
+            )
+            self.assertNotIn("Agent Status", stdout)
             self.assertIn("Coding agent: Codex", stdout)
             self.assertIn("For machine-readable output, rerun with `--json`.", stdout)
             with self.assertRaises(json.JSONDecodeError):
@@ -231,7 +259,7 @@ class MenubarStatusTests(unittest.TestCase):
             self.assertEqual(stderr, "")
             self.assertEqual(status, 0)
             payload = json.loads(stdout)
-            self.assertEqual(payload["schema_version"], "menubar_status/v1")
+            self.assertEqual(payload["schema_version"], "menubar_status/v2")
             self.assertEqual(payload["settings"]["coding_handoff"]["label"], "Coding agent: Codex")
 
     def test_process_overlay_applies_pid_status_and_model_only_when_fresh(self) -> None:
@@ -330,11 +358,7 @@ class MenubarStatusTests(unittest.TestCase):
             self.assertTrue(payload["external_coding_executors"][0]["pid_observed"])
             self.assertTrue(payload["external_coding_executors"][0]["status_observed"])
             self.assertEqual(payload["external_coding_executors"][0]["model"]["tooltip"], "gpt-5.5")
-            menu_cards = payload["display"]["menu_cards"]
-            self.assertEqual(menu_cards[0]["rows"][0]["pid"], "4312")
-            self.assertEqual(menu_cards[0]["rows"][0]["status"], "Running")
-            self.assertEqual(menu_cards[1]["rows"][2]["label"], "PID")
-            self.assertEqual(menu_cards[1]["rows"][2]["value"], "9821")
+            self.assertEqual([card["title"] for card in payload["display"]["menu_cards"]], ["Sessions", "Models", ""])
 
             status, stdout, stderr = run_cli(
                 [
@@ -520,20 +544,21 @@ class MenubarStatusTests(unittest.TestCase):
 
             ps_output = "\n".join(
                 [
-                    " 101 S /Applications/Codex.app/Contents/MacOS/Codex /Users/rlaope/Desktop/khope/hermes-agent",
-                    " 22064 S /Users/rlaope/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main gateway run --replace",
+                    " 101 1 /Applications/Codex.app/Contents/MacOS/Codex /Users/rlaope/Desktop/khope/hermes-agent",
+                    " 22064 1 /Users/rlaope/.hermes/hermes-agent/venv/bin/python /Users/rlaope/.hermes/hermes-agent/hermes",
+                    " 22065 22064 /opt/homebrew/bin/node --expose-gc /Users/rlaope/.hermes/hermes-agent/ui-tui/dist/entry.js",
                 ]
             )
 
             with patch(
-                "omh.menubar_status.subprocess.run",
+                "omh.surfaces.hermes_processes.subprocess.run",
                 return_value=subprocess.CompletedProcess(
                     args=["ps"],
                     returncode=0,
                     stdout=ps_output,
                     stderr="",
                 ),
-            ):
+            ) as run:
                 payload = build_menubar_status_payload(
                     paths,
                     observe_local_processes=True,
@@ -545,9 +570,25 @@ class MenubarStatusTests(unittest.TestCase):
             self.assertEqual(payload["hermes_agents"][0]["pid"], 22064)
             self.assertEqual(payload["hermes_agents"][0]["status"], "running")
             self.assertTrue(payload["hermes_agents"][0]["pid_observed"])
-            menu_cards = payload["display"]["menu_cards"]
-            self.assertEqual(menu_cards[0]["rows"][0]["pid"], "22064")
-            self.assertEqual(menu_cards[0]["rows"][0]["status"], "Running")
+            self.assertEqual(payload["hermes_processes"]["agent_count"], 1)
+            self.assertEqual(payload["hermes_processes"]["process_count"], 2)
+            run.assert_called_once()
+
+    def test_empty_hermes_home_degrades_and_plain_status_never_scans_processes(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            paths.hermes_home.mkdir()
+            with patch("omh.surfaces.hermes_processes.subprocess.run") as run:
+                payload = build_menubar_status_payload(paths)
+            run.assert_not_called()
+            self.assertEqual(payload["hermes_processes"]["reason"], "not_requested")
+            self.assertFalse(payload["hermes_sessions"]["observed"])
+            sessions_card = payload["display"]["menu_cards"][0]
+            self.assertEqual(sessions_card["columns"], ["Hermes session", "Count"])
+            self.assertEqual(sessions_card["rows"], [{"kind": "table_row", "left": "sessions", "right": "not observed"}])
+            self.assertEqual(sessions_card["footer"], "state_db_missing")
+            self.assertFalse(any(row.get("kind") == "agent_status" for card in payload["display"]["menu_cards"] for row in card["rows"]))
 
     def test_menubar_status_reports_multi_target_source_icons_without_process_claims(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -587,6 +628,42 @@ class MenubarStatusTests(unittest.TestCase):
         self.assertEqual(model_icon_descriptor("claude-sonnet")["icon_id"], "model.anthropic")
         self.assertEqual(model_icon_descriptor("gemini-3")["icon_id"], "model.google")
         self.assertEqual(model_icon_descriptor("ollama/llama")["icon_id"], "model.local")
+
+    @staticmethod
+    def _seed_hermes_observers(hermes_home: Path) -> None:
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        connection = sqlite3.connect(hermes_home / "state.db")
+        connection.execute(
+            """create table sessions (
+                source text, model text, model_config text, ended_at text,
+                archived integer not null, hidden integer not null,
+                started_at text, last_activity_at text
+            )"""
+        )
+        current_config = json.dumps({"provider": "openai-codex", "reasoning_config": {"effort": "medium"}})
+        connection.executemany(
+            "insert into sessions values (?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                ("tui", "gpt-5.6-sol", current_config, None, 0, 0, "2026-08-15", "2026-08-16"),
+                ("api", "older", "{}", "2026-08-15", 0, 0, "2026-08-14", "2026-08-15"),
+            ],
+        )
+        connection.commit()
+        connection.close()
+        (hermes_home / "config.yaml").write_text(
+            """model:
+  default: anthropic/claude-opus-4.6
+  provider: auto
+agent:
+  reasoning_effort: medium
+auxiliary:
+  web_extract:
+    model: google/gemini-2.5-flash
+  vision:
+    model: google/gemini-2.5-pro
+""",
+            encoding="utf-8",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_menubar_status.py
+++ b/tests/test_menubar_status.py
@@ -16,11 +16,52 @@ load_local_package()
 from omh.cli import build_parser
 from omh.menubar_status import build_menubar_status_payload, model_icon_descriptor, source_icon_descriptor
 from omh.paths import resolve_paths
-from omh.surfaces.menubar_status import _models_card
+from omh.surfaces.menubar_status import _display, _models_card
 from omh.targets import record_target_observation
 
 
 class MenubarStatusTests(unittest.TestCase):
+    def test_menu_bar_title_is_count_only_when_processes_and_sessions_are_observed(self) -> None:
+        display = _display(
+            {"omh_connection": {"value": "ready"}},
+            {"observed": True, "agent_count": 2, "process_count": 3},
+            {"observed": True, "live": 1, "total": 4},
+            {},
+            {},
+        )
+
+        self.assertEqual(display["menu_bar_title"], "2·1")
+        self.assertNotIn("omh ✓", display["menu_bar_title"])
+
+    def test_menu_bar_title_uses_only_attention_mark_when_connection_is_not_ready(self) -> None:
+        display = _display(
+            {"omh_connection": {"value": "stale"}},
+            {"observed": True, "agent_count": 2, "process_count": 3},
+            {"observed": True, "live": 1, "total": 4},
+            {},
+            {},
+        )
+
+        self.assertEqual(display["menu_bar_title"], "!")
+        self.assertNotIn("omh ✓", display["menu_bar_title"])
+
+    def test_ready_menu_bar_title_is_empty_until_both_observations_exist(self) -> None:
+        for processes_observed, sessions_observed in ((False, False), (True, False), (False, True)):
+            with self.subTest(
+                processes_observed=processes_observed,
+                sessions_observed=sessions_observed,
+            ):
+                display = _display(
+                    {"omh_connection": {"value": "ready"}},
+                    {"observed": processes_observed, "agent_count": 2, "process_count": 3},
+                    {"observed": sessions_observed, "live": 1, "total": 4},
+                    {},
+                    {},
+                )
+
+                self.assertEqual(display["menu_bar_title"], "")
+                self.assertNotIn("omh ✓", display["menu_bar_title"])
+
     def test_menubar_status_help_advertises_current_payload_schema(self) -> None:
         stdout = io.StringIO()
 

--- a/tests/test_menubar_status.py
+++ b/tests/test_menubar_status.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import json
 import sqlite3
 import subprocess
@@ -12,12 +13,150 @@ from _cli_harness import run_cli
 from _local_package import load_local_package
 
 load_local_package()
+from omh.cli import build_parser
 from omh.menubar_status import build_menubar_status_payload, model_icon_descriptor, source_icon_descriptor
 from omh.paths import resolve_paths
+from omh.surfaces.menubar_status import _models_card
 from omh.targets import record_target_observation
 
 
 class MenubarStatusTests(unittest.TestCase):
+    def test_menubar_status_help_advertises_current_payload_schema(self) -> None:
+        stdout = io.StringIO()
+
+        with patch("sys.stdout", stdout), self.assertRaises(SystemExit) as exit_context:
+            build_parser().parse_args(["menubar", "status", "--help"])
+
+        self.assertEqual(exit_context.exception.code, 0)
+        self.assertIn("Print the full menubar_status/v2 payload.", " ".join(stdout.getvalue().split()))
+        self.assertNotIn("menubar_status/v1", stdout.getvalue())
+
+    def test_long_model_is_bounded_in_human_output_but_preserved_in_payload(self) -> None:
+        long_model = "provider/" + "model-segment-" * 6
+        expected_display = long_model[:45] + "..."
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "setup"])[0], 0)
+            self._seed_hermes_observers(hermes_home)
+            connection = sqlite3.connect(hermes_home / "state.db")
+            connection.execute(
+                "update sessions set model = ?, model_config = '{}' where ended_at is null",
+                (long_model,),
+            )
+            connection.commit()
+            connection.close()
+
+            status, stdout, stderr = run_cli(
+                ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "menubar", "status"],
+                output_json=False,
+            )
+
+            self.assertEqual((status, stderr), (0, ""))
+            current_line = next(line for line in stdout.splitlines() if line.startswith("  current"))
+            self.assertEqual(current_line, f"  {'current'.ljust(20)} {expected_display}")
+            self.assertEqual(len(current_line.rsplit(" ", 1)[-1]), 48)
+            self.assertNotIn(long_model, stdout)
+            self.assertTrue(
+                stdout.endswith(
+                    "Observation\n"
+                    "  Process overlay: not supplied\n"
+                    "  Boundary: configured targets are not PID evidence unless observed by the helper.\n\n"
+                    "For machine-readable output, rerun with `--json`.\n"
+                )
+            )
+
+            status, stdout, stderr = run_cli(
+                ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "menubar", "status", "--json"],
+                output_json=False,
+            )
+
+            self.assertEqual((status, stderr), (0, ""))
+            payload = json.loads(stdout)
+            current_row = next(row for row in payload["display"]["menu_cards"][1]["rows"] if row["left"] == "current")
+            self.assertEqual(current_row["right"], long_model)
+
+    def test_models_card_reserves_final_row_for_inherited_auxiliary_summary(self) -> None:
+        card = _models_card(
+            {"current_model": {"observed": True, "label": "current-model"}},
+            {
+                "aliases": [
+                    {"alias": "main", "configured": True, "label": "main-model"},
+                    {"alias": "vision", "configured": True, "label": "vision-model"},
+                    {"alias": "web_extract", "configured": True, "label": "extract-model"},
+                    {"alias": "compression", "configured": True, "label": "compression-model"},
+                    *[
+                        {"alias": alias, "configured": False, "label": "inherit"}
+                        for alias in (
+                            "skills_hub",
+                            "approval",
+                            "mcp",
+                            "title_generation",
+                            "memory_query_rewrite",
+                            "tts_audio_tags",
+                            "triage_specifier",
+                            "kanban_decomposer",
+                            "profile_describer",
+                            "goal_judge",
+                            "curator",
+                        )
+                    ],
+                ],
+                "inherit_count": 11,
+            },
+        )
+
+        self.assertEqual(
+            [(row["left"], row["right"]) for row in card["rows"]],
+            [
+                ("current", "current-model"),
+                ("main", "main-model"),
+                ("vision", "vision-model"),
+                ("web_extract", "extract-model"),
+                ("+11 aliases", "inherit default"),
+            ],
+        )
+
+    def test_models_card_excludes_separately_rendered_main_from_inherited_auxiliary_count(self) -> None:
+        card = _models_card(
+            {"current_model": {"observed": True, "label": "current-model"}},
+            {
+                "aliases": [
+                    {"alias": "main", "configured": False, "label": "inherit"},
+                    *[
+                        {"alias": alias, "configured": False, "label": "inherit"}
+                        for alias in (
+                            "vision",
+                            "web_extract",
+                            "compression",
+                            "skills_hub",
+                            "approval",
+                            "mcp",
+                            "title_generation",
+                            "memory_query_rewrite",
+                            "tts_audio_tags",
+                            "triage_specifier",
+                            "kanban_decomposer",
+                            "profile_describer",
+                            "goal_judge",
+                            "curator",
+                        )
+                    ],
+                ],
+                "inherit_count": 15,
+            },
+        )
+
+        self.assertEqual(
+            [(row["left"], row["right"]) for row in card["rows"]],
+            [
+                ("current", "current-model"),
+                ("main", "inherit"),
+                ("+14 aliases", "inherit default"),
+            ],
+        )
+
     def test_menubar_status_keeps_hermes_agents_and_external_executors_separate(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Feature Report

### What Changed

- Added dependency-free, read-only observers for local Hermes processes,
  session state, and configured model aliases.
- Upgraded the menu bar payload to `menubar_status/v2` while preserving the
  legacy top-level compatibility fields.
- Replaced the legacy status cards with exact `Sessions` and `Models` tables:
  `Hermes session / Count`, `live` and `total` only, followed by current,
  main, configured auxiliary, and inherited model information.
- Updated the native AppKit helper to render bounded table rows and use the
  canonical OMH character silhouette with compact count-only status text.
- Documented the observation and installation contracts.

### Why This Exists

The previous `omh ✓` menu bar surface primarily reflected legacy OMH runtime
metadata. It did not answer the operator's immediate questions: whether Hermes
agents are actually running, how many live/recorded sessions exist, and which
models are currently active or configured.

### User / Operator Impact

After installing the helper, an operator can see:

- Hermes agent and process counts in the compact status summary.
- Live and total Hermes session counts without TUI/source-specific noise.
- The current live-session model, configured main model, explicit auxiliary
  aliases, and one bounded inherited-alias summary.
- The same information through the JSON and plain-text CLI renderers.

All observation is local and read-only. OMH does not modify Hermes-owned state
or configuration.

### How It Works

- `hermes_processes.py` runs one bounded, explicit `ps` query and structurally
  classifies real Hermes entrypoints while excluding shells, searches, and
  unrelated editor/Electron commands.
- `hermes_sessions.py` opens Hermes `state.db` with SQLite `mode=ro`, executes
  bounded `SELECT` queries, and degrades cleanly for missing or malformed state.
- `hermes_model_settings.py` reads only the relevant dependency-free YAML
  subset and reports configured versus inherited aliases without resolving
  inherited values.
- `menubar_status.py`, the CLI renderer, and the Swift helper project those
  observations into stable machine-readable and bounded human-readable rows.
- The installer materializes an embedded 36×36 canonical character mask under
  the OMH home and passes it to the helper through `--icon`; there is no
  repository-path dependency at runtime.

### Files And Contracts Touched

- New observers:
  `src/surfaces/hermes_processes.py`,
  `src/surfaces/hermes_sessions.py`,
  `src/surfaces/hermes_model_settings.py`
- Public projection: `menubar_status/v2`
- CLI/native renderers:
  `src/commands/menubar.py`,
  `src/surfaces/menubar_status.py`,
  `src/surfaces/menubar_app.py`
- Safety allowlist and focused regression suites under `tests/`
- Maintained installation and architecture documentation

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

Check only commands that completed successfully. Leave non-applicable checks
unchecked and explain why under **Not Tested / Not Applicable**.

- [x] `uv run --group lint ruff check src tests`
- [ ] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command:
  `PYTHONPATH=tests uv run python -m unittest tests.test_hermes_processes tests.test_hermes_sessions tests.test_hermes_model_settings tests.test_menubar_status tests.test_menubar_app tests.test_handoff_safety_contract_enforcement -q`
- [x] Manual Hermes/TUI check, or explicit reason it was not run:
  installed and inspected the actual native menu through macOS Accessibility;
  Hermes TUI/HUD is explicitly out of scope and untouched.

### Observed Evidence

- 81 focused observer, payload, renderer, AppKit compile, and safety tests passed.
- Ruff, compileall, all five maintained byte-exact documentation gates, and
  `git diff --check` passed.
- Full unittest discovery executed 6,734 tests. No changed menubar/observer
  test failed. The remaining 16 failures reproduce outside this change:
  15 real Hermes loader registration mismatches (`tools=[]`, `hooks=[]`) in
  setup/doctor/plugin tests and one missing local `bun` distribution tool.
- The installed helper was observed running with the exact installed icon
  path and matching embedded/installed SHA-256.
- macOS Accessibility opened the actual menu and observed compact title `2·1`,
  `Hermes session / Count`, `live`, `total`, `current`, `main`, one inherited
  alias summary, Refresh, and Quit.
- Independent plan-compliance, code-quality, security, hands-on QA, context,
  and visual reviewers approved the completed implementation before
  publication.

### Not Tested / Not Applicable

- The full suite is not checked green because of the 16 independently
  reproduced environment/baseline failures listed above.
- Release, harness, workflow-learning, and Hermes-smoke commands are unrelated
  to this local menu bar projection.
- The owner explicitly waived desktop screenshot capture. Native behavior was
  verified through Accessibility enumeration instead.

## Risk

Moderate. This changes a public payload version and a native macOS presentation
surface, but preserves existing top-level compatibility keys, keeps process
observation opt-in, bounds every external read, and degrades to explicit
unobserved/error reasons.

## Compatibility / Rollout

- Existing consumers retain legacy top-level status fields.
- The native helper must be reinstalled to receive the v2 renderer and compact
  icon; the installer performs that replacement.
- No data migration, Hermes config write, new runtime dependency, or network
  capability is introduced.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- None required for this user goal.
