### PR TITLE
feat(plugin): code-mode discipline guidance for execute_code results

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,11 @@ Rules:
 - Making Codex the implicit default owner in wording, schemas, or reports —
   keep Codex, Claude Code, Hermes runtime, and generic executors
   executor-neutral (`AGENTS.md`, Implementation Boundaries).
+- Reading Maestro/handoff surfaces (`src/coding/maestro/`, executor capability
+  snapshots, prompting contracts, throughput overlays) as the default coding
+  path — they activate only after an explicit coding-owner choice. The default
+  and normal path is the Hermes harness; `CONTEXT.md` (Coding delegation) and
+  `src/coding/orchestration_vocabulary.py` pin the two lanes.
 
 ## Working Style
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -115,17 +115,49 @@ _Avoid_: task list as evidence, TodoWrite (that is another product's tool name)
 
 ### Coding delegation
 
+**Default coding lane (Hermes harness)**:
+Absent an explicit coding-owner choice, coding work runs inside the Hermes
+harness and no external coding CLI is selected. This is the default and the
+normal path — most coding work in chat is this lane, and none of the
+Maestro/handoff machinery below participates in it. The nine-term contract in
+`src/coding/orchestration_vocabulary.py` pins this wording.
+_Avoid_: coding handoff (that is the Maestro lane), assuming an external
+executor by default, reading handoff modules as the main coding path
+
 **Coding owner**:
 The executor selected to perform coding work for a run: Codex, Claude Code, a
 Hermes runtime/handoff path, or a generic executor profile. OMH language,
 schemas, and reports stay neutral across all of them.
 _Avoid_: defaulting to Codex in wording, the agent
 
+**Maestro**:
+The operator lane by which an external coding CLI becomes the coding owner
+after an explicit user choice — `src/coding/maestro/` prepares a handoff for
+the chosen CLI and never runs it. Its facade rejects the `hermes` profile
+(`HermesNativeSelectionError`), so the default lane and Maestro never blur in
+code; keep them separate in prose too. Prepared handoffs, executor capability
+snapshots, executor prompting contracts, throughput overlays, and the handoff
+sections of `wrapper-routing.md` all belong to this lane, not to the default
+lane.
+_Avoid_: treating Maestro surfaces as the default coding path, legacy (it is
+current, just not default), "coding delegation" as a synonym for all coding
+work
+
 **Fanout dispatch**:
 OMH's one sanctioned execution surface — the explicit, operator-invoked
 `omh coding fanout dispatch` that spawns local agent CLIs as subprocesses.
 Nothing else in OMH executes anything.
 _Avoid_: implicit execution, background dispatch
+
+**Programmatic tool calling (`execute_code`)**:
+Hermes Agent's own tool: the model writes a Python script that calls a
+sandboxed subset of Hermes tools over RPC, collapsing a multi-step tool chain
+into one inference turn; only the script's stdout returns to context. Part of
+the default coding lane and owned entirely by Hermes — OMH neither implements
+nor wraps it and may only describe it in awareness guidance.
+_Avoid_: fanout dispatch (OMH's separate opt-in surface), an OMH execution
+surface, code-mode batching (a Maestro-lane handoff instruction, currently
+inert)
 
 **Wrapper session**:
 The metadata record of a chat-surface interaction (Discord, Slack, hosted

--- a/src/install/hook_integrity.py
+++ b/src/install/hook_integrity.py
@@ -160,12 +160,13 @@ HOOK_REVIEWS: dict[str, dict[str, Any]] = {
         "capability": "the OMH served-surface verification nudge before a Hermes coding verification",
     },
     "transform_tool_result": {
-        "source_path": "hooks/diff_presentation.py",
+        "source_path": "hooks/result_transforms.py",
         "event_scope": ("transform_tool_result",),
         "reviewed_timeout_ms": 1000,
         "capability": (
-            "full-width diff band padding of tool-result diffs (trailing "
-            "whitespace only; non-diff results pass through untouched)"
+            "once-per-session code-mode discipline annotation of execute_code "
+            "results plus full-width diff band padding of tool-result diffs "
+            "(non-matching results pass through untouched)"
         ),
     },
 }

--- a/src/plugin_bundle/omh/__init__.py
+++ b/src/plugin_bundle/omh/__init__.py
@@ -76,8 +76,8 @@ def register(ctx):
 
     _register_optional_surface(ctx, "register_memory_provider", OmhMemoryProvider())
 
-    from .hooks.diff_presentation import transform_tool_result
     from .hooks.llm_hooks import pre_llm_call
+    from .hooks.result_transforms import transform_tool_result
     from .hooks.session_hooks import on_session_end
     from .hooks.tool_hooks import pre_tool_call
     from .hooks.verify_hooks import pre_verify

--- a/src/plugin_bundle/omh/code_mode_guidance.py
+++ b/src/plugin_bundle/omh/code_mode_guidance.py
@@ -1,0 +1,113 @@
+"""Code-mode discipline guidance for Hermes ``execute_code`` results.
+
+Hermes' ``execute_code`` tool (programmatic tool calling) already rewards the
+code-mode call shape: it refunds the iteration budget for execute_code-only
+turns and collapses results to one line under context compression. What the
+host does not teach is the discipline that keeps those scripts trustworthy —
+a script that swallows its own exception exits 0, and exit 0 then reads as
+success in the next model turn.
+
+This module carries that discipline as a bounded, static guidance block that
+``transform_tool_result`` appends into the first ``execute_code`` result of a
+session, under its own JSON key so the host's result parsing is untouched.
+The rules were derived from reading the host implementation
+(``tools/code_execution_tool.py``): each ``execute_code`` run is a fresh
+child process, so state persists only through files, and the host surfaces
+``exit_code`` but cannot see whether the script verified its own effects.
+
+The guidance is prepared instruction only. Injecting it is not evidence that
+a script followed it, and an ``exit_code`` of 0 in an annotated result is
+still not execution, verification, review, CI, or merge evidence.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from typing import Final
+
+CODE_MODE_GUIDANCE_SCHEMA_VERSION: Final = "omh_code_mode_guidance/v1"
+CODE_MODE_GUIDANCE_KEY: Final = "omh_guidance"
+CODE_MODE_GUIDANCE_TOOL: Final = "execute_code"
+
+# One rule per failure mode this repo can name, each grounded in an observed
+# host fact rather than a style preference. Keep the block bounded: it rides
+# inside a tool result, so every character here is context spent on every
+# session's first execute_code call.
+CODE_MODE_DISCIPLINE_RULES: Final[tuple[str, ...]] = (
+    "Never swallow failures: no bare except or except-pass; let errors "
+    "propagate so they surface as a non-zero exit_code.",
+    "exit_code 0 is not verified success. After a script mutates files or "
+    "state, re-read the mutated target and confirm the change before "
+    "reporting it done.",
+    "Route every derived number (counts, sums, set differences, date math) "
+    "through code and print it; never report a figure the script did not "
+    "print.",
+    "Destructive operations run as a dry run first: print the affected set, "
+    "then mutate only after it is confirmed.",
+    "Scripts do not share variables — each execute_code run is a fresh "
+    "process. Persist intermediate state to files and read it back instead "
+    "of re-fetching the same data.",
+)
+
+_GUIDANCE_HEADER: Final = "[OMH Code-Mode Discipline]"
+
+# Session-scoped delivery dedup. In-process state is sufficient and correct
+# here: the injection rides the Hermes process that runs the hook, and
+# re-delivering once after a host restart is acceptable (even useful), so a
+# cross-process ledger would add I/O without adding a guarantee.
+_delivered_lock = threading.Lock()
+_delivered_sessions: set[str] = set()
+
+
+def code_mode_guidance_text() -> str:
+    """The bounded guidance block, static and free of any result content."""
+    lines = [_GUIDANCE_HEADER]
+    lines.extend(f"- {rule}" for rule in CODE_MODE_DISCIPLINE_RULES)
+    return "\n".join(lines)
+
+
+def annotate_execute_code_result(
+    *,
+    tool_name: object,
+    result: object,
+    session_id: str = "",
+) -> str | None:
+    """Return *result* with the guidance key added, or ``None`` to pass through.
+
+    Fail-open by seam contract: anything that is not a clean ``execute_code``
+    JSON-object result — or a session that already received the guidance —
+    passes through untouched.
+    """
+    if str(tool_name or "") != CODE_MODE_GUIDANCE_TOOL:
+        return None
+    if not isinstance(result, str) or not result:
+        return None
+    try:
+        parsed = json.loads(result)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(parsed, dict) or CODE_MODE_GUIDANCE_KEY in parsed:
+        return None
+    if not _claim_delivery(str(session_id or "")):
+        return None
+    parsed[CODE_MODE_GUIDANCE_KEY] = code_mode_guidance_text()
+    try:
+        return json.dumps(parsed, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return None
+
+
+def _claim_delivery(session_id: str) -> bool:
+    """Atomically claim one delivery per session (process-wide when unkeyed)."""
+    with _delivered_lock:
+        if session_id in _delivered_sessions:
+            return False
+        _delivered_sessions.add(session_id)
+    return True
+
+
+def _reset_delivery_state() -> None:
+    """Test seam: forget which sessions were served."""
+    with _delivered_lock:
+        _delivered_sessions.clear()

--- a/src/plugin_bundle/omh/hooks/result_transforms.py
+++ b/src/plugin_bundle/omh/hooks/result_transforms.py
@@ -1,0 +1,39 @@
+"""Composed ``transform_tool_result`` seam.
+
+This is the single registered entry for the hook; it chains the two OMH
+result transforms in a fixed order:
+
+1. Code-mode discipline annotation — the first ``execute_code`` result of a
+   session gains a bounded guidance block under its own JSON key
+   (``code_mode_guidance.py``).
+2. Full-width diff band padding — tool-result diffs get their painted lines
+   padded to a uniform band (``diff_presentation.py``).
+
+Both transforms are fail-open: anything either one declines passes through
+to the next, and ``None`` from both leaves the host result untouched. The
+order matters only when one result matches both (an execute_code result
+whose output embeds a diff): annotating first lets the diff pass still see
+and pad the final string.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..code_mode_guidance import annotate_execute_code_result
+from .diff_presentation import transform_tool_result as _pad_diff_result
+
+
+def transform_tool_result(**kwargs: Any) -> str | None:
+    """Return the transformed result string, or ``None`` to leave it alone."""
+    annotated = annotate_execute_code_result(
+        tool_name=kwargs.get("tool_name"),
+        result=kwargs.get("result"),
+        session_id=str(kwargs.get("session_id", "") or ""),
+    )
+    if annotated is not None:
+        kwargs = {**kwargs, "result": annotated}
+    padded = _pad_diff_result(**kwargs)
+    if padded is not None:
+        return padded
+    return annotated

--- a/tests/test_code_mode_guidance.py
+++ b/tests/test_code_mode_guidance.py
@@ -1,0 +1,202 @@
+"""Contracts for the code-mode discipline annotation of execute_code results.
+
+The transform_tool_result seam appends one bounded guidance block to the
+first ``execute_code`` result of a session, under its own JSON key so the
+host's result shape stays parseable. Everything else — other tools, non-JSON
+results, already-annotated results, already-served sessions — passes through
+untouched (None), because the seam replaces the result the model reads.
+"""
+
+import json
+import unittest
+
+from omh.plugin_bundle.omh.code_mode_guidance import (
+    CODE_MODE_DISCIPLINE_RULES,
+    CODE_MODE_GUIDANCE_KEY,
+    annotate_execute_code_result,
+    code_mode_guidance_text,
+    _reset_delivery_state,
+)
+from omh.plugin_bundle.omh.hooks.result_transforms import transform_tool_result
+
+EXECUTE_CODE_RESULT = json.dumps(
+    {
+        "status": "success",
+        "output": "12 rows\n",
+        "exit_code": 0,
+        "tool_calls_made": 3,
+        "duration_seconds": 1.2,
+    }
+)
+
+DIFF_RESULT = (
+    "--- a/plan.md\n"
+    "+++ b/plan.md\n"
+    "@@ -1,2 +1,2 @@\n"
+    " context stays\n"
+    "-short\n"
+    "+the replacement line is much longer\n"
+)
+
+
+class GuidanceTextTest(unittest.TestCase):
+    def test_every_discipline_rule_is_rendered(self):
+        text = code_mode_guidance_text()
+        for rule in CODE_MODE_DISCIPLINE_RULES:
+            self.assertIn(rule, text)
+
+    def test_names_the_failure_modes_it_guards(self):
+        text = code_mode_guidance_text()
+        self.assertIn("exit_code 0 is not verified success", text)
+        self.assertIn("Never swallow failures", text)
+        self.assertIn("dry run", text)
+        self.assertIn("fresh", text)
+        self.assertIn("Persist intermediate state to files", text)
+
+    def test_stays_bounded(self):
+        self.assertLess(len(code_mode_guidance_text()), 1200)
+
+
+class AnnotateExecuteCodeResultTest(unittest.TestCase):
+    def setUp(self):
+        _reset_delivery_state()
+
+    def test_first_result_of_a_session_gains_the_guidance_key(self):
+        annotated = annotate_execute_code_result(
+            tool_name="execute_code",
+            result=EXECUTE_CODE_RESULT,
+            session_id="session-a",
+        )
+        self.assertIsNotNone(annotated)
+        parsed = json.loads(annotated)
+        self.assertEqual(parsed[CODE_MODE_GUIDANCE_KEY], code_mode_guidance_text())
+        # Original result fields survive untouched.
+        self.assertEqual(parsed["exit_code"], 0)
+        self.assertEqual(parsed["output"], "12 rows\n")
+
+    def test_second_result_of_the_same_session_passes_through(self):
+        annotate_execute_code_result(
+            tool_name="execute_code",
+            result=EXECUTE_CODE_RESULT,
+            session_id="session-a",
+        )
+        self.assertIsNone(
+            annotate_execute_code_result(
+                tool_name="execute_code",
+                result=EXECUTE_CODE_RESULT,
+                session_id="session-a",
+            )
+        )
+
+    def test_a_different_session_is_served_independently(self):
+        annotate_execute_code_result(
+            tool_name="execute_code",
+            result=EXECUTE_CODE_RESULT,
+            session_id="session-a",
+        )
+        self.assertIsNotNone(
+            annotate_execute_code_result(
+                tool_name="execute_code",
+                result=EXECUTE_CODE_RESULT,
+                session_id="session-b",
+            )
+        )
+
+    def test_other_tools_pass_through(self):
+        self.assertIsNone(
+            annotate_execute_code_result(
+                tool_name="terminal",
+                result=EXECUTE_CODE_RESULT,
+                session_id="session-a",
+            )
+        )
+
+    def test_non_json_and_non_object_results_pass_through(self):
+        for result in ("plain text output", json.dumps([1, 2]), "", None):
+            with self.subTest(result=result):
+                self.assertIsNone(
+                    annotate_execute_code_result(
+                        tool_name="execute_code",
+                        result=result,
+                        session_id="session-a",
+                    )
+                )
+
+    def test_already_annotated_results_pass_through(self):
+        parsed = json.loads(EXECUTE_CODE_RESULT)
+        parsed[CODE_MODE_GUIDANCE_KEY] = "already here"
+        self.assertIsNone(
+            annotate_execute_code_result(
+                tool_name="execute_code",
+                result=json.dumps(parsed),
+                session_id="session-a",
+            )
+        )
+
+    def test_declined_results_do_not_consume_the_session_claim(self):
+        # A non-JSON result must not burn the one delivery the session gets.
+        annotate_execute_code_result(
+            tool_name="execute_code",
+            result="not json",
+            session_id="session-a",
+        )
+        self.assertIsNotNone(
+            annotate_execute_code_result(
+                tool_name="execute_code",
+                result=EXECUTE_CODE_RESULT,
+                session_id="session-a",
+            )
+        )
+
+    def test_guidance_never_echoes_result_content(self):
+        secret_result = json.dumps(
+            {"status": "success", "output": "secret-token-123", "exit_code": 0}
+        )
+        annotated = annotate_execute_code_result(
+            tool_name="execute_code",
+            result=secret_result,
+            session_id="session-a",
+        )
+        parsed = json.loads(annotated)
+        self.assertNotIn("secret-token-123", parsed[CODE_MODE_GUIDANCE_KEY])
+
+
+class ComposedTransformTest(unittest.TestCase):
+    def setUp(self):
+        _reset_delivery_state()
+
+    def test_execute_code_results_are_annotated(self):
+        transformed = transform_tool_result(
+            tool_name="execute_code",
+            result=EXECUTE_CODE_RESULT,
+            session_id="session-a",
+        )
+        self.assertIsNotNone(transformed)
+        self.assertIn(CODE_MODE_GUIDANCE_KEY, json.loads(transformed))
+
+    def test_diff_results_still_get_band_padding(self):
+        padded = transform_tool_result(
+            tool_name="patch",
+            result=DIFF_RESULT,
+            session_id="session-a",
+        )
+        self.assertIsNotNone(padded)
+        widths = {
+            len(line)
+            for line in padded.splitlines()
+            if line.startswith(("+", "-")) and not line.startswith(("+++", "---"))
+        }
+        self.assertEqual(len(widths), 1)
+
+    def test_irrelevant_results_pass_through(self):
+        self.assertIsNone(
+            transform_tool_result(
+                tool_name="web_search",
+                result=json.dumps({"data": {"web": []}}),
+                session_id="session-a",
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Capability

Two additions on one goal — make the default (Hermes-native) coding lane
code-mode aware:

1. **Code-mode discipline injection.** The plugin's `transform_tool_result`
   seam now annotates the first `execute_code` result of a session with a
   bounded `[OMH Code-Mode Discipline]` block under a dedicated
   `omh_guidance` JSON key: never swallow failures, exit 0 is not verified
   success, route derived numbers through code, dry-run destructive
   operations, persist state to files (each run is a fresh process).
2. **Lane glossary.** `CONTEXT.md` gains "Default coding lane (Hermes
   harness)", "Maestro", and "Programmatic tool calling (`execute_code`)"
   entries, and `CLAUDE.md` gains a pitfall bullet, so agent sessions stop
   reading Maestro/handoff surfaces as the default coding path.

## Motivation

Hermes already rewards programmatic tool calling — execute_code-only turns
refund the iteration budget, and context compression collapses results to
one line — but nothing teaches the discipline that keeps those scripts
trustworthy. A script that swallows its own exception exits 0, and exit 0
then reads as success in the next model turn. That silent-partial-failure
mode is exactly what OMH's prepared/observed evidence vocabulary exists to
prevent, so the guidance lands on existing product machinery rather than
adding a new concept.

The glossary half fixes the confusion that motivated the work: the two-lane
split (Hermes harness default vs. Maestro explicit-choice) was pinned in
`orchestration_vocabulary.py` and `docs/ARCHITECTURE.md` but absent from the
`CONTEXT.md` glossary sessions read first, so analyses kept grounding
themselves in the wrong lane.

## Implementation (boundary level)

- `src/plugin_bundle/omh/code_mode_guidance.py` — static rules text plus a
  fail-open `annotate_execute_code_result` (JSON-object results only,
  once-per-session in-process claim, never echoes result content, guidance
  is prepared instruction and carries no evidence claim).
- `src/plugin_bundle/omh/hooks/result_transforms.py` — new single registered
  `transform_tool_result` entry chaining code-mode annotation with the
  existing diff band padding; both stay fail-open.
- `src/install/hook_integrity.py` — the hook's reviewed source_path and
  capability line follow the new entry file.
- No Hermes patch, no LLM/network call, no new dependency. Host facts the
  rules rely on (fresh process per run, exit_code surfacing, iteration
  refund) were read from the installed Hermes implementation.

## Verification (observed)

- `PYTHONPATH=tests uv run python -m unittest tests.test_code_mode_guidance -v` — 14/14 OK
- `PYTHONPATH=tests uv run python -m unittest tests.test_hook_integrity tests.test_plugin_distribution tests.test_hook_manifest tests.test_diff_presentation tests.test_capability_impact` — 132 OK
- Full suite: `PYTHONPATH=tests uv run python -m unittest discover -s tests` — PASS (count in CI)
- `uv run --group lint ruff check src tests` — clean
- All five `omh docs … --check` byte gates — ok
- `git diff --check` — clean

## Risks

- The annotation rides inside the tool-result JSON; a host-side consumer
  that rejects unknown keys would break display. Mitigated: the host's own
  result parsing tolerates additive keys, and the transform is fail-open —
  any parse doubt passes the original through.
- Guidance text costs ~700 chars once per session; bounded by test.
- In-process dedup re-delivers after a host restart; accepted (a fresh
  process is a fresh model context).
