### PR TITLE
fix(tui): drop permanent not-collected cache/ctx labels from rows

### DIFF
--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -149,8 +149,13 @@ export default function register(sdk) {
   }
 
   const metricSegment = (kind, text) => ({ kind, text })
+  // Only observed values render. The old permanent not-collected labels on
+  // cache/ctx were honest but unresolvable for Hermes-native children — the
+  // host never records a child's context percentage — and read as a fixable
+  // problem ('서브에이전트 트리거는 다시 해야하나?'). Absence of a claim is
+  // just as honest, and the header's `ctx --` still marks the session gap.
   const observedPercent = (label, value) =>
-    Number.isFinite(value) ? `${label} ${value}%` : `${label} uncollected`
+    Number.isFinite(value) ? `${label} ${value}%` : ''
 
   const activityLayout = (row, columns, main) => {
     const state = safeText(row.state) || 'running'

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -392,7 +392,10 @@ class TuiWidgetPackTests(unittest.TestCase):
         self.assertIn("tok/s", widget)
         self.assertIn("cache_hit_percentage", widget)
         self.assertIn("context_percentage", widget)
-        self.assertIn("uncollected", widget)
+        # Only observed cache/ctx values render on rows: "uncollected" was a
+        # permanent label for hermes-native children (the host never records
+        # a child's context percentage) and read as a fixable problem.
+        self.assertNotIn("uncollected", widget)
         self.assertIn("'MAIN'", widget)
         self.assertIn("maestro.rows", widget)
         self.assertIn("fallback:", widget)


### PR DESCRIPTION
## Capability

Delegation rows in the `[OMH]` dock render `cache N%` / `ctx N%` only when the value was actually observed. The permanent `ctx uncollected` / `cache uncollected` labels are gone.

## Motivation

Owner, seeing `ctx uncollected` on a running child row: '서브에이전트 트리거는 다시 해야하나? ctx uncollected뜨는데' — the label read as a fixable problem, but it cannot resolve: Hermes never records a child session's context percentage, so re-triggering changes nothing.

## Implementation (boundary level)

Widget-only: `observedPercent` returns an empty segment when the value is not finite, and the existing segment filter drops it. No fabrication is introduced (estimating ctx from cumulative tokens was rejected as fabrication); the `[OMH]` header's `ctx --` still marks the session-level gap.

## Observed verification

- `node --check`: pass. Widget-pack + HUD suites (48 tests) at this exact commit in a clean worktree: OK.
- Full suite running in the same clean worktree; reported before merge alongside CI.

## Risks

- None functional; rows show fewer segments when metrics are absent, which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)