### PR TITLE
test: keep loop workflow site vocabulary in sync

### DIFF
--- a/site/docs/loop/index.html
+++ b/site/docs/loop/index.html
@@ -171,7 +171,7 @@
             <li><code>verification_plan</code> names the expected signal, evidence required, failure action, and stop signal for the current queue item.</li>
             <li>Inner-loop checks are cheap and frequent: syntax, compile or import, focused test, command smoke, and schema validation.</li>
             <li>Outer-loop checks are slower and rarer: integration evidence, semantic review, adversarial verifier, release gate, or human review.</li>
-            <li>Workflow patterns such as fan-out, adversarial verification, tournament, and triage batch are orchestration metadata, not dispatch evidence.</li>
+            <li>Workflow patterns such as single-step, fan-out-and-synthesize, adversarial verification, tournament, and triage batch are orchestration metadata, not dispatch evidence.</li>
             <li><code>failure_mode_summary</code> warns about verification gaps, comprehension debt, and cognitive surrender before the loop keeps moving.</li>
             <li>Cost policy keeps reads bounded, reuses stable schema scaffolds, and avoids extra verifier lanes unless evidence warrants them.</li>
             <li><code>omh loop run-once --loop &lt;id&gt;</code> can wake exactly one eligible tick for wrappers, cron, or future automation without running code, and its result distinguishes <code>created_tick</code> from <code>pending_queue_exists</code>.</li>

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -53,6 +53,7 @@ from omh.skills.catalog import (
 from omh.skills.render import frontmatter_description, workflow_reference_markdown, workflow_reference_payload, workflow_skill
 from omh.snippet import WORKSPACE_SNIPPET
 from omh.use_cases import USE_CASES, list_use_cases
+from test_loop_cycle import WORKFLOW_PATTERN_PROSE
 
 
 FLAGSHIP_SKILLS = {
@@ -3748,7 +3749,8 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("pending_queue_exists", site_loop)
         self.assertIn("Test as stop signal", site_loop)
         self.assertIn("Automation, worktree, skill, connector, and subagent blocks", site_loop)
-        self.assertIn("fan-out, adversarial verification, tournament, and triage batch", site_loop)
+        for workflow_pattern in WORKFLOW_PATTERN_PROSE.values():
+            self.assertIn(workflow_pattern, site_loop)
         self.assertIn("Cost policy keeps reads bounded", site_loop)
         self.assertIn("A loop tick is not execution", site_loop)
         self.assertNotIn('<button type="button">Observe only</button>', site_loop)


### PR DESCRIPTION
## Feature Report

### What Changed

- Updated the loop site to enumerate all five canonical workflow patterns.
- Replaced the frozen substring assertion with checks derived from `WORKFLOW_PATTERN_PROSE`.

### Why This Exists

Closes #1083. The site omitted `single-step` and used `fan-out` instead of the canonical `fan-out-and-synthesize` wording. The old test could not detect future vocabulary drift.

### User / Operator Impact

The public loop documentation now matches the workflow patterns accepted by OMH, and future additions to the canonical prose mapping will require the site contract to be updated.

### How It Works

The site sentence uses the current five prose forms. `test_router_content.py` imports the canonical `WORKFLOW_PATTERN_PROSE` mapping and asserts every documented form is present, so the test stays coupled to the vocabulary contract rather than one frozen sentence.

### Files And Contracts Touched

- `site/docs/loop/index.html`
- `tests/test_router_content.py`

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py tests/test_loop_cycle.py -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `git diff --check`

### Observed Evidence

- Focused tests: 144 passed, 1 skipped (POSIX-only advisory-lock test on Windows).
- Ruff: all checks passed.
- Compileall: completed successfully.
- Diff check: completed successfully.

### Not Tested / Not Applicable

- Full test suite was not run; the Issue's affected contracts are covered by the focused router-content and loop-cycle tests.
- Runtime, release, and Hermes/TUI checks are not applicable to a static site/test vocabulary change.

## Risk

Low. This changes one explanatory site sentence and strengthens a content contract test; runtime behavior is unchanged.

## Compatibility / Rollout

No API, persisted data, or runtime behavior changes. The site wording now reflects the existing canonical pattern set.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data

## Follow-Up

None.