### PR TITLE
fix(menubar): preserve npm runtime paths

### DIFF
--- a/src/surfaces/menubar_app.py
+++ b/src/surfaces/menubar_app.py
@@ -6,7 +6,8 @@ import platform
 import plistlib
 import shutil
 import subprocess
-from pathlib import Path
+import sys
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 from ..command_path import inspect_omh_command_path
@@ -240,18 +241,33 @@ def _write_launch_agent(plist_path: Path, executable: Path, omh_command: str, pa
 
 def _launch_agent_path(omh_command: str) -> str:
     node_command = shutil.which("node")
-    command_parent = Path(omh_command).expanduser().parent
     candidates = [
-        str(Path(node_command).expanduser().parent) if node_command else "",
-        str(command_parent) if command_parent != Path(".") else "",
+        _launch_agent_executable_parent(node_command or ""),
+        _launch_agent_executable_parent(sys.executable),
+        _launch_agent_executable_parent(omh_command),
         *_LAUNCH_AGENT_SYSTEM_PATHS,
     ]
     path_entries: list[str] = []
+    canonical_entries: set[str] = set()
     for candidate in candidates:
-        expanded = str(Path(candidate).expanduser()) if candidate else ""
-        if expanded and expanded not in path_entries:
-            path_entries.append(expanded)
+        if not candidate:
+            continue
+        canonical = str(Path(candidate).resolve()) if platform.system() == "Darwin" else candidate
+        if canonical not in canonical_entries:
+            path_entries.append(candidate)
+            canonical_entries.add(canonical)
     return ":".join(path_entries)
+
+
+def _launch_agent_executable_parent(command: str) -> str:
+    if not command:
+        return ""
+    expanded = os.path.expanduser(command)
+    if platform.system() == "Darwin":
+        command_path = Path(expanded)
+        return str(command_path.resolve().parent) if command_path.parent != Path(".") else ""
+    command_path = PurePosixPath(expanded)
+    return str(command_path.parent) if command_path.parent != PurePosixPath(".") else ""
 
 
 def _run_launchctl(args: list[str], *, check: bool) -> subprocess.CompletedProcess[str]:

--- a/src/surfaces/menubar_app.py
+++ b/src/surfaces/menubar_app.py
@@ -18,6 +18,14 @@ from ..runtime.artifacts import update_state
 MENUBAR_APP_SCHEMA_VERSION = "menubar_app/v1"
 MENUBAR_LABEL = "com.rlaope.omh.menubar"
 DEFAULT_REFRESH_INTERVAL_SECONDS = 8
+_LAUNCH_AGENT_SYSTEM_PATHS = (
+    "/usr/local/bin",
+    "/opt/homebrew/bin",
+    "/usr/bin",
+    "/bin",
+    "/usr/sbin",
+    "/sbin",
+)
 MENUBAR_ICON_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAACQAAAAkCAYAAADhAJiYAAAACXBIWXMAAAAAAAAAAQCEeRdzAAANYElEQVR4nKWYCXBUVRaGX3e/dDrpJJ2dAAlhC/sSJGyKbEEEAWeAYVegUDaxHLFAFCxFBasARUsKC0QcBIRSEQZkc0BEwLAFEEKAQDAJWUggobN0d5JO93vznfZlBmarmpmuetWv77vv3v+c85//nNsm5f/8mEwmRdf1//mdf3xf/W8WMpvNisViURoaGv42Jou1bt3a1KVLF2tQUJB8O7xer0/TNJmv+3w+paqqyn/x4kXXhQsX/PHx8cqdO3eUDh06KDdv3lRk3oOg/iMgmdi4aePvkJAQE4ACAwIgMTFRv3LlShfGmzBUf+bMmbK4uDh3bGxs+NGjR6vv3r2rP/vsszaex1+6dMmNQS4Aefv06eOfP3++b9u2bXqjsQLu3wJiAaW2tvYht1qtVpNY3TiHBfSIiAjTwYMH7+bl5d2LiopSn3vuuaLmzZsrTqdT4ZnSr18/2yOPPBKXlpYW2b1792Bes+NFWbj+888/9zBWt2jRIr+AEe//S0CqqgbAxMTEiAeUy5cvCwgTYwLA0rVrVwWv+PkoWK2MGzeu7MH35d3Q0FCz3W7XXS6XaeHCheUYUpacnKz27t3b3rNnTwllA2EL4plSXFxc+/XXX2slJSX/DEhQStxTUlIsuNXy3XffNRgh0ydPnhzbvn17fdeuXU5jTGL6EKMHDBgQx6bqBx98cIc5psOHD9c+8Ni7efNmD+squ3fvjsCrPjFwyZIlNsDVtmvXzvwQIAEjVrOpOmHCBNvy5ctdsrHD4VCwoE90dLT39ddfz7p27Zomc+GJHhYWFsS4ndC0HD9+fNrt27cLpk6derhHjx72Xr16mTdu3FhDqM2EXWOuuaamRs/JydHdbrfWrFkzXcIO54JHjx6t8NunMjkAovFic9PKlSujZs+eXSFgcLPpxIkTY4XATz755C4WDcGi2E6dOiUT/16tWrVKYY2m2BN89erV3e+8886ZF198sW19fb3n008/LREvcq+xjrmoqEiTPeCYZeDAgS5xAkDMb7/9tg0wQRIZtTGFsdjEZP3999+PzczM9JMdGvyxHD9+fHhSUlKbDz/88M/Eu/8TTzzRPTw8PAGOJGO1nVfjuGwVFRW3WSN1/fr1UefPnz915MiRHCxX7t27p8OxONZ2A6w2ODjYJGvDrcC+n332mYaxdS+//LKX/WyqeEGySMAwYJaXcXeuEHvnzp0pLVq0aOPxeEJI0Sl4oqMBQEJdybsqC1cJeUmA7lxpjNWhNX8YNWrU9aVLl95hs9i6urobpPcRvFu8f//+St7RyDrz9evXdfE84Q5t06ZNOOFrCHDIZrMFMmj48OERpK6jvLxcuOIAWAfcmCgZw7SWbBZlgHFgRFMuG5vwZbKIk3nu5z6YMRu/ozGmFvHb98MPP5zcsWMH1LsWCMdTTz1lf/zxx2PZo+CNN96wDxkyRDwdBaAqVQRJYicfkEbKg1mzZkWwWCQe6c2kEMIqKhzBZnXynCuGyyq8EVAAcYsscR/Gt4/fAsjObyfvCqHD5s6dm4pa1/Tt27fdnDlzOhP69bLnxx9/7HrhhRdiDVlxqyJIcsmHePvFsldffbVvWVmZeCWaxSIBk8B9iPzmiuAKMjxSS7aUMqeWsLWVccYEgMiBgIyE/LO5ZnJfLhLF5V+1atUSOObk3swzc9OmTa1wLx9N86rPP/988LfffusVZf3yyy8LJ02alEtGDGaSbB7C2vLtCAiRrgsTo/i24lkJj3DAC1FbiUcCwmQyqb9N1YO498O/s/AxCW+LV6vPnj27cd++fRm8Y0GDhHtSWvLhU0N2drau3rp1SyPGSUyIgDui0uKNULwm4VCNTJKYNuPeYYRJPOujaObDF7vhNTdFtQy31/BdSoaliYfgX1/xJhdJVn/75MmTZ9AvG3JRI6T+/vvvRYR1SB789NNPm9Uff/yxYejQoYUIWNLYsWPTKXw1IusAk7jGGqGysFERG93lUu7fv38EbtS0bNlyGh5qI9mBx6y8E4MnaghfB4NnouIuI5QaRtsQ3JnM+xPlJ5d1QlBnB9XguuAgqcJUw83mSD6gz+A+nHC1Fk9IAoq35F42QxqKUNntWOpNT09fTDp7WfQYXooCSBS/pZrbASde88i7AJFsbJDwCfGRluEvvfRSd+7LmH+ZcK2lvEiyKAUFBboqZYGq2yI/P/8OnuoImF5sYoGsJ9ioMzIQLxbiubMUwQu4ejBKO1SsB2AxdrQAQDReKpS059ssHgZgqGGsYiSAgBKtucn8IDzuQ8m3ZWVliZorM2fOtI4cOdKqogXRCGAxqdiFVO9BSKxiLZvFU5cuiXVsOoJnI7nGsKDf4JSPcEVK2gtX2CSSUDWWRcmmSsleRDBHwo1YpgPqHvMlhDq6tJJsuybiynu+adOmte/WrZtfRbhccCH2sccea4cL7xNnB+EJwjupEHMYAKX+eNhQ0jSWbxLHU0KR9JAlwYYk+CHoVjL1Kjqz1NAmqYVuUWrW6iThZzwEablBmCYzv4ZxS25uro965qDax/CsQrLFunjx4mTqVzaNU7fKyspawpTMuAAIw1uSQcIps3HZpPbgNR3w7US5mevht5XiWXLu3LlltB9rGG8Dn3TpMJW/f0rpDFJWr169DN4cok6egx6VUCWhSZMmSRhgV5ctWxZHhmUh3ymUkDgWzQZ5EpsmCgD6l+lU5rloUz/IfJcNUnnW3VDkCvhSLeJJKku25aAltwDkMwAEGZnmwdM38XwcIGsQwOOE7KJ0FmhgOj2UjXddeN+ikmp5oAuh2oq41dMGtC0tLb0KcZsyIQaQzSDefiw5T7sxDfIvJ1S/w9J+otyAC4XsJ1D2v6AloQBuZwDRDFAmEUk83UIkgPJxFCMsrFP+zTffTAPMo4DNkDZI1Fyl4Cl4KZFYFtBCVNPNpbOoCKCfhXwo9zwh7c986JOmwrmbU6ZM8QwbNqwtCxdhWTT90rqMjIxSuOZ87733tjwQooBk40EruuV86623ZrPGURmn+3S0bdu2iVBDxJhpRcxxixIrHTt2tFDgsiiqXQHkYVIorq0XUBA4DyX/CguC6a3zDx06pDInkxPFa/DNTduQtnbt2gOAaUHPNIMwZAE0mU2Eb/WGHtnJtixAZ0oxpweaNGjQoDgA5PI7VbjFVSF1UZVTAw17JSTz0grIIk7RC8kQgN1C+nuTUbuw7ACiGEwodbrCU3QGOZzHmtCM5bGRQp89i2f1hH7iRx99lMM6iUb5CXAIkK6JEye2x4hzVIQhNHkO7jMRw4sAyUcaPHJEUqlHgaad1AsnZaV9qMPaCrgRxoRwYr2/urpaBUBruPIrnwAvaNLvkx318MsrA6Tsz3j4FNIRw7P58GkCnaZoj8iCG2NyKQ8VNIBd2TPvxo0bl9gnVIQZQ1Iw3MV+ZergwYMtgLFB2Aga+SzUMg6C5pH6btz5K9X59Lx5805SlVXIFzhliNVCDVoIt1E4FUgejJrLeDkiu/fNN990ssZmGv5VUnyRgz3IxK9jxowZj+dqO3fuPICEkZBWiD2StRh3W+UspHNkkX63mhd0iFZy+vTpIsCUSmtRWFjolXYWwvuUhz86vBKQPg4EAyH5VA6Je/CmgiapNF6npXMknKOfeeaZcXJYGDFixAJKT0+OP9kHDhw4yPMq3uuEx8qJRC4ZqKi4UmtMUTmt0vtm0zRFcHLIhg+x6ErdggULkvfs2UNvfrcekGbCI2XDImBSU1NDNmzYsINQfkUCyDIqnvHJuR3ADRRTaUec8GY1SZH5ySefrAZURP/+/VtTCcS7TtEmjl5WuOlW16xZoxJzTSxDsLR169Y5qcYKfLJCznI5BPz0008eADYXdV6xYoV4z0yG+OGIeurUqX0sGo92HTZaYQ2e2JERkYaehHsJY1GbNm1aAXErMHK0tLQQuYBkKYY7TmqZFF4FiVFVYq+jIxrnbzOpaD527JiGu53EWCp04M8FFtIIayEVOYFNovfu3XtfrKNLmE4vc4QDolnCYIRS43AQRw89AkmYC7AMqvpCwjoKOnRgnR2EK5OEiGI/O6Ks4kUNWnhYx6ZOnz7dTNrLeUwjVCZRTGnCCJUf9IE/FBr/bABAKRY2gQsOEqEjXttJyKsoqjXyh4OgeffddxPx7nQkYTRgN2zfvn0T/fJr6FA5B80FzNW2bt3agxBF4iEyv9LJM4+ciqVLUOUvERRUxQsmwiWthQK5A6DkEPnAQTJwst2yZUs5mZLAO6c5ykTj0cWE8lFAXKH7u7Zo0aI/8n5XBHQVbc0uxHIO2eQkzU9iQDKejfviiy+K6d8vwEkf7askgZnUN3MS+a0hp1fRUWudlDeLalMaQklbD8249EJyiNDlECA31DQ/6V6MlUOxWPpl0Zl8Ud6EhIQ0wMTTeW4iVBfZeIFoFgX7MqRvoExVcmy+Ica98sorDoQyBB768VC9JA9cbVDpbUVbtBkzZpgAYiELFEpFHfpkEk/BF2nAVTJLYxONhaIJ7yCwxePVEshZSMizMTyail+H8u7nysYbvycchax1Dhp4CVE4muai1sXKGhhW+8svv7iIRANU0eCUAhbzXwHF+OPCP3lMAQAAAABJRU5ErkJggg=="
 
 
@@ -222,11 +230,28 @@ def _write_launch_agent(plist_path: Path, executable: Path, omh_command: str, pa
         ],
         "RunAtLoad": True,
         "KeepAlive": True,
+        "EnvironmentVariables": {"PATH": _launch_agent_path(omh_command)},
         "StandardOutPath": str(paths.runtime_dir / "menubar.out.log"),
         "StandardErrorPath": str(paths.runtime_dir / "menubar.err.log"),
     }
     paths.runtime_dir.mkdir(parents=True, exist_ok=True)
     plist_path.write_bytes(plistlib.dumps(payload))
+
+
+def _launch_agent_path(omh_command: str) -> str:
+    node_command = shutil.which("node")
+    command_parent = Path(omh_command).expanduser().parent
+    candidates = [
+        str(Path(node_command).expanduser().parent) if node_command else "",
+        str(command_parent) if command_parent != Path(".") else "",
+        *_LAUNCH_AGENT_SYSTEM_PATHS,
+    ]
+    path_entries: list[str] = []
+    for candidate in candidates:
+        expanded = str(Path(candidate).expanduser()) if candidate else ""
+        if expanded and expanded not in path_entries:
+            path_entries.append(expanded)
+    return ":".join(path_entries)
 
 
 def _run_launchctl(args: list[str], *, check: bool) -> subprocess.CompletedProcess[str]:

--- a/tests/test_memory_provider.py
+++ b/tests/test_memory_provider.py
@@ -365,11 +365,14 @@ class ProviderRegistrationTests(unittest.TestCase):
             pass
 
     class _PluginCtx:
-        """Mirrors the real Hermes plugin context, which has no provider method."""
+        """Mirrors Hermes' general context, including its inert provider stub."""
 
         def __init__(self) -> None:
             self.tools: list[str] = []
             self.hooks: list[str] = []
+
+        def register_memory_provider(self, provider) -> None:
+            pass
 
         def register_tool(self, name, *args, **kwargs) -> None:
             self.tools.append(name)
@@ -394,14 +397,15 @@ class ProviderRegistrationTests(unittest.TestCase):
         self.assertIsInstance(collector.provider, OmhMemoryProvider)
         self.assertEqual(sorted(collector.tools), sorted(PROVIDED_TOOLS))
 
-    def test_registration_survives_a_host_without_a_memory_surface(self) -> None:
-        # The guard that replaced the branch: a host that offers no
-        # `register_memory_provider` must still get every tool and hook, rather
-        # than dying on a missing attribute the way Hermes' own note describes.
+    def test_general_context_memory_stub_does_not_short_circuit_tools(self) -> None:
+        # Current Hermes exposes an inert `register_memory_provider` stub on
+        # the general plugin context. Its presence must not select a
+        # memory-only path or return before tool/hook registration.
         ctx = self._PluginCtx()
-        self.assertFalse(hasattr(ctx, "register_memory_provider"))
+        self.assertTrue(hasattr(ctx, "register_memory_provider"))
         register(ctx)
         self.assertEqual(sorted(ctx.tools), sorted(PROVIDED_TOOLS))
+        self.assertIn("on_session_end", ctx.hooks)
 
     def test_the_plugin_loader_still_gets_every_tool_and_hook(self) -> None:
         ctx = self._PluginCtx()

--- a/tests/test_memory_provider.py
+++ b/tests/test_memory_provider.py
@@ -380,6 +380,19 @@ class ProviderRegistrationTests(unittest.TestCase):
         def register_hook(self, name, callback) -> None:
             self.hooks.append(name)
 
+    class _NoMemorySurfaceCtx:
+        """Mirrors compatible hosts that expose only tool and hook methods."""
+
+        def __init__(self) -> None:
+            self.tools: list[str] = []
+            self.hooks: list[str] = []
+
+        def register_tool(self, name, *args, **kwargs) -> None:
+            self.tools.append(name)
+
+        def register_hook(self, name, callback) -> None:
+            self.hooks.append(name)
+
     def test_the_memory_loader_gets_a_provider_and_every_tool(self) -> None:
         # Inverted deliberately. This used to assert the memory path registered
         # NO tools, which was true only while `register()` returned early on
@@ -403,6 +416,13 @@ class ProviderRegistrationTests(unittest.TestCase):
         # memory-only path or return before tool/hook registration.
         ctx = self._PluginCtx()
         self.assertTrue(hasattr(ctx, "register_memory_provider"))
+        register(ctx)
+        self.assertEqual(sorted(ctx.tools), sorted(PROVIDED_TOOLS))
+        self.assertIn("on_session_end", ctx.hooks)
+
+    def test_registration_survives_a_host_without_a_memory_surface(self) -> None:
+        ctx = self._NoMemorySurfaceCtx()
+        self.assertFalse(hasattr(ctx, "register_memory_provider"))
         register(ctx)
         self.assertEqual(sorted(ctx.tools), sorted(PROVIDED_TOOLS))
         self.assertIn("on_session_end", ctx.hooks)

--- a/tests/test_menubar_app.py
+++ b/tests/test_menubar_app.py
@@ -45,6 +45,10 @@ class MenubarAppTests(unittest.TestCase):
                         "node": "/Users/example/.nvm/versions/node/v24/bin/node",
                     }.get(name),
                 ),
+                patch(
+                    "sys.executable",
+                    "/Users/example/.pyenv/versions/3.12/bin/python3",
+                ),
                 patch("omh.menubar_app._compile_swift_helper"),
             ):
                 payload = setup_menubar_app(
@@ -65,9 +69,10 @@ class MenubarAppTests(unittest.TestCase):
             self.assertEqual(arguments[icon_argument + 1], str(icon_path))
             launch_path = launch_agent_payload["EnvironmentVariables"]["PATH"].split(":")
             self.assertEqual(
-                launch_path[:2],
+                launch_path[:3],
                 [
                     "/Users/example/.nvm/versions/node/v24/bin",
+                    "/Users/example/.pyenv/versions/3.12/bin",
                     "/Users/example/.npm-global/bin",
                 ],
             )
@@ -77,6 +82,29 @@ class MenubarAppTests(unittest.TestCase):
             self.assertIn("/bin", launch_path)
             self.assertIn("/usr/sbin", launch_path)
             self.assertIn("/sbin", launch_path)
+
+    @unittest.skipUnless(platform.system() == "Darwin", "symlink resolution targets launchd")
+    def test_launch_agent_path_resolves_node_shim_and_deduplicates_real_bin(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            real_bin = root / "runtime" / "bin"
+            shim_bin = root / "shims"
+            real_bin.mkdir(parents=True)
+            shim_bin.mkdir()
+            real_node = real_bin / "node"
+            real_node.write_text("", encoding="utf-8")
+            shim_node = shim_bin / "node"
+            shim_node.symlink_to(real_node)
+
+            with (
+                patch("omh.menubar_app.shutil.which", return_value=str(shim_node)),
+                patch("sys.executable", str(real_bin / "python3")),
+            ):
+                launch_path = menubar_app_module._launch_agent_path(str(real_bin / "omh"))
+
+        path_entries = launch_path.split(":")
+        self.assertEqual(path_entries.count(str(real_bin.resolve())), 1)
+        self.assertNotIn(str(shim_bin), path_entries)
 
     def test_setup_menubar_app_skips_unsupported_platform(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_menubar_app.py
+++ b/tests/test_menubar_app.py
@@ -38,14 +38,20 @@ class MenubarAppTests(unittest.TestCase):
 
             with (
                 patch.object(menubar_app_module.Path, "home", return_value=root),
-                patch("omh.menubar_app.shutil.which", return_value="/usr/bin/swiftc"),
+                patch(
+                    "omh.menubar_app.shutil.which",
+                    side_effect=lambda name: {
+                        "swiftc": "/usr/bin/swiftc",
+                        "node": "/Users/example/.nvm/versions/node/v24/bin/node",
+                    }.get(name),
+                ),
                 patch("omh.menubar_app._compile_swift_helper"),
             ):
                 payload = setup_menubar_app(
                     paths,
                     platform_name="Darwin",
                     start=False,
-                    command_path="/usr/local/bin/omh",
+                    command_path="/Users/example/.npm-global/bin/omh",
                 )
 
             icon_path = paths.omh_home / "menubar" / "omh-character-mask.png"
@@ -53,9 +59,24 @@ class MenubarAppTests(unittest.TestCase):
             self.assertEqual(icon_path.read_bytes(), expected_icon)
             self.assertGreater(len(icon_path.read_bytes()), 0)
             launch_agent = root / "Library" / "LaunchAgents" / "com.rlaope.omh.menubar.plist"
-            arguments = plistlib.loads(launch_agent.read_bytes())["ProgramArguments"]
+            launch_agent_payload = plistlib.loads(launch_agent.read_bytes())
+            arguments = launch_agent_payload["ProgramArguments"]
             icon_argument = arguments.index("--icon")
             self.assertEqual(arguments[icon_argument + 1], str(icon_path))
+            launch_path = launch_agent_payload["EnvironmentVariables"]["PATH"].split(":")
+            self.assertEqual(
+                launch_path[:2],
+                [
+                    "/Users/example/.nvm/versions/node/v24/bin",
+                    "/Users/example/.npm-global/bin",
+                ],
+            )
+            self.assertIn("/usr/local/bin", launch_path)
+            self.assertIn("/opt/homebrew/bin", launch_path)
+            self.assertIn("/usr/bin", launch_path)
+            self.assertIn("/bin", launch_path)
+            self.assertIn("/usr/sbin", launch_path)
+            self.assertIn("/sbin", launch_path)
 
     def test_setup_menubar_app_skips_unsupported_platform(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Feature Report

Closes #994.

### What Changed

- Added a deterministic `EnvironmentVariables.PATH` to the macOS menu bar
  LaunchAgent.
- The PATH now preserves the canonical Node runtime, the Python interpreter
  selected by the npm launcher, the installed OMH command directory, and
  standard macOS executable directories.
- Canonicalized Darwin executable symlinks and deduplicated equivalent
  directories so transient version-manager shim paths are not persisted.
- Strengthened plugin registration regressions for both current Hermes'
  general context with an inert memory-provider stub and compatible hosts that
  expose no memory-provider method.

### Why This Exists

Issue #994 identified two independent failures in fresh preview installs:

1. Hermes' general plugin context exposes `register_memory_provider`, which
   previously selected a memory-only branch and skipped every OMH tool/hook.
2. launchd starts the menu bar helper with a minimal PATH, so an npm-installed
   `#!/usr/bin/env node` launcher could not find Node and reported
   `Status unavailable`.

The registration implementation itself was already corrected on current
`main` by `ea75d0f5` / PR #988. This change locks the exact current-context
collision as a regression while completing the independent LaunchAgent fix.
The npm launcher also discovers Python through PATH, so the selected Python
runtime is preserved alongside Node.

### User / Operator Impact

A fresh npm installation can start the native menu bar helper without a manual
plist workaround when Node and Python come from Homebrew, nvm, pyenv, uv, or
other user-local runtime locations. OMH tools/hooks remain registered across
both current and compatible Hermes context shapes.

### How It Works

- Setup resolves the current Node executable and `sys.executable`.
- On Darwin, executable symlinks are resolved before their parent directories
  are persisted.
- The generated launchd PATH is ordered as Node, selected Python, installed
  OMH command, then standard macOS paths, with canonical-directory
  deduplication.
- The interactive shell PATH is deliberately not copied.

### Files And Contracts Touched

- `src/surfaces/menubar_app.py`
  - LaunchAgent `EnvironmentVariables.PATH`
  - Runtime parent canonicalization and deduplication
- `tests/test_menubar_app.py`
  - Generated plist contract
  - Node/Python ordering
  - symlink and duplicate-directory behavior
- `tests/test_memory_provider.py`
  - inert memory-provider stub regression
  - host-without-memory-surface compatibility regression

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

Check only commands that completed successfully. Leave non-applicable checks
unchecked and explain why under **Not Tested / Not Applicable**.

- [x] `uv run --group lint ruff check src tests`
- [ ] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command:
  `PYTHONPATH=tests uv run python -m unittest tests.test_menubar_app tests.test_memory_provider tests.test_plugin_distribution tests.test_plugin_observations -q`
- [x] Manual Hermes/TUI check, or explicit reason it was not run:
  real plugin contexts and a clean launchd-like npm launcher environment were
  exercised; Hermes TUI behavior is not changed.

### Observed Evidence

- 212 affected plugin, memory-provider, loader-observation, and menu bar tests
  passed.
- Full discovery executed 6,808 tests; the only failure was the local
  workstation's missing `bun` executable. No changed or adjacent contract
  failed.
- Ruff, compileall, all five byte-exact documentation gates, and
  `git diff --check` passed.
- A clean `env -i` environment using only the generated PATH resolved canonical
  Node 26.7.0 and selected Python 3.11.16 and reached the npm launcher.
- Hands-on QA built and installed a user-local npm artifact; the launcher
  returned `omh 1.0.6`.
- Real Hermes `PluginContext` and `_ProviderCollector` shapes registered all
  12 declared tools, all 4 hooks, and `OmhMemoryProvider`.
- Independent goal, code-quality, security, hands-on QA, and repository-context
  reviewers all returned `PASS` for commit `5447b2fd`.

### Not Tested / Not Applicable

- Full discovery is left unchecked because Bun is not installed locally; its
  sole failing distribution test reports exactly that missing tool.
- Release, harness, workflow-learning, and live release-smoke commands do not
  apply to this focused installer/runtime-path fix.
- No Hermes TUI/HUD contract changed.

## Risk

Narrow. The change affects only the generated user LaunchAgent environment and
test fixtures. It does not copy arbitrary shell PATH entries, add dependencies,
make network calls, or write Hermes-owned state.

## Compatibility / Rollout

- Existing installations receive the corrected PATH on the next menu bar
  reinstall/setup/update that refreshes the managed LaunchAgent.
- Standard `/usr/local/bin`, `/opt/homebrew/bin`, `/usr/bin`, `/bin`,
  `/usr/sbin`, and `/sbin` remain available.
- Hosts without `register_memory_provider` and current Hermes hosts with an
  inert stub both retain full OMH tool/hook registration.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- None required for issue #994.
