### PR TITLE
feat(hud): show Hermes-native delegate_task subagents live in the OMH HUD

### DIFF
--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -68,9 +68,14 @@ export default function register(sdk) {
     if (!active) return 'ready'
     const running = Number(agents.running) || 0
     const blocked = Number(agents.blocked) || 0
+    const done = Number(agents.completed) || 0
+    // Lingering just-finished subagents keep the block alive without live
+    // work; "2 done" is the honest label there, not "0 agents".
+    if (!running && !blocked && done) return `${done} done`
     const parts = [plural(Number(agents.active) || 0, 'agent')]
     if (running) parts.push(`${running} running`)
     if (blocked) parts.push(`${blocked} blocked`)
+    if (done) parts.push(`${done} done`)
     return parts.join(' · ')
   }
   const readHud = () => new Promise(resolve => {
@@ -187,12 +192,13 @@ export default function register(sdk) {
   function ActivityRow({ columns, frame, main, row, t }) {
     const layout = activityLayout(row, columns, main)
     const blocked = row.state === 'blocked' || row.state === 'failed'
-    const marker = blocked ? '▲' : SPINNER_FRAMES[frame % SPINNER_FRAMES.length]
+    const done = row.state === 'done'
+    const marker = blocked ? '▲' : done ? '✓' : SPINNER_FRAMES[frame % SPINNER_FRAMES.length]
     const statusColor = blocked ? t.color.error : t.color.ok
     return h(
       Text,
       { wrap: 'truncate-end' },
-      h(Text, { color: blocked ? t.color.error : t.color.warn }, `${marker} `),
+      h(Text, { color: blocked ? t.color.error : done ? t.color.ok : t.color.warn }, `${marker} `),
       h(Text, { color: t.color.muted }, `${layout.taskId} `),
       h(Text, { color: t.color.text }, layout.action),
       layout.metadata ? h(Text, { color: t.color.muted }, '  ·  ') : null,

--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -219,8 +219,40 @@ export default function register(sdk) {
     )
   }
 
+  function LiveActivity({ columns, mainRows, rows, t, tick }) {
+    // Mounted only while live rows exist. The SDK shimmer clock is bounded —
+    // it stops advancing animateMs after MOUNT — so the old top-level
+    // useShimmerPhase(30_000) froze thirty seconds into a session and the
+    // spinner then jumped once per poll. A fresh mount per activity burst
+    // restarts the window, and thirty minutes bounds the render cost of one
+    // very long wave; the poll tick still nudges frames past that.
+    const frame = useShimmerPhase(1_800_000) + tick
+    return h(
+      Box,
+      { flexDirection: 'column', width: '100%' },
+      ...mainRows.map((row, index) =>
+        h(ActivityRow, {
+          columns,
+          frame,
+          key: `main-${index}`,
+          main: true,
+          row,
+          t,
+        })
+      ),
+      ...rows.map((row, index) =>
+        h(ActivityRow, {
+          columns,
+          frame,
+          key: `${safeText(row.task_id)}-${index}`,
+          row,
+          t,
+        })
+      ),
+    )
+  }
+
   function Hud({ columns, state, t, viewportRows }) {
-    const spinnerPhase = useShimmerPhase(30_000) + state.tick
     const payload = state.payload
     if (!payload || payload.error || payload.privacy !== 'metadata_only') return null
 
@@ -253,25 +285,9 @@ export default function register(sdk) {
         h(Text, { color: active ? t.color.warn : t.color.ok }, hudStateLabel(active, agents)),
         h(Text, { color: t.color.muted }, ` • ${metrics.cost} • ${metrics.ctx}`),
       ),
-      ...mainRows.map((row, index) =>
-        h(ActivityRow, {
-          columns,
-          frame: spinnerPhase,
-          key: `main-${index}`,
-          main: true,
-          row,
-          t,
-        })
-      ),
-      ...rows.map((row, index) =>
-        h(ActivityRow, {
-          columns,
-          frame: spinnerPhase,
-          key: `${safeText(row.task_id)}-${index}`,
-          row,
-          t,
-        })
-      ),
+      mainRows.length || rows.length
+        ? h(LiveActivity, { columns, mainRows, rows, t, tick: state.tick })
+        : null,
     )
   }
 

--- a/src/plugin_bundle/omh/hermes_delegation.py
+++ b/src/plugin_bundle/omh/hermes_delegation.py
@@ -1,0 +1,403 @@
+"""Read-only observation of Hermes-native subagent delegations.
+
+`delegate_task` children are first-class work the HUD must show live: Hermes
+already records everything needed — the child session's model and reasoning
+effort in `state.db` (`sessions.model_config`, with `_delegate_from` naming
+the parent), token/cache/cost tallies in `session_model_usage`, background
+lifecycle in `async_delegations`, and an append-only live transcript plus
+`manifest.json` per delegation under `cache/delegation/live/`. This module
+joins those surfaces into HUD activity rows without writing anything and
+without importing Hermes code.
+
+Everything here is observation of another product's on-disk state, so every
+read degrades to "nothing observed" instead of raising: a locked SQLite file,
+a torn manifest, or a missing directory must render as an idle HUD segment,
+never as a widget error.
+
+The category label is a *projection*, not an observed routing record: Hermes
+does not persist which OMH mixture category (if any) chose the child's model,
+so the label is derived by matching the observed model+effort against the
+shipped mixture chains. A child running the parent session's own model is
+labeled ``inherit`` — deliberately, so a delegation wave that never engaged
+mixture routing is visible as such instead of masquerading as a routed one.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any
+
+# Mirrors SHIPPED_MODEL_RECOMMENDATIONS["categories"] in
+# src/coding/model_recommendations.py, projected to (model_alias,
+# reasoning_effort) pairs in chain order. The plugin bundle ships standalone
+# into $HERMES_HOME/plugins and cannot import src/coding, so the chains are
+# embedded; tests/test_plugin_hermes_delegation.py holds the dict-parity gate.
+HERMES_MIXTURE_CATEGORY_CHAINS: dict[str, tuple[tuple[str, str], ...]] = {
+    "ultrabrain": (("gpt-5.6-sol", "xhigh"),),
+    "deep": (("gpt-5.6-terra", "high"),),
+    "unspecified-high": (("kimi-k3", ""), ("claude-opus-5", "")),
+    "unspecified-low": (("glm-5.2", ""), ("glm-5.2-ultrafast", "")),
+    "quick": (("glm-5.2-ultrafast", ""), ("kimi-k3", "")),
+    "writing": (("kimi-k3", ""), ("qwen3-coder", ""), ("gemini-3.1-pro", "")),
+    "visual-engineering": (("claude-fable-5", ""), ("kimi-k3", "")),
+    "artistry": (("gemini-3.1-pro", ""), ("claude-fable-5", ""), ("kimi-k3", "")),
+}
+
+# A child is "running" while its newest observable signal (live transcript
+# mtime, usage last_seen, session start) is at most this old. The live log
+# streams one line per child event, so an actively working child refreshes
+# well inside this window; a child that stalls longer than this reads as done
+# rather than spinning forever.
+RECENT_ACTIVITY_SECONDS = 150
+# Finished children linger as "done" rows for this long so the operator sees
+# what just completed — same shape as the todo panel's finished-plan linger.
+COMPLETED_LINGER_SECONDS = 15 * 60
+# Children older than this are history, not HUD material, regardless of state.
+_SESSION_WINDOW_SECONDS = 6 * 3600
+_ACTION_LIMIT = 140
+_ROW_LIMIT = 8
+
+
+def _text(value: Any, limit: int = 80) -> str:
+    return str(value or "").strip()[:limit]
+
+
+def _finite(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)) and value == value and abs(value) != float("inf"):
+        return float(value)
+    return None
+
+
+def mixture_category_for(model: str, effort: str, *, parent_model: str = "") -> str:
+    """Project an observed child model+effort onto a mixture category label.
+
+    ``inherit`` wins over any chain match: a child on the parent session's own
+    model was not routed, whatever chain its model also appears in. Otherwise
+    the first category (canonical chain order) whose head matches wins, then
+    the first category containing the model anywhere; a chain entry that
+    declares a reasoning effort only matches that effort.
+    """
+    observed_model = _text(model).casefold()
+    observed_effort = _text(effort, limit=40).casefold()
+    if not observed_model:
+        return ""
+    if parent_model and observed_model == _text(parent_model).casefold():
+        return "inherit"
+
+    def _entry_matches(entry: tuple[str, str]) -> bool:
+        alias, chain_effort = entry
+        if alias.casefold() != observed_model:
+            return False
+        return not chain_effort or chain_effort.casefold() == observed_effort
+
+    for category, chain in HERMES_MIXTURE_CATEGORY_CHAINS.items():
+        if chain and _entry_matches(chain[0]):
+            return category
+    for category, chain in HERMES_MIXTURE_CATEGORY_CHAINS.items():
+        if any(_entry_matches(entry) for entry in chain):
+            return category
+    return ""
+
+
+def _read_manifests(live_root: Path, *, now: float) -> list[dict[str, Any]]:
+    """Load recent delegation manifests plus each task log's mtime."""
+    manifests: list[dict[str, Any]] = []
+    try:
+        candidates = sorted(
+            (path for path in live_root.iterdir() if path.is_dir()),
+            key=lambda path: path.stat().st_mtime,
+            reverse=True,
+        )[:_ROW_LIMIT]
+    except OSError:
+        return []
+    for directory in candidates:
+        manifest_path = directory / "manifest.json"
+        try:
+            raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            continue
+        if not isinstance(raw, dict):
+            continue
+        started = _parse_local_timestamp(str(raw.get("started", "")))
+        tasks_raw = raw.get("tasks", [])
+        tasks: list[dict[str, Any]] = []
+        newest_log_mtime = 0.0
+        for task in tasks_raw if isinstance(tasks_raw, list) else []:
+            if not isinstance(task, dict):
+                continue
+            log_mtime = 0.0
+            log_path = _text(task.get("log", ""), limit=512)
+            if log_path:
+                try:
+                    log_mtime = Path(log_path).stat().st_mtime
+                except OSError:
+                    log_mtime = 0.0
+            newest_log_mtime = max(newest_log_mtime, log_mtime)
+            tasks.append(
+                {
+                    "goal": _text(task.get("goal", ""), limit=_ACTION_LIMIT),
+                    "log_mtime": log_mtime,
+                }
+            )
+        if started and now - max(started, newest_log_mtime) > _SESSION_WINDOW_SECONDS:
+            continue
+        manifests.append(
+            {
+                "delegation_id": _text(raw.get("delegation_id", directory.name)),
+                "started": started,
+                "tasks": tasks,
+            }
+        )
+    return manifests
+
+
+def _parse_local_timestamp(value: str) -> float:
+    # Manifest `started` is "YYYY-MM-DD HH:MM:SS" in local time (written by
+    # delegation_live_log with time.strftime).
+    try:
+        return time.mktime(time.strptime(value.strip(), "%Y-%m-%d %H:%M:%S"))
+    except (ValueError, OverflowError):
+        return 0.0
+
+
+def _query_state_db(state_db: Path, *, now: float) -> dict[str, Any]:
+    """Read child sessions, usage tallies, and delegation states, read-only."""
+    result: dict[str, Any] = {"children": [], "delegation_states": {}, "parent_models": {}}
+    try:
+        connection = sqlite3.connect(
+            f"file:{state_db}?mode=ro", uri=True, timeout=0.25
+        )
+    except sqlite3.Error:
+        return result
+    try:
+        cursor = connection.execute(
+            """
+            SELECT id, model, model_config, started_at
+            FROM sessions
+            WHERE model_config LIKE '%_delegate_from%' AND started_at >= ?
+            ORDER BY started_at DESC LIMIT 32
+            """,
+            (now - _SESSION_WINDOW_SECONDS,),
+        )
+        rows = cursor.fetchall()
+        parents_needed: set[str] = set()
+        children: list[dict[str, Any]] = []
+        for session_id, model, model_config, started_at in rows:
+            config: dict[str, Any] = {}
+            try:
+                parsed = json.loads(model_config or "{}")
+                if isinstance(parsed, dict):
+                    config = parsed
+            except (ValueError, TypeError):
+                config = {}
+            parent_id = _text(config.get("_delegate_from", ""))
+            if not parent_id:
+                continue
+            reasoning = config.get("reasoning_config", {})
+            effort = ""
+            if isinstance(reasoning, dict) and reasoning.get("enabled"):
+                effort = _text(reasoning.get("effort", ""), limit=40)
+            parents_needed.add(parent_id)
+            children.append(
+                {
+                    "session_id": _text(session_id),
+                    "parent_id": parent_id,
+                    "model": _text(model),
+                    "effort": effort,
+                    "started_at": _finite(started_at) or 0.0,
+                }
+            )
+        result["children"] = children
+
+        for parent_id in parents_needed:
+            cursor = connection.execute(
+                "SELECT model FROM sessions WHERE id = ?", (parent_id,)
+            )
+            row = cursor.fetchone()
+            if row:
+                result["parent_models"][parent_id] = _text(row[0])
+
+        if children:
+            placeholders = ",".join("?" for _ in children)
+            cursor = connection.execute(
+                f"""
+                SELECT session_id, SUM(api_call_count), SUM(input_tokens),
+                       SUM(output_tokens), SUM(cache_read_tokens),
+                       SUM(actual_cost_usd), SUM(estimated_cost_usd),
+                       MIN(first_seen), MAX(last_seen)
+                FROM session_model_usage
+                WHERE session_id IN ({placeholders})
+                GROUP BY session_id
+                """,
+                tuple(child["session_id"] for child in children),
+            )
+            usage: dict[str, dict[str, Any]] = {}
+            for row in cursor.fetchall():
+                usage[str(row[0])] = {
+                    "api_calls": _finite(row[1]),
+                    "input_tokens": _finite(row[2]),
+                    "output_tokens": _finite(row[3]),
+                    "cache_read_tokens": _finite(row[4]),
+                    "actual_cost_usd": _finite(row[5]),
+                    "estimated_cost_usd": _finite(row[6]),
+                    "first_seen": _finite(row[7]),
+                    "last_seen": _finite(row[8]),
+                }
+            for child in children:
+                child["usage"] = usage.get(child["session_id"], {})
+
+        cursor = connection.execute(
+            "SELECT delegation_id, state FROM async_delegations WHERE dispatched_at >= ?",
+            (now - _SESSION_WINDOW_SECONDS,),
+        )
+        result["delegation_states"] = {
+            str(row[0]): _text(row[1], limit=40) for row in cursor.fetchall()
+        }
+    except sqlite3.Error:
+        # A schema Hermes has since changed, a lock we lost the race for: the
+        # partial result still distinguishes "observed nothing" from success.
+        pass
+    finally:
+        try:
+            connection.close()
+        except sqlite3.Error:
+            pass
+    return result
+
+
+def _iso_utc(epoch: float) -> str:
+    try:
+        return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch))
+    except (ValueError, OverflowError, OSError):
+        return ""
+
+
+def read_hermes_native_subagents(
+    hermes_home: str | Path | None = None,
+    *,
+    now: float | None = None,
+    limit: int = _ROW_LIMIT,
+) -> dict[str, Any]:
+    """Project live Hermes-native delegation children into HUD activity rows."""
+    current = float(now) if now is not None else time.time()
+    home = Path(hermes_home).expanduser() if hermes_home else Path.home() / ".hermes"
+    payload: dict[str, Any] = {
+        "status": "idle",
+        "rows": [],
+        "active": 0,
+        "running": 0,
+        "blocked": 0,
+        "completed": 0,
+    }
+    state = _query_state_db(home / "state.db", now=current)
+    children = state.get("children", [])
+    if not children:
+        return payload
+    manifests = _read_manifests(home / "cache" / "delegation" / "live", now=current)
+
+    # Children of one manifest, oldest-first, pair with the manifest's tasks
+    # by dispatch order; the pairing is best-effort context (goal text and
+    # log mtime), never row identity — the child session id is the identity.
+    matched_tasks: dict[str, dict[str, Any]] = {}
+    matched_delegations: dict[str, str] = {}
+    for manifest in manifests:
+        window_children = sorted(
+            (
+                child
+                for child in children
+                if child["started_at"] >= manifest["started"] - 5
+                and (
+                    child["session_id"] not in matched_delegations
+                )
+            ),
+            key=lambda child: child["started_at"],
+        )[: len(manifest["tasks"])]
+        for task, child in zip(manifest["tasks"], window_children):
+            matched_tasks[child["session_id"]] = task
+            matched_delegations[child["session_id"]] = manifest["delegation_id"]
+
+    rows: list[dict[str, Any]] = []
+    running = 0
+    blocked = 0
+    completed = 0
+    for child in sorted(children, key=lambda item: item["started_at"], reverse=True):
+        usage = child.get("usage", {})
+        task = matched_tasks.get(child["session_id"], {})
+        delegation_id = matched_delegations.get(child["session_id"], "")
+        delegation_state = state.get("delegation_states", {}).get(delegation_id, "")
+        last_activity = max(
+            child["started_at"],
+            usage.get("last_seen") or 0.0,
+            task.get("log_mtime") or 0.0,
+        )
+        age = current - last_activity
+        if age > COMPLETED_LINGER_SECONDS:
+            continue
+        if delegation_state in {"completed", "failed", "cancelled"}:
+            row_state = "failed" if delegation_state == "failed" else "done"
+        elif age <= RECENT_ACTIVITY_SECONDS:
+            row_state = "running"
+        else:
+            row_state = "done"
+
+        input_tokens = usage.get("input_tokens") or 0.0
+        output_tokens = usage.get("output_tokens") or 0.0
+        cache_read = usage.get("cache_read_tokens") or 0.0
+        tokens_total = int(input_tokens + output_tokens)
+        first_seen = usage.get("first_seen")
+        last_seen = usage.get("last_seen")
+        tokens_per_second = None
+        if output_tokens and first_seen and last_seen and last_seen > first_seen:
+            tokens_per_second = output_tokens / (last_seen - first_seen)
+        cache_hit = None
+        if cache_read and (cache_read + input_tokens) > 0:
+            cache_hit = round(100.0 * cache_read / (cache_read + input_tokens), 1)
+        cost = usage.get("actual_cost_usd") or usage.get("estimated_cost_usd")
+
+        parent_model = state.get("parent_models", {}).get(child["parent_id"], "")
+        session_tail = child["session_id"].rsplit("_", 1)[-1][:8]
+        row: dict[str, Any] = {
+            "state": row_state,
+            "task_id": session_tail,
+            "role": "hermes-native",
+            "action": _text(task.get("goal", ""), limit=_ACTION_LIMIT),
+            "model": child["model"],
+            "effort": child["effort"],
+            "tokens": tokens_total if tokens_total else None,
+            "elapsed_seconds": max(0.0, current - child["started_at"]),
+            "observed_at": _iso_utc(last_activity),
+            "category": mixture_category_for(
+                child["model"], child["effort"], parent_model=parent_model
+            ),
+            "delegation_id": delegation_id,
+        }
+        api_calls = usage.get("api_calls")
+        if api_calls is not None:
+            row["turn_count"] = int(api_calls)
+        if cost is not None:
+            row["cost_usd"] = cost
+        if tokens_per_second is not None:
+            row["tokens_per_second"] = tokens_per_second
+        if cache_hit is not None:
+            row["cache_hit_percentage"] = cache_hit
+        rows.append(row)
+        if row_state == "running":
+            running += 1
+        elif row_state == "failed":
+            blocked += 1
+        elif row_state == "done":
+            completed += 1
+
+    rows = rows[: max(1, int(limit))]
+    payload["rows"] = rows
+    payload["running"] = running
+    payload["blocked"] = blocked
+    payload["completed"] = completed
+    payload["active"] = running + blocked
+    payload["status"] = "observed" if rows else "idle"
+    return payload

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -10,6 +10,7 @@ from functools import partial
 from pathlib import Path
 from typing import Any, Callable
 
+from .hermes_delegation import read_hermes_native_subagents
 from .metadata import (
     OPTIONAL_HOOKS,
     PROVIDED_HOOKS,
@@ -649,9 +650,23 @@ def read_omh_hud(
         "status": "observed" if payload["subagents"]["maestro_rows"] else "idle",
         "rows": payload["subagents"].pop("maestro_rows"),
     }
+    # Hermes-native delegate_task children are work the HUD must show even
+    # though they never touch the OMH runtime store; see hermes_delegation.
+    native = read_hermes_native_subagents(hermes)
+    if native["rows"]:
+        merged = payload["subagents"]
+        merged["rows"] = (list(merged["rows"]) + list(native["rows"]))[:5]
+        merged["active"] = int(merged.get("active", 0)) + int(native["active"])
+        merged["running"] = int(merged.get("running", 0)) + int(native["running"])
+        merged["blocked"] = int(merged.get("blocked", 0)) + int(native["blocked"])
+        merged["completed"] = int(merged.get("completed", 0)) + int(native["completed"])
+        if merged.get("status") == "idle":
+            merged["status"] = "observed"
     payload["active"] = bool(
         payload["runtime"]["workflow"] != "idle"
         or payload["subagents"]["active"]
+        # Lingering just-finished native rows keep the activity block visible.
+        or payload["subagents"]["rows"]
         or payload["maestro"]["rows"]
     )
     payload["display"] = {

--- a/tests/test_plugin_hermes_delegation.py
+++ b/tests/test_plugin_hermes_delegation.py
@@ -1,0 +1,336 @@
+"""Contracts for the Hermes-native delegation observation feeding the HUD.
+
+The reader joins three Hermes-owned surfaces (`state.db` sessions +
+`session_model_usage`, `async_delegations`, and the live transcript manifests)
+into HUD activity rows. These tests build a throwaway `$HERMES_HOME` with the
+same shapes Hermes v0.20.x writes and pin the projection: identity, model and
+effort, mixture-category attribution (including the deliberate ``inherit``
+label), liveness windows, and the read_omh_hud merge.
+"""
+
+import json
+import sqlite3
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from omh.plugin_bundle.omh.hermes_delegation import (
+    COMPLETED_LINGER_SECONDS,
+    HERMES_MIXTURE_CATEGORY_CHAINS,
+    RECENT_ACTIVITY_SECONDS,
+    mixture_category_for,
+    read_hermes_native_subagents,
+)
+
+NOW = 1_800_000_000.0
+PARENT_ID = "20260818_100000_parent"
+
+
+def _build_state_db(
+    home: Path,
+    children: list[dict],
+    *,
+    delegation_states: dict[str, str] | None = None,
+) -> None:
+    connection = sqlite3.connect(home / "state.db")
+    connection.executescript(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY, model TEXT, model_config TEXT,
+            started_at REAL NOT NULL
+        );
+        CREATE TABLE session_model_usage (
+            session_id TEXT NOT NULL, model TEXT NOT NULL,
+            api_call_count INTEGER NOT NULL DEFAULT 0,
+            input_tokens INTEGER NOT NULL DEFAULT 0,
+            output_tokens INTEGER NOT NULL DEFAULT 0,
+            cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+            actual_cost_usd REAL NOT NULL DEFAULT 0,
+            estimated_cost_usd REAL NOT NULL DEFAULT 0,
+            first_seen REAL, last_seen REAL
+        );
+        CREATE TABLE async_delegations (
+            delegation_id TEXT PRIMARY KEY, state TEXT NOT NULL,
+            dispatched_at REAL NOT NULL
+        );
+        """
+    )
+    connection.execute(
+        "INSERT INTO sessions VALUES (?, ?, ?, ?)",
+        (PARENT_ID, "gpt-5.6-sol", "", NOW - 4000),
+    )
+    for child in children:
+        config = {
+            "_delegate_from": PARENT_ID,
+            "reasoning_config": {"enabled": True, "effort": child.get("effort", "medium")},
+        }
+        connection.execute(
+            "INSERT INTO sessions VALUES (?, ?, ?, ?)",
+            (child["id"], child["model"], json.dumps(config), child["started_at"]),
+        )
+        usage = child.get("usage")
+        if usage:
+            connection.execute(
+                "INSERT INTO session_model_usage VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    child["id"],
+                    child["model"],
+                    usage.get("api_calls", 0),
+                    usage.get("input_tokens", 0),
+                    usage.get("output_tokens", 0),
+                    usage.get("cache_read_tokens", 0),
+                    usage.get("actual_cost_usd", 0.0),
+                    usage.get("estimated_cost_usd", 0.0),
+                    usage.get("first_seen"),
+                    usage.get("last_seen"),
+                ),
+            )
+    for delegation_id, state in (delegation_states or {}).items():
+        connection.execute(
+            "INSERT INTO async_delegations VALUES (?, ?, ?)",
+            (delegation_id, state, NOW - 600),
+        )
+    connection.commit()
+    connection.close()
+
+
+def _write_manifest(
+    home: Path, delegation_id: str, goals: list[str], *, started: float, log_mtime: float
+) -> None:
+    directory = home / "cache" / "delegation" / "live" / delegation_id
+    directory.mkdir(parents=True)
+    tasks = []
+    for index, goal in enumerate(goals):
+        log_path = directory / f"task-{index}.log"
+        log_path.write_text("header\n", encoding="utf-8")
+        import os
+
+        os.utime(log_path, (log_mtime, log_mtime))
+        tasks.append({"index": index, "goal": goal, "log": str(log_path), "status": "running"})
+    manifest = {
+        "delegation_id": delegation_id,
+        "started": time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(started)),
+        "task_count": len(tasks),
+        "tasks": tasks,
+    }
+    (directory / "manifest.json").write_text(
+        json.dumps(manifest, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+class MixtureCategoryProjectionTest(unittest.TestCase):
+    def test_a_child_on_the_parent_model_is_labeled_inherit(self):
+        self.assertEqual(
+            mixture_category_for("gpt-5.6-sol", "medium", parent_model="gpt-5.6-sol"),
+            "inherit",
+        )
+
+    def test_a_routed_ultrabrain_child_is_labeled_ultrabrain(self):
+        self.assertEqual(
+            mixture_category_for("gpt-5.6-sol", "xhigh", parent_model="kimi-k3"),
+            "ultrabrain",
+        )
+
+    def test_an_effort_mismatch_with_the_chain_entry_yields_no_category(self):
+        # gpt-5.6-sol appears only as the ultrabrain head, which declares
+        # xhigh; a medium run on a different parent matches nothing and must
+        # not be dressed up as a routed ultrabrain dispatch.
+        self.assertEqual(
+            mixture_category_for("gpt-5.6-sol", "medium", parent_model="kimi-k3"), ""
+        )
+
+    def test_head_match_beats_membership_match(self):
+        # glm-5.2-ultrafast heads `quick` and is also second in
+        # unspecified-low; the head attribution wins.
+        self.assertEqual(
+            mixture_category_for("glm-5.2-ultrafast", "", parent_model="kimi-k3"),
+            "quick",
+        )
+
+    def test_a_membership_only_model_falls_back_to_its_first_chain(self):
+        self.assertEqual(
+            mixture_category_for("claude-opus-5", "", parent_model="kimi-k3"),
+            "unspecified-high",
+        )
+
+    def test_the_embedded_chains_mirror_the_shipped_recommendation_catalog(self):
+        from omh.coding.model_recommendations import SHIPPED_MODEL_RECOMMENDATIONS
+        from omh.coding.model_routing import MODEL_CATEGORIES
+
+        shipped = {
+            category: tuple(
+                (str(entry["model_alias"]), str(entry.get("reasoning_effort", "")))
+                for entry in chain
+            )
+            for category, chain in SHIPPED_MODEL_RECOMMENDATIONS["categories"].items()
+        }
+        self.assertEqual(HERMES_MIXTURE_CATEGORY_CHAINS, shipped)
+        # Attribution order is the canonical category order; a reordered dict
+        # would silently change which chain claims a shared model.
+        self.assertEqual(tuple(HERMES_MIXTURE_CATEGORY_CHAINS), MODEL_CATEGORIES)
+
+
+class HermesNativeSubagentReaderTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.home = Path(self._tmp.name)
+
+    def test_a_missing_hermes_home_reads_as_idle(self):
+        payload = read_hermes_native_subagents(self.home / "absent", now=NOW)
+        self.assertEqual(payload["status"], "idle")
+        self.assertEqual(payload["rows"], [])
+        self.assertEqual(payload["active"], 0)
+
+    def test_a_live_child_projects_a_running_row_with_model_effort_and_metrics(self):
+        _build_state_db(
+            self.home,
+            [
+                {
+                    "id": "20260818_100100_aaaa11",
+                    "model": "gpt-5.6-sol",
+                    "effort": "medium",
+                    "started_at": NOW - 300,
+                    "usage": {
+                        "api_calls": 7,
+                        "input_tokens": 10_000,
+                        "output_tokens": 4_000,
+                        "cache_read_tokens": 30_000,
+                        "first_seen": NOW - 290,
+                        "last_seen": NOW - 10,
+                    },
+                }
+            ],
+        )
+        _write_manifest(
+            self.home,
+            "deleg_test1",
+            ["구현 lane"],
+            started=NOW - 305,
+            log_mtime=NOW - 5,
+        )
+        payload = read_hermes_native_subagents(self.home, now=NOW)
+        self.assertEqual(payload["status"], "observed")
+        self.assertEqual(payload["running"], 1)
+        row = payload["rows"][0]
+        self.assertEqual(row["state"], "running")
+        self.assertEqual(row["task_id"], "aaaa11")
+        self.assertEqual(row["role"], "hermes-native")
+        self.assertEqual(row["action"], "구현 lane")
+        self.assertEqual(row["model"], "gpt-5.6-sol")
+        self.assertEqual(row["effort"], "medium")
+        self.assertEqual(row["category"], "inherit")
+        self.assertEqual(row["tokens"], 14_000)
+        self.assertEqual(row["turn_count"], 7)
+        self.assertEqual(row["delegation_id"], "deleg_test1")
+        self.assertAlmostEqual(row["cache_hit_percentage"], 75.0)
+        self.assertAlmostEqual(row["tokens_per_second"], 4000 / 280)
+
+    def test_a_quiet_child_reads_done_and_expires_after_the_linger_window(self):
+        quiet_age = RECENT_ACTIVITY_SECONDS + 60
+        _build_state_db(
+            self.home,
+            [
+                {
+                    "id": "20260818_100100_bbbb22",
+                    "model": "gpt-5.6-sol",
+                    "started_at": NOW - quiet_age,
+                    "usage": {"last_seen": NOW - quiet_age, "output_tokens": 5},
+                }
+            ],
+        )
+        payload = read_hermes_native_subagents(self.home, now=NOW)
+        self.assertEqual(payload["rows"][0]["state"], "done")
+        self.assertEqual(payload["completed"], 1)
+        self.assertEqual(payload["active"], 0)
+
+        expired = read_hermes_native_subagents(
+            self.home, now=NOW + COMPLETED_LINGER_SECONDS + 1
+        )
+        self.assertEqual(expired["rows"], [])
+        self.assertEqual(expired["status"], "idle")
+
+    def test_a_completed_delegation_marks_its_child_done_even_while_recent(self):
+        _build_state_db(
+            self.home,
+            [
+                {
+                    "id": "20260818_100100_cccc33",
+                    "model": "gpt-5.6-sol",
+                    "started_at": NOW - 60,
+                    "usage": {"last_seen": NOW - 5, "output_tokens": 10},
+                }
+            ],
+            delegation_states={"deleg_done1": "completed"},
+        )
+        _write_manifest(
+            self.home, "deleg_done1", ["끝난 lane"], started=NOW - 65, log_mtime=NOW - 5
+        )
+        payload = read_hermes_native_subagents(self.home, now=NOW)
+        self.assertEqual(payload["rows"][0]["state"], "done")
+        self.assertEqual(payload["completed"], 1)
+
+    def test_a_failed_delegation_projects_a_failed_row_counted_as_blocked(self):
+        _build_state_db(
+            self.home,
+            [
+                {
+                    "id": "20260818_100100_dddd44",
+                    "model": "gpt-5.6-sol",
+                    "started_at": NOW - 60,
+                    "usage": {"last_seen": NOW - 5, "output_tokens": 10},
+                }
+            ],
+            delegation_states={"deleg_fail1": "failed"},
+        )
+        _write_manifest(
+            self.home, "deleg_fail1", ["실패 lane"], started=NOW - 65, log_mtime=NOW - 5
+        )
+        payload = read_hermes_native_subagents(self.home, now=NOW)
+        self.assertEqual(payload["rows"][0]["state"], "failed")
+        self.assertEqual(payload["blocked"], 1)
+        self.assertEqual(payload["active"], 1)
+
+
+class HudMergeTest(unittest.TestCase):
+    def test_read_omh_hud_merges_native_rows_and_stays_active_while_they_linger(self):
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / "omh"
+            hermes_home = root / "hermes"
+            omh_home.mkdir()
+            hermes_home.mkdir()
+            _build_state_db(
+                hermes_home,
+                [
+                    {
+                        "id": "20260818_100100_eeee55",
+                        "model": "gpt-5.6-terra",
+                        "effort": "high",
+                        "started_at": time.time() - 30,
+                        "usage": {
+                            "api_calls": 2,
+                            "input_tokens": 100,
+                            "output_tokens": 50,
+                            "first_seen": time.time() - 25,
+                            "last_seen": time.time() - 1,
+                        },
+                    }
+                ],
+            )
+            payload = read_omh_hud(omh_home, hermes_home)
+            self.assertTrue(payload["active"])
+            self.assertEqual(payload["subagents"]["running"], 1)
+            rows = payload["subagents"]["rows"]
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]["role"], "hermes-native")
+            # gpt-5.6-terra:high is the deep chain head and differs from the
+            # parent model, so the routed category is visible in the HUD row.
+            self.assertEqual(rows[0]["category"], "deep")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -299,6 +299,11 @@ class TuiWidgetPackTests(unittest.TestCase):
         self.assertIn("` v${version}`", widget)
         self.assertIn("hudStateLabel(active, agents)", widget)
         self.assertIn("if (!active) return 'ready'", widget)
+        # Hermes-native delegation rows linger after finishing: a done row
+        # carries a check mark instead of spinning forever, and a linger-only
+        # block says "N done" rather than the dishonest "0 agents".
+        self.assertIn("done ? '✓'", widget)
+        self.assertIn("if (!running && !blocked && done) return `${done} done`", widget)
         # (bracket-tag grammar asserted above replaces the BRAND_MARK pair)
         # The old header's literal pieces ("-", "Oh My Hermes", "Ultra Work",
         # "Ready") are gone on purpose; asserting them back would re-pin the


### PR DESCRIPTION
## Capability

The `[OMH]` dock now shows Hermes-native `delegate_task` subagents in real time — one line per child under the composer: id, goal, `model:effort`, mixture category, tokens, tok/s, cache%, cost, elapsed, state. Finished children linger 15 minutes as `✓ … done` rows and the header reads "N done" instead of "0 agents".

## Motivation

A ralplan/ulw-work wave spawns Hermes-native children (`sa-*`/`deleg_*`), but the HUD only read OMH's own runtime store, so the dock said `0 agents • $0.000 • ctx --` while three subagents were working, and the assistant narrated "추론 강도: unknown" even though Hermes records the child's reasoning effort. The owner reported both live from a running session.

## Implementation (boundary level)

- New `plugin_bundle/omh/hermes_delegation.py`: read-only join of the surfaces Hermes already writes — `state.db` child sessions (`model`, `reasoning_config.effort`, `_delegate_from`), `session_model_usage` (tokens/cache/cost/first-last seen), `async_delegations` lifecycle, and `cache/delegation/live/*/manifest.json` + task-log mtimes (goal text, liveness). Every read degrades to an idle segment; SQLite is opened `mode=ro`.
- Category label is an explicit projection from the shipped mixture chains (dict-parity test against `SHIPPED_MODEL_RECOMMENDATIONS`); a child on the parent session's own model is labeled `inherit` so an unrouted wave is visible as unrouted.
- `read_omh_hud` merges the native rows into the existing `subagents` projection; the widget reuses the existing `ActivityRow` renderer, plus a `✓` marker for done rows and an honest "N done" header label.

OMH still never patches Hermes, makes no network calls, and writes nothing.

## Observed verification

- 12 new tests (`tests/test_plugin_hermes_delegation.py`) + widget-frame contract additions; adjacent suites (`test_tui_widget_pack`, `test_hud`, `test_runtime_reader_filesystem_faults`, `test_plugin_capabilities`) green in a clean worktree.
- Live render observed against a real `~/.hermes` mid-delegation: reader returned the two running review lanes + one lingering done row with model `gpt-5.6-sol`, effort `medium`, category `inherit`, tokens/tok/s/cache% populated — matching the session the owner screenshotted.
- Full suite running in a clean worktree; result will be posted before merge.

## Risks

- Liveness windows (150s recent, 15m linger) are heuristics over log mtime and usage recency; a child idling longer than 150s between events briefly reads "done", then returns to "running" on its next event.
- The category label is attribution, not an observed routing record — documented in-module, and `inherit` deliberately outranks chain matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)