### PR TITLE
fix(routing): complete provider route integrity

### DIFF
--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -354,6 +354,17 @@ conversation:
    `mixture_chain_overrides/v1` document.
 4. Re-run `omh model-chains show` and report the confirmed state.
 
+If a chain alias needs a provider-specific wire model, edit the sibling
+`~/.omh/routing/model-providers.json` document:
+
+```json
+{"schema_version":"model_provider_routes/v1","models":{"glm-5.2-ultrafast":{"provider":"opengateway","model":"z-ai/glm-5.2-ultrafast"}}}
+```
+
+Re-run `omh_delegate_route` with `action=status` and report its complete
+alias/provider/model/effort route. Provider and model overrides are atomic;
+never copy credentials into OMH.
+
 A user who declines the interview keeps the shipped defaults; record that as
 the observed result instead of skipping the step silently.
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -226,6 +226,7 @@ $ cat ~/.omh/routing/model-chains.json
 ```
 
 現在有効な chain は `omh model-chains show` で確認できます。ファイルを直接編集したくない場合は、`omh model-chains set quick "kimi-k3-ultrafast:low, glm-5.2-ultrafast:low"` のようにコマンドから同じファイルを書き換えられます。
+alias に provider 固有の wire ID が必要な場合は、`model_provider_routes/v1` 形式の `~/.omh/routing/model-providers.json` に一度マッピングします。その後は `set`、`status`、fallback、HUD が alias/provider/wire model の完全な route を表示します。OMH が保存するのは provider ID だけで、credential は保存しません。
 
 Hermes に **モデルをセットアップして** と頼むと、確認や変更ができます。これは編集可能な優先設定であり、benchmark 結果ではありません。詳しい設定、fallback、provider、所有権のルールは [Guided Model Setup](docs/INSTALLATION.md#guided-model-setup) を参照してください。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -224,6 +224,7 @@ $ cat ~/.omh/routing/model-chains.json
 ```
 
 현재 적용 중인 chain은 `omh model-chains show`로 확인할 수 있습니다. 파일을 직접 고치는 대신 명령으로 바꾸고 싶다면 `omh model-chains set quick "kimi-k3-ultrafast:low, glm-5.2-ultrafast:low"`처럼 실행하면 이 파일이 그대로 수정됩니다.
+alias에 provider 전용 wire ID가 필요하면 `model_provider_routes/v1` 형식의 `~/.omh/routing/model-providers.json`에 한 번 매핑하세요. 이후 `set`, `status`, fallback, HUD가 alias/provider/wire model 전체 route를 표시합니다. OMH는 provider ID만 저장하며 credential은 저장하지 않습니다.
 
 Hermes에게 **모델을 설정해 줘**라고 요청해 검토하거나 변경할 수 있습니다. 이는 편집 가능한 선호이며 benchmark 결과가 아닙니다. 자세한 설정, fallback, provider, 소유권 규칙은 [Guided Model Setup](docs/INSTALLATION.md#guided-model-setup)을 참조하세요.
 

--- a/README.md
+++ b/README.md
@@ -309,6 +309,11 @@ fallback, and HUD labels alike —
 Check the chains currently in effect with `omh model-chains show`. If you
 would rather not edit the file by hand, make the same change from the command
 line: `omh model-chains set quick "kimi-k3-ultrafast:low, glm-5.2-ultrafast:low"`.
+When an alias uses a provider-specific wire ID, map it once in
+`~/.omh/routing/model-providers.json` with
+`model_provider_routes/v1`; `set`, `status`, fallback, and HUD then report the
+complete alias/provider/wire-model route. OMH stores only provider IDs, never
+provider credentials.
 
 Ask Hermes to **set up my models** to review or change them. These are editable
 preferences, not benchmark results. See

--- a/README.zh.md
+++ b/README.zh.md
@@ -225,6 +225,7 @@ $ cat ~/.omh/routing/model-chains.json
 ```
 
 当前生效的 chain 可用 `omh model-chains show` 查看。不想手动编辑文件的话，也可以运行 `omh model-chains set quick "kimi-k3-ultrafast:low, glm-5.2-ultrafast:low"`，同一个文件会被直接修改。
+如果 alias 需要 provider 专用的 wire ID，请在 `~/.omh/routing/model-providers.json` 中按 `model_provider_routes/v1` 映射一次。此后 `set`、`status`、fallback 和 HUD 都会显示完整的 alias/provider/wire model route。OMH 只保存 provider ID，不保存 credential。
 
 请让 Hermes **设置我的模型**，以查看或更改这些推荐。它们是可编辑的偏好，不是 benchmark 结果。详细的设置、fallback、provider 与所有权规则见 [Guided Model Setup](docs/INSTALLATION.md#guided-model-setup)。
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -301,12 +301,19 @@ Supply them in `~/.omh/routing/model-providers.json`
 An alias listed here dispatches as that provider's model; an alias not listed
 dispatches unchanged with no provider, which is what a direct-billing host
 wants — the file is optional and absent by default. A `provider` passed
-explicitly to `omh_delegate_route` outranks any stored route. Fallback still
-walks the chain by alias, so a routed model is translated back before its
-chain position is looked up. Validation matches the chain document: strict,
-token-only, atomic, with an invalid file ignored whole and reported by
-`action=status` as `provider_routes: invalid: ...` beside the resolved
-`provider_routes_path`.
+explicitly with its wire `model` to `omh_delegate_route` outranks any stored
+route. Provider and model change atomically; partial pairs and providerless
+wire-shaped models fail before Hermes config is mutated. Fallback translates
+an active exact provider/wire pair back to one alias and requires the category
+when that alias has multiple chain origins. Validation is strict, token-only,
+and atomic: an invalid file is reported by `action=status` and blocks set or
+fallback rather than silently inheriting a parent provider.
+
+`action=status` and fallback results expose the complete
+`alias`/`provider`/`model`/`reasoning_effort` shape. HUD rows use the same
+configured mapping for labeling and mark the provider source as
+`model_provider_routes`; that configured metadata is not provider execution
+or credential evidence.
 
 The X/Grok row is a static, editable affinity for work explicitly declaring X
 platform data. It is not a measured capability, performance, or availability

--- a/src/plugin_bundle/omh/delegation_routing.py
+++ b/src/plugin_bundle/omh/delegation_routing.py
@@ -30,17 +30,14 @@ import os
 import re
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 ROUTABLE_KEYS = ("model", "reasoning_effort", "provider")
 
 _VALUE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$")
 _SECTION_RE = re.compile(r"^delegation:\s*(#.*)?$")
-_TOP_LEVEL_RE = re.compile(r"^[A-Za-z0-9_-]+\s*:")
-
-
-def _managed_key_re(key: str) -> re.Pattern[str]:
-    return re.compile(rf"^\s+{re.escape(key)}\s*:")
+def _managed_key_re(key: str, indent: int) -> re.Pattern[str]:
+    return re.compile(rf"^ {{{indent}}}{re.escape(key)}\s*:")
 
 
 def read_delegation_route(hermes_home: str | Path | None = None) -> dict[str, str]:
@@ -50,24 +47,36 @@ def read_delegation_route(hermes_home: str | Path | None = None) -> dict[str, st
     this reports is what Hermes will actually resolve.
     """
     config_path = _config_path(hermes_home)
-    try:
-        text = config_path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
+    text, _, error = _read_config_snapshot(config_path)
+    if error:
         return {}
+    return _read_delegation_route_text(text)
+
+
+def _read_delegation_route_text(text: str) -> dict[str, str]:
+    lines = text.splitlines()
+    if _has_unsupported_delegation(lines):
+        return {}
+    child_indents = _delegation_child_indents(lines)
     values: dict[str, str] = {}
     in_section = False
-    for line in text.splitlines():
+    child_indent = 2
+    for index, line in enumerate(lines):
         if _SECTION_RE.match(line):
             in_section = True
+            child_indent = child_indents.get(index, 2)
             continue
-        if in_section and _TOP_LEVEL_RE.match(line):
+        if in_section and _top_level_key(line) is not None:
             in_section = False
         if not in_section:
             continue
         for key in ROUTABLE_KEYS:
-            if _managed_key_re(key).match(line):
+            if _managed_key_re(key, child_indent).match(line):
                 _, _, raw = line.partition(":")
-                values[key] = raw.split("#", 1)[0].strip().strip("'\"")
+                value = _yaml_string_token(raw)
+                if value is None:
+                    return {}
+                values[key] = value
     return values
 
 
@@ -78,6 +87,7 @@ def write_delegation_route(
     reasoning_effort: str = "",
     provider: str = "",
     clear: bool = False,
+    expected_previous: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
     """Set (or clear) the routable delegation keys, touching nothing else.
 
@@ -93,35 +103,48 @@ def write_delegation_route(
         if value and not _VALUE_RE.match(value):
             return {"status": "error", "error": f"invalid {key} value"}
     config_path = _config_path(hermes_home)
-    if config_path.is_symlink():
-        return {"status": "error", "error": "config.yaml is a symlink; refusing to rewrite it"}
-    try:
-        text = config_path.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        text = ""
-    except (OSError, UnicodeDecodeError) as exc:
-        return {"status": "error", "error": f"config unreadable: {type(exc).__name__}"}
-
-    previous = read_delegation_route(hermes_home)
+    text, signature, error = _read_config_snapshot(config_path)
+    if error:
+        return {"status": "error", "error": error}
+    if _file_signature(config_path) != signature:
+        return {"status": "error", "error": "config changed during route read"}
+    previous = _read_delegation_route_text(text)
+    if expected_previous is not None and previous != dict(expected_previous):
+        return {
+            "status": "error",
+            "error": "active route changed before fallback write",
+        }
     lines = text.splitlines()
+    if _has_unsupported_delegation(lines):
+        return {
+            "status": "error",
+            "error": "unsupported delegation mapping; refusing to rewrite it",
+        }
+    child_indents = _delegation_child_indents(lines)
     output: list[str] = []
     inserted = False
     in_section = False
     section_seen = False
-    for line in lines:
+    child_indent = 2
+    for index, line in enumerate(lines):
         if _SECTION_RE.match(line):
             in_section = True
             section_seen = True
             output.append(line)
+            child_indent = child_indents.get(index, 2)
+            prefix = " " * child_indent
             for key in ROUTABLE_KEYS:
                 value = desired.get(key, "")
                 if value:
-                    output.append(f"  {key}: {value}")
+                    output.append(f"{prefix}{key}: '{value}'")
             inserted = True
             continue
-        if in_section and _TOP_LEVEL_RE.match(line):
+        if in_section and _top_level_key(line) is not None:
             in_section = False
-        if in_section and any(_managed_key_re(key).match(line) for key in ROUTABLE_KEYS):
+        if in_section and any(
+            _managed_key_re(key, child_indent).match(line)
+            for key in ROUTABLE_KEYS
+        ):
             continue
         output.append(line)
     wanted = {key: value for key, value in desired.items() if value}
@@ -132,7 +155,7 @@ def write_delegation_route(
         for key in ROUTABLE_KEYS:
             value = wanted.get(key, "")
             if value:
-                output.append(f"  {key}: {value}")
+                output.append(f"  {key}: '{value}'")
         section_seen = True
     if not section_seen and not wanted:
         # Nothing to remove and nothing to add: leave the file untouched.
@@ -149,6 +172,12 @@ def write_delegation_route(
         try:
             with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
                 handle.write(new_text)
+            if _file_signature(config_path) != signature:
+                os.unlink(temp_name)
+                return {
+                    "status": "error",
+                    "error": "config changed during route update",
+                }
             if config_path.exists():
                 os.chmod(temp_name, config_path.stat().st_mode & 0o7777)
             os.replace(temp_name, config_path)
@@ -170,3 +199,111 @@ def write_delegation_route(
 def _config_path(hermes_home: str | Path | None) -> Path:
     home = Path(hermes_home).expanduser() if hermes_home else Path.home() / ".hermes"
     return home / "config.yaml"
+
+
+def _delegation_child_indents(lines: list[str]) -> dict[int, int]:
+    indents: dict[int, int] = {}
+    section_index: int | None = None
+    for index, line in enumerate(lines):
+        if _SECTION_RE.match(line):
+            section_index = index
+            continue
+        if section_index is None:
+            continue
+        if _top_level_key(line) is not None:
+            section_index = None
+            continue
+        stripped = line.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(line) - len(stripped)
+        if indent:
+            indents[section_index] = min(indents.get(section_index, indent), indent)
+    return indents
+
+
+def _file_signature(path: Path) -> tuple[int, int, int, int] | None:
+    try:
+        stat = path.lstat()
+    except FileNotFoundError:
+        return None
+    return (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns)
+
+
+def _read_config_snapshot(
+    path: Path,
+) -> tuple[str, tuple[int, int, int, int] | None, str]:
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except FileNotFoundError:
+        return "", None, ""
+    except OSError as exc:
+        if path.is_symlink():
+            return "", None, "config.yaml is a symlink; refusing to rewrite it"
+        return "", None, f"config unreadable: {type(exc).__name__}"
+    try:
+        stat = os.fstat(descriptor)
+        with os.fdopen(descriptor, "r", encoding="utf-8") as handle:
+            text = handle.read()
+    except (OSError, UnicodeDecodeError) as exc:
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+        return "", None, f"config unreadable: {type(exc).__name__}"
+    signature = (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns)
+    return text, signature, ""
+
+
+def _has_unsupported_delegation(lines: list[str]) -> bool:
+    return any(
+        _top_level_key(line) == "delegation" and not _SECTION_RE.match(line)
+        for line in lines
+    )
+
+
+def _top_level_key(line: str) -> str | None:
+    if not line or line[0].isspace() or line.startswith("#"):
+        return None
+    if line[0] in {"'", '"'}:
+        quote = line[0]
+        end = line.find(quote, 1)
+        if end < 0 or not line[end + 1 :].lstrip().startswith(":"):
+            return None
+        return line[1:end]
+    key, separator, _ = line.partition(":")
+    return key.strip() if separator and key.strip() else None
+
+
+def _yaml_string_token(raw: str) -> str | None:
+    value = raw.split("#", 1)[0].strip()
+    if (
+        len(value) >= 2
+        and value[0] in {"'", '"'}
+        and value[-1] == value[0]
+    ):
+        token = value[1:-1]
+        return token if _VALUE_RE.fullmatch(token) else None
+    lowered = value.casefold()
+    if lowered in {
+        "",
+        "~",
+        "null",
+        "true",
+        "false",
+        "yes",
+        "no",
+        "on",
+        "off",
+        "y",
+        "n",
+    }:
+        return None
+    if re.fullmatch(
+        r"(?:[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:e[-+]?\d+)?"
+        r"|0x[0-9a-f]+|0o[0-7]+|\d{4}-\d{2}-\d{2})",
+        lowered,
+    ):
+        return None
+    return value if _VALUE_RE.fullmatch(value) else None

--- a/src/plugin_bundle/omh/delegation_routing.py
+++ b/src/plugin_bundle/omh/delegation_routing.py
@@ -257,10 +257,30 @@ def _read_config_snapshot(
 
 
 def _has_unsupported_delegation(lines: list[str]) -> bool:
-    return any(
-        _top_level_key(line) == "delegation" and not _SECTION_RE.match(line)
-        for line in lines
-    )
+    child_indents = _delegation_child_indents(lines)
+    in_section = False
+    child_indent = 2
+    for index, line in enumerate(lines):
+        top_level_key = _top_level_key(line)
+        if top_level_key == "delegation":
+            if not _SECTION_RE.match(line):
+                return True
+            in_section = True
+            child_indent = child_indents.get(index, 2)
+            continue
+        if in_section and top_level_key is not None:
+            in_section = False
+        if not in_section:
+            continue
+        key = _mapping_key(line, child_indent)
+        if key not in ROUTABLE_KEYS:
+            continue
+        if not _managed_key_re(key, child_indent).match(line):
+            return True
+        _, _, raw = line.partition(":")
+        if _yaml_string_token(raw) is None:
+            return True
+    return False
 
 
 def _top_level_key(line: str) -> str | None:
@@ -274,6 +294,16 @@ def _top_level_key(line: str) -> str | None:
         return line[1:end]
     key, separator, _ = line.partition(":")
     return key.strip() if separator and key.strip() else None
+
+
+def _mapping_key(line: str, indent: int) -> str | None:
+    prefix = " " * indent
+    if not line.startswith(prefix):
+        return None
+    remainder = line[indent:]
+    if not remainder or remainder[0].isspace():
+        return None
+    return _top_level_key(remainder)
 
 
 def _yaml_string_token(raw: str) -> str | None:
@@ -302,7 +332,7 @@ def _yaml_string_token(raw: str) -> str | None:
         return None
     if re.fullmatch(
         r"(?:[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:e[-+]?\d+)?"
-        r"|0x[0-9a-f]+|0o[0-7]+|\d{4}-\d{2}-\d{2})",
+        r"|0x[0-9a-f]+|0o[0-7]+|0b[01]+|\d{4}-\d{2}-\d{2})",
         lowered,
     ):
         return None

--- a/src/plugin_bundle/omh/hermes_delegation.py
+++ b/src/plugin_bundle/omh/hermes_delegation.py
@@ -111,7 +111,7 @@ def load_mixture_chain_overrides(
     """
     path = mixture_chain_overrides_path(omh_home)
     try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
+        raw = _strict_json_loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError:
         return {}, "absent"
     except (OSError, UnicodeDecodeError, ValueError):
@@ -151,11 +151,13 @@ def parse_mixture_chain_overrides(
             unknown_keys = sorted(set(entry) - {"model", "reasoning_effort"})
             if unknown_keys:
                 return {}, f"invalid: category {name!r} entry fields {unknown_keys}"
-            model = str(entry.get("model", ""))
-            effort = str(entry.get("reasoning_effort", ""))
-            if not _CHAIN_TOKEN_RE.match(model):
+            model = entry.get("model", "")
+            effort = entry.get("reasoning_effort", "")
+            if not isinstance(model, str) or not _CHAIN_TOKEN_RE.fullmatch(model):
                 return {}, f"invalid: category {name!r} names a non-token model"
-            if effort and not _CHAIN_TOKEN_RE.match(effort):
+            if not isinstance(effort, str) or (
+                effort and not _CHAIN_TOKEN_RE.fullmatch(effort)
+            ):
                 return {}, f"invalid: category {name!r} names a non-token effort"
             chain.append((model, effort))
         overrides[name] = tuple(chain)
@@ -207,7 +209,7 @@ def load_model_provider_routes(
     """
     path = model_provider_routes_path(omh_home)
     try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
+        raw = _strict_json_loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError:
         return {}, "absent"
     except (OSError, UnicodeDecodeError, ValueError):
@@ -231,20 +233,20 @@ def parse_model_provider_routes(
         return {}, f"invalid: unsupported fields {unknown}"
     routes: dict[str, tuple[str, str]] = {}
     for alias, entry in models.items():
-        if not _CHAIN_TOKEN_RE.match(str(alias)):
+        if not isinstance(alias, str) or not _CHAIN_TOKEN_RE.fullmatch(alias):
             return {}, f"invalid: alias {alias!r} is not a token"
         if not isinstance(entry, dict):
             return {}, f"invalid: alias {alias!r} must map to an object"
         unknown_keys = sorted(set(entry) - {"provider", "model"})
         if unknown_keys:
             return {}, f"invalid: alias {alias!r} entry fields {unknown_keys}"
-        provider = str(entry.get("provider", ""))
-        model = str(entry.get("model", ""))
-        if not _CHAIN_TOKEN_RE.match(provider):
+        provider = entry.get("provider", "")
+        model = entry.get("model", "")
+        if not isinstance(provider, str) or not _CHAIN_TOKEN_RE.fullmatch(provider):
             return {}, f"invalid: alias {alias!r} names a non-token provider"
-        if not _CHAIN_TOKEN_RE.match(model):
+        if not isinstance(model, str) or not _CHAIN_TOKEN_RE.fullmatch(model):
             return {}, f"invalid: alias {alias!r} names a non-token model"
-        routes[str(alias)] = (provider, model)
+        routes[alias] = (provider, model)
     return routes, "applied"
 
 
@@ -270,6 +272,7 @@ def resolve_provider_model(
 
 def chain_alias_for(
     model: str,
+    provider: str = "",
     routes: Mapping[str, tuple[str, str]] | None = None,
 ) -> str:
     """Map a wire model back to the alias its chain uses.
@@ -278,10 +281,39 @@ def chain_alias_for(
     wire model has to be translated back before any chain lookup; otherwise a
     routed model looks absent from the chain it came from.
     """
-    for alias, (_, wire_model) in (routes or {}).items():
-        if model == wire_model:
-            return alias
-    return model
+    if not provider:
+        return model
+    aliases = {
+        alias
+        for alias, (route_provider, wire_model) in (routes or {}).items()
+        if provider == route_provider and model == wire_model
+    }
+    return next(iter(aliases)) if len(aliases) == 1 else model
+
+
+def configured_route_for_wire(
+    model: str,
+    routes: Mapping[str, tuple[str, str]] | None = None,
+) -> tuple[str, str]:
+    """Return one uniquely configured alias/provider for an observed wire model."""
+    matches = {
+        (alias, provider)
+        for alias, (provider, wire_model) in (routes or {}).items()
+        if model == wire_model
+    }
+    return next(iter(matches)) if len(matches) == 1 else (model, "")
+
+
+def _strict_json_loads(text: str) -> object:
+    def unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        result: dict[str, object] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"duplicate JSON key {key!r}")
+            result[key] = value
+        return result
+
+    return json.loads(text, object_pairs_hook=unique_object)
 
 # Rough USD-per-million-token list prices used ONLY when the host recorded no
 # cost (subscription billing bills nothing per call; the owner asked for an
@@ -584,6 +616,7 @@ def read_hermes_native_subagents(
     # Category labels honor the user's ~/.omh/routing/model-chains.json
     # overrides so a customized chain labels its children like a shipped one.
     active_chains = effective_mixture_category_chains(omh_home)
+    provider_routes, _ = load_model_provider_routes(omh_home)
     payload: dict[str, Any] = {
         "status": "idle",
         "rows": [],
@@ -677,6 +710,10 @@ def read_hermes_native_subagents(
                 cost_approximate = True
 
         parent_model = state.get("parent_models", {}).get(child["parent_id"], "")
+        route_alias, route_provider = configured_route_for_wire(
+            child["model"],
+            provider_routes,
+        )
         session_tail = child["session_id"].rsplit("_", 1)[-1][:8]
         # A finished child's elapsed is frozen at its last activity: a done
         # task should not keep aging, and a byte-stable lingering row is what
@@ -687,19 +724,23 @@ def read_hermes_native_subagents(
             "task_id": session_tail,
             "role": "hermes-native",
             "action": _text(task.get("goal", ""), limit=_ACTION_LIMIT),
+            "alias": route_alias,
+            "provider": route_provider,
             "model": child["model"],
             "effort": child["effort"],
             "tokens": tokens_total if tokens_total else None,
             "elapsed_seconds": max(0.0, elapsed_until - child["started_at"]),
             "observed_at": _iso_utc(last_activity),
             "category": mixture_category_for(
-                child["model"],
+                route_alias,
                 child["effort"],
                 parent_model=parent_model,
                 chains=active_chains,
             ),
             "delegation_id": delegation_id,
         }
+        if route_provider:
+            row["provider_source"] = "model_provider_routes"
         if failure_hint:
             row["failure_hint"] = failure_hint
         api_calls = usage.get("api_calls")

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -664,7 +664,7 @@ def read_omh_hud(
     }
     # Hermes-native delegate_task children are work the HUD must show even
     # though they never touch the OMH runtime store; see hermes_delegation.
-    native = read_hermes_native_subagents(hermes)
+    native = read_hermes_native_subagents(hermes, omh_home=home)
     if native["rows"]:
         merged = payload["subagents"]
         merged["rows"] = (list(merged["rows"]) + list(native["rows"]))[:5]

--- a/src/plugin_bundle/omh/tools/delegate_route_tool.py
+++ b/src/plugin_bundle/omh/tools/delegate_route_tool.py
@@ -196,6 +196,21 @@ def omh_delegate_route_handler(args: dict[str, Any], **kwargs) -> str:
         # wire model when a route applied. Chain positions are keyed by alias,
         # so translate back before any chain lookup below -- otherwise a routed
         # model reads as absent from the very chain it came from.
+        if not current_provider and any(
+            current_model in {alias, wire_model}
+            for alias, (_, wire_model) in provider_routes.items()
+        ):
+            payload = {
+                "status": "error",
+                "error": (
+                    f"current route {current_model!r} requires configured "
+                    "provider identity"
+                ),
+            }
+            return json.dumps(
+                attach_public_observation(payload, observation),
+                sort_keys=True,
+            )
         current_alias = chain_alias_for(
             current_model,
             current_provider,

--- a/src/plugin_bundle/omh/tools/delegate_route_tool.py
+++ b/src/plugin_bundle/omh/tools/delegate_route_tool.py
@@ -7,7 +7,6 @@ from ..delegation_routing import read_delegation_route, write_delegation_route
 from ..hermes_delegation import (
     HERMES_MIXTURE_CATEGORY_CHAINS,
     chain_alias_for,
-    effective_mixture_category_chains,
     load_mixture_chain_overrides,
     load_model_provider_routes,
     mixture_chain_overrides_path,
@@ -29,16 +28,19 @@ def _chain_entry(
 ) -> dict[str, str]:
     """Render one chain position.
 
-    `model` stays the alias the chain is written in, so a host with no
-    provider routes sees exactly what it always saw. The dispatched values
-    appear beside it only when a route actually applies, which is also the
-    only case where they differ.
+    The public shape always carries alias, provider, executable model, and
+    effort; unresolved aliases report an empty provider explicitly.
     """
-    entry = {"model": alias, "reasoning_effort": effort}
+    entry = {
+        "alias": alias,
+        "provider": "",
+        "model": alias,
+        "reasoning_effort": effort,
+    }
     wire_model, provider = resolve_provider_model(alias, routes=routes)
     if provider:
         entry["provider"] = provider
-        entry["wire_model"] = wire_model
+        entry["model"] = wire_model
     return entry
 
 
@@ -54,8 +56,9 @@ OMH_DELEGATE_ROUTE_SCHEMA = {
         "Hermes has NO provider-side fallback: a child whose model the billing account "
         "cannot serve dies on an HTTP 400 yet its delegation still reports completed with "
         "the error text as the result — a completed child with no recorded model usage "
-        "means exactly this. When that happens call action=fallback to advance the route "
-        "to the category chain's next candidate and re-dispatch; an exhausted chain "
+        "means exactly this. When that happens call action=fallback with the category "
+        "returned by set to advance the route and re-dispatch; shared routes fail "
+        "closed without that origin. An exhausted chain "
         "clears the route so the next dispatch inherits the parent's working model."
     ),
     "parameters": {
@@ -68,8 +71,8 @@ OMH_DELEGATE_ROUTE_SCHEMA = {
                     "set writes a route; clear removes the routable keys so children "
                     "inherit the parent again; status reads the current route; fallback "
                     "advances the current route to the next candidate in its category "
-                    "chain (clearing to parent inheritance once the chain is exhausted) "
-                    "— use it after a dispatched child completed with no model usage."
+                    "chain (clearing to parent inheritance once the chain is exhausted). "
+                    "Reuse the category returned by set; ambiguous origins fail closed."
                 ),
             },
             "category": {
@@ -102,9 +105,8 @@ OMH_DELEGATE_ROUTE_SCHEMA = {
             "provider": {
                 "type": "string",
                 "description": (
-                    "Optional delegation.provider override for models that live on a "
-                    "different provider than the parent session. Requires that provider "
-                    "to be configured in Hermes."
+                    "Hermes provider override. Supply it together with model so the "
+                    "provider/wire identity remains atomic."
                 ),
             },
             "hermes_home": {
@@ -114,8 +116,8 @@ OMH_DELEGATE_ROUTE_SCHEMA = {
             "omh_home": {
                 "type": "string",
                 "description": (
-                    "Optional OMH home override for the chain-override document "
-                    "(routing/model-chains.json). Defaults to ~/.omh."
+                    "Optional OMH home override for model-chains.json and "
+                    "model-providers.json. Defaults to ~/.omh."
                 ),
             },
             "observation": OBSERVATION_SCHEMA,
@@ -131,8 +133,11 @@ def omh_delegate_route_handler(args: dict[str, Any], **kwargs) -> str:
     omh_home = str(args.get("omh_home", "") or "") or None
     # Every chain read below honors the user's routing/model-chains.json
     # overrides; the category vocabulary itself stays the shipped closed set.
-    chains = effective_mixture_category_chains(omh_home)
-    _, override_status = load_mixture_chain_overrides(omh_home)
+    overrides, override_status = load_mixture_chain_overrides(omh_home)
+    chains = {
+        name: overrides.get(name, chain)
+        for name, chain in HERMES_MIXTURE_CATEGORY_CHAINS.items()
+    }
     # Chains name models the way a person says them. A host that reaches
     # models through a provider needs a provider id and that provider's own
     # (often namespaced) model string; routing/model-providers.json supplies
@@ -140,9 +145,17 @@ def omh_delegate_route_handler(args: dict[str, Any], **kwargs) -> str:
     provider_routes, provider_route_status = load_model_provider_routes(omh_home)
 
     if action == "status":
+        route = read_delegation_route(hermes_home)
+        if route.get("model"):
+            route.setdefault("provider", "")
+            route["alias"] = chain_alias_for(
+                str(route["model"]),
+                str(route["provider"]),
+                provider_routes,
+            )
         payload: dict[str, Any] = {
             "status": "status",
-            "route": read_delegation_route(hermes_home),
+            "route": route,
             "categories": {
                 category: [
                     _chain_entry(alias, effort, provider_routes)
@@ -164,14 +177,30 @@ def omh_delegate_route_handler(args: dict[str, Any], **kwargs) -> str:
         return json.dumps(attach_public_observation(result, observation), sort_keys=True)
 
     if action == "fallback":
+        if override_status.startswith("invalid:"):
+            payload = {"status": "error", "error": override_status}
+            return json.dumps(
+                attach_public_observation(payload, observation),
+                sort_keys=True,
+            )
+        if provider_route_status.startswith("invalid:"):
+            payload = {"status": "error", "error": provider_route_status}
+            return json.dumps(
+                attach_public_observation(payload, observation),
+                sort_keys=True,
+            )
         route = read_delegation_route(hermes_home)
         current_model = str(route.get("model", ""))
+        current_provider = str(route.get("provider", ""))
         # The live route holds whatever was dispatched, which is the provider's
         # wire model when a route applied. Chain positions are keyed by alias,
         # so translate back before any chain lookup below -- otherwise a routed
         # model reads as absent from the very chain it came from.
-        current_alias = chain_alias_for(current_model, provider_routes)
-        current_effort = str(route.get("reasoning_effort", ""))
+        current_alias = chain_alias_for(
+            current_model,
+            current_provider,
+            provider_routes,
+        )
         if not current_model:
             payload = {
                 "status": "error",
@@ -188,60 +217,51 @@ def omh_delegate_route_handler(args: dict[str, Any], **kwargs) -> str:
                 ),
             }
             return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
-        if not category:
-            # A (model, effort) pair can sit in several chains — e.g.
-            # glm-5.2-ultrafast:low ends unspecified-low AND heads quick.
-            # Prefer the effort-exact match, and within each pool prefer a
-            # chain that can still advance: fallback exists to move forward,
-            # so an ambiguous route only reads as exhausted when NO matching
-            # chain has a next candidate.
-            def _chain_index(chain: tuple) -> int:
-                return next((i for i, (alias, _) in enumerate(chain) if alias == current_alias), -1)
-
-            exact = [
-                name
-                for name, chain in chains.items()
-                if any(alias == current_alias and chain_effort == current_effort for alias, chain_effort in chain)
-            ]
-            loose = [
-                name
-                for name, chain in chains.items()
-                if any(alias == current_alias for alias, _ in chain)
-            ]
-            for pool in (exact, loose):
-                if not pool:
-                    continue
-                advancing = [
-                    name
-                    for name in pool
-                    if 0 <= _chain_index(chains[name])
-                    < len(chains[name]) - 1
-                ]
-                # Head-most wins: a route set from a category starts at that
-                # chain's head, so when a (model, effort) pair sits in several
-                # advancing chains, the one holding it earliest is the likely
-                # origin (glm-5.2-ultrafast:low heads quick but is mid-chain
-                # in unspecified-low). Explicit `category` overrides.
-                category = min(
-                    advancing or pool,
-                    key=lambda name: _chain_index(chains[name]),
-                )
-                break
-        if not category:
+        if not current_provider and "/" in current_model:
+            payload = {
+                "status": "error",
+                "error": f"current route {current_model!r} requires an explicit provider",
+            }
+            return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
+        matches = [
+            (name, index)
+            for name, chain in chains.items()
+            for index, (alias, _) in enumerate(chain)
+            if alias == current_alias and (not category or name == category)
+        ]
+        if not matches:
             payload = {
                 "status": "error",
                 "error": (
-                    f"current route model {current_model!r} is not in any mixture chain; "
-                    "pass category explicitly"
+                    f"current route model {current_model!r} does not match "
+                    + (
+                        f"category {category!r}"
+                        if category
+                        else "any mixture chain; pass category explicitly"
+                    )
                 ),
             }
             return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
+        if len(matches) > 1:
+            origins = ", ".join(sorted({name for name, _ in matches}))
+            payload = {
+                "status": "error",
+                "error": (
+                    f"current route model {current_model!r} has ambiguous origins "
+                    f"across {origins}; pass category explicitly"
+                ),
+            }
+            return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
+        category, index = matches[0]
         chain = chains[category]
-        index = next((i for i, (alias, _) in enumerate(chain) if alias == current_alias), -1)
-        if index < 0 or index + 1 >= len(chain):
+        if index + 1 >= len(chain):
             # Chain exhausted: restore inheritance so the next dispatch runs on
             # the parent's known-working model instead of one more rejection.
-            result = write_delegation_route(hermes_home, clear=True)
+            result = write_delegation_route(
+                hermes_home,
+                clear=True,
+                expected_previous=route,
+            )
             if result.get("status") == "cleared":
                 result["status"] = "exhausted_to_inherit"
             result["category"] = category
@@ -252,14 +272,25 @@ def omh_delegate_route_handler(args: dict[str, Any], **kwargs) -> str:
         wire_model, next_provider = resolve_provider_model(
             next_model, routes=provider_routes
         )
+        if "/" in wire_model and not next_provider:
+            payload = {
+                "status": "error",
+                "error": (
+                    f"next route {next_model!r} has no provider-aware wire model; "
+                    "fallback refused without mutation"
+                ),
+            }
+            return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
         result = write_delegation_route(
             hermes_home,
             model=wire_model,
             reasoning_effort=next_effort,
             provider=next_provider,
+            expected_previous=route,
         )
         if result.get("status") == "routed":
             result["status"] = "fell_back"
+            result["applied"]["alias"] = next_model
             result["category"] = category
             result["from"] = current_model
             result["fallback_candidates"] = [
@@ -276,6 +307,12 @@ def omh_delegate_route_handler(args: dict[str, Any], **kwargs) -> str:
         }
         return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
 
+    if override_status.startswith("invalid:"):
+        payload = {"status": "error", "error": override_status}
+        return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
+    if provider_route_status.startswith("invalid:"):
+        payload = {"status": "error", "error": provider_route_status}
+        return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
     category = str(args.get("category", "") or "").strip()
     model = str(args.get("model", "") or "").strip()
     effort = str(args.get("reasoning_effort", "") or "").strip()
@@ -289,23 +326,42 @@ def omh_delegate_route_handler(args: dict[str, Any], **kwargs) -> str:
             ),
         }
         return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
-    if not model:
-        if not category:
-            payload = {"status": "error", "error": "set needs a category or an explicit model"}
-            return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
-        head_model, head_effort = chains[category][0]
-        model = head_model
+    if provider and not model:
+        payload = {
+            "status": "error",
+            "error": "provider and model overrides must appear together",
+        }
+        return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
+    if not model and not category:
+        payload = {"status": "error", "error": "set needs a category or an explicit model"}
+        return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
+    alias = model
+    if category and not model:
+        alias, head_effort = chains[category][0]
         if not effort:
             effort = head_effort
-    model, provider = resolve_provider_model(model, provider, provider_routes)
+    if provider:
+        wire_model = model
+    else:
+        wire_model, provider = resolve_provider_model(alias, routes=provider_routes)
+    if "/" in wire_model and not provider:
+        payload = {
+            "status": "error",
+            "error": "a wire-shaped model requires an explicit provider",
+        }
+        return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
     result = write_delegation_route(
-        hermes_home, model=model, reasoning_effort=effort, provider=provider
+        hermes_home,
+        model=wire_model,
+        reasoning_effort=effort,
+        provider=provider,
     )
     if result.get("status") == "routed":
+        result["applied"]["alias"] = alias
         result["category"] = category
         chain = chains.get(category, ())
         result["fallback_candidates"] = [
-            {"model": alias, "reasoning_effort": chain_effort}
+            _chain_entry(alias, chain_effort, provider_routes)
             for alias, chain_effort in chain[1:]
         ]
     result["evidence_boundary"] = _EVIDENCE_BOUNDARY

--- a/tests/test_delegate_route_tool.py
+++ b/tests/test_delegate_route_tool.py
@@ -9,9 +9,11 @@ projection over the shipped mixture chains.
 """
 
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from omh.plugin_bundle.omh.delegation_routing import (
     read_delegation_route,
@@ -32,7 +34,7 @@ class DelegationRouteWriterTest(unittest.TestCase):
         self.assertEqual(result["status"], "routed")
         self.assertEqual(
             self.config.read_text(encoding="utf-8"),
-            "delegation:\n  model: gpt-5.6-sol\n  reasoning_effort: xhigh\n",
+            "delegation:\n  model: 'gpt-5.6-sol'\n  reasoning_effort: 'xhigh'\n",
         )
 
     def test_routing_preserves_every_unmanaged_byte_of_an_existing_config(self):
@@ -52,7 +54,7 @@ class DelegationRouteWriterTest(unittest.TestCase):
             self.config.read_text(encoding="utf-8"),
             "model: kimi-k3\n"
             "delegation:\n"
-            "  model: glm-5.2-ultrafast\n"
+            "  model: 'glm-5.2-ultrafast'\n"
             "  max_concurrent_children: 4\n"
             "display:\n"
             "  skin: omh\n",
@@ -96,12 +98,80 @@ class DelegationRouteWriterTest(unittest.TestCase):
         )
         self.assertEqual(read_delegation_route(self.home), {"model": "second"})
 
+    def test_yaml_scalars_nested_keys_and_dotted_sections_stay_safe(self):
+        self.config.write_text(
+            "delegation:\n"
+            "  metadata:\n"
+            "    model: keep-model\n"
+            "  model: old-model\n"
+            "crof.ai:\n"
+            "  provider: keep-provider\n",
+            encoding="utf-8",
+        )
+
+        result = write_delegation_route(
+            self.home,
+            model="vendor/foreign-wire",
+            provider="null",
+            reasoning_effort="false",
+        )
+
+        self.assertEqual(result["status"], "routed")
+        self.assertEqual(
+            self.config.read_text(encoding="utf-8"),
+            "delegation:\n"
+            "  model: 'vendor/foreign-wire'\n"
+            "  reasoning_effort: 'false'\n"
+            "  provider: 'null'\n"
+            "  metadata:\n"
+            "    model: keep-model\n"
+            "crof.ai:\n"
+            "  provider: keep-provider\n",
+        )
+
+    def test_flow_mapping_and_symlink_swap_are_refused(self):
+        self.config.write_text(
+            "delegation: {model: old-model}\n",
+            encoding="utf-8",
+        )
+        before = self.config.read_bytes()
+        result = write_delegation_route(self.home, clear=True)
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(self.config.read_bytes(), before)
+
+        target = self.home / "external.yaml"
+        target.write_text("credential_sentinel: keep\n", encoding="utf-8")
+        self.config.write_text("model: parent\n", encoding="utf-8")
+        real_open = os.open
+        swapped = False
+
+        def swap_then_open(path, flags, *args):
+            nonlocal swapped
+            if Path(path) == self.config and not swapped:
+                swapped = True
+                self.config.unlink()
+                self.config.symlink_to(target)
+            return real_open(path, flags, *args)
+
+        with mock.patch(
+            "omh.plugin_bundle.omh.delegation_routing.os.open",
+            side_effect=swap_then_open,
+        ):
+            result = write_delegation_route(self.home, model="child")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("symlink", result["error"])
+        self.assertEqual(
+            target.read_text(encoding="utf-8"),
+            "credential_sentinel: keep\n",
+        )
+
 
 class DelegateRouteToolTest(unittest.TestCase):
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
         self.addCleanup(self._tmp.cleanup)
         self.home = Path(self._tmp.name)
+        self.config = self.home / "config.yaml"
         # Hermetic OMH home: without it the handler would read the developer
         # machine's real ~/.omh/routing/model-chains.json overrides.
         self.omh_home = self.home / ".omh"
@@ -139,6 +209,7 @@ class DelegateRouteToolTest(unittest.TestCase):
         self.assertEqual(
             result["applied"],
             {
+                "alias": "gpt-5.6-sol",
                 "model": "vendor/gpt-5.6-sol",
                 "provider": "gateway",
                 "reasoning_effort": "xhigh",
@@ -151,7 +222,12 @@ class DelegateRouteToolTest(unittest.TestCase):
         )
         result = self._call(action="set", category="ultrabrain")
         self.assertEqual(
-            result["applied"], {"model": "gpt-5.6-sol", "reasoning_effort": "xhigh"}
+            result["applied"],
+            {
+                "alias": "gpt-5.6-sol",
+                "model": "gpt-5.6-sol",
+                "reasoning_effort": "xhigh",
+            },
         )
 
     def test_an_explicit_provider_outranks_a_stored_route(self):
@@ -163,7 +239,12 @@ class DelegateRouteToolTest(unittest.TestCase):
         )
         self.assertEqual(
             result["applied"],
-            {"model": "gpt-5.6-sol", "provider": "direct", "reasoning_effort": "high"},
+            {
+                "alias": "gpt-5.6-sol",
+                "model": "gpt-5.6-sol",
+                "provider": "direct",
+                "reasoning_effort": "high",
+            },
         )
 
     def test_fallback_finds_the_chain_position_of_a_routed_wire_model(self):
@@ -196,6 +277,7 @@ class DelegateRouteToolTest(unittest.TestCase):
         self.assertEqual(
             fallback["applied"],
             {
+                "alias": "second-model",
                 "model": "vendor/second",
                 "provider": "gateway",
                 "reasoning_effort": "low",
@@ -221,13 +303,106 @@ class DelegateRouteToolTest(unittest.TestCase):
             applied["categories"]["deep"],
             [
                 {
-                    "model": "aliased-model",
+                    "alias": "aliased-model",
+                    "model": "vendor/aliased",
                     "provider": "gateway",
                     "reasoning_effort": "xhigh",
-                    "wire_model": "vendor/aliased",
                 }
             ],
         )
+
+        routed = self._call(action="set", category="deep")
+        status = self._call(action="status")
+        self.assertEqual(
+            status["route"],
+            {
+                "alias": "aliased-model",
+                "provider": "gateway",
+                "model": "vendor/aliased",
+                "reasoning_effort": "xhigh",
+            },
+        )
+        self.assertEqual(routed["applied"]["alias"], "aliased-model")
+
+    def test_partial_or_unresolved_wire_routes_fail_without_mutation(self):
+        self._write_provider_routes(
+            {"head": {"provider": "gateway", "model": "vendor/head"}}
+        )
+        self._write_overrides(
+            {"quick": [{"model": "head", "reasoning_effort": "low"}]}
+        )
+        self._call(action="set", category="quick")
+        before = self.config.read_bytes()
+
+        for args in (
+            {"action": "set", "category": "quick", "provider": "other"},
+            {"action": "set", "model": "vendor/unresolved"},
+        ):
+            with self.subTest(args=args):
+                result = self._call(**args)
+                self.assertEqual(result["status"], "error")
+                self.assertEqual(self.config.read_bytes(), before)
+
+    def test_fallback_refuses_wrong_provider_and_shared_origins(self):
+        self._write_provider_routes(
+            {"shared": {"provider": "gateway", "model": "vendor/shared"}}
+        )
+        self._write_overrides(
+            {
+                "quick": [
+                    {"model": "shared", "reasoning_effort": "low"},
+                    {"model": "quick-next", "reasoning_effort": "low"},
+                ],
+                "writing": [
+                    {"model": "shared", "reasoning_effort": "high"},
+                    {"model": "writing-next", "reasoning_effort": "high"},
+                ],
+            }
+        )
+        self._call(action="set", category="quick")
+        before = self.config.read_bytes()
+        ambiguous = self._call(action="fallback")
+        self.assertEqual(ambiguous["status"], "error")
+        self.assertIn("ambiguous origins", ambiguous["error"])
+        self.assertEqual(self.config.read_bytes(), before)
+
+        write_delegation_route(
+            self.home,
+            model="vendor/shared",
+            provider="wrong-provider",
+            reasoning_effort="low",
+        )
+        before = self.config.read_bytes()
+        wrong = self._call(action="fallback", category="quick")
+        self.assertEqual(wrong["status"], "error")
+        self.assertEqual(self.config.read_bytes(), before)
+
+    def test_fallback_aborts_when_active_route_changes_after_selection(self):
+        self._write_overrides(
+            {
+                "quick": [
+                    {"model": "head", "reasoning_effort": "low"},
+                    {"model": "next", "reasoning_effort": "low"},
+                ]
+            }
+        )
+        self._call(action="set", category="quick")
+
+        def concurrent_write(*args, **kwargs):
+            self.config.write_text(
+                "delegation:\n  model: concurrent\n",
+                encoding="utf-8",
+            )
+            return write_delegation_route(*args, **kwargs)
+
+        with mock.patch(
+            "omh.plugin_bundle.omh.tools.delegate_route_tool."
+            "write_delegation_route",
+            side_effect=concurrent_write,
+        ):
+            result = self._call(action="fallback", category="quick")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("active route changed", result["error"])
 
     def test_an_invalid_provider_route_document_is_ignored_whole(self):
         path = self.omh_home / "routing" / "model-providers.json"
@@ -247,9 +422,8 @@ class DelegateRouteToolTest(unittest.TestCase):
         status = self._call(action="status")
         self.assertTrue(status["provider_routes"].startswith("invalid: "))
         result = self._call(action="set", category="ultrabrain")
-        self.assertEqual(
-            result["applied"], {"model": "gpt-5.6-sol", "reasoning_effort": "xhigh"}
-        )
+        self.assertEqual(result["status"], "error")
+        self.assertIn("invalid:", result["error"])
 
     def test_an_overridden_chain_routes_and_falls_back_on_the_users_order(self):
         self._write_overrides({
@@ -260,12 +434,22 @@ class DelegateRouteToolTest(unittest.TestCase):
         })
         result = self._call(action="set", category="quick")
         self.assertEqual(
-            result["applied"], {"model": "kimi-k3-ultrafast", "reasoning_effort": "low"}
+            result["applied"],
+            {
+                "alias": "kimi-k3-ultrafast",
+                "model": "kimi-k3-ultrafast",
+                "reasoning_effort": "low",
+            },
         )
         fallback = self._call(action="fallback")
         self.assertEqual(fallback["status"], "fell_back")
         self.assertEqual(
-            fallback["applied"], {"model": "glm-5.2-ultrafast", "reasoning_effort": "low"}
+            fallback["applied"],
+            {
+                "alias": "glm-5.2-ultrafast",
+                "model": "glm-5.2-ultrafast",
+                "reasoning_effort": "low",
+            },
         )
 
     def test_status_reports_the_override_state_and_path(self):
@@ -280,13 +464,27 @@ class DelegateRouteToolTest(unittest.TestCase):
         self.assertEqual(applied["chain_overrides"], "applied")
         self.assertEqual(
             applied["categories"]["deep"],
-            [{"model": "gpt-5.6-terra", "reasoning_effort": "xhigh"}],
+            [
+                {
+                    "alias": "gpt-5.6-terra",
+                    "provider": "",
+                    "model": "gpt-5.6-terra",
+                    "reasoning_effort": "xhigh",
+                }
+            ],
         )
 
     def test_setting_a_category_routes_to_the_chain_head(self):
         result = self._call(action="set", category="ultrabrain")
         self.assertEqual(result["status"], "routed")
-        self.assertEqual(result["applied"], {"model": "gpt-5.6-sol", "reasoning_effort": "xhigh"})
+        self.assertEqual(
+            result["applied"],
+            {
+                "alias": "gpt-5.6-sol",
+                "model": "gpt-5.6-sol",
+                "reasoning_effort": "xhigh",
+            },
+        )
         self.assertEqual(result["category"], "ultrabrain")
         self.assertIn("Prepared route only", result["evidence_boundary"])
         self.assertEqual(
@@ -300,7 +498,12 @@ class DelegateRouteToolTest(unittest.TestCase):
         # inherited the parent's level ("everything runs medium").
         result = self._call(action="set", category="quick")
         self.assertEqual(
-            result["applied"], {"model": "glm-5.2-ultrafast", "reasoning_effort": "low"}
+            result["applied"],
+            {
+                "alias": "glm-5.2-ultrafast",
+                "model": "glm-5.2-ultrafast",
+                "reasoning_effort": "low",
+            },
         )
         self.assertEqual(
             read_delegation_route(self.home),
@@ -309,10 +512,20 @@ class DelegateRouteToolTest(unittest.TestCase):
 
     def test_an_explicit_model_override_wins_over_the_chain_head(self):
         result = self._call(action="set", category="unspecified-high", model="claude-opus-5")
-        self.assertEqual(result["applied"], {"model": "claude-opus-5"})
+        self.assertEqual(
+            result["applied"],
+            {"alias": "claude-opus-5", "model": "claude-opus-5"},
+        )
         self.assertEqual(
             result["fallback_candidates"],
-            [{"model": "claude-opus-5", "reasoning_effort": "medium"}],
+            [
+                {
+                    "alias": "claude-opus-5",
+                    "provider": "",
+                    "model": "claude-opus-5",
+                    "reasoning_effort": "medium",
+                }
+            ],
         )
 
     def test_an_unknown_category_fails_with_the_valid_vocabulary(self):
@@ -322,7 +535,7 @@ class DelegateRouteToolTest(unittest.TestCase):
 
     def test_fallback_advances_to_the_next_chain_candidate(self):
         self._call(action="set", category="quick")
-        result = self._call(action="fallback")
+        result = self._call(action="fallback", category="quick")
         self.assertEqual(result["status"], "fell_back")
         self.assertEqual(result["category"], "quick")
         self.assertEqual(result["from"], "glm-5.2-ultrafast")
@@ -331,8 +544,18 @@ class DelegateRouteToolTest(unittest.TestCase):
         self.assertEqual(
             result["fallback_candidates"],
             [
-                {"model": "gpt-5.6-luna", "reasoning_effort": "low"},
-                {"model": "claude-fable-5", "reasoning_effort": "low"},
+                {
+                    "alias": "gpt-5.6-luna",
+                    "provider": "",
+                    "model": "gpt-5.6-luna",
+                    "reasoning_effort": "low",
+                },
+                {
+                    "alias": "claude-fable-5",
+                    "provider": "",
+                    "model": "claude-fable-5",
+                    "reasoning_effort": "low",
+                },
             ],
         )
         self.assertEqual(
@@ -346,10 +569,10 @@ class DelegateRouteToolTest(unittest.TestCase):
         # fallback past the end restores inheritance instead of routing one
         # more rejection.
         self._call(action="set", category="quick")
-        self._call(action="fallback")
-        self._call(action="fallback")
-        self._call(action="fallback")
-        result = self._call(action="fallback")
+        self._call(action="fallback", category="quick")
+        self._call(action="fallback", category="quick")
+        self._call(action="fallback", category="quick")
+        result = self._call(action="fallback", category="quick")
         self.assertEqual(result["status"], "exhausted_to_inherit")
         self.assertEqual(result["category"], "quick")
         self.assertEqual(result["from"], "claude-fable-5")

--- a/tests/test_delegate_route_tool.py
+++ b/tests/test_delegate_route_tool.py
@@ -159,7 +159,10 @@ class DelegationRouteWriterTest(unittest.TestCase):
         ):
             result = write_delegation_route(self.home, model="child")
         self.assertEqual(result["status"], "error")
-        self.assertIn("symlink", result["error"])
+        self.assertTrue(
+            "symlink" in result["error"]
+            or result["error"] == "config changed during route read"
+        )
         self.assertEqual(
             target.read_text(encoding="utf-8"),
             "credential_sentinel: keep\n",

--- a/tests/test_delegate_route_tool.py
+++ b/tests/test_delegate_route_tool.py
@@ -165,6 +165,21 @@ class DelegationRouteWriterTest(unittest.TestCase):
             "credential_sentinel: keep\n",
         )
 
+    def test_quoted_route_keys_and_binary_scalars_are_refused(self):
+        for content in (
+            "delegation:\n  'model': old-model\n",
+            "delegation:\n  model: 0b1010\n",
+        ):
+            with self.subTest(content=content):
+                self.config.write_text(content, encoding="utf-8")
+                before = self.config.read_bytes()
+
+                result = write_delegation_route(self.home, model="new-model")
+
+                self.assertEqual(result["status"], "error")
+                self.assertIn("unsupported delegation mapping", result["error"])
+                self.assertEqual(self.config.read_bytes(), before)
+
 
 class DelegateRouteToolTest(unittest.TestCase):
     def setUp(self):
@@ -375,6 +390,33 @@ class DelegateRouteToolTest(unittest.TestCase):
         before = self.config.read_bytes()
         wrong = self._call(action="fallback", category="quick")
         self.assertEqual(wrong["status"], "error")
+        self.assertEqual(self.config.read_bytes(), before)
+
+    def test_registry_backed_alias_requires_provider_before_fallback(self):
+        self._write_provider_routes(
+            {
+                "head": {"provider": "gateway", "model": "vendor/head"},
+                "next": {"provider": "gateway", "model": "vendor/next"},
+            }
+        )
+        self._write_overrides(
+            {
+                "quick": [
+                    {"model": "head", "reasoning_effort": "low"},
+                    {"model": "next", "reasoning_effort": "low"},
+                ]
+            }
+        )
+        self.config.write_text(
+            "delegation:\n  model: head\n  reasoning_effort: low\n",
+            encoding="utf-8",
+        )
+        before = self.config.read_bytes()
+
+        result = self._call(action="fallback", category="quick")
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("requires configured provider identity", result["error"])
         self.assertEqual(self.config.read_bytes(), before)
 
     def test_fallback_aborts_when_active_route_changes_after_selection(self):

--- a/tests/test_plugin_hermes_delegation.py
+++ b/tests/test_plugin_hermes_delegation.py
@@ -24,6 +24,7 @@ from omh.plugin_bundle.omh.hermes_delegation import (
     load_mixture_chain_overrides,
     mixture_category_for,
     mixture_chain_overrides_path,
+    parse_model_provider_routes,
     read_hermes_native_subagents,
 )
 
@@ -283,6 +284,22 @@ class MixtureChainOverridesTest(unittest.TestCase):
                     HERMES_MIXTURE_CATEGORY_CHAINS,
                 )
 
+    def test_provider_routes_reject_non_string_scalars(self):
+        routes, status = parse_model_provider_routes(
+            {
+                "schema_version": "model_provider_routes/v1",
+                "models": {
+                    "quick": {
+                        "provider": 123,
+                        "model": True,
+                    }
+                },
+            }
+        )
+
+        self.assertEqual(routes, {})
+        self.assertTrue(status.startswith("invalid:"), status)
+
     def test_the_embedded_chains_mirror_the_shipped_recommendation_catalog(self):
         from omh.coding.model_recommendations import SHIPPED_MODEL_RECOMMENDATIONS
         from omh.coding.model_routing import MODEL_CATEGORIES
@@ -311,6 +328,48 @@ class HermesNativeSubagentReaderTest(unittest.TestCase):
         self.assertEqual(payload["status"], "idle")
         self.assertEqual(payload["rows"], [])
         self.assertEqual(payload["active"], 0)
+
+    def test_provider_wire_child_uses_configured_alias_and_provider(self):
+        route_path = self.home / "routing" / "model-providers.json"
+        route_path.parent.mkdir(parents=True)
+        route_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "model_provider_routes/v1",
+                    "models": {
+                        "glm-5.2-ultrafast": {
+                            "provider": "gateway",
+                            "model": "z-ai/glm-5.2-ultrafast",
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        _build_state_db(
+            self.home,
+            [
+                {
+                    "id": "20260818_100100_provider",
+                    "model": "z-ai/glm-5.2-ultrafast",
+                    "effort": "low",
+                    "started_at": NOW - 60,
+                    "usage": {"last_seen": NOW - 5, "output_tokens": 10},
+                }
+            ],
+        )
+
+        row = read_hermes_native_subagents(
+            self.home,
+            now=NOW,
+            omh_home=self.home,
+        )["rows"][0]
+
+        self.assertEqual(row["alias"], "glm-5.2-ultrafast")
+        self.assertEqual(row["provider"], "gateway")
+        self.assertEqual(row["provider_source"], "model_provider_routes")
+        self.assertEqual(row["model"], "z-ai/glm-5.2-ultrafast")
+        self.assertEqual(row["category"], "quick")
 
     def test_a_live_child_projects_a_running_row_with_model_effort_and_metrics(self):
         _build_state_db(
@@ -544,6 +603,53 @@ class HermesNativeSubagentReaderTest(unittest.TestCase):
 
 
 class HudMergeTest(unittest.TestCase):
+    def test_read_omh_hud_uses_requested_provider_route_home(self):
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / "omh"
+            hermes_home = root / "hermes"
+            route_path = omh_home / "routing" / "model-providers.json"
+            route_path.parent.mkdir(parents=True)
+            hermes_home.mkdir()
+            route_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "model_provider_routes/v1",
+                        "models": {
+                            "glm-5.2-ultrafast": {
+                                "provider": "gateway",
+                                "model": "z-ai/glm-5.2-ultrafast",
+                            }
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            _build_state_db(
+                hermes_home,
+                [
+                    {
+                        "id": "20260818_100100_provider",
+                        "model": "z-ai/glm-5.2-ultrafast",
+                        "effort": "low",
+                        "started_at": time.time() - 30,
+                        "usage": {
+                            "api_calls": 1,
+                            "output_tokens": 10,
+                            "last_seen": time.time() - 1,
+                        },
+                    }
+                ],
+            )
+
+            row = read_omh_hud(omh_home, hermes_home)["subagents"]["rows"][0]
+
+            self.assertEqual(row["alias"], "glm-5.2-ultrafast")
+            self.assertEqual(row["provider"], "gateway")
+            self.assertEqual(row["category"], "quick")
+
     def test_read_omh_hud_merges_native_rows_and_stays_active_while_they_linger(self):
         from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
 


### PR DESCRIPTION
## Feature Report

### What Changed

- Completes the provider-route capability introduced by #1100 without adding a second route registry.
- Makes `model_provider_routes/v1` the single alias-to-provider/wire-model authority used by route set, status, fallback, and Hermes-native HUD rows.
- Returns the complete `alias` / `provider` / executable `model` / `reasoning_effort` shape on every route surface.
- Hardens config persistence with descriptor-safe no-follow reads, quoted YAML strings, semantic-shape refusal, nested-key preservation, route-state compare-and-swap checks, and byte-identical refusal paths.

### Why This Exists

- Closes #1095. Compact chain aliases could previously lose the provider-specific wire model, inherit the parent provider, or be reverse-matched to an unverified fallback origin.
- The merged registry established the correct account-local source of truth; this PR closes its remaining status, fallback, HUD, ambiguity, and local-integrity gaps.

### User / Operator Impact

- Operators can map a chain alias once in `~/.omh/routing/model-providers.json` and see the same complete route in set, status, fallback, and HUD output.
- Cross-provider fallbacks preserve the configured provider/wire pair.
- Partial identities, ambiguous origins, invalid registry documents, providerless wire models, and unsupported YAML shapes fail before config mutation.
- Hosts without a provider registry retain v1 direct-billing behavior: alias equals model and provider is empty.

### How It Works

- `hermes_delegation.py` strictly loads the existing registry, resolves exact aliases, and projects configured provider provenance into native HUD rows.
- `delegate_route_tool.py` resolves set/fallback candidates through that registry, requires exact active identity and explicit category when origins collide, and reports complete route objects.
- `delegation_routing.py` reads config through `O_NOFOLLOW`, preserves direct-child indentation and unrelated YAML bytes, quotes emitted scalars, and conditionally replaces only the route state it selected.
- `runtime_reader.py` now passes the requested OMH home into the Hermes-native reader.

### Files And Contracts Touched

- `model_provider_routes/v1` remains the only provider-route document; `mixture_chain_overrides/v1` remains backward compatible.
- Public route payloads now distinguish editorial `alias` from executable `model` and always include `provider`.
- HUD provider values derived from the registry include `provider_source: model_provider_routes` and remain configured metadata, not execution evidence.
- English, Korean, Japanese, Chinese, installation, and agent-install guidance describe the same contract.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [x] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [x] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: isolated `omh model-chains` plus real `omh_delegate_route` and HUD readers
- [x] Manual Hermes/TUI check, or explicit reason it was not run: real plugin and HUD surfaces were exercised from isolated homes; no live TUI/provider dispatch was used

### Observed Evidence

- 7,130 tests passed in one full-suite run.
- 107 focused route/parser/HUD tests passed after the final security fixes.
- Generated workflow, roles, capability-family, inventory, and site checks passed; release drift was 0/16.
- Wheel build, isolated install, and provider-route imports passed.
- Manual QA traversed registry-absent and cross-provider chains through exhaustion, verified atomic override refusals, custom-home HUD provenance, nested YAML preservation, and byte-identical bad-input refusal.
- Independent code review, adversarial security review, and hands-on QA all returned PASS on `05454ab7`.

### Not Tested / Not Applicable

- No live provider dispatch, credentials, network call, or Hermes TUI session was used; this change prepares and observes local metadata only.
- Release checklist and Hermes smoke are not applicable to this non-release routing fix.
- Workflow-learning review is not applicable because no learning contract changed.

## Risk

- Consumers of the very recent #1100 status shape must read `alias` separately; executable wire ID now lives consistently in `model`.
- Bare fallback for an alias present in multiple chains now requires the category returned by set. This is intentional fail-closed behavior.

## Compatibility / Rollout

- `mixture_chain_overrides/v1` and registry-absent direct-billing behavior remain supported.
- Existing `model_provider_routes/v1` files require no migration.
- Invalid or partial provider routes now stop set/fallback rather than silently inheriting a parent provider.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- None required for #1095. Live provider dispatch remains an operator-owned verification step because OMH does not own provider credentials.
