### PR TITLE
fix(tui): make the OMH docks drag-copyable during a running wave

### DIFF
--- a/src/maintenance/hermes_tui.py
+++ b/src/maintenance/hermes_tui.py
@@ -24,6 +24,10 @@ HERMES_TUI_PREFLIGHT_SCHEMA_VERSION = "omh_hermes_tui_preflight/v1"
 # The exact SDK names the installed widget destructures from ``register(sdk)``.
 # If Hermes drops or renames one, its loader skips the widget with only a log
 # line — this preflight is what turns that silent skip into a named finding.
+# ``useShimmerPhase`` left this list when the widget dropped its animation
+# subscription (shimmer repaints cleared terminal drag-selections over the
+# dock); requiring an SDK key the widget never touches would block installs
+# on hosts that render it fine.
 REQUIRED_WIDGET_SDK_KEYS = (
     "Box",
     "Text",
@@ -31,7 +35,6 @@ REQUIRED_WIDGET_SDK_KEYS = (
     "h",
     "openWidget",
     "updateWidget",
-    "useShimmerPhase",
 )
 
 # Reading caps: userWidgets.ts is ~8KB and config.yaml tens of KB today.

--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -1,7 +1,7 @@
 import { execFile } from 'node:child_process'
 
 export default function register(sdk) {
-  const { Box, Text, defineWidgetApp, h, openWidget, updateWidget, useShimmerPhase } = sdk
+  const { Box, Text, defineWidgetApp, h, openWidget, updateWidget } = sdk
   const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
   const HOME = process.env.OMH_HOME || `${process.env.HOME}/.omh`
   const HERMES_HOME = process.env.HERMES_HOME || `${process.env.HOME}/.hermes`
@@ -245,19 +245,6 @@ export default function register(sdk) {
     )
   }
 
-  function AnimatedActivity({ columns, mainRows, rows, t, tick }) {
-    // Mounted only while a RUNNING row needs the spinner. The SDK shimmer
-    // clock is bounded — it stops advancing animateMs after MOUNT — so the
-    // old top-level useShimmerPhase(30_000) froze thirty seconds into a
-    // session and the spinner then jumped once per poll. A fresh mount per
-    // activity burst restarts the window, and thirty minutes bounds the
-    // render cost of one very long wave. Done/blocked-only states render the
-    // static ActivityRows instead: no shimmer subscription, no repaints, so
-    // a lingering finished wave stays drag-copyable.
-    const frame = useShimmerPhase(1_800_000) + tick
-    return h(ActivityRows, { columns, frame, mainRows, rows, t })
-  }
-
   function Hud({ columns, state, t, viewportRows }) {
     const payload = state.payload
     if (!payload || payload.error || payload.privacy !== 'metadata_only') return null
@@ -291,10 +278,13 @@ export default function register(sdk) {
         h(Text, { color: active ? t.color.warn : t.color.ok }, hudStateLabel(active, agents)),
         h(Text, { color: t.color.muted }, ` • ${metrics.cost} • ${metrics.ctx}`),
       ),
+      // No animation subscription, ever: the dock must read like plain text
+      // so a terminal drag-selection over it survives. The spinner advances
+      // one frame per applied snapshot (state.tick) instead of on a shimmer
+      // clock — a running wave used to repaint several times a second, which
+      // cleared any in-progress selection before the drag could finish.
       mainRows.length || rows.length
-        ? ([...mainRows, ...rows].some(row => !row.state || row.state === 'running')
-            ? h(AnimatedActivity, { columns, mainRows, rows, t, tick: state.tick })
-            : h(ActivityRows, { columns, frame: 0, mainRows, rows, t }))
+        ? h(ActivityRows, { columns, frame: state.tick, mainRows, rows, t })
         : null,
     )
   }
@@ -419,12 +409,40 @@ export default function register(sdk) {
   // unchanged snapshot must produce NO updateWidget call at all. The reader
   // freezes per-row elapsed for finished subagents precisely so a lingering
   // done state serializes identically poll after poll.
+  //
+  // A RUNNING delegation defeats a plain byte-compare, though: elapsed,
+  // tok/s, cache% and cost drift on nearly every 2s poll, so the dock would
+  // still repaint every poll for the whole wave. The compare is therefore
+  // two-tier. Structural changes — a row appearing, a state transition, the
+  // action text, the todo checklist — repaint immediately. Metric-only drift
+  // repaints at most once per METRICS_REPAINT_MS, leaving long byte-stable
+  // windows in which the dock behaves like plain text under a drag.
+  const METRICS_REPAINT_MS = 30_000
+  const VOLATILE_KEYS = new Set([
+    'cache_hit_percentage',
+    'context_percentage',
+    'cost_usd',
+    'elapsed_seconds',
+    'observed_at',
+    'tokens',
+    'tokens_per_second',
+    'tool_count',
+    'turn_count',
+  ])
+  const structuralKey = payload =>
+    JSON.stringify(payload, (key, value) => (VOLATILE_KEYS.has(key) ? undefined : value))
   let lastSnapshot = ''
+  let lastStructural = ''
+  let lastPaintAt = 0
   const applySnapshot = payload => {
     if (!payload) return
     const serialized = JSON.stringify(payload)
     if (serialized === lastSnapshot) return
+    const structural = structuralKey(payload)
+    if (structural === lastStructural && Date.now() - lastPaintAt < METRICS_REPAINT_MS) return
     lastSnapshot = serialized
+    lastStructural = structural
+    lastPaintAt = Date.now()
     for (const target of [app, todoApp]) {
       updateWidget(target, state => ({ ...state, payload, tick: state.tick + 1 }))
     }

--- a/tests/test_hermes_tui_preflight.py
+++ b/tests/test_hermes_tui_preflight.py
@@ -147,6 +147,10 @@ class HermesTuiPreflightTests(unittest.TestCase):
             self.assertIn("hermes update", blockers[0])
 
     def test_stripped_sdk_surface_reports_each_missing_key(self) -> None:
+        # useShimmerPhase is stripped too, but its absence is NOT a finding:
+        # the widget no longer subscribes to the shimmer clock (animation
+        # repaints cleared drag-selections over the dock), so only the keys
+        # the widget actually destructures may block.
         stripped = _MODERN_SDK_SOURCE.replace("  useShimmerPhase\n", "").replace(
             "  updateWidget,\n", ""
         )
@@ -159,11 +163,10 @@ class HermesTuiPreflightTests(unittest.TestCase):
             preflight = hermes_tui_preflight(paths)
             blockers = widget_render_blockers(preflight)
 
-            self.assertEqual(
-                preflight["sdk_surface"]["missing"], ["updateWidget", "useShimmerPhase"]
-            )
+            self.assertEqual(preflight["sdk_surface"]["missing"], ["updateWidget"])
             self.assertEqual(len(blockers), 1)
-            self.assertIn("updateWidget, useShimmerPhase", blockers[0])
+            self.assertIn("updateWidget", blockers[0])
+            self.assertNotIn("useShimmerPhase", blockers[0])
 
     def test_unset_display_interface_is_a_blocker_and_explicit_cli_is_user_owned(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -309,11 +309,30 @@ class TuiWidgetPackTests(unittest.TestCase):
         self.assertIn("safeText(todo.display_phase)", widget)
         self.assertIn("` · ${phaseCount} phases`", widget)
         # Drag-copy contract: an unchanged snapshot must not repaint the docks
-        # (repaints clear an in-progress terminal selection), and the shimmer
-        # subscription mounts only while a running row needs the spinner.
+        # (repaints clear an in-progress terminal selection), there is NO
+        # animation subscription at all (the spinner advances one frame per
+        # applied snapshot), and metric-only drift on a running wave repaints
+        # at most once per throttle window instead of on every 2s poll.
         self.assertIn("if (serialized === lastSnapshot) return", widget)
-        self.assertIn("AnimatedActivity", widget)
-        self.assertIn("h(ActivityRows, { columns, frame: 0", widget)
+        self.assertNotIn("AnimatedActivity", widget)
+        self.assertIn("h(ActivityRows, { columns, frame: state.tick", widget)
+        self.assertIn("const METRICS_REPAINT_MS = 30_000", widget)
+        self.assertIn(
+            "if (structural === lastStructural && Date.now() - lastPaintAt < METRICS_REPAINT_MS) return",
+            widget,
+        )
+        for volatile in (
+            "'cache_hit_percentage'",
+            "'context_percentage'",
+            "'cost_usd'",
+            "'elapsed_seconds'",
+            "'observed_at'",
+            "'tokens'",
+            "'tokens_per_second'",
+            "'tool_count'",
+            "'turn_count'",
+        ):
+            self.assertIn(volatile, widget)
         # (bracket-tag grammar asserted above replaces the BRAND_MARK pair)
         # The old header's literal pieces ("-", "Oh My Hermes", "Ultra Work",
         # "Ready") are gone on purpose; asserting them back would re-pin the
@@ -321,9 +340,8 @@ class TuiWidgetPackTests(unittest.TestCase):
         # between both panels instead of hand-written per segment.
         self.assertNotIn("'Ultra Work'", widget)
         self.assertIn("SPINNER_FRAMES", widget)
-        self.assertIn("useShimmerPhase", widget)
+        self.assertNotIn("useShimmerPhase", widget)
         self.assertNotIn("Number.MAX_SAFE_INTEGER", widget)
-        self.assertIn("useShimmerPhase(30_000)", widget)
         self.assertIn("Math.min(3,", widget)
         self.assertNotIn("spinnerTimerKey", widget)
         self.assertIn("ActivityRow", widget)


### PR DESCRIPTION
## Capability

The bottom `[OMH]` dock (and the `[Plan]` dock) can be drag-selected and copied in the terminal like plain text, including while a Hermes-native delegation is running.

## Motivation

The owner reported the `[OMH]` region still could not be drag-copied while every other terminal region could, and the screenshot showed a running delegation row. #1004's byte-identical-snapshot skip only helped idle/lingering states; a running wave defeated it twice over.

## Implementation (boundary level)

Widget-only; OMH never touches Hermes or the terminal.

- **No animation subscription, ever.** `AnimatedActivity` and its `useShimmerPhase` subscription are removed — a running spinner used to repaint the dock several times a second, clearing any in-progress selection before the drag could finish. The spinner glyph now advances one frame per applied snapshot.
- **Two-tier snapshot compare.** Structural changes (a row appearing, a state transition, action text, todo checklist, header counts) repaint immediately. Metric-only drift (`elapsed_seconds`, `observed_at`, `tokens`, `tokens_per_second`, `cache_hit_percentage`, `context_percentage`, `cost_usd`, `turn_count`, `tool_count`) repaints at most once per 30s window, so mid-wave the dock is byte-stable — and therefore selectable — for up to 30s at a time.
- **Doctor parity.** `useShimmerPhase` leaves `REQUIRED_WIDGET_SDK_KEYS`: the widget no longer destructures it, and requiring an unused SDK key would block installs on hosts that render the widget fine.

Trade-off accepted: per-row metrics can lag up to 30s during a running wave; state transitions and new rows are still instant.

## Observed verification

- `node --check` on the widget: pass.
- Widget-pack + preflight suites (26 tests) in a clean worktree at this commit: OK.
- Byte gates (`docs workflows --check`, `docs roles --check`), `compileall`, `ruff`: pass in the clean worktree.
- Full suite run in progress in the clean worktree; will be reported before merge alongside CI.

Not observed here: a live drag on the owner's terminal — that requires the synced install and a TUI restart and is reported separately after merge.

## Risks

- 30s metric staleness mid-wave is a deliberate constant (`METRICS_REPAINT_MS`); if it feels laggy it is a one-line tune.
- If Hermes itself repaints docks independently of `updateWidget`, selection could still drop for host-driven reasons OMH cannot control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)