### PR TITLE
feat(coding): dependency-frontier admission with a seeded chaos bench

### DIFF
--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -102,12 +102,20 @@ Rules:
   one rate-limited provider is not hammered by the whole pool; owners not
   named there are governed by the global pool alone. A gated owner's units
   hold pool slots while they wait for a lane, so many same-owner units
-  queued ahead can delay another owner's units in the same wave — size
+  queued ahead can delay another owner's ready units — size
   `per_owner` with that trade in mind. An install written before this
   block existed resolves to the same defaults without showing the block;
   re-running `omh setup` writes it out, and rewrites the whole profile
   while doing so. `lane_budget_default` is advisory context for
   Hermes-native lanes — OMH never enforces a lane count inside Hermes.
+- **Admission is dependency-frontier, not wave-barrier.** A unit starts the
+  moment every unit it depends on has completed and a pool slot is free —
+  never because a wave boundary was reached — so an unrelated slow sibling
+  cannot starve ready dependents (OMO's DAG scheduler discipline). The
+  wave grouping in `merge_order` is informational; merge order itself is
+  unchanged. A seeded chaos bench (`tests/test_fanout_chaos.py`, replay
+  with `SEED=<n>`) drives random DAGs, outcomes, pool widths, and owner
+  lanes through the real engine and holds the scheduler invariants.
 - **Units are process groups; interrupts are honest.** The default runner
   spawns each unit as its own session/process group and records the leader
   pid in the unit's inflight marker. A timeout kills the whole group (no

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from concurrent.futures import FIRST_COMPLETED
 from concurrent.futures import CancelledError as FuturesCancelledError
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
+from concurrent.futures import wait as futures_wait
 from hashlib import sha256
 import json
 import os
@@ -11,6 +13,7 @@ import shlex
 import shutil
 import signal
 import subprocess
+import sys
 import threading
 import time
 from typing import Any, Callable, Iterable, Mapping, Sequence
@@ -961,8 +964,8 @@ def dispatch_fanout(
     # semaphore — the global pool alone governs everyone else. The gate
     # wraps the unit's WHOLE lifecycle (readiness probe, worktree, spawn,
     # and local verification when requested), so an over-subscribed owner
-    # holds a pool slot while it waits and can delay other owners' units
-    # queued behind it in the same wave; with the pool sized to the global
+    # holds a pool slot while it waits and can delay other owners' ready
+    # units queued behind it; with the pool sized to the global
     # ceiling that is the same trade OMO's global permit makes.
     owner_gates = {
         owner: threading.BoundedSemaphore(int(width))
@@ -1006,50 +1009,65 @@ def dispatch_fanout(
 
             previous_term = signal.signal(signal.SIGTERM, _on_sigterm)
             installed_term = True
+        # Dependency-frontier admission, learned from OMO's DAG scheduler: a
+        # unit is admitted the moment EVERY unit it depends on completed —
+        # never because a wave boundary was reached — so an unrelated slow
+        # sibling cannot starve ready dependents behind a barrier the
+        # contract never promised. `merge_order`'s wave grouping is
+        # informational from here on; admission is per-completion.
+        def _submit(unit_id: str) -> None:
+            futures[unit_id] = pool.submit(
+                _dispatch_with_owner_gate,
+                units[unit_id],
+                goal_text=goal_text,
+                repo_root=repo_root,
+                base_sha=base_sha,
+                source_ref=source_ref,
+                timeout=timeout,
+                dry_run=dry_run,
+                run_verification=run_verification,
+                runner=runner,
+                readiness=readiness,
+                current_catalog_digest=current_catalog_digest,
+                fanout_id=fanout_id,
+                discoveries=discoveries,
+                capability_precheck=capability_prechecks[unit_id],
+            )
+
+        def _admit_frontier() -> None:
+            # Blocking on a failed dependency is safe to do eagerly here:
+            # unit failure is terminal in this engine (no revive), unlike the
+            # OMO scheduler whose quiescence-gated cascade protects revivable
+            # nodes. The no-progress fallback below still catches a pending
+            # set that can neither run nor block (validated cycles aside).
+            for unit_id in list(pending):
+                if unit_id in futures:
+                    continue
+                if any(_dependency_failed(results.get(dep)) for dep in units[unit_id].get("depends_on", [])):
+                    results[unit_id] = _blocked(units[unit_id], results)
+                    pending.remove(unit_id)
+            for unit_id in list(pending):
+                if unit_id in futures:
+                    continue
+                if all(_dependency_satisfied(results.get(dep)) for dep in units[unit_id].get("depends_on", [])):
+                    _submit(unit_id)
+
+        _admit_frontier()
         while pending:
-            ready = [
-                unit_id
-                for unit_id in pending
-                if all(_dependency_satisfied(results.get(dep)) for dep in units[unit_id].get("depends_on", []))
-            ]
-            blocked = [
-                unit_id
-                for unit_id in pending
-                if any(_dependency_failed(results.get(dep)) for dep in units[unit_id].get("depends_on", []))
-            ]
-            for unit_id in blocked:
-                results[unit_id] = _blocked(units[unit_id], results)
-                pending.remove(unit_id)
-            ready = [unit_id for unit_id in ready if unit_id in pending]
-            if not ready:
-                if pending and not blocked:
-                    for unit_id in list(pending):
-                        results[unit_id] = _blocked(units[unit_id], results)
-                        pending.remove(unit_id)
-                continue
-            futures = {
-                unit_id: pool.submit(
-                    _dispatch_with_owner_gate,
-                    units[unit_id],
-                    goal_text=goal_text,
-                    repo_root=repo_root,
-                    base_sha=base_sha,
-                    source_ref=source_ref,
-                    timeout=timeout,
-                    dry_run=dry_run,
-                    run_verification=run_verification,
-                    runner=runner,
-                    readiness=readiness,
-                    current_catalog_digest=current_catalog_digest,
-                    fanout_id=fanout_id,
-                    discoveries=discoveries,
-                    capability_precheck=capability_prechecks[unit_id],
-                )
-                for unit_id in ready
-            }
-            for unit_id, future in futures.items():
-                results[unit_id] = future.result()
-                pending.remove(unit_id)
+            inflight = {unit_id: futures[unit_id] for unit_id in pending if unit_id in futures}
+            if not inflight:
+                # Nothing running and nothing admissible: the remainder can
+                # only be waiting on units that will never complete.
+                for unit_id in list(pending):
+                    results[unit_id] = _blocked(units[unit_id], results)
+                    pending.remove(unit_id)
+                break
+            done, _ = futures_wait(inflight.values(), return_when=FIRST_COMPLETED)
+            for unit_id, future in inflight.items():
+                if future in done:
+                    results[unit_id] = future.result()
+                    pending.remove(unit_id)
+            _admit_frontier()
         pool.shutdown(wait=True)
     except (KeyboardInterrupt, SystemExit) as exc:
         # Ctrl-C or a handled SIGTERM: stop admitting work, kill every live
@@ -1090,7 +1108,11 @@ def dispatch_fanout(
     finally:
         # Idempotent after the success/interrupt shutdowns; without it, a
         # worker exception re-raised by future.result() leaks live pool
-        # threads that the interpreter then joins at exit.
+        # threads that the interpreter then joins at exit. A plain exception
+        # unwinding here (not the handled interrupt) must also not orphan
+        # live agent groups — the same hazard the signal path closes.
+        if sys.exc_info()[0] is not None and interrupted_by is None:
+            terminate_live_unit_groups()
         pool.shutdown(wait=False, cancel_futures=True)
         if installed_term:
             signal.signal(signal.SIGTERM, previous_term)
@@ -2159,10 +2181,13 @@ def _dependency_failed(result: dict[str, Any] | None) -> bool:
 
 def _blocked(unit: Mapping[str, Any], results: Mapping[str, dict[str, Any]]) -> dict[str, Any]:
     entry = _skipped(unit, "blocked_by_dependency")
-    entry["blocked_on"] = [
-        str(dep)
-        for dep in unit.get("depends_on", []) or []
-        if _dependency_failed(results.get(str(dep)))
+    deps = [str(dep) for dep in unit.get("depends_on", []) or []]
+    failed = [dep for dep in deps if _dependency_failed(results.get(dep))]
+    # A dependency stuck in a non-terminal verdict (for example
+    # model_choice_required) is neither satisfied nor failed; the entry must
+    # still name what it was waiting on rather than blocking on nothing.
+    entry["blocked_on"] = failed or [
+        dep for dep in deps if not _dependency_satisfied(results.get(dep))
     ]
     return entry
 

--- a/tests/test_fanout_chaos.py
+++ b/tests/test_fanout_chaos.py
@@ -1,0 +1,245 @@
+"""Seeded adversarial invariants for the fanout dispatch scheduler.
+
+Adopted from OMO's chaos bench discipline: enumerated tests only find bugs
+someone already imagined, so this file drives the real dispatch engine over
+randomly shaped DAGs, outcomes, pool widths, and owner lanes, and checks
+invariants that must hold for EVERY shape. No wall clock and no bare
+`random` — every draw derives from one seed (`SEED` env replays a failure;
+each iteration gets an independent sub-stream so one iteration reproduces
+in isolation), and the seed is embedded in every assertion message.
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import subprocess
+import threading
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from omh.coding.fanout import build_fanout_contract
+from omh.coding.fanout_artifacts import write_fanout_contract
+from omh.coding.fanout_dispatch import dispatch_fanout
+from omh.system.paths import OmhPaths
+
+_SEED = int(os.environ.get("SEED", "20260827"))
+_ITERATIONS = int(os.environ.get("CHAOS_ITERATIONS", "25"))
+_GOAL = "chaos drill"
+_OWNERS = ("codex", "claude-code")
+
+
+def _ready(paths, profile, **kwargs):
+    return {"status": "ready", "profile": profile}
+
+
+class _FakeCompleted:
+    def __init__(self, returncode: int, stdout: str) -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = ""
+
+
+def _make_repo(root: Path) -> tuple[Path, str]:
+    repo = root / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=str(repo), check=True)
+    (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "seed.txt"], cwd=str(repo), check=True)
+    subprocess.run(
+        ["git", "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "init"],
+        cwd=str(repo),
+        check=True,
+    )
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=str(repo), capture_output=True, text=True, check=True
+    ).stdout.strip()
+    return repo, sha
+
+
+def _random_units(rng: random.Random) -> list[dict[str, object]]:
+    # Four is the spawn-plan-free ceiling; a larger split needs the
+    # spawn_plan rationale block, which is contract policy, not scheduling.
+    count = rng.randint(2, 4)
+    units: list[dict[str, object]] = []
+    for index in range(count):
+        unit: dict[str, object] = {
+            "unit_id": f"u{index}",
+            "title": f"Unit {index}",
+            "owner": rng.choice(_OWNERS),
+            "file_scope": [f"src/u{index}/"],
+        }
+        # Dependencies only point at lower indices, so every generated DAG
+        # is acyclic by construction and the contract validator accepts it.
+        candidates = [f"u{dep}" for dep in range(index)]
+        depends_on = [dep for dep in candidates if rng.random() < 0.35]
+        if depends_on:
+            unit["depends_on"] = depends_on
+        units.append(unit)
+    return units
+
+
+class FanoutChaosTests(unittest.TestCase):
+    def test_random_dags_hold_the_scheduler_invariants(self) -> None:
+        for iteration in range(_ITERATIONS):
+            rng = random.Random(f"{_SEED}:{iteration}")
+            label = f"SEED={_SEED} iteration={iteration}"
+            with self.subTest(label), TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+                repo, sha = _make_repo(root)
+                units = _random_units(rng)
+                units_by_id = {str(unit["unit_id"]): unit for unit in units}
+                outcomes = {
+                    str(unit["unit_id"]): rng.choices(
+                        ["ok", "fail", "timeout", "missing"], weights=[6, 2, 1, 1]
+                    )[0]
+                    for unit in units
+                }
+                dispatch_counts: dict[str, int] = {}
+                counts_lock = threading.Lock()
+
+                def runner(argv, **kwargs):
+                    if argv[0] == "git":
+                        return subprocess.run(argv, **kwargs)
+                    # The worktree path ends `-fanout-<unit_id>` — the one
+                    # anchor that names exactly this unit; prompt text also
+                    # mentions dependency ids and would misattribute.
+                    cwd = str(kwargs.get("cwd", ""))
+                    self.assertIn("-fanout-", cwd, f"{label}: unattributable spawn cwd {cwd!r}")
+                    unit_id = cwd.rsplit("-fanout-", 1)[-1]
+                    # Read-modify-write under a lock: a lost update would HIDE
+                    # a double dispatch, making the bench quieter, not louder.
+                    with counts_lock:
+                        dispatch_counts[unit_id] = dispatch_counts.get(unit_id, 0) + 1
+                    outcome = outcomes.get(unit_id, "ok")
+                    if outcome == "timeout":
+                        raise subprocess.TimeoutExpired(argv, kwargs.get("timeout", 0))
+                    if outcome == "missing":
+                        raise FileNotFoundError(argv[0])
+                    return _FakeCompleted(0 if outcome == "ok" else 1, f"unit {unit_id} done")
+
+                contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, units))
+                summary = dispatch_fanout(
+                    paths,
+                    contract,
+                    goal_text=_GOAL,
+                    repo_root=repo,
+                    base_sha=sha,
+                    concurrency=rng.randint(1, 4),
+                    per_owner_lanes={"codex": 1} if rng.random() < 0.5 else None,
+                    runner=runner,
+                    readiness=_ready,
+                )
+
+                entries = {entry["unit_id"]: entry for entry in summary["units"]}
+                # 1. Every planned unit reaches exactly one terminal entry.
+                self.assertEqual(set(entries), set(units_by_id), label)
+                # 2. No unit is ever dispatched twice within one run.
+                for unit_id, count in dispatch_counts.items():
+                    self.assertLessEqual(count, 1, f"{label}: {unit_id} dispatched {count}x")
+                # 3. merge_order is a topological order of depends_on.
+                positions = {unit_id: index for index, unit_id in enumerate(summary["merge_order"])}
+                for unit_id, unit in units_by_id.items():
+                    for dep in unit.get("depends_on", []) or []:
+                        self.assertLess(
+                            positions[str(dep)], positions[unit_id],
+                            f"{label}: {unit_id} merges before its dependency {dep}",
+                        )
+                # 4. A blocked unit has an unsuccessful direct dependency and
+                #    names what it blocked on; success never blocks anyone.
+                for unit_id, entry in entries.items():
+                    if entry["status"] == "blocked_by_dependency":
+                        deps = units_by_id[unit_id].get("depends_on", []) or []
+                        self.assertTrue(deps, f"{label}: {unit_id} blocked with no deps")
+                        self.assertTrue(
+                            any(not entries[str(dep)].get("process_succeeded") for dep in deps),
+                            f"{label}: {unit_id} blocked but every direct dep succeeded",
+                        )
+                        self.assertTrue(
+                            entry.get("blocked_on"),
+                            f"{label}: {unit_id} blocked without naming a dependency",
+                        )
+                # 5. An executed verdict means executed exactly once — this
+                #    catches both a phantom result for a never-dispatched unit
+                #    and a genuine second spawn, which worktree collisions
+                #    would otherwise mask as a different failure.
+                for unit_id, entry in entries.items():
+                    if entry["status"] in {"completed", "failed"}:
+                        self.assertEqual(
+                            dispatch_counts.get(unit_id, 0), 1,
+                            f"{label}: {unit_id} reports {entry['status']} with "
+                            f"{dispatch_counts.get(unit_id, 0)} dispatches",
+                        )
+                # 6. process_succeeded tracks the injected outcome exactly for
+                #    units that actually ran.
+                for unit_id, count in dispatch_counts.items():
+                    expected = outcomes[unit_id] == "ok"
+                    self.assertEqual(
+                        bool(entries[unit_id].get("process_succeeded")), expected,
+                        f"{label}: {unit_id} outcome {outcomes[unit_id]} vs entry",
+                    )
+                # 7. No interrupt was injected, so none may be reported.
+                self.assertNotIn("interrupted", summary, label)
+                for entry in entries.values():
+                    self.assertNotEqual(entry.get("status"), "interrupted", label)
+
+    def test_a_ready_dependent_starts_before_an_unrelated_slow_sibling_finishes(self) -> None:
+        # The frontier property itself — the reason the wave barrier was
+        # removed. Under the barrier, u1 (dependent on fast u0) could not
+        # start until the unrelated slow sibling drained the wave; under
+        # frontier admission it starts while `slow` is still running. This
+        # deterministic shape needs a real sleep, which the seeded bench
+        # deliberately avoids — hence a separate test.
+        import threading as _threading
+        import time as _time
+
+        units = [
+            {"unit_id": "slow", "title": "Slow sibling", "owner": "codex", "file_scope": ["src/slow/"]},
+            {"unit_id": "u0", "title": "Fast base", "owner": "codex", "file_scope": ["src/u0/"]},
+            {"unit_id": "u1", "title": "Dependent", "owner": "codex", "file_scope": ["src/u1/"], "depends_on": ["u0"]},
+        ]
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            repo, sha = _make_repo(root)
+            contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, units))
+            slow_done = _threading.Event()
+            events: list[tuple[str, str, bool]] = []
+            events_lock = _threading.Lock()
+
+            def runner(argv, **kwargs):
+                if argv[0] == "git":
+                    return subprocess.run(argv, **kwargs)
+                cwd = str(kwargs.get("cwd", ""))
+                unit_id = cwd.rsplit("-fanout-", 1)[-1]
+                with events_lock:
+                    events.append(("start", unit_id, slow_done.is_set()))
+                if unit_id == "slow":
+                    _time.sleep(1.0)
+                    slow_done.set()
+                with events_lock:
+                    events.append(("end", unit_id, slow_done.is_set()))
+                return _FakeCompleted(0, f"unit {unit_id} done")
+
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                concurrency=3,
+                runner=runner,
+                readiness=_ready,
+            )
+
+            statuses = {entry["unit_id"]: entry["status"] for entry in summary["units"]}
+            self.assertEqual(statuses["u1"], "completed", statuses)
+            # u1 was admitted while the unrelated slow sibling was still
+            # running — the wave barrier would have recorded True here.
+            self.assertIn(("start", "u1", False), events, events)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Capability

The fanout scheduler moves from a strict wave barrier to **dependency-frontier admission** (OMO's DAG scheduler discipline): a unit starts the moment every unit it depends on has completed and a pool slot is free — never because a wave boundary was reached — so an unrelated slow sibling no longer starves ready dependents. The scheduler also gains OMO's seeded adversarial bench: 25 replayable iterations of random DAGs, outcomes, pool widths, and owner lanes through the real engine, holding seven invariants.

## Motivation

The old loop drained every future in a wave before recomputing the frontier (`future.result()` over the whole wave), so one slow unit held back every dependent that its own dependencies had already unblocked. This was the #1-ranked adoptable improvement in the owner-directed OMO engineering comparison; the bench was its highest quality-per-line item ("enumerated tests only find bugs someone already imagined").

## Implementation (boundary level)

- `src/coding/fanout_dispatch.py` — `_admit_frontier()` blocks dependents of failed units eagerly (safe here: unit failure is terminal, no revive — the quiescence gate OMO needs for revivable nodes is deliberately not copied, reasoning at the site) and submits everything whose deps are satisfied; the loop waits `FIRST_COMPLETED`, folds, re-admits. `futures` is cumulative, which makes the interrupt path stricter than before (the old per-wave rebinding could orphan a partial wave mid-comprehension; reviewer verified byte-identical interrupt outcomes under a real SIGINT). Review-hardened riders: `blocked_on` names the unsatisfied deps when none is classified failed (a dep stuck in `model_choice_required` used to block dependents on an empty list — pre-existing, reproduced), and an exception unwinding the loop now terminates live unit groups in the `finally` (the orphan hazard #1135 closed for signals, still open for plain worker exceptions).
- `tests/test_fanout_chaos.py` (new) — seeded bench (SEED env replays; per-iteration sub-streams; zero wall clock; seed in every assertion message) plus a **deterministic frontier regression test** (review HIGH: the chaos invariants are safety properties the old barrier also satisfied — the reviewer proved the new bench passes on the barrier code; the deterministic test fails there, asserting a dependent starts while an unrelated slow sibling still runs). Invariants repaired per review: the vacuous `_transitive_failed` disjunct removed, "executed verdict ⟹ dispatched exactly once" catches phantom results and double spawns directly, `blocked_on` non-empty pinned, counts under a lock (a lost update would hide a double dispatch), attribution anchored to the `-fanout-<unit_id>` worktree path with a loud failure if the anchor moves.
- `docs/FANOUT.md` — frontier admission documented; stale "same wave" wording removed from the owner-gate prose and code comment.

## Verification (observed)

- `PYTHONPATH=tests uv run python -m unittest discover -s tests` — **7319 tests, OK** (final tree).
- All five byte gates, ruff, compileall, `git diff --check` clean; drift registry untouched.
- Separate-lane review ran both schedulers side by side and probed livelock, hot spin, wrong-future folding, gate deadlock, and interrupt interplay to definite answers: the production change had **0 defects**; all findings (1 HIGH, 4 MEDIUM, 4 LOW) were evidence/bench quality and pre-existing honesty gaps — all addressed.

## Risks

- The scheduler loop is shared by every fanout dispatch; blocking/interrupt/per-unit semantics are pinned by the existing 104-test fanout suites (unchanged) plus the new invariants.
- Wall-clock throughput gain on live multi-minute fanouts is `prepared_not_observed` — the bench proves ordering and safety, not speedup.
- Untracked `review-work-code.json` at the repo root (a review lane's scratch) reported, not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKo77o5dTJtLRWfDj4uBtq