### PR TITLE
feat(hud): yolo mode indicator on the [OMH] status line

### DIFF
--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -320,6 +320,23 @@ export default function register(sdk) {
         h(Text, { color: t.color.border }, SEPARATOR),
         h(Text, { color: active ? t.color.warn : t.color.ok }, hudStateLabel(active, agents)),
         h(Text, { color: t.color.muted }, `${metrics.cost ? ` • ${metrics.cost}` : ''} • ${metrics.ctx}`),
+        // Shift+Tab yolo state, as last observed by the plugin's turn and
+        // tool-call hooks (the host keeps the flag in process memory only).
+        // ON warns in the theme's yellow; OFF rests in the label blue —
+        // colours resolve through the active theme, never literals. An
+        // unobserved or stale ledger renders nothing rather than a guess.
+        payload.yolo && payload.yolo.status === 'observed'
+          ? h(
+              Text,
+              {},
+              h(Text, { color: t.color.muted }, ' • yolo mode: '),
+              h(
+                Text,
+                { bold: true, color: payload.yolo.enabled ? t.color.warn : t.color.label },
+                payload.yolo.enabled ? 'on' : 'off',
+              ),
+            )
+          : null,
       ),
       mainRows.length || rows.length
         ? ([...mainRows, ...rows].some(row => !row.state || row.state === 'running')

--- a/src/plugin_bundle/omh/approval_bypass.py
+++ b/src/plugin_bundle/omh/approval_bypass.py
@@ -1,0 +1,103 @@
+"""Effective approval-bypass (yolo) observation for the HUD.
+
+The Shift+Tab yolo toggle lives only in the host process's
+``tools.approval`` session state — nothing on disk records it — so the
+HUD can only report what the plugin's hooks observe in-process. Both
+``pre_llm_call`` (fires at each turn start, so a toggle shows up on the
+user's next message) and ``pre_tool_call`` tick this ledger with the same
+effective-bypass answer the host's own status surfaces report: global
+``approvals.mode=off``, the process-scoped ``--yolo`` env, or the
+per-session Shift+Tab flag, ORed together. Only the boolean and its
+timestamp are recorded — never a session key, command, or prompt.
+"""
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Reuse the awareness ledger's portable lock and atomic-write primitives so
+# there is exactly one file-locking implementation in the plugin.
+from .awareness_delivery import _awareness_delivery_lock, _write_delivery_record
+
+APPROVAL_BYPASS_SCHEMA_VERSION = "omh_approval_bypass/v1"
+APPROVAL_BYPASS_FILE = "approval-bypass.json"
+# A hook-observed flag outlives the turn that observed it, but not forever:
+# after a host restart the per-session flag resets to off in a fresh
+# process, and nothing re-observes until the next turn. Six hours bounds
+# how long a pre-restart observation can keep claiming a state no process
+# holds any more.
+APPROVAL_BYPASS_FRESH_SECONDS = 6 * 3600.0
+APPROVAL_BYPASS_CLAIM_BOUNDARY = (
+    "Hook-observed effective approval-bypass state; it can lag Shift+Tab "
+    "toggles and host restarts until the next turn or tool call, and is "
+    "never approval, execution, or safety evidence."
+)
+
+
+def _runtime_dir(omh_home: str = "") -> Path:
+    root = Path(omh_home).expanduser() if omh_home else Path.home() / ".omh"
+    return root / "runtime"
+
+
+def approval_bypass_path(omh_home: str = "") -> Path:
+    return _runtime_dir(omh_home) / APPROVAL_BYPASS_FILE
+
+
+def record_approval_bypass(*, omh_home: str = "", now: float | None = None) -> None:
+    """Record the current effective bypass state. Best-effort: losing an
+    observation is acceptable, breaking the hook that feeds the model is not."""
+    try:
+        from tools.approval import is_approval_bypass_active
+
+        enabled = bool(is_approval_bypass_active())
+    except Exception:
+        # No host approval surface in this process (unit tests, a stripped
+        # embed, an older Hermes): there is nothing true to record, and the
+        # ledger keeps whatever was last observed rather than a guess.
+        return
+    tick = float(now if now is not None else time.time())
+    path = approval_bypass_path(omh_home)
+    record = {
+        "schema_version": APPROVAL_BYPASS_SCHEMA_VERSION,
+        "enabled": enabled,
+        "observed_ts": tick,
+        "claim_boundary": APPROVAL_BYPASS_CLAIM_BOUNDARY,
+    }
+    try:
+        with _awareness_delivery_lock(path):
+            _write_delivery_record(path, record)
+    except (OSError, ValueError, TypeError):
+        return
+
+
+def latest_approval_bypass(omh_home: str = "", *, now: float | None = None) -> dict[str, Any]:
+    """Project the last observed bypass state, or an idle marker."""
+    import json
+
+    current = float(now if now is not None else time.time())
+    idle: dict[str, Any] = {"status": "idle"}
+    try:
+        record = json.loads(approval_bypass_path(omh_home).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return idle
+    if not isinstance(record, dict):
+        return idle
+    tick = record.get("observed_ts")
+    enabled = record.get("enabled")
+    if not isinstance(tick, (int, float)) or isinstance(tick, bool) or not isinstance(enabled, bool):
+        return idle
+    if current - float(tick) > APPROVAL_BYPASS_FRESH_SECONDS:
+        return idle
+    observed_at = (
+        datetime.fromtimestamp(float(tick), tz=timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+    return {
+        "status": "observed",
+        "enabled": enabled,
+        "observed_at": observed_at,
+        "claim_boundary": APPROVAL_BYPASS_CLAIM_BOUNDARY,
+    }

--- a/src/plugin_bundle/omh/hooks/llm_hooks.py
+++ b/src/plugin_bundle/omh/hooks/llm_hooks.py
@@ -18,6 +18,7 @@ from ..degradation import (
     degradation_payload,
     safe_error_type,
 )
+from ..approval_bypass import record_approval_bypass
 from ..awareness_delivery import claim_route_guidance_delivery, record_awareness_delivery
 from ..host_context import record_active_main_agent_model
 from ..host_observation import observe_plugin_hook_call
@@ -71,6 +72,10 @@ def pre_llm_call(**kwargs) -> dict[str, object] | None:
     """Inject bounded OMH role/status context without storing prompts."""
     record_active_main_agent_model(kwargs.get("model"))
     observe_plugin_hook_call("pre_llm_call", kwargs)
+    # Turn start is the freshest in-process view of the Shift+Tab yolo flag:
+    # a toggle shows on the HUD at the user's next message, not only at the
+    # next tool call.
+    record_approval_bypass(omh_home=str(kwargs.get("omh_home", "") or ""))
     context_parts: list[str] = []
     payload: dict[str, object] = {}
     user_message = str(kwargs.get("user_message", "") or "")

--- a/src/plugin_bundle/omh/hooks/tool_hooks.py
+++ b/src/plugin_bundle/omh/hooks/tool_hooks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 
+from ..approval_bypass import record_approval_bypass
 from ..host_observation import observe_plugin_hook_call
 from ..omh_roles import extract_role_marker, resolve_role_name, role_aliases, role_names
 from ..tool_bursts import record_tool_call
@@ -11,6 +12,10 @@ from ..toolcall_rules import toolcall_rule_directive
 def pre_tool_call(**kwargs) -> dict[str, object] | None:
     """Return only host-supported pre-tool directives or role warnings."""
     observe_plugin_hook_call("pre_tool_call", kwargs)
+    # The approval-bypass ledger observes session state, not this call's
+    # outcome, so it ticks before the rule gate — a blocked call still sees
+    # the same Shift+Tab flag.
+    record_approval_bypass(omh_home=str(kwargs.get("omh_home", "") or ""))
     # User-authored toolcall rules intervene first: a block directive is the
     # strongest host-supported response (hermes_cli/plugins.py,
     # `_get_pre_tool_call_directive_details`: "``block`` vetoes the tool call

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -11,6 +11,7 @@ from functools import partial
 from pathlib import Path
 from typing import Any, Callable
 
+from .approval_bypass import latest_approval_bypass
 from .hermes_delegation import read_hermes_native_subagents
 from .tool_bursts import latest_parallel_shot
 from .metadata import (
@@ -651,6 +652,10 @@ def read_omh_hud(
         # Concurrent tool-call batches observed by the pre_tool_call hook;
         # the [OMH] status line brands a fresh batch as a parallel shot.
         "parallel_shot": latest_parallel_shot(str(home)),
+        # Effective approval-bypass (yolo) state observed by the pre_llm_call
+        # and pre_tool_call hooks; the [OMH] status line renders it as
+        # "yolo mode: on/off".
+        "yolo": latest_approval_bypass(str(home)),
         "evidence_boundary": (
             "HUD is metadata-only. Prepared handoffs are not execution, review, CI, merge, or token-usage evidence. "
             "Todo items are plan declarations, not execution evidence."

--- a/tests/test_approval_bypass.py
+++ b/tests/test_approval_bypass.py
@@ -1,0 +1,117 @@
+"""Contracts for effective approval-bypass (yolo) observation.
+
+The Shift+Tab yolo toggle lives only in the host process's
+``tools.approval`` session state, so the HUD reports what the plugin's
+``pre_llm_call`` and ``pre_tool_call`` hooks last observed in-process.
+The ledger stores one boolean and a timestamp — never a session key,
+command, or prompt — and an unobserved or stale ledger projects idle so
+the widget renders nothing rather than a guess.
+"""
+
+import sys
+import tempfile
+import time
+import types
+import unittest
+from pathlib import Path
+
+from omh.plugin_bundle.omh.approval_bypass import (
+    APPROVAL_BYPASS_FRESH_SECONDS,
+    approval_bypass_path,
+    latest_approval_bypass,
+    record_approval_bypass,
+)
+from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+NOW = 1_787_040_000.0
+
+
+class ApprovalBypassLedgerTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.home = str(Path(self._tmp.name) / "omh")
+
+    def _install_host_approval(self, enabled: bool) -> None:
+        previous = {name: sys.modules.get(name) for name in ("tools", "tools.approval")}
+
+        def restore():
+            for name, module in previous.items():
+                if module is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = module
+
+        self.addCleanup(restore)
+        tools_module = types.ModuleType("tools")
+        approval_module = types.ModuleType("tools.approval")
+        approval_module.is_approval_bypass_active = lambda: enabled
+        tools_module.approval = approval_module
+        sys.modules["tools"] = tools_module
+        sys.modules["tools.approval"] = approval_module
+
+    def test_an_enabled_observation_projects_on(self):
+        self._install_host_approval(True)
+        record_approval_bypass(omh_home=self.home, now=NOW)
+        state = latest_approval_bypass(self.home, now=NOW + 5)
+        self.assertEqual(state["status"], "observed")
+        self.assertTrue(state["enabled"])
+        self.assertIn("never approval", state["claim_boundary"])
+
+    def test_a_disabled_observation_projects_off(self):
+        self._install_host_approval(False)
+        record_approval_bypass(omh_home=self.home, now=NOW)
+        state = latest_approval_bypass(self.home, now=NOW + 5)
+        self.assertEqual(state["status"], "observed")
+        self.assertFalse(state["enabled"])
+
+    def test_without_the_host_surface_nothing_is_recorded(self):
+        # No tools.approval in this process: the hook records nothing rather
+        # than a guess, and the projection stays idle.
+        record_approval_bypass(omh_home=self.home, now=NOW)
+        self.assertFalse(approval_bypass_path(self.home).exists())
+        self.assertEqual(latest_approval_bypass(self.home, now=NOW)["status"], "idle")
+
+    def test_a_stale_observation_expires_to_idle(self):
+        # A host restart resets the in-memory flag without any hook firing,
+        # so an old observation must stop claiming a state no process holds.
+        self._install_host_approval(True)
+        record_approval_bypass(omh_home=self.home, now=NOW)
+        fresh = latest_approval_bypass(self.home, now=NOW + APPROVAL_BYPASS_FRESH_SECONDS - 1)
+        self.assertEqual(fresh["status"], "observed")
+        stale = latest_approval_bypass(self.home, now=NOW + APPROVAL_BYPASS_FRESH_SECONDS + 1)
+        self.assertEqual(stale["status"], "idle")
+
+    def test_the_ledger_stores_metadata_only(self):
+        import json
+
+        self._install_host_approval(True)
+        record_approval_bypass(omh_home=self.home, now=NOW)
+        record = json.loads(approval_bypass_path(self.home).read_text(encoding="utf-8"))
+        self.assertEqual(
+            sorted(record), ["claim_boundary", "enabled", "observed_ts", "schema_version"]
+        )
+
+    def test_the_hud_payload_carries_the_state(self):
+        self._install_host_approval(True)
+        record_approval_bypass(omh_home=self.home, now=time.time())
+        hermes = str(Path(self._tmp.name) / "hermes")
+        payload = read_omh_hud(self.home, hermes)
+        self.assertEqual(payload["yolo"]["status"], "observed")
+        self.assertTrue(payload["yolo"]["enabled"])
+        self.assertEqual(payload["privacy"], "metadata_only")
+
+    def test_both_hooks_tick_the_ledger(self):
+        from omh.plugin_bundle.omh.hooks.llm_hooks import pre_llm_call
+        from omh.plugin_bundle.omh.hooks.tool_hooks import pre_tool_call
+
+        self._install_host_approval(True)
+        pre_tool_call(tool_name="terminal", omh_home=self.home)
+        self.assertTrue(approval_bypass_path(self.home).exists())
+        approval_bypass_path(self.home).unlink()
+        pre_llm_call(user_message="hello", omh_home=self.home, include_omh_awareness=False)
+        self.assertTrue(approval_bypass_path(self.home).exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_broad_exception_policy.py
+++ b/tests/test_broad_exception_policy.py
@@ -202,14 +202,23 @@ CLASSIFIED_SITES: tuple[ClassifiedSite, ...] = (
         "all unexpected failures, persist the interrupted or failed operation state and "
         "re-raise, so callers never read a crashed resume as a completed memory operation.",
     ),
+    ClassifiedSite(
+        "src/plugin_bundle/omh/approval_bypass.py",
+        "record_approval_bypass",
+        INTENTIONAL,
+        "Host-surface probe boundary: importing or calling tools.approval can fail in any "
+        "host-specific way (unit tests, a stripped embed, an older Hermes), and the hook that "
+        "feeds the model must never break for an optional HUD observation. The handler records "
+        "nothing, so an absent surface reads as an idle ledger, never as an observed state.",
+    ),
 )
 
 # Ruff reports one hit per handler; the inventory is keyed per enclosing
 # function. `_write_candidate_batch`, `_is_catalog_question`, `pre_llm_call`,
 # and `_resume_unlocked` each hold two handlers, so the handler count is four
 # above the anchor count.
-EXPECTED_HANDLER_COUNT = 20
-EXPECTED_ANCHOR_COUNT = 16
+EXPECTED_HANDLER_COUNT = 21
+EXPECTED_ANCHOR_COUNT = 17
 
 
 class DerivedSite(NamedTuple):

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -431,6 +431,12 @@ class TuiWidgetPackTests(unittest.TestCase):
         # 뜨면 의미가없지'). The bottom dock renders no parallel-shot text.
         self.assertIn("parallel shot ×", widget)
         self.assertIn("payload.parallel_shot", widget)
+        # Shift+Tab yolo state, as last hook-observed: ON warns in the
+        # theme's yellow, OFF rests in the label blue, and an unobserved or
+        # stale ledger renders nothing rather than a guessed "off".
+        self.assertIn("' • yolo mode: '", widget)
+        self.assertIn("payload.yolo && payload.yolo.status === 'observed'", widget)
+        self.assertIn("payload.yolo.enabled ? t.color.warn : t.color.label", widget)
         self.assertNotIn("• parallel shot", widget)
         self.assertIn("shot.status !== 'observed'", widget)
         self.assertIn("Math.min(3,", widget)


### PR DESCRIPTION
## Feature Report

### What Changed

- New plugin ledger `src/plugin_bundle/omh/approval_bypass.py`: the `pre_llm_call` and `pre_tool_call` hooks record the host's effective approval-bypass state (global `approvals.mode=off`, the `--yolo` env, or the per-session Shift+Tab flag, ORed together — the same answer the host's own status bar reports) into `$OMH_HOME/runtime/approval-bypass.json`. Only a boolean and a timestamp are stored.
- `read_omh_hud()` projects it as `payload.yolo` (`observed`/`idle`, six-hour freshness bound, claim boundary attached).
- The Modern-TUI widget renders `yolo mode: on` (theme warn — yellow in the omh skin) / `yolo mode: off` (theme label — blue) on the `⚚ [OMH]` status line. Unobserved or stale state renders nothing.

### Why This Exists

- The owner asked for the Hermes Shift+Tab yolo toggle to be visible on the OMH surface: whether tool calls are bypassing the approval gate is exactly the kind of session state the status line exists for.

### User / Operator Impact

- The `[OMH]` line now shows the effective yolo state, colored on=yellow / off=blue through theme tokens, updating at every turn start and tool call.

### How It Works

- The per-session yolo flag lives only in the host process's `tools.approval` memory — nothing on disk records it, and the widget SDK exposes no session info — so in-process hook observation is the only surface OMH can honestly read. Recording is best-effort and never breaks the hook on hosts without the approval surface (the broad handler is classified in the broad-except policy gate). A six-hour freshness bound stops a pre-restart observation from claiming a state no process holds; `pre_llm_call` observation means a toggle shows on the user's next message, not only at the next tool call.

### Files And Contracts Touched

- `src/plugin_bundle/omh/approval_bypass.py` (new), `src/plugin_bundle/omh/hooks/llm_hooks.py`, `src/plugin_bundle/omh/hooks/tool_hooks.py`, `src/plugin_bundle/omh/runtime_reader.py` (payload key `yolo`), `src/omh/tui_widgets/omh-status.mjs`, `tests/test_approval_bypass.py` (new), `tests/test_tui_widget_pack.py`, `tests/test_broad_exception_policy.py` (new classified site, handler/anchor counts 20→21 / 16→17).

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command: `node --check src/omh/tui_widgets/omh-status.mjs`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run in this environment; the segment is pinned by widget-pack contracts and will be observed on the owner machine after `omh update`.

### Observed Evidence

- Full suite: `Ran 7280 tests ... OK`, including the seven new `tests/test_approval_bypass.py` contracts (record/project, off state, no-host-surface no-record, staleness expiry, metadata-only ledger keys, HUD payload carry, both hooks tick).
- `node --check` on the widget passes; ruff, compileall, docs byte gates, `git diff --check` all pass.

### Not Tested / Not Applicable

- Release checklist/smoke and install-path smoke: no release, install-path, or catalog change in this PR.
- Live TUI render: no Hermes TUI in this environment.

## Risk

- The indicator can lag a Shift+Tab toggle until the next turn or tool call, and a host restart until the next observation — bounded by the six-hour expiry and stated in the claim boundary. It renders nothing rather than guessing.

## Compatibility / Rollout

- Additive: new runtime file, new payload key, new status-line segment. Older widgets ignore the new payload key; hosts without `tools.approval` record nothing. Reaches machines via `omh update`.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Move the `parallel shot ×N` badge from the composer frame rule to the `[Plan]` header line with a seconds-scale freshness window (owner direction, next PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CnQjUYKsqVxfMK8TW9Tmbi
