### PR TITLE
fix(delegation): no-usage children read failed, and routes can fall back

### DIFF
--- a/src/plugin_bundle/omh/hermes_delegation.py
+++ b/src/plugin_bundle/omh/hermes_delegation.py
@@ -352,6 +352,16 @@ def read_hermes_native_subagents(
             row_state = "running"
         else:
             row_state = "done"
+        # A terminal child with NO recorded model usage never completed a
+        # single API call, yet Hermes still marks the delegation "completed"
+        # and delivers the provider error text as a normal result (observed
+        # live: HTTP 400 "model is not supported when using Codex with a
+        # ChatGPT account" rendering as a ✓ done row). No usage means no
+        # work happened: project the row as failed, never done.
+        failure_hint = ""
+        if row_state == "done" and not usage:
+            row_state = "failed"
+            failure_hint = "no model usage observed"
 
         input_tokens = usage.get("input_tokens") or 0.0
         output_tokens = usage.get("output_tokens") or 0.0
@@ -388,6 +398,8 @@ def read_hermes_native_subagents(
             ),
             "delegation_id": delegation_id,
         }
+        if failure_hint:
+            row["failure_hint"] = failure_hint
         api_calls = usage.get("api_calls")
         if api_calls is not None:
             row["turn_count"] = int(api_calls)

--- a/src/plugin_bundle/omh/tools/delegate_route_tool.py
+++ b/src/plugin_bundle/omh/tools/delegate_route_tool.py
@@ -21,17 +21,26 @@ OMH_DELEGATE_ROUTE_SCHEMA = {
         "visual-engineering, artistry) by writing the delegation.model / "
         "delegation.reasoning_effort keys Hermes reads per dispatch. Sequence per lane: "
         "set the route, call delegate_task for that lane, then set the next lane's route "
-        "or clear to restore parent inheritance. Children already running keep their model."
+        "or clear to restore parent inheritance. Children already running keep their model. "
+        "Hermes has NO provider-side fallback: a child whose model the billing account "
+        "cannot serve dies on an HTTP 400 yet its delegation still reports completed with "
+        "the error text as the result — a completed child with no recorded model usage "
+        "means exactly this. When that happens call action=fallback to advance the route "
+        "to the category chain's next candidate and re-dispatch; an exhausted chain "
+        "clears the route so the next dispatch inherits the parent's working model."
     ),
     "parameters": {
         "type": "object",
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["set", "clear", "status"],
+                "enum": ["set", "clear", "status", "fallback"],
                 "description": (
                     "set writes a route; clear removes the routable keys so children "
-                    "inherit the parent again; status reads the current route."
+                    "inherit the parent again; status reads the current route; fallback "
+                    "advances the current route to the next candidate in its category "
+                    "chain (clearing to parent inheritance once the chain is exhausted) "
+                    "— use it after a dispatched child completed with no model usage."
                 ),
             },
             "category": {
@@ -101,8 +110,96 @@ def omh_delegate_route_handler(args: dict[str, Any], **kwargs) -> str:
         result["evidence_boundary"] = _EVIDENCE_BOUNDARY
         return json.dumps(attach_public_observation(result, observation), sort_keys=True)
 
+    if action == "fallback":
+        route = read_delegation_route(hermes_home)
+        current_model = str(route.get("model", ""))
+        current_effort = str(route.get("reasoning_effort", ""))
+        if not current_model:
+            payload = {
+                "status": "error",
+                "error": "no active route to fall back from; use set with a category first",
+            }
+            return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
+        category = str(args.get("category", "") or "").strip()
+        if category and category not in HERMES_MIXTURE_CATEGORY_CHAINS:
+            payload = {
+                "status": "error",
+                "error": (
+                    f"unknown category {category!r}; choose one of "
+                    + ", ".join(sorted(HERMES_MIXTURE_CATEGORY_CHAINS))
+                ),
+            }
+            return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
+        if not category:
+            # A (model, effort) pair can sit in several chains — e.g.
+            # glm-5.2-ultrafast:low ends unspecified-low AND heads quick.
+            # Prefer the effort-exact match, and within each pool prefer a
+            # chain that can still advance: fallback exists to move forward,
+            # so an ambiguous route only reads as exhausted when NO matching
+            # chain has a next candidate.
+            def _chain_index(chain: tuple) -> int:
+                return next((i for i, (alias, _) in enumerate(chain) if alias == current_model), -1)
+
+            exact = [
+                name
+                for name, chain in HERMES_MIXTURE_CATEGORY_CHAINS.items()
+                if any(alias == current_model and chain_effort == current_effort for alias, chain_effort in chain)
+            ]
+            loose = [
+                name
+                for name, chain in HERMES_MIXTURE_CATEGORY_CHAINS.items()
+                if any(alias == current_model for alias, _ in chain)
+            ]
+            for pool in (exact, loose):
+                if not pool:
+                    continue
+                advancing = [
+                    name
+                    for name in pool
+                    if 0 <= _chain_index(HERMES_MIXTURE_CATEGORY_CHAINS[name])
+                    < len(HERMES_MIXTURE_CATEGORY_CHAINS[name]) - 1
+                ]
+                category = (advancing or pool)[0]
+                break
+        if not category:
+            payload = {
+                "status": "error",
+                "error": (
+                    f"current route model {current_model!r} is not in any mixture chain; "
+                    "pass category explicitly"
+                ),
+            }
+            return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
+        chain = HERMES_MIXTURE_CATEGORY_CHAINS[category]
+        index = next((i for i, (alias, _) in enumerate(chain) if alias == current_model), -1)
+        if index < 0 or index + 1 >= len(chain):
+            # Chain exhausted: restore inheritance so the next dispatch runs on
+            # the parent's known-working model instead of one more rejection.
+            result = write_delegation_route(hermes_home, clear=True)
+            if result.get("status") == "cleared":
+                result["status"] = "exhausted_to_inherit"
+            result["category"] = category
+            result["from"] = current_model
+            result["evidence_boundary"] = _EVIDENCE_BOUNDARY
+            return json.dumps(attach_public_observation(result, observation), sort_keys=True)
+        next_model, next_effort = chain[index + 1]
+        result = write_delegation_route(hermes_home, model=next_model, reasoning_effort=next_effort)
+        if result.get("status") == "routed":
+            result["status"] = "fell_back"
+            result["category"] = category
+            result["from"] = current_model
+            result["fallback_candidates"] = [
+                {"model": alias, "reasoning_effort": chain_effort}
+                for alias, chain_effort in chain[index + 2 :]
+            ]
+        result["evidence_boundary"] = _EVIDENCE_BOUNDARY
+        return json.dumps(attach_public_observation(result, observation), sort_keys=True)
+
     if action != "set":
-        payload = {"status": "error", "error": f"unknown action {action!r}; use set, clear, or status"}
+        payload = {
+            "status": "error",
+            "error": f"unknown action {action!r}; use set, clear, status, or fallback",
+        }
         return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
 
     category = str(args.get("category", "") or "").strip()

--- a/tests/test_delegate_route_tool.py
+++ b/tests/test_delegate_route_tool.py
@@ -143,6 +143,47 @@ class DelegateRouteToolTest(unittest.TestCase):
         self.assertEqual(result["status"], "error")
         self.assertIn("ultrabrain", result["error"])
 
+    def test_fallback_advances_to_the_next_chain_candidate(self):
+        self._call(action="set", category="quick")
+        result = self._call(action="fallback")
+        self.assertEqual(result["status"], "fell_back")
+        self.assertEqual(result["category"], "quick")
+        self.assertEqual(result["from"], "glm-5.2-ultrafast")
+        self.assertEqual(result["fallback_candidates"], [])
+        self.assertEqual(
+            read_delegation_route(self.home),
+            {"model": "kimi-k3", "reasoning_effort": "low"},
+        )
+
+    def test_an_exhausted_chain_clears_the_route_to_parent_inheritance(self):
+        # The whole chain was rejected (e.g. a single-provider billing account
+        # serves none of it); the only known-working model is the parent's, so
+        # fallback past the end restores inheritance instead of routing one
+        # more rejection.
+        self._call(action="set", category="quick")
+        self._call(action="fallback")
+        result = self._call(action="fallback")
+        self.assertEqual(result["status"], "exhausted_to_inherit")
+        self.assertEqual(result["category"], "quick")
+        self.assertEqual(result["from"], "kimi-k3")
+        self.assertEqual(read_delegation_route(self.home), {})
+
+    def test_fallback_without_a_route_is_an_error(self):
+        result = self._call(action="fallback")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("no active route", result["error"])
+
+    def test_an_explicit_category_disambiguates_a_shared_model(self):
+        # kimi-k3:medium sits in more than one chain; the caller who routed
+        # writing passes the category so fallback advances inside writing.
+        self._call(action="set", category="writing")
+        result = self._call(action="fallback", category="writing")
+        self.assertEqual(result["status"], "fell_back")
+        self.assertEqual(
+            read_delegation_route(self.home),
+            {"model": "qwen3-coder", "reasoning_effort": "medium"},
+        )
+
     def test_clear_then_status_shows_an_inherited_route(self):
         self._call(action="set", category="deep")
         cleared = self._call(action="clear")

--- a/tests/test_plugin_hermes_delegation.py
+++ b/tests/test_plugin_hermes_delegation.py
@@ -301,6 +301,33 @@ class HermesNativeSubagentReaderTest(unittest.TestCase):
         self.assertEqual(payload["rows"][0]["state"], "done")
         self.assertEqual(payload["completed"], 1)
 
+    def test_a_completed_delegation_with_no_usage_projects_failed(self):
+        # Observed live: the billing account rejected the routed model with
+        # HTTP 400 ("not supported when using Codex with a ChatGPT account"),
+        # the child died in half a second with zero successful API calls, yet
+        # Hermes recorded the delegation "completed" and the HUD drew ✓.
+        # No recorded model usage on a terminal child means no work happened.
+        _build_state_db(
+            self.home,
+            [
+                {
+                    "id": "20260818_100100_eeee55",
+                    "model": "glm-5.2-ultrafast",
+                    "started_at": NOW - 60,
+                }
+            ],
+            delegation_states={"deleg_nousage": "completed"},
+        )
+        _write_manifest(
+            self.home, "deleg_nousage", ["rejected lane"], started=NOW - 65, log_mtime=NOW - 59
+        )
+        payload = read_hermes_native_subagents(self.home, now=NOW)
+        row = payload["rows"][0]
+        self.assertEqual(row["state"], "failed")
+        self.assertEqual(row["failure_hint"], "no model usage observed")
+        self.assertEqual(payload["blocked"], 1)
+        self.assertEqual(payload["completed"], 0)
+
     def test_a_failed_delegation_projects_a_failed_row_counted_as_blocked(self):
         _build_state_db(
             self.home,


### PR DESCRIPTION
## Capability

Two delegation-routing gaps closed:

1. **HUD honesty** — a terminal Hermes-native child with no recorded model usage (zero successful API calls) projects as `failed` (▲, counted blocked) with `failure_hint: "no model usage observed"`, instead of the false ✓ done.
2. **Route fallback** — `omh_delegate_route` gains `action=fallback`: advance the current route to the next candidate in its category chain; an exhausted chain clears the route so the next dispatch inherits the parent's known-working model.

## Motivation

Observed live on the owner's machine: a quick-lane child routed to `glm-5.2-ultrafast` died in 0.46s on **HTTP 400 "The 'glm-5.2-ultrafast' model is not supported when using Codex with a ChatGPT account"** with zero API calls — yet Hermes recorded the delegation `completed`, delivered the error text as a normal result summary, and the HUD drew ✓. A `claude-fable-5` (visual-engineering) child hit the same 400. Hermes has no provider-side fallback and nothing advanced the prepared fallback candidates.

## Implementation (boundary level)

- `hermes_delegation.py`: terminal `done` + empty `session_model_usage` → `failed` + `failure_hint`. A child that worked always has a usage row written per successful call.
- `delegate_route_tool.py`: `fallback` action. Ambiguity handling for a (model, effort) pair sitting in several chains: effort-exact matches win, chains that can still advance are preferred, and an explicit `category` argument disambiguates (the glm-5.2-ultrafast:low pair both ends unspecified-low and heads quick). Tool description now states the failure signature and recovery sequence so routing agents self-serve it.
- OMH still never dispatches or retries anything itself — fallback is a prepared route the parent agent applies on re-dispatch.

## Observed verification

- Route-tool + delegation-reader + HUD suites (68 tests) green locally, including the new contracts: no-usage→failed projection, fallback advance, chain-exhausted→inherit, no-route error, explicit-category disambiguation.
- Full suite running in a clean worktree at this commit; reported before merge alongside CI.

## Risks

- Done-with-no-usage rows flip to blocked in the HUD — that is the point, but any workflow reading `completed` counts sees fewer dones for rejected children.
- Implicit chain detection on ambiguous routes picks the advancing effort-exact chain; callers wanting a specific chain pass `category`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)