### PR TITLE
feat(update): seed the chain-override document on registered installs too

### DIFF
--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -279,6 +279,10 @@ def cmd_update(args: argparse.Namespace) -> int:
             if _paths(args).hermes_plugin_dir.is_dir():
                 _refresh_installed_plugin_bundle(args)
                 _refresh_hermes_registration(args)
+                # Same carry-forward rule as registration: a surface only
+                # setup seeds never lands on machines that update forever.
+                # Seeding is create-only, so user edits are never touched.
+                _seed_model_chains_result(_paths(args), dry_run=bool(args.dry_run))
             else:
                 _bootstrap_tui_surface(args)
         _refresh_installed_tui_widget(args)

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -1354,6 +1354,26 @@ class UpdateCarriesRegistrationTests(unittest.TestCase):
             self.assertEqual(status, 0, stderr)
             self.assertIn("provider: omh", self._config(root).read_text(encoding="utf-8"))
 
+    def test_update_seeds_the_chain_overrides_on_a_registered_install(self) -> None:
+        # Same carry-forward rule as registration: a document only setup seeds
+        # never lands on machines that update forever. Create-only — a user's
+        # edited document survives the next update untouched.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_cli(self._base(root) + ["setup"])
+            chains = root / ".omh" / "routing" / "model-chains.json"
+            chains.unlink()
+
+            status, _, stderr = run_cli(self._base(root) + ["update"])
+            self.assertEqual(status, 0, stderr)
+            self.assertTrue(chains.is_file())
+
+            custom = '{"schema_version": "mixture_chain_overrides/v1", "categories": {"deep": [{"model": "gpt-5.6-terra", "reasoning_effort": "xhigh"}]}}'
+            chains.write_text(custom, encoding="utf-8")
+            status, _, stderr = run_cli(self._base(root) + ["update"])
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(chains.read_text(encoding="utf-8"), custom)
+
     def test_update_respects_a_deliberate_unregistration(self) -> None:
         # `omh uninstall --registration-only` keeps the plugin directory, so
         # update never reaches the bootstrap path and must not re-register a


### PR DESCRIPTION
## Capability

`omh update` on an already-registered install now seeds `~/.omh/routing/model-chains.json` when it is absent, so machines that ran setup before the document existed (and update forever) still get the chain-customization surface. Create-only: a user's edited document is never touched.

## Motivation

Observed live immediately after #1038 merged: this machine updated to the new release, plugin byte-in-sync, but the chain-override document never appeared — its setup predates the surface, and only setup/bootstrap seeded it. This is the same carry-forward disease `_refresh_hermes_registration` documents ("update refreshed skills and the bundle, the new key never landed").

## Implementation (boundary level)

`cmd_update`'s registered-install path calls the existing `_seed_model_chains_result` (create-only, `already_present` short-circuit) after registration carry-forward. Contract test pins reseed-after-delete and edited-document preservation across consecutive updates.

## Observed verification

Plugin-distribution + cli batteries (365 tests) green locally; ruff/compileall/`git diff --check` clean. Full suite runs in CI (previous commit's full clean-worktree run was 6,920 OK; this adds one create-only call on one path).

## Risks

Low — one create-only file write on the registered path; the seed helper already refuses to overwrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)