### PR TITLE
docs(readme): required omh setup follow-up + fresh contributors image

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -101,7 +101,9 @@ curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh
 irm https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.ps1 | iex
 ```
 
-**インストール後に OMH をセットアップ:**
+**⚠️ 必須のフォローアップ — 上記どのインストール方法でもこのステップが必要です。**
+インストールは `omh` コマンドを PATH に置くだけで、`omh setup` がワークフローを
+インストールしてプラグインを Hermes に接続するまでは何も Hermes に反映されません:
 ```sh
 omh setup
 ```
@@ -325,5 +327,5 @@ OMH は [Team Art & Engineering](https://rlaope.github.io/artengine-lab/) の
 oh-my-hermes に貢献してくださった皆さまに感謝します。
 
 <a href="https://github.com/rlaope/oh-my-hermes/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=rlaope/oh-my-hermes" alt="oh-my-hermes contributors" />
+  <img src="https://contrib.rocks/image?repo=rlaope/oh-my-hermes&max=100&columns=10" alt="oh-my-hermes contributors" />
 </a>

--- a/README.ja.md
+++ b/README.ja.md
@@ -101,9 +101,8 @@ curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh
 irm https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.ps1 | iex
 ```
 
-**⚠️ 必須のフォローアップ — 上記どのインストール方法でもこのステップが必要です。**
-インストールは `omh` コマンドを PATH に置くだけで、`omh setup` がワークフローを
-インストールしてプラグインを Hermes に接続するまでは何も Hermes に反映されません:
+**⭐ インストール後に OMH をセットアップ (必須):**
+
 ```sh
 omh setup
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -101,7 +101,9 @@ curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh
 irm https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.ps1 | iex
 ```
 
-**설치 후 OMH를 설정합니다:**
+**⚠️ 필수 후속 단계 — 위의 모든 설치 방법이 여기서 끝나야 합니다.**
+설치는 `omh` 명령을 PATH에 올릴 뿐이며, `omh setup`이 워크플로를 설치하고
+플러그인을 Hermes에 연결하기 전까지는 아무것도 Hermes에 반영되지 않습니다:
 ```sh
 omh setup
 ```
@@ -325,5 +327,5 @@ OMH는 [Team Art & Engineering](https://rlaope.github.io/artengine-lab/)의
 oh-my-hermes에 기여해 주신 모든 분들께 감사드립니다.
 
 <a href="https://github.com/rlaope/oh-my-hermes/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=rlaope/oh-my-hermes" alt="oh-my-hermes contributors" />
+  <img src="https://contrib.rocks/image?repo=rlaope/oh-my-hermes&max=100&columns=10" alt="oh-my-hermes contributors" />
 </a>

--- a/README.ko.md
+++ b/README.ko.md
@@ -101,9 +101,8 @@ curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh
 irm https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.ps1 | iex
 ```
 
-**⚠️ 필수 후속 단계 — 위의 모든 설치 방법이 여기서 끝나야 합니다.**
-설치는 `omh` 명령을 PATH에 올릴 뿐이며, `omh setup`이 워크플로를 설치하고
-플러그인을 Hermes에 연결하기 전까지는 아무것도 Hermes에 반영되지 않습니다:
+**⭐ 설치 후 OMH를 설정합니다 (필수):**
+
 ```sh
 omh setup
 ```

--- a/README.md
+++ b/README.md
@@ -146,9 +146,7 @@ curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh
 irm https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.ps1 | iex
 ```
 
-**⚠️ Required follow-up — every install method above needs this step.**
-Installing only puts the `omh` command on your PATH; nothing reaches Hermes
-until `omh setup` installs the workflows and connects the plugin:
+**⭐ Set up OMH after installing (required):**
 
 ```sh
 omh setup

--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh
 irm https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.ps1 | iex
 ```
 
-**Set up OMH after installing:**
+**⚠️ Required follow-up — every install method above needs this step.**
+Installing only puts the `omh` command on your PATH; nothing reaches Hermes
+until `omh setup` installs the workflows and connects the plugin:
 
 ```sh
 omh setup
@@ -437,5 +439,5 @@ OMH is developed in the open as part of
 Thanks to everyone who has contributed to oh-my-hermes.
 
 <a href="https://github.com/rlaope/oh-my-hermes/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=rlaope/oh-my-hermes" alt="oh-my-hermes contributors" />
+  <img src="https://contrib.rocks/image?repo=rlaope/oh-my-hermes&max=100&columns=10" alt="oh-my-hermes contributors" />
 </a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -99,9 +99,8 @@ curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh
 irm https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.ps1 | iex
 ```
 
-**⚠️ 必需的后续步骤 —— 上述所有安装方式都必须执行这一步。**
-安装只是把 `omh` 命令放到 PATH 上；在 `omh setup` 安装工作流并把插件连接到
-Hermes 之前，任何内容都不会生效：
+**⭐ 安装后设置 OMH（必需）：
+
 ```sh
 omh setup
 ```

--- a/README.zh.md
+++ b/README.zh.md
@@ -99,7 +99,9 @@ curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh
 irm https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.ps1 | iex
 ```
 
-**安装后设置 OMH：**
+**⚠️ 必需的后续步骤 —— 上述所有安装方式都必须执行这一步。**
+安装只是把 `omh` 命令放到 PATH 上；在 `omh setup` 安装工作流并把插件连接到
+Hermes 之前，任何内容都不会生效：
 ```sh
 omh setup
 ```
@@ -324,5 +326,5 @@ OMH 是 [Team Art & Engineering](https://rlaope.github.io/artengine-lab/) 的
 感谢每一位为 oh-my-hermes 做出贡献的人。
 
 <a href="https://github.com/rlaope/oh-my-hermes/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=rlaope/oh-my-hermes" alt="oh-my-hermes contributors" />
+  <img src="https://contrib.rocks/image?repo=rlaope/oh-my-hermes&max=100&columns=10" alt="oh-my-hermes contributors" />
 </a>


### PR DESCRIPTION
## Capability

Quick Start now states that `omh setup` is a **required follow-up for every install method**, with the reason (install only puts `omh` on PATH; nothing reaches Hermes until setup runs). The Contributors image renders the current contributor set again.

## Motivation

- Every install path (brew/bun/npm/curl/PowerShell) ends at `omh setup`, but the line read as one more optional block in the list — users stopped after the package install.
- The contrib.rocks image is cached per-URL on their CDN, so the README kept showing a stale copy missing newer contributors.

## Implementation (boundary level)

- All four language READMEs (en/ko/ja/zh): the setup line becomes a ⚠️ required-follow-up statement with the why; the `omh setup` code fence stays standalone, which `tests/test_router_content.py`'s Quick Start contract pins.
- Contributors `<img>` URL gains explicit `max=100&columns=10` parameters — a new URL forces a fresh CDN render and future-proofs slot count. No workflow/action added.

## Observed verification

- Full suite: 7223 tests OK. Router-content / readme-highlights / ulw-inventory suites green; `docs ulw-inventory --check` and `docs ulw-site --check` byte gates OK; `git diff --check` clean.
- New image URL fetched: HTTP 200, `image/svg+xml`, freshly generated.

## Risks

- Rendered appearance on GitHub observed only after merge (content-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKo77o5dTJtLRWfDj4uBtq