### PR TITLE
docs(omh-store): using other wrappers ON this repo is normal, drift is about artifact ownership

### DIFF
--- a/.omh/README.md
+++ b/.omh/README.md
@@ -28,8 +28,13 @@ are already tracked stay tracked — gitignore only hides untracked files.
 ## Do not confuse with the neighbouring roots
 
 Several agent products keep look-alike dot-directories. They are different
-products with different owners; never write one product's state into
-another's root.
+products with different owners. Working ON this repository *with* one of
+those wrappers is perfectly normal — an oh-my-claudecode or oh-my-opencode
+session developing oh-my-hermes will naturally create its own `.omc/` or
+`.omo/` state here, and the top-level `.gitignore` keeps that local. The
+rule is about **ownership of artifacts**, not presence of directories:
+OMH's recorded artifacts belong in OMH's root, and another wrapper's
+runtime state never gets committed as if it were OMH's.
 
 | Root | Product | Notes |
 | --- | --- | --- |
@@ -37,12 +42,13 @@ another's root.
 | `~/.omh/` | oh-my-hermes user scope | Skills, runtime state, HUD/todo stores |
 | `~/.hermes/` | **Hermes Agent** (the host) | Hermes' own home: `config.yaml`, `state.db`, `plugins/`, `tui-widgets/`. The installed OMH **plugin** lives at `~/.hermes/plugins/omh/` and the OMH TUI widget at `~/.hermes/tui-widgets/omh-status.mjs` — both are OMH-managed installs *into* Hermes' home, refreshed only through `omh update`, never by hand-copying. OMH never patches Hermes itself (`~/.hermes/hermes-agent/`). |
 | `.hermes/` (repo-local) | Hermes Agent | Rare repo-scoped Hermes state; not OMH's |
-| `.omc/` | oh-my-claudecode | A different wrapper (Claude Code); OMH never writes here |
-| `.omo/` | oh-my-opencode | A different wrapper (OpenCode). OMH only *reads* `~/.omo/omo.json[c]` to import category model preferences; it never writes `.omo/` |
+| `.omc/` | oh-my-claudecode | That wrapper's own state when a Claude Code session works on this repo — fine locally, gitignored; OMH never writes here |
+| `.omo/` | oh-my-opencode | That wrapper's own state when an OpenCode session works on this repo — fine locally, gitignored. OMH only *reads* `~/.omo/omo.json[c]` to import category model preferences |
 | `.loop/` | loop runtimes | Not OMH's |
 
-If an agent proposes writing a plan, todo, or any state into `.omc/`,
-`.omo/`, or `~/.hermes/hermes-agent/`, that is state-root drift — the same
-class of bug fixed in #1017 (plans written to `.omc/`) and #1021 (plans
-committed under `.omo/`). The correct target is always this directory (via
-the named `omh` commands) or the OMH home.
+If an agent proposes recording an **OMH artifact** (a plan, todo, research
+dossier) into `.omc/`, `.omo/`, or `~/.hermes/hermes-agent/` — or
+committing another wrapper's state as if it were OMH's — that is state-root
+drift, the class of bug fixed in #1017 (plans written to `.omc/`) and #1021
+(plans committed under `.omo/`). The correct target for OMH artifacts is
+always this directory (via the named `omh` commands) or the OMH home.


### PR DESCRIPTION
## Capability

The `.omh/README.md` neighbour-roots section now states the rule at the right scope: developing oh-my-hermes *with* oh-my-claudecode or oh-my-opencode is normal (their `.omc/`/`.omo/` state dirs appearing locally is expected and gitignored); state-root drift is specifically about **artifact ownership** — OMH artifacts recorded into another wrapper's root, or another wrapper's state committed as if it were OMH's.

## Motivation

Owner correction on the previous framing: '아니 머 사용자체는 .omo .omc로 ohmyhermes 코드수정할수는있는거니까'. The prior wording could read as if those directories existing here were itself the bug.

## Implementation

Three wording edits in `.omh/README.md` (intro paragraph, two table rows, drift paragraph). No code.

## Observed verification

Docs-only; byte gates do not cover this file.

## Risks

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)