### PR TITLE
feat(hud): activity rows stop hiding running lanes and disclose every drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ What the terminal shows while OMH workflows run:
 - **Phase-structured TODO** — work is declared up front as numbered phases
   with tasks (`todo init`), rendered as the checklist above the prompt: one
   active item, tasks indented beneath every phase header, subtask nesting,
-  and fold lines once the plan grows past seven rows.
+  and fold lines once the plan grows past eight rows.
 
 <br>
 

--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -302,10 +302,25 @@ export default function register(sdk) {
     const metrics = sessionMetrics(payload)
     const maestro = payload.maestro || {}
     const mainRows = active && Array.isArray(maestro.rows) ? maestro.rows.slice(0, 1) : []
-    const activityLimit = Math.max(1, Math.min(3, viewportRows - 3))
-    const rows = active && Array.isArray(agents.rows)
-      ? agents.rows.slice(0, Math.max(0, activityLimit - mainRows.length))
-      : []
+    // Row budget learned from OMO's DAG status widget: five rows by default,
+    // but a RUNNING agent lane is never hidden by the cap — with many lanes
+    // executing at once the dock must tell that story. The viewport still
+    // wins: the dock keeps its chrome (Rule + header) plus prompt margin out
+    // of the budget, the `+N more` overflow line pays for a row of its own,
+    // and anything hidden — here or by the reader's own cap — is named by
+    // that line instead of vanishing.
+    const allAgentRows = active && Array.isArray(agents.rows) ? agents.rows : []
+    const runningAgents = allAgentRows
+      .filter(row => !row.state || row.state === 'running').length
+    const viewportBudget = Math.max(1, viewportRows - 5)
+    const agentBudget = Math.min(
+      Math.max(Math.max(5 - mainRows.length, 1), runningAgents),
+      Math.max(0, viewportBudget - mainRows.length),
+    )
+    let rows = allAgentRows.slice(0, agentBudget)
+    if (allAgentRows.length > rows.length && rows.length > 1) rows = rows.slice(0, rows.length - 1)
+    const hiddenRows =
+      Math.max(0, allAgentRows.length - rows.length) + (active ? Number(agents.hidden_rows) || 0 : 0)
     return h(
       Box,
       { flexDirection: 'column', width: '100%' },
@@ -342,6 +357,9 @@ export default function register(sdk) {
         ? ([...mainRows, ...rows].some(row => !row.state || row.state === 'running')
             ? h(LiveActivityRows, { columns, mainRows, receivedAt: state.receivedAt, rows, t })
             : h(ActivityRows, { columns, extraSeconds: 0, frame: 0, mainRows, rows, t }))
+        : null,
+      hiddenRows
+        ? h(Text, { color: t.color.muted, wrap: 'truncate-end' }, `  +${hiddenRows} more`)
         : null,
     )
   }
@@ -425,13 +443,13 @@ export default function register(sdk) {
         h(Rule, { columns, t }),
       )
     }
-    // The whole plan by default, bounded at seven visible item rows. Every
+    // The whole plan by default, bounded at eight visible item rows. Every
     // phase renders its name as a header row with one indented item per row
     // beneath it — even a phase with a single task. The old space-saving
     // merge (`Research [•] task`) collapsed exactly the structure the owner
     // wants to read ('[] 이거 탭한번쳐서 한개여도. 그 구조로 나오게'), so a
     // lone task indents under its header like any other. When the plan
-    // exceeds seven items the window anchors just before the first
+    // exceeds eight items the window anchors just before the first
     // remaining item so current work is always on screen, and hidden
     // neighbours fold into muted `... (N earlier/later tasks)` lines.
     const shown = Array.isArray(todo.items) ? todo.items : []
@@ -444,7 +462,7 @@ export default function register(sdk) {
       const depth = Number(item.depth)
       return Number.isInteger(depth) && depth > 0 ? Math.min(depth, 3) : 0
     }
-    const TODO_DISPLAY_ROWS = 7
+    const TODO_DISPLAY_ROWS = 8
     const total = shown.length
     const firstRemaining = shown.findIndex(item => item.state !== 'done')
     const anchor = firstRemaining < 0 ? 0 : Math.max(0, firstRemaining - 1)

--- a/src/plugin_bundle/omh/hermes_delegation.py
+++ b/src/plugin_bundle/omh/hermes_delegation.py
@@ -762,6 +762,9 @@ def read_hermes_native_subagents(
         elif row_state == "done":
             completed += 1
 
+    # The per-source bound is disclosed, not silent: the HUD merge adds this
+    # to its own drop count so the widget's `+N more` line stays honest.
+    payload["hidden"] = max(0, len(rows) - max(1, int(limit)))
     rows = rows[: max(1, int(limit))]
     payload["rows"] = rows
     payload["running"] = running

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -42,6 +42,10 @@ TODO_STALE_SECONDS = 86400
 # How long a fully-done plan keeps rendering after its last update.
 ALL_DONE_TODO_LINGER_SECONDS = 15 * 60
 TODO_DISPLAY_ITEM_LIMIT = 3
+# Merged activity rows carried to HUD surfaces. Matches the native reader's
+# own per-source bound (`hermes_delegation._ROW_LIMIT`); the TUI widget
+# applies its viewport clamp on top and names anything hidden with `+N more`.
+ACTIVITY_ROW_LIMIT = 8
 HUD_REQUIRED_TOOLS = PROVIDED_TOOLS
 HUD_REQUIRED_HOOKS = REQUIRED_HOOKS
 HUD_OPTIONAL_HOOKS = OPTIONAL_HOOKS
@@ -615,6 +619,26 @@ def _later_status(current: str, candidate: str) -> str:
         return candidate
 
 
+def _ordered_activity_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Running first, then blocked, then done; settled rows newest-first.
+
+    Display-priority ordering learned from OMO's DAG status widget: running
+    work outranks everything, and a late failure must never be pushed off
+    screen by older completed rows. Running rows keep dispatch order. The
+    helper orders only — the call site applies ACTIVITY_ROW_LIMIT and counts
+    what it drops, so a capped row is disclosed rather than silently gone.
+    """
+    def observed(row: dict[str, Any]) -> str:
+        return str(row.get("observed_at", ""))
+
+    running = [row for row in rows if str(row.get("state", "running")) not in {"blocked", "failed", "done"}]
+    blocked = [row for row in rows if str(row.get("state", "")) in {"blocked", "failed"}]
+    done = [row for row in rows if str(row.get("state", "")) == "done"]
+    blocked.sort(key=observed, reverse=True)
+    done.sort(key=observed, reverse=True)
+    return running + blocked + done
+
+
 def read_omh_hud(
     omh_home: str | Path | None = None,
     hermes_home: str | Path | None = None,
@@ -667,12 +691,27 @@ def read_omh_hud(
         "status": "observed" if payload["subagents"]["maestro_rows"] else "idle",
         "rows": payload["subagents"].pop("maestro_rows"),
     }
+    # Display-priority ordering applies to BOTH sources: the OMH-side rows
+    # keep dispatch order at their producer and can put a blocked row ahead
+    # of a running one, which the widget's running-exempt budget would then
+    # hide. Anything the cap drops is counted, never silently discarded.
+    ordered = _ordered_activity_rows(list(payload["subagents"]["rows"]))
+    payload["subagents"]["hidden_rows"] = int(payload["subagents"].get("hidden_rows", 0)) + max(
+        0, len(ordered) - ACTIVITY_ROW_LIMIT
+    )
+    payload["subagents"]["rows"] = ordered[:ACTIVITY_ROW_LIMIT]
     # Hermes-native delegate_task children are work the HUD must show even
     # though they never touch the OMH runtime store; see hermes_delegation.
     native = read_hermes_native_subagents(hermes, omh_home=home)
     if native["rows"]:
         merged = payload["subagents"]
-        merged["rows"] = (list(merged["rows"]) + list(native["rows"]))[:5]
+        combined = _ordered_activity_rows(list(merged["rows"]) + list(native["rows"]))
+        merged["hidden_rows"] = (
+            max(0, len(combined) - ACTIVITY_ROW_LIMIT)
+            + int(merged.get("hidden_rows", 0))
+            + int(native.get("hidden", 0))
+        )
+        merged["rows"] = combined[:ACTIVITY_ROW_LIMIT]
         merged["active"] = int(merged.get("active", 0)) + int(native["active"])
         merged["running"] = int(merged.get("running", 0)) + int(native["running"])
         merged["blocked"] = int(merged.get("blocked", 0)) + int(native["blocked"])
@@ -1059,7 +1098,11 @@ def _hud_subagent_summary(status: dict[str, Any]) -> dict[str, Any]:
             maestro_rows.append(projected)
         else:
             subagent_rows.append(projected)
+    # Executors past the projection bound are disclosed, not silently gone;
+    # the HUD carries the count into the widget's `+N more` line.
+    hidden_rows = max(0, sum(1 for row in active if isinstance(row, dict)) - 5)
     return {
+        "hidden_rows": hidden_rows,
         "status": "observed" if active or stale or progress else "idle",
         "active": len(active),
         "running": max(0, len(active) - blocked),

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -1361,5 +1361,77 @@ class TodoHudTests(unittest.TestCase):
             self.assertEqual(len(payload["display"]["todo_lines"]), 2)
 
 
+class ActivityRowOrderTests(unittest.TestCase):
+    """Merged activity rows: running first, settled newest-first, capped at 8.
+
+    Display-priority ordering adopted from OMO's DAG status widget — a late
+    failure must never be pushed off screen by older completed rows, and
+    running lanes keep dispatch order.
+    """
+
+    def _rows(self, *specs: tuple[str, str, str]) -> list[dict[str, str]]:
+        return [
+            {"task_id": task_id, "state": state, "observed_at": observed_at}
+            for task_id, state, observed_at in specs
+        ]
+
+    def test_running_rows_lead_and_keep_dispatch_order(self) -> None:
+        from omh.plugin_bundle.omh.runtime_reader import _ordered_activity_rows
+
+        rows = self._rows(
+            ("done-old", "done", "2026-08-26T10:00:00Z"),
+            ("run-b", "running", "2026-08-26T10:01:00Z"),
+            ("blocked-new", "blocked", "2026-08-26T10:05:00Z"),
+            ("run-a", "running", "2026-08-26T10:02:00Z"),
+            ("done-new", "done", "2026-08-26T10:04:00Z"),
+            ("failed-old", "failed", "2026-08-26T10:03:00Z"),
+        )
+        ordered = [row["task_id"] for row in _ordered_activity_rows(rows)]
+        self.assertEqual(
+            ordered,
+            ["run-b", "run-a", "blocked-new", "failed-old", "done-new", "done-old"],
+        )
+
+    def test_rows_without_a_state_count_as_running(self) -> None:
+        from omh.plugin_bundle.omh.runtime_reader import _ordered_activity_rows
+
+        rows = [{"task_id": "bare"}] + self._rows(("done", "done", "2026-08-26T10:00:00Z"))
+        self.assertEqual(
+            [row["task_id"] for row in _ordered_activity_rows(rows)],
+            ["bare", "done"],
+        )
+
+    def test_merged_rows_cap_at_eight_dropping_oldest_settled_first(self) -> None:
+        from omh.plugin_bundle.omh.runtime_reader import (
+            ACTIVITY_ROW_LIMIT,
+            _ordered_activity_rows,
+        )
+
+        self.assertEqual(ACTIVITY_ROW_LIMIT, 8)
+        rows = self._rows(
+            *[(f"run-{index}", "running", f"2026-08-26T10:0{index}:00Z") for index in range(6)],
+            ("done-new", "done", "2026-08-26T10:09:00Z"),
+            ("done-mid", "done", "2026-08-26T10:08:00Z"),
+            ("done-old", "done", "2026-08-26T10:07:00Z"),
+        )
+        ordered = [row["task_id"] for row in _ordered_activity_rows(rows)]
+        # The helper orders without dropping; the call site slices at the
+        # limit and discloses the count, so the capped view keeps all six
+        # running rows, fills the remainder with the newest settled rows, and
+        # the oldest settled row is the one that falls off.
+        self.assertEqual(len(ordered), 9)
+        capped = ordered[:ACTIVITY_ROW_LIMIT]
+        self.assertEqual(capped[:6], [f"run-{index}" for index in range(6)])
+        self.assertEqual(capped[6:], ["done-new", "done-mid"])
+
+    def test_row_limit_matches_the_native_reader_bound(self) -> None:
+        # The comment on ACTIVITY_ROW_LIMIT claims parity with the native
+        # reader's own per-source bound; make the claim enforceable.
+        from omh.plugin_bundle.omh.hermes_delegation import _ROW_LIMIT
+        from omh.plugin_bundle.omh.runtime_reader import ACTIVITY_ROW_LIMIT
+
+        self.assertEqual(ACTIVITY_ROW_LIMIT, _ROW_LIMIT)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_plugin_hermes_delegation.py
+++ b/tests/test_plugin_hermes_delegation.py
@@ -686,6 +686,45 @@ class HudMergeTest(unittest.TestCase):
             # gpt-5.6-terra:high is the deep chain head and differs from the
             # parent model, so the routed category is visible in the HUD row.
             self.assertEqual(rows[0]["category"], "deep")
+            # Nothing was dropped, so the disclosed hidden-row count is zero.
+            self.assertEqual(payload["subagents"]["hidden_rows"], 0)
+
+    def test_read_omh_hud_caps_many_native_rows_and_discloses_the_drop(self):
+        from omh.plugin_bundle.omh.runtime_reader import ACTIVITY_ROW_LIMIT, read_omh_hud
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / "omh"
+            hermes_home = root / "hermes"
+            omh_home.mkdir()
+            hermes_home.mkdir()
+            base = time.time()
+            _build_state_db(
+                hermes_home,
+                [
+                    {
+                        "id": f"20260818_1001{index:02d}_child{index:02d}",
+                        "model": "gpt-5.6-terra",
+                        "effort": "high",
+                        "started_at": base - 300 + index,
+                        "usage": {
+                            "api_calls": 1,
+                            "output_tokens": 10,
+                            "last_seen": base - 1,
+                        },
+                    }
+                    # One more child than the merge cap admits.
+                    for index in range(ACTIVITY_ROW_LIMIT + 1)
+                ],
+            )
+            payload = read_omh_hud(omh_home, hermes_home)
+            rows = payload["subagents"]["rows"]
+            self.assertEqual(len(rows), ACTIVITY_ROW_LIMIT)
+            # Every carried row is running (running rows outrank settled ones
+            # in the merged ordering) and the one capped row is disclosed so
+            # the widget can render `+N more` instead of silently truncating.
+            self.assertTrue(all(row["state"] == "running" for row in rows))
+            self.assertEqual(payload["subagents"]["hidden_rows"], 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -351,7 +351,8 @@ class TuiWidgetPackTests(unittest.TestCase):
         self.assertIn("last.phase === phase", widget)
         self.assertNotIn("isMerged", widget)
         self.assertNotIn("phaseColumn", widget)
-        self.assertIn("const TODO_DISPLAY_ROWS = 7", widget)
+        # Eight body rows matches the senpi/OMO todo widget's visible budget.
+        self.assertIn("const TODO_DISPLAY_ROWS = 8", widget)
         self.assertIn("depthOf", widget)
         self.assertIn("(!phase && depthOf(item) > 0)", widget)
         self.assertIn("'  '.repeat(depthOf(item) + (group.phase ? 1 : 0))", widget)
@@ -441,7 +442,18 @@ class TuiWidgetPackTests(unittest.TestCase):
         self.assertIn("payload.yolo && payload.yolo.status === 'observed'", widget)
         self.assertIn("payload.yolo.enabled ? t.color.warn : t.color.label", widget)
         self.assertNotIn("• parallel shot", widget)
-        self.assertIn("Math.min(3,", widget)
+        # Five-row activity budget with running AGENT lanes exempt from the
+        # cap (OMO DAG-widget pattern) — the old hard `Math.min(3, …)` clamp
+        # hid running lanes silently, which is the complaint that removed it.
+        # The viewport still bounds the dock (chrome included), and both the
+        # widget's own drop and the reader's cap surface as `+N more`.
+        self.assertNotIn("Math.min(3, viewportRows", widget)
+        self.assertIn("Math.max(Math.max(5 - mainRows.length, 1), runningAgents)", widget)
+        self.assertIn("viewportRows - 5", widget)
+        self.assertIn("const hiddenRows", widget)
+        self.assertIn("Number(agents.hidden_rows) || 0", widget)
+        self.assertIn("+${hiddenRows} more", widget)
+        self.assertIn("hiddenRows\n        ? h(Text", widget)
         self.assertNotIn("spinnerTimerKey", widget)
         self.assertIn("ActivityRow", widget)
         self.assertIn("truncateCells", widget)


### PR DESCRIPTION
## Capability

The Hermes TUI dock no longer hides parallel lanes: the activity budget rises from a hard 3-row clamp to 5 rows with **running agent lanes exempt from the cap**, every dropped row — widget slice, merged-payload cap, native reader bound, executor-summary bound — is disclosed through one `+N more` line, merged rows gain display-priority ordering (running first, then blocked/failed, then done, settled newest-first), the merge cap rises 5 → 8 to match the native reader (parity-pinned), and the todo window grows 7 → 8 body rows.

## Motivation

Owner compared live usability with OMO: parallel lanes and todos show generously there, while OMH capped at 3 rows and silently discarded the rest ("omo에서는 투두랑 병렬도 좀 많이 되는거같은데 내꺼에서는 3개까지만 뜨는거같길래"). Patterns adopted from the OMO/senpi source study: running-rows-exempt cap (DAG widget), `+N more` honest overflow, display-priority ordering with newest-first settled rows, and the senpi todo widget's 8-body-row budget.

## Implementation (boundary level)

- `src/omh/tui_widgets/omh-status.mjs` — activity budget `max(5 - mainRows, 1)` raised to `runningAgents` when more are running, clamped by `viewportRows - 5` (viewport minus prompt margin **and** the dock's own chrome); the `+N more` overflow line pays for a row of its own and sums the widget's drop with the reader's disclosed `hidden_rows`; todo `TODO_DISPLAY_ROWS` 7 → 8; stale "seven" comments updated (also `README.md`).
- `src/plugin_bundle/omh/runtime_reader.py` — `_ordered_activity_rows` (orders only; call sites cap and count), applied on **both** payload paths (review finding: the non-native path could put a blocked row ahead of a running one, which the widget's new budget would then hide); `ACTIVITY_ROW_LIMIT = 8`; executor-summary projection bound disclosed as `hidden_rows`.
- `src/plugin_bundle/omh/hermes_delegation.py` — the native reader's per-source bound now reports its own `hidden` count instead of dropping silently.
- Tests — ordering/cap unit tests with named scenarios, an `ACTIVITY_ROW_LIMIT ↔ _ROW_LIMIT` parity assertion, a `read_omh_hud` integration test spawning one more child than the cap admits and asserting the disclosed count, and widget string pins for the new arithmetic (clamp survival, overflow gating, narrowly-scoped negative pin on the removed `Math.min(3, viewportRows` clamp).

## Verification (observed)

- `PYTHONPATH=tests uv run python -m unittest discover -s tests` — **7285 tests, OK** (final tree).
- All five byte gates, `ruff`, `compileall`, `node --check` on the widget, `git diff --check` — clean. No drift-registry impact (no skill bodies touched).
- Separate-lane review (HIGH 1 / MEDIUM 5 / LOW 3): all addressed — viewport clamp now counts dock chrome and the overflow line; the running-exemption derives from agent rows so a blocked maestro row cannot eat a slot; both payload paths ordered; reader-side drops disclosed end-to-end; stale comments fixed; parity assertion and integration test added; the `[OMH]` line's summed cost now aggregating 8 rows is named in the commit body as a user-visible side effect.

## Risks

- Widget arithmetic is pinned by string assertions only (this repo runs no JS test runner) — the reviewer names this as residual risk; the payload-side semantics are covered by real tests.
- Live rendering of the wider dock on a busy session is `prepared_not_observed`; reaches machines via `omh update` + TUI restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKo77o5dTJtLRWfDj4uBtq

> Supersedes #1132, whose pull_request events never produced Actions runs; identical commit.