### PR TITLE
fanout: executable verification_commands with dispatcher-observed results (--run-verification)

### DIFF
--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -133,6 +133,34 @@ Rules:
   spawn and exit are recorded as journal observations
   (`worker_dispatch`/`worker_result`, canonicalized to
   `executor_dispatch_observed`/`executor_result_observed`).
+- **Executable verification (opt-in).** A unit may declare
+  `verification_commands: [...]` beside its prose `integration_checks`. The
+  field is optional and additive — a unit that declares none carries no key and
+  its contract stays byte-identical to one frozen before the field existed. At
+  freeze time each command is bounded (at most 8 per unit, 240 chars each), may
+  not be blank, and is split with `shlex` so a command no dispatcher could run
+  is refused while the operator is still holding it. Leading `NAME=VALUE`
+  tokens become environment overrides (this repo's own gate is spelled
+  `PYTHONPATH=tests uv run ...`); everything after them is an argv run with
+  `shell=False`, so pipes and redirections are argument text, not operators.
+  `omh coding fanout dispatch --run-verification` — explicit, never on by
+  default — runs those commands with `cwd` set to the unit's own worktree,
+  after that unit's process exited 0 *and* its sidecar validated, with a
+  10-minute ceiling per command. Each command becomes a check row omh both
+  reported and observed (`reported_by`/`observed_by: dispatcher`,
+  `observation_source: dispatch_verification`), validated through the same
+  `fanout_unit_result/v1` gate every executor-written row goes through. Only
+  when every command passes does dispatch append the unit's
+  `unit_verification_observed` journal event, which is what flips that rung of
+  the ladder — the semantics are unchanged, the observation is simply one omh
+  made itself instead of one a human recorded with `omh runtime observe`. Any
+  failure appends nothing, leaves the unit short of `integration_ready`, and is
+  reported in `verification_failures` with the exit code and a bounded output
+  tail. A command that cannot start is a failed check, never a failed dispatch.
+  Under `--dry-run` the flag only names the commands in
+  `planned_verification_commands`. This runs inside the same sanctioned
+  dispatch bridge as the unit spawns themselves: still operator-invoked, still
+  local, still no merge and no network from omh.
 - **Dependency bar.** A satisfied dependency means only that the owner agent
   process exited 0. It is not verified, reviewed, or correct work. Failed
   units block their dependents, never their independents.
@@ -409,7 +437,7 @@ omh coding fanout migrate-legacy <fanout-id> \
   [--confirm-contract-sha256 <digest>]  # operator/maintenance only
 omh coding fanout dispatch <fanout-id> --goal-file goal.txt \
   [--repo-root .] [--base-ref HEAD] [--concurrency 2] [--timeout 1800] \
-  [--unit <id> ...] [--dry-run]
+  [--unit <id> ...] [--dry-run] [--run-verification]
 omh coding model-route [--executor <profile>] [--role <role>] [--model <id>] [--effort <level>] [--domain <name>] [--explain] [--from-inventory] [--json]
 omh coding model-inventory [--json]
 omh coding composition-guide [--model <id>] [--json]
@@ -417,4 +445,5 @@ omh coding composition-guide [--model <id>] [--json]
 
 `--units` and `--goal-file` accept `-` for stdin. `--dry-run` resolves
 readiness, planned argv, and worktree paths without spawning anything or
-creating any runs.
+creating any runs. `--run-verification` is off unless typed; it runs only the
+`verification_commands` a unit's own contract declares.

--- a/src/coding/fanout.py
+++ b/src/coding/fanout.py
@@ -17,7 +17,10 @@ from .fanout_contracts import (
     FANOUT_UNIT_OWNERS,
     FanoutContractError,
     MAX_SPAWN_PLAN_FIELD_CHARS,
+    MAX_UNIT_VERIFICATION_COMMAND_CHARS,
+    MAX_UNIT_VERIFICATION_COMMANDS,
     PREPARED_NOT_OBSERVED,
+    verification_command_argv,
 )
 from .executor_capability_snapshots import (
     ExecutorCapabilitySnapshotError,
@@ -377,6 +380,12 @@ def _normalized_unit(unit: Mapping[str, object], index: int) -> dict[str, object
         # means "arrange from discovery at dispatch time", [] means "the operator
         # chose the pure prompt". Order is preserved — a sequence is a sequence.
         "skill_sequence": _normalized_skill_sequence(unit.get("skill_sequence"), index),
+        # Prose `integration_checks` say what "verified" means; these say how a
+        # dispatcher could observe it. An empty answer is the default and means
+        # the contract names no command anyone can run for this unit.
+        "verification_commands": _normalized_verification_commands(
+            unit.get("verification_commands"), index
+        ),
     }
 
 
@@ -405,6 +414,44 @@ def _normalized_skill_sequence(value: object, index: int) -> list[str] | None:
                 f"at most {_MAX_SKILL_INVOCATION_CHARS} chars, and contain no backticks"
             )
     return entries
+
+
+def _normalized_verification_commands(value: object, index: int) -> list[str]:
+    """Collapse a unit's declared verification commands to their stored shape.
+
+    Blank entries raise rather than being dropped: a command the operator meant
+    to write and left empty is a hole in the evidence they are asking the
+    dispatcher to produce, and silently shortening the list would hide it.
+    """
+    if value is None:
+        return []
+    if not isinstance(value, (list, tuple)):
+        raise FanoutContractError(
+            f"unit at index {index} verification_commands must be a list of command strings"
+        )
+    if len(value) > MAX_UNIT_VERIFICATION_COMMANDS:
+        raise FanoutContractError(
+            f"unit at index {index} verification_commands must have at most "
+            f"{MAX_UNIT_VERIFICATION_COMMANDS} commands"
+        )
+    commands: list[str] = []
+    for entry in value:
+        if not isinstance(entry, str) or not entry.strip():
+            raise FanoutContractError(
+                f"unit at index {index} verification_commands entries must be non-empty strings; "
+                f"got {entry!r}"
+            )
+        command = " ".join(entry.split())
+        if len(command) > MAX_UNIT_VERIFICATION_COMMAND_CHARS:
+            raise FanoutContractError(
+                f"unit at index {index} verification_commands entries must be at most "
+                f"{MAX_UNIT_VERIFICATION_COMMAND_CHARS} chars"
+            )
+        # Parsed at freeze time so a command no dispatcher could run fails here,
+        # where the operator is still holding it, rather than mid-dispatch.
+        verification_command_argv(command)
+        commands.append(command)
+    return commands
 
 
 def _sibling_scopes(units: Sequence[Mapping[str, object]], unit_id: str) -> list[str]:
@@ -468,4 +515,8 @@ def _contract_unit(
     # contracts byte-identical and means "arrange from discovery at dispatch".
     if unit.get("skill_sequence") is not None:
         contract_unit["skill_sequence"] = list(unit["skill_sequence"])
+    # Same additive rule: a unit that declared no runnable command carries no
+    # key, so contracts frozen before this field stay byte-identical.
+    if unit.get("verification_commands"):
+        contract_unit["verification_commands"] = list(unit["verification_commands"])
     return contract_unit

--- a/src/coding/fanout_contracts.py
+++ b/src/coding/fanout_contracts.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import re
+import shlex
+
 from .executors import EXECUTOR_PROFILES, HERMES_CODING_TEAM_STATUS_LADDER
 
 
@@ -73,5 +76,47 @@ FANOUT_SPAWN_PLAN_CLAIM_BOUNDARY = (
 )
 
 
+# Optional per-unit executable verification. A unit may carry command strings
+# the dispatcher runs itself under `--run-verification`; the prose
+# `integration_checks` stay beside them, unchanged. Bounded like every other
+# operator-typed contract string: eight commands is more than one unit boundary
+# can justify, and 240 chars is a command line rather than a pasted script.
+MAX_UNIT_VERIFICATION_COMMANDS = 8
+MAX_UNIT_VERIFICATION_COMMAND_CHARS = 240
+# Named once so the check rows the dispatcher writes, the journal event they
+# back, and the docs describing both cannot drift apart.
+UNIT_VERIFICATION_OBSERVATION_SOURCE = "dispatch_verification"
+
+# A leading `NAME=VALUE` token: the one shell idiom a verification command may
+# use, because the repo's own integration gate is spelled that way.
+_ENV_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+
 class FanoutContractError(ValueError):
     """Raised when a proposed fanout unit list cannot be frozen into a contract."""
+
+
+def verification_command_argv(command: str) -> tuple[dict[str, str], list[str]]:
+    """Split one verification command into env overrides and an argv.
+
+    No shell ever runs one of these — the split happens here and the argv is
+    executed with `shell=False` — so pipes, redirections, and substitutions are
+    ordinary argument text rather than operators. Leading `NAME=VALUE` tokens
+    are the single exception, kept because `PYTHONPATH=tests uv run ...` is how
+    this repo's own gate commands are written and refusing them would make the
+    field unusable for exactly the commands it exists to carry.
+
+    Raises `FanoutContractError` so the freeze path rejects an unrunnable
+    command where the operator can still fix it.
+    """
+    try:
+        tokens = shlex.split(command)
+    except ValueError as exc:
+        raise FanoutContractError(f"verification command is not parseable: {exc}") from exc
+    env: dict[str, str] = {}
+    while tokens and _ENV_ASSIGNMENT_RE.match(tokens[0]):
+        name, _, value = tokens.pop(0).partition("=")
+        env[name] = value
+    if not tokens:
+        raise FanoutContractError("verification command must name a program to run")
+    return env, tokens

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from concurrent.futures import ThreadPoolExecutor
 from hashlib import sha256
 import json
+import os
 from pathlib import Path
 import shlex
 import shutil
@@ -26,10 +27,13 @@ from .fanout_contracts import (
     FANOUT_CLAIM_BOUNDARY,
     FANOUT_CONTRACT_SCHEMA_VERSION,
     LEGACY_FANOUT_CONTRACT_SCHEMA_VERSION,
+    UNIT_VERIFICATION_OBSERVATION_SOURCE,
+    FanoutContractError,
+    verification_command_argv,
 )
 from .inflight import InflightMarkerError, clear_inflight_marker, write_inflight_marker
 from .unit_prompt_protocol import unit_protocol_lines
-from .fanout_unit_results import validate_unit_result
+from .fanout_unit_results import validate_check_rows, validate_unit_result
 from .unit_telemetry import parse_unit_telemetry
 
 FANOUT_DISPATCH_SCHEMA_VERSION = "fanout_dispatch_summary/v1"
@@ -37,6 +41,16 @@ DISPATCH_CLAIM_BOUNDARY = (
     "A dispatch summary records observed local subprocess activity only. It is not verification, review, CI, "
     "merge-readiness, or merge evidence, and omh never merges unit branches itself."
 )
+UNIT_VERIFICATION_CLAIM_BOUNDARY = (
+    "A dispatcher verification row records that omh itself ran one command the contract declared, in that "
+    "unit's worktree, and what it exited with. It is not review, CI, merge-readiness, or merge evidence, "
+    "and a passing command proves only that command."
+)
+# Ten minutes per command. The field exists to carry unit-test and byte-gate
+# commands, which finish well inside that; the ceiling is here so one hung
+# command cannot hold a whole dispatch open.
+_VERIFICATION_COMMAND_TIMEOUT = 600
+_MAX_VERIFICATION_OUTPUT_TAIL = 300
 EXECUTOR_LIMIT_SIGNALS_SCHEMA_VERSION = "executor_limit_signals/v1"
 EXECUTOR_LIMIT_SIGNALS_CLAIM_BOUNDARY = (
     "A limit signal records that one observed local dispatch failure matched a rate/usage-limit shape. "
@@ -572,6 +586,125 @@ def _unit_verification_is_observed(paths: OmhPaths, run_ref: str) -> bool:
     return bool(projection.get("unit_verification_observed"))
 
 
+def declared_verification_commands(unit: Mapping[str, Any]) -> list[str]:
+    """The runnable commands one contract unit declares, or an empty list."""
+    declared = unit.get("verification_commands")
+    if not isinstance(declared, (list, tuple)):
+        return []
+    return [str(entry).strip() for entry in declared if str(entry).strip()]
+
+
+def _run_verification_command(
+    command: str,
+    worktree: Path,
+    runner: Callable[..., Any],
+) -> tuple[str, str]:
+    """Run one command in the unit worktree; return its status and a bounded tail.
+
+    Never raises: a command that cannot start is a failed check, not a failed
+    dispatch. `shell=False`, so the argv comes from the contract's own frozen
+    split and nothing in the command string is reinterpreted here.
+    """
+    try:
+        env_overrides, argv = verification_command_argv(command)
+    except FanoutContractError as exc:
+        return "failed", str(exc)
+    try:
+        completed = runner(
+            argv,
+            cwd=str(worktree),
+            env={**os.environ, **env_overrides},
+            text=True,
+            capture_output=True,
+            timeout=_VERIFICATION_COMMAND_TIMEOUT,
+        )
+        exit_code = int(getattr(completed, "returncode", 1))
+        combined = (
+            f"{getattr(completed, 'stdout', '') or ''}{getattr(completed, 'stderr', '') or ''}"
+        )
+    except FileNotFoundError:
+        return "failed", f"{argv[0]} not found on PATH"
+    except subprocess.TimeoutExpired:
+        return "failed", f"timed out after {_VERIFICATION_COMMAND_TIMEOUT}s"
+    except (OSError, subprocess.SubprocessError, TypeError, ValueError) as exc:
+        return "failed", f"could not run: {exc}"
+    if exit_code == 0:
+        return "passed", ""
+    tail = redact_metadata_text(
+        combined[-_MAX_VERIFICATION_OUTPUT_TAIL:], limit=_MAX_VERIFICATION_OUTPUT_TAIL
+    )
+    return "failed", f"exit {exit_code}: {tail}"
+
+
+def _run_unit_verification(
+    paths: OmhPaths,
+    unit: Mapping[str, Any],
+    *,
+    run_ref: str,
+    unit_id: str,
+    worktree: Path,
+    owner: str,
+    runner: Callable[..., Any],
+) -> dict[str, Any]:
+    """Run one unit's declared verification commands and record what was observed.
+
+    Every row is dispatcher-reported AND dispatcher-observed: omh ran the
+    command itself, which is the only way the result schema allows an
+    observation to be claimed. All rows passing is what appends the per-unit
+    `unit_verification_observed` journal event, so the ladder flips from the
+    same evidence an operator would otherwise record by hand. Any failure
+    appends nothing, leaving the unit short of `integration_ready`.
+    """
+    commands = declared_verification_commands(unit)
+    if not commands:
+        return {}
+    rows: list[dict[str, object]] = []
+    failures: list[str] = []
+    for command in commands:
+        status, detail = _run_verification_command(command, worktree, runner)
+        rows.append(
+            {
+                "command": command,
+                "status": status,
+                "evidence_ref": f"journal:{UNIT_VERIFICATION_OBSERVATION_SOURCE}:{run_ref}",
+                "reported_by": "dispatcher",
+                "observed_by": "dispatcher",
+                "observation_source": UNIT_VERIFICATION_OBSERVATION_SOURCE,
+            }
+        )
+        if status != "passed":
+            failures.append(f"{command}: {detail}")
+    # Through the shared validator, not beside it: rows omh writes about itself
+    # are held to the schema every executor-written row goes through.
+    validated_rows = validate_check_rows(rows)
+    if not failures:
+        append_journal_observation(
+            paths,
+            {
+                "target_type": "run",
+                "target_id": run_ref,
+                "run_id": run_ref,
+                "event": "unit_verification_observed",
+                "status": "observed",
+                "summary": (
+                    f"dispatcher ran {len(validated_rows)} declared verification command(s) "
+                    f"for unit {unit_id}; all passed"
+                ),
+                "worker_ref": unit_id,
+                "worktree_ref": str(worktree),
+                "runtime_profile": owner,
+            },
+        )
+    verification: dict[str, Any] = {
+        "verification_status": "failed" if failures else "passed",
+        "verification_checks": validated_rows,
+        "verification_claim_boundary": UNIT_VERIFICATION_CLAIM_BOUNDARY,
+    }
+    if failures:
+        verification["verification_failures"] = failures
+    return verification
+
+
 def dispatch_fanout(
     paths: OmhPaths,
     contract: Mapping[str, Any],
@@ -584,6 +717,7 @@ def dispatch_fanout(
     timeout: int = 1800,
     only_units: Sequence[str] | None = None,
     dry_run: bool = False,
+    run_verification: bool = False,
     runner: Callable[..., Any] = subprocess.run,
     readiness: Callable[..., dict[str, object]] = probe_executor_readiness,
     live_safety_profile_revision: str | None = None,
@@ -728,6 +862,7 @@ def dispatch_fanout(
                     source_ref=source_ref,
                     timeout=timeout,
                     dry_run=dry_run,
+                    run_verification=run_verification,
                     runner=runner,
                     readiness=readiness,
                     current_catalog_digest=current_catalog_digest,
@@ -934,6 +1069,7 @@ def _dispatch_unit(
     base_sha: str,
     timeout: int,
     dry_run: bool,
+    run_verification: bool = False,
     source_ref: str = "",
     runner: Callable[..., Any],
     readiness: Callable[..., dict[str, object]],
@@ -1045,6 +1181,12 @@ def _dispatch_unit(
         }
         if fingerprint_note is not None:
             planned["inventory_fingerprint"] = fingerprint_note
+        # Only when the operator asked for verification: a plan that named
+        # commands nothing was going to run would read as a promise.
+        if run_verification:
+            declared_commands = declared_verification_commands(unit)
+            if declared_commands:
+                planned["planned_verification_commands"] = declared_commands
         # The deep-interview surface: when the unit has not answered (no
         # declared skill_sequence) and the environment offers a genuine
         # arrangement choice, the dry run carries the question card so a
@@ -1201,6 +1343,21 @@ def _dispatch_unit(
         worktree=worktree,
         owner=owner,
     )
+    # Both rungs below it must already hold: a unit whose process failed has
+    # nothing to verify, and one whose sidecar did not validate has not yet
+    # reported what it did. Runs before the ladder is built, so the journal
+    # event it may append is visible to `_unit_verification_is_observed`.
+    verification: dict[str, Any] = {}
+    if run_verification and exit_code == 0 and unit_result.get("result_schema_valid"):
+        verification = _run_unit_verification(
+            paths,
+            unit,
+            run_ref=run_ref,
+            unit_id=unit_id,
+            worktree=worktree,
+            owner=owner,
+            runner=runner,
+        )
     result = {
         "unit_id": unit_id,
         "run_ref": run_ref,
@@ -1216,6 +1373,7 @@ def _dispatch_unit(
             unit_verification_observed=_unit_verification_is_observed(paths, run_ref),
         ),
         **unit_result,
+        **verification,
         "started_at": started_at,
         "finished_at": finished_at,
         "duration_seconds": duration_seconds,

--- a/src/coding/fanout_unit_results.py
+++ b/src/coding/fanout_unit_results.py
@@ -90,6 +90,17 @@ def validate_unit_result(payload: Mapping[str, object]) -> dict[str, object]:
     return result
 
 
+def validate_check_rows(rows: object) -> list[dict[str, object]]:
+    """Return normalized check rows, or raise.
+
+    The same gate `validate_unit_result` applies to a payload's `checks`,
+    exposed on its own so rows the dispatcher writes about its own observations
+    pass through the identical schema — including the provenance rule — rather
+    than a second, looser copy of it.
+    """
+    return _validated_checks(rows)
+
+
 def _validated_schema_version(value: object) -> str:
     if value != FANOUT_UNIT_RESULT_SCHEMA_VERSION:
         raise ValueError(

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -1640,6 +1640,7 @@ def cmd_coding_fanout_dispatch(args: argparse.Namespace) -> int:
             timeout=args.timeout,
             only_units=args.unit,
             dry_run=bool(args.dry_run),
+            run_verification=bool(args.run_verification),
         )
         _print_json(summary)
         return 0
@@ -1667,6 +1668,7 @@ def cmd_coding_fanout_dispatch(args: argparse.Namespace) -> int:
             timeout=args.timeout,
             only_units=args.unit,
             dry_run=bool(args.dry_run),
+            run_verification=bool(args.run_verification),
         )
     except ValueError as exc:
         raise OmhError(str(exc)) from exc
@@ -1893,6 +1895,11 @@ def _add_coding_commands(sub) -> None:
     fanout_dispatch.add_argument("--timeout", type=int, default=1800, help="Per-unit subprocess timeout in seconds.")
     fanout_dispatch.add_argument("--unit", action="append", default=None, help="Dispatch only these unit ids (repeatable).")
     fanout_dispatch.add_argument("--dry-run", action="store_true", help="Resolve readiness, argv, and worktree paths; spawn nothing.")
+    fanout_dispatch.add_argument(
+        "--run-verification",
+        action="store_true",
+        help="Run each unit's contract verification_commands in its worktree after its sidecar validates.",
+    )
     fanout_dispatch.set_defaults(func=cmd_coding_fanout_dispatch)
 
     fanout_migrate = fanout_sub.add_parser(

--- a/tests/test_fanout_contract.py
+++ b/tests/test_fanout_contract.py
@@ -36,6 +36,9 @@ from omh.coding.fanout_contracts import (  # noqa: E402
     FANOUT_SPAWN_PLAN_THRESHOLD,
     FanoutContractError,
     MAX_SPAWN_PLAN_FIELD_CHARS,
+    MAX_UNIT_VERIFICATION_COMMAND_CHARS,
+    MAX_UNIT_VERIFICATION_COMMANDS,
+    verification_command_argv,
 )
 from omh.system.paths import OmhPaths  # noqa: E402
 
@@ -1351,6 +1354,91 @@ class FanoutCliTests(unittest.TestCase):
         self.assertEqual(stdout, "")
         self.assertIn("safe snapshot filename", stderr)
         self.assertNotIn("Traceback", stderr)
+
+
+class FanoutVerificationCommandTests(unittest.TestCase):
+    def _with_commands(self, commands: object) -> list[dict[str, object]]:
+        units = [dict(unit) for unit in _UNITS]
+        units[0]["verification_commands"] = commands
+        return units
+
+    def test_absent_field_leaves_the_contract_byte_identical(self) -> None:
+        without = build_fanout_contract("split work", _UNITS)
+        declared_empty = build_fanout_contract("split work", self._with_commands([]))
+
+        self.assertEqual(without, declared_empty)
+        for unit in without["units"]:
+            self.assertNotIn("verification_commands", unit)
+            # The prose checks are untouched by the new field either way.
+            self.assertEqual(
+                unit["integration_checks"],
+                [
+                    "unit tests covering the unit's file_scope pass",
+                    "no edits outside boundary.file_scope",
+                ],
+            )
+
+    def test_declared_commands_are_normalized_onto_the_owning_unit_only(self) -> None:
+        contract = build_fanout_contract(
+            "split work",
+            self._with_commands(["  python  -m   unittest  ", "python -c 'print(1)'"]),
+        )
+        units = {unit["unit_id"]: unit for unit in contract["units"]}
+
+        self.assertEqual(
+            units["core"]["verification_commands"],
+            ["python -m unittest", "python -c 'print(1)'"],
+        )
+        self.assertNotIn("verification_commands", units["tests"])
+        self.assertNotIn("verification_commands", units["docs"])
+
+    def test_blank_entry_is_refused_rather_than_dropped(self) -> None:
+        for bad in ([""], ["   "], ["python -m unittest", ""], [None], [42]):
+            with self.subTest(commands=bad):
+                with self.assertRaises(FanoutContractError) as raised:
+                    build_fanout_contract("split work", self._with_commands(bad))
+                self.assertIn("verification_commands entries must be non-empty", str(raised.exception))
+
+    def test_non_list_payload_is_refused(self) -> None:
+        with self.assertRaises(FanoutContractError) as raised:
+            build_fanout_contract("split work", self._with_commands("python -m unittest"))
+        self.assertIn("must be a list of command strings", str(raised.exception))
+
+    def test_count_and_length_caps_are_enforced(self) -> None:
+        too_many = [f"python -c 'print({index})'" for index in range(MAX_UNIT_VERIFICATION_COMMANDS + 1)]
+        with self.assertRaises(FanoutContractError) as raised:
+            build_fanout_contract("split work", self._with_commands(too_many))
+        self.assertIn(f"at most {MAX_UNIT_VERIFICATION_COMMANDS} commands", str(raised.exception))
+
+        too_long = ["python -c " + "a" * MAX_UNIT_VERIFICATION_COMMAND_CHARS]
+        with self.assertRaises(FanoutContractError) as raised:
+            build_fanout_contract("split work", self._with_commands(too_long))
+        self.assertIn(f"at most {MAX_UNIT_VERIFICATION_COMMAND_CHARS} chars", str(raised.exception))
+
+        at_cap = [f"python -c 'print({index})'" for index in range(MAX_UNIT_VERIFICATION_COMMANDS)]
+        contract = build_fanout_contract("split work", self._with_commands(at_cap))
+        units = {unit["unit_id"]: unit for unit in contract["units"]}
+        self.assertEqual(len(units["core"]["verification_commands"]), MAX_UNIT_VERIFICATION_COMMANDS)
+
+    def test_unrunnable_command_is_refused_at_freeze_time(self) -> None:
+        for bad in ("python -c 'unbalanced", "PYTHONPATH=tests"):
+            with self.subTest(command=bad):
+                with self.assertRaises(FanoutContractError):
+                    build_fanout_contract("split work", self._with_commands([bad]))
+
+    def test_command_split_keeps_leading_env_assignments_out_of_the_argv(self) -> None:
+        env, argv = verification_command_argv("PYTHONPATH=tests uv run python -m unittest")
+
+        self.assertEqual(env, {"PYTHONPATH": "tests"})
+        self.assertEqual(argv, ["uv", "run", "python", "-m", "unittest"])
+
+        env, argv = verification_command_argv("python -c 'print(1)'")
+        self.assertEqual(env, {})
+        self.assertEqual(argv, ["python", "-c", "print(1)"])
+
+        # No shell runs these, so a pipe is an argument rather than an operator.
+        _env, argv = verification_command_argv("python -c 'print(1)' | tee log")
+        self.assertEqual(argv, ["python", "-c", "print(1)", "|", "tee", "log"])
 
 
 if __name__ == "__main__":

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -2443,5 +2443,220 @@ class FanoutBriefTextCeilingTests(unittest.TestCase):
         self.assertTrue(text.endswith("Boundary text."))
 
 
+_PY = shlex.quote(sys.executable)
+_PASSING_COMMAND = f"{_PY} -c pass"
+_FAILING_COMMAND = f"{_PY} -c 'import sys; sys.stdout.write(\"boom\"); sys.exit(3)'"
+_ENV_COMMAND = f"OMH_VERIFY=1 {_PY} -c 'import os,sys; sys.exit(0 if os.environ.get(\"OMH_VERIFY\") else 1)'"
+
+
+def _verification_runner(script: Path, sidecar: Path, payload: dict[str, object], *, mode: str = "valid"):
+    """Agent spawns write a sidecar; verification commands really run."""
+    verified: list[list[str]] = []
+
+    def runner(argv, **kwargs):
+        if argv[0] == "git":
+            return subprocess.run(argv, **kwargs)
+        if argv[0] in {"codex", "claude"}:
+            return subprocess.run(
+                [sys.executable, str(script), mode, str(sidecar), json.dumps(payload)],
+                cwd=kwargs.get("cwd"),
+                text=True,
+                capture_output=True,
+                timeout=kwargs.get("timeout"),
+            )
+        verified.append(list(argv))
+        return subprocess.run(
+            argv,
+            cwd=kwargs.get("cwd"),
+            env=kwargs.get("env"),
+            text=True,
+            capture_output=True,
+            timeout=kwargs.get("timeout"),
+        )
+
+    runner.verified = verified
+    return runner
+
+
+class FanoutDispatchVerificationTests(unittest.TestCase):
+    def _setup(self, tmp: str, commands: list[str], *, mode: str = "valid"):
+        root = Path(tmp)
+        paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+        repo, sha = _make_repo(root)
+        units = [dict(unit) for unit in _UNITS]
+        units[0]["verification_commands"] = commands
+        contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, units))
+        sidecar = unit_result_path(paths, contract["fanout_id"], "core")
+        runner = _verification_runner(
+            _stub_executor_script(root),
+            sidecar,
+            _unit_result_payload(contract, sha),
+            mode=mode,
+        )
+        return paths, repo, sha, contract, runner
+
+    def _dispatch(self, paths, repo, sha, contract, runner, **kwargs):
+        summary = dispatch_fanout(
+            paths,
+            contract,
+            goal_text=_GOAL,
+            repo_root=repo,
+            base_sha=sha,
+            only_units=["core"],
+            runner=runner,
+            readiness=_ready,
+            **kwargs,
+        )
+        return {entry["unit_id"]: entry for entry in summary["units"]}["core"]
+
+    def test_all_passing_commands_are_dispatcher_observed_and_flip_the_ladder(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract, runner = self._setup(tmp, [_PASSING_COMMAND, _ENV_COMMAND])
+
+            core = self._dispatch(paths, repo, sha, contract, runner, run_verification=True)
+
+            self.assertEqual(core["verification_status"], "passed")
+            self.assertEqual(len(core["verification_checks"]), 2)
+            for row in core["verification_checks"]:
+                self.assertEqual(row["status"], "passed")
+                self.assertEqual(row["reported_by"], "dispatcher")
+                self.assertEqual(row["observed_by"], "dispatcher")
+                self.assertEqual(row["observation_source"], "dispatch_verification")
+            self.assertNotIn("verification_failures", core)
+            self.assertIn("not review, CI", core["verification_claim_boundary"])
+            # The ladder flips from the journal event the run appended, not from
+            # the row list: the existing reader is what advances it.
+            self.assertTrue(_unit_verification_is_observed(paths, core["run_ref"]))
+            self.assertTrue(core["unit_verification_observed"])
+            self.assertTrue(core["integration_ready"])
+            self.assertEqual(len(runner.verified), 2)
+
+    def test_a_failing_command_keeps_the_unit_short_of_integration_ready(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract, runner = self._setup(tmp, [_PASSING_COMMAND, _FAILING_COMMAND])
+
+            core = self._dispatch(paths, repo, sha, contract, runner, run_verification=True)
+
+            self.assertEqual(core["verification_status"], "failed")
+            self.assertEqual([row["status"] for row in core["verification_checks"]], ["passed", "failed"])
+            self.assertEqual(len(core["verification_failures"]), 1)
+            self.assertIn("exit 3: boom", core["verification_failures"][0])
+            self.assertFalse(_unit_verification_is_observed(paths, core["run_ref"]))
+            self.assertFalse(core["unit_verification_observed"])
+            self.assertFalse(core["integration_ready"])
+            # The unit's own process still succeeded; only verification failed.
+            self.assertTrue(core["process_succeeded"])
+            self.assertTrue(core["result_schema_valid"])
+
+    def test_a_command_that_cannot_start_is_a_failed_check_not_a_failed_dispatch(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract, runner = self._setup(
+                tmp, ["omh-no-such-verification-binary --check"]
+            )
+
+            core = self._dispatch(paths, repo, sha, contract, runner, run_verification=True)
+
+            self.assertEqual(core["verification_status"], "failed")
+            self.assertEqual(core["status"], "completed")
+            self.assertIn("not found on PATH", core["verification_failures"][0])
+
+    def test_nothing_runs_without_the_explicit_flag(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract, runner = self._setup(tmp, [_PASSING_COMMAND])
+
+            core = self._dispatch(paths, repo, sha, contract, runner)
+
+            self.assertNotIn("verification_status", core)
+            self.assertNotIn("verification_checks", core)
+            self.assertEqual(runner.verified, [])
+            self.assertFalse(core["unit_verification_observed"])
+            self.assertFalse(core["integration_ready"])
+
+    def test_a_unit_declaring_no_commands_is_unchanged_under_the_flag(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract, runner = self._setup(tmp, [])
+
+            core = self._dispatch(paths, repo, sha, contract, runner, run_verification=True)
+
+            self.assertNotIn("verification_status", core)
+            self.assertEqual(runner.verified, [])
+            self.assertFalse(core["unit_verification_observed"])
+
+    def test_verification_waits_on_a_sidecar_that_validated(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract, runner = self._setup(tmp, [_PASSING_COMMAND], mode="corrupt")
+
+            core = self._dispatch(paths, repo, sha, contract, runner, run_verification=True)
+
+            self.assertFalse(core["result_schema_valid"])
+            self.assertNotIn("verification_status", core)
+            self.assertEqual(runner.verified, [])
+
+    def test_dry_run_names_the_commands_the_flag_would_run(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract, runner = self._setup(tmp, [_PASSING_COMMAND])
+
+            planned = self._dispatch(
+                paths, repo, sha, contract, runner, dry_run=True, run_verification=True
+            )
+            self.assertEqual(planned["planned_verification_commands"], [_PASSING_COMMAND])
+
+            without = self._dispatch(paths, repo, sha, contract, runner, dry_run=True)
+            self.assertNotIn("planned_verification_commands", without)
+            self.assertEqual(runner.verified, [])
+
+
+class FanoutDispatchVerificationCliTests(unittest.TestCase):
+    def _prepare(self, root: Path, base: list[str]) -> str:
+        units_path = root / "units.json"
+        units = [dict(unit) for unit in _UNITS]
+        units[0]["verification_commands"] = [_PASSING_COMMAND]
+        units_path.write_text(json.dumps(units), encoding="utf-8")
+        status, stdout, stderr = run_cli(
+            base
+            + ["coding", "fanout", "prepare", "--goal", *_GOAL.split(), "--units", str(units_path), "--record"]
+        )
+        self.assertEqual(status, 0, stderr)
+        contract = json.loads(stdout)
+        units_by_id = {unit["unit_id"]: unit for unit in contract["units"]}
+        self.assertEqual(units_by_id["core"]["verification_commands"], [_PASSING_COMMAND])
+        return str(contract["fanout_id"])
+
+    def test_flag_is_off_by_default_and_threaded_when_passed(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo, _sha = _make_repo(root)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            fanout_id = self._prepare(root, base)
+            goal_path = root / "goal.txt"
+            goal_path.write_text(_GOAL, encoding="utf-8")
+            captured: dict[str, object] = {}
+
+            def fake_dispatch(paths, contract, **kwargs):
+                captured.update(kwargs)
+                return {"schema_version": "fanout_dispatch_summary/v1", "units": []}
+
+            argv = base + [
+                "coding",
+                "fanout",
+                "dispatch",
+                fanout_id,
+                "--goal-file",
+                str(goal_path),
+                "--repo-root",
+                str(repo),
+                "--dry-run",
+            ]
+            with mock.patch("omh.coding.fanout_dispatch.dispatch_fanout", fake_dispatch):
+                status, _stdout, stderr = run_cli(argv)
+            self.assertEqual(status, 0, stderr)
+            self.assertFalse(captured["run_verification"])
+
+            with mock.patch("omh.coding.fanout_dispatch.dispatch_fanout", fake_dispatch):
+                status, _stdout, stderr = run_cli(argv + ["--run-verification"])
+            self.assertEqual(status, 0, stderr)
+            self.assertTrue(captured["run_verification"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_fanout_unit_results.py
+++ b/tests/test_fanout_unit_results.py
@@ -20,6 +20,7 @@ from omh.coding.fanout_unit_results import (  # noqa: E402
     FANOUT_UNIT_RESULT_CHECK_STATUSES,
     FANOUT_UNIT_RESULT_PROCESS_STATUSES,
     FANOUT_UNIT_RESULT_SCHEMA_VERSION,
+    validate_check_rows,
     validate_unit_result,
 )
 
@@ -342,6 +343,34 @@ class FanoutUnitResultTests(unittest.TestCase):
 
         self.assertEqual(result["executor_note"], "written by a newer executor")
         self.assertEqual(result["checks"][0]["duration_ms"], 1234)
+
+
+class CheckRowValidatorTests(unittest.TestCase):
+    """The rows the dispatcher writes go through the same gate as the payload's."""
+
+    def _dispatcher_row(self, **overrides: object) -> dict[str, object]:
+        row = {
+            "command": "python -m unittest",
+            "status": "passed",
+            "evidence_ref": "journal:dispatch_verification:fanout-0123456789ab-core",
+            "reported_by": "dispatcher",
+            "observed_by": "dispatcher",
+            "observation_source": "dispatch_verification",
+        }
+        row.update(overrides)
+        return row
+
+    def test_dispatcher_observed_rows_validate(self) -> None:
+        rows = validate_check_rows([self._dispatcher_row(), self._dispatcher_row(status="failed")])
+
+        self.assertEqual([row["status"] for row in rows], ["passed", "failed"])
+        self.assertEqual(rows[0]["observation_source"], "dispatch_verification")
+
+    def test_a_dispatcher_row_still_has_to_name_its_observation_source(self) -> None:
+        with self.assertRaises(ValueError) as caught:
+            validate_check_rows([self._dispatcher_row(observation_source=None)])
+
+        self.assertIn("observation_source", str(caught.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Feature Report

### What Changed

- Fanout unit contracts accept an optional `verification_commands` list (max 8 per unit, 240 chars each, validated and argv-parsed at freeze time so an unrunnable command fails at prepare, not mid-dispatch).
- `omh coding fanout dispatch` gains an explicit `--run-verification` flag (default OFF). With the flag, after a unit's process exits 0 **and** its `fanout_unit_result/v1` sidecar validates, the dispatcher runs each declared command with cwd = that unit's worktree (shell=False, 10-minute per-command ceiling), records every command as a dispatcher-reported/dispatcher-observed check row through the same schema executor rows go through, and — only when all pass — appends the unit's `unit_verification_observed` journal event so the existing status ladder flips mechanically.
- Any failure appends no journal event, leaves the unit short of `integration_ready`, and reports the failing command with exit code and a redacted 300-char output tail. A command that cannot start is a failed check, never a failed dispatch. Dry-run names the planned commands.

### Why This Exists

The evidence ladder (`process_succeeded → result_schema_valid → unit_verification_observed → integration_ready`) previously stalled at `result_schema_valid` unless a human recorded a verification observation by hand — unit `integration_checks` were prose nothing executed, so verification was specified but never observed automatically. This was the largest gap found in the staged-pipeline audit of the coding surface. Closes #1070.

### User / Operator Impact

An operator dispatching a fanout can now declare the contract's verification as executable commands and, with one explicit flag, get the verification rung of the ladder flipped by observed dispatcher evidence instead of a manual `omh runtime observe` step — or leave the flag off and keep today's behavior byte-for-byte.

### How It Works

- `src/coding/fanout_contracts.py`: caps, `dispatch_verification` observation-source constant, and `verification_command_argv()` — splits a command into leading `NAME=VALUE` env overrides plus argv (the env prefix is the single shell idiom kept, because the repo's own canonical gate is spelled `PYTHONPATH=tests uv run ...`); pipes/redirections stay literal text, no shell ever runs.
- `src/coding/fanout.py`: freeze-time normalization/validation; the key is additive — a unit declaring none carries no key, existing contracts stay byte-identical, schema id stays `fanout_contract/v2`.
- `src/coding/fanout_dispatch.py`: `_run_unit_verification()` builds the check rows, validates them via the shared `validate_check_rows()` (provenance rules included), and appends the per-unit journal event only on all-pass. The ladder reader is untouched.
- `src/commands/coding.py`: flag wiring. `docs/FANOUT.md`: opt-in semantics documented, including that this stays inside the sanctioned dispatch bridge.

One deliberate deviation from the issue sketch: the journal event appended is `unit_verification_observed` (the per-unit event the ladder's reader actually consumes), not the `verification` alias, which canonicalizes to the run-level rung and would not flip the unit ladder.

### Files And Contracts Touched

`src/coding/fanout_contracts.py`, `src/coding/fanout.py`, `src/coding/fanout_dispatch.py`, `src/coding/fanout_unit_results.py` (new public `validate_check_rows`), `src/commands/coding.py`, `docs/FANOUT.md`, `tests/test_fanout_contract.py`, `tests/test_fanout_dispatch.py`, `tests/test_fanout_unit_results.py`. Contract change is additive; `fanout_contract/v2` retained.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [x] Codex
- [x] Claude Code
- [x] Hermes runtime or handoff
- [x] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` (6978 tests, OK)
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run

### Observed Evidence

- Author run: full suite 6978 tests OK (284s); 16 new tests across the three fanout test files; all five `omh docs … --check` gates ok; ruff clean.
- Independent reviewer re-run (separate pass): `tests/test_fanout_contract.py tests/test_fanout_dispatch.py tests/test_fanout_unit_results.py tests/test_cli.py` — 509 tests OK; `git diff --check` clean.

### Not Tested / Not Applicable

- No live dispatch with a real executor CLI running a real repo gate — command execution is exercised through `sys.executable` subprocesses in tests only.
- Release smoke / harness validate / TUI: no packaging, harness contract, or TUI surface changed.

## Risk

- This extends what the sanctioned fanout dispatch bridge executes (previously: agent CLI spawns; now additionally: the contract's own declared verification commands, still local, still only inside an explicit `dispatch --run-verification` invocation). Flagged `risk/contract-change`; the flag defaults OFF and nothing changes for existing contracts. Please review the boundary extension explicitly.

## Compatibility / Rollout

- Additive contract key; contracts without it are byte-identical. Reaches live machines through `omh update`.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [ ] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Coverage-evidence schema (`coverage_evidence/v1`, audit priority 2) remains a separate goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NvDSpN3rE15KtVZ7RG5GoS
