### PR TITLE
feat(memory): one-step confirm verb and review_due_soon advance warning

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -467,10 +467,12 @@ revalidation metadata — the payload digest deliberately excludes it, so the
 record's identity, admission, and immutable review record are untouched.
 `omh memory confirm --all-due` confirms every record whose sole problem is a
 passed deadline; each record still passes the single-record gates, so the
-batch reports expired, superseded, or source-changed records as skipped with
-their refusal reason rather than silently re-blessing them. Confirmation
-never resurrects an expired record and never overrides the source-evidence
-gate — a record whose cited source changed needs a correction, because a new
+batch reports superseded or source-changed records as skipped with their
+refusal reason and detail rather than silently re-blessing them. Expired
+records never enter the batch at all — their verdict is `retention_expired`,
+not `review_due`, and the fix is `omh memory retire`. Confirmation never
+resurrects an expired record and never overrides the source-evidence gate —
+a record whose cited source changed needs a correction, because a new
 deadline would not restore its eligibility anyway.
 
 The heavier verbs are unchanged: `omh memory correct` supersedes the record

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -451,12 +451,34 @@ rather than as a count, so a summarized handoff still says which record needs
 a decision. A warning is prepared context, never execution, review, CI, or
 merge evidence.
 
-Answering the warning uses the existing lifecycle verbs: `omh memory correct`
-supersedes the record with a reviewable replacement, `omh memory retire`
-archives it once expired. Both preserve the prior revision — a correction
-writes `history/<record-id>.r<revision>.json` carrying the original payload,
-its admission provenance, its source evidence, and a `superseded_by` link to
-the successor revision.
+The warning also fires *before* the cliff: for the last 14 days before a
+record's review deadline, packs still deliver it normally but carry a
+`review_due_soon` warning naming the deadline. Only delivered records earn the
+advance notice — due-soon is a statement about this pack's own content, not a
+store-wide page — and once the deadline actually passes, the ordinary
+`stale_review_required` warning covers held-back records as before.
+
+### Confirming, Correcting, or Retiring
+
+Answering the warning uses three verbs. `omh memory confirm <record-id>` is
+the lightweight one: it states the record is still true and resets its review
+deadline (default 90 days ahead, or `--stale-after-days N`), rewriting only
+revalidation metadata — the payload digest deliberately excludes it, so the
+record's identity, admission, and immutable review record are untouched.
+`omh memory confirm --all-due` confirms every record whose sole problem is a
+passed deadline; each record still passes the single-record gates, so the
+batch reports expired, superseded, or source-changed records as skipped with
+their refusal reason rather than silently re-blessing them. Confirmation
+never resurrects an expired record and never overrides the source-evidence
+gate — a record whose cited source changed needs a correction, because a new
+deadline would not restore its eligibility anyway.
+
+The heavier verbs are unchanged: `omh memory correct` supersedes the record
+with a reviewable replacement, `omh memory retire` archives it once expired.
+Both preserve the prior revision — a correction writes
+`history/<record-id>.r<revision>.json` carrying the original payload, its
+admission provenance, its source evidence, and a `superseded_by` link to the
+successor revision.
 
 ## Recall Ranking and Delivery Usage
 

--- a/src/commands/memory.py
+++ b/src/commands/memory.py
@@ -47,6 +47,8 @@ from ..memory import (
     build_project_memory_status,
     MAX_RETENTION_DAYS,
     capture_project_memory_candidate,
+    confirm_due_project_memory_records,
+    confirm_project_memory_record,
     read_memory_snapshot_file,
     reject_project_memory_candidate,
     review_memory_update_batch,
@@ -218,6 +220,29 @@ def cmd_memory_pin(args: argparse.Namespace) -> int:
 def cmd_memory_unpin(args: argparse.Namespace) -> int:
     try:
         payload = set_memory_pin(_paths(args), args.record_id, pinned=False)
+    except (OSError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(payload)
+    return 0
+
+
+def cmd_memory_confirm(args: argparse.Namespace) -> int:
+    if bool(args.all_due) == bool(args.record_id):
+        raise OmhError("pass exactly one of <record-id> or --all-due")
+    try:
+        if args.all_due:
+            payload = confirm_due_project_memory_records(
+                _paths(args),
+                confirmed_by=args.confirmed_by,
+                stale_after_days=args.stale_after_days,
+            )
+        else:
+            payload = confirm_project_memory_record(
+                _paths(args),
+                args.record_id,
+                confirmed_by=args.confirmed_by,
+                stale_after_days=args.stale_after_days,
+            )
     except (OSError, ValueError) as exc:
         raise OmhError(str(exc)) from exc
     _print_json(payload)

--- a/src/commands/memory_parser.py
+++ b/src/commands/memory_parser.py
@@ -126,6 +126,28 @@ def add_memory_commands(sub: argparse._SubParsersAction[argparse.ArgumentParser]
     unpin.add_argument("record_id")
     unpin.set_defaults(func=memory.cmd_memory_unpin)
 
+    confirm = memory_sub.add_parser(
+        "confirm",
+        help=(
+            "Confirm one approved record is still true and reset its review deadline; "
+            "--all-due confirms every record whose deadline has passed."
+        ),
+    )
+    confirm.add_argument("record_id", nargs="?", default="", help="Record to confirm; omit when using --all-due.")
+    confirm.add_argument(
+        "--all-due",
+        action="store_true",
+        help="Confirm every approved record whose review deadline has passed; refusals are reported as skipped.",
+    )
+    confirm.add_argument(
+        "--stale-after-days",
+        type=int,
+        default=None,
+        help="Days until the next review deadline (default 90).",
+    )
+    confirm.add_argument("--confirmed-by", default="operator", help="Who confirmed the record; stored as bounded metadata.")
+    confirm.set_defaults(func=memory.cmd_memory_confirm)
+
     attention = memory_sub.add_parser(
         "attention",
         help="Report how one record's attention tier would change the working context; --apply writes the local tier change.",

--- a/src/maintenance/doctor.py
+++ b/src/maintenance/doctor.py
@@ -771,6 +771,9 @@ def _memory_consolidation_check(paths: OmhPaths) -> Check:
     if expired > 0:
         # Expired records have an operator-runnable fix; consolidation does not.
         remedy = f"Run `omh memory retire` to archive {expired} expired record(s); OMH never deletes them."
+    elif any(reason.startswith("stale_review_required") for reason in reasons):
+        # Review-due records also have an operator-runnable fix now.
+        remedy = "Run `omh memory confirm --all-due` to re-bless still-true review-due records; refusals are reported, never forced."
     else:
         remedy = "Ask Hermes to review and consolidate its memory; OMH prepared the brief and cannot run it."
     return Check(

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -67,6 +67,8 @@ MEMORY_ATTENTION_CHANGE_SCHEMA_VERSION = "memory_attention_change/v1"
 MEMORY_ATTENTION_JOURNAL_SCHEMA_VERSION = "omh_memory_attention_journal/v1"
 MEMORY_ROLLUP_SCHEMA_VERSION = "omh_memory_rollup/v1"
 HERMES_MEMORY_BRIDGE_SCHEMA_VERSION = "hermes_memory_bridge/v1"
+MEMORY_CONFIRMATION_SCHEMA_VERSION = "memory_confirmation/v1"
+MEMORY_CONFIRMATION_BATCH_SCHEMA_VERSION = "memory_confirmation_batch/v1"
 
 SOURCE_TRUTH_LEVELS = {
     "runtime_evidence": "observed_evidence",
@@ -273,6 +275,23 @@ _MEMORY_ATTENTION_CLAIM_BOUNDARY = (
     "true, approved, fresh, or eligible, it never deletes anything, and it is not execution, review, CI, "
     "merge, or Hermes internal-memory evidence."
 )
+_MEMORY_CONFIRMATION_REFUSAL_DETAIL = {
+    "record_not_found": "No approved OMH memory record carries that id, so there is nothing to confirm.",
+    "record_unreadable": "That record file exists but could not be read as JSON, so it cannot be confirmed safely.",
+    "unsupported_record_schema": "That file is not a current approved OMH memory record, so confirmation does not apply to it.",
+    "superseded": "A newer revision supersedes this record; confirm the live revision instead.",
+    "retention_expired": "Its retention deadline passed; confirmation resets review deadlines, it does not resurrect expired records.",
+    "source_requires_correction": (
+        "The local source it cites changed or cannot be read now, and a new review deadline would not restore "
+        "eligibility past that gate. Correct or retire the record instead."
+    ),
+    "no_review_deadline": "It carries no review deadline, so there is nothing to confirm.",
+}
+_MEMORY_CONFIRMATION_CLAIM_BOUNDARY = (
+    "Confirmation resets one OMH-local review deadline only. It never changes the record's reviewed content, "
+    "admission, or immutable review record, and it is not execution, review, CI, merge, or Hermes "
+    "internal-memory evidence."
+)
 # Perspective is honcho's peer paradigm reinterpreted deterministically: an
 # optional (observer, observed) pair naming whose view a record is and which
 # actor it is about. Unscoped records behave exactly as before; a scoped
@@ -323,7 +342,17 @@ _SOURCE_EVIDENCE_MAX_BYTES = 4 * 1024 * 1024
 # `truncated` when its own budget cuts records.
 _FRESHNESS_WARNING_LIMIT = 12
 _FRESHNESS_NEXT_ACTION = "Confirm, replace, or retire this record before it steers the plan."
+# The pre-deadline window turns the 90-day cliff into a slope: for this many
+# days before a record's review deadline, packs still deliver it but carry a
+# named warning, so the operator hears about the deadline while confirming
+# still keeps recall intact -- not on the first day the record is gone.
+_REVIEW_DUE_SOON_DAYS = 14
+_DUE_SOON_NEXT_ACTION = (
+    "Run `omh memory confirm <record-id>` (or correct/retire it) before the deadline passes; "
+    "until then the record still recalls normally."
+)
 _FRESHNESS_REASON_TEXT = {
+    "review_due_soon": "Its revalidation deadline is approaching; unconfirmed, it will leave default recall packs then.",
     "stale_review_required": "Its revalidation deadline passed, so nobody has confirmed the record since then.",
     "source_changed": "The local source it cites changed after the record was approved.",
     "source_unverifiable": "The local source it cites cannot be read now, so its freshness is unobservable.",
@@ -1773,6 +1802,160 @@ def apply_memory_attention_change(
     }
 
 
+def confirm_project_memory_record(
+    paths: OmhPaths,
+    record_id: str,
+    *,
+    confirmed_by: str = "operator",
+    stale_after_days: int | None = None,
+    now: datetime | None = None,
+) -> dict[str, object]:
+    """Reset one approved record's review deadline after a human confirmed it.
+
+    This is the verb the freshness warning has always instructed ("Confirm,
+    replace, or retire") without a command behind it: replacing is the
+    correction path and retiring exists, but confirming -- the record is
+    still true, keep it recalling -- required a full correction plan plus
+    reapproval per record. Confirmation rewrites only revalidation metadata;
+    the canonical payload digest deliberately excludes revalidation, so the
+    record's identity, admission, and immutable review record are untouched.
+
+    Refusals are fail-closed and mirror recall's own gates: an expired record
+    is not resurrected here, a superseded one stays superseded, and a record
+    whose cited source changed or became unreadable needs a correction --
+    a new deadline would not make it eligible past the source gate anyway.
+    A record with no deadline (declared durable) has nothing to confirm.
+    """
+    normalized_id = str(record_id).strip()
+    if not _SAFE_REF.match(normalized_id):
+        raise ValueError(f"unsafe memory record id: {record_id!r}")
+    days = _validated_day_count(stale_after_days, field="stale_after_days")
+    if days is None:
+        days = _REVIEW_DEFAULT_DAYS
+    stamp = _attention_stamp(now)
+    moment = _parse_utc(stamp) or datetime.now(timezone.utc)
+    with file_lock(paths.memory_index_path, private=True):
+        record, error = read_json_object_result(_memory_record_path(paths, normalized_id))
+        if error:
+            return _refused_confirmation(normalized_id, "record_unreadable")
+        if not isinstance(record, dict) or str(record.get("record_id", "")) != normalized_id:
+            return _refused_confirmation(normalized_id, "record_not_found")
+        if record.get("schema_version") != PROJECT_MEMORY_RECORD_SCHEMA_VERSION:
+            return _refused_confirmation(normalized_id, "unsupported_record_schema")
+        if str(record.get("superseded_by", "") or ""):
+            return _refused_confirmation(normalized_id, "superseded")
+        staleness = _record_staleness(record, now=moment)
+        state = str(staleness.get("state", ""))
+        if state == "expired":
+            return _refused_confirmation(normalized_id, "retention_expired")
+        if str(staleness.get("source_state", "")) in {"changed", "unreadable"}:
+            return _refused_confirmation(normalized_id, "source_requires_correction")
+        previous_due = str(staleness.get("review_due_at", "") or "")
+        if not previous_due:
+            return _refused_confirmation(normalized_id, "no_review_deadline")
+        revalidation = record.get("revalidation") if isinstance(record.get("revalidation"), dict) else {}
+        new_deadline = _days_after(stamp, days)
+        updated_revalidation = {
+            **revalidation,
+            "deadline": new_deadline,
+            "confirmed_at": stamp,
+            "confirmed_by": str(confirmed_by or "operator"),
+        }
+        _write_project_memory_record(
+            paths,
+            {
+                **record,
+                "revalidation": updated_revalidation,
+                "staleness": _staleness_projection(updated_revalidation),
+                "updated_at": stamp,
+            },
+        )
+        _write_memory_index_unlocked(paths)
+    return {
+        "schema_version": MEMORY_CONFIRMATION_SCHEMA_VERSION,
+        "record_id": normalized_id,
+        "applied": True,
+        "reason_code": "confirmed",
+        "was_stale": state == "stale",
+        "previous_review_due_at": previous_due,
+        "review_due_at": new_deadline,
+        "stale_after_days": days,
+        "confirmed_at": stamp,
+        "confirmed_by": str(confirmed_by or "operator"),
+        "redaction_policy": "metadata_only",
+        "next_action": f"The record recalls normally until {new_deadline}; confirm, correct, or retire it again by then.",
+        "claim_boundary": _MEMORY_CONFIRMATION_CLAIM_BOUNDARY,
+    }
+
+
+def confirm_due_project_memory_records(
+    paths: OmhPaths,
+    *,
+    confirmed_by: str = "operator",
+    stale_after_days: int | None = None,
+    now: datetime | None = None,
+) -> dict[str, object]:
+    """Confirm every approved record whose review deadline has passed.
+
+    Default deadlines land 90 days after capture, so the store tends to go
+    review-due all at once -- the operator who ignored it for a season faces
+    dozens of one-by-one confirmations, which is how the warnings get ignored
+    for another season. The batch confirms only records whose sole problem is
+    the passed deadline: every record still goes through the single-record
+    gates, so an expired, superseded, or source-changed record is reported as
+    skipped with its refusal reason, never silently re-blessed.
+    """
+    moment = _parse_utc(_attention_stamp(now)) or datetime.now(timezone.utc)
+    due = sorted(
+        str(record.get("record_id", ""))
+        for record in _read_project_memory_records(paths)
+        if _record_staleness(record, now=moment).get("reason") == "review_due"
+    )
+    confirmed: list[dict[str, object]] = []
+    skipped: list[dict[str, object]] = []
+    for due_id in due:
+        result = confirm_project_memory_record(
+            paths,
+            due_id,
+            confirmed_by=confirmed_by,
+            stale_after_days=stale_after_days,
+            now=now,
+        )
+        if bool(result.get("applied")):
+            confirmed.append({"record_id": due_id, "review_due_at": str(result.get("review_due_at", ""))})
+        else:
+            skipped.append({"record_id": due_id, "reason_code": str(result.get("reason_code", ""))})
+    return {
+        "schema_version": MEMORY_CONFIRMATION_BATCH_SCHEMA_VERSION,
+        "due_count": len(due),
+        "confirmed": confirmed,
+        "skipped": skipped,
+        "confirmed_count": len(confirmed),
+        "skipped_count": len(skipped),
+        "confirmed_by": str(confirmed_by or "operator"),
+        "redaction_policy": "metadata_only",
+        "next_action": (
+            "Review the skipped records individually; each carries the refusal reason."
+            if skipped
+            else "Every review-due record was confirmed; recall packs deliver them again."
+        ),
+        "claim_boundary": _MEMORY_CONFIRMATION_CLAIM_BOUNDARY,
+    }
+
+
+def _refused_confirmation(record_id: str, reason_code: str) -> dict[str, object]:
+    return {
+        "schema_version": MEMORY_CONFIRMATION_SCHEMA_VERSION,
+        "record_id": record_id,
+        "applied": False,
+        "reason_code": reason_code,
+        "detail": _MEMORY_CONFIRMATION_REFUSAL_DETAIL[reason_code],
+        "redaction_policy": "metadata_only",
+        "next_action": f"Inspect the record with `omh memory inspect {record_id}`; nothing was changed.",
+        "claim_boundary": _MEMORY_CONFIRMATION_CLAIM_BOUNDARY,
+    }
+
+
 def _age_tier(approved_at: str, *, now: datetime) -> int:
     """0 for young, 1 for aging, 2 for old; unparseable timestamps stay 0 so
     a malformed record is never silently downweighted."""
@@ -2897,6 +3080,15 @@ def _freshness_warnings(
         state = str(staleness.get("state", ""))
         reason_code = str(entry.get("eligibility_reason", "") or "")
         known_reason = reason_code in _FRESHNESS_REASON_TEXT
+        if not known_reason and delivered and str(staleness.get("reason", "") or "") == "review_due_soon":
+            # A still-fresh record inside the pre-deadline window: eligibility
+            # has nothing to say about it, so the advance notice comes from
+            # the staleness verdict instead. Only a DELIVERED record earns it
+            # -- a due-soon warning on every unrelated record in the store
+            # would page the operator about records this task never touched,
+            # and once the deadline actually passes the ordinary stale warning
+            # fires for held-back records as before.
+            reason_code, known_reason = "review_due_soon", True
         if not known_reason and state in {"", "fresh", "not_checked"}:
             continue
         if not record_id or record_id in seen:
@@ -2912,7 +3104,7 @@ def _freshness_warnings(
                 "review_due_at": str(staleness.get("review_due_at", "") or ""),
                 "detail": _FRESHNESS_REASON_TEXT[reason_code],
                 "delivered": bool(delivered),
-                "next_action": _FRESHNESS_NEXT_ACTION,
+                "next_action": _DUE_SOON_NEXT_ACTION if reason_code == "review_due_soon" else _FRESHNESS_NEXT_ACTION,
             }
         )
         if len(warnings) >= _FRESHNESS_WARNING_LIMIT:
@@ -3170,6 +3362,12 @@ def _record_staleness(record: dict[str, Any], *, now: datetime | None = None) ->
         return {"state": "stale", "reason": "source_changed", **fields}
     if source_state == "unreadable":
         return {"state": "unknown", "reason": "source_unreadable", **fields}
+    if deadline and deadline - now <= timedelta(days=_REVIEW_DUE_SOON_DAYS):
+        # Still fresh and still eligible: the record delivers exactly as
+        # before. The reason is the advance notice recall packs turn into a
+        # warning, so the deadline stops being a surprise discovered only
+        # after the record has already left every pack.
+        return {"state": "fresh", "reason": "review_due_soon", **fields}
     return {"state": "fresh", "reason": "", **fields}
 
 

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -341,7 +341,10 @@ _SOURCE_EVIDENCE_MAX_BYTES = 4 * 1024 * 1024
 # list is bounded like every other polled surface; the pack already says
 # `truncated` when its own budget cuts records.
 _FRESHNESS_WARNING_LIMIT = 12
-_FRESHNESS_NEXT_ACTION = "Confirm, replace, or retire this record before it steers the plan."
+_FRESHNESS_NEXT_ACTION = (
+    "Confirm, replace, or retire this record before it steers the plan; "
+    "`omh memory confirm <record-id>` resets its review deadline."
+)
 # The pre-deadline window turns the 90-day cliff into a slope: for this many
 # days before a record's review deadline, packs still deliver it but carry a
 # named warning, so the operator hears about the deadline while confirming
@@ -365,6 +368,11 @@ _FRESHNESS_REASON_TEXT = {
 # Reasons `--include-stale` may surface for inspection. They carry ineligible
 # replay evidence, so the pack still cannot be attached as approved context.
 _INSPECTABLE_STALE_REASONS = {"stale_review_required", "source_changed", "source_unverifiable"}
+# Advisory freshness reasons describe a record that is still fresh and still
+# delivered. Consumers that treat "has a freshness reason" as "this record is
+# stale" (wrapper continuity, role-context-pack diffs) must subtract this set,
+# or the advance notice would read as the failure it exists to prevent.
+ADVISORY_FRESHNESS_REASONS = frozenset({"review_due_soon"})
 _HANDOFF_CONTEXT_PACK_KEYS = {
     "schema_version",
     "executor_target",
@@ -1830,8 +1838,12 @@ def confirm_project_memory_record(
     if not _SAFE_REF.match(normalized_id):
         raise ValueError(f"unsafe memory record id: {record_id!r}")
     days = _validated_day_count(stale_after_days, field="stale_after_days")
-    if days is None:
-        days = _REVIEW_DEFAULT_DAYS
+    # The actor claim is bounded and redacted exactly like the attention
+    # reason: operator prose must never become an unbounded stored field, and
+    # a sensitive-looking value must degrade to `[redacted]` here rather than
+    # fail the whole record write with an error naming a field the operator
+    # cannot see.
+    actor = _redact(str(confirmed_by or "operator"))[:_MEMORY_ATTENTION_REASON_LIMIT]
     stamp = _attention_stamp(now)
     moment = _parse_utc(stamp) or datetime.now(timezone.utc)
     with file_lock(paths.memory_index_path, private=True):
@@ -1853,37 +1865,49 @@ def confirm_project_memory_record(
         previous_due = str(staleness.get("review_due_at", "") or "")
         if not previous_due:
             return _refused_confirmation(normalized_id, "no_review_deadline")
+        if days is None:
+            # No explicit cadence: honour the one stored on the record by an
+            # earlier confirm, so `--all-due` cannot silently pull a record
+            # confirmed at 180 days back to the 90-day default.
+            stored_days = record.get("staleness", {}).get("stale_after_days") if isinstance(record.get("staleness"), dict) else None
+            days = stored_days if isinstance(stored_days, int) and not isinstance(stored_days, bool) and stored_days > 0 else _REVIEW_DEFAULT_DAYS
         revalidation = record.get("revalidation") if isinstance(record.get("revalidation"), dict) else {}
         new_deadline = _days_after(stamp, days)
         updated_revalidation = {
             **revalidation,
             "deadline": new_deadline,
             "confirmed_at": stamp,
-            "confirmed_by": str(confirmed_by or "operator"),
+            "confirmed_by": actor,
         }
         _write_project_memory_record(
             paths,
             {
                 **record,
                 "revalidation": updated_revalidation,
-                "staleness": _staleness_projection(updated_revalidation),
+                "staleness": {**_staleness_projection(updated_revalidation), "stale_after_days": days},
                 "updated_at": stamp,
             },
         )
         _write_memory_index_unlocked(paths)
+    previous_deadline = _parse_utc(previous_due)
+    shortened = previous_deadline is not None and (_parse_utc(new_deadline) or previous_deadline) < previous_deadline
     return {
         "schema_version": MEMORY_CONFIRMATION_SCHEMA_VERSION,
         "record_id": normalized_id,
         "applied": True,
         "reason_code": "confirmed",
         "was_stale": state == "stale",
+        "shortened": shortened,
         "previous_review_due_at": previous_due,
         "review_due_at": new_deadline,
         "stale_after_days": days,
         "confirmed_at": stamp,
-        "confirmed_by": str(confirmed_by or "operator"),
+        "confirmed_by": actor,
         "redaction_policy": "metadata_only",
-        "next_action": f"The record recalls normally until {new_deadline}; confirm, correct, or retire it again by then.",
+        "next_action": (
+            f"The record recalls normally until {new_deadline}; confirm, correct, or retire it again by then."
+            + (f" Note: this moved the deadline earlier than {previous_due}." if shortened else "")
+        ),
         "claim_boundary": _MEMORY_CONFIRMATION_CLAIM_BOUNDARY,
     }
 
@@ -1905,6 +1929,10 @@ def confirm_due_project_memory_records(
     gates, so an expired, superseded, or source-changed record is reported as
     skipped with its refusal reason, never silently re-blessed.
     """
+    # Validate the cadence before touching the store: an invalid value must
+    # fail the same way on an empty store as on a full one, never depend on
+    # whether a due record happened to exist.
+    _validated_day_count(stale_after_days, field="stale_after_days")
     moment = _parse_utc(_attention_stamp(now)) or datetime.now(timezone.utc)
     due = sorted(
         str(record.get("record_id", ""))
@@ -1914,17 +1942,31 @@ def confirm_due_project_memory_records(
     confirmed: list[dict[str, object]] = []
     skipped: list[dict[str, object]] = []
     for due_id in due:
-        result = confirm_project_memory_record(
-            paths,
-            due_id,
-            confirmed_by=confirmed_by,
-            stale_after_days=stale_after_days,
-            now=now,
-        )
+        try:
+            result = confirm_project_memory_record(
+                paths,
+                due_id,
+                confirmed_by=confirmed_by,
+                stale_after_days=stale_after_days,
+                now=now,
+            )
+        except (OSError, ValueError) as exc:
+            # A write-time rejection on one record must not abandon the batch
+            # mid-flight: earlier records are already committed, so the report
+            # -- who was confirmed, who was not, and why -- is the only
+            # containment the batch can offer.
+            skipped.append({"record_id": due_id, "reason_code": "write_rejected", "detail": str(exc)})
+            continue
         if bool(result.get("applied")):
             confirmed.append({"record_id": due_id, "review_due_at": str(result.get("review_due_at", ""))})
         else:
-            skipped.append({"record_id": due_id, "reason_code": str(result.get("reason_code", ""))})
+            skipped.append(
+                {
+                    "record_id": due_id,
+                    "reason_code": str(result.get("reason_code", "")),
+                    "detail": str(result.get("detail", "")),
+                }
+            )
     return {
         "schema_version": MEMORY_CONFIRMATION_BATCH_SCHEMA_VERSION,
         "due_count": len(due),
@@ -1932,12 +1974,16 @@ def confirm_due_project_memory_records(
         "skipped": skipped,
         "confirmed_count": len(confirmed),
         "skipped_count": len(skipped),
-        "confirmed_by": str(confirmed_by or "operator"),
+        "confirmed_by": _redact(str(confirmed_by or "operator"))[:_MEMORY_ATTENTION_REASON_LIMIT],
         "redaction_policy": "metadata_only",
         "next_action": (
             "Review the skipped records individually; each carries the refusal reason."
             if skipped
-            else "Every review-due record was confirmed; recall packs deliver them again."
+            else (
+                "Every review-due record was confirmed; recall packs deliver them again."
+                if confirmed
+                else "No review-due record required confirmation; expired records need `omh memory retire`, not confirmation."
+            )
         ),
         "claim_boundary": _MEMORY_CONFIRMATION_CLAIM_BOUNDARY,
     }
@@ -3072,7 +3118,8 @@ def _freshness_warnings(
     (``no_query_overlap``, ``over_budget`` on a fresh record) never warn:
     a warning that fires for everything is read as noise and stops working.
     """
-    warnings: list[dict[str, object]] = []
+    blocking: list[dict[str, object]] = []
+    advisory: list[dict[str, object]] = []
     seen: set[str] = set()
     for delivered, entry in [*((True, item) for item in included), *((False, item) for item in excluded)]:
         record_id = str(entry.get("record_id", ""))
@@ -3096,7 +3143,11 @@ def _freshness_warnings(
         seen.add(record_id)
         if not known_reason:
             reason_code = "freshness_unconfirmed"
-        warnings.append(
+        advisory_reason = reason_code in ADVISORY_FRESHNESS_REASONS
+        # The limit truncates advisory notices first: an advance heads-up must
+        # never displace the name of a record that actually left the pack --
+        # naming those is the guarantee this list exists to keep.
+        (advisory if advisory_reason else blocking).append(
             {
                 "record_id": record_id,
                 "state": state or "unknown",
@@ -3104,12 +3155,12 @@ def _freshness_warnings(
                 "review_due_at": str(staleness.get("review_due_at", "") or ""),
                 "detail": _FRESHNESS_REASON_TEXT[reason_code],
                 "delivered": bool(delivered),
-                "next_action": _DUE_SOON_NEXT_ACTION if reason_code == "review_due_soon" else _FRESHNESS_NEXT_ACTION,
+                "next_action": _DUE_SOON_NEXT_ACTION if advisory_reason else _FRESHNESS_NEXT_ACTION,
             }
         )
-        if len(warnings) >= _FRESHNESS_WARNING_LIMIT:
+        if len(blocking) >= _FRESHNESS_WARNING_LIMIT:
             break
-    return warnings
+    return (blocking + advisory)[:_FRESHNESS_WARNING_LIMIT]
 
 
 def freshness_reason_detail(reason_code: str) -> str:
@@ -3119,7 +3170,9 @@ def freshness_reason_detail(reason_code: str) -> str:
     the recall pack already emits instead of growing a parallel table that
     drifts from it. Read-only on purpose: adding a code to `_FRESHNESS_REASON_TEXT`
     also changes what `_freshness_warnings` treats as a freshness reason, so
-    the table stays owned by recall.
+    the table stays owned by recall. Membership no longer implies stale:
+    codes in `ADVISORY_FRESHNESS_REASONS` describe a still-fresh record, and
+    consumers that map "has a reason" to "is stale" must subtract that set.
     """
     return _FRESHNESS_REASON_TEXT.get(str(reason_code), "")
 

--- a/src/workflows/role_context_packs.py
+++ b/src/workflows/role_context_packs.py
@@ -48,6 +48,7 @@ from ..local_store import atomic_write_json, read_json_object
 from ..paths import OmhPaths
 from ..system.metadata_safety import is_secret_value_shaped
 from .memory import (
+    ADVISORY_FRESHNESS_REASONS,
     HANDOFF_CONTEXT_PACK_SCHEMA_VERSION,
     PROJECT_MEMORY_RECALL_PACK_SCHEMA_VERSION,
     freshness_reason_detail,
@@ -490,8 +491,12 @@ def _reason_text(reason_code: str) -> str:
 
 
 def _is_stale_reason(reason_code: str) -> bool:
-    """Stale means the recall pack's own freshness vocabulary claimed it."""
-    return bool(freshness_reason_detail(reason_code))
+    """Stale means the recall pack's own freshness vocabulary claimed it.
+
+    Advisory codes are subtracted: they describe a record that is still fresh
+    and still delivered, so listing it under "stale" would be false.
+    """
+    return reason_code not in ADVISORY_FRESHNESS_REASONS and bool(freshness_reason_detail(reason_code))
 
 
 def _pack_scope(scope: Any, context_pack: Any, memory_recall_pack: Any) -> dict[str, str]:

--- a/src/wrapper/continuity.py
+++ b/src/wrapper/continuity.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Final, Literal, TypeAlias, TypedDict, assert_never
 
+from ..workflows.memory import ADVISORY_FRESHNESS_REASONS
 from .continuity_state import json_strings as _strings, resume_status_from_evidence
 
 JsonValue: TypeAlias = None | bool | int | float | str | Sequence["JsonValue"] | Mapping[str, "JsonValue"]
@@ -261,7 +262,18 @@ def _warning_count(pack: Mapping[str, JsonValue]) -> int | None:
     if count is not None:
         return count
     warnings = pack.get("freshness_warnings")
-    return len(warnings) if _is_json_list(warnings) else None
+    if not _is_json_list(warnings):
+        return None
+    # Advisory notices (a delivered record approaching its review deadline)
+    # describe a still-fresh pack; counting them would flip `freshness` to
+    # `warnings_present` for a store where nothing is actually unconfirmed.
+    # An entry that is not a mapping still counts -- unknown shapes fail
+    # toward warning, never toward silence.
+    return sum(
+        1
+        for warning in warnings
+        if not (isinstance(warning, Mapping) and str(warning.get("reason_code", "")) in ADVISORY_FRESHNESS_REASONS)
+    )
 
 
 def _unknown_memory() -> MemoryContinuity:

--- a/tests/test_memory_staleness.py
+++ b/tests/test_memory_staleness.py
@@ -46,6 +46,7 @@ from omh.workflows.memory_lifecycle import (
 from omh.workflows.memory_lifecycle_executor import execute_memory_lifecycle
 from omh.runtime.artifacts import _memory_recall_pack_summary as artifact_pack_summary
 from omh.wrapper.briefing import _memory_recall_pack_summary as briefing_pack_summary
+from omh.wrapper.continuity import _warning_count as continuity_warning_count
 
 PAST = "2020-01-01T00:00:00Z"
 
@@ -636,6 +637,60 @@ class ReviewDueSoonWarningTests(unittest.TestCase):
             )
             self.assertTrue(windowed["freshness_warnings"][0]["delivered"])
 
+    def test_the_window_boundaries_are_exact(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            _approved(paths, "staging runs postgres 15", tags=["staging"])
+            base = datetime.now(timezone.utc)
+            outside = build_project_memory_recall_pack(paths, "postgres staging", now=base + timedelta(days=75))
+            self.assertEqual(outside["freshness_warnings"], [])
+            inside = build_project_memory_recall_pack(paths, "postgres staging", now=base + timedelta(days=76))
+            self.assertEqual([w["reason_code"] for w in inside["freshness_warnings"]], ["review_due_soon"])
+            past = build_project_memory_recall_pack(paths, "postgres staging", now=base + timedelta(days=91))
+            self.assertEqual(past["record_count"], 0)
+            self.assertEqual([w["reason_code"] for w in past["freshness_warnings"]], ["stale_review_required"])
+            self.assertFalse(past["freshness_warnings"][0]["delivered"])
+
+    def test_advisory_notices_never_displace_blocking_warnings(self) -> None:
+        # Synthetic pack entries, driven straight through the warning builder:
+        # 12 delivered due-soon notices would fill the budget on their own,
+        # and the one record that actually left the pack must still be named.
+        advisory_entries = [
+            {
+                "record_id": f"mem_advisory{index:02d}",
+                "eligibility_reason": "eligible",
+                "staleness": {"state": "fresh", "reason": "review_due_soon", "review_due_at": "2099-01-01T00:00:00Z"},
+            }
+            for index in range(12)
+        ]
+        held_back = [
+            {
+                "record_id": "mem_heldback",
+                "eligibility_reason": "stale_review_required",
+                "staleness": {"state": "stale", "reason": "review_due", "review_due_at": PAST},
+            }
+        ]
+        warnings = memory_workflow._freshness_warnings(advisory_entries, held_back)
+        self.assertLessEqual(len(warnings), 12)
+        self.assertEqual(warnings[0]["record_id"], "mem_heldback")
+        self.assertEqual(warnings[0]["reason_code"], "stale_review_required")
+
+    def test_wrapper_continuity_does_not_count_advisory_notices(self) -> None:
+        self.assertEqual(
+            continuity_warning_count(
+                {"freshness_warnings": [{"reason_code": "review_due_soon"}, {"reason_code": "stale_review_required"}]}
+            ),
+            1,
+        )
+        self.assertEqual(
+            continuity_warning_count({"freshness_warnings": [{"reason_code": "review_due_soon"}]}),
+            0,
+        )
+        # An explicit producer count and unknown warning shapes stay untouched:
+        # both fail toward warning, never toward silence.
+        self.assertEqual(continuity_warning_count({"freshness_warning_count": 3}), 3)
+        self.assertEqual(continuity_warning_count({"freshness_warnings": ["not-a-mapping"]}), 1)
+
 
 class MemoryConfirmationTests(unittest.TestCase):
     """`omh memory confirm` is the missing verb behind the freshness warning."""
@@ -694,6 +749,71 @@ class MemoryConfirmationTests(unittest.TestCase):
             moved = memory_workflow.confirm_project_memory_record(paths, cited["record_id"])
             self.assertEqual((moved["applied"], moved["reason_code"]), (False, "source_requires_correction"))
 
+            replaced = _approved(paths, "an already superseded claim")
+            _mutate_record(paths, replaced["record_id"], superseded_by="mem_0000000000000001")
+            stale_rev = memory_workflow.confirm_project_memory_record(paths, replaced["record_id"])
+            self.assertEqual((stale_rev["applied"], stale_rev["reason_code"]), (False, "superseded"))
+
+            garbled = _approved(paths, "a record about to be corrupted")
+            atomic_write_text(_record_path(paths, garbled["record_id"]), "{", private=True)
+            unreadable = memory_workflow.confirm_project_memory_record(paths, garbled["record_id"])
+            self.assertEqual((unreadable["applied"], unreadable["reason_code"]), (False, "record_unreadable"))
+
+            legacy = _approved(paths, "a legacy-schema record")
+            _mutate_record(paths, legacy["record_id"], schema_version="project_memory_record/v1")
+            old_schema = memory_workflow.confirm_project_memory_record(paths, legacy["record_id"])
+            self.assertEqual((old_schema["applied"], old_schema["reason_code"]), (False, "unsupported_record_schema"))
+
+            with self.assertRaises(ValueError):
+                memory_workflow.confirm_project_memory_record(paths, "../escape")
+
+    def test_confirm_heals_a_legacy_stale_after_only_record_to_full_parity(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record = _approved(paths, "written before review_due_at existed")
+            _mutate_record(paths, record["record_id"], revalidation={}, staleness={"stale_after": PAST})
+            result = memory_workflow.confirm_project_memory_record(paths, record["record_id"])
+            self.assertTrue(result["applied"])
+            self.assertTrue(result["was_stale"])
+            stored = json.loads(_record_path(paths, record["record_id"]).read_text(encoding="utf-8"))
+            self.assertEqual(stored["revalidation"]["deadline"], result["review_due_at"])
+            self.assertEqual(stored["staleness"]["review_due_at"], result["review_due_at"])
+            self.assertEqual(stored["staleness"]["stale_after"], result["review_due_at"])
+
+    def test_confirm_bounds_the_actor_and_names_a_shortened_deadline(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record = _approved(paths, "a slow-rotting claim", stale_after_days=365)
+            result = memory_workflow.confirm_project_memory_record(
+                paths, record["record_id"], confirmed_by="ci-token-bot " + "A" * 5000
+            )
+            self.assertTrue(result["applied"])
+            # Sensitive-looking prose degrades to a redaction and a bound, the
+            # same way the attention reason does -- never to a record-level
+            # validation error naming a field the operator cannot see.
+            stored = json.loads(_record_path(paths, record["record_id"]).read_text(encoding="utf-8"))
+            self.assertLessEqual(len(stored["revalidation"]["confirmed_by"]), 240)
+            self.assertNotIn("ci-token-bot", stored["revalidation"]["confirmed_by"])
+            # The default 90-day reset lands earlier than the 365-day capture
+            # deadline; the payload must say so instead of shortening silently.
+            self.assertTrue(result["shortened"])
+            self.assertIn("earlier", result["next_action"])
+
+    def test_confirm_persists_and_reuses_an_explicit_cadence(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record = _approved(paths, "reviewed on a slow cadence")
+            first = memory_workflow.confirm_project_memory_record(
+                paths, record["record_id"], stale_after_days=180
+            )
+            self.assertEqual(first["stale_after_days"], 180)
+            stored = json.loads(_record_path(paths, record["record_id"]).read_text(encoding="utf-8"))
+            self.assertEqual(stored["staleness"]["stale_after_days"], 180)
+            # A later flagless confirm honours the stored cadence instead of
+            # silently resetting the record to the 90-day default.
+            second = memory_workflow.confirm_project_memory_record(paths, record["record_id"])
+            self.assertEqual(second["stale_after_days"], 180)
+
     def test_confirm_all_due_reblesses_only_clean_deadline_records(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -714,14 +834,43 @@ class MemoryConfirmationTests(unittest.TestCase):
             batch = memory_workflow.confirm_due_project_memory_records(paths)
             self.assertEqual(batch["due_count"], 2)
             self.assertEqual([entry["record_id"] for entry in batch["confirmed"]], [overdue["record_id"]])
-            self.assertEqual(
-                batch["skipped"],
-                [{"record_id": tainted["record_id"], "reason_code": "source_requires_correction"}],
-            )
+            self.assertEqual(len(batch["skipped"]), 1)
+            self.assertEqual(batch["skipped"][0]["record_id"], tainted["record_id"])
+            self.assertEqual(batch["skipped"][0]["reason_code"], "source_requires_correction")
+            self.assertIn("Correct or retire", batch["skipped"][0]["detail"])
             # The fresh record was never touched: its deadline still derives
             # from capture, not from the batch run.
             untouched = json.loads(_record_path(paths, fresh["record_id"]).read_text(encoding="utf-8"))
             self.assertEqual(untouched["staleness"]["review_due_at"], fresh["staleness"]["review_due_at"])
+
+    def test_a_write_rejection_mid_batch_is_contained_and_reported(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            clean = _approved(paths, "a record that confirms cleanly", tags=["clean"])
+            poisoned = _approved(paths, "a record whose write will be refused", tags=["poison"])
+            for record_id in (clean["record_id"], poisoned["record_id"]):
+                _mutate_record(
+                    paths,
+                    record_id,
+                    revalidation={"deadline": PAST},
+                    staleness={"stale_after": PAST, "stale_after_days": None, "review_due_at": PAST},
+                )
+            # An unknown top-level key makes `_write_project_memory_record`
+            # raise at validation time -- after the gates, at the write. The
+            # batch must absorb it, keep going, and say what happened.
+            _mutate_record(paths, poisoned["record_id"], unexpected_key="boom")
+            batch = memory_workflow.confirm_due_project_memory_records(paths)
+            self.assertEqual(batch["due_count"], 2)
+            self.assertEqual([entry["record_id"] for entry in batch["confirmed"]], [clean["record_id"]])
+            self.assertEqual(batch["skipped"][0]["record_id"], poisoned["record_id"])
+            self.assertEqual(batch["skipped"][0]["reason_code"], "write_rejected")
+            self.assertIn("unsupported keys", batch["skipped"][0]["detail"])
+
+    def test_batch_rejects_an_invalid_cadence_even_on_an_empty_store(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            with self.assertRaises(ValueError):
+                memory_workflow.confirm_due_project_memory_records(paths, stale_after_days=-5)
 
 
 if __name__ == "__main__":

--- a/tests/test_memory_staleness.py
+++ b/tests/test_memory_staleness.py
@@ -597,5 +597,132 @@ class DurableRecordsAreActuallyPermanentTests(unittest.TestCase):
             self.assertEqual((changed["state"], changed["reason"]), ("stale", "source_changed"))
 
 
+class ReviewDueSoonWarningTests(unittest.TestCase):
+    """A record announces its deadline while confirming still keeps recall intact."""
+
+    def test_a_delivered_record_warns_inside_the_pre_deadline_window(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record = _approved(paths, "staging runs postgres 15", tags=["staging"])
+            probe = datetime.now(timezone.utc) + timedelta(days=80)  # 10 days before the 90-day deadline
+            pack = build_project_memory_recall_pack(paths, "postgres staging", now=probe)
+            self.assertEqual(pack["record_count"], 1)
+            self.assertEqual(validate_project_memory_recall_pack(pack), [])
+            warnings = pack["freshness_warnings"]
+            self.assertEqual(len(warnings), 1)
+            self.assertEqual(warnings[0]["record_id"], record["record_id"])
+            self.assertEqual(warnings[0]["reason_code"], "review_due_soon")
+            self.assertTrue(warnings[0]["delivered"])
+            self.assertIn("omh memory confirm", warnings[0]["next_action"])
+
+    def test_outside_the_window_and_undelivered_records_stay_silent(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            _approved(paths, "staging runs postgres 15", tags=["staging"])
+            _approved(paths, "we lint with ruff", tags=["lint"])
+            quiet = build_project_memory_recall_pack(
+                paths, "postgres staging", now=datetime.now(timezone.utc) + timedelta(days=60)
+            )
+            self.assertEqual(quiet["freshness_warnings"], [])
+            # Inside the window, the record this query never delivered stays
+            # silent: due-soon is advance notice about the pack's own content,
+            # not a store-wide page.
+            windowed = build_project_memory_recall_pack(
+                paths, "postgres staging", now=datetime.now(timezone.utc) + timedelta(days=80)
+            )
+            self.assertEqual(
+                [warning["reason_code"] for warning in windowed["freshness_warnings"]],
+                ["review_due_soon"],
+            )
+            self.assertTrue(windowed["freshness_warnings"][0]["delivered"])
+
+
+class MemoryConfirmationTests(unittest.TestCase):
+    """`omh memory confirm` is the missing verb behind the freshness warning."""
+
+    def test_confirm_returns_a_review_due_record_to_recall(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record = _approved(paths, "staging runs postgres 15", tags=["staging"])
+            _mutate_record(
+                paths,
+                record["record_id"],
+                revalidation={"deadline": PAST},
+                staleness={"stale_after": PAST, "stale_after_days": None, "review_due_at": PAST},
+            )
+            dark = build_project_memory_recall_pack(paths, "postgres staging")
+            self.assertEqual(dark["record_count"], 0)
+            self.assertEqual(dark["excluded_records"][0]["reason"], "stale_review_required")
+
+            result = memory_workflow.confirm_project_memory_record(
+                paths, record["record_id"], confirmed_by="operator"
+            )
+            self.assertTrue(result["applied"])
+            self.assertTrue(result["was_stale"])
+            self.assertEqual(result["previous_review_due_at"], PAST)
+
+            restored = build_project_memory_recall_pack(paths, "postgres staging")
+            self.assertEqual(restored["record_count"], 1)
+            self.assertEqual(restored["freshness_warnings"], [])
+            stored = json.loads(_record_path(paths, record["record_id"]).read_text(encoding="utf-8"))
+            self.assertEqual(stored["revalidation"]["deadline"], result["review_due_at"])
+            self.assertEqual(stored["staleness"]["review_due_at"], result["review_due_at"])
+            self.assertEqual(stored["staleness"]["stale_after"], result["review_due_at"])
+            self.assertEqual(stored["revalidation"]["confirmed_by"], "operator")
+            self.assertEqual(validate_project_memory_record(stored), [])
+
+    def test_confirm_refuses_what_a_new_deadline_cannot_fix(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+
+            missing = memory_workflow.confirm_project_memory_record(paths, "mem_ffffffffffffffff")
+            self.assertEqual((missing["applied"], missing["reason_code"]), (False, "record_not_found"))
+
+            durable = _approved(paths, "the license is Apache-2.0", retention_class="durable")
+            no_deadline = memory_workflow.confirm_project_memory_record(paths, durable["record_id"])
+            self.assertEqual((no_deadline["applied"], no_deadline["reason_code"]), (False, "no_review_deadline"))
+
+            expired = _approved(paths, "volatile branch note", ttl_days=1)
+            _mutate_record(paths, expired["record_id"], ttl={"ttl_days": 1, "expires_at": PAST})
+            dead = memory_workflow.confirm_project_memory_record(paths, expired["record_id"])
+            self.assertEqual((dead["applied"], dead["reason_code"]), (False, "retention_expired"))
+
+            source = _source_file(root, "cited.md", "the original claim\n")
+            cited = _approved(paths, "claim with a cited source", source_ref=str(source))
+            atomic_write_text(source, "the claim, edited\n")
+            moved = memory_workflow.confirm_project_memory_record(paths, cited["record_id"])
+            self.assertEqual((moved["applied"], moved["reason_code"]), (False, "source_requires_correction"))
+
+    def test_confirm_all_due_reblesses_only_clean_deadline_records(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            overdue = _approved(paths, "staging runs postgres 15", tags=["staging"])
+            fresh = _approved(paths, "we lint with ruff", tags=["lint"])
+            source = _source_file(root, "cited.md", "the original claim\n")
+            tainted = _approved(paths, "claim with a cited source", source_ref=str(source))
+            for record_id in (overdue["record_id"], tainted["record_id"]):
+                _mutate_record(
+                    paths,
+                    record_id,
+                    revalidation={"deadline": PAST},
+                    staleness={"stale_after": PAST, "stale_after_days": None, "review_due_at": PAST},
+                )
+            atomic_write_text(source, "the claim, edited\n")
+
+            batch = memory_workflow.confirm_due_project_memory_records(paths)
+            self.assertEqual(batch["due_count"], 2)
+            self.assertEqual([entry["record_id"] for entry in batch["confirmed"]], [overdue["record_id"]])
+            self.assertEqual(
+                batch["skipped"],
+                [{"record_id": tainted["record_id"], "reason_code": "source_requires_correction"}],
+            )
+            # The fresh record was never touched: its deadline still derives
+            # from capture, not from the batch run.
+            untouched = json.loads(_record_path(paths, fresh["record_id"]).read_text(encoding="utf-8"))
+            self.assertEqual(untouched["staleness"]["review_due_at"], fresh["staleness"]["review_due_at"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parser_memory.py
+++ b/tests/test_parser_memory.py
@@ -32,6 +32,8 @@ class MemoryParserTests(unittest.TestCase):
             (["memory", "rollup", "--tag", "deploy", "--apply"], "cmd_memory_rollup"),
             (["memory", "capture", "summary", "--observed", "codex"], "cmd_memory_capture"),
             (["memory", "recall", "query", "--observer", "operator", "--observed", "codex"], "cmd_memory_recall"),
+            (["memory", "confirm", "record-one"], "cmd_memory_confirm"),
+            (["memory", "confirm", "--all-due", "--stale-after-days", "120"], "cmd_memory_confirm"),
         )
 
         for argv, handler_name in cases:

--- a/tests/test_parser_memory.py
+++ b/tests/test_parser_memory.py
@@ -41,6 +41,15 @@ class MemoryParserTests(unittest.TestCase):
                 args = build_parser().parse_args(argv)
                 self.assertEqual(args.func.__name__, handler_name)
 
+    def test_memory_confirm_requires_exactly_one_target(self) -> None:
+        from omh.installer import OmhError
+
+        for argv in (["memory", "confirm"], ["memory", "confirm", "record-one", "--all-due"]):
+            with self.subTest(argv=argv):
+                args = build_parser().parse_args(argv)
+                with self.assertRaises(OmhError):
+                    args.func(args)
+
     def test_memory_capture_rejects_invalid_source_class_at_parser_boundary(self) -> None:
         with self.assertRaises(SystemExit) as raised:
             build_parser().parse_args(["memory", "capture", "--source-class", "unknown", "summary"])


### PR DESCRIPTION
## Capability

Two additions from an UltraQA inspection of the memory system, answering the reported symptom "records from ~3 months ago stop coming back":

1. **`omh memory confirm <record-id>` (+ `--all-due`)** — a one-step revalidation verb. It states an approved record is still true and resets its review deadline (default 90 days ahead, `--stale-after-days N` to choose). `--all-due` confirms every record whose sole problem is a passed deadline and reports every refusal as skipped with its reason.
2. **`review_due_soon` advance warning** — for the last 14 days before a delivered record's review deadline, recall packs still deliver it normally but carry a named warning with the deadline and the confirm command.

## Motivation

Every default record type mints the same 90-day review deadline at capture, so a store captured together goes review-due together: recall packs turn empty overnight (measured: day 89 delivers, day 92 delivers nothing — every record excluded `stale_review_required`), and the operator experiences memory loss. The freshness warning has always instructed "Confirm, replace, or retire", but "confirm" had no command behind it — it required a correction plan plus candidate reapproval per record. There was also no notice before the cliff: a record reads `fresh` until the day it silently leaves every pack.

## Implementation (boundary level)

- `confirm_project_memory_record` rewrites only revalidation metadata (`revalidation.deadline` + the `staleness` projection + `updated_at`), under the store lock with an index rewrite. The canonical payload digest deliberately excludes revalidation, so record identity, admission, and the immutable review record are untouched — verified by re-running `validate_project_memory_record` on the stored result in tests.
- Refusals are fail-closed and mirror recall's own gates: `retention_expired` (no resurrection), `superseded`, `source_requires_correction` (changed/unreadable cited source routes to correction — a new deadline would not restore eligibility past the source gate anyway), `no_review_deadline` (durable records), plus not-found/unreadable/schema guards.
- `confirm_due_project_memory_records` derives due records from the same `_record_staleness` verdict recall uses, then routes each through the single-record gates.
- The due-soon notice lives in the recall staleness verdict only (`state: fresh`, `reason: review_due_soon`) and is surfaced by `_freshness_warnings` for **delivered** records only — eligibility, ranking, budgets, and the shared governance evaluator are untouched. Once the deadline passes, the existing `stale_review_required` warning covers held-back records as before.
- CLI: `memory confirm` subcommand (record-id XOR `--all-due`, `--stale-after-days`, `--confirmed-by`); docs/MEMORY.md freshness section updated.

## Observed verification

- Full suite: `PYTHONPATH=tests uv run python -m unittest discover -s tests` → 7214 tests, OK.
- New tests: 5 (confirm restores recall + field parity; refusal matrix incl. source-changed via real digest change; `--all-due` skips tainted records and leaves fresh ones untouched; due-soon warning inside window with confirm pointer; silence outside window and for undelivered records) + 2 parser cases.
- Gates: `ruff check src tests` clean; `compileall` clean; all five `docs … --check` byte gates OK; `git diff --check` clean.
- CLI smoke: capture → time-travelled recall (empty at +92d) → `confirm` → recall delivers; `--all-due` batch; `--help`.

## Risks

- The 14-day window and 90-day reset default are product defaults, not config; tuning them later is additive.
- `--all-due` re-blesses in bulk by design; the guardrails are that it only touches records whose *sole* problem is the passed deadline and that every refusal is named. A store with genuinely rotten records still needs per-record review.
- Not observed here: Windows CI legs (repo CI runs them), live Hermes TUI rendering of the new warning text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKo77o5dTJtLRWfDj4uBtq