### PR TITLE
fix(hud): stop repainting the docks when nothing changed so drag-copy works

### DIFF
--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -219,14 +219,7 @@ export default function register(sdk) {
     )
   }
 
-  function LiveActivity({ columns, mainRows, rows, t, tick }) {
-    // Mounted only while live rows exist. The SDK shimmer clock is bounded —
-    // it stops advancing animateMs after MOUNT — so the old top-level
-    // useShimmerPhase(30_000) froze thirty seconds into a session and the
-    // spinner then jumped once per poll. A fresh mount per activity burst
-    // restarts the window, and thirty minutes bounds the render cost of one
-    // very long wave; the poll tick still nudges frames past that.
-    const frame = useShimmerPhase(1_800_000) + tick
+  function ActivityRows({ columns, frame, mainRows, rows, t }) {
     return h(
       Box,
       { flexDirection: 'column', width: '100%' },
@@ -250,6 +243,19 @@ export default function register(sdk) {
         })
       ),
     )
+  }
+
+  function AnimatedActivity({ columns, mainRows, rows, t, tick }) {
+    // Mounted only while a RUNNING row needs the spinner. The SDK shimmer
+    // clock is bounded — it stops advancing animateMs after MOUNT — so the
+    // old top-level useShimmerPhase(30_000) froze thirty seconds into a
+    // session and the spinner then jumped once per poll. A fresh mount per
+    // activity burst restarts the window, and thirty minutes bounds the
+    // render cost of one very long wave. Done/blocked-only states render the
+    // static ActivityRows instead: no shimmer subscription, no repaints, so
+    // a lingering finished wave stays drag-copyable.
+    const frame = useShimmerPhase(1_800_000) + tick
+    return h(ActivityRows, { columns, frame, mainRows, rows, t })
   }
 
   function Hud({ columns, state, t, viewportRows }) {
@@ -286,7 +292,9 @@ export default function register(sdk) {
         h(Text, { color: t.color.muted }, ` • ${metrics.cost} • ${metrics.ctx}`),
       ),
       mainRows.length || rows.length
-        ? h(LiveActivity, { columns, mainRows, rows, t, tick: state.tick })
+        ? ([...mainRows, ...rows].some(row => !row.state || row.state === 'running')
+            ? h(AnimatedActivity, { columns, mainRows, rows, t, tick: state.tick })
+            : h(ActivityRows, { columns, frame: 0, mainRows, rows, t }))
         : null,
     )
   }
@@ -406,11 +414,19 @@ export default function register(sdk) {
 
   openWidget(app, app.init(''))
   openWidget(todoApp, todoApp.init(''))
+  // Render quiescence is what makes the docks drag-copyable: every repaint of
+  // these lines clears an in-progress terminal selection over them, so an
+  // unchanged snapshot must produce NO updateWidget call at all. The reader
+  // freezes per-row elapsed for finished subagents precisely so a lingering
+  // done state serializes identically poll after poll.
+  let lastSnapshot = ''
   const applySnapshot = payload => {
+    if (!payload) return
+    const serialized = JSON.stringify(payload)
+    if (serialized === lastSnapshot) return
+    lastSnapshot = serialized
     for (const target of [app, todoApp]) {
-      updateWidget(target, state =>
-        payload ? { ...state, payload, tick: state.tick + 1 } : state
-      )
+      updateWidget(target, state => ({ ...state, payload, tick: state.tick + 1 }))
     }
   }
   const timerKey = Symbol.for('omh.hermes-tui-widget.refresh')

--- a/src/plugin_bundle/omh/hermes_delegation.py
+++ b/src/plugin_bundle/omh/hermes_delegation.py
@@ -361,6 +361,10 @@ def read_hermes_native_subagents(
 
         parent_model = state.get("parent_models", {}).get(child["parent_id"], "")
         session_tail = child["session_id"].rsplit("_", 1)[-1][:8]
+        # A finished child's elapsed is frozen at its last activity: a done
+        # task should not keep aging, and a byte-stable lingering row is what
+        # lets the widget skip repaints so the dock stays drag-copyable.
+        elapsed_until = last_activity if row_state != "running" else current
         row: dict[str, Any] = {
             "state": row_state,
             "task_id": session_tail,
@@ -369,7 +373,7 @@ def read_hermes_native_subagents(
             "model": child["model"],
             "effort": child["effort"],
             "tokens": tokens_total if tokens_total else None,
-            "elapsed_seconds": max(0.0, current - child["started_at"]),
+            "elapsed_seconds": max(0.0, elapsed_until - child["started_at"]),
             "observed_at": _iso_utc(last_activity),
             "category": mixture_category_for(
                 child["model"], child["effort"], parent_model=parent_model

--- a/tests/test_plugin_hermes_delegation.py
+++ b/tests/test_plugin_hermes_delegation.py
@@ -251,6 +251,27 @@ class HermesNativeSubagentReaderTest(unittest.TestCase):
         self.assertEqual(expired["rows"], [])
         self.assertEqual(expired["status"], "idle")
 
+    def test_a_finished_row_is_byte_stable_across_polls(self):
+        # The widget skips repaints when a snapshot serializes identically,
+        # which is what keeps the dock drag-copyable while a done row lingers
+        # — so a finished child's row must not vary with the reader's clock.
+        quiet_age = RECENT_ACTIVITY_SECONDS + 60
+        _build_state_db(
+            self.home,
+            [
+                {
+                    "id": "20260818_100100_ffff66",
+                    "model": "gpt-5.6-sol",
+                    "started_at": NOW - quiet_age,
+                    "usage": {"last_seen": NOW - quiet_age, "output_tokens": 5},
+                }
+            ],
+        )
+        first = read_hermes_native_subagents(self.home, now=NOW)
+        second = read_hermes_native_subagents(self.home, now=NOW + 30)
+        self.assertEqual(first["rows"][0]["state"], "done")
+        self.assertEqual(first["rows"], second["rows"])
+
     def test_a_completed_delegation_marks_its_child_done_even_while_recent(self):
         _build_state_db(
             self.home,

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -308,6 +308,12 @@ class TuiWidgetPackTests(unittest.TestCase):
         # above its checklist and the phase count next to done/total.
         self.assertIn("safeText(todo.display_phase)", widget)
         self.assertIn("` · ${phaseCount} phases`", widget)
+        # Drag-copy contract: an unchanged snapshot must not repaint the docks
+        # (repaints clear an in-progress terminal selection), and the shimmer
+        # subscription mounts only while a running row needs the spinner.
+        self.assertIn("if (serialized === lastSnapshot) return", widget)
+        self.assertIn("AnimatedActivity", widget)
+        self.assertIn("h(ActivityRows, { columns, frame: 0", widget)
         # (bracket-tag grammar asserted above replaces the BRAND_MARK pair)
         # The old header's literal pieces ("-", "Oh My Hermes", "Ultra Work",
         # "Ready") are gone on purpose; asserting them back would re-pin the


### PR DESCRIPTION
## Capability

The `[OMH]` docks under/over the composer are drag-copyable like the rest of the TUI: an unchanged snapshot no longer repaints them, so terminal selection over those lines survives.

## Motivation

The owner reported the bottom `[OMH]` area could not be drag-copied while every other region could. Cause: the widget called `updateWidget` on every 2-second poll regardless of change — each repaint of those exact lines clears an in-progress selection — and the shimmer subscription kept repainting at animation rate while rows lingered. (A first diagnosis blamed DEC mouse tracking and toggled `display.mouse_tracking`; that was wrong — other regions copied fine, so capture was never the difference — and it was reverted on the owner's machine.)

## Implementation (boundary level)

- `applySnapshot` skips byte-identical snapshots entirely (no `updateWidget`, no repaint).
- The shimmer-driven activity component mounts only while a RUNNING row needs the spinner; done/blocked-only states render static rows with no clock subscription.
- The delegation reader freezes a finished child's `elapsed_seconds` at its last activity so a lingering done row serializes identically poll after poll (a done task also stops visually aging).

Live rows still animate — quiescence applies exactly when the payload is unchanged, which running rows never are.

## Observed verification

- New reader contract: a finished row is byte-stable across polls with different clocks; widget-frame contract pins the snapshot skip and the animated/static split.
- Affected suites green (single failure = the known stale-worktree environmental case, green in a clean worktree); node module-load of the widget; ruff; compileall. Full suite running in a clean worktree — result posted before merge.

## Risks

- Any future now()-derived field on a finished row would reintroduce the 2s repaint (recorded as a Directive in the commit).
- Live drag-copy on the owner's terminal is verified after the TUI restart that also activates the routing tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)