### PR TITLE
fix(tui): keep submitted prompts visible

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -109,7 +109,7 @@ _Avoid_: process handle, job
 
 **Plan todo**:
 The declared checklist at `$OMH_HOME/runtime/todo.json` that HUD surfaces
-render above the Hermes prompt input. Items are plan declarations; a done mark
+render below the Hermes prompt input. Items are plan declarations; a done mark
 never upgrades into observed evidence.
 _Avoid_: task list as evidence, TodoWrite (that is another product's tool name)
 
@@ -190,9 +190,11 @@ _Avoid_: assuming dock-bottom means above the input
 
 **OMH status widget**:
 `omh-status.mjs`, the managed Modern-TUI widget file OMH installs into
-`$HERMES_HOME/tui-widgets/`. It registers two apps: the status HUD in
-`dock-bottom` (header always visible when installed; activity rows only
-during live work) and the plan-todo checklist in `dock-top`.
+`$HERMES_HOME/tui-widgets/`. It registers one `dock-bottom` app that renders
+the status HUD first (header always visible when installed; activity rows only
+during live work), followed by the plan-todo checklist. Keeping all OMH chrome
+below the composer leaves newly submitted transcript text adjacent to the
+prompt input.
 _Avoid_: statusline (that is a different, host-owned surface), HUD (the widget
 renders the HUD payload; it is not the payload)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -174,7 +174,7 @@ OMH ワークフローの実行中にターミナルが表示するもの:
   dispatch され、自己承認なしで相互検証されます。各 lane は turn・cost・cache
   指標付きの HUD 行として見えます。
 - **Phase-structured TODO** — 作業は開始前に phase と task として宣言され
-  (`todo init`)、プロンプト上のチェックリストとして描画されます: アクティブ
+  (`todo init`)、プロンプト下のチェックリストとして描画されます: アクティブ
   項目は常に一つ、サブタスクのネスト、7 行を超えると折りたたみ。
 
 <br>
@@ -275,7 +275,7 @@ OMH は、モデル選択とコーディングの所有者を別の判断とし�
 | インテリジェンス | OMH が追加するもの |
 | --- | --- |
 | 🧭 **Mixture-of-models ルーティング** | 委譲される lane ごとにカテゴリ(モデル + 推論強度)を dispatch 単位で適用し、provider がモデルを拒否したら編集可能な fallback chain に沿って前進します — 仕事をしなかった子は正直に `failed` と表示されます。 |
-| 🖥️ **ネイティブ TUI サーフェス** | OMH HUD(カテゴリ・ターン・コスト・キャッシュ付きのライブ delegation 行)、プロンプト上の phase todo チェックリスト、`parallel shot ×N` 表示、full-row diff バンド、管理されたスキン — すべて Hermes の隣にインストールされ、Hermes 本体にはパッチしません。 |
+| 🖥️ **ネイティブ TUI サーフェス** | OMH HUD(カテゴリ・ターン・コスト・キャッシュ付きのライブ delegation 行)、プロンプト下の phase todo チェックリスト、`parallel shot ×N` 表示、full-row diff バンド、管理されたスキン — すべて Hermes の隣にインストールされ、Hermes 本体にはパッチしません。 |
 | 📋 **Phase 構造のプラン** | `todo init` がエンジン作業の前に phase と task を宣言し、実行を開かれた推論ループではなく有界のチェックリストにします。 |
 | ⚡ **観測可能な並列作業** | 独立した作業を所有権の分かれた fanout unit に分割し、進行状況と verification gate を観測します。 |
 | 🎼 **Maestro handoff** | 隠れた executor にならず、準備を実行として扱わずに、明示的な coding owner と runtime profile への handoff を準備します。 |

--- a/README.ko.md
+++ b/README.ko.md
@@ -172,7 +172,7 @@ OMH 워크플로가 도는 동안 터미널이 보여주는 것:
   자기승인 없이 교차 검증되고, 각 lane이 turn·cost·cache 지표가 붙은 HUD
   행으로 보입니다.
 - **Phase-structured TODO** — 작업은 시작 전에 phase와 task로 선언되고
-  (`todo init`), 프롬프트 위 체크리스트로 렌더됩니다: 활성 항목 하나,
+  (`todo init`), 프롬프트 아래 체크리스트로 렌더됩니다: 활성 항목 하나,
   서브태스크 중첩, 7행 초과 시 접기.
 
 <br>
@@ -273,7 +273,7 @@ OMH는 모델 선택과 코딩 소유권을 서로 다른 결정으로 다루며
 | 인텔리전스 | OMH가 더하는 것 |
 | --- | --- |
 | 🧭 **Mixture-of-models 라우팅** | 위임되는 lane마다 카테고리(모델 + 추론 강도)를 dispatch 단위로 적용하고, provider가 모델을 거부하면 편집 가능한 fallback chain을 따라 전진합니다 — 일을 하지 않은 자식은 정직하게 `failed`로 표시됩니다. |
-| 🖥️ **네이티브 TUI 표면** | OMH HUD(카테고리·턴·비용·캐시가 붙은 실시간 delegation 행), 프롬프트 위 phase todo 체크리스트, `parallel shot ×N` 표시, full-row diff 밴드, 관리형 스킨 — 모두 Hermes 옆에 설치되며 Hermes를 패치하지 않습니다. |
+| 🖥️ **네이티브 TUI 표면** | OMH HUD(카테고리·턴·비용·캐시가 붙은 실시간 delegation 행), 프롬프트 아래 phase todo 체크리스트, `parallel shot ×N` 표시, full-row diff 밴드, 관리형 스킨 — 모두 Hermes 옆에 설치되며 Hermes를 패치하지 않습니다. |
 | 📋 **Phase 구조 플랜** | `todo init`이 엔진 작업 전에 phase와 task를 선언해, 실행이 열린 추론 루프가 아니라 유한한 체크리스트를 걷게 합니다. |
 | ⚡ **관측 가능한 병렬 작업** | 독립적인 작업을 소유권이 분리된 fanout unit으로 나누고, 진행 상황과 verification gate를 관측합니다. |
 | 🎼 **Maestro handoff** | 숨은 executor가 되거나 준비를 실행으로 취급하지 않으면서 명시적인 코딩 owner와 runtime profile을 위한 handoff를 준비합니다. |

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ What the terminal shows while OMH workflows run:
   subagents whose findings are cross-checked instead of self-approved, each
   visible as its own HUD row with turn, cost, and cache metrics.
 - **Phase-structured TODO** — work is declared up front as phases with tasks
-  (`todo init`), rendered as the checklist above the prompt: one active item,
+  (`todo init`), rendered as the checklist below the prompt: one active item,
   subtask nesting, and fold lines once the plan grows past seven rows.
 
 <br>
@@ -368,7 +368,7 @@ generated catalog, triggers, harnesses, and evidence rules live in
 | Intelligence | What OMH adds |
 | --- | --- |
 | 🧭 **Mixture-of-models routing** | Routes each delegated lane onto a category (model + reasoning effort) applied per dispatch, with editable fallback chains that advance when a provider rejects a model — and honest `failed` rows when a child did no work. |
-| 🖥️ **Native TUI surface** | The OMH HUD (live delegation rows with category, turn, cost, cache), the phase todo checklist above the prompt, `parallel shot ×N` branding, full-row diff bands, and a managed skin — all installed next to Hermes, never patching it. |
+| 🖥️ **Native TUI surface** | The OMH HUD (live delegation rows with category, turn, cost, cache), the phase todo checklist below the prompt, `parallel shot ×N` branding, full-row diff bands, and a managed skin — all installed next to Hermes, never patching it. |
 | 📋 **Phase-structured plans** | `todo init` declares phases and tasks before engine work so runs walk a bounded checklist instead of an open-ended reasoning loop. |
 | ⚡ **Observed parallel work** | Splits independent work into explicit fanout units with isolated ownership, progress observation, and verification gates. |
 | 🎼 **Maestro handoffs** | Prepares handoffs to explicit coding owners and runtime profiles without becoming a hidden executor or treating preparation as execution. |

--- a/README.zh.md
+++ b/README.zh.md
@@ -173,7 +173,7 @@ OMH 工作流运行时,终端会展示:
 - **Parallel Evals** — 评审与验证 lane 作为独立子代理调度,交叉核验而非
   自我批准,每条 lane 都是一个带 turn、cost、cache 指标的 HUD 行。
 - **Phase-structured TODO** — 工作在开始前以 phase 和 task 声明
-  (`todo init`),渲染为提示符上方的清单:单一活动项、子任务嵌套、超过
+  (`todo init`),渲染为提示符下方的清单:单一活动项、子任务嵌套、超过
   七行后折叠。
 
 <br>
@@ -273,7 +273,7 @@ OMH 把模型选择和编码所有权作为两个独立决策，并且绝不把�
 | 智能层 | OMH 提供什么 |
 | --- | --- |
 | 🧭 **Mixture-of-models 路由** | 每条委派 lane 按类别(模型 + 推理强度)在每次 dispatch 时应用,provider 拒绝某个模型时沿可编辑的 fallback chain 前进 — 没有做任何工作的子代理会诚实地标记为 `failed`。 |
-| 🖥️ **原生 TUI 表面** | OMH HUD(带类别、轮次、成本、缓存的实时 delegation 行)、提示符上方的 phase todo 清单、`parallel shot ×N` 标注、整行 diff 色带、受管理的皮肤 — 全部安装在 Hermes 旁边,绝不修改 Hermes 本体。 |
+| 🖥️ **原生 TUI 表面** | OMH HUD(带类别、轮次、成本、缓存的实时 delegation 行)、提示符下方的 phase todo 清单、`parallel shot ×N` 标注、整行 diff 色带、受管理的皮肤 — 全部安装在 Hermes 旁边,绝不修改 Hermes 本体。 |
 | 📋 **Phase 结构化计划** | `todo init` 在引擎工作开始前声明 phase 和 task,让运行沿有界清单推进,而不是陷入开放式推理循环。 |
 | ⚡ **可观测的并行工作** | 把独立工作拆成所有权隔离的 fanout unit,并观测进度和 verification gate。 |
 | 🎼 **Maestro handoff** | 在不成为隐藏 executor、也不把准备当作执行的前提下,为明确的 coding owner 和 runtime profile 准备 handoff。 |

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -601,9 +601,9 @@ JSON.
 The HUD payload also carries a metadata-only plan todo list. When a todo is
 declared — by Hermes through the `omh_todo` plugin tool, or by an agent or
 operator through `omh runtime todo set` — the modern Hermes TUI
-(`hermes --tui`) renders it as a compact checklist directly above the prompt
-input, while the status widget stays below the input. The classic Python TUI
-does not load TUI widget files, so this panel is a modern-TUI-only surface.
+(`hermes --tui`) renders it as a compact checklist below the prompt input,
+after the status and activity rows. The classic Python TUI does not load TUI
+widget files, so this panel is a modern-TUI-only surface.
 `omh runtime todo show` prints the todo projection the HUD payload carries
 (`todo` plus `display.todo_lines`), and `omh runtime todo clear` removes it. Todo items are plan declarations, never execution, review, CI, or
 merge evidence; an all-done list collapses to a single header line and a list

--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -29,9 +29,10 @@ export default function register(sdk) {
   // Colours still resolve only through the active theme, never literals.
   const SEPARATOR = ' │ '
   // The classic REPL frames the composer with horizontal rules; the modern
-  // TUI draws none. These docks sit exactly above and below the composer, so
-  // they carry the frame: a themed rule closes the top dock and opens the
-  // bottom one, and the input reads like classic Hermes again.
+  // TUI draws none. OMH keeps all of its variable-height chrome below the
+  // composer so a submitted prompt remains adjacent to the input. Themed
+  // rules open and close that single dock, and the input reads like classic
+  // Hermes again without a tall plan separating it from the transcript.
   // Host cols include the dock's side margins, so a full-cols rule wraps by
   // two cells. The rules sit tight against the composer, exactly like the
   // classic REPL's frame -- padding was tried at one and two rows against
@@ -303,7 +304,6 @@ export default function register(sdk) {
     return h(
       Box,
       { flexDirection: 'column', width: '100%' },
-      h(Rule, { columns, t }),
       h(
         Text,
         { wrap: 'truncate-end' },
@@ -341,11 +341,11 @@ export default function register(sdk) {
   // ACTIVE item's characters (the text itself never moves — each character
   // dims as the wave passes and brightens back), and a walking ellipsis on
   // the [Plan] header. An idle or all-done plan stays byte-stable and
-  // drag-copyable; while active, the TOP dock deliberately trades selection
-  // stability for the motion cue. The bottom [OMH] dock stays static. The
-  // SDK shimmer clock is mount-bounded, so thirty minutes caps one
-  // continuous wave; guarded access keeps hosts without the hook rendering
-  // a static line instead of crashing the widget.
+  // drag-copyable; while active, the plan rows in the combined bottom dock
+  // deliberately trade selection stability for the motion cue. The SDK
+  // shimmer clock is mount-bounded, so thirty minutes caps one continuous
+  // wave; guarded access keeps hosts without the hook rendering a static
+  // line instead of crashing the widget.
   const shimmerFrame = () =>
     typeof sdk.useShimmerPhase === 'function' ? sdk.useShimmerPhase(1_800_000) : 0
 
@@ -401,8 +401,8 @@ export default function register(sdk) {
         h(
           Text,
           { wrap: 'truncate-end' },
-          // Same grammar as the status line below the prompt, so the two
-          // surfaces read as one product.
+          // Same grammar as the status line above it in the combined dock, so
+          // the two surfaces read as one product.
           h(Text, { bold: true, color: t.color.primary }, '[Plan]'),
           title ? h(Text, { color: t.color.muted }, ` ${title}`) : null,
           h(Text, { color: t.color.border }, SEPARATOR),
@@ -509,7 +509,7 @@ export default function register(sdk) {
           h(
             Text,
             { key: `todo-${groupIndex}-${index}`, wrap: 'truncate-end' },
-            itemNode(item, '  '.repeat(depthOf(item))),
+            itemNode(item, '  '.repeat(depthOf(item) + (group.phase ? 1 : 0))),
           ),
         )
       }
@@ -535,7 +535,7 @@ export default function register(sdk) {
 
   const app = defineWidgetApp({
     id: 'omh-status',
-    help: 'OMH workflow and subagent status',
+    help: 'OMH workflow, plan, and subagent status',
     mode: 'ambient',
     zone: 'dock-bottom',
     init: () => ({ payload: null, receivedAt: 0, tick: 0 }),
@@ -543,29 +543,25 @@ export default function register(sdk) {
       input.kind === 'snapshot'
         ? { ...state, payload: input.payload, receivedAt: Date.now(), tick: state.tick + 1 }
         : state,
-    render: ({ cols, rows, state, t }) => h(Hud, {
-      columns: Math.max(20, cols),
-      state,
-      t,
-      viewportRows: Math.max(1, rows),
-    }),
-  })
-
-  const todoApp = defineWidgetApp({
-    id: 'omh-todo',
-    help: 'OMH plan todo checklist above the prompt input',
-    mode: 'ambient',
-    zone: 'dock-top',
-    init: () => ({ payload: null, receivedAt: 0, tick: 0 }),
-    reduce: (state, input) =>
-      input.kind === 'snapshot'
-        ? { ...state, payload: input.payload, receivedAt: Date.now(), tick: state.tick + 1 }
-        : state,
-    render: ({ cols, state, t }) => h(TodoPanel, { columns: Math.max(20, cols), state, t }),
+    render: ({ cols, rows, state, t }) => {
+      if (!state.payload || state.payload.error || state.payload.privacy !== 'metadata_only') return null
+      const columns = Math.max(20, cols)
+      return h(
+        Box,
+        { flexDirection: 'column', width: '100%' },
+        h(Rule, { columns, t }),
+        h(Hud, {
+          columns,
+          state,
+          t,
+          viewportRows: Math.max(1, rows),
+        }),
+        h(TodoPanel, { columns, state, t }),
+      )
+    },
   })
 
   openWidget(app, app.init(''))
-  openWidget(todoApp, todoApp.init(''))
   // Render quiescence is what makes the docks drag-copyable: every repaint of
   // these lines clears an in-progress terminal selection over them, so an
   // unchanged snapshot must produce NO updateWidget call at all. The reader
@@ -605,9 +601,7 @@ export default function register(sdk) {
     lastSnapshot = serialized
     lastStructural = structural
     lastPaintAt = Date.now()
-    for (const target of [app, todoApp]) {
-      updateWidget(target, state => ({ ...state, payload, receivedAt: Date.now(), tick: state.tick + 1 }))
-    }
+    updateWidget(app, state => ({ ...state, payload, receivedAt: Date.now(), tick: state.tick + 1 }))
   }
   const timerKey = Symbol.for('omh.hermes-tui-widget.refresh')
   const generationKey = Symbol.for('omh.hermes-tui-widget.generation')

--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -5804,7 +5804,7 @@ def awareness_primer_payload() -> dict[str, object]:
             "Use omh_capabilities for detailed workflow catalog and capability manifest lookup.",
             "Use omh_probe when the user asks whether OMH is installed, what is missing, or what the next setup/runtime evidence step should be.",
             "Use omh_status or omh_hud for metadata-only runtime state.",
-            "Use omh_todo to declare or update the plan todo checklist that the Hermes TUI renders above the prompt input; items are declarations, never execution evidence.",
+            "Use omh_todo to declare or update the plan todo checklist that the Hermes TUI renders below the prompt input; items are declarations, never execution evidence.",
             "Use omh_memory before adding to Hermes memory: it reports what Hermes already holds, what OMH holds that it does not, and the remaining character headroom.",
             "Use omh_role for responsibility context when a role marker is present.",
             "Use wrapper cards/actions for user-facing choices instead of asking users to approve shell catalog commands.",

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -1201,10 +1201,17 @@ def _todo_summary(home: Path) -> dict[str, Any]:
     summary["updated_at"] = strip_control_characters(record.get("updated_at", ""))[:40]
     summary["items"] = items
     phases: list[str] = []
+    item_phases: list[str] = []
+    inherited_phase = ""
     for item in items:
         name = item.get("phase", "")
+        if name:
+            inherited_phase = name
+        elif int(item.get("depth", 0) or 0) == 0:
+            inherited_phase = ""
         if name and name not in phases:
             phases.append(name)
+        item_phases.append(inherited_phase)
     counts = {
         "total": len(items),
         "done": sum(1 for item in items if item["state"] == "done"),
@@ -1236,14 +1243,18 @@ def _todo_summary(home: Path) -> dict[str, Any]:
     display_pool = items
     if phases:
         current_phase = next(
-            (item.get("phase", "") for item in items if item["state"] == "active" and item.get("phase")),
-            "",
-        ) or next(
-            (item.get("phase", "") for item in items if item["state"] == "pending" and item.get("phase")),
-            phases[-1],
+            (phase for item, phase in zip(items, item_phases, strict=True) if item["state"] == "active"),
+            None,
         )
+        if current_phase is None:
+            current_phase = next(
+                (phase for item, phase in zip(items, item_phases, strict=True) if item["state"] == "pending"),
+                phases[-1],
+            )
         summary["display_phase"] = current_phase
-        display_pool = [item for item in items if item.get("phase", "") == current_phase]
+        display_pool = [
+            item for item, phase in zip(items, item_phases, strict=True) if phase == current_phase
+        ]
     summary["display_items"] = _collapse_todo_items(display_pool)
     # "+N more" counts hidden remaining work only (later phases included);
     # hidden done items are already summarized by the header's done/total.
@@ -1283,16 +1294,22 @@ def _hud_todo_lines(todo: dict[str, Any], *, preset: str = "focused") -> list[st
         last_phase = None
         for item in shown:
             phase = item.get("phase", "")
+            depth = int(item.get("depth", 0) or 0)
             if phase and phase != last_phase:
                 lines.append(phase)
                 last_phase = phase
-            lines.append(f"{'  ' * int(item.get('depth', 0) or 0)}{marker[item['state']]} {item['text']}")
+            elif not phase and depth == 0:
+                last_phase = ""
+            indent_depth = depth + (1 if last_phase else 0)
+            lines.append(f"{'  ' * indent_depth}{marker[item['state']]} {item['text']}")
     else:
         display_phase = str(todo.get("display_phase", ""))
         if display_phase:
             lines.append(display_phase)
+        base_depth = 1 if display_phase else 0
         lines.extend(
-            f"{'  ' * int(item.get('depth', 0) or 0)}{marker[item['state']]} {item['text']}" for item in shown
+            f"{'  ' * (base_depth + int(item.get('depth', 0) or 0))}{marker[item['state']]} {item['text']}"
+            for item in shown
         )
     more = 0 if full else int(todo.get("more_count", 0) or 0)
     if more > 0:

--- a/src/plugin_bundle/omh/tools/todo_tool.py
+++ b/src/plugin_bundle/omh/tools/todo_tool.py
@@ -18,7 +18,7 @@ OMH_TODO_SCHEMA = {
     "name": "omh_todo",
     "description": (
         "Declare, clear, or read the metadata-only plan todo list that OMH HUD surfaces render "
-        "above the Hermes prompt input. Initialize it BEFORE starting engine work (todo init): "
+        "below the Hermes prompt input. Initialize it BEFORE starting engine work (todo init): "
         "declare phases with their tasks so the run walks a bounded checklist instead of an "
         "open-ended reasoning loop, keep exactly one item active, and update states as work "
         "completes. Todo items are plan declarations, never execution evidence."

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -1012,6 +1012,109 @@ class TodoHudTests(unittest.TestCase):
             )
             self.assertIn("Todo items are plan declarations", payload["evidence_boundary"])
 
+    def test_hud_indents_multiple_tasks_beneath_their_phase_header(self) -> None:
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            items = [
+                {"text": "Edit source", "state": "active", "phase": "Implementation"},
+                {"text": "Run tests", "state": "pending", "phase": "Implementation"},
+            ]
+            self._write_todo(root / ".omh", self._record(items=items))
+
+            payload = read_omh_hud(root / ".omh", root / ".hermes")
+
+            self.assertEqual(
+                payload["display"]["todo_lines"],
+                [
+                    "Todo · Foundation   0/2",
+                    "Implementation",
+                    "  [•] Edit source",
+                    "  [ ] Run tests",
+                ],
+            )
+
+    def test_hud_inherits_phase_for_unphased_nested_tasks(self) -> None:
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            items = [
+                {"text": "Verify", "state": "active", "phase": "Verification"},
+                {"text": "Usability", "state": "pending", "depth": 1},
+            ]
+            self._write_todo(root / ".omh", self._record(items=items))
+
+            focused = read_omh_hud(root / ".omh", root / ".hermes")
+            full = read_omh_hud(root / ".omh", root / ".hermes", preset="full")
+
+            expected_lines = [
+                "Todo · Foundation   0/2",
+                "Verification",
+                "  [•] Verify",
+                "    [ ] Usability",
+            ]
+            self.assertEqual(
+                [item["text"] for item in focused["todo"]["display_items"]],
+                ["Verify", "Usability"],
+            )
+            self.assertEqual(focused["display"]["todo_lines"], expected_lines)
+            self.assertEqual(full["display"]["todo_lines"], expected_lines)
+
+    def test_hud_keeps_unphased_root_tasks_outside_neighboring_phases(self) -> None:
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+        phase_item = {"text": "Phase task", "state": "pending", "phase": "Implementation"}
+        root_item = {"text": "Standalone", "state": "active"}
+        scenarios = (
+            ([phase_item, root_item], ["Implementation", "  [ ] Phase task", "[•] Standalone"]),
+            ([root_item, phase_item], ["[•] Standalone", "Implementation", "  [ ] Phase task"]),
+        )
+
+        for items, full_rows in scenarios:
+            with self.subTest(items=items), TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                self._write_todo(root / ".omh", self._record(items=items))
+
+                focused = read_omh_hud(root / ".omh", root / ".hermes")
+                full = read_omh_hud(root / ".omh", root / ".hermes", preset="full")
+
+                self.assertEqual(focused["todo"].get("display_phase", ""), "")
+                self.assertEqual(
+                    focused["display"]["todo_lines"],
+                    ["Todo · Foundation   0/2", "[•] Standalone   +1 more"],
+                )
+                self.assertEqual(
+                    full["display"]["todo_lines"],
+                    ["Todo · Foundation   0/2", *full_rows],
+                )
+
+    def test_hud_full_keeps_consecutive_root_tasks_under_their_phase(self) -> None:
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            items = [
+                {"text": "First phased", "state": "active", "phase": "Implementation"},
+                {"text": "Second phased", "state": "pending", "phase": "Implementation"},
+                {"text": "Standalone", "state": "pending"},
+            ]
+            self._write_todo(root / ".omh", self._record(items=items))
+
+            payload = read_omh_hud(root / ".omh", root / ".hermes", preset="full")
+
+            self.assertEqual(
+                payload["display"]["todo_lines"],
+                [
+                    "Todo · Foundation   0/3",
+                    "Implementation",
+                    "  [•] First phased",
+                    "  [ ] Second phased",
+                    "[ ] Standalone",
+                ],
+            )
+
     def test_hud_todo_lines_respect_minimal_and_full_presets(self) -> None:
         from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
 

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -241,16 +241,29 @@ class TuiWidgetPackTests(unittest.TestCase):
             self.assertEqual(unrelated.read_text(encoding="utf-8"), "personal\n")
             self.assertEqual(json.loads(stdout)["tui_widget"]["status"], "removed")
 
+    def test_widget_docks_all_omh_chrome_below_the_prompt_input(self) -> None:
+        widget = resources.files("omh.tui_widgets").joinpath("omh-status.mjs").read_text(encoding="utf-8")
+
+        self.assertEqual(widget.count("defineWidgetApp({"), 1)
+        self.assertEqual(widget.count("zone: 'dock-bottom'"), 1)
+        self.assertNotIn("zone: 'dock-top'", widget)
+        self.assertNotIn("id: 'omh-todo'", widget)
+        self.assertIn("h(TodoPanel", widget)
+        self.assertIn(
+            "if (!state.payload || state.payload.error || state.payload.privacy !== 'metadata_only') return null",
+            widget,
+        )
+
     def test_widget_is_bottom_docked_and_omits_host_status_fields(self) -> None:
         widget = resources.files("omh.tui_widgets").joinpath("omh-status.mjs").read_text(encoding="utf-8")
 
         self.assertIn("zone: 'dock-bottom'", widget)
         self.assertNotIn("zone: 'top-right'", widget)
-        # The todo checklist is the one dock-top app; the status app stays
-        # dock-bottom so the panel renders above the prompt input and the
-        # activity rows below it.
-        self.assertEqual(widget.count("zone: 'dock-top'"), 1)
-        self.assertIn("id: 'omh-todo'", widget)
+        # Status, activity, and todo rows share one vertical dock below the
+        # composer. A variable-height dock-top panel would separate newly
+        # submitted transcript text from the prompt input.
+        self.assertEqual(widget.count("zone: 'dock-top'"), 0)
+        self.assertNotIn("id: 'omh-todo'", widget)
         self.assertIn("TodoPanel", widget)
         self.assertIn("truncateCells(item.text", widget)
         self.assertIn("safeText(todo.title)", widget)
@@ -316,7 +329,8 @@ class TuiWidgetPackTests(unittest.TestCase):
         self.assertIn("' '.repeat(phaseColumn - cellWidth(label) + 1)", widget)
         self.assertIn("const TODO_DISPLAY_ROWS = 7", widget)
         self.assertIn("depthOf", widget)
-        self.assertIn("'  '.repeat(depthOf(item))", widget)
+        self.assertIn("(!phase && depthOf(item) > 0)", widget)
+        self.assertIn("'  '.repeat(depthOf(item) + (group.phase ? 1 : 0))", widget)
         self.assertIn("task${count === 1 ? '' : 's'}", widget)
         self.assertIn("'todo-earlier'", widget)
         self.assertIn("'todo-later'", widget)
@@ -410,9 +424,10 @@ class TuiWidgetPackTests(unittest.TestCase):
         self.assertIn("generation !== globalThis[generationKey]", widget)
         self.assertIn("clearTimeout(", widget)
         self.assertNotIn("payload ? { payload } : state", widget)
-        # One immutable snapshot-apply helper feeds both widget apps, and both
-        # the initial read and the refresh timer go through it; each applied
-        # snapshot stamps receivedAt so running rows can tick elapsed live.
+        # One immutable snapshot-apply helper feeds the combined dock app, and
+        # both the initial read and the refresh timer go through it; each
+        # applied snapshot stamps receivedAt so running rows can tick elapsed
+        # live.
         self.assertEqual(
             widget.count("{ ...state, payload, receivedAt: Date.now(), tick: state.tick + 1 }"), 1
         )


### PR DESCRIPTION
## Feature Report

### What Changed

- Combined the OMH status/activity HUD and phase TODO panel into one vertical `dock-bottom` Modern TUI widget.
- Added a two-space base indent for task rows rendered beneath a phase header in both the widget and metadata-only CLI projection.
- Kept subagent activity summaries responsive to terminal width without introducing a fixed cap.
- Updated English, Korean, Japanese, and Chinese documentation plus plugin guidance to describe the new below-composer placement.

### Why This Exists

The variable-height TODO panel previously occupied `dock-top`, which Hermes renders between the transcript and composer. After a user submitted a prompt, the plan could push the submitted text far enough upward that the user had to scroll to confirm what was sent. Multi-task phases also placed each task marker at the same column as the phase header, making the newline look accidental rather than hierarchical.

### Decision Provenance

This intentionally supersedes the placement criterion in #959 and the prior rejection recorded in #972 / commit `d74cb1f7`. Those decisions targeted a Claude Code-style checklist above the prompt. Live Modern TUI evidence subsequently showed that the variable-height top dock separates newly submitted transcript text from the composer and can force users to scroll merely to confirm what they sent. This PR preserves #959's remaining TODO capability goals while replacing only that placement requirement with the observed, usability-driven single-bottom-dock contract.

### User / Operator Impact

- Newly submitted text remains directly adjacent to the composer.
- OMH status, activity, and plan information remains visible below the composer in one bounded vertical surface.
- Tasks under a multi-task phase visibly belong to that phase through a two-space indent.
- Nested tasks without a repeated `phase` field inherit the preceding phase consistently in widget and Python HUD projections.
- Existing responsive activity-summary behavior is unchanged.

### How It Works

- `omh-status.mjs` registers one ambient bottom-dock app and renders an opening rule, the HUD, the TODO panel, and a closing rule in a single column.
- A metadata-only payload guard prevents an orphan rule during startup or HUD read failures.
- Phase task indentation adds one base level only when a separate phase header is rendered; nested task depth remains additive.
- `runtime_reader.py` tracks the inherited phase for unphased descendants and applies the same grouping and indentation contract to `display.todo_lines`.

### Files And Contracts Touched

- Modern TUI widget registration, layout, and task rendering.
- Metadata-only HUD TODO projection.
- `omh_todo` tool guidance and OMH awareness hints.
- TUI placement documentation in all maintained README languages, installation docs, and `CONTEXT.md`.
- Regression tests for dock ownership, null-payload rendering, direct phase-task indentation, and inherited-phase nested tasks.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

Check only commands that completed successfully. Leave non-applicable checks
unchecked and explain why under **Not Tested / Not Applicable**.

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [ ] `uv run python -m omh.cli docs workflows --check`
- [ ] `uv run python -m omh.cli docs roles --check`
- [ ] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: focused HUD, phase-todo, widget, distribution, and locale tests.
- [x] Manual Hermes/TUI check, or explicit reason it was not run: real Hermes Modern TUI at 150x40 and 100x30.

### Observed Evidence

- Full suite: 7,085 tests passed on the post-guard implementation.
- Focused HUD and phase-todo tests passed after the inherited-phase correction.
- Real Modern TUI at 100 columns kept submitted invalid-command text and its response directly above the composer while OMH status and Korean TODO rows rendered below it.
- Korean phase tasks retained correct CJK cell alignment and two-space relative indentation at 100 columns.
- Independent goal, code-quality, security, hands-on QA, and repository-context reviews are required to pass at the final PR head before merge.

### Not Tested / Not Applicable

- Provider-backed model completion was not invoked; manual QA used safe-mode local command paths to avoid an unrelated external provider call.
- Generated workflow/role/capability-family sources, harness contracts, and release machinery were not changed, so their dedicated commands were not required for this TUI-only behavior change.
- The installed user-home widget is updated through normal `omh setup` or `omh update`; this PR does not mutate a reviewer's live installation.

## Risk

Moderate but bounded to the Modern TUI dock layout and metadata-only TODO formatting. The main risk is excessive vertical space when both activity and plan rows are populated; responsive truncation, the existing three-activity-row cap, and the seven-plan-row window remain in force.

## Compatibility / Rollout

- No Hermes core patching or network integration.
- No schema or persisted-data migration.
- Existing installations receive the managed widget update through `omh setup` or `omh update`.
- Restart any open Modern TUI session after updating; the Hermes hot-reload host retains removed widget app ids until process restart.
- Classic Python TUI behavior remains outside this Modern-TUI-only surface.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Keep #959 open for any remaining TODO capability criteria; this PR supersedes only its placement requirement.