### PR TITLE
fix(tui): align todo markers into one column across merged phase rows

### DIFF
--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -380,17 +380,25 @@ export default function register(sdk) {
         { key, wrap: 'truncate-end' },
         h(Text, { color: t.color.muted }, `... (${count} ${side} task${count === 1 ? '' : 's'})`),
       )
+    const isMerged = group => group.phase && group.items.length === 1 && depthOf(group.items[0]) === 0
+    // Merged rows share one marker column: phase names differ in width
+    // (Discovery vs Implementation), so each phase pads to the widest merged
+    // label and every `[ ]` starts at the same cell.
+    const phaseColumn = Math.max(
+      0,
+      ...groups.filter(isMerged).map(group => cellWidth(truncateCells(group.phase, budget))),
+    )
     const rows = []
     if (start > 0) rows.push(foldLine('todo-earlier', start, 'earlier'))
     groups.forEach((group, groupIndex) => {
-      const merged = group.phase && group.items.length === 1 && depthOf(group.items[0]) === 0
-      if (merged) {
+      if (isMerged(group)) {
         const item = group.items[0]
+        const label = truncateCells(group.phase, budget)
         rows.push(
           h(
             Text,
             { key: `todo-${groupIndex}`, wrap: 'truncate-end' },
-            h(Text, phaseProps(group.phase), `${truncateCells(group.phase, budget)} `),
+            h(Text, phaseProps(group.phase), `${label}${' '.repeat(phaseColumn - cellWidth(label) + 1)}`),
             h(Text, itemProps(item), itemLabel(item)),
           ),
         )

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -315,7 +315,10 @@ class TuiWidgetPackTests(unittest.TestCase):
         # muted "... (N earlier/later tasks)" fold lines.
         self.assertIn("Array.isArray(todo.items)", widget)
         self.assertIn("last.phase === phase", widget)
-        self.assertIn("${truncateCells(group.phase, budget)} `", widget)
+        # Merged rows pad every phase label to one shared marker column so
+        # `[ ]` lines up regardless of phase-name width.
+        self.assertIn("const phaseColumn = Math.max(", widget)
+        self.assertIn("' '.repeat(phaseColumn - cellWidth(label) + 1)", widget)
         self.assertIn("const TODO_DISPLAY_ROWS = 7", widget)
         self.assertIn("depthOf", widget)
         self.assertIn("'  '.repeat(depthOf(item))", widget)


### PR DESCRIPTION
## Capability

Merged single-task phase rows in the `[Plan]` panel share one marker column: every `[ ]`/`[•]` starts at the same cell regardless of phase-name width.

## Motivation

Owner, on the live render: 'todo 정렬이 살짝 안맞네, [] 부터는 같은줄에 있게 해줘' — `Discovery`, `Design`, `Implementation` rows each started their marker at a different column.

## Implementation (boundary level)

Widget-only. Each merged row pads its (truncated) phase label to the widest merged label currently in view, using the existing CJK-aware `cellWidth`, then places the marker. Dense-phase header rows and indented subtask rows are unchanged. Payload untouched.

## Observed verification

- `node --check`: pass; padding math simulated against the screenshot's six phases produces a single aligned marker column.
- Phase-todo suite locally: OK. Widget/HUD/phase suites plus the full suite running in a clean worktree at this commit; reported before merge alongside CI.

## Risks

- None beyond rendering; a plan mixing one very long phase name with short ones pushes the column right, bounded by the existing truncation budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)