### PR TITLE
fix(release): cut releases only on demand, never on a schedule

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,10 +1,11 @@
-name: Auto Release
+name: Cut Release
 
-# Cuts one stable patch release per day when main has moved past the last
-# tag, so the npm/Bun package, GitHub wheel, and Homebrew tap track main
-# instead of waiting for a manual tag. The cadence is daily rather than
-# per-merge because the protected `npm` environment requires one human
-# deployment approval per release run.
+# Runs the mechanics of a stable patch release -- bump every version surface,
+# gate, tag, dispatch the distribution workflow -- but only when a maintainer
+# asks for one. There is deliberately NO schedule: deciding that main's
+# current state is worth a version belongs to a person. An earlier revision
+# of this file cut a release every day, which moved the public version
+# without anyone choosing to, and made the number meaningless.
 #
 # The tag and the workflow_dispatch of release.yml are both created with
 # GITHUB_TOKEN on purpose: a GITHUB_TOKEN tag push cannot trigger the
@@ -12,8 +13,6 @@ name: Auto Release
 # exception that still creates a run.
 
 on:
-  schedule:
-    - cron: "30 22 * * *"
   workflow_dispatch:
 
 concurrency:
@@ -96,13 +95,13 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add pyproject.toml src/omh/version.py \
             src/plugin_bundle/omh/plugin.yaml .release-channel
-          git commit -s -m "chore(release): cut v$NEW_VERSION on the daily stable cadence
+          git commit -s -m "chore(release): cut v$NEW_VERSION
 
-          Constraint: npm/Bun, the GitHub wheel, and the Homebrew tap publish only from vX.Y.Z tags, so tracking main requires this version-bump commit on main
-          Rejected: per-merge releases | the protected npm environment requires one human deployment approval per run
+          Constraint: npm/Bun, the GitHub wheel, and the Homebrew tap publish only from vX.Y.Z tags, so a release requires this version-bump commit on main
+          Rejected: any automatic trigger | choosing that main is worth a version is a maintainer decision, not a schedule's
           Confidence: high
           Scope-risk: narrow
-          Directive: pause the cadence by disabling the auto-release workflow, never by reverting bump commits
+          Directive: this commit exists because a maintainer ran the Cut Release workflow; never add a trigger that creates it unattended
           Tested: full unittest suite and compileall on the bumped tree inside this workflow run
           Not-tested: npm environment approval and downstream release.yml publication happen after this commit"
           git tag "v$NEW_VERSION"

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -94,33 +94,41 @@ All distribution tags share one non-cancelling concurrency group. The tap
 update cannot run before npm publication succeeds, and an older run cannot
 downgrade a newer tap formula.
 
-## Automated stable cadence
+## Cutting a release on demand
 
-`.github/workflows/auto-release.yml` keeps the package-manager channels
-tracking `main` without a human remembering to tag. Once a day (and on
-manual dispatch) it checks whether the `main` tip has moved past the tag of
-the current `pyproject.toml` version. When it has, the workflow bumps every
-version surface to the next patch release with
-`tools/package_manager/bump_version.py` (pyproject, `src/omh/version.py`,
-the plugin manifest, and `.release-channel` back to `stable`), runs the full
-test suite on the bumped tree, pushes the commit and `vX.Y.Z` tag to `main`
-atomically, and dispatches the distribution workflow for that tag.
+**Deciding that `main` deserves a version is a human decision.** Nothing in
+this repository cuts a release on its own: `main` may sit any distance ahead
+of the published packages, and that gap is not a fault to be automated away.
+People who want `main` itself install the preview channel, which needs no
+version at all.
 
-Boundaries of the automation:
+`.github/workflows/auto-release.yml` (Actions → *Cut Release* → Run workflow)
+performs the release mechanics once a maintainer asks for one. It bumps every
+version surface to the next patch with `tools/package_manager/bump_version.py`
+(pyproject, `src/omh/version.py`, the plugin manifest, and `.release-channel`
+back to `stable`), runs the full test suite on the bumped tree, pushes the
+commit and `vX.Y.Z` tag to `main` atomically, and dispatches the distribution
+workflow for that tag.
 
+Boundaries:
+
+- `workflow_dispatch` is the only trigger. An earlier revision carried a daily
+  `schedule:`; it advanced the public version every day that `main` moved,
+  without anyone choosing to release. `tests/test_auto_release.py` now fails if
+  a schedule, push, or pull_request trigger reappears.
 - It cuts stable patch releases only. When the version in `pyproject.toml`
-  has no tag yet, a manual release (stable or beta) is staged and the
-  automation skips without touching anything.
-- The cadence is daily, not per-merge, because the protected `npm`
-  environment requires one human deployment approval per release run. Each
-  automated release still pauses at that approval before anything publishes.
+  has no tag yet, a release is already staged by hand and the workflow skips
+  without touching anything.
+- Publication still pauses at the protected `npm` environment for one human
+  deployment approval, after the tag exists and before anything is published.
 - The bump commit and tag are pushed with the workflow's `GITHUB_TOKEN`, so
   they do not trigger the tag-push path of the distribution workflow or a CI
-  run on `main`; the auto-release job runs the full suite itself before
-  pushing, and it starts the distribution workflow through
-  `workflow_dispatch` with the new tag.
-- Pause the cadence by disabling the Auto Release workflow in the Actions
-  UI, never by reverting a bump commit.
+  run on `main`; the job runs the full suite itself before pushing, and it
+  starts the distribution workflow through `workflow_dispatch` with the new
+  tag.
+- To bump by hand instead, run `uv run tools/package_manager/bump_version.py`
+  (`--set X.Y.Z` for a minor or major, `--dry-run` to preview) and follow the
+  Required Checks in [Release](RELEASE.md).
 
 ## Resume and rollback
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -30,10 +30,11 @@ The tag-driven npm/Bun, GitHub wheel, and Homebrew tap release is defined by
 `.github/workflows/release.yml`. Its release order, one-time external setup,
 resume rules, rollback matrix, immutable artifact checks, and pending-first-
 release status are the single contract in [Distribution](DISTRIBUTION.md).
-A daily auto-release workflow cuts the next stable patch tag whenever `main`
-has moved past the last release, so these channels track `main` instead of
-waiting for a manual tag; its guards and boundaries live in the same
-Distribution contract under "Automated stable cadence".
+Releases are cut only when a maintainer asks for one; the *Cut Release*
+workflow performs the mechanics on demand, and its guards live in the same
+Distribution contract under "Cutting a release on demand". Package-manager
+channels therefore advance per release, not per merge — people who want
+`main` itself use the preview channel below, which needs no version.
 
 Those package-manager artifacts extend the stable channel; they do not replace
 the installer, Hermes skill tap, generated-document, or evidence checks below.

--- a/tests/test_auto_release.py
+++ b/tests/test_auto_release.py
@@ -145,10 +145,18 @@ class AutoReleaseWorkflowTests(unittest.TestCase):
     def setUp(self) -> None:
         self.workflow = AUTO_RELEASE.read_text()
 
-    def test_cadence_is_scheduled_not_per_merge(self) -> None:
-        self.assertIn("schedule:", self.workflow)
-        self.assertIn('cron: "30 22 * * *"', self.workflow)
-        self.assertIn("workflow_dispatch:", self.workflow)
+    def test_release_is_cut_only_on_demand(self) -> None:
+        """No trigger may cut a release without a person asking for one.
+
+        A scheduled revision of this workflow moved the public version daily,
+        which is what this guard exists to prevent: choosing that main is
+        worth a version is a human decision, not a cron's.
+        """
+
+        triggers = self.workflow.split("\non:\n", 1)[1].split("\nconcurrency:", 1)[0]
+        self.assertEqual(triggers.strip(), "workflow_dispatch:")
+        self.assertNotIn("\n  schedule:", self.workflow)
+        self.assertNotIn("cron:", self.workflow)
         self.assertNotIn("\n  push:", self.workflow)
         self.assertNotIn("pull_request", self.workflow)
         self.assertIn("group: auto-release\n", self.workflow)


### PR DESCRIPTION
## Feature Report

### What Changed

- `.github/workflows/auto-release.yml` loses its daily `schedule:` trigger. `workflow_dispatch` is now the only way it runs, and it is renamed *Cut Release*.
- `tests/test_auto_release.py` replaces the cadence assertion with a guard that fails if a `schedule`, `push`, or `pull_request` trigger reappears, parsing the `on:` block rather than substring-matching the file.
- `docs/DISTRIBUTION.md` and `docs/RELEASE.md` restate the policy: nothing cuts a release on its own, `main` sitting ahead of the published packages is the normal state, and the preview channel is how someone follows `main` without a version.

### Why This Exists

- The daily cron advanced the public version every day `main` moved. In one day it took the packages 1.0.6 → 1.0.9 and the repo 1.0.7 → 1.0.9. Nobody chose those releases, which makes the version number meaningless as a signal.
- Owner decision: the release version moves when a maintainer says so. The mechanics are still worth automating; the *decision* is not.

### User / Operator Impact

- No release happens unless a maintainer runs Actions → *Cut Release* → Run workflow. Merge volume no longer influences the version at all.
- The button still does the whole sequence: bump every version surface, run the full suite on the bumped tree, tag, and dispatch the distribution workflow — then publication waits on the npm environment approval as before.
- To bump by hand instead, `uv run tools/package_manager/bump_version.py` (`--set X.Y.Z`, `--dry-run`) remains available.

### How It Works

- Trigger removal only; every guard, gate, and step in the job is unchanged. The workflow's own commit message no longer claims a cadence.

### Files And Contracts Touched

- `.github/workflows/auto-release.yml`, `tests/test_auto_release.py`, `docs/DISTRIBUTION.md`, `docs/RELEASE.md`.

### Affected Surfaces

- [x] Not executor-specific

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_auto_release tests.test_homebrew_distribution tests.test_release_smoke` (63 tests OK)
- [x] `uv run --group lint ruff check src tests tools packaging`
- [x] `git diff --check`

### Observed Evidence

- The new guard was verified to actually bite: with the `on:` block still carrying `schedule:`/`cron:`, `test_release_is_cut_only_on_demand` failed; it passes only after the trigger was removed.
- The workflow is currently `disabled_manually` in the Actions UI, so no run was possible between the incident and this change.

### Not Tested / Not Applicable

- A dispatched run under the new trigger set. The job body is untouched and was observed working end to end (bump → gates → atomic tag push → distribution dispatch) in run 32711522755.

## Risk

- Removal of a trigger. The failure mode it prevents already occurred; the one it introduces is a release being forgotten, which is the intended trade.

## Compatibility / Rollout

- Version stays 1.0.9 everywhere, matching the published wheel, npm `latest`, and tap formula. Re-enable the workflow in the Actions UI when you want the button available.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GRSYnsBfXd5hALXNA6333f
