### PR TITLE
fix: add Solar Pro 2 price approximation

### DIFF
--- a/src/plugin_bundle/omh/hermes_delegation.py
+++ b/src/plugin_bundle/omh/hermes_delegation.py
@@ -195,6 +195,7 @@ APPROX_PRICE_PER_MTOK: dict[str, tuple[float, float]] = {
     "kimi-k3-ultrafast": (0.3, 1.25),
     "gemini-3.1-pro": (1.25, 10.0),
     "qwen3-coder": (0.4, 1.6),
+    "solar-pro2": (0.15, 0.60),
 }
 
 

--- a/tests/test_plugin_hermes_delegation.py
+++ b/tests/test_plugin_hermes_delegation.py
@@ -365,6 +365,46 @@ class HermesNativeSubagentReaderTest(unittest.TestCase):
             (10_000 * 1.25 + 30_000 * 0.125 + 4_000 * 10.0) / 1_000_000,
         )
 
+    def test_solar_pro2_unrecorded_cost_is_approximated_at_list_price(self):
+        _build_state_db(
+            self.home,
+            [
+                {
+                    "id": "20260818_100100_solar01",
+                    "model": "solar-pro2",
+                    "effort": "low",
+                    "started_at": NOW - 300,
+                    "usage": {
+                        "api_calls": 5,
+                        "input_tokens": 20_000,
+                        "output_tokens": 5_000,
+                        "cache_read_tokens": 10_000,
+                        "first_seen": NOW - 290,
+                        "last_seen": NOW - 10,
+                    },
+                }
+            ],
+        )
+        _write_manifest(
+            self.home,
+            "deleg_solar",
+            ["solar lane"],
+            started=NOW - 305,
+            log_mtime=NOW - 5,
+        )
+        payload = read_hermes_native_subagents(self.home, now=NOW, omh_home=self.home / ".omh")
+        self.assertEqual(payload["status"], "observed")
+        self.assertEqual(payload["running"], 1)
+        row = payload["rows"][0]
+        self.assertEqual(row["model"], "solar-pro2")
+        # Solar Pro 2 list price: $0.15/M input, $0.60/M output; cache reads @ tenth of input ($0.015/M).
+        # 20k input @ $0.15/M + 10k cache reads @ $0.015/M + 5k output @ $0.60/M.
+        self.assertTrue(row["cost_approximate"])
+        self.assertAlmostEqual(
+            row["cost_usd"],
+            (20_000 * 0.15 + 10_000 * 0.015 + 5_000 * 0.60) / 1_000_000,
+        )
+
     def test_an_observed_host_cost_is_never_replaced_by_the_approximation(self):
         _build_state_db(
             self.home,


### PR DESCRIPTION
## Summary

Fixes #1057.

Adds an approximate token price entry for `solar-pro2` using its
publicly documented list price:

- Input: $0.15 / MTok
- Output: $0.60 / MTok

The model ID was verified against the repository's routing/model
conventions, and the pricing was verified from Upstage's public
pricing page.

I intentionally did not add `grok`, `mistral`, `llama`, or `codestral`
rows where a stable, citable model ID and public pricing could not be
established.

## Changes

- Add `solar-pro2` to `APPROX_PRICE_PER_MTOK`
- Add regression coverage for Solar Pro 2 approximate-cost calculation

## Validation

- `$env:PYTHONPATH="src;tests"; python -m unittest tests/test_plugin_hermes_delegation.py -v`
  - 23/23 tests passed, including the new Solar Pro 2 regression test.
- `uv run --group lint ruff check src tests`
  - All checks passed.
- `git diff --check`
  - Passed.
- Full test suite:
  - 6,955 tests ran; 25 failures, 53 errors, 264 skipped.
  - The targeted `tests/test_plugin_hermes_delegation.py` suite passes
    completely; the full-suite failures/errors were outside the touched
    files.

## Pricing source

- Upstage official pricing: https://www.upstage.ai/pricing
  - Solar Pro 2: $0.15 / MTok input, $0.60 / MTok output

## Risk / known gaps

Low risk. The change is limited to one pricing-table entry and
regression coverage. The focused delegation suite passes and the
linting gate passes.