### PR TITLE
docs(readme): close every README with the contributors avatar wall

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -319,3 +319,10 @@ git diff --check
 OMH は [Team Art & Engineering](https://rlaope.github.io/artengine-lab/) の
 オープンプロジェクトとして開発されています。更新情報は
 [@rlaope](https://github.com/rlaope) で確認できます。
+## コントリビューター
+
+oh-my-hermes に貢献してくださった皆さまに感謝します。
+
+<a href="https://github.com/rlaope/oh-my-hermes/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=rlaope/oh-my-hermes" alt="oh-my-hermes contributors" />
+</a>

--- a/README.ko.md
+++ b/README.ko.md
@@ -319,3 +319,10 @@ git diff --check
 OMH는 [Team Art & Engineering](https://rlaope.github.io/artengine-lab/)의
 공개 프로젝트로 개발되고 있습니다. 프로젝트 소식은
 [@rlaope](https://github.com/rlaope)에서 확인할 수 있습니다.
+## 기여자
+
+oh-my-hermes에 기여해 주신 모든 분들께 감사드립니다.
+
+<a href="https://github.com/rlaope/oh-my-hermes/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=rlaope/oh-my-hermes" alt="oh-my-hermes contributors" />
+</a>

--- a/README.md
+++ b/README.md
@@ -427,3 +427,10 @@ git diff --check
 OMH is developed in the open as part of
 [Team Art & Engineering](https://rlaope.github.io/artengine-lab/). Follow
 [@rlaope](https://github.com/rlaope) for project updates.
+## Contributors
+
+Thanks to everyone who has contributed to oh-my-hermes.
+
+<a href="https://github.com/rlaope/oh-my-hermes/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=rlaope/oh-my-hermes" alt="oh-my-hermes contributors" />
+</a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -318,3 +318,10 @@ git diff --check
 
 OMH 是 [Team Art & Engineering](https://rlaope.github.io/artengine-lab/) 的
 开源项目。请关注 [@rlaope](https://github.com/rlaope) 获取更新。
+## 贡献者
+
+感谢每一位为 oh-my-hermes 做出贡献的人。
+
+<a href="https://github.com/rlaope/oh-my-hermes/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=rlaope/oh-my-hermes" alt="oh-my-hermes contributors" />
+</a>

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -3394,6 +3394,9 @@ class RouterContentTests(unittest.TestCase):
             self.assertIn("omh setup", localized_readme)
             self.assertIn("```sh\nomh update\n```", localized_readme)
             self.assertIn("```sh\nomh doctor\n```", localized_readme)
+            # The contributors avatar wall closes every README so external
+            # contributions are visible on all four landing pages.
+            self.assertIn("contrib.rocks/image?repo=rlaope/oh-my-hermes", localized_readme)
             self.assertNotIn(
                 "```sh\nomh update\nomh doctor\n```",
                 localized_readme,
@@ -3427,6 +3430,7 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("`Code · reported done`", readme)
         self.assertIn("assets/hermes-agent-hero.png", readme)
         self.assertIn("assets/friren-agent-omh-callout.png", readme)
+        self.assertIn("contrib.rocks/image?repo=rlaope/oh-my-hermes", readme)
         self.assertNotIn("assets/artengine-friren-profile-card.png", readme)
         self.assertNotIn("assets/omh-core-workflows.png", readme)
         self.assertNotIn("assets/omh-skill-magic-promo.png", readme)
@@ -3957,6 +3961,10 @@ class RouterContentTests(unittest.TestCase):
             ),
             ("## Documentation", {"ko": "## 문서", "ja": "## ドキュメント", "zh": "## 文档"}),
             ("## Development", {"ko": "## 개발", "ja": "## 開発", "zh": "## 开发"}),
+            (
+                "## Contributors",
+                {"ko": "## 기여자", "ja": "## コントリビューター", "zh": "## 贡献者"},
+            ),
         )
 
         readme = Path("README.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Capability

Every README (en/ko/ja/zh) now ends with a Contributors section: the contrib.rocks avatar grid linking to the repository's contributors graph — external contributions (like #1064) become visible on all four landing pages.

## Motivation

Owner request following the first external contribution: contributors should be visible at the bottom of the README the way most open-source landing pages do it.

## Implementation (boundary level)

- README.md/.ko/.ja/.zh: `## Contributors` (localized headings: 기여자 / コントリビューター / 贡献者) + contrib.rocks image linked to the contributors graph, appended as the final section.
- `tests/test_router_content.py`: the localized structural-sync test's translation table gains the new section (it pins heading set/order parity across locales); the contrib.rocks URL is pinned in the English README assertions and in the per-locale loop.

## Observed verification

- Clean worktree full suite green; localized line budgets 328/328/327, under the documented 340 cap; ulw-inventory byte gate and `git diff --check` pass.

## Risks

- contrib.rocks is an external image service; if it is ever unreachable the image degrades to alt text, the link to the GitHub contributors graph still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)