### PR TITLE
feat(dispatch): allow direct xai and moonshot provider credentials

### DIFF
--- a/src/coding/hermes_child_dispatch.py
+++ b/src/coding/hermes_child_dispatch.py
@@ -70,6 +70,8 @@ _PROVIDER_ENV: Final = {
     "deepseek": ("DEEPSEEK_API_KEY", "DEEPSEEK_BASE_URL"),
     "upstage": ("UPSTAGE_API_KEY", "UPSTAGE_BASE_URL"),
     "zai": ("ZAI_API_KEY", "ZAI_BASE_URL"),
+    "xai": ("XAI_API_KEY", "XAI_BASE_URL"),
+    "moonshot": ("MOONSHOT_API_KEY", "MOONSHOT_BASE_URL"),
 }
 _CREDENTIAL_NAME = re.compile(r"(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|AUTHORIZATION)", re.IGNORECASE)
 


### PR DESCRIPTION
### Summary

Fixes #1058

  ### What Changed
 - `_PROVIDER_ENV` in `src/coding/hermes_child_dispatch.py` gains two direct-provider rows: `"xai":  ("XAI_API_KEY", "XAI_BASE_URL")` and `"moonshot": ("MOONSHOT_API_KEY", "MOONSHOT_BASE_URL")`.

  ### Why This Exists
  Grok and Kimi family models could previously reach `omh coding fanout dispatch` only through gateway rows (openrouter, opengateway). Comparable families (qwen, deepseek, upstage, zai) all have direct rows; xai and moonshot were the gap.

  ### User / Operator Impact

  Operators dispatching grok/kimi children directly no longer need a gateway just to pass credentials. The isolation contract is unchanged: only the selected provider's named variables cross the child boundary; every other provider's credentials stay out.

  ### How It Works

  `_child_env()` already resolves `_PROVIDER_ENV.get(request.provider.lower(), ())` and copies only those names from the parent environment. The two new rows make that passthrough reach `xai` and `moonshot` children. No other behavior changes.

  Env-var names verified against provider docs:
  - `XAI_API_KEY` — xAI's official Python SDK reads it by default:
  https://github.com/xai-org/xai-sdk-python (quickstart: https://docs.x.ai/developers/quickstart)
  - `MOONSHOT_API_KEY` — documented at https://platform.kimi.ai/docs/overview (`export
  MOONSHOT_API_KEY=...`)

  Honesty note: neither provider documents a base-url environment variable. `XAI_BASE_URL` /
  `MOONSHOT_BASE_URL` follow OMH's existing `<PROVIDER>_BASE_URL` convention (`QWEN_BASE_URL`,
  `DEEPSEEK_BASE_URL`, `UPSTAGE_BASE_URL`, `ZAI_BASE_URL`); if unset, the child uses its default
  endpoint. The map stores names only — never credential values or URLs.

  ### Files And Contracts Touched

  - `src/coding/hermes_child_dispatch.py` — two rows in `_PROVIDER_ENV`. Nothing else: no test pins the provider set, no generated artifact or catalog data is involved, `_CREDENTIAL_NAME` already matches both new key names for redaction.

  ### Affected Surfaces

  - [ ] Hermes chat or wrapper
  - [ ] Codex
  - [ ] Claude Code
  - [x] Hermes runtime or handoff
  - [ ] Generic executor
  - [ ] Not executor-specific

  
 ## Validation

  - [x] `uv run --group lint ruff check src tests`
  - [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
  - [x] `uv run python -m compileall -q src tests`
  - [ ] `uv run python -m omh.cli docs roles --check`
  - [ ] `uv run python -m omh.cli docs workflows --check`
  - [ ] `uv run python -m omh.cli docs capability-families --check`
  - [ ] `uv run python -m omh.cli harness validate`
  - [ ] `uv run python -m omh.cli release checklist --json`
  - [ ] `uv run python -m omh.cli release hermes-smoke`
  - [x] `git diff --check`
  - [ ] `omh --help`
  - [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke
  --install-path setup --omh-command omh --include-command-smoke`

 ### Observed Evidence

  - Targeted dispatch contracts: `PYTHONPATH=tests uv run python -m unittest
  tests.test_hermes_child_dispatch -v` — Ran 16 tests in 3.030s, OK.
  - Full suite: `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — Ran 6955 tests,
  FAILED (failures=3, skipped=256); tests corresponding to `test_hermes_child_dispatch` all passed.
  - `uv run --group lint ruff check src tests` — All checks passed.
  - `uv run python -m compileall -q src tests` — clean exit.
  - `git diff --check` — clean exit.

  ### Not Tested / Not Applicable

  - `docs workflows/roles/capability-families --check` — no catalog or render source changed; no
  generated artifact touched.
  - `harness validate`, `release checklist`, `release hermes-smoke` — no installer, packaging, or
  release-channel change.
  - Live dispatch against real xAI/Moonshot endpoints — requires provider credentials; env isolation is
  covered by the dispatch contract tests (`test_environment_allowlists_only_selected_provider_auth`,
  `test_unknown_provider_cannot_project_dynamic_token`).

  ## Risk

  - Low. Additive allowlist rows only. Unknown providers remain blocked; other providers' credentials remain excluded; both new key names are auto-redacted from child output by the existing `_CREDENTIAL_NAME` regex.

  ## Compatibility / Rollout

  - No CLI, schema, manifest, or dependency change. No new network surface — the dispatched Hermes CLI makes its own provider calls, as before. Existing rows unchanged.

  ## Release / Claims

  - [x] Release-channel impact considered — none (library-internal mapping).
  - [x] Runtime/native capability claims backed by evidence or marked not observed— live dispatch marked Not Tested above.
  - [x] No `prepared_not_observed` items presented as execution evidence.
  - [x] Evidence contains no credentials, raw prompts, or private data.
  - [x] Known manual Hermes checks listed — live xai/moonshot dispatch gap noted under Not Tested.

  ## Follow-Up

  - None.
