### PR TITLE
feat(routing): map chain aliases to provider-specific model names via config

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -276,6 +276,38 @@ walks, and HUD category labels alike — until the user removes it. An invalid
 document is ignored whole (defaults apply) and reported by
 `omh_delegate_route` `action=status` as `chain_overrides: invalid: ...`.
 
+### Reaching models through a provider
+
+Chains name models the way a person says them (`glm-5.2`, `kimi-k3`). A host
+that reaches models through a provider usually needs two different values
+instead: a provider id, and that provider's own model string, which is often
+namespaced like `vendor/model-name`. Which provider serves which model, and
+under what name, belongs to one account — so OMH ships no routes and hardcodes
+no provider.
+
+Supply them in `~/.omh/routing/model-providers.json`
+(`model_provider_routes/v1`), a sibling of the chain document:
+
+```json
+{
+  "schema_version": "model_provider_routes/v1",
+  "models": {
+    "glm-5.2": {"provider": "my-gateway", "model": "z-ai/glm-5.2"},
+    "kimi-k3": {"provider": "my-gateway", "model": "moonshotai/kimi-k3"}
+  }
+}
+```
+
+An alias listed here dispatches as that provider's model; an alias not listed
+dispatches unchanged with no provider, which is what a direct-billing host
+wants — the file is optional and absent by default. A `provider` passed
+explicitly to `omh_delegate_route` outranks any stored route. Fallback still
+walks the chain by alias, so a routed model is translated back before its
+chain position is looked up. Validation matches the chain document: strict,
+token-only, atomic, with an invalid file ignored whole and reported by
+`action=status` as `provider_routes: invalid: ...` beside the resolved
+`provider_routes_path`.
+
 The X/Grok row is a static, editable affinity for work explicitly declaring X
 platform data. It is not a measured capability, performance, or availability
 claim, never removes another candidate, and never overrides an explicit user

--- a/src/plugin_bundle/omh/hermes_delegation.py
+++ b/src/plugin_bundle/omh/hermes_delegation.py
@@ -28,6 +28,7 @@ import json
 import re
 import sqlite3
 import time
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -172,6 +173,115 @@ def effective_mixture_category_chains(
         name: overrides.get(name, chain)
         for name, chain in HERMES_MIXTURE_CATEGORY_CHAINS.items()
     }
+
+
+# User-editable alias -> (provider, wire model) routes.
+#
+# A chain names a model the way a person says it (`glm-5.2`, `kimi-k3`), but a
+# host that reaches models through a provider usually needs two different
+# values: a provider id and that provider's own model string, which is often
+# namespaced (`vendor/model`). Which provider serves which model, and under
+# what name, is a property of one person's account -- so OMH ships NO routes
+# and hardcodes no provider. Absent this document every alias dispatches
+# unchanged, which is the behavior every host without a provider indirection
+# wants.
+#
+# Validation mirrors the chain-override contract exactly: strict, atomic, and
+# token-only, so a crafted value can never smuggle structure into config.yaml
+# through a later omh_delegate_route write.
+MODEL_PROVIDER_ROUTES_SCHEMA_VERSION = "model_provider_routes/v1"
+
+
+def model_provider_routes_path(omh_home: str | Path | None = None) -> Path:
+    root = Path(omh_home).expanduser() if omh_home else Path.home() / ".omh"
+    return root / "routing" / "model-providers.json"
+
+
+def load_model_provider_routes(
+    omh_home: str | Path | None = None,
+) -> tuple[dict[str, tuple[str, str]], str]:
+    """Read the user's alias -> (provider, model) document.
+
+    Returns ``(routes, status)`` where status is ``absent``, ``applied``, or
+    ``invalid: <reason>``, matching `load_mixture_chain_overrides`.
+    """
+    path = model_provider_routes_path(omh_home)
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}, "absent"
+    except (OSError, UnicodeDecodeError, ValueError):
+        return {}, "invalid: unreadable JSON"
+    return parse_model_provider_routes(raw)
+
+
+def parse_model_provider_routes(
+    raw: object,
+) -> tuple[dict[str, tuple[str, str]], str]:
+    """Validate one already-parsed provider-route document."""
+    if not isinstance(raw, dict):
+        return {}, "invalid: document must be a JSON object"
+    if raw.get("schema_version") != MODEL_PROVIDER_ROUTES_SCHEMA_VERSION:
+        return {}, f"invalid: schema_version must be {MODEL_PROVIDER_ROUTES_SCHEMA_VERSION}"
+    models = raw.get("models")
+    if not isinstance(models, dict):
+        return {}, "invalid: models must be an object"
+    unknown = sorted(set(raw) - {"schema_version", "models"})
+    if unknown:
+        return {}, f"invalid: unsupported fields {unknown}"
+    routes: dict[str, tuple[str, str]] = {}
+    for alias, entry in models.items():
+        if not _CHAIN_TOKEN_RE.match(str(alias)):
+            return {}, f"invalid: alias {alias!r} is not a token"
+        if not isinstance(entry, dict):
+            return {}, f"invalid: alias {alias!r} must map to an object"
+        unknown_keys = sorted(set(entry) - {"provider", "model"})
+        if unknown_keys:
+            return {}, f"invalid: alias {alias!r} entry fields {unknown_keys}"
+        provider = str(entry.get("provider", ""))
+        model = str(entry.get("model", ""))
+        if not _CHAIN_TOKEN_RE.match(provider):
+            return {}, f"invalid: alias {alias!r} names a non-token provider"
+        if not _CHAIN_TOKEN_RE.match(model):
+            return {}, f"invalid: alias {alias!r} names a non-token model"
+        routes[str(alias)] = (provider, model)
+    return routes, "applied"
+
+
+def resolve_provider_model(
+    model: str,
+    provider: str = "",
+    routes: Mapping[str, tuple[str, str]] | None = None,
+) -> tuple[str, str]:
+    """Expand one alias into ``(wire model, provider)``.
+
+    A caller that pinned a provider is answered verbatim: an explicit choice
+    outranks a stored route. An alias with no route is returned unchanged with
+    no provider, which is what a direct-billing host needs.
+    """
+    if provider:
+        return model, provider
+    resolved = (routes or {}).get(model)
+    if resolved is None:
+        return model, ""
+    resolved_provider, wire_model = resolved
+    return wire_model, resolved_provider
+
+
+def chain_alias_for(
+    model: str,
+    routes: Mapping[str, tuple[str, str]] | None = None,
+) -> str:
+    """Map a wire model back to the alias its chain uses.
+
+    Chain positions are matched by alias, so a route that was written as a
+    wire model has to be translated back before any chain lookup; otherwise a
+    routed model looks absent from the chain it came from.
+    """
+    for alias, (_, wire_model) in (routes or {}).items():
+        if model == wire_model:
+            return alias
+    return model
 
 # Rough USD-per-million-token list prices used ONLY when the host recorded no
 # cost (subscription billing bills nothing per call; the owner asked for an

--- a/src/plugin_bundle/omh/tools/delegate_route_tool.py
+++ b/src/plugin_bundle/omh/tools/delegate_route_tool.py
@@ -6,9 +6,13 @@ from typing import Any
 from ..delegation_routing import read_delegation_route, write_delegation_route
 from ..hermes_delegation import (
     HERMES_MIXTURE_CATEGORY_CHAINS,
+    chain_alias_for,
     effective_mixture_category_chains,
     load_mixture_chain_overrides,
+    load_model_provider_routes,
     mixture_chain_overrides_path,
+    model_provider_routes_path,
+    resolve_provider_model,
 )
 from ..host_observation import OBSERVATION_SCHEMA, attach_public_observation, observe_plugin_tool_call
 
@@ -17,6 +21,26 @@ _EVIDENCE_BOUNDARY = (
     "dispatch (Hermes re-reads config.yaml per dispatch). Writing a route is not "
     "execution, dispatch, or completion evidence."
 )
+
+def _chain_entry(
+    alias: str,
+    effort: str,
+    routes: dict[str, tuple[str, str]],
+) -> dict[str, str]:
+    """Render one chain position.
+
+    `model` stays the alias the chain is written in, so a host with no
+    provider routes sees exactly what it always saw. The dispatched values
+    appear beside it only when a route actually applies, which is also the
+    only case where they differ.
+    """
+    entry = {"model": alias, "reasoning_effort": effort}
+    wire_model, provider = resolve_provider_model(alias, routes=routes)
+    if provider:
+        entry["provider"] = provider
+        entry["wire_model"] = wire_model
+    return entry
+
 
 OMH_DELEGATE_ROUTE_SCHEMA = {
     "name": "omh_delegate_route",
@@ -109,6 +133,11 @@ def omh_delegate_route_handler(args: dict[str, Any], **kwargs) -> str:
     # overrides; the category vocabulary itself stays the shipped closed set.
     chains = effective_mixture_category_chains(omh_home)
     _, override_status = load_mixture_chain_overrides(omh_home)
+    # Chains name models the way a person says them. A host that reaches
+    # models through a provider needs a provider id and that provider's own
+    # (often namespaced) model string; routing/model-providers.json supplies
+    # that mapping. With no document every alias dispatches unchanged.
+    provider_routes, provider_route_status = load_model_provider_routes(omh_home)
 
     if action == "status":
         payload: dict[str, Any] = {
@@ -116,13 +145,15 @@ def omh_delegate_route_handler(args: dict[str, Any], **kwargs) -> str:
             "route": read_delegation_route(hermes_home),
             "categories": {
                 category: [
-                    {"model": alias, "reasoning_effort": effort}
+                    _chain_entry(alias, effort, provider_routes)
                     for alias, effort in chain
                 ]
                 for category, chain in chains.items()
             },
             "chain_overrides": override_status,
             "chain_overrides_path": str(mixture_chain_overrides_path(omh_home)),
+            "provider_routes": provider_route_status,
+            "provider_routes_path": str(model_provider_routes_path(omh_home)),
             "evidence_boundary": _EVIDENCE_BOUNDARY,
         }
         return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
@@ -135,6 +166,11 @@ def omh_delegate_route_handler(args: dict[str, Any], **kwargs) -> str:
     if action == "fallback":
         route = read_delegation_route(hermes_home)
         current_model = str(route.get("model", ""))
+        # The live route holds whatever was dispatched, which is the provider's
+        # wire model when a route applied. Chain positions are keyed by alias,
+        # so translate back before any chain lookup below -- otherwise a routed
+        # model reads as absent from the very chain it came from.
+        current_alias = chain_alias_for(current_model, provider_routes)
         current_effort = str(route.get("reasoning_effort", ""))
         if not current_model:
             payload = {
@@ -160,17 +196,17 @@ def omh_delegate_route_handler(args: dict[str, Any], **kwargs) -> str:
             # so an ambiguous route only reads as exhausted when NO matching
             # chain has a next candidate.
             def _chain_index(chain: tuple) -> int:
-                return next((i for i, (alias, _) in enumerate(chain) if alias == current_model), -1)
+                return next((i for i, (alias, _) in enumerate(chain) if alias == current_alias), -1)
 
             exact = [
                 name
                 for name, chain in chains.items()
-                if any(alias == current_model and chain_effort == current_effort for alias, chain_effort in chain)
+                if any(alias == current_alias and chain_effort == current_effort for alias, chain_effort in chain)
             ]
             loose = [
                 name
                 for name, chain in chains.items()
-                if any(alias == current_model for alias, _ in chain)
+                if any(alias == current_alias for alias, _ in chain)
             ]
             for pool in (exact, loose):
                 if not pool:
@@ -201,7 +237,7 @@ def omh_delegate_route_handler(args: dict[str, Any], **kwargs) -> str:
             }
             return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
         chain = chains[category]
-        index = next((i for i, (alias, _) in enumerate(chain) if alias == current_model), -1)
+        index = next((i for i, (alias, _) in enumerate(chain) if alias == current_alias), -1)
         if index < 0 or index + 1 >= len(chain):
             # Chain exhausted: restore inheritance so the next dispatch runs on
             # the parent's known-working model instead of one more rejection.
@@ -213,13 +249,21 @@ def omh_delegate_route_handler(args: dict[str, Any], **kwargs) -> str:
             result["evidence_boundary"] = _EVIDENCE_BOUNDARY
             return json.dumps(attach_public_observation(result, observation), sort_keys=True)
         next_model, next_effort = chain[index + 1]
-        result = write_delegation_route(hermes_home, model=next_model, reasoning_effort=next_effort)
+        wire_model, next_provider = resolve_provider_model(
+            next_model, routes=provider_routes
+        )
+        result = write_delegation_route(
+            hermes_home,
+            model=wire_model,
+            reasoning_effort=next_effort,
+            provider=next_provider,
+        )
         if result.get("status") == "routed":
             result["status"] = "fell_back"
             result["category"] = category
             result["from"] = current_model
             result["fallback_candidates"] = [
-                {"model": alias, "reasoning_effort": chain_effort}
+                _chain_entry(alias, chain_effort, provider_routes)
                 for alias, chain_effort in chain[index + 2 :]
             ]
         result["evidence_boundary"] = _EVIDENCE_BOUNDARY
@@ -253,6 +297,7 @@ def omh_delegate_route_handler(args: dict[str, Any], **kwargs) -> str:
         model = head_model
         if not effort:
             effort = head_effort
+    model, provider = resolve_provider_model(model, provider, provider_routes)
     result = write_delegation_route(
         hermes_home, model=model, reasoning_effort=effort, provider=provider
     )

--- a/tests/test_delegate_route_tool.py
+++ b/tests/test_delegate_route_tool.py
@@ -123,6 +123,134 @@ class DelegateRouteToolTest(unittest.TestCase):
             encoding="utf-8",
         )
 
+    def _write_provider_routes(self, models: dict) -> None:
+        path = self.omh_home / "routing" / "model-providers.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"schema_version": "model_provider_routes/v1", "models": models}),
+            encoding="utf-8",
+        )
+
+    def test_a_routed_alias_dispatches_the_providers_own_model_name(self):
+        self._write_provider_routes(
+            {"gpt-5.6-sol": {"provider": "gateway", "model": "vendor/gpt-5.6-sol"}}
+        )
+        result = self._call(action="set", category="ultrabrain")
+        self.assertEqual(
+            result["applied"],
+            {
+                "model": "vendor/gpt-5.6-sol",
+                "provider": "gateway",
+                "reasoning_effort": "xhigh",
+            },
+        )
+
+    def test_an_unrouted_alias_dispatches_unchanged_with_no_provider(self):
+        self._write_provider_routes(
+            {"some-other-model": {"provider": "gateway", "model": "vendor/other"}}
+        )
+        result = self._call(action="set", category="ultrabrain")
+        self.assertEqual(
+            result["applied"], {"model": "gpt-5.6-sol", "reasoning_effort": "xhigh"}
+        )
+
+    def test_an_explicit_provider_outranks_a_stored_route(self):
+        self._write_provider_routes(
+            {"gpt-5.6-sol": {"provider": "gateway", "model": "vendor/gpt-5.6-sol"}}
+        )
+        result = self._call(
+            action="set", model="gpt-5.6-sol", reasoning_effort="high", provider="direct"
+        )
+        self.assertEqual(
+            result["applied"],
+            {"model": "gpt-5.6-sol", "provider": "direct", "reasoning_effort": "high"},
+        )
+
+    def test_fallback_finds_the_chain_position_of_a_routed_wire_model(self):
+        """The live route holds the wire model; chains are keyed by alias.
+
+        Without translating back, a routed model reads as absent from its own
+        chain and fallback errors instead of advancing.
+        """
+
+        self._write_overrides(
+            {
+                "quick": [
+                    {"model": "first-model", "reasoning_effort": "low"},
+                    {"model": "second-model", "reasoning_effort": "low"},
+                ]
+            }
+        )
+        self._write_provider_routes(
+            {
+                "first-model": {"provider": "gateway", "model": "vendor/first"},
+                "second-model": {"provider": "gateway", "model": "vendor/second"},
+            }
+        )
+        self._call(action="set", category="quick")
+        self.assertEqual(
+            read_delegation_route(self.home)["model"], "vendor/first"
+        )
+        fallback = self._call(action="fallback")
+        self.assertEqual(fallback["status"], "fell_back")
+        self.assertEqual(
+            fallback["applied"],
+            {
+                "model": "vendor/second",
+                "provider": "gateway",
+                "reasoning_effort": "low",
+            },
+        )
+
+    def test_status_reports_provider_route_state_and_dispatched_values(self):
+        result = self._call(action="status")
+        self.assertEqual(result["provider_routes"], "absent")
+        self.assertEqual(
+            Path(result["provider_routes_path"]),
+            self.omh_home / "routing" / "model-providers.json",
+        )
+        self._write_overrides(
+            {"deep": [{"model": "aliased-model", "reasoning_effort": "xhigh"}]}
+        )
+        self._write_provider_routes(
+            {"aliased-model": {"provider": "gateway", "model": "vendor/aliased"}}
+        )
+        applied = self._call(action="status")
+        self.assertEqual(applied["provider_routes"], "applied")
+        self.assertEqual(
+            applied["categories"]["deep"],
+            [
+                {
+                    "model": "aliased-model",
+                    "provider": "gateway",
+                    "reasoning_effort": "xhigh",
+                    "wire_model": "vendor/aliased",
+                }
+            ],
+        )
+
+    def test_an_invalid_provider_route_document_is_ignored_whole(self):
+        path = self.omh_home / "routing" / "model-providers.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "model_provider_routes/v1",
+                    "models": {
+                        "gpt-5.6-sol": {"provider": "gateway", "model": "vendor/ok"},
+                        "bad": {"provider": "gateway", "model": "not a token"},
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        status = self._call(action="status")
+        self.assertTrue(status["provider_routes"].startswith("invalid: "))
+        result = self._call(action="set", category="ultrabrain")
+        self.assertEqual(
+            result["applied"], {"model": "gpt-5.6-sol", "reasoning_effort": "xhigh"}
+        )
+
     def test_an_overridden_chain_routes_and_falls_back_on_the_users_order(self):
         self._write_overrides({
             "quick": [


### PR DESCRIPTION
## Feature Report

### What Changed

- New optional config surface `~/.omh/routing/model-providers.json` (`model_provider_routes/v1`) mapping a chain alias to `{provider, model}`.
- `hermes_delegation.py` gains the loader, parser, and two resolvers (`resolve_provider_model`, `chain_alias_for`) alongside the existing chain-override machinery it mirrors.
- `omh_delegate_route` applies those routes on `set` and on `fallback`, and `action=status` reports `provider_routes` / `provider_routes_path` beside the chain-override fields.
- `docs/INSTALLATION.md` documents the file under "Reaching models through a provider".

### Why This Exists

- Mixture chains name models the way a person says them (`glm-5.2`, `kimi-k3`). A host that reaches models through a provider needs two different values instead: a provider id, and that provider's own model string, usually namespaced `vendor/model-name`.
- Nothing bridged the two, so anyone in that position had to hand-edit the installed plugin file. That edit drifts from the install manifest and makes the next `omh setup` refuse to refresh — a real, recurring failure: the refusal has to be forced past and the edit re-applied on every update.
- Which provider serves which model, and under what name, is a property of one account. The repository must carry the mechanism and none of the values.

### User / Operator Impact

- Anyone routing through a gateway (OpenRouter, Together, Groq, a self-hosted proxy, anything) declares their mapping once in config and stops patching installed files. `omh setup` no longer has a reason to refuse.
- Hosts that bill providers directly see **no change**: OMH ships no routes and names no provider, and an alias with no entry dispatches exactly as before with no provider field.

### How It Works

- `set`: the alias is resolved to `(wire model, provider)` immediately before the route is written. An explicit `provider` argument short-circuits resolution, so a caller's direct choice outranks any stored route.
- `fallback`: the live route holds whatever was dispatched — the wire model when a route applied — while chain positions are keyed by alias. The wire model is translated back with `chain_alias_for` before any chain lookup; without that a routed model reads as absent from the very chain it came from and fallback errors instead of advancing. The next candidate is then resolved forward again.
- `status`: `model` stays the alias, with `provider` and `wire_model` added only when a route actually applies (the only case where they differ), so existing readers are unaffected.
- Validation is the chain-override contract verbatim: schema-version pinned, unknown fields rejected, every alias/provider/model matched against the same token regex, and an invalid document ignored **whole** rather than half-applied — surfaced as `provider_routes: invalid: <reason>`.

### Files And Contracts Touched

- `src/plugin_bundle/omh/hermes_delegation.py`, `src/plugin_bundle/omh/tools/delegate_route_tool.py`, `tests/test_delegate_route_tool.py`, `docs/INSTALLATION.md`.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests` (ran the CI form with `tools packaging`)
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `git diff --check`

### Observed Evidence

- Six new contracts in `tests/test_delegate_route_tool.py` (23/23 in that module): a routed alias dispatches the provider's model; an unrouted alias dispatches unchanged; an explicit provider outranks a stored route; fallback finds the chain position of a routed wire model and advances; status reports state, path, and dispatched values; an invalid document is ignored whole and the alias still dispatches plainly.
- Related modules together: 88/88 OK (`test_delegate_route_tool`, `test_plugin_distribution`, `test_model_chains_command`, `test_plugin_capabilities`).
- Full suite: 7120 tests. The only 28 failures are the known `.claude`-path `unsafe_read_root` refusal in `test_cross_harness_adapters` / `test_cross_harness_adapter_security`, caused by this checkout living under `.claude/worktrees/...`; unrelated to this change and green in CI.

### Not Tested / Not Applicable

- A live Hermes dispatch through a provider route. The tool contract is proven locally; the host's acceptance of the dispatched `(model, provider)` pair is not observed here.

## Risk

- Additive and opt-in. With the file absent — the default for every existing install — resolution is an identity function and every code path behaves as before.

## Compatibility / Rollout

- No migration. `status` gains two fields and keeps `model` semantics unchanged.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data

## Follow-Up

- An `omh model-providers` command mirroring `omh model-chains show/set` would make this reachable without editing JSON; not required for the fix and deliberately left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GRSYnsBfXd5hALXNA6333f
