### PR TITLE
feat(memory): L1→L2 demotion, expiry advance notice, cadence tunables

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -365,6 +365,35 @@ Expiry removes influence only; it does not move an artifact or prove any
 absence. A stale revalidation deadline requires fresh review or a bounded,
 identity-specific confirmation.
 
+A reviewer can re-class a record at approval:
+`omh memory approve <candidate-id> --retention-class durable` promotes a
+settled decision so it does not inherit the default review clock nobody chose
+for it. The override re-derives retention and a *defaulted* review deadline
+with the new class's own rules — but a cadence the captor explicitly chose
+(`--stale-after-days` at capture, recorded as `cadence_source: explicit`)
+survives the re-class: durable makes the deadline optional, not forbidden,
+and a flag about retention never silently removes a review date the reviewer
+saw on the card. Supplying the class the candidate already has is a
+validated no-op. Lifecycle (correction/restore) candidates keep their
+reviewed class; the flag applies to plain approvals only.
+
+### Cadence Tunables
+
+The three memory clocks are policy tunables, not baked-in constants. A stored
+setup profile's `memory_policy` block may carry, additively and optionally:
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `stale_after_days_default` | 90 | Review cadence minted for fact/decision/lesson/procedure captures without an explicit `--stale-after-days`. |
+| `episode_ttl_days` | 30 | TTL minted for episode captures without an explicit `--ttl-days`. |
+| `due_soon_days` | 14 | Advance-notice window recall packs warn inside, shared by review-due and expiry notices; accepted range 1–365. |
+
+An absent or invalid value falls back to the named default, and the effective
+values are always disclosed on the `project_memory_policy/v1` payload, so
+`omh memory status` shows what is actually in force. A capture's cadence
+(explicit or default) is stored on the record and honoured by later flagless
+`omh memory confirm` runs.
+
 ### Durability Receipts
 
 "Written" is not one event. A memory operation reports exactly which of four
@@ -451,12 +480,21 @@ rather than as a count, so a summarized handoff still says which record needs
 a decision. A warning is prepared context, never execution, review, CI, or
 merge evidence.
 
-The warning also fires *before* the cliff: for the last 14 days before a
-record's review deadline, packs still deliver it normally but carry a
-`review_due_soon` warning naming the deadline. Only delivered records earn the
-advance notice — due-soon is a statement about this pack's own content, not a
-store-wide page — and once the deadline actually passes, the ordinary
-`stale_review_required` warning covers held-back records as before.
+The warning also fires *before* the cliff: for the last 14 days (the
+`due_soon_days` tunable) before a record's review deadline, packs still
+deliver it normally but carry a `review_due_soon` warning naming the deadline;
+inside the same window before a retention TTL ends, the warning is
+`expires_soon` — the retention twin, pointing out that confirmation cannot
+extend a TTL and the honest moves are a re-capture, a correction, or letting
+it expire. The expiry window scales down to half the record's own TTL (never
+below one day), so a short-lived volatile record warns near its end instead
+of carrying a permanent banner from the day it was approved. Expiry outranks
+review-due when both windows overlap: a passed TTL is terminal, a passed
+review date is not. Only delivered records earn advance
+notice — it is a statement about this pack's own content, not a store-wide
+page — advisory notices never displace blocking warnings inside the bounded
+list, and once a deadline actually passes, the ordinary blocking warning
+covers held-back records as before.
 
 ### Confirming, Correcting, or Retiring
 
@@ -838,6 +876,52 @@ The ranking inputs do not expand eligibility or establish truth:
 
 Dreaming prepares a reminder and metadata-only evidence. It never invokes a
 model or performs consolidation, retirement, restore, or prune.
+
+## Hermes Memory Tiering: Demotion (L1 → L2)
+
+Hermes-native memory files (`MEMORY.md`, `USER.md`) are L1: small,
+character-capped, and paid for on every turn. The OMH record store is L2:
+reviewed, governed, and not bound by that cap. When L1 fills, the usual move
+is deleting an entry — which loses the fact. Demotion is the other move: the
+content goes down into L2 and a short reference line stays in L1.
+
+```sh
+# Agent/operator only: plan which entries to move, biggest savings first.
+omh memory demote [--file MEMORY.md] [--max 5]
+
+# Capture the planned entries as review-first OMH candidates.
+omh memory demote --stage
+```
+
+The plan selects entries no approved OMH record already explains, ranked by
+size; an entry an approved record covers is reported separately as deletable
+rather than copied down twice, and each planned row carries its
+`staging_status` (`unstaged`, `already_staged`, `previously_rejected`) so the
+plan advertises exactly the work `--stage` would do. Each row carries a
+prepared reference line — `[omh#<sha12>] <first 60 chars…>` — keyed by the
+sha256 of the entry's exact bytes, the one identifier both stores can
+compute, so the line survives the candidate → record lifecycle it points
+into.
+
+Demotion moves content intact or it refuses; it never quietly damages it.
+An entry the 240-char summary bound would truncate is refused as
+`summary_bound_exceeded` (split it to demote it), and one the
+sensitive-content redactor would collapse is refused as
+`redacted_cannot_demote` — both stay in L1, because the next documented step
+deletes the L1 original and that must never happen to a copy that is not
+intact. Staging is idempotent (`already_staged` / `previously_rejected`,
+never a duplicate candidate), cleanly staged candidates go through the
+ordinary review gates, and the payload counts `captured_count` vs
+`refused_count`. Note the plan output prints entry text verbatim — it is the
+operator's own local Hermes memory content, but treat the plan like that
+content when capturing terminal transcripts.
+
+The L1 half stays with Hermes: OMH reads Hermes memory and cannot change it.
+After approving the staged candidates, ask Hermes to replace each original
+entry with its reference line through Hermes's own memory tool. Everything on
+this surface is `prepared_not_observed` until that happens. The reverse move
+— promoting an approved OMH record up into L1 — remains the memory bridge's
+`promotable` surface (`omh memory status`).
 
 ## Prepared Context Boundary
 

--- a/src/commands/memory.py
+++ b/src/commands/memory.py
@@ -46,9 +46,11 @@ from ..memory import (
     build_project_memory_review,
     build_project_memory_status,
     MAX_RETENTION_DAYS,
+    build_memory_demotion,
     capture_project_memory_candidate,
     confirm_due_project_memory_records,
     confirm_project_memory_record,
+    stage_memory_demotion,
     read_memory_snapshot_file,
     reject_project_memory_candidate,
     review_memory_update_batch,
@@ -131,8 +133,18 @@ def cmd_memory_review(args: argparse.Namespace) -> int:
 def cmd_memory_approve(args: argparse.Namespace) -> int:
     paths = _paths(args)
     try:
-        payload = approve_project_memory_candidate(paths, args.candidate_id, approved_by=args.approved_by)
+        payload = approve_project_memory_candidate(
+            paths,
+            args.candidate_id,
+            approved_by=args.approved_by,
+            retention_class=args.retention_class,
+        )
     except LifecycleCandidateError:
+        if args.retention_class is not None:
+            raise OmhError(
+                "lifecycle candidates keep their reviewed retention class; "
+                "--retention-class applies only to plain approvals"
+            ) from None
         # Correction/restore candidates approve through the lifecycle
         # executor so the replacement payload and revision survive; the
         # operator keeps one approve verb either way.
@@ -220,6 +232,20 @@ def cmd_memory_pin(args: argparse.Namespace) -> int:
 def cmd_memory_unpin(args: argparse.Namespace) -> int:
     try:
         payload = set_memory_pin(_paths(args), args.record_id, pinned=False)
+    except (OSError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(payload)
+    return 0
+
+
+def cmd_memory_demote(args: argparse.Namespace) -> int:
+    try:
+        build = stage_memory_demotion if args.stage else build_memory_demotion
+        payload = build(
+            _paths(args),
+            file_label=args.file,
+            max_entries=_optional_positive_int(args.max, "--max") or 5,
+        )
     except (OSError, ValueError) as exc:
         raise OmhError(str(exc)) from exc
     _print_json(payload)

--- a/src/commands/memory_parser.py
+++ b/src/commands/memory_parser.py
@@ -53,6 +53,15 @@ def add_memory_commands(sub: argparse._SubParsersAction[argparse.ArgumentParser]
     approve = memory_sub.add_parser("approve", help="Approve a reviewed project-memory candidate.")
     approve.add_argument("candidate_id")
     approve.add_argument("--approved-by", default="operator")
+    approve.add_argument(
+        "--retention-class",
+        choices=("volatile", "standard", "durable"),
+        default=None,
+        help=(
+            "Re-class the record at approval (most usefully durable, which drops the default "
+            "90-day review clock); retention and the review deadline are re-derived for the new class."
+        ),
+    )
     approve.set_defaults(func=memory.cmd_memory_approve)
 
     reject = memory_sub.add_parser("reject", help="Reject a project-memory candidate.")
@@ -125,6 +134,22 @@ def add_memory_commands(sub: argparse._SubParsersAction[argparse.ArgumentParser]
     unpin = memory_sub.add_parser("unpin", help="Remove one record's recall-anchor marker.")
     unpin.add_argument("record_id")
     unpin.set_defaults(func=memory.cmd_memory_unpin)
+
+    demote = memory_sub.add_parser(
+        "demote",
+        help=(
+            "Plan moving capped Hermes memory entries (L1) down into the OMH store (L2), leaving a short "
+            "reference line; --stage captures the planned entries as review-first candidates."
+        ),
+    )
+    demote.add_argument("--file", default=None, help="Only plan one Hermes memory file (MEMORY.md or USER.md).")
+    demote.add_argument("--max", type=int, default=5, help="Most entries to plan, biggest savings first (default 5).")
+    demote.add_argument(
+        "--stage",
+        action="store_true",
+        help="Capture the planned entries as OMH candidates (default is report-only). Hermes itself applies the L1 edits.",
+    )
+    demote.set_defaults(func=memory.cmd_memory_demote)
 
     confirm = memory_sub.add_parser(
         "confirm",

--- a/src/plugin_bundle/omh/hermes_memory.py
+++ b/src/plugin_bundle/omh/hermes_memory.py
@@ -497,3 +497,188 @@ def _unsourced_entry_rows(entries: tuple[str, ...], matched: set[int]) -> list[d
         for index, entry in enumerate(entries)
         if index not in matched
     ]
+
+
+MEMORY_DEMOTION_PLAN_SCHEMA_VERSION = "hermes_memory_demotion_plan/v1"
+
+# How much of the entry the reference line quotes back. Long enough that an
+# operator recognises which fact moved, short enough that the move still frees
+# space -- freeing space is the entire reason to make it.
+DEMOTION_REFERENCE_LABEL_CHARS = 60
+
+
+def build_memory_demotion_plan(
+    omh_home: str | Path,
+    hermes_home: str | Path,
+    *,
+    file_label: str | None = None,
+    max_entries: int = 5,
+) -> dict[str, object]:
+    """Plan which Hermes entries to move down into OMH's store, biggest first.
+
+    Hermes memory is L1: small, character-capped, and paid for on every turn.
+    The OMH record store is L2: reviewed, governed, and not bound by that cap.
+    When L1 fills the usual move is deleting an entry, which loses the fact.
+    Demotion is the other move -- the content goes to L2 and a short reference
+    line stays in L1 -- and this function is the plan for it.
+
+    An entry an approved OMH record already explains is not demotion work: its
+    content is in L2 already, so it is reported separately as deletable rather
+    than copied down a second time. What remains is ranked by size, so the
+    first row an operator applies buys the most headroom.
+
+    The reference line is keyed by the sha256 of the entry's exact UTF-8 bytes,
+    which is the one identifier both stores can compute without agreeing on
+    anything: it is the same before the candidate is captured and after the
+    record is approved, so the line survives the lifecycle it points into.
+
+    Prepared text only. Nothing here opens a Hermes file for writing -- Hermes
+    applies a row through its own `memory` tool, or the row is not applied.
+    """
+    if isinstance(max_entries, bool) or not isinstance(max_entries, int) or max_entries < 1:
+        raise ValueError(f"max_entries must be an integer of at least 1, got {max_entries!r}")
+    readings = read_hermes_memory(hermes_home)
+    if file_label is not None and not any(reading.label == file_label for reading in readings):
+        return _unknown_file_label_plan(file_label, readings)
+    selected = [reading for reading in readings if file_label is None or reading.label == file_label]
+    summaries = [
+        (str(record.get("record_id", "")), str(record.get("summary", "") or ""))
+        for record in read_approved_records(omh_home)
+    ]
+    already_covered: list[dict[str, object]] = []
+    candidates: list[tuple[str, int, str]] = []
+    for reading in selected:
+        for index, entry in enumerate(reading.entries):
+            record_id, score = _nearest_record(entry, summaries)
+            if score >= DUPLICATE_SIMILARITY_THRESHOLD:
+                already_covered.append(_already_covered_row(reading.label, index, entry, record_id, score))
+                continue
+            candidates.append((reading.label, index, entry))
+    # Biggest saving first; label and index only break ties, so two runs over
+    # the same store propose the same rows in the same order.
+    candidates.sort(key=lambda candidate: (-len(candidate[2]), candidate[0], candidate[1]))
+    rows = [_demotion_row(label, index, entry) for label, index, entry in candidates[:max_entries]]
+    return {
+        "schema_version": MEMORY_DEMOTION_PLAN_SCHEMA_VERSION,
+        "files": [_demotion_file_summary(reading, rows) for reading in selected],
+        "rows": rows,
+        "already_covered": already_covered,
+        "row_count": len(rows),
+        "estimated_savings_chars": sum(max(int(row["savings_chars"]), 0) for row in rows),
+        "redaction_policy": "local_content_plan",
+        "next_action": _DEMOTION_NEXT_ACTION,
+        "claim_boundary": _DEMOTION_CLAIM_BOUNDARY,
+    }
+
+
+# Unlike the bridge, these rows carry entry text: a demotion cannot be reviewed
+# or applied without the content being moved. The text is the operator's own
+# local Hermes memory, staying on the same host, and no lane transmits it.
+_DEMOTION_NEXT_ACTION = (
+    "Stage the rows with `omh memory demote --stage`, approve the staged candidates, then ask Hermes to "
+    "replace each original entry with its reference line through Hermes's own memory tool."
+)
+_DEMOTION_CLAIM_BOUNDARY = (
+    "OMH reads Hermes memory and cannot change it. This plan is prepared local text only "
+    "(prepared_not_observed); it is not a Hermes memory write, execution, review, CI, or merge evidence."
+)
+
+
+def _unknown_file_label_plan(file_label: str, readings: tuple[HermesMemoryFile, ...]) -> dict[str, object]:
+    """An empty plan that names the labels that do exist.
+
+    A typo'd label must not read as "this file has nothing to demote": the two
+    answers look identical from the payload unless the reason is stated.
+    """
+    return {
+        "schema_version": MEMORY_DEMOTION_PLAN_SCHEMA_VERSION,
+        "files": [],
+        "rows": [],
+        "already_covered": [],
+        "row_count": 0,
+        "estimated_savings_chars": 0,
+        "reason_code": "unknown_file_label",
+        "requested_file_label": file_label,
+        "known_file_labels": [reading.label for reading in readings],
+        "redaction_policy": "local_content_plan",
+        "next_action": _DEMOTION_NEXT_ACTION,
+        "claim_boundary": _DEMOTION_CLAIM_BOUNDARY,
+    }
+
+
+def _nearest_record(entry: str, summaries: list[tuple[str, str]]) -> tuple[str, float]:
+    """Record id and score of the approved summary closest to ``entry``."""
+    best_id = ""
+    best_score = 0.0
+    for record_id, summary in summaries:
+        score = similarity(entry, summary)
+        if score > best_score:
+            best_id, best_score = record_id, score
+    return best_id, best_score
+
+
+def _already_covered_row(
+    label: str,
+    index: int,
+    entry: str,
+    record_id: str,
+    score: float,
+) -> dict[str, object]:
+    """One L1 entry an approved L2 record already explains: delete, don't demote."""
+    return {
+        "file": label,
+        "entry_index": index,
+        "chars": len(entry),
+        "sha256": _entry_digest(entry),
+        "matched_record_id": record_id,
+        "similarity": round(score, 2),
+        "already_in_omh": True,
+    }
+
+
+def _demotion_row(label: str, index: int, entry: str) -> dict[str, object]:
+    """One proposed move, with the text to store and the line that replaces it."""
+    reference_line = demotion_reference_line(entry)
+    return {
+        "file": label,
+        "entry_index": index,
+        "chars": len(entry),
+        "sha256": _entry_digest(entry),
+        "entry_text": entry,
+        "reference_line": reference_line,
+        "reference_chars": len(reference_line),
+        # Negative for an entry shorter than its own reference line. Reported
+        # rather than hidden: a row that costs characters is still a real
+        # answer, and clamping it would inflate the total saving.
+        "savings_chars": len(entry) - len(reference_line),
+    }
+
+
+def demotion_reference_line(entry: str) -> str:
+    """The line that stays in L1 once the entry's content lives in OMH."""
+    digest = _entry_digest(entry)
+    label_text = " ".join(entry.split())
+    if len(label_text) > DEMOTION_REFERENCE_LABEL_CHARS:
+        label_text = label_text[:DEMOTION_REFERENCE_LABEL_CHARS] + "…"
+    return f"[omh#{digest[:12]}] {label_text}"
+
+
+def _entry_digest(entry: str) -> str:
+    """The entry's identity in both stores: sha256 of its exact UTF-8 bytes."""
+    return hashlib.sha256(entry.encode("utf-8")).hexdigest()
+
+
+def _demotion_file_summary(reading: HermesMemoryFile, rows: list[dict[str, object]]) -> dict[str, object]:
+    """One file's headroom now, and the headroom the planned rows would leave."""
+    planned = [row for row in rows if row["file"] == reading.label]
+    return {
+        "label": reading.label,
+        "cap": reading.cap,
+        "chars": reading.chars,
+        "headroom_chars": reading.headroom_chars,
+        "over_cap": reading.over_cap,
+        "entry_count": len(reading.entries),
+        "planned_demotions": len(planned),
+        "estimated_headroom_after": reading.headroom_chars
+        + sum(max(int(row["savings_chars"]), 0) for row in planned),
+    }

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -20,6 +20,7 @@ from ..local_store import (
 )
 
 from ..plugin_bundle.omh.hermes_memory import build_hermes_memory_bridge as _bundle_memory_bridge
+from ..plugin_bundle.omh.hermes_memory import build_memory_demotion_plan as _bundle_demotion_plan
 from ..plugin_bundle.omh.hermes_memory import classify_record_expiry as _classify_record_expiry
 from ..plugin_bundle.omh.memory_dreaming import consolidation_path as _consolidation_path
 from ..plugin_bundle.omh.memory_governance import (
@@ -165,6 +166,7 @@ _FRESHNESS_WARNING_KEYS = {
     "state",
     "reason_code",
     "review_due_at",
+    "expires_at",
     "detail",
     "delivered",
     "next_action",
@@ -354,8 +356,22 @@ _DUE_SOON_NEXT_ACTION = (
     "Run `omh memory confirm <record-id>` (or correct/retire it) before the deadline passes; "
     "until then the record still recalls normally."
 )
+# The retention twin of the review window: an expiring record (an episode's
+# 30-day TTL, most often) gets the same advance notice. Confirmation cannot
+# extend a TTL -- the honest actions are a correction with a longer TTL or
+# letting it expire and retiring it.
+_EXPIRES_SOON_DAYS = 14
+_EXPIRES_SOON_NEXT_ACTION = (
+    "Its retention TTL is about to end and confirmation cannot extend a TTL: "
+    "re-capture it (`omh memory capture --ttl-days N ...`) or correct it to keep the content, or let it expire."
+)
+_ADVISORY_NEXT_ACTIONS = {
+    "review_due_soon": _DUE_SOON_NEXT_ACTION,
+    "expires_soon": _EXPIRES_SOON_NEXT_ACTION,
+}
 _FRESHNESS_REASON_TEXT = {
     "review_due_soon": "Its revalidation deadline is approaching; unconfirmed, it will leave default recall packs then.",
+    "expires_soon": "Its retention TTL is approaching; once it expires the record leaves recall entirely.",
     "stale_review_required": "Its revalidation deadline passed, so nobody has confirmed the record since then.",
     "source_changed": "The local source it cites changed after the record was approved.",
     "source_unverifiable": "The local source it cites cannot be read now, so its freshness is unobservable.",
@@ -372,7 +388,7 @@ _INSPECTABLE_STALE_REASONS = {"stale_review_required", "source_changed", "source
 # delivered. Consumers that treat "has a freshness reason" as "this record is
 # stale" (wrapper continuity, role-context-pack diffs) must subtract this set,
 # or the advance notice would read as the failure it exists to prevent.
-ADVISORY_FRESHNESS_REASONS = frozenset({"review_due_soon"})
+ADVISORY_FRESHNESS_REASONS = frozenset({"review_due_soon", "expires_soon"})
 _HANDOFF_CONTEXT_PACK_KEYS = {
     "schema_version",
     "executor_target",
@@ -432,8 +448,34 @@ def build_project_memory_policy(paths: OmhPaths, *, mode: str | None = None) -> 
         "redaction_policy": "metadata_only",
         "backend": "local_json",
         "optional_backend_extension": True,
+        **dict(_MEMORY_CADENCE_DEFAULTS),
         "claim_boundary": "Project memory configures OMH-local prepared context only; it does not mutate Hermes global or internal memory.",
     }
+
+
+# A notice window is not a retention period: a year is already generous, and
+# accepting the 100-year retention ceiling here would let one config typo turn
+# every record with any TTL into a permanent warning.
+_MEMORY_CADENCE_MAX = {"due_soon_days": 365}
+
+
+def _cadence_value(policy: dict[str, object], key: str) -> int | None:
+    """One validated cadence day-count from a policy mapping, or None."""
+    value = policy.get(key)
+    maximum = _MEMORY_CADENCE_MAX.get(key, MAX_RETENTION_DAYS)
+    if isinstance(value, int) and not isinstance(value, bool) and 1 <= value <= maximum:
+        return value
+    return None
+
+
+def _policy_cadence_overrides(stored_policy: dict[str, object]) -> dict[str, int]:
+    """Validated cadence overrides from a stored profile's memory_policy."""
+    overrides: dict[str, int] = {}
+    for key in _MEMORY_CADENCE_DEFAULTS:
+        value = _cadence_value(stored_policy, key)
+        if value is not None:
+            overrides[key] = value
+    return overrides
 
 
 def read_project_memory_policy(paths: OmhPaths) -> dict[str, object]:
@@ -449,7 +491,8 @@ def read_project_memory_policy(paths: OmhPaths) -> dict[str, object]:
         return build_project_memory_policy(paths, mode="off")
     policy = setup.get("memory_policy")
     if isinstance(policy, dict):
-        return build_project_memory_policy(paths, mode=str(policy.get("mode", "") or "review-first"))
+        base = build_project_memory_policy(paths, mode=str(policy.get("mode", "") or "review-first"))
+        return {**base, **_policy_cadence_overrides(policy)}
     return build_project_memory_policy(paths, mode=str(setup.get("memory_mode", "") or "review-first"))
 
 
@@ -467,6 +510,192 @@ def _retain_knowledge_family_enabled(setup: dict[str, object]) -> bool:
     if not isinstance(disabled, list):
         return True
     return "retain_knowledge" not in {str(value) for value in disabled}
+
+
+MEMORY_DEMOTION_STAGE_SCHEMA_VERSION = "memory_demotion_stage/v1"
+
+
+def build_memory_demotion(paths: OmhPaths, *, file_label: str | None = None, max_entries: int = 5) -> dict[str, object]:
+    """Plan L1->L2 demotions: which Hermes entries to move into the OMH store.
+
+    Same delegation shape as the bridge: the planner lives in the plugin
+    bundle because the Hermes host can only import that package, and this
+    wrapper points the dependency the direction that works on both hosts.
+
+    The wrapper annotates each planned row with its `staging_status` from the
+    OMH candidate store -- `unstaged`, `already_staged`, or
+    `previously_rejected` -- so the plan advertises exactly the work `--stage`
+    would actually do instead of re-proposing rows staging will refuse.
+    """
+    plan = _bundle_demotion_plan(paths.omh_home, paths.hermes_home, file_label=file_label, max_entries=max_entries)
+    rows = plan.get("rows") if isinstance(plan.get("rows"), list) else []
+    if not rows:
+        return plan
+    status_by_ref = _demotion_status_by_ref(paths)
+    annotated = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        annotated.append({**row, "staging_status": status_by_ref.get(_demotion_origin_ref(row), "unstaged")})
+    return {**plan, "rows": annotated}
+
+
+def _demotion_origin_ref(row: dict[str, object]) -> str:
+    return f"hermes:{row.get('file', '')}#{str(row.get('sha256', ''))[:16]}"
+
+
+def _demotion_status_by_ref(paths: OmhPaths) -> dict[str, str]:
+    """Origin ref -> staging verdict, from the candidate store."""
+    status_by_ref: dict[str, str] = {}
+    for candidate in _read_project_memory_candidates(paths):
+        ref = str(candidate.get("source_ref", ""))
+        if not ref:
+            continue
+        status = str(candidate.get("status", "") or "")
+        status_by_ref[ref] = "previously_rejected" if status == "rejected" else "already_staged"
+    return status_by_ref
+
+
+def _refused_demotion_row(row: dict[str, object], status: str, detail: str) -> dict[str, object]:
+    return {
+        "file": str(row.get("file", "")),
+        "entry_index": int(row.get("entry_index", 0) or 0),
+        "sha256": str(row.get("sha256", "")),
+        "candidate_id": "",
+        "status": status,
+        "auto_approved": False,
+        "detail": detail,
+        "reference_line": str(row.get("reference_line", "")),
+    }
+
+
+def stage_memory_demotion(paths: OmhPaths, *, file_label: str | None = None, max_entries: int = 5) -> dict[str, object]:
+    """Capture each planned demotion row as an OMH candidate (L2 side only).
+
+    Staging is the half of a demotion OMH can actually do: the entry's
+    content becomes a review-first candidate in the governed store, keyed
+    back to its L1 origin through `source_ref` carrying the entry digest.
+    The L1 half -- replacing the original entry with the short reference
+    line -- stays with Hermes's own memory tool, so the plan's reference
+    lines travel on this payload as prepared text and nothing else.
+
+    Demotion moves content or it refuses; it never quietly damages it. An
+    entry the summary bound would truncate, or one the sensitive-content
+    redactor would collapse to `[redacted]`, is refused with a named status
+    and STAYS IN L1 -- because the very next documented step is deleting the
+    L1 original, which must never happen to a copy that is not intact.
+    Staging is also idempotent: a ref already in the candidate store reports
+    `already_staged`, or `previously_rejected` when a reviewer already said
+    no to exactly this entry, and never mints a duplicate candidate.
+    """
+    plan = build_memory_demotion(paths, file_label=file_label, max_entries=max_entries)
+    rows = plan.get("rows") if isinstance(plan.get("rows"), list) else []
+    staged: list[dict[str, object]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        entry_text = str(row.get("entry_text", "")).strip()
+        origin_ref = _demotion_origin_ref(row)
+        staging_status = str(row.get("staging_status", "unstaged"))
+        if staging_status != "unstaged":
+            staged.append(
+                _refused_demotion_row(
+                    row,
+                    staging_status,
+                    "A candidate for exactly this entry already exists in the OMH store."
+                    if staging_status == "already_staged"
+                    else "A reviewer already rejected exactly this entry; the refusal is the standing decision.",
+                )
+            )
+            continue
+        if _looks_sensitive(entry_text):
+            # The capture redactor would store the literal string
+            # "[redacted]" and the fact would exist nowhere but the L1
+            # entry the workflow then says to delete.
+            staged.append(
+                _refused_demotion_row(
+                    row,
+                    "redacted_cannot_demote",
+                    "The sensitive-content redactor would collapse this entry; it stays in L1 intact.",
+                )
+            )
+            continue
+        if len(entry_text) > _MEMORY_ATTENTION_REASON_LIMIT:
+            staged.append(
+                _refused_demotion_row(
+                    row,
+                    "summary_bound_exceeded",
+                    f"The {_MEMORY_ATTENTION_REASON_LIMIT}-char summary bound would truncate this entry; it stays in L1 intact. "
+                    "Split it into smaller entries to demote it.",
+                )
+            )
+            continue
+        captured = capture_project_memory_candidate(
+            paths,
+            entry_text,
+            record_type="fact",
+            tags=["hermes-demotion"],
+            source="hermes_demotion",
+            source_ref=origin_ref,
+        )
+        if not bool(captured.get("captured", True)):
+            # Any refused capture ends the staging run honestly: nothing
+            # after this row was attempted, and the payload says why.
+            return {
+                **captured,
+                "schema_version": MEMORY_DEMOTION_STAGE_SCHEMA_VERSION,
+                "staged": staged,
+                "staged_count": len(staged),
+            }
+        candidate = captured.get("candidate") if isinstance(captured.get("candidate"), dict) else {}
+        record = captured.get("record") if isinstance(captured.get("record"), dict) else {}
+        stored_summary = str(candidate.get("summary", "") or record.get("summary", ""))
+        if stored_summary != entry_text:
+            # Belt over the two named guards above: if capture stored
+            # anything other than the exact entry, the copy is not intact
+            # and the row must say so rather than claim a clean stage.
+            staged.append(
+                _refused_demotion_row(
+                    row,
+                    "content_not_intact",
+                    "Capture stored an altered copy of this entry; keep the L1 original.",
+                )
+            )
+            continue
+        staged.append(
+            {
+                "file": str(row.get("file", "")),
+                "entry_index": int(row.get("entry_index", 0) or 0),
+                "sha256": str(row.get("sha256", "")),
+                "candidate_id": str(candidate.get("candidate_id", "") or record.get("candidate_id", "")),
+                "status": str(candidate.get("status", "") or ("approved" if record else "")),
+                "auto_approved": bool(captured.get("auto_approved", False)),
+                "reference_line": str(row.get("reference_line", "")),
+            }
+        )
+    captured_count = sum(1 for row in staged if str(row.get("status", "")) in {"pending_review", "approved"})
+    return {
+        "schema_version": MEMORY_DEMOTION_STAGE_SCHEMA_VERSION,
+        **({"reason_code": str(plan["reason_code"])} if plan.get("reason_code") else {}),
+        "staged": staged,
+        "staged_count": len(staged),
+        "captured_count": captured_count,
+        "refused_count": len(staged) - captured_count,
+        "files": plan.get("files", []),
+        "already_covered": plan.get("already_covered", []),
+        "redaction_policy": "local_content_plan",
+        "next_action": (
+            "Approve the staged candidates (`omh memory review`, `omh memory approve`), then ask Hermes to "
+            "replace each cleanly staged entry with its reference line through Hermes's own memory tool. "
+            "Refused rows were NOT copied to L2 -- leave their L1 entries in place."
+        ),
+        "claim_boundary": (
+            "Staging captured OMH-local candidates only (prepared_not_observed). OMH reads Hermes memory and "
+            "cannot change it; no Hermes entry was edited, and this payload is not execution, review, CI, or "
+            "merge evidence."
+        ),
+    }
+
 
 
 def build_hermes_memory_bridge(paths: OmhPaths) -> dict[str, object]:
@@ -568,6 +797,8 @@ def capture_project_memory_candidate(
         retention_class=retention_class,
         derived_from=_normalize_derived_from(paths, derived_from),
         perspective=_normalize_perspective(observer, observed),
+        default_stale_after_days=_cadence_value(policy, "stale_after_days_default"),
+        episode_ttl_days=_cadence_value(policy, "episode_ttl_days"),
     )
     # Exact-summary duplicate detection, mnemosyne-style but review-first:
     # the match is surfaced on the candidate for the reviewer to decide, never
@@ -659,7 +890,13 @@ class LifecycleCandidateError(ValueError):
     """A v2 lifecycle candidate reached the plain approval path."""
 
 
-def approve_project_memory_candidate(paths: OmhPaths, candidate_id: str, *, approved_by: str = "operator") -> dict[str, object]:
+def approve_project_memory_candidate(
+    paths: OmhPaths,
+    candidate_id: str,
+    *,
+    approved_by: str = "operator",
+    retention_class: str | None = None,
+) -> dict[str, object]:
     candidate = _read_project_memory_candidate(paths, candidate_id)
     if not candidate:
         raise FileNotFoundError(candidate_id)
@@ -685,6 +922,8 @@ def approve_project_memory_candidate(paths: OmhPaths, candidate_id: str, *, appr
         approved_at=approved_at,
         review_id=review_id,
         admission_state=admission_state,
+        retention_class=retention_class,
+        default_stale_after_days=_cadence_value(read_project_memory_policy(paths), "stale_after_days_default"),
     )
     review = _project_memory_review_record(record, review_id=review_id, reviewer=approved_by, decision=admission_state)
     # The whole mutate sequence holds the store lock so a concurrent retirement
@@ -833,7 +1072,7 @@ def build_project_memory_recall_pack(
             stale_override=stale_override,
             run_id=run_id,
         )
-        staleness = _record_staleness(record, now=now)
+        staleness = _record_staleness(record, now=now, due_soon_days=_cadence_value(policy, "due_soon_days"))
         # Source-evidence freshness gates recall exactly like the time
         # deadline does. The shared evaluator only knows deadlines, so the
         # verdict `_record_staleness` derived from the record's own recorded
@@ -1866,11 +2105,16 @@ def confirm_project_memory_record(
         if not previous_due:
             return _refused_confirmation(normalized_id, "no_review_deadline")
         if days is None:
-            # No explicit cadence: honour the one stored on the record by an
-            # earlier confirm, so `--all-due` cannot silently pull a record
-            # confirmed at 180 days back to the 90-day default.
+            # No explicit cadence: honour the one stored on the record (set
+            # at capture or by an earlier confirm), so `--all-due` cannot
+            # silently pull a record confirmed at 180 days back to the
+            # default -- then the policy's default cadence, then the
+            # built-in 90 days.
             stored_days = record.get("staleness", {}).get("stale_after_days") if isinstance(record.get("staleness"), dict) else None
-            days = stored_days if isinstance(stored_days, int) and not isinstance(stored_days, bool) and stored_days > 0 else _REVIEW_DEFAULT_DAYS
+            if isinstance(stored_days, int) and not isinstance(stored_days, bool) and stored_days > 0:
+                days = stored_days
+            else:
+                days = _cadence_value(read_project_memory_policy(paths), "stale_after_days_default") or _REVIEW_DEFAULT_DAYS
         revalidation = record.get("revalidation") if isinstance(record.get("revalidation"), dict) else {}
         new_deadline = _days_after(stamp, days)
         updated_revalidation = {
@@ -1934,11 +2178,19 @@ def confirm_due_project_memory_records(
     # whether a due record happened to exist.
     _validated_day_count(stale_after_days, field="stale_after_days")
     moment = _parse_utc(_attention_stamp(now)) or datetime.now(timezone.utc)
-    due = sorted(
-        str(record.get("record_id", ""))
-        for record in _read_project_memory_records(paths)
-        if _record_staleness(record, now=moment).get("reason") == "review_due"
-    )
+    due: list[str] = []
+    expired_count = 0
+    for record in _read_project_memory_records(paths):
+        verdict = _record_staleness(record, now=moment)
+        if verdict.get("reason") == "review_due":
+            due.append(str(record.get("record_id", "")))
+        elif verdict.get("state") == "expired":
+            # Expired records never enter the batch -- their fix is retire,
+            # not confirmation -- but a batch that stays silent about them
+            # reads as "everything is handled" over a store that still holds
+            # dead records. The count keeps the report honest.
+            expired_count += 1
+    due.sort()
     confirmed: list[dict[str, object]] = []
     skipped: list[dict[str, object]] = []
     for due_id in due:
@@ -1967,24 +2219,28 @@ def confirm_due_project_memory_records(
                     "detail": str(result.get("detail", "")),
                 }
             )
+    next_action = (
+        "Review the skipped records individually; each carries the refusal reason."
+        if skipped
+        else (
+            "Every review-due record was confirmed; recall packs deliver them again."
+            if confirmed
+            else "No review-due record required confirmation."
+        )
+    )
+    if expired_count:
+        next_action += f" {expired_count} expired record(s) were not touched; expiry needs `omh memory retire`, not confirmation."
     return {
         "schema_version": MEMORY_CONFIRMATION_BATCH_SCHEMA_VERSION,
         "due_count": len(due),
+        "expired_count": expired_count,
         "confirmed": confirmed,
         "skipped": skipped,
         "confirmed_count": len(confirmed),
         "skipped_count": len(skipped),
         "confirmed_by": _redact(str(confirmed_by or "operator"))[:_MEMORY_ATTENTION_REASON_LIMIT],
         "redaction_policy": "metadata_only",
-        "next_action": (
-            "Review the skipped records individually; each carries the refusal reason."
-            if skipped
-            else (
-                "Every review-due record was confirmed; recall packs deliver them again."
-                if confirmed
-                else "No review-due record required confirmation; expired records need `omh memory retire`, not confirmation."
-            )
-        ),
+        "next_action": next_action,
         "claim_boundary": _MEMORY_CONFIRMATION_CLAIM_BOUNDARY,
     }
 
@@ -2165,6 +2421,9 @@ def build_memory_lineage(paths: OmhPaths, record_id: str, *, depth: int = 3) -> 
     cannot make the report unbounded.
     """
     depth = max(1, min(int(depth), _LINEAGE_MAX_DEPTH))
+    # The same advance-notice window recall uses, so lineage and recall never
+    # disagree about whether one record is due soon.
+    window = _cadence_value(read_project_memory_policy(paths), "due_soon_days")
     records = {
         str(record.get("record_id", "")): record
         for record in _read_project_memory_records(paths)
@@ -2214,7 +2473,7 @@ def build_memory_lineage(paths: OmhPaths, record_id: str, *, depth: int = 3) -> 
                         unresolved.append({"record_id": ref, "referenced_by": node_id})
                     continue
                 visited.add(ref)
-                ancestors.append(_lineage_card(records[ref], depth=hop))
+                ancestors.append(_lineage_card(records[ref], depth=hop, due_soon_days=window))
                 next_frontier.append(ref)
         frontier = next_frontier
     # Any unexpanded ref past the horizon -- resolvable or dangling -- means
@@ -2235,7 +2494,7 @@ def build_memory_lineage(paths: OmhPaths, record_id: str, *, depth: int = 3) -> 
                 if child_id in visited_down:
                     continue
                 visited_down.add(child_id)
-                descendants.append(_lineage_card(records[child_id], depth=hop))
+                descendants.append(_lineage_card(records[child_id], depth=hop, due_soon_days=window))
                 next_frontier.append(child_id)
         frontier = next_frontier
     truncated = truncated or any(
@@ -2246,7 +2505,7 @@ def build_memory_lineage(paths: OmhPaths, record_id: str, *, depth: int = 3) -> 
     return {
         **base,
         "found": True,
-        "record": _lineage_card(root, depth=0),
+        "record": _lineage_card(root, depth=0, due_soon_days=window),
         "ancestors": ancestors,
         "descendants": descendants,
         "unresolved_refs": unresolved,
@@ -2255,7 +2514,7 @@ def build_memory_lineage(paths: OmhPaths, record_id: str, *, depth: int = 3) -> 
     }
 
 
-def _lineage_card(record: dict[str, Any], *, depth: int) -> dict[str, object]:
+def _lineage_card(record: dict[str, Any], *, depth: int, due_soon_days: int | None = None) -> dict[str, object]:
     return {
         "record_id": str(record.get("record_id", "")),
         "depth": depth,
@@ -2264,7 +2523,7 @@ def _lineage_card(record: dict[str, Any], *, depth: int) -> dict[str, object]:
         "scope": _normalize_scope(record.get("scope", _scope("project", "default"))),
         "tags": _normalize_tags(record.get("tags", [])),
         "approved_at": str(record.get("approved_at", "")),
-        "staleness": _record_staleness(record),
+        "staleness": _record_staleness(record, due_soon_days=due_soon_days),
         "derived_from": _string_list(record.get("derived_from", [])),
     }
 
@@ -2843,6 +3102,8 @@ def _build_project_memory_candidate(
     retention_class: str,
     derived_from: list[str] | tuple[str, ...] = (),
     perspective: dict[str, str] | None = None,
+    default_stale_after_days: int | None = None,
+    episode_ttl_days: int | None = None,
 ) -> dict[str, object]:
     normalized_type = _normalize_record_type(record_type)
     scope = _scope_for_project_memory(scope_kind, scope_ref)
@@ -2850,10 +3111,20 @@ def _build_project_memory_candidate(
     content_text = str(content or "")
     safety = _project_memory_safety(summary, content_text, tags=normalized_tags)
     now = utc_now()
-    ttl = _ttl_metadata(ttl_days, record_type=normalized_type, created_at=now)
-    staleness = _staleness_metadata(
-        stale_after_days, record_type=normalized_type, retention_class=retention_class, created_at=now
-    )
+    ttl = _ttl_metadata(ttl_days, record_type=normalized_type, created_at=now, episode_ttl_days=episode_ttl_days)
+    # `cadence_source` records whether the captor chose the cadence or the
+    # default supplied it -- the one fact an approval-time re-class needs to
+    # honour an explicit deadline without freezing a defaulted one.
+    staleness = {
+        **_staleness_metadata(
+            stale_after_days,
+            record_type=normalized_type,
+            retention_class=retention_class,
+            created_at=now,
+            default_days=default_stale_after_days,
+        ),
+        "cadence_source": "explicit" if stale_after_days is not None else "default",
+    }
     candidate_id = "cand_" + os.urandom(8).hex()
     status = "blocked_review_required" if safety["status"] == "blocked" else "pending_review"
     # Digest the ref exactly as it will be stored, not as it was passed:
@@ -2896,6 +3167,8 @@ def _record_from_candidate(
     approved_at: str,
     review_id: str,
     admission_state: str,
+    retention_class: str | None = None,
+    default_stale_after_days: int | None = None,
 ) -> dict[str, object]:
     if admission_state not in ADMISSION_STATES:
         raise ValueError(f"unsupported memory admission state: {admission_state}")
@@ -2903,22 +3176,63 @@ def _record_from_candidate(
     if approved_at_value is None:
         raise ValueError("approved_at must be an ISO timestamp")
     record_type = _normalize_record_type(str(candidate.get("record_type", "fact")))
+    # The reviewer may re-class the record at approval -- most usefully
+    # promoting a settled decision to `durable` so it does not inherit the
+    # 90-day review clock nobody chose for it. The override re-derives
+    # retention AND the review deadline with the new class's own defaults;
+    # a captor who wants a specific cadence on a durable record sets it at
+    # capture, where the explicit value is recorded.
+    requested_class = str(candidate.get("retention_class", "standard"))
+    override = None
+    if retention_class is not None:
+        supplied = str(retention_class)
+        if supplied not in {"volatile", "standard", "durable"}:
+            raise ValueError(f"unsupported retention class: {supplied}")
+        # An identity override (the class the candidate already has) is a
+        # validated no-op: the record mints exactly as a plain approval
+        # would, carry-overs included.
+        if supplied != requested_class:
+            override = supplied
+            requested_class = supplied
     retention = build_retention(
-        str(candidate.get("retention_class", "standard")),
+        requested_class,
         record_type=record_type,
         admitted_at=approved_at_value,
-        ttl_days=_candidate_ttl_days(candidate),
+        ttl_days=_candidate_ttl_days(candidate) if override is None else None,
     )
     # Approval must not silently extend the deadline shown to the reviewer.
     # `utc_now` is second-truncated, so deriving it again from `approved_at`
     # made this record expire one second later whenever review crossed a clock
     # boundary. The candidate's stored deadline is the authoritative value.
+    # An overridden class skips the carry-over on purpose: that deadline was
+    # minted for the class the reviewer just rejected.
     candidate_ttl = candidate.get("ttl")
-    if "expires_at" in retention and isinstance(candidate_ttl, dict) and candidate_ttl.get("expires_at"):
+    if override is None and "expires_at" in retention and isinstance(candidate_ttl, dict) and candidate_ttl.get("expires_at"):
         retention["expires_at"] = str(candidate_ttl["expires_at"])
     record_id = "mem_" + os.urandom(8).hex()
     scope = _normalize_scope(candidate.get("scope", _scope("project", "default")))
     revalidation = _candidate_revalidation(candidate)
+    staleness_days = _candidate_stale_after_days(candidate)
+    if override is not None:
+        candidate_staleness = candidate.get("staleness") if isinstance(candidate.get("staleness"), dict) else {}
+        explicit_cadence = str(candidate_staleness.get("cadence_source", "") or "") == "explicit" and staleness_days is not None
+        if explicit_cadence:
+            # A cadence the captor explicitly chose survives the re-class:
+            # `_staleness_metadata` is explicit that durable makes the
+            # deadline optional, not forbidden, and the reviewer's flag was
+            # about retention, not about removing a review date they saw on
+            # the card. The candidate's revalidation carries over untouched.
+            pass
+        else:
+            refreshed = _staleness_metadata(
+                None,
+                record_type=record_type,
+                created_at=str(candidate.get("created_at", approved_at)),
+                retention_class=override,
+                default_days=default_stale_after_days,
+            )
+            revalidation = {"deadline": str(refreshed["stale_after"])} if refreshed["stale_after"] else {}
+            staleness_days = refreshed["stale_after_days"]
     record: dict[str, object] = {
         "schema_version": PROJECT_MEMORY_RECORD_SCHEMA_VERSION,
         "record_id": record_id,
@@ -2954,7 +3268,15 @@ def _record_from_candidate(
         "created_at": str(candidate.get("created_at", approved_at)),
         "updated_at": approved_at,
         "ttl": _ttl_projection(retention),
-        "staleness": _staleness_projection(revalidation),
+        # The projection alone nulls `stale_after_days`, which lost the
+        # cadence the captor chose: a record captured at 365 days silently
+        # fell back to the 90-day default on its first flagless confirm.
+        # Carrying the candidate's cadence onto the record keeps `omh memory
+        # confirm` honouring it.
+        "staleness": {
+            **_staleness_projection(revalidation),
+            "stale_after_days": staleness_days,
+        },
         # Every approved record states its tier explicitly. An implicit
         # default would make "this record is active" and "nobody ever set a
         # tier" the same fact, and the operator could not tell an intentional
@@ -3001,6 +3323,12 @@ def _write_project_memory_review_decision(paths: OmhPaths, review: dict[str, obj
         raise ValueError(f"unsafe memory review id: {review_id!r}")
     atomic_write_json(_memory_review_path(paths, review_id), review, private=True)
     return review
+
+
+def _candidate_stale_after_days(candidate: dict[str, Any]) -> int | None:
+    staleness = candidate.get("staleness")
+    days = staleness.get("stale_after_days") if isinstance(staleness, dict) else None
+    return days if isinstance(days, int) and not isinstance(days, bool) and days > 0 else None
 
 
 def _candidate_ttl_days(candidate: dict[str, Any]) -> int | None:
@@ -3127,15 +3455,16 @@ def _freshness_warnings(
         state = str(staleness.get("state", ""))
         reason_code = str(entry.get("eligibility_reason", "") or "")
         known_reason = reason_code in _FRESHNESS_REASON_TEXT
-        if not known_reason and delivered and str(staleness.get("reason", "") or "") == "review_due_soon":
-            # A still-fresh record inside the pre-deadline window: eligibility
-            # has nothing to say about it, so the advance notice comes from
-            # the staleness verdict instead. Only a DELIVERED record earns it
-            # -- a due-soon warning on every unrelated record in the store
-            # would page the operator about records this task never touched,
-            # and once the deadline actually passes the ordinary stale warning
-            # fires for held-back records as before.
-            reason_code, known_reason = "review_due_soon", True
+        staleness_reason = str(staleness.get("reason", "") or "")
+        if not known_reason and delivered and staleness_reason in ADVISORY_FRESHNESS_REASONS:
+            # A still-fresh record inside a pre-deadline window (review-due or
+            # TTL expiry): eligibility has nothing to say about it, so the
+            # advance notice comes from the staleness verdict instead. Only a
+            # DELIVERED record earns it -- an advisory on every unrelated
+            # record in the store would page the operator about records this
+            # task never touched, and once the deadline actually passes the
+            # ordinary blocking warning fires for held-back records as before.
+            reason_code, known_reason = staleness_reason, True
         if not known_reason and state in {"", "fresh", "not_checked"}:
             continue
         if not record_id or record_id in seen:
@@ -3153,9 +3482,10 @@ def _freshness_warnings(
                 "state": state or "unknown",
                 "reason_code": reason_code,
                 "review_due_at": str(staleness.get("review_due_at", "") or ""),
+                "expires_at": str(staleness.get("expires_at", "") or ""),
                 "detail": _FRESHNESS_REASON_TEXT[reason_code],
                 "delivered": bool(delivered),
-                "next_action": _DUE_SOON_NEXT_ACTION if advisory_reason else _FRESHNESS_NEXT_ACTION,
+                "next_action": _ADVISORY_NEXT_ACTIONS.get(reason_code, _FRESHNESS_NEXT_ACTION),
             }
         )
         if len(blocking) >= _FRESHNESS_WARNING_LIMIT:
@@ -3374,7 +3704,12 @@ def _record_scope_matches(record: dict[str, Any], *, scope_kind: str | None, sco
     return (not scope_kind or scope["kind"] == scope_kind) and (not scope_ref or scope["ref"] == scope_ref)
 
 
-def _record_staleness(record: dict[str, Any], *, now: datetime | None = None) -> dict[str, object]:
+def _record_staleness(
+    record: dict[str, Any],
+    *,
+    now: datetime | None = None,
+    due_soon_days: int | None = None,
+) -> dict[str, object]:
     """The one freshness verdict: TTL, review-due date, and source evidence.
 
     The TTL half is decided by the bundle classifier, the single source of
@@ -3415,11 +3750,27 @@ def _record_staleness(record: dict[str, Any], *, now: datetime | None = None) ->
         return {"state": "stale", "reason": "source_changed", **fields}
     if source_state == "unreadable":
         return {"state": "unknown", "reason": "source_unreadable", **fields}
-    if deadline and deadline - now <= timedelta(days=_REVIEW_DUE_SOON_DAYS):
-        # Still fresh and still eligible: the record delivers exactly as
-        # before. The reason is the advance notice recall packs turn into a
-        # warning, so the deadline stops being a surprise discovered only
-        # after the record has already left every pack.
+    # Still fresh and still eligible below here: the record delivers exactly
+    # as before. The reason is the advance notice recall packs turn into a
+    # warning, so a deadline stops being a surprise discovered only after the
+    # record has already left every pack. Expiry outranks review-due when both
+    # windows overlap: a passed TTL is terminal, a passed review date is not.
+    # Naive TTL timestamps read as UTC, matching the expiry classifier that
+    # decides the terminal verdict above; `_parse_utc` would read them as
+    # host-local and move this window by up to +/-14 hours.
+    expiry = _parse_utc_naive_as_utc(expires_at)
+    expiry_window = due_soon_days if due_soon_days is not None else _EXPIRES_SOON_DAYS
+    ttl_days_value = ttl.get("ttl_days")
+    if isinstance(ttl_days_value, int) and not isinstance(ttl_days_value, bool) and ttl_days_value > 0:
+        # A notice window longer than half the record's own life is not
+        # advance notice, it is a permanent banner: a 7-day volatile record
+        # would warn from the moment it was approved. Scale the window down
+        # to half the TTL (never below one day) so short-lived records warn
+        # near the end, which is when the warning means something.
+        expiry_window = min(expiry_window, max(ttl_days_value // 2, 1))
+    if expiry and expiry - now <= timedelta(days=expiry_window):
+        return {"state": "fresh", "reason": "expires_soon", **fields}
+    if deadline and deadline - now <= timedelta(days=due_soon_days if due_soon_days is not None else _REVIEW_DUE_SOON_DAYS):
         return {"state": "fresh", "reason": "review_due_soon", **fields}
     return {"state": "fresh", "reason": "", **fields}
 
@@ -3529,6 +3880,18 @@ MAX_RETENTION_DAYS = 36500
 
 _EPISODE_DEFAULT_TTL_DAYS = 30
 _REVIEW_DEFAULT_DAYS = 90
+# The three memory clocks, as product tunables rather than constants baked
+# into one machine's build: the default review cadence, the episode TTL, and
+# the advance-notice window recall packs warn inside (shared by review-due
+# and expiry notices). Stored setup profiles may carry them inside
+# `memory_policy` -- additive and optional, exactly like the rest of that
+# block -- and an absent or invalid value falls back to the named default
+# while the effective value is always disclosed on the policy payload.
+_MEMORY_CADENCE_DEFAULTS = {
+    "stale_after_days_default": _REVIEW_DEFAULT_DAYS,
+    "episode_ttl_days": _EPISODE_DEFAULT_TTL_DAYS,
+    "due_soon_days": _REVIEW_DUE_SOON_DAYS,
+}
 
 
 def _validated_day_count(days: int | None, *, field: str) -> int | None:
@@ -3555,10 +3918,16 @@ def _validated_day_count(days: int | None, *, field: str) -> int | None:
     return days
 
 
-def _ttl_metadata(ttl_days: int | None, *, record_type: str, created_at: str) -> dict[str, object]:
+def _ttl_metadata(
+    ttl_days: int | None,
+    *,
+    record_type: str,
+    created_at: str,
+    episode_ttl_days: int | None = None,
+) -> dict[str, object]:
     days = _validated_day_count(ttl_days, field="ttl_days")
     if days is None and record_type == "episode":
-        days = _EPISODE_DEFAULT_TTL_DAYS
+        days = episode_ttl_days if episode_ttl_days is not None else _EPISODE_DEFAULT_TTL_DAYS
     # `is None` rather than falsiness: "no deadline" and "zero days" are
     # different statements, and only the first one may produce an empty
     # `expires_at`. The falsy test is what let a rejected-at-the-CLI zero
@@ -3575,6 +3944,7 @@ def _staleness_metadata(
     record_type: str,
     created_at: str,
     retention_class: str = "standard",
+    default_days: int | None = None,
 ) -> dict[str, object]:
     """The review-due deadline, or none for a record declared durable.
 
@@ -3596,7 +3966,7 @@ def _staleness_metadata(
     """
     days = _validated_day_count(stale_after_days, field="stale_after_days")
     if days is None and retention_class != "durable" and record_type in {"fact", "decision", "lesson", "procedure"}:
-        days = _REVIEW_DEFAULT_DAYS
+        days = default_days if default_days is not None else _REVIEW_DEFAULT_DAYS
     default_days = days
     deadline = _days_after(created_at, days) if days is not None else ""
     # `review_due_at` is the readable name for the date `stale_after` always

--- a/tests/test_memory_demotion.py
+++ b/tests/test_memory_demotion.py
@@ -1,0 +1,358 @@
+"""Demotion moves an L1 entry's content into L2 and leaves a pointer behind.
+
+Hermes memory is character-capped, so the only ways to make room are deleting
+an entry (the fact is gone) or demoting it (the fact moves to OMH's governed
+store and a short reference line stays). These tests pin the second one:
+
+- an entry an approved OMH record already explains is *not* demotion work, it
+  is deletable, and must never be proposed for a move that copies it down twice;
+- the plan ranks by characters saved, because a plan whose first row frees the
+  least is a plan nobody can act on under a full cap;
+- the reference line is keyed by the entry's own sha256, which is what makes
+  the pointer survive the candidate -> record lifecycle it points into.
+
+Nothing here writes a Hermes file: the plan is prepared text and Hermes' own
+memory tool is the only thing that may apply it.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.memory import approve_project_memory_candidate, capture_project_memory_candidate
+from omh.paths import resolve_paths
+from omh.plugin_bundle.omh.hermes_memory import (
+    DEFAULT_MEMORY_FILE_CAP_CHARS,
+    DEMOTION_REFERENCE_LABEL_CHARS,
+    HERMES_MEMORY_DELIMITER,
+    MEMORY_DEMOTION_PLAN_SCHEMA_VERSION,
+    build_memory_demotion_plan,
+)
+
+LONG_ENTRY = ("문서 하네스는 에이전트가 HTML을 먼저 작성하고 변환하는 시스템이다. " * 6).strip()
+MEDIUM_ENTRY = ("release 스크립트는 --dry-run 플래그로 계획만 출력한다. " * 3).strip()
+SHORT_ENTRY = "커피 원두는 밀봉 용기에 보관한다"
+
+
+def _write_memory_file(home: Path, label: str, *entries: str) -> Path:
+    path = home / "memories" / label
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(HERMES_MEMORY_DELIMITER.join(entries), encoding="utf-8")
+    return path
+
+
+def _write_memory(home: Path, *entries: str) -> Path:
+    return _write_memory_file(home, "MEMORY.md", *entries)
+
+
+def _approved(paths, summary: str) -> str:
+    capture = capture_project_memory_candidate(paths, summary, scope_ref="demo")
+    approval = approve_project_memory_candidate(paths, str(capture["candidate"]["candidate_id"]))
+    return str(approval["record"]["record_id"])
+
+
+class _PlanCase(unittest.TestCase):
+    def _homes(self, tmp: str) -> tuple[Path, Path, object]:
+        root = Path(tmp)
+        paths = resolve_paths(root / ".omh", root / ".hermes")
+        return root / ".omh", root / ".hermes", paths
+
+
+class RankingTests(_PlanCase):
+    def test_unsourced_entries_rank_by_characters_saved(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home, hermes_home, _ = self._homes(tmp)
+            _write_memory(hermes_home, MEDIUM_ENTRY, LONG_ENTRY, SHORT_ENTRY)
+
+            plan = build_memory_demotion_plan(omh_home, hermes_home)
+            self.assertEqual(plan["schema_version"], MEMORY_DEMOTION_PLAN_SCHEMA_VERSION)
+            # No approved records, so every entry qualifies; biggest first.
+            self.assertEqual([row["entry_index"] for row in plan["rows"]], [1, 0, 2])
+            self.assertEqual(plan["row_count"], 3)
+            self.assertEqual(plan["already_covered"], [])
+            self.assertEqual([row["chars"] for row in plan["rows"]], sorted((len(LONG_ENTRY), len(MEDIUM_ENTRY), len(SHORT_ENTRY)), reverse=True))
+
+    def test_max_entries_caps_the_plan_at_the_biggest_rows(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home, hermes_home, _ = self._homes(tmp)
+            _write_memory(hermes_home, MEDIUM_ENTRY, LONG_ENTRY, SHORT_ENTRY)
+
+            plan = build_memory_demotion_plan(omh_home, hermes_home, max_entries=1)
+            self.assertEqual(plan["row_count"], 1)
+            self.assertEqual(plan["rows"][0]["entry_text"], LONG_ENTRY)
+
+    def test_per_file_summary_projects_the_headroom_the_rows_would_leave(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home, hermes_home, _ = self._homes(tmp)
+            _write_memory(hermes_home, LONG_ENTRY)
+
+            plan = build_memory_demotion_plan(omh_home, hermes_home)
+            summary = plan["files"][0]
+            row = plan["rows"][0]
+            self.assertEqual(summary["label"], "MEMORY.md")
+            self.assertEqual(summary["cap"], DEFAULT_MEMORY_FILE_CAP_CHARS)
+            self.assertEqual(summary["entry_count"], 1)
+            self.assertEqual(summary["planned_demotions"], 1)
+            self.assertFalse(summary["over_cap"])
+            self.assertEqual(
+                summary["estimated_headroom_after"],
+                summary["headroom_chars"] + row["savings_chars"],
+            )
+            self.assertEqual(plan["estimated_savings_chars"], row["savings_chars"])
+
+    def test_the_second_file_is_planned_too_and_owns_its_own_rows(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home, hermes_home, _ = self._homes(tmp)
+            _write_memory(hermes_home, MEDIUM_ENTRY)
+            _write_memory_file(hermes_home, "USER.md", LONG_ENTRY)
+
+            plan = build_memory_demotion_plan(omh_home, hermes_home)
+            self.assertEqual([row["file"] for row in plan["rows"]], ["USER.md", "MEMORY.md"])
+            planned = {summary["label"]: summary["planned_demotions"] for summary in plan["files"]}
+            self.assertEqual(planned, {"MEMORY.md": 1, "USER.md": 1})
+
+
+class AlreadyCoveredTests(_PlanCase):
+    def test_an_entry_an_approved_record_explains_is_deletable_not_demotable(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home, hermes_home, paths = self._homes(tmp)
+            record_id = _approved(paths, "document-harness는 HTML을 먼저 작성하고 PPTX로 변환하는 문서 시스템이다")
+            entry = "document-harness: HTML을 먼저 작성하고 PPTX로 변환하는 문서 시스템"
+            _write_memory(hermes_home, entry, SHORT_ENTRY)
+
+            plan = build_memory_demotion_plan(omh_home, hermes_home)
+            self.assertEqual(len(plan["already_covered"]), 1)
+            covered = plan["already_covered"][0]
+            self.assertEqual(covered["entry_index"], 0)
+            self.assertEqual(covered["matched_record_id"], record_id)
+            self.assertTrue(covered["already_in_omh"])
+            self.assertGreaterEqual(covered["similarity"], 0.6)
+            # Demoting it would copy into L2 what L2 already holds.
+            self.assertEqual([row["entry_text"] for row in plan["rows"]], [SHORT_ENTRY])
+
+    def test_an_unrelated_record_leaves_every_entry_demotable(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home, hermes_home, paths = self._homes(tmp)
+            _approved(paths, "release 스크립트는 --dry-run 플래그로 계획만 출력한다")
+            _write_memory(hermes_home, SHORT_ENTRY)
+
+            plan = build_memory_demotion_plan(omh_home, hermes_home)
+            self.assertEqual(plan["already_covered"], [])
+            self.assertEqual(plan["row_count"], 1)
+
+
+class FileLabelTests(_PlanCase):
+    def test_a_label_filter_plans_only_that_file(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home, hermes_home, _ = self._homes(tmp)
+            _write_memory(hermes_home, MEDIUM_ENTRY)
+            _write_memory_file(hermes_home, "USER.md", LONG_ENTRY)
+
+            plan = build_memory_demotion_plan(omh_home, hermes_home, file_label="USER.md")
+            self.assertEqual([summary["label"] for summary in plan["files"]], ["USER.md"])
+            self.assertEqual([row["file"] for row in plan["rows"]], ["USER.md"])
+
+    def test_an_unknown_label_says_so_instead_of_reporting_nothing_to_do(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home, hermes_home, _ = self._homes(tmp)
+            _write_memory(hermes_home, LONG_ENTRY)
+
+            plan = build_memory_demotion_plan(omh_home, hermes_home, file_label="MEMORIES.md")
+            self.assertEqual(plan["reason_code"], "unknown_file_label")
+            self.assertEqual(plan["requested_file_label"], "MEMORIES.md")
+            self.assertEqual(plan["known_file_labels"], ["MEMORY.md", "USER.md"])
+            self.assertEqual(plan["rows"], [])
+            self.assertEqual(plan["files"], [])
+            self.assertEqual(plan["row_count"], 0)
+
+
+class ReferenceLineTests(_PlanCase):
+    def test_the_line_carries_the_sha_prefix_and_a_collapsed_label(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home, hermes_home, _ = self._homes(tmp)
+            entry = "첫 줄\n\n  둘째   줄은 아주 길어서 라벨이 잘려야 한다 " * 4
+            _write_memory(hermes_home, entry.strip())
+
+            row = build_memory_demotion_plan(omh_home, hermes_home)["rows"][0]
+            collapsed = " ".join(row["entry_text"].split())
+            expected = f"[omh#{row['sha256'][:12]}] {collapsed[:DEMOTION_REFERENCE_LABEL_CHARS]}…"
+            self.assertEqual(row["reference_line"], expected)
+            self.assertEqual(row["reference_chars"], len(row["reference_line"]))
+            self.assertNotIn("\n", row["reference_line"])
+            self.assertEqual(row["savings_chars"], row["chars"] - row["reference_chars"])
+
+    def test_a_short_entry_keeps_its_whole_label_and_no_ellipsis(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home, hermes_home, _ = self._homes(tmp)
+            _write_memory(hermes_home, SHORT_ENTRY)
+
+            row = build_memory_demotion_plan(omh_home, hermes_home)["rows"][0]
+            self.assertEqual(row["reference_line"], f"[omh#{row['sha256'][:12]}] {SHORT_ENTRY}")
+            self.assertNotIn("…", row["reference_line"])
+
+    def test_an_entry_smaller_than_its_pointer_reports_a_negative_saving(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home, hermes_home, _ = self._homes(tmp)
+            _write_memory(hermes_home, "ok")
+
+            plan = build_memory_demotion_plan(omh_home, hermes_home)
+            self.assertLess(plan["rows"][0]["savings_chars"], 0)
+            # A row that costs characters must not be counted as a saving.
+            self.assertEqual(plan["estimated_savings_chars"], 0)
+            self.assertEqual(plan["files"][0]["estimated_headroom_after"], plan["files"][0]["headroom_chars"])
+
+
+class EmptyStoreTests(_PlanCase):
+    def test_an_empty_hermes_home_still_returns_a_valid_plan(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home, hermes_home, _ = self._homes(tmp)
+
+            plan = build_memory_demotion_plan(omh_home, hermes_home)
+            self.assertEqual(plan["rows"], [])
+            self.assertEqual(plan["already_covered"], [])
+            self.assertEqual(plan["row_count"], 0)
+            self.assertEqual(plan["estimated_savings_chars"], 0)
+            self.assertEqual([summary["entry_count"] for summary in plan["files"]], [0, 0])
+            self.assertEqual(plan["redaction_policy"], "local_content_plan")
+            self.assertIn("cannot change it", str(plan["claim_boundary"]))
+            self.assertIn("prepared_not_observed", str(plan["claim_boundary"]))
+
+    def test_an_empty_record_store_makes_every_entry_qualify(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home, hermes_home, _ = self._homes(tmp)
+            _write_memory(hermes_home, MEDIUM_ENTRY, SHORT_ENTRY)
+
+            plan = build_memory_demotion_plan(omh_home, hermes_home)
+            self.assertEqual(plan["already_covered"], [])
+            self.assertEqual(plan["row_count"], 2)
+
+
+class ArgumentTests(_PlanCase):
+    def test_max_entries_below_one_is_refused(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home, hermes_home, _ = self._homes(tmp)
+            _write_memory(hermes_home, LONG_ENTRY)
+            for value in (0, -1, "3", 2.0):
+                with self.subTest(value=value), self.assertRaises(ValueError):
+                    build_memory_demotion_plan(omh_home, hermes_home, max_entries=value)
+
+
+class StagingTests(_PlanCase):
+    """`omh memory demote --stage`: the L2 half of a demotion, review-first."""
+
+    def test_stage_captures_rows_as_candidates_and_restage_is_idempotent(self) -> None:
+        from omh.memory import build_project_memory_recall_pack, stage_memory_demotion
+
+        with TemporaryDirectory() as tmp:
+            _omh_home, hermes_home, paths = self._homes(tmp)
+            _write_memory(hermes_home, MEDIUM_ENTRY, LONG_ENTRY)
+            staged = stage_memory_demotion(paths)
+            self.assertEqual(staged["schema_version"], "memory_demotion_stage/v1")
+            self.assertEqual(staged["staged_count"], 2)
+            self.assertEqual([row["status"] for row in staged["staged"]], ["pending_review", "pending_review"])
+            self.assertTrue(all(row["candidate_id"] for row in staged["staged"]))
+            self.assertTrue(all(row["reference_line"].startswith("[omh#") for row in staged["staged"]))
+            self.assertIn("Hermes's own memory tool", staged["next_action"])
+            # Staging again must not stack duplicate candidates for the same
+            # entries: the origin ref is the stable key.
+            restaged = stage_memory_demotion(paths)
+            self.assertEqual([row["status"] for row in restaged["staged"]], ["already_staged", "already_staged"])
+            # Approving the staged candidates makes the content recallable
+            # from L2, which is the entire point of the move.
+            for row in staged["staged"]:
+                approve_project_memory_candidate(paths, str(row["candidate_id"]))
+            pack = build_project_memory_recall_pack(paths, LONG_ENTRY.split()[0])
+            self.assertEqual(pack["record_count"], 1)
+
+    def test_an_entry_the_summary_bound_would_truncate_is_refused_intact(self) -> None:
+        from omh.memory import build_memory_demotion, stage_memory_demotion
+
+        with TemporaryDirectory() as tmp:
+            _omh_home, hermes_home, paths = self._homes(tmp)
+            oversized = ("이 항목은 요약 경계보다 길어서 그대로 옮길 수 없다. " * 10).strip()
+            self.assertGreater(len(oversized), 240)
+            _write_memory(hermes_home, oversized)
+            staged = stage_memory_demotion(paths)
+            self.assertEqual([row["status"] for row in staged["staged"]], ["summary_bound_exceeded"])
+            self.assertEqual(staged["captured_count"], 0)
+            self.assertEqual(staged["refused_count"], 1)
+            self.assertIn("stays in L1 intact", staged["staged"][0]["detail"])
+            # Nothing was captured: the L1 entry remains the only copy and
+            # the next plan still proposes it as unstaged work.
+            replan = build_memory_demotion(paths)
+            self.assertEqual([row["staging_status"] for row in replan["rows"]], ["unstaged"])
+
+    def test_a_sensitive_looking_entry_is_refused_not_hollowed(self) -> None:
+        from omh.memory import stage_memory_demotion
+
+        with TemporaryDirectory() as tmp:
+            _omh_home, hermes_home, paths = self._homes(tmp)
+            _write_memory(hermes_home, "the deploy token for staging lives in the infra vault")
+            staged = stage_memory_demotion(paths)
+            # The capture redactor would store the literal "[redacted]" and
+            # the workflow's next step deletes the L1 original -- refusal is
+            # the only honest verdict.
+            self.assertEqual([row["status"] for row in staged["staged"]], ["redacted_cannot_demote"])
+            self.assertEqual(staged["captured_count"], 0)
+
+    def test_a_cleanly_staged_entry_survives_byte_for_byte(self) -> None:
+        from omh.memory import stage_memory_demotion
+
+        with TemporaryDirectory() as tmp:
+            _omh_home, hermes_home, paths = self._homes(tmp)
+            _write_memory(hermes_home, LONG_ENTRY)
+            staged = stage_memory_demotion(paths)
+            record = approve_project_memory_candidate(paths, str(staged["staged"][0]["candidate_id"]))["record"]
+            # The whole point of the move: the approved L2 record holds the
+            # exact entry, tail included, before anyone deletes the original.
+            self.assertEqual(record["summary"], LONG_ENTRY)
+
+    def test_stage_on_an_empty_store_still_speaks_the_stage_schema(self) -> None:
+        from omh.memory import stage_memory_demotion
+
+        with TemporaryDirectory() as tmp:
+            _omh_home, _hermes_home, paths = self._homes(tmp)
+            staged = stage_memory_demotion(paths)
+            self.assertEqual(staged["schema_version"], "memory_demotion_stage/v1")
+            self.assertEqual(staged["staged"], [])
+            self.assertEqual(staged["staged_count"], 0)
+
+    def test_a_rejected_demotion_reads_as_the_standing_decision(self) -> None:
+        from omh.memory import reject_project_memory_candidate, stage_memory_demotion
+
+        with TemporaryDirectory() as tmp:
+            _omh_home, hermes_home, paths = self._homes(tmp)
+            _write_memory(hermes_home, LONG_ENTRY)
+            staged = stage_memory_demotion(paths)
+            reject_project_memory_candidate(paths, str(staged["staged"][0]["candidate_id"]), rejected_by="user")
+            restaged = stage_memory_demotion(paths)
+            # The reviewer said no to exactly this entry; restaging reports
+            # that standing decision instead of `already_staged` (work in
+            # progress) and never mints a fresh candidate around it.
+            self.assertEqual([row["status"] for row in restaged["staged"]], ["previously_rejected"])
+            self.assertEqual(restaged["staged"][0]["candidate_id"], "")
+
+    def test_approved_demotions_turn_into_deletable_already_covered_rows(self) -> None:
+        from omh.memory import stage_memory_demotion
+
+        with TemporaryDirectory() as tmp:
+            _omh_home, hermes_home, paths = self._homes(tmp)
+            _write_memory(hermes_home, LONG_ENTRY)
+            staged = stage_memory_demotion(paths)
+            approve_project_memory_candidate(paths, str(staged["staged"][0]["candidate_id"]))
+            replanned = stage_memory_demotion(paths)
+            # Nothing left to stage; the entry is now L1 content an approved
+            # L2 record already explains, reported as deletable.
+            self.assertEqual(replanned.get("rows", replanned.get("staged", [])), [])
+            covered = replanned["already_covered"]
+            self.assertEqual(len(covered), 1)
+            self.assertTrue(covered[0]["matched_record_id"].startswith("mem_"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_memory_staleness.py
+++ b/tests/test_memory_staleness.py
@@ -692,6 +692,177 @@ class ReviewDueSoonWarningTests(unittest.TestCase):
         self.assertEqual(continuity_warning_count({"freshness_warnings": ["not-a-mapping"]}), 1)
 
 
+class ExpiresSoonWarningTests(unittest.TestCase):
+    """The retention twin of review-due-soon: TTL expiry gets advance notice."""
+
+    def test_an_expiring_episode_warns_while_still_delivered(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record = _approved(paths, "incident: cache stampede after deploy", record_type="episode", tags=["incident"])
+            probe = datetime.now(timezone.utc) + timedelta(days=20)  # 10 days before the 30-day TTL
+            pack = build_project_memory_recall_pack(paths, "incident cache", now=probe)
+            self.assertEqual(pack["record_count"], 1)
+            warnings = pack["freshness_warnings"]
+            self.assertEqual([w["reason_code"] for w in warnings], ["expires_soon"])
+            self.assertTrue(warnings[0]["delivered"])
+            self.assertEqual(warnings[0]["expires_at"], record["ttl"]["expires_at"])
+            self.assertIn("cannot extend a TTL", warnings[0]["next_action"])
+            self.assertEqual(validate_project_memory_recall_pack(pack), [])
+            quiet = build_project_memory_recall_pack(
+                paths, "incident cache", now=datetime.now(timezone.utc) + timedelta(days=10)
+            )
+            self.assertEqual(quiet["freshness_warnings"], [])
+
+    def test_the_window_scales_down_for_short_lived_records(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record = _approved(paths, "a week-long volatile note", ttl_days=7)
+            # 7-day TTL -> 3-day window: silent on approval day and mid-life,
+            # warning near the end. A window wider than the record's life
+            # would be a permanent banner, not advance notice.
+            day0 = memory_workflow._record_staleness(record, now=datetime.now(timezone.utc))
+            self.assertEqual(day0["reason"], "")
+            day3 = memory_workflow._record_staleness(record, now=datetime.now(timezone.utc) + timedelta(days=3))
+            self.assertEqual(day3["reason"], "")
+            day5 = memory_workflow._record_staleness(record, now=datetime.now(timezone.utc) + timedelta(days=5))
+            self.assertEqual(day5["reason"], "expires_soon")
+
+    def test_expiry_notice_outranks_the_review_notice_when_both_windows_overlap(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record = _approved(paths, "a fact that expires and comes due together", ttl_days=90)
+            probe = datetime.now(timezone.utc) + timedelta(days=80)
+            verdict = memory_workflow._record_staleness(record, now=probe)
+            self.assertEqual((verdict["state"], verdict["reason"]), ("fresh", "expires_soon"))
+
+
+class CadencePolicyTests(unittest.TestCase):
+    """The three memory clocks are policy tunables, not baked-in constants."""
+
+    def _write_policy(self, paths, **cadence) -> None:
+        paths.setup_profile_path.parent.mkdir(parents=True, exist_ok=True)
+        paths.setup_profile_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "setup_profile/v1",
+                    "memory_policy": {"mode": "review-first", **cadence},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def test_policy_cadence_overrides_reach_capture_and_the_warning_window(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            self._write_policy(paths, stale_after_days_default=30, episode_ttl_days=60, due_soon_days=3)
+            fact = _approved(paths, "fact on a 30-day cadence", tags=["cadence"])
+            self.assertEqual(fact["staleness"]["stale_after_days"], 30)
+            episode = _approved(paths, "episode on a 60-day ttl", record_type="episode")
+            self.assertEqual(episode["ttl"]["ttl_days"], 60)
+            # The 3-day window: quiet 4 days out, warning 2 days out.
+            quiet = build_project_memory_recall_pack(
+                paths, "cadence fact", now=datetime.now(timezone.utc) + timedelta(days=26)
+            )
+            self.assertEqual(quiet["freshness_warnings"], [])
+            warned = build_project_memory_recall_pack(
+                paths, "cadence fact", now=datetime.now(timezone.utc) + timedelta(days=28)
+            )
+            self.assertEqual([w["reason_code"] for w in warned["freshness_warnings"]], ["review_due_soon"])
+
+    def test_invalid_overrides_fall_back_to_named_defaults_and_are_disclosed(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            self._write_policy(paths, stale_after_days_default=-5, episode_ttl_days="soon", due_soon_days=True)
+            policy = memory_workflow.read_project_memory_policy(paths)
+            self.assertEqual(policy["stale_after_days_default"], 90)
+            self.assertEqual(policy["episode_ttl_days"], 30)
+            self.assertEqual(policy["due_soon_days"], 14)
+
+    def test_capture_cadence_survives_approval_and_flagless_confirm(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record = _approved(paths, "captured on a yearly cadence", stale_after_days=365)
+            self.assertEqual(record["staleness"]["stale_after_days"], 365)
+            result = memory_workflow.confirm_project_memory_record(paths, record["record_id"])
+            self.assertEqual(result["stale_after_days"], 365)
+            self.assertFalse(result["shortened"])
+
+
+class DurablePromotionTests(unittest.TestCase):
+    """`omh memory approve --retention-class durable` drops the default review clock."""
+
+    def test_durable_override_removes_deadline_and_recalls_forever(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            captured = capture_project_memory_candidate(paths, "the license is Apache-2.0", tags=["license"])
+            record = approve_project_memory_candidate(
+                paths, captured["candidate"]["candidate_id"], retention_class="durable"
+            )["record"]
+            self.assertEqual(record["retention"].get("class"), "durable")
+            self.assertEqual(record["staleness"]["review_due_at"], "")
+            self.assertEqual(record["revalidation"], {})
+            self.assertEqual(validate_project_memory_record(record), [])
+            far = build_project_memory_recall_pack(
+                paths, "license apache", now=datetime.now(timezone.utc) + timedelta(days=400)
+            )
+            self.assertEqual(far["record_count"], 1)
+            self.assertEqual(far["freshness_warnings"], [])
+
+    def test_an_explicit_capture_cadence_survives_the_durable_override(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            captured = capture_project_memory_candidate(paths, "durable but still reviewed", stale_after_days=30)
+            record = approve_project_memory_candidate(
+                paths, captured["candidate"]["candidate_id"], retention_class="durable"
+            )["record"]
+            # The captor chose 30 days deliberately; a flag about retention
+            # must not silently remove a review date the reviewer saw.
+            self.assertEqual(record["retention"].get("class"), "durable")
+            self.assertEqual(record["staleness"]["stale_after_days"], 30)
+            self.assertNotEqual(record["staleness"]["review_due_at"], "")
+            self.assertEqual(record["revalidation"].get("deadline"), record["staleness"]["review_due_at"])
+
+    def test_policy_default_cadence_reaches_the_override_rederive(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            paths.setup_profile_path.parent.mkdir(parents=True, exist_ok=True)
+            paths.setup_profile_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "setup_profile/v1",
+                        "memory_policy": {"mode": "review-first", "stale_after_days_default": 30},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            captured = capture_project_memory_candidate(paths, "durable capture, standard approval", retention_class="durable")
+            record = approve_project_memory_candidate(
+                paths, captured["candidate"]["candidate_id"], retention_class="standard"
+            )["record"]
+            self.assertEqual(record["staleness"]["stale_after_days"], 30)
+
+    def test_supplying_the_same_class_is_a_validated_noop(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            captured = capture_project_memory_candidate(paths, "a plain standard fact")
+            plain = approve_project_memory_candidate(
+                paths, captured["candidate"]["candidate_id"], retention_class="standard"
+            )["record"]
+            self.assertEqual(plain["staleness"]["stale_after_days"], 90)
+            other = capture_project_memory_candidate(paths, "another fact")
+            with self.assertRaises(ValueError):
+                approve_project_memory_candidate(paths, other["candidate"]["candidate_id"], retention_class="eternal")
+
+    def test_unknown_override_class_is_refused(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            captured = capture_project_memory_candidate(paths, "a fact")
+            with self.assertRaises(ValueError):
+                approve_project_memory_candidate(
+                    paths, captured["candidate"]["candidate_id"], retention_class="forever"
+                )
+
+
 class MemoryConfirmationTests(unittest.TestCase):
     """`omh memory confirm` is the missing verb behind the freshness warning."""
 
@@ -794,10 +965,15 @@ class MemoryConfirmationTests(unittest.TestCase):
             stored = json.loads(_record_path(paths, record["record_id"]).read_text(encoding="utf-8"))
             self.assertLessEqual(len(stored["revalidation"]["confirmed_by"]), 240)
             self.assertNotIn("ci-token-bot", stored["revalidation"]["confirmed_by"])
-            # The default 90-day reset lands earlier than the 365-day capture
-            # deadline; the payload must say so instead of shortening silently.
-            self.assertTrue(result["shortened"])
-            self.assertIn("earlier", result["next_action"])
+            # A flagless confirm honours the captured 365-day cadence, so
+            # nothing shortened; an explicit shorter cadence does, and the
+            # payload must say so instead of shortening silently.
+            self.assertFalse(result["shortened"])
+            shorter = memory_workflow.confirm_project_memory_record(
+                paths, record["record_id"], stale_after_days=30
+            )
+            self.assertTrue(shorter["shortened"])
+            self.assertIn("earlier", shorter["next_action"])
 
     def test_confirm_persists_and_reuses_an_explicit_cadence(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -865,6 +1041,16 @@ class MemoryConfirmationTests(unittest.TestCase):
             self.assertEqual(batch["skipped"][0]["record_id"], poisoned["record_id"])
             self.assertEqual(batch["skipped"][0]["reason_code"], "write_rejected")
             self.assertIn("unsupported keys", batch["skipped"][0]["detail"])
+
+    def test_batch_names_expired_records_it_will_not_touch(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            expired = _approved(paths, "an expired volatile note", ttl_days=1)
+            _mutate_record(paths, expired["record_id"], ttl={"ttl_days": 1, "expires_at": PAST})
+            batch = memory_workflow.confirm_due_project_memory_records(paths)
+            self.assertEqual(batch["due_count"], 0)
+            self.assertEqual(batch["expired_count"], 1)
+            self.assertIn("omh memory retire", batch["next_action"])
 
     def test_batch_rejects_an_invalid_cadence_even_on_an_empty_store(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_parser_memory.py
+++ b/tests/test_parser_memory.py
@@ -34,6 +34,9 @@ class MemoryParserTests(unittest.TestCase):
             (["memory", "recall", "query", "--observer", "operator", "--observed", "codex"], "cmd_memory_recall"),
             (["memory", "confirm", "record-one"], "cmd_memory_confirm"),
             (["memory", "confirm", "--all-due", "--stale-after-days", "120"], "cmd_memory_confirm"),
+            (["memory", "approve", "cand-one", "--retention-class", "durable"], "cmd_memory_approve"),
+            (["memory", "demote"], "cmd_memory_demote"),
+            (["memory", "demote", "--file", "USER.md", "--max", "3", "--stage"], "cmd_memory_demote"),
         )
 
         for argv, handler_name in cases:


### PR DESCRIPTION
## Capability

Six follow-ups from the memory-system inspection, closing one gap — memory that silently forgets:

1. **L1→L2 demotion** — `omh memory demote` plans moving capped Hermes memory entries (L1) down into the governed OMH store (L2) with a sha-keyed reference line (`[omh#<sha12>] …`) prepared for L1; `--stage` captures the planned entries as review-first candidates.
2. **`expires_soon` advance notice** — recall packs warn before a retention TTL ends (an episode's 30-day expiry stops being a silent disappearance), window scaled to half the record's own TTL.
3. **Capture cadence persistence** — `--stale-after-days 365` at capture now survives onto the record and through flagless `omh memory confirm`.
4. **Durable promotion at approval** — `omh memory approve --retention-class durable` drops a *defaulted* review clock while an explicitly captured cadence survives (`cadence_source` provenance).
5. **Policy cadence tunables** — `stale_after_days_default` / `episode_ttl_days` / `due_soon_days` (1–365) read from the setup profile's `memory_policy`, validated with fallback, effective values disclosed.
6. **Batch honesty** — `confirm --all-due` reports `expired_count` and points at retire.

## Motivation

The owner directed the L1→L2 direction: Hermes-native memory files are small, capped, and paid for on every turn — when they fill, the only move was deleting a fact. The OMH store is reviewed and uncapped but had no inflow path. The remaining items came out of the same inspection: episode TTL was a silent cliff, capture cadence was lost at approval, durable was unreachable in practice, and the memory clocks were constants.

## Implementation (boundary level)

- The demotion planner lives in the plugin bundle (`hermes_memory.py`, Hermes-importable, stdlib-only, **read-only** — verified no write/unlink on any Hermes path). The workflow wrapper annotates rows with `staging_status` from the candidate store; staging captures via the ordinary review-first gates with `source_ref="hermes:<file>#<sha16>"` as the idempotency key (`already_staged` / `previously_rejected`).
- **Demotion moves content intact or it refuses**: entries the 240-char summary bound would truncate (`summary_bound_exceeded`) or the sensitive-content redactor would collapse (`redacted_cannot_demote`) are refused with named statuses and stay in L1 — the documented next step deletes the L1 original, which must never happen to a damaged copy. A belt-check refuses anything capture stored altered. The L1 half stays with Hermes's own memory tool; everything here is `prepared_not_observed`.
- `expires_soon` shares the advisory machinery with `review_due_soon` (`ADVISORY_FRESHNESS_REASONS`): advisory notices never displace blocking warnings, never flip wrapper continuity, and both downstream consumers key off the same frozenset. Naive TTL timestamps read as UTC, matching the terminal expiry classifier.
- The approval override re-derives retention/staleness only for a *defaulted* cadence; digest integrity holds (canonical payload digest excludes retention/revalidation — probed by the reviewer). Same-class flag is a validated no-op; lifecycle candidates refuse the flag at the CLI.
- Policy tunables thread through capture, recall's warning window, confirm's default chain, and lineage cards (recall and lineage share one window).

## Observed verification

- Full suite green before commit (see commit trailer for exact count); targeted suites `test_memory_staleness` / `test_memory_demotion` / `test_memory` / `test_parser_memory`: 128 tests.
- Separate-lane code review ran mid-branch (2 Critical / 3 Major / 8 Minor findings); every Critical/Major and all actionable Minors fixed, each with a test reproducing the reviewer's probe (content-intact byte-for-byte, sensitive refusal, truncation refusal, volatile window scaling, explicit-cadence survival, policy-default threading, empty-store stage schema, rejected-restage standing decision).
- ruff, compileall, all five docs `--check` byte gates, `git diff --check` clean.
- CLI smokes: demote plan/stage/re-stage/approve→already_covered; cadence/durable/expiry paths.

## Risks

- Demotion's L1 half is deliberately unobserved: OMH never edits Hermes files, so "entry replaced by reference" only happens when Hermes applies it — payloads and docs state this at every step.
- Refusal statuses mean some entries (long or sensitive-looking) are not demotable by design; the plan says so instead of quietly damaging them.
- Window/cadence defaults are now tunables; absurd values are bounded (`due_soon_days` ≤ 365) and invalid ones fall back with disclosure.
- Not observed here: Windows CI legs (repo CI), live Hermes TUI rendering of the new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKo77o5dTJtLRWfDj4uBtq
