### PR TITLE
feat(skills): report trigger loss and collision ownership

### DIFF
--- a/src/commands/docs.py
+++ b/src/commands/docs.py
@@ -135,6 +135,15 @@ def _sync_ulw_region(*, path: Path, check: bool, label: str, site: bool = False)
     return 0
 
 
+def cmd_docs_skill_trigger_report(args: argparse.Namespace) -> int:
+    from ..skills.trigger_review import skill_trigger_review_payload
+
+    if args.format != "json":
+        raise OmhError(f"unsupported skill-trigger-report format: {args.format}")
+    _print_json(skill_trigger_review_payload())
+    return 0
+
+
 def cmd_docs_skill_context_cost(args: argparse.Namespace) -> int:
     if args.json:
         _print_json(skill_context_cost_payload())
@@ -253,6 +262,21 @@ def _add_docs_commands(sub) -> None:
         help="Print the machine-readable omh_skill_context_cost/v1 payload.",
     )
     docs_skill_context_cost.set_defaults(func=cmd_docs_skill_context_cost)
+
+    docs_skill_trigger_report = docs_sub.add_parser(
+        "skill-trigger-report",
+        help=(
+            "Report which defined triggers reached picker frontmatter, why the rest did not, "
+            "and which normalized trigger identities are shared across skills."
+        ),
+    )
+    docs_skill_trigger_report.add_argument(
+        "--format",
+        default="json",
+        choices=("json",),
+        help="Output format for the skill_trigger_review/v1 payload.",
+    )
+    docs_skill_trigger_report.set_defaults(func=cmd_docs_skill_trigger_report)
 
 
 def _add_harness_commands(sub) -> None:

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -214,13 +214,43 @@ _FRONTMATTER_TRIGGER_LIMIT = 8
 _FRONTMATTER_SAFE_TRIGGER = re.compile(r"^[0-9A-Za-z가-힣][0-9A-Za-z가-힣 _.-]*$")
 
 
-def _frontmatter_trigger_tail(definition: SkillDefinition | None) -> str:
-    if definition is None:
-        return ""
+# Why a trigger defined in the catalog never reaches the picker description.
+# The set is closed: every omission the emission rule below can produce maps
+# to exactly one of these, so a reviewer never sees an unexplained loss.
+ROUTER_CARVE_OUT = "router_carve_out"
+UNSAFE_FOR_FRONTMATTER = "unsafe_for_frontmatter"
+DUPLICATE_OF_ALIAS = "duplicate_of_alias"
+BUDGET_OVERFLOW = "budget_overflow"
+
+
+def frontmatter_trigger_emission(definition: SkillDefinition) -> tuple[list[str], list[tuple[str, str]]]:
+    """Split a definition's triggers into what the picker sees and what it loses.
+
+    Returned as `(emitted, [(trigger, reason), ...])`. `_frontmatter_trigger_tail()`
+    renders from the same call, so the review report can never describe an
+    emission rule the renderer no longer applies.
+    """
+    safe_aliases = _safe_aliases(definition)
     # The router describes plumbing, not an intent; surfacing its `omh`
     # tokens would also collide with the substring-trap detectors.
     if definition.name == "oh-my-hermes":
-        return ""
+        return [], [(trigger, ROUTER_CARVE_OUT) for trigger in definition.triggers]
+    safe_alias_keys = {alias.casefold() for alias in safe_aliases}
+    emitted: list[str] = []
+    omitted: list[tuple[str, str]] = []
+    for trigger in definition.triggers:
+        if not _FRONTMATTER_SAFE_TRIGGER.fullmatch(trigger):
+            omitted.append((trigger, UNSAFE_FOR_FRONTMATTER))
+        elif trigger.casefold() in safe_alias_keys:
+            omitted.append((trigger, DUPLICATE_OF_ALIAS))
+        elif len(emitted) >= _FRONTMATTER_TRIGGER_LIMIT:
+            omitted.append((trigger, BUDGET_OVERFLOW))
+        else:
+            emitted.append(trigger)
+    return emitted, omitted
+
+
+def _safe_aliases(definition: SkillDefinition) -> list[str]:
     safe_aliases = [
         alias
         for alias in definition.aliases
@@ -229,18 +259,18 @@ def _frontmatter_trigger_tail(definition: SkillDefinition | None) -> str:
     if len(safe_aliases) != len(definition.aliases):
         invalid = sorted(set(definition.aliases) - set(safe_aliases))
         raise ValueError(f"unsafe picker aliases for {definition.name}: {', '.join(invalid)}")
-    safe_alias_keys = {alias.casefold() for alias in safe_aliases}
-    safe_triggers = [
-        trigger
-        for trigger in definition.triggers
-        if _FRONTMATTER_SAFE_TRIGGER.fullmatch(trigger) and trigger.casefold() not in safe_alias_keys
-    ]
+    return safe_aliases
+
+
+def _frontmatter_trigger_tail(definition: SkillDefinition | None) -> str:
+    if definition is None:
+        return ""
+    safe_aliases = _safe_aliases(definition)
+    if definition.name == "oh-my-hermes":
+        return ""
+    emitted, _ = frontmatter_trigger_emission(definition)
     alias_tail = " Aliases: " + ", ".join(safe_aliases) + "." if safe_aliases else ""
-    trigger_tail = (
-        " Use when the user says: " + ", ".join(safe_triggers[:_FRONTMATTER_TRIGGER_LIMIT]) + "."
-        if safe_triggers
-        else ""
-    )
+    trigger_tail = " Use when the user says: " + ", ".join(emitted) + "." if emitted else ""
     return alias_tail + trigger_tail
 
 

--- a/src/skills/trigger_collisions.py
+++ b/src/skills/trigger_collisions.py
@@ -1,0 +1,126 @@
+"""Approved trigger-collision declarations.
+
+Each entry records that a maintainer looked at one normalized trigger identity
+shared by two or more skills and judged the sharing intentional. A declaration
+carries only the normalized identity, the exact owner set that was reviewed,
+and a rationale ID -- never the trigger phrases themselves, so this file cannot
+become a second source of truth about what a skill routes on.
+
+`validate_collision_declarations()` in `trigger_review.py` fails closed on an
+undeclared group, on a declaration whose group no longer collides, and on a
+group whose owner set grew beyond what was approved. Adding a trigger that
+collides with another skill's trigger or alias is not a defect; it just has to
+be reviewed here first.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CollisionDeclaration:
+    """An approval record for one normalized collision group.
+
+    It stores only the normalized identity, the exact owner set that was
+    reviewed, and a rationale ID. It deliberately does NOT restate the trigger
+    phrases themselves: the catalog stays the single source of truth, and a
+    declaration cannot drift into a competing definition of what a skill routes
+    on.
+    """
+
+    identity: str
+    owners: tuple[str, ...]
+    rationale_id: str
+
+# Why each family of shared identities is intentional. The IDs are stable so a
+# reviewer can find every group approved for the same reason.
+COLLISION_RATIONALES: dict[str, str] = {
+    "R-OMH-ENTRYPOINT": (
+        "The `/omh` entrypoint token is the meta-router's job to detect and the router skill's job to describe; both must answer to it."
+    ),
+    "R-ACCESSIBILITY-SURFACE": (
+        "Accessibility is a real concern of both the visual frontend surface and the voice operator surface."
+    ),
+    "R-LAYOUT-DEFECT-INTAKE": (
+        "A reported broken layout is legitimately either a frontend fix or a visual-QA verification request."
+    ),
+    "R-CI-FAILURE-INTAKE": (
+        "A CI failure is both a build-triage subject and a GitHub event to operate on."
+    ),
+    "R-PARALLEL-EXECUTION": (
+        "Coordinated parallel workers are the shared vocabulary of team orchestration and ultrawork fan-out."
+    ),
+    "R-DELIVERY-CYCLE": (
+        "End-to-end delivery through a PR is the overlapping promise of the process and ultrawork engines."
+    ),
+    "R-FEEDBACK-SIGNAL": (
+        "Customer feedback is both a triage input and a research subject."
+    ),
+    "R-PERSISTENT-EXECUTION": (
+        "Run-until-done persistence is the defining behavior of ralph and a mode of ultrawork."
+    ),
+    "R-ISSUE-INTAKE": (
+        "Issue triage is both a GitHub operation and a planning intake."
+    ),
+    "R-ENVIRONMENT-INVENTORY": (
+        "MCP inventory is read by both the harness session view and the workspace audit."
+    ),
+    "R-RELEASE-GATE": (
+        "A release gate is enforced by the verification gate and inspected during code review."
+    ),
+    "R-RELEASE-READINESS": (
+        "Release readiness is both an executive loop question and a production-audit subject."
+    ),
+    "R-RENDER-QA": (
+        "Render QA covers both produced material packages and on-screen visual verification."
+    ),
+    "R-CHAT-GATEWAY": (
+        "Chat gateway platform names belong to both automation blueprints and gateway intent cards."
+    ),
+    "R-SUBAGENT-VIEW": (
+        "Subagent state is shown by the agent board and assessed by executor runtime readiness."
+    ),
+    "R-LONG-HORIZON-GOAL": (
+        "A long-horizon goal is owned by the goal engine and driven by the loop engine."
+    ),
+}
+
+INTENTIONAL_COLLISIONS: tuple[CollisionDeclaration, ...] = (
+    CollisionDeclaration(identity="./omh", owners=("meta-router", "oh-my-hermes",), rationale_id="R-OMH-ENTRYPOINT"),
+    CollisionDeclaration(identity="/omh", owners=("meta-router", "oh-my-hermes",), rationale_id="R-OMH-ENTRYPOINT"),
+    CollisionDeclaration(identity="accessibility", owners=("frontend", "voice-operator",), rationale_id="R-ACCESSIBILITY-SURFACE"),
+    CollisionDeclaration(identity="broken layout", owners=("frontend", "visual-qa",), rationale_id="R-LAYOUT-DEFECT-INTAKE"),
+    CollisionDeclaration(identity="ci failed", owners=("build-failure-triage", "github-event-ops",), rationale_id="R-CI-FAILURE-INTAKE"),
+    CollisionDeclaration(identity="ci 실패", owners=("build-failure-triage", "github-event-ops",), rationale_id="R-CI-FAILURE-INTAKE"),
+    CollisionDeclaration(identity="coordinated workers", owners=("team", "ultrawork",), rationale_id="R-PARALLEL-EXECUTION"),
+    CollisionDeclaration(identity="delivery process", owners=("ultraprocess", "ultrawork",), rationale_id="R-DELIVERY-CYCLE"),
+    CollisionDeclaration(identity="end-to-end process", owners=("ultraprocess", "ultrawork",), rationale_id="R-DELIVERY-CYCLE"),
+    CollisionDeclaration(identity="feedback trends", owners=("feedback-triage", "research-brief",), rationale_id="R-FEEDBACK-SIGNAL"),
+    CollisionDeclaration(identity="finish until done", owners=("ralph", "ultrawork",), rationale_id="R-PERSISTENT-EXECUTION"),
+    CollisionDeclaration(identity="issue triage", owners=("github-event-ops", "plan",), rationale_id="R-ISSUE-INTAKE"),
+    CollisionDeclaration(identity="layout broken", owners=("frontend", "visual-qa",), rationale_id="R-LAYOUT-DEFECT-INTAKE"),
+    CollisionDeclaration(identity="make a pr", owners=("ultraprocess", "ultrawork",), rationale_id="R-DELIVERY-CYCLE"),
+    CollisionDeclaration(identity="mcp inventory", owners=("harness-session-inventory", "workspace-audit",), rationale_id="R-ENVIRONMENT-INVENTORY"),
+    CollisionDeclaration(identity="one-cycle delivery", owners=("ultraprocess", "ultrawork",), rationale_id="R-DELIVERY-CYCLE"),
+    CollisionDeclaration(identity="open a pr", owners=("ultraprocess", "ultrawork",), rationale_id="R-DELIVERY-CYCLE"),
+    CollisionDeclaration(identity="persistent execution", owners=("ralph", "ultrawork",), rationale_id="R-PERSISTENT-EXECUTION"),
+    CollisionDeclaration(identity="plan implement review docs pr", owners=("ultraprocess", "ultrawork",), rationale_id="R-DELIVERY-CYCLE"),
+    CollisionDeclaration(identity="pr-ready", owners=("ultraprocess", "ultrawork",), rationale_id="R-DELIVERY-CYCLE"),
+    CollisionDeclaration(identity="prepare a pr", owners=("ultraprocess", "ultrawork",), rationale_id="R-DELIVERY-CYCLE"),
+    CollisionDeclaration(identity="release gate", owners=("code-review", "verification-gate",), rationale_id="R-RELEASE-GATE"),
+    CollisionDeclaration(identity="release readiness", owners=("cto-loop", "production-audit",), rationale_id="R-RELEASE-READINESS"),
+    CollisionDeclaration(identity="render qa", owners=("materials-package", "visual-qa",), rationale_id="R-RENDER-QA"),
+    CollisionDeclaration(identity="research plan implement review docs pr", owners=("ultraprocess", "ultrawork",), rationale_id="R-DELIVERY-CYCLE"),
+    CollisionDeclaration(identity="single-cycle delivery", owners=("ultraprocess", "ultrawork",), rationale_id="R-DELIVERY-CYCLE"),
+    CollisionDeclaration(identity="고객 피드백", owners=("feedback-triage", "research",), rationale_id="R-FEEDBACK-SIGNAL"),
+    CollisionDeclaration(identity="디스코드", owners=("automation-blueprint", "gateway-intent-card",), rationale_id="R-CHAT-GATEWAY"),
+    CollisionDeclaration(identity="레이아웃 깨짐", owners=("frontend", "visual-qa",), rationale_id="R-LAYOUT-DEFECT-INTAKE"),
+    CollisionDeclaration(identity="서브에이전트", owners=("agent-board", "executor-runtime-readiness",), rationale_id="R-SUBAGENT-VIEW"),
+    CollisionDeclaration(identity="슬랙", owners=("automation-blueprint", "gateway-intent-card",), rationale_id="R-CHAT-GATEWAY"),
+    CollisionDeclaration(identity="장기 목표", owners=("loop", "ultragoal",), rationale_id="R-LONG-HORIZON-GOAL"),
+    CollisionDeclaration(identity="접근성", owners=("frontend", "voice-operator",), rationale_id="R-ACCESSIBILITY-SURFACE"),
+    CollisionDeclaration(identity="조용히", owners=("automation-blueprint", "gateway-intent-card",), rationale_id="R-CHAT-GATEWAY"),
+    CollisionDeclaration(identity="출시 준비", owners=("cto-loop", "production-audit",), rationale_id="R-RELEASE-READINESS"),
+    CollisionDeclaration(identity="텔레그램", owners=("automation-blueprint", "gateway-intent-card",), rationale_id="R-CHAT-GATEWAY"),
+)

--- a/src/skills/trigger_review.py
+++ b/src/skills/trigger_review.py
@@ -15,6 +15,8 @@ group's sharing has never been reviewed at all.
 
 from __future__ import annotations
 
+from collections import Counter
+
 from ..routing.localization import normalized_phrase
 from .catalog import SkillDefinition, builtin_definitions
 from .trigger_collisions import INTENTIONAL_COLLISIONS, CollisionDeclaration
@@ -99,11 +101,18 @@ def validate_collision_declarations(
     *,
     declarations: tuple[CollisionDeclaration, ...] | None = None,
 ) -> dict[str, object]:
-    """Fail closed when a collision group's sharing has not been reviewed.
+    """Fail closed unless every group's declared owners equal its observed owners.
 
-    Three states fail, each naming the exact edit that resolves it:
-    an undeclared group, a declaration whose group no longer collides (stale),
-    and a group whose owner set grew past what was approved.
+    The comparison runs in both directions, because either mismatch hides an
+    unreviewed collision. An owner observed but not declared is sharing nobody
+    approved. An owner declared but not observed is a pre-approval: it signs off
+    on a group that does not exist yet, so when that owner really does join, the
+    declaration already covers it and no review is ever triggered.
+
+    Failing states, each naming the exact edit that resolves it: an undeclared
+    group, a declaration whose group no longer collides (stale), a group whose
+    owner set grew past what was approved, a declaration naming an owner the
+    catalog does not share, and two declarations for one identity.
     """
     approved = _declarations(declarations)
     observed = {
@@ -113,6 +122,14 @@ def validate_collision_declarations(
     declared_by_identity = {declaration.identity: declaration for declaration in approved}
     errors: list[str] = []
 
+    counted = Counter(declaration.identity for declaration in approved)
+    for identity in sorted(identity for identity, count in counted.items() if count > 1):
+        errors.append(
+            f"duplicate trigger collision declaration {identity!r}: one identity is reviewed once, "
+            f"so merge its {counted[identity]} entries into a single CollisionDeclaration "
+            f"in INTENTIONAL_COLLISIONS"
+        )
+
     for identity in sorted(observed):
         declaration = declared_by_identity.get(identity)
         if declaration is None:
@@ -121,11 +138,20 @@ def validate_collision_declarations(
                 f"{', '.join(observed[identity])}: {_DECLARATION_HINT}"
             )
             continue
+        approved_owners = ", ".join(sorted(set(declaration.owners)))
         expanded = sorted(set(observed[identity]) - set(declaration.owners))
         if expanded:
             errors.append(
                 f"owner-expanded trigger collision {identity!r} adds {', '.join(expanded)} "
-                f"beyond the approved owners {', '.join(sorted(declaration.owners))}: {_DECLARATION_HINT}"
+                f"beyond the approved owners {approved_owners}: {_DECLARATION_HINT}"
+            )
+        phantom = sorted(set(declaration.owners) - set(observed[identity]))
+        if phantom:
+            errors.append(
+                f"unobserved owner in trigger collision declaration {identity!r}: "
+                f"{', '.join(phantom)} does not share this identity, so approving "
+                f"{approved_owners} pre-approves sharing nobody reviewed; narrow its owners to "
+                f"{', '.join(observed[identity])} in INTENTIONAL_COLLISIONS"
             )
 
     for identity in sorted(declared_by_identity):

--- a/src/skills/trigger_review.py
+++ b/src/skills/trigger_review.py
@@ -1,0 +1,205 @@
+"""Deterministic, offline review surface for picker trigger loss and collisions.
+
+Two things about routing triggers were previously invisible. First, a trigger
+defined in the catalog does not always reach the picker frontmatter: it may be
+unsafe as an unquoted YAML scalar, duplicate an alias, or fall past the
+description budget. Second, several triggers normalize onto the same identity
+across skills, and some of that sharing is deliberate while some is accidental.
+
+This module reports both from the existing catalog. It adds no second catalog,
+rewrites no trigger, changes no routing behavior, and emits no score, grade, or
+badge. A collision is NOT presented as a defect; the report exposes the group
+and its declared ownership so a human can judge, and the gate only fails when a
+group's sharing has never been reviewed at all.
+"""
+
+from __future__ import annotations
+
+from ..routing.localization import normalized_phrase
+from .catalog import SkillDefinition, builtin_definitions
+from .trigger_collisions import INTENTIONAL_COLLISIONS, CollisionDeclaration
+from .render import (
+    BUDGET_OVERFLOW,
+    DUPLICATE_OF_ALIAS,
+    ROUTER_CARVE_OUT,
+    UNSAFE_FOR_FRONTMATTER,
+    frontmatter_trigger_emission,
+)
+
+TRIGGER_REVIEW_SCHEMA_VERSION = "skill_trigger_review/v1"
+
+# Closed reason set. `frontmatter_trigger_emission()` is the only producer, so a
+# reason outside this tuple means the emission rule grew a case the review
+# surface has not been taught to explain.
+OMISSION_REASONS: tuple[str, ...] = (
+    ROUTER_CARVE_OUT,
+    UNSAFE_FOR_FRONTMATTER,
+    DUPLICATE_OF_ALIAS,
+    BUDGET_OVERFLOW,
+)
+
+DECLARED = "declared"
+UNDECLARED = "undeclared"
+COLLISION_STATUS_VALUES: tuple[str, ...] = (DECLARED, UNDECLARED)
+
+_DECLARATION_HINT = (
+    "add a CollisionDeclaration(identity=..., owners=(...), rationale_id=...) entry to "
+    "INTENTIONAL_COLLISIONS in src/skills/trigger_collisions.py"
+)
+
+
+def trigger_omissions(definitions: list[SkillDefinition] | None = None) -> list[dict[str, str]]:
+    """List every catalog-defined trigger that never reached picker frontmatter."""
+    entries: list[dict[str, str]] = []
+    for definition in _definitions(definitions):
+        _, omitted = frontmatter_trigger_emission(definition)
+        for trigger, reason in omitted:
+            entries.append({"skill": definition.name, "trigger": trigger, "reason": reason})
+    return entries
+
+
+def collision_owner_map(definitions: list[SkillDefinition] | None = None) -> dict[str, list[tuple[str, str, str]]]:
+    """Map each shared normalized identity to its sorted `(skill, source, phrase)` owners.
+
+    Aliases participate because the picker reads them from the same description
+    line: an alias colliding with another skill's trigger is the same review
+    question as two triggers colliding. This is the one place ownership is
+    derived, so the report and the gate can never disagree about who owns a
+    group.
+    """
+    owners_by_identity: dict[str, set[tuple[str, str, str]]] = {}
+    for definition in _definitions(definitions):
+        for phrase in definition.triggers:
+            _record_owner(owners_by_identity, phrase, definition.name, "trigger")
+        for phrase in definition.aliases:
+            _record_owner(owners_by_identity, phrase, definition.name, "alias")
+
+    return {
+        identity: sorted(owners)
+        for identity, owners in sorted(owners_by_identity.items())
+        if len({owner[0] for owner in owners}) > 1
+    }
+
+
+def collision_groups(definitions: list[SkillDefinition] | None = None) -> list[dict[str, object]]:
+    """Render the shared-identity map as the report's collision-group rows."""
+    return [
+        {
+            "identity": identity,
+            "owners": [
+                {"skill": skill, "source": source, "phrase": phrase} for skill, source, phrase in owners
+            ],
+        }
+        for identity, owners in collision_owner_map(definitions).items()
+    ]
+
+
+def validate_collision_declarations(
+    definitions: list[SkillDefinition] | None = None,
+    *,
+    declarations: tuple[CollisionDeclaration, ...] | None = None,
+) -> dict[str, object]:
+    """Fail closed when a collision group's sharing has not been reviewed.
+
+    Three states fail, each naming the exact edit that resolves it:
+    an undeclared group, a declaration whose group no longer collides (stale),
+    and a group whose owner set grew past what was approved.
+    """
+    approved = _declarations(declarations)
+    observed = {
+        identity: sorted({owner[0] for owner in owners})
+        for identity, owners in collision_owner_map(definitions).items()
+    }
+    declared_by_identity = {declaration.identity: declaration for declaration in approved}
+    errors: list[str] = []
+
+    for identity in sorted(observed):
+        declaration = declared_by_identity.get(identity)
+        if declaration is None:
+            errors.append(
+                f"undeclared trigger collision {identity!r} shared by "
+                f"{', '.join(observed[identity])}: {_DECLARATION_HINT}"
+            )
+            continue
+        expanded = sorted(set(observed[identity]) - set(declaration.owners))
+        if expanded:
+            errors.append(
+                f"owner-expanded trigger collision {identity!r} adds {', '.join(expanded)} "
+                f"beyond the approved owners {', '.join(sorted(declaration.owners))}: {_DECLARATION_HINT}"
+            )
+
+    for identity in sorted(declared_by_identity):
+        if identity not in observed:
+            errors.append(
+                f"stale trigger collision declaration {identity!r}: the catalog no longer shares "
+                f"this identity, so remove its entry from INTENTIONAL_COLLISIONS"
+            )
+
+    return {"ok": not errors, "errors": errors}
+
+
+def skill_trigger_review_payload(definitions: list[SkillDefinition] | None = None) -> dict[str, object]:
+    """Build the full `skill_trigger_review/v1` payload.
+
+    Deterministic and offline: catalog order for skills, normalized-identity
+    order for collisions, and no timestamps, hostnames, or environment reads.
+    """
+    resolved = _definitions(definitions)
+    declared_by_identity = {declaration.identity: declaration for declaration in _declarations(None)}
+
+    skills: list[dict[str, object]] = []
+    for definition in resolved:
+        emitted, omitted = frontmatter_trigger_emission(definition)
+        skills.append(
+            {
+                "skill": definition.name,
+                "defined_triggers": list(definition.triggers),
+                "aliases": list(definition.aliases),
+                "emitted_triggers": emitted,
+                "omitted_triggers": [{"trigger": trigger, "reason": reason} for trigger, reason in omitted],
+            }
+        )
+
+    collisions: list[dict[str, object]] = []
+    for group in collision_groups(resolved):
+        declaration = declared_by_identity.get(str(group["identity"]))
+        entry = dict(group)
+        entry["status"] = DECLARED if declaration is not None else UNDECLARED
+        entry["rationale_id"] = declaration.rationale_id if declaration is not None else ""
+        collisions.append(entry)
+
+    return {
+        "schema_version": TRIGGER_REVIEW_SCHEMA_VERSION,
+        "review_boundary": (
+            "A shared trigger is not asserted to be a defect. This report shows which defined "
+            "triggers reached the picker description and which normalized identities are shared, "
+            "so a maintainer can decide; judgment is reserved to the reviewer."
+        ),
+        "omission_reasons": list(OMISSION_REASONS),
+        "skills": skills,
+        "omissions": trigger_omissions(resolved),
+        "collisions": collisions,
+        "declaration_gate": validate_collision_declarations(resolved),
+    }
+
+
+def _record_owner(
+    owners_by_identity: dict[str, set[tuple[str, str, str]]],
+    phrase: str,
+    skill: str,
+    source: str,
+) -> None:
+    identity = normalized_phrase(phrase)
+    if not identity:
+        return
+    owners_by_identity.setdefault(identity, set()).add((skill, source, phrase))
+
+
+def _definitions(definitions: list[SkillDefinition] | None) -> list[SkillDefinition]:
+    return builtin_definitions() if definitions is None else list(definitions)
+
+
+def _declarations(
+    declarations: tuple[CollisionDeclaration, ...] | None,
+) -> tuple[CollisionDeclaration, ...]:
+    return INTENTIONAL_COLLISIONS if declarations is None else declarations

--- a/src/skills/validation.py
+++ b/src/skills/validation.py
@@ -41,6 +41,7 @@ def validate_catalog_contract() -> dict[str, object]:
         errors.extend(_validate_harness_quality_payload(quality, f"harness {harness.name} harness_quality"))
         errors.extend(_validate_harness_quality_matches_definition(quality, harness))
     errors.extend(_validate_named_harness_gates({harness.name: harness for harness in harnesses}))
+    errors.extend(_collision_declaration_errors(definitions))
 
     return {
         "schema_version": CATALOG_VALIDATION_SCHEMA_VERSION,
@@ -49,6 +50,20 @@ def validate_catalog_contract() -> dict[str, object]:
         "errors": errors,
         "warnings": warnings,
     }
+
+
+def _collision_declaration_errors(definitions: list[SkillDefinition]) -> list[str]:
+    """Fail the catalog gate when a normalized trigger collision is unreviewed.
+
+    Sharing a trigger is not treated as a defect; only shipping one that no
+    maintainer has judged is.
+    """
+    from .trigger_review import validate_collision_declarations
+
+    result = validate_collision_declarations(definitions)
+    errors = result["errors"]
+    assert isinstance(errors, list)
+    return [str(error) for error in errors]
 
 
 def validate_skill_definition_contract(definition: SkillDefinition) -> list[str]:

--- a/tests/test_skill_trigger_review.py
+++ b/tests/test_skill_trigger_review.py
@@ -157,7 +157,7 @@ class CollisionOwnershipTests(unittest.TestCase):
 
 
 class CollisionGateTests(unittest.TestCase):
-    """The gate fails closed on undeclared, stale, and owner-expanded entries."""
+    """The gate fails closed unless declared owners equal observed owners exactly."""
 
     def _fixture_definitions(self) -> list[SkillDefinition]:
         return [
@@ -206,6 +206,66 @@ class CollisionGateTests(unittest.TestCase):
         self.assertFalse(result["ok"])
         message = "\n".join(result["errors"])
         self.assertIn("fixture-three", message)
+
+    def test_declaration_naming_an_unobserved_owner_fails(self) -> None:
+        """Given a declaration approving an owner the catalog does not share,
+        When the gate runs, Then it fails and names the phantom owner.
+
+        A superset declaration is a pre-approval: it signs off on sharing that
+        no maintainer has actually reviewed, because the group it describes has
+        never existed.
+        """
+        result = validate_collision_declarations(
+            self._fixture_definitions(),
+            declarations=(self._declaration(("fixture-one", "fixture-two", "fixture-future")),),
+        )
+        self.assertFalse(result["ok"])
+        message = "\n".join(result["errors"])
+        self.assertIn("fixture-future", message)
+        self.assertIn(normalized_phrase("shared phrase"), message)
+        self.assertIn("INTENTIONAL_COLLISIONS", message)
+
+    def test_phantom_owner_cannot_pre_approve_a_future_expansion(self) -> None:
+        """Given one superset declaration, When the catalog is evaluated before and
+        after the phantom owner really joins, Then the gate's verdict differs.
+
+        This is the whole fail-closed claim. A gate that only compares observed
+        against declared in one direction accepts the superset in BOTH states,
+        so the expansion lands already approved and no review is ever triggered.
+        """
+        pre_expansion = self._fixture_definitions()
+        expanded = self._fixture_definitions()
+        expanded.append(_definition("fixture-future", triggers=("shared phrase",)))
+        superset = self._declaration(("fixture-one", "fixture-two", "fixture-future"))
+
+        before = validate_collision_declarations(pre_expansion, declarations=(superset,))
+        after = validate_collision_declarations(expanded, declarations=(superset,))
+
+        self.assertFalse(before["ok"], "a superset declaration must be rejected while its owner is unobserved")
+        self.assertTrue(after["ok"], after["errors"])
+        self.assertNotEqual(
+            before["ok"],
+            after["ok"],
+            "the gate must distinguish the two catalog states; one accepting both pre-approves the expansion",
+        )
+
+    def test_duplicate_declaration_identities_are_rejected(self) -> None:
+        """Given two declarations for one identity, When the gate runs, Then it fails.
+
+        Silently collapsing duplicates lets a second entry with different owners
+        or a different rationale shadow the reviewed one.
+        """
+        result = validate_collision_declarations(
+            self._fixture_definitions(),
+            declarations=(
+                self._declaration(("fixture-one", "fixture-two")),
+                self._declaration(("fixture-one", "fixture-two")),
+            ),
+        )
+        self.assertFalse(result["ok"])
+        message = "\n".join(result["errors"])
+        self.assertIn("duplicate", message.lower())
+        self.assertIn(normalized_phrase("shared phrase"), message)
 
     def test_declaration_stores_only_identity_owners_and_rationale(self) -> None:
         fields = set(CollisionDeclaration.__dataclass_fields__)

--- a/tests/test_skill_trigger_review.py
+++ b/tests/test_skill_trigger_review.py
@@ -1,0 +1,235 @@
+"""Contract tests for the deterministic trigger loss + collision ownership report.
+
+The report exists so a maintainer can see which catalog-defined triggers never
+reached picker frontmatter and why, and can review which normalized trigger
+overlaps are intentionally shared. A collision is not asserted to be a defect
+here; only the review surface and its fail-closed declaration gate are.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.routing.localization import normalized_phrase
+from omh.skills.catalog import builtin_definitions
+from omh.skills.catalog_types import SkillDefinition
+from omh.skills.trigger_review import (
+    COLLISION_STATUS_VALUES,
+    OMISSION_REASONS,
+    TRIGGER_REVIEW_SCHEMA_VERSION,
+    CollisionDeclaration,
+    collision_groups,
+    skill_trigger_review_payload,
+    trigger_omissions,
+    validate_collision_declarations,
+)
+
+
+def _definition(name: str, triggers: tuple[str, ...], aliases: tuple[str, ...] = ()) -> SkillDefinition:
+    return SkillDefinition(
+        name=name,
+        description=f"Fixture skill {name} used only by the trigger-review contract tests.",
+        triggers=triggers,
+        use_when=f"Fixture {name} routing surface.",
+        aliases=aliases,
+    )
+
+
+class TriggerOmissionReportTests(unittest.TestCase):
+    def test_payload_carries_the_versioned_schema(self) -> None:
+        payload = skill_trigger_review_payload()
+        self.assertEqual(payload["schema_version"], TRIGGER_REVIEW_SCHEMA_VERSION)
+        self.assertEqual(TRIGGER_REVIEW_SCHEMA_VERSION, "skill_trigger_review/v1")
+
+    def test_every_omission_carries_a_reason_from_the_closed_set(self) -> None:
+        payload = skill_trigger_review_payload()
+        omissions = payload["omissions"]
+        self.assertIsInstance(omissions, list)
+        self.assertTrue(omissions, "the shipped catalog omits triggers; the report must show them")
+        for entry in omissions:
+            self.assertIn(entry["reason"], OMISSION_REASONS)
+            self.assertIn("skill", entry)
+            self.assertIn("trigger", entry)
+
+    def test_budget_overflow_and_unsafe_and_alias_duplicates_are_distinguished(self) -> None:
+        definitions = [
+            _definition(
+                "fixture-overflow",
+                triggers=tuple(f"phrase {index}" for index in range(12)) + ("/sigil", "ulf"),
+                aliases=("ulf",),
+            )
+        ]
+        omissions = trigger_omissions(definitions)
+        by_trigger = {entry["trigger"]: entry["reason"] for entry in omissions}
+        self.assertEqual(by_trigger["/sigil"], "unsafe_for_frontmatter")
+        self.assertEqual(by_trigger["ulf"], "duplicate_of_alias")
+        self.assertEqual(by_trigger["phrase 11"], "budget_overflow")
+        self.assertNotIn("phrase 0", by_trigger)
+
+    def test_emitted_triggers_match_the_rendered_frontmatter_description(self) -> None:
+        from omh.skills.render import frontmatter_description
+
+        payload = skill_trigger_review_payload()
+        emitted = {entry["skill"]: entry["emitted_triggers"] for entry in payload["skills"]}
+        for definition in builtin_definitions():
+            description = frontmatter_description(definition)
+            for trigger in emitted[definition.name]:
+                self.assertIn(trigger, description)
+
+    def test_report_grades_nothing(self) -> None:
+        """No scoring vocabulary in the report's own structure.
+
+        Catalog trigger phrases are echoed verbatim and some legitimately
+        contain words like `badges`, so the assertion walks the payload's keys
+        and generated values rather than grepping the serialized blob.
+        """
+        banned = ("score", "grade", "badge", "rank", "percent", "severity")
+        payload = skill_trigger_review_payload()
+
+        def walk_keys(node: object) -> None:
+            if isinstance(node, dict):
+                for key, value in node.items():
+                    for word in banned:
+                        self.assertNotIn(word, key.casefold())
+                    walk_keys(value)
+            elif isinstance(node, list):
+                for item in node:
+                    walk_keys(item)
+
+        walk_keys(payload)
+        generated = " ".join(
+            [str(payload["review_boundary"]), *[str(reason) for reason in payload["omission_reasons"]]]
+        ).casefold()
+        for word in banned:
+            self.assertNotIn(word, generated)
+
+
+class CollisionOwnershipTests(unittest.TestCase):
+    def test_groups_key_on_the_shared_normalization_helper(self) -> None:
+        """Case and compatibility folding are the shared helper's, not a local copy."""
+        definitions = [
+            _definition("fixture-a", triggers=("Deploy Review",)),
+            _definition("fixture-b", triggers=("ｄeploy review",)),
+        ]
+        groups = collision_groups(definitions)
+        identities = {group["identity"] for group in groups}
+        self.assertEqual(identities, {normalized_phrase("Deploy Review")})
+
+    def test_identity_is_exactly_the_shared_helper_output(self) -> None:
+        """The report never re-normalizes; a phrase the helper keeps distinct stays distinct."""
+        definitions = [
+            _definition("fixture-a", triggers=("deploy  review",)),
+            _definition("fixture-b", triggers=("deploy review",)),
+        ]
+        self.assertEqual(collision_groups(definitions), [])
+
+    def test_aliases_participate_in_collision_ownership(self) -> None:
+        definitions = [
+            _definition("fixture-alias-owner", triggers=("standalone",), aliases=("shared-id",)),
+            _definition("fixture-trigger-owner", triggers=("shared-id",)),
+        ]
+        groups = collision_groups(definitions)
+        group = next(group for group in groups if group["identity"] == normalized_phrase("shared-id"))
+        sources = {(owner["skill"], owner["source"]) for owner in group["owners"]}
+        self.assertIn(("fixture-alias-owner", "alias"), sources)
+        self.assertIn(("fixture-trigger-owner", "trigger"), sources)
+
+    def test_single_owner_phrases_are_not_collisions(self) -> None:
+        definitions = [_definition("fixture-solo", triggers=("only here", "only here"))]
+        self.assertEqual(collision_groups(definitions), [])
+
+    def test_every_group_carries_a_declaration_status(self) -> None:
+        payload = skill_trigger_review_payload()
+        self.assertTrue(payload["collisions"])
+        for group in payload["collisions"]:
+            self.assertIn(group["status"], COLLISION_STATUS_VALUES)
+
+    def test_shipped_catalog_collisions_are_all_declared(self) -> None:
+        result = validate_collision_declarations()
+        self.assertEqual(result["errors"], [])
+        self.assertTrue(result["ok"])
+
+
+class CollisionGateTests(unittest.TestCase):
+    """The gate fails closed on undeclared, stale, and owner-expanded entries."""
+
+    def _fixture_definitions(self) -> list[SkillDefinition]:
+        return [
+            _definition("fixture-one", triggers=("shared phrase",)),
+            _definition("fixture-two", triggers=("Shared Phrase",)),
+        ]
+
+    def _declaration(self, owners: tuple[str, ...]) -> CollisionDeclaration:
+        return CollisionDeclaration(
+            identity=normalized_phrase("shared phrase"),
+            owners=owners,
+            rationale_id="R-FIXTURE",
+        )
+
+    def test_undeclared_collision_fails_with_paste_ready_instructions(self) -> None:
+        result = validate_collision_declarations(self._fixture_definitions(), declarations=())
+        self.assertFalse(result["ok"])
+        message = "\n".join(result["errors"])
+        self.assertIn(normalized_phrase("shared phrase"), message)
+        self.assertIn("CollisionDeclaration", message)
+        self.assertIn("rationale_id", message)
+
+    def test_declared_collision_passes(self) -> None:
+        result = validate_collision_declarations(
+            self._fixture_definitions(),
+            declarations=(self._declaration(("fixture-one", "fixture-two")),),
+        )
+        self.assertTrue(result["ok"], result["errors"])
+        self.assertEqual(result["errors"], [])
+
+    def test_stale_declaration_fails(self) -> None:
+        result = validate_collision_declarations(
+            [_definition("fixture-one", triggers=("shared phrase",))],
+            declarations=(self._declaration(("fixture-one", "fixture-two")),),
+        )
+        self.assertFalse(result["ok"])
+        self.assertIn("stale", "\n".join(result["errors"]))
+
+    def test_owner_expanded_collision_fails(self) -> None:
+        definitions = self._fixture_definitions()
+        definitions.append(_definition("fixture-three", triggers=("shared phrase",)))
+        result = validate_collision_declarations(
+            definitions,
+            declarations=(self._declaration(("fixture-one", "fixture-two")),),
+        )
+        self.assertFalse(result["ok"])
+        message = "\n".join(result["errors"])
+        self.assertIn("fixture-three", message)
+
+    def test_declaration_stores_only_identity_owners_and_rationale(self) -> None:
+        fields = set(CollisionDeclaration.__dataclass_fields__)
+        self.assertEqual(fields, {"identity", "owners", "rationale_id"})
+
+    def test_catalog_contract_fails_closed_on_undeclared_collisions(self) -> None:
+        from omh.skills import validation
+
+        report = validation.validate_catalog_contract()
+        self.assertTrue(report["ok"], report["errors"])
+
+
+class TriggerReviewCliTests(unittest.TestCase):
+    def test_command_emits_the_schema(self) -> None:
+        status, stdout, _ = run_cli(["docs", "skill-trigger-report", "--format", "json"])
+        self.assertEqual(status, 0)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["schema_version"], TRIGGER_REVIEW_SCHEMA_VERSION)
+
+    def test_two_runs_are_byte_identical(self) -> None:
+        _, first, _ = run_cli(["docs", "skill-trigger-report", "--format", "json"])
+        _, second, _ = run_cli(["docs", "skill-trigger-report", "--format", "json"])
+        self.assertEqual(first, second)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- Added deterministic `omh docs skill-trigger-report --format json` output using the versioned `skill_trigger_review/v1` schema.
- Reports every defined trigger omitted from generated frontmatter with a closed reason and every normalized collision group with its observed owners.
- Added source-controlled collision declarations and a fail-closed catalog gate.
- Tightened declarations after review so declared owners must equal observed owners exactly, duplicate identities fail, and phantom or future owner expansion cannot be pre-authorized.

### Why This Exists

Maintainers could not tell which picker triggers were silently omitted from generated frontmatter or whether normalized trigger sharing was intentional. That made routing fixes guesswork and allowed future collision growth to bypass review.

The new report makes trigger loss and ownership inspectable offline, while the exact-owner gate turns every new, stale, phantom, or expanded collision into an explicit review event.

Closes #1116.

### User / Operator Impact

- Maintainers can inspect trigger omissions and collision ownership with one deterministic local command.
- Every omission uses one of four closed reasons: `router_carve_out`, `unsafe_for_frontmatter`, `duplicate_of_alias`, or `budget_overflow`.
- A catalog edit that creates or expands a collision now fails with paste-ready declaration guidance.
- Reports contain no scores, grades, badges, or subjective ranking.
- Existing rendered skill frontmatter remains byte-identical.

### How It Works

- `src/skills/trigger_review.py` derives the versioned report from the existing catalog and renderer behavior.
- `src/skills/trigger_collisions.py` owns reviewed collision declarations.
- `src/skills/validation.py` compares the complete observed/declaration identity and owner sets, rejecting undeclared, stale, phantom, expanded, or duplicate states.
- `src/commands/docs.py` exposes the report as a maintainer command.
- Tests cover the seven-state declaration lifecycle, alias participation, deterministic output, fail-closed CLI behavior, and the exact-owner review fix.

### Files And Contracts Touched

- `src/commands/docs.py`
- `src/skills/render.py`
- `src/skills/trigger_collisions.py`
- `src/skills/trigger_review.py`
- `src/skills/validation.py`
- `tests/test_skill_trigger_review.py`

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

Check only commands that completed successfully. Leave non-applicable checks
unchecked and explain why under **Not Tested / Not Applicable**.

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: two real `skill-trigger-report` CLI runs plus clean/phantom/revert `harness validate`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: maintainer-only offline report and validation gate; no Hermes/TUI surface changed

### Observed Evidence

- Final branch is two logical commits on frozen delivery cut `f7ca9ca`.
- Full discovery: 7,295 tests passed with zero skips or expected failures.
- Targeted report/governance/router suites: 134 tests passed.
- Exact-owner review fix: 22/22 tests passed; reverting the fix fails exactly three named regressions; each guard was mutation-proven.
- Seven-state lifecycle result: undeclared FAIL, declared PASS, owner-expanded FAIL, stale FAIL, phantom FAIL, clean PASS, duplicate FAIL.
- Real `harness validate`: clean exit 0, injected phantom owner exit 1 naming `production-audit`, reverted tree exit 0.
- Two clean CLI subprocess runs were byte-identical with empty stderr.
- Shipped catalog: 36 observed collision groups equal 36 reviewed declarations.
- Render identity: all 107 generated skill frontmatter projections remained byte-identical.
- All five docs checks, Ruff, compileall, generated-drift, and diff checks passed.
- Basedpyright comparison remained 18 base errors to 18 branch errors on existing files, with zero errors in new modules.
- Independent implementation verification and all five review-work lanes passed after the exact-owner correction.

### Not Tested / Not Applicable

- Release smoke, live Hermes, and TUI checks do not exercise this offline maintainer report.
- No network-backed integration is involved; both report and gate are deterministic local computations.
- CI is not claimed here; checks will run on the opened pull request.

## Risk

Moderate but intentional. The fail-closed gate will reject future catalog edits that change collision ownership until maintainers review and update the exact declaration. This is the capability, not a compatibility fallback. Report generation is linear in the local catalog and introduces no network or subprocess behavior inside core OMH.

## Compatibility / Rollout

- Existing skill rendering is unchanged byte-for-byte.
- The command and declaration source are additive.
- Future collision changes must be reviewed explicitly; no historical runtime data or persisted user state is migrated.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- No required follow-up for the complete #1116 capability. Additional alias-mutation ergonomics may be considered separately without weakening the exact-owner gate shipped here.
