### PR TITLE
feat(coding): deterministic commit-split planner (omh coding commit-plan)

### DIFF
--- a/src/coding/commit_planning.py
+++ b/src/coding/commit_planning.py
@@ -1,0 +1,299 @@
+"""Deterministic commit-split planning over observed working-tree metadata.
+
+`wrapper-routing.md` (Commit Planning) states five prose rules for multi-commit
+handoffs: overview first, bounded diffs, complete non-overlapping coverage,
+dependency order, and lockfile-manifest pairing. This module operationalizes
+those rules as a pure function over git *metadata* — changed paths and
+statuses — so a wrapper, an operator, or a prepared handoff can
+carry an actual plan instead of re-deriving the prose every time.
+
+Scope boundaries, in this repo's vocabulary:
+
+- Input is observed metadata (`git status --porcelain=v1 -z` output, or a
+  pre-captured equivalent). No diff bodies are read and no content
+  heuristics run; grouping uses paths only.
+- The output is a prepared artifact. A commit plan is not a commit, and it is
+  never execution, review, CI, or merge evidence.
+- Grouping is deterministic: same inputs, same plan, byte for byte.
+
+The planner never guesses about dependency cycles because its ordering is a
+fixed category sequence (manifests -> source -> tests -> docs -> config),
+which is acyclic by construction; within a category, groups and files sort
+lexicographically.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Any, Final
+
+COMMIT_PLAN_SCHEMA_VERSION: Final = "commit_plan/v1"
+COMMIT_PLAN_CLAIM_BOUNDARY: Final = (
+    "This is a prepared commit plan derived from observed working-tree metadata. "
+    "It is not a commit, and it is not execution, review, CI, or merge evidence."
+)
+
+MAX_PLAN_FILES: Final = 2000
+
+
+class CommitPlanError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class ChangedFile:
+    path: str
+    status: str  # one of M A D R C ? (porcelain XY collapsed to one letter)
+    renamed_from: str | None = None
+
+
+_MANIFEST_LOCKFILES: Final = {
+    "package.json": ("package-lock.json", "bun.lock", "bun.lockb", "yarn.lock", "pnpm-lock.yaml"),
+    "pyproject.toml": ("uv.lock", "poetry.lock", "pdm.lock"),
+    "Cargo.toml": ("Cargo.lock",),
+    "go.mod": ("go.sum",),
+    "Gemfile": ("Gemfile.lock",),
+    "composer.json": ("composer.lock",),
+}
+_LOCKFILE_NAMES: Final = frozenset(
+    name for names in _MANIFEST_LOCKFILES.values() for name in names
+)
+_MANIFEST_NAMES: Final = frozenset(_MANIFEST_LOCKFILES)
+
+_DOC_SUFFIXES: Final = frozenset({".md", ".markdown", ".rst", ".adoc", ".txt"})
+_CONFIG_SUFFIXES: Final = frozenset({".json", ".jsonc", ".yaml", ".yml", ".toml", ".ini", ".cfg", ".editorconfig"})
+_TEST_DIR_MARKERS: Final = ("tests", "test", "__tests__", "spec")
+
+
+def parse_status_porcelain_z(payload: str) -> list[ChangedFile]:
+    """Parse `git status --porcelain=v1 -z` output into changed files.
+
+    Rename/copy entries carry two NUL-separated fields (new path, then
+    original path); every other entry carries one.
+    """
+    fields = [field for field in payload.split("\0")]
+    files: list[ChangedFile] = []
+    index = 0
+    while index < len(fields):
+        field = fields[index]
+        index += 1
+        if not field:
+            continue
+        if len(field) < 4 or field[2] != " ":
+            raise CommitPlanError(f"unrecognized porcelain entry: {field!r}")
+        xy, path = field[:2], field[3:]
+        status = _collapse_status(xy)
+        renamed_from = None
+        if "R" in xy or "C" in xy:
+            if index >= len(fields):
+                raise CommitPlanError(f"rename entry missing original path: {field!r}")
+            renamed_from = fields[index]
+            index += 1
+        files.append(ChangedFile(path=path, status=status, renamed_from=renamed_from))
+    return files
+
+
+def build_commit_plan(files: list[ChangedFile]) -> dict[str, Any]:
+    """The deterministic commit plan for *files*.
+
+    Every input file lands in exactly one commit (complete, non-overlapping
+    coverage); every manifest and lockfile shares the single deps commit;
+    commits follow the fixed category order.
+    """
+    if len(files) > MAX_PLAN_FILES:
+        raise CommitPlanError(f"commit planning is bounded to {MAX_PLAN_FILES} changed files")
+    deduped: dict[str, ChangedFile] = {}
+    for entry in files:
+        if not entry.path:
+            raise CommitPlanError("changed file with empty path")
+        if entry.path in deduped:
+            raise CommitPlanError(f"duplicate changed-file path: {entry.path}")
+        deduped[entry.path] = entry
+    ordered_paths = sorted(deduped)
+
+    assigned: dict[str, str] = {}  # path -> group key
+    groups: dict[str, dict[str, Any]] = {}
+
+    def _put(path: str, key: str, category: str, reason: str) -> None:
+        if path in assigned:
+            return
+        assigned[path] = key
+        group = groups.setdefault(
+            key,
+            {"category": category, "files": [], "reasons": []},
+        )
+        group["files"].append(path)
+        if reason not in group["reasons"]:
+            group["reasons"].append(reason)
+
+    # Pass 1 — every manifest and lockfile shares ONE repo-wide deps commit.
+    # One group (not one per directory) is what makes the pairing rule true in
+    # monorepos, where a workspace manifest changes beside a root lockfile; a
+    # per-directory split would land a lockfile describing a manifest that has
+    # not changed yet.
+    for path in ordered_paths:
+        name = PurePosixPath(path).name
+        if name in _MANIFEST_NAMES or name in _LOCKFILE_NAMES:
+            _put(
+                path,
+                "deps",
+                "deps",
+                "dependency manifests and lockfiles land together, never split",
+            )
+
+    # Pass 2 — tests pair with same-stem source files when both changed.
+    stems_by_name: dict[str, list[str]] = {}
+    for path in ordered_paths:
+        if path in assigned:
+            continue
+        stems_by_name.setdefault(PurePosixPath(path).stem, []).append(path)
+    for path in ordered_paths:
+        if path in assigned or not _is_test_path(path):
+            continue
+        stem = _test_stem(path)
+        sources = [
+            candidate
+            for candidate in stems_by_name.get(stem, [])
+            if candidate != path and not _is_test_path(candidate) and _category_for(candidate) == "source"
+        ]
+        if sources:
+            source = sources[0]
+            key = f"source:{_group_dir(source)}"
+            _put(source, key, "source", "source change and the test that proves it share a commit")
+            _put(path, key, "source", "source change and the test that proves it share a commit")
+
+    # Pass 3 — remaining files bucket by category, grouped by top directory.
+    for path in ordered_paths:
+        if path in assigned:
+            continue
+        category = _category_for(path)
+        _put(path, f"{category}:{_group_dir(path)}", category, _CATEGORY_REASONS[category])
+
+    category_rank = {"deps": 0, "source": 1, "tests": 2, "docs": 3, "config": 4}
+    ordered_keys = sorted(
+        groups,
+        key=lambda key: (category_rank[groups[key]["category"]], key),
+    )
+    commits = []
+    for order, key in enumerate(ordered_keys, start=1):
+        group = groups[key]
+        group_files = sorted(group["files"])
+        renames = {
+            path: deduped[path].renamed_from
+            for path in group_files
+            if deduped[path].renamed_from
+        }
+        commit: dict[str, Any] = {
+            "order": order,
+            "category": group["category"],
+            "title": _suggested_title(group["category"], key, group_files, deduped),
+            "files": group_files,
+            "rationale": "; ".join(group["reasons"]),
+        }
+        if renames:
+            # Staging a rename needs both sides; `files` carries the new
+            # path, and this map names the old path to stage with it.
+            commit["renames"] = renames
+        commits.append(commit)
+
+    covered = sorted(path for commit in commits for path in commit["files"])
+    if covered != ordered_paths:
+        raise CommitPlanError("internal error: plan coverage is not complete and non-overlapping")
+
+    return {
+        "schema_version": COMMIT_PLAN_SCHEMA_VERSION,
+        "changed_file_count": len(ordered_paths),
+        "commit_count": len(commits),
+        "commits": commits,
+        "rules": [
+            "complete, non-overlapping coverage: every changed file belongs to exactly one commit (renamed files list their old path in the commit's renames map)",
+            "lockfile-manifest pairing: all dependency manifests and lockfiles share one commit, so a lockfile never lands apart from its manifest",
+            "fixed dependency order: deps -> source -> tests -> docs -> config",
+            "bounded diffs: one reviewable idea per commit; split further by hand if a group reads as two ideas",
+        ],
+        "claim_boundary": COMMIT_PLAN_CLAIM_BOUNDARY,
+    }
+
+
+def _collapse_status(xy: str) -> str:
+    if "U" in xy or xy in ("AA", "DD"):
+        raise CommitPlanError(
+            f"unmerged entry {xy!r}: resolve the merge before planning commits"
+        )
+    for letter in (xy[0], xy[1]):
+        if letter in "MADRC":
+            return letter
+    if "?" in xy:
+        return "?"
+    return "M"
+
+
+def _is_test_path(path: str) -> bool:
+    parts = PurePosixPath(path).parts
+    if any(part in _TEST_DIR_MARKERS for part in parts[:-1]):
+        return True
+    name = PurePosixPath(path).stem
+    return name.startswith("test_") or name.endswith("_test") or name.endswith(".test") or name.endswith(".spec")
+
+
+def _test_stem(path: str) -> str:
+    stem = PurePosixPath(path).stem
+    for prefix in ("test_",):
+        if stem.startswith(prefix):
+            return stem[len(prefix):]
+    for suffix in ("_test", ".test", ".spec"):
+        if stem.endswith(suffix):
+            return stem[: -len(suffix)]
+    return stem
+
+
+def _category_for(path: str) -> str:
+    pure = PurePosixPath(path)
+    suffix = pure.suffix.lower()
+    # File type outranks directory ancestry: docs/spec/api.md is a doc and
+    # spec/openapi.yaml is config, even though a `spec` ancestor also names a
+    # test convention elsewhere.
+    if suffix in _DOC_SUFFIXES:
+        return "docs"
+    if suffix in _CONFIG_SUFFIXES or pure.name.startswith("."):
+        return "config"
+    if _is_test_path(path):
+        return "tests"
+    return "source"
+
+
+def _group_dir(path: str) -> str:
+    parts = PurePosixPath(path).parts
+    if len(parts) <= 1:
+        return "."
+    return "/".join(parts[:2]) if len(parts) > 2 else parts[0]
+
+
+_CATEGORY_REASONS: Final = {
+    "source": "one reviewable source change grouped by directory",
+    "tests": "standalone test changes grouped by directory",
+    "docs": "documentation-only changes grouped by directory",
+    "config": "configuration and tooling changes grouped by directory",
+    "deps": "dependency manifest and lockfile land together, never split",
+}
+
+
+def _suggested_title(category: str, key: str, files: list[str], entries: dict[str, ChangedFile]) -> str:
+    scope = key.split(":", 1)[1] if ":" in key else key
+    scope = scope.strip("/").replace("/", "-") or "repo"
+    statuses = {entries[path].status for path in files}
+    if category == "source":
+        source_kind = "feat" if "A" in statuses else "chore" if statuses == {"D"} else "refactor"
+    else:
+        source_kind = ""
+    kind = {
+        "deps": "chore(deps)",
+        "source": source_kind,
+        "tests": "test",
+        "docs": "docs",
+        "config": "chore",
+    }[category]
+    verb = "remove" if statuses == {"D"} else "add" if statuses == {"A"} else "update"
+    noun = PurePosixPath(files[0]).name if len(files) == 1 else f"{len(files)} files"
+    return f"{kind}({scope}): {verb} {noun}"

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -1846,6 +1846,49 @@ def _reject_near_miss_key(payload: dict[str, object], expected: str) -> None:
             raise OmhError(f"unknown key {key!r} in fanout units payload; did you mean {expected!r}?")
 
 
+def cmd_coding_commit_plan(args: argparse.Namespace) -> int:
+    import subprocess as _subprocess
+
+    from ..coding.commit_planning import (
+        CommitPlanError,
+        build_commit_plan,
+        parse_status_porcelain_z,
+    )
+
+    def _read_source(path_text: str) -> str:
+        return sys.stdin.read() if path_text == "-" else Path(path_text).expanduser().read_text(encoding="utf-8")
+
+    try:
+        if args.status_file:
+            status_payload = _read_source(args.status_file)
+        else:
+            repo_root = Path(args.repo_root).expanduser().resolve()
+            if not (repo_root / ".git").exists():
+                raise OmhError(f"--repo-root is not a git checkout root: {repo_root}")
+            # Read-only metadata probes, same class as the worktree observation
+            # ledger reads: nothing is staged, committed, or mutated.
+            status = _subprocess.run(
+                ["git", "status", "--porcelain=v1", "-z", "--untracked-files=all"],
+                cwd=str(repo_root),
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if status.returncode != 0:
+                raise OmhError(f"git status failed in {repo_root}: {status.stderr.strip()}")
+            status_payload = status.stdout
+        files = parse_status_porcelain_z(status_payload)
+        if not files:
+            raise OmhError("nothing to plan: the working tree has no changed files")
+        plan = build_commit_plan(files)
+    except CommitPlanError as exc:
+        raise OmhError(str(exc)) from exc
+    except (OSError, ValueError, _subprocess.TimeoutExpired) as exc:
+        raise OmhError(f"could not gather commit-plan inputs: {exc}") from exc
+    _print_json(plan)
+    return 0
+
+
 def _add_coding_commands(sub) -> None:
     coding = sub.add_parser("coding", help="Prepare executor-neutral or tracked coding handoff artifacts.")
     coding_sub = coding.add_subparsers(dest="coding_command", required=True)
@@ -2122,6 +2165,18 @@ def _add_coding_commands(sub) -> None:
     show_quality_harness = quality_harness_sub.add_parser("show")
     show_quality_harness.add_argument("--family", choices=PRODUCT_FAMILIES, required=True)
     show_quality_harness.set_defaults(func=cmd_coding_quality_harness_show)
+
+    commit_plan = coding_sub.add_parser(
+        "commit-plan",
+        help="Prepare a deterministic commit-split plan from observed working-tree metadata (read-only; never commits).",
+    )
+    commit_plan.add_argument("--repo-root", default=".", help="Git checkout root to read status metadata from.")
+    commit_plan.add_argument(
+        "--status-file",
+        default="",
+        help="Pre-captured `git status --porcelain=v1 -z` output ('-' for stdin) instead of probing --repo-root.",
+    )
+    commit_plan.set_defaults(func=cmd_coding_commit_plan)
 
     _add_dynamic_workflow_command(coding_sub)
     _add_capability_snapshot_commands(coding_sub)

--- a/tests/test_commit_planning.py
+++ b/tests/test_commit_planning.py
@@ -1,0 +1,232 @@
+"""Contracts for the deterministic commit-split planner.
+
+The plan operationalizes the five Commit Planning rules from
+wrapper-routing.md: complete non-overlapping coverage, lockfile-manifest
+pairing, fixed dependency order, bounded reviewable groups, and a stated
+claim boundary (a prepared plan is never a commit).
+"""
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from omh.coding.commit_planning import (
+    COMMIT_PLAN_SCHEMA_VERSION,
+    ChangedFile,
+    CommitPlanError,
+    build_commit_plan,
+    parse_status_porcelain_z,
+)
+
+
+def _paths(plan):
+    return sorted(path for commit in plan["commits"] for path in commit["files"])
+
+
+class PorcelainParsingTest(unittest.TestCase):
+    def test_parses_modified_added_deleted_and_untracked(self):
+        payload = " M src/a.py\0A  src/b.py\0 D docs/gone.md\0?? notes.txt\0"
+        files = parse_status_porcelain_z(payload)
+        self.assertEqual(
+            [(f.path, f.status) for f in files],
+            [("src/a.py", "M"), ("src/b.py", "A"), ("docs/gone.md", "D"), ("notes.txt", "?")],
+        )
+
+    def test_rename_entries_carry_the_original_path(self):
+        payload = "R  src/new.py\0src/old.py\0 M other.py\0"
+        files = parse_status_porcelain_z(payload)
+        self.assertEqual(files[0].path, "src/new.py")
+        self.assertEqual(files[0].renamed_from, "src/old.py")
+        self.assertEqual(files[1].path, "other.py")
+
+    def test_garbage_entries_are_rejected(self):
+        with self.assertRaises(CommitPlanError):
+            parse_status_porcelain_z("garbage-without-status\0")
+
+
+class PlanInvariantsTest(unittest.TestCase):
+    def test_every_file_lands_in_exactly_one_commit(self):
+        files = [
+            ChangedFile("src/pkg/core.py", "M"),
+            ChangedFile("tests/test_core.py", "M"),
+            ChangedFile("docs/guide.md", "M"),
+            ChangedFile("pyproject.toml", "M"),
+            ChangedFile("uv.lock", "M"),
+            ChangedFile(".editorconfig", "M"),
+        ]
+        plan = build_commit_plan(files)
+        self.assertEqual(plan["schema_version"], COMMIT_PLAN_SCHEMA_VERSION)
+        self.assertEqual(_paths(plan), sorted(f.path for f in files))
+        self.assertEqual(plan["changed_file_count"], len(files))
+
+    def test_manifest_and_lockfile_share_a_commit(self):
+        plan = build_commit_plan(
+            [
+                ChangedFile("pyproject.toml", "M"),
+                ChangedFile("uv.lock", "M"),
+                ChangedFile("src/app.py", "M"),
+            ]
+        )
+        deps_commits = [c for c in plan["commits"] if c["category"] == "deps"]
+        self.assertEqual(len(deps_commits), 1)
+        self.assertEqual(sorted(deps_commits[0]["files"]), ["pyproject.toml", "uv.lock"])
+
+    def test_monorepo_workspace_manifest_joins_the_root_lockfile_commit(self):
+        # A per-directory split would land a lockfile describing a manifest
+        # that has not changed yet; the single deps group prevents it.
+        plan = build_commit_plan(
+            [
+                ChangedFile("apps/web/package.json", "M"),
+                ChangedFile("package-lock.json", "M"),
+            ]
+        )
+        deps_commits = [c for c in plan["commits"] if c["category"] == "deps"]
+        self.assertEqual(len(deps_commits), 1)
+        self.assertEqual(
+            sorted(deps_commits[0]["files"]),
+            ["apps/web/package.json", "package-lock.json"],
+        )
+
+    def test_renames_carry_their_old_path_for_staging(self):
+        plan = build_commit_plan(
+            [ChangedFile("src/new.py", "R", renamed_from="src/old.py")]
+        )
+        commit = plan["commits"][0]
+        self.assertEqual(commit["renames"], {"src/new.py": "src/old.py"})
+
+    def test_unmerged_entries_are_a_named_refusal(self):
+        with self.assertRaises(CommitPlanError):
+            parse_status_porcelain_z("UU conflicted.py\0")
+
+    def test_duplicate_paths_are_a_named_refusal(self):
+        with self.assertRaises(CommitPlanError):
+            build_commit_plan([ChangedFile("src/a.py", "M"), ChangedFile("src/a.py", "A")])
+
+    def test_doc_and_config_suffixes_outrank_test_directory_ancestry(self):
+        plan = build_commit_plan(
+            [
+                ChangedFile("docs/spec/api.md", "M"),
+                ChangedFile("spec/openapi.yaml", "M"),
+            ]
+        )
+        by_path = {path: c["category"] for c in plan["commits"] for path in c["files"]}
+        self.assertEqual(by_path["docs/spec/api.md"], "docs")
+        self.assertEqual(by_path["spec/openapi.yaml"], "config")
+
+    def test_test_pairs_with_same_stem_source(self):
+        plan = build_commit_plan(
+            [
+                ChangedFile("src/pkg/router.py", "M"),
+                ChangedFile("tests/test_router.py", "M"),
+                ChangedFile("tests/test_unrelated.py", "M"),
+            ]
+        )
+        paired = [c for c in plan["commits"] if "src/pkg/router.py" in c["files"]]
+        self.assertEqual(len(paired), 1)
+        self.assertIn("tests/test_router.py", paired[0]["files"])
+        standalone = [c for c in plan["commits"] if "tests/test_unrelated.py" in c["files"]]
+        self.assertEqual(standalone[0]["category"], "tests")
+
+    def test_fixed_category_order(self):
+        plan = build_commit_plan(
+            [
+                ChangedFile("docs/guide.md", "M"),
+                ChangedFile("src/app.py", "M"),
+                ChangedFile("package.json", "M"),
+                ChangedFile("package-lock.json", "M"),
+                ChangedFile(".prettierrc.json", "M"),
+                ChangedFile("tests/test_extra.py", "M"),
+            ]
+        )
+        categories = [commit["category"] for commit in plan["commits"]]
+        self.assertEqual(categories, sorted(categories, key=["deps", "source", "tests", "docs", "config"].index))
+        self.assertEqual(plan["commits"][0]["category"], "deps")
+
+    def test_deterministic_output(self):
+        files = [
+            ChangedFile("src/b.py", "M"),
+            ChangedFile("src/a.py", "M"),
+            ChangedFile("docs/x.md", "M"),
+        ]
+        first = json.dumps(build_commit_plan(files), sort_keys=True)
+        second = json.dumps(build_commit_plan(list(reversed(files))), sort_keys=True)
+        self.assertEqual(first, second)
+
+    def test_claim_boundary_is_present(self):
+        plan = build_commit_plan([ChangedFile("src/a.py", "M")])
+        self.assertIn("not a commit", plan["claim_boundary"])
+
+    def test_bounded_file_count(self):
+        files = [ChangedFile(f"src/f{i}.py", "M") for i in range(2001)]
+        with self.assertRaises(CommitPlanError):
+            build_commit_plan(files)
+
+    def test_empty_path_is_rejected(self):
+        with self.assertRaises(CommitPlanError):
+            build_commit_plan([ChangedFile("", "M")])
+
+
+class CliIntegrationTest(unittest.TestCase):
+    def test_commit_plan_reads_a_real_repo_read_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+            (root / "src").mkdir()
+            (root / "src" / "app.py").write_text("print('hi')\n", encoding="utf-8")
+            (root / "README.md").write_text("# demo\n", encoding="utf-8")
+            head_before = subprocess.run(
+                ["git", "status", "--porcelain"], cwd=root, capture_output=True, text=True, check=True
+            ).stdout
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "omh.cli",
+                    "coding",
+                    "commit-plan",
+                    "--repo-root",
+                    str(root),
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            plan = json.loads(result.stdout)
+            self.assertEqual(plan["schema_version"], COMMIT_PLAN_SCHEMA_VERSION)
+            self.assertEqual(
+                sorted(p for c in plan["commits"] for p in c["files"]),
+                ["README.md", "src/app.py"],
+            )
+            # Read-only proof: the probe changed nothing.
+            head_after = subprocess.run(
+                ["git", "status", "--porcelain"], cwd=root, capture_output=True, text=True, check=True
+            ).stdout
+            self.assertEqual(head_before, head_after)
+
+    def test_status_file_input_is_hermetic(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            status_file = Path(tmp) / "status.z"
+            status_file.write_bytes(b" M src/a.py\x00?? notes.txt\x00")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "omh.cli",
+                    "coding",
+                    "commit-plan",
+                    "--status-file",
+                    str(status_file),
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            plan = json.loads(result.stdout)
+            self.assertEqual(plan["changed_file_count"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_handoff_safety_contract_enforcement.py
+++ b/tests/test_handoff_safety_contract_enforcement.py
@@ -474,6 +474,11 @@ GIT_ARGV_ALLOWLIST: dict[tuple[str, tuple[str, ...]], str] = {
     ("src/commands/coding.py", ("rev-parse",)): (
         "resolves --base-ref to a commit sha inside `coding fanout dispatch`; read-only"
     ),
+    ("src/commands/coding.py", ("status",)): (
+        "`git status --porcelain=v1 -z` inside `coding commit-plan`, the metadata the "
+        "commit-split planner groups; read-only, names no remote, and the prepared plan "
+        "it feeds is never a commit"
+    ),
     ("src/coding/fanout_dispatch.py", ("add", ".")): (
         "`git add -N -- .` inside a FAILED unit's own isolated worktree, so the recovery probe can "
         "measure files that unit created. Not read-only: it writes intent-to-add entries to that "


### PR DESCRIPTION
## Capability

`omh coding commit-plan` turns the working tree's observed metadata into a `commit_plan/v1` artifact: ordered commits with files, titles, rationale, and rename staging maps. It operationalizes the five Commit Planning rules `wrapper-routing.md` already states as prose — complete non-overlapping coverage (runtime-asserted), lockfile-manifest pairing (one repo-wide deps commit, correct in monorepos), test↔source stem pairing, fixed acyclic category order (deps → source → tests → docs → config), bounded reviewable groups — plus named refusals for unmerged entries and duplicate paths, and a claim boundary: a prepared plan is not a commit.

## Motivation

Multi-commit handoffs today re-derive the prose rules by hand, and the usual failure is one mixed mega-commit or a lockfile landing apart from its manifest. A deterministic planner (same input → byte-identical plan) makes the plan a carryable artifact for wrappers, operators, and prepared handoffs — squarely inside OMH's no-LLM, metadata-only lane.

## Implementation (boundary level)

- `src/coding/commit_planning.py` — pure functions over `git status --porcelain=v1 -z` output; `-z` rename field order (new\0old) handled, statuses collapsed with unmerged shapes refused; grouping and ordering fully deterministic; ≤2000 files.
- CLI gathers status via one read-only probe of `--repo-root` (registered in the handoff-safety `GIT_ARGV_ALLOWLIST` with its reason — the same gate that proves every git argv OMH constructs is enumerated), or consumes a pre-captured `--status-file` for hermetic use.
- The `--numstat` pipeline from the first draft was deleted per review: its counts were never consumed, and its unquoted paths could never match `-z` paths for non-ASCII names.

## Verification (observed)

- `tests/test_commit_planning.py` — 18 tests: parsing (renames, garbage, unmerged), monorepo pairing, rename staging maps, determinism under input reordering, coverage invariant, category ordering, bounded inputs, hermetic CLI runs, and a read-only proof (git status identical before/after the probe)
- Handoff safety contract suite green with the new allowlist entry · full suite OK · ruff clean · five `docs --check` byte gates
- Reviewer pass: P0 (allowlist) and both P1s (monorepo pairing claim, rename stageability) fixed; P2s resolved by numstat deletion, conflict refusal, suffix-over-ancestry categorization, `sys.executable` in tests

## Risks

- Grouping is path-heuristic; a group that reads as two ideas still needs a hand split (stated in the plan's own rules).
- Titles are suggestions derived from statuses (feat/refactor/chore), not semantic analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKo77o5dTJtLRWfDj4uBtq