### PR TITLE
feat(hud): brand concurrent tool-call batches as a parallel shot

### DIFF
--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -290,6 +290,16 @@ export default function register(sdk) {
         h(Text, { color: t.color.border }, SEPARATOR),
         h(Text, { color: active ? t.color.warn : t.color.ok }, hudStateLabel(active, agents)),
         h(Text, { color: t.color.muted }, ` • ${metrics.cost} • ${metrics.ctx}`),
+        // A fresh concurrent tool-call batch (observed by the pre_tool_call
+        // hook) gets branded on the status line: the transcript's collapsed
+        // "Tool calls (N)" group never says whether the batch ran parallel.
+        payload.parallel_shot && payload.parallel_shot.status === 'observed'
+          ? h(
+              Text,
+              { color: t.color.label },
+              ` • parallel shot ×${Number(payload.parallel_shot.size) || 0}`,
+            )
+          : null,
       ),
       // No animation, ever: the dock must read like plain text so a terminal
       // drag-selection over it survives, and under throttled repaints any

--- a/src/plugin_bundle/omh/hooks/tool_hooks.py
+++ b/src/plugin_bundle/omh/hooks/tool_hooks.py
@@ -4,11 +4,15 @@ import json
 
 from ..host_observation import observe_plugin_hook_call
 from ..omh_roles import extract_role_marker, resolve_role_name, role_aliases, role_names
+from ..tool_bursts import record_tool_call
 
 
 def pre_tool_call(**kwargs) -> dict[str, object] | None:
     """Return only host-supported pre-tool directives or role warnings."""
     observe_plugin_hook_call("pre_tool_call", kwargs)
+    # Tick the parallel-shot ledger: concurrent batch members start within
+    # milliseconds of each other, and this is the only place OMH can see it.
+    record_tool_call(kwargs.get("tool_name"), omh_home=str(kwargs.get("omh_home", "") or ""))
     context_parts: list[str] = []
     payload: dict[str, object] = {}
     role_warning = _delegate_role_warning(kwargs)

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from .hermes_delegation import read_hermes_native_subagents
+from .tool_bursts import latest_parallel_shot
 from .metadata import (
     OPTIONAL_HOOKS,
     PROVIDED_HOOKS,
@@ -641,6 +642,9 @@ def read_omh_hud(
         "achievements": _achievements_summary(hermes),
         "tokens": _token_summary(token_metadata or {}),
         "todo": _todo_summary(home),
+        # Concurrent tool-call batches observed by the pre_tool_call hook;
+        # the [OMH] status line brands a fresh batch as a parallel shot.
+        "parallel_shot": latest_parallel_shot(str(home)),
         "evidence_boundary": (
             "HUD is metadata-only. Prepared handoffs are not execution, review, CI, merge, or token-usage evidence. "
             "Todo items are plan declarations, not execution evidence."

--- a/src/plugin_bundle/omh/tool_bursts.py
+++ b/src/plugin_bundle/omh/tool_bursts.py
@@ -1,0 +1,121 @@
+"""Parallel tool-call burst observation for the HUD.
+
+Hermes executes a model turn's batched tool calls concurrently (its
+``_execute_tool_calls_concurrent`` dispatch), but the transcript renders
+only a collapsed "Tool calls (N)" group — nothing tells the user whether
+that batch actually ran as a parallel shot. The ``pre_tool_call`` hook
+fires once per call, so calls whose start ticks land inside one short
+window are the concurrent batch. This module records those ticks (tool
+name and timestamp only, never arguments or results) and projects the
+latest burst for the ``[OMH]`` status line.
+"""
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Reuse the awareness ledger's portable lock and atomic-write primitives so
+# there is exactly one file-locking implementation in the plugin.
+from .awareness_delivery import _awareness_delivery_lock, _write_delivery_record
+
+TOOL_BURSTS_SCHEMA_VERSION = "omh_tool_bursts/v1"
+TOOL_BURSTS_FILE = "tool-bursts.json"
+MAX_TOOL_BURST_ENTRIES = 40
+# Ticks closer together than this belong to one dispatch burst: Hermes
+# starts a concurrent batch's workers within milliseconds of each other,
+# while consecutive sequential turns are separated by at least one model
+# round-trip.
+BURST_WINDOW_SECONDS = 1.5
+# The HUD shows the latest burst only while it is recent enough to still
+# describe "what just happened".
+BURST_FRESH_SECONDS = 90.0
+TOOL_BURST_CLAIM_BOUNDARY = (
+    "Burst grouping observes pre_tool_call start ticks only; it is evidence "
+    "the host dispatched the calls as one batch, not proof every call "
+    "overlapped for its full duration."
+)
+_MAX_TOOL_NAME_CHARS = 48
+
+
+def _runtime_dir(omh_home: str = "") -> Path:
+    root = Path(omh_home).expanduser() if omh_home else Path.home() / ".omh"
+    return root / "runtime"
+
+
+def tool_bursts_path(omh_home: str = "") -> Path:
+    return _runtime_dir(omh_home) / TOOL_BURSTS_FILE
+
+
+def record_tool_call(tool_name: object, *, omh_home: str = "", now: float | None = None) -> None:
+    """Append one pre_tool_call tick. Best-effort: losing a tick is acceptable,
+    breaking the hook that feeds the model is not."""
+    name = " ".join(str(tool_name or "").split())[:_MAX_TOOL_NAME_CHARS]
+    if not name:
+        return
+    tick = float(now if now is not None else time.time())
+    path = tool_bursts_path(omh_home)
+    try:
+        with _awareness_delivery_lock(path):
+            entries = _read_entries(path)
+            entries.append({"tool": name, "ts": tick})
+            entries = entries[-MAX_TOOL_BURST_ENTRIES:]
+            _write_delivery_record(
+                path,
+                {"schema_version": TOOL_BURSTS_SCHEMA_VERSION, "entries": entries},
+            )
+    except (OSError, ValueError, TypeError):
+        return
+
+
+def _read_entries(path: Path) -> list[dict[str, Any]]:
+    try:
+        record = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    raw = record.get("entries") if isinstance(record, dict) else None
+    entries: list[dict[str, Any]] = []
+    for item in raw if isinstance(raw, list) else []:
+        if not isinstance(item, dict):
+            continue
+        tick = item.get("ts")
+        tool = str(item.get("tool", "") or "")
+        if isinstance(tick, (int, float)) and not isinstance(tick, bool) and tool:
+            entries.append({"tool": tool[:_MAX_TOOL_NAME_CHARS], "ts": float(tick)})
+    entries.sort(key=lambda entry: entry["ts"])
+    return entries
+
+
+def latest_parallel_shot(omh_home: str = "", *, now: float | None = None) -> dict[str, Any]:
+    """Project the most recent concurrent batch, or an idle marker."""
+    current = float(now if now is not None else time.time())
+    entries = _read_entries(tool_bursts_path(omh_home))
+    idle: dict[str, Any] = {"status": "idle"}
+    if not entries:
+        return idle
+    groups: list[list[dict[str, Any]]] = [[entries[0]]]
+    for entry in entries[1:]:
+        if entry["ts"] - groups[-1][-1]["ts"] <= BURST_WINDOW_SECONDS:
+            groups[-1].append(entry)
+        else:
+            groups.append([entry])
+    latest = next((group for group in reversed(groups) if len(group) >= 2), None)
+    if latest is None:
+        return idle
+    last_tick = latest[-1]["ts"]
+    if current - last_tick > BURST_FRESH_SECONDS:
+        return idle
+    observed_at = (
+        datetime.fromtimestamp(last_tick, tz=timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+    return {
+        "status": "observed",
+        "size": len(latest),
+        "distinct_tools": len({entry["tool"] for entry in latest}),
+        "observed_at": observed_at,
+        "claim_boundary": TOOL_BURST_CLAIM_BOUNDARY,
+    }

--- a/tests/test_tool_bursts.py
+++ b/tests/test_tool_bursts.py
@@ -1,0 +1,82 @@
+"""Contracts for parallel tool-call burst observation.
+
+Hermes dispatches a model turn's batched tool calls concurrently, but the
+transcript renders only a collapsed "Tool calls (N)" group. The
+pre_tool_call hook ticks this ledger per call; ticks inside one short
+window are the concurrent batch, and the HUD brands the latest fresh one
+as a parallel shot.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+from omh.plugin_bundle.omh.tool_bursts import (
+    BURST_FRESH_SECONDS,
+    MAX_TOOL_BURST_ENTRIES,
+    latest_parallel_shot,
+    record_tool_call,
+    tool_bursts_path,
+)
+
+NOW = 1_787_040_000.0
+
+
+class ToolBurstLedgerTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.home = str(Path(self._tmp.name) / "omh")
+
+    def test_calls_within_the_window_group_into_one_parallel_shot(self):
+        for offset, tool in ((0.0, "read_file"), (0.1, "read_file"), (0.2, "terminal"), (0.3, "search_files")):
+            record_tool_call(tool, omh_home=self.home, now=NOW + offset)
+        shot = latest_parallel_shot(self.home, now=NOW + 5)
+        self.assertEqual(shot["status"], "observed")
+        self.assertEqual(shot["size"], 4)
+        self.assertEqual(shot["distinct_tools"], 3)
+        self.assertIn("not proof", shot["claim_boundary"])
+
+    def test_sequential_calls_separated_by_round_trips_never_form_a_shot(self):
+        for offset in (0.0, 10.0, 25.0):
+            record_tool_call("terminal", omh_home=self.home, now=NOW + offset)
+        self.assertEqual(latest_parallel_shot(self.home, now=NOW + 30)["status"], "idle")
+
+    def test_a_stale_burst_expires_from_the_projection(self):
+        record_tool_call("read_file", omh_home=self.home, now=NOW)
+        record_tool_call("read_file", omh_home=self.home, now=NOW + 0.2)
+        self.assertEqual(latest_parallel_shot(self.home, now=NOW + 1)["status"], "observed")
+        self.assertEqual(
+            latest_parallel_shot(self.home, now=NOW + BURST_FRESH_SECONDS + 1)["status"],
+            "idle",
+        )
+
+    def test_the_ledger_is_capped_and_a_blank_tool_name_is_ignored(self):
+        record_tool_call("", omh_home=self.home, now=NOW)
+        self.assertFalse(tool_bursts_path(self.home).exists())
+        for index in range(MAX_TOOL_BURST_ENTRIES + 10):
+            record_tool_call("terminal", omh_home=self.home, now=NOW + index * 5)
+        import json
+
+        record = json.loads(tool_bursts_path(self.home).read_text(encoding="utf-8"))
+        self.assertEqual(len(record["entries"]), MAX_TOOL_BURST_ENTRIES)
+
+    def test_the_hud_payload_carries_the_latest_shot(self):
+        # The reader checks freshness against wall time, so record against
+        # wall time here.
+        import time
+
+        base = time.time()
+        record_tool_call("read_file", omh_home=self.home, now=base)
+        record_tool_call("terminal", omh_home=self.home, now=base + 0.3)
+        hermes = str(Path(self._tmp.name) / "hermes")
+        payload = read_omh_hud(self.home, hermes)
+        shot = payload["parallel_shot"]
+        self.assertEqual(shot["status"], "observed")
+        self.assertEqual(shot["size"], 2)
+        self.assertEqual(shot["distinct_tools"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -380,6 +380,9 @@ class TuiWidgetPackTests(unittest.TestCase):
         self.assertIn("PlanPulse", widget)
         self.assertIn("hasActive ? h(PlanPulse, { t }) : null", widget)
         self.assertNotIn("Number.MAX_SAFE_INTEGER", widget)
+        # A fresh concurrent tool-call batch is branded on the status line.
+        self.assertIn("parallel shot ×", widget)
+        self.assertIn("payload.parallel_shot", widget)
         self.assertIn("Math.min(3,", widget)
         self.assertNotIn("spinnerTimerKey", widget)
         self.assertIn("ActivityRow", widget)


### PR DESCRIPTION
## Capability

When the model batches tool calls and Hermes dispatches them concurrently, the `[OMH]` status line brands it: ` • parallel shot ×6`, fresh for 90 seconds after the batch.

## Motivation

Owner, looking at a collapsed `▾ Tool calls (6)` transcript group with six near-identical sub-second durations: '병렬이 된건가 가시성이 없어서 (Parallel Shot) 같은 괄호같은게 쳐지면 좋겠는데'. Verified in the Hermes source that batched calls DO run concurrently (`agent/tool_executor.py`, `_execute_tool_calls_concurrent`, thread pool) and that batching is encouraged by the default `parallel_tool_call_guidance` plus OMH's parallel-tools guidance — but nothing in the UI said so.

## Implementation (boundary level)

- New `tool_bursts.py` in the plugin: the `pre_tool_call` hook ticks a runtime ledger (tool name + start timestamp only, never arguments/results; 40-entry cap; reuses the awareness ledger's portable lock/atomic-write primitives; fail-open).
- Ticks within a 1.5s window form one dispatch burst — concurrent batch workers start within milliseconds, sequential turns are separated by a model round-trip. The claim boundary states this is dispatch evidence, not full-duration overlap proof.
- `read_omh_hud` projects `parallel_shot` (`size`, `distinct_tools`, `observed_at`) while the latest burst is <90s old; the widget appends the branded segment to the `[OMH]` header.
- Transcript annotation and `transform_tool_result` injection were rejected (host-owned UI / pollutes model-visible results).

## Observed verification

- 5 new tool-burst contracts + HUD + CLI + plugin-distribution + capability-impact + hook-manifest suites green locally (only the known stale-worktree env failure, unrelated); `node --check` pass.
- Full suite running in a clean worktree at this commit; reported before merge alongside CI.

## Risks

- Global (not per-session) signal: delegation children also tick the ledger, so a fresh burst from any local Hermes process shows. That is the honest simple contract; per-session attribution is a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)