### PR TITLE
docs(readme): slim the terminal section to titles and the feature list

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -150,24 +150,15 @@ omh
 <table align="center">
   <tr>
     <td width="50%" align="center">
-      <img src="assets/omh-terminal-boot-hud.png" alt="OH-MY-HERMES terminal boot: rebranded banner, available tools and skills, phase todo checklist above the prompt, and the OMH HUD with live delegation rows"><br>
-      <sub><b>OH-MY-HERMES の起動画面。</b><br>リブランドされたバナー、ツールとスキルの一覧、プロンプト上の phase todo チェックリスト、OMH HUD のライブ delegation 行。</sub>
+      <img src="assets/omh-terminal-boot-hud.png" alt="The OH-MY-HERMES boot"><br>
+      <sub><b>OH-MY-HERMES の起動画面。</b></sub>
     </td>
     <td width="50%" align="center">
-      <img src="assets/omh-terminal-ulw-work-session.png" alt="An ulw-work session in the OH-MY-HERMES terminal: mixture-routed research lanes dispatching Hermes-native subagents"><br>
-      <sub><b><code>ulw-work</code> 実行中。</b><br>mixture ルーティングされた lane が Hermes ネイティブのサブエージェントを dispatch し、各行に category・model:effort・turn・cost・cache が表示されます。</sub>
+      <img src="assets/omh-terminal-ulw-work-session.png" alt="An ulw-work run"><br>
+      <sub><b><code>ulw-work</code> 実行中。</b></sub>
     </td>
   </tr>
 </table>
-
-setup は管理された `omh` スキンをインストールします — 上のバッジ色を基準とした
-スカイターコイズのパレットで、バナー・ウェルカム行・レスポンスラベルが
-OH-MY-HERMES にリブランドされます。スキンが未選択の場合にのみデフォルトとして
-有効化されます。`hermes skin use <name>`(`default` を含む)は恒久的に優先され、
-OMH が明示的な選択を書き換えることはありません。TUI 内では OMH HUD がテーマ
-パネルとして描画されます: 作業中はコスト・ターン・キャッシュ指標付きの
-サブエージェント活動行、プロンプトの上にはプラン todo チェックリストが
-表示されます。
 
 OMH ワークフローの実行中にターミナルが表示するもの:
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -150,23 +150,15 @@ omh
 <table align="center">
   <tr>
     <td width="50%" align="center">
-      <img src="assets/omh-terminal-boot-hud.png" alt="OH-MY-HERMES terminal boot: rebranded banner, available tools and skills, phase todo checklist above the prompt, and the OMH HUD with live delegation rows"><br>
-      <sub><b>OH-MY-HERMES 부팅.</b><br>리브랜딩된 배너, 도구·스킬 목록, 프롬프트 위 phase todo 체크리스트, OMH HUD의 실시간 delegation 행.</sub>
+      <img src="assets/omh-terminal-boot-hud.png" alt="The OH-MY-HERMES boot"><br>
+      <sub><b>OH-MY-HERMES 부팅.</b></sub>
     </td>
     <td width="50%" align="center">
-      <img src="assets/omh-terminal-ulw-work-session.png" alt="An ulw-work session in the OH-MY-HERMES terminal: mixture-routed research lanes dispatching Hermes-native subagents"><br>
-      <sub><b><code>ulw-work</code> 실행.</b><br>mixture 라우팅된 lane이 Hermes-native 서브에이전트를 dispatch하고, 각 행에 category·model:effort·turn·cost·cache가 표시됩니다.</sub>
+      <img src="assets/omh-terminal-ulw-work-session.png" alt="An ulw-work run"><br>
+      <sub><b><code>ulw-work</code> 실행.</b></sub>
     </td>
   </tr>
 </table>
-
-setup은 관리형 `omh` 스킨을 설치합니다 — 위 배지 색을 기준으로 한 하늘색
-터쿼이즈 팔레트에, 배너·환영 문구·응답 라벨이 OH-MY-HERMES로 리브랜딩됩니다.
-스킨은 아무것도 선택되지 않았을 때만 기본으로 활성화됩니다. `hermes skin use
-<name>`(`default` 포함)은 영구히 우선하며, OMH는 명시적 선택을 절대 다시 쓰지
-않습니다. TUI 안에서 OMH HUD는 테마 패널로 렌더됩니다: 작업 중에는 비용·턴·캐시
-지표가 붙은 서브에이전트 활동 행이, 프롬프트 위에는 플랜 todo 체크리스트가
-표시됩니다.
 
 OMH 워크플로가 도는 동안 터미널이 보여주는 것:
 

--- a/README.md
+++ b/README.md
@@ -223,23 +223,15 @@ omh
 <table align="center">
   <tr>
     <td width="50%" align="center">
-      <img src="assets/omh-terminal-boot-hud.png" alt="OH-MY-HERMES terminal boot: rebranded banner, available tools and skills, phase todo checklist above the prompt, and the OMH HUD with live delegation rows carrying category, turn, cost, and cache metrics"><br>
-      <sub><b>The OH-MY-HERMES boot.</b><br>Rebranded banner, tools and skills at a glance, the phase todo checklist above the prompt, and live delegation rows in the OMH HUD.</sub>
+      <img src="assets/omh-terminal-boot-hud.png" alt="The OH-MY-HERMES boot"><br>
+      <sub><b>The OH-MY-HERMES boot.</b></sub>
     </td>
     <td width="50%" align="center">
-      <img src="assets/omh-terminal-ulw-work-session.png" alt="An ulw-work session in the OH-MY-HERMES terminal: mixture-routed research lanes dispatching Hermes-native subagents, with the plan checklist and per-agent activity rows tracking the run"><br>
-      <sub><b>An <code>ulw-work</code> run.</b><br>Mixture-routed lanes dispatch Hermes-native subagents; each row shows its category, model:effort, turn, cost, and cache.</sub>
+      <img src="assets/omh-terminal-ulw-work-session.png" alt="An ulw-work run"><br>
+      <sub><b>An <code>ulw-work</code> run.</b></sub>
     </td>
   </tr>
 </table>
-
-Setup installs a managed `omh` skin — sky turquoise anchored on the badge
-colour above, with the banner, welcome line, and response label rebranded to
-OH-MY-HERMES — and selects it only when no skin is chosen. `hermes skin use
-<name>` (including `default`) overrides it permanently; OMH never rewrites an
-explicit choice. Inside the TUI, the OMH HUD renders as a themed panel:
-subagent activity rows with cost, turn, and cache metrics while work runs, and
-the plan todo checklist above the prompt.
 
 What the terminal shows while OMH workflows run:
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -152,21 +152,15 @@ omh
 <table align="center">
   <tr>
     <td width="50%" align="center">
-      <img src="assets/omh-terminal-boot-hud.png" alt="OH-MY-HERMES terminal boot: rebranded banner, available tools and skills, phase todo checklist above the prompt, and the OMH HUD with live delegation rows"><br>
-      <sub><b>OH-MY-HERMES 启动画面。</b><br>重塑品牌的横幅、工具与技能一览、提示符上方的 phase todo 清单,以及 OMH HUD 中的实时 delegation 行。</sub>
+      <img src="assets/omh-terminal-boot-hud.png" alt="The OH-MY-HERMES boot"><br>
+      <sub><b>OH-MY-HERMES 启动画面。</b></sub>
     </td>
     <td width="50%" align="center">
-      <img src="assets/omh-terminal-ulw-work-session.png" alt="An ulw-work session in the OH-MY-HERMES terminal: mixture-routed research lanes dispatching Hermes-native subagents"><br>
-      <sub><b><code>ulw-work</code> 运行中。</b><br>mixture 路由的 lane 调度 Hermes 原生子代理,每行显示 category、model:effort、turn、cost 和 cache。</sub>
+      <img src="assets/omh-terminal-ulw-work-session.png" alt="An ulw-work run"><br>
+      <sub><b><code>ulw-work</code> 运行中。</b></sub>
     </td>
   </tr>
 </table>
-
-setup 会安装受管理的 `omh` 皮肤 — 以上方徽章颜色为基准的天空绿松石配色,
-横幅、欢迎语和响应标签均重塑为 OH-MY-HERMES。仅当未选择任何皮肤时才会默认
-激活。`hermes skin use <name>`(包括 `default`)将永久优先,OMH 绝不改写
-显式选择。在 TUI 中,OMH HUD 以主题面板呈现:工作进行时显示带成本、轮次和
-缓存指标的子代理活动行,提示符上方显示计划 todo 清单。
 
 OMH 工作流运行时,终端会展示:
 


### PR DESCRIPTION
## Capability

The OH-MY-HERMES terminal section in all four language editions now reads: bare `omh`, the two screenshots with title-only captions, and the four feature callouts. The managed-skin paragraph is gone.

## Motivation

Owner: caption prose and skin/palette details are noise next to the capability list — '이런문구 제목만 넣어', '이런내용도 빼라고', 'sky건 확장하건 이게 뭐가중요해 차라리 아래 핵심기능 리스트가 더 중요하지'.

## Implementation

Caption `<sub>` blocks trimmed to titles (alts shortened to match) and the skin paragraph removed in README.md/ko/ja/zh. Pinned heading and ULW byte-gated regions untouched.

## Observed verification

Router-content + distribution-surfaces suites green; localized editions back under the line budget.

## Risks

None; docs only. Skin behavior remains documented in Installation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)