### PR TITLE
feat(skin): dark-palette diff underlays for the identity skin

### DIFF
--- a/src/omh/skins/omh.yaml
+++ b/src/omh/skins/omh.yaml
@@ -48,6 +48,17 @@ colors:
   syntax_number: "#E4FAFF"
   syntax_keyword: "#7FDBFF"
   syntax_comment: "#3E7C8A"
+  # Diff line underlays. The engine defaults are light pastels tuned for
+  # light terminals; on this dark identity palette they render as harsh
+  # full-brightness bands behind the text (owner report, 2026-08-18). These
+  # stay in the dark palette's register: deep low-chroma red/green
+  # backgrounds with soft matching foregrounds, so add/delete reads as a
+  # subtle tinted band instead of a highlighter stripe. Full-row (not
+  # text-width) fill is renderer-owned; asked upstream in hermes-agent.
+  diff_removed: "#3A2027"
+  diff_removed_word: "#FF8A96"
+  diff_added: "#12362D"
+  diff_added_word: "#6FE0B8"
 
 spinner:
   waiting_faces:

--- a/tests/test_skin_pack.py
+++ b/tests/test_skin_pack.py
@@ -34,6 +34,12 @@ class SkinPayloadTests(unittest.TestCase):
         self.assertIn("banner_logo:", text)
         # The palette anchors on the README badge turquoise.
         self.assertIn('"#00CED1"', text)
+        # Diff underlays are dark-palette overrides: the engine's light-pastel
+        # defaults render as harsh full-brightness bands on a dark terminal.
+        self.assertIn('diff_removed: "#3A2027"', text)
+        self.assertIn('diff_added: "#12362D"', text)
+        self.assertIn("diff_removed_word:", text)
+        self.assertIn("diff_added_word:", text)
 
     def test_the_logo_rows_are_equally_wide(self) -> None:
         # A block logo with ragged rows renders as visible corruption in the


### PR DESCRIPTION
## Capability

Diff add/delete lines in the TUI now render as subtle dark tinted bands under the omh identity skin instead of harsh full-brightness pastel stripes.

## Motivation

The engine's diff background defaults (`#dcffdc`/`#ffdcdc`) are light-terminal pastels; on the dark identity palette they read as highlighter bands (owner screenshot). The skin schema already exposes `diff_added`/`diff_removed`(+`_word`) — the identity skin now overrides them with deep low-chroma red/green (`#3A2027`/`#12362D`) and soft matching foregrounds.

## Boundary

Color is skin-owned; **fill geometry is renderer-owned** — the TUI paints backgrounds text-width, producing the ragged edge the owner sketched over. The full-row band is requested upstream: NousResearch/hermes-agent#88919. OMH patches nothing.

## Observed verification

- The edited skin loads through Hermes' own `skin_engine` with all four tokens resolving to the declared values (hermes venv).
- `tests/test_skin_pack.py` pins the dark diff tokens; skin-pack + release-smoke suites green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)