### PR TITLE
fix(release): expand empty channel arrays safely under macOS bash 3.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,12 +184,16 @@ jobs:
             if [ "$RELEASE_CHANNEL" = "beta" ]; then
               extra+=(--prerelease)
             fi
+            # macos-latest ships bash 3.2, where `set -u` treats an empty
+            # array's "${a[@]}" as unbound. Only the stable path leaves this
+            # array empty, so v1.0.7 (beta) never reached it and v1.0.8 --
+            # the first stable cut -- failed before creating the release.
             gh release create "$RELEASE_TAG" \
               "$OMH_WHEEL#Python wheel" \
               --verify-tag \
               --generate-notes \
               --title "$RELEASE_TAG" \
-              "${extra[@]}"
+              ${extra[@]+"${extra[@]}"}
           fi
 
       - name: Verify immutable release wheel
@@ -224,7 +228,8 @@ jobs:
             if [ "$RELEASE_CHANNEL" = "beta" ]; then
               tag_args+=(--tag beta)
             fi
-            npm publish "$OMH_TARBALL" --access public --provenance "${tag_args[@]}"
+            # Same bash 3.2 empty-array guard as the release-create step.
+            npm publish "$OMH_TARBALL" --access public --provenance ${tag_args[@]+"${tag_args[@]}"}
           fi
 
       - name: Render verified Homebrew formula

--- a/tests/test_homebrew_distribution.py
+++ b/tests/test_homebrew_distribution.py
@@ -462,6 +462,39 @@ class DistributionReleaseContractTests(unittest.TestCase):
         self.assertNotIn("tr -d '\"' || true", workflow)
         self.assertIn('npm publish "$OMH_TARBALL"', workflow)
 
+    def test_channel_arrays_expand_safely_on_bash_3_2(self) -> None:
+        """The stable path leaves both channel arrays empty.
+
+        The release job runs on macos-latest, whose /bin/bash is 3.2, where
+        `set -u` rejects a bare "${a[@]}" for an empty array. Only the beta
+        path appends to these arrays, so the bug stayed invisible through
+        v1.0.7 (beta) and broke v1.0.8, the first stable cut, before it could
+        create the GitHub release.
+        """
+
+        workflow = (
+            PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+        ).read_text()
+        for array in ("extra", "tag_args"):
+            with self.subTest(array=array):
+                self.assertIn(
+                    '${%s[@]+"${%s[@]}"}' % (array, array),
+                    workflow,
+                )
+                self.assertNotIn(f'"${{{array}[@]}}"\n', workflow)
+        if not Path("/bin/bash").is_file():
+            self.skipTest("no /bin/bash to execute the expansion against")
+        for channel, expected in (("stable", ""), ("beta", "--prerelease")):
+            with self.subTest(channel=channel):
+                script = (
+                    "set -euo pipefail\n"
+                    "extra=()\n"
+                    f'if [ "{channel}" = "beta" ]; then extra+=(--prerelease); fi\n'
+                    'printf "%s" "${extra[@]+"${extra[@]}"}"\n'
+                )
+                result = run(["/bin/bash", "-c", script])
+                self.assertEqual(result.stdout, expected)
+
     def test_npm_template_has_no_published_placeholder_version(self) -> None:
         template = NPM_PACKAGE_SOURCE / "package.template.json"
         self.assertTrue(template.is_file(), "npm package template missing")


### PR DESCRIPTION
## Feature Report

### What Changed

- Both per-channel arrays in `.github/workflows/release.yml` (`extra` for `--prerelease`, `tag_args` for the npm `beta` dist-tag) now expand as `${a[@]+"${a[@]}"}` so an empty array is safe under `set -u`.
- New regression test in `tests/test_homebrew_distribution.py` locks the idiom for both arrays and executes both channel expansions against the machine's real `/bin/bash` (skipped where there is none, e.g. Windows CI).

### Why This Exists

- The v1.0.8 distribution run ([32709426805](https://github.com/rlaope/oh-my-hermes/actions/runs/32709426805)) passed validation, built the wheel and npm tarball, preflighted npm and the tap, then died at the first write step with `extra[@]: unbound variable`.
- The publish job runs on `macos-latest`, whose `/bin/bash` is 3.2. Bash only exempted `"${a[@]}"` on an empty array from `set -u` in 4.4. Both arrays are empty on **exactly the stable path** — beta appends `--prerelease` and `--tag beta` — so every beta release (v1.0.7) filled them and passed, and the first stable cut was the first run to hit it.
- Verified nothing was published before the failure: no `v1.0.8` GitHub release, npm `latest` still 1.0.6, tap formula still 1.0.6. The `v1.0.8` tag exists on `main` and stays valid.

### User / Operator Impact

- The stable release path works. Without this, every stable tag fails at the same step and the package channels can never advance past the last beta.

### How It Works

- `${a[@]+"${a[@]}"}` expands to nothing when the array is unset/empty and to the quoted elements otherwise — the standard bash 3.2-compatible form. No change to ordering, guards, immutability checks, or the beta contract.

### Files And Contracts Touched

- `.github/workflows/release.yml`, `tests/test_homebrew_distribution.py`. Both are inside the documented release-recovery allowlist, so `v1.0.8` can be resumed with `workflow_dispatch` on the same tag rather than needing a new patch version.

### Affected Surfaces

- [x] Not executor-specific

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_homebrew_distribution tests.test_auto_release` (36 tests OK)
- [x] `uv run --group lint ruff check src tests tools packaging`
- [x] `git diff --check`

### Observed Evidence

- Failing run log: `/Users/runner/work/_temp/....sh: line 20: extra[@]: unbound variable` with `RELEASE_CHANNEL: stable`, `OMH_VERSION: 1.0.8`, right after the wheel and tarball were built.
- Local `/bin/bash` is 3.2.57; the new test runs both channel expansions under it and asserts `""` for stable and `--prerelease` for beta.
- Post-failure state confirmed clean via `gh release view` (not found), `npm view oh-my-hermes dist-tags` (latest 1.0.6), and the tap formula (`version "1.0.6"`).

### Not Tested / Not Applicable

- The resumed v1.0.8 publication itself; it runs after this merges and is `prepared_not_observed` until then.

## Risk

- Two-token change in shell expansion with a test that executes the real behavior. The failure mode it replaces is a hard stop before any write, so there is no partial-release state to reconcile.

## Compatibility / Rollout

- After merge, resume with `gh workflow run release.yml --field tag=v1.0.8`; the recovery path accepts it because every `main` change after the tag is allowlisted. npm environment approval still gates publication.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data

## Follow-Up

- Observe the resumed v1.0.8 run end to end and record npm `latest` plus the tap formula version in the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GRSYnsBfXd5hALXNA6333f
