### PR TITLE
feat(update): bootstrap the full OMH TUI on machines setup never touched

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -92,6 +92,15 @@ same flow through their isolated managed virtual environment. After the command
 package succeeds, the re-entered command refreshes managed skills, an already
 installed plugin bundle, and existing Hermes registration.
 
+On a machine that never completed `omh setup`, `omh update` bootstraps the
+full OMH TUI surface instead of skipping it: it installs the plugin bundle,
+registers and enables OMH in the Hermes config (activating the skin), installs
+the TUI widget, and seeds `~/.omh/routing/model-chains.json` — update and
+setup converge on the same machine state. One deliberate opt-out is honored:
+after `omh uninstall --registration-only` the plugin directory stays in place,
+so update never re-registers a machine whose owner removed the registration
+on purpose.
+
 An explicit `--source` or `--from-skills-dir` remains a workflow-content-only
 operation, and `--dry-run` never changes the command package. A source checkout
 or other unmanaged Python environment is not rewritten implicitly; the result

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -276,11 +276,50 @@ def cmd_update(args: argparse.Namespace) -> int:
     code = cmd_install(args)
     if code == 0:
         if not (args.from_skills_dir or args.source):
-            _refresh_installed_plugin_bundle(args)
-            _refresh_hermes_registration(args)
+            if _paths(args).hermes_plugin_dir.is_dir():
+                _refresh_installed_plugin_bundle(args)
+                _refresh_hermes_registration(args)
+            else:
+                _bootstrap_tui_surface(args)
         _refresh_installed_tui_widget(args)
         _refresh_installed_menubar_app(args)
     return code
+
+
+def _bootstrap_tui_surface(args: argparse.Namespace) -> dict[str, object] | None:
+    """Give `omh update` on a never-set-up machine the full OMH TUI.
+
+    Update and setup must converge on the same machine state (owner decision,
+    2026-08-20): a user who only ever runs `omh update` still ends with the
+    plugin bundle installed, OMH registered and enabled in the Hermes config
+    (which also activates the skin), and the chain-override document seeded —
+    instead of a plain Hermes that silently lacks the OMH identity. The
+    deliberate opt-out stays respected: `omh uninstall --registration-only`
+    keeps the plugin directory in place, so an unregistered-but-installed
+    machine never reaches this path and stays unregistered.
+    """
+    paths = _paths(args)
+    try:
+        result = install_plugin_bundle(paths, force=args.force, dry_run=args.dry_run)
+    except PluginPackError as exc:
+        print(
+            f"note: could not install the OMH plugin bundle: {exc}; run `omh setup --force`",
+            file=sys.stderr,
+        )
+        return None
+    if not args.dry_run:
+        update_state(paths, {"last_plugin_distribution": result})
+    _seed_model_chains_result(paths, dry_run=bool(args.dry_run))
+    try:
+        _apply_result(args)
+    except OmhError as exc:
+        # The bundle landed; an unwritable config must not fail the update.
+        # Say what is missing instead of leaving a half-silent install.
+        print(
+            f"note: could not register OMH in the Hermes config: {exc}; run `omh setup`",
+            file=sys.stderr,
+        )
+    return result
 
 
 def _refresh_hermes_registration(args: argparse.Namespace) -> dict[str, object] | None:
@@ -317,9 +356,9 @@ def _refresh_installed_plugin_bundle(args: argparse.Namespace) -> dict[str, obje
     ran setup. The three commands AGENTS.md tells ordinary users to know are
     setup, update, and doctor -- and update was the one that did not update.
 
-    Only refreshes what is already there. Installing the bundle for the first
-    time is setup's job, because that is also where Hermes registration and
-    enablement happen, and half of that pair is worse than neither.
+    Only refreshes what is already there; a machine with no bundle at all goes
+    through `_bootstrap_tui_surface` instead, which installs the bundle AND
+    performs the Hermes registration/enablement half of the pair.
     """
     paths = _paths(args)
     if not paths.hermes_plugin_dir.is_dir():

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -1269,15 +1269,21 @@ class UpdateRefreshesTheBundleTests(unittest.TestCase):
             self.assertFalse(stray.exists())
             self.assertTrue((self._bundle_dir(root / ".hermes") / "memory_provider.py").is_file())
 
-    def test_update_does_not_install_a_bundle_setup_never_installed(self) -> None:
-        # Installing it here would write plugin files without the Hermes
-        # enablement setup also does, and half that pair is worse than neither.
+    def test_update_bootstraps_a_bundle_setup_never_installed(self) -> None:
+        # Update and setup converge on the same machine state (owner decision,
+        # 2026-08-20): a machine that only ever ran `omh update` still gets the
+        # plugin bundle, the widget, the registration, and the seeded chain
+        # overrides — the full pair, not the half that is worse than neither.
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
             base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
             status, _, stderr = run_cli(base + ["update"])
             self.assertEqual(status, 0, stderr)
-            self.assertFalse(self._bundle_dir(root / ".hermes").exists())
+            self.assertTrue((self._bundle_dir(root / ".hermes") / "memory_provider.py").is_file())
+            self.assertTrue((root / ".hermes" / "tui-widgets" / "omh-status.mjs").is_file())
+            self.assertTrue((root / ".omh" / "routing" / "model-chains.json").is_file())
+            config_text = (root / ".hermes" / "config.yaml").read_text(encoding="utf-8")
+            self.assertIn("provider: omh", config_text)
 
     def test_a_dry_run_update_leaves_the_installed_bundle_alone(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -1338,14 +1344,30 @@ class UpdateCarriesRegistrationTests(unittest.TestCase):
             self.assertEqual(status, 0, stderr)
             self.assertIn("provider: omh", self._config(root).read_text(encoding="utf-8"))
 
-    def test_update_does_not_register_an_install_setup_never_registered(self) -> None:
-        # Someone who unregistered OMH deliberately must not have update put it
-        # back, and a first registration stays setup's to make.
+    def test_update_registers_a_machine_setup_never_touched(self) -> None:
+        # Update bootstraps the full TUI surface on a never-set-up machine
+        # (owner decision, 2026-08-20): registration included, because plugin
+        # files without Hermes enablement render nothing.
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
             status, _, stderr = run_cli(self._base(root) + ["update"])
             self.assertEqual(status, 0, stderr)
-            self.assertFalse(self._config(root).exists())
+            self.assertIn("provider: omh", self._config(root).read_text(encoding="utf-8"))
+
+    def test_update_respects_a_deliberate_unregistration(self) -> None:
+        # `omh uninstall --registration-only` keeps the plugin directory, so
+        # update never reaches the bootstrap path and must not re-register a
+        # machine whose owner removed the registration on purpose.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_cli(self._base(root) + ["setup"])
+            status, _, stderr = run_cli(self._base(root) + ["uninstall", "--registration-only"])
+            self.assertEqual(status, 0, stderr)
+            unregistered = self._config(root).read_text(encoding="utf-8")
+
+            status, _, stderr = run_cli(self._base(root) + ["update"])
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(self._config(root).read_text(encoding="utf-8"), unregistered)
 
     def test_update_never_takes_a_slot_another_product_holds(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Capability

`omh update` on a machine that never completed `omh setup` now produces the full OMH TUI — plugin bundle, Hermes registration/enablement (skin activation included), TUI widget, and the seeded `~/.omh/routing/model-chains.json` — instead of refreshing skills and silently leaving plain Hermes. Update and setup converge on the same machine state.

## Motivation

Observed on a real second machine: `omh update` succeeded, but launching Hermes showed the stock "Hermes Agent" TUI. Every TUI surface in `cmd_update` was refresh-only, gated on `hermes_plugin_dir` already existing ("first install is setup's job"), so a machine that only ever ran `update` got skills and nothing else — with no message saying why. Owner direction: `omh update` or `omh setup` must both end in the OMH TUI.

## Implementation (boundary level)

- `cmd_update`: when the plugin bundle directory exists, the previous refresh path runs unchanged (bundle refresh + registration carry-forward). When it is absent, the new `_bootstrap_tui_surface` runs: `install_plugin_bundle` → state record → chain-override seed → full config apply (registration + enablement + skin activation). The existing widget/skin refresh then proceeds since the plugin dir now exists.
- Deliberate opt-out preserved: `omh uninstall --registration-only` keeps the plugin directory, so an unregistered-but-installed machine never reaches the bootstrap path and stays unregistered — pinned by a new contract test.
- Failures degrade to printed notes naming the repair command (`omh setup --force` / `omh setup`) instead of silence; an unwritable config does not fail the update.
- Policy-contract tests rewritten deliberately: `test_update_does_not_install_a_bundle_setup_never_installed` → `test_update_bootstraps_a_bundle_setup_never_installed` (bundle + widget + registration + seeded overrides asserted), `test_update_does_not_register_an_install_setup_never_registered` → `test_update_registers_a_machine_setup_never_touched` + `test_update_respects_a_deliberate_unregistration`. Refresh, idempotency, dry-run, drift-tolerance, and foreign-slot contracts unchanged and green.
- `docs/INSTALLATION.md` documents the new behavior and the opt-out.

## Observed verification

- Full suite in a clean detached worktree at this commit: `Ran 6920 tests — OK`.
- Plugin-distribution battery (38) green, including the new bootstrap and deliberate-unregistration contracts; cli/wrapper/guidance/memory/release batteries (667) green; ruff, compileall, docs byte gates, `git diff --check` clean.
- Not observable from this repo: the second machine itself — its installed command package predates this change, so there run `omh setup` once (works today), or take this via a command-package release.

## Risks

Medium: update now writes Hermes config on never-set-up machines. Bounded by the plugin-dir gate (registration-only unregisters keep it), dry-run passthrough on every step, and note-not-failure error handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)