### PR TITLE
feat(reliability): add failure mender decisions

### DIFF
--- a/docs/failure-mender.md
+++ b/docs/failure-mender.md
@@ -1,0 +1,23 @@
+# Failure mender
+
+The failure mender produces a bounded, metadata-only decision for an observed
+error. It classifies failures as transient, persistent, permanent,
+external-wait, or unknown and maps them to retry, replan, stop, or escalate.
+
+Transient failures may retry only while `attempt < max_retries`. Persistent,
+permanent, external-wait, and unknown failures do not authorize blind retry.
+The original error text is never returned in the decision; a SHA-256 digest
+provides a safe correlation key.
+
+For `replan` and `escalate` outcomes, `build_escalation_request` prepares a
+reviewable Seed proposal. It does not create a Seed or perform escalation.
+Operators should inspect the proposal, reproduce the failure, and then invoke
+the project task tracker explicitly.
+
+## Rollout and rollback
+
+The MCP bridge attaches the decision to tool-error results while preserving the
+existing error status and payload. Consumers can ignore the additive field.
+Rollback is therefore a caller-side compatibility change: stop reading
+`failure_decision` or revert the bridge integration, without changing the
+classifier contract or stored artifacts.

--- a/src/core/failure_mender.py
+++ b/src/core/failure_mender.py
@@ -1,0 +1,103 @@
+"""Pure failure classification and no-blind-retry decisions."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any, Final, Mapping
+
+FAILURE_MENDER_SCHEMA_VERSION: Final = "failure_mender_decision/v1"
+FAILURE_KINDS: Final = ("transient", "persistent", "permanent", "external_wait", "unknown")
+FAILURE_ACTIONS: Final = ("retry", "replan", "stop", "escalate")
+_MAX_REASON_LENGTH: Final = 120
+
+_TRANSIENT_PATTERNS: Final = (
+    "timeout", "timed out", "temporarily unavailable", "connection reset",
+    "connection refused", "rate limit", "too many requests", "service unavailable",
+)
+_PERSISTENT_PATTERNS: Final = ("conflict", "stale", "revision", "out of date", "concurrent")
+_EXTERNAL_WAIT_PATTERNS: Final = (
+    "consent required", "awaiting approval", "credential required",
+    "authentication required", "login required",
+)
+_PERMANENT_PATTERNS: Final = (
+    "permission denied", "unauthorized", "forbidden", "invalid", "malformed", "unsupported", "not found",
+)
+
+
+def classify_failure(error: BaseException | str) -> tuple[str, str]:
+    """Return ``(kind, reason_code)`` using bounded, deterministic signals."""
+    message = str(error).casefold()
+    if isinstance(error, (TimeoutError, ConnectionError)) or any(pattern in message for pattern in _TRANSIENT_PATTERNS):
+        return "transient", "provider_or_transport_unavailable"
+    if any(pattern in message for pattern in _EXTERNAL_WAIT_PATTERNS):
+        return "external_wait", "external_authorization_or_approval"
+    if isinstance(error, PermissionError) or any(pattern in message for pattern in _PERMANENT_PATTERNS):
+        return "permanent", "invalid_or_unauthorized_request"
+    if any(pattern in message for pattern in _PERSISTENT_PATTERNS):
+        return "persistent", "state_conflict_requires_replan"
+    if isinstance(error, ValueError):
+        return "permanent", "invalid_input"
+    return "unknown", "unclassified_failure"
+
+
+def decide_failure(
+    error: BaseException | str,
+    *,
+    attempt: int = 0,
+    max_retries: int = 2,
+    source: str = "",
+) -> dict[str, Any]:
+    """Build an actionable decision without echoing the failure text."""
+    if isinstance(attempt, bool) or attempt < 0:
+        raise ValueError("attempt must be a non-negative integer")
+    if isinstance(max_retries, bool) or max_retries < 0:
+        raise ValueError("max_retries must be a non-negative integer")
+    kind, reason_code = classify_failure(error)
+    action = {
+        "transient": "retry" if attempt < max_retries else "escalate",
+        "persistent": "replan",
+        "permanent": "stop",
+        "external_wait": "escalate",
+        "unknown": "escalate",
+    }[kind]
+    text = str(error)
+    return {
+        "schema_version": FAILURE_MENDER_SCHEMA_VERSION,
+        "kind": kind,
+        "reason_code": reason_code,
+        "action": action,
+        "attempt": attempt,
+        "max_retries": max_retries,
+        "retry_allowed": action == "retry",
+        "source": _safe_source(source),
+        "failure_sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+        "claim_boundary": "A mender decision is a policy recommendation, not proof that a retry, replan, or escalation occurred.",
+    }
+
+
+def validate_failure_decision(decision: Mapping[str, object] | object) -> list[str]:
+    if not isinstance(decision, Mapping):
+        return ["decision must be an object"]
+    errors: list[str] = []
+    if decision.get("schema_version") != FAILURE_MENDER_SCHEMA_VERSION:
+        errors.append("schema_version is invalid")
+    if decision.get("kind") not in FAILURE_KINDS:
+        errors.append("kind is invalid")
+    if decision.get("action") not in FAILURE_ACTIONS:
+        errors.append("action is invalid")
+    for key in ("attempt", "max_retries"):
+        value = decision.get(key)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            errors.append(f"{key} must be a non-negative integer")
+    if decision.get("retry_allowed") is not (decision.get("action") == "retry"):
+        errors.append("retry_allowed must match action")
+    if not re.fullmatch(r"[0-9a-f]{64}", str(decision.get("failure_sha256", ""))):
+        errors.append("failure_sha256 must be a sha256 digest")
+    if "not" not in str(decision.get("claim_boundary", "")).casefold():
+        errors.append("claim_boundary must state a limitation")
+    return errors
+
+
+def _safe_source(value: str) -> str:
+    return " ".join(str(value).split())[:_MAX_REASON_LENGTH]

--- a/src/core/failure_mender.py
+++ b/src/core/failure_mender.py
@@ -99,5 +99,34 @@ def validate_failure_decision(decision: Mapping[str, object] | object) -> list[s
     return errors
 
 
+def build_escalation_request(decision: Mapping[str, object] | object) -> dict[str, Any] | None:
+    """Prepare a safe, deterministic Seed handoff for non-retry decisions.
+
+    The request is a proposal only. Callers must review it and invoke their own
+    task tracker; this module never creates external issues or retries work.
+    """
+    if validate_failure_decision(decision):
+        raise ValueError("cannot build an escalation request from an invalid decision")
+    record = decision
+    action = str(record["action"])
+    if action not in {"escalate", "replan"}:
+        return None
+    digest = str(record["failure_sha256"])
+    seed_id = f"failure-{digest[:12]}"
+    return {
+        "schema_version": "failure_escalation_request/v1",
+        "seed_id": seed_id,
+        "title": f"Investigate {record['reason_code']}",
+        "labels": ["failure", "escalation", str(record["kind"])],
+        "description": "Investigate the classified failure using the recorded metadata and reproduce it before changing retry behavior.",
+        "reason_code": record["reason_code"],
+        "source": record["source"],
+        "failure_sha256": digest,
+        "recommended_action": action,
+        "create_command": f"sd create --title 'Investigate {record['reason_code']}' --type bug --labels failure,escalation",
+        "claim_boundary": "This is a task proposal; it is not proof that a Seed was created or that escalation occurred.",
+    }
+
+
 def _safe_source(value: str) -> str:
     return " ".join(str(value).split())[:_MAX_REASON_LENGTH]

--- a/src/mcp/bridge.py
+++ b/src/mcp/bridge.py
@@ -12,6 +12,7 @@ from ..paths import OmhPaths
 from ..probe import probe_capabilities
 from ..routing.recommend import recommend_skills
 from ..runtime.artifacts import update_state
+from ..core.failure_mender import decide_failure
 
 MCP_PROTOCOL_VERSION = "2025-06-18"
 MCP_BRIDGE_SCHEMA_VERSION = "omh_mcp_bridge/v1"
@@ -511,12 +512,14 @@ def _tool_result(result_schema_version: str, tool: str, payload: dict[str, Any])
 
 
 def _error_tool_result(tool: str, message: str) -> dict[str, Any]:
+    failure_decision = decide_failure(message, source=f"mcp:{tool or 'unknown'}")
     return {
         "schema_version": MCP_TOOL_RESULT_SCHEMA_VERSION,
         "result_schema_version": "omh_tool_error/v1",
         "tool": tool or "unknown",
         "status": "tool_error",
         "error": message,
+        "failure_decision": failure_decision,
         "payload": {},
         "claim_boundary": MCP_BRIDGE_CLAIM_BOUNDARY,
     }

--- a/tests/test_failure_mender.py
+++ b/tests/test_failure_mender.py
@@ -6,7 +6,11 @@ from _local_package import load_local_package
 
 load_local_package()
 
-from omh.core.failure_mender import decide_failure, validate_failure_decision  # noqa: E402
+from omh.core.failure_mender import (  # noqa: E402
+    build_escalation_request,
+    decide_failure,
+    validate_failure_decision,
+)
 
 
 class FailureMenderTests(unittest.TestCase):
@@ -30,3 +34,13 @@ class FailureMenderTests(unittest.TestCase):
         self.assertEqual(decision["source"], "tool call")
         self.assertEqual(validate_failure_decision(decision), [])
         self.assertTrue(validate_failure_decision({**decision, "action": "retry", "retry_allowed": False}))
+
+    def test_escalation_request_is_safe_and_reviewable(self) -> None:
+        decision = decide_failure("provider timed out", attempt=2, max_retries=2, source="mcp:shell")
+        request = build_escalation_request(decision)
+        self.assertIsNotNone(request)
+        assert request is not None
+        self.assertEqual(request["seed_id"], "failure-" + decision["failure_sha256"][:12])
+        self.assertNotIn("provider timed out", str(request))
+        self.assertIn("sd create", request["create_command"])
+        self.assertIsNone(build_escalation_request(decide_failure(TimeoutError("temporary"), attempt=0)))

--- a/tests/test_failure_mender.py
+++ b/tests/test_failure_mender.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.core.failure_mender import decide_failure, validate_failure_decision  # noqa: E402
+
+
+class FailureMenderTests(unittest.TestCase):
+    def test_transient_failures_retry_until_the_cap_then_escalate(self) -> None:
+        retry = decide_failure(TimeoutError("provider timed out"), attempt=0, max_retries=2, source="mcp")
+        capped = decide_failure(TimeoutError("provider timed out"), attempt=2, max_retries=2, source="mcp")
+        self.assertEqual(retry["action"], "retry")
+        self.assertTrue(retry["retry_allowed"])
+        self.assertEqual(capped["action"], "escalate")
+        self.assertFalse(capped["retry_allowed"])
+        self.assertEqual(validate_failure_decision(retry), [])
+
+    def test_persistent_and_external_failures_do_not_retry_blindly(self) -> None:
+        self.assertEqual(decide_failure("stale revision conflict")["action"], "replan")
+        self.assertEqual(decide_failure("consent required by provider")["action"], "escalate")
+        self.assertEqual(decide_failure(PermissionError("permission denied"))["action"], "stop")
+
+    def test_decision_is_metadata_only_and_validates_tampering(self) -> None:
+        decision = decide_failure("private prompt content", source="  tool\n  call ")
+        self.assertNotIn("private prompt content", str(decision))
+        self.assertEqual(decision["source"], "tool call")
+        self.assertEqual(validate_failure_decision(decision), [])
+        self.assertTrue(validate_failure_decision({**decision, "action": "retry", "retry_allowed": False}))

--- a/tests/test_mcp_bridge.py
+++ b/tests/test_mcp_bridge.py
@@ -184,6 +184,9 @@ class McpBridgeTests(unittest.TestCase):
             structured = payload["result"]["structuredContent"]
             self.assertEqual(structured["status"], "tool_error")
             self.assertIn("Unknown tool", structured["error"])
+            self.assertEqual(structured["failure_decision"]["action"], "escalate")
+            self.assertEqual(structured["failure_decision"]["source"], "mcp:shell")
+            self.assertNotIn("whoami", json.dumps(structured["failure_decision"]))
 
     def test_mcp_host_observation_records_host_session_evidence(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

Adds a metadata-only failure mender that classifies failures, bounds transient retries, prevents blind retries, and exposes safe escalation guidance at the MCP error boundary.

## Validation

- Focused pytest: 11 passed
- Ruff passed
- Python compileall passed
- git diff --check passed

## Seed

- ubuntu-335a
- Commits: b04a6f4e, 5ceb3282

Escalation proposals are reviewable only; the module does not create external Seeds or perform retries automatically.