### PR TITLE
fix(release): pin the plugin manifest version to the package and gate parity

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -93,6 +93,22 @@ Advanced one-shot setup compatibility smoke:
 curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | OMH_RUN_SETUP=1 OMH_PROFILE_PACKS=cto-loop OMH_RUN_DOCTOR=0 sh
 ```
 
+## Version Bump Surfaces
+
+The release bump commit must move every current-version surface together.
+`src/omh/version.py` (`__version__`) is canonical; the others must match it:
+
+| Surface | Why it must move |
+| --- | --- |
+| `pyproject.toml` `version` | wheel and package metadata |
+| `src/plugin_bundle/omh/plugin.yaml` `version` | the installed Hermes plugin manifest — `hermes plugins doctor` and the plugin listing report this value, so leaving it behind under-reports every install (issue #1079: it sat at 1.0.5 through the 1.0.6 and 1.0.7 releases) |
+
+`VersionSurfaceParityTests` in `tests/test_release_smoke.py` gates both: a bump
+commit that misses one fails the suite instead of shipping the drift. Version
+strings quoted in README/docs prose and CLI help examples are illustrative and
+deliberately not parity-gated — update them in the bump commit, but a stale
+example is a docs nit, not a diagnostics lie.
+
 ## Required Checks
 
 Run before tagging:

--- a/src/plugin_bundle/omh/plugin.yaml
+++ b/src/plugin_bundle/omh/plugin.yaml
@@ -1,6 +1,6 @@
 name: omh
 kind: standalone
-version: "1.0.5"
+version: "1.0.7"
 description: "Oh My Hermes native bridge for metadata-only runtime status, HUD, role context, bounded evidence probes, evidence-boundary context, and a deterministic file-backed memory provider."
 author: oh-my-hermes maintainers
 provides_memory_provider: omh

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -23,6 +23,7 @@ from omh.release import (
 )
 from omh.release_install_smoke import install_script_smoke_plan, run_install_script_smoke
 from omh.release_smoke_core import CommandResult, subprocess_runner, subprocess_runner_exact_env
+from omh.version import __version__ as package_version
 
 
 class ReleaseSmokeTests(unittest.TestCase):
@@ -976,6 +977,39 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertEqual(result.returncode, 124)
         self.assertIn("hello", result.stdout)
         self.assertTrue(result.stderr)
+
+
+class VersionSurfaceParityTests(unittest.TestCase):
+    """Every current-version surface must move together in the release bump.
+
+    Issue #1079: the 1.0.6 and 1.0.7 releases bumped `src/omh/version.py` and
+    `pyproject.toml` but left `src/plugin_bundle/omh/plugin.yaml` at 1.0.5, so
+    every version-sensitive Hermes surface (`hermes plugins doctor`, the plugin
+    listing) under-reported the installed plugin for two releases. The manifest
+    is a diagnostics surface, not just packaging metadata. These gates fail the
+    release bump commit that misses a surface, instead of leaving the drift to
+    a field report.
+    """
+
+    def test_plugin_manifest_version_matches_the_package(self) -> None:
+        import omh.plugin_bundle.omh as bundle
+
+        manifest = Path(bundle.__file__).resolve().parent / "plugin.yaml"
+        versions = [
+            line.split(":", 1)[1].strip().strip('"')
+            for line in manifest.read_text(encoding="utf-8").splitlines()
+            if line.startswith("version:")
+        ]
+        self.assertEqual(versions, [package_version])
+
+    def test_pyproject_version_matches_the_package(self) -> None:
+        pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+        versions = [
+            line.split("=", 1)[1].strip().strip('"')
+            for line in pyproject.read_text(encoding="utf-8").splitlines()
+            if line.startswith("version = ")
+        ]
+        self.assertEqual(versions, [package_version])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Capability

`hermes plugins doctor` and the plugin listing now report the true plugin version: the shipped Hermes plugin manifest moves with the package version, and a parity gate makes it impossible for a future release bump to leave it behind.

## Motivation

Issue #1079 (field report, well-evidenced): the 1.0.7 npm package's vendored wheel carries `omh/plugin_bundle/omh/plugin.yaml` pinned at `1.0.5`. Verified at HEAD: the manifest was last bumped in the `release: 1.0.5` commit (6d113d35); the 1.0.6 and 1.0.7 bumps moved `src/omh/version.py` and `pyproject.toml` but not the manifest, and no gate enforced parity. Functional impact is none (discovery/import/registration pass); diagnostics impact is real - every version-sensitive surface under-reports the installed plugin, which misleads support triage.

## Implementation (boundary level)

- `src/plugin_bundle/omh/plugin.yaml` — `version: "1.0.5"` → `"1.0.7"`.
- `tests/test_release_smoke.py` — new `VersionSurfaceParityTests`: the manifest's `version:` line and `pyproject.toml`'s `version =` line must each equal `omh.version.__version__` (line-scan parsing, no new dependency; the manifest is located through the importable `omh.plugin_bundle.omh` package so the test works in both checkout and wheel layouts).
- `docs/RELEASE.md` — new **Version Bump Surfaces** section (recurrence guidance): names the canonical version source, the two gated surfaces and why the manifest is a diagnostics surface, and draws the line at illustrative version strings in docs/help examples, which stay ungated.

Rejected alternative: stamping the manifest from the package version at build time — hides drift instead of failing it, and adds build machinery to a zero-dependency repo. Source-level parity + a test matches the repo's gates-as-contracts philosophy.

## Verification (observed)

- `PYTHONPATH=tests uv run python -m unittest discover -s tests` → **Ran 7056 tests … OK** (includes the two new parity tests).
- `VersionSurfaceParityTests` green after the bump; fails by construction on the pre-fix tree (manifest at 1.0.5 ≠ 1.0.7).
- `compileall`, `ruff check src tests`, `docs workflows --check`, `docs capability-families --check`, `git diff --check` all clean.
- Grepped tests for stale `1.0.5` manifest pins: none (remaining `1.0.5` literals are unrelated version-comparison fixtures and Cellar paths).

## Risks

- Every future release bump commit must now touch three files together (`version.py`, `pyproject.toml`, `plugin.yaml`) or CI fails — that is the point; the RELEASE.md section documents it where the release operator looks.
- The reporter's install is fixed only by the next published package; the repo-side manifest is correct as of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpnRcM3HSjCPg2PHPhdYqc