### PR TITLE
fix(tui): render the whole plan in the todo dock, not a +N more collapse

### DIFF
--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -320,15 +320,28 @@ export default function register(sdk) {
         h(Rule, { columns, t }),
       )
     }
-    const shown = Array.isArray(todo.display_items) ? todo.display_items : []
-    const more = Number.isFinite(todo.more_count) ? todo.more_count : 0
+    // The whole plan, always. The earlier focused projection (current phase
+    // only, "+N more" for the rest) hid the shape of the work the owner had
+    // just declared — a six-phase plan rendered as one line and a count. The
+    // panel now walks every item in declaration order, emitting a phase
+    // header whenever it changes; the CURRENT phase's header carries the
+    // label colour, finished/upcoming phases stay muted. The todo store caps
+    // plans at 20 items, which bounds the panel's height.
+    const shown = Array.isArray(todo.items) ? todo.items : []
     const markers = { active: '[•]', done: '[✓]', pending: '[ ]' }
     const budget = Math.max(16, columns - 10)
-    // A phase-structured plan (todo init with phases) shows the current
-    // phase's name above its checklist — the reader already narrowed
-    // display_items to that phase, so the panel walks one phase at a time.
-    const phase = safeText(todo.display_phase)
+    const currentPhase = safeText(todo.display_phase)
     const phaseCount = Number.isFinite(counts.phases) ? counts.phases : 0
+    const lines = []
+    let lastPhase = null
+    for (const item of shown) {
+      const phase = safeText(item.phase)
+      if (phase && phase !== lastPhase) {
+        lines.push({ kind: 'phase', text: phase })
+        lastPhase = phase
+      }
+      lines.push({ kind: 'item', item })
+    }
     return h(
       Box,
       { flexDirection: 'column', width: '100%' },
@@ -341,32 +354,31 @@ export default function register(sdk) {
         h(Text, { color: t.color.warn }, `${counts.done ?? 0}/${counts.total ?? 0}`),
         phaseCount > 1 ? h(Text, { color: t.color.muted }, ` · ${phaseCount} phases`) : null,
       ),
-      phase
-        ? h(
-            Text,
-            { wrap: 'truncate-end' },
-            h(Text, { bold: true, color: t.color.label }, truncateCells(phase, budget)),
-          )
-        : null,
-      ...shown.map((item, index) => {
-        const withMore = more > 0 && index === shown.length - 1
-        // Reserve the "+N more" suffix width so truncation never eats it.
-        const rowBudget = withMore ? Math.max(12, budget - 11) : budget
-        return h(
-          Text,
-          { key: `todo-${index}`, wrap: 'truncate-end' },
-          h(
-            Text,
-            {
-              bold: item.state === 'active',
-              color: item.state === 'active' ? t.color.ok : item.state === 'done' ? t.color.muted : t.color.text,
-              strikethrough: item.state === 'done',
-            },
-            `${Object.hasOwn(markers, item.state) ? markers[item.state] : '[ ]'} ${truncateCells(item.text, rowBudget)}`,
-          ),
-          withMore ? h(Text, { color: t.color.muted }, `   +${more} more`) : null,
-        )
-      }),
+      ...lines.map((line, index) =>
+        line.kind === 'phase'
+          ? h(
+              Text,
+              { key: `todo-${index}`, wrap: 'truncate-end' },
+              h(
+                Text,
+                { bold: true, color: line.text === currentPhase ? t.color.label : t.color.muted },
+                truncateCells(line.text, budget),
+              ),
+            )
+          : h(
+              Text,
+              { key: `todo-${index}`, wrap: 'truncate-end' },
+              h(
+                Text,
+                {
+                  bold: line.item.state === 'active',
+                  color: line.item.state === 'active' ? t.color.ok : line.item.state === 'done' ? t.color.muted : t.color.text,
+                  strikethrough: line.item.state === 'done',
+                },
+                `${Object.hasOwn(markers, line.item.state) ? markers[line.item.state] : '[ ]'} ${truncateCells(line.item.text, budget)}`,
+              ),
+            )
+      ),
       h(Rule, { columns, t }),
     )
   }

--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -320,28 +320,57 @@ export default function register(sdk) {
         h(Rule, { columns, t }),
       )
     }
-    // The whole plan, always. The earlier focused projection (current phase
-    // only, "+N more" for the rest) hid the shape of the work the owner had
-    // just declared — a six-phase plan rendered as one line and a count. The
-    // panel now walks every item in declaration order, emitting a phase
-    // header whenever it changes; the CURRENT phase's header carries the
-    // label colour, finished/upcoming phases stay muted. The todo store caps
-    // plans at 20 items, which bounds the panel's height.
+    // The whole plan, always — the focused "+N more" collapse hid declared
+    // work behind a count. One row PER PHASE, not per line-break-heavy
+    // header: the phase name leads the row and its items follow inline
+    // (`Research [•] task  [ ] task`), which the owner asked for after the
+    // header-above-checklist layout doubled the panel's height. The CURRENT
+    // phase's name carries the label colour, other phases stay muted; done
+    // items keep the strikethrough. Unphased plans keep one item per row.
+    // The todo store caps plans at 20 items, which bounds the height.
     const shown = Array.isArray(todo.items) ? todo.items : []
     const markers = { active: '[•]', done: '[✓]', pending: '[ ]' }
     const budget = Math.max(16, columns - 10)
     const currentPhase = safeText(todo.display_phase)
     const phaseCount = Number.isFinite(counts.phases) ? counts.phases : 0
-    const lines = []
-    let lastPhase = null
+    const groups = []
     for (const item of shown) {
       const phase = safeText(item.phase)
-      if (phase && phase !== lastPhase) {
-        lines.push({ kind: 'phase', text: phase })
-        lastPhase = phase
-      }
-      lines.push({ kind: 'item', item })
+      const last = groups[groups.length - 1]
+      if (last && last.phase === phase) last.items.push(item)
+      else groups.push({ phase, items: [item] })
     }
+    const itemText = (item, index, limit) =>
+      `${index ? '  ' : ''}${Object.hasOwn(markers, item.state) ? markers[item.state] : '[ ]'} ${truncateCells(item.text, limit)}`
+    const itemProps = item => ({
+      bold: item.state === 'active',
+      color: item.state === 'active' ? t.color.ok : item.state === 'done' ? t.color.muted : t.color.text,
+      strikethrough: item.state === 'done',
+    })
+    const rows = groups.flatMap((group, groupIndex) =>
+      group.phase
+        ? [
+            h(
+              Text,
+              { key: `todo-${groupIndex}`, wrap: 'truncate-end' },
+              h(
+                Text,
+                { bold: true, color: group.phase === currentPhase ? t.color.label : t.color.muted },
+                `${truncateCells(group.phase, budget)} `,
+              ),
+              ...group.items.map((item, index) =>
+                h(Text, { key: `todo-${groupIndex}-${index}`, ...itemProps(item) }, itemText(item, index, budget)),
+              ),
+            ),
+          ]
+        : group.items.map((item, index) =>
+            h(
+              Text,
+              { key: `todo-${groupIndex}-${index}`, wrap: 'truncate-end' },
+              h(Text, itemProps(item), itemText(item, 0, budget)),
+            ),
+          )
+    )
     return h(
       Box,
       { flexDirection: 'column', width: '100%' },
@@ -354,31 +383,7 @@ export default function register(sdk) {
         h(Text, { color: t.color.warn }, `${counts.done ?? 0}/${counts.total ?? 0}`),
         phaseCount > 1 ? h(Text, { color: t.color.muted }, ` · ${phaseCount} phases`) : null,
       ),
-      ...lines.map((line, index) =>
-        line.kind === 'phase'
-          ? h(
-              Text,
-              { key: `todo-${index}`, wrap: 'truncate-end' },
-              h(
-                Text,
-                { bold: true, color: line.text === currentPhase ? t.color.label : t.color.muted },
-                truncateCells(line.text, budget),
-              ),
-            )
-          : h(
-              Text,
-              { key: `todo-${index}`, wrap: 'truncate-end' },
-              h(
-                Text,
-                {
-                  bold: line.item.state === 'active',
-                  color: line.item.state === 'active' ? t.color.ok : line.item.state === 'done' ? t.color.muted : t.color.text,
-                  strikethrough: line.item.state === 'done',
-                },
-                `${Object.hasOwn(markers, line.item.state) ? markers[line.item.state] : '[ ]'} ${truncateCells(line.item.text, budget)}`,
-              ),
-            )
-      ),
+      ...rows,
       h(Rule, { columns, t }),
     )
   }

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -257,7 +257,7 @@ class TuiWidgetPackTests(unittest.TestCase):
         self.assertEqual(widget.count("zone: 'dock-top'"), 1)
         self.assertIn("id: 'omh-todo'", widget)
         self.assertIn("TodoPanel", widget)
-        self.assertIn("truncateCells(line.item.text", widget)
+        self.assertIn("truncateCells(item.text", widget)
         self.assertIn("safeText(todo.title)", widget)
         # An installed OMH stays discoverable from an idle session: only the
         # activity rows are gated on live work, never the header.
@@ -308,10 +308,13 @@ class TuiWidgetPackTests(unittest.TestCase):
         # above its checklist and the phase count next to done/total.
         self.assertIn("safeText(todo.display_phase)", widget)
         self.assertIn("` · ${phaseCount} phases`", widget)
-        # The todo panel renders the WHOLE plan (todo.items), emitting a phase
-        # header whenever the phase changes; the focused "+N more" collapse is
-        # gone on purpose — it hid declared work behind a count.
+        # The todo panel renders the WHOLE plan (todo.items) as one row per
+        # phase — the phase name leads and its items follow inline; the
+        # focused "+N more" collapse is gone on purpose, it hid declared work
+        # behind a count, and per-phase header lines doubled the height.
         self.assertIn("Array.isArray(todo.items)", widget)
+        self.assertIn("last.phase === phase", widget)
+        self.assertIn("${truncateCells(group.phase, budget)} `", widget)
         self.assertNotIn("todo.display_items", widget)
         self.assertNotIn("more_count", widget)
         self.assertNotIn("more}", widget)

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -257,7 +257,7 @@ class TuiWidgetPackTests(unittest.TestCase):
         self.assertEqual(widget.count("zone: 'dock-top'"), 1)
         self.assertIn("id: 'omh-todo'", widget)
         self.assertIn("TodoPanel", widget)
-        self.assertIn("truncateCells(item.text", widget)
+        self.assertIn("truncateCells(line.item.text", widget)
         self.assertIn("safeText(todo.title)", widget)
         # An installed OMH stays discoverable from an idle session: only the
         # activity rows are gated on live work, never the header.
@@ -308,6 +308,13 @@ class TuiWidgetPackTests(unittest.TestCase):
         # above its checklist and the phase count next to done/total.
         self.assertIn("safeText(todo.display_phase)", widget)
         self.assertIn("` · ${phaseCount} phases`", widget)
+        # The todo panel renders the WHOLE plan (todo.items), emitting a phase
+        # header whenever the phase changes; the focused "+N more" collapse is
+        # gone on purpose — it hid declared work behind a count.
+        self.assertIn("Array.isArray(todo.items)", widget)
+        self.assertNotIn("todo.display_items", widget)
+        self.assertNotIn("more_count", widget)
+        self.assertNotIn("more}", widget)
         # Drag-copy contract: an unchanged snapshot must not repaint the docks
         # (repaints clear an in-progress terminal selection), there is NO
         # animation subscription at all (the spinner advances one frame per


### PR DESCRIPTION
## Capability

The dock-top `[Plan]` panel renders the entire declared plan — every phase header and every item in declaration order — instead of the current phase's collapsed checklist plus `+N more`.

## Motivation

Owner, seeing a six-phase plan render as one row and `+3 more`: "투두는 전부 출력해야지 왜 +more로 떠?" The focused projection hid the shape of the work that had just been declared.

## Implementation (boundary level)

Widget-only. The HUD payload already carried the full `todo.items` list with per-item phases; the panel simply was not using it.

- `TodoPanel` walks `todo.items`, emitting a phase header whenever the phase changes. The CURRENT phase's header (still taken from the reader's `display_phase`) keeps the label colour; other phases render muted. Done items stay struck-through, the active item stays bold.
- The `+N more` suffix and its width reservation are gone.
- Height is bounded by the todo store's existing 20-item cap.
- Reader untouched: `display_items`/`more_count` still exist for the context-line surfaces and their payload pins.

## Observed verification

- `node --check` on the widget: pass.
- Widget-pack + HUD suites (48 tests) in a fresh detached worktree at this commit: OK.
- Byte gates, compileall, ruff, and the full suite running in the same clean worktree; results reported before merge alongside CI.

## Risks

- A 20-item, many-phase plan makes a tall dock-top panel; that is the explicit ask, and the item cap bounds it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)