### PR TITLE
fix(catalog): refresh stale lintlang snapshot entry

### DIFF
--- a/src/catalogs/awesome_hermes_agent_catalog.json
+++ b/src/catalogs/awesome_hermes_agent_catalog.json
@@ -1586,16 +1586,16 @@
       "url": "https://github.com/Tranquil-Flow/hermes-neurovision"
     },
     {
-      "author": "roli-lpci",
-      "author_url": "https://github.com/roli-lpci",
+      "author": "Hermes Labs",
+      "author_url": "https://github.com/hermes-labs-ai",
       "id": "lintlang",
       "maturity": "beta",
       "name": "lintlang",
       "readme_line": 289,
       "section": "Tools & Utilities",
       "subsection": "Tools & Utilities",
-      "summary": "Static linter for AI agent configs and prompts with HERM v1.1 scoring. Catches config mistakes that silently degrade agent behavior.",
-      "url": "https://github.com/roli-lpci/lintlang"
+      "summary": "Static analysis for AI agent configs, tool descriptions, and system prompts, returning a PASS / REVIEW / FAIL verdict. Zero-LLM, deterministic checks, built for CI.",
+      "url": "https://github.com/hermes-labs-ai/lintlang"
     },
     {
       "author": "0xrsydn",

--- a/src/catalogs/awesome_hermes_agent_rules.py
+++ b/src/catalogs/awesome_hermes_agent_rules.py
@@ -543,8 +543,8 @@ _RULES = (
     ),
     CoverageRule(
         (
-            "static linter for ai agent configs",
-            "herm v1 1 scoring",
+            "static analysis for ai agent configs",
+            "pass review fail verdict",
             "community migration tool from openclaw",
             "native hermes migrate",
             "one command setup for the full hermes agent stack",


### PR DESCRIPTION
## Problem

Per #968, the bundled awesome-hermes-agent snapshot catalog
(`src/catalogs/awesome_hermes_agent_catalog.json`) still carries a stale
`lintlang` entry:

- The owner path points at the former `roli-lpci/lintlang` repository, which
  only redirects; the canonical repository is now
  `https://github.com/hermes-labs-ai/lintlang` (Hermes Labs).
- The summary claims "HERM v1.1 scoring", a numeric score replaced by a
  `PASS / REVIEW / FAIL` verdict in lintlang v0.2.0 (2026-03-25), per the
  project's changelog.

## Solution

Update the bundled `lintlang` entry to the corrected values reported in the
issue (`author`, `author_url`, `summary`, `url`). Because `lintlang` coverage
is mapped by term matching in `src/catalogs/awesome_hermes_agent_rules.py`,
refresh the two stale `quality_config_migration` matching phrases
("static linter for ai agent configs", "herm v1 1 scoring") to phrases derived
from the corrected summary, so the item keeps its existing rule, surfaces, and
`partial` coverage status.

No schema, architecture, dependency, or generated-file regeneration is
touched. The upstream correction (0xNyk/awesome-hermes-agent#307) has landed,
so a future catalog regeneration will pick up the canonical wording; this PR
keeps the shipped snapshot accurate in the meantime.

## Testing

- `PYTHONPATH=tests uv run python -m unittest discover -s tests -p "test_awesome_hermes_agent*.py"` — 45 tests, all pass.
- Full suite (`uv run python -m unittest discover -s tests`, 6921 tests):
  identical failing-test set before and after the change (only the
  pre-existing Windows symlink/locale environment failures on this machine).
- `uv run --group lint ruff check src tests` — passes.
- `uv run python -m compileall -q src tests` — passes.
- `uv run python -m omh.cli docs workflows --check` — passes (no generated docs affected).
- `git diff --check` — clean.
- `omh ecosystem awesome-hermes inspect lintlang --json` — shows the corrected
  entry (`hermes-labs-ai`, `Hermes Labs`, `quality_config_migration`, surfaces
  unchanged).

## Risk

Low. Two files, six changed lines, no new dependencies, no runtime contract
change. Coverage mapping for `openclaw-to-hermes` and `evey-setup`
(quality_config_migration) is unaffected because their matching terms were
left untouched.