### PR TITLE
docs(claude): machine reflection goes through omh update, never hand-copies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,10 @@ Rules:
 - Report only observed evidence. `prepared_not_observed` is never execution,
   review, CI, or merge evidence.
 - Never revert or clean up unrelated dirty files; report them instead.
+- Reflecting merged changes onto a live machine goes through `omh update`
+  (plus a TUI restart), never by hand-copying files into `~/.hermes/plugins/`
+  or `~/.hermes/tui-widgets/`. Hand-copied artifacts drift from the install
+  manifests and make later updates refuse or require `--force`.
 
 ## Common Pitfalls
 


### PR DESCRIPTION
## Capability

CLAUDE.md's Workflow Rules now state that reflecting merged changes onto a live machine goes through `omh update` plus a TUI restart — never by hand-copying files into `~/.hermes/plugins/` or `~/.hermes/tui-widgets/`.

## Motivation

Owner directive after two observed drift incidents: hand-copied artifacts desynced from the install manifests, making the widget installer refuse a managed replace and setting up a future `--force` requirement on the plugin bundle.

## Implementation

One bullet added to the Workflow Rules list in CLAUDE.md. No code.

## Observed verification

Docs-only; the byte gates do not cover CLAUDE.md.

## Risks

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)