### PR TITLE
docs(readme): show the model-chains file with cat output and edit examples

### DIFF
--- a/MODEL_OPTI.md
+++ b/MODEL_OPTI.md
@@ -1,0 +1,305 @@
+# Model Optimization Guidance
+
+What OMH does differently per model, how it actually works at runtime, and —
+for every family-specific prompt guideline — exactly why it exists and where
+it came from. This document is a reader's map; the source of truth is the code
+it cites, and a drift test (`tests/test_unit_prompt_protocol.py`) fails when a
+calibrated family disappears from this file.
+
+Boundary first: OMH never calls a model. Every optimization below is prepared
+text or prepared configuration — calibration blocks ride prepared unit
+prompts, routing rides Hermes config keys, and execution evidence always comes
+from the runtime that actually ran the model.
+
+## How it works, end to end
+
+1. **A lane gets a model.** The mixture chains (shipped defaults plus your
+   `~/.omh/routing/model-chains.json` overrides) pick a model and reasoning
+   effort per category; `omh_delegate_route` writes them as explicit Hermes
+   delegation keys. Any token-shaped model id is accepted — if the provider
+   cannot serve it, the error comes back as a normal result and the chain
+   falls over to its next entry (Hermes itself has no provider-side fallback).
+2. **The model id is classified into a family.** `model_family()` in
+   `src/coding/model_routing.py` strips a provider prefix
+   (`opencode/kimi-k3` → `kimi-k3`) and matches by prefix. Unknown ids get
+   family `unknown` — never an error, just generic discipline.
+3. **The prepared prompt is assembled.** Every dispatched unit prompt carries
+   the universal protocols (goal echo-back, numbered completion criteria,
+   bounded verification). If the routed effort is `high`/`xhigh`/`max`, one
+   family-specific calibration paragraph is appended for the subagent; the
+   composer writing the split follows the calibration for its *own* model
+   (`omh coding composition-guide --model <id>` prints it).
+4. **The model runs it.** Tool calling, todo rendering, and parallel
+   execution are Hermes runtime capabilities — OMH's ULW behaviors
+   (`todo init`, phase checklists, parallel evals, interjection-resume) live
+   in skill contracts and prepared handoffs, so they apply identically to
+   every lane regardless of which model the chain routed there.
+
+So "optimizing for a model" in OMH means exactly one thing: a short,
+evidence-backed paragraph of counter-guidance appended to an otherwise
+identical prompt. Nothing else about the pipeline changes per model.
+
+## How a model is recognized
+
+| Family | Matched by | Example ids |
+| --- | --- | --- |
+| `gpt` | `gpt-` | `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` |
+| `claude` | `claude-`, bare tiers `opus`/`sonnet`/`haiku` | `claude-fable-5`, `claude-opus-5` |
+| `gemini` | `gemini-` | `gemini-3.1-pro` |
+| `kimi` | `kimi-` | `kimi-k3`, `kimi-k3-ultrafast` |
+| `glm` | `glm-` | `glm-5.2`, `glm-5.2-ultrafast` |
+| `grok` | `grok-` | `grok-code-fast-1` |
+| `qwen` | `qwen-`, alias `qwen3-` | `qwen3-coder` |
+| `deepseek` | `deepseek-` | versioned DeepSeek ids |
+| `mistral`, `llama`, `codestral` | own prefixes | — (recognized, not yet calibrated) |
+| `openai`, `anthropic` | bare-vendor prefixes | rarely-seen ids (not yet calibrated) |
+| `unknown` | anything else | e.g. `solar-*` today |
+
+## Universal protocols (every model, every family)
+
+`src/coding/unit_prompt_protocol.py` attaches three deterministic blocks to
+every dispatched unit prompt, regardless of model:
+
+- **Goal echo-back** — before the first tool use, the subagent restates the
+  goal, its deliverable, and the numbered criteria, and reports (never
+  guesses) if its reading conflicts with the declared boundary. *Why:* a
+  misread boundary is cheapest to catch before any edit exists.
+- **Pre-declared completion criteria** — "done" is a numbered list derived
+  from the frozen unit contract before work starts. *Why:* completion must be
+  a check against stated criteria, not a feeling.
+- **Bounded verification** — exactly one full verification pass is both the
+  floor (never skipped) and the ceiling (once criteria pass, re-verifying is
+  forbidden; at most two fix-and-verify cycles before reporting the failing
+  criterion). *Why:* the two dominant agent failure modes are opposites —
+  skipping verification, and looping on it — and one bounded rule counters
+  both. Review-role units add criterion-bound blocking with a two-round cap.
+
+These originate from the stop-condition techniques the oh-my-openagent
+research surfaced for high-effort models (terminal-condition rules,
+criterion-bound blocking, capped re-review), generalized to every family.
+
+## Per-family calibrations: what, why, and where each came from
+
+Two tables in `src/coding/unit_prompt_protocol.py` carry the family-specific
+guidance: `HIGH_EFFORT_CALIBRATIONS` for the **subagent executing a unit**,
+and `MAIN_AGENT_COMPOSITION_CALIBRATIONS` for the **composer** splitting work
+and writing unit prompts. A parity test forces the two tables to share one key
+set — no family gets subagent discipline without composer discipline.
+
+The governing rule, stated in the module docstring: a calibration counters a
+family's *known* failure mode. No family carries richer guidance than another
+without a stated reason, and no vendor is privileged. Provenance falls into
+three buckets, each named per family below:
+
+- **Adapted research** — stop-condition work from the oh-my-openagent
+  project on how high-effort reasoning models over-verify.
+- **Observed failure modes** — behavior seen in live OMH/Hermes usage of that
+  family (recorded in the commits that introduced each block).
+- **Provider-published model characteristics** — facts the vendor states
+  about the model's design (e.g. a non-thinking architecture), which make
+  certain prompt shapes actively harmful.
+
+Validation is common to all: `benchmarks/live-model-tools/v1` runs
+baseline-vs-calibrated prompt pairs where the *only* difference is the
+calibration block, and `tests/test_omh_live_model_benchmark.py` pins that
+pairing so a benchmark claim can never mix in other prompt changes.
+
+### `gpt` (GPT-5.6 Sol / Terra / Luna)
+
+- **Model trait:** a strong long-horizon reasoner. Its characteristic waste
+  is spending depth on things that are already decided: re-deriving facts it
+  established earlier, and re-running verification "for reassurance".
+- **What OMH injects (subagent):** reasoning depth belongs to the hard parts
+  of *this* unit; once the decisive fact is in view, act on it; a passed
+  criterion is settled evidence, reopened only by contradicting output.
+- **What OMH injects (composer):** compose outcome-first, but never compress
+  the contract away — GPT's tight compositional style tends to drop stated
+  boundaries and criteria while shortening a prompt, and a tighter prompt
+  that loses an invariant is a worse prompt.
+- **Source:** adapted research (oh-my-openagent stop-condition findings on
+  high-effort models), one of the two original calibration entries.
+
+### `claude` (Fable, Opus, Sonnet, Haiku)
+
+- **Model trait:** conscientious to a fault. Left alone it grows the
+  checklist mid-run ("while I'm here…"), adds just-to-be-sure verification
+  passes, and — as a composer — fans out speculative subagents, including
+  ones that only re-check its own work.
+- **What OMH injects (subagent):** the numbered criteria are the *complete*
+  checklist — do not grow it mid-run; deliberate deeply only where
+  correctness is genuinely at risk, and let the single verification pass
+  prove the mechanical steps.
+- **What OMH injects (composer):** split only what the goal requires, no
+  speculative units, and never spawn a subagent to double-check your own
+  composition.
+- **Source:** adapted research (same origin as `gpt`); the composer block was
+  added after observing over-fan-out in live composition.
+
+### `gemini` (Gemini 3.1 Pro)
+
+- **Model trait:** fluent and confident narration. Its observed failure mode
+  is asserting results from recall rather than from tool output, sounding
+  "done" before verification has run, and creatively expanding beyond the
+  declared boundary because the expansion seems like an improvement.
+- **What OMH injects (subagent):** a claim without the tool output that
+  proves it is not evidence — run the actual check and report from its
+  output; done-sounding language before the mandatory verification pass is a
+  failure, not optimism; expansion outside the boundary is a defect here.
+- **What OMH injects (composer):** compose from tool-verified facts, not
+  recall — run the inventory and readiness commands before naming owners or
+  models; a unit is "prepared" only when the prepare command produced its
+  artifact.
+- **Source:** observed failure modes in live usage (authored in the
+  per-family calibration commit; no upstream text existed for this shape).
+
+### `grok` (Grok Code Fast)
+
+- **Model trait:** speed-first, search-heavy. The risk profile is the inverse
+  of the deep reasoners: not over-verification but *under*-verification —
+  fast answers that skip the proof, and repeated re-querying when a search
+  surfaces many candidates.
+- **What OMH injects (subagent):** speed is the default and the numbered
+  criteria are the brake — a fast first answer never skips the single
+  mandatory verification pass; pick from search results once, by the stated
+  criteria, and act.
+- **What OMH injects (composer):** run the overlap and dependency-cycle
+  checks *before* recording the contract, not after dispatch fails;
+  re-querying for a better split is re-verifying a settled decision.
+- **Source:** written fresh for OMH — the calibration commit records that
+  grok had no upstream precedent; the content encodes the family's publicly
+  stated speed-first design plus observed search-churn behavior.
+
+### `kimi` (Kimi K3, K3 Ultrafast)
+
+- **Model trait:** a deep decompose-compare-verify reasoning loop. Excellent
+  on genuinely hard problems; wasteful on low-entropy mechanical steps, where
+  it enumerates alternatives that no stated criterion distinguishes.
+- **What OMH injects (subagent):** reserve the decompose-compare-verify loop
+  for the genuinely hard parts; mechanical steps are low-entropy — execute
+  them directly; if you catch yourself listing options for a step no
+  criterion distinguishes, stop analyzing and act.
+- **What OMH injects (composer):** partitioning work is mostly low-entropy —
+  decide the split once and freeze it; keep the deep reasoning for boundary
+  overlaps and dependency cycles; if two partitions both satisfy the
+  boundaries, take the first and move.
+- **Source:** observed failure modes in live OMH usage of Kimi K3 (authored
+  in the per-family calibration commit).
+
+### `glm` (GLM 5.2, 5.2 Ultrafast)
+
+- **Model trait:** an interleaved-reasoning style — thinking woven between
+  tool calls. That style genuinely improves tool-result interpretation, but
+  applied indiscriminately it plans mechanical steps that need no plan.
+- **What OMH injects (subagent):** use interleaved reasoning only where it
+  improves a tool decision — interpret each result, choose the next bounded
+  action, preserve prior reasoning context when the runtime exposes it;
+  mechanical steps need no extended plan.
+- **What OMH injects (composer):** interleave reasoning to interpret evidence
+  between contract-building tools; mechanical field assembly needs no extra
+  planning; freeze the smallest split once boundaries are clean.
+- **Source:** observed failure modes plus the family's documented
+  interleaved-thinking design; the GLM guidance shipped with the
+  baseline-vs-calibrated benchmark harness so its effect is measurable.
+
+### `qwen` (Qwen3-Coder)
+
+- **Model trait:** the current Qwen3-Coder is, per its own release
+  documentation, a **non-thinking** coding-agent model — it does not emit
+  reasoning traces, and prompting it for chain-of-thought or thinking tags
+  degrades it rather than helping.
+- **What OMH injects (subagent):** do not ask it to emit reasoning or
+  thinking tags; give the exact goal, repository state, allowed boundaries,
+  tool schemas, and completion criteria; follow one explicit plan; recover
+  from failures using observed tool output; stop after one passing
+  verification run.
+- **What OMH injects (composer):** freeze one ordered split with exact
+  owners, boundaries, tool contracts, dependencies, and verification
+  commands instead of requesting reasoning output.
+- **Source:** provider-published model characteristics (Qwen3-Coder's
+  non-thinking architecture); shipped with the benchmark harness.
+
+### `deepseek` (DeepSeek versioned line)
+
+- **Model trait:** a heterogeneous family — some variants are reasoning
+  models, some are not, and the split moved across versions. The common
+  error in the wild is applying legacy R1-era reasoning prompts to every
+  DeepSeek model, which is wrong on the non-reasoning variants.
+- **What OMH injects (subagent):** treat the model version and its declared
+  thinking mode as *contract fields*; preserve runtime-provided reasoning
+  context across tool results only on a reasoning-capable route; otherwise
+  use the same explicit goal/boundaries/criteria without thinking tags; make
+  the smallest correct change, verify once, stop.
+- **What OMH injects (composer):** keep the DeepSeek version and thinking
+  mode explicit in the prepared route; no synthetic thinking instructions on
+  non-reasoning routes.
+- **Source:** provider-published model characteristics (DeepSeek's
+  reasoning/non-reasoning variant split); shipped with the benchmark
+  harness.
+
+### `generic` (mandatory fallback — solar and every unknown id today)
+
+- **What OMH injects:** reserve extended reasoning for genuine ambiguity with
+  materially different outcomes; decide once, act, verify once against the
+  criteria, and stop — speed never skips the verification pass, and
+  thoroughness never repeats it.
+- **Why it exists:** an unknown family must never receive *weaker* discipline
+  than a known one. The generic block carries the same core stop rules as
+  every family block (a test asserts this), so putting `solar-pro2` or any
+  unlisted model in a chain still yields a disciplined lane — what it misses
+  is only the counter to its own family-specific failure mode.
+
+### When the calibration is (and is not) applied
+
+`calibration_for_route()` appends the family block **only when the routed
+reasoning effort is `high`, `xhigh`, or `max`**. The calibrations exist to
+counter the over-verification inertia of high-effort routes; low-effort
+routes do not exhibit that inertia, and every byte rides a prepared prompt
+whose worst-case assembled size is policy-gated in tests
+(`UNIT_PROMPT_MAX_BYTES = 8000`) rather than truncated at runtime.
+
+## Throughput overlays (per family, ULW-facing)
+
+`build_throughput_overlay()` in `src/coding/throughput_prompting.py` gives
+every family the base rules — batch independent tool calls and reads in one
+shot, keep dependency-bound work sequential. Two advanced modes are gated to
+the `gpt` family: `gpt_sol_codex_handoff` (a `*-sol` model on the codex
+profile, adding single-eval-cell internal parallelism) and `gpt_hermes_ulw`
+(gpt family on the hermes profile running ultrawork). *Why gated:* the
+eval-batching behavior was designed and verified against GPT-5.6 Sol's
+execution surface; extending an unverified throughput claim to other families
+would be guidance without a stated reason, which the governing rule forbids.
+
+## Routing, chains, and per-model bookkeeping
+
+- **Mixture chains** — per-category ordered model chains (see the README
+  model-routing section), user-editable via
+  `~/.omh/routing/model-chains.json` (`mixture_chain_overrides/v1`).
+- **Ultrafast variants are not a separate family** — `kimi-k3-ultrafast` and
+  `glm-5.2-ultrafast` are the same base models served on OpenGateway's speed
+  tier: same weights, same family (`kimi-` / `glm-` prefix match), and
+  therefore exactly the same calibration — only serving speed differs. A
+  `-ultrafast` variant the chains do not name still projects onto its base
+  model's category for HUD labels (`mixture_category_for`), so speed tiers
+  never unlabel a lane.
+- **Cost approximation** — `APPROX_PRICE_PER_MTOK` in
+  `src/plugin_bundle/omh/hermes_delegation.py` supplies `~$` estimates only
+  when the host recorded no cost; models absent from the table show no
+  approximation (never a fabricated number).
+- **Fanout dispatch credentials** — `_PROVIDER_ENV` in
+  `src/coding/hermes_child_dispatch.py` maps providers (anthropic, openai,
+  gemini/google/vertex, qwen, deepseek, zai, opengateway, openrouter, nous,
+  azure, bedrock, …) to the environment variables a dispatched child needs.
+
+## Coverage matrix and known gaps
+
+| Family | Recognized | Calibrated (both tables) | Status |
+| --- | --- | --- | --- |
+| `gpt`, `claude`, `gemini`, `grok`, `kimi`, `glm`, `qwen`, `deepseek` | yes | yes | full guidance, provenance above |
+| `mistral`, `llama`, `codestral` | yes | no → `generic` | tracked in issue #1051 |
+| `openai`, `anthropic` (bare-vendor prefixes) | yes | no → `generic` | tracked in issue #1051 |
+| `solar` (Upstage) and other emerging families | no → `unknown` | no → `generic` | tracked in issue #1052 |
+
+Gaps close by evidence, not by copywriting: a new calibration entry needs an
+observed failure mode (or provider-stated characteristic) worth countering,
+lands in both tables at once (parity-gated), and states its reason and source
+in this document.

--- a/README.ja.md
+++ b/README.ja.md
@@ -197,7 +197,35 @@ OMH には次の編集可能な順序付き recommendation chain が含まれて
 
 Ultrafast ティアを試したいなら — Kimi K3 Ultrafast(300 TPS)、GLM 5.2 Ultrafast(600 TPS)は [OpenGateway](https://opengateway.ai/) で利用できます。
 
-上記のすべての chain はコードを触らずに編集できます: `omh setup` が `~/.omh/routing/model-chains.json` をシードし、このファイルに書いたカテゴリはルーティング・fallback・HUD ラベルのすべてでその chain を置き換えます。
+上記のすべての chain はコードを触らずに編集できます。chain は 1 つのファイルで管理され、`omh setup` がシードします:
+
+```sh
+$ cat ~/.omh/routing/model-chains.json
+{
+  "categories": {},
+  "schema_version": "mixture_chain_overrides/v1"
+}
+```
+
+`categories` が空なら上記の既定 chain がそのまま有効です。編集するのはこのファイルです: ここに書いたカテゴリはルーティング・fallback・HUD ラベルのすべてでその chain を置き換えます —
+
+```json
+{
+  "schema_version": "mixture_chain_overrides/v1",
+  "categories": {
+    "architect": [
+      {"model": "claude-fable-5", "reasoning_effort": "xhigh"},
+      {"model": "gpt-5.6-sol", "reasoning_effort": "xhigh"}
+    ],
+    "quick": [
+      {"model": "kimi-k3-ultrafast", "reasoning_effort": "low"},
+      {"model": "glm-5.2-ultrafast", "reasoning_effort": "low"}
+    ]
+  }
+}
+```
+
+`omh model-chains show` が現在有効な chain を出力し、`omh model-chains set quick "kimi-k3-ultrafast:low, glm-5.2-ultrafast:low"` が同じドキュメントを代わりに書き込みます。
 
 Hermes に **モデルをセットアップして** と頼むと、確認や変更ができます。これは編集可能な優先設定であり、benchmark 結果ではありません。詳しい設定、fallback、provider、所有権のルールは [Guided Model Setup](docs/INSTALLATION.md#guided-model-setup) を参照してください。
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -225,7 +225,7 @@ $ cat ~/.omh/routing/model-chains.json
 }
 ```
 
-`omh model-chains show` が現在有効な chain を出力し、`omh model-chains set quick "kimi-k3-ultrafast:low, glm-5.2-ultrafast:low"` が同じドキュメントを代わりに書き込みます。
+現在有効な chain は `omh model-chains show` で確認できます。ファイルを直接編集したくない場合は、`omh model-chains set quick "kimi-k3-ultrafast:low, glm-5.2-ultrafast:low"` のようにコマンドから同じファイルを書き換えられます。
 
 Hermes に **モデルをセットアップして** と頼むと、確認や変更ができます。これは編集可能な優先設定であり、benchmark 結果ではありません。詳しい設定、fallback、provider、所有権のルールは [Guided Model Setup](docs/INSTALLATION.md#guided-model-setup) を参照してください。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -223,7 +223,7 @@ $ cat ~/.omh/routing/model-chains.json
 }
 ```
 
-`omh model-chains show`가 현재 적용 중인 chain을 출력하고, `omh model-chains set quick "kimi-k3-ultrafast:low, glm-5.2-ultrafast:low"`가 같은 문서를 대신 써 줍니다.
+현재 적용 중인 chain은 `omh model-chains show`로 확인할 수 있습니다. 파일을 직접 고치는 대신 명령으로 바꾸고 싶다면 `omh model-chains set quick "kimi-k3-ultrafast:low, glm-5.2-ultrafast:low"`처럼 실행하면 이 파일이 그대로 수정됩니다.
 
 Hermes에게 **모델을 설정해 줘**라고 요청해 검토하거나 변경할 수 있습니다. 이는 편집 가능한 선호이며 benchmark 결과가 아닙니다. 자세한 설정, fallback, provider, 소유권 규칙은 [Guided Model Setup](docs/INSTALLATION.md#guided-model-setup)을 참조하세요.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -195,7 +195,35 @@ OMH에는 다음과 같이 편집 가능한 순서형 recommendation chain이 �
 
 Ultrafast 티어가 궁금하다면 — Kimi K3 Ultrafast(300 TPS), GLM 5.2 Ultrafast(600 TPS) — [OpenGateway](https://opengateway.ai/)에서 만나볼 수 있습니다.
 
-위 모든 chain은 코드를 건드리지 않고 편집할 수 있습니다: `omh setup`이 `~/.omh/routing/model-chains.json`을 시드하며, 이 파일에 적은 카테고리는 라우팅·fallback·HUD 라벨 모두에서 해당 chain을 대체합니다.
+위 모든 chain은 코드를 건드리지 않고 편집할 수 있습니다. chain은 파일 하나로 관리되며 `omh setup`이 시드합니다:
+
+```sh
+$ cat ~/.omh/routing/model-chains.json
+{
+  "categories": {},
+  "schema_version": "mixture_chain_overrides/v1"
+}
+```
+
+`categories`가 비어 있으면 위의 기본 chain이 그대로 살아 있습니다. 이 파일을 직접 수정하시면 됩니다: 여기에 적은 카테고리는 라우팅·fallback·HUD 라벨 모두에서 해당 chain을 대체합니다 —
+
+```json
+{
+  "schema_version": "mixture_chain_overrides/v1",
+  "categories": {
+    "architect": [
+      {"model": "claude-fable-5", "reasoning_effort": "xhigh"},
+      {"model": "gpt-5.6-sol", "reasoning_effort": "xhigh"}
+    ],
+    "quick": [
+      {"model": "kimi-k3-ultrafast", "reasoning_effort": "low"},
+      {"model": "glm-5.2-ultrafast", "reasoning_effort": "low"}
+    ]
+  }
+}
+```
+
+`omh model-chains show`가 현재 적용 중인 chain을 출력하고, `omh model-chains set quick "kimi-k3-ultrafast:low, glm-5.2-ultrafast:low"`가 같은 문서를 대신 써 줍니다.
 
 Hermes에게 **모델을 설정해 줘**라고 요청해 검토하거나 변경할 수 있습니다. 이는 편집 가능한 선호이며 benchmark 결과가 아닙니다. 자세한 설정, fallback, provider, 소유권 규칙은 [Guided Model Setup](docs/INSTALLATION.md#guided-model-setup)을 참조하세요.
 

--- a/README.md
+++ b/README.md
@@ -306,9 +306,9 @@ fallback, and HUD labels alike —
 }
 ```
 
-`omh model-chains show` prints the effective chains, and
-`omh model-chains set quick "kimi-k3-ultrafast:low, glm-5.2-ultrafast:low"`
-writes the same document for you.
+Check the chains currently in effect with `omh model-chains show`. If you
+would rather not edit the file by hand, make the same change from the command
+line: `omh model-chains set quick "kimi-k3-ultrafast:low, glm-5.2-ultrafast:low"`.
 
 Ask Hermes to **set up my models** to review or change them. These are editable
 preferences, not benchmark results. See

--- a/README.md
+++ b/README.md
@@ -275,9 +275,40 @@ Want to try the Ultrafast tier — Kimi K3 Ultrafast (300 TPS) and
 GLM 5.2 Ultrafast (600 TPS)? They are served on
 [OpenGateway](https://opengateway.ai/).
 
-Every chain above is user-editable without touching code: `omh setup` seeds
-`~/.omh/routing/model-chains.json`, and a category you write there replaces
-that chain for routing, fallback, and HUD labels alike.
+Every chain above is user-editable without touching code. The chains are
+managed in one file — `omh setup` seeds it:
+
+```sh
+$ cat ~/.omh/routing/model-chains.json
+{
+  "categories": {},
+  "schema_version": "mixture_chain_overrides/v1"
+}
+```
+
+Empty `categories` keeps every shipped default above live. This file is the
+place to edit: a category you write there replaces that chain for routing,
+fallback, and HUD labels alike —
+
+```json
+{
+  "schema_version": "mixture_chain_overrides/v1",
+  "categories": {
+    "architect": [
+      {"model": "claude-fable-5", "reasoning_effort": "xhigh"},
+      {"model": "gpt-5.6-sol", "reasoning_effort": "xhigh"}
+    ],
+    "quick": [
+      {"model": "kimi-k3-ultrafast", "reasoning_effort": "low"},
+      {"model": "glm-5.2-ultrafast", "reasoning_effort": "low"}
+    ]
+  }
+}
+```
+
+`omh model-chains show` prints the effective chains, and
+`omh model-chains set quick "kimi-k3-ultrafast:low, glm-5.2-ultrafast:low"`
+writes the same document for you.
 
 Ask Hermes to **set up my models** to review or change them. These are editable
 preferences, not benchmark results. See

--- a/README.zh.md
+++ b/README.zh.md
@@ -224,7 +224,7 @@ $ cat ~/.omh/routing/model-chains.json
 }
 ```
 
-`omh model-chains show` 会输出当前生效的 chain，`omh model-chains set quick "kimi-k3-ultrafast:low, glm-5.2-ultrafast:low"` 会代你写入同一份文档。
+当前生效的 chain 可用 `omh model-chains show` 查看。不想手动编辑文件的话，也可以运行 `omh model-chains set quick "kimi-k3-ultrafast:low, glm-5.2-ultrafast:low"`，同一个文件会被直接修改。
 
 请让 Hermes **设置我的模型**，以查看或更改这些推荐。它们是可编辑的偏好，不是 benchmark 结果。详细的设置、fallback、provider 与所有权规则见 [Guided Model Setup](docs/INSTALLATION.md#guided-model-setup)。
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -196,7 +196,35 @@ OMH 随附以下可编辑的有序 recommendation chain。guided model setup 只
 
 想试试 Ultrafast 档? Kimi K3 Ultrafast(300 TPS)与 GLM 5.2 Ultrafast(600 TPS)都在 [OpenGateway](https://opengateway.ai/) 上提供。
 
-上面的每条 chain 都可以在不改代码的情况下编辑: `omh setup` 会生成 `~/.omh/routing/model-chains.json`，写入该文件的类别会在路由、fallback 与 HUD 标签中替换对应 chain。
+上面的每条 chain 都可以在不改代码的情况下编辑。chain 由一个文件管理，`omh setup` 会生成它:
+
+```sh
+$ cat ~/.omh/routing/model-chains.json
+{
+  "categories": {},
+  "schema_version": "mixture_chain_overrides/v1"
+}
+```
+
+`categories` 为空时，上面的默认 chain 全部保持生效。要修改就编辑这个文件: 写入其中的类别会在路由、fallback 与 HUD 标签中替换对应 chain —
+
+```json
+{
+  "schema_version": "mixture_chain_overrides/v1",
+  "categories": {
+    "architect": [
+      {"model": "claude-fable-5", "reasoning_effort": "xhigh"},
+      {"model": "gpt-5.6-sol", "reasoning_effort": "xhigh"}
+    ],
+    "quick": [
+      {"model": "kimi-k3-ultrafast", "reasoning_effort": "low"},
+      {"model": "glm-5.2-ultrafast", "reasoning_effort": "low"}
+    ]
+  }
+}
+```
+
+`omh model-chains show` 会输出当前生效的 chain，`omh model-chains set quick "kimi-k3-ultrafast:low, glm-5.2-ultrafast:low"` 会代你写入同一份文档。
 
 请让 Hermes **设置我的模型**，以查看或更改这些推荐。它们是可编辑的偏好，不是 benchmark 结果。详细的设置、fallback、provider 与所有权规则见 [Guided Model Setup](docs/INSTALLATION.md#guided-model-setup)。
 

--- a/tests/test_model_recommendations.py
+++ b/tests/test_model_recommendations.py
@@ -119,6 +119,23 @@ class RecommendationCatalogTests(unittest.TestCase):
             with self.subTest(surface=surface, contract="chain-interview-step"):
                 self.assertIn("model-chain interview", text)
                 self.assertNotIn("interactive model setup, and doctor steps", text)
+        # The README model-routing section shows where the chains live: a cat
+        # of the seeded file (matching its real key order and indentation) and
+        # an edited example, so readers learn the file is the tuning surface.
+        seeded_cat_block = (
+            "$ cat ~/.omh/routing/model-chains.json\n"
+            "{\n"
+            '  "categories": {},\n'
+            '  "schema_version": "mixture_chain_overrides/v1"\n'
+            "}"
+        )
+        for surface in ("readme", "ko", "ja", "zh"):
+            with self.subTest(surface=surface, contract="chains-file-example"):
+                self.assertIn(seeded_cat_block, surfaces[surface])
+                self.assertIn('"claude-fable-5", "reasoning_effort": "xhigh"', surfaces[surface])
+                self.assertIn('"gpt-5.6-sol", "reasoning_effort": "xhigh"', surfaces[surface])
+                self.assertIn('"kimi-k3-ultrafast", "reasoning_effort": "low"', surfaces[surface])
+                self.assertIn("omh model-chains show", surfaces[surface])
         self.assertIn('data-i18n="route.state.owner_default"', surfaces["site"])
         translations = Path("site/i18n.js").read_text(encoding="utf-8")
         self.assertIn('"route.state.owner_default"', translations)

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -3340,9 +3340,11 @@ class RouterContentTests(unittest.TestCase):
             # (h2 + badge + 12-row table, ~27 lines) landed in every language,
             # and from 290 when the terminal screenshots table and the
             # English-named feature callouts (owner-directed localized
-            # parity) landed in every language; it still sits below
-            # README.md's length.
-            self.assertLess(len(localized_readme.splitlines()), 320)
+            # parity) landed in every language, and from 320 when the
+            # model-chains file example (cat of the seeded file plus an
+            # edited-category block, ~26 lines, owner-directed) landed in
+            # every language; it still sits below README.md's length.
+            self.assertLess(len(localized_readme.splitlines()), 340)
             # The trust surface is the evidence table, not the wire token that
             # used to stand in for it. Pinning the token meant a README could
             # satisfy this by naming a value no reader could decode; pinning

--- a/tests/test_unit_prompt_protocol.py
+++ b/tests/test_unit_prompt_protocol.py
@@ -275,5 +275,39 @@ class PromptBudgetPolicyTests(unittest.TestCase):
         self.assertEqual(HIGH_EFFORT_TIER, frozenset({"high", "xhigh", "max"}))
 
 
+class ModelOptiDocTests(unittest.TestCase):
+    """MODEL_OPTI.md is the human-readable map of the calibration surface.
+
+    The doc promises a section (with trait/injected/why/source) for every
+    calibrated family and names the recognized-but-uncalibrated families as
+    tracked gaps — so a table change without a doc change fails here.
+    """
+
+    def _doc(self) -> str:
+        from pathlib import Path
+
+        return (Path(__file__).resolve().parents[1] / "MODEL_OPTI.md").read_text(
+            encoding="utf-8"
+        )
+
+    def test_every_calibrated_family_has_a_documented_section(self) -> None:
+        doc = self._doc()
+        for family in HIGH_EFFORT_CALIBRATIONS:
+            self.assertIn(f"### `{family}`", doc, family)
+        self.assertIn("HIGH_EFFORT_CALIBRATIONS", doc)
+        self.assertIn("MAIN_AGENT_COMPOSITION_CALIBRATIONS", doc)
+        self.assertIn("UNIT_PROMPT_MAX_BYTES", doc)
+
+    def test_uncalibrated_recognized_families_stay_named_as_gaps(self) -> None:
+        doc = self._doc()
+        for family in ("mistral", "llama", "codestral"):
+            self.assertNotIn(family, HIGH_EFFORT_CALIBRATIONS)
+            self.assertIn(f"`{family}`", doc, family)
+        # The gaps carry their tracking issues; when a calibration lands,
+        # move the family into a documented section instead of the gap table.
+        self.assertIn("#1051", doc)
+        self.assertIn("#1052", doc)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Capability

The README model-routing section (all four languages) now documents where the chains actually live: a `cat ~/.omh/routing/model-chains.json` block showing the seeded file exactly as setup writes it, a this-is-the-file-to-edit note, and an edited example covering both a frontier chain (`architect`: Claude Fable 5 + GPT-5.6 Sol at xhigh) and a speed chain (`quick`: Kimi K3 / GLM 5.2 Ultrafast at low), followed by the `omh model-chains show` / `set` commands that write the same document.

## Motivation

#1048/#1049 made the chains tunable and recommended, but the README only said the file exists in one sentence. A reader scanning the model-routing section had no picture of the file's shape, where to edit, or what a written category looks like.

## Implementation (boundary level)

- README.md/.ko/.ja/.zh: the one-sentence chains paragraph became cat output + edit note + example + commands. The cat block matches the seeded file byte-shape (sorted keys, `categories` first); the example document was run through `parse_mixture_chain_overrides` and returns `applied`.
- `tests/test_model_recommendations.py`: pins the seeded cat block, the Fable/GPT and Kimi-Ultrafast example lines, and the commands per README surface.
- `tests/test_router_content.py`: the localized-README line budget grew 320 → 340 with the rationale appended to its own growth-history comment (owner-directed localized parity addition, ~26 lines per language) — the budget's documented pattern.

## Observed verification

- Clean feature worktree full suite: **6,934 tests OK**.
- Example JSON validated by the real overrides parser: status `applied` with both categories parsed.
- `docs ulw-inventory --check` (README carries a marked ULW region) and `git diff --check` pass.

## Risks

- Docs-only; no code paths change. The cat block could drift if the seeder's serialization changes, but the new test pins the exact block so drift fails CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)