### PR TITLE
fix(update): refresh installed menu bar helper

### DIFF
--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -385,15 +385,19 @@ def _refresh_installed_menubar_app(args: argparse.Namespace) -> dict[str, object
     if not is_managed_menubar_install(paths):
         return None
     try:
-        return setup_menubar_app(
+        result = setup_menubar_app(
             paths,
             dry_run=bool(args.dry_run),
             start=True,
             force=bool(args.force),
         )
-    except RuntimeError as exc:
+    except (OSError, RuntimeError) as exc:
         print(f"note: OMH menu bar helper was not refreshed: {exc}", file=sys.stderr)
         return {"status": "failed", "reason": str(exc)}
+    if result.get("status") == "installed_start_failed":
+        reason = str(result.get("start_message", "launchctl start failed"))
+        print(f"note: OMH menu bar helper was not refreshed: {reason}", file=sys.stderr)
+    return result
 
 
 def _command_package_self_update_plan(args: argparse.Namespace) -> dict[str, object]:

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -384,8 +384,8 @@ def _refresh_installed_menubar_app(args: argparse.Namespace) -> dict[str, object
     configured_omh_home = getattr(args, "omh_home", None)
     configured_hermes_home = getattr(args, "hermes_home", None)
     raw_homes = (
-        configured_omh_home if configured_omh_home is not None else os.environ.get("OMH_HOME"),
-        configured_hermes_home if configured_hermes_home is not None else os.environ.get("HERMES_HOME"),
+        configured_omh_home if configured_omh_home not in (None, "") else os.environ.get("OMH_HOME"),
+        configured_hermes_home if configured_hermes_home not in (None, "") else os.environ.get("HERMES_HOME"),
     )
     if any(_configured_path_contains_symlink(value) for value in raw_homes):
         return None

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -381,10 +381,13 @@ def _refresh_installed_tui_widget(args: argparse.Namespace) -> dict[str, object]
 
 def _refresh_installed_menubar_app(args: argparse.Namespace) -> dict[str, object] | None:
     """Bring an already-installed native menu bar helper up to date."""
-    if any(
-        _configured_path_contains_symlink(getattr(args, name, None))
-        for name in ("omh_home", "hermes_home")
-    ):
+    configured_omh_home = getattr(args, "omh_home", None)
+    configured_hermes_home = getattr(args, "hermes_home", None)
+    raw_homes = (
+        configured_omh_home if configured_omh_home is not None else os.environ.get("OMH_HOME"),
+        configured_hermes_home if configured_hermes_home is not None else os.environ.get("HERMES_HOME"),
+    )
+    if any(_configured_path_contains_symlink(value) for value in raw_homes):
         return None
     paths = _paths(args)
     if not is_managed_menubar_install(paths):
@@ -408,7 +411,7 @@ def _refresh_installed_menubar_app(args: argparse.Namespace) -> dict[str, object
 def _configured_path_contains_symlink(value: object) -> bool:
     if value is None or value == "":
         return False
-    path = Path(str(value)).expanduser()
+    path = Path(os.path.expandvars(str(value))).expanduser()
     if not path.is_absolute():
         path = Path.cwd() / path
     current = path

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -60,7 +60,7 @@ from ..installer import (
 from ..local_store import atomic_write_text
 from ..install.installer import DEFAULT_SKILL_PROFILE, SKILL_PROFILES
 from ..manifest import read_manifest
-from ..menubar_app import setup_menubar_app, uninstall_menubar_app
+from ..menubar_app import is_managed_menubar_install, setup_menubar_app, uninstall_menubar_app
 from ..mcp.host_config import install_mcp_host_config
 from ..mcp_bridge import MCP_HOST_CONFIG_RECIPE_HOSTS
 from ..paths import OmhPaths, managed_command_venv_dir
@@ -279,6 +279,7 @@ def cmd_update(args: argparse.Namespace) -> int:
             _refresh_installed_plugin_bundle(args)
             _refresh_hermes_registration(args)
         _refresh_installed_tui_widget(args)
+        _refresh_installed_menubar_app(args)
     return code
 
 
@@ -376,6 +377,23 @@ def _refresh_installed_tui_widget(args: argparse.Namespace) -> dict[str, object]
     # behaves like a failure; say so at update time (same note as setup).
     _hermes_tui_preflight_step(paths, quiet=_wants_json(args), dry_run=bool(args.dry_run))
     return result
+
+
+def _refresh_installed_menubar_app(args: argparse.Namespace) -> dict[str, object] | None:
+    """Bring an already-installed native menu bar helper up to date."""
+    paths = _paths(args)
+    if not is_managed_menubar_install(paths):
+        return None
+    try:
+        return setup_menubar_app(
+            paths,
+            dry_run=bool(args.dry_run),
+            start=True,
+            force=bool(args.force),
+        )
+    except RuntimeError as exc:
+        print(f"note: OMH menu bar helper was not refreshed: {exc}", file=sys.stderr)
+        return {"status": "failed", "reason": str(exc)}
 
 
 def _command_package_self_update_plan(args: argparse.Namespace) -> dict[str, object]:

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -381,6 +381,11 @@ def _refresh_installed_tui_widget(args: argparse.Namespace) -> dict[str, object]
 
 def _refresh_installed_menubar_app(args: argparse.Namespace) -> dict[str, object] | None:
     """Bring an already-installed native menu bar helper up to date."""
+    if any(
+        _configured_path_contains_symlink(getattr(args, name, None))
+        for name in ("omh_home", "hermes_home")
+    ):
+        return None
     paths = _paths(args)
     if not is_managed_menubar_install(paths):
         return None
@@ -398,6 +403,21 @@ def _refresh_installed_menubar_app(args: argparse.Namespace) -> dict[str, object
         reason = str(result.get("start_message", "launchctl start failed"))
         print(f"note: OMH menu bar helper was not refreshed: {reason}", file=sys.stderr)
     return result
+
+
+def _configured_path_contains_symlink(value: object) -> bool:
+    if value is None or value == "":
+        return False
+    path = Path(str(value)).expanduser()
+    if not path.is_absolute():
+        path = Path.cwd() / path
+    current = path
+    while True:
+        if current.is_symlink():
+            return True
+        if current.parent == current:
+            return False
+        current = current.parent
 
 
 def _command_package_self_update_plan(args: argparse.Namespace) -> dict[str, object]:

--- a/src/surfaces/menubar_app.py
+++ b/src/surfaces/menubar_app.py
@@ -195,8 +195,11 @@ def menubar_app_paths(paths: OmhPaths) -> dict[str, Path]:
 def is_managed_menubar_install(paths: OmhPaths) -> bool:
     app_paths = menubar_app_paths(paths)
     launch_agent = app_paths["launch_agent"]
-    if not launch_agent.exists():
-        return app_paths["app_dir"].is_dir()
+    if _path_contains_symlink(launch_agent, Path.home()):
+        return False
+    for name in ("app_dir", "source", "executable", "icon"):
+        if _path_contains_symlink(app_paths[name], paths.omh_home):
+            return False
     if not launch_agent.is_file():
         return False
     try:
@@ -215,6 +218,20 @@ def is_managed_menubar_install(paths: OmhPaths) -> bool:
         _launch_agent_argument(arguments, "--omh-home") == str(paths.omh_home)
         and _launch_agent_argument(arguments, "--hermes-home") == str(paths.hermes_home)
     )
+
+
+def _path_contains_symlink(path: Path, boundary: Path) -> bool:
+    try:
+        path.relative_to(boundary)
+    except ValueError:
+        return True
+    current = path
+    while True:
+        if current.is_symlink():
+            return True
+        if current == boundary:
+            return False
+        current = current.parent
 
 
 def _launch_agent_argument(arguments: list[str], name: str) -> str:

--- a/src/surfaces/menubar_app.py
+++ b/src/surfaces/menubar_app.py
@@ -192,6 +192,40 @@ def menubar_app_paths(paths: OmhPaths) -> dict[str, Path]:
     }
 
 
+def is_managed_menubar_install(paths: OmhPaths) -> bool:
+    app_paths = menubar_app_paths(paths)
+    launch_agent = app_paths["launch_agent"]
+    if not launch_agent.exists():
+        return app_paths["app_dir"].is_dir()
+    if not launch_agent.is_file():
+        return False
+    try:
+        payload = plistlib.loads(launch_agent.read_bytes())
+    except (OSError, plistlib.InvalidFileException):
+        return False
+    if not isinstance(payload, dict) or payload.get("Label") != MENUBAR_LABEL:
+        return False
+    raw_arguments = payload.get("ProgramArguments")
+    if not isinstance(raw_arguments, list) or any(not isinstance(value, str) for value in raw_arguments):
+        return False
+    arguments = [str(value) for value in raw_arguments]
+    if not arguments or arguments[0] != str(app_paths["executable"]):
+        return False
+    return (
+        _launch_agent_argument(arguments, "--omh-home") == str(paths.omh_home)
+        and _launch_agent_argument(arguments, "--hermes-home") == str(paths.hermes_home)
+    )
+
+
+def _launch_agent_argument(arguments: list[str], name: str) -> str:
+    try:
+        index = arguments.index(name)
+    except ValueError:
+        return ""
+    value_index = index + 1
+    return arguments[value_index] if value_index < len(arguments) else ""
+
+
 def _resolved_omh_command() -> str:
     command = inspect_omh_command_path()
     if command.get("found") and command.get("path"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3689,6 +3689,10 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
                 setup_commands,
                 "_refresh_installed_tui_widget",
             ) as widget_refresh,
+            patch.object(
+                setup_commands,
+                "_refresh_installed_menubar_app",
+            ) as menubar_refresh,
         ):
             status = setup_commands.cmd_update(args)
 
@@ -3696,6 +3700,135 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
         plugin_refresh.assert_not_called()
         registration_refresh.assert_not_called()
         widget_refresh.assert_called_once_with(args)
+        menubar_refresh.assert_called_once_with(args)
+
+    def test_update_refreshes_an_existing_native_menubar_install(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            app_dir = root / ".omh" / "menubar"
+            app_dir.mkdir(parents=True)
+            executable = app_dir / "omh-menubar"
+            executable.touch()
+            launch_agent = root / "Library" / "LaunchAgents" / "com.rlaope.omh.menubar.plist"
+            launch_agent.parent.mkdir(parents=True)
+            launch_agent.touch()
+            args = Namespace(
+                omh_home=str(root / ".omh"),
+                hermes_home=str(root / ".hermes"),
+                scope=None,
+                dry_run=False,
+                force=False,
+            )
+            with (
+                patch.object(
+                    setup_commands,
+                    "is_managed_menubar_install",
+                    return_value=True,
+                ),
+                patch.object(
+                    setup_commands,
+                    "setup_menubar_app",
+                    return_value={"status": "running"},
+                ) as setup_menubar,
+            ):
+                result = setup_commands._refresh_installed_menubar_app(args)
+
+        self.assertEqual(result, {"status": "running"})
+        setup_menubar.assert_called_once()
+        called_paths = setup_menubar.call_args.args[0]
+        self.assertEqual(called_paths.omh_home, (root / ".omh").resolve())
+        self.assertEqual(
+            setup_menubar.call_args.kwargs,
+            {"dry_run": False, "start": True, "force": False},
+        )
+
+    def test_update_does_not_install_the_native_menubar_for_the_first_time(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            args = Namespace(
+                omh_home=str(root / ".omh"),
+                hermes_home=str(root / ".hermes"),
+                scope=None,
+                dry_run=False,
+                force=False,
+            )
+            with (
+                patch.object(
+                    setup_commands,
+                    "is_managed_menubar_install",
+                    return_value=False,
+                ),
+                patch.object(setup_commands, "setup_menubar_app") as setup_menubar,
+            ):
+                result = setup_commands._refresh_installed_menubar_app(args)
+
+        self.assertIsNone(result)
+        setup_menubar.assert_not_called()
+
+    def test_update_does_not_take_over_another_menubar_install(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            app_dir = root / ".omh" / "menubar"
+            app_dir.mkdir(parents=True)
+            executable = app_dir / "omh-menubar"
+            executable.touch()
+            launch_agent = root / "Library" / "LaunchAgents" / "com.rlaope.omh.menubar.plist"
+            launch_agent.parent.mkdir(parents=True)
+            launch_agent.touch()
+            args = Namespace(
+                omh_home=str(root / ".omh"),
+                hermes_home=str(root / ".hermes"),
+                scope=None,
+                dry_run=False,
+                force=False,
+            )
+            with (
+                patch.object(
+                    setup_commands,
+                    "is_managed_menubar_install",
+                    return_value=False,
+                ),
+                patch.object(setup_commands, "setup_menubar_app") as setup_menubar,
+            ):
+                result = setup_commands._refresh_installed_menubar_app(args)
+
+        self.assertIsNone(result)
+        setup_menubar.assert_not_called()
+
+    def test_update_survives_an_optional_menubar_rebuild_failure(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            app_dir = root / ".omh" / "menubar"
+            app_dir.mkdir(parents=True)
+            executable = app_dir / "omh-menubar"
+            executable.touch()
+            launch_agent = root / "Library" / "LaunchAgents" / "com.rlaope.omh.menubar.plist"
+            launch_agent.parent.mkdir(parents=True)
+            launch_agent.touch()
+            args = Namespace(
+                omh_home=str(root / ".omh"),
+                hermes_home=str(root / ".hermes"),
+                scope=None,
+                dry_run=False,
+                force=False,
+            )
+            with (
+                patch.object(
+                    setup_commands,
+                    "is_managed_menubar_install",
+                    return_value=True,
+                ),
+                patch.object(
+                    setup_commands,
+                    "setup_menubar_app",
+                    side_effect=RuntimeError("swiftc failed"),
+                ),
+                patch("sys.stderr", new_callable=io.StringIO) as stderr,
+            ):
+                result = setup_commands._refresh_installed_menubar_app(args)
+
+        self.assertEqual(result, {"status": "failed", "reason": "swiftc failed"})
+        self.assertIn("menu bar helper was not refreshed", stderr.getvalue())
 
     def test_update_self_update_recognizes_venv_python_symlink_path(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3878,8 +3878,10 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
                 ("direct_omh", str(aliased_home / ".omh"), canonical_hermes, {}),
                 ("expanded_omh", "$OMH_ALIAS_ROOT/.omh", canonical_hermes, {}),
                 ("default_omh", None, canonical_hermes, {"OMH_HOME": str(aliased_home / ".omh")}),
+                ("empty_omh", "", canonical_hermes, {"OMH_HOME": str(aliased_home / ".omh")}),
                 ("direct_hermes", canonical_omh, str(aliased_home / ".hermes"), {}),
                 ("default_hermes", canonical_omh, None, {"HERMES_HOME": str(aliased_home / ".hermes")}),
+                ("empty_hermes", canonical_omh, "", {"HERMES_HOME": str(aliased_home / ".hermes")}),
             )
             for name, configured_omh, configured_hermes, environment in cases:
                 with self.subTest(case=name):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3713,8 +3713,8 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             launch_agent.parent.mkdir(parents=True)
             launch_agent.touch()
             args = Namespace(
-                omh_home=str(root / ".omh"),
-                hermes_home=str(root / ".hermes"),
+                omh_home=str((root / ".omh").resolve()),
+                hermes_home=str((root / ".hermes").resolve()),
                 scope=None,
                 dry_run=False,
                 force=False,
@@ -3806,8 +3806,8 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             launch_agent.parent.mkdir(parents=True)
             launch_agent.touch()
             args = Namespace(
-                omh_home=str(root / ".omh"),
-                hermes_home=str(root / ".hermes"),
+                omh_home=str((root / ".omh").resolve()),
+                hermes_home=str((root / ".hermes").resolve()),
                 scope=None,
                 dry_run=False,
                 force=False,
@@ -3836,8 +3836,8 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
             args = Namespace(
-                omh_home=str(root / ".omh"),
-                hermes_home=str(root / ".hermes"),
+                omh_home=str((root / ".omh").resolve()),
+                hermes_home=str((root / ".hermes").resolve()),
                 scope=None,
                 dry_run=False,
                 force=False,
@@ -3863,6 +3863,34 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
 
         self.assertEqual(result, failed_result)
         self.assertIn("launchctl bootstrap failed", stderr.getvalue())
+
+    @unittest.skipIf(sys.platform == "win32", "symlink privileges vary on Windows")
+    def test_update_rejects_a_symlinked_raw_omh_home(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            real_home = root / "real-home"
+            real_home.mkdir()
+            aliased_home = root / "aliased-home"
+            aliased_home.symlink_to(real_home, target_is_directory=True)
+            args = Namespace(
+                omh_home=str(aliased_home / ".omh"),
+                hermes_home=str(root / ".hermes"),
+                scope=None,
+                dry_run=False,
+                force=False,
+            )
+            with (
+                patch.object(
+                    setup_commands,
+                    "is_managed_menubar_install",
+                    return_value=True,
+                ),
+                patch.object(setup_commands, "setup_menubar_app") as setup_menubar,
+            ):
+                result = setup_commands._refresh_installed_menubar_app(args)
+
+        self.assertIsNone(result)
+        setup_menubar.assert_not_called()
 
     def test_update_self_update_recognizes_venv_python_symlink_path(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3872,25 +3872,43 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             real_home.mkdir()
             aliased_home = root / "aliased-home"
             aliased_home.symlink_to(real_home, target_is_directory=True)
-            args = Namespace(
-                omh_home=str(aliased_home / ".omh"),
-                hermes_home=str(root / ".hermes"),
-                scope=None,
-                dry_run=False,
-                force=False,
+            canonical_omh = str((root / "canonical-omh").resolve())
+            canonical_hermes = str((root / "canonical-hermes").resolve())
+            cases = (
+                ("direct_omh", str(aliased_home / ".omh"), canonical_hermes, {}),
+                ("expanded_omh", "$OMH_ALIAS_ROOT/.omh", canonical_hermes, {}),
+                ("default_omh", None, canonical_hermes, {"OMH_HOME": str(aliased_home / ".omh")}),
+                ("direct_hermes", canonical_omh, str(aliased_home / ".hermes"), {}),
+                ("default_hermes", canonical_omh, None, {"HERMES_HOME": str(aliased_home / ".hermes")}),
             )
-            with (
-                patch.object(
-                    setup_commands,
-                    "is_managed_menubar_install",
-                    return_value=True,
-                ),
-                patch.object(setup_commands, "setup_menubar_app") as setup_menubar,
-            ):
-                result = setup_commands._refresh_installed_menubar_app(args)
+            for name, configured_omh, configured_hermes, environment in cases:
+                with self.subTest(case=name):
+                    args = Namespace(
+                        omh_home=configured_omh,
+                        hermes_home=configured_hermes,
+                        scope=None,
+                        dry_run=False,
+                        force=False,
+                    )
+                    test_environment = {
+                        "OMH_ALIAS_ROOT": str(aliased_home),
+                        "OMH_HOME": canonical_omh,
+                        "HERMES_HOME": canonical_hermes,
+                        **environment,
+                    }
+                    with (
+                        patch.dict(os.environ, test_environment),
+                        patch.object(
+                            setup_commands,
+                            "is_managed_menubar_install",
+                            return_value=True,
+                        ),
+                        patch.object(setup_commands, "setup_menubar_app") as setup_menubar,
+                    ):
+                        result = setup_commands._refresh_installed_menubar_app(args)
 
-        self.assertIsNone(result)
-        setup_menubar.assert_not_called()
+                    self.assertIsNone(result)
+                    setup_menubar.assert_not_called()
 
     def test_update_self_update_recognizes_venv_python_symlink_path(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3812,6 +3812,40 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
                 dry_run=False,
                 force=False,
             )
+            for failure in (RuntimeError("swiftc failed"), OSError("write failed")):
+                with self.subTest(error=type(failure).__name__):
+                    with (
+                        patch.object(
+                            setup_commands,
+                            "is_managed_menubar_install",
+                            return_value=True,
+                        ),
+                        patch.object(
+                            setup_commands,
+                            "setup_menubar_app",
+                            side_effect=failure,
+                        ),
+                        patch("sys.stderr", new_callable=io.StringIO) as stderr,
+                    ):
+                        result = setup_commands._refresh_installed_menubar_app(args)
+
+                    self.assertEqual(result, {"status": "failed", "reason": str(failure)})
+                    self.assertIn("menu bar helper was not refreshed", stderr.getvalue())
+
+    def test_update_reports_an_installed_menubar_restart_failure(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            args = Namespace(
+                omh_home=str(root / ".omh"),
+                hermes_home=str(root / ".hermes"),
+                scope=None,
+                dry_run=False,
+                force=False,
+            )
+            failed_result = {
+                "status": "installed_start_failed",
+                "start_message": "launchctl bootstrap failed",
+            }
             with (
                 patch.object(
                     setup_commands,
@@ -3821,14 +3855,14 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
                 patch.object(
                     setup_commands,
                     "setup_menubar_app",
-                    side_effect=RuntimeError("swiftc failed"),
+                    return_value=failed_result,
                 ),
                 patch("sys.stderr", new_callable=io.StringIO) as stderr,
             ):
                 result = setup_commands._refresh_installed_menubar_app(args)
 
-        self.assertEqual(result, {"status": "failed", "reason": "swiftc failed"})
-        self.assertIn("menu bar helper was not refreshed", stderr.getvalue())
+        self.assertEqual(result, failed_result)
+        self.assertIn("launchctl bootstrap failed", stderr.getvalue())
 
     def test_update_self_update_recognizes_venv_python_symlink_path(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_menubar_app.py
+++ b/tests/test_menubar_app.py
@@ -7,6 +7,7 @@ import plistlib
 import shutil
 import struct
 import subprocess
+import sys
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -85,18 +86,93 @@ class MenubarAppTests(unittest.TestCase):
             self.assertIn("/usr/sbin", launch_path)
             self.assertIn("/sbin", launch_path)
 
-    def test_partial_managed_copy_without_launch_agent_is_refreshable(self) -> None:
+    def test_valid_launch_agent_repairs_a_missing_managed_copy(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            with patch.object(menubar_app_module.Path, "home", return_value=root):
+                app_paths = menubar_app_module.menubar_app_paths(paths)
+                app_paths["launch_agent"].parent.mkdir(parents=True)
+                app_paths["launch_agent"].write_bytes(
+                    plistlib.dumps(
+                        {
+                            "Label": menubar_app_module.MENUBAR_LABEL,
+                            "ProgramArguments": [
+                                str(app_paths["executable"]),
+                                "--omh-command",
+                                "/usr/local/bin/omh",
+                                "--omh-home",
+                                str(paths.omh_home),
+                                "--hermes-home",
+                                str(paths.hermes_home),
+                            ],
+                        }
+                    )
+                )
+
+                managed = menubar_app_module.is_managed_menubar_install(paths)
+
+        self.assertTrue(managed)
+
+    def test_operator_owned_directory_without_launch_agent_is_not_managed(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
             paths = resolve_paths(root / ".omh", root / ".hermes")
             with patch.object(menubar_app_module.Path, "home", return_value=root):
                 app_paths = menubar_app_module.menubar_app_paths(paths)
                 app_paths["app_dir"].mkdir(parents=True)
-                app_paths["source"].write_text("managed source", encoding="utf-8")
+                (app_paths["app_dir"] / "README.txt").write_text("operator owned", encoding="utf-8")
 
                 managed = menubar_app_module.is_managed_menubar_install(paths)
 
-        self.assertTrue(managed)
+        self.assertFalse(managed)
+
+    @unittest.skipIf(sys.platform == "win32", "symlink privileges vary on Windows")
+    def test_symlinked_managed_paths_are_not_trusted(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            with patch.object(menubar_app_module.Path, "home", return_value=root):
+                app_paths = menubar_app_module.menubar_app_paths(paths)
+                paths.omh_home.mkdir(parents=True)
+                target_dir = root / "attacker-owned"
+                target_dir.mkdir()
+                app_paths["app_dir"].symlink_to(target_dir, target_is_directory=True)
+                app_paths["launch_agent"].parent.mkdir(parents=True)
+                app_paths["launch_agent"].write_bytes(
+                    plistlib.dumps(
+                        {
+                            "Label": menubar_app_module.MENUBAR_LABEL,
+                            "ProgramArguments": [
+                                str(app_paths["executable"]),
+                                "--omh-command",
+                                "/usr/local/bin/omh",
+                                "--omh-home",
+                                str(paths.omh_home),
+                                "--hermes-home",
+                                str(paths.hermes_home),
+                            ],
+                        }
+                    )
+                )
+
+                managed = menubar_app_module.is_managed_menubar_install(paths)
+
+        self.assertFalse(managed)
+
+    @unittest.skipIf(sys.platform == "win32", "symlink privileges vary on Windows")
+    def test_broken_launch_agent_symlink_is_not_managed(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            with patch.object(menubar_app_module.Path, "home", return_value=root):
+                app_paths = menubar_app_module.menubar_app_paths(paths)
+                app_paths["launch_agent"].parent.mkdir(parents=True)
+                app_paths["launch_agent"].symlink_to(root / "missing.plist")
+
+                managed = menubar_app_module.is_managed_menubar_install(paths)
+
+        self.assertFalse(managed)
 
     def test_global_launch_agent_must_match_target_homes(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_menubar_app.py
+++ b/tests/test_menubar_app.py
@@ -57,6 +57,7 @@ class MenubarAppTests(unittest.TestCase):
                     start=False,
                     command_path="/Users/example/.npm-global/bin/omh",
                 )
+                managed = menubar_app_module.is_managed_menubar_install(paths)
 
             icon_path = paths.omh_home / "menubar" / "omh-character-mask.png"
             self.assertEqual(payload["icon"], str(icon_path))
@@ -67,6 +68,7 @@ class MenubarAppTests(unittest.TestCase):
             arguments = launch_agent_payload["ProgramArguments"]
             icon_argument = arguments.index("--icon")
             self.assertEqual(arguments[icon_argument + 1], str(icon_path))
+            self.assertTrue(managed)
             launch_path = launch_agent_payload["EnvironmentVariables"]["PATH"].split(":")
             self.assertEqual(
                 launch_path[:3],
@@ -82,6 +84,49 @@ class MenubarAppTests(unittest.TestCase):
             self.assertIn("/bin", launch_path)
             self.assertIn("/usr/sbin", launch_path)
             self.assertIn("/sbin", launch_path)
+
+    def test_partial_managed_copy_without_launch_agent_is_refreshable(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            with patch.object(menubar_app_module.Path, "home", return_value=root):
+                app_paths = menubar_app_module.menubar_app_paths(paths)
+                app_paths["app_dir"].mkdir(parents=True)
+                app_paths["source"].write_text("managed source", encoding="utf-8")
+
+                managed = menubar_app_module.is_managed_menubar_install(paths)
+
+        self.assertTrue(managed)
+
+    def test_global_launch_agent_must_match_target_homes(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            with patch.object(menubar_app_module.Path, "home", return_value=root):
+                app_paths = menubar_app_module.menubar_app_paths(paths)
+                app_paths["app_dir"].mkdir(parents=True)
+                app_paths["executable"].touch()
+                app_paths["launch_agent"].parent.mkdir(parents=True)
+                app_paths["launch_agent"].write_bytes(
+                    plistlib.dumps(
+                        {
+                            "Label": menubar_app_module.MENUBAR_LABEL,
+                            "ProgramArguments": [
+                                str(app_paths["executable"]),
+                                "--omh-command",
+                                "/usr/local/bin/omh",
+                                "--omh-home",
+                                str(paths.omh_home),
+                                "--hermes-home",
+                                str(root / "another-hermes-home"),
+                            ],
+                        }
+                    )
+                )
+
+                managed = menubar_app_module.is_managed_menubar_install(paths)
+
+        self.assertFalse(managed)
 
     @unittest.skipUnless(platform.system() == "Darwin", "symlink resolution targets launchd")
     def test_launch_agent_path_resolves_node_shim_and_deduplicates_real_bin(self) -> None:


### PR DESCRIPTION
## Feature Report

### What Changed

- Refresh an already-installed native macOS menu bar helper after a successful
  `omh update`.
- Reinstall the managed Swift source, character icon, compiled helper, and
  LaunchAgent so package updates cannot leave an older `omh` text helper
  running indefinitely.
- Require the global LaunchAgent to belong to the selected executable, OMH
  home, and Hermes home before replacing it.
- Reject operator-owned, corrupt, or symlinked managed paths, including direct,
  environment-expanded, default-environment, and empty-CLI fallback paths.
- Keep optional Swift compilation, filesystem, and launchctl restart failures
  visible on stderr without turning an already-completed core update into a
  crash.

### Why This Exists

The character status icon shipped in PR #992, but an existing installation
could continue displaying the old `omh` text. The installed Python package
already contained the new icon and AppKit implementation; `omh update`
refreshed the plugin and TUI managed layers but never refreshed the copied and
compiled native menu bar layer under `~/.omh`.

The fix is stacked on and follows PR #996 so a refreshed LaunchAgent also
preserves the canonical Node and selected Python runtime paths needed by npm
installations.

### User / Operator Impact

Users who already enabled the menu bar receive the current character icon and
status behavior on their next normal update. Users who never installed the
menu bar do not receive a surprise first-time installation. Custom OMH/Hermes
homes cannot take over another setup's user-global LaunchAgent.

### How It Works

- `cmd_update()` invokes a dedicated native menu bar refresh after the core
  install and existing managed plugin/TUI refresh steps.
- Refresh eligibility requires a regular, parseable plist with the expected
  label, executable, OMH home, and Hermes home.
- Managed app and LaunchAgent paths are rejected when they or user-controlled
  ancestors are symlinks.
- Raw CLI and environment path sources are checked before `resolve_paths()`
  can erase symlink provenance. This includes `$VAR` expansion and the same
  `None`/empty fallback semantics used by path resolution.
- A valid owned LaunchAgent can repair missing generated app files. An absent,
  operator-created, mismatched, corrupt, or symlinked installation is left
  untouched.

### Files And Contracts Touched

- `src/commands/setup.py`
  - update lifecycle integration
  - raw configured-home provenance checks
  - optional refresh failure reporting
- `src/surfaces/menubar_app.py`
  - managed LaunchAgent ownership inspection
  - bounded symlink-component validation
- `tests/test_cli.py`
  - update ordering, first-install boundary, failure handling, and raw path
    source matrix
- `tests/test_menubar_app.py`
  - plist ownership, partial repair, operator-owned path, and symlink contracts

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [ ] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [x] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command:
  `PYTHONPATH=tests uv run python -m unittest tests.test_cli tests.test_menubar_app tests.test_memory_provider tests.test_plugin_distribution tests.test_plugin_observations -q`
- [x] Manual Hermes/TUI check, or explicit reason it was not run:
  the real native menu bar helper was reinstalled and exercised through
  AppKit, launchd, and Accessibility; Hermes TUI behavior is unchanged.

### Observed Evidence

- 542 affected CLI, menu bar, plugin, provider, and loader-observation tests
  passed on the final implementation.
- Full discovery executed 6,819 tests. The sole failure was the workstation's
  missing `bun` executable; no changed or adjacent test failed.
- Ruff, compileall, all five byte-exact generated documentation gates, and
  `git diff --check` passed.
- The live LaunchAgent and process use
  `--icon ~/.omh/menubar/omh-character-mask.png`.
- AppKit loaded the exact embedded 36x36 RGBA character asset as an 18x18
  template image.
- Accessibility exposed title `4·3` and a useful `OMH — Hermes running — ...`
  description; stale lowercase `omh` text was absent.
- Direct, expanded, default-environment, and empty-CLI OMH/Hermes symlink
  aliases were rejected without modifying or restarting the helper.
- Independent goal, code-quality, repository-context, hands-on QA,
  filesystem-safety, and two visual reviewers returned `PASS` on the final
  behavior. No screenshots were captured, honoring the operator preference.

### Not Tested / Not Applicable

- Full discovery is unchecked because Bun is unavailable locally. GitHub's
  required distribution jobs cover that packaging surface before merge.
- Release, harness, and live release-smoke commands do not apply to this
  focused managed-artifact lifecycle fix.
- No Hermes TUI, routing, prompt, generated skill, or network contract changed.

## Risk

Moderate and bounded to an already-installed native menu bar. A normal update
may compile and restart that optional helper, but only after strict ownership
and path checks. Failures are reported without rolling back or invalidating the
completed core update.

## Compatibility / Rollout

- Depends on merged PR #996 for the corrected LaunchAgent Node/Python PATH.
- Existing menu bar users receive the refresh on their next update.
- Users without an owned LaunchAgent remain unchanged.
- A release newer than v1.0.6 is required before package-manager users can
  receive this behavior; release preparation remains a separate rollout
  boundary.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Publish this capability in the next post-v1.0.6 release.
