### PR TITLE
fix(tui): parallel shot rides the [Plan] header and fades in seconds

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -224,8 +224,9 @@ _Avoid_: assuming dock-bottom means above the input
 `omh-status.mjs`, the managed Modern-TUI widget file OMH installs into
 `$HERMES_HOME/tui-widgets/`. It registers two ambient apps that frame the
 composer like the classic REPL: a `dock-top` app renders the plan-todo
-checklist above the input, closed by the frame rule that also carries the
-`parallel shot ×N` badge, and a `dock-bottom` app opens with the frame rule
+checklist above the input — its `[Plan]` header carries the transient
+`parallel shot ×N` badge — closed by the frame rule above the composer,
+and a `dock-bottom` app opens with the frame rule
 below the input and renders the status HUD (header always visible when
 installed; activity rows only during live work).
 _Avoid_: statusline (that is a different, host-owned surface), HUD (the widget

--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -403,7 +403,7 @@ export default function register(sdk) {
     // above the input renders unconditionally so the composer frame never
     // blinks with the plan lifecycle.
     if (todo.status !== 'established' && todo.status !== 'all_done') {
-      return h(FrameRule, { columns, payload, t })
+      return h(Rule, { columns, t })
     }
     const counts = todo.counts || {}
     const title = safeText(todo.title)
@@ -420,8 +420,9 @@ export default function register(sdk) {
           title ? h(Text, { color: t.color.muted }, ` ${title}`) : null,
           h(Text, { color: t.color.border }, SEPARATOR),
           h(Text, { color: t.color.ok }, `✓ ${counts.done ?? 0}/${counts.total ?? 0}`),
+          planShotBadge(payload, t),
         ),
-        h(FrameRule, { columns, payload, t }),
+        h(Rule, { columns, t }),
       )
     }
     // The whole plan by default, bounded at seven visible item rows. Every
@@ -519,37 +520,29 @@ export default function register(sdk) {
         h(Text, { color: t.color.border }, SEPARATOR),
         h(Text, { color: t.color.warn }, `${counts.done ?? 0}/${counts.total ?? 0}`),
         phaseCount > 1 ? h(Text, { color: t.color.muted }, ` · ${phaseCount} phases`) : null,
+        planShotBadge(payload, t),
         hasActive ? h(PlanPulse, { t }) : null,
       ),
       ...rows,
-      h(FrameRule, { columns, payload, t }),
+      h(Rule, { columns, t }),
     )
   }
 
-  // The upper half of the composer frame — the todo panel's closing line.
-  // It also carries the parallel-shot badge: a fresh concurrent tool-call
-  // batch (observed by the pre_tool_call hook) reads meaningfully only near
-  // the transcript's collapsed "Tool calls (N)" group, and that group is
-  // host-owned rendering OMH cannot decorate — this rule in the top dock is
-  // the closest OMH-owned surface to it, and the badge sat unread down in
-  // the bottom dock ('하단에 뜨면 의미가없지'). Idle bursts render a plain
-  // rule, so the frame stays byte-stable outside the 90s freshness window.
-  function FrameRule({ columns, payload, t }) {
-    const width = Math.max(1, columns - 2)
-    const shot = payload.parallel_shot
-    if (!shot || shot.status !== 'observed') {
-      return h(Rule, { columns, t })
-    }
-    const label = ` parallel shot ×${Number(shot.size) || 0} `
-    const lead = 3
-    return h(
-      Text,
-      { wrap: 'truncate-end' },
-      h(Text, { color: t.color.border }, '─'.repeat(lead)),
-      h(Text, { color: t.color.label }, label),
-      h(Text, { color: t.color.border }, '─'.repeat(Math.max(1, width - lead - cellWidth(label)))),
-    )
-  }
+  // The parallel-shot badge rides the [Plan] header — the owner moved it
+  // here from the frame rule ('parallel shot을 지금 위치에 두지말고 여기
+  // 위치 옆에 뜨게'), the line sitting directly under the host status rule.
+  // A fresh concurrent tool-call batch (observed by the pre_tool_call hook)
+  // is the only thing it brands, and the reader's seconds-scale freshness
+  // window makes it vanish right after the batch lands instead of lingering
+  // as standing chrome.
+  const planShotBadge = (payload, t) =>
+    payload.parallel_shot && payload.parallel_shot.status === 'observed'
+      ? h(
+          Text,
+          { color: t.color.label },
+          ` · parallel shot ×${Number(payload.parallel_shot.size) || 0}`,
+        )
+      : null
 
   const sharedInit = () => ({ payload: null, receivedAt: 0, tick: 0 })
   const sharedReduce = (state, input) =>
@@ -558,8 +551,8 @@ export default function register(sdk) {
       : state
 
   // The todo panel reads above the input, where the owner always looked for
-  // it; the panel itself ends with the FrameRule that tops the composer
-  // frame, so the dock never renders taller than the plan plus one line.
+  // it; the panel itself ends with the rule that tops the composer frame,
+  // so the dock never renders taller than the plan plus one line.
   const todoApp = defineWidgetApp({
     id: 'omh-todo',
     help: 'OMH plan todo and the composer frame above the prompt input',

--- a/src/plugin_bundle/omh/tool_bursts.py
+++ b/src/plugin_bundle/omh/tool_bursts.py
@@ -30,8 +30,11 @@ MAX_TOOL_BURST_ENTRIES = 40
 # round-trip.
 BURST_WINDOW_SECONDS = 1.5
 # The HUD shows the latest burst only while it is recent enough to still
-# describe "what just happened".
-BURST_FRESH_SECONDS = 90.0
+# describe "what just happened". Seconds, not minutes, by owner direction
+# ('한 몇초만 지나면 바로없어지게'): the badge flags the batch as it lands
+# and vanishes right after, refreshed continuously through a busy wave by
+# the next batch's ticks.
+BURST_FRESH_SECONDS = 8.0
 TOOL_BURST_CLAIM_BOUNDARY = (
     "Burst grouping observes pre_tool_call start ticks only; it is evidence "
     "the host dispatched the calls as one batch, not proof every call "

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -247,8 +247,8 @@ class TuiWidgetPackTests(unittest.TestCase):
         # instead of the chat input ('채팅창에 선 두개가 있어야지 왜 tui에
         # 있어') and sank the plan the owner always read above the input
         # ('투두가 왜 하단에 떠 기존에는 상단에 잘 떴었는데'). The layout is
-        # now: plan todo in dock-top, closed by the FrameRule directly above
-        # the input; the bottom dock opens with the rule below the input and
+        # now: plan todo in dock-top, closed by the rule directly above the
+        # input; the bottom dock opens with the rule below the input and
         # carries status and activity rows with no closing rule.
         widget = resources.files("omh.tui_widgets").joinpath("omh-status.mjs").read_text(encoding="utf-8")
 
@@ -258,10 +258,10 @@ class TuiWidgetPackTests(unittest.TestCase):
         self.assertIn("id: 'omh-todo'", widget)
         self.assertIn("id: 'omh-status'", widget)
         # The todo panel renders only in the top dock, and every branch of it
-        # (no plan, all done, established) closes with the frame rule so the
-        # composer frame never blinks with the plan lifecycle.
+        # (no plan, all done, established) closes with the plain frame rule
+        # so the composer frame never blinks with the plan lifecycle.
         self.assertEqual(widget.count("h(TodoPanel"), 1)
-        self.assertEqual(widget.count("h(FrameRule, { columns, payload, t })"), 3)
+        self.assertNotIn("FrameRule", widget)
         # Both apps gate on the same payload validity, so neither half of the
         # frame renders on a host where the plugin does not answer.
         self.assertEqual(
@@ -295,13 +295,13 @@ class TuiWidgetPackTests(unittest.TestCase):
         # The Rule frame replaced the marginTop spacer: the docks carry the
         # classic composer frame, rules sitting tight against the input --
         # padding was tried at one and two rows and the owner picked none.
-        # Exactly two plain-rule renders remain (the dock-bottom opener and
-        # the frame app's idle fallback): the closing rules that used to
-        # follow the plan panel framed the OMH section instead of the input
-        # and were removed on owner direction.
+        # Exactly four plain-rule renders: the dock-bottom opener plus the
+        # three todo-panel closers (no plan, all done, established). The
+        # badge that briefly dressed the top rule moved to the [Plan] header,
+        # so every rule is plain, byte-stable chrome again.
         self.assertIn("const Rule = ", widget)
         self.assertNotIn("Gap", widget)
-        self.assertEqual(widget.count("h(Rule, { columns, t })"), 2)
+        self.assertEqual(widget.count("h(Rule, { columns, t })"), 4)
         # Text, not chrome — changed on purpose a second time, by owner
         # direction after living with the bordered card: the OMH surface reads
         # like the host's own status line, dense text in the TUI's idiom. The
@@ -425,12 +425,15 @@ class TuiWidgetPackTests(unittest.TestCase):
         self.assertNotIn("Number.MAX_SAFE_INTEGER", widget)
         # Changed on purpose: the parallel-shot badge moved off the bottom
         # status line onto the dock-top frame rule — the transcript's
-        # "Tool calls (N)" group is host-owned rendering OMH cannot decorate,
-        # and the rule directly under the newest transcript lines is the
-        # closest OMH-owned surface ('tool calling 옆에서 떠야지 하단에
-        # 뜨면 의미가없지'). The bottom dock renders no parallel-shot text.
+        # "Tool calls (N)" group is host-owned rendering OMH cannot decorate.
+        # Changed on purpose a second time: the badge now rides the [Plan]
+        # header — the owner's chosen spot, directly under the host status
+        # rule ('여기 위치 옆에 뜨게') — and the seconds-scale reader
+        # freshness makes it vanish right after the batch lands. The bottom
+        # dock and the frame rules render no parallel-shot text.
         self.assertIn("parallel shot ×", widget)
         self.assertIn("payload.parallel_shot", widget)
+        self.assertIn("planShotBadge(payload, t)", widget)
         # Shift+Tab yolo state, as last hook-observed: ON warns in the
         # theme's yellow, OFF rests in the label blue, and an unobserved or
         # stale ledger renders nothing rather than a guessed "off".
@@ -438,7 +441,6 @@ class TuiWidgetPackTests(unittest.TestCase):
         self.assertIn("payload.yolo && payload.yolo.status === 'observed'", widget)
         self.assertIn("payload.yolo.enabled ? t.color.warn : t.color.label", widget)
         self.assertNotIn("• parallel shot", widget)
-        self.assertIn("shot.status !== 'observed'", widget)
         self.assertIn("Math.min(3,", widget)
         self.assertNotIn("spinnerTimerKey", widget)
         self.assertIn("ActivityRow", widget)


### PR DESCRIPTION
## Feature Report

### What Changed

- The `parallel shot ×N` badge moved off the composer's top frame rule onto the `[Plan]` header line (both established and all-done headers), rendered as `· parallel shot ×N` in the header's own grammar.
- `BURST_FRESH_SECONDS` dropped 90 → 8, so the badge appears as a batch lands and vanishes seconds later; a busy wave keeps it alive through the next batch's ticks.
- The composer frame rules return to plain byte-stable chrome; the `FrameRule` variant is deleted. CONTEXT.md's widget entry follows.

### Why This Exists

- The owner moved the badge explicitly: woven into the frame rule it went unnoticed, and the 90-second lifetime made a momentary event read as standing chrome. The `[Plan]` header sits directly under the host status rule — the spot the owner pointed at.

### User / Operator Impact

- `[Plan] <title> │ 3/5 · 5 phases · parallel shot ×8` for a few seconds after each concurrent batch; plain header otherwise. Frame rules never carry text again.

### How It Works

- The reader already gates freshness (`latest_parallel_shot`); only the constant changed. Eight seconds guarantees at least two widget repaints at the 2-second poll cadence — anything under ~4s could vanish between paints. The badge helper renders nothing when the projection is idle.

### Files And Contracts Touched

- `src/plugin_bundle/omh/tool_bursts.py` (freshness constant), `src/omh/tui_widgets/omh-status.mjs` (badge placement, FrameRule removed), `tests/test_tui_widget_pack.py` (contracts updated same-commit), `CONTEXT.md`.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command: `node --check src/omh/tui_widgets/omh-status.mjs`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run in this environment; placement is pinned by widget-pack contracts and will be observed on the owner machine after `omh update`.

### Observed Evidence

- Full suite: `Ran 7280 tests ... OK` on the stacked tree; targeted widget/burst/preflight suites green after the contract rewrite; ruff, compileall, docs byte gates, `git diff --check` pass.

### Not Tested / Not Applicable

- Release checklist/smoke and install-path smoke: no release or install-path change.
- Live TUI render: no Hermes TUI in this environment.

## Risk

- An 8-second window means a batch that lands while the user looks away is simply gone — intended: the badge is an event flash, not a log. The transcript keeps no record (host-owned), and `tool-bursts.json` still holds the raw ticks.

## Compatibility / Rollout

- Constant + widget-only change; reaches machines via `omh update`. Older installed widgets keep rendering with the shorter reader freshness (their frame-rule badge just fades sooner).

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CnQjUYKsqVxfMK8TW9Tmbi
