### PR TITLE
feat(skills): ralplan declares a HUD plan todo and runs bounded in-plan research

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -3542,9 +3542,11 @@ These surfaces are generated command references, not installed Hermes workflow s
   - Why: Ralplan is a planning gate, not implementation, review, CI, or PR evidence.
 - Quality bar:
   - Start from observed repo facts and source/web evidence when freshness or external behavior matters.
+  - Initialize the plan todo before the first planning step: declare the planning stages as `omh_todo` items (todo init) — repo facts and evidence check, options and tradeoffs, risk review, acceptance criteria and verification commands, plan record and acceptance — keep exactly one item active, and when the evidence check reveals a gap rewrite the list (`omh_todo` action=set) to insert the research stage; update the list as stages complete so the HUD todo panel shows plan progress as a bounded checklist, and treat items as declarations, never execution evidence.
   - Include planner view, critic/risk review, alternative paths, rejected options, and a testability check before handoff.
   - Produce testable acceptance criteria and exact verification commands or explain why they are not yet knowable.
   - Record unresolved tradeoffs and evidence gaps instead of flattening uncertainty.
+  - When plan-shaping evidence is missing — current external behavior, contested claims, or unstudied reference implementations — run the `research` workflow as a bounded in-plan stage (not an exhaustive deep-research run) before comparing options, record its dossier the way the `research` artifact contract requires, and consume it instead of planning on assumptions.
   - Consume a recorded `research` dossier when one exists: plan options and rejected alternatives should cite its decision drivers and verified claims.
   - End with a selected executor/runtime handoff shape only after the plan is accepted.
   - Plan acceptance approves the plan content, not execution: after acceptance, recommend the follow-on path that fits the work's shape — `ultrawork` durable checkpoints for progress that must survive sessions as a checkpointed ledger, `ultrawork` coordinated lanes for an accepted plan split into disjoint parallel lanes, `ultrawork` single-owner persistence for one already-scoped task with a single owner, `ultrawork` for one bounded delivery cycle, or a direct selected executor/runtime handoff for a single prepared coding change — state the fit reason in one line, and start it only after the user's explicit go-ahead.
@@ -3559,12 +3561,11 @@ These surfaces are generated command references, not installed Hermes workflow s
 - Recovery notes:
   - If requirements are still fuzzy, route back to deep-interview before planning.
   - If current-source evidence is missing, route a `research` step before accepting the plan.
-  - If the plan depends on unstudied reference implementations or contested external claims, route a deep research step and consume its dossier before accepting the plan.
   - If the user asks for implementation after acceptance, recommend the follow-on path that fits the work's shape (`ultrawork` with the matching capability — durable checkpoint, coordinated lanes, single-owner persistence, or one delivery cycle — or a direct selected executor handoff) with a one-line fit reason, and start it only on the user's explicit go-ahead — never auto-start an engine from acceptance alone.
 - Required inputs:
   - requirements
   - codebase facts
-  - source or web evidence when needed
+  - source or web evidence when needed, or an in-plan research stage to obtain it
   - options
   - tradeoffs
   - test shape

--- a/skills/ulw-plan/SKILL.md
+++ b/skills/ulw-plan/SKILL.md
@@ -53,7 +53,6 @@ Bad example:
 
 - If requirements are still fuzzy, route back to deep-interview before planning.
 - If current-source evidence is missing, route a `research` step before accepting the plan.
-- If the plan depends on unstudied reference implementations or contested external claims, route a deep research step and consume its dossier before accepting the plan.
 - If the user asks for implementation after acceptance, recommend the follow-on path that fits the work's shape (`ultrawork` with the matching capability — durable checkpoint, coordinated lanes, single-owner persistence, or one delivery cycle — or a direct selected executor handoff) with a one-line fit reason, and start it only on the user's explicit go-ahead — never auto-start an engine from acceptance alone.
 
 ## Workflow Lane
@@ -79,9 +78,11 @@ Reasoning demand: `standard`
 Quality bar:
 
 - Start from observed repo facts and source/web evidence when freshness or external behavior matters.
+- Initialize the plan todo before the first planning step: declare the planning stages as `omh_todo` items (todo init) — repo facts and evidence check, options and tradeoffs, risk review, acceptance criteria and verification commands, plan record and acceptance — keep exactly one item active, and when the evidence check reveals a gap rewrite the list (`omh_todo` action=set) to insert the research stage; update the list as stages complete so the HUD todo panel shows plan progress as a bounded checklist, and treat items as declarations, never execution evidence.
 - Include planner view, critic/risk review, alternative paths, rejected options, and a testability check before handoff.
 - Produce testable acceptance criteria and exact verification commands or explain why they are not yet knowable.
 - Record unresolved tradeoffs and evidence gaps instead of flattening uncertainty.
+- When plan-shaping evidence is missing — current external behavior, contested claims, or unstudied reference implementations — run the `research` workflow as a bounded in-plan stage (not an exhaustive deep-research run) before comparing options, record its dossier the way the `research` artifact contract requires, and consume it instead of planning on assumptions.
 - Consume a recorded `research` dossier when one exists: plan options and rejected alternatives should cite its decision drivers and verified claims.
 - End with a selected executor/runtime handoff shape only after the plan is accepted.
 - Plan acceptance approves the plan content, not execution: after acceptance, recommend the follow-on path that fits the work's shape — `ultrawork` durable checkpoints for progress that must survive sessions as a checkpointed ledger, `ultrawork` coordinated lanes for an accepted plan split into disjoint parallel lanes, `ultrawork` single-owner persistence for one already-scoped task with a single owner, `ultrawork` for one bounded delivery cycle, or a direct selected executor/runtime handoff for a single prepared coding change — state the fit reason in one line, and start it only after the user's explicit go-ahead.
@@ -95,7 +96,7 @@ Required inputs:
 
 - requirements
 - codebase facts
-- source or web evidence when needed
+- source or web evidence when needed, or an in-plan research stage to obtain it
 - options
 - tradeoffs
 - test shape

--- a/src/maintenance/release.py
+++ b/src/maintenance/release.py
@@ -187,7 +187,12 @@ STANDALONE_CAPABILITY_SKILL_ITEM_CHAR_LIMIT = 2200
 # the bare-number collision rule, the mid-interview option shape, and one
 # quality-bar bullet), replacing free-text-only replies with an
 # AskUserQuestion-shaped numbered list; warranted growth.
-FULL_PROFILE_SKILL_BODY_CHAR_LIMIT = 714446
+# 714446 -> 715255: the ralplan skill gained the plan-todo checklist rule
+# (`omh_todo` stage declaration with the declarations-not-evidence boundary,
+# HUD-panel wording, and the rewrite-on-evidence-gap step) and the bounded
+# in-plan research stage rule with its dossier-recording obligation, minus
+# one subsumed recovery note (net +809 chars); warranted growth.
+FULL_PROFILE_SKILL_BODY_CHAR_LIMIT = 715255
 FULL_PROFILE_SKILL_BODY_REVIEWED_EXCEPTION_CHARS = 0
 
 

--- a/src/skills/catalog_definitions.py
+++ b/src/skills/catalog_definitions.py
@@ -4563,7 +4563,7 @@ _DEFINITIONS = [
         phase="reviewed-plan",
         hermes_role="retained-cognition",
         handoff_policy="Keep consensus planning and review in Hermes; produce explicit selected executor/runtime handoff guidance only after the plan is accepted, and start a follow-on workflow engine only after the user explicitly confirms the recommended path.",
-        required_inputs=("requirements", "codebase facts", "source or web evidence when needed", "options", "tradeoffs", "test shape"),
+        required_inputs=("requirements", "codebase facts", "source or web evidence when needed, or an in-plan research stage to obtain it", "options", "tradeoffs", "test shape"),
         expected_outputs=("reviewed plan", "acceptance criteria", "risk register", "verification commands", "handoff guidance"),
         # Naming the commands is the point. This used to read "plan and review
         # artifacts when a wrapper supports file-backed planning", which names
@@ -4584,9 +4584,11 @@ _DEFINITIONS = [
         quality_tier="reviewed-plan-gated",
         quality_bar=(
             "Start from observed repo facts and source/web evidence when freshness or external behavior matters.",
+            "Initialize the plan todo before the first planning step: declare the planning stages as `omh_todo` items (todo init) — repo facts and evidence check, options and tradeoffs, risk review, acceptance criteria and verification commands, plan record and acceptance — keep exactly one item active, and when the evidence check reveals a gap rewrite the list (`omh_todo` action=set) to insert the research stage; update the list as stages complete so the HUD todo panel shows plan progress as a bounded checklist, and treat items as declarations, never execution evidence.",
             "Include planner view, critic/risk review, alternative paths, rejected options, and a testability check before handoff.",
             "Produce testable acceptance criteria and exact verification commands or explain why they are not yet knowable.",
             "Record unresolved tradeoffs and evidence gaps instead of flattening uncertainty.",
+            "When plan-shaping evidence is missing — current external behavior, contested claims, or unstudied reference implementations — run the `research` workflow as a bounded in-plan stage (not an exhaustive deep-research run) before comparing options, record its dossier the way the `research` artifact contract requires, and consume it instead of planning on assumptions.",
             "Consume a recorded `research` dossier when one exists: plan options and rejected alternatives should cite its decision drivers and verified claims.",
             "End with a selected executor/runtime handoff shape only after the plan is accepted.",
             ENGINE_FIT_RECOMMENDATION_RULE,
@@ -4621,7 +4623,6 @@ _DEFINITIONS = [
         recovery_notes=(
             "If requirements are still fuzzy, route back to deep-interview before planning.",
             "If current-source evidence is missing, route a `research` step before accepting the plan.",
-            "If the plan depends on unstudied reference implementations or contested external claims, route a deep research step and consume its dossier before accepting the plan.",
             "If the user asks for implementation after acceptance, recommend the follow-on path that fits the work's shape (`ultrawork` with the matching capability — durable checkpoint, coordinated lanes, single-owner persistence, or one delivery cycle — or a direct selected executor handoff) with a one-line fit reason, and start it only on the user's explicit go-ahead — never auto-start an engine from acceptance alone.",
         ),
     ),

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -2861,6 +2861,27 @@ class RouterContentTests(unittest.TestCase):
         self.assertTrue(any("source or web evidence" in item for item in definitions["ralplan"].required_inputs))
         self.assertIn("verification commands", definitions["ralplan"].expected_outputs)
         self.assertTrue(any("rejected options" in item for item in definitions["ralplan"].quality_bar))
+        # The plan run must surface a TUI todo checklist (`omh_todo`), like the
+        # ultrawork engine already does, and run research as an in-plan stage
+        # when plan-shaping evidence is missing instead of only consuming a
+        # dossier that happens to exist.
+        ralplan_bar = definitions["ralplan"].quality_bar
+        self.assertTrue(any("`omh_todo`" in item and "todo init" in item for item in ralplan_bar))
+        self.assertTrue(
+            any("declarations, never execution evidence" in item for item in ralplan_bar)
+        )
+        self.assertTrue(
+            any(
+                "run the `research` workflow as a bounded in-plan stage" in item
+                for item in ralplan_bar
+            )
+        )
+        # The todo rule stays off the shared `planning` harness and off the lighter
+        # `plan` skill on purpose: `plan`, `curriculum-design`, and `product-brief`
+        # share that harness and should not gain a HUD checklist obligation.
+        self.assertFalse(any("omh_todo" in item for item in definitions["plan"].quality_bar))
+        planning_harness = next(item for item in builtin_harnesses() if item.name == "planning")
+        self.assertFalse(any("omh_todo" in item for item in planning_harness.quality_bar))
         self.assertTrue(any("prepared_not_observed" in item for item in definitions["ralplan"].final_checklist))
         self.assertEqual(primary_harness_for_skill("research"), "research")
         self.assertEqual(primary_harness_for_skill("research-brief"), "business-research")


### PR DESCRIPTION
## Capability

`ulw-plan` (the installed `ralplan` skill) now (1) declares a plan todo checklist through the `omh_todo` plugin tool so the Hermes TUI HUD shows plan progress below the prompt input — the same surface the `ulw-work` engine already drives — and (2) runs the `research` workflow as a bounded in-plan stage when plan-shaping evidence is missing, recording and consuming its dossier, instead of only consuming a dossier that happens to already exist.

## Motivation

Live usage: ulw-plan runs surfaced no TODO in the TUI (the todo instruction existed only on the ultrawork engine's quality bar), and planning could proceed on assumptions when current-source evidence was missing because ralplan's contract only said "consume a recorded dossier when one exists" and "route a research step" — it never ran one.

## Implementation (boundary level)

- `src/skills/catalog_definitions.py` (ralplan quality bar):
  - Todo bullet: declare the planning stages as `omh_todo` items before the first planning step (repo facts and evidence check, options and tradeoffs, risk review, acceptance criteria and verification commands, plan record and acceptance), keep exactly one active, rewrite the list (`omh_todo` action=set) to insert the research stage when the evidence check reveals a gap, and treat items as declarations, never execution evidence. The conditional stage was deliberately resolved out of the init list (review finding: the todo store has no skipped state, so a declared-but-unneeded item would strand the panel).
  - Research bullet: run `research` as a **bounded** in-plan stage (not an exhaustive deep-research fan-out), record its dossier per the research artifact contract, and cite it — placed directly before the existing consume-a-dossier bullet so produce-then-consume reads in order.
  - One subsumed recovery note dropped; `required_inputs` reworded to admit the in-plan stage as the way to obtain missing evidence.
- The todo rule stays **off** the shared `planning` harness on purpose — `plan`, `curriculum-design`, and `product-brief` share it and must not gain a HUD checklist obligation. A negative assertion in `tests/test_router_content.py` pins that decision (plus positives for both new bullets and the declarations-not-evidence boundary).
- `src/maintenance/release.py` — full-profile skill-body budget 714446 → 715255 with the house-style ratchet note (net +809 chars).
- Regenerated: `skills/ulw-plan/SKILL.md`, `docs/WORKFLOWS.md`.

## Verification (observed)

- `PYTHONPATH=tests uv run python -m unittest discover -s tests` — **7273 tests, OK** (final tree).
- All five byte gates pass (workflows incl. tap-skills 124/124, roles, capability-families, ulw-inventory, ulw-site); `ruff check`, `compileall`, `git diff --check` clean.
- Separate-lane code review: 0 CRITICAL / 0 HIGH; all 5 MEDIUMs addressed (conditional todo stage resolved, claim-boundary clause added, dossier-recording obligation added, harness-exclusion negative guard added, subsumed recovery note dropped) plus the cheap LOWs (HUD-panel wording, list-rewrite wording, required-inputs reword). Reviewer verified the budget delta arithmetic and the `omh_todo` tool contract independently.

## Risks

- The todo panel is a modern-TUI-only surface (the classic Python TUI loads no widget files); the bullet says "HUD todo panel" to match.
- `omh_todo` set/clear/show only — the bullet's "rewrite the list" wording matches the tool's whole-list `set` semantics.
- Live TUI rendering of the checklist during a plan run is not observed here (`prepared_not_observed`); reaches machines via `omh update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKo77o5dTJtLRWfDj4uBtq