### PR TITLE
fix(tests): routing-quality baseline names the canonical engine, not a retired alias

### DIFF
--- a/tests/test_routing_quality.py
+++ b/tests/test_routing_quality.py
@@ -20,7 +20,11 @@ class RoutingQualityGateTests(unittest.TestCase):
     DISPATCH_CASES = (
         ("find official docs for the current OpenAI API version", "best-practice-research"),
         ("plan a safe implementation for this feature", "plan"),
-        ("fix the failing test in this repository", "ultraprocess"),
+        # `ultraprocess` is a retired engine alias (see ulw_equivalence); the
+        # canonical delivery engine this lane dispatches to is `ultrawork`.
+        # The original fork-authored baseline pinned the retired name and
+        # broke main the moment it merged next to the current catalog.
+        ("fix the failing test in this repository", "ultrawork"),
         ("remember this decision for later", "memory-new"),
         ("explain this paper at expert level", "paper-learning"),
         ("create an image summary card", "img-summary"),


### PR DESCRIPTION
## Capability

Main's routing-quality golden gate is green again: the 'fix the failing test in this repository' lane expects `ultrawork` — the canonical delivery engine — instead of `ultraprocess`, a retired engine alias that exists nowhere in the installed catalog (one of the four retiring contracts in `src/quality/ulw_equivalence.py`).

## Motivation

Main went red after #1029 (fork PR) merged next to the current catalog; its golden baseline pinned the retired name. Each fork PR was green against its own stale base — the combination surfaced the pin. #961 fails on the same main-inherited gate, so this also unblocks it.

## Implementation

One expectation string plus a comment. The gate is not weakened: the lane still requires a dispatch at medium/high confidence.

## Observed verification

Routing-quality + routing-precision + chat-router suites (163 tests) green locally; full suite running in a clean worktree; CI on this PR before merge.

## Risks

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)