### PR TITLE
feat(tui): text HUD in the host's status-line idiom

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -140,8 +140,8 @@ omh doctor
 
 ## OH-MY-HERMES ターミナル
 
-`omh` と入力するだけで、OMH のアイデンティティをまとった Hermes のモダン TUI が
-開きます:
+`omh` と入力するだけで、`hermes` と同じ入口から、OMH のアイデンティティをまとった
+Hermes が開きます:
 
 ```sh
 omh

--- a/README.ko.md
+++ b/README.ko.md
@@ -141,7 +141,7 @@ omh doctor
 
 ## OH-MY-HERMES 터미널
 
-`omh`만 입력하면 OMH 정체성을 입은 Hermes 모던 TUI가 열립니다:
+`omh`만 입력하면 `hermes`와 동일한 문으로, OMH 정체성을 입은 Hermes가 열립니다:
 
 ```sh
 omh

--- a/README.md
+++ b/README.md
@@ -213,7 +213,8 @@ Maintenance paths such as reconciling a `--full` install back to core live in
 
 ## The OH-MY-HERMES terminal
 
-Bare `omh` opens Hermes' modern TUI wearing the OMH identity:
+Bare `omh` opens Hermes — the same door as `hermes` — wearing the OMH
+identity:
 
 ```sh
 omh

--- a/README.zh.md
+++ b/README.zh.md
@@ -143,7 +143,7 @@ omh doctor
 
 ## OH-MY-HERMES 终端
 
-只需输入 `omh`,即可打开带有 OMH 标识的 Hermes 现代 TUI:
+只需输入 `omh`,即可从与 `hermes` 相同的入口,打开带有 OMH 标识的 Hermes:
 
 ```sh
 omh

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -370,15 +370,18 @@ Run `omh --help` for the full command list."""
 
 
 def _launch_hermes_tui() -> int | None:
-    """Open the OH-MY-HERMES terminal: bare `omh` boots Hermes' Ink TUI.
+    """Open the OH-MY-HERMES terminal: bare `omh` is the same door as `hermes`.
 
     The oh-my-zsh contract, applied here: the wrapper's bare name IS the
-    styled experience. This execs the user's own `hermes` binary with
-    `--tui` -- a user-invoked local launch, not background dispatch, and the
-    one flag Hermes documents for opening the Ink TUI for a single session
-    without touching `display.interface`. No terminal or no Hermes install
-    means there is nothing to launch, and the caller falls back to the
-    welcome text.
+    styled experience. This execs the user's own `hermes` binary with no
+    flags -- a user-invoked local launch, not background dispatch. It used to
+    force `--tui`, which made the two doors open DIFFERENT terminals whenever
+    `display.interface` selected the classic REPL: `omh` showed the HUD, bare
+    `hermes` showed no OMH surface at all, and the split read as a bug from
+    the first boot. Which terminal opens belongs to Hermes' own
+    `display.interface`; OMH's door just walks through it. No terminal or no
+    Hermes install means there is nothing to launch, and the caller falls
+    back to the welcome text.
     """
     import shutil
     import subprocess
@@ -389,7 +392,7 @@ def _launch_hermes_tui() -> int | None:
     if not hermes:
         return None
     try:
-        return int(subprocess.run([hermes, "--tui"]).returncode)
+        return int(subprocess.run([hermes]).returncode)
     except (OSError, KeyboardInterrupt):
         return None
 

--- a/src/maintenance/doctor.py
+++ b/src/maintenance/doctor.py
@@ -477,28 +477,30 @@ def _hermes_tui_checks(paths: OmhPaths) -> list[Check]:
         )
     )
     if widget["installed"]:
-        # A widget from an OMH that predated panel chrome loads and runs, so
-        # every check above stays green while the HUD renders as borderless
-        # text beside the prompt — the exact "it still looks like the old
-        # version, and has no bright border" report this check exists to name.
+        # A widget from an older OMH loads and runs, so every check above
+        # stays green while the HUD renders yesterday's surface beside the
+        # prompt — the exact "it still looks like the old version" report this
+        # check exists to name. Current design: dense text in the host's
+        # status-line idiom, themed from the active skin; a bordered card
+        # marks the retired interim design.
         skin = preflight["display_skin"]
         checks.append(
             Check(
                 "hermes_tui_widget_chrome",
                 True,
                 (
-                    f"OMH status widget borders its panel from the active Hermes skin ({skin['value']})"
+                    f"OMH status widget renders the current text HUD themed from the active Hermes skin ({skin['value']})"
                     if widget["themed_panel"]
                     else (
-                        "installed OMH status widget predates themed panel chrome; it renders as borderless "
-                        f"text instead of a card bordered from the active skin ({skin['value']})"
+                        "installed OMH status widget predates the current text HUD; it renders an older "
+                        f"surface instead of the status-line-style HUD themed from the active skin ({skin['value']})"
                     )
                 ),
                 severity="ok" if widget["themed_panel"] else "warning",
                 next_action=(
                     ""
                     if widget["themed_panel"]
-                    else "run `omh setup` to refresh the managed TUI widget with themed panel chrome"
+                    else "run `omh setup` to refresh the managed TUI widget"
                 ),
             )
         )

--- a/src/maintenance/hermes_tui.py
+++ b/src/maintenance/hermes_tui.py
@@ -121,16 +121,22 @@ def _display_skin(config_text: str) -> dict[str, Any]:
 
 
 def _widget_draws_themed_panel(widget_text: str) -> bool:
-    """Does the INSTALLED widget draw a bordered card coloured by the theme?
+    """Does the INSTALLED widget render the current text-line HUD?
 
-    A widget left over from an OMH that predated panel chrome loads and runs
-    fine — it just renders as borderless text beside the prompt, which reads
-    as "the HUD still looks like the old version" with nothing else wrong.
-    Both halves matter: a border alone could be a hardcoded palette that
-    fights the user's skin, so the colour must resolve through the theme
-    object the host hands the app.
+    A widget left over from an older OMH loads and runs fine — it just
+    renders yesterday's surface beside the prompt, which reads as "the HUD
+    still looks like the old version" with nothing else wrong. The current
+    design is dense text in the host's own status-line idiom (the bordered
+    card that briefly replaced it was retired by owner direction), so the
+    markers are the derived state label the text header carries and colours
+    resolving through the theme object — never a border, whose presence now
+    marks the RETIRED card design.
     """
-    return "borderStyle:" in widget_text and re.search(r"borderColor:\s*t\.color\.", widget_text) is not None
+    return (
+        "hudStateLabel" in widget_text
+        and "borderStyle:" not in widget_text
+        and re.search(r"color:\s*t\.color\.", widget_text) is not None
+    )
 
 
 def _widget_interpreter(widget_text: str) -> str:

--- a/src/omh/skins/omh.yaml
+++ b/src/omh/skins/omh.yaml
@@ -10,7 +10,11 @@ name: omh
 description: OH-MY-HERMES — sky turquoise orchestration identity
 
 colors:
-  background: "#081C22"
+  # No `background` token on purpose: the classic banner paints text runs on
+  # it, and any value that differs from the user's actual terminal background
+  # renders every run as a lighter "selected-looking" box (observed on a real
+  # terminal). Omitting it inherits the default seed, which is what stock
+  # Hermes ships and what nobody reports boxes against.
   banner_border: "#1E8A99"
   banner_title: "#7FDBFF"
   banner_accent: "#00CED1"

--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -22,21 +22,12 @@ export default function register(sdk) {
 
   const safeText = value => String(value ?? '').replace(/[^\p{L}\p{N} .:/_·|+\-]/gu, '').slice(0, 96)
 
-  // Panel chrome. Both apps draw their own bordered, padded card so the OMH
-  // surface reads as a piece of the TUI instead of loose text floating around
-  // the prompt. Every colour comes from the active theme the host hands
-  // `render`, never a literal: `primary` is the token Hermes' own Dialog card
-  // borders with, so the panel follows whatever skin is active (default gold,
-  // ares crimson, mono, …) with no OMH-side palette to keep in sync.
-  // The card costs two columns of border plus two of padding, and two rows of
-  // border; the render callsites hand the components the INNER budget.
-  const PANEL_CHROME_COLUMNS = 4
-  const PANEL_CHROME_ROWS = 2
-  // Shared header grammar for both panels: mark, then muted detail, then the
-  // one segment that carries state. Kept as constants so the two headers can
-  // never drift into looking like two different products.
-  const BRAND_MARK = '◆'
-  const SEPARATOR = '  ·  '
+  // Text, not chrome. The owner's direction after living with the bordered
+  // cards: the OMH surface should read like the host's own status line
+  // (` ─ ready │ gpt 5.6 sol │ … `) and like oh-my-claudecode's HUD -- dense
+  // text in the TUI's idiom, not a boxed widget that announces itself.
+  // Colours still resolve only through the active theme, never literals.
+  const SEPARATOR = ' │ '
 
   const plural = (count, noun) => `${count} ${noun}${count === 1 ? '' : 's'}`
 
@@ -52,14 +43,6 @@ export default function register(sdk) {
     if (blocked) parts.push(`${blocked} blocked`)
     return parts.join(' · ')
   }
-  const panelProps = t => ({
-    borderColor: t.color.primary,
-    borderStyle: 'round',
-    flexDirection: 'column',
-    paddingX: 1,
-    width: '100%',
-  })
-
   const readHud = () => new Promise(resolve => {
     execFile(
       __OMH_PYTHON_EXECUTABLE__,
@@ -210,7 +193,7 @@ export default function register(sdk) {
     // part gated on live work.
     const active = !!payload.active
     const agents = payload.subagents || {}
-    const version = safeText(payload.version) || 'unknown'
+    const version = safeText(payload.version)
     const maestro = payload.maestro || {}
     const mainRows = active && Array.isArray(maestro.rows) ? maestro.rows.slice(0, 1) : []
     const activityLimit = Math.max(1, Math.min(3, viewportRows - 3))
@@ -219,19 +202,16 @@ export default function register(sdk) {
       : []
     return h(
       Box,
-      { ...panelProps(t), marginTop: 1 },
+      { flexDirection: 'column', marginTop: 1, width: '100%' },
       h(
         Text,
         { wrap: 'truncate-end' },
-        // One role per colour, so state is what the eye lands on and the
-        // decoration never competes with it: the mark and name carry the
-        // panel's own border colour, the version recedes into muted, and only
-        // the state segment changes hue. The previous header spent its width
-        // naming the product twice ("[OMH] … Oh My Hermes") and then claimed
-        // "Ultra Work Ready" whether or not anything was actually running.
-        h(Text, { bold: true, color: t.color.primary }, `${BRAND_MARK} OMH`),
-        h(Text, { color: t.color.border }, SEPARATOR),
-        h(Text, { color: t.color.muted }, `v${version}`),
+        // One role per colour: the bracket tag carries the brand, the version
+        // recedes into muted, and only the state segment changes hue. Idle
+        // says "ready"; active derives its counts from the same payload the
+        // activity rows below render.
+        h(Text, { bold: true, color: t.color.primary }, '[OMH]'),
+        version ? h(Text, { color: t.color.muted }, ` v${version}`) : null,
         h(Text, { color: t.color.border }, SEPARATOR),
         h(Text, { color: active ? t.color.warn : t.color.ok }, hudStateLabel(active, agents)),
       ),
@@ -270,15 +250,14 @@ export default function register(sdk) {
     if (todo.status === 'all_done') {
       return h(
         Box,
-        panelProps(t),
+        { flexDirection: 'column', width: '100%' },
         h(
           Text,
           { wrap: 'truncate-end' },
-          // Same grammar as the status header, so the two panels read as one
-          // surface rather than two widgets that happen to share a border.
-          h(Text, { bold: true, color: t.color.primary }, `${BRAND_MARK} Plan`),
-          title ? h(Text, { color: t.color.border }, SEPARATOR) : null,
-          title ? h(Text, { color: t.color.muted }, title) : null,
+          // Same grammar as the status line below the prompt, so the two
+          // surfaces read as one product.
+          h(Text, { bold: true, color: t.color.primary }, '[Plan]'),
+          title ? h(Text, { color: t.color.muted }, ` ${title}`) : null,
           h(Text, { color: t.color.border }, SEPARATOR),
           h(Text, { color: t.color.ok }, `✓ ${counts.done ?? 0}/${counts.total ?? 0}`),
         ),
@@ -290,13 +269,12 @@ export default function register(sdk) {
     const budget = Math.max(16, columns - 10)
     return h(
       Box,
-      panelProps(t),
+      { flexDirection: 'column', width: '100%' },
       h(
         Text,
         { wrap: 'truncate-end' },
-        h(Text, { bold: true, color: t.color.primary }, `${BRAND_MARK} Plan`),
-        title ? h(Text, { color: t.color.border }, SEPARATOR) : null,
-        title ? h(Text, { color: t.color.muted }, title) : null,
+        h(Text, { bold: true, color: t.color.primary }, '[Plan]'),
+        title ? h(Text, { color: t.color.muted }, ` ${title}`) : null,
         h(Text, { color: t.color.border }, SEPARATOR),
         h(Text, { color: t.color.warn }, `${counts.done ?? 0}/${counts.total ?? 0}`),
       ),
@@ -332,13 +310,11 @@ export default function register(sdk) {
       input.kind === 'snapshot'
         ? { ...state, payload: input.payload, tick: state.tick + 1 }
         : state,
-    // The panel's own border and padding are not content space, so both
-    // components budget against the INNER card, not the raw terminal.
     render: ({ cols, rows, state, t }) => h(Hud, {
-      columns: Math.max(20, cols - PANEL_CHROME_COLUMNS),
+      columns: Math.max(20, cols),
       state,
       t,
-      viewportRows: Math.max(1, rows - PANEL_CHROME_ROWS),
+      viewportRows: Math.max(1, rows),
     }),
   })
 
@@ -352,7 +328,7 @@ export default function register(sdk) {
       input.kind === 'snapshot'
         ? { ...state, payload: input.payload, tick: state.tick + 1 }
         : state,
-    render: ({ cols, state, t }) => h(TodoPanel, { columns: Math.max(20, cols - PANEL_CHROME_COLUMNS), state, t }),
+    render: ({ cols, state, t }) => h(TodoPanel, { columns: Math.max(20, cols), state, t }),
   })
 
   openWidget(app, app.init(''))

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -33,6 +33,8 @@ STATUS_SCHEMA_VERSION = "omh_status/v1"
 HUD_SCHEMA_VERSION = "omh_hud/v1"
 HUD_PRESETS = {"minimal", "focused", "full"}
 TODO_STALE_SECONDS = 86400
+# How long a fully-done plan keeps rendering after its last update.
+ALL_DONE_TODO_LINGER_SECONDS = 15 * 60
 TODO_DISPLAY_ITEM_LIMIT = 3
 HUD_REQUIRED_TOOLS = PROVIDED_TOOLS
 HUD_REQUIRED_HOOKS = REQUIRED_HOOKS
@@ -1170,6 +1172,14 @@ def _todo_summary(home: Path) -> dict[str, Any]:
         summary["status"] = "stale"
         return summary
     if counts["done"] == counts["total"]:
+        # A finished plan is a receipt, not ambient chrome. It lingers briefly
+        # so the session that finished it sees the ✓, then leaves -- without
+        # this, a plan completed in one session greeted every NEW session as a
+        # "Plan ... 3/3" box for a full day, reading as state the new session
+        # never created (observed on a fresh boot the morning after a QA run).
+        if age > ALL_DONE_TODO_LINGER_SECONDS:
+            summary["status"] = "absent"
+            return summary
         summary["status"] = "all_done"
         return summary
     summary["status"] = "established"

--- a/tests/test_handoff_safety_contract_enforcement.py
+++ b/tests/test_handoff_safety_contract_enforcement.py
@@ -155,8 +155,8 @@ PROCESS_SPAWN_ALLOWLIST: dict[str, str] = {
         "to resolve the base commit before the fanout bridge above runs."
     ),
     "src/commands/main.py": (
-        "bare `omh` with a tty -- the operator's own launch of `hermes --tui`, the "
-        "OH-MY-HERMES terminal; never reached from any prepared-handoff path."
+        "bare `omh` with a tty -- the operator's own launch of `hermes`, the same "
+        "door as typing it themselves; never reached from any prepared-handoff path."
     ),
     "src/commands/setup.py": (
         "`omh setup` / `omh update` -- pip self-update, CLI re-entry after update, and the "

--- a/tests/test_hermes_tui_preflight.py
+++ b/tests/test_hermes_tui_preflight.py
@@ -87,9 +87,10 @@ class HermesTuiPreflightTests(unittest.TestCase):
             self.assertEqual(preflight["display_skin"], {"value": "default", "explicit": False})
             self.assertEqual(widget_render_blockers(preflight), [])
 
-    def test_preflight_names_an_explicit_skin_and_a_borderless_widget(self) -> None:
-        # A widget that predates panel chrome loads fine, so it is a degraded
-        # look and never a render blocker.
+    def test_preflight_names_an_explicit_skin_and_a_stale_widget(self) -> None:
+        # A widget from an older OMH loads fine, so it is a degraded look and
+        # never a render blocker. Staleness is simulated by stripping the
+        # current design's marker (the derived state label).
         with TemporaryDirectory() as tmp:
             paths = _make_paths(Path(tmp))
             _make_hermes_install(paths.hermes_home)
@@ -99,7 +100,7 @@ class HermesTuiPreflightTests(unittest.TestCase):
             install_tui_widget(paths.hermes_home)
             widget = paths.hermes_home / "tui-widgets" / "omh-status.mjs"
             widget.write_text(
-                widget.read_text(encoding="utf-8").replace("borderStyle:", "noBorderStyle:"),
+                widget.read_text(encoding="utf-8").replace("hudStateLabel", "oldStateLabel"),
                 encoding="utf-8",
             )
 
@@ -109,9 +110,9 @@ class HermesTuiPreflightTests(unittest.TestCase):
             self.assertEqual(preflight["display_skin"], {"value": "ares", "explicit": True})
             self.assertEqual(widget_render_blockers(preflight), [])
 
-    def test_preflight_rejects_a_hardcoded_border_colour_as_unthemed(self) -> None:
-        # A border alone is not the contract: a literal palette would fight
-        # whatever skin the user runs, so it reads as unthemed chrome.
+    def test_preflight_rejects_the_retired_bordered_card_as_stale(self) -> None:
+        # The bordered card was the interim design; its border marker now
+        # identifies a widget that predates the text-line HUD.
         with TemporaryDirectory() as tmp:
             paths = _make_paths(Path(tmp))
             _make_hermes_install(paths.hermes_home)
@@ -120,7 +121,9 @@ class HermesTuiPreflightTests(unittest.TestCase):
             widget = paths.hermes_home / "tui-widgets" / "omh-status.mjs"
             widget.write_text(
                 widget.read_text(encoding="utf-8").replace(
-                    "borderColor: t.color.primary", "borderColor: '#FFD700'"
+                    "{ flexDirection: 'column', width: '100%' }",
+                    "{ borderStyle: 'round', flexDirection: 'column', width: '100%' }",
+                    1,
                 ),
                 encoding="utf-8",
             )
@@ -294,7 +297,7 @@ class DoctorHermesTuiChecksTests(unittest.TestCase):
                 self.assertTrue(checks[name].ok, name)
                 self.assertEqual(checks[name].severity, "ok", name)
 
-    def test_doctor_warns_on_a_borderless_widget_without_flipping_the_exit_code(self) -> None:
+    def test_doctor_warns_on_a_stale_widget_without_flipping_the_exit_code(self) -> None:
         with TemporaryDirectory() as tmp:
             paths = _make_paths(Path(tmp))
             _make_hermes_install(paths.hermes_home)
@@ -302,7 +305,7 @@ class DoctorHermesTuiChecksTests(unittest.TestCase):
             install_tui_widget(paths.hermes_home)
             widget = paths.hermes_home / "tui-widgets" / "omh-status.mjs"
             widget.write_text(
-                widget.read_text(encoding="utf-8").replace("borderStyle:", "noBorderStyle:"),
+                widget.read_text(encoding="utf-8").replace("hudStateLabel", "oldStateLabel"),
                 encoding="utf-8",
             )
 
@@ -311,7 +314,7 @@ class DoctorHermesTuiChecksTests(unittest.TestCase):
 
             self.assertTrue(chrome.ok)
             self.assertEqual(chrome.severity, "warning")
-            self.assertIn("borderless", chrome.message)
+            self.assertIn("predates the current text HUD", chrome.message)
             self.assertIn("omh setup", chrome.next_action)
             # The widget itself is still installed and loadable; only its look
             # is stale, so the sibling state check stays clean.

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -1033,6 +1033,29 @@ class TodoHudTests(unittest.TestCase):
             self.assertEqual(payload["todo"]["display_items"], [])
             self.assertEqual(payload["display"]["todo_lines"], ["Todo · Foundation ✓ 2/2"])
 
+    def test_hud_retires_a_finished_plan_after_its_linger_window(self) -> None:
+        # A finished plan is a receipt, not ambient chrome: it lingers briefly
+        # for the session that finished it, then leaves. Without this, a plan
+        # completed in one session greeted every NEW session as a "Plan 3/3"
+        # panel for a full day (observed on a fresh boot the morning after).
+        from datetime import datetime, timedelta, timezone
+
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            done_items = [{"text": "Ship", "state": "done"}]
+            old_stamp = (
+                (datetime.now(timezone.utc) - timedelta(minutes=20))
+                .isoformat()
+                .replace("+00:00", "Z")
+            )
+            self._write_todo(root / ".omh", self._record(items=done_items, updated_at=old_stamp))
+            payload = read_omh_hud(root / ".omh", root / ".hermes")
+
+            self.assertEqual(payload["todo"]["status"], "absent")
+            self.assertEqual(payload["display"]["todo_lines"], [])
+
     def test_hud_hides_stale_and_unparseable_todo_updates(self) -> None:
         from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
 

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -265,24 +265,20 @@ class TuiWidgetPackTests(unittest.TestCase):
         self.assertIn("const active = !!payload.active", widget)
         self.assertIn("width: '100%'", widget)
         self.assertIn("marginTop: 1", widget)
-        # Panel chrome, changed on purpose (this used to assert
-        # `assertNotIn("borderStyle:")`). The borderless design rendered the
-        # HUD as loose text floating around the prompt instead of a piece of
-        # the TUI. Both apps now draw a bordered, padded card, and the border
-        # colour must come from the ACTIVE THEME the host hands `render` — a
-        # literal hex would freeze the panel on one palette while the rest of
-        # the TUI followed the user's skin.
-        self.assertIn("borderStyle: 'round'", widget)
-        self.assertIn("borderColor: t.color.primary", widget)
-        self.assertIn("paddingX: 1", widget)
+        # Text, not chrome — changed on purpose a second time, by owner
+        # direction after living with the bordered card: the OMH surface reads
+        # like the host's own status line, dense text in the TUI's idiom. The
+        # border that briefly asserted the panel identity now marks the
+        # RETIRED design, and colours still resolve only through the active
+        # theme — a literal hex would freeze the surface on one palette while
+        # the rest of the TUI followed the user's skin.
+        self.assertNotIn("borderStyle:", widget)
+        self.assertNotIn("panelProps", widget)
         self.assertNotIn("color: '#", widget)
-        # One panel definition serves the status HUD and both todo states, so
-        # the chrome can never drift between them.
-        self.assertEqual(widget.count("panelProps(t)"), 3)
-        # Border + padding are chrome, not content: both apps budget against
-        # the inner card, not the raw terminal.
-        self.assertIn("cols - PANEL_CHROME_COLUMNS", widget)
-        self.assertIn("rows - PANEL_CHROME_ROWS", widget)
+        # The bracket tags are the shared grammar between the two docks.
+        self.assertIn("'[OMH]'", widget)
+        self.assertEqual(widget.count("'[Plan]'"), 2)
+        self.assertIn("const SEPARATOR = ' │ '", widget)
         self.assertNotIn("metricRow", widget)
         self.assertIn("...rows.map", widget)
         self.assertNotIn("...maestroRows.map", widget)
@@ -295,18 +291,14 @@ class TuiWidgetPackTests(unittest.TestCase):
         # What matters now is the contract, not the wording: the version is
         # still shown, every colour still resolves through the active theme,
         # and the state segment is derived rather than fixed.
-        self.assertIn("`v${version}`", widget)
+        self.assertIn("` v${version}`", widget)
         self.assertIn("hudStateLabel(active, agents)", widget)
         self.assertIn("if (!active) return 'ready'", widget)
-        # Both panels share one header grammar so they cannot drift into
-        # looking like two different products.
-        self.assertEqual(widget.count("`${BRAND_MARK} Plan`"), 2)
-        self.assertIn("`${BRAND_MARK} OMH`", widget)
+        # (bracket-tag grammar asserted above replaces the BRAND_MARK pair)
         # The old header's literal pieces ("-", "Oh My Hermes", "Ultra Work",
         # "Ready") are gone on purpose; asserting them back would re-pin the
         # wording this change exists to replace. The separator is now shared
         # between both panels instead of hand-written per segment.
-        self.assertIn("const SEPARATOR = '  ·  '", widget)
         self.assertNotIn("'Ultra Work'", widget)
         self.assertIn("SPINNER_FRAMES", widget)
         self.assertIn("useShimmerPhase", widget)


### PR DESCRIPTION
## Capability

The OMH TUI surface becomes dense text in Hermes' own status-line idiom —
owner direction after living with the bordered cards — scoped back to the
original intent: plan todo above the composer, `[OMH] v1.x.x │ state` below
it, and per-subagent activity rows (id, action, model:effort, cost, tok/s,
cache, ctx) only while parallel work runs.

## Observed render (throwaway HERMES_HOME, real boot)

```
 ─ ready │ gpt 5.6 sol │ 28s │ voice off │ 1 session
 [Plan] Text HUD QA │ 1/3
 [✓] render header
 [•] render todo
 [ ] ship
 ❯ Ask me anything…

 [OMH] v1.0.6 │ ready
```

Active state derives from the payload (`[OMH] v1.0.6 │ 3 agents · 2 running`);
the activity-row format is unchanged from what live sessions already render.

## Four observed fixes ride along

1. **Skin `background` dropped.** The classic banner paints text runs on that
   token; any value differing from the user's real terminal background rendered
   every run as a lighter, selected-looking box (screenshot-confirmed).
   Omitting it inherits the default seed — stock behaviour nobody reports
   boxes against.
2. **Finished plans retire after 15 minutes.** An `all_done` todo lingered a
   full day, so a plan completed in one session greeted every NEW session as a
   "Plan ✓ 3/3" panel the morning after — state the new session never created.
   New `ALL_DONE_TODO_LINGER_SECONDS` in the reader, with a contract test.
3. **One door.** Bare `omh` execs plain `hermes` instead of forcing `--tui`.
   Forcing the flag made the two doors open *different* terminals whenever
   `display.interface` selected the classic REPL — `omh` showed the HUD, bare
   `hermes` showed no OMH surface — and the split read as a bug from the first
   boot. Which terminal opens belongs to Hermes' config; OMH's door walks
   through it. READMEs updated in all four locales (structural sync green).
4. **Freshness detector inverted.** `borderStyle:` now marks the *retired*
   card design; current markers are the derived state label plus
   theme-resolved colours. Doctor copy follows.

## Contract tests updated deliberately

- Widget-pack border block inverted a second time, with the owner-direction
  rationale in the comment; bracket-tag grammar (`'[OMH]'`, two `'[Plan]'`)
  and the `│` separator are the new pins.
- Preflight staleness tests simulate an old widget by stripping the current
  marker; a new test pins the retired bordered card as stale.
- New `test_hud_retires_a_finished_plan_after_its_linger_window`.
- `PROCESS_SPAWN_ALLOWLIST` reason updated to the plain-`hermes` launch.

## Verification

- Full suite: **6807 tests, 1 failure** — the pre-existing missing-`bun` gap.
- Five `docs --check` byte gates, `ruff`, `git diff --check`, `node --check` — clean.
- Throwaway-home boot above; both docks rendered as text.

## Risks

- Live activity rows during real parallel work not re-observed in this PR
  (format unchanged; unit-covered).
- Users who liked the bordered card lose it; that is the point of the change.