### PR TITLE
feat(coding): add measured Claude throughput overlay

### DIFF
--- a/MODEL_OPTI.md
+++ b/MODEL_OPTI.md
@@ -382,13 +382,36 @@ whose worst-case assembled size is policy-gated in tests
 
 `build_throughput_overlay()` in `src/coding/throughput_prompting.py` gives
 every family the base rules — batch independent tool calls and reads in one
-shot, keep dependency-bound work sequential. Two advanced modes are gated to
-the `gpt` family: `gpt_sol_codex_handoff` (a `*-sol` model on the codex
-profile, adding single-eval-cell internal parallelism) and `gpt_hermes_ulw`
-(gpt family on the hermes profile running ultrawork). *Why gated:* the
-eval-batching behavior was designed and verified against GPT-5.6 Sol's
-execution surface; extending an unverified throughput claim to other families
-would be guidance without a stated reason, which the governing rule forbids.
+shot, keep dependency-bound work sequential. Three advanced modes are gated to
+measured family/surface pairs:
+
+- `gpt_sol_codex_handoff` applies to a `*-sol` model on the codex profile and
+  adds single-eval-cell internal parallelism.
+- `gpt_hermes_ulw` applies to the gpt family on the hermes profile running
+  ultrawork.
+- `claude_code_handoff` applies to the claude family on the Claude Code
+  profile. It adds advanced handoff and stop-condition rules but no eval
+  strategy: the measured Claude Code surface exposed parallel tool use and
+  agents, not a batchable eval cell.
+
+The Claude gate comes from a 2026-08-23 counterbalanced six-pair live comparison
+on Claude Fable 5 at medium effort. Both conditions received the identical
+six-file independent-read task and base throughput rules; the advanced
+condition added only `_ADVANCED_THROUGHPUT_RULES`. Both passed 6/6. Advanced
+was faster in 4/6 pairs, with median wall time 13.28 s versus 15.82 s
+(87.31 s versus 110.33 s total), and used 435,295 versus 490,034 reported
+tokens. The narrow synthetic corpus does not establish general model
+superiority, but it supports this exact prepared-guidance gate on the measured
+Claude Code surface.
+
+Kimi and Gemini stay on `parallel_handoff`. Credential-readiness probes on the
+same host completed zero live pairs: Kimi (`opengateway` and `kimi-coding`)
+and Gemini (`google`, `opencode`, and `github-copilot`) all reported
+`credentials_not_configured` or `invalid_state`. Existing Kimi calibration
+measurements do not compare these throughput rules, so they cannot justify an
+advanced overlay. No eval strategy is claimed for either family. This is an
+explicit measured availability null, not model-performance evidence; a future
+gate requires a completed paired run on the intended execution surface.
 
 ## Routing, chains, and per-model bookkeeping
 

--- a/src/coding/throughput_prompting.py
+++ b/src/coding/throughput_prompting.py
@@ -34,6 +34,9 @@ def build_throughput_overlay(
         rules.extend(_ADVANCED_THROUGHPUT_RULES)
         rules.append(_EVAL_BATCHING_RULE)
         eval_strategy = "single_cell_internal_parallel"
+    elif profile == "claude-code" and family == "claude":
+        mode = "claude_code_handoff"
+        rules.extend(_ADVANCED_THROUGHPUT_RULES)
     elif (
         profile == "hermes"
         and family == "gpt"

--- a/src/runtime/records.py
+++ b/src/runtime/records.py
@@ -2987,18 +2987,19 @@ def _validate_executor_throughput_overlay(
     _require(overlay_contract.get("status") == "enabled", errors, f"{label} status must be enabled")
     mode = str(overlay_contract.get("mode", ""))
     specialized_mode = {
-        "gpt_sol_codex_handoff": "codex",
-        "gpt_hermes_ulw": "hermes",
+        "gpt_sol_codex_handoff": ("codex", "gpt"),
+        "gpt_hermes_ulw": ("hermes", "gpt"),
+        "claude_code_handoff": ("claude-code", "claude"),
     }.get(mode)
     _require(
-        mode == "parallel_handoff" or specialized_mode == expected_profile,
+        mode == "parallel_handoff" or (specialized_mode and specialized_mode[0] == expected_profile),
         errors,
         f"{label} mode does not match selected executor",
     )
     family = str(overlay_contract.get("model_family", ""))
     _require(bool(family), errors, f"{label} model_family must be non-empty")
     if specialized_mode:
-        _require(family == "gpt", errors, f"{label} specialized mode requires gpt model_family")
+        _require(family == specialized_mode[1], errors, f"{label} specialized mode requires matching model_family")
     eval_strategy = overlay_contract.get("eval_strategy")
     if mode == "gpt_sol_codex_handoff":
         _require(

--- a/tests/test_executor_prompting.py
+++ b/tests/test_executor_prompting.py
@@ -262,29 +262,52 @@ class ExecutorPromptingTests(unittest.TestCase):
                 for rule in overlay["rules"]:
                     self.assertIn(rule, handoff["prompt_template"])
 
-    def test_parallel_guidance_reaches_non_gpt_handoffs(self) -> None:
-        cases = (
-            (
-                build_coding_delegation_payload(
-                    "Implement src/example.py",
-                    executor_target="claude-code",
-                    main_agent_model="claude-fable-5",
-                )["prompt_handoff"],
-                "claude-code",
-            ),
-            (
-                build_coding_delegation_payload(
-                    "Implement src/example.py",
-                    executor_target="generic",
-                )["prompt_handoff"],
-                "generic",
-            ),
+    def test_claude_code_handoff_adds_measured_advanced_rules(self) -> None:
+        # Given: a Claude-family model on the measured Claude Code surface.
+        payload = build_coding_delegation_payload(
+            "Implement src/example.py",
+            executor_target="claude-code",
+            main_agent_model="claude-fable-5",
         )
 
-        for handoff, profile in cases:
-            with self.subTest(profile=profile):
+        # When: the portable prompt handoff is prepared.
+        handoff = payload["prompt_handoff"]
+        overlay = handoff["executor_prompting_contract"]["throughput_overlay"]
+
+        # Then: Claude gets advanced handoff discipline without an eval strategy.
+        self.assertEqual(overlay["mode"], "claude_code_handoff")
+        self.assertGreater(len(overlay["rules"]), 2)
+        self.assertNotIn("eval_strategy", overlay)
+        for rule in overlay["rules"]:
+            self.assertIn(rule, handoff["prompt_template"])
+        self.assertEqual(validate_coding_prompt_handoff(handoff), [])
+
+    def test_unmeasured_non_gpt_handoffs_keep_base_parallel_guidance(self) -> None:
+        # Given: families without a completed advanced-overlay comparison.
+        cases = (
+            ("generic", "", "unknown"),
+            ("hermes", "moonshotai/kimi-k3-ultrafast", "kimi"),
+            ("hermes", "gemini-3.1-pro", "gemini"),
+        )
+
+        for profile, model, family in cases:
+            with self.subTest(family=family):
+                # When: a handoff is prepared for the unmeasured surface.
+                payload = build_coding_delegation_payload(
+                    "Implement src/example.py",
+                    executor_target=profile,
+                    preferred_workflow="ultrawork" if profile == "hermes" else "",
+                    preferred_workflow_score=10 if profile == "hermes" else 0,
+                    force_coding_handoff=profile == "hermes",
+                    main_agent_model=model,
+                )
+                handoff = payload["runtime_handoff" if profile == "hermes" else "prompt_handoff"]
                 overlay = handoff["executor_prompting_contract"]["throughput_overlay"]
+
+                # Then: no unsupported advanced or eval claim is prepared.
                 self.assertEqual(overlay["mode"], "parallel_handoff")
+                self.assertEqual(overlay["model_family"], family)
+                self.assertEqual(len(overlay["rules"]), 2)
                 self.assertNotIn("eval_strategy", overlay)
 
     def test_strategy_selection_distinguishes_plan_risk_and_repair(self) -> None:


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a measured `claude_code_handoff` throughput mode for Claude-family models running through Claude Code.
- Kept Kimi, Gemini, Hermes-profile Claude, and generic executors on the existing base `parallel_handoff` rules.
- Preserved `executor_throughput_overlay/v1` and intentionally omitted an eval strategy because Claude Code has no batchable eval-cell surface in this contract.

### Why This Exists

- Advanced throughput guidance previously shipped only for measured GPT surfaces.
- Issue #1059 required evidence, not family-name inference, before enabling the advanced rules for any non-GPT family.
- A paired Claude Code comparison showed equal task success with lower median and total wall time under the advanced rules.

### User / Operator Impact

- Claude Code handoffs for Claude-family models now receive the three measured advanced parallel-work rules in addition to the base rules.
- Kimi and Gemini behavior does not change because usable provider credentials were unavailable; no performance claim was fabricated from an availability failure.
- Operators can inspect the selected mode and rationale through the existing handoff and routing records.

### How It Works

- `build_throughput_overlay()` selects `claude_code_handoff` only when the executor profile is `claude-code` and the normalized family is `claude`.
- Runtime record validation recognizes that exact mode/profile/family tuple without adding schema fields.
- Positive intervention coverage locks the Claude Code gate; Kimi, Gemini, Hermes-profile Claude, and generic-executor cases are negative controls.

### Files And Contracts Touched

- `src/coding/throughput_prompting.py`
- `src/runtime/records.py`
- `tests/test_executor_prompting.py`
- `MODEL_OPTI.md`
- `executor_throughput_overlay/v1` values only; schema shape is unchanged

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [x] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: benchmark doctor/corpus/smoke plus real model-route and rendered-handoff inspection
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- Six counterbalanced Claude Code pairs, all 6/6 successful in both conditions.
- Advanced rules were faster in 4/6 pairs; median wall time was 13.28 s versus 15.82 s and total wall time was 87.31 s versus 110.33 s.
- Reported-token totals were 435,295 advanced versus 490,034 baseline.
- The real route selected Claude Code with `claude-fable-5`; the rendered handoff reported `mode=claude_code_handoff`, five rules, no `eval_strategy`, and `schema_version=executor_throughput_overlay/v1`.
- After rebasing onto the merged vendor-prefix routing change: 141 targeted tests and the full 7,048-test suite passed, followed by Ruff, compileall, five generated-document gates, and `git diff --check`.
- Independent goal/constraint, code-quality, security, hands-on QA, and repository-context reviews passed.

### Not Tested / Not Applicable

- Kimi and Gemini A/B performance was not tested because every discovered route returned `credentials_not_configured`; both remain ungated.
- The Claude evidence is scoped to Claude Code, not Hermes-profile Claude and not a universal family-performance claim.
- Release, live Hermes, and TUI checks do not exercise this prepared handoff-rule selection and are not applicable.

## Risk

- Narrowly gated behavior with moderate prompt-surface risk. The main risk is overgeneralizing the measurement, mitigated by the exact Claude Code profile/family gate and negative controls.

## Compatibility / Rollout

- Base throughput rules and all other profiles retain their existing behavior.
- Existing record schema version and fields are unchanged.
- Rollback is the removal of the single mode gate and tuple validation.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Measure Kimi or Gemini only when a credential-ready route exists; do not infer support from family identity. Closes #1059.

Closes #1059
