### PR TITLE
feat(plugin): user-authored toolcall rules at the pre_tool_call seam

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -219,7 +219,8 @@ actions, generic-tool checkpoint rules, and boundaries; it does not include the
 raw user message or prove a workflow executed. For capability/catalog questions,
 the context brief adds `omh_catalog_question_hint/v1` so Hermes can show the
 workflow picker or capability summary without shell approval. The `pre_tool_call`
-hook is limited to validating delegate role markers and warning on unknown
+hook enforces user-authored toolcall rules (a matching rule returns the host's
+block directive) and validates delegate role markers, warning on unknown
 roles; it does not inject generic-tool checkpoint metadata or raw tool input.
 `omh hud`
 exposes the same status-line payload for local operator smoke tests. The HUD
@@ -1332,10 +1333,11 @@ completed" a property of the `OUTCOME_WORK_CLAIMS` table that something can
 violate, rather than an accidental absence of rows.
 
 `DECISION_SOURCES` is split into enforcing and observing sources. The Hermes
-plugin hook contract has no deny channel — `pre_tool_call` returns injected
-context or `None`, and `pre_verify`'s only action value is `"continue"` — so a
-hook can mint a record *about* a block something else performed and is pinned to
-`declared_not_enforced` with a stated blocker. It cannot mint an allow at all.
+plugin host honors a `pre_tool_call` block directive (`hermes_cli/plugins.py`),
+and OMH's user-authored toolcall rules return one — but a returned directive is
+a request whose receipt OMH cannot observe, so a hook-minted record stays
+pinned to `declared_not_enforced` with a stated blocker. It cannot mint an
+allow at all.
 
 **What is wired, as opposed to declared.** The vocabularies above are wider than
 the lanes that use them, and reading `DECISION_SOURCES` as a coverage claim would

--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -389,7 +389,8 @@ before a generic tool, while image generation, file export, search retrieval,
 coding dispatch, review, CI, and merge remain observed-only claims.
 
 The managed plugin does not mirror this checkpoint from its `pre_tool_call`
-hook. That hook is limited to validating `delegate_task` role markers and
+hook. That hook enforces user-authored toolcall rules (returning the host's
+block directive on a match) and validates `delegate_task` role markers,
 warning when a requested OMH role is unknown; it does not copy raw tool input
 into injected context.
 

--- a/docs/TOOLCALL-RULES.md
+++ b/docs/TOOLCALL-RULES.md
@@ -1,0 +1,74 @@
+# Toolcall Rules
+
+User-authored rules that block a Hermes tool call the moment it matches a
+pattern you wrote. Rules sit dormant until the model goes off-script; when a
+call matches, the call is refused before execution and the model reads your
+rule text as the tool result, then course-corrects. You pay no context cost on
+calls that never match.
+
+Enforcement rides the OMH plugin's `pre_tool_call` hook using the Hermes
+host's own block directive (`hermes_cli/plugins.py`,
+`_get_pre_tool_call_directive_details`): a hook may return
+`{"action": "block", "message": ...}` and the message becomes the tool result
+the model sees.
+
+## Opt-in
+
+Create the rules file — its presence is the opt-in:
+
+```
+$OMH_HOME/rules/toolcall-rules.json     (default: ~/.omh/rules/toolcall-rules.json)
+```
+
+```json
+{
+  "schema_version": "omh_toolcall_rules/v1",
+  "rules": [
+    {
+      "name": "no-box-leak",
+      "pattern": "Box::leak",
+      "message": "Do not reach for Box::leak in production code paths; use Arc instead.",
+      "tools": ["write_file", "patch", "execute_code"],
+      "repeat": "once"
+    }
+  ]
+}
+```
+
+## Fields
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `name` | yes | Unique rule name, at most 64 characters. Shown in the block message. |
+| `pattern` | yes | Python regex, at most 512 characters, matched against the tool name plus the JSON-serialized tool arguments (first 20,000 characters). Patterns that nest unbounded repeats — `(a+)+`, `(x*)*` — are refused as catastrophic-backtracking shapes. |
+| `message` | yes | The rule text the model reads, at most 1,000 characters. |
+| `tools` | no | Tool names this rule watches (at most 16). Empty or omitted means every tool. |
+| `repeat` | no | `"once"` (default): fire at most once per session, so a blocked retry cannot loop. `"always"`: fire on every matching call. |
+
+Rules match in file order; the first match wins. At most 64 rules are read,
+and a file over 262,144 bytes is ignored whole.
+
+## Validation
+
+The enforcing hook fails open — an invalid rule is silently skipped — so
+validate after editing:
+
+```sh
+omh ops toolcall-rules-validate            # default path
+omh ops toolcall-rules-validate --path …   # explicit file
+```
+
+Exit 0 with `"valid": true` means every rule parses and loads; exit 1 lists
+each defect with its rule index, including patterns the enforcing hook would
+refuse and a file-size overflow that would disable the whole file.
+
+## Boundaries
+
+- Everything fails open: a missing, malformed, or oversized rules file and any
+  single invalid rule degrade to "no intervention", never to a broken hook.
+- A returned block directive is a request to the host. OMH does not observe
+  whether the host honored it, so a block is never recorded as evidence that
+  OMH stopped anything (see the enforcing/observing split in
+  `src/workflows/blocked_work_records.py`).
+- The block message contains only your rule text plus a fixed suffix; tool
+  input is never echoed back into context.

--- a/src/capabilities/hooks.py
+++ b/src/capabilities/hooks.py
@@ -102,7 +102,7 @@ def _hook_payload_fields(name: str) -> list[str]:
             "redacted",
         ]
     if name == "pre_tool_call":
-        return ["context"]
+        return ["context", "action", "message"]
     if name == "on_session_end":
         return ["session_summary", "metadata_only"]
     if name == "pre_verify":

--- a/src/commands/ops.py
+++ b/src/commands/ops.py
@@ -903,6 +903,7 @@ def _add_ops_commands(sub) -> None:
     from .plugin_risk_audit import add_ops_plugin_risk_audit_command
     from .provider_profile_posture import add_ops_provider_profile_posture_command
     from .prompt_compatibility import add_ops_prompt_compatibility_command
+    from .toolcall_rules import add_ops_toolcall_rules_command
 
     ops = sub.add_parser("ops", help="Create, inspect, validate, and export local operations artifacts.")
     ops_sub = ops.add_subparsers(dest="ops_command", required=True)
@@ -910,6 +911,7 @@ def _add_ops_commands(sub) -> None:
     add_ops_provider_profile_posture_command(ops_sub)
     add_ops_prompt_compatibility_command(ops_sub)
     add_ops_plugin_risk_audit_command(ops_sub)
+    add_ops_toolcall_rules_command(ops_sub)
 
     data_harness = ops_sub.add_parser(
         "data-harness",

--- a/src/commands/toolcall_rules.py
+++ b/src/commands/toolcall_rules.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from ..installer import OmhError
+from ..plugin_bundle.omh.toolcall_rules import (
+    MAX_RULES_FILE_BYTES,
+    TOOLCALL_RULES_SCHEMA_VERSION,
+    toolcall_rules_path,
+    validate_toolcall_rules_document,
+)
+from .common import _print_json
+
+
+def cmd_ops_toolcall_rules_validate(args: argparse.Namespace) -> int:
+    path = Path(args.path).expanduser() if args.path else toolcall_rules_path(args.omh_home or "")
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise OmhError(
+            f"toolcall rules file not found: {path} (the file's presence is the opt-in; "
+            f"create it with schema_version {TOOLCALL_RULES_SCHEMA_VERSION})"
+        ) from exc
+    except (OSError, ValueError) as exc:
+        raise OmhError(f"could not parse toolcall rules file {path}: {exc}") from exc
+    errors, accepted = validate_toolcall_rules_document(raw)
+    size = path.stat().st_size
+    if size > MAX_RULES_FILE_BYTES:
+        # The enforcing hook refuses the whole file above this bound, so a
+        # "valid" verdict here would certify rules the hook never loads.
+        errors.append(
+            f"rules file is {size} bytes; the enforcing hook ignores files over "
+            f"{MAX_RULES_FILE_BYTES} bytes, so no rule is loaded"
+        )
+        accepted = 0
+    _print_json(
+        {
+            "schema_version": TOOLCALL_RULES_SCHEMA_VERSION,
+            "rules_path": str(path),
+            "valid": not errors,
+            "accepted_rules": accepted,
+            "errors": errors,
+            "claim_boundary": (
+                "Validation proves the rules file parses; it is not evidence any rule "
+                "matched, blocked a call, or improved an outcome."
+            ),
+        }
+    )
+    return 0 if not errors else 1
+
+
+def add_ops_toolcall_rules_command(ops_sub: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    validate = ops_sub.add_parser(
+        "toolcall-rules-validate",
+        help=(
+            "Validate the user-authored toolcall rules file the plugin enforces at "
+            "pre_tool_call; the enforcing hook fails open, so this is where a "
+            "silently skipped rule becomes visible."
+        ),
+    )
+    validate.add_argument(
+        "--path",
+        help="Explicit rules file to validate (default: <omh-home>/rules/toolcall-rules.json).",
+    )
+    validate.add_argument(
+        "--omh-home",
+        default="",
+        help="OMH home used to resolve the default rules path.",
+    )
+    validate.set_defaults(func=cmd_ops_toolcall_rules_validate)

--- a/src/install/hook_integrity.py
+++ b/src/install/hook_integrity.py
@@ -151,7 +151,10 @@ HOOK_REVIEWS: dict[str, dict[str, Any]] = {
         "source_path": "hooks/tool_hooks.py",
         "event_scope": ("pre_tool_call",),
         "reviewed_timeout_ms": 1000,
-        "capability": "the OMH unknown-role warning before a Hermes delegation tool call",
+        "capability": (
+            "user-authored toolcall-rule block directives and the OMH "
+            "unknown-role warning before a Hermes tool call"
+        ),
     },
     "pre_verify": {
         "source_path": "hooks/verify_hooks.py",

--- a/src/plugin_bundle/omh/hooks/tool_hooks.py
+++ b/src/plugin_bundle/omh/hooks/tool_hooks.py
@@ -5,11 +5,29 @@ import json
 from ..host_observation import observe_plugin_hook_call
 from ..omh_roles import extract_role_marker, resolve_role_name, role_aliases, role_names
 from ..tool_bursts import record_tool_call
+from ..toolcall_rules import toolcall_rule_directive
 
 
 def pre_tool_call(**kwargs) -> dict[str, object] | None:
     """Return only host-supported pre-tool directives or role warnings."""
     observe_plugin_hook_call("pre_tool_call", kwargs)
+    # User-authored toolcall rules intervene first: a block directive is the
+    # strongest host-supported response (hermes_cli/plugins.py,
+    # `_get_pre_tool_call_directive_details`: "``block`` vetoes the tool call
+    # outright (the message becomes the tool result the model sees)"). The
+    # host passes the tool arguments as ``args``; ``tool_input`` is accepted
+    # for bundle-internal callers and tests.
+    rule_directive = toolcall_rule_directive(
+        tool_name=kwargs.get("tool_name"),
+        tool_input=kwargs.get("tool_input") if "tool_input" in kwargs else kwargs.get("args"),
+        session_id=str(kwargs.get("session_id", "") or kwargs.get("task_id", "") or ""),
+        omh_home=str(kwargs.get("omh_home", "") or ""),
+    )
+    if rule_directive is not None:
+        # A blocked call never dispatches, so it must not tick the
+        # parallel-shot burst ledger (its claim boundary is "the host
+        # dispatched the calls as one batch").
+        return dict(rule_directive)
     # Tick the parallel-shot ledger: concurrent batch members start within
     # milliseconds of each other, and this is the only place OMH can see it.
     record_tool_call(kwargs.get("tool_name"), omh_home=str(kwargs.get("omh_home", "") or ""))

--- a/src/plugin_bundle/omh/toolcall_rules.py
+++ b/src/plugin_bundle/omh/toolcall_rules.py
@@ -1,0 +1,328 @@
+"""User-authored tool-call rules, enforced at the ``pre_tool_call`` seam.
+
+The idea is borrowed from stream-rule systems in other harnesses (rules sit
+dormant until the model goes off-script, then intervene once), scaled to the
+one intervention point the Hermes plugin host actually supports. Host
+contract, read from the installed Hermes implementation
+(``hermes_cli/plugins.py``, ``_get_pre_tool_call_directive_details`` /
+``_dispatch_pre_tool_call_hooks``): a ``pre_tool_call`` hook may return
+``{"action": "block", "message": ...}``, ``block`` "vetoes the tool call
+outright (the message becomes the tool result the model sees)", and the host
+passes ``tool_name``, ``args``, ``task_id``, ``session_id``, and turn
+identifiers to the hook. OMH cannot abort a stream mid-token — that is
+host-owned — but it can deterministically refuse one tool call and hand the
+model the rule text, which produces the same course-correction loop at
+tool-call granularity. Rules match in file order and the first match wins.
+
+Rules are user-authored local configuration at
+``$OMH_HOME/rules/toolcall-rules.json``; the file's presence is the opt-in.
+Everything here is fail-open: a missing, malformed, or oversized rules file
+and any single invalid rule degrade to "no intervention", never to a broken
+hook. Matching is plain regex over the tool name and the JSON-serialized
+tool arguments — no model call, no network, no clever parsing.
+
+A blocked call is prevented, not judged: the block is instruction to the
+model, not evidence that the rule's concern applied, and it is never
+execution, verification, review, CI, or merge evidence.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+# `re._parser` is the stdlib regex AST walker (formerly `sre_parse`); linters
+# use the same surface. It exists so the validator can refuse
+# catastrophic-backtracking patterns instead of certifying them.
+from re import _parser as _re_parser  # type: ignore[attr-defined]
+
+TOOLCALL_RULES_SCHEMA_VERSION: Final = "omh_toolcall_rules/v1"
+TOOLCALL_RULES_FILE: Final = "toolcall-rules.json"
+RULE_REPEAT_MODES: Final = ("once", "always")
+
+MAX_RULES: Final = 64
+MAX_RULE_NAME_CHARS: Final = 64
+MAX_PATTERN_CHARS: Final = 512
+MAX_MESSAGE_CHARS: Final = 1000
+MAX_TOOL_SCOPE_ITEMS: Final = 16
+MAX_RULES_FILE_BYTES: Final = 262_144
+# Serialized-args match window. Bounding it keeps one pathological tool call
+# (a giant write_file body) from turning every rule check into a slow scan.
+MAX_MATCH_TEXT_CHARS: Final = 20_000
+
+_BLOCK_SUFFIX: Final = (
+    "This tool call was blocked by a user-defined OMH rule before execution. "
+    "Adjust the approach to satisfy the rule instead of retrying the same "
+    "call. A blocked call did not run."
+)
+
+
+@dataclass(frozen=True)
+class ToolcallRule:
+    name: str
+    pattern: re.Pattern[str]
+    message: str
+    tools: tuple[str, ...]  # empty = every tool
+    repeat: str  # "once" | "always"
+
+
+# Parsed-rules cache keyed by rules-file path; entries are (mtime_ns, size,
+# rules). A hook runs on every tool call, so the file is re-parsed only when
+# it visibly changed.
+_cache_lock = threading.Lock()
+_rules_cache: dict[str, tuple[int, int, tuple[ToolcallRule, ...]]] = {}
+
+# Sessions that already consumed a repeat="once" rule: {(session_id, rule name)}.
+# In-process state is the point — one intervention per rule per session within
+# this host process, and a host restart naturally re-arms the rules.
+_fired_lock = threading.Lock()
+_fired: set[tuple[str, str]] = set()
+_MAX_FIRED_ENTRIES: Final = 1024
+_MAX_CACHED_RULE_FILES: Final = 8
+
+
+def toolcall_rules_path(omh_home: str = "") -> Path:
+    # Same home resolution as session_hooks.py: an explicit kwarg wins, then
+    # $OMH_HOME, then ~/.omh — so the documented rules path is the read path.
+    resolved = omh_home or os.environ.get("OMH_HOME", "") or "~/.omh"
+    return Path(resolved).expanduser() / "rules" / TOOLCALL_RULES_FILE
+
+
+def load_toolcall_rules(path: Path) -> tuple[ToolcallRule, ...]:
+    """Parse the rules file, skipping every invalid entry. Fail-open."""
+    try:
+        stat = path.stat()
+    except OSError:
+        return ()
+    if stat.st_size > MAX_RULES_FILE_BYTES:
+        return ()
+    key = str(path)
+    with _cache_lock:
+        cached = _rules_cache.get(key)
+        if cached is not None and cached[0] == stat.st_mtime_ns and cached[1] == stat.st_size:
+            return cached[2]
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return ()
+    rules = _parse_rules(raw)
+    with _cache_lock:
+        if len(_rules_cache) >= _MAX_CACHED_RULE_FILES and key not in _rules_cache:
+            _rules_cache.pop(next(iter(_rules_cache)))
+        _rules_cache[key] = (stat.st_mtime_ns, stat.st_size, rules)
+    return rules
+
+
+def validate_toolcall_rules_document(raw: object) -> tuple[list[str], int]:
+    """Return (errors, accepted_count) for a rules document.
+
+    The hook itself never reports these errors — it fails open — so this is
+    the surface `omh ops toolcall-rules-validate` uses to make a silently
+    skipped rule visible to the person who wrote it.
+    """
+    errors: list[str] = []
+    if not isinstance(raw, dict):
+        return (["rules document must be a JSON object"], 0)
+    if raw.get("schema_version") != TOOLCALL_RULES_SCHEMA_VERSION:
+        # The loader refuses the whole document on a wrong schema_version, so
+        # reporting any rule as accepted would certify a file the hook will
+        # never read.
+        return ([f"schema_version must be {TOOLCALL_RULES_SCHEMA_VERSION}; no rule is loaded"], 0)
+    entries = raw.get("rules")
+    if not isinstance(entries, list):
+        errors.append("rules must be a list")
+        return (errors, 0)
+    if len(entries) > MAX_RULES:
+        errors.append(f"at most {MAX_RULES} rules are read; extra entries are ignored")
+    accepted = 0
+    seen_names: set[str] = set()
+    for index, entry in enumerate(entries[:MAX_RULES]):
+        entry_errors = _entry_errors(entry, seen_names)
+        if entry_errors:
+            errors.extend(f"rules[{index}]: {error}" for error in entry_errors)
+        else:
+            assert isinstance(entry, dict)
+            seen_names.add(str(entry["name"]).strip())
+            accepted += 1
+    return (errors, accepted)
+
+
+def toolcall_rule_directive(
+    *,
+    tool_name: object,
+    tool_input: object,
+    session_id: str = "",
+    omh_home: str = "",
+) -> dict[str, str] | None:
+    """The block directive for this call, or ``None`` to let it proceed."""
+    name = str(tool_name or "").strip()
+    if not name:
+        return None
+    try:
+        path = toolcall_rules_path(omh_home)
+    except (OSError, RuntimeError):
+        # Path.home()/expanduser can raise when no home resolves; a rules
+        # fault must never break the tool hook.
+        return None
+    rules = load_toolcall_rules(path)
+    if not rules:
+        return None
+    match_text = _match_text(name, tool_input)
+    for rule in rules:
+        if rule.tools and name not in rule.tools:
+            continue
+        if rule.pattern.search(match_text) is None:
+            continue
+        if rule.repeat == "once" and not _claim_fire(session_id, rule.name):
+            continue
+        return {
+            "action": "block",
+            "message": f"[OMH Rule] {rule.name}: {rule.message}\n{_BLOCK_SUFFIX}",
+        }
+    return None
+
+
+def _parse_rules(raw: object) -> tuple[ToolcallRule, ...]:
+    if not isinstance(raw, dict) or raw.get("schema_version") != TOOLCALL_RULES_SCHEMA_VERSION:
+        return ()
+    entries = raw.get("rules")
+    if not isinstance(entries, list):
+        return ()
+    rules: list[ToolcallRule] = []
+    seen_names: set[str] = set()
+    for entry in entries[:MAX_RULES]:
+        if _entry_errors(entry, seen_names):
+            continue
+        assert isinstance(entry, dict)
+        name = str(entry["name"]).strip()
+        try:
+            pattern = re.compile(str(entry["pattern"]))
+        except re.error:
+            continue
+        seen_names.add(name)
+        tools_value = entry.get("tools", [])
+        tools = tuple(str(tool).strip() for tool in tools_value) if isinstance(tools_value, list) else ()
+        rules.append(
+            ToolcallRule(
+                name=name,
+                pattern=pattern,
+                message=str(entry["message"]).strip(),
+                tools=tools,
+                repeat=str(entry.get("repeat", "once")),
+            )
+        )
+    return tuple(rules)
+
+
+def _entry_errors(entry: object, seen_names: set[str]) -> list[str]:
+    if not isinstance(entry, dict):
+        return ["rule must be an object"]
+    errors: list[str] = []
+    name = entry.get("name")
+    if not isinstance(name, str) or not name.strip() or len(name.strip()) > MAX_RULE_NAME_CHARS:
+        errors.append("name must be a nonempty string of at most " f"{MAX_RULE_NAME_CHARS} characters")
+    elif name.strip() in seen_names:
+        errors.append(f"duplicate rule name: {name.strip()!r}")
+    pattern = entry.get("pattern")
+    if not isinstance(pattern, str) or not pattern or len(pattern) > MAX_PATTERN_CHARS:
+        errors.append(f"pattern must be a nonempty regex string of at most {MAX_PATTERN_CHARS} characters")
+    else:
+        try:
+            re.compile(pattern)
+        except re.error as exc:
+            errors.append(f"pattern does not compile: {exc}")
+        else:
+            if _has_nested_unbounded_repeat(pattern):
+                errors.append(
+                    "pattern nests an unbounded repeat inside another repeat "
+                    "(catastrophic-backtracking shape); rewrite it without "
+                    "nested + or * quantifiers"
+                )
+    message = entry.get("message")
+    if not isinstance(message, str) or not message.strip() or len(message.strip()) > MAX_MESSAGE_CHARS:
+        errors.append(f"message must be a nonempty string of at most {MAX_MESSAGE_CHARS} characters")
+    tools = entry.get("tools", [])
+    if not isinstance(tools, list) or len(tools) > MAX_TOOL_SCOPE_ITEMS or not all(
+        isinstance(tool, str) and tool.strip() and len(tool) <= MAX_RULE_NAME_CHARS for tool in tools
+    ):
+        errors.append(
+            f"tools must be a list of at most {MAX_TOOL_SCOPE_ITEMS} nonempty tool names "
+            f"of at most {MAX_RULE_NAME_CHARS} characters each"
+        )
+    repeat = entry.get("repeat", "once")
+    if repeat not in RULE_REPEAT_MODES:
+        errors.append(f"repeat must be one of {', '.join(RULE_REPEAT_MODES)}")
+    return errors
+
+
+def _match_text(tool_name: str, tool_input: object) -> str:
+    if isinstance(tool_input, str):
+        args_text = tool_input
+    else:
+        try:
+            args_text = json.dumps(tool_input, ensure_ascii=False, sort_keys=True)
+        except (TypeError, ValueError):
+            args_text = str(tool_input)
+    return f"{tool_name}\n{args_text}"[:MAX_MATCH_TEXT_CHARS]
+
+
+def _claim_fire(session_id: str, rule_name: str) -> bool:
+    key = (str(session_id or ""), rule_name)
+    with _fired_lock:
+        if key in _fired:
+            return False
+        if len(_fired) >= _MAX_FIRED_ENTRIES:
+            _fired.pop()
+        _fired.add(key)
+    return True
+
+
+def _has_nested_unbounded_repeat(pattern: str) -> bool:
+    """True when an unbounded repeat wraps a subpattern containing a repeat.
+
+    The classic catastrophic-backtracking shapes — ``(a+)+``, ``(a*)*``,
+    ``(?:x+y*)+`` — all parse to MAX_REPEAT nodes with another repeat in
+    their body. Walking the parsed AST refuses the shape itself instead of
+    trying to predict runtime, so the validator and the loader agree.
+    """
+    try:
+        parsed = _re_parser.parse(pattern)
+    except (re.error, ValueError, RecursionError, OverflowError):
+        # re.compile upstream already rejected anything unparseable; an AST
+        # walk failure here must not turn into a hook fault.
+        return False
+    return _subpattern_has_nested_repeat(parsed, inside_repeat=False)
+
+
+def _subpattern_has_nested_repeat(nodes, *, inside_repeat: bool) -> bool:
+    for opcode, value in nodes:
+        opcode_name = str(opcode)
+        if opcode_name in ("MAX_REPEAT", "MIN_REPEAT"):
+            _minimum, maximum, body = value
+            unbounded = maximum is None or maximum >= _re_parser.MAXREPEAT
+            if inside_repeat and unbounded:
+                return True
+            if _subpattern_has_nested_repeat(body, inside_repeat=inside_repeat or unbounded):
+                return True
+        elif opcode_name == "SUBPATTERN":
+            body = value[3]
+            if _subpattern_has_nested_repeat(body, inside_repeat=inside_repeat):
+                return True
+        elif opcode_name == "BRANCH":
+            for branch in value[1]:
+                if _subpattern_has_nested_repeat(branch, inside_repeat=inside_repeat):
+                    return True
+    return False
+
+
+def _reset_state() -> None:
+    """Test seam: forget parsed files and fired rules."""
+    with _cache_lock:
+        _rules_cache.clear()
+    with _fired_lock:
+        _fired.clear()

--- a/src/plugin_bundle/omh/tools/capability_tool.py
+++ b/src/plugin_bundle/omh/tools/capability_tool.py
@@ -689,7 +689,7 @@ def _standalone_hook_payload_fields(name: str) -> list[str]:
             "redacted",
         ]
     if name == "pre_tool_call":
-        return ["context"]
+        return ["context", "action", "message"]
     if name == "on_session_end":
         return ["session_summary", "metadata_only"]
     if name == "pre_verify":

--- a/src/workflows/blocked_work_records.py
+++ b/src/workflows/blocked_work_records.py
@@ -88,12 +88,16 @@ never rendered as attempted or completed" into an enforceable invariant over
 Enforcing versus observing
 --------------------------
 
-The Hermes plugin hook contract has no deny channel. `pre_tool_call` returns
-injected context or None, and `pre_verify`'s only action value is `"continue"`.
-A hook can therefore mint a record *about* a block that something else
-performed, and can never claim OMH stopped anything. `DECISION_SOURCES` is split
-into `ENFORCING_SOURCES` and `OBSERVING_SOURCES` for that reason, an observing
-source is pinned to `declared_not_enforced` with a stated blocker, and
+The Hermes plugin host does honor a `pre_tool_call` deny channel
+(`hermes_cli/plugins.py`, `_get_pre_tool_call_directive_details`: a returned
+`{"action": "block", "message": ...}` vetoes the call and the message becomes
+the tool result), and OMH's toolcall rules use it. That does not move
+`plugin_hook_observation` into the enforcing set: returning a block directive
+is not evidence the host received, honored, or surfaced it — hook invocation
+is host-owned and unobserved from here. A hook can mint a record *about* a
+block, and cannot prove one happened. `DECISION_SOURCES` therefore stays split
+into `ENFORCING_SOURCES` and `OBSERVING_SOURCES`, an observing source is
+pinned to `declared_not_enforced` with a stated blocker, and
 `build_blocked_work_record` refuses the combination that would lie.
 
 What actually produces and reads these records today
@@ -195,11 +199,11 @@ CLAIM_BOUNDARY: Final[str] = (
 
 # Sources that can actually stop work, and sources that can only watch it stop.
 #
-# The split is not stylistic. The Hermes plugin hook contract has no deny
-# channel -- `pre_tool_call` returns injected context or None, `pre_verify`'s
-# only action value is "continue" -- so a record minted from a hook is a report
-# about someone else's block. Collapsing the two would ship an outcome that
-# implies OMH blocked a tool call it has no way to block.
+# The split is not stylistic. The host does honor a `pre_tool_call` block
+# directive (see the module docstring), but returning one is a request whose
+# receipt OMH cannot observe -- so a record minted from a hook remains a
+# report, never proof OMH stopped anything. Collapsing the two would ship an
+# outcome that implies OMH verified a block it has no way to verify.
 ENFORCING_SOURCES: Final[tuple[str, ...]] = (
     "safety_preflight",
     "action_gate",

--- a/tests/test_hook_manifest.py
+++ b/tests/test_hook_manifest.py
@@ -78,7 +78,7 @@ class HookManifestTests(unittest.TestCase):
         self.assertIn("omh_route_hint", hooks["pre_llm_call"]["payload_fields"])
         self.assertIn("bounded_status_context", hooks["pre_llm_call"]["payload_fields"])
         self.assertNotIn("omh_generic_tool_checkpoint", hooks["pre_tool_call"]["payload_fields"])
-        self.assertEqual(hooks["pre_tool_call"]["payload_fields"], ["context"])
+        self.assertEqual(hooks["pre_tool_call"]["payload_fields"], ["context", "action", "message"])
         self.assertIn("executor_opened", events)
         self.assertIn("selected_executor_profile", events["executor_opened"]["payload_fields"])
         self.assertIn("native_command_registered", events)

--- a/tests/test_toolcall_rules.py
+++ b/tests/test_toolcall_rules.py
@@ -1,0 +1,385 @@
+"""Contracts for user-authored toolcall rules at the pre_tool_call seam.
+
+The rules file's presence is the opt-in; everything degrades fail-open (no
+file, malformed file, invalid rule, oversized file -> no intervention). A
+matching rule returns the one host-supported strong response — a block
+directive whose message becomes the tool result the model reads — and a
+repeat="once" rule fires at most once per session so a blocked retry loop
+cannot form.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from omh.plugin_bundle.omh.hooks.tool_hooks import pre_tool_call
+from omh.plugin_bundle.omh.toolcall_rules import (
+    MAX_RULES,
+    TOOLCALL_RULES_SCHEMA_VERSION,
+    _reset_state,
+    load_toolcall_rules,
+    toolcall_rule_directive,
+    toolcall_rules_path,
+    validate_toolcall_rules_document,
+)
+
+
+def _write_rules(home: Path, rules: list[dict]) -> Path:
+    path = toolcall_rules_path(str(home))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"schema_version": TOOLCALL_RULES_SCHEMA_VERSION, "rules": rules}),
+        encoding="utf-8",
+    )
+    return path
+
+
+BOX_LEAK_RULE = {
+    "name": "no-box-leak",
+    "pattern": r"Box::leak",
+    "message": "Do not reach for Box::leak in production code paths.",
+}
+
+
+class LoadAndValidateTest(unittest.TestCase):
+    def setUp(self):
+        _reset_state()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.home = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_missing_file_yields_no_rules(self):
+        self.assertEqual(load_toolcall_rules(toolcall_rules_path(str(self.home))), ())
+
+    def test_malformed_json_fails_open(self):
+        path = toolcall_rules_path(str(self.home))
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{not json", encoding="utf-8")
+        self.assertEqual(load_toolcall_rules(path), ())
+
+    def test_wrong_schema_version_yields_no_rules(self):
+        path = toolcall_rules_path(str(self.home))
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"schema_version": "other/v9", "rules": [BOX_LEAK_RULE]}), encoding="utf-8")
+        self.assertEqual(load_toolcall_rules(path), ())
+
+    def test_invalid_entries_are_skipped_and_valid_ones_kept(self):
+        path = _write_rules(
+            self.home,
+            [
+                BOX_LEAK_RULE,
+                {"name": "broken", "pattern": "(", "message": "unclosed group"},
+                {"name": "", "pattern": "x", "message": "empty name"},
+                {"name": "no-message", "pattern": "x", "message": "   "},
+            ],
+        )
+        rules = load_toolcall_rules(path)
+        self.assertEqual([rule.name for rule in rules], ["no-box-leak"])
+
+    def test_mtime_cache_serves_and_refreshes(self):
+        path = _write_rules(self.home, [BOX_LEAK_RULE])
+        self.assertEqual(len(load_toolcall_rules(path)), 1)
+        # Rewrite with two rules; force a visible stat change.
+        _write_rules(self.home, [BOX_LEAK_RULE, {"name": "second", "pattern": "y", "message": "m"}])
+        import os
+
+        stat = path.stat()
+        os.utime(path, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000))
+        self.assertEqual(len(load_toolcall_rules(path)), 2)
+
+    def test_validation_reports_every_defect_with_indexes(self):
+        errors, accepted = validate_toolcall_rules_document(
+            {
+                "schema_version": TOOLCALL_RULES_SCHEMA_VERSION,
+                "rules": [
+                    BOX_LEAK_RULE,
+                    {"name": "broken", "pattern": "(", "message": "m"},
+                    {"name": "no-box-leak", "pattern": "x", "message": "duplicate name"},
+                    {"name": "bad-repeat", "pattern": "x", "message": "m", "repeat": "sometimes"},
+                ],
+            }
+        )
+        self.assertEqual(accepted, 1)
+        self.assertTrue(any("rules[1]" in error and "compile" in error for error in errors))
+        self.assertTrue(any("duplicate rule name" in error for error in errors))
+        self.assertTrue(any("repeat" in error for error in errors))
+
+    def test_validation_rejects_non_object_documents(self):
+        errors, accepted = validate_toolcall_rules_document([])
+        self.assertEqual(accepted, 0)
+        self.assertTrue(errors)
+
+    def test_catastrophic_backtracking_patterns_are_refused(self):
+        errors, accepted = validate_toolcall_rules_document(
+            {
+                "schema_version": TOOLCALL_RULES_SCHEMA_VERSION,
+                "rules": [
+                    {"name": "redos", "pattern": "(a+)+$", "message": "m"},
+                    {"name": "redos-star", "pattern": "(x*)*y", "message": "m"},
+                    {"name": "fine-anchor", "pattern": "Box::leak", "message": "m"},
+                    {"name": "fine-bounded", "pattern": "(ab){1,4}c", "message": "m"},
+                ],
+            }
+        )
+        self.assertEqual(accepted, 2)
+        self.assertEqual(sum("catastrophic-backtracking" in error for error in errors), 2)
+        # And the loader agrees: the pathological rules never load.
+        path = _write_rules(
+            self.home,
+            [
+                {"name": "redos", "pattern": "(a+)+$", "message": "m"},
+                {"name": "kept", "pattern": "Box::leak", "message": "m"},
+            ],
+        )
+        self.assertEqual([rule.name for rule in load_toolcall_rules(path)], ["kept"])
+
+    def test_wrong_schema_version_reports_zero_accepted(self):
+        errors, accepted = validate_toolcall_rules_document(
+            {"schema_version": "other/v9", "rules": [BOX_LEAK_RULE]}
+        )
+        self.assertEqual(accepted, 0)
+        self.assertTrue(any("no rule is loaded" in error for error in errors))
+
+    def test_omh_home_env_var_resolves_the_rules_path(self):
+        previous = os.environ.get("OMH_HOME")
+        os.environ["OMH_HOME"] = str(self.home)
+        try:
+            self.assertEqual(
+                toolcall_rules_path(),
+                self.home / "rules" / "toolcall-rules.json",
+            )
+        finally:
+            if previous is None:
+                del os.environ["OMH_HOME"]
+            else:
+                os.environ["OMH_HOME"] = previous
+
+    def test_rule_count_is_bounded(self):
+        rules = [
+            {"name": f"rule-{index}", "pattern": "x", "message": "m"}
+            for index in range(MAX_RULES + 5)
+        ]
+        path = _write_rules(self.home, rules)
+        self.assertEqual(len(load_toolcall_rules(path)), MAX_RULES)
+
+
+class DirectiveTest(unittest.TestCase):
+    def setUp(self):
+        _reset_state()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.home = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_matching_call_is_blocked_with_rule_text(self):
+        _write_rules(self.home, [BOX_LEAK_RULE])
+        directive = toolcall_rule_directive(
+            tool_name="write_file",
+            tool_input={"path": "src/lib.rs", "content": "let s = Box::leak(name);"},
+            session_id="session-a",
+            omh_home=str(self.home),
+        )
+        self.assertIsNotNone(directive)
+        self.assertEqual(directive["action"], "block")
+        self.assertIn("[OMH Rule] no-box-leak", directive["message"])
+        self.assertIn("Box::leak", directive["message"])
+        self.assertIn("did not run", directive["message"])
+
+    def test_non_matching_call_proceeds(self):
+        _write_rules(self.home, [BOX_LEAK_RULE])
+        self.assertIsNone(
+            toolcall_rule_directive(
+                tool_name="write_file",
+                tool_input={"path": "src/lib.rs", "content": "Arc::new(name)"},
+                session_id="session-a",
+                omh_home=str(self.home),
+            )
+        )
+
+    def test_tool_scope_filters(self):
+        _write_rules(self.home, [{**BOX_LEAK_RULE, "tools": ["patch"]}])
+        self.assertIsNone(
+            toolcall_rule_directive(
+                tool_name="write_file",
+                tool_input={"content": "Box::leak"},
+                session_id="session-a",
+                omh_home=str(self.home),
+            )
+        )
+        self.assertIsNotNone(
+            toolcall_rule_directive(
+                tool_name="patch",
+                tool_input={"content": "Box::leak"},
+                session_id="session-a",
+                omh_home=str(self.home),
+            )
+        )
+
+    def test_repeat_once_fires_once_per_session(self):
+        _write_rules(self.home, [BOX_LEAK_RULE])
+        args = {"tool_name": "write_file", "tool_input": {"content": "Box::leak"}, "omh_home": str(self.home)}
+        self.assertIsNotNone(toolcall_rule_directive(session_id="session-a", **args))
+        self.assertIsNone(toolcall_rule_directive(session_id="session-a", **args))
+        # A different session gets its own intervention.
+        self.assertIsNotNone(toolcall_rule_directive(session_id="session-b", **args))
+
+    def test_repeat_always_fires_every_time(self):
+        _write_rules(self.home, [{**BOX_LEAK_RULE, "repeat": "always"}])
+        args = {"tool_name": "write_file", "tool_input": {"content": "Box::leak"}, "omh_home": str(self.home)}
+        self.assertIsNotNone(toolcall_rule_directive(session_id="session-a", **args))
+        self.assertIsNotNone(toolcall_rule_directive(session_id="session-a", **args))
+
+    def test_string_tool_input_is_matched_directly(self):
+        _write_rules(self.home, [BOX_LEAK_RULE])
+        self.assertIsNotNone(
+            toolcall_rule_directive(
+                tool_name="execute_code",
+                tool_input='{"code": "Box::leak(x)"}',
+                session_id="session-a",
+                omh_home=str(self.home),
+            )
+        )
+
+    def test_empty_tool_name_proceeds(self):
+        _write_rules(self.home, [BOX_LEAK_RULE])
+        self.assertIsNone(
+            toolcall_rule_directive(
+                tool_name="",
+                tool_input={"content": "Box::leak"},
+                session_id="session-a",
+                omh_home=str(self.home),
+            )
+        )
+
+
+class HookWiringTest(unittest.TestCase):
+    def setUp(self):
+        _reset_state()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.home = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_pre_tool_call_returns_block_directive_for_matching_rule(self):
+        _write_rules(self.home, [BOX_LEAK_RULE])
+        result = pre_tool_call(
+            tool_name="write_file",
+            tool_input={"content": "Box::leak(x)"},
+            session_id="session-a",
+            omh_home=str(self.home),
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result["action"], "block")
+        self.assertIn("[OMH Rule] no-box-leak", str(result["message"]))
+
+    def test_pre_tool_call_stays_quiet_without_a_rules_file(self):
+        result = pre_tool_call(
+            tool_name="write_file",
+            tool_input={"content": "Box::leak(x)"},
+            session_id="session-a",
+            omh_home=str(self.home),
+        )
+        self.assertIsNone(result)
+
+    def test_rule_block_takes_precedence_over_role_warning(self):
+        _write_rules(self.home, [{"name": "goal-guard", "pattern": "forbidden", "message": "m"}])
+        result = pre_tool_call(
+            tool_name="delegate_task",
+            tool_input={"goal": "[omh-role:not-a-role] forbidden work"},
+            session_id="session-a",
+            omh_home=str(self.home),
+        )
+        self.assertEqual(result.get("action"), "block")
+
+
+class ValidateCliTest(unittest.TestCase):
+    def setUp(self):
+        _reset_state()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.home = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _run(self, *argv):
+        return subprocess.run(
+            [sys.executable, "-m", "omh.cli", "ops", "toolcall-rules-validate", *argv],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_valid_file_exits_zero_with_report(self):
+        path = _write_rules(self.home, [BOX_LEAK_RULE])
+        result = self._run("--path", str(path))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertTrue(payload["valid"])
+        self.assertEqual(payload["accepted_rules"], 1)
+        self.assertIn("not evidence", payload["claim_boundary"])
+
+    def test_invalid_rule_exits_one_with_indexed_error(self):
+        path = _write_rules(self.home, [{"name": "broken", "pattern": "(", "message": "m"}])
+        result = self._run("--path", str(path))
+        self.assertEqual(result.returncode, 1)
+        payload = json.loads(result.stdout)
+        self.assertFalse(payload["valid"])
+        self.assertTrue(any("rules[0]" in error for error in payload["errors"]))
+
+    def test_missing_file_is_a_named_error(self):
+        result = self._run("--path", str(self.home / "nope.json"))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("not found", result.stderr)
+
+    def test_oversized_file_is_not_certified(self):
+        rules = [dict(BOX_LEAK_RULE)]
+        path = _write_rules(self.home, rules)
+        # Pad the document over the loader's byte bound while keeping it valid JSON.
+        document = json.loads(path.read_text(encoding="utf-8"))
+        document["rules"][0]["message"] = "x" * 900
+        document["padding"] = "y" * 300_000
+        path.write_text(json.dumps(document), encoding="utf-8")
+        result = self._run("--path", str(path))
+        self.assertEqual(result.returncode, 1)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["accepted_rules"], 0)
+        self.assertTrue(any("no rule is loaded" in error for error in payload["errors"]))
+
+
+class BurstLedgerOrderingTest(unittest.TestCase):
+    def setUp(self):
+        _reset_state()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.home = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_blocked_calls_do_not_tick_the_burst_ledger(self):
+        _write_rules(self.home, [BOX_LEAK_RULE])
+        pre_tool_call(
+            tool_name="write_file",
+            tool_input={"content": "Box::leak(x)"},
+            session_id="session-a",
+            omh_home=str(self.home),
+        )
+        self.assertFalse((self.home / "runtime" / "tool-bursts.json").exists())
+        # An allowed call ticks it.
+        pre_tool_call(
+            tool_name="write_file",
+            tool_input={"content": "Arc::new(x)"},
+            session_id="session-a",
+            omh_home=str(self.home),
+        )
+        self.assertTrue((self.home / "runtime" / "tool-bursts.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Capability

User-authored rules at `$OMH_HOME/rules/toolcall-rules.json` (the file's presence is the opt-in) are matched deterministically against every Hermes tool call's name + JSON-serialized arguments at the plugin's `pre_tool_call` hook. A match returns the host's block directive, so the call is refused before execution and the model reads the rule text as the tool result, then course-corrects. `repeat: "once"` (default) fires each rule at most once per session so a blocked retry cannot loop. `omh ops toolcall-rules-validate` surfaces everything the fail-open hook would silently skip. Schema and bounds documented in `docs/TOOLCALL-RULES.md`.

## Motivation

Borrowed from stream-rule systems in other harnesses (oh-my-pi's TTSR): rules sit dormant until the model goes off-script, so standing guidance costs zero context on turns that never violate it. OMH cannot abort a stream mid-token — that is host-owned — but the host's own `pre_tool_call` dispatcher honors `{"action":"block","message":...}` (`hermes_cli/plugins.py`, `_get_pre_tool_call_directive_details`: "``block`` vetoes the tool call outright (the message becomes the tool result the model sees)"), which gives the same course-correction loop at tool-call granularity with zero Hermes patching.

## Implementation (boundary level)

- `src/plugin_bundle/omh/toolcall_rules.py` — bounded parsing (≤64 rules, pattern ≤512, message ≤1000, file ≤256KiB, match window 20k chars), mtime-cached loads, per-session once-dedup, `$OMH_HOME` env resolution, and an AST-walk refusal of catastrophic-backtracking patterns (`(a+)+` shapes) so a user rule cannot wedge the hook — validator and loader share the refusal.
- `hooks/tool_hooks.py` — rules run first; a blocked call does not tick the parallel-shot burst ledger (its claim boundary is "the host dispatched the calls").
- The four repo statements predating this host capability ("the hook contract has no deny channel") are reconciled in the same change; `blocked_work_records` keeps its enforcing/observing split because a returned directive is a request whose receipt OMH cannot observe.
- `capabilities/hooks.py` + standalone copy advertise the new payload fields in lockstep.

## Verification (observed)

- `tests/test_toolcall_rules.py` — 26 tests: fail-open paths, ReDoS refusal (validator+loader agreement), tool scoping, once/always semantics, OMH_HOME resolution, CLI subprocess exit codes, burst-ledger ordering, block-over-role-warning precedence
- Full suite 7,170 OK · ruff clean · all five `docs --check` byte gates · `git diff --check`
- Reviewer pass (code-reviewer agent): P0/P1 findings all addressed in this diff (host-contract citation + stale-statement reconciliation, ReDoS guard, env resolution, validator size/schema parity, bounded caches, CLI coverage)

## Risks

- Enforcement depends on the host honoring the directive; not yet observed on a live machine (needs `omh update` + a matching call). The block path is fail-open in every error case, so a host that ignored the directive degrades to no intervention.
- `repeat:"once"` dedup is in-process; a host restart re-arms rules (accepted, documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKo77o5dTJtLRWfDj4uBtq