### PR TITLE
feat(site): recommended-chain category section and README effort levels

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -185,15 +185,15 @@ OMH には次の編集可能な順序付き recommendation chain が含まれて
 
 | カテゴリ alias | 用途 | 編集可能な recommendation 順序 |
 | --- | --- | --- |
-| `ultrabrain` | 最も深い推論 | GPT-5.6 Sol |
-| `deep` | 強力なデフォルト層 | GPT-5.6 Terra、次に DeepSeek V3.2 |
+| `ultrabrain` | 最も深い推論 | GPT-5.6 Sol (xhigh) |
+| `deep` | 強力なデフォルト層 | GPT-5.6 Terra、次に DeepSeek V3.2 (high) |
 | `architect` | アーキテクチャ・システム設計 | Claude Fable 5、次に GPT-5.6 Sol、次に Kimi K3 (xhigh) |
-| `unspecified-high` | デフォルト作業モデル | Kimi K3、次に Claude Opus 5 |
+| `unspecified-high` | デフォルト作業モデル | Kimi K3、次に Claude Opus 5 (medium) |
 | `unspecified-low` | 低コストのフォールバック | GLM 5.2、次に GLM 5.2 Ultrafast、次に DeepSeek V3.2、次に Claude Opus 5 (low) |
 | `quick` | 短いタスク | GLM 5.2 Ultrafast、次に Kimi K3、次に GPT-5.6 Luna、次に Claude Fable 5 (low) |
-| `writing` | 文章・ドキュメント | Kimi K3、次に Qwen3-Coder、次に Gemini 3.1 Pro |
-| `visual-engineering` | フロントエンド・ビジュアル | Claude Fable 5、次に Kimi K3 |
-| `artistry` | 型にはまらない創作 | Gemini 3.1 Pro、次に Claude Fable 5、次に Kimi K3 |
+| `writing` | 文章・ドキュメント | Kimi K3、次に Qwen3-Coder、次に Gemini 3.1 Pro (medium) |
+| `visual-engineering` | フロントエンド・ビジュアル | Claude Fable 5、次に Kimi K3 (high) |
+| `artistry` | 型にはまらない創作 | Gemini 3.1 Pro、次に Claude Fable 5、次に Kimi K3 (high) |
 
 Ultrafast ティアを試したいなら — Kimi K3 Ultrafast(300 TPS)、GLM 5.2 Ultrafast(600 TPS)は [OpenGateway](https://opengateway.ai/) で利用できます。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -183,15 +183,15 @@ OMH에는 다음과 같이 편집 가능한 순서형 recommendation chain이 �
 
 | 카테고리 alias | 용도 | 편집 가능한 recommendation 순서 |
 | --- | --- | --- |
-| `ultrabrain` | 가장 깊은 추론 | GPT-5.6 Sol |
-| `deep` | 강력한 기본 티어 | GPT-5.6 Terra, 다음 DeepSeek V3.2 |
+| `ultrabrain` | 가장 깊은 추론 | GPT-5.6 Sol (xhigh) |
+| `deep` | 강력한 기본 티어 | GPT-5.6 Terra, 다음 DeepSeek V3.2 (high) |
 | `architect` | 아키텍처·시스템 설계 | Claude Fable 5, 다음 GPT-5.6 Sol, 다음 Kimi K3 (xhigh) |
-| `unspecified-high` | 기본 작업 모델 | Kimi K3, 다음 Claude Opus 5 |
+| `unspecified-high` | 기본 작업 모델 | Kimi K3, 다음 Claude Opus 5 (medium) |
 | `unspecified-low` | 저비용 폴백 | GLM 5.2, 다음 GLM 5.2 Ultrafast, 다음 DeepSeek V3.2, 다음 Claude Opus 5 (low) |
 | `quick` | 짧은 작업 | GLM 5.2 Ultrafast, 다음 Kimi K3, 다음 GPT-5.6 Luna, 다음 Claude Fable 5 (low) |
-| `writing` | 문서·산문 | Kimi K3, 다음 Qwen3-Coder, 다음 Gemini 3.1 Pro |
-| `visual-engineering` | 프론트엔드·비주얼 | Claude Fable 5, 다음 Kimi K3 |
-| `artistry` | 비정형 창작 | Gemini 3.1 Pro, 다음 Claude Fable 5, 다음 Kimi K3 |
+| `writing` | 문서·산문 | Kimi K3, 다음 Qwen3-Coder, 다음 Gemini 3.1 Pro (medium) |
+| `visual-engineering` | 프론트엔드·비주얼 | Claude Fable 5, 다음 Kimi K3 (high) |
+| `artistry` | 비정형 창작 | Gemini 3.1 Pro, 다음 Claude Fable 5, 다음 Kimi K3 (high) |
 
 Ultrafast 티어가 궁금하다면 — Kimi K3 Ultrafast(300 TPS), GLM 5.2 Ultrafast(600 TPS) — [OpenGateway](https://opengateway.ai/)에서 만나볼 수 있습니다.
 

--- a/README.md
+++ b/README.md
@@ -261,15 +261,15 @@ credential, dispatch, or execution evidence:
 
 | Category alias | What it is for | Editable recommendation order |
 | --- | --- | --- |
-| `ultrabrain` | Deepest reasoning | GPT-5.6 Sol |
-| `deep` | Strong default tier | GPT-5.6 Terra, then DeepSeek V3.2 |
+| `ultrabrain` | Deepest reasoning | GPT-5.6 Sol (xhigh) |
+| `deep` | Strong default tier | GPT-5.6 Terra, then DeepSeek V3.2 (high) |
 | `architect` | Architecture and system design | Claude Fable 5, then GPT-5.6 Sol, then Kimi K3 (xhigh) |
-| `unspecified-high` | Default working model | Kimi K3, then Claude Opus 5 |
+| `unspecified-high` | Default working model | Kimi K3, then Claude Opus 5 (medium) |
 | `unspecified-low` | Cheaper fallback | GLM 5.2, then GLM 5.2 Ultrafast, then DeepSeek V3.2, then Claude Opus 5 (low) |
 | `quick` | Short tasks | GLM 5.2 Ultrafast, then Kimi K3, then GPT-5.6 Luna, then Claude Fable 5 (low) |
-| `writing` | Prose and docs | Kimi K3, then Qwen3-Coder, then Gemini 3.1 Pro |
-| `visual-engineering` | Frontend and visual | Claude Fable 5, then Kimi K3 |
-| `artistry` | Unconventional work | Gemini 3.1 Pro, then Claude Fable 5, then Kimi K3 |
+| `writing` | Prose and docs | Kimi K3, then Qwen3-Coder, then Gemini 3.1 Pro (medium) |
+| `visual-engineering` | Frontend and visual | Claude Fable 5, then Kimi K3 (high) |
+| `artistry` | Unconventional work | Gemini 3.1 Pro, then Claude Fable 5, then Kimi K3 (high) |
 
 Want to try the Ultrafast tier — Kimi K3 Ultrafast (300 TPS) and
 GLM 5.2 Ultrafast (600 TPS)? They are served on

--- a/README.zh.md
+++ b/README.zh.md
@@ -184,15 +184,15 @@ OMH 随附以下可编辑的有序 recommendation chain。guided model setup 只
 
 | 类别 alias | 用途 | 可编辑的 recommendation 顺序 |
 | --- | --- | --- |
-| `ultrabrain` | 最深度推理 | GPT-5.6 Sol |
-| `deep` | 强力默认层 | GPT-5.6 Terra，其次 DeepSeek V3.2 |
+| `ultrabrain` | 最深度推理 | GPT-5.6 Sol (xhigh) |
+| `deep` | 强力默认层 | GPT-5.6 Terra，其次 DeepSeek V3.2 (high) |
 | `architect` | 架构与系统设计 | Claude Fable 5，其次 GPT-5.6 Sol，其次 Kimi K3 (xhigh) |
-| `unspecified-high` | 默认工作模型 | Kimi K3，其次 Claude Opus 5 |
+| `unspecified-high` | 默认工作模型 | Kimi K3，其次 Claude Opus 5 (medium) |
 | `unspecified-low` | 低成本回退 | GLM 5.2，其次 GLM 5.2 Ultrafast，其次 DeepSeek V3.2，其次 Claude Opus 5 (low) |
 | `quick` | 短任务 | GLM 5.2 Ultrafast，其次 Kimi K3，其次 GPT-5.6 Luna，其次 Claude Fable 5 (low) |
-| `writing` | 文章与文档 | Kimi K3，其次 Qwen3-Coder，其次 Gemini 3.1 Pro |
-| `visual-engineering` | 前端与视觉 | Claude Fable 5，其次 Kimi K3 |
-| `artistry` | 非常规创作 | Gemini 3.1 Pro，其次 Claude Fable 5，其次 Kimi K3 |
+| `writing` | 文章与文档 | Kimi K3，其次 Qwen3-Coder，其次 Gemini 3.1 Pro (medium) |
+| `visual-engineering` | 前端与视觉 | Claude Fable 5，其次 Kimi K3 (high) |
+| `artistry` | 非常规创作 | Gemini 3.1 Pro，其次 Claude Fable 5，其次 Kimi K3 (high) |
 
 想试试 Ultrafast 档? Kimi K3 Ultrafast(300 TPS)与 GLM 5.2 Ultrafast(600 TPS)都在 [OpenGateway](https://opengateway.ai/) 上提供。
 

--- a/site/home.css
+++ b/site/home.css
@@ -963,7 +963,8 @@
   overflow-x: auto;
 }
 
-.fam-table {
+.fam-table,
+.chain-table {
   width: 100%;
   min-width: 720px;
   border-collapse: collapse;
@@ -971,14 +972,17 @@
 }
 
 .fam-table th,
-.fam-table td {
+.fam-table td,
+.chain-table th,
+.chain-table td {
   padding: 17px 18px;
   text-align: left;
   vertical-align: top;
   border-bottom: 1px solid var(--glass-edge);
 }
 
-.fam-table thead th {
+.fam-table thead th,
+.chain-table thead th {
   color: var(--quiet);
   font-size: 11px;
   font-weight: 700;
@@ -986,16 +990,31 @@
   text-transform: uppercase;
 }
 
+/* Latin tracking and casing are no-ops or damaging on Hangul/Kana/Han. */
+:lang(ko) .fam-table thead th,
+:lang(ja) .fam-table thead th,
+:lang(zh) .fam-table thead th,
+:lang(ko) .chain-table thead th,
+:lang(ja) .chain-table thead th,
+:lang(zh) .chain-table thead th {
+  letter-spacing: 0.02em;
+  text-transform: none;
+}
+
 .fam-table tbody tr:last-child th,
-.fam-table tbody tr:last-child td {
+.fam-table tbody tr:last-child td,
+.chain-table tbody tr:last-child th,
+.chain-table tbody tr:last-child td {
   border-bottom: 0;
 }
 
-.fam-table tbody tr {
+.fam-table tbody tr,
+.chain-table tbody tr {
   transition: background-color 300ms var(--ease-out);
 }
 
-.fam-table tbody tr:hover {
+.fam-table tbody tr:hover,
+.chain-table tbody tr:hover {
   background: rgba(76, 194, 255, 0.055);
 }
 
@@ -1011,7 +1030,8 @@
   font-size: 15px;
 }
 
-.fam-table td code {
+.fam-table td code,
+.chain-table td code {
   display: inline-block;
   margin: 0 5px 5px 0;
   padding: 3px 8px;
@@ -1025,6 +1045,74 @@
 .fam-table tbody td:last-child {
   color: var(--muted);
   line-height: 1.6;
+}
+
+/* ---------------------------------------------------------------- chains */
+
+.chain-table tbody th {
+  width: 19%;
+}
+
+/* The category alias is the row key, so it carries the same monospace chip
+   treatment the rest of the page gives aliases. */
+.chain-table tbody th span {
+  display: inline-block;
+  padding: 4px 10px;
+  border: 1px solid var(--glass-edge);
+  border-radius: 999px;
+  background: rgba(76, 194, 255, 0.09);
+  color: var(--accent-strong);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.chain-table tbody td {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.chain-table .chain-order {
+  width: 46%;
+}
+
+.chain-table .chain-order code {
+  margin-right: 0;
+  font-family: var(--font-mono);
+}
+
+.chain-arrow {
+  display: inline-block;
+  margin: 0 7px 5px;
+  color: var(--quiet);
+  font-size: 11.5px;
+}
+
+.chain-effort {
+  width: 12%;
+}
+
+.chain-badge {
+  display: inline-block;
+  padding: 4px 10px;
+  border: 1px solid var(--glass-edge);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--quiet);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  line-height: 1.5;
+}
+
+#chains .ev-note code {
+  padding: 2px 7px;
+  border: 1px solid var(--glass-edge);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--accent-strong);
+  font-size: 12px;
+  overflow-wrap: anywhere;
 }
 
 /* ---------------------------------------------------------------- memory */

--- a/site/i18n.js
+++ b/site/i18n.js
@@ -500,10 +500,10 @@ window.OMH_I18N = {
       zh: "按工作类型指定模型。"
     },
     "route.lead": {
-      en: "Eight editable categories. Missing models are skipped, not fatal.",
-      ko: "편집 가능한 8개 카테고리. 없는 모델은 건너뛸 뿐, 설치를 막지 않습니다.",
-      ja: "編集可能な 8 カテゴリ。持っていないモデルはスキップされ、失敗にはなりません。",
-      zh: "八个可编辑类别。缺少的模型只会被跳过，不会导致失败。"
+      en: "Nine editable categories. Missing models are skipped, not fatal.",
+      ko: "편집 가능한 9개 카테고리. 없는 모델은 건너뛸 뿐, 설치를 막지 않습니다.",
+      ja: "編集可能な 9 カテゴリ。持っていないモデルはスキップされ、失敗にはなりません。",
+      zh: "九个可编辑类别。缺少的模型只会被跳过，不会导致失败。"
     },
     "route.edit.tag": { en: "Editable", ko: "편집 가능", ja: "編集可能", zh: "可编辑" },
     "route.edit.title": {
@@ -589,6 +589,51 @@ window.OMH_I18N = {
       ja: "ルーティング設定ガイドを読む",
       zh: "阅读路由设置指南"
     },
+    /* --------------------------------------------------------------- chains */
+    "chain.kicker": { en: "Recommended chains", ko: "추천 체인", ja: "推奨チェーン", zh: "推荐候选链" },
+    "chain.title": {
+      en: "Nine categories, in the order we ship.",
+      ko: "9개 카테고리, 기본 제공 순서 그대로.",
+      ja: "9 つのカテゴリを、同梱の順序のまま。",
+      zh: "九个类别，按内置顺序呈现。"
+    },
+    "chain.lead": {
+      en: "OMH ships with these editable, ordered recommendation chains. Guided model setup resolves them only against candidates the user confirms as active.",
+      ko: "OMH는 편집 가능한 순서형 추천 체인을 이렇게 기본 제공합니다. 가이드형 모델 설정은 사용자가 활성으로 확인한 후보에 대해서만 이 체인을 해석합니다.",
+      ja: "OMH はこれらの編集可能な順序付き推奨チェーンを同梱します。ガイド付きモデル設定は、利用者が有効と確認した候補に対してのみチェーンを解決します。",
+      zh: "OMH 内置这些可编辑的有序推荐链。引导式模型设置只会针对用户确认为活跃的候选来解析它们。"
+    },
+    "chain.head.category": { en: "Category", ko: "카테고리", ja: "カテゴリ", zh: "类别" },
+    "chain.head.purpose": { en: "Purpose", ko: "용도", ja: "用途", zh: "用途" },
+    "chain.head.order": { en: "Shipped order", ko: "기본 순서", ja: "同梱の順序", zh: "内置顺序" },
+    "chain.head.effort": { en: "Effort", ko: "추론 강도", ja: "推論強度", zh: "推理强度" },
+    "chain.ultrabrain": { en: "Deepest reasoning", ko: "가장 깊은 추론", ja: "最も深い推論", zh: "最深度的推理" },
+    "chain.deep": { en: "Strong default tier", ko: "강력한 기본 등급", ja: "強力な既定ティア", zh: "强力默认档" },
+    "chain.architect": {
+      en: "Architecture and system design",
+      ko: "아키텍처와 시스템 설계",
+      ja: "アーキテクチャとシステム設計",
+      zh: "架构与系统设计"
+    },
+    "chain.unspecified-high": { en: "Default working model", ko: "기본 작업 모델", ja: "既定の作業モデル", zh: "默认工作模型" },
+    "chain.unspecified-low": { en: "Cheaper fallback", ko: "더 저렴한 대안", ja: "より安価なフォールバック", zh: "更省钱的回退" },
+    "chain.quick": { en: "Short tasks", ko: "짧은 작업", ja: "短いタスク", zh: "短任务" },
+    "chain.writing": { en: "Prose and docs", ko: "산문과 문서", ja: "文章とドキュメント", zh: "文案与文档" },
+    "chain.visual-engineering": { en: "Frontend and visual", ko: "프런트엔드와 비주얼", ja: "フロントエンドとビジュアル", zh: "前端与视觉" },
+    "chain.artistry": { en: "Unconventional work", ko: "관습을 벗어난 작업", ja: "型にはまらない作業", zh: "非常规工作" },
+    "chain.note": {
+      en: "The result is prepared routing configuration, not provider availability, credential, dispatch, or execution evidence.",
+      ko: "그 결과물은 준비된 라우팅 설정일 뿐이며, 제공자 가용성·자격 증명·디스패치·실행의 증거가 아닙니다.",
+      ja: "その結果は準備されたルーティング設定であり、プロバイダの可用性・認証情報・ディスパッチ・実行の証拠ではありません。",
+      zh: "其结果是准备好的路由配置，而非提供方可用性、凭据、派发或执行的证据。"
+    },
+    "chain.edit": {
+      en: 'Every chain is yours to reorder. Edit <code>~/.omh/routing/model-chains.json</code>, then run <code>omh model-chains show</code> to print what is in effect.',
+      ko: '모든 체인은 직접 순서를 바꿀 수 있습니다. <code>~/.omh/routing/model-chains.json</code>을 편집한 뒤 <code>omh model-chains show</code>로 현재 적용된 내용을 출력하세요.',
+      ja: 'どのチェーンも自分で並べ替えられます。<code>~/.omh/routing/model-chains.json</code> を編集し、<code>omh model-chains show</code> で現在有効な内容を出力してください。',
+      zh: '每条链都可以由你重新排序。编辑 <code>~/.omh/routing/model-chains.json</code>，再运行 <code>omh model-chains show</code> 打印当前生效的配置。'
+    },
+
     "install.routing.note": {
       en: "Setup records which models are reachable here. Routing order stays editable afterwards.",
       ko: "설치 과정에서 이 컴퓨터에서 쓸 수 있는 모델이 기록됩니다. 라우팅 순서는 그 뒤에도 계속 편집할 수 있습니다.",

--- a/site/index.html
+++ b/site/index.html
@@ -250,7 +250,7 @@
         <div class="section__head section__head--center" data-reveal>
           <p class="kicker" data-i18n="route.kicker">Model routing</p>
           <h2 id="routing-title" data-i18n="route.title">Set the model per kind of work.</h2>
-          <p class="section__lead" data-i18n="route.lead">Eight editable categories. Missing models are skipped, not fatal.</p>
+          <p class="section__lead" data-i18n="route.lead">Nine editable categories. Missing models are skipped, not fatal.</p>
           <p class="exec-route"><code>routing-model-setup</code></p>
         </div>
 
@@ -322,6 +322,42 @@
         <div class="route-cta" data-reveal>
           <a class="button button--chrome" href="docs/model-routing/" data-i18n="route.cta">Read the routing setup guide</a>
         </div>
+      </section>
+
+      <!-- ========================================================== CHAINS -->
+      <section class="section section--tight" id="chains" aria-labelledby="chains-title">
+        <div class="section__head section__head--center" data-reveal>
+          <p class="kicker" data-i18n="chain.kicker">Recommended chains</p>
+          <h2 id="chains-title" data-i18n="chain.title">Nine categories, in the order we ship.</h2>
+          <p class="section__lead" data-i18n="chain.lead">OMH ships with these editable, ordered recommendation chains. Guided model setup resolves them only against candidates the user confirms as active.</p>
+        </div>
+
+        <div class="glass-card table-card" data-reveal>
+          <table class="chain-table">
+            <thead>
+              <tr>
+                <th scope="col" data-i18n="chain.head.category">Category</th>
+                <th scope="col" data-i18n="chain.head.purpose">Purpose</th>
+                <th scope="col" data-i18n="chain.head.order">Shipped order</th>
+                <th scope="col" data-i18n="chain.head.effort">Effort</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr><th scope="row"><span>ultrabrain</span></th><td data-i18n="chain.ultrabrain">Deepest reasoning</td><td class="chain-order"><code>GPT-5.6 Sol</code></td><td class="chain-effort"><span class="chain-badge">xhigh</span></td></tr>
+              <tr><th scope="row"><span>deep</span></th><td data-i18n="chain.deep">Strong default tier</td><td class="chain-order"><code>GPT-5.6 Terra</code><span class="chain-arrow" aria-hidden="true">→</span><code>DeepSeek V3.2</code></td><td class="chain-effort"><span class="chain-badge">high</span></td></tr>
+              <tr><th scope="row"><span>architect</span></th><td data-i18n="chain.architect">Architecture and system design</td><td class="chain-order"><code>Claude Fable 5</code><span class="chain-arrow" aria-hidden="true">→</span><code>GPT-5.6 Sol</code><span class="chain-arrow" aria-hidden="true">→</span><code>Kimi K3</code></td><td class="chain-effort"><span class="chain-badge">xhigh</span></td></tr>
+              <tr><th scope="row"><span>unspecified-high</span></th><td data-i18n="chain.unspecified-high">Default working model</td><td class="chain-order"><code>Kimi K3</code><span class="chain-arrow" aria-hidden="true">→</span><code>Claude Opus 5</code></td><td class="chain-effort"><span class="chain-badge">medium</span></td></tr>
+              <tr><th scope="row"><span>unspecified-low</span></th><td data-i18n="chain.unspecified-low">Cheaper fallback</td><td class="chain-order"><code>GLM 5.2</code><span class="chain-arrow" aria-hidden="true">→</span><code>GLM 5.2 Ultrafast</code><span class="chain-arrow" aria-hidden="true">→</span><code>DeepSeek V3.2</code><span class="chain-arrow" aria-hidden="true">→</span><code>Claude Opus 5</code></td><td class="chain-effort"><span class="chain-badge">low</span></td></tr>
+              <tr><th scope="row"><span>quick</span></th><td data-i18n="chain.quick">Short tasks</td><td class="chain-order"><code>GLM 5.2 Ultrafast</code><span class="chain-arrow" aria-hidden="true">→</span><code>Kimi K3</code><span class="chain-arrow" aria-hidden="true">→</span><code>GPT-5.6 Luna</code><span class="chain-arrow" aria-hidden="true">→</span><code>Claude Fable 5</code></td><td class="chain-effort"><span class="chain-badge">low</span></td></tr>
+              <tr><th scope="row"><span>writing</span></th><td data-i18n="chain.writing">Prose and docs</td><td class="chain-order"><code>Kimi K3</code><span class="chain-arrow" aria-hidden="true">→</span><code>Qwen3-Coder</code><span class="chain-arrow" aria-hidden="true">→</span><code>Gemini 3.1 Pro</code></td><td class="chain-effort"><span class="chain-badge">medium</span></td></tr>
+              <tr><th scope="row"><span>visual-engineering</span></th><td data-i18n="chain.visual-engineering">Frontend and visual</td><td class="chain-order"><code>Claude Fable 5</code><span class="chain-arrow" aria-hidden="true">→</span><code>Kimi K3</code></td><td class="chain-effort"><span class="chain-badge">high</span></td></tr>
+              <tr><th scope="row"><span>artistry</span></th><td data-i18n="chain.artistry">Unconventional work</td><td class="chain-order"><code>Gemini 3.1 Pro</code><span class="chain-arrow" aria-hidden="true">→</span><code>Claude Fable 5</code><span class="chain-arrow" aria-hidden="true">→</span><code>Kimi K3</code></td><td class="chain-effort"><span class="chain-badge">high</span></td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <p class="ev-note" data-reveal data-i18n="chain.note">The result is prepared routing configuration, not provider availability, credential, dispatch, or execution evidence.</p>
+        <p class="ev-note" data-reveal data-i18n-html="chain.edit">Every chain is yours to reorder. Edit <code>~/.omh/routing/model-chains.json</code>, then run <code>omh model-chains show</code> to print what is in effect.</p>
       </section>
 
       <!-- ======================================================= PLATFORMS -->

--- a/tests/test_model_recommendations.py
+++ b/tests/test_model_recommendations.py
@@ -65,7 +65,12 @@ class RecommendationCatalogTests(unittest.TestCase):
             "ja": Path("README.ja.md").read_text(encoding="utf-8"),
             "zh": Path("README.zh.md").read_text(encoding="utf-8"),
             "site": Path("site/docs/model-routing/index.html").read_text(encoding="utf-8"),
+            "home": Path("site/index.html").read_text(encoding="utf-8"),
         }
+        # Both HTML surfaces put one category per source line and key the row
+        # on a bare ``<span>{category}</span>``; the markdown READMEs use a
+        # table row instead.
+        html_surfaces = {"site", "home"}
         categories = SHIPPED_MODEL_RECOMMENDATIONS["categories"]
         assert isinstance(categories, dict)
 
@@ -74,7 +79,7 @@ class RecommendationCatalogTests(unittest.TestCase):
             aliases = [str(candidate["model_alias"]) for candidate in chain]
             for surface, text in docs.items():
                 with self.subTest(category=name, surface=surface):
-                    if surface == "site":
+                    if surface in html_surfaces:
                         row = next(
                             line for line in text.splitlines() if f"<span>{name}</span>" in line
                         )


### PR DESCRIPTION
## Capability

The home page now presents the nine shipped recommendation chains — category alias, purpose, ordered candidate chain, and the chain's uniform reasoning-effort badge — and the README "Recommended models" table (all four locales) carries the shipped effort on every row.

## Motivation

The chains existed on the model-routing docs page and in the README, but the home page only listed bare category chips, and six README rows omitted the reasoning effort even though every shipped chain declares one (the category IS the model+effort pair, per the catalog's own comment). Owner request: surface the categories on the site with the page's design language and complete the effort annotations.

## Implementation (boundary level)

- `site/index.html` — new `#chains` section after `#routing`, in the page's established idiom (section head + kicker, `glass-card` table, `data-reveal`): a four-column chain table with per-row `<span>{category}</span>` markers, chain arrows, effort badges, the evidence-boundary note ("prepared routing configuration, not provider availability, credential, dispatch, or execution evidence"), and the `~/.omh/routing/model-chains.json` / `omh model-chains show` editing pointer. All copy rides the existing `data-i18n` / `data-i18n-html` pipeline.
- `site/i18n.js` — 18 new `chain.*` keys with en/ko/ja/zh strings (exactly the translatable copy: kicker, title, lead, four column heads, nine purposes, two notes). Aliases, model names, and effort levels stay literal.
- `site/home.css` — table-card styles from existing tokens.
- `README.md` + ko/ja/zh — the six rows lacking a trailing effort parenthetical gain the real shipped value (`ultrabrain` xhigh, `deep` high, `unspecified-high` medium, `writing` medium, `visual-engineering` high, `artistry` high), read off `SHIPPED_MODEL_RECOMMENDATIONS`; the three rows that already declared one are untouched, and model order is unchanged.
- `tests/test_model_recommendations.py` — the chain-order walker gains the home page as a gated surface (same `<span>{category}</span>` row convention as the model-routing docs page), so a future chain change that misses the new section fails CI.

## Verification (observed)

- Full suite: `PYTHONPATH=tests uv run python -m unittest discover -s tests` → **Ran 7056 tests … OK** (after rebase onto main with #1086 and #1087 merged).
- All five byte gates green (`docs workflows/roles/capability-families/ulw-inventory/ulw-site --check`) — the new section does not touch the marked ULW region.
- Chain-order walker green across all six surfaces (README ×4, model-routing docs page, home page); `ruff check src tests` and `git diff --check` clean.

## Risks

- The home page is now a pinned chain surface: future chain edits must update it (that is the point — the walker fails with a clear subTest naming the surface).
- i18n purposes are new translations; ko/ja/zh strings were kept short and literal to the English column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpnRcM3HSjCPg2PHPhdYqc