### PR TITLE
feat(coding): parallelism policy with OMO defaults, installed and editable

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ What the terminal shows while OMH workflows run:
 - **Phase-structured TODO** — work is declared up front as numbered phases
   with tasks (`todo init`), rendered as the checklist above the prompt: one
   active item, tasks indented beneath every phase header, subtask nesting,
-  and fold lines once the plan grows past seven rows.
+  and fold lines once the plan grows past eight rows.
 
 <br>
 

--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -91,6 +91,23 @@ Rules:
 
 ## Dispatch bridge semantics
 
+- **Concurrency is a profile tunable.** The dispatch pool width comes from
+  the setup profile's `parallelism` block — `default_concurrency` (5) sized
+  against a `global_concurrency` ceiling (8), the same defaults OMO's task
+  engine ships. A fresh `omh setup` writes the block into the profile so it
+  is visible and editable; an explicit `--concurrency` flag still wins,
+  clamped to the ceiling, and the dispatch summary's `concurrency` block
+  records the requested and applied widths plus their source. `per_owner`
+  maps an executor owner (for example `codex: 2`) to its own lane width so
+  one rate-limited provider is not hammered by the whole pool; owners not
+  named there are governed by the global pool alone. A gated owner's units
+  hold pool slots while they wait for a lane, so many same-owner units
+  queued ahead can delay another owner's units in the same wave — size
+  `per_owner` with that trade in mind. An install written before this
+  block existed resolves to the same defaults without showing the block;
+  re-running `omh setup` writes it out, and rewrites the whole profile
+  while doing so. `lane_budget_default` is advisory context for
+  Hermes-native lanes — OMH never enforces a lane count inside Hermes.
 - **Spawnability is data.** `DISPATCH_COMMAND_TEMPLATES` in
   `src/coding/fanout_dispatch.py` maps profiles with a local headless CLI to
   fixed argv templates — currently codex (`codex exec`), claude-code
@@ -436,7 +453,7 @@ omh coding fanout status --fanout-id <fanout-id> [--json]
 omh coding fanout migrate-legacy <fanout-id> \
   [--confirm-contract-sha256 <digest>]  # operator/maintenance only
 omh coding fanout dispatch <fanout-id> --goal-file goal.txt \
-  [--repo-root .] [--base-ref HEAD] [--concurrency 2] [--timeout 1800] \
+  [--repo-root .] [--base-ref HEAD] [--concurrency N] [--timeout 1800] \
   [--unit <id> ...] [--dry-run] [--run-verification]
 omh coding model-route [--executor <profile>] [--role <role>] [--model <id>] [--effort <level>] [--domain <name>] [--explain] [--from-inventory] [--json]
 omh coding model-inventory [--json]

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import shlex
 import shutil
 import subprocess
+import threading
 import time
 from typing import Any, Callable, Iterable, Mapping, Sequence
 
@@ -713,6 +714,8 @@ def dispatch_fanout(
     repo_root: Path,
     base_sha: str,
     source_ref: str = "",
+    # Conservative library fallback only: the CLI resolves the pool width
+    # from the setup profile's `parallelism` block (default 5, ceiling 8).
     concurrency: int = 2,
     timeout: int = 1800,
     only_units: Sequence[str] | None = None,
@@ -721,6 +724,8 @@ def dispatch_fanout(
     runner: Callable[..., Any] = subprocess.run,
     readiness: Callable[..., dict[str, object]] = probe_executor_readiness,
     live_safety_profile_revision: str | None = None,
+    per_owner_lanes: Mapping[str, int] | None = None,
+    concurrency_policy: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     # Both boundary re-checks run first, before discovery, readiness probing,
     # any unit spawn, and any summary write: nothing downstream should observe a
@@ -829,6 +834,27 @@ def dispatch_fanout(
             results[unit_id] = _skipped(unit, "not_selected")
 
     pending = [unit_id for unit_id in order if unit_id not in results]
+    # Per-owner lanes (OMO's per-provider limiter, reduced to what this
+    # blocking pool can honor): only owners the policy names get a lane
+    # semaphore — the global pool alone governs everyone else. The gate
+    # wraps the unit's WHOLE lifecycle (readiness probe, worktree, spawn,
+    # and local verification when requested), so an over-subscribed owner
+    # holds a pool slot while it waits and can delay other owners' units
+    # queued behind it in the same wave; with the pool sized to the global
+    # ceiling that is the same trade OMO's global permit makes.
+    owner_gates = {
+        owner: threading.BoundedSemaphore(int(width))
+        for owner, width in (per_owner_lanes or {}).items()
+        if isinstance(width, int) and not isinstance(width, bool) and int(width) >= 1
+    }
+
+    def _dispatch_with_owner_gate(unit: Mapping[str, Any], **kwargs: Any) -> dict[str, Any]:
+        gate = owner_gates.get(str(unit.get("owner") or "choose"))
+        if gate is None:
+            return _dispatch_unit(paths, unit, **kwargs)
+        with gate:
+            return _dispatch_unit(paths, unit, **kwargs)
+
     with ThreadPoolExecutor(max_workers=max(1, concurrency)) as pool:
         while pending:
             ready = [
@@ -853,8 +879,7 @@ def dispatch_fanout(
                 continue
             futures = {
                 unit_id: pool.submit(
-                    _dispatch_unit,
-                    paths,
+                    _dispatch_with_owner_gate,
                     units[unit_id],
                     goal_text=goal_text,
                     repo_root=repo_root,
@@ -899,6 +924,10 @@ def dispatch_fanout(
         "base_sha": base_sha,
         "claim_boundary": f"{DISPATCH_CLAIM_BOUNDARY} {FANOUT_CLAIM_BOUNDARY}",
     }
+    if concurrency_policy:
+        # How the pool width was chosen (policy default vs flag, any clamp)
+        # so a dispatch record answers "why did only N run at once".
+        summary["concurrency"] = dict(concurrency_policy)
     if not dry_run and fanout_id:
         from .fanout_artifacts import fanout_dispatch_summary_path
 

--- a/src/coding/parallelism_policy.py
+++ b/src/coding/parallelism_policy.py
@@ -1,0 +1,126 @@
+"""Execution-concurrency policy for the opt-in fanout dispatch path.
+
+Defaults mirror OMO's task engine (per-lane default 5, global ceiling 8) on
+owner direction. Every value is a setup-profile tunable under `parallelism`,
+read with the same validated-override-plus-disclosure shape as the memory
+policy's cadence block: an invalid stored value falls back to the default
+and is named in `ignored_keys` instead of failing the read or silently
+winning. OMH core still makes no LLM or network calls — this policy only
+sizes the explicit `omh coding fanout dispatch` subprocess pool and its
+per-owner lanes, and states the advisory lane budget a Hermes-native run
+may read; it never patches Hermes and never enforces anything there.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..profiles.setup import (
+    PARALLELISM_DEFAULTS,
+    PARALLELISM_POLICY_SCHEMA_VERSION,
+    read_setup_profile,
+)
+from ..system.paths import OmhPaths
+
+# One config typo must not turn the fanout pool into a fork bomb: 32 is far
+# above any real local agent-CLI fleet while still catching a stray 500.
+_PARALLELISM_MAX = 32
+
+_COUNT_KEYS = ("default_concurrency", "global_concurrency", "lane_budget_default")
+
+PARALLELISM_CLAIM_BOUNDARY = (
+    "Parallelism policy sizes the explicit `omh coding fanout dispatch` "
+    "subprocess pool only. Hermes-native lanes read `lane_budget_default` as "
+    "advisory context; OMH never enforces a lane count inside Hermes."
+)
+
+
+def _bounded_count(policy: dict[str, Any], key: str) -> int | None:
+    """One validated lane/pool width from a policy mapping, or None."""
+    value = policy.get(key)
+    if isinstance(value, int) and not isinstance(value, bool) and 1 <= value <= _PARALLELISM_MAX:
+        return value
+    return None
+
+
+def build_parallelism_policy() -> dict[str, Any]:
+    return {
+        "schema_version": PARALLELISM_POLICY_SCHEMA_VERSION,
+        **dict(PARALLELISM_DEFAULTS),
+        "per_owner": {},
+        "ignored_keys": [],
+        "claim_boundary": PARALLELISM_CLAIM_BOUNDARY,
+    }
+
+
+def read_parallelism_policy(paths: OmhPaths) -> dict[str, Any]:
+    """The effective policy: stored `parallelism` overrides on the defaults."""
+    policy = build_parallelism_policy()
+    setup = read_setup_profile(paths)
+    stored = setup.get("parallelism") if isinstance(setup, dict) else None
+    if not isinstance(stored, dict):
+        return policy
+    ignored: list[str] = []
+    for key in _COUNT_KEYS:
+        if key not in stored:
+            continue
+        value = _bounded_count(stored, key)
+        if value is None:
+            ignored.append(key)
+        else:
+            policy[key] = value
+    raw_owners = stored.get("per_owner")
+    if isinstance(raw_owners, dict):
+        for owner, value in raw_owners.items():
+            label = owner.strip() if isinstance(owner, str) else ""
+            width = (
+                value
+                if isinstance(value, int) and not isinstance(value, bool) and 1 <= value <= _PARALLELISM_MAX
+                else None
+            )
+            if label and width is not None:
+                policy["per_owner"][label] = width
+            else:
+                ignored.append("per_owner." + (label or repr(owner)))
+    elif "per_owner" in stored:
+        ignored.append("per_owner")
+    # A per-lane default above the global ceiling would promise lanes the
+    # pool cannot grant; clamp and disclose rather than refuse the profile.
+    if policy["default_concurrency"] > policy["global_concurrency"]:
+        policy["default_concurrency_clamped_from"] = policy["default_concurrency"]
+        policy["default_concurrency"] = policy["global_concurrency"]
+    policy["ignored_keys"] = ignored
+    return policy
+
+
+def resolve_fanout_concurrency(policy: dict[str, Any], requested: int | None) -> dict[str, Any]:
+    """The pool width one dispatch runs with, and where it came from.
+
+    An explicit `--concurrency` flag wins over the policy default; the
+    global ceiling always clamps, and a clamp is disclosed so the operator
+    sees the requested and applied widths side by side.
+    """
+    global_cap = int(policy.get("global_concurrency", PARALLELISM_DEFAULTS["global_concurrency"]))
+    if requested is None:
+        wanted = int(policy.get("default_concurrency", PARALLELISM_DEFAULTS["default_concurrency"]))
+        source = "policy_default"
+    else:
+        wanted = max(1, int(requested))
+        source = "cli_flag"
+    resolution: dict[str, Any] = {
+        "schema_version": PARALLELISM_POLICY_SCHEMA_VERSION,
+        "requested": requested,
+        "applied": min(wanted, global_cap),
+        "source": source,
+        "global_concurrency": global_cap,
+        "clamped": wanted > global_cap,
+        # The reader's disclosures ride along so the dispatch record — the
+        # one surface an operator reads after the fact — names an ignored
+        # profile key or a clamped default instead of discarding the finding.
+        "ignored_keys": list(policy.get("ignored_keys", [])),
+    }
+    clamped_from = policy.get("default_concurrency_clamped_from")
+    if source == "policy_default" and clamped_from is not None:
+        resolution["clamped"] = True
+        resolution["policy_clamped_from"] = clamped_from
+    return resolution

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -1607,8 +1607,11 @@ def cmd_coding_fanout_dispatch(args: argparse.Namespace) -> int:
         read_fanout_contract_provenance,
     )
     from ..coding.fanout_dispatch import dispatch_fanout, fanout_dispatch_preflight
+    from ..coding.parallelism_policy import read_parallelism_policy, resolve_fanout_concurrency
 
     paths = _paths(args)
+    parallelism = read_parallelism_policy(paths)
+    concurrency = resolve_fanout_concurrency(parallelism, args.concurrency)
     try:
         contract = read_fanout_contract(paths, args.fanout_id)
         read_fanout_contract_provenance(
@@ -1636,7 +1639,9 @@ def cmd_coding_fanout_dispatch(args: argparse.Namespace) -> int:
             goal_text=goal_text,
             repo_root=repo_root,
             base_sha="",
-            concurrency=args.concurrency,
+            concurrency=concurrency["applied"],
+            per_owner_lanes=parallelism["per_owner"],
+            concurrency_policy=concurrency,
             timeout=args.timeout,
             only_units=args.unit,
             dry_run=bool(args.dry_run),
@@ -1664,7 +1669,9 @@ def cmd_coding_fanout_dispatch(args: argparse.Namespace) -> int:
             # worktree add can re-check that the base has not moved between
             # this single resolve and the unit's own creation.
             source_ref=args.base_ref,
-            concurrency=args.concurrency,
+            concurrency=concurrency["applied"],
+            per_owner_lanes=parallelism["per_owner"],
+            concurrency_policy=concurrency,
             timeout=args.timeout,
             only_units=args.unit,
             dry_run=bool(args.dry_run),
@@ -1934,7 +1941,18 @@ def _add_coding_commands(sub) -> None:
     fanout_dispatch.add_argument("--goal-file", required=True, help="File with the goal text frozen at prepare time ('-' for stdin).")
     fanout_dispatch.add_argument("--repo-root", default=".", help="Repository the unit worktrees branch from.")
     fanout_dispatch.add_argument("--base-ref", default="HEAD", help="Ref resolved once to a SHA all unit branches start from.")
-    fanout_dispatch.add_argument("--concurrency", type=int, default=2)
+    # Default None resolves through the setup profile's `parallelism` block
+    # (default_concurrency 5, global_concurrency 8 unless edited); an
+    # explicit flag still wins, clamped to the global ceiling.
+    fanout_dispatch.add_argument(
+        "--concurrency",
+        type=int,
+        default=None,
+        help=(
+            "Pool width override; defaults to the setup profile's "
+            "parallelism.default_concurrency and is clamped to global_concurrency."
+        ),
+    )
     fanout_dispatch.add_argument("--timeout", type=int, default=1800, help="Per-unit subprocess timeout in seconds.")
     fanout_dispatch.add_argument("--unit", action="append", default=None, help="Dispatch only these unit ids (repeatable).")
     fanout_dispatch.add_argument("--dry-run", action="store_true", help="Resolve readiness, argv, and worktree paths; spawn nothing.")

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -1370,6 +1370,7 @@ def _setup_operator_summary(
         "operating_model_id": operating_model_id,
         "memory_mode": memory_mode,
         "memory_policy": memory_policy if isinstance(memory_policy, dict) else {},
+        "parallelism": profile.get("parallelism", {}) if isinstance(profile, dict) else {},
         "status": status,
         "requires_hermes_reload": bool(hermes_native.get("requires_hermes_reload", False)),
         "paths": {

--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -302,10 +302,25 @@ export default function register(sdk) {
     const metrics = sessionMetrics(payload)
     const maestro = payload.maestro || {}
     const mainRows = active && Array.isArray(maestro.rows) ? maestro.rows.slice(0, 1) : []
-    const activityLimit = Math.max(1, Math.min(3, viewportRows - 3))
-    const rows = active && Array.isArray(agents.rows)
-      ? agents.rows.slice(0, Math.max(0, activityLimit - mainRows.length))
-      : []
+    // Row budget learned from OMO's DAG status widget: five rows by default,
+    // but a RUNNING agent lane is never hidden by the cap — with many lanes
+    // executing at once the dock must tell that story. The viewport still
+    // wins: the dock keeps its chrome (Rule + header) plus prompt margin out
+    // of the budget, the `+N more` overflow line pays for a row of its own,
+    // and anything hidden — here or by the reader's own cap — is named by
+    // that line instead of vanishing.
+    const allAgentRows = active && Array.isArray(agents.rows) ? agents.rows : []
+    const runningAgents = allAgentRows
+      .filter(row => !row.state || row.state === 'running').length
+    const viewportBudget = Math.max(1, viewportRows - 5)
+    const agentBudget = Math.min(
+      Math.max(Math.max(5 - mainRows.length, 1), runningAgents),
+      Math.max(0, viewportBudget - mainRows.length),
+    )
+    let rows = allAgentRows.slice(0, agentBudget)
+    if (allAgentRows.length > rows.length && rows.length > 1) rows = rows.slice(0, rows.length - 1)
+    const hiddenRows =
+      Math.max(0, allAgentRows.length - rows.length) + (active ? Number(agents.hidden_rows) || 0 : 0)
     return h(
       Box,
       { flexDirection: 'column', width: '100%' },
@@ -342,6 +357,9 @@ export default function register(sdk) {
         ? ([...mainRows, ...rows].some(row => !row.state || row.state === 'running')
             ? h(LiveActivityRows, { columns, mainRows, receivedAt: state.receivedAt, rows, t })
             : h(ActivityRows, { columns, extraSeconds: 0, frame: 0, mainRows, rows, t }))
+        : null,
+      hiddenRows
+        ? h(Text, { color: t.color.muted, wrap: 'truncate-end' }, `  +${hiddenRows} more`)
         : null,
     )
   }
@@ -425,13 +443,13 @@ export default function register(sdk) {
         h(Rule, { columns, t }),
       )
     }
-    // The whole plan by default, bounded at seven visible item rows. Every
+    // The whole plan by default, bounded at eight visible item rows. Every
     // phase renders its name as a header row with one indented item per row
     // beneath it — even a phase with a single task. The old space-saving
     // merge (`Research [•] task`) collapsed exactly the structure the owner
     // wants to read ('[] 이거 탭한번쳐서 한개여도. 그 구조로 나오게'), so a
     // lone task indents under its header like any other. When the plan
-    // exceeds seven items the window anchors just before the first
+    // exceeds eight items the window anchors just before the first
     // remaining item so current work is always on screen, and hidden
     // neighbours fold into muted `... (N earlier/later tasks)` lines.
     const shown = Array.isArray(todo.items) ? todo.items : []
@@ -444,7 +462,7 @@ export default function register(sdk) {
       const depth = Number(item.depth)
       return Number.isInteger(depth) && depth > 0 ? Math.min(depth, 3) : 0
     }
-    const TODO_DISPLAY_ROWS = 7
+    const TODO_DISPLAY_ROWS = 8
     const total = shown.length
     const firstRemaining = shown.findIndex(item => item.state !== 'done')
     const anchor = firstRemaining < 0 ? 0 : Math.max(0, firstRemaining - 1)

--- a/src/plugin_bundle/omh/hermes_delegation.py
+++ b/src/plugin_bundle/omh/hermes_delegation.py
@@ -762,6 +762,9 @@ def read_hermes_native_subagents(
         elif row_state == "done":
             completed += 1
 
+    # The per-source bound is disclosed, not silent: the HUD merge adds this
+    # to its own drop count so the widget's `+N more` line stays honest.
+    payload["hidden"] = max(0, len(rows) - max(1, int(limit)))
     rows = rows[: max(1, int(limit))]
     payload["rows"] = rows
     payload["running"] = running

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -42,6 +42,10 @@ TODO_STALE_SECONDS = 86400
 # How long a fully-done plan keeps rendering after its last update.
 ALL_DONE_TODO_LINGER_SECONDS = 15 * 60
 TODO_DISPLAY_ITEM_LIMIT = 3
+# Merged activity rows carried to HUD surfaces. Matches the native reader's
+# own per-source bound (`hermes_delegation._ROW_LIMIT`); the TUI widget
+# applies its viewport clamp on top and names anything hidden with `+N more`.
+ACTIVITY_ROW_LIMIT = 8
 HUD_REQUIRED_TOOLS = PROVIDED_TOOLS
 HUD_REQUIRED_HOOKS = REQUIRED_HOOKS
 HUD_OPTIONAL_HOOKS = OPTIONAL_HOOKS
@@ -615,6 +619,26 @@ def _later_status(current: str, candidate: str) -> str:
         return candidate
 
 
+def _ordered_activity_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Running first, then blocked, then done; settled rows newest-first.
+
+    Display-priority ordering learned from OMO's DAG status widget: running
+    work outranks everything, and a late failure must never be pushed off
+    screen by older completed rows. Running rows keep dispatch order. The
+    helper orders only — the call site applies ACTIVITY_ROW_LIMIT and counts
+    what it drops, so a capped row is disclosed rather than silently gone.
+    """
+    def observed(row: dict[str, Any]) -> str:
+        return str(row.get("observed_at", ""))
+
+    running = [row for row in rows if str(row.get("state", "running")) not in {"blocked", "failed", "done"}]
+    blocked = [row for row in rows if str(row.get("state", "")) in {"blocked", "failed"}]
+    done = [row for row in rows if str(row.get("state", "")) == "done"]
+    blocked.sort(key=observed, reverse=True)
+    done.sort(key=observed, reverse=True)
+    return running + blocked + done
+
+
 def read_omh_hud(
     omh_home: str | Path | None = None,
     hermes_home: str | Path | None = None,
@@ -667,12 +691,27 @@ def read_omh_hud(
         "status": "observed" if payload["subagents"]["maestro_rows"] else "idle",
         "rows": payload["subagents"].pop("maestro_rows"),
     }
+    # Display-priority ordering applies to BOTH sources: the OMH-side rows
+    # keep dispatch order at their producer and can put a blocked row ahead
+    # of a running one, which the widget's running-exempt budget would then
+    # hide. Anything the cap drops is counted, never silently discarded.
+    ordered = _ordered_activity_rows(list(payload["subagents"]["rows"]))
+    payload["subagents"]["hidden_rows"] = int(payload["subagents"].get("hidden_rows", 0)) + max(
+        0, len(ordered) - ACTIVITY_ROW_LIMIT
+    )
+    payload["subagents"]["rows"] = ordered[:ACTIVITY_ROW_LIMIT]
     # Hermes-native delegate_task children are work the HUD must show even
     # though they never touch the OMH runtime store; see hermes_delegation.
     native = read_hermes_native_subagents(hermes, omh_home=home)
     if native["rows"]:
         merged = payload["subagents"]
-        merged["rows"] = (list(merged["rows"]) + list(native["rows"]))[:5]
+        combined = _ordered_activity_rows(list(merged["rows"]) + list(native["rows"]))
+        merged["hidden_rows"] = (
+            max(0, len(combined) - ACTIVITY_ROW_LIMIT)
+            + int(merged.get("hidden_rows", 0))
+            + int(native.get("hidden", 0))
+        )
+        merged["rows"] = combined[:ACTIVITY_ROW_LIMIT]
         merged["active"] = int(merged.get("active", 0)) + int(native["active"])
         merged["running"] = int(merged.get("running", 0)) + int(native["running"])
         merged["blocked"] = int(merged.get("blocked", 0)) + int(native["blocked"])
@@ -1059,7 +1098,11 @@ def _hud_subagent_summary(status: dict[str, Any]) -> dict[str, Any]:
             maestro_rows.append(projected)
         else:
             subagent_rows.append(projected)
+    # Executors past the projection bound are disclosed, not silently gone;
+    # the HUD carries the count into the widget's `+N more` line.
+    hidden_rows = max(0, sum(1 for row in active if isinstance(row, dict)) - 5)
     return {
+        "hidden_rows": hidden_rows,
         "status": "observed" if active or stale or progress else "idle",
         "active": len(active),
         "running": max(0, len(active) - blocked),

--- a/src/profiles/setup.py
+++ b/src/profiles/setup.py
@@ -11,6 +11,16 @@ from .team import inspect_operating_model, operating_model_ids
 
 SETUP_PROFILE_SCHEMA_VERSION = "setup_profile/v1"
 PROJECT_MEMORY_POLICY_SCHEMA_VERSION = "project_memory_policy/v1"
+PARALLELISM_POLICY_SCHEMA_VERSION = "parallelism_policy/v1"
+# OMO's task engine ships a per-lane default of 5 and a global ceiling of 8;
+# the owner asked for the same defaults installed by setup and editable in the
+# profile. `per_owner` maps an executor owner (codex, claude-code, ...) to its
+# own lane width; an absent owner is governed by the global pool alone.
+PARALLELISM_DEFAULTS: dict[str, int] = {
+    "default_concurrency": 5,
+    "global_concurrency": 8,
+    "lane_budget_default": 5,
+}
 PROJECT_MEMORY_MODES = ("off", "review-first", "auto-safe")
 
 SETUP_PROFILE_CATEGORIES = (
@@ -69,6 +79,21 @@ def setup_profile_choices() -> list[dict[str, str]]:
     return [{key: str(value) for key, value in item.items()} for item in SETUP_PROFILE_CATEGORIES]
 
 
+def build_parallelism_settings() -> dict[str, Any]:
+    """The editable parallelism block a fresh setup writes into the profile.
+
+    A strict subset of the resolved policy payload
+    (`omh.coding.parallelism_policy.build_parallelism_policy`), which adds
+    read-time fields (`ignored_keys`, `claim_boundary`) under the same
+    schema id — the stored block carries only what a user would edit.
+    """
+    return {
+        "schema_version": PARALLELISM_POLICY_SCHEMA_VERSION,
+        **dict(PARALLELISM_DEFAULTS),
+        "per_owner": {},
+    }
+
+
 def build_setup_profile(
     values: list[str] | tuple[str, ...] | None = None,
     *,
@@ -97,6 +122,10 @@ def build_setup_profile(
         # all six families are offered, so an install written before this key
         # existed keeps working without a migration.
         "capability_policy": build_capability_policy(),
+        # Additive and optional: readers fall back to the same defaults when
+        # the key is absent, so pre-existing installs keep working while a
+        # fresh setup writes the block out for the user to see and edit.
+        "parallelism": build_parallelism_settings(),
         "normal_user_surface": "Hermes Agent chat and installed Hermes skills",
         "local_only": True,
         "network_calls": False,

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -493,6 +493,103 @@ class FanoutDispatchEngineTests(unittest.TestCase):
         contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, _UNITS))
         return paths, repo, sha, contract
 
+    def test_summary_discloses_how_the_pool_width_was_chosen(self) -> None:
+        # The command layer resolves the parallelism policy and hands the
+        # resolution in; the dispatch record must answer "why did only N run
+        # at once" without re-deriving policy state after the fact.
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                only_units=["core"],
+                runner=_agent_runner(),
+                readiness=_ready,
+                per_owner_lanes={"codex": 2},
+                concurrency_policy={
+                    "applied": 5,
+                    "source": "policy_default",
+                    "global_concurrency": 8,
+                    "clamped": False,
+                },
+            )
+
+            self.assertEqual(summary["concurrency"]["applied"], 5)
+            self.assertEqual(summary["concurrency"]["source"], "policy_default")
+
+    def test_owner_gate_limits_simultaneous_spawns_for_a_configured_owner(self) -> None:
+        # Enforcement, not just the summary echo: with a codex lane width of
+        # one and three parallel-safe codex units, no two codex spawns may
+        # ever overlap, while the unconfigured claude-code owner is ungated
+        # and the whole batch still completes.
+        import threading as _threading
+        import time as _time
+
+        goal = "gate the codex lane"
+        units = [
+            {"unit_id": f"cx{index}", "title": f"Codex {index}", "owner": "codex", "file_scope": [f"src/cx{index}/"]}
+            for index in range(3)
+        ] + [{"unit_id": "cc", "title": "Claude work", "owner": "claude-code", "file_scope": ["docs/"]}]
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            repo, sha = _make_repo(root)
+            contract = write_fanout_contract(paths, build_fanout_contract(goal, units))
+            lock = _threading.Lock()
+            live = {"codex": 0}
+            max_live = {"codex": 0}
+
+            def runner(argv, **kwargs):
+                if argv[0] == "git":
+                    return subprocess.run(argv, **kwargs)
+                is_codex = argv[0] == "codex"
+                if is_codex:
+                    with lock:
+                        live["codex"] += 1
+                        max_live["codex"] = max(max_live["codex"], live["codex"])
+                _time.sleep(0.05)
+                if is_codex:
+                    with lock:
+                        live["codex"] -= 1
+                return _FakeCompleted(0, "done")
+
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=goal,
+                repo_root=repo,
+                base_sha=sha,
+                concurrency=4,
+                per_owner_lanes={"codex": 1},
+                runner=runner,
+                readiness=_ready,
+            )
+
+            self.assertEqual(max_live["codex"], 1)
+            statuses = {entry["unit_id"]: entry["process_succeeded"] for entry in summary["units"]}
+            self.assertTrue(all(statuses.values()), statuses)
+
+    def test_summary_omits_the_concurrency_block_when_none_was_resolved(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                only_units=["core"],
+                runner=_agent_runner(),
+                readiness=_ready,
+            )
+
+            self.assertNotIn("concurrency", summary)
+
     def test_summary_process_succeeded_only_on_exit_zero(self) -> None:
         with TemporaryDirectory() as tmp:
             paths, repo, sha, contract = self._setup(tmp)

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -1361,5 +1361,77 @@ class TodoHudTests(unittest.TestCase):
             self.assertEqual(len(payload["display"]["todo_lines"]), 2)
 
 
+class ActivityRowOrderTests(unittest.TestCase):
+    """Merged activity rows: running first, settled newest-first, capped at 8.
+
+    Display-priority ordering adopted from OMO's DAG status widget — a late
+    failure must never be pushed off screen by older completed rows, and
+    running lanes keep dispatch order.
+    """
+
+    def _rows(self, *specs: tuple[str, str, str]) -> list[dict[str, str]]:
+        return [
+            {"task_id": task_id, "state": state, "observed_at": observed_at}
+            for task_id, state, observed_at in specs
+        ]
+
+    def test_running_rows_lead_and_keep_dispatch_order(self) -> None:
+        from omh.plugin_bundle.omh.runtime_reader import _ordered_activity_rows
+
+        rows = self._rows(
+            ("done-old", "done", "2026-08-26T10:00:00Z"),
+            ("run-b", "running", "2026-08-26T10:01:00Z"),
+            ("blocked-new", "blocked", "2026-08-26T10:05:00Z"),
+            ("run-a", "running", "2026-08-26T10:02:00Z"),
+            ("done-new", "done", "2026-08-26T10:04:00Z"),
+            ("failed-old", "failed", "2026-08-26T10:03:00Z"),
+        )
+        ordered = [row["task_id"] for row in _ordered_activity_rows(rows)]
+        self.assertEqual(
+            ordered,
+            ["run-b", "run-a", "blocked-new", "failed-old", "done-new", "done-old"],
+        )
+
+    def test_rows_without_a_state_count_as_running(self) -> None:
+        from omh.plugin_bundle.omh.runtime_reader import _ordered_activity_rows
+
+        rows = [{"task_id": "bare"}] + self._rows(("done", "done", "2026-08-26T10:00:00Z"))
+        self.assertEqual(
+            [row["task_id"] for row in _ordered_activity_rows(rows)],
+            ["bare", "done"],
+        )
+
+    def test_merged_rows_cap_at_eight_dropping_oldest_settled_first(self) -> None:
+        from omh.plugin_bundle.omh.runtime_reader import (
+            ACTIVITY_ROW_LIMIT,
+            _ordered_activity_rows,
+        )
+
+        self.assertEqual(ACTIVITY_ROW_LIMIT, 8)
+        rows = self._rows(
+            *[(f"run-{index}", "running", f"2026-08-26T10:0{index}:00Z") for index in range(6)],
+            ("done-new", "done", "2026-08-26T10:09:00Z"),
+            ("done-mid", "done", "2026-08-26T10:08:00Z"),
+            ("done-old", "done", "2026-08-26T10:07:00Z"),
+        )
+        ordered = [row["task_id"] for row in _ordered_activity_rows(rows)]
+        # The helper orders without dropping; the call site slices at the
+        # limit and discloses the count, so the capped view keeps all six
+        # running rows, fills the remainder with the newest settled rows, and
+        # the oldest settled row is the one that falls off.
+        self.assertEqual(len(ordered), 9)
+        capped = ordered[:ACTIVITY_ROW_LIMIT]
+        self.assertEqual(capped[:6], [f"run-{index}" for index in range(6)])
+        self.assertEqual(capped[6:], ["done-new", "done-mid"])
+
+    def test_row_limit_matches_the_native_reader_bound(self) -> None:
+        # The comment on ACTIVITY_ROW_LIMIT claims parity with the native
+        # reader's own per-source bound; make the claim enforceable.
+        from omh.plugin_bundle.omh.hermes_delegation import _ROW_LIMIT
+        from omh.plugin_bundle.omh.runtime_reader import ACTIVITY_ROW_LIMIT
+
+        self.assertEqual(ACTIVITY_ROW_LIMIT, _ROW_LIMIT)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parallelism_policy.py
+++ b/tests/test_parallelism_policy.py
@@ -1,0 +1,240 @@
+"""Parallelism policy: OMO-shaped defaults, profile overrides, clamps.
+
+The owner asked for OMO's execution-concurrency defaults (per-lane 5,
+global 8) installed by setup and editable in the profile. These tests pin
+the defaults, the validated-override-with-disclosure read (an invalid
+stored value falls back and is named, never silently wins), and the
+flag-vs-policy resolution the fanout dispatch command runs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from omh.coding.parallelism_policy import (
+    build_parallelism_policy,
+    read_parallelism_policy,
+    resolve_fanout_concurrency,
+)
+from omh.profiles.setup import (
+    PARALLELISM_DEFAULTS,
+    build_setup_profile,
+    write_setup_profile,
+)
+from omh.system.local_store import atomic_write_json
+from omh.system.paths import OmhPaths
+
+
+def _paths(tmp: str) -> OmhPaths:
+    root = Path(tmp)
+    return OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+
+
+class ParallelismDefaultsTests(unittest.TestCase):
+    def test_defaults_mirror_the_omo_engine_bounds(self) -> None:
+        self.assertEqual(PARALLELISM_DEFAULTS["default_concurrency"], 5)
+        self.assertEqual(PARALLELISM_DEFAULTS["global_concurrency"], 8)
+        self.assertEqual(PARALLELISM_DEFAULTS["lane_budget_default"], 5)
+        policy = build_parallelism_policy()
+        self.assertEqual(policy["default_concurrency"], 5)
+        self.assertEqual(policy["global_concurrency"], 8)
+        self.assertEqual(policy["per_owner"], {})
+        self.assertEqual(policy["ignored_keys"], [])
+
+    def test_a_fresh_setup_profile_writes_the_editable_block(self) -> None:
+        profile = build_setup_profile()
+        block = profile["parallelism"]
+        self.assertEqual(block["schema_version"], "parallelism_policy/v1")
+        self.assertEqual(block["default_concurrency"], 5)
+        self.assertEqual(block["global_concurrency"], 8)
+        self.assertEqual(block["per_owner"], {})
+
+    def test_a_missing_profile_or_block_reads_as_the_defaults(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            self.assertEqual(read_parallelism_policy(paths)["default_concurrency"], 5)
+            write_setup_profile(paths)
+            policy = read_parallelism_policy(paths)
+            self.assertEqual(policy["default_concurrency"], 5)
+            self.assertEqual(policy["global_concurrency"], 8)
+
+
+class ParallelismOverrideTests(unittest.TestCase):
+    def _write_profile(self, paths: OmhPaths, parallelism: object) -> None:
+        profile = build_setup_profile()
+        profile["parallelism"] = parallelism
+        paths.setup_profile_path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write_json(paths.setup_profile_path, profile, private=True)
+
+    def test_stored_overrides_apply(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            self._write_profile(
+                paths,
+                {
+                    "default_concurrency": 3,
+                    "global_concurrency": 12,
+                    "lane_budget_default": 4,
+                    "per_owner": {"codex": 2, "claude-code": 3},
+                },
+            )
+            policy = read_parallelism_policy(paths)
+            self.assertEqual(policy["default_concurrency"], 3)
+            self.assertEqual(policy["global_concurrency"], 12)
+            self.assertEqual(policy["lane_budget_default"], 4)
+            self.assertEqual(policy["per_owner"], {"codex": 2, "claude-code": 3})
+            self.assertEqual(policy["ignored_keys"], [])
+
+    def test_invalid_values_fall_back_and_are_disclosed(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            self._write_profile(
+                paths,
+                {
+                    "default_concurrency": True,
+                    "global_concurrency": 0,
+                    "lane_budget_default": 500,
+                    "per_owner": {"codex": 0, "": 2, "claude-code": 2},
+                },
+            )
+            policy = read_parallelism_policy(paths)
+            self.assertEqual(policy["default_concurrency"], 5)
+            self.assertEqual(policy["global_concurrency"], 8)
+            self.assertEqual(policy["lane_budget_default"], 5)
+            self.assertEqual(policy["per_owner"], {"claude-code": 2})
+            for key in ("default_concurrency", "global_concurrency", "lane_budget_default"):
+                self.assertIn(key, policy["ignored_keys"])
+            self.assertTrue(any(item.startswith("per_owner.") for item in policy["ignored_keys"]))
+
+    def test_a_non_mapping_block_reads_as_defaults(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            self._write_profile(paths, "everything, please")
+            policy = read_parallelism_policy(paths)
+            self.assertEqual(policy["default_concurrency"], 5)
+            self.assertEqual(policy["ignored_keys"], [])
+
+    def test_default_above_global_is_clamped_and_disclosed(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            self._write_profile(paths, {"default_concurrency": 10, "global_concurrency": 4})
+            policy = read_parallelism_policy(paths)
+            self.assertEqual(policy["default_concurrency"], 4)
+            self.assertEqual(policy["default_concurrency_clamped_from"], 10)
+
+
+class FanoutConcurrencyResolutionTests(unittest.TestCase):
+    def test_no_flag_uses_the_policy_default(self) -> None:
+        resolution = resolve_fanout_concurrency(build_parallelism_policy(), None)
+        self.assertEqual(resolution["applied"], 5)
+        self.assertEqual(resolution["source"], "policy_default")
+        self.assertFalse(resolution["clamped"])
+
+    def test_an_explicit_flag_wins_within_the_ceiling(self) -> None:
+        resolution = resolve_fanout_concurrency(build_parallelism_policy(), 3)
+        self.assertEqual(resolution["applied"], 3)
+        self.assertEqual(resolution["source"], "cli_flag")
+
+    def test_a_flag_above_the_ceiling_is_clamped_and_disclosed(self) -> None:
+        resolution = resolve_fanout_concurrency(build_parallelism_policy(), 20)
+        self.assertEqual(resolution["applied"], 8)
+        self.assertTrue(resolution["clamped"])
+        self.assertEqual(resolution["requested"], 20)
+
+    def test_a_sub_one_flag_floors_at_one(self) -> None:
+        resolution = resolve_fanout_concurrency(build_parallelism_policy(), 0)
+        self.assertEqual(resolution["applied"], 1)
+
+    def test_the_readers_disclosures_ride_into_the_resolution(self) -> None:
+        # The dispatch record is the surface an operator reads after the
+        # fact; a computed-then-discarded disclosure is no disclosure.
+        policy = build_parallelism_policy()
+        policy["ignored_keys"] = ["global_concurrency"]
+        resolution = resolve_fanout_concurrency(policy, None)
+        self.assertEqual(resolution["ignored_keys"], ["global_concurrency"])
+
+    def test_a_clamped_policy_default_reports_clamped_with_its_origin(self) -> None:
+        policy = build_parallelism_policy()
+        policy["default_concurrency"] = 4
+        policy["global_concurrency"] = 4
+        policy["default_concurrency_clamped_from"] = 10
+        resolution = resolve_fanout_concurrency(policy, None)
+        self.assertTrue(resolution["clamped"])
+        self.assertEqual(resolution["policy_clamped_from"], 10)
+        self.assertEqual(resolution["applied"], 4)
+        # An explicit flag is the operator's own number; the reader's clamp
+        # note does not apply to it.
+        flagged = resolve_fanout_concurrency(policy, 3)
+        self.assertFalse(flagged["clamped"])
+
+
+class CliWiringTests(unittest.TestCase):
+    def test_parser_default_is_none_and_dispatch_receives_the_policy_width(self) -> None:
+        # The headline behavior of this change is the CLI moving from a
+        # hardcoded default of 2 to the profile-resolved width; without this
+        # test, reverting the parser default breaks nothing.
+        import contextlib
+        import io
+        import subprocess
+        from unittest.mock import patch
+
+        from omh.coding.fanout import build_fanout_contract
+        from omh.coding.fanout_artifacts import write_fanout_contract
+        from omh.commands.main import build_parser
+
+        goal_text = "split the sample feature across agents"
+        units = [
+            {"unit_id": "core", "title": "Core work", "owner": "codex", "file_scope": ["src/core/"]},
+            {"unit_id": "docs", "title": "Docs work", "owner": "claude-code", "file_scope": ["docs/"]},
+        ]
+        parser = build_parser()
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            contract = write_fanout_contract(paths, build_fanout_contract(goal_text, units))
+            goal = Path(tmp) / "goal.txt"
+            goal.write_text(goal_text, encoding="utf-8")
+            repo = Path(tmp) / "repo"
+            repo.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=str(repo), check=True)
+            (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+            subprocess.run(["git", "add", "seed.txt"], cwd=str(repo), check=True)
+            subprocess.run(
+                ["git", "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "init"],
+                cwd=str(repo),
+                check=True,
+            )
+            args = parser.parse_args(
+                [
+                    "--omh-home",
+                    str(paths.omh_home),
+                    "--hermes-home",
+                    str(paths.hermes_home),
+                    "coding",
+                    "fanout",
+                    "dispatch",
+                    contract["fanout_id"],
+                    "--goal-file",
+                    str(goal),
+                    "--repo-root",
+                    str(repo),
+                ]
+            )
+            self.assertIsNone(args.concurrency)
+            captured: dict[str, object] = {}
+
+            def _capture(*call_args, **kwargs):
+                captured.update(kwargs)
+                return {"schema_version": "fanout_dispatch_summary/v1", "units": []}
+
+            with patch("omh.coding.fanout_dispatch.dispatch_fanout", new=_capture):
+                with contextlib.redirect_stdout(io.StringIO()):
+                    args.func(args)
+            self.assertEqual(captured["concurrency"], 5)
+            self.assertEqual(captured["per_owner_lanes"], {})
+            self.assertEqual(captured["concurrency_policy"]["source"], "policy_default")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plugin_hermes_delegation.py
+++ b/tests/test_plugin_hermes_delegation.py
@@ -686,6 +686,45 @@ class HudMergeTest(unittest.TestCase):
             # gpt-5.6-terra:high is the deep chain head and differs from the
             # parent model, so the routed category is visible in the HUD row.
             self.assertEqual(rows[0]["category"], "deep")
+            # Nothing was dropped, so the disclosed hidden-row count is zero.
+            self.assertEqual(payload["subagents"]["hidden_rows"], 0)
+
+    def test_read_omh_hud_caps_many_native_rows_and_discloses_the_drop(self):
+        from omh.plugin_bundle.omh.runtime_reader import ACTIVITY_ROW_LIMIT, read_omh_hud
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / "omh"
+            hermes_home = root / "hermes"
+            omh_home.mkdir()
+            hermes_home.mkdir()
+            base = time.time()
+            _build_state_db(
+                hermes_home,
+                [
+                    {
+                        "id": f"20260818_1001{index:02d}_child{index:02d}",
+                        "model": "gpt-5.6-terra",
+                        "effort": "high",
+                        "started_at": base - 300 + index,
+                        "usage": {
+                            "api_calls": 1,
+                            "output_tokens": 10,
+                            "last_seen": base - 1,
+                        },
+                    }
+                    # One more child than the merge cap admits.
+                    for index in range(ACTIVITY_ROW_LIMIT + 1)
+                ],
+            )
+            payload = read_omh_hud(omh_home, hermes_home)
+            rows = payload["subagents"]["rows"]
+            self.assertEqual(len(rows), ACTIVITY_ROW_LIMIT)
+            # Every carried row is running (running rows outrank settled ones
+            # in the merged ordering) and the one capped row is disclosed so
+            # the widget can render `+N more` instead of silently truncating.
+            self.assertTrue(all(row["state"] == "running" for row in rows))
+            self.assertEqual(payload["subagents"]["hidden_rows"], 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -351,7 +351,8 @@ class TuiWidgetPackTests(unittest.TestCase):
         self.assertIn("last.phase === phase", widget)
         self.assertNotIn("isMerged", widget)
         self.assertNotIn("phaseColumn", widget)
-        self.assertIn("const TODO_DISPLAY_ROWS = 7", widget)
+        # Eight body rows matches the senpi/OMO todo widget's visible budget.
+        self.assertIn("const TODO_DISPLAY_ROWS = 8", widget)
         self.assertIn("depthOf", widget)
         self.assertIn("(!phase && depthOf(item) > 0)", widget)
         self.assertIn("'  '.repeat(depthOf(item) + (group.phase ? 1 : 0))", widget)
@@ -441,7 +442,18 @@ class TuiWidgetPackTests(unittest.TestCase):
         self.assertIn("payload.yolo && payload.yolo.status === 'observed'", widget)
         self.assertIn("payload.yolo.enabled ? t.color.warn : t.color.label", widget)
         self.assertNotIn("• parallel shot", widget)
-        self.assertIn("Math.min(3,", widget)
+        # Five-row activity budget with running AGENT lanes exempt from the
+        # cap (OMO DAG-widget pattern) — the old hard `Math.min(3, …)` clamp
+        # hid running lanes silently, which is the complaint that removed it.
+        # The viewport still bounds the dock (chrome included), and both the
+        # widget's own drop and the reader's cap surface as `+N more`.
+        self.assertNotIn("Math.min(3, viewportRows", widget)
+        self.assertIn("Math.max(Math.max(5 - mainRows.length, 1), runningAgents)", widget)
+        self.assertIn("viewportRows - 5", widget)
+        self.assertIn("const hiddenRows", widget)
+        self.assertIn("Number(agents.hidden_rows) || 0", widget)
+        self.assertIn("+${hiddenRows} more", widget)
+        self.assertIn("hiddenRows\n        ? h(Text", widget)
         self.assertNotIn("spinnerTimerKey", widget)
         self.assertIn("ActivityRow", widget)
         self.assertIn("truncateCells", widget)


### PR DESCRIPTION
## Capability

Execution concurrency becomes a first-class, installed, editable policy: a fresh `omh setup` writes a `parallelism` block (`parallelism_policy/v1`) into the setup profile with OMO's task-engine defaults — `default_concurrency: 5` under a `global_concurrency: 8` ceiling, plus `per_owner` lane widths and an advisory `lane_budget_default` — and `omh coding fanout dispatch` resolves its pool width from that block instead of a hardcoded `--concurrency 2`.

## Motivation

Owner: "우리도 병렬 가능성 이런거 기본값 저걸로 세팅되게해주고 install될때도, 마찬가지로 수정가능하게도 해주고" — referring to OMO's configurable execution concurrency (default 5 / global 8) found in the engineering comparison. OMH's only real parallel-execution surface (the opt-in fanout dispatch pool) ran 2-wide with no configuration surface at all.

## Implementation (boundary level)

- `src/profiles/setup.py` — `PARALLELISM_DEFAULTS` (single source; the coding-side reader imports it, avoiding the two-copy drift the memory policy has) and `build_parallelism_settings()`, written into the profile by `build_setup_profile` (additive key, `capability_policy` precedent — no schema bump). The stored block is documented as a strict subset of the resolved payload.
- `src/coding/parallelism_policy.py` (new) — validated-override-with-disclosure reader: bool-as-int rejected, every width bounded 1..32 (fork-bomb guard), invalid values fall back **and are named in `ignored_keys`**; a default above the ceiling is clamped with `default_concurrency_clamped_from`. `resolve_fanout_concurrency` — flag wins, ceiling always clamps, and the resolution carries the reader's disclosures (review HIGH ×2: a computed-then-discarded disclosure is no disclosure).
- `src/coding/fanout_dispatch.py` — optional `per_owner_lanes` (a `BoundedSemaphore` per explicitly named owner; default profile creates zero semaphores) and `concurrency_policy` embedded as `summary["concurrency"]` so the dispatch record answers "why did only N run at once". The head-of-line trade (a gated owner's queued units hold pool slots) is named in the comment and in `docs/FANOUT.md`, not hidden.
- `src/commands/coding.py` — `--concurrency` default `None` with help text pointing at the profile block; both dispatch call sites pass the resolved width, lanes, and resolution.
- `src/commands/setup.py` — the setup operator summary echoes the `parallelism` block, memory_policy parity.
- `docs/FANOUT.md` — tunables section, including the pre-existing-install caveat (no block on disk still resolves to the same defaults; re-running `omh setup` rewrites the profile).

## Verification (observed)

- `PYTHONPATH=tests uv run python -m unittest discover -s tests` — **7302 tests, OK** (pre-rebase tree; post-rebase targeted policy+fanout suites 108 OK, statics clean — full suite rerun rides this PR's CI).
- 14 policy tests incl. negative cases for every invalid shape; a CLI wiring test pinning parser default `None` and the resolved width 5 reaching dispatch with a real contract; an enforcement test proving a width-1 codex lane never overlaps two spawns while an unnamed owner stays ungated and the batch completes; summary embed/omission tests.
- All five byte gates, ruff, compileall, `git diff --check` clean; no drift-registry impact.
- Separate-lane review: 0 CRITICAL, 2 HIGH (disclosures dropped before any surface — fixed by carrying them into the resolution), 6 MEDIUM (all fixed: repr-quoting, help text, CLI test, gate behavioral test, comment accuracy, head-of-line documentation), 5 LOW (all taken).

## Risks

- Stacked on #1133 (HUD visibility); merge that first and this PR reduces to the parallelism commit.
- A gated owner's queued units hold pool slots while waiting (documented trade, same as OMO's global permit); operators sizing `per_owner` should read the FANOUT.md note.
- Existing installs get the new defaults (2 → 5) without a visible block until they re-run `omh setup`; documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKo77o5dTJtLRWfDj4uBtq