### PR TITLE
test(catalog): lock current lintlang metadata

### DIFF
--- a/tests/test_awesome_hermes_agent_catalog.py
+++ b/tests/test_awesome_hermes_agent_catalog.py
@@ -55,6 +55,18 @@ class AwesomeHermesAgentCatalogTests(unittest.TestCase):
         self.assertEqual(len({item.item.id for item in coverage}), 216)
         self.assertEqual(sum(1 for item in coverage if item.item.subsection == PLUGIN_SUBSECTION), 35)
 
+    def test_lintlang_metadata_matches_current_upstream_contract(self) -> None:
+        lintlang = awesome_hermes_item("lintlang").item
+
+        self.assertEqual(lintlang.author, "Hermes Labs")
+        self.assertEqual(lintlang.author_url, "https://github.com/hermes-labs-ai")
+        self.assertEqual(
+            lintlang.summary,
+            "Static analysis for AI agent configs, tool descriptions, and system prompts, "
+            "returning a PASS / REVIEW / FAIL verdict. Zero-LLM, deterministic checks, built for CI.",
+        )
+        self.assertEqual(lintlang.url, "https://github.com/hermes-labs-ai/lintlang")
+
     def test_plugin_coverage_maps_high_value_gaps_to_existing_omh_surfaces(self) -> None:
         web_search = awesome_hermes_item("hermes-web-search-plus")
         self.assertEqual(web_search.status, "partial")


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a machine-consumed regression contract for the bundled `lintlang` catalog record.
- Locks the current Hermes Labs owner, canonical repository URLs, and deterministic PASS / REVIEW / FAIL summary.

### Why This Exists

- The stale owner and HERM v1.1 summary reported in #968 were already corrected on `main`, but nothing prevented the snapshot from regressing.
- This test preserves the corrected public catalog contract without rewriting an already-authoritative snapshot.

### User / Operator Impact

- `omh ecosystem awesome-hermes inspect lintlang --json` remains aligned with the current upstream project.
- Future catalog drift fails CI before stale ownership or scoring language ships.

### How It Works

- The catalog test resolves `lintlang` through the same public lookup used by product code.
- It asserts only machine-consumed metadata values rather than prose layout or source line numbers.

### Files And Contracts Touched

- `tests/test_awesome_hermes_agent_catalog.py`
- Bundled awesome-hermes catalog metadata contract for `lintlang`

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `omh ecosystem awesome-hermes inspect lintlang --json`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- Mutation proof: restoring the obsolete `roli-lpci` values failed the new assertion; restoring the corrected snapshot passed.
- 39 catalog/coherence tests passed.
- Full 7,044-test suite, Ruff, compileall, five generated-document checks, and `git diff --check` passed.
- CLI JSON returned `Hermes Labs`, `https://github.com/hermes-labs-ai`, the canonical lintlang URL, and the PASS / REVIEW / FAIL summary.

### Not Tested / Not Applicable

- Harness, release, and live Hermes/TUI checks do not apply to a test-only catalog metadata contract.
- No upstream repository or package was mutated or executed.

## Risk

- Narrow test-only change. The main risk is an intentional future metadata update requiring the assertion to change in the same PR.

## Compatibility / Rollout

- No runtime or stored-data migration.
- Compatible with the existing corrected catalog snapshot on `main`.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- None. Closes #968.

Closes #968
