### PR TITLE
feat(memory): absolute deadlines, relative-time prose lint, stated intent

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -440,6 +440,26 @@ caller's clock. Nothing is inferred from conversation, and nothing is fetched.
 always held; both are written, and when they disagree the earlier one wins, so
 editing one spelling can never restore freshness.
 
+Deadlines can be given as absolute dates, not only day counts:
+`--stale-after YYYY-MM-DD` (review deadline) and `--expires-at YYYY-MM-DD`
+(retention expiry) accept a bare date — meaning the **start** of that UTC day,
+the conservative reading — or a full ISO timestamp. Each is mutually
+exclusive with its day-count twin, past dates are refused at capture, and the
+class rules mirror the day-count gates (volatile keeps its 1–7 day TTL;
+durable cannot set `expires_at`). An absolute review date counts as an
+explicit cadence, so it survives an approval-time re-class.
+
+Relative-time **prose** is the opposite case and capture lints it: a summary
+like "계약 만료는 3주 뒤" or "renew in 3 weeks" is a fact with a hidden expiry —
+its anchor (the moment of writing) is not part of the stored content, so it
+reads wrong once time passes. Detection is a tight deterministic pattern
+(number-plus-unit or an unambiguous deictic word; bare "후/전" never match)
+and only **forces review** — never blocks, never auto-rewrites — with the
+candidate carrying a `time_sensitivity` verdict telling the reviewer to
+restate the fact with an absolute date or set the deadline structurally. The
+verdict is a capture gate, not record metadata: it rides the candidate and
+the review card, and deliberately does not survive onto the approved record.
+
 Source evidence is opt-in and local. When `--source-ref` names an absolute
 path to a readable local file, capture records the file's SHA-256 alongside it.
 Every later freshness check re-reads that file and compares. A ref that is not
@@ -500,7 +520,8 @@ covers held-back records as before.
 
 Answering the warning uses three verbs. `omh memory confirm <record-id>` is
 the lightweight one: it states the record is still true and resets its review
-deadline (default 90 days ahead, or `--stale-after-days N`), rewriting only
+deadline (default 90 days ahead, `--stale-after-days N`, or an absolute
+`--stale-after YYYY-MM-DD` for a date-pinned record), rewriting only
 revalidation metadata — the payload digest deliberately excludes it, so the
 record's identity, admission, and immutable review record are untouched.
 `omh memory confirm --all-due` confirms every record whose sole problem is a

--- a/src/commands/memory.py
+++ b/src/commands/memory.py
@@ -106,6 +106,8 @@ def cmd_memory_capture(args: argparse.Namespace) -> int:
             tags=args.tag or [],
             ttl_days=args.ttl_days,
             stale_after_days=args.stale_after_days,
+            stale_after=args.stale_after,
+            expires_at=args.expires_at,
             retention_class=args.retention_class,
             derived_from=args.derived_from or [],
             observer=args.observer,
@@ -257,6 +259,8 @@ def cmd_memory_confirm(args: argparse.Namespace) -> int:
         raise OmhError("pass exactly one of <record-id> or --all-due")
     try:
         if args.all_due:
+            if args.stale_after:
+                raise OmhError("--stale-after pins one record to one date; --all-due takes --stale-after-days")
             payload = confirm_due_project_memory_records(
                 _paths(args),
                 confirmed_by=args.confirmed_by,
@@ -268,6 +272,7 @@ def cmd_memory_confirm(args: argparse.Namespace) -> int:
                 args.record_id,
                 confirmed_by=args.confirmed_by,
                 stale_after_days=args.stale_after_days,
+                stale_after=args.stale_after,
             )
     except (OSError, ValueError) as exc:
         raise OmhError(str(exc)) from exc

--- a/src/commands/memory_parser.py
+++ b/src/commands/memory_parser.py
@@ -32,6 +32,18 @@ def add_memory_commands(sub: argparse._SubParsersAction[argparse.ArgumentParser]
     capture.add_argument("--tag", action="append", default=[])
     capture.add_argument("--ttl-days", type=int, default=None)
     capture.add_argument("--stale-after-days", type=int, default=None)
+    capture.add_argument(
+        "--stale-after",
+        default="",
+        metavar="DATE",
+        help="Absolute review deadline (YYYY-MM-DD = start of that UTC day, or a full ISO timestamp); mutually exclusive with --stale-after-days.",
+    )
+    capture.add_argument(
+        "--expires-at",
+        default="",
+        metavar="DATE",
+        help="Absolute retention expiry (YYYY-MM-DD = start of that UTC day, or a full ISO timestamp); mutually exclusive with --ttl-days.",
+    )
     capture.add_argument("--retention-class", choices=("volatile", "standard", "durable"), default="standard", help="Retention class for the review candidate.")
     capture.add_argument(
         "--derived-from",
@@ -169,6 +181,12 @@ def add_memory_commands(sub: argparse._SubParsersAction[argparse.ArgumentParser]
         type=int,
         default=None,
         help="Days until the next review deadline (default 90).",
+    )
+    confirm.add_argument(
+        "--stale-after",
+        default="",
+        metavar="DATE",
+        help="Absolute next review deadline (YYYY-MM-DD = start of that UTC day, or ISO timestamp); mutually exclusive with --stale-after-days.",
     )
     confirm.add_argument("--confirmed-by", default="operator", help="Who confirmed the record; stored as bounded metadata.")
     confirm.set_defaults(func=memory.cmd_memory_confirm)

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -767,6 +767,8 @@ def capture_project_memory_candidate(
     tags: list[str] | tuple[str, ...] | None = None,
     ttl_days: int | None = None,
     stale_after_days: int | None = None,
+    stale_after: str = "",
+    expires_at: str = "",
     retention_class: str = "standard",
     derived_from: list[str] | tuple[str, ...] | None = None,
     observer: str | None = None,
@@ -783,6 +785,30 @@ def capture_project_memory_candidate(
             "reason": "project_memory_disabled",
             "claim_boundary": "Memory capture is disabled by OMH project policy; Hermes global or internal memory is not mutated.",
         }
+    # Absolute deadlines: "the contract ends on the 18th" is a date, not a
+    # day count, and forcing the captor to do the subtraction moved the
+    # anchor to whenever they happened to run the command. Each absolute
+    # form is mutually exclusive with its day-count twin. The class gates
+    # live HERE, not only in argparse: this function is the plugin-bundle
+    # and wrapper-facing API, and a guard that lives only at the CLI is the
+    # exact failure mode `_validated_day_count` already documents -- which
+    # is how a durable candidate once reached approval carrying a TTL.
+    stale_after = str(stale_after or "").strip()
+    expires_at = str(expires_at or "").strip()
+    if stale_after and stale_after_days is not None:
+        raise ValueError("pass at most one of stale_after and stale_after_days")
+    if expires_at and ttl_days is not None:
+        raise ValueError("pass at most one of expires_at and ttl_days")
+    if retention_class == "volatile" and (stale_after or expires_at):
+        raise ValueError("volatile memory keeps its 1-7 day TTL; absolute deadlines do not apply")
+    if retention_class == "volatile" and stale_after_days is not None:
+        raise ValueError("volatile memory cannot set stale_after_days")
+    if retention_class == "durable" and expires_at:
+        raise ValueError("durable memory cannot set expires_at")
+    if retention_class == "durable" and ttl_days is not None:
+        raise ValueError("durable memory cannot set ttl_days")
+    stale_after_value = _absolute_deadline(stale_after, field="stale_after")
+    expires_at_value = _absolute_deadline(expires_at, field="expires_at")
     candidate = _build_project_memory_candidate(
         summary,
         content=content,
@@ -794,6 +820,8 @@ def capture_project_memory_candidate(
         tags=tags or [],
         ttl_days=ttl_days,
         stale_after_days=stale_after_days,
+        stale_after_at=stale_after_value,
+        expires_at_value=expires_at_value,
         retention_class=retention_class,
         derived_from=_normalize_derived_from(paths, derived_from),
         perspective=_normalize_perspective(observer, observed),
@@ -810,13 +838,31 @@ def capture_project_memory_candidate(
     duplicate_of = _find_duplicate_record(paths, str(candidate.get("summary", "")))
     if duplicate_of:
         candidate["duplicate_of"] = duplicate_of
+    # Relative-time prose is detected on the summary as it will be STORED
+    # (post-redaction), because that is the text that will lie later. The
+    # verdict rides on the candidate for the review card, and it suppresses
+    # auto-approval below: a fact with a hidden expiry needs a human to
+    # either accept the rot or restate it with an absolute date.
+    relative_phrase = _relative_time_phrase(str(candidate.get("summary", "")))
+    if relative_phrase:
+        candidate["time_sensitivity"] = {
+            "relative_phrase": relative_phrase,
+            "detail": (
+                "The summary contains a relative-time phrase whose anchor (the moment of capture) "
+                "is not part of the stored content, so it will read wrong once time passes."
+            ),
+            "next_action": (
+                "Restate the fact with an absolute date, or set the deadline structurally "
+                "(--stale-after YYYY-MM-DD / --stale-after-days N) and approve as-is."
+            ),
+        }
     _write_project_memory_candidate(paths, candidate)
     auto_approved = False
     record: dict[str, object] = {}
     # force_review keeps derived aggregates (e.g. rollup episodes) on the
     # review path even under auto-safe: derived content is a curation act,
     # not a captured observation.
-    if bool(policy.get("auto_approve_safe")) and candidate.get("safety", {}).get("status") == "safe" and not duplicate_of and not force_review:
+    if bool(policy.get("auto_approve_safe")) and candidate.get("safety", {}).get("status") == "safe" and not duplicate_of and not force_review and not relative_phrase:
         approved = approve_project_memory_candidate(paths, str(candidate["candidate_id"]), approved_by="auto-safe")
         record = approved.get("record", {}) if isinstance(approved.get("record"), dict) else {}
         candidate = approved.get("candidate", candidate) if isinstance(approved.get("candidate"), dict) else candidate
@@ -871,6 +917,11 @@ def build_project_memory_review_card(candidate: dict[str, Any]) -> dict[str, obj
         "tags": _string_list(candidate.get("tags", [])),
         "created_at": str(candidate.get("created_at", "")),
         **({"duplicate_of": str(candidate["duplicate_of"])} if candidate.get("duplicate_of") else {}),
+        **(
+            {"time_sensitivity": candidate["time_sensitivity"]}
+            if isinstance(candidate.get("time_sensitivity"), dict)
+            else {}
+        ),
         "safety": safety,
         "recommended_action": recommended_action,
         "actions": [
@@ -1208,6 +1259,7 @@ def memory_recall_pack_for_handoff(
     executor_target: str = "generic",
     session_id: str = "",
     limit: int = 5,
+    query_intent: str | None = None,
 ) -> dict[str, object] | None:
     # The executor target is the handoff's perspective lens: unscoped records
     # pass as always, and records observed for this executor join them --
@@ -1222,6 +1274,10 @@ def memory_recall_pack_for_handoff(
         scope_ref=pack_scope["ref"],
         limit=limit,
         observed=_handoff_perspective_lens(executor_target),
+        # Per the routing-language policy the cue table stays English-only;
+        # a caller that read the message and knows the user asked for the
+        # latest -- in any language -- states it here instead.
+        query_intent=query_intent,
     )
     # A pack with no eligible records but a freshness warning still travels.
     # Dropping it here was the silent failure: the handoff went out with no
@@ -2055,6 +2111,7 @@ def confirm_project_memory_record(
     *,
     confirmed_by: str = "operator",
     stale_after_days: int | None = None,
+    stale_after: str = "",
     now: datetime | None = None,
 ) -> dict[str, object]:
     """Reset one approved record's review deadline after a human confirmed it.
@@ -2076,6 +2133,9 @@ def confirm_project_memory_record(
     normalized_id = str(record_id).strip()
     if not _SAFE_REF.match(normalized_id):
         raise ValueError(f"unsafe memory record id: {record_id!r}")
+    stale_after = str(stale_after or "").strip()
+    if stale_after and stale_after_days is not None:
+        raise ValueError("pass at most one of stale_after and stale_after_days")
     days = _validated_day_count(stale_after_days, field="stale_after_days")
     # The actor claim is bounded and redacted exactly like the attention
     # reason: operator prose must never become an unbounded stored field, and
@@ -2085,6 +2145,10 @@ def confirm_project_memory_record(
     actor = _redact(str(confirmed_by or "operator"))[:_MEMORY_ATTENTION_REASON_LIMIT]
     stamp = _attention_stamp(now)
     moment = _parse_utc(stamp) or datetime.now(timezone.utc)
+    # An absolute date confirms a record TO a date -- the shape a
+    # contract-pinned deadline needs, which a day-count fallback would
+    # silently push past the date it was pinned to.
+    absolute_deadline = _absolute_deadline(stale_after, field="stale_after", now=moment)
     with file_lock(paths.memory_index_path, private=True):
         record, error = read_json_object_result(_memory_record_path(paths, normalized_id))
         if error:
@@ -2104,19 +2168,27 @@ def confirm_project_memory_record(
         previous_due = str(staleness.get("review_due_at", "") or "")
         if not previous_due:
             return _refused_confirmation(normalized_id, "no_review_deadline")
-        if days is None:
-            # No explicit cadence: honour the one stored on the record (set
-            # at capture or by an earlier confirm), so `--all-due` cannot
-            # silently pull a record confirmed at 180 days back to the
-            # default -- then the policy's default cadence, then the
-            # built-in 90 days.
-            stored_days = record.get("staleness", {}).get("stale_after_days") if isinstance(record.get("staleness"), dict) else None
-            if isinstance(stored_days, int) and not isinstance(stored_days, bool) and stored_days > 0:
-                days = stored_days
-            else:
-                days = _cadence_value(read_project_memory_policy(paths), "stale_after_days_default") or _REVIEW_DEFAULT_DAYS
+        cadence_reset = False
+        if absolute_deadline:
+            new_deadline = absolute_deadline
+            days = None
+        else:
+            if days is None:
+                # No explicit cadence: honour the one stored on the record
+                # (set at capture or by an earlier confirm), so `--all-due`
+                # cannot silently pull a record confirmed at 180 days back
+                # to the default -- then the policy's default cadence, then
+                # the built-in 90 days. A record with no stored day count
+                # (an absolute-date cadence, or a legacy record) falls back
+                # to a relative cadence; `cadence_reset` says so out loud.
+                stored_days = record.get("staleness", {}).get("stale_after_days") if isinstance(record.get("staleness"), dict) else None
+                if isinstance(stored_days, int) and not isinstance(stored_days, bool) and stored_days > 0:
+                    days = stored_days
+                else:
+                    days = _cadence_value(read_project_memory_policy(paths), "stale_after_days_default") or _REVIEW_DEFAULT_DAYS
+                    cadence_reset = True
+            new_deadline = _days_after(stamp, days)
         revalidation = record.get("revalidation") if isinstance(record.get("revalidation"), dict) else {}
-        new_deadline = _days_after(stamp, days)
         updated_revalidation = {
             **revalidation,
             "deadline": new_deadline,
@@ -2142,6 +2214,7 @@ def confirm_project_memory_record(
         "reason_code": "confirmed",
         "was_stale": state == "stale",
         "shortened": shortened,
+        "cadence_reset": cadence_reset,
         "previous_review_due_at": previous_due,
         "review_due_at": new_deadline,
         "stale_after_days": days,
@@ -2151,6 +2224,12 @@ def confirm_project_memory_record(
         "next_action": (
             f"The record recalls normally until {new_deadline}; confirm, correct, or retire it again by then."
             + (f" Note: this moved the deadline earlier than {previous_due}." if shortened else "")
+            + (
+                " Note: the record had no day-count cadence (an absolute or legacy deadline); this confirm"
+                " re-anchored it to a relative cadence -- pass --stale-after DATE to pin a date instead."
+                if cadence_reset
+                else ""
+            )
         ),
         "claim_boundary": _MEMORY_CONFIRMATION_CLAIM_BOUNDARY,
     }
@@ -3104,6 +3183,8 @@ def _build_project_memory_candidate(
     perspective: dict[str, str] | None = None,
     default_stale_after_days: int | None = None,
     episode_ttl_days: int | None = None,
+    stale_after_at: str = "",
+    expires_at_value: str = "",
 ) -> dict[str, object]:
     normalized_type = _normalize_record_type(record_type)
     scope = _scope_for_project_memory(scope_kind, scope_ref)
@@ -3111,20 +3192,33 @@ def _build_project_memory_candidate(
     content_text = str(content or "")
     safety = _project_memory_safety(summary, content_text, tags=normalized_tags)
     now = utc_now()
-    ttl = _ttl_metadata(ttl_days, record_type=normalized_type, created_at=now, episode_ttl_days=episode_ttl_days)
+    if expires_at_value:
+        # An absolute expiry carries no day count -- the date IS the policy.
+        ttl: dict[str, object] = {"ttl_days": None, "expires_at": expires_at_value}
+    else:
+        ttl = _ttl_metadata(ttl_days, record_type=normalized_type, created_at=now, episode_ttl_days=episode_ttl_days)
     # `cadence_source` records whether the captor chose the cadence or the
     # default supplied it -- the one fact an approval-time re-class needs to
-    # honour an explicit deadline without freezing a defaulted one.
-    staleness = {
-        **_staleness_metadata(
-            stale_after_days,
-            record_type=normalized_type,
-            retention_class=retention_class,
-            created_at=now,
-            default_days=default_stale_after_days,
-        ),
-        "cadence_source": "explicit" if stale_after_days is not None else "default",
-    }
+    # honour an explicit deadline without freezing a defaulted one. An
+    # absolute review date is explicit by definition.
+    if stale_after_at:
+        staleness: dict[str, object] = {
+            "stale_after_days": None,
+            "stale_after": stale_after_at,
+            "review_due_at": stale_after_at,
+            "cadence_source": "explicit",
+        }
+    else:
+        staleness = {
+            **_staleness_metadata(
+                stale_after_days,
+                record_type=normalized_type,
+                retention_class=retention_class,
+                created_at=now,
+                default_days=default_stale_after_days,
+            ),
+            "cadence_source": "explicit" if stale_after_days is not None else "default",
+        }
     candidate_id = "cand_" + os.urandom(8).hex()
     status = "blocked_review_required" if safety["status"] == "blocked" else "pending_review"
     # Digest the ref exactly as it will be stored, not as it was passed:
@@ -3203,11 +3297,18 @@ def _record_from_candidate(
     # Approval must not silently extend the deadline shown to the reviewer.
     # `utc_now` is second-truncated, so deriving it again from `approved_at`
     # made this record expire one second later whenever review crossed a clock
-    # boundary. The candidate's stored deadline is the authoritative value.
-    # An overridden class skips the carry-over on purpose: that deadline was
-    # minted for the class the reviewer just rejected.
+    # boundary. The candidate's stored deadline is the authoritative value --
+    # including an absolute `expires_at` captured without a day count, which
+    # `build_retention` cannot re-derive (there is no ttl_days to hand it) and
+    # which would otherwise vanish at approval. An overridden class skips the
+    # carry-over on purpose: that deadline was minted for the class the
+    # reviewer just rejected.
+    # A durable record must never gain an expiry through the carry-over: the
+    # class exists to say "this does not expire", the workflow gate refuses
+    # durable+ttl at capture, and a legacy candidate that slipped one in is
+    # exactly the record this guard must not resurrect a deadline onto.
     candidate_ttl = candidate.get("ttl")
-    if override is None and "expires_at" in retention and isinstance(candidate_ttl, dict) and candidate_ttl.get("expires_at"):
+    if override is None and requested_class != "durable" and isinstance(candidate_ttl, dict) and candidate_ttl.get("expires_at"):
         retention["expires_at"] = str(candidate_ttl["expires_at"])
     record_id = "mem_" + os.urandom(8).hex()
     scope = _normalize_scope(candidate.get("scope", _scope("project", "default")))
@@ -3215,7 +3316,14 @@ def _record_from_candidate(
     staleness_days = _candidate_stale_after_days(candidate)
     if override is not None:
         candidate_staleness = candidate.get("staleness") if isinstance(candidate.get("staleness"), dict) else {}
-        explicit_cadence = str(candidate_staleness.get("cadence_source", "") or "") == "explicit" and staleness_days is not None
+        # Explicit is explicit in either shape: a day count (staleness_days)
+        # or an absolute review date, which mints no day count but does mint
+        # a revalidation deadline. Requiring the day count made the absolute
+        # form strictly weaker -- a re-class silently dropped a date the
+        # reviewer saw on the card.
+        explicit_cadence = str(candidate_staleness.get("cadence_source", "") or "") == "explicit" and (
+            staleness_days is not None or bool(_candidate_revalidation(candidate))
+        )
         if explicit_cadence:
             # A cadence the captor explicitly chose survives the re-class:
             # `_staleness_metadata` is explicit that durable makes the
@@ -3760,14 +3868,24 @@ def _record_staleness(
     # host-local and move this window by up to +/-14 hours.
     expiry = _parse_utc_naive_as_utc(expires_at)
     expiry_window = due_soon_days if due_soon_days is not None else _EXPIRES_SOON_DAYS
+    # A notice window longer than half the record's own life is not advance
+    # notice, it is a permanent banner: a 7-day volatile record would warn
+    # from the moment it was approved. Scale the window down to half the
+    # record's lifespan (never below one day) so short-lived records warn
+    # near the end, which is when the warning means something. The span
+    # comes from ttl_days when there is one, else from the distance between
+    # creation and the absolute expiry date -- an absolute two-day deadline
+    # must not warn from birth either.
     ttl_days_value = ttl.get("ttl_days")
+    span_days: int | None = None
     if isinstance(ttl_days_value, int) and not isinstance(ttl_days_value, bool) and ttl_days_value > 0:
-        # A notice window longer than half the record's own life is not
-        # advance notice, it is a permanent banner: a 7-day volatile record
-        # would warn from the moment it was approved. Scale the window down
-        # to half the TTL (never below one day) so short-lived records warn
-        # near the end, which is when the warning means something.
-        expiry_window = min(expiry_window, max(ttl_days_value // 2, 1))
+        span_days = ttl_days_value
+    elif expiry is not None:
+        created = _parse_utc_naive_as_utc(str(record.get("created_at", "") or ""))
+        if created is not None and expiry > created:
+            span_days = max(int((expiry - created).total_seconds() // 86400), 1)
+    if span_days is not None:
+        expiry_window = min(expiry_window, max(span_days // 2, 1))
     if expiry and expiry - now <= timedelta(days=expiry_window):
         return {"state": "fresh", "reason": "expires_soon", **fields}
     if deadline and deadline - now <= timedelta(days=due_soon_days if due_soon_days is not None else _REVIEW_DUE_SOON_DAYS):
@@ -3857,6 +3975,35 @@ def _project_memory_safety(summary: str, content: str, *, tags: list[str]) -> di
         "review_reasons": [] if status == "safe" else [status],
         "protected_inputs": ["credentials", "raw_logs", "full_transcripts", "temporary_task_progress"],
     }
+
+
+# Relative-time prose in a stored summary is a fact with a hidden expiry:
+# "계약 만료는 3주 뒤" is true for exactly one day and then lies, and nothing in
+# the store can tell, because the phrase's anchor -- the moment of writing --
+# is not part of the record's content. This is a content-quality lint on what
+# the store accepts, not a language trigger table: matches only force review
+# (never block, never auto-fix), so a false positive costs one review click
+# and a false negative is the status quo. Patterns are deliberately tight --
+# bare "후/전" ("리뷰 후 머지") never match; a number-plus-unit or an
+# unambiguous deictic word must be present.
+_RELATIVE_TIME_PATTERN = re.compile(
+    r"(?<!\d)\d{1,4}\s*(?:일|주|개월|달|년|시간|분)\s*(?:뒤|후|이내|안에|내로)"
+    # Deictic words may carry an ordinary particle (내일부터, 오늘은) -- the
+    # idiomatic majority -- but a following non-particle hangul syllable
+    # (오늘의집, 내일정) means a compound, not a time reference.
+    r"|(?<![가-힣])(?:그저께|어제|오늘|내일|모레|다음\s*주|다음\s*달|이번\s*주)(?:은|는|이|가|에|에는|부터|까지|도|만)?(?![가-힣])"
+    r"|\b(?:yesterday|today|tomorrow|next\s+(?:week|month|year)|in\s+\d{1,4}\s+(?:days?|weeks?|months?|years?|hours?|minutes?))\b"
+    r"|(?<!\d)\d{1,4}\s*(?:日|週間|ヶ月|か月|年)\s*(?:後|以内)"
+    r"|(?<!\d)\d{1,4}\s*(?:天|周|個月|个月|年)\s*(?:后|後|以内|以內|内|內)"
+    r"|明日|昨日|来週|来月|明天|昨天|下周(?!期)|下個月|下个月",
+    re.IGNORECASE,
+)
+
+
+def _relative_time_phrase(value: str) -> str:
+    """The first relative-time phrase in stored prose, or ""."""
+    match = _RELATIVE_TIME_PATTERN.search(value)
+    return match.group(0) if match else ""
 
 
 def _looks_like_raw_log(value: str) -> bool:
@@ -3977,6 +4124,41 @@ def _staleness_metadata(
         "stale_after": deadline,
         "review_due_at": deadline,
     }
+
+
+def _absolute_deadline(value: str, *, field: str, now: datetime | None = None) -> str:
+    """Normalize an absolute deadline: a future UTC instant, fail-closed.
+
+    A bare date (`YYYY-MM-DD`) means the START of that UTC day -- the
+    conservative reading: a record whose deadline is "the 18th" goes
+    review-due or expires the moment the 18th begins, never quietly late on
+    the 18th's last second. A full ISO timestamp is taken exactly (naive
+    reads as UTC, matching every other deadline in this module). The past is
+    refused rather than stored: a deadline that has already happened is a
+    statement for `correct` or `retire`, not for capture.
+    """
+    raw = str(value or "").strip()
+    if not raw:
+        return ""
+    moment = now if now is not None else datetime.now(timezone.utc)
+    if re.fullmatch(r"\d{4}-\d{2}-\d{2}", raw):
+        try:
+            parsed: datetime | None = datetime(int(raw[:4]), int(raw[5:7]), int(raw[8:10]), tzinfo=timezone.utc)
+        except ValueError:
+            parsed = None
+    else:
+        parsed = _parse_utc_naive_as_utc(raw)
+    if parsed is None:
+        raise ValueError(f"{field} must be YYYY-MM-DD or an ISO timestamp; got {value!r}")
+    # Truncate BEFORE the future check: the stored value is the truncated
+    # one, and a sub-second future instant would otherwise be accepted and
+    # then stored already past.
+    parsed = parsed.replace(microsecond=0)
+    if parsed <= moment:
+        raise ValueError(f"{field} must be in the future; got {value!r}")
+    if parsed - moment > timedelta(days=MAX_RETENTION_DAYS):
+        raise ValueError(f"{field} must be within {MAX_RETENTION_DAYS} days; got {value!r}")
+    return parsed.isoformat().replace("+00:00", "Z")
 
 
 def _days_after(created_at: str, days: int | None) -> str:

--- a/tests/test_memory_rollup_signals.py
+++ b/tests/test_memory_rollup_signals.py
@@ -283,6 +283,20 @@ class RecallSignalTests(unittest.TestCase):
         for query in ("what changed yesterday", "most recent deploy failure", "deploys from last week"):
             self.assertEqual(_recall_query_intent(query), "temporal", query)
 
+    def test_handoff_packs_accept_caller_stated_intent(self) -> None:
+        # The cue table stays English-only by policy; the handoff surface is
+        # where a caller that read the message -- in any language -- states
+        # the intent instead. Auto stays default for Korean on purpose.
+        from omh.workflows.memory import memory_recall_pack_for_handoff
+
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            _approve_capture(paths, "배포는 금요일에 하지 않는다")
+            stated = memory_recall_pack_for_handoff(paths, "배포 결정", executor_target="codex", query_intent="temporal")
+            self.assertEqual(stated["query_intent"], "temporal")
+            auto = memory_recall_pack_for_handoff(paths, "배포 결정", executor_target="codex")
+            self.assertEqual(auto["query_intent"], "default")
+
     def test_validator_rejects_malformed_query_intent(self) -> None:
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")

--- a/tests/test_memory_staleness.py
+++ b/tests/test_memory_staleness.py
@@ -692,6 +692,191 @@ class ReviewDueSoonWarningTests(unittest.TestCase):
         self.assertEqual(continuity_warning_count({"freshness_warnings": ["not-a-mapping"]}), 1)
 
 
+class AbsoluteDeadlineTests(unittest.TestCase):
+    """Deadlines as dates, not day counts: 'the 18th', anchored once, exactly."""
+
+    def test_an_absolute_review_date_lands_verbatim_and_reads_explicit(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            future = (datetime.now(timezone.utc) + timedelta(days=23)).date().isoformat()
+            captured = capture_project_memory_candidate(paths, "vendor contract renewal due", stale_after=future)
+            self.assertEqual(captured["candidate"]["staleness"]["cadence_source"], "explicit")
+            record = approve_project_memory_candidate(paths, captured["candidate"]["candidate_id"])["record"]
+            # A bare date means the START of that UTC day -- review-due the
+            # moment the 18th begins, never quietly late on its last second.
+            self.assertEqual(record["staleness"]["review_due_at"], f"{future}T00:00:00Z")
+            self.assertIsNone(record["staleness"]["stale_after_days"])
+
+    def test_an_absolute_expiry_survives_approval_and_gates_recall(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            future = (datetime.now(timezone.utc) + timedelta(days=23)).date().isoformat()
+            captured = capture_project_memory_candidate(paths, "promo code FALL26 is valid", tags=["promo"], expires_at=future)
+            record = approve_project_memory_candidate(paths, captured["candidate"]["candidate_id"])["record"]
+            # `build_retention` cannot re-derive a date it was never handed a
+            # day count for; approval must carry the candidate's date over.
+            self.assertEqual(record["retention"]["expires_at"], f"{future}T00:00:00Z")
+            self.assertEqual(record["ttl"]["expires_at"], f"{future}T00:00:00Z")
+            edge = datetime.fromisoformat(f"{future}T00:00:00+00:00")
+            before = build_project_memory_recall_pack(paths, "promo code", now=edge - timedelta(seconds=1))
+            after = build_project_memory_recall_pack(paths, "promo code", now=edge)
+            self.assertEqual((before["record_count"], after["record_count"]), (1, 0))
+
+    def test_an_absolute_review_date_survives_a_durable_reclass(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            future = (datetime.now(timezone.utc) + timedelta(days=15)).date().isoformat()
+            captured = capture_project_memory_candidate(paths, "date-pinned but durable", stale_after=future)
+            record = approve_project_memory_candidate(
+                paths, captured["candidate"]["candidate_id"], retention_class="durable"
+            )["record"]
+            # Explicit is explicit in either shape: the reviewer saw this
+            # date on the card, and a flag about retention must not drop it.
+            self.assertEqual(record["retention"].get("class"), "durable")
+            self.assertEqual(record["staleness"]["review_due_at"], f"{future}T00:00:00Z")
+            self.assertEqual(record["revalidation"].get("deadline"), f"{future}T00:00:00Z")
+
+    def test_workflow_class_gates_refuse_durable_ttl_and_volatile_cadence(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            # The workflow is the plugin-bundle-facing API; these gates must
+            # not live only in argparse. A durable candidate carrying a TTL
+            # is exactly how a "never expires" record once learned to expire.
+            with self.assertRaises(ValueError):
+                capture_project_memory_candidate(paths, "durable with ttl", retention_class="durable", ttl_days=10)
+            with self.assertRaises(ValueError):
+                capture_project_memory_candidate(paths, "volatile with cadence", retention_class="volatile", stale_after_days=5)
+            # Day-count carry-over parity is untouched: a standard fact with
+            # an explicit TTL keeps its capture-time deadline at approval.
+            captured = capture_project_memory_candidate(paths, "standard with ttl", ttl_days=10)
+            record = approve_project_memory_candidate(paths, captured["candidate"]["candidate_id"])["record"]
+            self.assertEqual(record["retention"]["expires_at"], captured["candidate"]["ttl"]["expires_at"])
+
+    def test_an_absolute_expiry_scales_its_advance_notice_window_too(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            near = (datetime.now(timezone.utc) + timedelta(days=2)).date().isoformat()
+            captured = capture_project_memory_candidate(paths, "two-day absolute note", expires_at=near)
+            record = approve_project_memory_candidate(paths, captured["candidate"]["candidate_id"])["record"]
+            verdict = memory_workflow._record_staleness(record, now=datetime.now(timezone.utc))
+            # A 2-day absolute deadline must not warn from birth any more
+            # than a 2-day TTL would; the span derives from the dates.
+            self.assertEqual(verdict["reason"], "")
+
+    def test_confirm_accepts_an_absolute_date_and_names_a_cadence_reset(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            future = (datetime.now(timezone.utc) + timedelta(days=15)).date().isoformat()
+            captured = capture_project_memory_candidate(paths, "contract-pinned record", stale_after=future)
+            record = approve_project_memory_candidate(paths, captured["candidate"]["candidate_id"])["record"]
+            later = (datetime.now(timezone.utc) + timedelta(days=40)).date().isoformat()
+            pinned = memory_workflow.confirm_project_memory_record(paths, record["record_id"], stale_after=later)
+            self.assertTrue(pinned["applied"])
+            self.assertEqual(pinned["review_due_at"], f"{later}T00:00:00Z")
+            self.assertIsNone(pinned["stale_after_days"])
+            self.assertFalse(pinned["cadence_reset"])
+            # A flagless confirm on a date-pinned record has no day count to
+            # honour; it re-anchors relative and must say so out loud.
+            reset = memory_workflow.confirm_project_memory_record(paths, record["record_id"])
+            self.assertTrue(reset["cadence_reset"])
+            self.assertIn("--stale-after DATE", reset["next_action"])
+            with self.assertRaises(ValueError):
+                memory_workflow.confirm_project_memory_record(
+                    paths, record["record_id"], stale_after=later, stale_after_days=30
+                )
+
+    def test_absolute_deadline_normalization_edges(self) -> None:
+        now = datetime(2026, 8, 26, 12, 0, 0, tzinfo=timezone.utc)
+        # An offset timestamp normalizes to UTC; truncation happens before
+        # the future check so a sub-second future instant is refused.
+        self.assertEqual(
+            memory_workflow._absolute_deadline("2027-01-15T09:00:00+09:00", field="x", now=now),
+            "2027-01-15T00:00:00Z",
+        )
+        for bad in ("2026-2-3", "2027-02-29", "2026-13-01"):
+            with self.subTest(bad=bad), self.assertRaises(ValueError):
+                memory_workflow._absolute_deadline(bad, field="x", now=now)
+        with self.assertRaises(ValueError):
+            memory_workflow._absolute_deadline((now + timedelta(microseconds=400000)).isoformat(), field="x", now=now)
+
+    def test_absolute_deadline_inputs_fail_closed(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            future = (datetime.now(timezone.utc) + timedelta(days=23)).date().isoformat()
+            refusals = (
+                (dict(stale_after="2020-01-01"), "must be in the future"),
+                (dict(stale_after="three weeks"), "YYYY-MM-DD or an ISO timestamp"),
+                (dict(stale_after=future, stale_after_days=10), "at most one of"),
+                (dict(expires_at=future, ttl_days=5), "at most one of"),
+                (dict(expires_at=future, retention_class="durable"), "durable memory cannot set expires_at"),
+                (dict(stale_after=future, retention_class="volatile"), "volatile memory keeps"),
+            )
+            for kwargs, fragment in refusals:
+                with self.subTest(kwargs=kwargs), self.assertRaises(ValueError) as raised:
+                    capture_project_memory_candidate(paths, "a fact", **kwargs)
+                self.assertIn(fragment, str(raised.exception))
+
+
+class RelativeTimeProseTests(unittest.TestCase):
+    """A summary saying '3주 뒤' is a fact with a hidden expiry; review it."""
+
+    def _auto_safe(self, paths) -> None:
+        paths.setup_profile_path.parent.mkdir(parents=True, exist_ok=True)
+        paths.setup_profile_path.write_text(
+            json.dumps({"schema_version": "setup_profile/v1", "memory_policy": {"mode": "auto-safe"}}),
+            encoding="utf-8",
+        )
+
+    def test_relative_time_prose_forces_review_even_under_auto_safe(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            self._auto_safe(paths)
+            control = capture_project_memory_candidate(paths, "the staging db is postgres 15")
+            self.assertTrue(control["auto_approved"])
+            for summary in (
+                "계약 만료는 3주 2일 뒤",
+                "renew the cert in 3 weeks",
+                "내일 배포 예정",
+                "내일부터 새 정책이 적용된다",
+                "cert rotation is tomorrow",
+                "2년 뒤 갱신 예정",
+                "3日後にリリースする",
+                "3天后发布新版本",
+            ):
+                with self.subTest(summary=summary):
+                    captured = capture_project_memory_candidate(paths, summary)
+                    self.assertFalse(captured["auto_approved"])
+                    sensitivity = captured["candidate"]["time_sensitivity"]
+                    self.assertTrue(sensitivity["relative_phrase"])
+                    self.assertIn("--stale-after", sensitivity["next_action"])
+
+    def test_ordinary_prose_with_bare_relational_words_stays_untouched(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            self._auto_safe(paths)
+            # "후/전/주" as ordinary grammar, compounds around deictic words,
+            # and a number without a time unit must not trip the lint.
+            for summary in (
+                "리뷰 후 머지하는 프로세스를 따른다",
+                "배포 전 체크리스트를 확인한다",
+                "매주 회고를 진행한다",
+                "3개의 서비스로 구성된다",
+                "오늘의집 스타일 UI를 참고한다",
+                "下周期性任务由调度器管理",
+            ):
+                with self.subTest(summary=summary):
+                    captured = capture_project_memory_candidate(paths, summary)
+                    self.assertTrue(captured["auto_approved"])
+                    self.assertNotIn("time_sensitivity", captured["candidate"])
+
+    def test_the_review_card_carries_the_time_sensitivity_verdict(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            captured = capture_project_memory_candidate(paths, "계약 만료는 3주 2일 뒤")
+            card = memory_workflow.build_project_memory_review_card(captured["candidate"])
+            self.assertIn("relative-time phrase", card["time_sensitivity"]["detail"])
+
+
 class ExpiresSoonWarningTests(unittest.TestCase):
     """The retention twin of review-due-soon: TTL expiry gets advance notice."""
 

--- a/tests/test_parser_memory.py
+++ b/tests/test_parser_memory.py
@@ -34,7 +34,10 @@ class MemoryParserTests(unittest.TestCase):
             (["memory", "recall", "query", "--observer", "operator", "--observed", "codex"], "cmd_memory_recall"),
             (["memory", "confirm", "record-one"], "cmd_memory_confirm"),
             (["memory", "confirm", "--all-due", "--stale-after-days", "120"], "cmd_memory_confirm"),
+            (["memory", "confirm", "record-one", "--stale-after", "2027-01-15"], "cmd_memory_confirm"),
             (["memory", "approve", "cand-one", "--retention-class", "durable"], "cmd_memory_approve"),
+            (["memory", "capture", "summary", "--stale-after", "2027-01-15"], "cmd_memory_capture"),
+            (["memory", "capture", "summary", "--expires-at", "2027-01-15T09:00:00Z"], "cmd_memory_capture"),
             (["memory", "demote"], "cmd_memory_demote"),
             (["memory", "demote", "--file", "USER.md", "--max", "3", "--stage"], "cmd_memory_demote"),
         )


### PR DESCRIPTION
## Capability

Three follow-ups from the time-semantics probe of the memory system ("계약 만료가 3주 2일 뒤 같은 특정 시각도 잘 구분하나"):

1. **Absolute deadline inputs** — `omh memory capture --stale-after YYYY-MM-DD` / `--expires-at YYYY-MM-DD` (bare date = **start** of that UTC day, the conservative reading; full ISO timestamps taken exactly, offsets normalized to UTC). `omh memory confirm --stale-after DATE` pins a record's next review to a date.
2. **Relative-time prose lint** — a summary like "계약 만료는 3주 2일 뒤" / "renew in 3 weeks" / "3日後にリリース" is a fact with a hidden expiry (its anchor is the moment of writing, which is not stored). Capture detects tight deterministic patterns and **forces review** — never blocks, never rewrites — with a `time_sensitivity` verdict on the candidate and review card.
3. **Stated intent on handoff packs** — `memory_recall_pack_for_handoff` gains `query_intent` passthrough. The temporal cue table stays **English-only by the repo's ratified routing-language policy** (growing it "fixes five languages and leaves the rest"); this closes the one recall surface that had nowhere for a caller to state intent. Adding ko/ja/zh cue tokens remains an owner-level policy decision, deliberately not made here.

## Motivation

The clock machinery was already sound — relative day counts anchor to an absolute UTC instant exactly once, at capture — but the edges where human time enters the system were not: no absolute-date input (the captor did the subtraction, anchored to whenever the command ran), no guard against relative prose that lies once time passes, and one recall surface with no way to state temporal intent in any language.

## Implementation (boundary level)

- `_absolute_deadline`: fail-closed normalization (future-only, `MAX_RETENTION_DAYS` horizon, microsecond truncation **before** the future check). Mutual exclusion with day-count twins; class gates (volatile refuses absolutes and cadence; durable refuses TTL forms) now live in the **workflow** — the plugin-facing API — not only argparse.
- Approval carry-over widened so an absolute expiry (which `build_retention` cannot re-derive — it was never handed a day count) survives approval; guarded so a durable record can never receive a carried expiry, and probed for parity on every pre-existing day-count path (volatile default/explicit, standard, episode).
- An absolute review date counts as **explicit cadence**: it survives an approval-time re-class (durable promotion keeps the date the reviewer saw). Absolute expiries scale the `expires_soon` advance-notice window from the creation→expiry span, exactly like TTLs scale from day counts — no warn-from-birth.
- Flagless `confirm` on a date-pinned (or legacy) record reports `cadence_reset` and points at `--stale-after DATE` instead of silently re-anchoring.
- The lint runs on the **post-redaction** summary (the text that will actually lie later), with hangul-particle-aware boundaries (내일부터 matches; 오늘의집 does not), `\b`-bounded English, ja/zh number+unit forms, bounded digit runs (no ReDoS), and auto-approve suppression additive to the existing gate chain (rollup/force_review verified unaffected).

## Observed verification

- Full suite green before commit (see commit trailer); targeted suites incl. `test_routing_language_policy`: 165 tests.
- Separate-lane review (2 HIGH / 4 MEDIUM / 6 LOW) — every HIGH/MEDIUM and all actionable LOWs fixed, each pinned by a test reproducing the reviewer's probe (durable+ttl regression guard, absolute-date re-class survival, absolute-expiry window scaling, confirm cadence_reset, particle-aware lint positives, second-precision cutover, offset-ISO normalization).
- ruff, compileall, five docs `--check` byte gates, `git diff --check` clean; CLI smokes of all three features.

## Risks

- Bare-date = start-of-day is a semantic choice (documented); operators wanting end-of-day pass a full timestamp.
- The lint's false positives cost one review click by design; false negatives are the status quo. Its verdict is a capture gate, not record metadata (documented).
- Not observed: Windows CI legs (repo CI), live Hermes TUI rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKo77o5dTJtLRWfDj4uBtq
