### PR TITLE
fix(release): install node and bun for the auto-release full-suite gate

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -36,6 +36,14 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
+      # The full-suite gate below includes the npm/Bun launcher tests, which
+      # require the same node and bun toolchain CI installs.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.14"
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
       - name: Decide whether main needs a release

--- a/tests/test_auto_release.py
+++ b/tests/test_auto_release.py
@@ -182,6 +182,11 @@ class AutoReleaseWorkflowTests(unittest.TestCase):
             self.workflow,
         )
         self.assertIn("uv run python -m compileall -q src tests", self.workflow)
+        # The full suite includes the npm/Bun launcher tests, so the gate job
+        # needs the same toolchain CI installs.
+        self.assertIn("actions/setup-node@", self.workflow)
+        self.assertIn("oven-sh/setup-bun@", self.workflow)
+        self.assertIn('bun-version: "1.3.14"', self.workflow)
 
     def test_push_is_atomic_and_commit_is_signed_off(self) -> None:
         self.assertIn("git commit -s -m", self.workflow)


### PR DESCRIPTION
## Feature Report

### What Changed

- The auto-release `cut` job now installs the pinned node (22) and bun (1.3.14) toolchain before running the full-suite release gate, mirroring `ci.yml`.
- `tests/test_auto_release.py` locks the gate-toolchain requirement so a future edit cannot drop it silently.

### Why This Exists

- The first dispatched auto-release run ([32689922507](https://github.com/rlaope/oh-my-hermes/actions/runs/32689922507)) worked end to end until the release gate: decide passed, the bump produced 1.0.8, and 7,070 tests ran — with exactly one failure, `test_global_tarball_launchers`, because `bun` was not installed in the job. The gate deliberately runs the same full suite as CI, so it needs the same toolchain.

### User / Operator Impact

- The daily cadence can actually cut v1.0.8; without this the gate fails every run and the package channels stay stale.

### How It Works

- Adds the same pinned `actions/setup-node` and `oven-sh/setup-bun` steps CI uses to the `cut` job, before the gate step. No guard, ordering, or publication logic changes.

### Files And Contracts Touched

- `.github/workflows/auto-release.yml`, `tests/test_auto_release.py`.

### Affected Surfaces

- [x] Not executor-specific

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_auto_release tests.test_homebrew_distribution tests.test_release_smoke` (62 tests OK, including the new toolchain assertions and the version-surface parity gates)
- [x] `uv run --group lint ruff check src tests tools packaging`
- [x] `git diff --check`

### Observed Evidence

- Auto-release run 32689922507 log: `AssertionError: required distribution test tool is missing: bun` as the only failure in 7,070 tests; every prior step (decide, bump to 1.0.8, docs/state) behaved as designed.

### Not Tested / Not Applicable

- The next live auto-release run on GitHub infrastructure; it will be dispatched after this merges.
- Full local suite: only workflow strings and one test file changed; the two-file diff is covered by the targeted modules, and the known `.claude`-path adapter refusal makes local full-suite runs non-authoritative (CI is the oracle).

## Risk

- Toolchain-install-only change inside a workflow that has not yet cut a release; worst case is the same failing gate as today.

## Compatibility / Rollout

- After merge, dispatching Auto Release once cuts v1.0.8 (then waits on the npm environment approval).

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GRSYnsBfXd5hALXNA6333f
