### PR TITLE
feat(runtime): add opt-in truthful Hermes skill-load observation probe

### DIFF
--- a/docs/MULTI_AGENT_OPERATIONS.md
+++ b/docs/MULTI_AGENT_OPERATIONS.md
@@ -76,6 +76,34 @@ isolated child, and records `routing_observation/v1`. Status, tool count, token
 usage, and cost are shown only when Hermes produced observed telemetry; OMH
 does not estimate missing values.
 
+The same boundary has a separate, explicit loaded-skill capability probe:
+
+```bash
+omh coding hermes-child skill-load-probe --confirm-dispatch \
+  --run-id load-1 --expected-skill ulw-work --json
+omh coding hermes-child skill-load-status --run-id load-1 --json
+```
+
+This command implements `skill_load_observation/v1`. `probe_status` is
+orthogonal to `load_state`: only a validated, fresh
+`hermes_skill_inventory/v1` response bound to the generated nonce, expected-set
+digest, inventory digest, and executable fingerprint can emit `observed`.
+Observed inventories contain sorted expected, observed, missing, and unexpected
+skill-name sets. An empty expected set becomes `not_applicable` only after that
+valid response. Unsupported and failed probes omit `load_state` and every
+inventory claim, retain only closed reason codes and fingerprints, and never
+persist command output.
+
+Hermes Agent v0.20.5 at upstream `5259f565` has no such inventory command. Its
+`--skills` option preloads prompt content and `hermes skills list
+--enabled-only` lists configured candidates, but neither returns a nonce-bound
+runtime inventory. The real host probe therefore reports
+`inventory_protocol_unavailable`; child success, model self-report, static
+scheduler source, and installed/enabled listings are deliberately insufficient.
+The complete observed host capability remains blocked on an external Hermes
+machine-inventory protocol. This OMH contract does not patch Hermes, execute a
+skill body, mutate config, call a provider directly, or run by default.
+
 Model routing preferences are also an agent/operator surface:
 
 ```bash

--- a/src/coding/hermes_child_dispatch.py
+++ b/src/coding/hermes_child_dispatch.py
@@ -164,6 +164,18 @@ class CancellationToken:
             self._callbacks.discard(callback)
 
 
+def require_hermes_child_dispatch_boundary(
+    *, dispatch_policy: str, confirmed: bool, depth: int = 0
+) -> None:
+    """Enforce the shared confirmation and depth-one child boundary."""
+    if dispatch_policy != "ask_before_dispatch" or not confirmed:
+        raise DispatchConfirmationError(
+            "isolated Hermes dispatch requires ask_before_dispatch and explicit confirmation"
+        )
+    if depth >= MAX_CHILD_DEPTH or _environment_is_child():
+        raise DispatchRecursionError("isolated Hermes child dispatch depth is limited to one")
+
+
 def dispatch_hermes_child(
     request: HermesChildRequest,
     *,
@@ -173,12 +185,9 @@ def dispatch_hermes_child(
     observe: Callable[[HermesChildObservation], None] | None = None,
 ) -> HermesChildResult:
     """Run one explicitly confirmed local Hermes child and observe its state."""
-    if dispatch_policy != "ask_before_dispatch" or not confirmed:
-        raise DispatchConfirmationError(
-            "isolated Hermes dispatch requires ask_before_dispatch and explicit confirmation"
-        )
-    if request.depth >= MAX_CHILD_DEPTH or _environment_is_child():
-        raise DispatchRecursionError("isolated Hermes child dispatch depth is limited to one")
+    require_hermes_child_dispatch_boundary(
+        dispatch_policy=dispatch_policy, confirmed=confirmed, depth=request.depth
+    )
     if not request.prompt or not request.model or request.timeout_seconds <= 0:
         raise ValueError("prompt, model, and a positive timeout are required")
     _enter_dispatch_guard()

--- a/src/coding/skill_load_observation.py
+++ b/src/coding/skill_load_observation.py
@@ -277,6 +277,8 @@ def _run_inventory_process(
     )
     process: subprocess.Popen[bytes] | None = None
     drainers = None
+    kind = "spawn_error"
+    cleanup_verified = True
     try:
         process = subprocess.Popen(
             argv, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
@@ -288,18 +290,27 @@ def _run_inventory_process(
             kind = "complete"
         except subprocess.TimeoutExpired:
             kind = "timeout"
-            terminate_process_group(process, request.termination_grace_seconds, signal.SIGTERM)
-        finally:
-            terminate_process_group(process, request.termination_grace_seconds, signal.SIGTERM)
-            for drainer in drainers:
-                drainer.done.wait(max(0.1, request.termination_grace_seconds))
-                drainer.thread.join(timeout=max(0.1, request.termination_grace_seconds))
-        stdout_capture = drainers[0].capture()
-        if stdout_capture.truncated:
-            return _ProcessOutcome("complete", process.returncode, b"")
-        return _ProcessOutcome(kind, process.returncode, stdout_capture.data)
     except OSError:
+        pass
+    finally:
+        if process is not None:
+            _signals, cleanup_verified = terminate_process_group(
+                process, request.termination_grace_seconds, signal.SIGTERM
+            )
+            if drainers is None:
+                for pipe in (process.stdout, process.stderr):
+                    if pipe is not None:
+                        pipe.close()
+            else:
+                for drainer in drainers:
+                    drainer.done.wait(max(0.1, request.termination_grace_seconds))
+                    drainer.thread.join(timeout=max(0.1, request.termination_grace_seconds))
+    if not cleanup_verified or process is None or drainers is None:
         return _ProcessOutcome("spawn_error", None, b"")
+    stdout_capture = drainers[0].capture()
+    if stdout_capture.truncated:
+        return _ProcessOutcome("complete", process.returncode, b"")
+    return _ProcessOutcome(kind, process.returncode, stdout_capture.data)
 
 
 def _validated_inventory_response(

--- a/src/coding/skill_load_observation.py
+++ b/src/coding/skill_load_observation.py
@@ -16,7 +16,9 @@ import json
 import os
 from pathlib import Path
 import re
+import shutil
 import signal
+import stat
 import subprocess
 from threading import Lock
 from typing import Final, cast
@@ -32,6 +34,7 @@ REASON_CODES: Final = (
     "inventory_validated",
     "inventory_protocol_unavailable",
     "inventory_process_error",
+    "inventory_executable_unavailable",
     "inventory_timeout",
     "inventory_response_malformed",
     "inventory_nonce_mismatch",
@@ -136,16 +139,27 @@ def probe_skill_load(
     if not _HEX_64.fullmatch(nonce):
         raise ValueError("skill-load probe nonce must be 64 lowercase hexadecimal characters")
     expected_digest = _set_digest(expected)
-    tool_fingerprint = _tool_fingerprint(request.hermes)
     runtime_unavailable = hashlib.sha256(b"runtime-unavailable").hexdigest()
+    unavailable_tool = hashlib.sha256(b"unresolved-executable").hexdigest()
     observed_at = _utc(now)
+    env = _probe_environment(request.env)
+    try:
+        tool = _resolve_tool(request.hermes, env)
+    except OSError:
+        return _closed_observation(
+            "probe_error", "inventory_executable_unavailable", nonce,
+            expected_digest, unavailable_tool, runtime_unavailable, observed_at,
+        )
+    tool_fingerprint = tool.fingerprint
     if nonce_ledger is not None and nonce_ledger.contains(nonce):
         return _closed_observation(
             "probe_error", "inventory_nonce_replayed", nonce, expected_digest,
             tool_fingerprint, runtime_unavailable, observed_at,
         )
 
-    outcome = _run_inventory_process(request, nonce, expected_digest, tool_fingerprint)
+    outcome = _run_inventory_process(
+        request, tool.executable, env, nonce, expected_digest, tool_fingerprint
+    )
     if outcome.kind == "timeout":
         return _closed_observation(
             "probe_error", "inventory_timeout", nonce, expected_digest,
@@ -222,6 +236,12 @@ def probe_skill_load(
 
 
 @dataclass(frozen=True, slots=True)
+class _ResolvedTool:
+    executable: str
+    fingerprint: str
+
+
+@dataclass(frozen=True, slots=True)
 class _ProcessOutcome:
     kind: str
     exit_code: int | None
@@ -230,27 +250,17 @@ class _ProcessOutcome:
 
 def _run_inventory_process(
     request: SkillLoadProbeRequest,
+    executable: str,
+    env: Mapping[str, str],
     nonce: str,
     expected_digest: str,
     tool_fingerprint: str,
 ) -> _ProcessOutcome:
     argv = (
-        request.hermes, "--safe-mode", "--ignore-user-config", "--ignore-rules",
+        executable, "--safe-mode", "--ignore-user-config", "--ignore-rules",
         "skills", "inventory", "--protocol",
         HERMES_SKILL_INVENTORY_SCHEMA_VERSION, "--nonce", nonce,
         "--expected-digest", expected_digest, "--tool-fingerprint", tool_fingerprint,
-    )
-    source = os.environ if request.env is None else request.env
-    env = {name: source[name] for name in _SAFE_ENV_NAMES if source.get(name)}
-    env.setdefault("PATH", os.defpath)
-    env.update(
-        {
-            "HERMES_SAFE_MODE": "1",
-            "HERMES_IGNORE_USER_CONFIG": "1",
-            "HERMES_IGNORE_RULES": "1",
-            "OMH_ISOLATED_HERMES_ROUTING": "disabled",
-            "OMH_ISOLATED_HERMES_MAX_DEPTH": "1",
-        }
     )
     process: subprocess.Popen[bytes] | None = None
     drainers = None
@@ -469,15 +479,51 @@ def _set_digest(values: Sequence[str]) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
-def _tool_fingerprint(executable: str) -> str:
-    candidate = Path(executable).expanduser()
-    try:
-        resolved = candidate.resolve(strict=True)
-        stat_result = resolved.stat()
-        identity = f"{resolved}\0{stat_result.st_size}\0{stat_result.st_mtime_ns}"
-    except OSError:
-        identity = executable
-    return hashlib.sha256(identity.encode("utf-8", errors="surrogateescape")).hexdigest()
+def _probe_environment(source: Mapping[str, str] | None) -> dict[str, str]:
+    values = os.environ if source is None else source
+    env = {name: values[name] for name in _SAFE_ENV_NAMES if values.get(name)}
+    env.setdefault("PATH", os.defpath)
+    env.update(
+        {
+            "HERMES_SAFE_MODE": "1",
+            "HERMES_IGNORE_USER_CONFIG": "1",
+            "HERMES_IGNORE_RULES": "1",
+            "OMH_ISOLATED_HERMES_ROUTING": "disabled",
+            "OMH_ISOLATED_HERMES_MAX_DEPTH": "1",
+        }
+    )
+    return env
+
+
+def _resolve_tool(executable: str, env: Mapping[str, str]) -> _ResolvedTool:
+    has_separator = os.sep in executable or bool(os.altsep and os.altsep in executable)
+    if has_separator or Path(executable).is_absolute():
+        selected = Path(executable).expanduser()
+    else:
+        found = shutil.which(executable, path=env.get("PATH"))
+        if found is None:
+            raise FileNotFoundError(executable)
+        selected = Path(found)
+    resolved = selected.resolve(strict=True)
+    before = resolved.stat()
+    if not stat.S_ISREG(before.st_mode) or not os.access(resolved, os.R_OK | os.X_OK):
+        raise PermissionError(executable)
+
+    digest = hashlib.sha256()
+    digest.update(b"omh-skill-load-tool/v1\0")
+    digest.update(os.fsencode(resolved))
+    digest.update(
+        f"\0{before.st_dev}\0{before.st_ino}\0{before.st_mode}\0{before.st_size}".encode("ascii")
+    )
+    with resolved.open("rb") as stream:
+        while chunk := stream.read(64 * 1024):
+            digest.update(chunk)
+        after = os.fstat(stream.fileno())
+    identity_before = (before.st_dev, before.st_ino, before.st_mode, before.st_size, before.st_mtime_ns)
+    identity_after = (after.st_dev, after.st_ino, after.st_mode, after.st_size, after.st_mtime_ns)
+    if identity_after != identity_before:
+        raise OSError("executable changed during fingerprinting")
+    return _ResolvedTool(str(resolved), digest.hexdigest())
 
 
 def _parse_time(value: object) -> datetime:

--- a/src/coding/skill_load_observation.py
+++ b/src/coding/skill_load_observation.py
@@ -1,0 +1,500 @@
+"""Fail-closed, opt-in Hermes loaded-skill inventory observation.
+
+A successful child process, model response, static skill listing, or scheduler
+source is not an inventory.  ``observed`` is emitted only for the closed,
+nonce-bound machine protocol parsed here.  Installed Hermes versions that do
+not implement that protocol are reported as ``unsupported``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import signal
+import subprocess
+from threading import Lock
+from typing import Final, cast
+
+from ._hermes_child_process import start_pipe_drainers, terminate_process_group
+from .hermes_child_dispatch import require_hermes_child_dispatch_boundary
+
+SKILL_LOAD_OBSERVATION_SCHEMA_VERSION: Final = "skill_load_observation/v1"
+HERMES_SKILL_INVENTORY_SCHEMA_VERSION: Final = "hermes_skill_inventory/v1"
+PROBE_STATUSES: Final = ("observed", "unsupported", "probe_error")
+LOAD_STATES: Final = ("all_loaded", "partially_loaded", "none_loaded", "not_applicable")
+REASON_CODES: Final = (
+    "inventory_validated",
+    "inventory_protocol_unavailable",
+    "inventory_process_error",
+    "inventory_timeout",
+    "inventory_response_malformed",
+    "inventory_nonce_mismatch",
+    "inventory_expected_digest_mismatch",
+    "inventory_digest_mismatch",
+    "inventory_response_expired",
+    "inventory_response_stale",
+    "inventory_nonce_replayed",
+)
+_MAX_PROTOCOL_SECONDS: Final = 300
+_SKILL_NAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}\Z")
+_HEX_64 = re.compile(r"[0-9a-f]{64}\Z")
+_OBSERVATION_FIELDS: Final = frozenset(
+    {
+        "schema_version", "probe_status", "reason_code", "nonce",
+        "expected_digest", "inventory_digest", "tool_fingerprint",
+        "runtime_fingerprint", "observed_at", "expires_at", "load_state",
+        "expected_skills", "observed_skills", "missing_skills", "unexpected_skills",
+    }
+)
+_INVENTORY_FIELDS: Final = frozenset(
+    {
+        "schema_version", "nonce", "expected_digest", "inventory_digest",
+        "tool_fingerprint", "runtime_fingerprint", "observed_at", "expires_at",
+        "observed_skills",
+    }
+)
+_INVENTORY_CLAIM_FIELDS: Final = frozenset(
+    {
+        "inventory_digest", "load_state", "expected_skills", "observed_skills",
+        "missing_skills", "unexpected_skills",
+    }
+)
+_SAFE_ENV_NAMES: Final = frozenset(
+    {
+        "PATH", "LANG", "LANGUAGE", "LC_ALL", "LC_CTYPE", "TERM",
+        "TMPDIR", "TMP", "TEMP", "SYSTEMROOT", "WINDIR", "PATHEXT", "COMSPEC",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SkillLoadProbeRequest:
+    expected_skills: Sequence[str]
+    hermes: str = "hermes"
+    timeout_seconds: float = 10.0
+    termination_grace_seconds: float = 0.25
+    env: Mapping[str, str] | None = None
+    nonce: str | None = None
+
+
+class InventoryNonceLedger:
+    """Bounded in-process replay ledger for validated protocol nonces."""
+
+    def __init__(self, *, capacity: int = 1024) -> None:
+        if capacity <= 0:
+            raise ValueError("nonce ledger capacity must be positive")
+        self._capacity = capacity
+        self._ordered: list[str] = []
+        self._seen: set[str] = set()
+        self._lock = Lock()
+
+    def contains(self, nonce: str) -> bool:
+        with self._lock:
+            return nonce in self._seen
+
+    def consume(self, nonce: str) -> bool:
+        with self._lock:
+            if nonce in self._seen:
+                return False
+            self._seen.add(nonce)
+            self._ordered.append(nonce)
+            if len(self._ordered) > self._capacity:
+                self._seen.discard(self._ordered.pop(0))
+            return True
+
+
+def expected_skills_digest(skills: Sequence[str]) -> str:
+    normalized = _normalized_skill_set(skills, field="expected_skills")
+    return _set_digest(normalized)
+
+
+def probe_skill_load(
+    request: SkillLoadProbeRequest,
+    *,
+    confirmed: bool,
+    nonce_ledger: InventoryNonceLedger | None = None,
+    now: datetime | None = None,
+) -> dict[str, object]:
+    """Run the explicit machine inventory protocol once.
+
+    Constructing a request does nothing.  Confirmation is checked before path
+    inspection or process creation, matching the Hermes-child dispatch boundary.
+    """
+    require_hermes_child_dispatch_boundary(
+        dispatch_policy="ask_before_dispatch", confirmed=confirmed
+    )
+    if request.timeout_seconds <= 0:
+        raise ValueError("skill-load probe timeout must be positive")
+    expected = _normalized_skill_set(request.expected_skills, field="expected_skills")
+    nonce = request.nonce or os.urandom(32).hex()
+    if not _HEX_64.fullmatch(nonce):
+        raise ValueError("skill-load probe nonce must be 64 lowercase hexadecimal characters")
+    expected_digest = _set_digest(expected)
+    tool_fingerprint = _tool_fingerprint(request.hermes)
+    runtime_unavailable = hashlib.sha256(b"runtime-unavailable").hexdigest()
+    observed_at = _utc(now)
+    if nonce_ledger is not None and nonce_ledger.contains(nonce):
+        return _closed_observation(
+            "probe_error", "inventory_nonce_replayed", nonce, expected_digest,
+            tool_fingerprint, runtime_unavailable, observed_at,
+        )
+
+    outcome = _run_inventory_process(request, nonce, expected_digest, tool_fingerprint)
+    if outcome.kind == "timeout":
+        return _closed_observation(
+            "probe_error", "inventory_timeout", nonce, expected_digest,
+            tool_fingerprint, runtime_unavailable, observed_at,
+        )
+    if outcome.kind == "spawn_error":
+        return _closed_observation(
+            "probe_error", "inventory_process_error", nonce, expected_digest,
+            tool_fingerprint, runtime_unavailable, observed_at,
+        )
+    if outcome.exit_code == 2:
+        return _closed_observation(
+            "unsupported", "inventory_protocol_unavailable", nonce, expected_digest,
+            tool_fingerprint, runtime_unavailable, observed_at,
+        )
+    if outcome.exit_code != 0:
+        return _closed_observation(
+            "probe_error", "inventory_process_error", nonce, expected_digest,
+            tool_fingerprint, runtime_unavailable, observed_at,
+        )
+    response, reason = _validated_inventory_response(
+        outcome.stdout, nonce=nonce, expected_digest=expected_digest,
+        tool_fingerprint=tool_fingerprint, now=observed_at,
+    )
+    if response is None:
+        return _closed_observation(
+            "probe_error", reason, nonce, expected_digest, tool_fingerprint,
+            runtime_unavailable, observed_at,
+        )
+    if nonce_ledger is not None and not nonce_ledger.consume(nonce):
+        return _closed_observation(
+            "probe_error", "inventory_nonce_replayed", nonce, expected_digest,
+            tool_fingerprint, runtime_unavailable, observed_at,
+        )
+
+    observed_value = response["observed_skills"]
+    if not isinstance(observed_value, list):  # Kept local for static narrowing.
+        raise ValueError("validated inventory lost its observed skill list")
+    observed = tuple(cast(list[str], observed_value))
+    missing = tuple(sorted(set(expected) - set(observed)))
+    unexpected = tuple(sorted(set(observed) - set(expected)))
+    if not expected:
+        state = "not_applicable"
+    elif set(expected).isdisjoint(observed):
+        state = "none_loaded"
+    elif missing:
+        state = "partially_loaded"
+    else:
+        state = "all_loaded"
+    payload: dict[str, object] = {
+        "schema_version": SKILL_LOAD_OBSERVATION_SCHEMA_VERSION,
+        "probe_status": "observed",
+        "reason_code": "inventory_validated",
+        "nonce": nonce,
+        "expected_digest": expected_digest,
+        "inventory_digest": response["inventory_digest"],
+        "tool_fingerprint": tool_fingerprint,
+        "runtime_fingerprint": response["runtime_fingerprint"],
+        "observed_at": response["observed_at"],
+        "expires_at": response["expires_at"],
+        "load_state": state,
+        "expected_skills": list(expected),
+        "observed_skills": list(observed),
+        "missing_skills": list(missing),
+        "unexpected_skills": list(unexpected),
+    }
+    errors = validate_skill_load_observation(payload)
+    if errors:
+        return _closed_observation(
+            "probe_error", "inventory_response_malformed", nonce, expected_digest,
+            tool_fingerprint, runtime_unavailable, observed_at,
+        )
+    return payload
+
+
+@dataclass(frozen=True, slots=True)
+class _ProcessOutcome:
+    kind: str
+    exit_code: int | None
+    stdout: bytes
+
+
+def _run_inventory_process(
+    request: SkillLoadProbeRequest,
+    nonce: str,
+    expected_digest: str,
+    tool_fingerprint: str,
+) -> _ProcessOutcome:
+    argv = (
+        request.hermes, "--safe-mode", "--ignore-user-config", "--ignore-rules",
+        "skills", "inventory", "--protocol",
+        HERMES_SKILL_INVENTORY_SCHEMA_VERSION, "--nonce", nonce,
+        "--expected-digest", expected_digest, "--tool-fingerprint", tool_fingerprint,
+    )
+    source = os.environ if request.env is None else request.env
+    env = {name: source[name] for name in _SAFE_ENV_NAMES if source.get(name)}
+    env.setdefault("PATH", os.defpath)
+    env.update(
+        {
+            "HERMES_SAFE_MODE": "1",
+            "HERMES_IGNORE_USER_CONFIG": "1",
+            "HERMES_IGNORE_RULES": "1",
+            "OMH_ISOLATED_HERMES_ROUTING": "disabled",
+            "OMH_ISOLATED_HERMES_MAX_DEPTH": "1",
+        }
+    )
+    process: subprocess.Popen[bytes] | None = None
+    drainers = None
+    try:
+        process = subprocess.Popen(
+            argv, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            env=env, text=False, close_fds=True, start_new_session=os.name != "nt",
+        )
+        drainers = start_pipe_drainers(process)
+        try:
+            process.wait(timeout=request.timeout_seconds)
+            kind = "complete"
+        except subprocess.TimeoutExpired:
+            kind = "timeout"
+            terminate_process_group(process, request.termination_grace_seconds, signal.SIGTERM)
+        finally:
+            terminate_process_group(process, request.termination_grace_seconds, signal.SIGTERM)
+            for drainer in drainers:
+                drainer.done.wait(max(0.1, request.termination_grace_seconds))
+                drainer.thread.join(timeout=max(0.1, request.termination_grace_seconds))
+        stdout_capture = drainers[0].capture()
+        if stdout_capture.truncated:
+            return _ProcessOutcome("complete", process.returncode, b"")
+        return _ProcessOutcome(kind, process.returncode, stdout_capture.data)
+    except OSError:
+        return _ProcessOutcome("spawn_error", None, b"")
+
+
+def _validated_inventory_response(
+    raw: bytes,
+    *,
+    nonce: str,
+    expected_digest: str,
+    tool_fingerprint: str,
+    now: datetime,
+) -> tuple[dict[str, object] | None, str]:
+    try:
+        decoded = raw.decode("utf-8")
+        decoded_candidate = json.loads(decoded)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None, "inventory_response_malformed"
+    if not isinstance(decoded_candidate, dict) or set(decoded_candidate) != _INVENTORY_FIELDS:
+        return None, "inventory_response_malformed"
+    candidate = cast(dict[str, object], decoded_candidate)
+    if candidate.get("schema_version") != HERMES_SKILL_INVENTORY_SCHEMA_VERSION:
+        return None, "inventory_response_malformed"
+    if candidate.get("nonce") != nonce:
+        return None, "inventory_nonce_mismatch"
+    if candidate.get("expected_digest") != expected_digest:
+        return None, "inventory_expected_digest_mismatch"
+    if candidate.get("tool_fingerprint") != tool_fingerprint:
+        return None, "inventory_response_malformed"
+    runtime = candidate.get("runtime_fingerprint")
+    if not isinstance(runtime, str) or not _HEX_64.fullmatch(runtime):
+        return None, "inventory_response_malformed"
+    observed_raw = candidate.get("observed_skills")
+    if not isinstance(observed_raw, list):
+        return None, "inventory_response_malformed"
+    try:
+        observed = _normalized_skill_set(observed_raw, field="observed_skills")
+    except ValueError:
+        return None, "inventory_response_malformed"
+    if observed_raw != list(observed):
+        return None, "inventory_response_malformed"
+    inventory_digest = candidate.get("inventory_digest")
+    if inventory_digest != _set_digest(observed):
+        return None, "inventory_digest_mismatch"
+    try:
+        response_observed = _parse_time(candidate.get("observed_at"))
+        expires = _parse_time(candidate.get("expires_at"))
+    except ValueError:
+        return None, "inventory_response_malformed"
+    if response_observed > now + timedelta(seconds=5):
+        return None, "inventory_response_malformed"
+    if response_observed < now - timedelta(seconds=_MAX_PROTOCOL_SECONDS):
+        return None, "inventory_response_stale"
+    if expires <= now:
+        return None, "inventory_response_expired"
+    if expires <= response_observed or expires > response_observed + timedelta(seconds=_MAX_PROTOCOL_SECONDS):
+        return None, "inventory_response_malformed"
+    candidate["observed_skills"] = list(observed)
+    return candidate, "inventory_validated"
+
+
+def _closed_observation(
+    status: str,
+    reason: str,
+    nonce: str,
+    expected_digest: str,
+    tool_fingerprint: str,
+    runtime_fingerprint: str,
+    observed_at: datetime,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": SKILL_LOAD_OBSERVATION_SCHEMA_VERSION,
+        "probe_status": status,
+        "reason_code": reason,
+        "nonce": nonce,
+        "expected_digest": expected_digest,
+        "tool_fingerprint": tool_fingerprint,
+        "runtime_fingerprint": runtime_fingerprint,
+        "observed_at": _format_time(observed_at),
+        "expires_at": _format_time(observed_at + timedelta(seconds=_MAX_PROTOCOL_SECONDS)),
+    }
+    errors = validate_skill_load_observation(payload)
+    if errors:
+        raise ValueError("invalid closed skill-load observation: " + "; ".join(errors))
+    return payload
+
+
+def validate_skill_load_observation(payload: Mapping[str, object] | object) -> list[str]:
+    if not isinstance(payload, Mapping):
+        return ["payload must be an object"]
+    errors: list[str] = []
+    extras = sorted(set(payload) - _OBSERVATION_FIELDS)
+    if extras:
+        errors.append(f"unsupported fields: {extras}")
+    if payload.get("schema_version") != SKILL_LOAD_OBSERVATION_SCHEMA_VERSION:
+        errors.append("schema_version is invalid")
+    status = payload.get("probe_status")
+    if status not in PROBE_STATUSES:
+        errors.append("probe_status is invalid")
+    if payload.get("reason_code") not in REASON_CODES:
+        errors.append("reason_code is invalid")
+    for field in ("nonce", "expected_digest", "tool_fingerprint", "runtime_fingerprint"):
+        value = payload.get(field)
+        if not isinstance(value, str) or not _HEX_64.fullmatch(value):
+            errors.append(f"{field} is invalid")
+    for field in ("observed_at", "expires_at"):
+        try:
+            _parse_time(payload.get(field))
+        except ValueError:
+            errors.append(f"{field} is invalid")
+    if status == "observed":
+        if payload.get("reason_code") != "inventory_validated":
+            errors.append("observed probe requires inventory_validated")
+        if payload.get("load_state") not in LOAD_STATES:
+            errors.append("observed probe requires load_state")
+        sets: dict[str, tuple[str, ...]] = {}
+        for field in ("expected_skills", "observed_skills", "missing_skills", "unexpected_skills"):
+            raw = payload.get(field)
+            if not isinstance(raw, list):
+                errors.append(f"{field} must be a sorted unique list")
+                continue
+            try:
+                normalized = _normalized_skill_set(raw, field=field)
+            except ValueError:
+                errors.append(f"{field} must be a sorted unique list")
+                continue
+            if raw != list(normalized):
+                errors.append(f"{field} must be a sorted unique list")
+            sets[field] = normalized
+        digest = payload.get("inventory_digest")
+        if not isinstance(digest, str) or not _HEX_64.fullmatch(digest):
+            errors.append("inventory_digest is invalid")
+        if len(sets) == 4:
+            expected = sets["expected_skills"]
+            observed = sets["observed_skills"]
+            missing = tuple(sorted(set(expected) - set(observed)))
+            unexpected = tuple(sorted(set(observed) - set(expected)))
+            if sets["missing_skills"] != missing or sets["unexpected_skills"] != unexpected:
+                errors.append("inventory set differences are invalid")
+            if payload.get("expected_digest") != _set_digest(expected):
+                errors.append("expected_digest does not bind expected_skills")
+            if digest != _set_digest(observed):
+                errors.append("inventory_digest does not bind observed_skills")
+            expected_state = (
+                "not_applicable" if not expected else
+                "none_loaded" if set(expected).isdisjoint(observed) else
+                "partially_loaded" if missing else "all_loaded"
+            )
+            if payload.get("load_state") != expected_state:
+                errors.append("load_state does not match inventory sets")
+    else:
+        forbidden = sorted(set(payload) & _INVENTORY_CLAIM_FIELDS)
+        if forbidden:
+            errors.append(f"non-observed probe carries inventory claims: {forbidden}")
+        if status == "unsupported" and payload.get("reason_code") != "inventory_protocol_unavailable":
+            errors.append("unsupported probe reason is invalid")
+        if status == "probe_error" and payload.get("reason_code") in {
+            "inventory_validated", "inventory_protocol_unavailable"
+        }:
+            errors.append("probe_error reason is invalid")
+    return errors
+
+
+def skill_load_observation_is_fresh(
+    payload: Mapping[str, object], *, now: datetime | None = None
+) -> bool:
+    if validate_skill_load_observation(payload):
+        return False
+    try:
+        observed = _parse_time(payload.get("observed_at"))
+        expires = _parse_time(payload.get("expires_at"))
+    except ValueError:
+        return False
+    current = _utc(now)
+    return observed <= current < expires
+
+
+def _normalized_skill_set(values: Sequence[object], *, field: str) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)):
+        raise ValueError(f"{field} must be a sequence")
+    normalized: list[str] = []
+    for value in values:
+        if not isinstance(value, str) or not _SKILL_NAME.fullmatch(value):
+            raise ValueError(f"{field} contains an invalid skill name")
+        normalized.append(value)
+    if len(normalized) != len(set(normalized)):
+        raise ValueError(f"{field} contains duplicate skill names")
+    return tuple(sorted(normalized))
+
+
+def _set_digest(values: Sequence[str]) -> str:
+    encoded = json.dumps(list(values), separators=(",", ":"), ensure_ascii=True).encode("ascii")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _tool_fingerprint(executable: str) -> str:
+    candidate = Path(executable).expanduser()
+    try:
+        resolved = candidate.resolve(strict=True)
+        stat_result = resolved.stat()
+        identity = f"{resolved}\0{stat_result.st_size}\0{stat_result.st_mtime_ns}"
+    except OSError:
+        identity = executable
+    return hashlib.sha256(identity.encode("utf-8", errors="surrogateescape")).hexdigest()
+
+
+def _parse_time(value: object) -> datetime:
+    if not isinstance(value, str) or not value.endswith("Z"):
+        raise ValueError("timestamp must be UTC")
+    parsed = datetime.fromisoformat(value[:-1] + "+00:00")
+    if parsed.tzinfo is None:
+        raise ValueError("timestamp must have timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def _utc(value: datetime | None) -> datetime:
+    current = value or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+    return current.astimezone(timezone.utc)
+
+
+def _format_time(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")

--- a/src/coding/skill_load_observation.py
+++ b/src/coding/skill_load_observation.py
@@ -20,6 +20,8 @@ import shutil
 import signal
 import stat
 import subprocess
+import sys
+import tempfile
 from threading import Lock
 from typing import Final, cast
 
@@ -142,24 +144,26 @@ def probe_skill_load(
     runtime_unavailable = hashlib.sha256(b"runtime-unavailable").hexdigest()
     unavailable_tool = hashlib.sha256(b"unresolved-executable").hexdigest()
     observed_at = _utc(now)
+    if nonce_ledger is not None and nonce_ledger.contains(nonce):
+        return _closed_observation(
+            "probe_error", "inventory_nonce_replayed", nonce, expected_digest,
+            unavailable_tool, runtime_unavailable, observed_at,
+        )
     env = _probe_environment(request.env)
     try:
-        tool = _resolve_tool(request.hermes, env)
+        tool = _snapshot_resolved_tool(request.hermes, env)
     except OSError:
         return _closed_observation(
             "probe_error", "inventory_executable_unavailable", nonce,
             expected_digest, unavailable_tool, runtime_unavailable, observed_at,
         )
     tool_fingerprint = tool.fingerprint
-    if nonce_ledger is not None and nonce_ledger.contains(nonce):
-        return _closed_observation(
-            "probe_error", "inventory_nonce_replayed", nonce, expected_digest,
-            tool_fingerprint, runtime_unavailable, observed_at,
+    try:
+        outcome = _run_inventory_process(
+            request, tool.executable, env, nonce, expected_digest, tool_fingerprint
         )
-
-    outcome = _run_inventory_process(
-        request, tool.executable, env, nonce, expected_digest, tool_fingerprint
-    )
+    finally:
+        tool.cleanup()
     if outcome.kind == "timeout":
         return _closed_observation(
             "probe_error", "inventory_timeout", nonce, expected_digest,
@@ -235,10 +239,14 @@ def probe_skill_load(
     return payload
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(slots=True)
 class _ResolvedTool:
     executable: str
     fingerprint: str
+    _scratch: tempfile.TemporaryDirectory[str]
+
+    def cleanup(self) -> None:
+        self._scratch.cleanup()
 
 
 @dataclass(frozen=True, slots=True)
@@ -256,11 +264,16 @@ def _run_inventory_process(
     expected_digest: str,
     tool_fingerprint: str,
 ) -> _ProcessOutcome:
+    protocol_argv = (
+        "--safe-mode", "--ignore-user-config", "--ignore-rules",
+        "skills", "inventory", "--protocol", HERMES_SKILL_INVENTORY_SCHEMA_VERSION,
+        "--nonce", nonce, "--expected-digest", expected_digest,
+        "--tool-fingerprint", tool_fingerprint,
+    )
     argv = (
-        executable, "--safe-mode", "--ignore-user-config", "--ignore-rules",
-        "skills", "inventory", "--protocol",
-        HERMES_SKILL_INVENTORY_SCHEMA_VERSION, "--nonce", nonce,
-        "--expected-digest", expected_digest, "--tool-fingerprint", tool_fingerprint,
+        (sys.executable, executable, *protocol_argv)
+        if os.name == "nt" and Path(executable).suffix.casefold() == ".py"
+        else (executable, *protocol_argv)
     )
     process: subprocess.Popen[bytes] | None = None
     drainers = None
@@ -495,7 +508,13 @@ def _probe_environment(source: Mapping[str, str] | None) -> dict[str, str]:
     return env
 
 
-def _resolve_tool(executable: str, env: Mapping[str, str]) -> _ResolvedTool:
+def _snapshot_resolved_tool(executable: str, env: Mapping[str, str]) -> _ResolvedTool:
+    """Copy one opened executable inode into a private per-probe snapshot.
+
+    Resolution happens once. The source descriptor supplies both fingerprint
+    bytes and snapshot bytes, so replacing or restoring its pathname cannot
+    alter what the later process consumes.
+    """
     has_separator = os.sep in executable or bool(os.altsep and os.altsep in executable)
     if has_separator or Path(executable).is_absolute():
         selected = Path(executable).expanduser()
@@ -505,25 +524,78 @@ def _resolve_tool(executable: str, env: Mapping[str, str]) -> _ResolvedTool:
             raise FileNotFoundError(executable)
         selected = Path(found)
     resolved = selected.resolve(strict=True)
-    before = resolved.stat()
-    if not stat.S_ISREG(before.st_mode) or not os.access(resolved, os.R_OK | os.X_OK):
-        raise PermissionError(executable)
-
-    digest = hashlib.sha256()
-    digest.update(b"omh-skill-load-tool/v1\0")
-    digest.update(os.fsencode(resolved))
-    digest.update(
-        f"\0{before.st_dev}\0{before.st_ino}\0{before.st_mode}\0{before.st_size}".encode("ascii")
+    source_fd = os.open(
+        resolved,
+        os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_CLOEXEC", 0),
     )
-    with resolved.open("rb") as stream:
-        while chunk := stream.read(64 * 1024):
-            digest.update(chunk)
-        after = os.fstat(stream.fileno())
-    identity_before = (before.st_dev, before.st_ino, before.st_mode, before.st_size, before.st_mtime_ns)
-    identity_after = (after.st_dev, after.st_ino, after.st_mode, after.st_size, after.st_mtime_ns)
-    if identity_after != identity_before:
-        raise OSError("executable changed during fingerprinting")
-    return _ResolvedTool(str(resolved), digest.hexdigest())
+    scratch: tempfile.TemporaryDirectory[str] | None = None
+    snapshot_fd: int | None = None
+    keep_snapshot = False
+    try:
+        source_identity = os.fstat(source_fd)
+        if not stat.S_ISREG(source_identity.st_mode):
+            raise PermissionError(executable)
+        if os.name != "nt" and source_identity.st_mode & 0o111 == 0:
+            raise PermissionError(executable)
+
+        scratch = tempfile.TemporaryDirectory(prefix="omh-skill-load-tool-")
+        snapshot = Path(scratch.name) / resolved.name
+        snapshot_fd = os.open(
+            snapshot,
+            os.O_RDWR | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0),
+            0o500,
+        )
+        source_content = hashlib.sha256()
+        copied = 0
+        while chunk := os.read(source_fd, 64 * 1024):
+            source_content.update(chunk)
+            copied += len(chunk)
+            view = memoryview(chunk)
+            while view:
+                written = os.write(snapshot_fd, view)
+                if written <= 0:
+                    raise OSError("snapshot write did not advance")
+                view = view[written:]
+        if copied != source_identity.st_size:
+            raise OSError("executable size changed during snapshot")
+        fchmod = getattr(os, "fchmod", None)
+        if fchmod is None:
+            os.chmod(snapshot, 0o500)
+        else:
+            fchmod(snapshot_fd, 0o500)
+        os.fsync(snapshot_fd)
+        snapshot_identity = os.fstat(snapshot_fd)
+        if not stat.S_ISREG(snapshot_identity.st_mode) or snapshot_identity.st_size != copied:
+            raise OSError("executable snapshot is incomplete")
+        os.lseek(snapshot_fd, 0, os.SEEK_SET)
+        snapshot_content = hashlib.sha256()
+        while chunk := os.read(snapshot_fd, 64 * 1024):
+            snapshot_content.update(chunk)
+        if snapshot_content.digest() != source_content.digest():
+            raise OSError("executable snapshot bytes do not match source descriptor")
+        fingerprint = hashlib.sha256()
+        fingerprint.update(b"omh-skill-load-tool/v2\0")
+        fingerprint.update(os.fsencode(resolved))
+        fingerprint.update(
+            (
+                f"\0{source_identity.st_dev}\0{source_identity.st_ino}"
+                f"\0{source_identity.st_mode}\0{source_identity.st_size}\0"
+            ).encode("ascii")
+        )
+        fingerprint.update(snapshot_content.digest())
+        os.close(snapshot_fd)
+        snapshot_fd = None
+        os.close(source_fd)
+        source_fd = -1
+        keep_snapshot = True
+        return _ResolvedTool(str(snapshot), fingerprint.hexdigest(), scratch)
+    finally:
+        if snapshot_fd is not None:
+            os.close(snapshot_fd)
+        if source_fd >= 0:
+            os.close(source_fd)
+        if scratch is not None and not keep_snapshot:
+            scratch.cleanup()
 
 
 def _parse_time(value: object) -> datetime:

--- a/src/coding/skill_load_observation.py
+++ b/src/coding/skill_load_observation.py
@@ -1,91 +1,54 @@
 """Fail-closed, opt-in Hermes loaded-skill inventory observation.
 
 A successful child process, model response, static skill listing, or scheduler
-source is not an inventory.  ``observed`` is emitted only for the closed,
-nonce-bound machine protocol parsed here.  Installed Hermes versions that do
+source is not an inventory. ``observed`` is emitted only for the closed,
+nonce-bound machine protocol parsed here. Installed Hermes versions that do
 not implement that protocol are reported as ``unsupported``.
 """
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 import hashlib
-import json
 import os
-from pathlib import Path
-import re
-import shutil
-import signal
-import stat
-import subprocess
-import sys
-import tempfile
 from threading import Lock
-from typing import Final, cast
+from typing import cast
 
-from ._hermes_child_process import start_pipe_drainers, terminate_process_group
 from .hermes_child_dispatch import require_hermes_child_dispatch_boundary
-
-SKILL_LOAD_OBSERVATION_SCHEMA_VERSION: Final = "skill_load_observation/v1"
-HERMES_SKILL_INVENTORY_SCHEMA_VERSION: Final = "hermes_skill_inventory/v1"
-PROBE_STATUSES: Final = ("observed", "unsupported", "probe_error")
-LOAD_STATES: Final = ("all_loaded", "partially_loaded", "none_loaded", "not_applicable")
-REASON_CODES: Final = (
-    "inventory_validated",
-    "inventory_protocol_unavailable",
-    "inventory_process_error",
-    "inventory_executable_unavailable",
-    "inventory_timeout",
-    "inventory_response_malformed",
-    "inventory_nonce_mismatch",
-    "inventory_expected_digest_mismatch",
-    "inventory_digest_mismatch",
-    "inventory_response_expired",
-    "inventory_response_stale",
-    "inventory_nonce_replayed",
+from .skill_load_process import (
+    ProcessOutcome as _ProcessOutcome,
+    ResolvedTool as _ResolvedTool,
+    SkillLoadProbeRequest,
+    inventory_argv as _inventory_argv,
+    probe_environment as _probe_environment,
+    resolve_executable as _resolve_executable,
+    run_inventory_process as _run_inventory_process,
+    snapshot_resolved_tool as _snapshot_resolved_tool,
 )
-_MAX_PROTOCOL_SECONDS: Final = 300
-_SKILL_NAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}\Z")
-_HEX_64 = re.compile(r"[0-9a-f]{64}\Z")
-_OBSERVATION_FIELDS: Final = frozenset(
-    {
-        "schema_version", "probe_status", "reason_code", "nonce",
-        "expected_digest", "inventory_digest", "tool_fingerprint",
-        "runtime_fingerprint", "observed_at", "expires_at", "load_state",
-        "expected_skills", "observed_skills", "missing_skills", "unexpected_skills",
-    }
-)
-_INVENTORY_FIELDS: Final = frozenset(
-    {
-        "schema_version", "nonce", "expected_digest", "inventory_digest",
-        "tool_fingerprint", "runtime_fingerprint", "observed_at", "expires_at",
-        "observed_skills",
-    }
-)
-_INVENTORY_CLAIM_FIELDS: Final = frozenset(
-    {
-        "inventory_digest", "load_state", "expected_skills", "observed_skills",
-        "missing_skills", "unexpected_skills",
-    }
-)
-_SAFE_ENV_NAMES: Final = frozenset(
-    {
-        "PATH", "LANG", "LANGUAGE", "LC_ALL", "LC_CTYPE", "TERM",
-        "TMPDIR", "TMP", "TEMP", "SYSTEMROOT", "WINDIR", "PATHEXT", "COMSPEC",
-    }
+from .skill_load_protocol import (
+    HERMES_SKILL_INVENTORY_SCHEMA_VERSION,
+    HEX_64 as _HEX_64,
+    LOAD_STATES,
+    PROBE_STATUSES,
+    REASON_CODES,
+    SKILL_LOAD_OBSERVATION_SCHEMA_VERSION,
+    closed_observation as _closed_observation,
+    expected_skills_digest,
+    normalized_skill_set as _normalized_skill_set,
+    set_digest as _set_digest,
+    skill_load_observation_is_fresh,
+    utc as _utc,
+    validate_skill_load_observation,
+    validated_inventory_response as _validated_inventory_response,
 )
 
-
-@dataclass(frozen=True, slots=True)
-class SkillLoadProbeRequest:
-    expected_skills: Sequence[str]
-    hermes: str = "hermes"
-    timeout_seconds: float = 10.0
-    termination_grace_seconds: float = 0.25
-    env: Mapping[str, str] | None = None
-    nonce: str | None = None
+__all__ = (
+    "HERMES_SKILL_INVENTORY_SCHEMA_VERSION", "InventoryNonceLedger", "LOAD_STATES",
+    "PROBE_STATUSES", "REASON_CODES", "SKILL_LOAD_OBSERVATION_SCHEMA_VERSION",
+    "SkillLoadProbeRequest", "expected_skills_digest", "probe_skill_load",
+    "skill_load_observation_is_fresh", "validate_skill_load_observation",
+    "_ProcessOutcome", "_ResolvedTool", "_inventory_argv", "_resolve_executable",
+)
 
 
 class InventoryNonceLedger:
@@ -114,11 +77,6 @@ class InventoryNonceLedger:
             return True
 
 
-def expected_skills_digest(skills: Sequence[str]) -> str:
-    normalized = _normalized_skill_set(skills, field="expected_skills")
-    return _set_digest(normalized)
-
-
 def probe_skill_load(
     request: SkillLoadProbeRequest,
     *,
@@ -126,11 +84,7 @@ def probe_skill_load(
     nonce_ledger: InventoryNonceLedger | None = None,
     now: datetime | None = None,
 ) -> dict[str, object]:
-    """Run the explicit machine inventory protocol once.
-
-    Constructing a request does nothing.  Confirmation is checked before path
-    inspection or process creation, matching the Hermes-child dispatch boundary.
-    """
+    """Run the explicit machine inventory protocol once after confirmation."""
     require_hermes_child_dispatch_boundary(
         dispatch_policy="ask_before_dispatch", confirmed=confirmed
     )
@@ -154,8 +108,8 @@ def probe_skill_load(
         tool = _snapshot_resolved_tool(request.hermes, env)
     except OSError:
         return _closed_observation(
-            "probe_error", "inventory_executable_unavailable", nonce,
-            expected_digest, unavailable_tool, runtime_unavailable, observed_at,
+            "probe_error", "inventory_executable_unavailable", nonce, expected_digest,
+            unavailable_tool, runtime_unavailable, observed_at,
         )
     tool_fingerprint = tool.fingerprint
     try:
@@ -198,480 +152,30 @@ def probe_skill_load(
             "probe_error", "inventory_nonce_replayed", nonce, expected_digest,
             tool_fingerprint, runtime_unavailable, observed_at,
         )
-
     observed_value = response["observed_skills"]
-    if not isinstance(observed_value, list):  # Kept local for static narrowing.
+    if not isinstance(observed_value, list):
         raise ValueError("validated inventory lost its observed skill list")
     observed = tuple(cast(list[str], observed_value))
     missing = tuple(sorted(set(expected) - set(observed)))
     unexpected = tuple(sorted(set(observed) - set(expected)))
-    if not expected:
-        state = "not_applicable"
-    elif set(expected).isdisjoint(observed):
-        state = "none_loaded"
-    elif missing:
-        state = "partially_loaded"
-    else:
-        state = "all_loaded"
+    state = (
+        "not_applicable" if not expected else "none_loaded" if set(expected).isdisjoint(observed)
+        else "partially_loaded" if missing else "all_loaded"
+    )
     payload: dict[str, object] = {
         "schema_version": SKILL_LOAD_OBSERVATION_SCHEMA_VERSION,
-        "probe_status": "observed",
-        "reason_code": "inventory_validated",
-        "nonce": nonce,
-        "expected_digest": expected_digest,
-        "inventory_digest": response["inventory_digest"],
+        "probe_status": "observed", "reason_code": "inventory_validated", "nonce": nonce,
+        "expected_digest": expected_digest, "inventory_digest": response["inventory_digest"],
         "tool_fingerprint": tool_fingerprint,
         "runtime_fingerprint": response["runtime_fingerprint"],
-        "observed_at": response["observed_at"],
-        "expires_at": response["expires_at"],
-        "load_state": state,
-        "expected_skills": list(expected),
-        "observed_skills": list(observed),
-        "missing_skills": list(missing),
+        "observed_at": response["observed_at"], "expires_at": response["expires_at"],
+        "load_state": state, "expected_skills": list(expected),
+        "observed_skills": list(observed), "missing_skills": list(missing),
         "unexpected_skills": list(unexpected),
     }
-    errors = validate_skill_load_observation(payload)
-    if errors:
+    if validate_skill_load_observation(payload):
         return _closed_observation(
             "probe_error", "inventory_response_malformed", nonce, expected_digest,
             tool_fingerprint, runtime_unavailable, observed_at,
         )
     return payload
-
-
-@dataclass(slots=True)
-class _ResolvedTool:
-    executable: str
-    fingerprint: str
-    _scratch: tempfile.TemporaryDirectory[str]
-
-    def cleanup(self) -> None:
-        self._scratch.cleanup()
-
-
-@dataclass(frozen=True, slots=True)
-class _ProcessOutcome:
-    kind: str
-    exit_code: int | None
-    stdout: bytes
-
-
-def _run_inventory_process(
-    request: SkillLoadProbeRequest,
-    executable: str,
-    env: Mapping[str, str],
-    nonce: str,
-    expected_digest: str,
-    tool_fingerprint: str,
-) -> _ProcessOutcome:
-    protocol_argv = (
-        "--safe-mode", "--ignore-user-config", "--ignore-rules",
-        "skills", "inventory", "--protocol", HERMES_SKILL_INVENTORY_SCHEMA_VERSION,
-        "--nonce", nonce, "--expected-digest", expected_digest,
-        "--tool-fingerprint", tool_fingerprint,
-    )
-    argv = _inventory_argv(executable, protocol_argv, windows=os.name == "nt")
-    process: subprocess.Popen[bytes] | None = None
-    drainers = None
-    kind = "spawn_error"
-    cleanup_verified = True
-    try:
-        process = subprocess.Popen(
-            argv, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-            env=env, text=False, close_fds=True, start_new_session=os.name != "nt",
-        )
-        drainers = start_pipe_drainers(process)
-        try:
-            process.wait(timeout=request.timeout_seconds)
-            kind = "complete"
-        except subprocess.TimeoutExpired:
-            kind = "timeout"
-    except OSError:
-        pass
-    finally:
-        if process is not None:
-            _signals, cleanup_verified = terminate_process_group(
-                process, request.termination_grace_seconds, signal.SIGTERM
-            )
-            if drainers is None:
-                for pipe in (process.stdout, process.stderr):
-                    if pipe is not None:
-                        pipe.close()
-            else:
-                for drainer in drainers:
-                    drainer.done.wait(max(0.1, request.termination_grace_seconds))
-                    drainer.thread.join(timeout=max(0.1, request.termination_grace_seconds))
-    if not cleanup_verified or process is None or drainers is None:
-        return _ProcessOutcome("spawn_error", None, b"")
-    stdout_capture = drainers[0].capture()
-    if stdout_capture.truncated:
-        return _ProcessOutcome("complete", process.returncode, b"")
-    return _ProcessOutcome(kind, process.returncode, stdout_capture.data)
-
-
-def _validated_inventory_response(
-    raw: bytes,
-    *,
-    nonce: str,
-    expected_digest: str,
-    tool_fingerprint: str,
-    now: datetime,
-) -> tuple[dict[str, object] | None, str]:
-    try:
-        decoded = raw.decode("utf-8")
-        decoded_candidate = json.loads(decoded)
-    except (UnicodeDecodeError, json.JSONDecodeError):
-        return None, "inventory_response_malformed"
-    if not isinstance(decoded_candidate, dict) or set(decoded_candidate) != _INVENTORY_FIELDS:
-        return None, "inventory_response_malformed"
-    candidate = cast(dict[str, object], decoded_candidate)
-    if candidate.get("schema_version") != HERMES_SKILL_INVENTORY_SCHEMA_VERSION:
-        return None, "inventory_response_malformed"
-    if candidate.get("nonce") != nonce:
-        return None, "inventory_nonce_mismatch"
-    if candidate.get("expected_digest") != expected_digest:
-        return None, "inventory_expected_digest_mismatch"
-    if candidate.get("tool_fingerprint") != tool_fingerprint:
-        return None, "inventory_response_malformed"
-    runtime = candidate.get("runtime_fingerprint")
-    if not isinstance(runtime, str) or not _HEX_64.fullmatch(runtime):
-        return None, "inventory_response_malformed"
-    observed_raw = candidate.get("observed_skills")
-    if not isinstance(observed_raw, list):
-        return None, "inventory_response_malformed"
-    try:
-        observed = _normalized_skill_set(observed_raw, field="observed_skills")
-    except ValueError:
-        return None, "inventory_response_malformed"
-    if observed_raw != list(observed):
-        return None, "inventory_response_malformed"
-    inventory_digest = candidate.get("inventory_digest")
-    if inventory_digest != _set_digest(observed):
-        return None, "inventory_digest_mismatch"
-    try:
-        response_observed = _parse_time(candidate.get("observed_at"))
-        expires = _parse_time(candidate.get("expires_at"))
-    except ValueError:
-        return None, "inventory_response_malformed"
-    if response_observed > now + timedelta(seconds=5):
-        return None, "inventory_response_malformed"
-    if response_observed < now - timedelta(seconds=_MAX_PROTOCOL_SECONDS):
-        return None, "inventory_response_stale"
-    if expires <= now:
-        return None, "inventory_response_expired"
-    if expires <= response_observed or expires > response_observed + timedelta(seconds=_MAX_PROTOCOL_SECONDS):
-        return None, "inventory_response_malformed"
-    candidate["observed_skills"] = list(observed)
-    return candidate, "inventory_validated"
-
-
-def _closed_observation(
-    status: str,
-    reason: str,
-    nonce: str,
-    expected_digest: str,
-    tool_fingerprint: str,
-    runtime_fingerprint: str,
-    observed_at: datetime,
-) -> dict[str, object]:
-    payload: dict[str, object] = {
-        "schema_version": SKILL_LOAD_OBSERVATION_SCHEMA_VERSION,
-        "probe_status": status,
-        "reason_code": reason,
-        "nonce": nonce,
-        "expected_digest": expected_digest,
-        "tool_fingerprint": tool_fingerprint,
-        "runtime_fingerprint": runtime_fingerprint,
-        "observed_at": _format_time(observed_at),
-        "expires_at": _format_time(observed_at + timedelta(seconds=_MAX_PROTOCOL_SECONDS)),
-    }
-    errors = validate_skill_load_observation(payload)
-    if errors:
-        raise ValueError("invalid closed skill-load observation: " + "; ".join(errors))
-    return payload
-
-
-def validate_skill_load_observation(payload: Mapping[str, object] | object) -> list[str]:
-    if not isinstance(payload, Mapping):
-        return ["payload must be an object"]
-    errors: list[str] = []
-    extras = sorted(set(payload) - _OBSERVATION_FIELDS)
-    if extras:
-        errors.append(f"unsupported fields: {extras}")
-    if payload.get("schema_version") != SKILL_LOAD_OBSERVATION_SCHEMA_VERSION:
-        errors.append("schema_version is invalid")
-    status = payload.get("probe_status")
-    if status not in PROBE_STATUSES:
-        errors.append("probe_status is invalid")
-    if payload.get("reason_code") not in REASON_CODES:
-        errors.append("reason_code is invalid")
-    for field in ("nonce", "expected_digest", "tool_fingerprint", "runtime_fingerprint"):
-        value = payload.get(field)
-        if not isinstance(value, str) or not _HEX_64.fullmatch(value):
-            errors.append(f"{field} is invalid")
-    for field in ("observed_at", "expires_at"):
-        try:
-            _parse_time(payload.get(field))
-        except ValueError:
-            errors.append(f"{field} is invalid")
-    if status == "observed":
-        if payload.get("reason_code") != "inventory_validated":
-            errors.append("observed probe requires inventory_validated")
-        if payload.get("load_state") not in LOAD_STATES:
-            errors.append("observed probe requires load_state")
-        sets: dict[str, tuple[str, ...]] = {}
-        for field in ("expected_skills", "observed_skills", "missing_skills", "unexpected_skills"):
-            raw = payload.get(field)
-            if not isinstance(raw, list):
-                errors.append(f"{field} must be a sorted unique list")
-                continue
-            try:
-                normalized = _normalized_skill_set(raw, field=field)
-            except ValueError:
-                errors.append(f"{field} must be a sorted unique list")
-                continue
-            if raw != list(normalized):
-                errors.append(f"{field} must be a sorted unique list")
-            sets[field] = normalized
-        digest = payload.get("inventory_digest")
-        if not isinstance(digest, str) or not _HEX_64.fullmatch(digest):
-            errors.append("inventory_digest is invalid")
-        if len(sets) == 4:
-            expected = sets["expected_skills"]
-            observed = sets["observed_skills"]
-            missing = tuple(sorted(set(expected) - set(observed)))
-            unexpected = tuple(sorted(set(observed) - set(expected)))
-            if sets["missing_skills"] != missing or sets["unexpected_skills"] != unexpected:
-                errors.append("inventory set differences are invalid")
-            if payload.get("expected_digest") != _set_digest(expected):
-                errors.append("expected_digest does not bind expected_skills")
-            if digest != _set_digest(observed):
-                errors.append("inventory_digest does not bind observed_skills")
-            expected_state = (
-                "not_applicable" if not expected else
-                "none_loaded" if set(expected).isdisjoint(observed) else
-                "partially_loaded" if missing else "all_loaded"
-            )
-            if payload.get("load_state") != expected_state:
-                errors.append("load_state does not match inventory sets")
-    else:
-        forbidden = sorted(set(payload) & _INVENTORY_CLAIM_FIELDS)
-        if forbidden:
-            errors.append(f"non-observed probe carries inventory claims: {forbidden}")
-        if status == "unsupported" and payload.get("reason_code") != "inventory_protocol_unavailable":
-            errors.append("unsupported probe reason is invalid")
-        if status == "probe_error" and payload.get("reason_code") in {
-            "inventory_validated", "inventory_protocol_unavailable"
-        }:
-            errors.append("probe_error reason is invalid")
-    return errors
-
-
-def skill_load_observation_is_fresh(
-    payload: Mapping[str, object], *, now: datetime | None = None
-) -> bool:
-    if validate_skill_load_observation(payload):
-        return False
-    try:
-        observed = _parse_time(payload.get("observed_at"))
-        expires = _parse_time(payload.get("expires_at"))
-    except ValueError:
-        return False
-    current = _utc(now)
-    return observed <= current < expires
-
-
-def _normalized_skill_set(values: Sequence[object], *, field: str) -> tuple[str, ...]:
-    if isinstance(values, (str, bytes)):
-        raise ValueError(f"{field} must be a sequence")
-    normalized: list[str] = []
-    for value in values:
-        if not isinstance(value, str) or not _SKILL_NAME.fullmatch(value):
-            raise ValueError(f"{field} contains an invalid skill name")
-        normalized.append(value)
-    if len(normalized) != len(set(normalized)):
-        raise ValueError(f"{field} contains duplicate skill names")
-    return tuple(sorted(normalized))
-
-
-def _set_digest(values: Sequence[str]) -> str:
-    encoded = json.dumps(list(values), separators=(",", ":"), ensure_ascii=True).encode("ascii")
-    return hashlib.sha256(encoded).hexdigest()
-
-
-def _probe_environment(source: Mapping[str, str] | None) -> dict[str, str]:
-    values = os.environ if source is None else source
-    folded = {name.casefold(): value for name, value in values.items()}
-    env = {
-        name: folded[name.casefold()]
-        for name in _SAFE_ENV_NAMES
-        if folded.get(name.casefold())
-    }
-    if source is None:
-        env.setdefault("PATH", os.defpath)
-    env.update(
-        {
-            "HERMES_SAFE_MODE": "1",
-            "HERMES_IGNORE_USER_CONFIG": "1",
-            "HERMES_IGNORE_RULES": "1",
-            "OMH_ISOLATED_HERMES_ROUTING": "disabled",
-            "OMH_ISOLATED_HERMES_MAX_DEPTH": "1",
-        }
-    )
-    return env
-
-
-def _inventory_argv(
-    executable: str,
-    protocol_argv: Sequence[str],
-    *,
-    windows: bool,
-) -> tuple[str, ...]:
-    if windows and Path(executable).suffix.casefold() == ".py":
-        return (sys.executable, executable, *protocol_argv)
-    return (executable, *protocol_argv)
-
-
-def _resolve_executable(
-    executable: str,
-    env: Mapping[str, str],
-    *,
-    windows: bool,
-) -> Path | None:
-    has_separator = "/" in executable or "\\" in executable
-    if has_separator or Path(executable).is_absolute():
-        return Path(executable).expanduser()
-    folded = {name.casefold(): value for name, value in env.items()}
-    path_value = folded.get("path", "")
-    if not windows:
-        found = shutil.which(executable, path=path_value)
-        return None if found is None else Path(found)
-    extensions = tuple(
-        extension if extension.startswith(".") else f".{extension}"
-        for extension in folded.get("pathext", ".COM;.EXE;.BAT;.CMD").split(";")
-        if extension
-    )
-    supplied_suffix = Path(executable).suffix.casefold()
-    names = (
-        (executable,)
-        if supplied_suffix in {extension.casefold() for extension in extensions}
-        else tuple(f"{executable}{extension}" for extension in extensions)
-    )
-    for directory_name in path_value.split(";"):
-        if not directory_name:
-            continue
-        directory = Path(directory_name)
-        try:
-            entries = {entry.name.casefold(): entry for entry in directory.iterdir()}
-        except OSError:
-            continue
-        for name in names:
-            selected = entries.get(name.casefold())
-            if selected is not None and selected.is_file():
-                return selected
-    return None
-
-
-def _snapshot_resolved_tool(executable: str, env: Mapping[str, str]) -> _ResolvedTool:
-    """Copy one opened executable inode into a private per-probe snapshot.
-
-    Resolution happens once. The source descriptor supplies both fingerprint
-    bytes and snapshot bytes, so replacing or restoring its pathname cannot
-    alter what the later process consumes.
-    """
-    selected = _resolve_executable(executable, env, windows=os.name == "nt")
-    if selected is None:
-        raise FileNotFoundError(executable)
-    resolved = selected.resolve(strict=True)
-    source_fd = os.open(
-        resolved,
-        os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_CLOEXEC", 0),
-    )
-    scratch: tempfile.TemporaryDirectory[str] | None = None
-    snapshot_fd: int | None = None
-    keep_snapshot = False
-    try:
-        source_identity = os.fstat(source_fd)
-        if not stat.S_ISREG(source_identity.st_mode):
-            raise PermissionError(executable)
-        if os.name != "nt" and source_identity.st_mode & 0o111 == 0:
-            raise PermissionError(executable)
-
-        scratch = tempfile.TemporaryDirectory(prefix="omh-skill-load-tool-")
-        snapshot = Path(scratch.name) / resolved.name
-        snapshot_fd = os.open(
-            snapshot,
-            os.O_RDWR | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0),
-            0o500,
-        )
-        source_content = hashlib.sha256()
-        copied = 0
-        while chunk := os.read(source_fd, 64 * 1024):
-            source_content.update(chunk)
-            copied += len(chunk)
-            view = memoryview(chunk)
-            while view:
-                written = os.write(snapshot_fd, view)
-                if written <= 0:
-                    raise OSError("snapshot write did not advance")
-                view = view[written:]
-        if copied != source_identity.st_size:
-            raise OSError("executable size changed during snapshot")
-        fchmod = getattr(os, "fchmod", None)
-        if fchmod is None:
-            os.chmod(snapshot, 0o500)
-        else:
-            fchmod(snapshot_fd, 0o500)
-        os.fsync(snapshot_fd)
-        snapshot_identity = os.fstat(snapshot_fd)
-        if not stat.S_ISREG(snapshot_identity.st_mode) or snapshot_identity.st_size != copied:
-            raise OSError("executable snapshot is incomplete")
-        os.lseek(snapshot_fd, 0, os.SEEK_SET)
-        snapshot_content = hashlib.sha256()
-        while chunk := os.read(snapshot_fd, 64 * 1024):
-            snapshot_content.update(chunk)
-        if snapshot_content.digest() != source_content.digest():
-            raise OSError("executable snapshot bytes do not match source descriptor")
-        fingerprint = hashlib.sha256()
-        fingerprint.update(b"omh-skill-load-tool/v2\0")
-        fingerprint.update(os.fsencode(resolved))
-        fingerprint.update(
-            (
-                f"\0{source_identity.st_dev}\0{source_identity.st_ino}"
-                f"\0{source_identity.st_mode}\0{source_identity.st_size}\0"
-            ).encode("ascii")
-        )
-        fingerprint.update(snapshot_content.digest())
-        os.close(snapshot_fd)
-        snapshot_fd = None
-        os.close(source_fd)
-        source_fd = -1
-        keep_snapshot = True
-        return _ResolvedTool(str(snapshot), fingerprint.hexdigest(), scratch)
-    finally:
-        if snapshot_fd is not None:
-            os.close(snapshot_fd)
-        if source_fd >= 0:
-            os.close(source_fd)
-        if scratch is not None and not keep_snapshot:
-            scratch.cleanup()
-
-
-def _parse_time(value: object) -> datetime:
-    if not isinstance(value, str) or not value.endswith("Z"):
-        raise ValueError("timestamp must be UTC")
-    parsed = datetime.fromisoformat(value[:-1] + "+00:00")
-    if parsed.tzinfo is None:
-        raise ValueError("timestamp must have timezone")
-    return parsed.astimezone(timezone.utc)
-
-
-def _utc(value: datetime | None) -> datetime:
-    current = value or datetime.now(timezone.utc)
-    if current.tzinfo is None:
-        raise ValueError("now must be timezone-aware")
-    return current.astimezone(timezone.utc)
-
-
-def _format_time(value: datetime) -> str:
-    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")

--- a/src/coding/skill_load_observation.py
+++ b/src/coding/skill_load_observation.py
@@ -270,11 +270,7 @@ def _run_inventory_process(
         "--nonce", nonce, "--expected-digest", expected_digest,
         "--tool-fingerprint", tool_fingerprint,
     )
-    argv = (
-        (sys.executable, executable, *protocol_argv)
-        if os.name == "nt" and Path(executable).suffix.casefold() == ".py"
-        else (executable, *protocol_argv)
-    )
+    argv = _inventory_argv(executable, protocol_argv, windows=os.name == "nt")
     process: subprocess.Popen[bytes] | None = None
     drainers = None
     kind = "spawn_error"
@@ -505,8 +501,14 @@ def _set_digest(values: Sequence[str]) -> str:
 
 def _probe_environment(source: Mapping[str, str] | None) -> dict[str, str]:
     values = os.environ if source is None else source
-    env = {name: values[name] for name in _SAFE_ENV_NAMES if values.get(name)}
-    env.setdefault("PATH", os.defpath)
+    folded = {name.casefold(): value for name, value in values.items()}
+    env = {
+        name: folded[name.casefold()]
+        for name in _SAFE_ENV_NAMES
+        if folded.get(name.casefold())
+    }
+    if source is None:
+        env.setdefault("PATH", os.defpath)
     env.update(
         {
             "HERMES_SAFE_MODE": "1",
@@ -519,6 +521,57 @@ def _probe_environment(source: Mapping[str, str] | None) -> dict[str, str]:
     return env
 
 
+def _inventory_argv(
+    executable: str,
+    protocol_argv: Sequence[str],
+    *,
+    windows: bool,
+) -> tuple[str, ...]:
+    if windows and Path(executable).suffix.casefold() == ".py":
+        return (sys.executable, executable, *protocol_argv)
+    return (executable, *protocol_argv)
+
+
+def _resolve_executable(
+    executable: str,
+    env: Mapping[str, str],
+    *,
+    windows: bool,
+) -> Path | None:
+    has_separator = "/" in executable or "\\" in executable
+    if has_separator or Path(executable).is_absolute():
+        return Path(executable).expanduser()
+    folded = {name.casefold(): value for name, value in env.items()}
+    path_value = folded.get("path", "")
+    if not windows:
+        found = shutil.which(executable, path=path_value)
+        return None if found is None else Path(found)
+    extensions = tuple(
+        extension if extension.startswith(".") else f".{extension}"
+        for extension in folded.get("pathext", ".COM;.EXE;.BAT;.CMD").split(";")
+        if extension
+    )
+    supplied_suffix = Path(executable).suffix.casefold()
+    names = (
+        (executable,)
+        if supplied_suffix in {extension.casefold() for extension in extensions}
+        else tuple(f"{executable}{extension}" for extension in extensions)
+    )
+    for directory_name in path_value.split(";"):
+        if not directory_name:
+            continue
+        directory = Path(directory_name)
+        try:
+            entries = {entry.name.casefold(): entry for entry in directory.iterdir()}
+        except OSError:
+            continue
+        for name in names:
+            selected = entries.get(name.casefold())
+            if selected is not None and selected.is_file():
+                return selected
+    return None
+
+
 def _snapshot_resolved_tool(executable: str, env: Mapping[str, str]) -> _ResolvedTool:
     """Copy one opened executable inode into a private per-probe snapshot.
 
@@ -526,14 +579,9 @@ def _snapshot_resolved_tool(executable: str, env: Mapping[str, str]) -> _Resolve
     bytes and snapshot bytes, so replacing or restoring its pathname cannot
     alter what the later process consumes.
     """
-    has_separator = os.sep in executable or bool(os.altsep and os.altsep in executable)
-    if has_separator or Path(executable).is_absolute():
-        selected = Path(executable).expanduser()
-    else:
-        found = shutil.which(executable, path=env.get("PATH"))
-        if found is None:
-            raise FileNotFoundError(executable)
-        selected = Path(found)
+    selected = _resolve_executable(executable, env, windows=os.name == "nt")
+    if selected is None:
+        raise FileNotFoundError(executable)
     resolved = selected.resolve(strict=True)
     source_fd = os.open(
         resolved,

--- a/src/coding/skill_load_process.py
+++ b/src/coding/skill_load_process.py
@@ -1,0 +1,238 @@
+"""Executable selection, snapshot binding, and process lifecycle for skill probes."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import hashlib
+import os
+from pathlib import Path
+import shutil
+import signal
+import stat
+import subprocess
+import sys
+import tempfile
+from typing import Final
+
+from ._hermes_child_process import start_pipe_drainers, terminate_process_group
+from .skill_load_protocol import HERMES_SKILL_INVENTORY_SCHEMA_VERSION
+
+SAFE_ENV_NAMES: Final = frozenset({
+    "PATH", "LANG", "LANGUAGE", "LC_ALL", "LC_CTYPE", "TERM", "TMPDIR", "TMP", "TEMP",
+    "SYSTEMROOT", "WINDIR", "PATHEXT", "COMSPEC",
+})
+
+
+@dataclass(frozen=True, slots=True)
+class SkillLoadProbeRequest:
+    expected_skills: Sequence[str]
+    hermes: str = "hermes"
+    timeout_seconds: float = 10.0
+    termination_grace_seconds: float = 0.25
+    env: Mapping[str, str] | None = None
+    nonce: str | None = None
+
+
+@dataclass(slots=True)
+class ResolvedTool:
+    executable: str
+    fingerprint: str
+    _scratch: tempfile.TemporaryDirectory[str]
+
+    def cleanup(self) -> None:
+        self._scratch.cleanup()
+
+
+@dataclass(frozen=True, slots=True)
+class ProcessOutcome:
+    kind: str
+    exit_code: int | None
+    stdout: bytes
+
+
+def run_inventory_process(
+    request: SkillLoadProbeRequest,
+    executable: str,
+    env: Mapping[str, str],
+    nonce: str,
+    expected_digest: str,
+    tool_fingerprint: str,
+) -> ProcessOutcome:
+    protocol_argv = (
+        "--safe-mode", "--ignore-user-config", "--ignore-rules", "skills", "inventory",
+        "--protocol", HERMES_SKILL_INVENTORY_SCHEMA_VERSION, "--nonce", nonce,
+        "--expected-digest", expected_digest, "--tool-fingerprint", tool_fingerprint,
+    )
+    argv = inventory_argv(executable, protocol_argv, windows=os.name == "nt")
+    process: subprocess.Popen[bytes] | None = None
+    drainers = None
+    kind = "spawn_error"
+    cleanup_verified = True
+    try:
+        process = subprocess.Popen(
+            argv, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            env=env, text=False, close_fds=True, start_new_session=os.name != "nt",
+        )
+        drainers = start_pipe_drainers(process)
+        try:
+            process.wait(timeout=request.timeout_seconds)
+            kind = "complete"
+        except subprocess.TimeoutExpired:
+            kind = "timeout"
+    except OSError:
+        pass
+    finally:
+        if process is not None:
+            _signals, cleanup_verified = terminate_process_group(
+                process, request.termination_grace_seconds, signal.SIGTERM
+            )
+            if drainers is None:
+                for pipe in (process.stdout, process.stderr):
+                    if pipe is not None:
+                        pipe.close()
+            else:
+                for drainer in drainers:
+                    drainer.done.wait(max(0.1, request.termination_grace_seconds))
+                    drainer.thread.join(timeout=max(0.1, request.termination_grace_seconds))
+    if not cleanup_verified or process is None or drainers is None:
+        return ProcessOutcome("spawn_error", None, b"")
+    stdout_capture = drainers[0].capture()
+    if stdout_capture.truncated:
+        return ProcessOutcome("complete", process.returncode, b"")
+    return ProcessOutcome(kind, process.returncode, stdout_capture.data)
+
+
+def probe_environment(source: Mapping[str, str] | None) -> dict[str, str]:
+    values = os.environ if source is None else source
+    folded = {name.casefold(): value for name, value in values.items()}
+    env = {
+        name: folded[name.casefold()]
+        for name in SAFE_ENV_NAMES
+        if folded.get(name.casefold())
+    }
+    if source is None:
+        env.setdefault("PATH", os.defpath)
+    env.update({
+        "HERMES_SAFE_MODE": "1", "HERMES_IGNORE_USER_CONFIG": "1", "HERMES_IGNORE_RULES": "1",
+        "OMH_ISOLATED_HERMES_ROUTING": "disabled", "OMH_ISOLATED_HERMES_MAX_DEPTH": "1",
+    })
+    return env
+
+
+def inventory_argv(
+    executable: str, protocol_argv: Sequence[str], *, windows: bool,
+) -> tuple[str, ...]:
+    if windows and Path(executable).suffix.casefold() == ".py":
+        return (sys.executable, executable, *protocol_argv)
+    return (executable, *protocol_argv)
+
+
+def resolve_executable(
+    executable: str, env: Mapping[str, str], *, windows: bool,
+) -> Path | None:
+    has_separator = "/" in executable or "\\" in executable
+    if has_separator or Path(executable).is_absolute():
+        return Path(executable).expanduser()
+    folded = {name.casefold(): value for name, value in env.items()}
+    path_value = folded.get("path", "")
+    if not windows:
+        found = shutil.which(executable, path=path_value)
+        return None if found is None else Path(found)
+    extensions = tuple(
+        extension if extension.startswith(".") else f".{extension}"
+        for extension in folded.get("pathext", ".COM;.EXE;.BAT;.CMD").split(";")
+        if extension
+    )
+    supplied_suffix = Path(executable).suffix.casefold()
+    names = (
+        (executable,) if supplied_suffix in {extension.casefold() for extension in extensions}
+        else tuple(f"{executable}{extension}" for extension in extensions)
+    )
+    for directory_name in path_value.split(";"):
+        if not directory_name:
+            continue
+        directory = Path(directory_name)
+        try:
+            entries = {entry.name.casefold(): entry for entry in directory.iterdir()}
+        except OSError:
+            continue
+        for name in names:
+            selected = entries.get(name.casefold())
+            if selected is not None and selected.is_file():
+                return selected
+    return None
+
+
+def snapshot_resolved_tool(executable: str, env: Mapping[str, str]) -> ResolvedTool:
+    """Copy one opened executable inode into a private per-probe snapshot."""
+    selected = resolve_executable(executable, env, windows=os.name == "nt")
+    if selected is None:
+        raise FileNotFoundError(executable)
+    resolved = selected.resolve(strict=True)
+    source_fd = os.open(
+        resolved, os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_CLOEXEC", 0),
+    )
+    scratch: tempfile.TemporaryDirectory[str] | None = None
+    snapshot_fd: int | None = None
+    keep_snapshot = False
+    try:
+        source_identity = os.fstat(source_fd)
+        if not stat.S_ISREG(source_identity.st_mode):
+            raise PermissionError(executable)
+        if os.name != "nt" and source_identity.st_mode & 0o111 == 0:
+            raise PermissionError(executable)
+        scratch = tempfile.TemporaryDirectory(prefix="omh-skill-load-tool-")
+        snapshot = Path(scratch.name) / resolved.name
+        snapshot_fd = os.open(
+            snapshot, os.O_RDWR | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0), 0o500,
+        )
+        source_content = hashlib.sha256()
+        copied = 0
+        while chunk := os.read(source_fd, 64 * 1024):
+            source_content.update(chunk)
+            copied += len(chunk)
+            view = memoryview(chunk)
+            while view:
+                written = os.write(snapshot_fd, view)
+                if written <= 0:
+                    raise OSError("snapshot write did not advance")
+                view = view[written:]
+        if copied != source_identity.st_size:
+            raise OSError("executable size changed during snapshot")
+        fchmod = getattr(os, "fchmod", None)
+        if fchmod is None:
+            os.chmod(snapshot, 0o500)
+        else:
+            fchmod(snapshot_fd, 0o500)
+        os.fsync(snapshot_fd)
+        snapshot_identity = os.fstat(snapshot_fd)
+        if not stat.S_ISREG(snapshot_identity.st_mode) or snapshot_identity.st_size != copied:
+            raise OSError("executable snapshot is incomplete")
+        os.lseek(snapshot_fd, 0, os.SEEK_SET)
+        snapshot_content = hashlib.sha256()
+        while chunk := os.read(snapshot_fd, 64 * 1024):
+            snapshot_content.update(chunk)
+        if snapshot_content.digest() != source_content.digest():
+            raise OSError("executable snapshot bytes do not match source descriptor")
+        fingerprint = hashlib.sha256()
+        fingerprint.update(b"omh-skill-load-tool/v2\0")
+        fingerprint.update(os.fsencode(resolved))
+        fingerprint.update(
+            (f"\0{source_identity.st_dev}\0{source_identity.st_ino}\0{source_identity.st_mode}"
+             f"\0{source_identity.st_size}\0").encode("ascii")
+        )
+        fingerprint.update(snapshot_content.digest())
+        os.close(snapshot_fd)
+        snapshot_fd = None
+        os.close(source_fd)
+        source_fd = -1
+        keep_snapshot = True
+        return ResolvedTool(str(snapshot), fingerprint.hexdigest(), scratch)
+    finally:
+        if snapshot_fd is not None:
+            os.close(snapshot_fd)
+        if source_fd >= 0:
+            os.close(source_fd)
+        if scratch is not None and not keep_snapshot:
+            scratch.cleanup()

--- a/src/coding/skill_load_protocol.py
+++ b/src/coding/skill_load_protocol.py
@@ -1,0 +1,239 @@
+"""Closed schemas and validation for Hermes skill-load observations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timedelta, timezone
+import hashlib
+import json
+import re
+from typing import Final, cast
+
+SKILL_LOAD_OBSERVATION_SCHEMA_VERSION: Final = "skill_load_observation/v1"
+HERMES_SKILL_INVENTORY_SCHEMA_VERSION: Final = "hermes_skill_inventory/v1"
+PROBE_STATUSES: Final = ("observed", "unsupported", "probe_error")
+LOAD_STATES: Final = ("all_loaded", "partially_loaded", "none_loaded", "not_applicable")
+REASON_CODES: Final = (
+    "inventory_validated", "inventory_protocol_unavailable", "inventory_process_error",
+    "inventory_executable_unavailable", "inventory_timeout", "inventory_response_malformed",
+    "inventory_nonce_mismatch", "inventory_expected_digest_mismatch",
+    "inventory_digest_mismatch", "inventory_response_expired", "inventory_response_stale",
+    "inventory_nonce_replayed",
+)
+MAX_PROTOCOL_SECONDS: Final = 300
+SKILL_NAME: Final = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}\Z")
+HEX_64: Final = re.compile(r"[0-9a-f]{64}\Z")
+OBSERVATION_FIELDS: Final = frozenset({
+    "schema_version", "probe_status", "reason_code", "nonce", "expected_digest",
+    "inventory_digest", "tool_fingerprint", "runtime_fingerprint", "observed_at",
+    "expires_at", "load_state", "expected_skills", "observed_skills", "missing_skills",
+    "unexpected_skills",
+})
+INVENTORY_FIELDS: Final = frozenset({
+    "schema_version", "nonce", "expected_digest", "inventory_digest", "tool_fingerprint",
+    "runtime_fingerprint", "observed_at", "expires_at", "observed_skills",
+})
+INVENTORY_CLAIM_FIELDS: Final = frozenset({
+    "inventory_digest", "load_state", "expected_skills", "observed_skills", "missing_skills",
+    "unexpected_skills",
+})
+
+
+def expected_skills_digest(skills: Sequence[str]) -> str:
+    return set_digest(normalized_skill_set(skills, field="expected_skills"))
+
+
+def validated_inventory_response(
+    raw: bytes, *, nonce: str, expected_digest: str, tool_fingerprint: str, now: datetime,
+) -> tuple[dict[str, object] | None, str]:
+    try:
+        decoded_candidate = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None, "inventory_response_malformed"
+    if not isinstance(decoded_candidate, dict) or set(decoded_candidate) != INVENTORY_FIELDS:
+        return None, "inventory_response_malformed"
+    candidate = cast(dict[str, object], decoded_candidate)
+    if candidate.get("schema_version") != HERMES_SKILL_INVENTORY_SCHEMA_VERSION:
+        return None, "inventory_response_malformed"
+    if candidate.get("nonce") != nonce:
+        return None, "inventory_nonce_mismatch"
+    if candidate.get("expected_digest") != expected_digest:
+        return None, "inventory_expected_digest_mismatch"
+    if candidate.get("tool_fingerprint") != tool_fingerprint:
+        return None, "inventory_response_malformed"
+    runtime = candidate.get("runtime_fingerprint")
+    if not isinstance(runtime, str) or not HEX_64.fullmatch(runtime):
+        return None, "inventory_response_malformed"
+    observed_raw = candidate.get("observed_skills")
+    if not isinstance(observed_raw, list):
+        return None, "inventory_response_malformed"
+    try:
+        observed = normalized_skill_set(observed_raw, field="observed_skills")
+    except ValueError:
+        return None, "inventory_response_malformed"
+    if observed_raw != list(observed):
+        return None, "inventory_response_malformed"
+    if candidate.get("inventory_digest") != set_digest(observed):
+        return None, "inventory_digest_mismatch"
+    try:
+        response_observed = parse_time(candidate.get("observed_at"))
+        expires = parse_time(candidate.get("expires_at"))
+    except ValueError:
+        return None, "inventory_response_malformed"
+    if response_observed > now + timedelta(seconds=5):
+        return None, "inventory_response_malformed"
+    if response_observed < now - timedelta(seconds=MAX_PROTOCOL_SECONDS):
+        return None, "inventory_response_stale"
+    if expires <= now:
+        return None, "inventory_response_expired"
+    if expires <= response_observed or expires > response_observed + timedelta(seconds=MAX_PROTOCOL_SECONDS):
+        return None, "inventory_response_malformed"
+    candidate["observed_skills"] = list(observed)
+    return candidate, "inventory_validated"
+
+
+def closed_observation(
+    status: str, reason: str, nonce: str, expected_digest: str, tool_fingerprint: str,
+    runtime_fingerprint: str, observed_at: datetime,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": SKILL_LOAD_OBSERVATION_SCHEMA_VERSION, "probe_status": status,
+        "reason_code": reason, "nonce": nonce, "expected_digest": expected_digest,
+        "tool_fingerprint": tool_fingerprint, "runtime_fingerprint": runtime_fingerprint,
+        "observed_at": format_time(observed_at),
+        "expires_at": format_time(observed_at + timedelta(seconds=MAX_PROTOCOL_SECONDS)),
+    }
+    errors = validate_skill_load_observation(payload)
+    if errors:
+        raise ValueError("invalid closed skill-load observation: " + "; ".join(errors))
+    return payload
+
+
+def validate_skill_load_observation(payload: Mapping[str, object] | object) -> list[str]:
+    if not isinstance(payload, Mapping):
+        return ["payload must be an object"]
+    errors: list[str] = []
+    extras = sorted(set(payload) - OBSERVATION_FIELDS)
+    if extras:
+        errors.append(f"unsupported fields: {extras}")
+    if payload.get("schema_version") != SKILL_LOAD_OBSERVATION_SCHEMA_VERSION:
+        errors.append("schema_version is invalid")
+    status = payload.get("probe_status")
+    if status not in PROBE_STATUSES:
+        errors.append("probe_status is invalid")
+    if payload.get("reason_code") not in REASON_CODES:
+        errors.append("reason_code is invalid")
+    for field in ("nonce", "expected_digest", "tool_fingerprint", "runtime_fingerprint"):
+        value = payload.get(field)
+        if not isinstance(value, str) or not HEX_64.fullmatch(value):
+            errors.append(f"{field} is invalid")
+    for field in ("observed_at", "expires_at"):
+        try:
+            parse_time(payload.get(field))
+        except ValueError:
+            errors.append(f"{field} is invalid")
+    if status == "observed":
+        _validate_observed_claims(payload, errors)
+    else:
+        forbidden = sorted(set(payload) & INVENTORY_CLAIM_FIELDS)
+        if forbidden:
+            errors.append(f"non-observed probe carries inventory claims: {forbidden}")
+        if status == "unsupported" and payload.get("reason_code") != "inventory_protocol_unavailable":
+            errors.append("unsupported probe reason is invalid")
+        if status == "probe_error" and payload.get("reason_code") in {
+            "inventory_validated", "inventory_protocol_unavailable"
+        }:
+            errors.append("probe_error reason is invalid")
+    return errors
+
+
+def _validate_observed_claims(payload: Mapping[str, object], errors: list[str]) -> None:
+    if payload.get("reason_code") != "inventory_validated":
+        errors.append("observed probe requires inventory_validated")
+    if payload.get("load_state") not in LOAD_STATES:
+        errors.append("observed probe requires load_state")
+    sets: dict[str, tuple[str, ...]] = {}
+    for field in ("expected_skills", "observed_skills", "missing_skills", "unexpected_skills"):
+        raw = payload.get(field)
+        if not isinstance(raw, list):
+            errors.append(f"{field} must be a sorted unique list")
+            continue
+        try:
+            normalized = normalized_skill_set(raw, field=field)
+        except ValueError:
+            errors.append(f"{field} must be a sorted unique list")
+            continue
+        if raw != list(normalized):
+            errors.append(f"{field} must be a sorted unique list")
+        sets[field] = normalized
+    digest = payload.get("inventory_digest")
+    if not isinstance(digest, str) or not HEX_64.fullmatch(digest):
+        errors.append("inventory_digest is invalid")
+    if len(sets) != 4:
+        return
+    expected, observed = sets["expected_skills"], sets["observed_skills"]
+    missing = tuple(sorted(set(expected) - set(observed)))
+    unexpected = tuple(sorted(set(observed) - set(expected)))
+    if sets["missing_skills"] != missing or sets["unexpected_skills"] != unexpected:
+        errors.append("inventory set differences are invalid")
+    if payload.get("expected_digest") != set_digest(expected):
+        errors.append("expected_digest does not bind expected_skills")
+    if digest != set_digest(observed):
+        errors.append("inventory_digest does not bind observed_skills")
+    expected_state = (
+        "not_applicable" if not expected else "none_loaded" if set(expected).isdisjoint(observed)
+        else "partially_loaded" if missing else "all_loaded"
+    )
+    if payload.get("load_state") != expected_state:
+        errors.append("load_state does not match inventory sets")
+
+
+def skill_load_observation_is_fresh(
+    payload: Mapping[str, object], *, now: datetime | None = None,
+) -> bool:
+    if validate_skill_load_observation(payload):
+        return False
+    try:
+        observed, expires = parse_time(payload.get("observed_at")), parse_time(payload.get("expires_at"))
+    except ValueError:
+        return False
+    current = utc(now)
+    return observed <= current < expires
+
+
+def normalized_skill_set(values: Sequence[object], *, field: str) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)):
+        raise ValueError(f"{field} must be a sequence")
+    normalized: list[str] = []
+    for value in values:
+        if not isinstance(value, str) or not SKILL_NAME.fullmatch(value):
+            raise ValueError(f"{field} contains an invalid skill name")
+        normalized.append(value)
+    if len(normalized) != len(set(normalized)):
+        raise ValueError(f"{field} contains duplicate skill names")
+    return tuple(sorted(normalized))
+
+
+def set_digest(values: Sequence[str]) -> str:
+    encoded = json.dumps(list(values), separators=(",", ":"), ensure_ascii=True).encode("ascii")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def parse_time(value: object) -> datetime:
+    if not isinstance(value, str) or not value.endswith("Z"):
+        raise ValueError("timestamp must be UTC")
+    parsed = datetime.fromisoformat(value[:-1] + "+00:00")
+    if parsed.tzinfo is None:
+        raise ValueError("timestamp must have timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def utc(value: datetime | None) -> datetime:
+    current = value or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+    return current.astimezone(timezone.utc)
+
+
+def format_time(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")

--- a/src/commands/hermes_child.py
+++ b/src/commands/hermes_child.py
@@ -28,6 +28,12 @@ from ..coding.routing_observation import (
     render_routing_status_rows,
     validate_routing_observation,
 )
+from ..coding.skill_load_observation import (
+    SkillLoadProbeRequest,
+    probe_skill_load,
+    skill_load_observation_is_fresh,
+    validate_skill_load_observation,
+)
 from ..installer import OmhError
 from ..local_store import atomic_write_json, read_json_object
 from ..system.metadata_safety import require_opaque_metadata_ref
@@ -111,6 +117,58 @@ def cmd_hermes_child_dispatch(args: argparse.Namespace) -> int:
     _write_observation(args, observation)
     _emit(args, observation)
     return 0 if result.status == "completed" else 1
+
+
+def cmd_hermes_child_skill_load_probe(args: argparse.Namespace) -> int:
+    if not args.confirm_dispatch:
+        raise OmhError("Hermes skill-load probe requires --confirm-dispatch")
+    _validate_run_id(args.run_id)
+    run_dir = _run_dir(args)
+    run_dir.mkdir(mode=0o700, exist_ok=True)
+    reservation_path = run_dir / "skill-load-probe.reserved"
+    try:
+        reservation = os.open(
+            reservation_path,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+    except FileExistsError as exc:
+        raise OmhError(f"Hermes skill-load probe run already exists: {args.run_id}") from exc
+    os.close(reservation)
+    try:
+        observation = probe_skill_load(
+            SkillLoadProbeRequest(
+                expected_skills=tuple(args.expected_skill),
+                hermes=args.hermes,
+                timeout_seconds=args.timeout,
+                termination_grace_seconds=args.termination_grace,
+            ),
+            confirmed=True,
+        )
+    except (RuntimeError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    _write_skill_load_observation(args, observation)
+    _emit_skill_load(args, observation)
+    return 1 if observation["probe_status"] == "probe_error" else 0
+
+
+def cmd_hermes_child_skill_load_status(args: argparse.Namespace) -> int:
+    _validate_run_id(args.run_id)
+    try:
+        observation = read_json_object(_run_dir(args) / "skill-load-observation.json")
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        raise OmhError(f"Hermes skill-load observation is unreadable: {exc}") from exc
+    if observation is None:
+        raise OmhError(f"Hermes skill-load probe not found: {args.run_id}")
+    if (
+        validate_skill_load_observation(observation)
+        or not _skill_load_signature_valid(args, observation)
+    ):
+        raise OmhError("Hermes skill-load observation is invalid")
+    if not skill_load_observation_is_fresh(observation):
+        raise OmhError("Hermes skill-load observation is expired")
+    _emit_skill_load(args, observation)
+    return 0
 
 
 def cmd_hermes_child_status(args: argparse.Namespace) -> int:
@@ -440,6 +498,49 @@ def _write_observation(args: argparse.Namespace, observation: dict[str, object])
     )
 
 
+def _write_skill_load_observation(
+    args: argparse.Namespace,
+    observation: dict[str, object],
+) -> None:
+    run_dir = _run_dir(args)
+    atomic_write_json(run_dir / "skill-load-observation.json", observation, private=True)
+    signature = hmac.new(
+        _observation_key(args),
+        _canonical_observation(observation),
+        hashlib.sha256,
+    ).hexdigest()
+    atomic_write_json(
+        run_dir / "skill-load-observation.signature.json",
+        {"schema_version": "skill_load_observation_signature/v1", "hmac_sha256": signature},
+        private=True,
+    )
+
+
+def _skill_load_signature_valid(
+    args: argparse.Namespace,
+    observation: dict[str, object],
+) -> bool:
+    try:
+        signature = read_json_object(
+            _run_dir(args) / "skill-load-observation.signature.json"
+        )
+    except (OSError, json.JSONDecodeError, ValueError):
+        return False
+    if not isinstance(signature, dict) or set(signature) != {"schema_version", "hmac_sha256"}:
+        return False
+    if signature.get("schema_version") != "skill_load_observation_signature/v1":
+        return False
+    observed = signature.get("hmac_sha256")
+    if not isinstance(observed, str):
+        return False
+    expected = hmac.new(
+        _observation_key(args),
+        _canonical_observation(observation),
+        hashlib.sha256,
+    ).hexdigest()
+    return hmac.compare_digest(observed, expected)
+
+
 def _observation_signature_valid(
     args: argparse.Namespace,
     observation: dict[str, object],
@@ -505,6 +606,17 @@ def _emit(args: argparse.Namespace, observation: dict[str, object]) -> None:
     print("\n".join(render_routing_status_rows(observation)))
 
 
+def _emit_skill_load(args: argparse.Namespace, observation: dict[str, object]) -> None:
+    if _wants_json(args):
+        _print_json(observation)
+        return
+    print(f"AUDIENCE {_AUDIENCE}")
+    print(f"PROBE {observation['probe_status']}")
+    print(f"REASON {observation['reason_code']}")
+    if "load_state" in observation:
+        print(f"LOAD {observation['load_state']}")
+
+
 def _add_request_arguments(parser: argparse.ArgumentParser, *, dispatch: bool) -> None:
     parser.add_argument("--prompt-file", default="-", help="Prompt file, or '-' for stdin (default). Prompt text is never accepted on argv.")
     parser.add_argument("--model", required=True, help="Hermes model alias metadata and --model value.")
@@ -537,6 +649,25 @@ def add_hermes_child_command(coding_sub: argparse._SubParsersAction) -> None:
     dispatch = actions.add_parser("dispatch", help="Explicitly dispatch one bounded local Hermes --oneshot child.")
     _add_request_arguments(dispatch, dispatch=True)
     dispatch.set_defaults(func=cmd_hermes_child_dispatch)
+    probe = actions.add_parser(
+        "skill-load-probe",
+        help="Explicitly probe a nonce-bound machine skill inventory; unsupported hosts stay unsupported.",
+    )
+    probe.add_argument("--confirm-dispatch", action="store_true", help="Required explicit approval to start the local inventory probe.")
+    probe.add_argument("--expected-skill", action="append", default=[], help="Expected skill name; repeat for multiple skills. An empty set is valid only after a protocol response.")
+    probe.add_argument("--run-id", required=True, help="Opaque isolated probe run id.")
+    probe.add_argument("--hermes", default="hermes", help="Hermes CLI executable path.")
+    probe.add_argument("--timeout", type=float, default=10.0, help="Hard inventory protocol timeout in seconds.")
+    probe.add_argument("--termination-grace", type=float, default=0.25, help="SIGTERM grace before SIGKILL.")
+    probe.add_argument("--json", action="store_true", help="Emit skill_load_observation/v1 JSON.")
+    probe.set_defaults(func=cmd_hermes_child_skill_load_probe)
+    probe_status = actions.add_parser(
+        "skill-load-status",
+        help="Read a fresh authenticated skill_load_observation/v1 record.",
+    )
+    probe_status.add_argument("--run-id", required=True)
+    probe_status.add_argument("--json", action="store_true")
+    probe_status.set_defaults(func=cmd_hermes_child_skill_load_status)
     status = actions.add_parser("status", help="Read the metadata-only routing observation for one child run.")
     status.add_argument("--run-id", required=True)
     status.add_argument("--json", action="store_true")

--- a/src/commands/hermes_child.py
+++ b/src/commands/hermes_child.py
@@ -506,12 +506,16 @@ def _write_skill_load_observation(
     atomic_write_json(run_dir / "skill-load-observation.json", observation, private=True)
     signature = hmac.new(
         _observation_key(args),
-        _canonical_observation(observation),
+        _skill_load_signature_message(args.run_id, observation),
         hashlib.sha256,
     ).hexdigest()
     atomic_write_json(
         run_dir / "skill-load-observation.signature.json",
-        {"schema_version": "skill_load_observation_signature/v1", "hmac_sha256": signature},
+        {
+            "schema_version": "skill_load_observation_signature/v2",
+            "run_id": args.run_id,
+            "hmac_sha256": signature,
+        },
         private=True,
     )
 
@@ -526,19 +530,36 @@ def _skill_load_signature_valid(
         )
     except (OSError, json.JSONDecodeError, ValueError):
         return False
-    if not isinstance(signature, dict) or set(signature) != {"schema_version", "hmac_sha256"}:
+    if not isinstance(signature, dict) or set(signature) != {
+        "schema_version", "run_id", "hmac_sha256"
+    }:
         return False
-    if signature.get("schema_version") != "skill_load_observation_signature/v1":
+    if (
+        signature.get("schema_version") != "skill_load_observation_signature/v2"
+        or signature.get("run_id") != args.run_id
+    ):
         return False
     observed = signature.get("hmac_sha256")
     if not isinstance(observed, str):
         return False
     expected = hmac.new(
         _observation_key(args),
-        _canonical_observation(observation),
+        _skill_load_signature_message(args.run_id, observation),
         hashlib.sha256,
     ).hexdigest()
     return hmac.compare_digest(observed, expected)
+
+
+def _skill_load_signature_message(
+    run_id: str,
+    observation: dict[str, object],
+) -> bytes:
+    return (
+        b"omh-skill-load-observation-signature/v2\0"
+        + run_id.encode("utf-8")
+        + b"\0"
+        + _canonical_observation(observation)
+    )
 
 
 def _observation_signature_valid(

--- a/src/evidence/labels.py
+++ b/src/evidence/labels.py
@@ -39,6 +39,20 @@ from typing import Final
 
 EVIDENCE_LABELS_SCHEMA_VERSION: Final[str] = "omh_evidence_labels/v1"
 
+# Orthogonal skill-load probe labels. These describe protocol capability and
+# inventory comparison; they never inherit routing or child-success wording.
+SKILL_LOAD_PROBE_LABELS: Final[dict[str, str]] = {
+    "observed": "machine inventory observed",
+    "unsupported": "machine inventory unsupported",
+    "probe_error": "machine inventory probe failed",
+}
+SKILL_LOAD_STATE_LABELS: Final[dict[str, str]] = {
+    "all_loaded": "all expected skills loaded",
+    "partially_loaded": "some expected skills missing",
+    "none_loaded": "no expected skills loaded",
+    "not_applicable": "no skills expected",
+}
+
 # The separator between the two axes. U+00B7 rather than an em dash because the
 # status board already joins its own fields with " — "; an em dash here would
 # make a six-field row read as seven. Already shipping elsewhere in this repo

--- a/src/quality/harness_quality.py
+++ b/src/quality/harness_quality.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
-from typing import Iterable
+from datetime import datetime
+from typing import Iterable, Mapping
+
+from ..coding.skill_load_observation import (
+    skill_load_observation_is_fresh,
+    validate_skill_load_observation,
+)
 
 
 HARNESS_QUALITY_SCHEMA_VERSION = "harness_quality/v1"
@@ -82,6 +88,20 @@ def build_harness_progress(contract: dict[str, object], step_states: dict[str, s
         "complete": bool(steps) and completed == len(steps),
         "next_step": next_step,
     }
+
+
+def skill_load_evidence_state(
+    observation: Mapping[str, object], *, now: datetime | None = None
+) -> str:
+    """Consume the probe without promoting unsupported, errors, or stale data."""
+    if validate_skill_load_observation(observation):
+        return "invalid"
+    if not skill_load_observation_is_fresh(observation, now=now):
+        return "stale"
+    status = observation.get("probe_status")
+    if status != "observed":
+        return str(status)
+    return str(observation.get("load_state"))
 
 
 def _progress_state(value: str) -> str:

--- a/tests/_skill_load_observation_support.py
+++ b/tests/_skill_load_observation_support.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import textwrap
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.coding.skill_load_observation import SkillLoadProbeRequest  # noqa: E402
+
+
+_FAKE = r'''#!/usr/bin/env python3
+import hashlib
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+args = sys.argv[1:]
+if args[:6] != ["--safe-mode", "--ignore-user-config", "--ignore-rules", "skills", "inventory", "--protocol"]:
+    raise SystemExit(91)
+protocol = args[6]
+nonce = args[args.index("--nonce") + 1]
+expected_digest = args[args.index("--expected-digest") + 1]
+tool_fingerprint = args[args.index("--tool-fingerprint") + 1]
+mode = __import__("pathlib").Path(sys.argv[0]).stem
+expected = [] if mode == "not-applicable" else ["alpha", "beta"]
+observed = {
+    "all": expected,
+    "partial": expected[:1],
+    "none": [],
+    "unexpected": [*expected, "gamma"],
+    "unexpected-only": ["gamma"],
+    "not-applicable": [],
+}.get(mode, expected)
+now = datetime.now(timezone.utc).replace(microsecond=0)
+payload = {
+    "schema_version": protocol,
+    "nonce": nonce,
+    "expected_digest": expected_digest,
+    "inventory_digest": hashlib.sha256(json.dumps(sorted(observed), separators=(",", ":")).encode()).hexdigest(),
+    "observed_skills": observed,
+    "tool_fingerprint": tool_fingerprint,
+    "runtime_fingerprint": "b" * 64,
+    "observed_at": now.isoformat().replace("+00:00", "Z"),
+    "expires_at": (now + timedelta(seconds=60)).isoformat().replace("+00:00", "Z"),
+}
+if mode == "unsupported":
+    print("unsupported inventory command", file=sys.stderr)
+    raise SystemExit(2)
+if mode == "error":
+    print("SECRET_RAW_LOG must not escape", file=sys.stderr)
+    raise SystemExit(9)
+if mode == "malformed":
+    print('{"prompt":"SECRET_PROMPT"}')
+    raise SystemExit(0)
+if mode == "duplicate":
+    payload["observed_skills"] = ["alpha", "alpha"]
+if mode == "nonce-mismatch":
+    payload["nonce"] = "f" * 64
+if mode == "digest-mismatch":
+    payload["expected_digest"] = "e" * 64
+if mode == "inventory-digest-mismatch":
+    payload["inventory_digest"] = "d" * 64
+if mode == "tool-mismatch":
+    payload["tool_fingerprint"] = "c" * 64
+if mode == "expired":
+    payload["observed_at"] = (now - timedelta(seconds=120)).isoformat().replace("+00:00", "Z")
+    payload["expires_at"] = (now - timedelta(seconds=60)).isoformat().replace("+00:00", "Z")
+if mode == "stale":
+    payload["observed_at"] = (now - timedelta(seconds=600)).isoformat().replace("+00:00", "Z")
+    payload["expires_at"] = (now + timedelta(seconds=60)).isoformat().replace("+00:00", "Z")
+if mode == "forbidden":
+    payload["raw_log"] = "SECRET_CREDENTIAL"
+print(json.dumps(payload))
+'''
+
+
+class SkillLoadObservationTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = TemporaryDirectory(prefix="omh-skill-load-")
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.hermes = self.root / "hermes.py"
+        self.hermes.write_text(textwrap.dedent(_FAKE), encoding="utf-8")
+        self.hermes.chmod(0o755)
+    def executable(self, path: Path, runtime_digit: str) -> Path:
+        path.write_text(
+            textwrap.dedent(_FAKE).replace(
+                '"runtime_fingerprint": "b" * 64',
+                f'"runtime_fingerprint": "{runtime_digit}" * 64',
+            ),
+            encoding="utf-8",
+        )
+        path.chmod(0o755)
+        return path
+    def request(self, mode: str, expected: tuple[str, ...] = ("beta", "alpha"), **changes: object) -> SkillLoadProbeRequest:
+        executable = self.root / f"{mode}.py"
+        executable.write_bytes(self.hermes.read_bytes())
+        executable.chmod(0o755)
+        values: dict[str, object] = {
+            "expected_skills": expected,
+            "hermes": str(executable),
+            "timeout_seconds": 5.0,
+            "env": {"PATH": "/usr/bin:/bin"},
+        }
+        values.update(changes)
+        return SkillLoadProbeRequest(**values)  # type: ignore[arg-type]

--- a/tests/test_handoff_safety_contract_enforcement.py
+++ b/tests/test_handoff_safety_contract_enforcement.py
@@ -146,6 +146,10 @@ PROCESS_SPAWN_ALLOWLIST: dict[str, str] = {
         "operator-only, explicitly confirmed `ask_before_dispatch` seam for one bounded local "
         "`hermes --oneshot --model` child; suppresses recursion and cleans its process group."
     ),
+    "src/coding/skill_load_observation.py": (
+        "operator-only `omh coding hermes-child skill-load-probe --confirm-dispatch`; runs one "
+        "bounded local machine-inventory command, never a model or skill body."
+    ),
     "src/coding/_hermes_child_process.py": (
         "private lifecycle helper for the explicitly confirmed Hermes child seam; relays signals, "
         "escalates SIGTERM to SIGKILL, and verifies that the child process group is absent."

--- a/tests/test_handoff_safety_contract_enforcement.py
+++ b/tests/test_handoff_safety_contract_enforcement.py
@@ -146,9 +146,10 @@ PROCESS_SPAWN_ALLOWLIST: dict[str, str] = {
         "operator-only, explicitly confirmed `ask_before_dispatch` seam for one bounded local "
         "`hermes --oneshot --model` child; suppresses recursion and cleans its process group."
     ),
-    "src/coding/skill_load_observation.py": (
-        "operator-only `omh coding hermes-child skill-load-probe --confirm-dispatch`; runs one "
-        "bounded local machine-inventory command, never a model or skill body."
+    "src/coding/skill_load_process.py": (
+        "private executable snapshot and process lifecycle adapter for the operator-only "
+        "`omh coding hermes-child skill-load-probe --confirm-dispatch`; runs one bounded local "
+        "machine-inventory command, never a model or skill body."
     ),
     "src/coding/_hermes_child_process.py": (
         "private lifecycle helper for the explicitly confirmed Hermes child seam; relays signals, "

--- a/tests/test_hermes_child_cli.py
+++ b/tests/test_hermes_child_cli.py
@@ -84,6 +84,73 @@ class HermesChildCliTests(unittest.TestCase):
         self.assertIn("--confirm-dispatch", stderr)
         self.assertFalse((self.root / "argv.json").exists())
 
+    def test_skill_load_probe_requires_confirmation_and_real_unsupported_is_truthful(self) -> None:
+        marker = self.root / "inventory-called"
+        unsupported = self.root / "unsupported-hermes.py"
+        unsupported.write_text(
+            "#!/usr/bin/env python3\nfrom pathlib import Path\nimport sys\n"
+            f"Path({str(marker)!r}).touch()\nraise SystemExit(2)\n",
+            encoding="utf-8",
+        )
+        unsupported.chmod(0o755)
+        command = [
+            "--omh-home", str(self.omh_home), "coding", "hermes-child",
+            "skill-load-probe", "--run-id", "probe-1", "--hermes", str(unsupported),
+            "--expected-skill", "alpha",
+        ]
+        status, stdout, stderr = run_cli(command)
+        self.assertEqual((status, stdout), (2, ""))
+        self.assertIn("--confirm-dispatch", stderr)
+        self.assertFalse(marker.exists())
+
+        status, stdout, stderr = run_cli([*command, "--confirm-dispatch"])
+        self.assertEqual(status, 0, stderr)
+        payload = json.loads(stdout)
+        self.assertEqual(
+            (payload["schema_version"], payload["probe_status"], payload["reason_code"]),
+            ("skill_load_observation/v1", "unsupported", "inventory_protocol_unavailable"),
+        )
+        self.assertNotIn("load_state", payload)
+        self.assertTrue(marker.exists())
+        stored = (
+            self.omh_home / "coding" / "hermes-child" / "probe-1"
+            / "skill-load-observation.json"
+        ).read_text(encoding="utf-8")
+        self.assertNotIn("prompt", stored)
+        self.assertNotIn("credential", stored)
+
+        status, status_stdout, stderr = run_cli([
+            "--omh-home", str(self.omh_home), "coding", "hermes-child",
+            "skill-load-status", "--run-id", "probe-1",
+        ])
+        self.assertEqual(status, 0, stderr)
+        self.assertEqual(json.loads(status_stdout)["probe_status"], "unsupported")
+
+    def test_skill_load_status_rejects_tampering(self) -> None:
+        unsupported = self.root / "unsupported.py"
+        unsupported.write_text("#!/usr/bin/env python3\nraise SystemExit(2)\n", encoding="utf-8")
+        unsupported.chmod(0o755)
+        command = [
+            "--omh-home", str(self.omh_home), "coding", "hermes-child",
+            "skill-load-probe", "--confirm-dispatch", "--run-id", "probe-tamper",
+            "--hermes", str(unsupported),
+        ]
+        self.assertEqual(run_cli(command)[0], 0)
+        path = (
+            self.omh_home / "coding" / "hermes-child" / "probe-tamper"
+            / "skill-load-observation.json"
+        )
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload["probe_status"] = "observed"
+        payload["load_state"] = "all_loaded"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        status, stdout, stderr = run_cli([
+            "--omh-home", str(self.omh_home), "coding", "hermes-child",
+            "skill-load-status", "--run-id", "probe-tamper",
+        ])
+        self.assertEqual((status, stdout), (2, ""))
+        self.assertIn("invalid", stderr)
+
     def test_real_fake_cli_happy_bad_timeout_and_secret_free_argv(self) -> None:
         cases = (
             ("SECRET_HAPPY_22", "completed", 0, "2"),

--- a/tests/test_skill_load_observation.py
+++ b/tests/test_skill_load_observation.py
@@ -13,6 +13,7 @@ from _local_package import load_local_package
 
 load_local_package()
 
+from omh.coding import skill_load_observation as skill_load_module  # noqa: E402
 from omh.coding.skill_load_observation import (  # noqa: E402
     InventoryNonceLedger,
     SkillLoadProbeRequest,
@@ -101,6 +102,17 @@ class SkillLoadObservationTests(unittest.TestCase):
         self.hermes.write_text(textwrap.dedent(_FAKE), encoding="utf-8")
         self.hermes.chmod(0o755)
 
+    def executable(self, path: Path, runtime_digit: str) -> Path:
+        path.write_text(
+            textwrap.dedent(_FAKE).replace(
+                '"runtime_fingerprint": "b" * 64',
+                f'"runtime_fingerprint": "{runtime_digit}" * 64',
+            ),
+            encoding="utf-8",
+        )
+        path.chmod(0o755)
+        return path
+
     def request(self, mode: str, expected: tuple[str, ...] = ("beta", "alpha"), **changes: object) -> SkillLoadProbeRequest:
         executable = self.root / f"{mode}.py"
         executable.write_bytes(self.hermes.read_bytes())
@@ -133,20 +145,118 @@ class SkillLoadObservationTests(unittest.TestCase):
                 self.assertEqual(payload["unexpected_skills"], list(unexpected))
                 self.assertEqual(validate_skill_load_observation(payload), [])
 
+    def test_atomic_replace_after_fingerprint_never_executes_unbound_bytes(self) -> None:
+        original = self.executable(self.root / "all.py", "1")
+        replacement = self.executable(self.root / "replacement.py", "9")
+        real_run = skill_load_module._run_inventory_process
+
+        def replace_then_run(*args: object, **kwargs: object):
+            os.replace(replacement, original)
+            return real_run(*args, **kwargs)  # type: ignore[arg-type]
+
+        request = SkillLoadProbeRequest(
+            expected_skills=("alpha", "beta"), hermes=str(original), timeout_seconds=5.0,
+            env={"PATH": os.defpath},
+        )
+        with patch.object(skill_load_module, "_run_inventory_process", replace_then_run):
+            payload = probe_skill_load(request, confirmed=True)
+        self.assertEqual(payload["probe_status"], "observed")
+        self.assertEqual(payload["runtime_fingerprint"], "1" * 64)
+
+    def test_atomic_replace_and_restore_cannot_evade_executable_binding(self) -> None:
+        original = self.executable(self.root / "all.py", "1")
+        replacement = self.executable(self.root / "replacement.py", "9")
+        backup = self.root / "original-backup.py"
+        real_run = skill_load_module._run_inventory_process
+
+        def swap_run_restore(*args: object, **kwargs: object):
+            os.replace(original, backup)
+            os.replace(replacement, original)
+            try:
+                return real_run(*args, **kwargs)  # type: ignore[arg-type]
+            finally:
+                os.replace(original, replacement)
+                os.replace(backup, original)
+
+        request = SkillLoadProbeRequest(
+            expected_skills=("alpha", "beta"), hermes=str(original), timeout_seconds=5.0,
+            env={"PATH": os.defpath},
+        )
+        with patch.object(skill_load_module, "_run_inventory_process", swap_run_restore):
+            payload = probe_skill_load(request, confirmed=True)
+        self.assertEqual(original.read_text(encoding="utf-8").count('"1" * 64'), 1)
+        self.assertEqual(payload["probe_status"], "observed")
+        self.assertEqual(payload["runtime_fingerprint"], "1" * 64)
+
+    def test_symlink_target_replace_after_fingerprint_never_executes_replacement(self) -> None:
+        target = self.executable(self.root / "all.py", "1")
+        replacement = self.executable(self.root / "replacement.py", "9")
+        link = self.root / "selected-hermes"
+        link.symlink_to(target)
+        real_run = skill_load_module._run_inventory_process
+
+        def replace_target_then_run(*args: object, **kwargs: object):
+            os.replace(replacement, target)
+            return real_run(*args, **kwargs)  # type: ignore[arg-type]
+
+        request = SkillLoadProbeRequest(
+            expected_skills=("alpha", "beta"), hermes=str(link), timeout_seconds=5.0,
+            env={"PATH": os.defpath},
+        )
+        with patch.object(skill_load_module, "_run_inventory_process", replace_target_then_run):
+            payload = probe_skill_load(request, confirmed=True)
+        self.assertEqual(payload["probe_status"], "observed")
+        self.assertEqual(payload["runtime_fingerprint"], "1" * 64)
+
+    def test_executable_snapshot_is_removed_after_success_timeout_and_error(self) -> None:
+        snapshots: list[Path] = []
+        real_run = skill_load_module._run_inventory_process
+
+        def capture_then_run(*args: object, **kwargs: object):
+            snapshots.append(Path(str(args[1])))
+            return real_run(*args, **kwargs)  # type: ignore[arg-type]
+
+        with patch.object(skill_load_module, "_run_inventory_process", capture_then_run):
+            self.assertEqual(
+                probe_skill_load(self.request("all"), confirmed=True)["probe_status"],
+                "observed",
+            )
+            self.assertEqual(
+                probe_skill_load(self.request("error"), confirmed=True)["reason_code"],
+                "inventory_process_error",
+            )
+            sleeper = self.root / "sleep.py"
+            sleeper.write_text(
+                "#!/usr/bin/env python3\nimport time\ntime.sleep(60)\n",
+                encoding="utf-8",
+            )
+            sleeper.chmod(0o755)
+            timed_out = probe_skill_load(
+                self.request("all", hermes=str(sleeper), timeout_seconds=0.05),
+                confirmed=True,
+            )
+            self.assertEqual(timed_out["reason_code"], "inventory_timeout")
+
+        def capture_then_raise(*args: object, **_kwargs: object):
+            snapshots.append(Path(str(args[1])))
+            raise RuntimeError("synthetic process adapter failure")
+
+        with patch.object(skill_load_module, "_run_inventory_process", capture_then_raise):
+            with self.assertRaisesRegex(RuntimeError, "synthetic process adapter failure"):
+                probe_skill_load(self.request("all"), confirmed=True)
+
+        self.assertEqual(len(snapshots), 4)
+        for snapshot in snapshots:
+            self.assertFalse(snapshot.exists())
+            self.assertFalse(snapshot.parent.exists())
+
     def test_path_selected_executable_fingerprint_binds_the_binary_that_ran(self) -> None:
         fingerprints: list[str] = []
         for label, runtime_digit in (("first", "1"), ("second", "2")):
             binary_dir = self.root / label
             binary_dir.mkdir()
             executable = binary_dir / "hermes"
-            executable.write_text(
-                textwrap.dedent(_FAKE).replace(
-                    '"runtime_fingerprint": "b" * 64',
-                    f'"runtime_fingerprint": "{runtime_digit}" * 64',
-                ),
-                encoding="utf-8",
-            )
-            executable.chmod(0o755)
+            self.executable(executable, runtime_digit)
             payload = probe_skill_load(
                 SkillLoadProbeRequest(
                     expected_skills=("alpha", "beta"),
@@ -187,7 +297,7 @@ class SkillLoadObservationTests(unittest.TestCase):
         self.assertNotIn("observed_skills", missing)
 
         executable = self.request("all")
-        with patch("omh.coding.skill_load_observation.Path.open", side_effect=PermissionError):
+        with patch.object(skill_load_module.os, "read", side_effect=PermissionError):
             unreadable = probe_skill_load(executable, confirmed=True)
         self.assertEqual(
             (unreadable["probe_status"], unreadable["reason_code"]),

--- a/tests/test_skill_load_observation.py
+++ b/tests/test_skill_load_observation.py
@@ -78,6 +78,8 @@ if mode == "digest-mismatch":
     payload["expected_digest"] = "e" * 64
 if mode == "inventory-digest-mismatch":
     payload["inventory_digest"] = "d" * 64
+if mode == "tool-mismatch":
+    payload["tool_fingerprint"] = "c" * 64
 if mode == "expired":
     payload["observed_at"] = (now - timedelta(seconds=120)).isoformat().replace("+00:00", "Z")
     payload["expires_at"] = (now - timedelta(seconds=60)).isoformat().replace("+00:00", "Z")
@@ -106,7 +108,7 @@ class SkillLoadObservationTests(unittest.TestCase):
         values: dict[str, object] = {
             "expected_skills": expected,
             "hermes": str(executable),
-            "timeout_seconds": 1.0,
+            "timeout_seconds": 5.0,
             "env": {"PATH": "/usr/bin:/bin"},
         }
         values.update(changes)
@@ -130,6 +132,67 @@ class SkillLoadObservationTests(unittest.TestCase):
                 self.assertEqual(payload["missing_skills"], list(missing))
                 self.assertEqual(payload["unexpected_skills"], list(unexpected))
                 self.assertEqual(validate_skill_load_observation(payload), [])
+
+    def test_path_selected_executable_fingerprint_binds_the_binary_that_ran(self) -> None:
+        fingerprints: list[str] = []
+        for label, runtime_digit in (("first", "1"), ("second", "2")):
+            binary_dir = self.root / label
+            binary_dir.mkdir()
+            executable = binary_dir / "hermes"
+            executable.write_text(
+                textwrap.dedent(_FAKE).replace(
+                    '"runtime_fingerprint": "b" * 64',
+                    f'"runtime_fingerprint": "{runtime_digit}" * 64',
+                ),
+                encoding="utf-8",
+            )
+            executable.chmod(0o755)
+            payload = probe_skill_load(
+                SkillLoadProbeRequest(
+                    expected_skills=("alpha", "beta"),
+                    hermes="hermes",
+                    env={"PATH": os.pathsep.join((str(binary_dir), os.defpath))},
+                ),
+                confirmed=True,
+            )
+            self.assertEqual(payload["probe_status"], "observed")
+            self.assertEqual(payload["runtime_fingerprint"], runtime_digit * 64)
+            fingerprints.append(str(payload["tool_fingerprint"]))
+
+        self.assertNotEqual(fingerprints[0], fingerprints[1])
+
+    def test_explicit_symlink_binds_the_resolved_executable(self) -> None:
+        target = self.root / "all.py"
+        target.write_bytes(self.hermes.read_bytes())
+        target.chmod(0o755)
+        link = self.root / "selected-hermes"
+        link.symlink_to(target)
+        direct = probe_skill_load(self.request("all", hermes=str(target)), confirmed=True)
+        selected = probe_skill_load(self.request("all", hermes=str(link)), confirmed=True)
+        self.assertEqual(direct["probe_status"], "observed")
+        self.assertEqual(selected["probe_status"], "observed")
+        self.assertEqual(direct["tool_fingerprint"], selected["tool_fingerprint"])
+
+    def test_unresolvable_or_unreadable_executable_fails_closed_without_path_leak(self) -> None:
+        secret_path = self.root / "SECRET_EXECUTABLE_PATH" / "hermes"
+        missing = probe_skill_load(
+            SkillLoadProbeRequest(expected_skills=("alpha",), hermes=str(secret_path)),
+            confirmed=True,
+        )
+        self.assertEqual(
+            (missing["probe_status"], missing["reason_code"]),
+            ("probe_error", "inventory_executable_unavailable"),
+        )
+        self.assertNotIn("SECRET_EXECUTABLE_PATH", json.dumps(missing))
+        self.assertNotIn("observed_skills", missing)
+
+        executable = self.request("all")
+        with patch("omh.coding.skill_load_observation.Path.open", side_effect=PermissionError):
+            unreadable = probe_skill_load(executable, confirmed=True)
+        self.assertEqual(
+            (unreadable["probe_status"], unreadable["reason_code"]),
+            ("probe_error", "inventory_executable_unavailable"),
+        )
 
     def test_confirmation_is_mandatory_and_default_construction_starts_nothing(self) -> None:
         request = self.request("all")
@@ -156,6 +219,7 @@ class SkillLoadObservationTests(unittest.TestCase):
             "nonce-mismatch": "inventory_nonce_mismatch",
             "digest-mismatch": "inventory_expected_digest_mismatch",
             "inventory-digest-mismatch": "inventory_digest_mismatch",
+            "tool-mismatch": "inventory_response_malformed",
             "expired": "inventory_response_expired",
             "stale": "inventory_response_stale",
             "forbidden": "inventory_response_malformed",

--- a/tests/test_skill_load_observation.py
+++ b/tests/test_skill_load_observation.py
@@ -255,13 +255,16 @@ class SkillLoadObservationTests(unittest.TestCase):
         for label, runtime_digit in (("first", "1"), ("second", "2")):
             binary_dir = self.root / label
             binary_dir.mkdir()
-            executable = binary_dir / "hermes"
+            executable = binary_dir / ("hermes.py" if os.name == "nt" else "hermes")
             self.executable(executable, runtime_digit)
+            env = {"PATH": os.pathsep.join((str(binary_dir), os.defpath))}
+            if os.name == "nt":
+                env["PATHEXT"] = ".PY"
             payload = probe_skill_load(
                 SkillLoadProbeRequest(
                     expected_skills=("alpha", "beta"),
                     hermes="hermes",
-                    env={"PATH": os.pathsep.join((str(binary_dir), os.defpath))},
+                    env=env,
                 ),
                 confirmed=True,
             )

--- a/tests/test_skill_load_observation.py
+++ b/tests/test_skill_load_observation.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import json
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import textwrap
+import unittest
+from unittest.mock import patch
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.coding.skill_load_observation import (  # noqa: E402
+    InventoryNonceLedger,
+    SkillLoadProbeRequest,
+    expected_skills_digest,
+    probe_skill_load,
+    skill_load_observation_is_fresh,
+    validate_skill_load_observation,
+)
+from omh.evidence.labels import SKILL_LOAD_PROBE_LABELS, SKILL_LOAD_STATE_LABELS  # noqa: E402
+from omh.quality.harness_quality import skill_load_evidence_state  # noqa: E402
+
+
+_FAKE = r'''#!/usr/bin/env python3
+import hashlib
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+args = sys.argv[1:]
+if args[:6] != ["--safe-mode", "--ignore-user-config", "--ignore-rules", "skills", "inventory", "--protocol"]:
+    raise SystemExit(91)
+protocol = args[6]
+nonce = args[args.index("--nonce") + 1]
+expected_digest = args[args.index("--expected-digest") + 1]
+tool_fingerprint = args[args.index("--tool-fingerprint") + 1]
+mode = __import__("pathlib").Path(sys.argv[0]).stem
+expected = [] if mode == "not-applicable" else ["alpha", "beta"]
+observed = {
+    "all": expected,
+    "partial": expected[:1],
+    "none": [],
+    "unexpected": [*expected, "gamma"],
+    "unexpected-only": ["gamma"],
+    "not-applicable": [],
+}.get(mode, expected)
+now = datetime.now(timezone.utc).replace(microsecond=0)
+payload = {
+    "schema_version": protocol,
+    "nonce": nonce,
+    "expected_digest": expected_digest,
+    "inventory_digest": hashlib.sha256(json.dumps(sorted(observed), separators=(",", ":")).encode()).hexdigest(),
+    "observed_skills": observed,
+    "tool_fingerprint": tool_fingerprint,
+    "runtime_fingerprint": "b" * 64,
+    "observed_at": now.isoformat().replace("+00:00", "Z"),
+    "expires_at": (now + timedelta(seconds=60)).isoformat().replace("+00:00", "Z"),
+}
+if mode == "unsupported":
+    print("unsupported inventory command", file=sys.stderr)
+    raise SystemExit(2)
+if mode == "error":
+    print("SECRET_RAW_LOG must not escape", file=sys.stderr)
+    raise SystemExit(9)
+if mode == "malformed":
+    print('{"prompt":"SECRET_PROMPT"}')
+    raise SystemExit(0)
+if mode == "duplicate":
+    payload["observed_skills"] = ["alpha", "alpha"]
+if mode == "nonce-mismatch":
+    payload["nonce"] = "f" * 64
+if mode == "digest-mismatch":
+    payload["expected_digest"] = "e" * 64
+if mode == "inventory-digest-mismatch":
+    payload["inventory_digest"] = "d" * 64
+if mode == "expired":
+    payload["observed_at"] = (now - timedelta(seconds=120)).isoformat().replace("+00:00", "Z")
+    payload["expires_at"] = (now - timedelta(seconds=60)).isoformat().replace("+00:00", "Z")
+if mode == "stale":
+    payload["observed_at"] = (now - timedelta(seconds=600)).isoformat().replace("+00:00", "Z")
+    payload["expires_at"] = (now + timedelta(seconds=60)).isoformat().replace("+00:00", "Z")
+if mode == "forbidden":
+    payload["raw_log"] = "SECRET_CREDENTIAL"
+print(json.dumps(payload))
+'''
+
+
+class SkillLoadObservationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = TemporaryDirectory(prefix="omh-skill-load-")
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.hermes = self.root / "hermes.py"
+        self.hermes.write_text(textwrap.dedent(_FAKE), encoding="utf-8")
+        self.hermes.chmod(0o755)
+
+    def request(self, mode: str, expected: tuple[str, ...] = ("beta", "alpha"), **changes: object) -> SkillLoadProbeRequest:
+        executable = self.root / f"{mode}.py"
+        executable.write_bytes(self.hermes.read_bytes())
+        executable.chmod(0o755)
+        values: dict[str, object] = {
+            "expected_skills": expected,
+            "hermes": str(executable),
+            "timeout_seconds": 1.0,
+            "env": {"PATH": "/usr/bin:/bin"},
+        }
+        values.update(changes)
+        return SkillLoadProbeRequest(**values)  # type: ignore[arg-type]
+
+    def test_fake_protocol_all_partial_none_unexpected_and_not_applicable(self) -> None:
+        cases = (
+            ("all", ("alpha", "beta"), "all_loaded", (), ()),
+            ("partial", ("alpha", "beta"), "partially_loaded", ("beta",), ()),
+            ("none", ("alpha", "beta"), "none_loaded", ("alpha", "beta"), ()),
+            ("unexpected", ("alpha", "beta"), "all_loaded", (), ("gamma",)),
+            ("unexpected-only", ("alpha", "beta"), "none_loaded", ("alpha", "beta"), ("gamma",)),
+            ("not-applicable", (), "not_applicable", (), ()),
+        )
+        for mode, expected, state, missing, unexpected in cases:
+            with self.subTest(mode=mode):
+                payload = probe_skill_load(self.request(mode, expected), confirmed=True)
+                self.assertEqual(payload["probe_status"], "observed")
+                self.assertEqual(payload["load_state"], state)
+                self.assertEqual(payload["expected_skills"], list(expected))
+                self.assertEqual(payload["missing_skills"], list(missing))
+                self.assertEqual(payload["unexpected_skills"], list(unexpected))
+                self.assertEqual(validate_skill_load_observation(payload), [])
+
+    def test_confirmation_is_mandatory_and_default_construction_starts_nothing(self) -> None:
+        request = self.request("all")
+        self.assertFalse((self.root / "called").exists())
+        with self.assertRaisesRegex(RuntimeError, "confirmation"):
+            probe_skill_load(request, confirmed=False)
+
+    def test_unsupported_and_process_error_are_inventory_free_and_redacted(self) -> None:
+        for mode, status, reason in (
+            ("unsupported", "unsupported", "inventory_protocol_unavailable"),
+            ("error", "probe_error", "inventory_process_error"),
+        ):
+            with self.subTest(mode=mode):
+                payload = probe_skill_load(self.request(mode), confirmed=True)
+                self.assertEqual((payload["probe_status"], payload["reason_code"]), (status, reason))
+                for key in ("load_state", "expected_skills", "observed_skills", "missing_skills", "unexpected_skills", "inventory_digest"):
+                    self.assertNotIn(key, payload)
+                self.assertNotIn("SECRET", json.dumps(payload))
+
+    def test_malformed_binding_duplicate_expiry_and_forbidden_fields_fail_closed(self) -> None:
+        reasons = {
+            "malformed": "inventory_response_malformed",
+            "duplicate": "inventory_response_malformed",
+            "nonce-mismatch": "inventory_nonce_mismatch",
+            "digest-mismatch": "inventory_expected_digest_mismatch",
+            "inventory-digest-mismatch": "inventory_digest_mismatch",
+            "expired": "inventory_response_expired",
+            "stale": "inventory_response_stale",
+            "forbidden": "inventory_response_malformed",
+        }
+        for mode, reason in reasons.items():
+            with self.subTest(mode=mode):
+                payload = probe_skill_load(self.request(mode), confirmed=True)
+                self.assertEqual(payload["probe_status"], "probe_error")
+                self.assertEqual(payload["reason_code"], reason)
+                self.assertNotIn("observed_skills", payload)
+                self.assertNotIn("SECRET", json.dumps(payload))
+
+    def test_child_recursion_marker_refuses_probe_before_spawn(self) -> None:
+        with patch.dict(os.environ, {"OMH_ISOLATED_HERMES_DEPTH": "1"}):
+            with self.assertRaisesRegex(RuntimeError, "depth is limited"):
+                probe_skill_load(self.request("all"), confirmed=True)
+
+    def test_timeout_fails_closed(self) -> None:
+        sleeper = self.root / "sleep.py"
+        sleeper.write_text("#!/usr/bin/env python3\nimport time\ntime.sleep(60)\n", encoding="utf-8")
+        sleeper.chmod(0o755)
+        payload = probe_skill_load(self.request("all", hermes=str(sleeper), timeout_seconds=0.05), confirmed=True)
+        self.assertEqual((payload["probe_status"], payload["reason_code"]), ("probe_error", "inventory_timeout"))
+
+    def test_replay_is_rejected_by_bounded_nonce_ledger(self) -> None:
+        ledger = InventoryNonceLedger(capacity=2)
+        fixed_nonce = "a" * 64
+        first = probe_skill_load(self.request("all", nonce=fixed_nonce), confirmed=True, nonce_ledger=ledger)
+        second = probe_skill_load(self.request("all", nonce=fixed_nonce), confirmed=True, nonce_ledger=ledger)
+        self.assertEqual(first["probe_status"], "observed")
+        self.assertEqual((second["probe_status"], second["reason_code"]), ("probe_error", "inventory_nonce_replayed"))
+
+    def test_observation_expiry_and_schema_forbidden_keys(self) -> None:
+        payload = probe_skill_load(self.request("all"), confirmed=True)
+        self.assertTrue(skill_load_observation_is_fresh(payload))
+        future = datetime.now(timezone.utc) + timedelta(days=1)
+        self.assertFalse(skill_load_observation_is_fresh(payload, now=future))
+        for forbidden in ("prompt", "raw_log", "credential", "cpu", "ram", "resource_score"):
+            errors = validate_skill_load_observation({**payload, forbidden: "x"})
+            self.assertTrue(errors, forbidden)
+
+    def test_expected_digest_is_sorted_and_stable(self) -> None:
+        self.assertEqual(expected_skills_digest(("beta", "alpha")), expected_skills_digest(("alpha", "beta")))
+        self.assertEqual(len(expected_skills_digest(("alpha",))), 64)
+
+    def test_labels_and_harness_consumer_preserve_probe_axes(self) -> None:
+        observed = probe_skill_load(self.request("partial"), confirmed=True)
+        unsupported = probe_skill_load(self.request("unsupported"), confirmed=True)
+        self.assertEqual(skill_load_evidence_state(observed), "partially_loaded")
+        self.assertEqual(skill_load_evidence_state(unsupported), "unsupported")
+        self.assertEqual(set(SKILL_LOAD_PROBE_LABELS), {"observed", "unsupported", "probe_error"})
+        self.assertEqual(set(SKILL_LOAD_STATE_LABELS), {"all_loaded", "partially_loaded", "none_loaded", "not_applicable"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_skill_load_observation.py
+++ b/tests/test_skill_load_observation.py
@@ -2,130 +2,21 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 import json
-import os
-from pathlib import Path
-from tempfile import TemporaryDirectory
-import textwrap
 import unittest
-from unittest.mock import patch
 
-from _local_package import load_local_package
-
-load_local_package()
-
-from omh.coding import skill_load_observation as skill_load_module  # noqa: E402
-from omh.coding.skill_load_observation import (  # noqa: E402
+from _skill_load_observation_support import SkillLoadObservationTestCase
+from omh.coding.skill_load_observation import (
     InventoryNonceLedger,
-    SkillLoadProbeRequest,
     expected_skills_digest,
     probe_skill_load,
     skill_load_observation_is_fresh,
     validate_skill_load_observation,
 )
-from omh.evidence.labels import SKILL_LOAD_PROBE_LABELS, SKILL_LOAD_STATE_LABELS  # noqa: E402
-from omh.quality.harness_quality import skill_load_evidence_state  # noqa: E402
+from omh.evidence.labels import SKILL_LOAD_PROBE_LABELS, SKILL_LOAD_STATE_LABELS
+from omh.quality.harness_quality import skill_load_evidence_state
 
 
-_FAKE = r'''#!/usr/bin/env python3
-import hashlib
-import json
-import os
-import sys
-from datetime import datetime, timedelta, timezone
-
-args = sys.argv[1:]
-if args[:6] != ["--safe-mode", "--ignore-user-config", "--ignore-rules", "skills", "inventory", "--protocol"]:
-    raise SystemExit(91)
-protocol = args[6]
-nonce = args[args.index("--nonce") + 1]
-expected_digest = args[args.index("--expected-digest") + 1]
-tool_fingerprint = args[args.index("--tool-fingerprint") + 1]
-mode = __import__("pathlib").Path(sys.argv[0]).stem
-expected = [] if mode == "not-applicable" else ["alpha", "beta"]
-observed = {
-    "all": expected,
-    "partial": expected[:1],
-    "none": [],
-    "unexpected": [*expected, "gamma"],
-    "unexpected-only": ["gamma"],
-    "not-applicable": [],
-}.get(mode, expected)
-now = datetime.now(timezone.utc).replace(microsecond=0)
-payload = {
-    "schema_version": protocol,
-    "nonce": nonce,
-    "expected_digest": expected_digest,
-    "inventory_digest": hashlib.sha256(json.dumps(sorted(observed), separators=(",", ":")).encode()).hexdigest(),
-    "observed_skills": observed,
-    "tool_fingerprint": tool_fingerprint,
-    "runtime_fingerprint": "b" * 64,
-    "observed_at": now.isoformat().replace("+00:00", "Z"),
-    "expires_at": (now + timedelta(seconds=60)).isoformat().replace("+00:00", "Z"),
-}
-if mode == "unsupported":
-    print("unsupported inventory command", file=sys.stderr)
-    raise SystemExit(2)
-if mode == "error":
-    print("SECRET_RAW_LOG must not escape", file=sys.stderr)
-    raise SystemExit(9)
-if mode == "malformed":
-    print('{"prompt":"SECRET_PROMPT"}')
-    raise SystemExit(0)
-if mode == "duplicate":
-    payload["observed_skills"] = ["alpha", "alpha"]
-if mode == "nonce-mismatch":
-    payload["nonce"] = "f" * 64
-if mode == "digest-mismatch":
-    payload["expected_digest"] = "e" * 64
-if mode == "inventory-digest-mismatch":
-    payload["inventory_digest"] = "d" * 64
-if mode == "tool-mismatch":
-    payload["tool_fingerprint"] = "c" * 64
-if mode == "expired":
-    payload["observed_at"] = (now - timedelta(seconds=120)).isoformat().replace("+00:00", "Z")
-    payload["expires_at"] = (now - timedelta(seconds=60)).isoformat().replace("+00:00", "Z")
-if mode == "stale":
-    payload["observed_at"] = (now - timedelta(seconds=600)).isoformat().replace("+00:00", "Z")
-    payload["expires_at"] = (now + timedelta(seconds=60)).isoformat().replace("+00:00", "Z")
-if mode == "forbidden":
-    payload["raw_log"] = "SECRET_CREDENTIAL"
-print(json.dumps(payload))
-'''
-
-
-class SkillLoadObservationTests(unittest.TestCase):
-    def setUp(self) -> None:
-        self.temp = TemporaryDirectory(prefix="omh-skill-load-")
-        self.addCleanup(self.temp.cleanup)
-        self.root = Path(self.temp.name)
-        self.hermes = self.root / "hermes.py"
-        self.hermes.write_text(textwrap.dedent(_FAKE), encoding="utf-8")
-        self.hermes.chmod(0o755)
-
-    def executable(self, path: Path, runtime_digit: str) -> Path:
-        path.write_text(
-            textwrap.dedent(_FAKE).replace(
-                '"runtime_fingerprint": "b" * 64',
-                f'"runtime_fingerprint": "{runtime_digit}" * 64',
-            ),
-            encoding="utf-8",
-        )
-        path.chmod(0o755)
-        return path
-
-    def request(self, mode: str, expected: tuple[str, ...] = ("beta", "alpha"), **changes: object) -> SkillLoadProbeRequest:
-        executable = self.root / f"{mode}.py"
-        executable.write_bytes(self.hermes.read_bytes())
-        executable.chmod(0o755)
-        values: dict[str, object] = {
-            "expected_skills": expected,
-            "hermes": str(executable),
-            "timeout_seconds": 5.0,
-            "env": {"PATH": "/usr/bin:/bin"},
-        }
-        values.update(changes)
-        return SkillLoadProbeRequest(**values)  # type: ignore[arg-type]
-
+class SkillLoadObservationTests(SkillLoadObservationTestCase):
     def test_fake_protocol_all_partial_none_unexpected_and_not_applicable(self) -> None:
         cases = (
             ("all", ("alpha", "beta"), "all_loaded", (), ()),
@@ -144,174 +35,6 @@ class SkillLoadObservationTests(unittest.TestCase):
                 self.assertEqual(payload["missing_skills"], list(missing))
                 self.assertEqual(payload["unexpected_skills"], list(unexpected))
                 self.assertEqual(validate_skill_load_observation(payload), [])
-
-    def test_atomic_replace_after_fingerprint_never_executes_unbound_bytes(self) -> None:
-        original = self.executable(self.root / "all.py", "1")
-        replacement = self.executable(self.root / "replacement.py", "9")
-        real_run = skill_load_module._run_inventory_process
-
-        def replace_then_run(*args: object, **kwargs: object):
-            os.replace(replacement, original)
-            return real_run(*args, **kwargs)  # type: ignore[arg-type]
-
-        request = SkillLoadProbeRequest(
-            expected_skills=("alpha", "beta"), hermes=str(original), timeout_seconds=5.0,
-            env={"PATH": os.defpath},
-        )
-        with patch.object(skill_load_module, "_run_inventory_process", replace_then_run):
-            payload = probe_skill_load(request, confirmed=True)
-        self.assertEqual(payload["probe_status"], "observed")
-        self.assertEqual(payload["runtime_fingerprint"], "1" * 64)
-
-    def test_atomic_replace_and_restore_cannot_evade_executable_binding(self) -> None:
-        original = self.executable(self.root / "all.py", "1")
-        replacement = self.executable(self.root / "replacement.py", "9")
-        backup = self.root / "original-backup.py"
-        real_run = skill_load_module._run_inventory_process
-
-        def swap_run_restore(*args: object, **kwargs: object):
-            os.replace(original, backup)
-            os.replace(replacement, original)
-            try:
-                return real_run(*args, **kwargs)  # type: ignore[arg-type]
-            finally:
-                os.replace(original, replacement)
-                os.replace(backup, original)
-
-        request = SkillLoadProbeRequest(
-            expected_skills=("alpha", "beta"), hermes=str(original), timeout_seconds=5.0,
-            env={"PATH": os.defpath},
-        )
-        with patch.object(skill_load_module, "_run_inventory_process", swap_run_restore):
-            payload = probe_skill_load(request, confirmed=True)
-        self.assertEqual(original.read_text(encoding="utf-8").count('"1" * 64'), 1)
-        self.assertEqual(payload["probe_status"], "observed")
-        self.assertEqual(payload["runtime_fingerprint"], "1" * 64)
-
-    def test_symlink_target_replace_after_fingerprint_never_executes_replacement(self) -> None:
-        target = self.executable(self.root / "all.py", "1")
-        replacement = self.executable(self.root / "replacement.py", "9")
-        link = self.root / "selected-hermes"
-        link.symlink_to(target)
-        real_run = skill_load_module._run_inventory_process
-
-        def replace_target_then_run(*args: object, **kwargs: object):
-            os.replace(replacement, target)
-            return real_run(*args, **kwargs)  # type: ignore[arg-type]
-
-        request = SkillLoadProbeRequest(
-            expected_skills=("alpha", "beta"), hermes=str(link), timeout_seconds=5.0,
-            env={"PATH": os.defpath},
-        )
-        with patch.object(skill_load_module, "_run_inventory_process", replace_target_then_run):
-            payload = probe_skill_load(request, confirmed=True)
-        self.assertEqual(payload["probe_status"], "observed")
-        self.assertEqual(payload["runtime_fingerprint"], "1" * 64)
-
-    def test_executable_snapshot_is_removed_after_success_timeout_and_error(self) -> None:
-        snapshots: list[Path] = []
-        real_run = skill_load_module._run_inventory_process
-
-        def capture_then_run(*args: object, **kwargs: object):
-            snapshots.append(Path(str(args[1])))
-            return real_run(*args, **kwargs)  # type: ignore[arg-type]
-
-        with patch.object(skill_load_module, "_run_inventory_process", capture_then_run):
-            self.assertEqual(
-                probe_skill_load(self.request("all"), confirmed=True)["probe_status"],
-                "observed",
-            )
-            self.assertEqual(
-                probe_skill_load(self.request("error"), confirmed=True)["reason_code"],
-                "inventory_process_error",
-            )
-            sleeper = self.root / "sleep.py"
-            sleeper.write_text(
-                "#!/usr/bin/env python3\nimport time\ntime.sleep(60)\n",
-                encoding="utf-8",
-            )
-            sleeper.chmod(0o755)
-            timed_out = probe_skill_load(
-                self.request("all", hermes=str(sleeper), timeout_seconds=0.05),
-                confirmed=True,
-            )
-            self.assertEqual(timed_out["reason_code"], "inventory_timeout")
-
-        def capture_then_raise(*args: object, **_kwargs: object):
-            snapshots.append(Path(str(args[1])))
-            raise RuntimeError("synthetic process adapter failure")
-
-        with patch.object(skill_load_module, "_run_inventory_process", capture_then_raise):
-            with self.assertRaisesRegex(RuntimeError, "synthetic process adapter failure"):
-                probe_skill_load(self.request("all"), confirmed=True)
-
-        self.assertEqual(len(snapshots), 4)
-        for snapshot in snapshots:
-            self.assertFalse(snapshot.exists())
-            self.assertFalse(snapshot.parent.exists())
-
-    def test_path_selected_executable_fingerprint_binds_the_binary_that_ran(self) -> None:
-        fingerprints: list[str] = []
-        for label, runtime_digit in (("first", "1"), ("second", "2")):
-            binary_dir = self.root / label
-            binary_dir.mkdir()
-            executable = binary_dir / ("hermes.py" if os.name == "nt" else "hermes")
-            self.executable(executable, runtime_digit)
-            env = {"PATH": os.pathsep.join((str(binary_dir), os.defpath))}
-            if os.name == "nt":
-                env["PATHEXT"] = ".PY"
-            payload = probe_skill_load(
-                SkillLoadProbeRequest(
-                    expected_skills=("alpha", "beta"),
-                    hermes="hermes",
-                    env=env,
-                ),
-                confirmed=True,
-            )
-            self.assertEqual(payload["probe_status"], "observed")
-            self.assertEqual(payload["runtime_fingerprint"], runtime_digit * 64)
-            fingerprints.append(str(payload["tool_fingerprint"]))
-
-        self.assertNotEqual(fingerprints[0], fingerprints[1])
-
-    def test_explicit_symlink_binds_the_resolved_executable(self) -> None:
-        target = self.root / "all.py"
-        target.write_bytes(self.hermes.read_bytes())
-        target.chmod(0o755)
-        link = self.root / "selected-hermes"
-        link.symlink_to(target)
-        direct = probe_skill_load(self.request("all", hermes=str(target)), confirmed=True)
-        selected = probe_skill_load(self.request("all", hermes=str(link)), confirmed=True)
-        self.assertEqual(direct["probe_status"], "observed")
-        self.assertEqual(selected["probe_status"], "observed")
-        self.assertEqual(direct["tool_fingerprint"], selected["tool_fingerprint"])
-
-    def test_unresolvable_or_unreadable_executable_fails_closed_without_path_leak(self) -> None:
-        secret_path = self.root / "SECRET_EXECUTABLE_PATH" / "hermes"
-        missing = probe_skill_load(
-            SkillLoadProbeRequest(expected_skills=("alpha",), hermes=str(secret_path)),
-            confirmed=True,
-        )
-        self.assertEqual(
-            (missing["probe_status"], missing["reason_code"]),
-            ("probe_error", "inventory_executable_unavailable"),
-        )
-        self.assertNotIn("SECRET_EXECUTABLE_PATH", json.dumps(missing))
-        self.assertNotIn("observed_skills", missing)
-
-        executable = self.request("all")
-        with patch.object(skill_load_module.os, "read", side_effect=PermissionError):
-            unreadable = probe_skill_load(executable, confirmed=True)
-        self.assertEqual(
-            (unreadable["probe_status"], unreadable["reason_code"]),
-            ("probe_error", "inventory_executable_unavailable"),
-        )
-
-    def test_confirmation_is_mandatory_and_default_construction_starts_nothing(self) -> None:
-        request = self.request("all")
-        self.assertFalse((self.root / "called").exists())
-        with self.assertRaisesRegex(RuntimeError, "confirmation"):
-            probe_skill_load(request, confirmed=False)
 
     def test_unsupported_and_process_error_are_inventory_free_and_redacted(self) -> None:
         for mode, status, reason in (
@@ -344,18 +67,6 @@ class SkillLoadObservationTests(unittest.TestCase):
                 self.assertEqual(payload["reason_code"], reason)
                 self.assertNotIn("observed_skills", payload)
                 self.assertNotIn("SECRET", json.dumps(payload))
-
-    def test_child_recursion_marker_refuses_probe_before_spawn(self) -> None:
-        with patch.dict(os.environ, {"OMH_ISOLATED_HERMES_DEPTH": "1"}):
-            with self.assertRaisesRegex(RuntimeError, "depth is limited"):
-                probe_skill_load(self.request("all"), confirmed=True)
-
-    def test_timeout_fails_closed(self) -> None:
-        sleeper = self.root / "sleep.py"
-        sleeper.write_text("#!/usr/bin/env python3\nimport time\ntime.sleep(60)\n", encoding="utf-8")
-        sleeper.chmod(0o755)
-        payload = probe_skill_load(self.request("all", hermes=str(sleeper), timeout_seconds=0.05), confirmed=True)
-        self.assertEqual((payload["probe_status"], payload["reason_code"]), ("probe_error", "inventory_timeout"))
 
     def test_replay_is_rejected_by_bounded_nonce_ledger(self) -> None:
         ledger = InventoryNonceLedger(capacity=2)

--- a/tests/test_skill_load_observation_lifecycle.py
+++ b/tests/test_skill_load_observation_lifecycle.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import unittest
+from unittest.mock import patch
+
+from _skill_load_observation_support import SkillLoadObservationTestCase
+from omh.coding import skill_load_observation as skill_load_module
+from omh.coding.skill_load_observation import SkillLoadProbeRequest, probe_skill_load
+
+
+class SkillLoadObservationTests(SkillLoadObservationTestCase):
+    def test_atomic_replace_after_fingerprint_never_executes_unbound_bytes(self) -> None:
+        original = self.executable(self.root / "all.py", "1")
+        replacement = self.executable(self.root / "replacement.py", "9")
+        real_run = skill_load_module._run_inventory_process
+
+        def replace_then_run(*args: object, **kwargs: object):
+            os.replace(replacement, original)
+            return real_run(*args, **kwargs)  # type: ignore[arg-type]
+
+        request = SkillLoadProbeRequest(
+            expected_skills=("alpha", "beta"), hermes=str(original), timeout_seconds=5.0,
+            env={"PATH": os.defpath},
+        )
+        with patch.object(skill_load_module, "_run_inventory_process", replace_then_run):
+            payload = probe_skill_load(request, confirmed=True)
+        self.assertEqual(payload["probe_status"], "observed")
+        self.assertEqual(payload["runtime_fingerprint"], "1" * 64)
+
+    def test_atomic_replace_and_restore_cannot_evade_executable_binding(self) -> None:
+        original = self.executable(self.root / "all.py", "1")
+        replacement = self.executable(self.root / "replacement.py", "9")
+        backup = self.root / "original-backup.py"
+        real_run = skill_load_module._run_inventory_process
+
+        def swap_run_restore(*args: object, **kwargs: object):
+            os.replace(original, backup)
+            os.replace(replacement, original)
+            try:
+                return real_run(*args, **kwargs)  # type: ignore[arg-type]
+            finally:
+                os.replace(original, replacement)
+                os.replace(backup, original)
+
+        request = SkillLoadProbeRequest(
+            expected_skills=("alpha", "beta"), hermes=str(original), timeout_seconds=5.0,
+            env={"PATH": os.defpath},
+        )
+        with patch.object(skill_load_module, "_run_inventory_process", swap_run_restore):
+            payload = probe_skill_load(request, confirmed=True)
+        self.assertEqual(original.read_text(encoding="utf-8").count('"1" * 64'), 1)
+        self.assertEqual(payload["probe_status"], "observed")
+        self.assertEqual(payload["runtime_fingerprint"], "1" * 64)
+
+    def test_symlink_target_replace_after_fingerprint_never_executes_replacement(self) -> None:
+        target = self.executable(self.root / "all.py", "1")
+        replacement = self.executable(self.root / "replacement.py", "9")
+        link = self.root / "selected-hermes"
+        link.symlink_to(target)
+        real_run = skill_load_module._run_inventory_process
+
+        def replace_target_then_run(*args: object, **kwargs: object):
+            os.replace(replacement, target)
+            return real_run(*args, **kwargs)  # type: ignore[arg-type]
+
+        request = SkillLoadProbeRequest(
+            expected_skills=("alpha", "beta"), hermes=str(link), timeout_seconds=5.0,
+            env={"PATH": os.defpath},
+        )
+        with patch.object(skill_load_module, "_run_inventory_process", replace_target_then_run):
+            payload = probe_skill_load(request, confirmed=True)
+        self.assertEqual(payload["probe_status"], "observed")
+        self.assertEqual(payload["runtime_fingerprint"], "1" * 64)
+
+    def test_executable_snapshot_is_removed_after_success_timeout_and_error(self) -> None:
+        snapshots: list[Path] = []
+        real_run = skill_load_module._run_inventory_process
+
+        def capture_then_run(*args: object, **kwargs: object):
+            snapshots.append(Path(str(args[1])))
+            return real_run(*args, **kwargs)  # type: ignore[arg-type]
+
+        with patch.object(skill_load_module, "_run_inventory_process", capture_then_run):
+            self.assertEqual(
+                probe_skill_load(self.request("all"), confirmed=True)["probe_status"],
+                "observed",
+            )
+            self.assertEqual(
+                probe_skill_load(self.request("error"), confirmed=True)["reason_code"],
+                "inventory_process_error",
+            )
+            sleeper = self.root / "sleep.py"
+            sleeper.write_text(
+                "#!/usr/bin/env python3\nimport time\ntime.sleep(60)\n",
+                encoding="utf-8",
+            )
+            sleeper.chmod(0o755)
+            timed_out = probe_skill_load(
+                self.request("all", hermes=str(sleeper), timeout_seconds=0.05),
+                confirmed=True,
+            )
+            self.assertEqual(timed_out["reason_code"], "inventory_timeout")
+
+        def capture_then_raise(*args: object, **_kwargs: object):
+            snapshots.append(Path(str(args[1])))
+            raise RuntimeError("synthetic process adapter failure")
+
+        with patch.object(skill_load_module, "_run_inventory_process", capture_then_raise):
+            with self.assertRaisesRegex(RuntimeError, "synthetic process adapter failure"):
+                probe_skill_load(self.request("all"), confirmed=True)
+
+        self.assertEqual(len(snapshots), 4)
+        for snapshot in snapshots:
+            self.assertFalse(snapshot.exists())
+            self.assertFalse(snapshot.parent.exists())
+
+    def test_path_selected_executable_fingerprint_binds_the_binary_that_ran(self) -> None:
+        fingerprints: list[str] = []
+        for label, runtime_digit in (("first", "1"), ("second", "2")):
+            binary_dir = self.root / label
+            binary_dir.mkdir()
+            executable = binary_dir / ("hermes.py" if os.name == "nt" else "hermes")
+            self.executable(executable, runtime_digit)
+            env = {"PATH": os.pathsep.join((str(binary_dir), os.defpath))}
+            if os.name == "nt":
+                env["PATHEXT"] = ".PY"
+            payload = probe_skill_load(
+                SkillLoadProbeRequest(
+                    expected_skills=("alpha", "beta"),
+                    hermes="hermes",
+                    env=env,
+                ),
+                confirmed=True,
+            )
+            self.assertEqual(payload["probe_status"], "observed")
+            self.assertEqual(payload["runtime_fingerprint"], runtime_digit * 64)
+            fingerprints.append(str(payload["tool_fingerprint"]))
+
+        self.assertNotEqual(fingerprints[0], fingerprints[1])
+
+    def test_explicit_symlink_binds_the_resolved_executable(self) -> None:
+        target = self.root / "all.py"
+        target.write_bytes(self.hermes.read_bytes())
+        target.chmod(0o755)
+        link = self.root / "selected-hermes"
+        link.symlink_to(target)
+        direct = probe_skill_load(self.request("all", hermes=str(target)), confirmed=True)
+        selected = probe_skill_load(self.request("all", hermes=str(link)), confirmed=True)
+        self.assertEqual(direct["probe_status"], "observed")
+        self.assertEqual(selected["probe_status"], "observed")
+        self.assertEqual(direct["tool_fingerprint"], selected["tool_fingerprint"])
+
+    def test_unresolvable_or_unreadable_executable_fails_closed_without_path_leak(self) -> None:
+        secret_path = self.root / "SECRET_EXECUTABLE_PATH" / "hermes"
+        missing = probe_skill_load(
+            SkillLoadProbeRequest(expected_skills=("alpha",), hermes=str(secret_path)),
+            confirmed=True,
+        )
+        self.assertEqual(
+            (missing["probe_status"], missing["reason_code"]),
+            ("probe_error", "inventory_executable_unavailable"),
+        )
+        self.assertNotIn("SECRET_EXECUTABLE_PATH", json.dumps(missing))
+        self.assertNotIn("observed_skills", missing)
+
+        executable = self.request("all")
+        with patch.object(skill_load_module.os, "read", side_effect=PermissionError):
+            unreadable = probe_skill_load(executable, confirmed=True)
+        self.assertEqual(
+            (unreadable["probe_status"], unreadable["reason_code"]),
+            ("probe_error", "inventory_executable_unavailable"),
+        )
+
+    def test_confirmation_is_mandatory_and_default_construction_starts_nothing(self) -> None:
+        request = self.request("all")
+        self.assertFalse((self.root / "called").exists())
+        with self.assertRaisesRegex(RuntimeError, "confirmation"):
+            probe_skill_load(request, confirmed=False)
+
+    def test_child_recursion_marker_refuses_probe_before_spawn(self) -> None:
+        with patch.dict(os.environ, {"OMH_ISOLATED_HERMES_DEPTH": "1"}):
+            with self.assertRaisesRegex(RuntimeError, "depth is limited"):
+                probe_skill_load(self.request("all"), confirmed=True)
+
+    def test_timeout_fails_closed(self) -> None:
+        sleeper = self.root / "sleep.py"
+        sleeper.write_text("#!/usr/bin/env python3\nimport time\ntime.sleep(60)\n", encoding="utf-8")
+        sleeper.chmod(0o755)
+        payload = probe_skill_load(self.request("all", hermes=str(sleeper), timeout_seconds=0.05), confirmed=True)
+        self.assertEqual((payload["probe_status"], payload["reason_code"]), ("probe_error", "inventory_timeout"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_skill_load_process_cleanup.py
+++ b/tests/test_skill_load_process_cleanup.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from threading import Event
+import unittest
+from unittest.mock import patch
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.coding import skill_load_observation as observation  # noqa: E402
+from omh.coding._hermes_child_process import (  # noqa: E402
+    process_absent,
+    terminate_process_group,
+)
+
+
+class SkillLoadProcessCleanupTests(unittest.TestCase):
+    def test_setup_failure_after_popen_reaps_child(self) -> None:
+        # Given: a real long-lived child and a subscription at post-Popen setup.
+        with TemporaryDirectory(prefix="omh-skill-cleanup-") as temporary:
+            executable = Path(temporary) / "hermes.py"
+            executable.write_text(
+                "#!/usr/bin/env python3\nfrom threading import Event\nEvent().wait()\n",
+                encoding="utf-8",
+            )
+            executable.chmod(0o755)
+            setup_entered = Event()
+            created = []
+
+            def fail_setup(process):
+                created.append(process)
+                setup_entered.set()
+                raise OSError("synthetic drainer setup failure")
+
+            request = observation.SkillLoadProbeRequest(
+                expected_skills=("alpha",),
+                hermes=str(executable),
+                timeout_seconds=2.0,
+                termination_grace_seconds=0.05,
+                env={"PATH": "/usr/bin:/bin"},
+            )
+
+            # When: setup raises synchronously after the child has been created.
+            try:
+                with patch.object(observation, "start_pipe_drainers", fail_setup):
+                    payload = observation.probe_skill_load(request, confirmed=True)
+                self.assertTrue(setup_entered.wait(1.0))
+
+                # Then: the fail-closed result is returned only after child reap.
+                self.assertEqual(payload["reason_code"], "inventory_process_error")
+                self.assertEqual(len(created), 1)
+                self.assertTrue(process_absent(created[0].pid))
+                self.assertIsNotNone(created[0].returncode)
+            finally:
+                for process in created:
+                    if process.poll() is None:
+                        terminate_process_group(process, 0.05, 15)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_skill_load_process_cleanup.py
+++ b/tests/test_skill_load_process_cleanup.py
@@ -11,6 +11,7 @@ from _local_package import load_local_package
 load_local_package()
 
 from omh.coding import skill_load_observation as observation  # noqa: E402
+from omh.coding import skill_load_process  # noqa: E402
 from omh.coding._hermes_child_process import (  # noqa: E402
     process_absent,
     terminate_process_group,
@@ -45,7 +46,7 @@ class SkillLoadProcessCleanupTests(unittest.TestCase):
 
             # When: setup raises synchronously after the child has been created.
             try:
-                with patch.object(observation, "start_pipe_drainers", fail_setup):
+                with patch.object(skill_load_process, "start_pipe_drainers", fail_setup):
                     payload = observation.probe_skill_load(request, confirmed=True)
                 self.assertTrue(setup_entered.wait(1.0))
 

--- a/tests/test_skill_load_replay_boundary.py
+++ b/tests/test_skill_load_replay_boundary.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from _cli_harness import run_cli
+
+
+class SkillLoadReplayBoundaryTests(unittest.TestCase):
+    def test_authenticated_observation_cannot_move_to_another_run(self) -> None:
+        # Given: one authenticated unsupported observation in its original run.
+        with TemporaryDirectory(prefix="omh-skill-replay-") as temporary:
+            root = Path(temporary)
+            home = root / ".omh"
+            hermes = root / "unsupported.py"
+            hermes.write_text("#!/usr/bin/env python3\nraise SystemExit(2)\n", encoding="utf-8")
+            hermes.chmod(0o755)
+            base = ["--omh-home", str(home), "coding", "hermes-child"]
+            probe = [
+                *base, "skill-load-probe", "--confirm-dispatch", "--run-id", "run-a",
+                "--hermes", str(hermes),
+            ]
+            self.assertEqual(run_cli(probe)[0], 0)
+            runs = home / "coding" / "hermes-child"
+            shutil.copytree(runs / "run-a", runs / "run-b")
+
+            # When: another run asks status for the byte-identical copied record.
+            status, stdout, stderr = run_cli(
+                [*base, "skill-load-status", "--run-id", "run-b"]
+            )
+
+            # Then: persisted authentication remains bound to the original run.
+            self.assertEqual((status, stdout), (2, ""))
+            self.assertIn("invalid", stderr)
+            original = run_cli([*base, "skill-load-status", "--run-id", "run-a"])
+            self.assertEqual(original[0], 0, original[2])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_skill_load_windows_resolution.py
+++ b/tests/test_skill_load_windows_resolution.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.coding import skill_load_observation as observation  # noqa: E402
+
+
+class SkillLoadWindowsResolutionTests(unittest.TestCase):
+    def test_supplied_path_and_pathext_are_case_insensitive(self) -> None:
+        # Given: an isolated Windows-style environment absent from the parent env.
+        with TemporaryDirectory(prefix="omh-windows-resolution-") as temporary:
+            root = Path(temporary)
+            executable = root / "HERMES.PY"
+            executable.write_text("raise SystemExit(2)\n", encoding="utf-8")
+            env = {"Path": str(root), "PathExt": ".EXE;.Py;.CMD"}
+
+            # When: a bare command is resolved using Windows semantics.
+            selected = observation._resolve_executable("hermes", env, windows=True)
+
+            # Then: caller PATH/PATHEXT and filesystem casing select the script.
+            self.assertEqual(selected, executable)
+
+    def test_windows_resolution_does_not_consult_parent_path(self) -> None:
+        # Given: an explicitly empty child PATH and a parent-resolvable command.
+        env = {"PATH": "", "PATHEXT": ".EXE;.PY"}
+
+        # When/Then: resolution does not silently fall back to os.environ.
+        self.assertIsNone(
+            observation._resolve_executable("python", env, windows=True)
+        )
+
+    def test_windows_python_snapshot_uses_current_interpreter(self) -> None:
+        # Given: a mixed-case Python snapshot suffix.
+        executable = str(Path("C:/private/HERMES.Py"))
+
+        # When: protocol argv is assembled for Windows.
+        argv = observation._inventory_argv(executable, ("--protocol", "v1"), windows=True)
+
+        # Then: Python fixtures retain explicit interpreter semantics.
+        self.assertEqual(argv[1:], (executable, "--protocol", "v1"))
+        self.assertNotEqual(argv[0], executable)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- Added an explicit, confirmation-gated Hermes-child skill-load probe: `omh coding hermes-child skill-load-probe --confirm-dispatch --run-id <id> [--expected-skill NAME ...]` and its read-back companion `omh coding hermes-child skill-load-status --run-id <id>`.
- Added the closed `skill_load_observation/v1` record contract: `probe_status` (`observed` / `unsupported` / `probe_error`) is orthogonal to `load_state` (`all_loaded` / `partially_loaded` / `none_loaded` / `not_applicable`), and `load_state` plus every inventory claim exists only on a validated `observed` record.
- Bound each probe to the exact executable bytes it ran: the resolved inode is opened once, copied into a private per-probe snapshot (`O_CREAT|O_EXCL`, mode `0500`), re-read and SHA-256 verified against the source descriptor digest, and only that snapshot is launched.
- Bound persisted evidence to its run: the stored HMAC is domain-separated `skill_load_observation_signature/v2` and signs the validated `run_id`, so a byte-identical record copied into another run fails closed while the original stays readable across process boundaries.
- Installed one child-lifecycle cleanup boundary around process creation, so any post-`Popen` failure still terminates, reaps, closes undrained pipes, awaits started drainers, and returns a process error rather than a result.
- Resolved Windows executables only from the explicitly supplied child environment (case-insensitive `PATH`/`PATHEXT`, no parent-process fallback, `.py` fixtures through the current interpreter argv).
- Split the implementation into three cohesive modules (`skill_load_observation.py` orchestration, `skill_load_protocol.py` schema/validation, `skill_load_process.py` resolution/lifecycle) while keeping the public `omh.coding.skill_load_observation` import surface unchanged.
- Documented the surface, the orthogonal state model, and the explicit v0.20.5 capability boundary in `docs/MULTI_AGENT_OPERATIONS.md`.

Refs #1118.

### Why This Exists

- Byte-for-byte parity between generated files and source files never proved that the host actually loaded a skill. The Hermes scheduler can skip an empty, failed, or invalid skill, add its name to `skipped`, inject a prompt-level warning, and keep going, so a user can be told a skill is installed while it silently did nothing (issue observations O009/O024/O032, converged claims C012/C015).
- Issue #1118 asks for exactly one opt-in probe that can tell all-loaded from partially-loaded from not-loaded, and reports unsupported hosts and probe errors honestly instead of inheriting a success claim from child exit codes or model self-report.
- The honest answer today matters more than a green one. Installed Hermes Agent v0.20.5 (upstream `5259f565`) exposes no bounded machine loaded-skill inventory protocol, so the contract had to be built such that the real host truthfully reports `unsupported` rather than fabricating an inventory.

### User / Operator Impact

- An agent or maintainer can now run one explicit local probe and get a machine answer about loaded-skill state, or an honest capability boundary, without patching Hermes, executing a skill body, mutating config, or calling a provider.
- Against the installed Hermes v0.20.5 host, the probe returns `probe_status=unsupported`, `reason_code=inventory_protocol_unavailable`, exit code 0, with no `load_state`, no observed/missing/unexpected sets, no `inventory_digest`, and no filesystem path in the payload. That is the correct terminal answer for a host without the protocol, not a failure.
- Nothing runs by default. There is exactly one production call site for `probe_skill_load`, inside the confirmation-gated subcommand; no scheduler, hook, startup, or background path calls it. Without `--confirm-dispatch` the CLI exits 2 before creating a run directory or touching any executable.
- Downstream quality consumption is fail-closed: `skill_load_evidence_state` returns `invalid` or `stale` rather than promoting a record, and never turns a non-`observed` status into a load state.
- Status is `IMPLEMENTATION_READY_EXTERNAL_PROTOCOL_BLOCKED`. `real_observed=false` and `issue_closing_authorized=false`. This PR does not claim a real provider load, a real skill load, or an observed host inventory.

### How It Works

- **Approval boundary.** `cmd_hermes_child_skill_load_probe` rejects a missing `--confirm-dispatch` up front; `probe_skill_load` independently calls the shared `require_hermes_child_dispatch_boundary` with `dispatch_policy="ask_before_dispatch"` and `confirmed=True`. Construction and status reads never spawn.
- **Isolation.** One confirmed probe owns one `subprocess.Popen` local child: stdin on `DEVNULL`, bounded stdout/stderr drainers, hard timeout, new POSIX session, verified termination and reap. The existing depth-one rule still applies, so `OMH_ISOLATED_HERMES_PARENT` or depth >= 1 is rejected before spawn. The child argv is a machine command under `--safe-mode --ignore-user-config --ignore-rules` with no prompt, model, provider, oneshot, or skill-body argument, and the child environment is allowlisted with no provider credentials.
- **Executable identity.** `snapshot_resolved_tool` resolves the command through the exact child `PATH`, pins the selected inode with `os.open`, verifies regular-file and executable bits, copies descriptor bytes into a private snapshot, checks size against `fstat`, fsyncs, re-reads through the snapshot's own descriptor, and compares SHA-256. `tool_fingerprint` covers domain tag `omh-skill-load-tool/v2`, resolved path, `st_dev`/`st_ino`/`st_mode`/`st_size`, and the verified digest. The mutable source pathname is never re-looked-up for execution, so atomic replacement, replace-and-restore, and symlink-target swaps cannot change what runs. Snapshots are removed after success, process error, timeout, and raised adapter failure alike.
- **Observation validation.** `observed` requires the exact closed `hermes_skill_inventory/v1` shape plus the generated nonce, expected-set digest, inventory digest, executable and runtime fingerprints, bounded observation time, and expiry. Set membership is re-derived from sorted unique expected/observed sets. `MAX_PROTOCOL_SECONDS=300` bounds skew, staleness, and expiry; `skill-load-status` refuses expired records.
- **Replay boundary.** The CLI reserves a run with `O_EXCL` (one probe per run id), generates a fresh `os.urandom(32)` nonce, and signs the record with the run-bound v2 HMAC. `skill-load-status` recomputes over the requested run id and compares with `hmac.compare_digest`, so transplanted evidence is rejected.
- **Evidence shape.** The record is a closed 15-field allowlist with no message, detail, error text, or traceback field. Child stdout is consumed transiently and never persisted; stderr is drained and discarded. Failure detail is limited to the closed `REASON_CODES` tuple. Files are written private (`0600`).

### Files And Contracts Touched

Diff scope: `0c4f0fe5cabdcc034027e95f1e43a426f249a09d..2428848e`, 9 commits, 0 merges, 16 files changed, 1528 insertions, 7 deletions. The ninth commit is test-only: it splits executable-lifecycle coverage from protocol/replay coverage below the 250-pure-LOC gate and changes no production or generated file.

Production:

- `src/coding/skill_load_observation.py` (new, 169 pure LOC, meaning non-blank and non-comment): public orchestration, `SkillLoadProbeRequest`, `probe_skill_load`, `InventoryNonceLedger`, stable re-export surface.
- `src/coding/skill_load_protocol.py` (new, 214 pure LOC): closed schemas, validation, digests, freshness, `closed_observation`.
- `src/coding/skill_load_process.py` (new, 217 pure LOC): executable resolution, snapshot fingerprint binding, process lifecycle.
- `src/commands/hermes_child.py`: `skill-load-probe` / `skill-load-status` subcommands, run reservation, v2 signature write and verify.
- `src/coding/hermes_child_dispatch.py`: extracts `require_hermes_child_dispatch_boundary`; `dispatch_hermes_child` now calls it. Behavior preserved, no new capability.
- `src/evidence/labels.py`: `SKILL_LOAD_PROBE_LABELS` and `SKILL_LOAD_STATE_LABELS` constants only.
- `src/quality/harness_quality.py`: `skill_load_evidence_state` consumer that refuses invalid or stale records.

Tests: protocol/replay coverage in `tests/test_skill_load_observation.py`,
executable lifecycle/identity/PATH coverage in
`tests/test_skill_load_observation_lifecycle.py`, shared support in
`tests/_skill_load_observation_support.py`,
`tests/test_skill_load_process_cleanup.py` (1),
`tests/test_skill_load_replay_boundary.py` (1),
`tests/test_skill_load_windows_resolution.py` (3), plus updates to
`tests/test_hermes_child_cli.py` (16) and
`tests/test_handoff_safety_contract_enforcement.py`.

Docs: `docs/MULTI_AGENT_OPERATIONS.md` (+28 lines).

Contracts: `skill_load_observation/v1`, `hermes_skill_inventory/v1`, `skill_load_observation_signature/v2`, `omh-skill-load-tool/v2` fingerprint domain. No new dependencies. Public import surface preserved across the module split.

Evidence: canonical manifest `omo_issue_delivery_manifest/v2` with 53 entries, all sizes and SHA-256 values re-verified with zero mismatches; release reconstruction receipt records patch-id preservation for the three mapped source commits and clean linear history.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

Check only commands that completed successfully. Leave non-applicable checks
unchecked and explain why under **Not Tested / Not Applicable**.

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [x] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `omh coding hermes-child skill-load-probe --confirm-dispatch --run-id <id> --hermes <real hermes> --expected-skill ... --json` against the installed Hermes v0.20.5 in a disposable `OMH_HOME`
- [x] Manual Hermes/TUI check, or explicit reason it was not run: real `hermes --version` (`Hermes Agent v0.20.5 (2026.8.19)`, upstream `5259f565`), `hermes skills --help`, and `hermes skills list --enabled-only` were inspected on the live host

### Observed Evidence

- Targeted tests, commands, CI checks, and manual behavior actually observed:
- Test-only size-gate follow-up at `2428848e`: the original 348-pure-LOC
  observation test is now split into modules measuring 90, 169, and 102 pure
  LOC. The 17 original test names, method source hashes, and 52 assertion ASTs
  are unchanged; the complete 22-test skill-load lane and two relevant CLI
  tests pass. Ruff, `compileall`, and `git diff --check` are clean.
- GitHub Actions CI at the previous production-equivalent head (`c3bb7514`, run
  `33027113246`) completed all six checks successfully, including 7343 Windows
  tests. Remote CI at test-only head `2428848e` is now complete: all six
  required checks pass, including native Windows and DCO.
- Chronology, disclosed in full: the first push (`f9443fb0`, run `33025587102`) **failed** on `test-windows` only, with `test_path_selected_executable_fingerprint_binds_the_binary_that_ran` asserting `'probe_error' != 'observed'`. Root cause: the fixture created an extensionless `hermes` file, which native Windows PATHEXT cannot resolve, so the probe failed closed before reaching the snapshot and fingerprint assertion the test exists to make. The fix (`c3bb7514`) is **test-only** -- a `hermes.py` fixture plus caller-supplied `PATHEXT='.PY'` -- and deliberately did not teach the resolver to execute extensionless scripts, which would have violated native Windows semantics. No production file changed; the four Linux/macOS jobs and DCO were green before and after.
- Full suite at production-equivalent head `c3bb7514`:
  `PYTHONPATH=tests uv run python -m unittest discover -s tests` ran **7343
  tests, OK**, exit 0, reproduced in multiple independent lanes. It is
  historical evidence for the unchanged production tree; full discovery was
  not rerun locally for the test-only split.
- One independent code/QA environment ran the same canonical discovery and saw 7343 tests with 6 failures and 1 error, all seven in `test_cross_harness_adapter_security` / `test_cross_harness_adapters`. Base `0c4f0fe5` reproduces a byte-identical failure set (diff of sorted FAIL/ERROR lines empty), so this is a pre-existing sandbox/environment issue, not a regression from this branch.
- Focused release suite: `tests.test_skill_load_observation tests.test_skill_load_process_cleanup tests.test_skill_load_windows_resolution tests.test_skill_load_replay_boundary tests.test_hermes_child_cli tests.test_handoff_safety_contract_enforcement` ran **56 tests, OK** under `-W error::ResourceWarning`, in the release receipt and again in independent goal and QA lanes. The code-review lane instead ran a narrower `test_skill_load_*.py` discovery (**22 tests**) repeated 5 consecutive clean runs with `ResourceWarning` promoted to error, showing no flake and no leaked pipes or descriptors.
- Real host probe: on the installed Hermes v0.20.5 the probe returned `probe_status=unsupported`, `reason_code=inventory_protocol_unavailable`, exit 0, payload limited to schema version, status, reason, nonce, expected digest, tool fingerprint, runtime fingerprint, `observed_at`, `expires_at`. No `load_state`, no `observed_skills`, no `inventory_digest`, no path leak. Independently corroborated: `hermes skills --help` lists trust/untrust/browse/search/install/inspect/list/check/update/audit/uninstall/reset/list-modified/diff/opt-out/opt-in/repair-official/publish/snapshot/tap/config and no `inventory`; `hermes skills list --enabled-only` returns a human Rich table, not a nonce-bound runtime inventory.
- Manual CLI matrix: help exit 0; missing `--confirm-dispatch` exit 2; second probe on a reserved run id exit 2; missing run status exit 2; `../` traversal run id rejected with `run_id must be a safe opaque metadata reference` (exit 2); tampered record exit 2; cross-process cross-run replay exit 2 while the same-run read stays exit 0; timeout and process error exit 1; privacy scan PASS.
- Adversarial controls: TOCTOU (`os.replace` of the source after snapshotting) still executed the fingerprinted bytes; child and detached grandchild both reaped with `process_absent` true and zero leftover `omh-skill-load-tool-*` scratch dirs; a fixture emitting `RAW_SECRET` on stdout and stderr persisted nothing, record mode `0600`; 9 hostile protocol inputs (unsorted sets, future/stale timestamps, extra/missing fields, invalid UTF-8, skill-name injection, nested lists) all returned closed reason codes; 7 Windows `PATH`/`PATHEXT` cases matched documented semantics including no parent-PATH fallback. An out-of-band recomputation of `tool_fingerprint` for the real installed `hermes` from a separate Python process reproduced the CLI value exactly.
- Static and docs: Ruff `All checks passed!`; `compileall` exit 0; `git diff --check 0c4f0fe5..HEAD` exit 0; 5 of 5 docs generation gates passed; documented commands and flags in `docs/MULTI_AGENT_OPERATIONS.md` were executed and parse exactly as written, and the v0.20.5 / `5259f565` claim was verified against the live host.
- basedpyright: zero introduced errors on every lane. Release environment reported 0 errors / 25 warnings versus 0 errors / 34 warnings for the source control run (warning delta -9 on the changed-file pair); the reviewer's toolchain (basedpyright 1.39.10 / pyright 1.1.412 over the whole `src` tree) reported 2338 errors at HEAD and 2338 at base, again zero introduced, with zero errors inside the three new modules. Raw exit 1 in the release lane comes from warnings being reported, not errors.
- Evidence integrity: all 53 manifest entries re-hashed with 0 mismatches and 0 missing; release worktree clean before and after every review; no product edits made during review.
- History: independent lane verdict `HISTORY_CONFIRMED`, recorded twice -- once at the seven-commit release head `f9443fb0` and again at this eight-commit HEAD. Eight linear unique commits, no merges, `origin/main` `0c4f0fe5` is the direct parent of the first commit, all three mapped source commits preserve patch id and full binary diff, the eighth commit is test-only (one test file, +5/-2, zero production paths), and all eight commits carry exactly one each of Constraint / Rejected / Confidence / Scope-risk / Directive / Tested / Not-tested / Omo-Task plus the omo footer, co-author, and trailing sign-off.
- Six independent final review lanes all recorded PASS: goal-and-constraint, context/integration, code, QA, security (0 release-blocking defects, 0 critical/major/minor, 3 informational), and history. These are internal review artifacts, not GitHub PR approvals and not CI results.
- No fixed sleeps were used in production code, tests, or any QA driver. Async waits are event-based (`threading.Event`) or bounded process waits; the only blocking behavior is a fixture child that deliberately blocks so the timeout path can be exercised.

### Not Tested / Not Applicable

- Skipped checks and the concrete reason each one does not apply:
- `harness validate` and `release checklist --json`: not run. This branch changes no harness definition and adds no release-channel surface. The three docs gates above did run and are checked; all five generated-doc byte gates passed at the release worktree (5/5, exit 0). `docs/MULTI_AGENT_OPERATIONS.md` is hand-written prose, not a generated file, so no generation gate covers it.
- `release hermes-smoke` (and the `--install-path setup --include-command-smoke` variant): not run. This branch adds no installer, setup, or release-channel surface; the Hermes interaction it does add was exercised directly against the real installed host instead.
- Workflow-learning review queue smoke: not applicable, no learning contract changed.
- **Real observed Hermes inventory: not possible.** Hermes Agent v0.20.5 (upstream `5259f565`) exposes no bounded machine loaded-skill inventory protocol, so no real `observed` record exists anywhere in this evidence. `real_observed=false`, `issue_closing_authorized=false`.
- **The synthetic protocol matrix is local contract verification only.** Fake all/partial/none/unexpected/not-applicable, unsupported, error, replay, malformed, duplicate, nonce/digest mismatch, timeout, expiry, masking, recursion, confirmation, tamper, and schema-key cases exercise OMH's own fail-closed logic against fixture processes. None of it is evidence that Hermes supports or loaded any skill, and no provider-load or skill-load success is claimed.
- Native Windows execution: **now observed in CI**, not on this workstation. The local workstation is macOS (darwin arm64), so local coverage remains the deterministic platform-parameterized pure resolver tests. On GitHub Actions the `test-windows` job (`windows-latest`) ran the full suite at this exact HEAD: **7343 tests, OK (skipped=267)**, including all 22 skill-load tests with no Windows skip guards. Windows `PATH`/`PATHEXT` selection and `.py` interpreter argv are therefore natively exercised. Windows `taskkill` termination is driven indirectly by the two timeout tests, which launch a real 60-second child with a 0.05s timeout so `terminate_process_group` takes the `_terminate_windows_process_tree` branch; there is no dedicated assertion naming `taskkill`.
- `pyright` via `uv run --group lint pyright`: could not spawn in one QA environment (binary absent); recorded as a non-blocking environment finding. basedpyright was executed in the other lanes with the introduced-error delta reported above.
- No network access, no credential access, and no provider or LLM client execution occurred anywhere in this work. Static inspection of the delta found no network, API, LLM, or provider client.

## Risk

- **Truthfulness risk, mitigated by design.** The single largest risk is a false `observed`. `observed` is reachable only through a validated, fresh, nonce-bound `hermes_skill_inventory/v1` response; the observed payload is re-validated before return and downgraded to `probe_error` on any violation. Non-observed records that carry inventory claim fields are rejected outright.
- **Execution risk, bounded.** One confirmed probe equals one local isolated subprocess with a hard timeout, new session, and verified reap. There is no default, background, or scheduled invocation path and no way to reach a provider or the network through this surface.
- **Evidence risk, closed.** Records are metadata-only with a closed field allowlist; no raw prompt, output, log body, traceback, credential, CPU, RAM, or resource-score field can be stored. Files are private mode. Cross-run transplant fails closed.
- **Windows platform, now covered by CI.** Native Windows execution is no longer unobserved: the `test-windows` job on `windows-latest` runs the full suite as an enforcing gate and is green at this HEAD (7343 tests, OK). The first push at `f9443fb0` did fail exactly this way -- a POSIX-only extensionless fixture that native PATHEXT cannot resolve -- and `c3bb7514` fixed the fixture without weakening resolver semantics. Residual risk is now limited to Windows behavior that the suite does not assert directly, such as an explicit `taskkill` outcome assertion.
- **Pre-existing sandbox noise.** Seven cross-harness adapter failures appear in one restricted environment on both this branch and its base. They are unrelated to this change and should be triaged separately.

## Compatibility / Rollout

- Additive only. Two new subcommands under an existing agent/maintainer-only parent, three new modules, two new label constants, and one new consumer function. No existing command, flag, schema, or output changed.
- `hermes_child_dispatch.py` only extracts `require_hermes_child_dispatch_boundary` and calls it from `dispatch_hermes_child`; dispatch behavior is unchanged and no new capability is added.
- The module split preserves the public `omh.coding.skill_load_observation` import surface; downstream imports keep working unchanged. No dependencies were added.
- Release-channel impact: none by default. The probe runs only when a human passes `--confirm-dispatch`, so shipping it changes no default behavior on any channel.
- Composition: this branch branches from `0c4f0fe5` and has zero changed-file overlap with #1142 (#1117) and #1139 (#1119); `git merge-tree` confirms zero conflicts against both heads, and it merges cleanly against current main `940bc720`. Note that #1142 and #1139 do overlap each other on 14 files and conflict in `src/maintenance/release.py` (`FULL_PROFILE_SKILL_BODY_CHAR_LIMIT` `718294` vs `720443`); whichever lands second must remeasure from the canonical producer. That constraint is between those two branches and does not affect this one. The approved order (#1117, #1119, then #1118) is a plan preference, not a dependency of this branch.
- Test-count bookkeeping, stated precisely: **56 is the previous production-equivalent focused count** for `c3bb7514`; the test-only split separately reran the complete **22-test** skill-load lane plus two CLI tests at `2428848e`. The **122** figure comes from a disposable composition run that cherry-picked #1119 (11 commits), #1117 (1 commit), and #1118 (7 commits, before the Windows fixture fix) onto `0c4f0fe5`. The **126** figure comes from a separate composition run that took all 3 of #1117's commits instead of 1. Both composition counts are historical selections of different scope; neither is an ancestry count or a current-head focused count. All three runs applied with zero cherry-pick conflicts and `git diff --check` exit 0.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

Explicit claim statement: implementation status is `IMPLEMENTATION_READY_EXTERNAL_PROTOCOL_BLOCKED`. `real_observed=false`, `issue_closing_authorized=false`, no provider-load claim, no skill-load success claim, and no merge claim. Six-of-six CI is green at test-only head `2428848e`; passing CI is not a review approval, maintainer sign-off, or evidence of a real Hermes skill load. The internal review lanes and post-CI addenda are repository review artifacts, not GitHub approvals. `omh release hermes-smoke --live` was not run because this branch touches no release or installer surface.

## Follow-Up

- Keep issue #1118 **open**. Close it only when an upstream Hermes bounded machine loaded-skill inventory protocol exists, is linked, and real `all_loaded` / `partially_loaded` / `none_loaded` behavior has been independently observed on a real host. Refs #1118.
- File or track the upstream Hermes request for a nonce-bound `skills inventory` machine protocol; that is the sole external blocker for the `observed` path.
- Windows resolver and lifecycle paths now run on every push through the `windows-latest` CI job and are green at this HEAD. Remaining follow-up: add an explicit assertion for `taskkill` termination outcome, which is currently only exercised implicitly through the timeout tests.
- Triage the seven pre-existing cross-harness adapter failures seen in one restricted environment; they reproduce byte-identically on base and are out of scope here.
- Non-blocking residuals, none of which affect a shipped surface:
  - `InventoryNonceLedger` is in-process and opt-in (`nonce_ledger=None` is accepted), so a library caller who pins a nonce and supplies no ledger could validate it twice. The shipped CLI is unaffected: it always generates a fresh `os.urandom(32)` nonce, enforces one probe per run id with an `O_EXCL` reservation, and blocks cross-run transplant with the run-bound HMAC. A docstring note pointing at the reservation plus signature as the real cross-process defense would help.
  - Four underscore-prefixed seams (`_ProcessOutcome`, `_ResolvedTool`, `_inventory_argv`, `_resolve_executable`) are re-exported through `__all__` so the module split kept `patch.object` seams working from the stable import surface. Only tests reference them; no production caller does. Cosmetic, could later become documented non-underscore aliases.
  - `docs/MULTI_AGENT_OPERATIONS.md` prose is deliberately not byte-pinned by any test, consistent with test discipline. Its factual claims were verified by executing the documented commands and by checking the version claim against the live host.
