### PR TITLE
feat(routing): western comparable-tier tails for open-weight-only chains

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -197,11 +197,13 @@ OMH には次の編集可能な順序付き recommendation chain が含まれて
 | `ultrabrain` | GPT-5.6 Sol |
 | `deep` | GPT-5.6 Terra |
 | `unspecified-high` | Kimi K3、次に Claude Opus 5 |
-| `unspecified-low` | GLM 5.2、次に GLM 5.2 Ultrafast |
-| `quick` | GLM 5.2 Ultrafast、次に Kimi K3 |
+| `unspecified-low` | GLM 5.2、次に GLM 5.2 Ultrafast、次に Claude Sonnet 5 (low) |
+| `quick` | GLM 5.2 Ultrafast、次に Kimi K3、次に Claude Fable 5 (low) |
 | `writing` | Kimi K3、次に Qwen3-Coder、次に Gemini 3.1 Pro |
 | `visual-engineering` | Claude Fable 5、次に Kimi K3 |
 | `artistry` | Gemini 3.1 Pro、次に Claude Fable 5、次に Kimi K3 |
+
+中国のオープンウェイトモデルで始まる chain は、同等ティアの GPT/Claude 候補で終わるため、一つの provider エコシステムが拒否されても chain 全体は尽きません。GLM 5.2 Ultrafast は [OpenGateway](https://opengateway.ai/) 経由で提供されます。
 
 Hermes に **モデルをセットアップして** と頼むと、確認や変更ができます。これは編集可能な優先設定であり、benchmark 結果ではありません。詳しい設定、fallback、provider、所有権のルールは [Guided Model Setup](docs/INSTALLATION.md#guided-model-setup) を参照してください。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -194,11 +194,13 @@ OMH에는 다음과 같이 편집 가능한 순서형 recommendation chain이 �
 | `ultrabrain` | GPT-5.6 Sol |
 | `deep` | GPT-5.6 Terra |
 | `unspecified-high` | Kimi K3, 다음 Claude Opus 5 |
-| `unspecified-low` | GLM 5.2, 다음 GLM 5.2 Ultrafast |
-| `quick` | GLM 5.2 Ultrafast, 다음 Kimi K3 |
+| `unspecified-low` | GLM 5.2, 다음 GLM 5.2 Ultrafast, 다음 Claude Sonnet 5 (low) |
+| `quick` | GLM 5.2 Ultrafast, 다음 Kimi K3, 다음 Claude Fable 5 (low) |
 | `writing` | Kimi K3, 다음 Qwen3-Coder, 다음 Gemini 3.1 Pro |
 | `visual-engineering` | Claude Fable 5, 다음 Kimi K3 |
 | `artistry` | Gemini 3.1 Pro, 다음 Claude Fable 5, 다음 Kimi K3 |
+
+중국 오픈웨이트 모델로 시작하는 chain은 비슷한 성능대의 GPT/Claude 후보로 끝나므로, 한 provider 생태계가 거부되어도 chain 전체가 소진되지 않습니다. GLM 5.2 Ultrafast는 [OpenGateway](https://opengateway.ai/)를 통해 제공됩니다.
 
 Hermes에게 **모델을 설정해 줘**라고 요청해 검토하거나 변경할 수 있습니다. 이는 편집 가능한 선호이며 benchmark 결과가 아닙니다. 자세한 설정, fallback, provider, 소유권 규칙은 [Guided Model Setup](docs/INSTALLATION.md#guided-model-setup)을 참조하세요.
 

--- a/README.md
+++ b/README.md
@@ -272,11 +272,16 @@ credential, dispatch, or execution evidence:
 | `ultrabrain` | GPT-5.6 Sol |
 | `deep` | GPT-5.6 Terra |
 | `unspecified-high` | Kimi K3, then Claude Opus 5 |
-| `unspecified-low` | GLM 5.2, then GLM 5.2 Ultrafast |
-| `quick` | GLM 5.2 Ultrafast, then Kimi K3 |
+| `unspecified-low` | GLM 5.2, then GLM 5.2 Ultrafast, then Claude Sonnet 5 (low) |
+| `quick` | GLM 5.2 Ultrafast, then Kimi K3, then Claude Fable 5 (low) |
 | `writing` | Kimi K3, then Qwen3-Coder, then Gemini 3.1 Pro |
 | `visual-engineering` | Claude Fable 5, then Kimi K3 |
 | `artistry` | Gemini 3.1 Pro, then Claude Fable 5, then Kimi K3 |
+
+Chains that lead with Chinese open-weight models end on a comparable-tier
+GPT/Claude candidate, so one rejected provider ecosystem cannot exhaust the
+whole chain. GLM 5.2 Ultrafast is served through
+[OpenGateway](https://opengateway.ai/).
 
 Ask Hermes to **set up my models** to review or change them. These are editable
 preferences, not benchmark results. See

--- a/README.zh.md
+++ b/README.zh.md
@@ -193,11 +193,13 @@ OMH 随附以下可编辑的有序 recommendation chain。guided model setup 只
 | `ultrabrain` | GPT-5.6 Sol |
 | `deep` | GPT-5.6 Terra |
 | `unspecified-high` | Kimi K3，其次 Claude Opus 5 |
-| `unspecified-low` | GLM 5.2，其次 GLM 5.2 Ultrafast |
-| `quick` | GLM 5.2 Ultrafast，其次 Kimi K3 |
+| `unspecified-low` | GLM 5.2，其次 GLM 5.2 Ultrafast，其次 Claude Sonnet 5 (low) |
+| `quick` | GLM 5.2 Ultrafast，其次 Kimi K3，其次 Claude Fable 5 (low) |
 | `writing` | Kimi K3，其次 Qwen3-Coder，其次 Gemini 3.1 Pro |
 | `visual-engineering` | Claude Fable 5，其次 Kimi K3 |
 | `artistry` | Gemini 3.1 Pro，其次 Claude Fable 5，其次 Kimi K3 |
+
+以中国开放权重模型开头的 chain 会以同级别的 GPT/Claude 候选收尾,因此单个 provider 生态被拒绝时不会耗尽整条 chain。GLM 5.2 Ultrafast 通过 [OpenGateway](https://opengateway.ai/) 提供。
 
 请让 Hermes **设置我的模型**，以查看或更改这些推荐。它们是可编辑的偏好，不是 benchmark 结果。详细的设置、fallback、provider 与所有权规则见 [Guided Model Setup](docs/INSTALLATION.md#guided-model-setup)。
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -245,9 +245,9 @@ The shipped catalog is editorial policy, not benchmark output:
 | `ultrabrain` | GPT-5.6 Sol (`xhigh`) |
 | `deep` | GPT-5.6 Terra (`high`) |
 | `unspecified-high` | Kimi K3, Claude Opus 5 |
-| `unspecified-low` | GLM 5.2, GLM 5.2 Ultrafast |
+| `unspecified-low` | GLM 5.2, GLM 5.2 Ultrafast, Claude Sonnet 5 (low) |
 | `visual-engineering` | Claude Fable 5, Kimi K3 |
-| `quick` | GLM 5.2 Ultrafast, Kimi K3 |
+| `quick` | GLM 5.2 Ultrafast, Kimi K3, Claude Fable 5 (low) |
 | `writing` | Kimi K3, Qwen3-Coder, Gemini 3.1 Pro |
 | `artistry` | Gemini 3.1 Pro, Claude Fable 5, Kimi K3 |
 | `x_platform_data` affinity | Grok, Kimi K3, Gemini |

--- a/site/docs/model-routing/index.html
+++ b/site/docs/model-routing/index.html
@@ -116,8 +116,8 @@
             <a class="reference-link" href="#missing"><span>ultrabrain</span><h3>Deepest reasoning</h3><p>GPT-5.6 Sol.</p></a>
             <a class="reference-link" href="#missing"><span>deep</span><h3>Strong default tier</h3><p>GPT-5.6 Terra.</p></a>
             <a class="reference-link" href="#missing"><span>unspecified-high</span><h3>Default working model</h3><p>Kimi K3 → Claude Opus 5.</p></a>
-            <a class="reference-link" href="#missing"><span>unspecified-low</span><h3>Cheaper fallback</h3><p>GLM 5.2 → GLM 5.2 Ultrafast.</p></a>
-            <a class="reference-link" href="#missing"><span>quick</span><h3>Short tasks</h3><p>GLM 5.2 Ultrafast → Kimi K3.</p></a>
+            <a class="reference-link" href="#missing"><span>unspecified-low</span><h3>Cheaper fallback</h3><p>GLM 5.2 → GLM 5.2 Ultrafast → Claude Sonnet 5.</p></a>
+            <a class="reference-link" href="#missing"><span>quick</span><h3>Short tasks</h3><p>GLM 5.2 Ultrafast → Kimi K3 → Claude Fable 5.</p></a>
             <a class="reference-link" href="#missing"><span>writing</span><h3>Prose and docs</h3><p>Kimi K3 → Qwen3-Coder → Gemini 3.1 Pro.</p></a>
             <a class="reference-link" href="#missing"><span>visual-engineering</span><h3>Frontend and visual</h3><p>Claude Fable 5 → Kimi K3.</p></a>
             <a class="reference-link" href="#missing"><span>artistry</span><h3>Unconventional work</h3><p>Gemini 3.1 Pro → Claude Fable 5 → Kimi K3.</p></a>

--- a/src/coding/model_recommendations.py
+++ b/src/coding/model_recommendations.py
@@ -138,6 +138,12 @@ _QWEN = _candidate(
     ("qwen-oauth", "openrouter", "opencode"),
     reasoning="Editorial coding and structured-writing alternative; not a benchmark claim.",
 )
+_SONNET_5 = _candidate(
+    "claude-sonnet-5",
+    "claude",
+    ("ccapi", "anthropic", "openrouter"),
+    reasoning="Editorial comparable-tier tail for open-weight chains; not a benchmark claim.",
+)
 
 # The category keys are exactly the existing closed vocabulary. Categories for
 # which the approved profile defines no recommendation remain explicit empty
@@ -159,8 +165,23 @@ SHIPPED_MODEL_RECOMMENDATIONS: Final[dict[str, object]] = {
         "ultrabrain": [deepcopy(_SOL_XHIGH)],
         "deep": [deepcopy(_TERRA)],
         "unspecified-high": [_with_effort(_KIMI_K3, "medium"), _with_effort(_OPUS_5, "medium")],
-        "unspecified-low": [_with_effort(_GLM, "low"), _with_effort(_GLM_FAST, "low")],
-        "quick": [_with_effort(_GLM_FAST, "low"), _with_effort(_KIMI_K3, "low")],
+        # Owner rule (2026-08-19): a chain made only of Chinese open-weight
+        # models ends with a comparable-tier GPT/Claude candidate, so one
+        # rejected ecosystem cannot exhaust the whole chain (observed live:
+        # a Codex-billed account 400'd every GLM child and quick fell
+        # straight to inherit). Sonnet 5 at low is the general comparable
+        # tier for unspecified-low; quick's order and Fable tail are the
+        # owner's explicit pick.
+        "unspecified-low": [
+            _with_effort(_GLM, "low"),
+            _with_effort(_GLM_FAST, "low"),
+            _with_effort(_SONNET_5, "low"),
+        ],
+        "quick": [
+            _with_effort(_GLM_FAST, "low"),
+            _with_effort(_KIMI_K3, "low"),
+            _with_effort(_FABLE_5, "low"),
+        ],
         "writing": [
             _with_effort(_KIMI_K3, "medium"),
             _with_effort(_QWEN, "medium"),

--- a/src/plugin_bundle/omh/hermes_delegation.py
+++ b/src/plugin_bundle/omh/hermes_delegation.py
@@ -39,8 +39,19 @@ HERMES_MIXTURE_CATEGORY_CHAINS: dict[str, tuple[tuple[str, str], ...]] = {
     "ultrabrain": (("gpt-5.6-sol", "xhigh"),),
     "deep": (("gpt-5.6-terra", "high"),),
     "unspecified-high": (("kimi-k3", "medium"), ("claude-opus-5", "medium")),
-    "unspecified-low": (("glm-5.2", "low"), ("glm-5.2-ultrafast", "low")),
-    "quick": (("glm-5.2-ultrafast", "low"), ("kimi-k3", "low")),
+    # Chains made only of Chinese open-weight models end with a
+    # comparable-tier GPT/Claude candidate (owner rule, 2026-08-19), so one
+    # rejected ecosystem cannot exhaust the whole chain.
+    "unspecified-low": (
+        ("glm-5.2", "low"),
+        ("glm-5.2-ultrafast", "low"),
+        ("claude-sonnet-5", "low"),
+    ),
+    "quick": (
+        ("glm-5.2-ultrafast", "low"),
+        ("kimi-k3", "low"),
+        ("claude-fable-5", "low"),
+    ),
     "writing": (
         ("kimi-k3", "medium"),
         ("qwen3-coder", "medium"),

--- a/src/plugin_bundle/omh/tools/delegate_route_tool.py
+++ b/src/plugin_bundle/omh/tools/delegate_route_tool.py
@@ -159,7 +159,15 @@ def omh_delegate_route_handler(args: dict[str, Any], **kwargs) -> str:
                     if 0 <= _chain_index(HERMES_MIXTURE_CATEGORY_CHAINS[name])
                     < len(HERMES_MIXTURE_CATEGORY_CHAINS[name]) - 1
                 ]
-                category = (advancing or pool)[0]
+                # Head-most wins: a route set from a category starts at that
+                # chain's head, so when a (model, effort) pair sits in several
+                # advancing chains, the one holding it earliest is the likely
+                # origin (glm-5.2-ultrafast:low heads quick but is mid-chain
+                # in unspecified-low). Explicit `category` overrides.
+                category = min(
+                    advancing or pool,
+                    key=lambda name: _chain_index(HERMES_MIXTURE_CATEGORY_CHAINS[name]),
+                )
                 break
         if not category:
             payload = {

--- a/tests/test_delegate_route_tool.py
+++ b/tests/test_delegate_route_tool.py
@@ -149,7 +149,12 @@ class DelegateRouteToolTest(unittest.TestCase):
         self.assertEqual(result["status"], "fell_back")
         self.assertEqual(result["category"], "quick")
         self.assertEqual(result["from"], "glm-5.2-ultrafast")
-        self.assertEqual(result["fallback_candidates"], [])
+        # quick now carries the owner-ordered Western tail (Fable 5 at low)
+        # so a rejected open-weight ecosystem cannot exhaust the chain.
+        self.assertEqual(
+            result["fallback_candidates"],
+            [{"model": "claude-fable-5", "reasoning_effort": "low"}],
+        )
         self.assertEqual(
             read_delegation_route(self.home),
             {"model": "kimi-k3", "reasoning_effort": "low"},
@@ -162,10 +167,11 @@ class DelegateRouteToolTest(unittest.TestCase):
         # more rejection.
         self._call(action="set", category="quick")
         self._call(action="fallback")
+        self._call(action="fallback")
         result = self._call(action="fallback")
         self.assertEqual(result["status"], "exhausted_to_inherit")
         self.assertEqual(result["category"], "quick")
-        self.assertEqual(result["from"], "kimi-k3")
+        self.assertEqual(result["from"], "claude-fable-5")
         self.assertEqual(read_delegation_route(self.home), {})
 
     def test_fallback_without_a_route_is_an_error(self):

--- a/tests/test_model_recommendations.py
+++ b/tests/test_model_recommendations.py
@@ -156,11 +156,20 @@ class RecommendationCatalogTests(unittest.TestCase):
         self.assertEqual(aliases("role_suggestions", "main"), [
             "kimi-k3", "claude-opus-5", "claude-fable-5", "gpt-5.6-sol", "gpt-5.6-terra",
         ])
-        self.assertEqual(aliases("categories", "unspecified-low"), ["glm-5.2", "glm-5.2-ultrafast"])
+        # Open-weight-only chains carry a comparable-tier GPT/Claude tail
+        # (owner rule, 2026-08-19) so one rejected ecosystem cannot exhaust
+        # the chain.
+        self.assertEqual(
+            aliases("categories", "unspecified-low"),
+            ["glm-5.2", "glm-5.2-ultrafast", "claude-sonnet-5"],
+        )
         self.assertEqual(aliases("categories", "unspecified-high"), ["kimi-k3", "claude-opus-5"])
         self.assertEqual(aliases("categories", "ultrabrain"), ["gpt-5.6-sol"])
         self.assertEqual(aliases("categories", "deep"), ["gpt-5.6-terra"])
-        self.assertEqual(aliases("categories", "quick"), ["glm-5.2-ultrafast", "kimi-k3"])
+        self.assertEqual(
+            aliases("categories", "quick"),
+            ["glm-5.2-ultrafast", "kimi-k3", "claude-fable-5"],
+        )
         self.assertEqual(
             aliases("categories", "writing"),
             ["kimi-k3", "qwen3-coder", "gemini-3.1-pro"],
@@ -174,7 +183,10 @@ class RecommendationCatalogTests(unittest.TestCase):
             ["gemini-3.1-pro", "claude-fable-5", "kimi-k3"],
         )
         self.assertEqual(aliases("categories", "visual-engineering"), ["claude-fable-5", "kimi-k3"])
-        self.assertEqual(aliases("categories", "quick"), ["glm-5.2-ultrafast", "kimi-k3"])
+        self.assertEqual(
+            aliases("categories", "quick"),
+            ["glm-5.2-ultrafast", "kimi-k3", "claude-fable-5"],
+        )
         self.assertEqual(aliases("categories", "writing"), ["kimi-k3", "qwen3-coder", "gemini-3.1-pro"])
         self.assertEqual(aliases("categories", "artistry"), ["gemini-3.1-pro", "claude-fable-5", "kimi-k3"])
         self.assertEqual(aliases("domain_affinities", "x_platform_data"), [
@@ -489,7 +501,8 @@ class LastResortFallbackTests(unittest.TestCase):
         self.assertEqual(route["selected"]["model_alias"], "claude-opus-5")
         self.assertEqual(route["available_chain"], ["claude-opus-5"])
         self.assertEqual(
-            route["inactive_candidates"], ["glm-5.2-ultrafast", "kimi-k3", "gpt-5.6-sol"]
+            route["inactive_candidates"],
+            ["glm-5.2-ultrafast", "kimi-k3", "claude-fable-5", "gpt-5.6-sol"],
         )
         self.assertEqual(route["projection"]["kind"], "hermes_native_binding")
         self.assertEqual(route["projection"]["apply_state"], "approval_required")
@@ -532,7 +545,7 @@ class LastResortFallbackTests(unittest.TestCase):
         self.assertEqual(route["status"], "owner_default")
         self.assertEqual(
             route["inactive_candidates"],
-            ["glm-5.2-ultrafast", "kimi-k3", "claude-opus-5", "gpt-5.6-sol"],
+            ["glm-5.2-ultrafast", "kimi-k3", "claude-fable-5", "claude-opus-5", "gpt-5.6-sol"],
         )
 
     def test_maestro_projection_carries_the_whole_last_resort_order(self) -> None:


### PR DESCRIPTION
## Capability

Recommendation chains that consist only of Chinese open-weight models now end with a comparable-tier GPT/Claude candidate:

- `quick`: GLM 5.2 Ultrafast → Kimi K3 → **Claude Fable 5 (low)** (owner-ordered)
- `unspecified-low`: GLM 5.2 → GLM 5.2 Ultrafast → **Claude Sonnet 5 (low)**

so a single rejected provider ecosystem cannot exhaust a chain. The shipped catalog and the plugin's mixture chains move together (parity-gated); README model tables (all four languages) and `docs/INSTALLATION.md` follow, with a note stating the rule and that GLM 5.2 Ultrafast is served through [OpenGateway](https://opengateway.ai/).

## Motivation

Observed live: a Codex-billed account 400'd every GLM child; `quick`'s all-GLM/Kimi chain walked to exhaustion and inherited. Owner set the rule and the `quick` order explicitly, offered haiku/sonnet/opus-low/gpt-low for `unspecified-low`, and asked for the OpenGateway link.

## Implementation (boundary level)

- `model_recommendations.py`: new `_SONNET_5` candidate; both chains extended with rationale comments. `unspecified-high` (Opus tail), `writing` (Gemini tail) and the mixed chains already satisfy the rule.
- `hermes_delegation.py`: mirror chains updated (dict-parity gate keeps them locked together).
- `delegate_route_tool.py`: fallback ambiguity resolution gains a head-most preference — `glm-5.2-ultrafast:low` now advances in both `quick` (head) and `unspecified-low` (middle); a route set from a category starts at its head, so the head-most chain is the likely origin. Explicit `category` still overrides.
- Sonnet over Haiku for `unspecified-low` is an editorial pick (Haiku matches the Ultrafast speed tier; Opus/GPT overshoot a low lane) and remains user-editable via overrides.

## Observed verification

- Route-tool, delegation-parity, router-content, model-routing, model-setup, HUD, CLI suites: **508 tests OK** locally.
- All five byte gates green.
- Full suite running in a clean worktree at this commit; reported before merge alongside CI.

## Risks

- `quick` fallback walks one extra candidate before inheriting.
- Implicit fallback category detection prefers head-most chains; a route genuinely set from `unspecified-low` sitting on its middle candidate should pass `category` explicitly (documented in the tool description).

🤖 Generated with [Claude Code](https://claude.com/claude-code)