### PR TITLE
prompting: adopt DeepSeek-harness findings — universal failure-kind protocol + deepseek calibration upgrade

### DIFF
--- a/MODEL_OPTI.md
+++ b/MODEL_OPTI.md
@@ -60,7 +60,7 @@ identical prompt. Nothing else about the pipeline changes per model.
 
 ## Universal protocols (every model, every family)
 
-`src/coding/unit_prompt_protocol.py` attaches three deterministic blocks to
+`src/coding/unit_prompt_protocol.py` attaches four deterministic blocks to
 every dispatched unit prompt, regardless of model:
 
 - **Goal echo-back** — before the first tool use, the subagent restates the
@@ -76,10 +76,36 @@ every dispatched unit prompt, regardless of model:
   criterion). *Why:* the two dominant agent failure modes are opposites —
   skipping verification, and looping on it — and one bounded rule counters
   both. Review-role units add criterion-bound blocking with a two-round cap.
+- **Failure-kind discipline** — a permission, sandbox, or policy denial is a
+  boundary, not a bug: the unit must not retry it through another tool or
+  route, and may report `blocked` only for a named concrete condition that
+  survives the bounded fix cycles — difficulty, uncertainty, or useful
+  remaining work is not blocked. *Why:* models over-generalize "failure →
+  try another way", which turns policy refusals into route-around attempts,
+  and under-specify "blocked", which turns difficulty into a stop. Adapted
+  from the DeepSeek Harness sandbox-denial no-retry marker and its
+  goal-policy blocked threshold ("difficulty, uncertainty, or useful
+  remaining work is not blocked"), generalized to every family because both
+  failure modes are cross-family (deepseek-ai/deepseek-harness, master
+  2026-08-13; adopted in #1071).
 
-These originate from the stop-condition techniques the oh-my-openagent
-research surfaced for high-effort models (terminal-condition rules,
-criterion-bound blocking, capped re-review), generalized to every family.
+The first three originate from the stop-condition techniques the
+oh-my-openagent research surfaced for high-effort models (terminal-condition
+rules, criterion-bound blocking, capped re-review), generalized to every
+family. The fourth comes from the DeepSeek Harness review named above.
+
+### Techniques compared and already structural (DeepSeek Harness review)
+
+The same harness review surfaced techniques OMH already carries structurally,
+recorded here so the comparison stays auditable instead of being relitigated:
+single-owner-of-facts (the skill catalog and its byte-gated generated
+projections), negative instructions phrased as the concrete behavior they
+forbid (the house calibration style throughout this file), and numeric stop
+bounds for ambiguous judgments (one-pass verification, two fix-and-verify
+cycles, two review rounds). Machine-readable result markers and
+KV-cache-aware request assembly belong to the executor/runtime that actually
+calls a model — outside the `deepseek` composer note below, they are out of
+OMH's boundary by design.
 
 ## Per-family calibrations: what, why, and where each came from
 
@@ -226,18 +252,30 @@ pairing so a benchmark claim can never mix in other prompt changes.
 - **Model trait:** a heterogeneous family — some variants are reasoning
   models, some are not, and the split moved across versions. The common
   error in the wild is applying legacy R1-era reasoning prompts to every
-  DeepSeek model, which is wrong on the non-reasoning variants.
+  DeepSeek model, which is wrong on the non-reasoning variants. Two further
+  facts come from DeepSeek's own agent harness
+  (deepseek-ai/deepseek-harness, master 2026-08-13): its benchmark preset
+  reproduces the Claude-SWE-compatible exact-string editor contract
+  verbatim — the family is post-trained on exact-literal `old_str` edit
+  semantics with uniqueness and whitespace discipline — and DeepSeek
+  serving prices cached prefixes, which that harness treats as a
+  first-class composition constraint.
 - **What OMH injects (subagent):** treat the model version and its declared
   thinking mode as *contract fields*; preserve runtime-provided reasoning
   context across tool results only on a reasoning-capable route; otherwise
-  use the same explicit goal/boundaries/criteria without thinking tags; make
+  use the same explicit goal/boundaries/criteria without thinking tags; edit
+  by exact literal strings (a unique match with exact whitespace); make
   the smallest correct change, verify once, stop.
 - **What OMH injects (composer):** keep the DeepSeek version and thinking
   mode explicit in the prepared route; no synthetic thinking instructions on
-  non-reasoning routes.
+  non-reasoning routes; keep the shared preamble byte-identical across unit
+  prompts — stable ordering, no timestamps or volatile status — with
+  unit-specific content appended after it, because cached prefixes are
+  priced.
 - **Source:** provider-published model characteristics (DeepSeek's
-  reasoning/non-reasoning variant split); shipped with the benchmark
-  harness.
+  reasoning/non-reasoning variant split; shipped with the benchmark
+  harness), plus the DeepSeek Harness review adopted in #1071 (exact-string
+  RL edit contract, priced prefix caching).
 
 ### `mistral` (Mistral Large / Medium)
 

--- a/src/coding/unit_prompt_protocol.py
+++ b/src/coding/unit_prompt_protocol.py
@@ -1,6 +1,6 @@
 """Verification discipline for prepared fanout unit prompts.
 
-Three deterministic text blocks ride every dispatched unit prompt:
+Four deterministic text blocks ride every dispatched unit prompt:
 
 1. **Goal echo-back** — before any tool use the subagent restates the goal,
    its own deliverable, and the completion criteria, and stops to report (not
@@ -12,6 +12,10 @@ Three deterministic text blocks ride every dispatched unit prompt:
    full pass is the floor, never skipped) and bounded (after the criteria
    pass, re-verifying is forbidden; on failure, at most two fix-and-verify
    cycles before reporting the failing criterion instead of looping).
+4. **Failure-kind discipline** — a permission, sandbox, or policy denial is
+   a boundary, not a bug (never retried through another route), and
+   "blocked" requires a named concrete condition that survives the bounded
+   fix cycles — difficulty, uncertainty, or remaining work is not blocked.
 
 High-effort routes additionally get a per-family calibration block that
 counters the known over-verification inertia of strong reasoning models.
@@ -50,6 +54,14 @@ VERIFICATION_STOP_PROTOCOL: Final[str] = (
     "has passed, STOP: do not re-verify, do not add a just-to-be-sure pass, and do not restart verification "
     "after edits that no criterion covers. If a criterion still fails after two fix-and-verify cycles, "
     "commit what passes and report the failing criterion with its output instead of looping."
+)
+
+FAILURE_KIND_PROTOCOL: Final[str] = (
+    "Failure-kind discipline: a permission, sandbox, or policy denial is a boundary, not a bug — do "
+    "not retry it through another tool or route; record the denial and continue with what the boundary "
+    "allows, or report it. Report blocked only when the same concrete condition still holds after the "
+    "bounded fix-and-verify cycles, and name that condition; difficulty, uncertainty, or useful "
+    "remaining work is not blocked."
 )
 
 REVIEW_ROLE_PROTOCOL: Final[str] = (
@@ -108,8 +120,9 @@ HIGH_EFFORT_CALIBRATIONS: Final[dict[str, str]] = {
         "High-effort calibration: treat the model version and declared thinking mode as contract "
         "fields; never apply legacy R1 prompting to every DeepSeek model. Preserve runtime-provided "
         "reasoning context across tool results only on a reasoning-capable route; otherwise use the "
-        "same explicit goal, boundaries, and completion criteria without thinking tags. Make the "
-        "smallest correct change, verify once, and stop."
+        "same explicit goal, boundaries, and completion criteria without thinking tags. Edit by exact "
+        "literal strings — a unique match with exact whitespace — as this family's edit training "
+        "expects. Make the smallest correct change, verify once, and stop."
     ),
     "mistral": (
         "High-effort calibration: instructions are followed literally here, so the stated criteria "
@@ -196,7 +209,9 @@ MAIN_AGENT_COMPOSITION_CALIBRATIONS: Final[dict[str, str]] = {
         "Composition calibration: keep the DeepSeek model version and thinking mode explicit in the "
         "prepared route. Preserve runtime reasoning context only when the selected model and executor "
         "support it; otherwise compose exact owners, scopes, dependencies, and verification commands "
-        "without synthetic thinking instructions. Validate once and stop."
+        "without synthetic thinking instructions. DeepSeek serving prices cached prefixes, so keep the "
+        "shared preamble byte-identical across unit prompts — stable ordering, no timestamps or "
+        "volatile status — with unit-specific content appended after it. Validate once and stop."
     ),
     "mistral": (
         "Composition calibration: write unit prompts literally and completely — a Mistral-family "
@@ -332,6 +347,7 @@ def unit_protocol_lines(unit: Mapping[str, Any]) -> list[str]:
     lines = [GOAL_ECHO_PROTOCOL, "Done means, and only means:"]
     lines.extend(f"{index}. {criterion}" for index, criterion in enumerate(criteria, start=1))
     lines.append(VERIFICATION_STOP_PROTOCOL)
+    lines.append(FAILURE_KIND_PROTOCOL)
     handoff = unit.get("handoff", {}) if isinstance(unit.get("handoff"), Mapping) else {}
     model_route = handoff.get("model_route") if isinstance(handoff.get("model_route"), Mapping) else None
     # Contract units carry the declared role inside the recorded route, not as

--- a/tests/test_unit_prompt_protocol.py
+++ b/tests/test_unit_prompt_protocol.py
@@ -12,6 +12,7 @@ from omh.coding.fanout_dispatch import build_unit_prompt  # noqa: E402
 from omh.coding.model_routing import EXECUTOR_MODEL_OPTIONS, MODEL_ROLES  # noqa: E402
 from _cli_harness import run_cli  # noqa: E402
 from omh.coding.unit_prompt_protocol import (  # noqa: E402
+    FAILURE_KIND_PROTOCOL,
     GOAL_ECHO_PROTOCOL,
     HIGH_EFFORT_CALIBRATIONS,
     HIGH_EFFORT_TIER,
@@ -46,8 +47,13 @@ class ProtocolContentTests(unittest.TestCase):
         self.assertIn(GOAL_ECHO_PROTOCOL, prompt)
         self.assertIn("Done means, and only means:", prompt)
         self.assertIn(VERIFICATION_STOP_PROTOCOL, prompt)
+        self.assertIn(FAILURE_KIND_PROTOCOL, prompt)
         # Verification stays mandatory: the discipline bounds it, never skips it.
         self.assertIn("verification is never skipped", prompt)
+        # A policy denial is a boundary, and "blocked" needs a named persistent
+        # condition — neither may be relitigated by a rewrite.
+        self.assertIn("policy denial is a boundary, not a bug", prompt)
+        self.assertIn("remaining work is not blocked", prompt)
         self.assertIn("Commit your work; do not merge or push other branches.", prompt)
 
     def test_integration_checks_become_numbered_criteria(self) -> None:
@@ -142,6 +148,11 @@ class CalibrationSelectionTests(unittest.TestCase):
         self.assertIn("non-thinking", HIGH_EFFORT_CALIBRATIONS["qwen"])
         self.assertNotIn("<think>", HIGH_EFFORT_CALIBRATIONS["qwen"])
         self.assertIn("model version", HIGH_EFFORT_CALIBRATIONS["deepseek"])
+        # DeepSeek's own harness ships the exact-string editor contract the
+        # family is post-trained on, and treats cached prefixes as priced —
+        # both facts ride the calibration pair (deepseek-harness, 2026-08-13).
+        self.assertIn("exact literal strings", HIGH_EFFORT_CALIBRATIONS["deepseek"])
+        self.assertIn("byte-identical", MAIN_AGENT_COMPOSITION_CALIBRATIONS["deepseek"])
         self.assertIn("interleaved", HIGH_EFFORT_CALIBRATIONS["glm"])
 
     def test_no_route_means_no_calibration(self) -> None:


### PR DESCRIPTION
## Feature Report

### What Changed

- Every dispatched fanout unit prompt now carries a fourth universal protocol block, **failure-kind discipline**: a permission, sandbox, or policy denial is a boundary, not a bug — never retried through another tool or route — and `blocked` may be reported only for a named concrete condition that survives the bounded fix-and-verify cycles; difficulty, uncertainty, or useful remaining work is not blocked.
- The `deepseek` calibration pair gained provider-published harness facts: the subagent block now instructs exact-literal-string editing (unique match, exact whitespace — the edit contract the family is post-trained on), and the composer block now instructs byte-identical shared preambles across unit prompts (stable ordering, no timestamps/volatile status) because DeepSeek serving prices cached prefixes.
- `MODEL_OPTI.md` documents the new universal block with its why/provenance, updates the `deepseek` section, and records the techniques reviewed and found **already structural** in OMH (single-owner-of-facts via byte-gated generated projections, negative instructions as concrete behaviors, numeric stop bounds) so the comparison stays auditable.

### Why This Exists

A review of DeepSeek's own agent harness (deepseek-ai/deepseek-harness, master 2026-08-13) surfaced evidence-backed counter-techniques for two cross-family model failure modes OMH's universal protocols did not cover: retrying around policy refusals, and subjectively declaring "blocked". It also published two DeepSeek-specific facts (Claude-SWE-compatible exact-string RL edit contract; priced prefix caching) that belong in the family calibration. Closes #1071.

### User / Operator Impact

Every fanout unit — regardless of executor or model — now ships with explicit denial-handling and blocked-definition discipline, and units routed to DeepSeek models get edit-contract and cache-cost guidance matching how the family was actually trained and served.

### How It Works

`unit_protocol_lines()` in `src/coding/unit_prompt_protocol.py` appends the new `FAILURE_KIND_PROTOCOL` block right after the verification-stop block; the deepseek entries in `HIGH_EFFORT_CALIBRATIONS` / `MAIN_AGENT_COMPOSITION_CALIBRATIONS` are extended in place. All content is prepared text; OMH still calls no model. The worst-case assembled prompt stays under the `UNIT_PROMPT_MAX_BYTES` (8000) policy ceiling, asserted by the existing budget test.

### Files And Contracts Touched

- `src/coding/unit_prompt_protocol.py` — new universal block, deepseek calibration pair, module docstring (three → four blocks)
- `tests/test_unit_prompt_protocol.py` — new block asserted in assembled prompts; new deepseek phrases pinned ("exact literal strings", "byte-identical"); existing pins ("model version") preserved
- `MODEL_OPTI.md` — universal-protocols section (fourth block + provenance), already-structural comparison record, `deepseek` section update

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [x] Codex
- [x] Claude Code
- [x] Hermes runtime or handoff
- [x] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` (6961 tests, OK)
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run

### Observed Evidence

- Targeted: `PYTHONPATH=tests uv run python -m unittest tests/test_unit_prompt_protocol.py -v` — 21 tests OK, including the worst-case prompt budget test with the new block included.
- Full suite: 6961 tests OK in 302s; ruff "All checks passed!"; `docs ulw-inventory --check` and `docs ulw-site --check` also pass (no generated artifact touched).

### Not Tested / Not Applicable

- Release smoke / harness validate / TUI: no CLI surface, packaging, harness contract, or TUI-rendered content changed — the diff is prepared prompt text, its tests, and hand-written docs.
- Live baseline-vs-calibrated benchmark for the updated deepseek block: OMH calls no model; the benchmark harness pairing (`tests/test_omh_live_model_benchmark.py`) still pins the calibration into the optimized prompt.

## Risk

- Low. Prompt text only; no schema, routing, or contract change. The one behavioral surface is unit prompt size, which stays under the policy ceiling by test.

## Compatibility / Rollout

- Fully backward compatible; prompts regenerate on next dispatch. Reaches live machines through `omh update` as usual.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [ ] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Run the live baseline-vs-calibrated benchmark pair for the updated deepseek block when a DeepSeek route is next exercised on a live machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NvDSpN3rE15KtVZ7RG5GoS
