### PR TITLE
chore(lint): use the allow: marker for the SIZE_OK annotation

### DIFF
--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -1,4 +1,4 @@
-# noqa: SIZE_OK -- Central argparse registry intentionally keeps all command wiring cohesive and auditable.
+# allow: SIZE_OK -- Central argparse registry intentionally keeps all command wiring cohesive and auditable.
 from __future__ import annotations
 
 import argparse


### PR DESCRIPTION
## Capability

Clears the new ruff 0.16.3 warning (`Invalid # noqa directive on src/commands/main.py:1`) by spelling the house SIZE_OK annotation as `# allow: SIZE_OK`, matching the existing instance in `src/quality/common_request_cases.py`.

## Motivation

ruff 0.16.3 (merged via #1040) validates `# noqa` codes and warns on the custom marker. No gate consumes the marker (verified by grep) — it is a human-facing rationale, so it should not wear lint-suppression syntax.

## Implementation

One comment line: `# noqa: SIZE_OK` → `# allow: SIZE_OK`.

## Observed verification

`uv run --group lint ruff check src tests` clean with no warning; compileall; test_cli battery (326) OK. Full suite in CI.

## Risks

None — comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)