### PR TITLE
fix(plugin): dedupe persisted awareness primer

### DIFF
--- a/src/plugin_bundle/omh/hooks/llm_hooks.py
+++ b/src/plugin_bundle/omh/hooks/llm_hooks.py
@@ -69,6 +69,32 @@ def _record_delivery(
         return
 
 
+def _primer_already_in_api_history(conversation_history: object, primer: str) -> bool:
+    """Whether Hermes already persisted this primer in an API-content sidecar.
+
+    Hermes replays prior ``api_content`` values byte-for-byte for prompt-cache
+    stability. Re-emitting the same primer on a later turn therefore grows the
+    prompt permanently. Inspect only the host-injected suffix of that sidecar,
+    subtracting the clean message prefix, so a user quoting
+    ``[OMH Awareness]`` cannot suppress guidance.
+    """
+    if not primer or not isinstance(conversation_history, (list, tuple)):
+        return False
+    for message in reversed(conversation_history):
+        if not isinstance(message, dict):
+            continue
+        api_content = message.get("api_content")
+        if not isinstance(api_content, str):
+            continue
+        clean_content = message.get("content")
+        injected_content = api_content
+        if isinstance(clean_content, str) and api_content.startswith(clean_content):
+            injected_content = api_content[len(clean_content) :]
+        if primer in injected_content:
+            return True
+    return False
+
+
 def pre_llm_call(**kwargs) -> dict[str, object] | None:
     """Inject bounded OMH role/status context without storing prompts."""
     record_active_main_agent_model(kwargs.get("model"))
@@ -124,7 +150,9 @@ def pre_llm_call(**kwargs) -> dict[str, object] | None:
         and (bool(route_hint_context) or message_matches_awareness)
     )
     if should_include_awareness:
-        context_parts.append(awareness_primer_context())
+        primer = awareness_primer_context()
+        if not _primer_already_in_api_history(kwargs.get("conversation_history"), primer):
+            context_parts.append(primer)
         payload["omh_context_brief"] = build_context_brief(
             user_message,
             source=str(kwargs.get("source") or kwargs.get("host") or "pre_llm_call"),
@@ -202,19 +230,21 @@ def pre_llm_call(**kwargs) -> dict[str, object] | None:
         degraded.append((COMPONENT_RUNTIME_STATUS_READ, safe_error_type(error_type)))
 
     if include_awareness and is_first_turn and status.get("active_executors") and not should_include_awareness:
-        context_parts.insert(0, awareness_primer_context())
-        payload["omh_context_brief"] = build_context_brief(
-            user_message,
-            source=str(kwargs.get("source") or kwargs.get("host") or "pre_llm_call"),
-            max_hints=2,
-            include_prompt_context=False,
-            route_hint_payload=route_hint_payload,
-        )
-        brief = payload.get("omh_context_brief")
-        if isinstance(brief, dict):
-            for row in brief.get("degradation", {}).get("components", []):
-                if isinstance(row, dict):
-                    degraded.append((str(row.get("component", "")), str(row.get("error_type", ""))))
+        primer = awareness_primer_context()
+        if not _primer_already_in_api_history(kwargs.get("conversation_history"), primer):
+            context_parts.insert(0, primer)
+            payload["omh_context_brief"] = build_context_brief(
+                user_message,
+                source=str(kwargs.get("source") or kwargs.get("host") or "pre_llm_call"),
+                max_hints=2,
+                include_prompt_context=False,
+                route_hint_payload=route_hint_payload,
+            )
+            brief = payload.get("omh_context_brief")
+            if isinstance(brief, dict):
+                for row in brief.get("degradation", {}).get("components", []):
+                    if isinstance(row, dict):
+                        degraded.append((str(row.get("component", "")), str(row.get("error_type", ""))))
 
     board = read_running_work_board(omh_home, limit=6)
     running_count = int(board.get("running_count", 0) or 0)

--- a/tests/test_hook_manifest.py
+++ b/tests/test_hook_manifest.py
@@ -11,7 +11,7 @@ load_local_package()
 
 from omh.capabilities.hooks import hook_manifest
 from omh.install.hook_integrity import HOOK_REVIEWS, VALID_HOOK_EVENTS
-from omh.plugin_bundle.omh.awareness import awareness_route_hint
+from omh.plugin_bundle.omh.awareness import awareness_primer_context, awareness_route_hint
 from omh.plugin_bundle.omh.awareness_delivery import read_awareness_delivery
 from omh.plugin_bundle.omh.hooks.llm_hooks import pre_llm_call
 from omh.plugin_bundle.omh.hooks.tool_hooks import pre_tool_call
@@ -270,6 +270,84 @@ class HookManifestTests(unittest.TestCase):
                 serialized = handle.read()
             for raw_identifier in ("session-a", "session-b", "task-a", "task-b", "turn-1"):
                 self.assertNotIn(raw_identifier, serialized)
+
+    def test_prior_api_content_primer_is_not_replayed_for_a_new_route(self) -> None:
+        with TemporaryDirectory() as omh_home:
+            primer = awareness_primer_context()
+            result = pre_llm_call(
+                user_message="review this PR",
+                conversation_history=[
+                    {
+                        "role": "user",
+                        "content": "make an image explaining the cron feature",
+                        "api_content": "make an image explaining the cron feature\n\n" + primer,
+                    }
+                ],
+                is_first_turn=False,
+                session_id="session-a",
+                task_id="task-a",
+                turn_id="turn-2",
+                omh_home=omh_home,
+            )
+
+            self.assertIsNotNone(result)
+            assert result is not None
+            self.assertNotIn("[OMH Awareness]", result["context"])
+            self.assertIn("[OMH Route Hint]", result["context"])
+
+    def test_prior_api_content_primer_suppresses_primer_only_match(self) -> None:
+        with TemporaryDirectory() as omh_home:
+            primer = awareness_primer_context()
+            with (
+                patch(
+                    "omh.plugin_bundle.omh.hooks.llm_hooks.awareness_context_matches_message",
+                    return_value=True,
+                ),
+                patch(
+                    "omh.plugin_bundle.omh.hooks.llm_hooks.awareness_route_hint",
+                    return_value={"status": "no_hint"},
+                ),
+                patch(
+                    "omh.plugin_bundle.omh.hooks.llm_hooks.awareness_route_hint_context_from_payload",
+                    return_value="",
+                ),
+            ):
+                result = pre_llm_call(
+                    user_message="is OMH memory compatible with codebase memory?",
+                    conversation_history=[
+                        {
+                            "role": "user",
+                            "content": "prepare a safe feature plan",
+                            "api_content": "prepare a safe feature plan\n\n" + primer,
+                        }
+                    ],
+                    is_first_turn=False,
+                    session_id="session-a",
+                    omh_home=omh_home,
+                )
+
+            self.assertIsNone(result)
+
+    def test_user_pasted_primer_in_sidecar_content_does_not_suppress_delivery(self) -> None:
+        with TemporaryDirectory() as omh_home:
+            primer = awareness_primer_context()
+            result = pre_llm_call(
+                user_message="review this PR",
+                conversation_history=[
+                    {
+                        "role": "user",
+                        "content": primer,
+                        "api_content": primer + "\n\n[Other Plugin] unrelated context",
+                    }
+                ],
+                is_first_turn=False,
+                session_id="session-a",
+                omh_home=omh_home,
+            )
+
+            self.assertIsNotNone(result)
+            assert result is not None
+            self.assertIn("[OMH Awareness]", result["context"])
 
     def test_first_turn_route_failure_keeps_degradation_signal(self) -> None:
         route_failure = {


### PR DESCRIPTION
## Summary

- keep the OMH awareness primer to one persisted copy while it remains in Hermes conversation history
- continue emitting message-specific route hints and independent status/todo context
- inspect only Hermes-owned `api_content` sidecars, so user-quoted awareness text cannot suppress guidance

## Why

Hermes persists `pre_llm_call` context in a user message's `api_content` sidecar and replays that sidecar byte-for-byte to preserve the prompt-cache prefix. OMH previously emitted the same fixed awareness primer again on later relevant turns. Each copy was then persisted and replayed, so a long session could accumulate several identical primers even though route-hint delivery was already fingerprinted.

This is a follow-up to the accumulated hook-context behavior addressed in #938 / #943. The remaining case is a changed or primer-only route: the route fingerprint is new or absent, but the fixed primer is still already present in prior API content.

## Behavior after this change

- the first relevant turn emits the fixed OMH awareness primer
- later relevant turns do not emit that exact primer while it remains in a prior `api_content` sidecar
- new route hints are still emitted normally
- active-executor status, plan-todo reminders, degradation signals, and running-work context keep their existing behavior
- a user pasting `[OMH Awareness]` in clean message content does not suppress the real primer
- if compaction removes the prior sidecar, or a future release changes the primer bytes, the current primer can be emitted once again

## Implementation

`llm_hooks.py` checks prior conversation entries in reverse order for the exact current primer inside the host-injected suffix of `api_content`. It subtracts the clean message prefix first, deliberately does not treat user content as delivery evidence, does not alter prior messages, does not add persistent state, and does not change Hermes core or the awareness-delivery ledger schema.

## Verification

- focused regression tests for changed-route, primer-only, and user-quoted-marker cases
- hook/delivery/efficiency/todo test group: 137 tests passed
- 10-turn host-contract probe: 1 exact primer, 1 awareness marker, 8 route hints
- full repository unittest suite: 7,322 passed, 11 platform-specific skips
- `ruff check src tests`: passed
- `python -m compileall -q src tests`: passed
- generated workflow, role, and capability-family projections: passed
- `git diff --check`: passed

## Risk and rollout

The check is bounded to existing conversation history and reads only string `api_content` sidecars. It does not mutate prompt history, preserving Hermes prompt-cache stability. A very old primer that has been compacted out is intentionally treated as absent, allowing one fresh primer after compaction.
