### PR TITLE
feat(release): daily auto-release cadence keeps npm/Bun/Homebrew tracking main

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,113 @@
+name: Auto Release
+
+# Cuts one stable patch release per day when main has moved past the last
+# tag, so the npm/Bun package, GitHub wheel, and Homebrew tap track main
+# instead of waiting for a manual tag. The cadence is daily rather than
+# per-merge because the protected `npm` environment requires one human
+# deployment approval per release run.
+#
+# The tag and the workflow_dispatch of release.yml are both created with
+# GITHUB_TOKEN on purpose: a GITHUB_TOKEN tag push cannot trigger the
+# tag-push path of release.yml, and workflow_dispatch is the documented
+# exception that still creates a run.
+
+on:
+  schedule:
+    - cron: "30 22 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: auto-release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  cut:
+    permissions:
+      contents: write
+      actions: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+
+      - name: Decide whether main needs a release
+        id: decide
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(uv run tools/package_manager/metadata.py --version)"
+          if ! git show-ref --verify --quiet "refs/tags/v$version"; then
+            echo "v$version is staged for a manual release; not interfering"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$(git rev-list -n 1 "v$version")" = "$(git rev-parse HEAD)" ]; then
+            echo "main tip is already released as v$version"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Bump every version surface
+        if: steps.decide.outputs.proceed == 'true'
+        id: bump
+        shell: bash
+        run: |
+          set -euo pipefail
+          new_version="$(uv run tools/package_manager/bump_version.py)"
+          if git show-ref --verify --quiet "refs/tags/v$new_version"; then
+            echo "tag v$new_version already exists; refusing to reuse it" >&2
+            exit 1
+          fi
+          echo "version=$new_version" >> "$GITHUB_OUTPUT"
+
+      - name: Run release gates on the bumped tree
+        if: steps.decide.outputs.proceed == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          PYTHONPATH=tests uv run python -m unittest discover -s tests
+          uv run python -m compileall -q src tests
+
+      - name: Commit, tag, and push atomically
+        if: steps.decide.outputs.proceed == 'true'
+        shell: bash
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml src/omh/version.py \
+            src/plugin_bundle/omh/plugin.yaml .release-channel
+          git commit -s -m "chore(release): cut v$NEW_VERSION on the daily stable cadence
+
+          Constraint: npm/Bun, the GitHub wheel, and the Homebrew tap publish only from vX.Y.Z tags, so tracking main requires this version-bump commit on main
+          Rejected: per-merge releases | the protected npm environment requires one human deployment approval per run
+          Confidence: high
+          Scope-risk: narrow
+          Directive: pause the cadence by disabling the auto-release workflow, never by reverting bump commits
+          Tested: full unittest suite and compileall on the bumped tree inside this workflow run
+          Not-tested: npm environment approval and downstream release.yml publication happen after this commit"
+          git tag "v$NEW_VERSION"
+          git push --atomic origin HEAD:refs/heads/main "refs/tags/v$NEW_VERSION"
+
+      - name: Dispatch the distribution release
+        if: steps.decide.outputs.proceed == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_VERSION: ${{ steps.bump.outputs.version }}
+        run: |
+          set -euo pipefail
+          gh workflow run release.yml --ref main --field tag="v$NEW_VERSION"
+          echo "release.yml dispatched for v$NEW_VERSION;" \
+            "publication still waits for the npm environment approval"

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -94,6 +94,34 @@ All distribution tags share one non-cancelling concurrency group. The tap
 update cannot run before npm publication succeeds, and an older run cannot
 downgrade a newer tap formula.
 
+## Automated stable cadence
+
+`.github/workflows/auto-release.yml` keeps the package-manager channels
+tracking `main` without a human remembering to tag. Once a day (and on
+manual dispatch) it checks whether the `main` tip has moved past the tag of
+the current `pyproject.toml` version. When it has, the workflow bumps every
+version surface to the next patch release with
+`tools/package_manager/bump_version.py` (pyproject, `src/omh/version.py`,
+the plugin manifest, and `.release-channel` back to `stable`), runs the full
+test suite on the bumped tree, pushes the commit and `vX.Y.Z` tag to `main`
+atomically, and dispatches the distribution workflow for that tag.
+
+Boundaries of the automation:
+
+- It cuts stable patch releases only. When the version in `pyproject.toml`
+  has no tag yet, a manual release (stable or beta) is staged and the
+  automation skips without touching anything.
+- The cadence is daily, not per-merge, because the protected `npm`
+  environment requires one human deployment approval per release run. Each
+  automated release still pauses at that approval before anything publishes.
+- The bump commit and tag are pushed with the workflow's `GITHUB_TOKEN`, so
+  they do not trigger the tag-push path of the distribution workflow or a CI
+  run on `main`; the auto-release job runs the full suite itself before
+  pushing, and it starts the distribution workflow through
+  `workflow_dispatch` with the new tag.
+- Pause the cadence by disabling the Auto Release workflow in the Actions
+  UI, never by reverting a bump commit.
+
 ## Resume and rollback
 
 The workflow is safe to resume with `workflow_dispatch` and the existing tag

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -30,6 +30,10 @@ The tag-driven npm/Bun, GitHub wheel, and Homebrew tap release is defined by
 `.github/workflows/release.yml`. Its release order, one-time external setup,
 resume rules, rollback matrix, immutable artifact checks, and pending-first-
 release status are the single contract in [Distribution](DISTRIBUTION.md).
+A daily auto-release workflow cuts the next stable patch tag whenever `main`
+has moved past the last release, so these channels track `main` instead of
+waiting for a manual tag; its guards and boundaries live in the same
+Distribution contract under "Automated stable cadence".
 
 Those package-manager artifacts extend the stable channel; they do not replace
 the installer, Hermes skill tap, generated-document, or evidence checks below.

--- a/tests/test_auto_release.py
+++ b/tests/test_auto_release.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from tempfile import TemporaryDirectory
+import unittest
+
+from _distribution_helpers import PROJECT_ROOT, run
+from tools.package_manager.bump_version import (
+    PLUGIN_VERSION_PATTERN,
+    PYPROJECT_VERSION_PATTERN,
+    SOURCE_VERSION_PATTERN,
+    bump_version_surfaces,
+    next_patch_version,
+)
+from tools.package_manager.metadata import DistributionError
+
+BUMP_VERSION = PROJECT_ROOT / "tools" / "package_manager" / "bump_version.py"
+AUTO_RELEASE = PROJECT_ROOT / ".github" / "workflows" / "auto-release.yml"
+
+
+def _write_project(root: Path, *, source_version: str = "1.0.7") -> None:
+    (root / "src" / "omh").mkdir(parents=True)
+    (root / "src" / "plugin_bundle" / "omh").mkdir(parents=True)
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "oh-my-hermes"\nversion = "1.0.7"\n'
+    )
+    (root / "src" / "omh" / "version.py").write_text(
+        f'__version__ = "{source_version}"\n'
+    )
+    (root / "src" / "plugin_bundle" / "omh" / "plugin.yaml").write_text(
+        'name: omh\nversion: "1.0.5"\ndescription: "bundle"\n'
+    )
+    (root / ".release-channel").write_text("beta\n")
+
+
+class BumpVersionToolTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.stack = TemporaryDirectory()
+        self.addCleanup(self.stack.cleanup)
+        self.root = Path(self.stack.name)
+
+    def test_bump_moves_every_surface_and_resets_channel(self) -> None:
+        _write_project(self.root)
+        new_version = bump_version_surfaces(self.root)
+        self.assertEqual(new_version, "1.0.8")
+        self.assertIn(
+            'version = "1.0.8"', (self.root / "pyproject.toml").read_text()
+        )
+        self.assertIn(
+            '__version__ = "1.0.8"',
+            (self.root / "src" / "omh" / "version.py").read_text(),
+        )
+        self.assertIn(
+            'version: "1.0.8"',
+            (
+                self.root / "src" / "plugin_bundle" / "omh" / "plugin.yaml"
+            ).read_text(),
+        )
+        self.assertEqual(
+            (self.root / ".release-channel").read_text(), "stable\n"
+        )
+
+    def test_explicit_target_must_be_canonical_and_different(self) -> None:
+        _write_project(self.root)
+        self.assertEqual(
+            bump_version_surfaces(self.root, target="2.0.0"), "2.0.0"
+        )
+        with self.assertRaises(DistributionError):
+            bump_version_surfaces(self.root, target="not-a-version")
+        with self.assertRaises(DistributionError):
+            bump_version_surfaces(self.root, target="2.0.0")
+
+    def test_dry_run_reports_without_writing(self) -> None:
+        _write_project(self.root)
+        self.assertEqual(bump_version_surfaces(self.root, dry_run=True), "1.0.8")
+        self.assertIn(
+            'version = "1.0.7"', (self.root / "pyproject.toml").read_text()
+        )
+        self.assertEqual((self.root / ".release-channel").read_text(), "beta\n")
+
+    def test_bump_refuses_enforced_surface_parity_drift(self) -> None:
+        _write_project(self.root, source_version="1.0.6")
+        with self.assertRaises(DistributionError):
+            bump_version_surfaces(self.root)
+
+    def test_bump_refuses_plugin_manifest_without_version_line(self) -> None:
+        _write_project(self.root)
+        (self.root / "src" / "plugin_bundle" / "omh" / "plugin.yaml").write_text(
+            "name: omh\n"
+        )
+        with self.assertRaises(DistributionError):
+            bump_version_surfaces(self.root)
+
+    def test_next_patch_version_contract(self) -> None:
+        self.assertEqual(next_patch_version("1.0.7"), "1.0.8")
+        self.assertEqual(next_patch_version("2.9.19"), "2.9.20")
+        with self.assertRaises(DistributionError):
+            next_patch_version("v1.0.7")
+
+    def test_cli_refusal_exits_nonzero(self) -> None:
+        _write_project(self.root)
+        result = run(
+            [
+                sys.executable,
+                str(BUMP_VERSION),
+                "--project-root",
+                str(self.root),
+                "--set",
+                "not-a-version",
+            ],
+            check=False,
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("bump refused", result.stderr)
+
+    def test_cli_prints_only_the_new_version(self) -> None:
+        _write_project(self.root)
+        result = run(
+            [
+                sys.executable,
+                str(BUMP_VERSION),
+                "--project-root",
+                str(self.root),
+            ]
+        )
+        self.assertEqual(result.stdout.strip(), "1.0.8")
+
+    def test_repository_surfaces_each_carry_one_version_line(self) -> None:
+        surfaces = {
+            PROJECT_ROOT / "pyproject.toml": PYPROJECT_VERSION_PATTERN,
+            PROJECT_ROOT / "src" / "omh" / "version.py": SOURCE_VERSION_PATTERN,
+            PROJECT_ROOT
+            / "src"
+            / "plugin_bundle"
+            / "omh"
+            / "plugin.yaml": PLUGIN_VERSION_PATTERN,
+        }
+        for path, pattern in surfaces.items():
+            with self.subTest(surface=str(path.relative_to(PROJECT_ROOT))):
+                self.assertEqual(len(pattern.findall(path.read_text())), 1)
+
+
+class AutoReleaseWorkflowTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.workflow = AUTO_RELEASE.read_text()
+
+    def test_cadence_is_scheduled_not_per_merge(self) -> None:
+        self.assertIn("schedule:", self.workflow)
+        self.assertIn('cron: "30 22 * * *"', self.workflow)
+        self.assertIn("workflow_dispatch:", self.workflow)
+        self.assertNotIn("\n  push:", self.workflow)
+        self.assertNotIn("pull_request", self.workflow)
+        self.assertIn("group: auto-release\n", self.workflow)
+        self.assertNotIn("group: auto-release-${{", self.workflow)
+
+    def test_release_decision_guards_are_present(self) -> None:
+        for contract in (
+            "tools/package_manager/metadata.py --version",
+            'git show-ref --verify --quiet "refs/tags/v$version"',
+            'git rev-list -n 1 "v$version"',
+            "not interfering",
+            "proceed=false",
+            'git show-ref --verify --quiet "refs/tags/v$new_version"',
+        ):
+            self.assertIn(contract, self.workflow)
+
+    def test_gates_run_between_bump_and_push(self) -> None:
+        bump = self.workflow.index("- name: Bump every version surface")
+        gates = self.workflow.index(
+            "- name: Run release gates on the bumped tree"
+        )
+        push = self.workflow.index("- name: Commit, tag, and push atomically")
+        dispatch = self.workflow.index(
+            "- name: Dispatch the distribution release"
+        )
+        self.assertLess(bump, gates)
+        self.assertLess(gates, push)
+        self.assertLess(push, dispatch)
+        self.assertIn(
+            "PYTHONPATH=tests uv run python -m unittest discover -s tests",
+            self.workflow,
+        )
+        self.assertIn("uv run python -m compileall -q src tests", self.workflow)
+
+    def test_push_is_atomic_and_commit_is_signed_off(self) -> None:
+        self.assertIn("git commit -s -m", self.workflow)
+        self.assertIn(
+            'git push --atomic origin HEAD:refs/heads/main "refs/tags/v$NEW_VERSION"',
+            self.workflow,
+        )
+        for staged in (
+            "pyproject.toml",
+            "src/omh/version.py",
+            "src/plugin_bundle/omh/plugin.yaml",
+            ".release-channel",
+        ):
+            self.assertIn(staged, self.workflow)
+
+    def test_dispatch_targets_the_distribution_workflow(self) -> None:
+        self.assertIn(
+            'gh workflow run release.yml --ref main --field tag="v$NEW_VERSION"',
+            self.workflow,
+        )
+        self.assertIn("permissions:\n  contents: read", self.workflow)
+        self.assertIn(
+            "permissions:\n      contents: write\n      actions: write",
+            self.workflow,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_homebrew_distribution.py
+++ b/tests/test_homebrew_distribution.py
@@ -393,6 +393,7 @@ class DistributionReleaseContractTests(unittest.TestCase):
             r"(?:-\s+)?uses:\s+[^@\s]+@[0-9a-f]{40}(?:\s+#.*)?$"
         )
         for relative in (
+            ".github/workflows/auto-release.yml",
             ".github/workflows/ci.yml",
             ".github/workflows/release.yml",
         ):

--- a/tools/package_manager/bump_version.py
+++ b/tools/package_manager/bump_version.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+# ─── How to run ───
+# uv run tools/package_manager/bump_version.py
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import re
+import sys
+
+try:
+    from tools.package_manager.metadata import (
+        PROJECT_ROOT,
+        VERSION_PATTERN,
+        DistributionError,
+        canonical_version,
+    )
+except ImportError:  # running as a standalone script from tools/package_manager
+    from metadata import (
+        PROJECT_ROOT,
+        VERSION_PATTERN,
+        DistributionError,
+        canonical_version,
+    )
+
+
+PYPROJECT_VERSION_PATTERN = re.compile(r'^version = "([^"]+)"$', re.MULTILINE)
+SOURCE_VERSION_PATTERN = re.compile(r'^__version__ = "([^"]+)"$', re.MULTILINE)
+PLUGIN_VERSION_PATTERN = re.compile(r'^version: "([^"]+)"$', re.MULTILINE)
+STABLE_CHANNEL = "stable"
+
+
+def next_patch_version(version: str) -> str:
+    """Return the next patch release after one canonical X.Y.Z version."""
+
+    if not VERSION_PATTERN.fullmatch(version):
+        raise DistributionError("release versions must use X.Y.Z")
+    major, minor, patch = (int(part) for part in version.split("."))
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def _rewrite_one_version(
+    path: Path,
+    pattern: re.Pattern[str],
+    replacement: str,
+    *,
+    surface: str,
+) -> str:
+    try:
+        content = path.read_text()
+    except OSError as exc:
+        raise DistributionError(f"could not read {surface}") from exc
+    matches = pattern.findall(content)
+    if len(matches) != 1:
+        raise DistributionError(
+            f"{surface} must carry exactly one literal version line"
+        )
+    return pattern.sub(replacement, content, count=1)
+
+
+def bump_version_surfaces(
+    project_root: Path,
+    *,
+    target: str | None = None,
+    dry_run: bool = False,
+) -> str:
+    """Move every version surface to the next release and return it.
+
+    The pyproject/version.py parity refusal in ``canonical_version`` runs
+    first, so a tree whose enforced surfaces already disagree is never
+    bumped further apart. The plugin manifest is rewritten to the same
+    target even when it lags behind, which heals historical drift instead
+    of freezing it. The channel file is reset to ``stable`` because an
+    automated bump is by definition the commit that cuts the next stable
+    release.
+    """
+
+    current = canonical_version(project_root)
+    new_version = target if target is not None else next_patch_version(current)
+    if not VERSION_PATTERN.fullmatch(new_version):
+        raise DistributionError("release versions must use X.Y.Z")
+    if target is not None and new_version == current:
+        raise DistributionError("target version must differ from the current one")
+
+    rewrites = {
+        project_root / "pyproject.toml": _rewrite_one_version(
+            project_root / "pyproject.toml",
+            PYPROJECT_VERSION_PATTERN,
+            f'version = "{new_version}"',
+            surface="pyproject.toml",
+        ),
+        project_root / "src" / "omh" / "version.py": _rewrite_one_version(
+            project_root / "src" / "omh" / "version.py",
+            SOURCE_VERSION_PATTERN,
+            f'__version__ = "{new_version}"',
+            surface="src/omh/version.py",
+        ),
+        project_root
+        / "src"
+        / "plugin_bundle"
+        / "omh"
+        / "plugin.yaml": _rewrite_one_version(
+            project_root / "src" / "plugin_bundle" / "omh" / "plugin.yaml",
+            PLUGIN_VERSION_PATTERN,
+            f'version: "{new_version}"',
+            surface="src/plugin_bundle/omh/plugin.yaml",
+        ),
+    }
+    if dry_run:
+        return new_version
+    for path, content in rewrites.items():
+        path.write_text(content)
+    (project_root / ".release-channel").write_text(f"{STABLE_CHANNEL}\n")
+    return new_version
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Bump every OMH version surface to the next patch release and "
+            "reset the release channel to stable."
+        )
+    )
+    parser.add_argument("--set", dest="target", help="explicit X.Y.Z target")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=PROJECT_ROOT,
+        help="repository root holding the version surfaces",
+    )
+    arguments = parser.parse_args(argv)
+    try:
+        new_version = bump_version_surfaces(
+            arguments.project_root,
+            target=arguments.target,
+            dry_run=arguments.dry_run,
+        )
+    except DistributionError as exc:
+        print(f"bump refused: {exc}", file=sys.stderr)
+        return 1
+    print(new_version)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Feature Report

### What Changed

- New scheduled workflow `.github/workflows/auto-release.yml` cuts one stable patch release per day whenever `main` has moved past the last `vX.Y.Z` tag, then dispatches the existing `release.yml` for that tag.
- New `tools/package_manager/bump_version.py` moves every version surface together — `pyproject.toml`, `src/omh/version.py`, `src/plugin_bundle/omh/plugin.yaml` — and resets `.release-channel` to `stable`, refusing when the enforced pyproject/version.py parity is already broken or a surface does not carry exactly one literal version line.
- `docs/DISTRIBUTION.md` gains an "Automated stable cadence" section (guards, cadence rationale, pause procedure); `docs/RELEASE.md` points at it from the package-manager section.
- `tests/test_auto_release.py` locks the bump-tool and workflow contracts (14 tests); the pinned-actions gate in `tests/test_homebrew_distribution.py` now covers the new workflow file.

### Why This Exists

- npm/Bun, the GitHub wheel, and the Homebrew tap publish only from `vX.Y.Z` tags. The last tag (v1.0.7, beta, 2026-08-17) left the package channels a week — 169 commits — behind `main`, with npm `latest` still at 1.0.6, while `omh update` on the preview channel stayed current. GitHub's Deployments page showing npm "last week" is that gap.
- The plugin manifest version had also drifted (1.0.5); the bump tool heals it to the release version on every cut instead of freezing the drift.

### User / Operator Impact

- Package-manager installs (`npm install -g oh-my-hermes`, `bun`, `brew install rlaope/tap/omh`) and the stable installer now stay at most ~one day behind `main`, with no maintainer remembering to tag.
- Each automated release still pauses at the protected `npm` environment for one human deployment approval before anything publishes; nothing publishes unattended.
- A manually staged release always wins: when the `pyproject.toml` version has no tag yet, the automation skips without touching anything.

### How It Works

- Daily (`30 22 * * *` UTC) and on `workflow_dispatch`, the job checks whether `v$(metadata.py --version)` exists and whether the `main` tip is that tag's commit. If a release is staged or `main` is already released, it exits.
- Otherwise it bumps to the next patch via `bump_version.py`, runs the full unittest suite and `compileall` on the bumped tree, commits with DCO signoff and Lore trailers, pushes commit+tag with one `git push --atomic`, and starts `release.yml` via `gh workflow run --field tag=...`.
- The dispatch is deliberate: a `GITHUB_TOKEN` tag push cannot trigger `release.yml`'s tag-push path; `workflow_dispatch` is the documented exception that still creates a run. Immediately after the atomic push, the tag commit equals `origin/main`, so `release.yml`'s recovery allowlist check passes with an empty diff.
- `.release-channel` returns to `stable` in the bump commit, matching the documented beta contract ("set the file back to stable in the commit that cuts the next stable release"). The current tree still says `beta` from v1.0.7, so the first automated cut also closes that loop.

### Files And Contracts Touched

- `.github/workflows/auto-release.yml` (new), `tools/package_manager/bump_version.py` (new), `tests/test_auto_release.py` (new), `tests/test_homebrew_distribution.py` (pinned-actions tuple), `docs/DISTRIBUTION.md`, `docs/RELEASE.md`.
- No `omh` runtime code changes; core `omh` still makes no network calls.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests` (ran the CI form: `ruff check src tests tools packaging`)
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli release checklist --json`
- [x] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [x] `omh --help`
- [x] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `uv run tools/package_manager/bump_version.py --dry-run` on the real tree printed `1.0.8` and wrote nothing (`git status` clean of version surfaces)
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: no Hermes-facing surface changed

### Observed Evidence

- `tests.test_auto_release`: 14/14 OK. Distribution family (`test_homebrew_distribution`, `test_distribution_packages`, `test_distribution_surfaces`, `test_release_smoke`): 77/77 OK.
- Full suite: 7068 tests; 28 failures, all confined to `tests/test_cross_harness_adapters.py` + `tests/test_cross_harness_adapter_security.py` and caused by the checkout living under a `.claude/worktrees/...` path (the adapter sandbox fail-closes on a `.claude` path part with `unsafe_read_root`). Re-running exactly those two modules from a neutral-path export of this branch's HEAD: 32/32 OK. CI's checkout path is unaffected.
- Repository state observed while designing: `main` has no branch protection blocking the workflow's push; the `npm` environment carries a required-reviewer rule, which is why the cadence is daily rather than per-merge.

### Not Tested / Not Applicable

- A live scheduled run end to end: the first automated cut can only be observed on GitHub infrastructure and needs the `npm` environment approval; until then the new workflow is `prepared_not_observed`.
- `release.yml` consumption of an auto-created tag via `workflow_dispatch` on real infrastructure (the recovery-allowlist path is exercised only by string contracts and reasoning here).
- Workflow-learning queue smoke: no learning contracts changed.

## Risk

- A merge landing between the automation's atomic push and `release.yml`'s validation would make the recovery diff non-empty and refuse that run; the next daily cut simply supersedes it. The orphaned tag stays consistent with its bumped commit.
- The bump commit is pushed with `GITHUB_TOKEN`, so CI does not run on it; the auto-release job runs the full suite itself before pushing, and the next PR's CI covers the tree.
- Homebrew tap monotonicity, npm immutability, and the beta contract are untouched — publication still flows through the existing `release.yml` guards.

## Compatibility / Rollout

- First cut will be v1.0.8 (stable), flipping `.release-channel` back from the v1.0.7 beta state. To pause the cadence, disable the Auto Release workflow in the Actions UI; never revert bump commits.
- To make publication fully hands-free, the only remaining lever is the `npm` environment's required-reviewer rule (repo settings, owner decision) — the workflow needs no change for that.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Observe the first scheduled cut (decide → bump → gates → push → dispatch → npm approval → publish) and record it in the release notes; adjust the cron if a different cadence is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GRSYnsBfXd5hALXNA6333f
