### PR TITLE
fix(tests): pin the phases count in the runtime-todo round trip

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13552,7 +13552,10 @@ class RuntimeTodoCliTests(unittest.TestCase):
             written = json.loads(stdout)
             self.assertEqual(written["status"], "written")
             self.assertEqual(written["todo"]["status"], "established")
-            self.assertEqual(written["todo"]["counts"], {"total": 3, "done": 1, "active": 1, "pending": 1})
+            self.assertEqual(
+                written["todo"]["counts"],
+                {"total": 3, "done": 1, "active": 1, "pending": 1, "phases": 0},
+            )
 
             status, stdout, _ = run_cli(base + ["show"])
             self.assertEqual(status, 0)


### PR DESCRIPTION
Main CI (test 3.11 + test-windows) fails on `test_runtime_todo_set_show_clear_round_trip`: #1003 added `counts.phases` to the todo projection and updated the `tests/test_hud.py` pins but missed this CLI round-trip pin. Reproduced locally on main; green after the pin update; repo-wide sweep found no other counts pin missing `phases`.

Process fix going forward: PRs merge only after their CI checks report green (this regression reached main because merges ran on local + clean-worktree suites without waiting for CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)