### PR TITLE
feat(tui): todo subtask depth and seven-row window with fold lines

### DIFF
--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -332,57 +332,90 @@ export default function register(sdk) {
         h(Rule, { columns, t }),
       )
     }
-    // The whole plan, always — the focused "+N more" collapse hid declared
-    // work behind a count. One row PER PHASE, not per line-break-heavy
-    // header: the phase name leads the row and its items follow inline
-    // (`Research [•] task  [ ] task`), which the owner asked for after the
-    // header-above-checklist layout doubled the panel's height. The CURRENT
-    // phase's name carries the label colour, other phases stay muted; done
-    // items keep the strikethrough. Unphased plans keep one item per row.
-    // The todo store caps plans at 20 items, which bounds the height.
+    // The whole plan by default, bounded at seven visible item rows. A phase
+    // whose single top-level task fits on one line stays merged
+    // (`Research [•] task`); a phase with several tasks — or with indented
+    // subtasks (depth 1..3) — renders its name as a header with one item per
+    // row beneath it, which is the owner's layout for dense phases. When the
+    // plan exceeds seven items the window anchors just before the first
+    // remaining item so current work is always on screen, and hidden
+    // neighbours fold into muted `... (N earlier/later tasks)` lines.
     const shown = Array.isArray(todo.items) ? todo.items : []
     const markers = { active: '[•]', done: '[✓]', pending: '[ ]' }
     const budget = Math.max(16, columns - 10)
     const currentPhase = safeText(todo.display_phase)
     const phaseCount = Number.isFinite(counts.phases) ? counts.phases : 0
+    const depthOf = item => {
+      const depth = Number(item.depth)
+      return Number.isInteger(depth) && depth > 0 ? Math.min(depth, 3) : 0
+    }
+    const TODO_DISPLAY_ROWS = 7
+    const total = shown.length
+    const firstRemaining = shown.findIndex(item => item.state !== 'done')
+    const anchor = firstRemaining < 0 ? 0 : Math.max(0, firstRemaining - 1)
+    const start = total > TODO_DISPLAY_ROWS ? Math.min(anchor, total - TODO_DISPLAY_ROWS) : 0
+    const end = Math.min(total, start + TODO_DISPLAY_ROWS)
     const groups = []
-    for (const item of shown) {
+    for (const item of shown.slice(start, end)) {
       const phase = safeText(item.phase)
       const last = groups[groups.length - 1]
-      if (last && last.phase === phase) last.items.push(item)
+      // A subtask with no phase of its own continues its parent's group.
+      if (last && (last.phase === phase || (!phase && depthOf(item) > 0))) last.items.push(item)
       else groups.push({ phase, items: [item] })
     }
-    const itemText = (item, index, limit) =>
-      `${index ? '  ' : ''}${Object.hasOwn(markers, item.state) ? markers[item.state] : '[ ]'} ${truncateCells(item.text, limit)}`
+    const itemLabel = item =>
+      `${Object.hasOwn(markers, item.state) ? markers[item.state] : '[ ]'} ${truncateCells(item.text, budget)}`
     const itemProps = item => ({
       bold: item.state === 'active',
       color: item.state === 'active' ? t.color.ok : item.state === 'done' ? t.color.muted : t.color.text,
       strikethrough: item.state === 'done',
     })
-    const rows = groups.flatMap((group, groupIndex) =>
-      group.phase
-        ? [
-            h(
-              Text,
-              { key: `todo-${groupIndex}`, wrap: 'truncate-end' },
-              h(
-                Text,
-                { bold: true, color: group.phase === currentPhase ? t.color.label : t.color.muted },
-                `${truncateCells(group.phase, budget)} `,
-              ),
-              ...group.items.map((item, index) =>
-                h(Text, { key: `todo-${groupIndex}-${index}`, ...itemProps(item) }, itemText(item, index, budget)),
-              ),
-            ),
-          ]
-        : group.items.map((item, index) =>
-            h(
-              Text,
-              { key: `todo-${groupIndex}-${index}`, wrap: 'truncate-end' },
-              h(Text, itemProps(item), itemText(item, 0, budget)),
-            ),
-          )
-    )
+    const phaseProps = phase => ({
+      bold: true,
+      color: phase === currentPhase ? t.color.label : t.color.muted,
+    })
+    const foldLine = (key, count, side) =>
+      h(
+        Text,
+        { key, wrap: 'truncate-end' },
+        h(Text, { color: t.color.muted }, `... (${count} ${side} task${count === 1 ? '' : 's'})`),
+      )
+    const rows = []
+    if (start > 0) rows.push(foldLine('todo-earlier', start, 'earlier'))
+    groups.forEach((group, groupIndex) => {
+      const merged = group.phase && group.items.length === 1 && depthOf(group.items[0]) === 0
+      if (merged) {
+        const item = group.items[0]
+        rows.push(
+          h(
+            Text,
+            { key: `todo-${groupIndex}`, wrap: 'truncate-end' },
+            h(Text, phaseProps(group.phase), `${truncateCells(group.phase, budget)} `),
+            h(Text, itemProps(item), itemLabel(item)),
+          ),
+        )
+        return
+      }
+      if (group.phase) {
+        rows.push(
+          h(
+            Text,
+            { key: `todo-${groupIndex}-phase`, wrap: 'truncate-end' },
+            h(Text, phaseProps(group.phase), truncateCells(group.phase, budget)),
+          ),
+        )
+      }
+      for (const [index, item] of group.items.entries()) {
+        rows.push(
+          h(
+            Text,
+            { key: `todo-${groupIndex}-${index}`, wrap: 'truncate-end' },
+            h(Text, itemProps(item), `${'  '.repeat(depthOf(item))}${itemLabel(item)}`),
+          ),
+        )
+      }
+    })
+    if (end < total) rows.push(foldLine('todo-later', total - end, 'later'))
     return h(
       Box,
       { flexDirection: 'column', width: '100%' },

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -20,6 +20,7 @@ from .metadata import (
     TOOLS_REQUIRING_ROLE_CATALOG,
 )
 from .todo_store import (
+    MAX_TODO_DEPTH,
     MAX_TODO_ITEMS,
     MAX_TODO_PHASE_CHARS,
     MAX_TODO_SOURCE_CHARS,
@@ -1157,7 +1158,7 @@ def _todo_summary(home: Path) -> dict[str, Any]:
     record = _read_hud_json(todo_path(home), root=home)
     if record.get("schema_version") != TODO_SCHEMA_VERSION:
         return empty
-    items: list[dict[str, str]] = []
+    items: list[dict[str, Any]] = []
     raw_items = record.get("items")
     for raw in raw_items if isinstance(raw_items, list) else []:
         if not isinstance(raw, dict):
@@ -1165,10 +1166,18 @@ def _todo_summary(home: Path) -> dict[str, Any]:
         text = strip_control_characters(raw.get("text", ""))[:MAX_TODO_TEXT_CHARS]
         state = str(raw.get("state", ""))
         phase = strip_control_characters(raw.get("phase", ""))[:MAX_TODO_PHASE_CHARS]
+        raw_depth = raw.get("depth", 0)
+        depth = (
+            min(raw_depth, MAX_TODO_DEPTH)
+            if isinstance(raw_depth, int) and not isinstance(raw_depth, bool) and raw_depth > 0
+            else 0
+        )
         if text and state in TODO_ITEM_STATES:
-            entry = {"text": text, "state": state}
+            entry: dict[str, Any] = {"text": text, "state": state}
             if phase:
                 entry["phase"] = phase
+            if depth:
+                entry["depth"] = depth
             items.append(entry)
         if len(items) >= MAX_TODO_ITEMS:
             break
@@ -1259,19 +1268,22 @@ def _hud_todo_lines(todo: dict[str, Any], *, preset: str = "focused") -> list[st
     marker = {"done": "[✓]", "active": "[•]", "pending": "[ ]"}
     lines = [header]
     if full:
-        # Full preset walks every phase in declaration order with headers.
+        # Full preset walks every phase in declaration order with headers;
+        # subtasks (depth 1..3) indent beneath their parent.
         last_phase = None
         for item in shown:
             phase = item.get("phase", "")
             if phase and phase != last_phase:
                 lines.append(phase)
                 last_phase = phase
-            lines.append(f"{marker[item['state']]} {item['text']}")
+            lines.append(f"{'  ' * int(item.get('depth', 0) or 0)}{marker[item['state']]} {item['text']}")
     else:
         display_phase = str(todo.get("display_phase", ""))
         if display_phase:
             lines.append(display_phase)
-        lines.extend(f"{marker[item['state']]} {item['text']}" for item in shown)
+        lines.extend(
+            f"{'  ' * int(item.get('depth', 0) or 0)}{marker[item['state']]} {item['text']}" for item in shown
+        )
     more = 0 if full else int(todo.get("more_count", 0) or 0)
     if more > 0:
         lines[-1] = f"{lines[-1]}   +{more} more"

--- a/src/plugin_bundle/omh/todo_store.py
+++ b/src/plugin_bundle/omh/todo_store.py
@@ -25,6 +25,11 @@ MAX_TODO_SOURCE_CHARS = 80
 # phase-structured plan declared BEFORE engine work bounds the run: progress
 # is a checklist walked phase by phase, not an open-ended reasoning loop.
 MAX_TODO_PHASE_CHARS = 60
+# Optional nesting depth per item: 0 is a top-level task, 1..3 are subtask
+# levels rendered indented beneath it (e.g. "검증작업하기" with usability /
+# UI / load-verification children). Three levels is the owner's declared
+# ceiling; deeper nesting stops reading as a checklist.
+MAX_TODO_DEPTH = 3
 TODO_CLAIM_BOUNDARY = (
     "Todo items are plan declarations. They are not execution, verification, "
     "review, CI, merge-readiness, or merge evidence."
@@ -49,7 +54,7 @@ def strip_control_characters(value: object) -> str:
     return str(value or "").translate(_CONTROL_CHARACTERS).strip()
 
 
-def validate_todo_items(items: object) -> list[dict[str, str]]:
+def validate_todo_items(items: object) -> list[dict[str, Any]]:
     if not isinstance(items, list) or not items:
         raise TodoValidationError("todo items must be a non-empty list")
     if len(items) > MAX_TODO_ITEMS:
@@ -69,9 +74,14 @@ def validate_todo_items(items: object) -> list[dict[str, str]]:
         phase = strip_control_characters(item.get("phase", ""))
         if len(phase) > MAX_TODO_PHASE_CHARS:
             raise TodoValidationError(f"todo item phase is capped at {MAX_TODO_PHASE_CHARS} characters")
-        entry = {"text": text, "state": state}
+        depth = item.get("depth", 0)
+        if isinstance(depth, bool) or not isinstance(depth, int) or not 0 <= depth <= MAX_TODO_DEPTH:
+            raise TodoValidationError(f"todo item depth must be an integer from 0 to {MAX_TODO_DEPTH}")
+        entry: dict[str, Any] = {"text": text, "state": state}
         if phase:
             entry["phase"] = phase
+        if depth:
+            entry["depth"] = depth
         validated.append(entry)
     return validated
 

--- a/src/plugin_bundle/omh/tools/todo_tool.py
+++ b/src/plugin_bundle/omh/tools/todo_tool.py
@@ -55,6 +55,17 @@ OMH_TODO_SCHEMA = {
                                 "current phase's checklist."
                             ),
                         },
+                        "depth": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 3,
+                            "description": (
+                                "Optional subtask nesting level (0 = top-level task, 1-3 = "
+                                "subtasks rendered indented beneath the preceding shallower "
+                                "item). Subtasks may omit phase; they continue their parent's "
+                                "section."
+                            ),
+                        },
                     },
                     "required": ["text"],
                 },

--- a/tests/test_phase_todo.py
+++ b/tests/test_phase_todo.py
@@ -51,6 +51,37 @@ class PhaseFieldStoreTest(unittest.TestCase):
             validate_todo_items([{"text": "task", "phase": "x" * (MAX_TODO_PHASE_CHARS + 1)}])
 
 
+class DepthFieldStoreTest(unittest.TestCase):
+    def test_depth_is_optional_and_absent_at_zero(self):
+        validated = validate_todo_items([{"text": "task", "depth": 0}])
+        self.assertEqual(validated, [{"text": "task", "state": "pending"}])
+
+    def test_a_subtask_depth_up_to_three_is_kept(self):
+        validated = validate_todo_items(
+            [
+                {"text": "검증작업하기", "phase": "Verification"},
+                {"text": "사용성 검증", "depth": 1},
+                {"text": "UI 검증", "depth": 2},
+                {"text": "부하 검증", "depth": 3},
+            ]
+        )
+        self.assertEqual([item.get("depth", 0) for item in validated], [0, 1, 2, 3])
+
+    def test_a_depth_beyond_three_or_non_integer_is_refused(self):
+        for depth in (4, -1, True, "1"):
+            with self.assertRaises(TodoValidationError):
+                validate_todo_items([{"text": "task", "depth": depth}])
+
+    def test_the_hud_projection_carries_depth_through(self):
+        todo = _projected_todo(
+            [
+                {"text": "Verify", "state": "active", "phase": "Verification"},
+                {"text": "usability", "state": "pending", "depth": 1},
+            ]
+        )
+        self.assertEqual([item.get("depth", 0) for item in todo["items"]], [0, 1])
+
+
 class PhaseProjectionTest(unittest.TestCase):
     def test_the_current_phase_is_the_one_holding_the_active_item(self):
         todo = _projected_todo(PHASED_ITEMS)

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -308,13 +308,20 @@ class TuiWidgetPackTests(unittest.TestCase):
         # above its checklist and the phase count next to done/total.
         self.assertIn("safeText(todo.display_phase)", widget)
         self.assertIn("` · ${phaseCount} phases`", widget)
-        # The todo panel renders the WHOLE plan (todo.items) as one row per
-        # phase — the phase name leads and its items follow inline; the
-        # focused "+N more" collapse is gone on purpose, it hid declared work
-        # behind a count, and per-phase header lines doubled the height.
+        # The todo panel renders the plan from todo.items: a single-task phase
+        # stays merged on one line, a dense phase renders a header with one
+        # item per row, subtasks (depth 1..3) indent beneath their parent, and
+        # past seven visible items the window anchors at current work with
+        # muted "... (N earlier/later tasks)" fold lines.
         self.assertIn("Array.isArray(todo.items)", widget)
         self.assertIn("last.phase === phase", widget)
         self.assertIn("${truncateCells(group.phase, budget)} `", widget)
+        self.assertIn("const TODO_DISPLAY_ROWS = 7", widget)
+        self.assertIn("depthOf", widget)
+        self.assertIn("'  '.repeat(depthOf(item))", widget)
+        self.assertIn("task${count === 1 ? '' : 's'}", widget)
+        self.assertIn("'todo-earlier'", widget)
+        self.assertIn("'todo-later'", widget)
         self.assertNotIn("todo.display_items", widget)
         self.assertNotIn("more_count", widget)
         self.assertNotIn("more}", widget)


### PR DESCRIPTION
## Capability

The plan panel supports nested subtasks and stays height-bounded:

- Todo items accept an optional integer `depth` (0–3). Subtasks render indented beneath their parent (`검증작업하기` → usability / UI / load verification), and a subtask with no phase of its own continues its parent's section.
- At most seven item rows are visible. Past seven, the window anchors just before the first remaining item so current work stays on screen, and hidden neighbours fold into muted `... (N earlier tasks)` / `... (N later tasks)` lines — the owner's sample format.
- Layout is adaptive: a phase with a single top-level task stays merged on one line (`Research [•] task`); a dense phase — several tasks or any subtasks — renders its name as a header with one item per row.

## Motivation

Owner: todos can realistically grow past 10 with up to three subtask levels, and past seven items the panel should fold ("이런 투두들이 7개가 넘어가면 그때부터 +N more") with an explicit `... (3 later tasks)` sample.

## Implementation (boundary level)

- `todo_store.py`: `MAX_TODO_DEPTH = 3`; `depth` validated as a non-bool integer 0–3, stored only when > 0. The 20-item cap and control stripping are unchanged.
- `runtime_reader.py`: the HUD projection carries `depth` through (clamped); the context-line presets indent by depth.
- `omh_todo` tool schema gains the optional `depth` property.
- Widget `TodoPanel`: depth indentation, adaptive merge-vs-header layout, seven-row window with fold lines.

## Observed verification

- `node --check`: pass. Phase-todo suite (10 tests, including the new depth store/projection contracts): OK locally.
- Clean worktree at this commit: phase-todo + widget-pack + HUD + distribution + CLI suites, 420 tests, OK.
- Byte gates, compileall, ruff, and the full suite running in the same clean worktree; reported before merge alongside CI.

## Risks

- The window anchor prefers keeping current work visible over literal top-down truncation; whenever work is near the top (the sample's case) the two are identical.
- `omh_todo` gains an optional schema property; existing callers are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)