### PR TITLE
feat(hud): open-plan reconciliation reminder binds completion claims

### DIFF
--- a/src/plugin_bundle/omh/hooks/llm_hooks.py
+++ b/src/plugin_bundle/omh/hooks/llm_hooks.py
@@ -24,6 +24,7 @@ from ..host_context import record_active_main_agent_model
 from ..host_observation import observe_plugin_hook_call
 from ..omh_roles import extract_role_marker, role_context_payload
 from ..runtime_reader import read_omh_activity, read_omh_hud, read_omh_status
+from ..todo_reconciliation import open_todo_reminder
 from ..status_board_reader import (
     last_running_work_board_fingerprint,
     read_running_work_board,
@@ -157,6 +158,14 @@ def pre_llm_call(**kwargs) -> dict[str, object] | None:
                 "[OMH Role Warning] "
                 f"Unknown role '{marker}'. Available roles: {', '.join(role_payload['available_roles']) or '(none)'}."
             )
+
+    # An open plan is a state, not a phrasing: while one exists, every turn
+    # carries the reconciliation line so a completion claim cannot part ways
+    # with the HUD checklist unnoticed. Honors the caller's awareness opt-out.
+    if include_awareness:
+        todo_reminder = open_todo_reminder(omh_home=str(kwargs.get("omh_home", "") or ""))
+        if todo_reminder:
+            context_parts.append(todo_reminder)
 
     omh_home: str | None = None
     try:

--- a/src/plugin_bundle/omh/todo_reconciliation.py
+++ b/src/plugin_bundle/omh/todo_reconciliation.py
@@ -1,0 +1,50 @@
+"""Per-turn reconciliation reminder for an open plan todo.
+
+A model that declares a plan (todo init) and then answers "all done" in
+chat while the checklist still shows open items leaves the HUD lying to
+the user ('작업 다됐다는데 투두는 이렇게 남아있네'). No keyword trigger
+can catch every phrasing of a completion claim, but an OPEN plan is a
+state, not a phrasing — so while one exists, every turn's context
+carries one compact line that binds completion claims to the checklist.
+The reminder is awareness (instruction), never state and never
+evidence; it stops the moment the plan is all done or cleared.
+"""
+from __future__ import annotations
+
+from .runtime_reader import read_omh_todo
+
+_MAX_ACTIVE_TEXT_CHARS = 80
+
+TODO_RECONCILIATION_RULE = (
+    "Before claiming this work is finished, reconcile the checklist with "
+    "omh_todo: mark completed items done, keep exactly one item active, and "
+    "either finish the remaining items or say which stay open and why. A "
+    "completion claim in chat while the HUD checklist shows open items is a "
+    "visible contradiction. Todo updates are declarations, never execution "
+    "evidence."
+)
+
+
+def open_todo_reminder(*, omh_home: str = "") -> str:
+    """One compact context line while an established plan has open items."""
+    todo = read_omh_todo(omh_home or None)
+    if todo.get("status") != "established":
+        return ""
+    counts = todo.get("counts") if isinstance(todo.get("counts"), dict) else {}
+    done = counts.get("done")
+    total = counts.get("total")
+    if not isinstance(done, int) or not isinstance(total, int) or total <= 0 or done >= total:
+        return ""
+    items = todo.get("items") if isinstance(todo.get("items"), list) else []
+    active = next(
+        (
+            str(item.get("text", ""))[:_MAX_ACTIVE_TEXT_CHARS]
+            for item in items
+            if isinstance(item, dict) and item.get("state") == "active"
+        ),
+        "",
+    )
+    head = f"[OMH plan todo] {done}/{total} done"
+    if active:
+        head = f"{head} · active: {active}"
+    return f"{head}. {TODO_RECONCILIATION_RULE}"

--- a/tests/test_todo_reconciliation.py
+++ b/tests/test_todo_reconciliation.py
@@ -1,0 +1,67 @@
+"""Contracts for the open-plan reconciliation reminder.
+
+A completion claim in chat while the HUD checklist shows open items is a
+visible contradiction the user reported directly. An open plan is a
+state, not a phrasing, so the guard is stateful: while an established
+todo has open items, every pre_llm_call turn carries one compact
+reconciliation line; a finished, cleared, or absent plan carries none.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from omh.plugin_bundle.omh.hooks.llm_hooks import pre_llm_call
+from omh.plugin_bundle.omh.todo_reconciliation import (
+    TODO_RECONCILIATION_RULE,
+    open_todo_reminder,
+)
+from omh.plugin_bundle.omh.todo_store import build_todo_record, write_todo
+
+
+class TodoReconciliationReminderTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.home = str(Path(self._tmp.name) / "omh")
+
+    def _write_plan(self, states):
+        items = [
+            {"text": f"task {index}", "state": state, "phase": "Review"}
+            for index, state in enumerate(states)
+        ]
+        write_todo(Path(self.home), build_todo_record("plan", items, source="test"))
+
+    def test_an_open_plan_yields_one_compact_line(self):
+        self._write_plan(["done", "active", "pending"])
+        line = open_todo_reminder(omh_home=self.home)
+        self.assertIn("[OMH plan todo] 1/3 done", line)
+        self.assertIn("active: task 1", line)
+        self.assertIn(TODO_RECONCILIATION_RULE, line)
+        self.assertNotIn("\n", line)
+
+    def test_a_finished_plan_yields_nothing(self):
+        self._write_plan(["done", "done"])
+        self.assertEqual(open_todo_reminder(omh_home=self.home), "")
+
+    def test_an_absent_plan_yields_nothing(self):
+        self.assertEqual(open_todo_reminder(omh_home=self.home), "")
+
+    def test_pre_llm_call_carries_the_reminder_every_turn_while_open(self):
+        self._write_plan(["done", "active", "pending"])
+        for _ in range(2):
+            payload = pre_llm_call(user_message="다 됐어?", omh_home=self.home)
+            self.assertIsNotNone(payload)
+            self.assertIn("[OMH plan todo] 1/3 done", str(payload.get("context", "")))
+            self.assertIn("reconcile the checklist", str(payload.get("context", "")))
+
+    def test_the_awareness_opt_out_suppresses_the_reminder(self):
+        self._write_plan(["done", "active", "pending"])
+        payload = pre_llm_call(
+            user_message="다 됐어?", omh_home=self.home, include_omh_awareness=False
+        )
+        self.assertNotIn("[OMH plan todo]", str((payload or {}).get("context", "")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New `src/plugin_bundle/omh/todo_reconciliation.py`: while an established plan todo has open items, `open_todo_reminder()` builds one compact context line — `[OMH plan todo] 1/3 done · active: <item>` plus the reconciliation rule (mark completed items done via `omh_todo`, keep exactly one item active, finish the rest or name what stays open and why).
- `pre_llm_call` appends that line to the injected context on every turn while the plan is open, honoring the `include_omh_awareness` opt-out. A finished, cleared, or absent plan injects nothing.

### Why This Exists

- The owner watched Hermes declare "요청한 범위는 모두 완료됐습니다" while the HUD checklist still read 3/5 with the review phase active: the model declared a plan, stopped updating it, and chat and HUD silently disagreed. The desync had no OMH-level guard.

### User / Operator Impact

- While a plan is open, every model turn carries the checklist state and the obligation to reconcile it before claiming completion; the reminder disappears as soon as the plan is done or cleared.

### How It Works

- An open plan is a state, not a phrasing — the guard keys on todo state (like the running-work board keys on a running-unit count) instead of trying to keyword-match completion claims, which appear in the model's answer, not reliably in the user's message. It is awareness (instruction), never state rewriting, and adds one line only while the contradiction is possible.

### Files And Contracts Touched

- `src/plugin_bundle/omh/todo_reconciliation.py` (new), `src/plugin_bundle/omh/hooks/llm_hooks.py`, `tests/test_todo_reconciliation.py` (new; open/finished/absent plans, per-turn injection, opt-out).

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run in this environment; behavior is pinned by the new hook-level tests and will be observed on the owner machine after `omh update`.

### Observed Evidence

- Full suite: `Ran 7285 tests ... OK`, including the five new `tests/test_todo_reconciliation.py` contracts (open plan yields one line, finished/absent plans yield nothing, per-turn injection through `pre_llm_call`, awareness opt-out).
- ruff, compileall, docs byte gates, `git diff --check` pass.

### Not Tested / Not Applicable

- Release checklist/smoke, install-path smoke: no release, install-path, or catalog change.
- Live Hermes behavior: no Hermes TUI in this environment; the reminder's effect on model behavior is observable only in live sessions.

## Risk

- One extra context line per turn while a plan is open (~60 tokens). The reminder instructs; it cannot force a model to comply — but it removes the "no signal" excuse and stops the moment the checklist is reconciled.

## Compatibility / Rollout

- Additive hook context only; no schema, router, or widget change. Reaches machines via `omh update` (plugin file sync; the reader spawns fresh per poll, hooks reload with the host process).

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CnQjUYKsqVxfMK8TW9Tmbi
