### PR TITLE
feat(skills): interview questions ship candidate answers plus free input

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -411,6 +411,7 @@ These surfaces are generated command references, not installed Hermes workflow s
   - Why: The required facts are already available, so more questions would slow the workflow.
 - Quality bar:
   - Ask exactly one blocking question per turn unless the wrapper explicitly supports a structured batch.
+  - Offer two to four candidate answers plus a free-input option with every question, and accept free text over the list at any time.
   - Tie each question to a missing decision that changes the plan, handoff, or stop condition.
   - Emit a clarified brief with non-goals and acceptance criteria before planning or delegation.
 - Completion checklist:
@@ -8999,6 +9000,7 @@ Clarify intent and boundaries one question at a time before planning or executio
 - Quality bar:
   - Name the missing decision, why it matters, and the smallest answer that would unblock the next step.
   - Ask one blocking question tied to a missing decision.
+  - Offer two to four candidate answers plus a free-input entry with every question, and accept free text over the list.
   - Use discovered facts before asking the user for information already available locally.
   - Produce a clarified brief with non-goals, acceptance criteria, and remaining unknowns before planning or handoff.
 - Inputs:
@@ -9036,7 +9038,7 @@ Clarify intent and boundaries one question at a time before planning or executio
 - Overclaim guards:
   - A clarification question is not a plan approval.
   - Do not start a handoff while the blocking decision is unanswered.
-- Fallback: If structured question UI is unavailable, ask one direct question in the current surface.
+- Fallback: If structured question UI is unavailable, ask one direct question in the current surface, with its candidate answers as a numbered list ending in a free-input entry.
 
 ### decision-frontier
 

--- a/skills/ulw-interview/SKILL.md
+++ b/skills/ulw-interview/SKILL.md
@@ -83,7 +83,7 @@ mid-interview check now and continue from Round 4.
 
 - Never fold counters, ratios, or dimension names into the question sentence.
 - Ask the way a senior colleague would ask out loud: one sentence, no preamble, no restating
-  what the user just said, no numbered sub-parts. If it reads like a form field, rewrite it.
+  what the user just said, no numbered sub-questions. If it reads like a form field, rewrite it.
 - Outside the header line, the user never hears the words round, budget, dimension, or resolved.
 - Mirror the user's language in the header labels and the question. Korean header:
   `라운드 {n}/6 · 명확도: {percent}% ({resolved}/3) · 확인 중: {목표/제약과 비목표/성공 기준}`.
@@ -91,12 +91,28 @@ mid-interview check now and continue from Round 4.
 - The clarified brief follows the same rule: write its headings and labels in the user's
   language. Translate those terms, never transliterate them.
 
+**Answer options — every question ships with candidates.**
+
+After the question sentence, offer the likely answers as a short numbered list: two to four
+real candidates, then one final free-input entry. Each candidate is an answer the user could
+actually pick — drawn from the request, repo evidence, or the tradeoff the question is really
+about, never filler to reach a count, and never a candidate whose text is itself a bare number
+(it would collide with reply-by-number). The last entry is always the open door, in the user's
+language — for example English `N) Something else — type your answer`, Korean `N) 기타 — 직접 입력`.
+
+- A number, an option's own words, or a completely different free-text answer are all valid;
+  free text is always accepted, even when it matches no option. Never re-ask because the reply
+  was not a listed option.
+- Options mirror the user's language, like the header and the question.
+- The list is an answer palette, not extra questions; it does not break the one-question rule.
+
 **Mid-interview check — this is not a stop rule.**
 
 Before asking the question that would be Round 4, offer the choice instead: say where
 things stand and ask whether to keep going or plan now — your own words, the user's language,
-one short sentence. The check is not a round: emit it without a header. If the user chooses to
-continue, the next question is Round 4; if they choose to plan, stop rule 2 applies.
+one short sentence, with the same option shape: keep going / plan now / free input.
+The check is not a round: emit it without a header. If the user chooses to continue, the next
+question is Round 4; if they choose to plan, stop rule 2 applies.
 
 **Stop rules — the first match ends the interview.**
 
@@ -128,6 +144,7 @@ Reasoning demand: `light`
 Quality bar:
 
 - Ask exactly one blocking question per turn unless the wrapper explicitly supports a structured batch.
+- Offer two to four candidate answers plus a free-input option with every question, and accept free text over the list at any time.
 - Tie each question to a missing decision that changes the plan, handoff, or stop condition.
 - Emit a clarified brief with non-goals and acceptance criteria before planning or delegation.
 

--- a/src/maintenance/release.py
+++ b/src/maintenance/release.py
@@ -182,7 +182,12 @@ STANDALONE_CAPABILITY_SKILL_ITEM_CHAR_LIMIT = 2200
 # (+546 chars: maintainer ownership, matched observed comparison conditions,
 # unresolved-evidence fallback, and separation from runtime/completion and
 # measured-loop keep/discard decisions); warranted growth.
-FULL_PROFILE_SKILL_BODY_CHAR_LIMIT = 713238
+# 713238 -> 714446: the deep-interview skill gained the answer-options
+# contract (+1208 chars: the candidate-list block with a free-input entry,
+# the bare-number collision rule, the mid-interview option shape, and one
+# quality-bar bullet), replacing free-text-only replies with an
+# AskUserQuestion-shaped numbered list; warranted growth.
+FULL_PROFILE_SKILL_BODY_CHAR_LIMIT = 714446
 FULL_PROFILE_SKILL_BODY_REVIEWED_EXCEPTION_CHARS = 0
 
 

--- a/src/skills/catalog_definitions.py
+++ b/src/skills/catalog_definitions.py
@@ -652,6 +652,7 @@ _DEFINITIONS = [
         quality_tier="clarity-gated",
         quality_bar=(
             "Ask exactly one blocking question per turn unless the wrapper explicitly supports a structured batch.",
+            "Offer two to four candidate answers plus a free-input option with every question, and accept free text over the list at any time.",
             "Tie each question to a missing decision that changes the plan, handoff, or stop condition.",
             "Emit a clarified brief with non-goals and acceptance criteria before planning or delegation.",
         ),

--- a/src/skills/catalog_harnesses.py
+++ b/src/skills/catalog_harnesses.py
@@ -2070,7 +2070,7 @@ _HARNESSES = [
             "the round budget is exhausted or the user asked to stop",
         ),
         ("pressure-test assumptions", "capture transcript or summary"),
-        "If structured question UI is unavailable, ask one direct question in the current surface.",
+        "If structured question UI is unavailable, ask one direct question in the current surface, with its candidate answers as a numbered list ending in a free-input entry.",
         ("interview_started", "question_asked", "clarity_recorded"),
         "Record a delegated interviewer only when Hermes exposes that lane; otherwise record sequential clarification.",
         "metadata_only",
@@ -2078,6 +2078,7 @@ _HARNESSES = [
         quality_bar=(
             "Name the missing decision, why it matters, and the smallest answer that would unblock the next step.",
             "Ask one blocking question tied to a missing decision.",
+            "Offer two to four candidate answers plus a free-input entry with every question, and accept free text over the list.",
             "Use discovered facts before asking the user for information already available locally.",
             "Produce a clarified brief with non-goals, acceptance criteria, and remaining unknowns before planning or handoff.",
         ),

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -1232,7 +1232,7 @@ mid-interview check now and continue from Round {soft_round}.
 
 - Never fold counters, ratios, or dimension names into the question sentence.
 - Ask the way a senior colleague would ask out loud: one sentence, no preamble, no restating
-  what the user just said, no numbered sub-parts. If it reads like a form field, rewrite it.
+  what the user just said, no numbered sub-questions. If it reads like a form field, rewrite it.
 - Outside the header line, the user never hears the words round, budget, dimension, or resolved.
 - Mirror the user's language in the header labels and the question. Korean header:
   `라운드 {{n}}/{max_rounds} · 명확도: {{percent}}% ({{resolved}}/3) · 확인 중: {{목표/제약과 비목표/성공 기준}}`.
@@ -1240,12 +1240,28 @@ mid-interview check now and continue from Round {soft_round}.
 - The clarified brief follows the same rule: write its headings and labels in the user's
   language. Translate those terms, never transliterate them.
 
+**Answer options — every question ships with candidates.**
+
+After the question sentence, offer the likely answers as a short numbered list: two to four
+real candidates, then one final free-input entry. Each candidate is an answer the user could
+actually pick — drawn from the request, repo evidence, or the tradeoff the question is really
+about, never filler to reach a count, and never a candidate whose text is itself a bare number
+(it would collide with reply-by-number). The last entry is always the open door, in the user's
+language — for example English `N) Something else — type your answer`, Korean `N) 기타 — 직접 입력`.
+
+- A number, an option's own words, or a completely different free-text answer are all valid;
+  free text is always accepted, even when it matches no option. Never re-ask because the reply
+  was not a listed option.
+- Options mirror the user's language, like the header and the question.
+- The list is an answer palette, not extra questions; it does not break the one-question rule.
+
 **Mid-interview check — this is not a stop rule.**
 
 Before asking the question that would be Round {soft_round}, offer the choice instead: say where
 things stand and ask whether to keep going or plan now — your own words, the user's language,
-one short sentence. The check is not a round: emit it without a header. If the user chooses to
-continue, the next question is Round {soft_round}; if they choose to plan, stop rule 2 applies.
+one short sentence, with the same option shape: keep going / plan now / free input.
+The check is not a round: emit it without a header. If the user chooses to continue, the next
+question is Round {soft_round}; if they choose to plan, stop rule 2 applies.
 
 **Stop rules — the first match ends the interview.**
 

--- a/tests/test_deep_interview_bounds.py
+++ b/tests/test_deep_interview_bounds.py
@@ -86,6 +86,60 @@ class DeepInterviewProtocolTest(unittest.TestCase):
         # of the English term, which reads as broken Korean.
         self.assertIn("Translate those terms, never transliterate them.", _unwrapped_body())
 
+    def test_every_question_offers_candidate_answers_plus_free_input(self) -> None:
+        # Live ulw-interview runs forced free-text-only replies; the OMH-native equivalent of
+        # a structured question UI is a numbered candidate list ending in a free-input entry
+        # (the same shape the model-chains interview already uses).
+        body = _skill_body()
+        self.assertIn("**Answer options — every question ships with candidates.**", body)
+        unwrapped = _unwrapped_body()
+        self.assertIn("two to four real candidates, then one final free-input entry.", unwrapped)
+        # English is the canonical rendering; Korean is the localized illustration.
+        self.assertIn("Something else — type your answer", body)
+        self.assertIn("기타 — 직접 입력", body)
+        self.assertIn("free text is always accepted, even when it matches no option.", unwrapped)
+        self.assertIn("Never re-ask because the reply was not a listed option.", unwrapped)
+        # A candidate whose text is a bare number would make a numeric reply undecidable
+        # between "option 3" and "the literal answer 3".
+        self.assertIn("never a candidate whose text is itself a bare number", unwrapped)
+        # The candidate list must not read as extra questions, or it would collide with the
+        # one-question-per-round rule the header advertises.
+        self.assertIn("it does not break the one-question rule.", unwrapped)
+        # "no numbered sub-questions" (not the old "sub-parts") is what keeps the numbered
+        # answer list from contradicting the voice rules.
+        self.assertIn("no numbered sub-questions.", unwrapped)
+        self.assertNotIn("no numbered sub-parts", body)
+
+    def test_option_block_sits_between_voice_rules_and_the_soft_check(self) -> None:
+        body = _skill_body()
+        self.assertLess(body.index("**Voice —"), body.index("**Answer options —"))
+        self.assertLess(body.index("**Answer options —"), body.index("**Mid-interview check"))
+
+    def test_mid_interview_check_uses_the_same_option_shape(self) -> None:
+        self.assertIn(
+            "with the same option shape: keep going / plan now / free input.",
+            _unwrapped_body(),
+        )
+
+    def test_catalog_quality_bar_names_the_option_contract(self) -> None:
+        bar = _definition().quality_bar
+        self.assertTrue(
+            any("free-input option" in item and "free text" in item for item in bar),
+            bar,
+        )
+
+    def test_harness_fallback_and_quality_bar_carry_the_option_contract(self) -> None:
+        # The harness fallback used to prescribe the pre-change behavior (a bare direct
+        # question); a runtime reading both surfaces must not get contradictory shapes.
+        from omh.skills.catalog import builtin_harnesses
+
+        harness = next(item for item in builtin_harnesses() if item.name == "deep-interview")
+        self.assertIn("numbered list ending in a free-input entry", harness.fallback)
+        self.assertTrue(
+            any("free-input entry" in item and "free text" in item for item in harness.quality_bar),
+            harness.quality_bar,
+        )
+
     def test_soft_check_is_not_a_stop_rule_and_does_not_consume_a_round(self) -> None:
         body = _skill_body()
         self.assertIn("**Mid-interview check — this is not a stop rule.**", body)


### PR DESCRIPTION
## Capability

`ulw-interview` (the installed `deep-interview` skill) now presents every interview question with two to four candidate answers as a numbered list ending in a free-input entry, instead of forcing free-text-only replies. This is the Hermes-TUI-native equivalent of OMC deep-interview's AskUserQuestion pattern, and reuses the option shape the model-chains interview already ships (`1) … 4) custom entry (직접 입력)`).

## Motivation

Live usage feedback: running `ulw-interview`, no recommended choices appear and the user must type a full free-text answer to every round. OMC's deep-interview offers clickable options plus an "other" input; Hermes has no clickable widget, so the native equivalent is a numbered candidate list with an always-present open door.

## Implementation (boundary level)

- `src/skills/render.py` — new **Answer options** block in the Interview Round Protocol, between the voice rules and the mid-interview check: 2–4 real candidates (drawn from the request, repo evidence, or the tradeoff at stake — never filler, never a bare number, which would collide with reply-by-number), then a final free-input entry rendered in the user's language (English canonical `N) Something else — type your answer`, Korean `N) 기타 — 직접 입력`). A number, an option's own words, or unrelated free text are all valid; free text is always accepted; the runtime never re-asks because a reply was off-list. The list is an answer palette, not extra questions, so the one-question-per-round rule stands (voice rule reworded `sub-parts` → `sub-questions` to keep the reconciliation exact). The mid-interview check carries the same keep-going / plan-now / free-input shape.
- `src/skills/catalog_definitions.py` — one quality-bar bullet pinning the option contract on the catalog surface.
- `src/skills/catalog_harnesses.py` — the harness fallback previously prescribed the pre-change behavior ("ask one direct question"); it now names the numbered-list shape, and the harness quality bar carries the matching bullet (review finding, HIGH).
- `src/maintenance/release.py` — full-profile skill-body budget 713238 → 714446 with the house-style ratchet note (+1208 chars, warranted growth; the per-skill ceiling stays 10,000 with the body at 9,539).
- Regenerated: `skills/ulw-interview/SKILL.md`, `docs/WORKFLOWS.md` (renderer-first; no hand edits).
- `tests/test_deep_interview_bounds.py` — pins the option block, its ordering between voice rules and soft check, the English and Korean open-door strings, the bare-number collision rule, the free-text-always-accepted sentence, the `sub-questions` reconciliation (with `assertNotIn` on the old wording), and the harness fallback/quality-bar parity.

## Verification (observed)

- `PYTHONPATH=tests uv run python -m unittest discover -s tests` — **7273 tests, OK** (fresh run on the final tree).
- All five byte gates pass: `docs workflows --check`, `docs roles --check`, `docs capability-families --check`, `docs ulw-inventory --check`, `docs ulw-site --check`.
- `uv run --group lint ruff check src tests`, `uv run python -m compileall -q src tests`, `git diff --check` — clean.
- Separate-lane code review: 1 CRITICAL (drift budget, reproduced and fixed), 1 HIGH (harness fallback contradiction, fixed), 4 MEDIUM fixed (harness quality-bar parity, two unpinned invariants now pinned, numeric-reply collision rule, "always wins" ambiguity reworded); remaining LOWs are cosmetic and noted below.

## Risks

- `deep_interview_contract/v1` (`src/workflows/hermes_planning.py`) is the machine-readable twin and still describes `one_question` without an option-shape field; adding one is a schema version decision deliberately deferred — the SKILL.md protocol is the surface a Hermes runtime follows.
- Only `en`/`ko` open-door illustrations are given ("for example" phrasing); a `ja`/`zh` run follows the general mirror-the-user's-language rule, same precedent as the existing Korean header illustration.
- Live TUI rendering of an interview round is not observed here (`prepared_not_observed`); the skill text is the shipped surface and reaches machines via `omh update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKo77o5dTJtLRWfDj4uBtq