### PR TITLE
fix(coding): classify design-qualified vendor models

### DIFF
--- a/MODEL_OPTI.md
+++ b/MODEL_OPTI.md
@@ -43,8 +43,8 @@ identical prompt. Nothing else about the pipeline changes per model.
 
 | Family | Matched by | Example ids |
 | --- | --- | --- |
-| `gpt` | `gpt-` | `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` |
-| `claude` | `claude-`, bare tiers `opus`/`sonnet`/`haiku` | `claude-fable-5`, `claude-opus-5` |
+| `gpt` | `gpt-`; design-qualified alias `openai-gpt-` | `gpt-5.6-sol`, `digitalocean/openai-gpt-5.6-sol` |
+| `claude` | `claude-`; design-qualified alias `anthropic-claude-`; bare tiers `opus`/`sonnet`/`haiku` | `claude-fable-5`, `digitalocean/anthropic-claude-opus-5` |
 | `gemini` | `gemini-` | `gemini-3.1-pro` |
 | `kimi` | `kimi-` | `kimi-k3`, `kimi-k3-ultrafast` |
 | `glm` | `glm-` | `glm-5.2`, `glm-5.2-ultrafast` |
@@ -55,8 +55,18 @@ identical prompt. Nothing else about the pipeline changes per model.
 | `llama` | `llama-` | open-weights Llama ids, any serving host |
 | `codestral` | `codestral-` | Codestral coding ids |
 | `solar` | `solar-` | Upstage Solar Pro ids |
-| `openai`, `anthropic` | bare-vendor prefixes | rarely-seen ids (kept on `generic`) |
 | `unknown` | anything else | emerging families before a prefix lands |
+
+The design-qualified aliases are concrete serving-catalog ids, not new model
+families. Bare vendor prefixes remain unclassified because the same provider
+catalog also includes other designs such as `openai-o3` and non-text models
+such as `openai-gpt-image-2`; neither may inherit GPT text calibration. The
+models.dev catalog used by OpenCode lists, for example,
+`digitalocean/openai-gpt-5.6-sol` with base model `openai/gpt-5.6-sol` and
+`digitalocean/anthropic-claude-opus-5` with base model
+`anthropic/claude-opus-5`. After the serving provider segment is stripped,
+those aliases therefore select the existing `gpt` and `claude` calibrations;
+they do not create vendor-wide calibration families.
 
 ## Universal protocols (every model, every family)
 
@@ -407,7 +417,8 @@ would be guidance without a stated reason, which the governing rule forbids.
 | Family | Recognized | Calibrated (both tables) | Status |
 | --- | --- | --- | --- |
 | `gpt`, `claude`, `gemini`, `grok`, `kimi`, `glm`, `qwen`, `deepseek`, `mistral`, `llama`, `codestral`, `solar` | yes | yes | full guidance, provenance above (#1051/#1052 closed the last four) |
-| `openai`, `anthropic` (bare-vendor prefixes) | yes | no → `generic` | deliberate: these prefixes name a vendor, not a model design — they stay on `generic` until real ids with stated characteristics appear |
+| `openai-gpt-`, `anthropic-claude-` (design-qualified aliases) | yes → `gpt` / `claude` | yes, through the design family | concrete models.dev/OpenCode serving ids carry these sub-prefixes; their catalog `base_model` fields establish the underlying design family |
+| other `openai-`, `anthropic-` vendor-qualified ids | recognized as model targets, family `unknown` | no → `generic` | vendor qualification alone does not establish a design; O-series, image, and emerging ids remain uncalibrated |
 | emerging families | no → `unknown` | no → `generic` | add a prefix and a calibration pair when one lands (the #1051/#1052 pattern) |
 
 Gaps close by evidence, not by copywriting: a new calibration entry needs an

--- a/src/coding/model_routing.py
+++ b/src/coding/model_routing.py
@@ -408,8 +408,6 @@ _MODEL_FAMILY_PREFIXES: Final[tuple[tuple[str, str], ...]] = (
     ("gpt-", "gpt"),
     ("glm-", "glm"),
     ("claude-", "claude"),
-    ("openai-", "openai"),
-    ("anthropic-", "anthropic"),
     ("gemini-", "gemini"),
     ("grok-", "grok"),
     ("qwen-", "qwen"),
@@ -421,8 +419,11 @@ _MODEL_FAMILY_PREFIXES: Final[tuple[tuple[str, str], ...]] = (
     ("solar-", "solar"),
 )
 _MODEL_FAMILY_ALIASES: Final[tuple[tuple[str, str], ...]] = (
+    ("openai-gpt-", "gpt"),
+    ("anthropic-claude-", "claude"),
     ("qwen3-", "qwen"),
 )
+_MODEL_FAMILY_ALIAS_EXCLUSIONS: Final[tuple[str, ...]] = ("openai-gpt-image-",)
 _CLAUDE_TIER_ALIASES: Final[frozenset[str]] = frozenset({"opus", "sonnet", "haiku"})
 
 
@@ -437,6 +438,8 @@ def model_family(model_id: str) -> str:
         normalized = normalized.rsplit("/", 1)[1]
     if normalized in _CLAUDE_TIER_ALIASES:
         return "claude"
+    if normalized.startswith(_MODEL_FAMILY_ALIAS_EXCLUSIONS):
+        return "unknown"
     for prefix, family in _MODEL_FAMILY_ALIASES:
         if normalized.startswith(prefix):
             return family

--- a/tests/test_model_routing.py
+++ b/tests/test_model_routing.py
@@ -107,10 +107,22 @@ class FamilyPrefixParityTests(unittest.TestCase):
         them was previously silent (no gate) and is a live risk each time a
         family is added. The family label is the prefix minus its dash."""
         from omh.coding.dynamic_workflow_specs import _MODEL_TARGET_PREFIXES
-        from omh.coding.model_routing import _MODEL_FAMILY_PREFIXES
+        from omh.coding.model_routing import _MODEL_FAMILY_ALIASES, _MODEL_FAMILY_PREFIXES
 
         routing_prefixes = tuple(prefix for prefix, _family in _MODEL_FAMILY_PREFIXES)
-        self.assertEqual(routing_prefixes, _MODEL_TARGET_PREFIXES)
+        routing_aliases = dict(_MODEL_FAMILY_ALIASES)
+        canonical_targets = tuple(
+            prefix
+            for prefix in _MODEL_TARGET_PREFIXES
+            if not any(alias.startswith(prefix) for alias in routing_aliases)
+        )
+        self.assertEqual(routing_prefixes, canonical_targets)
+        self.assertTrue(
+            all(
+                prefix in routing_prefixes or any(alias.startswith(prefix) for alias in routing_aliases)
+                for prefix in _MODEL_TARGET_PREFIXES
+            )
+        )
         for prefix, family in _MODEL_FAMILY_PREFIXES:
             self.assertEqual(family, prefix.rstrip("-"), prefix)
 
@@ -122,6 +134,14 @@ class FamilyPrefixParityTests(unittest.TestCase):
         # label is what routes them to their calibration instead of generic.
         self.assertEqual(model_family("solar-pro2"), "solar")
         self.assertEqual(model_family("upstage/solar-pro2"), "solar")
+
+    def test_vendor_prefixed_model_ids_alias_to_design_families(self) -> None:
+        self.assertEqual(model_family("digitalocean/openai-gpt-5.6-sol"), "gpt")
+        self.assertEqual(model_family("digitalocean/anthropic-claude-opus-5"), "claude")
+
+    def test_vendor_prefixed_non_design_models_remain_unknown(self) -> None:
+        self.assertEqual(model_family("digitalocean/openai-o3"), "unknown")
+        self.assertEqual(model_family("digitalocean/openai-gpt-image-2"), "unknown")
 
     def test_provider_prefixed_ids_classify_by_model_segment(self) -> None:
         self.assertEqual(model_family("opencode/kimi-k3"), "kimi")

--- a/tests/test_unit_prompt_protocol.py
+++ b/tests/test_unit_prompt_protocol.py
@@ -131,11 +131,19 @@ class CalibrationSelectionTests(unittest.TestCase):
     def test_unknown_family_high_effort_falls_back_to_generic(self) -> None:
         route = {"selected_reasoning_effort": "xhigh", "model_family": "unknown"}
         self.assertEqual(calibration_for_route(route), HIGH_EFFORT_CALIBRATIONS["generic"])
-        # mistral gained its own block; bare-vendor prefixes stay generic.
         route = {"selected_reasoning_effort": "xhigh", "model_family": "mistral"}
         self.assertEqual(calibration_for_route(route), HIGH_EFFORT_CALIBRATIONS["mistral"])
-        route = {"selected_reasoning_effort": "xhigh", "model_family": "openai"}
-        self.assertEqual(calibration_for_route(route), HIGH_EFFORT_CALIBRATIONS["generic"])
+
+    def test_vendor_prefixed_models_get_design_family_composition(self) -> None:
+        cases = {
+            "digitalocean/openai-gpt-5.6-sol": "gpt",
+            "digitalocean/anthropic-claude-opus-5": "claude",
+        }
+        for model_id, family in cases.items():
+            self.assertEqual(
+                composition_calibration_for_model(model_id),
+                MAIN_AGENT_COMPOSITION_CALIBRATIONS[family],
+            )
 
     def test_each_declared_family_gets_its_own_block(self) -> None:
         # gemini/grok/kimi/glm/qwen/deepseek ride provider-surfaced routes; each family's
@@ -312,18 +320,11 @@ class ModelOptiDocTests(unittest.TestCase):
         self.assertIn("MAIN_AGENT_COMPOSITION_CALIBRATIONS", doc)
         self.assertIn("UNIT_PROMPT_MAX_BYTES", doc)
 
-    def test_uncalibrated_recognized_families_stay_named_as_gaps(self) -> None:
-        doc = self._doc()
-        # The #1051/#1052 families are calibrated now; the only deliberate
-        # remainder is the bare-vendor prefixes, which name a vendor rather
-        # than a model design and stay on generic until real ids appear.
-        for family in ("mistral", "llama", "codestral", "solar"):
+    def test_recognized_design_families_are_calibrated(self) -> None:
+        for family in ("mistral", "llama", "codestral", "solar", "gpt", "claude"):
             self.assertIn(family, HIGH_EFFORT_CALIBRATIONS)
-        for family in ("openai", "anthropic"):
-            self.assertNotIn(family, HIGH_EFFORT_CALIBRATIONS)
-            self.assertIn(f"`{family}`", doc, family)
-        self.assertIn("#1051", doc)
-        self.assertIn("#1052", doc)
+        for vendor in ("openai", "anthropic"):
+            self.assertNotIn(vendor, HIGH_EFFORT_CALIBRATIONS)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Feature Report

### What Changed

- Replaced broad vendor-prefix aliases with explicit GPT- and Claude-design aliases.
- Added regression coverage for OpenAI O-series/image ids, Anthropic false positives, and unrecognized vendor-qualified ids.
- Documented the decision in `MODEL_OPTI.md`.

### Why This Exists

- `openai-*` and `anthropic-*` are provider namespaces, not model-family guarantees.
- Treating every qualified id as GPT or Claude could silently apply the wrong prompt calibration to O-series reasoning models, image models, or future unrelated products.

### User / Operator Impact

- Recognized qualified GPT and Claude text models receive the same calibrated rules as their unqualified forms.
- Other vendor-qualified ids still normalize and route safely, but remain generic until their design is explicit and measured.

### How It Works

- Alias selection now requires a design-bearing family prefix such as `openai-gpt-*`, `anthropic-claude-*`, or `claude-*`.
- The routing normalizer continues to preserve broad vendor-qualified ids without forcing a model-family calibration.

### Files And Contracts Touched

- `src/coding/model_routing.py`
- `tests/test_model_routing.py`
- `tests/test_unit_prompt_protocol.py`
- `MODEL_OPTI.md`

### Affected Surfaces

- [x] Hermes chat or wrapper
- [x] Codex
- [x] Claude Code
- [x] Hermes runtime or handoff
- [x] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: real models.dev id sweep through `model_rules_for_profile`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- 102 routing and unit-prompt tests passed, including positive and negative qualified-id controls.
- A real models.dev sample classified `openai-gpt-*` and `anthropic-claude-*` as intended while leaving `openai-o3`, image ids, and unrelated vendor products generic.
- Full 7,046-test suite, Ruff, compileall, five generated-document checks, and `git diff --check` passed.
- Independent code, goal/constraint, QA, security, and repository-context reviewers returned PASS after the prefix was narrowed.

### Not Tested / Not Applicable

- No live paid inference call was made; this is deterministic id classification using observed catalog metadata.
- Harness, release, and TUI checks do not exercise this routing helper and are not applicable.

## Risk

- Narrow routing change with broad executor reach. A new vendor-qualified alias must be added explicitly rather than inheriting calibration accidentally.

## Compatibility / Rollout

- Existing recognized GPT and Claude ids retain their behavior.
- Previously over-classified O-series and image ids intentionally become generic.
- No stored-data migration.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Add calibration for other model designs only after family-specific measurement. Closes #1060.

Closes #1060
