### PR TITLE
feat(install): make the full skill catalog the default profile

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -113,11 +113,12 @@ First-run expectation:
 4. You restart or reload Hermes Agent.
 5. You ask Hermes normally, for example: `I want to safely add a feature to this repo.`
 
-By default, `omh setup` installs the **core** skill profile: the doctor health
-floor plus the chat/plan/status/handoff essentials a messenger-first user needs
-for a first session, not every packaged skill. Pass `--full` to install every
-skill in the catalog; see [Skill Profiles: Core vs Full](#skill-profiles-core-vs-full)
-for why the smaller default exists and how to opt in.
+By default, `omh setup` installs the **full** skill profile: every packaged
+skill, the ULW engines included — installing OMH means getting OMH. Pass
+`--core` for the lightweight footprint (the doctor health floor plus the
+chat/plan/status/handoff essentials); see
+[Skill Profiles: Core vs Full](#skill-profiles-core-vs-full) for the
+context-weight trade-off each choice makes.
 
 You do not need to know or name a workflow. The quickstart card offers
 representative natural-language starters from the locally tested request corpus
@@ -1599,7 +1600,7 @@ Then restart Hermes Agent.
 `omh setup`, `omh install`, and `omh update` install one of two skill
 profiles:
 
-- **`core` (default).** Installs the doctor health floor (the router plus the
+- **`core`** (opt-in via `--core`). Installs the doctor health floor (the router plus the
   `doctor`, `skill`, `cancel`, and `agent-ops-review` operator skills OMH needs
   to describe, diagnose, manage, and stop itself) plus the workflow skills a
   messenger-first user needs for a first chat/plan/status/handoff session
@@ -1607,13 +1608,14 @@ profiles:
   delivery/status-update policy, `executor-runtime-readiness` for handoff
   readiness, and `ops-observability-card` for status questions). Everything
   else in the catalog stays opt-in.
-- **`full`.** Installs every packaged skill (~89 skills, growing over time).
-  Pass `--full` to opt in:
+- **`full` (default).** Installs every packaged skill, ULW engines included.
+  This is what a plain `omh setup` does; `--full` remains for upgrading an
+  install that previously chose core and for script compatibility:
 
 ```sh
-omh setup --full
-omh install --full
-omh update --full
+omh setup            # full catalog
+omh setup --core     # lightweight footprint instead
+omh update --full    # widen an existing core install
 ```
 
 Every skill OMH installs is skill guidance that Hermes carries into its

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -826,6 +826,8 @@ def _resolved_skill_profile(args: argparse.Namespace, paths) -> str:
     An update carries the install forward. Only `--full` and an explicit
     reconcile change the profile, and reconcile stays the one path that deletes.
     """
+    if bool(getattr(args, "core", False)):
+        return "core"
     if bool(getattr(args, "full", False)):
         return "full"
     installed = str((read_manifest(paths.manifest_path) or {}).get("skill_profile") or "")
@@ -3510,10 +3512,20 @@ def _add_common_install_options(p: argparse.ArgumentParser) -> None:
         "--full",
         action="store_true",
         help=(
-            "Install every packaged skill instead of the smaller core default "
-            "(chat/plan/status/handoff essentials plus the doctor health floor); "
-            "the result records a context-cost warning because every extra skill "
-            "adds per-turn context weight."
+            "Install every packaged skill. This is already the default for a "
+            "fresh install; the flag remains to upgrade an existing core "
+            "install and for script compatibility."
+        ),
+    )
+    p.add_argument(
+        "--core",
+        action="store_true",
+        help=(
+            "Install only the lightweight core profile (chat/plan/status/"
+            "handoff essentials plus the doctor health floor) instead of the "
+            "full default. Every installed skill adds per-turn context weight; "
+            "core keeps that footprint minimal at the cost of the ULW engines "
+            "and most workflow skills."
         ),
     )
 

--- a/src/install/installer.py
+++ b/src/install/installer.py
@@ -26,7 +26,13 @@ from ..skill_pack import (
 )
 
 SKILL_PROFILES = ("core", "full")
-DEFAULT_SKILL_PROFILE = "core"
+# The full catalog is the default: installing OMH means getting OMH, ULW
+# engines included -- a fresh setup that silently withheld 90+ skills read as
+# "ULW is broken" to the owner, not as a context optimisation. `--core` is the
+# explicit opt-in for the lightweight footprint, and reconcile still shrinks
+# to core only (CORE_SKILL_PROFILE below), decoupled from this default.
+DEFAULT_SKILL_PROFILE = "full"
+CORE_SKILL_PROFILE = "core"
 CONTEXT_COST_WARNING_SCHEMA_VERSION = "omh_skill_profile_context_cost_warning/v1"
 SKILL_PROFILE_STATE_SCHEMA_VERSION = "omh_skill_profile_state/v1"
 SKILL_PROFILE_RECONCILE_SCHEMA_VERSION = "omh_skill_profile_reconcile/v1"
@@ -678,7 +684,7 @@ def skill_profile_report(paths: OmhPaths) -> dict:
 def reconcile_skill_profile(
     paths: OmhPaths,
     *,
-    target_profile: str = DEFAULT_SKILL_PROFILE,
+    target_profile: str = CORE_SKILL_PROFILE,
     dry_run: bool = False,
 ) -> dict:
     """Explicitly shrink an existing install down to the core profile.
@@ -687,9 +693,9 @@ def reconcile_skill_profile(
     setup/install/update. It removes only unmodified managed full-only skills; locally modified and
     non-managed directories stay on disk and are reported as retained exceptions.
     """
-    if target_profile != DEFAULT_SKILL_PROFILE:
+    if target_profile != CORE_SKILL_PROFILE:
         raise OmhError(
-            f"skill profile reconcile only shrinks to {DEFAULT_SKILL_PROFILE!r}; "
+            f"skill profile reconcile only shrinks to {CORE_SKILL_PROFILE!r}; "
             "install the wider catalog with `omh install --full` instead"
         )
     manifest = read_manifest(paths.manifest_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,7 +24,7 @@ from omh.paths import resolve_paths
 from omh.plugin_bundle.omh.memory_governance import canonical_payload_digest
 from omh.record_revision import MAX_MUTATION_ID_CHARS
 from omh.routing.intent import classify_omh_quality_intent
-from omh.skill_pack import CORE_PROFILE_SKILLS, builtin_skill_reference_templates, builtin_skill_templates
+from omh.skill_pack import builtin_skill_reference_templates, builtin_skill_templates
 from omh.skills.catalog import builtin_harnesses, installable_skill_names
 from omh.wrapper.localized_copy import detect_copy_locale
 from omh.wrapper_sessions import (
@@ -2879,7 +2879,7 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             self.assertEqual(status, 0, stderr)
             self.assertEqual(stderr, "")
             self.assertIn("刷新 OMH 工作流包", stdout)
-            self.assertIn(f"已准备 {len(CORE_PROFILE_SKILLS)} 个工作流", stdout)
+            self.assertIn(f"已准备 {len(builtin_skill_templates())} 个工作流", stdout)
             self.assertIn("OMH install 已完成。", stdout)
 
     def test_setup_reports_status_helper_conflict_in_plain_language(self) -> None:
@@ -2929,7 +2929,7 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             self.assertEqual(stderr, "")
             self.assertIn("Installing OMH workflows", stdout)
             self.assertIn("OMH install complete.", stdout)
-            self.assertIn(f"OMH workflows: {len(CORE_PROFILE_SKILLS)} ready", stdout)
+            self.assertIn(f"OMH workflows: {len(builtin_skill_templates())} ready", stdout)
             self.assertIn("Run `omh setup`", stdout)
             with self.assertRaises(json.JSONDecodeError):
                 json.loads(stdout)
@@ -2983,7 +2983,7 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             self.assertEqual(state["last_update"]["operation"], "update")
             self.assertEqual(state["last_update"]["command_package"]["status"], "not_updated")
             self.assertEqual(state["last_update"]["release_update"]["status"], "refreshed")
-            self.assertEqual(state["last_update"]["managed_skills"]["count"], len(CORE_PROFILE_SKILLS))
+            self.assertEqual(state["last_update"]["managed_skills"]["count"], len(builtin_skill_templates()))
 
     def test_package_manager_update_uses_native_command_guidance(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_installer_skill_profile.py
+++ b/tests/test_installer_skill_profile.py
@@ -213,7 +213,9 @@ class InstallerSkillProfileTests(unittest.TestCase):
 
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
-            result = install_skill_pack(paths, dry_run=True)
+            # profile passed explicitly: the API default is now "full", and this
+            # test exercises the core profile mechanics, not the default.
+            result = install_skill_pack(paths, dry_run=True, profile="core")
 
         self.assertEqual(result["skill_profile"], "core")
         installed_names = set(result["skills"])
@@ -245,7 +247,7 @@ class InstallerSkillProfileTests(unittest.TestCase):
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
 
-            core_manifest = install_skill_pack(paths)
+            core_manifest = install_skill_pack(paths, profile="core")
             self.assertEqual(core_manifest["skill_profile"], "core")
             on_disk = json.loads(paths.manifest_path.read_text(encoding="utf-8"))
             self.assertEqual(on_disk["skill_profile"], "core")
@@ -465,7 +467,7 @@ class SkillProfileReconcileTests(unittest.TestCase):
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
 
-            manifest = install_skill_pack(paths)
+            manifest = install_skill_pack(paths, profile="core")
 
             state = manifest["skill_profile_state"]
             self.assertEqual(state["schema_version"], "omh_skill_profile_state/v1")

--- a/tests/test_skill_profile_inheritance.py
+++ b/tests/test_skill_profile_inheritance.py
@@ -66,9 +66,13 @@ class SkillProfileInheritanceTests(unittest.TestCase):
             self.assertEqual(self._profile(root), "full")
 
     def test_a_core_install_stays_core(self) -> None:
+        # `--core` is now the explicit opt-in (the default flipped to full: an
+        # install that silently withheld the ULW engines read as "ULW is
+        # broken", not as an optimisation). The inheritance contract is
+        # unchanged: once core is chosen, plain updates never widen it.
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
-            run_cli(self._base(root) + ["install"])
+            run_cli(self._base(root) + ["install", "--core"])
             self.assertEqual(self._profile(root), "core")
             self.assertEqual(self._installed(root), len(CORE_PROFILE_SKILLS))
 
@@ -76,23 +80,38 @@ class SkillProfileInheritanceTests(unittest.TestCase):
             self.assertEqual(self._profile(root), "core")
             self.assertEqual(self._installed(root), len(CORE_PROFILE_SKILLS))
 
-    def test_a_first_install_with_no_flag_is_core(self) -> None:
-        # Inheritance must not turn the default into "whatever was there", and
-        # there is nothing to inherit on a fresh machine.
+    def test_a_first_install_with_no_flag_is_full(self) -> None:
+        # Inverted deliberately when the default flipped: installing OMH means
+        # getting OMH, ULW engines included. There is nothing to inherit on a
+        # fresh machine, so the recorded profile is the full default.
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
             run_cli(self._base(root) + ["update"])
-            self.assertEqual(self._profile(root), "core")
+            self.assertEqual(self._profile(root), "full")
 
     def test_the_full_flag_still_widens_a_core_install(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
-            run_cli(self._base(root) + ["install"])
+            run_cli(self._base(root) + ["install", "--core"])
             self.assertEqual(self._profile(root), "core")
 
             run_cli(self._base(root) + ["update", "--full"])
             self.assertEqual(self._profile(root), "full")
             self.assertGreater(self._installed(root), len(CORE_PROFILE_SKILLS))
+
+    def test_the_core_flag_never_shrinks_an_existing_full_install(self) -> None:
+        # Installs never delete; `--core` on a full install records core going
+        # forward but the wider skill set stays on disk until an explicit
+        # `omh skill-profile reconcile --to core`.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_cli(self._base(root) + ["install"])
+            self.assertEqual(self._profile(root), "full")
+            installed = self._installed(root)
+
+            run_cli(self._base(root) + ["update", "--core"])
+            self.assertEqual(self._profile(root), "core")
+            self.assertEqual(self._installed(root), installed)
 
     def test_update_no_longer_reports_a_divergence_it_created(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Capability

`omh setup` installs the full skill catalog — ULW engines included — by
default. `--core` becomes the explicit opt-in for the lightweight footprint.

## Motivation

The owner hit the consequence of the old default directly: a fresh `omh setup`
installed ten skills, every ULW engine stayed uninstalled, and the absence read
as **"ULW is broken"** — not as a context optimisation nobody had asked for.
Installing OMH should mean getting OMH.

## Implementation, at the boundary level

- `DEFAULT_SKILL_PROFILE` flips to `"full"`; new `CORE_SKILL_PROFILE = "core"`
  keeps reconcile's shrink target decoupled from the default (both reconcile
  guards now reference it).
- New `--core` flag on setup/install/update; resolution order is
  `--core` → `--full` → installed profile → default.
- **Unchanged contracts, verified empirically:**
  - Updates carry the installed profile forward: a core install stays core/10
    across a plain builtin re-setup (observed).
  - Installs never delete: `--core` on a full install records core going
    forward but sheds nothing until explicit
    `omh skill-profile reconcile --to core` (new test pins this).
  - The context-cost warning still records on full installs — the weight
    trade-off is real even as the default.
- `docs/INSTALLATION.md` updated in both places that taught core-as-default.

## Contract tests updated deliberately

- `test_a_first_install_with_no_flag_is_core` → `..._is_full`, inverted with a
  comment.
- `test_a_core_install_stays_core` / `test_the_full_flag_still_widens_a_core_install`
  now opt in via `--core` first; the inheritance contract itself is untouched.
- New `test_the_core_flag_never_shrinks_an_existing_full_install`.
- Three core-mechanics tests pass `profile="core"` explicitly — they test the
  core profile, not the default.
- `test_cli` human-summary counts derive from `builtin_skill_templates()`
  instead of the hardcoded core count.

## Observed verification

- Fresh default install → manifest records `full`, 102 skills.
- `--core` install → `core`, 10 skills.
- Core install + plain builtin setup → still `core`, 10 skills.
- Full suite: **6806 tests, 1 failure** — the pre-existing missing-`bun` gap.
- Five `docs --check` byte gates, `ruff`, `git diff --check` — clean.

## Risks

- Fresh installs now carry the full catalog's per-turn context weight by
  default (~3.5k tokens of skill guidance in Hermes' routing context). That is
  the deliberate trade: discoverability of the product over a default
  optimisation users could not see. `--core` and reconcile keep the lean path
  one flag away.
- Existing core installs do NOT auto-upgrade (their recorded profile may be a
  deliberate reconcile choice); they widen only via an explicit `--full`.