### PR TITLE
feat(update): name the real upgrade owner for repo-link pip/uv installs

### DIFF
--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -78,6 +78,19 @@ curl -fsSL "https://raw.githubusercontent.com/rlaope/oh-my-hermes/$OMH_REF/insta
     OMH_SOURCE_REF="$OMH_REF" sh
 ```
 
+Direct pip or uv install from the repository (for agents handed only the
+repository link) — pin the same resolved SHA:
+
+```sh
+python3 -m pip install "git+https://github.com/rlaope/oh-my-hermes@$OMH_REF"
+# or, isolated on PATH:
+uv tool install "git+https://github.com/rlaope/oh-my-hermes@$OMH_REF"
+```
+
+Both leave a PEP 610 origin record, so a later `omh update` names the exact
+upgrade command for this owner (`pip install --upgrade "git+..."` or
+`uv tool upgrade oh-my-hermes`) instead of the generic installer line.
+
 Native Windows (PowerShell 5.1+):
 
 ```powershell
@@ -161,6 +174,8 @@ Use the owning manager directly only as a reported repair fallback:
 | Homebrew | `brew upgrade rlaope/tap/omh` | `brew uninstall omh` |
 | Bun | `bun update -g --latest oh-my-hermes` | `bun remove -g oh-my-hermes` |
 | npm | `npm update -g oh-my-hermes` | `npm uninstall -g oh-my-hermes` |
+| pip (repo link) | `pip install --upgrade "git+https://github.com/rlaope/oh-my-hermes"` | `pip uninstall oh-my-hermes` |
+| uv tool (repo link) | `uv tool upgrade oh-my-hermes` | `uv tool uninstall oh-my-hermes` |
 
 Removing the command package preserves OMH state. For full cleanup, run
 `omh uninstall --all` before the manager's remove command. Never run the curl

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -145,7 +145,60 @@ def _command_package_update_guidance() -> tuple[str, str]:
         return explicit, COMMAND_PACKAGE_UPDATE_COMMANDS[explicit]
     if _homebrew_prefix_root() is not None:
         return "homebrew", COMMAND_PACKAGE_UPDATE_COMMANDS["homebrew"]
+    direct = _direct_url_update_guidance()
+    if direct is not None:
+        return direct
     return "installer", installer_command()
+
+
+def _direct_url_update_guidance() -> tuple[str, str] | None:
+    """Name the real owner of a PEP 610 direct-URL install.
+
+    An agent handed only the repository link often installs the command with
+    `pip install git+...`, `pip install <clone>`, or `uv tool install`. Those
+    installs carry no manager provenance state, and the generic curl fallback
+    would create a second, conflicting install next to the one that already
+    owns the command. The dist-info `direct_url.json` records the actual
+    origin, so the update instruction points there instead. The curl
+    installer's own managed venv also leaves a `direct_url.json`, but it
+    names the deleted download directory, so it falls through to the
+    installer fallback as before.
+    """
+    import importlib.metadata
+    from urllib.parse import unquote, urlsplit
+
+    try:
+        raw = importlib.metadata.distribution("oh-my-hermes").read_text("direct_url.json")
+    except (importlib.metadata.PackageNotFoundError, OSError):
+        return None
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    url = str(data.get("url", "") or "")
+    prefix_parts = tuple(part.casefold() for part in Path(sys.prefix).parts)
+    if "uv" in prefix_parts and "tools" in prefix_parts:
+        return "uv-tool", "uv tool upgrade oh-my-hermes"
+    if isinstance(data.get("vcs_info"), dict) and url and not url.startswith("file:"):
+        return "pip", f'{sys.executable} -m pip install --upgrade "git+{url}"'
+    dir_info = data.get("dir_info")
+    if isinstance(dir_info, dict) and url.startswith("file://"):
+        if dir_info.get("editable"):
+            # An editable install is a development checkout; its command
+            # updates through `git pull` alone and keeps the long-standing
+            # installer fallback wording rather than a pip reinstall.
+            return None
+        checkout = Path(unquote(urlsplit(url).path))
+        if checkout.is_dir():
+            return "pip", (
+                f"git -C {checkout} pull && "
+                f"{sys.executable} -m pip install --upgrade {checkout}"
+            )
+    return None
 
 
 def _homebrew_prefix_root() -> Path | None:

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -165,7 +165,8 @@ def _direct_url_update_guidance() -> tuple[str, str] | None:
     installer fallback as before.
     """
     import importlib.metadata
-    from urllib.parse import unquote, urlsplit
+    from urllib.parse import urlsplit
+    from urllib.request import url2pathname
 
     try:
         raw = importlib.metadata.distribution("oh-my-hermes").read_text("direct_url.json")
@@ -192,7 +193,9 @@ def _direct_url_update_guidance() -> tuple[str, str] | None:
             # updates through `git pull` alone and keeps the long-standing
             # installer fallback wording rather than a pip reinstall.
             return None
-        checkout = Path(unquote(urlsplit(url).path))
+        # url2pathname handles Windows drive letters (`file:///C:/...`),
+        # which a bare unquote of the URL path would leave unusable.
+        checkout = Path(url2pathname(urlsplit(url).path))
         if checkout.is_dir():
             return "pip", (
                 f"git -C {checkout} pull && "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3010,6 +3010,49 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             self.assertEqual(state["last_update"]["release_update"]["status"], "refreshed")
             self.assertEqual(state["last_update"]["managed_skills"]["count"], len(builtin_skill_templates()))
 
+    def test_repo_link_installs_get_their_real_update_owner(self) -> None:
+        """An agent handed only the repository URL often installs via
+        `pip install git+...`, `pip install <clone>`, or `uv tool install`.
+        The update instruction must name that owner — the curl fallback would
+        create a second, conflicting install — while editable dev checkouts
+        and the curl installer's own deleted download dir keep the
+        long-standing installer fallback."""
+
+        def guidance_with(direct_url: object) -> tuple[str, str]:
+            with patch.dict(os.environ, {"OMH_COMMAND_PACKAGE_MANAGER": ""}):
+                with patch("importlib.metadata.distribution") as dist:
+                    dist.return_value.read_text.return_value = (
+                        json.dumps(direct_url) if direct_url is not None else None
+                    )
+                    return setup_commands._command_package_update_guidance()
+
+        manager, instruction = guidance_with(
+            {"url": "https://github.com/rlaope/oh-my-hermes", "vcs_info": {"vcs": "git"}}
+        )
+        self.assertEqual(manager, "pip")
+        self.assertIn('install --upgrade "git+https://github.com/rlaope/oh-my-hermes"', instruction)
+
+        with TemporaryDirectory() as tmp:
+            manager, instruction = guidance_with({"url": f"file://{tmp}", "dir_info": {}})
+            self.assertEqual(manager, "pip")
+            self.assertIn(f"git -C {tmp} pull", instruction)
+            self.assertIn("install --upgrade", instruction)
+
+        manager, _ = guidance_with({"url": "file:///dev/checkout", "dir_info": {"editable": True}})
+        self.assertEqual(manager, "installer")
+
+        manager, _ = guidance_with({"url": "file:///tmp/omh-download-gone-xyz", "dir_info": {}})
+        self.assertEqual(manager, "installer")
+
+        manager, _ = guidance_with(None)
+        self.assertEqual(manager, "installer")
+
+        with patch.object(setup_commands.sys, "prefix", "/home/u/.local/share/uv/tools/oh-my-hermes"):
+            manager, instruction = guidance_with(
+                {"url": "https://github.com/rlaope/oh-my-hermes", "vcs_info": {"vcs": "git"}}
+            )
+        self.assertEqual((manager, instruction), ("uv-tool", "uv tool upgrade oh-my-hermes"))
+
     def test_package_manager_update_uses_native_command_guidance(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3033,9 +3033,9 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
         self.assertIn('install --upgrade "git+https://github.com/rlaope/oh-my-hermes"', instruction)
 
         with TemporaryDirectory() as tmp:
-            manager, instruction = guidance_with({"url": f"file://{tmp}", "dir_info": {}})
+            manager, instruction = guidance_with({"url": Path(tmp).as_uri(), "dir_info": {}})
             self.assertEqual(manager, "pip")
-            self.assertIn(f"git -C {tmp} pull", instruction)
+            self.assertIn(f"git -C {Path(tmp)} pull", instruction)
             self.assertIn("install --upgrade", instruction)
 
         manager, _ = guidance_with({"url": "file:///dev/checkout", "dir_info": {"editable": True}})

--- a/tests/test_handoff_safety_contract_enforcement.py
+++ b/tests/test_handoff_safety_contract_enforcement.py
@@ -353,6 +353,7 @@ PARSING_ONLY_URLLIB_REQUEST_NAMES = frozenset({"url2pathname", "pathname2url"})
 PARSING_ONLY_URLLIB_REQUEST_FILES: dict[str, str] = {
     "src/workflows/visual_summary.py": "resolves screenshot `file://` references to local paths",
     "src/workflows/web_visual_qa_contracts.py": "resolves visual-QA `file://` references to local paths",
+    "src/commands/setup.py": "resolves PEP 610 direct_url.json `file://` origins to local paths for update guidance",
 }
 
 


### PR DESCRIPTION
## Capability

Agents (or people) handed only `https://github.com/rlaope/oh-my-hermes` and told "install this" get a fully working lifecycle: install by any natural repo-link path (`pip install git+…`, `pip install <clone>`, `uv tool install`, curl installer, source checkout), then `omh setup` and `omh update` behave like a packaged install — including a *correct* command-upgrade instruction instead of the generic curl line.

## Motivation

Owner directive (2026-08-20). Sandbox journey testing showed the functional surface already works on repo-link installs — `setup` lands the plugin bundle, TUI widget, skin, registration, and chain-override seed; `update` refreshes workflows from GitHub, bootstraps never-set-up machines, and `doctor` reports no blockers. The one lifecycle break: with no package-manager provenance, `omh update` told pip/uv installers to run the curl installer — which creates a second, conflicting install and never upgrades the command that actually owns `omh`, so plugin/widget code would silently stay at install-day versions forever.

## Implementation (boundary level)

- `_command_package_update_guidance` gains a PEP 610 step: it reads the distribution's `direct_url.json` and names the real owner — vcs installs get `python -m pip install --upgrade "git+<url>"`, surviving non-editable clone installs get `git pull` + pip reinstall, uv-tool environments get `uv tool upgrade oh-my-hermes`. Editable dev checkouts and the curl installer's deleted download dir deliberately keep the long-standing installer fallback, and auto self-update still runs only for npm/bun/homebrew (`COMMAND_PACKAGE_UPDATE_ARGUMENTS` keys).
- `INSTALL_FOR_AGENTS.md` documents the repo-link pip/uv install path with the same pinned-SHA discipline and adds both owners to the lifecycle table.
- Guidance matrix test covers vcs / non-editable dir / editable / deleted dir / absent metadata / uv-tool prefix.

## Observed verification

- Full suite in a clean detached worktree at this commit: `Ran 6922 tests — OK`.
- Sandbox journeys observed green: (a) source checkout `setup` → plugin+widget+skin+chains+registration; (b) fresh venv `pip install <repo>` → `omh --version` → `setup` full surface → `update` (workflows refreshed from GitHub archive, release state refreshed) → `doctor` no blocking checks.
- cli/model-recommendations/plugin-distribution/release-smoke batteries (417) green; ruff, compileall, `git diff --check` clean.

## Risks

Low — guidance strings and docs only; no execution-path change. PEP 668/externally-managed pip environments are why the pip upgrade stays an instruction, not an auto-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)