### PR TITLE
fix(ralplan): pin plan artifacts to the OMH state root, never .omc

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -3787,6 +3787,7 @@ These surfaces are generated command references, not installed Hermes workflow s
   - Make acceptance criteria testable.
   - Record unresolved tradeoffs explicitly.
   - Keep rejected options and handoff readiness separate from accepted execution evidence.
+  - Write plan artifacts only through the named `omh hermes plan` commands under `<repo>/.omh/plans/`; never write plans or planning state into `.omc/**` or any other wrapper's state root — `.omc/` belongs to oh-my-claudecode, a different product.
 
 ### code-review
 

--- a/skills/ulw-plan/SKILL.md
+++ b/skills/ulw-plan/SKILL.md
@@ -120,6 +120,7 @@ Safety rules:
 - Make acceptance criteria testable.
 - Record unresolved tradeoffs explicitly.
 - Keep rejected options and handoff readiness separate from accepted execution evidence.
+- Write plan artifacts only through the named `omh hermes plan` commands under `<repo>/.omh/plans/`; never write plans or planning state into `.omc/**` or any other wrapper's state root — `.omc/` belongs to oh-my-claudecode, a different product.
 
 ## Runtime Evidence
 

--- a/src/maintenance/release.py
+++ b/src/maintenance/release.py
@@ -133,7 +133,10 @@ STANDALONE_CAPABILITY_SKILL_ITEM_CHAR_LIMIT = 2200
 # Re-measured for the phase-todo discipline (todo init before engine work,
 # bounded HUD-visible checklist instead of an open-ended reasoning loop) added
 # to the same quality bar. Deliberate; the ceiling stays the measured value.
-FULL_PROFILE_SKILL_BODY_CHAR_LIMIT = 700058
+# 700058 -> 700304: ralplan gained a state-root guard safety rule (+246
+# chars) pinning plan artifacts to <repo>/.omh/plans/ and forbidding .omc/**
+# after observed cross-product drift; warranted growth, not padding.
+FULL_PROFILE_SKILL_BODY_CHAR_LIMIT = 700304
 FULL_PROFILE_SKILL_BODY_REVIEWED_EXCEPTION_CHARS = 0
 
 

--- a/src/skills/catalog_definitions.py
+++ b/src/skills/catalog_definitions.py
@@ -4549,6 +4549,7 @@ _DEFINITIONS = [
             "Make acceptance criteria testable.",
             "Record unresolved tradeoffs explicitly.",
             "Keep rejected options and handoff readiness separate from accepted execution evidence.",
+            "Write plan artifacts only through the named `omh hermes plan` commands under `<repo>/.omh/plans/`; never write plans or planning state into `.omc/**` or any other wrapper's state root — `.omc/` belongs to oh-my-claudecode, a different product.",
         ),
         quality_tier="reviewed-plan-gated",
         quality_bar=(


### PR DESCRIPTION
## Capability

`ralplan` (installed as `ulw-plan`) now carries an explicit state-root guard in its safety rules: plan artifacts go only through the named `omh hermes plan` commands under `<repo>/.omh/plans/`, and never into `.omc/**` or any other wrapper's state root — `.omc/` belongs to oh-my-claudecode, a different product.

## Motivation

Owner observed agents running ulw-plan writing plan files into `.omc/…`. The skill already named the correct command and path but had no negative guard, so a model with oh-my-claudecode habits (the skill's lineage name, ralplan, comes from there) invented `.omc/plans` whenever it skipped the recording command.

## Implementation (boundary level)

One safety-rule line in `src/skills/catalog_definitions.py`; `skills/ulw-plan/SKILL.md` and `docs/WORKFLOWS.md` regenerated in the same commit per the byte-gate rule. No routing triggers, counts, or schemas change.

## Observed verification

- `docs workflows --check` / `docs roles --check` byte gates: pass (tap-skills staleness cleared).
- Router-content + application-cases suites (103 tests): OK.
- Full suite running in a clean worktree at this commit; reported before merge alongside CI.

## Risks

- Instruction-level guard: if the drift recurs despite it, the next rung is a `pre_tool_call` path guard rejecting `.omc/**` writes from the planning lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)