### PR TITLE
refactor(model-chains): derive Ultrafast interview swaps from known models

### DIFF
--- a/src/commands/model_chains.py
+++ b/src/commands/model_chains.py
@@ -25,6 +25,7 @@ import sys
 
 from ..local_store import atomic_write_text
 from ..plugin_bundle.omh.hermes_delegation import (
+    APPROX_PRICE_PER_MTOK,
     HERMES_MIXTURE_CATEGORY_CHAINS,
     MIXTURE_CHAIN_OVERRIDES_SCHEMA_VERSION,
     load_mixture_chain_overrides,
@@ -35,12 +36,17 @@ from .common import _paths
 
 _ENTRY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$")
 
-# The Ultrafast-tier interview option: the open-weight chain members that the
-# OpenGateway Ultrafast tier serves as faster variants. Editorial pairs, not a
-# capability claim; the option is offered only when it changes the chain.
+# The Ultrafast-tier interview option: a chain member is offered its
+# `<model>-ultrafast` speed variant when that token is a known model (shipped
+# chains or the price table), so no variant is invented. Editorial offer, not
+# a capability claim; the option is offered only when it changes the chain.
+_KNOWN_MODEL_TOKENS = frozenset(APPROX_PRICE_PER_MTOK) | {
+    model for chain in HERMES_MIXTURE_CATEGORY_CHAINS.values() for model, _ in chain
+}
 _ULTRAFAST_SWAPS = {
-    "glm-5.2": "glm-5.2-ultrafast",
-    "kimi-k3": "kimi-k3-ultrafast",
+    model: f"{model}-ultrafast"
+    for model in _KNOWN_MODEL_TOKENS
+    if f"{model}-ultrafast" in _KNOWN_MODEL_TOKENS
 }
 
 

--- a/tests/test_model_chains_command.py
+++ b/tests/test_model_chains_command.py
@@ -18,6 +18,7 @@ from unittest.mock import patch
 
 from _cli_harness import run_cli
 
+from omh.commands.model_chains import _ultrafast_variant
 from omh.plugin_bundle.omh.hermes_delegation import HERMES_MIXTURE_CATEGORY_CHAINS
 
 
@@ -161,6 +162,17 @@ class ModelChainsInterviewTests(unittest.TestCase):
                     {"model": "kimi-k3", "reasoning_effort": "high"},
                 ],
             )
+
+    def test_ultrafast_option_never_invents_an_unknown_variant(self) -> None:
+        # The offer follows the -ultrafast suffix only when that token is a known
+        # model (shipped chains or price table). deepseek-v3.2-ultrafast exists in
+        # neither source, so no swap is offered; an already-suffixed member never re-swaps.
+        self.assertEqual(
+            _ultrafast_variant((("glm-5.2", "low"), ("kimi-k3", "high"))),
+            (("glm-5.2-ultrafast", "low"), ("kimi-k3-ultrafast", "high")),
+        )
+        self.assertIsNone(_ultrafast_variant((("deepseek-v3.2", "high"),)))
+        self.assertIsNone(_ultrafast_variant((("glm-5.2-ultrafast", "low"),)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Feature Report
Fixes #1062 
 ### What Changed

  - `omh model-chains interview`'s option 3 ("Ultrafast tier") is no longer driven by a hand-maintained dict of base→variant pairs. The swaps are now derived from the `-ultrafast` suffix convention: a chain member is offered `f"{model}-ultrafast"` only when that exact token is a known model — present in the shipped chains (`HERMES_MIXTURE_CATEGORY_CHAINS`) or the price table (`APPROX_PRICE_PER_MTOK`).
  - One new negative-contract test locks the rule: an unknown `-ultrafast` token is never offered.

  ### Why This Exists

  - The tier pairs were duplicated by hand in `src/commands/model_chains.py` — the one place the pairing lived as data while the HUD side (`mixture_category_for` in
    `src/plugin_bundle/omh/hermes_delegation.py`) already treated speed tiers structurally via the suffix. Adding a new speed variant required remembering to edit the interview dict separately from every other surface that already knows the token.
  - With the derivation, adding a variant token to the price table (or a chain) is enough: the interview picks it up with no further edits, and a token that is not known is never offered — no invented variants.

  ### User / Operator Impact

  - None visible: for the current two swaps (`glm-5.2`, `kimi-k3`) the interview renders byte-identical options, including numbering. The verified runtime equality is
    `{'glm-5.2': 'glm-5.2-ultrafast', 'kimi-k3': 'kimi-k3-ultrafast'}` — exactly the old hardcoded dict.
  - Future variants become automatically available in the interview instead of requiring a source edit to a second location.

  ### How It Works

  - `src/commands/model_chains.py` builds `_KNOWN_MODEL_TOKENS` as the union of the price table keys and every model alias appearing in the shipped chains, then derives `_ULTRAFAST_SWAPS` as the set of known tokens whose `-ultrafast` counterpart is also known. `_ultrafast_variant` itself is unchanged.
  - Both sources are required: `kimi-k3-ultrafast` exists only in the price table (never in the shipped chains), so a chains-only union would have silently dropped the kimi swap.
  - Exact-match tokens, no casefolding or suffix parsing at offer time — same matching semantics as the dict it replaces. The editorial framing is preserved in the comment: this is an offer, not a capability claim, and the option is only shown when it changes the chain.

  ### Files And Contracts Touched

  - `src/commands/model_chains.py` — `_ULTRAFAST_SWAPS` derived instead of hardcoded; one added import (`APPROX_PRICE_PER_MTOK`). No other function, output string, or command surface changed.
  - `tests/test_model_chains_command.py` — one new test  (`test_ultrafast_option_never_invents_an_unknown_variant`) proving `deepseek-v3.2` gets no offer and an already-suffixed member never re-swaps. All eight existing tests are byte-identical and pass unchanged, as the issue requires.
  - No generated artifacts touched (no catalog/render/capability source changed).

  ### Affected Surfaces

  - [ ] Hermes chat or wrapper
  - [ ] Codex
  - [ ] Claude Code
  - [ ] Hermes runtime or handoff
  - [ ] Generic executor
  - [x] Not executor-specific

  ## Validation

  Check only commands that completed successfully. Leave non-applicable checks
  unchecked and explain why under **Not Tested / Not Applicable**.

- [x] `uv run --group lint ruff check src tests`
 - [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
 - [x] `uv run python -m compileall -q src tests`
 - [ ] `uv run python -m omh.cli docs workflows --check`                  
 - [ ]  `uv run python -m omh.cli docs roles --check`
 - [ ] `uv run python -m omh.cli docs capability-families --check`
 - [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
 - [ ] `uv run python -m omh.cli release hermes-smoke`
 - [x] `git diff --check`
 - [x] `omh --help`
 - [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke
  --install-path setup --omh-command omh --include-command-smoke`
  - [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
  - [x] Relevant dry-run or smoke command: `omh model-chains show` (exercises the edited
    command module end to end, including the new import)
  - [ ] Manual Hermes/TUI check, or explicit reason it was not run:

  ### Observed Evidence

 - `PYTHONPATH=tests uv run python -m unittest tests.test_model_chains_command -v` 9 tests, OK (8 pre-existing interview/show/set contracts unchanged + 1 new negative test).
  - `PYTHONPATH=tests uv run python -m unittest discover -s tests` — Ran 7013 tests, OK (skipped=256). 
  - `uv run --group lint ruff check src tests` — All checks passed.
  - `uv run python -m compileall -q src tests` — clean.
  - `git diff --check` — clean.
  - Runtime assertion that the derived dict equals the previous hardcoded dict
    (`{'glm-5.2': 'glm-5.2-ultrafast', 'kimi-k3': 'kimi-k3-ultrafast'}`) —observed via a read-only interpreter check before editing.
  - `omh --help` and `omh model-chains show` — clean output; the touched module wires up outside the test harness.

  ### Not Tested / Not Applicable

  - Full suite (`discover`) — pending, run before opening the PR.
  - `docs workflows/roles --check`, `capability-families --check` — not applicable: no
    catalog, render, or capability source changed, so no generated artifact can drift.
  - `harness validate`, `release checklist`, `release hermes-smoke`, `omh --help` smoke —
    not applicable: no installer, packaging, release-channel, or help-text surface
    changed.
  - Manual terminal interview session — not run; the interview flow (numbering, custom
    entry, refusal on a pipe) is covered by the mocked-stdin contract tests.

  ## Risk

  - Low. Behavior for the two existing swaps is provably identical (asserted equality
    against the old dict; existing tests pass unchanged). The only semantic edge — a
    model whose `-ultrafast` token is unknown — now returns no offer, which is the intended rule and is pinned by the new test.
  - Latent coupling note: the price table doubles as a model registry for this offer. A
    future price-table entry ending in `-ultrafast` without a real base model would 		only produce a spurious offer if its base token were also known; both conditions make that a non-scenario today.

  ## Compatibility / Rollout

  - No schema, document, config, or CLI-output change. Existing override documents at `<omh-home>/routing/model-chains.json` are unaffected; no migration, no `omh update` implications beyond the regular file copy.

  ## Release / Claims

  - [x] Release-channel impact considered (`stable`, `preview`, or `local`) — none; pure
    internal refactor with byte-identical user-facing behavior.
  - [x] Runtime/native capability claims are backed by evidence or marked as not observed
    — the Ultrafast option remains framed as an editorial offer, not a capability claim.
  - [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as
    execution, review, CI, or merge evidence — none produced.
  - [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts,
    or unrelated private data.
  - [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke
    --live` gap — no live smoke run; none required for this surface (see Not Tested).

  ## Follow-Up

  - None required. When a new speed tier lands, adding the variant token to the price table (or a shipped chain) is now sufficient for the interview to offer it.