### PR TITLE
fix(coding): fanout owns its children as process groups and reaps orphans

### DIFF
--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -108,6 +108,22 @@ Rules:
   re-running `omh setup` writes it out, and rewrites the whole profile
   while doing so. `lane_budget_default` is advisory context for
   Hermes-native lanes — OMH never enforces a lane count inside Hermes.
+- **Units are process groups; interrupts are honest.** The default runner
+  spawns each unit as its own session/process group and records the leader
+  pid in the unit's inflight marker. A timeout kills the whole group (no
+  surviving grandchildren against the worktree). Ctrl-C stops admitting
+  work, terminates every live group, marks never-started units
+  `interrupted`, prints the summary with `"interrupted": true`, and exits
+  130. SIGTERM writes the same summary FILE but prints nothing: the
+  original termination is re-raised after the write so a supervisor
+  observes the death it asked for, and the process exits 143. If the
+  dispatcher dies without cleanup, `omh coding fanout reap` terminates the
+  marker-named groups — liveness is judged at the GROUP level (a dead
+  leader with live grandchildren stays reapable), a live pid no longer
+  leading its own group is refused as recycled, and a pid the markers do
+  not name is refused whatever its process name. The reaper does not check
+  that the dispatcher is dead — verify that first; a live dispatcher's
+  running units are equally marker-named.
 - **Spawnability is data.** `DISPATCH_COMMAND_TEMPLATES` in
   `src/coding/fanout_dispatch.py` maps profiles with a local headless CLI to
   fixed argv templates — currently codex (`codex exec`), claude-code
@@ -455,6 +471,9 @@ omh coding fanout migrate-legacy <fanout-id> \
 omh coding fanout dispatch <fanout-id> --goal-file goal.txt \
   [--repo-root .] [--base-ref HEAD] [--concurrency N] [--timeout 1800] \
   [--unit <id> ...] [--dry-run] [--run-verification]
+omh coding fanout reap <fanout-id> [--pid N ...]  # terminate marker-named
+  # unit process groups (verify the dispatcher is dead first); refuses any
+  # pid the inflight markers do not name — never kills by process name
 omh coding model-route [--executor <profile>] [--role <role>] [--model <id>] [--effort <level>] [--domain <name>] [--explain] [--from-inventory] [--json]
 omh coding model-inventory [--json]
 omh coding composition-guide [--model <id>] [--json]

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+from concurrent.futures import CancelledError as FuturesCancelledError
 from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from hashlib import sha256
 import json
 import os
 from pathlib import Path
 import shlex
 import shutil
+import signal
 import subprocess
 import threading
 import time
@@ -16,6 +19,7 @@ from ..runtime.artifacts import append_journal_observation, create_run, show_run
 from ..system.local_store import atomic_write_json, ensure_dir, locked_json_update, utc_now
 from ..system.metadata_safety import redact_metadata_text
 from ..system.paths import OmhPaths
+from ._hermes_child_process import terminate_process_group
 from .action_gate import recheck_safety_profile_revision
 from .coding_contracts import STRUCTURAL_SEARCH_GUIDANCE
 from .executor_capability_snapshots import (
@@ -38,6 +42,124 @@ from .fanout_unit_results import validate_check_rows, validate_unit_result
 from .unit_telemetry import parse_unit_telemetry
 
 FANOUT_DISPATCH_SCHEMA_VERSION = "fanout_dispatch_summary/v1"
+
+# Grace between SIGTERM and SIGKILL when a unit group must die — OMO's
+# launcher uses the same 10s window before re-raising on itself.
+UNIT_TERMINATE_GRACE_SECONDS = 10.0
+
+# Live unit process groups, registered by the signal-safe default runner so
+# an interrupt terminates them instead of orphaning them to pid 1. OMO
+# shipped exactly this incident: a launcher blocked in spawnSync died on
+# SIGTERM and its engine reparented to init, still writing into the tree.
+# Injected test runners never register here. The lock is reentrant because
+# the SIGTERM handler can fire while the main thread already holds it.
+_LIVE_UNIT_LOCK = threading.RLock()
+_LIVE_UNIT_GROUPS: dict[int, subprocess.Popen] = {}
+
+# Set BEFORE any group is terminated, checked by workers before and after
+# the owner gate and by the runner immediately after registering its child
+# (register-then-check): either the terminator's snapshot contains the
+# process, or the worker sees the flag — no spawn slips through the gap.
+# One dispatch per process is the supported shape; the flag is cleared at
+# dispatch entry.
+_INTERRUPT_FLAG = threading.Event()
+
+
+def _register_live_unit(process: subprocess.Popen) -> None:
+    with _LIVE_UNIT_LOCK:
+        _LIVE_UNIT_GROUPS[process.pid] = process
+
+
+def _unregister_live_unit(process: subprocess.Popen) -> None:
+    with _LIVE_UNIT_LOCK:
+        _LIVE_UNIT_GROUPS.pop(process.pid, None)
+
+
+def terminate_live_unit_groups(*, grace: float = UNIT_TERMINATE_GRACE_SECONDS) -> list[int]:
+    """SIGTERM every live unit group, escalating to SIGKILL after `grace`.
+
+    Sets the interrupt flag first so a worker that has not spawned yet
+    refuses to, and a spawn racing this snapshot terminates itself on the
+    runner's register-then-check.
+    """
+    _INTERRUPT_FLAG.set()
+    with _LIVE_UNIT_LOCK:
+        processes = list(_LIVE_UNIT_GROUPS.values())
+    terminated: list[int] = []
+    for process in processes:
+        # The child may have been reaped between snapshot and signal; a
+        # freed pid must not be signalled — the reaper refuses recycled
+        # pids and the in-process path holds the same line.
+        if process.poll() is None:
+            terminate_process_group(process, grace, signal.SIGTERM)
+        terminated.append(process.pid)
+        _unregister_live_unit(process)
+    return terminated
+
+
+def signal_safe_unit_runner(
+    argv: Sequence[str],
+    *,
+    cwd: str | None = None,
+    env: Mapping[str, str] | None = None,
+    text: bool | None = None,
+    errors: str | None = None,
+    capture_output: bool = False,
+    timeout: float | None = None,
+    on_spawn: Callable[[subprocess.Popen], None] | None = None,
+) -> subprocess.CompletedProcess:
+    """Drop-in for `subprocess.run` that owns each child as a process group.
+
+    A blocking `subprocess.run` orphans the agent CLI when the dispatcher
+    dies: the child reparents to pid 1 and keeps writing into the worktree.
+    A session-leader child can be terminated as a group on interrupt or
+    timeout, and its pid is real state the fanout reaper can verify against
+    the inflight marker. `on_spawn` hands the live process to the caller
+    (the dispatch path records the pid in the unit's inflight marker).
+    """
+    pipe = subprocess.PIPE if capture_output else None
+    process = subprocess.Popen(
+        list(argv),
+        cwd=cwd,
+        env=dict(env) if env is not None else None,
+        text=text,
+        errors=errors,
+        stdout=pipe,
+        stderr=pipe,
+        start_new_session=os.name != "nt",
+    )
+    with process:
+        _register_live_unit(process)
+        try:
+            # Register-then-check: a spawn racing the interrupt either lands
+            # in the terminator's snapshot or sees the flag here and dies at
+            # once instead of outliving the dispatcher.
+            if _INTERRUPT_FLAG.is_set():
+                terminate_process_group(process, UNIT_TERMINATE_GRACE_SECONDS, signal.SIGTERM)
+            try:
+                if on_spawn is not None:
+                    on_spawn(process)
+            except Exception:
+                # A raising hook must not leak the child it was handed.
+                terminate_process_group(process, UNIT_TERMINATE_GRACE_SECONDS, signal.SIGTERM)
+                raise
+            stdout, stderr = process.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            # The whole group dies with the leader — a timed-out unit must
+            # not leave grandchildren running against the worktree.
+            terminate_process_group(process, UNIT_TERMINATE_GRACE_SECONDS, signal.SIGTERM)
+            raise
+        finally:
+            _unregister_live_unit(process)
+    return subprocess.CompletedProcess(list(argv), int(process.returncode or 0), stdout, stderr)
+
+
+# Capability marker, not an identity check: a wrapper (functools.partial, a
+# retry decorator) can propagate it so the dispatch path keeps recording the
+# reapable pid instead of silently dropping it.
+signal_safe_unit_runner.accepts_on_spawn = True  # type: ignore[attr-defined]
+
+
 DISPATCH_CLAIM_BOUNDARY = (
     "A dispatch summary records observed local subprocess activity only. It is not verification, review, CI, "
     "merge-readiness, or merge evidence, and omh never merges unit branches itself."
@@ -721,7 +843,7 @@ def dispatch_fanout(
     only_units: Sequence[str] | None = None,
     dry_run: bool = False,
     run_verification: bool = False,
-    runner: Callable[..., Any] = subprocess.run,
+    runner: Callable[..., Any] = signal_safe_unit_runner,
     readiness: Callable[..., dict[str, object]] = probe_executor_readiness,
     live_safety_profile_revision: str | None = None,
     per_owner_lanes: Mapping[str, int] | None = None,
@@ -849,13 +971,41 @@ def dispatch_fanout(
     }
 
     def _dispatch_with_owner_gate(unit: Mapping[str, Any], **kwargs: Any) -> dict[str, Any]:
+        # A worker that reaches its turn after the interrupt — queued in the
+        # pool, or parked on the owner gate while the batch died — must not
+        # start a fresh agent CLI nobody will ever collect.
+        if _INTERRUPT_FLAG.is_set():
+            return _skipped(unit, "interrupted")
         gate = owner_gates.get(str(unit.get("owner") or "choose"))
         if gate is None:
             return _dispatch_unit(paths, unit, **kwargs)
         with gate:
+            if _INTERRUPT_FLAG.is_set():
+                return _skipped(unit, "interrupted")
             return _dispatch_unit(paths, unit, **kwargs)
 
-    with ThreadPoolExecutor(max_workers=max(1, concurrency)) as pool:
+    # SIGTERM must not orphan the spawned agent CLIs (OMO's launcher
+    # incident): the handler terminates every live unit group and raises so
+    # the interrupt path below records the batch honestly, then the original
+    # signal is re-raised to the caller — a supervisor still observes the
+    # death it asked for. Installed only in the main thread; anywhere else
+    # Python forbids signal.signal and the default disposition stands.
+    # One dispatch per process is the supported shape, so clearing the
+    # interrupt flag here cannot strand another run's interrupt.
+    _INTERRUPT_FLAG.clear()
+    installed_term = False
+    previous_term: Any = None
+    interrupted_by: BaseException | None = None
+    futures: dict[str, Any] = {}
+    pool = ThreadPoolExecutor(max_workers=max(1, concurrency))
+    try:
+        if threading.current_thread() is threading.main_thread():
+            def _on_sigterm(signum: int, frame: Any) -> None:
+                terminate_live_unit_groups()
+                raise SystemExit(128 + signum)
+
+            previous_term = signal.signal(signal.SIGTERM, _on_sigterm)
+            installed_term = True
         while pending:
             ready = [
                 unit_id
@@ -900,6 +1050,50 @@ def dispatch_fanout(
             for unit_id, future in futures.items():
                 results[unit_id] = future.result()
                 pending.remove(unit_id)
+        pool.shutdown(wait=True)
+    except (KeyboardInterrupt, SystemExit) as exc:
+        # Ctrl-C or a handled SIGTERM: stop admitting work, kill every live
+        # unit group (children run in their own sessions now, so the tty no
+        # longer delivers SIGINT to them), collect what the killed workers
+        # still return, and mark everything never started as interrupted —
+        # a unit silently missing from the rollup would read as never
+        # planned rather than cut short.
+        interrupted_by = exc
+        _INTERRUPT_FLAG.set()
+        pool.shutdown(wait=False, cancel_futures=True)
+        terminate_live_unit_groups()
+        for unit_id, future in list(futures.items()):
+            if unit_id in results:
+                continue
+            try:
+                results[unit_id] = future.result(timeout=UNIT_TERMINATE_GRACE_SECONDS + 5)
+            except (
+                FuturesCancelledError,
+                FuturesTimeoutError,
+                KeyboardInterrupt,
+                SystemExit,
+            ):
+                results[unit_id] = _skipped(units[unit_id], "interrupted")
+            if unit_id in pending:
+                pending.remove(unit_id)
+        for unit_id in list(pending):
+            if unit_id not in results:
+                results[unit_id] = _skipped(units[unit_id], "interrupted")
+            pending.remove(unit_id)
+        # A group-terminated unit exits with a negative signal code and would
+        # otherwise read as a genuine model failure in the merged summary;
+        # the flag keeps a re-dispatch decision from blaming the model.
+        for entry in results.values():
+            exit_code = entry.get("exit_code")
+            if isinstance(exit_code, int) and exit_code < 0:
+                entry["interrupted"] = True
+    finally:
+        # Idempotent after the success/interrupt shutdowns; without it, a
+        # worker exception re-raised by future.result() leaks live pool
+        # threads that the interpreter then joins at exit.
+        pool.shutdown(wait=False, cancel_futures=True)
+        if installed_term:
+            signal.signal(signal.SIGTERM, previous_term)
 
     summary_units = [results[unit_id] for unit_id in order]
     _apply_integration_readiness(summary_units)
@@ -928,6 +1122,11 @@ def dispatch_fanout(
         # How the pool width was chosen (policy default vs flag, any clamp)
         # so a dispatch record answers "why did only N run at once".
         summary["concurrency"] = dict(concurrency_policy)
+    if interrupted_by is not None:
+        # A cut-short batch says so; units that never started carry the
+        # `interrupted` status rather than silently vanishing from the
+        # rollup as if they were never planned.
+        summary["interrupted"] = True
     if not dry_run and fanout_id:
         from .fanout_artifacts import fanout_dispatch_summary_path
 
@@ -949,6 +1148,12 @@ def dispatch_fanout(
         # so `already_completed` still means "I did not re-run this".
         summary["units"] = _with_carried_recovery(summary["units"], stored.get("units", []))
         summary["recovery_available_units"] = _recovery_available(summary["units"])
+    if isinstance(interrupted_by, SystemExit):
+        # The summary is written; now honor the termination that was asked
+        # for, so a supervisor still observes the death it requested (OMO's
+        # launcher discipline). Ctrl-C returns the summary instead — the
+        # operator is at the keyboard reading it.
+        raise interrupted_by
     return summary
 
 
@@ -1317,8 +1522,33 @@ def _dispatch_unit(
             "started_at": started_at,
         },
     )
+    spawn_kwargs: dict[str, Any] = {}
+    if getattr(runner, "accepts_on_spawn", False):
+        # The signal-safe runner hands back the live process so the marker
+        # carries the real group-leader pid the fanout reaper verifies
+        # against; injected test runners keep the plain protocol.
+        def _record_pid(process: subprocess.Popen) -> None:
+            _write_inflight(
+                paths,
+                fanout_id,
+                unit_id,
+                {
+                    "owner": owner,
+                    "owner_host": owner_host,
+                    "model": routed_model,
+                    "reasoning_effort": routed_effort,
+                    "run_ref": run_ref,
+                    "worktree": str(worktree),
+                    "started_at": started_at,
+                    "pid": str(process.pid),
+                },
+            )
+
+        spawn_kwargs["on_spawn"] = _record_pid
     try:
-        completed = runner(argv, cwd=str(worktree), text=True, capture_output=True, timeout=timeout)
+        completed = runner(
+            argv, cwd=str(worktree), text=True, capture_output=True, timeout=timeout, **spawn_kwargs
+        )
         exit_code = int(getattr(completed, "returncode", 1))
         stdout_text = str(getattr(completed, "stdout", "") or "")
         output_tail = stdout_text[-2000:]

--- a/src/coding/fanout_reap.py
+++ b/src/coding/fanout_reap.py
@@ -1,0 +1,147 @@
+"""Reap fanout unit process groups — marker-verified pids only.
+
+`omh coding fanout dispatch` spawns each unit as its own process group and
+records the leader pid in the unit's inflight marker. When the dispatcher
+dies without running its cleanup (SIGKILL, power loss), those groups can
+survive against the worktree with a marker left behind — including the
+shape OMO shipped as an incident, where the LEADER is already gone but its
+grandchildren live on in the group. This reaper therefore judges liveness
+at the GROUP level, and terminates ONLY pids an inflight marker names:
+
+- a pid no marker names is refused, whatever its process name says — there
+  is deliberately no pattern-matching kill (OMO's `doctor --reap` carries
+  the same constraint);
+- a live leader that is no longer its own group leader is refused as a
+  recycled pid;
+- markers are cleared only once the whole group is gone.
+
+The reaper does not check that the dispatcher is dead: every marker-named
+group is fair game, including a live dispatcher's running units — verify
+the dispatcher first. It adds remediation, not a liveness claim; the
+marker's presence-is-not-liveness boundary is untouched. Known limit: a
+dispatcher killed between spawn and the marker's pid write leaves an
+orphan no marker names, which this module refuses by design.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import time
+from typing import Any
+
+from ..system.paths import OmhPaths
+from ._hermes_child_process import group_absent
+from .inflight import clear_inflight_marker, read_inflight_markers
+
+REAP_SCHEMA_VERSION = "fanout_reap_report/v1"
+REAP_GRACE_SECONDS = 10.0
+
+REAP_CLAIM_BOUNDARY = (
+    "A reap report records signals sent to marker-named process groups only. "
+    "It is not execution, verification, or recovery evidence, and it never "
+    "kills by process name."
+)
+
+
+def _leader_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _leader_recycled(pid: int) -> bool:
+    """A live process that no longer leads its own group is a recycled pid."""
+    if not _leader_alive(pid):
+        return False
+    try:
+        return os.getpgid(pid) != pid
+    except OSError:
+        # The process vanished between the checks; not recycled, just gone.
+        return False
+
+
+def _terminate_group(pid: int, grace: float) -> list[str]:
+    """SIGTERM then SIGKILL the group, polling GROUP absence between."""
+    sent: list[str] = []
+    for signum, label in ((signal.SIGTERM, "SIGTERM"), (getattr(signal, "SIGKILL", signal.SIGTERM), "SIGKILL")):
+        try:
+            os.killpg(pid, signum)
+            sent.append(label)
+        except PermissionError:
+            sent.append(f"{label}:refused_permission")
+            return sent
+        except OSError:
+            break
+        deadline = time.monotonic() + max(0.1, grace)
+        while time.monotonic() < deadline:
+            if group_absent(pid):
+                return sent
+            time.sleep(0.05)
+        if group_absent(pid):
+            break
+    return sent
+
+
+def reap_fanout_units(
+    paths: OmhPaths,
+    fanout_id: str,
+    *,
+    pids: list[int] | None = None,
+    grace: float = REAP_GRACE_SECONDS,
+) -> dict[str, Any]:
+    """Terminate marker-named unit groups for one fanout; refuse the rest."""
+    report: dict[str, Any] = {
+        "schema_version": REAP_SCHEMA_VERSION,
+        "fanout_id": fanout_id,
+        "candidates": [],
+        "claim_boundary": REAP_CLAIM_BOUNDARY,
+    }
+    if os.name == "nt":
+        # POSIX process groups are the verification mechanism; without them
+        # the leader re-check cannot hold, so the reaper refuses outright.
+        report["status"] = "unsupported_platform"
+        return report
+    marked: dict[int, dict[str, Any]] = {}
+    for entry in read_inflight_markers(paths, limit=200, fanout_id=fanout_id):
+        raw_pid = str(entry.get("pid", "") or "")
+        if raw_pid.isdigit():
+            marked[int(raw_pid)] = entry
+    requested = pids if pids is not None else sorted(marked)
+    for pid in requested:
+        row: dict[str, Any] = {"pid": pid}
+        entry = marked.get(pid)
+        if entry is None:
+            # The refusal, not the kill, is the point: a pid outside the
+            # markers is somebody else's process however promising its name.
+            row["status"] = "refused_not_marker_named"
+        elif group_absent(pid):
+            # Group-level absence, not leader absence: a dead leader with
+            # live grandchildren keeps the group present and stays reapable.
+            row["status"] = "already_gone"
+            row["unit_id"] = entry.get("unit_id", "")
+            clear_inflight_marker(paths, fanout_id, str(entry.get("unit_id", "")))
+        elif _leader_recycled(pid):
+            # Alive but led by someone else means the pid was recycled by an
+            # unrelated process; killing its group would be a name-free
+            # version of the pattern kill this module refuses.
+            row["status"] = "refused_not_group_leader"
+            row["unit_id"] = entry.get("unit_id", "")
+        else:
+            signals_sent = _terminate_group(pid, grace)
+            row["signals_sent"] = signals_sent
+            row["unit_id"] = entry.get("unit_id", "")
+            if any(item.endswith("refused_permission") for item in signals_sent):
+                row["status"] = "refused_permission"
+            elif group_absent(pid):
+                row["status"] = "reaped"
+                clear_inflight_marker(paths, fanout_id, str(entry.get("unit_id", "")))
+            else:
+                row["status"] = "still_alive"
+        report["candidates"].append(row)
+    report["status"] = "observed"
+    return report

--- a/src/coding/inflight.py
+++ b/src/coding/inflight.py
@@ -77,6 +77,10 @@ INFLIGHT_MARKER_FIELDS: Final[tuple[str, ...]] = (
     "run_ref",
     "worktree",
     "started_at",
+    # Group-leader pid of the spawned unit, recorded by the signal-safe
+    # runner. It does not upgrade the liveness claim — presence is still not
+    # liveness — but it is the only pid the fanout reaper will ever touch.
+    "pid",
 )
 
 DEFAULT_INFLIGHT_READ_LIMIT: Final[int] = 20
@@ -132,7 +136,9 @@ def clear_inflight_marker(paths: OmhPaths, fanout_id: str, unit_id: str) -> bool
     return True
 
 
-def read_inflight_markers(paths: OmhPaths, *, limit: int = DEFAULT_INFLIGHT_READ_LIMIT) -> list[dict[str, Any]]:
+def read_inflight_markers(
+    paths: OmhPaths, *, limit: int = DEFAULT_INFLIGHT_READ_LIMIT, fanout_id: str = ""
+) -> list[dict[str, Any]]:
     """List markers across every fanout, newest-sorting last, never raising.
 
     Ordering is `(started_at, unit_id, fanout_id)` so repeated reads of the
@@ -140,13 +146,17 @@ def read_inflight_markers(paths: OmhPaths, *, limit: int = DEFAULT_INFLIGHT_READ
     `INFLIGHT_MARKER_STATUSES` — a marker that vanished between listing and
     reading is `absent`, one that could not be parsed is `unreadable`, and
     neither reports a path or an error string. No entry claims the unit is
-    alive: compare `started_at` against your own threshold.
+    alive: compare `started_at` against your own threshold. `fanout_id`
+    filters BEFORE the limit slice — a reader asking about one fanout must
+    never lose its markers to older fanouts' backlog.
     """
     if limit <= 0:
         return []
     entries: list[dict[str, Any]] = []
-    for marker_path, fanout_id, unit_id in _marker_files(paths):
-        entries.append(_entry_for(marker_path, fanout_id, unit_id))
+    for marker_path, marker_fanout_id, unit_id in _marker_files(paths):
+        if fanout_id and marker_fanout_id != fanout_id:
+            continue
+        entries.append(_entry_for(marker_path, marker_fanout_id, unit_id))
     entries.sort(key=lambda entry: (entry["started_at"], entry["unit_id"], entry["fanout_id"]))
     return entries[:limit]
 

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -1648,7 +1648,7 @@ def cmd_coding_fanout_dispatch(args: argparse.Namespace) -> int:
             run_verification=bool(args.run_verification),
         )
         _print_json(summary)
-        return 0
+        return 130 if summary.get("interrupted") else 0
     resolved = _subprocess.run(
         ["git", "rev-parse", args.base_ref],
         cwd=str(repo_root),
@@ -1680,7 +1680,25 @@ def cmd_coding_fanout_dispatch(args: argparse.Namespace) -> int:
     except ValueError as exc:
         raise OmhError(str(exc)) from exc
     _print_json(summary)
-    return 0
+    return 130 if summary.get("interrupted") else 0
+
+
+def cmd_coding_fanout_reap(args: argparse.Namespace) -> int:
+    from ..coding.fanout_reap import reap_fanout_units
+
+    paths = _paths(args)
+    report = reap_fanout_units(paths, args.fanout_id, pids=args.pid or None)
+    _print_json(report)
+    if report.get("status") != "observed":
+        return 1
+    # A candidate that survived or could not be signalled is a failed
+    # remediation; exiting 0 would let `reap && rm -rf <worktree>` proceed
+    # against a live agent.
+    failed = any(
+        row.get("status") in {"still_alive", "refused_permission"}
+        for row in report.get("candidates", [])
+    )
+    return 1 if failed else 0
 
 
 def cmd_coding_fanout_migrate_legacy(args: argparse.Namespace) -> int:
@@ -1997,6 +2015,23 @@ def _add_coding_commands(sub) -> None:
     )
     fanout_status.add_argument("--json", action="store_true", help="Emit the machine payload instead of plain text.")
     fanout_status.set_defaults(func=cmd_coding_fanout_status)
+
+    fanout_reap = fanout_sub.add_parser(
+        "reap",
+        help=(
+            "Terminate marker-named unit process groups for one fanout. Verify the dispatcher is dead "
+            "first — a live dispatcher's running units are equally marker-named. Refuses any pid the "
+            "markers do not name; never kills by process name."
+        ),
+    )
+    fanout_reap.add_argument("fanout_id", help="Fanout id whose inflight markers name the candidate pids.")
+    fanout_reap.add_argument(
+        "--pid",
+        type=int,
+        action="append",
+        help="Restrict to specific marker-named pids; default reaps every marker-named pid.",
+    )
+    fanout_reap.set_defaults(func=cmd_coding_fanout_reap)
 
     model_route = coding_sub.add_parser(
         "model-route",

--- a/tests/test_broad_exception_policy.py
+++ b/tests/test_broad_exception_policy.py
@@ -68,6 +68,16 @@ class ClassifiedSite(NamedTuple):
 
 CLASSIFIED_SITES: tuple[ClassifiedSite, ...] = (
     ClassifiedSite(
+        "src/coding/fanout_dispatch.py",
+        "signal_safe_unit_runner",
+        INTENTIONAL,
+        "A raising on_spawn hook must not leak the process group it was just handed: the "
+        "handler terminates the group it created, then immediately re-raises the same "
+        "exception so the caller still sees the hook's failure. Nothing is swallowed or "
+        "relabeled; the broad catch exists only so no exception type can leave a live "
+        "orphan behind.",
+    ),
+    ClassifiedSite(
         "src/workflows/domain_intelligence_store_security.py",
         "_open_store_lock_descriptor",
         INTENTIONAL,
@@ -217,8 +227,8 @@ CLASSIFIED_SITES: tuple[ClassifiedSite, ...] = (
 # function. `_write_candidate_batch`, `_is_catalog_question`, `pre_llm_call`,
 # and `_resume_unlocked` each hold two handlers, so the handler count is four
 # above the anchor count.
-EXPECTED_HANDLER_COUNT = 21
-EXPECTED_ANCHOR_COUNT = 17
+EXPECTED_HANDLER_COUNT = 22
+EXPECTED_ANCHOR_COUNT = 18
 
 
 class DerivedSite(NamedTuple):

--- a/tests/test_fanout_signal_safety.py
+++ b/tests/test_fanout_signal_safety.py
@@ -1,0 +1,441 @@
+"""Signal-safe fanout dispatch: process groups, interrupts, and the reaper.
+
+OMO shipped the incident this guards against: a launcher blocked in a
+synchronous spawn died on SIGTERM and its engine reparented to pid 1, still
+writing into the tree. The fanout runner now owns each unit as a process
+group, an interrupt terminates the groups and records the batch honestly,
+and the reaper terminates only marker-named pids — never by process name.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from omh.coding.fanout import build_fanout_contract
+from omh.coding.fanout_artifacts import fanout_dispatch_summary_path, write_fanout_contract
+from omh.coding.fanout_dispatch import (
+    dispatch_fanout,
+    signal_safe_unit_runner,
+    terminate_live_unit_groups,
+)
+from omh.coding.fanout_reap import reap_fanout_units
+from omh.coding.inflight import read_inflight_markers, write_inflight_marker
+from omh.system.local_store import read_json_object
+from omh.system.paths import OmhPaths
+
+posix_only = unittest.skipIf(os.name == "nt", "POSIX process groups required")
+
+_GOAL = "signal safety drill"
+_UNITS = [
+    {"unit_id": "one", "title": "One", "owner": "codex", "file_scope": ["src/one/"]},
+    {"unit_id": "two", "title": "Two", "owner": "codex", "file_scope": ["src/two/"]},
+]
+
+
+def _paths(tmp: str) -> OmhPaths:
+    root = Path(tmp)
+    return OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+
+
+def _make_repo(root: Path) -> tuple[Path, str]:
+    repo = root / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=str(repo), check=True)
+    (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "seed.txt"], cwd=str(repo), check=True)
+    subprocess.run(
+        ["git", "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "init"],
+        cwd=str(repo),
+        check=True,
+    )
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=str(repo), capture_output=True, text=True, check=True
+    ).stdout.strip()
+    return repo, sha
+
+
+def _ready(paths, profile, **kwargs):
+    return {"status": "ready", "profile": profile}
+
+
+class SignalSafeRunnerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # The interrupt flag is process-global (one dispatch per process is
+        # the supported shape); direct runner tests must not inherit a
+        # sibling test's interrupt.
+        from omh.coding.fanout_dispatch import _INTERRUPT_FLAG
+
+        _INTERRUPT_FLAG.clear()
+
+    @posix_only
+    def test_unit_runs_as_its_own_group_leader(self) -> None:
+        seen: dict[str, int] = {}
+
+        def on_spawn(process) -> None:
+            seen["pid"] = process.pid
+
+        completed = signal_safe_unit_runner(
+            [sys.executable, "-c", "import os; print(os.getpgid(0))"],
+            text=True,
+            capture_output=True,
+            timeout=30,
+            on_spawn=on_spawn,
+        )
+        self.assertEqual(completed.returncode, 0)
+        child_pgid = int(completed.stdout.strip())
+        # The child led its own group — not ours — so the whole group can be
+        # terminated without touching the dispatcher.
+        self.assertEqual(child_pgid, seen["pid"])
+        self.assertNotEqual(child_pgid, os.getpgid(0))
+
+    @posix_only
+    def test_timeout_kills_the_whole_group_including_grandchildren(self) -> None:
+        seen: dict[str, int] = {}
+
+        def on_spawn(process) -> None:
+            seen["pid"] = process.pid
+
+        script = "import subprocess, time; subprocess.Popen(['sleep', '60']); time.sleep(60)"
+        with self.assertRaises(subprocess.TimeoutExpired):
+            signal_safe_unit_runner(
+                [sys.executable, "-c", script],
+                text=True,
+                capture_output=True,
+                timeout=0.5,
+                on_spawn=on_spawn,
+            )
+        # The leader AND its grandchild are gone: signalling the dead group
+        # raises, which is the proof the tree did not outlive the timeout.
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            try:
+                os.killpg(seen["pid"], 0)
+            except ProcessLookupError:
+                break
+            time.sleep(0.05)
+        with self.assertRaises(ProcessLookupError):
+            os.killpg(seen["pid"], 0)
+
+    @posix_only
+    def test_terminate_live_unit_groups_reaps_a_registered_unit(self) -> None:
+        import threading
+
+        seen: dict[str, int] = {}
+        started = threading.Event()
+
+        def on_spawn(process) -> None:
+            seen["pid"] = process.pid
+            started.set()
+
+        def run() -> None:
+            try:
+                signal_safe_unit_runner(
+                    ["sleep", "60"], text=True, capture_output=True, timeout=60, on_spawn=on_spawn
+                )
+            except (subprocess.SubprocessError, OSError):
+                pass
+
+        worker = threading.Thread(target=run)
+        worker.start()
+        self.assertTrue(started.wait(timeout=10))
+        terminated = terminate_live_unit_groups(grace=2)
+        worker.join(timeout=10)
+        self.assertIn(seen["pid"], terminated)
+        with self.assertRaises(ProcessLookupError):
+            os.killpg(seen["pid"], 0)
+
+
+class InterruptedDispatchTests(unittest.TestCase):
+    def _fixture(self, tmp: str):
+        root = Path(tmp)
+        paths = _paths(tmp)
+        repo, sha = _make_repo(root)
+        contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, _UNITS))
+        return paths, repo, sha, contract
+
+    def test_keyboard_interrupt_marks_unstarted_units_and_returns_the_summary(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._fixture(tmp)
+
+            def runner(argv, **kwargs):
+                if argv[0] == "git":
+                    return subprocess.run(argv, **kwargs)
+                raise KeyboardInterrupt
+
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                concurrency=1,
+                runner=runner,
+                readiness=_ready,
+            )
+
+            self.assertTrue(summary["interrupted"])
+            statuses = {entry["unit_id"]: entry["status"] for entry in summary["units"]}
+            # Both units surface in the rollup — nothing silently vanishes as
+            # if it were never planned.
+            self.assertEqual(set(statuses), {"one", "two"})
+            self.assertIn("interrupted", set(statuses.values()))
+
+    def test_system_exit_re_raises_after_the_summary_is_written(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._fixture(tmp)
+
+            def runner(argv, **kwargs):
+                if argv[0] == "git":
+                    return subprocess.run(argv, **kwargs)
+                raise SystemExit(143)
+
+            with self.assertRaises(SystemExit):
+                dispatch_fanout(
+                    paths,
+                    contract,
+                    goal_text=_GOAL,
+                    repo_root=repo,
+                    base_sha=sha,
+                    concurrency=1,
+                    runner=runner,
+                    readiness=_ready,
+                )
+            # The stored summary was written before the re-raise: a
+            # supervisor observes the death it asked for AND the record
+            # says the batch was cut short.
+            stored = read_json_object(fanout_dispatch_summary_path(paths, contract["fanout_id"]))
+            self.assertTrue(stored and stored.get("interrupted"))
+
+
+class AsyncSignalTests(unittest.TestCase):
+    @posix_only
+    def test_sigterm_mid_flight_kills_groups_and_blocks_new_spawns(self) -> None:
+        # A REAL signal, delivered while workers are mid-flight — the shape
+        # the synchronous raise-inside-a-worker tests cannot reach. The
+        # spawned group must die, no unit spawn may survive the signal, the
+        # summary file must say interrupted, and the whole thing must settle
+        # within the grace budget rather than the 1800s unit timeout.
+        import threading as _threading
+
+        from omh.coding.fanout_dispatch import signal_safe_unit_runner as safe_runner
+
+        units = [
+            {"unit_id": f"u{index}", "title": f"U{index}", "owner": "codex", "file_scope": [f"src/u{index}/"]}
+            for index in range(3)
+        ]
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = _paths(tmp)
+            repo, sha = _make_repo(root)
+            contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, units))
+            spawn_pids: list[int] = []
+            first_spawn = _threading.Event()
+            lock = _threading.Lock()
+
+            def runner(argv, **kwargs):
+                if argv[0] == "git":
+                    return subprocess.run(argv, **kwargs)
+
+                def on_spawn(process) -> None:
+                    with lock:
+                        spawn_pids.append(process.pid)
+                    first_spawn.set()
+
+                # Delegate to the real signal-safe runner with a long-lived
+                # stand-in child so the signal lands mid-communicate.
+                return safe_runner(
+                    ["sleep", "30"], text=True, capture_output=True, timeout=60, on_spawn=on_spawn
+                )
+
+            def fire_sigterm() -> None:
+                first_spawn.wait(timeout=30)
+                time.sleep(0.2)
+                os.kill(os.getpid(), signal.SIGTERM)
+
+            killer = _threading.Thread(target=fire_sigterm)
+            killer.start()
+            started = time.monotonic()
+            with self.assertRaises(SystemExit) as caught:
+                dispatch_fanout(
+                    paths,
+                    contract,
+                    goal_text=_GOAL,
+                    repo_root=repo,
+                    base_sha=sha,
+                    concurrency=2,
+                    runner=runner,
+                    readiness=_ready,
+                )
+            elapsed = time.monotonic() - started
+            killer.join(timeout=10)
+            self.assertEqual(caught.exception.code, 143)
+            # Settled within the grace budget, not the unit timeout.
+            self.assertLess(elapsed, 25)
+            stored = read_json_object(fanout_dispatch_summary_path(paths, contract["fanout_id"]))
+            self.assertTrue(stored and stored.get("interrupted"))
+            # Every spawned stand-in group is dead — a spawn that raced the
+            # signal was terminated by the runner's register-then-check.
+            deadline = time.monotonic() + 10
+            while time.monotonic() < deadline:
+                if all(not _group_exists(pid) for pid in spawn_pids):
+                    break
+                time.sleep(0.05)
+            for pid in spawn_pids:
+                self.assertFalse(_group_exists(pid), f"group {pid} outlived the interrupt")
+
+
+def _group_exists(pid: int) -> bool:
+    try:
+        os.killpg(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+class FanoutReapTests(unittest.TestCase):
+    @posix_only
+    def test_reaps_only_marker_named_group_leaders(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, _UNITS))
+            fanout_id = contract["fanout_id"]
+            # A genuinely reparented orphan — the intermediary exits after
+            # printing the leader pid, exactly the state a dead dispatcher
+            # leaves behind. A direct child would linger as our own zombie
+            # and read as alive after the kill.
+            intermediary = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    "import subprocess; p = subprocess.Popen(['sleep', '60'], start_new_session=True,"
+                    " stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL); print(p.pid)",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=30,
+            )
+            orphan_pid = int(intermediary.stdout.strip())
+            try:
+                write_inflight_marker(
+                    paths,
+                    fanout_id,
+                    "one",
+                    {"owner": "codex", "pid": str(orphan_pid), "started_at": ""},
+                )
+                report = reap_fanout_units(paths, fanout_id, grace=2)
+                rows = {row["pid"]: row for row in report["candidates"]}
+                self.assertEqual(rows[orphan_pid]["status"], "reaped")
+                self.assertIn("SIGTERM", rows[orphan_pid]["signals_sent"])
+                # The reaped unit's marker is cleared; presence-is-not-liveness
+                # never had to be weakened to get here.
+                remaining = [
+                    entry
+                    for entry in read_inflight_markers(paths, limit=50)
+                    if entry.get("fanout_id") == fanout_id
+                ]
+                self.assertEqual(remaining, [])
+            finally:
+                try:
+                    os.killpg(orphan_pid, signal.SIGKILL)
+                except OSError:
+                    pass
+
+    @posix_only
+    def test_refuses_pids_the_markers_do_not_name(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, _UNITS))
+            bystander = subprocess.Popen(["sleep", "60"], start_new_session=True)
+            try:
+                report = reap_fanout_units(paths, contract["fanout_id"], pids=[bystander.pid], grace=1)
+                row = report["candidates"][0]
+                self.assertEqual(row["status"], "refused_not_marker_named")
+                # The bystander survives: no marker, no kill, whatever the name.
+                self.assertIsNone(bystander.poll())
+            finally:
+                bystander.kill()
+                bystander.wait(timeout=10)
+
+    @posix_only
+    def test_a_recycled_pid_with_a_dead_group_is_already_gone_and_never_signalled(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, _UNITS))
+            # Our own pid is alive but the GROUP named by it does not exist —
+            # the recycled-pid shape after the original unit group fully
+            # exited. Group-level liveness reports the truth (`already_gone`)
+            # and nothing is ever signalled at the live bystander.
+            own_pid = os.getpid()
+            if os.getpgid(own_pid) == own_pid:
+                self.skipTest("test process is itself a group leader")
+            write_inflight_marker(
+                paths,
+                contract["fanout_id"],
+                "one",
+                {"owner": "codex", "pid": str(own_pid), "started_at": ""},
+            )
+            report = reap_fanout_units(paths, contract["fanout_id"], grace=1)
+            row = report["candidates"][0]
+            self.assertEqual(row["status"], "already_gone")
+            self.assertNotIn("signals_sent", row)
+
+    @posix_only
+    def test_a_dead_leader_with_live_grandchildren_is_still_reapable(self) -> None:
+        # The OMO incident shape: the leader exited, the engine below it
+        # survives in the group. Leader-only liveness called this
+        # `already_gone` and destroyed the marker while the orphan ran on;
+        # group-level liveness reaps it.
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, _UNITS))
+            fanout_id = contract["fanout_id"]
+            probe = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    "import os, subprocess, sys\n"
+                    "leader = subprocess.Popen([sys.executable, '-c', "
+                    "\"import subprocess, sys; subprocess.Popen(['sleep', '60'], "
+                    "stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL); sys.exit(0)\"], "
+                    "start_new_session=True)\n"
+                    "leader.wait()\n"
+                    "print(leader.pid)\n",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=30,
+            )
+            leader_pid = int(probe.stdout.strip())
+            try:
+                # The leader is dead; the group it led still exists.
+                with self.assertRaises(ProcessLookupError):
+                    os.kill(leader_pid, 0)
+                write_inflight_marker(
+                    paths,
+                    fanout_id,
+                    "one",
+                    {"owner": "codex", "pid": str(leader_pid), "started_at": ""},
+                )
+                report = reap_fanout_units(paths, fanout_id, grace=2)
+                row = report["candidates"][0]
+                self.assertEqual(row["status"], "reaped")
+            finally:
+                try:
+                    os.killpg(leader_pid, signal.SIGKILL)
+                except OSError:
+                    pass
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Capability

The opt-in fanout dispatch path stops orphaning its children: every unit spawns as its own session/process group under a signal-safe default runner, timeouts kill the whole group, Ctrl-C/SIGTERM terminate every live group and record the batch as `interrupted` (never-started units carry an `interrupted` status; killed units are flagged so a `-15` exit is not re-read as a model failure), and a new `omh coding fanout reap <fanout-id>` terminates marker-named orphan groups — group-level liveness, recycled-pid refusal, and deliberately **no pattern-matching kill**.

## Motivation

Top correctness finding of the owner-directed OMO engineering comparison: OMO shipped a launcher incident where a process blocked in a synchronous spawn died on SIGTERM and its engine reparented to pid 1, still holding the terminal — and OMH's fanout had the identical shape (`subprocess.run` in pool workers, zero signal handling, no reaper for the honest-but-unremediable `liveness: "unknown"` markers). Every primitive for the fix already existed unused in `_hermes_child_process.py`.

## Implementation (boundary level)

- `src/coding/fanout_dispatch.py` — `signal_safe_unit_runner` (drop-in default; session groups, live-groups registry, group kill on timeout, `on_spawn` hook records the leader pid into the inflight marker; `accepts_on_spawn` capability attribute so wrappers can propagate); process-wide interrupt flag set before any termination and checked before/after the owner gate plus register-then-check in the runner (review HIGH, reproduced: a gate-parked worker used to spawn a fresh 1800s agent CLI *after* the interrupt); pool shutdown in `finally` on every exit path (review HIGH: a worker exception used to leak live pool threads into the atexit join); SIGTERM handler (main thread) re-raises SystemExit(143) **after** the summary file is written; Ctrl-C prints the summary and the CLI exits 130.
- `src/coding/fanout_reap.py` (new) — group-level liveness via the existing `group_absent` (review HIGH, reproduced: leader-only liveness reported `already_gone` and destroyed the marker while the orphan group ran on); dead-leader-with-live-grandchildren stays reapable; recycled pids and unmarked pids refused; `refused_permission` distinguished from `still_alive`; markers cleared only when the group is gone; Windows fails closed. The reaper does not claim the dispatcher is dead — help text and docs say to verify that first.
- `src/coding/inflight.py` — `pid` joins the marker field allowlist (liveness claim untouched); `read_inflight_markers` gains a `fanout_id` filter applied **before** the limit slice (review MEDIUM: the global-oldest-200 slice could silently drop the target fanout's markers and fail open).
- `src/commands/coding.py` — `fanout reap` subcommand; dispatch exits 130 on an interrupted batch; reap exits 1 when any candidate ends `still_alive`/`refused_permission`.
- `tests/test_fanout_signal_safety.py` (new, 10 tests) — real process groups: session-leader assertion, timeout-kills-grandchildren, registry termination, **async mid-flight SIGTERM** (asserts groups die, no spawn survives, stored summary says interrupted, settles within grace not the 1800s timeout), synchronous interrupt paths, dead-leader reap, unmarked-pid refusal, recycled-pid-with-dead-group safety.
- `tests/test_broad_exception_policy.py` — the runner's one broad `except` (terminate the child the raising hook leaked, re-raise the same exception) classified per the #652 policy; counts updated.

## Verification (observed)

- `PYTHONPATH=tests uv run python -m unittest discover -s tests` — **7317 tests, OK** (final tree).
- All five byte gates, ruff, compileall, `git diff --check` clean.
- Separate-lane review: 0 CRITICAL, **4 HIGH — all reproduced by the reviewer with live repros, all fixed with regression tests**; 6 MEDIUM addressed (async-interrupt test, fanout-scoped marker read, reap exit codes, "orphaned" wording, SIGTERM/130 docs split, killed-unit interrupted flag); LOWs taken (RLock, poll-before-signal, on_spawn leak guard, `with process:` pipe close, capability attribute, docstring limit note, handler-restore boolean, install-inside-try).

## Risks

- The default runner changed for every fanout call site (git and verification calls included) — all four call sites verified signature-compatible including bytes mode; injected test runners keep the plain protocol.
- Windows: the dispatcher keeps the `taskkill` fallback without session isolation (documented); the reaper refuses on Windows by design.
- One dispatch per process is the supported shape for the interrupt flag (documented in code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKo77o5dTJtLRWfDj4uBtq