### PR TITLE
feat(routing): every mixture category carries a fixed default reasoning effort

### DIFF
--- a/src/coding/model_recommendations.py
+++ b/src/coding/model_recommendations.py
@@ -144,17 +144,34 @@ _QWEN = _candidate(
 # chains rather than gaining invented defaults. `main` is separate because it
 # is a Hermes setup slot, and `x_platform_data` is separate because it is a
 # domain affinity.
+def _with_effort(candidate: Mapping[str, object], effort: str) -> dict[str, object]:
+    return dict(deepcopy(dict(candidate)), reasoning_effort=effort)
+
+
+# Every category carries an explicit default reasoning effort (owner decision,
+# 2026-08-18): before this, only ultrabrain/deep declared one and every other
+# routed lane silently inherited the parent session's level — a wave looked
+# like "everything runs medium" no matter which category chose the model. The
+# category IS the model+effort pair; a per-lane override still wins.
 SHIPPED_MODEL_RECOMMENDATIONS: Final[dict[str, object]] = {
     "schema_version": MODEL_RECOMMENDATION_CATALOG_SCHEMA_VERSION,
     "categories": {
         "ultrabrain": [deepcopy(_SOL_XHIGH)],
         "deep": [deepcopy(_TERRA)],
-        "unspecified-high": [deepcopy(_KIMI_K3), deepcopy(_OPUS_5)],
-        "unspecified-low": [deepcopy(_GLM), deepcopy(_GLM_FAST)],
-        "quick": [deepcopy(_GLM_FAST), deepcopy(_KIMI_K3)],
-        "writing": [deepcopy(_KIMI_K3), deepcopy(_QWEN), deepcopy(_GEMINI)],
-        "visual-engineering": [deepcopy(_FABLE_5), deepcopy(_KIMI_K3)],
-        "artistry": [deepcopy(_GEMINI), deepcopy(_FABLE_5), deepcopy(_KIMI_K3)],
+        "unspecified-high": [_with_effort(_KIMI_K3, "medium"), _with_effort(_OPUS_5, "medium")],
+        "unspecified-low": [_with_effort(_GLM, "low"), _with_effort(_GLM_FAST, "low")],
+        "quick": [_with_effort(_GLM_FAST, "low"), _with_effort(_KIMI_K3, "low")],
+        "writing": [
+            _with_effort(_KIMI_K3, "medium"),
+            _with_effort(_QWEN, "medium"),
+            _with_effort(_GEMINI, "medium"),
+        ],
+        "visual-engineering": [_with_effort(_FABLE_5, "high"), _with_effort(_KIMI_K3, "high")],
+        "artistry": [
+            _with_effort(_GEMINI, "high"),
+            _with_effort(_FABLE_5, "high"),
+            _with_effort(_KIMI_K3, "high"),
+        ],
     },
     "role_suggestions": {
         "main": [

--- a/src/plugin_bundle/omh/hermes_delegation.py
+++ b/src/plugin_bundle/omh/hermes_delegation.py
@@ -38,12 +38,20 @@ from typing import Any
 HERMES_MIXTURE_CATEGORY_CHAINS: dict[str, tuple[tuple[str, str], ...]] = {
     "ultrabrain": (("gpt-5.6-sol", "xhigh"),),
     "deep": (("gpt-5.6-terra", "high"),),
-    "unspecified-high": (("kimi-k3", ""), ("claude-opus-5", "")),
-    "unspecified-low": (("glm-5.2", ""), ("glm-5.2-ultrafast", "")),
-    "quick": (("glm-5.2-ultrafast", ""), ("kimi-k3", "")),
-    "writing": (("kimi-k3", ""), ("qwen3-coder", ""), ("gemini-3.1-pro", "")),
-    "visual-engineering": (("claude-fable-5", ""), ("kimi-k3", "")),
-    "artistry": (("gemini-3.1-pro", ""), ("claude-fable-5", ""), ("kimi-k3", "")),
+    "unspecified-high": (("kimi-k3", "medium"), ("claude-opus-5", "medium")),
+    "unspecified-low": (("glm-5.2", "low"), ("glm-5.2-ultrafast", "low")),
+    "quick": (("glm-5.2-ultrafast", "low"), ("kimi-k3", "low")),
+    "writing": (
+        ("kimi-k3", "medium"),
+        ("qwen3-coder", "medium"),
+        ("gemini-3.1-pro", "medium"),
+    ),
+    "visual-engineering": (("claude-fable-5", "high"), ("kimi-k3", "high")),
+    "artistry": (
+        ("gemini-3.1-pro", "high"),
+        ("claude-fable-5", "high"),
+        ("kimi-k3", "high"),
+    ),
 }
 
 # A child is "running" while its newest observable signal (live transcript

--- a/tests/test_delegate_route_tool.py
+++ b/tests/test_delegate_route_tool.py
@@ -117,17 +117,25 @@ class DelegateRouteToolTest(unittest.TestCase):
             {"model": "gpt-5.6-sol", "reasoning_effort": "xhigh"},
         )
 
-    def test_a_chain_entry_without_declared_effort_leaves_effort_inherited(self):
+    def test_every_category_now_routes_an_explicit_effort(self):
+        # Owner decision: the category IS the model+effort pair. Before this,
+        # quick and friends declared no effort and every routed lane silently
+        # inherited the parent's level ("everything runs medium").
         result = self._call(action="set", category="quick")
-        self.assertEqual(result["applied"], {"model": "glm-5.2-ultrafast"})
-        self.assertEqual(read_delegation_route(self.home), {"model": "glm-5.2-ultrafast"})
+        self.assertEqual(
+            result["applied"], {"model": "glm-5.2-ultrafast", "reasoning_effort": "low"}
+        )
+        self.assertEqual(
+            read_delegation_route(self.home),
+            {"model": "glm-5.2-ultrafast", "reasoning_effort": "low"},
+        )
 
     def test_an_explicit_model_override_wins_over_the_chain_head(self):
         result = self._call(action="set", category="unspecified-high", model="claude-opus-5")
         self.assertEqual(result["applied"], {"model": "claude-opus-5"})
         self.assertEqual(
             result["fallback_candidates"],
-            [{"model": "claude-opus-5", "reasoning_effort": ""}],
+            [{"model": "claude-opus-5", "reasoning_effort": "medium"}],
         )
 
     def test_an_unknown_category_fails_with_the_valid_vocabulary(self):

--- a/tests/test_plugin_hermes_delegation.py
+++ b/tests/test_plugin_hermes_delegation.py
@@ -141,17 +141,26 @@ class MixtureCategoryProjectionTest(unittest.TestCase):
         )
 
     def test_head_match_beats_membership_match(self):
-        # glm-5.2-ultrafast heads `quick` and is also second in
+        # glm-5.2-ultrafast:low heads `quick` and is also second in
         # unspecified-low; the head attribution wins.
         self.assertEqual(
-            mixture_category_for("glm-5.2-ultrafast", "", parent_model="kimi-k3"),
+            mixture_category_for("glm-5.2-ultrafast", "low", parent_model="kimi-k3"),
             "quick",
         )
 
     def test_a_membership_only_model_falls_back_to_its_first_chain(self):
         self.assertEqual(
-            mixture_category_for("claude-opus-5", "", parent_model="kimi-k3"),
+            mixture_category_for("claude-opus-5", "medium", parent_model="kimi-k3"),
             "unspecified-high",
+        )
+
+    def test_an_effort_that_matches_no_chain_entry_is_not_attributed(self):
+        # Every category now declares its effort (owner decision), so a child
+        # whose effort matches no entry — e.g. an inherited medium on the
+        # quick chain's model — shows the bare model, not a routed category.
+        self.assertEqual(
+            mixture_category_for("glm-5.2-ultrafast", "medium", parent_model="kimi-k3"),
+            "",
         )
 
     def test_the_embedded_chains_mirror_the_shipped_recommendation_catalog(self):


### PR DESCRIPTION
## Capability

Each mixture category now routes a fixed model **and** reasoning effort — the category is the pair:

| category | route |
|---|---|
| ultrabrain | gpt-5.6-sol **xhigh** (unchanged) |
| deep | gpt-5.6-terra **high** (unchanged) |
| visual-engineering / artistry | claude-fable-5 / gemini-3.1-pro … **high** |
| writing / unspecified-high | kimi-k3 … **medium** |
| quick / unspecified-low | glm-5.2-ultrafast / glm-5.2 … **low** |

Per-lane `omh_delegate_route(reasoning_effort=…)` overrides still win.

## Motivation

Owner watched a fully routed wave and read it as "다 medium으로만 보내는 것 같아" — correct: only ultrabrain/deep declared efforts, so every other category silently inherited the parent session's medium (observed live: a visual-engineering lane ran claude-fable-5 at inherited medium while a deep lane correctly ran terra:high).

## Implementation (boundary level)

- `SHIPPED_MODEL_RECOMMENDATIONS`: every category candidate declares its effort (fallbacks carry the chain's effort).
- Plugin `HERMES_MIXTURE_CATEGORY_CHAINS` mirrored (dict-parity gate).
- HUD attribution stays strict: a child running an inherited effort on a chain's model shows the bare model, never a category it didn't actually get.

## Observed verification

Chain-dependent suites green (routing journey, maestro integration, coding delegation, recommendations, route tool, HUD attribution, cli, release-smoke, ux-quality — 436 tests); all five `docs --check` byte gates; ruff; compileall. Clean-worktree full suite + CI green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)