### PR TITLE
feat(skills): design family gains a named craft bar and on-demand references

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -2017,7 +2017,7 @@ These surfaces are generated command references, not installed Hermes workflow s
   - Why: A prepared orchestration contract cannot create implementation or rendered evidence.
 - Quality bar:
   - Make the design job, context boundary, direction, downstream lane ownership, and visual evidence requirements readable before handoff.
-  - Reject generic default drift by naming hierarchy, palette, typography, layout, signature element, and avoid patterns deliberately.
+  - Reject generic default drift by naming hierarchy, palette, typography, layout, signature element, and avoid patterns deliberately — the direction vocabulary and anti-slop patterns live in the frontend skill's `omh-frontend/references/taste-foundations.md`; prepared directions inherit its named bar (technically clean but flat fails).
   - Require the selected executor and fresh visual evidence separately before any implementation or quality completion claim.
 - Completion checklist:
   - The bounded intent, opaque context references, direction vocabulary, and avoid patterns are explicit.
@@ -2084,7 +2084,7 @@ These surfaces are generated command references, not installed Hermes workflow s
   - Expected behavior: Require rendered PDF/page screenshots or mark visual QA as not_observed.
   - Why: A quality brief is not render, visual QA, export, deployment, or delivery evidence.
 - Quality bar:
-  - Define superior design quality with references, audience, hierarchy, style, and measurable QA gates.
+  - Define superior design quality with references, audience, hierarchy, style, and measurable QA gates. The bar is named, not relative: what a senior product designer at a top-tier product company (the Linear/Stripe/Supabase class) would sign off on — technically clean but flat output fails it. Load `references/design-critique-rubric.md` and judge every axis with named evidence.
   - State why the result should be better than ordinary output, including content depth, visual hierarchy, spacing, typography, and interaction or export polish.
   - Review content accuracy and hierarchy before visual polish.
   - Use design-system/reference rules for web, deck, PDF, and poster surfaces.
@@ -2164,8 +2164,9 @@ These surfaces are generated command references, not installed Hermes workflow s
   - Why: A frontend brief is not implementation, browser, performance, or visual QA evidence.
 - Quality bar:
   - Name the product goal, audience, target surfaces, routes, states, and visual quality bar.
-  - Use references and domain fit to avoid generic AI-looking frontend output.
-  - Prepare a concrete design-system contract before implementation handoff.
+  - Hold the named bar: what a senior product designer at a top-tier product company (the Linear/Stripe/Supabase class) would sign off on — technically clean but flat output fails it. Load `references/taste-foundations.md`, name one primary taste direction, and reject the anti-slop patterns it lists.
+  - Use references and domain fit to avoid generic AI-looking frontend output; when the user supplies a visual reference, load `references/reference-token-extraction.md` and extract tokens into the contract instead of eyeballing.
+  - Prepare a concrete design-system contract before implementation handoff: load `references/design-system-contract.md` and write DESIGN.md before the first component — no component code before the contract exists.
   - For first-time UI creation, name the initial generation branch, reference direction, reusable primitives, state coverage, and required visual QA path.
   - Cover responsive layout, empty/loading/error states, hover/focus/active states, CJK text, accessibility, and performance expectations.
   - Prefer native UI controls, stable dimensions, and realistic content over decorative cards, blobs, and placeholder-heavy screens.

--- a/skills/omh-design-orchestration/SKILL.md
+++ b/skills/omh-design-orchestration/SKILL.md
@@ -73,7 +73,7 @@ Reasoning demand: `standard`
 Quality bar:
 
 - Make the design job, context boundary, direction, downstream lane ownership, and visual evidence requirements readable before handoff.
-- Reject generic default drift by naming hierarchy, palette, typography, layout, signature element, and avoid patterns deliberately.
+- Reject generic default drift by naming hierarchy, palette, typography, layout, signature element, and avoid patterns deliberately — the direction vocabulary and anti-slop patterns live in the frontend skill's `omh-frontend/references/taste-foundations.md`; prepared directions inherit its named bar (technically clean but flat fails).
 - Require the selected executor and fresh visual evidence separately before any implementation or quality completion claim.
 
 Handoff policy:

--- a/skills/omh-design-quality-gate/SKILL.md
+++ b/skills/omh-design-quality-gate/SKILL.md
@@ -74,7 +74,7 @@ Reasoning demand: `standard`
 
 Quality bar:
 
-- Define superior design quality with references, audience, hierarchy, style, and measurable QA gates.
+- Define superior design quality with references, audience, hierarchy, style, and measurable QA gates. The bar is named, not relative: what a senior product designer at a top-tier product company (the Linear/Stripe/Supabase class) would sign off on — technically clean but flat output fails it. Load `references/design-critique-rubric.md` and judge every axis with named evidence.
 - State why the result should be better than ordinary output, including content depth, visual hierarchy, spacing, typography, and interaction or export polish.
 - Review content accuracy and hierarchy before visual polish.
 - Use design-system/reference rules for web, deck, PDF, and poster surfaces.

--- a/skills/omh-design-quality-gate/references/design-critique-rubric.md
+++ b/skills/omh-design-quality-gate/references/design-critique-rubric.md
@@ -1,0 +1,61 @@
+# Design Critique Rubric
+
+The critique lane's question is never "is it correct?" — it is "does this
+clear what a senior product designer at a top-tier product company — the Linear/Stripe/Supabase class — would sign off on?". **Technically clean but flat fails.** Judge each
+axis explicitly; a PASS with no named evidence per axis is not a review.
+
+## Axes
+
+- **Hierarchy** — one glance names what leads, what supports, what recedes.
+  FAIL: adjacent elements competing at equal weight; headings that do not
+  organize scanning.
+- **Type discipline** — a modular scale is in use; display and body behave
+  differently on purpose. FAIL: arbitrary sizes, one step doing three jobs,
+  broken CJK line-height.
+- **Spacing rhythm** — values come from the scale; sibling gaps agree;
+  sections breathe in proportion to their weight. FAIL: off-scale values,
+  touching sections, arrhythmic padding.
+- **Color system** — layered backgrounds, text hierarchy through color, a
+  deliberate accent budget, semantic states. FAIL: one flood color plus
+  gray; decorative gradients with no role; contrast under the floor.
+- **State coverage** — primitives show hover, focus-visible, active,
+  disabled, loading, error, and empty. FAIL: any interactive element with
+  only a default state.
+- **Signature** — at least one deliberate element a template would not
+  have. FAIL: nothing distinguishes this surface from its framework's
+  example app.
+- **Motion restraint** — animation communicates state or causality within
+  duration tokens and respects reduced motion. FAIL: decorative motion,
+  scroll hijacking, ignored `prefers-reduced-motion`.
+- **CJK and localization fit** — when the audience needs it: fallback
+  stacks, line-height, and truncation behave in the heavy script. FAIL:
+  Latin-tuned metrics breaking CJK text.
+
+## Verdict discipline
+
+- Review content accuracy and hierarchy before visual polish; a beautiful
+  wrong page fails first on content.
+- Name the taste direction the work claims — the primary direction
+  (operational, minimalist/editorial, premium/soft, or bold/expressive)
+  declared per the frontend skill's
+  `omh-frontend/references/taste-foundations.md` — then judge inside it: an
+  operational tool is not failed for lacking gloss, and a premium surface
+  is failed for it.
+- Every FAIL names the axis, the evidence, and the smallest change that
+  would flip it.
+- A PASS requires fresh rendered evidence from the visual-QA owner across
+  the declared pages, states, and viewports; the rubric never passes work
+  from description alone.
+
+## Attribution
+
+The idea of pairing a design-system contract file with taste-direction
+material and an evidence-bound critique lane adapts concepts from the
+`frontend` skill of `code-yeongyu/oh-my-openagent@9c62b62` (Sustainable Use
+License 1.0) and its permissively licensed design upstreams:
+`Leonxlnx/taste-skill` (MIT), `nextlevelbuilder/ui-ux-pro-max-skill` (MIT),
+`Owl-Listener/designpowers` (MIT), and `nexu-io/open-design` (Apache-2.0).
+No upstream text is reproduced; the wording here is OMH's own, and OMH keeps
+its deterministic no-render boundary. Product names appear as quality
+analogies only; OMH is not affiliated with, endorsed by, or sponsored by any
+named company.

--- a/skills/omh-frontend/SKILL.md
+++ b/skills/omh-frontend/SKILL.md
@@ -77,8 +77,9 @@ Reasoning demand: `standard`
 Quality bar:
 
 - Name the product goal, audience, target surfaces, routes, states, and visual quality bar.
-- Use references and domain fit to avoid generic AI-looking frontend output.
-- Prepare a concrete design-system contract before implementation handoff.
+- Hold the named bar: what a senior product designer at a top-tier product company (the Linear/Stripe/Supabase class) would sign off on — technically clean but flat output fails it. Load `references/taste-foundations.md`, name one primary taste direction, and reject the anti-slop patterns it lists.
+- Use references and domain fit to avoid generic AI-looking frontend output; when the user supplies a visual reference, load `references/reference-token-extraction.md` and extract tokens into the contract instead of eyeballing.
+- Prepare a concrete design-system contract before implementation handoff: load `references/design-system-contract.md` and write DESIGN.md before the first component — no component code before the contract exists.
 - For first-time UI creation, name the initial generation branch, reference direction, reusable primitives, state coverage, and required visual QA path.
 - Cover responsive layout, empty/loading/error states, hover/focus/active states, CJK text, accessibility, and performance expectations.
 - Prefer native UI controls, stable dimensions, and realistic content over decorative cards, blobs, and placeholder-heavy screens.

--- a/skills/omh-frontend/references/design-system-contract.md
+++ b/skills/omh-frontend/references/design-system-contract.md
@@ -1,0 +1,77 @@
+# Design System Contract (DESIGN.md)
+
+**The gate: no component code before `DESIGN.md` exists.** Design decisions
+that live only in chat evaporate between screens; a contract file makes every
+later component answer to the same tokens. When a project already has one,
+read it and follow it — and when the work introduces a token, primitive,
+interaction state, motion rule, or piece of accepted debt the contract
+lacks, amend the contract before touching the code.
+
+## Structure
+
+`DESIGN.md` carries these sections, in order. An empty section is written as
+an explicit decision ("no elevation system; flat surfaces only") — silence is
+not a decision.
+
+0. **Research Log** (greenfield builds) — an entry for every research lane
+   that ran: the source consulted, what was taken from it (layout rhythm,
+   color logic, type pairing choices), and any skipped lane with its
+   reason. No log entry means the lane did not run.
+1. **Atmosphere & Identity** — three adjectives the surface must read as,
+   the chosen taste direction (primary, plus any deliberately borrowed
+   elements with their reasons), the one signature element a template would
+   not have, and the audience.
+2. **Color** — the full palette as tokens: background layers, text
+   hierarchy, accent budget, semantic states, borders. Name the proportion
+   discipline (for example 60/30/10) and the contrast floor (WCAG AA at
+   minimum).
+3. **Typography** — the pairing (at most two families), a modular scale with
+   named steps, weights in use, and line-height rules for body versus
+   display. When the audience reads CJK: the fallback stacks, CJK
+   line-height and letter-spacing rules, and `word-break`/truncation
+   behavior for the heavy script.
+4. **Spacing & Layout** — the base unit, the spacing scale, container
+   widths, the grid, and which element owns scroll on every screen shape.
+5. **Components** — the reusable primitives (button, input, card, nav,
+   table, ...) with their variants and every interaction state: default,
+   hover, focus-visible, active, disabled, loading, error, empty.
+6. **Motion & Interaction** — duration and easing tokens, what animates and
+   what never does, and the `prefers-reduced-motion` behavior. Motion is
+   punctuation, not decoration.
+7. **Depth & Surface** — the elevation system (shadows, borders, blur) or
+   the explicit decision not to have one.
+8. **Accessibility Constraints & Accepted Debt** — the constraints honored
+   (keyboard paths, focus order, contrast) and the debt knowingly accepted,
+   each with its reason.
+
+## Workflow
+
+- Greenfield: design research is a build step, not optional exploration —
+  consult references and real product surfaces, record each lane in section
+  0, and write the contract BEFORE the first component.
+- Existing UI without a contract: stop and ask the user which path they
+  want — either match the existing visual language and keep new styling
+  local to the code it touches, or pause to extract the contract and shared
+  primitives before continuing. Never decide silently.
+- Every implementation cites the token it uses. A value that appears in
+  code but not in `DESIGN.md` is drift: either the contract or the code is
+  wrong, and one of them gets fixed.
+
+## Boundary
+
+`DESIGN.md` is a prepared contract, not rendered evidence: implementation,
+screenshots, accessibility checks, and visual verdicts stay observed-only
+through the visual-QA and web-QA owners.
+
+## Attribution
+
+The idea of pairing a design-system contract file with taste-direction
+material and an evidence-bound critique lane adapts concepts from the
+`frontend` skill of `code-yeongyu/oh-my-openagent@9c62b62` (Sustainable Use
+License 1.0) and its permissively licensed design upstreams:
+`Leonxlnx/taste-skill` (MIT), `nextlevelbuilder/ui-ux-pro-max-skill` (MIT),
+`Owl-Listener/designpowers` (MIT), and `nexu-io/open-design` (Apache-2.0).
+No upstream text is reproduced; the wording here is OMH's own, and OMH keeps
+its deterministic no-render boundary. Product names appear as quality
+analogies only; OMH is not affiliated with, endorsed by, or sponsored by any
+named company.

--- a/skills/omh-frontend/references/reference-token-extraction.md
+++ b/skills/omh-frontend/references/reference-token-extraction.md
@@ -1,0 +1,60 @@
+# Reference Token Extraction
+
+A user-supplied reference is the visual contract. The work is extraction
+into `DESIGN.md`, not admiration: a reference that is only glanced at
+degrades into a vague mood, the contract inherits none of its precision,
+and the output lands back at generic — which is what the gate exists to
+stop.
+
+## Static reference (screenshot, mockup, Figma export)
+
+Extract into `DESIGN.md`, naming the reference in the Research Log:
+
+- palette samples per background layer, text level, and accent;
+- the type scale as measured ratios (display/heading/body/caption), the
+  weights in play, and how line-height behaves;
+- layout geometry: container width, column rhythm, section spacing values;
+- component anatomy: radii, borders, shadows, and every state treatment the
+  reference shows;
+- copy tone and density — the real shape of the content, not lorem
+  geometry.
+
+## Live URL reference
+
+When the user's selected executor or browser lane can drive a page, extract
+runtime truth instead of guessing from pixels: computed styles for tokens,
+the actual default/hover/focus/active states, transition durations and
+easings, and responsive behavior at the breakpoints that matter. Record
+what was extracted in the Research Log. OMH itself never launches a
+browser, network call, or daemon — extraction happens in the lane the user
+selected, and only its recorded findings enter the contract.
+
+## Fidelity discipline
+
+- Extract tokens and layout grammar; never copy logos, trademarks, or
+  brand copy.
+- Recombine into project-specific primitives — the reference calibrates
+  quality; it does not become the product.
+- Final QA for reference-driven work goes to the visual-QA owner: request a
+  `visual_qa_plan/v1` whose references name the supplied reference, with
+  the visual-fidelity review perspective comparing the rendered result
+  against it side by side — and verify the implementation is a reusable
+  design-system build, not a screenshot-matched one-off.
+
+## Boundary
+
+Extraction produces a prepared contract. Rendered comparisons, screenshots,
+and PASS verdicts belong to the visual-QA owner and stay observed-only.
+
+## Attribution
+
+The idea of pairing a design-system contract file with taste-direction
+material and an evidence-bound critique lane adapts concepts from the
+`frontend` skill of `code-yeongyu/oh-my-openagent@9c62b62` (Sustainable Use
+License 1.0) and its permissively licensed design upstreams:
+`Leonxlnx/taste-skill` (MIT), `nextlevelbuilder/ui-ux-pro-max-skill` (MIT),
+`Owl-Listener/designpowers` (MIT), and `nexu-io/open-design` (Apache-2.0).
+No upstream text is reproduced; the wording here is OMH's own, and OMH keeps
+its deterministic no-render boundary. Product names appear as quality
+analogies only; OMH is not affiliated with, endorsed by, or sponsored by any
+named company.

--- a/skills/omh-frontend/references/taste-foundations.md
+++ b/skills/omh-frontend/references/taste-foundations.md
@@ -1,0 +1,77 @@
+# Taste Foundations
+
+**Hold the work to what a senior product designer at a top-tier product company — the Linear/Stripe/Supabase class — would sign off on. Technically clean output that reads
+flat does not clear this bar — flatness is a defect to fix, not a baseline
+to accept.** Generic output is not a neutral outcome; it is the specific
+failure this reference exists to prevent.
+
+## Name one primary direction
+
+Taste directions pull in different directions; blending them by accident
+produces mud. Name ONE primary direction in `DESIGN.md` section 1. An
+element genuinely borrowed from another direction is allowed — named there
+with its reason — so a hybrid brief (a premium marketing shell over an
+operational product) stays expressible without dissolving into no direction
+at all.
+
+- **Operational** — dense internal tools and dashboards where utility
+  leads: information density over drama, native controls, stable
+  dimensions, restrained color. Typical failure: settling here when the
+  brief wants a public, polished surface.
+- **Minimalist / editorial** — briefs that want whitespace-led calm and
+  reading-first structure: generous space, a strict type scale doing the
+  hierarchy work, a single accent, almost no ornament. Typical failure:
+  emptiness without rhythm — minimal is a spacing system, not an absence.
+- **Premium / soft** — surfaces that should feel costly and unhurried:
+  layered depth, soft large-radius shadows, muted-but-saturated palette,
+  slow small motion. Typical failure: gloss layered over weak hierarchy.
+- **Bold / expressive** — statement pages that lead with oversized display
+  type and hard contrast, breaking one grid rule at a time on purpose.
+  Typical failure: every element shouting, so nothing leads.
+
+## Anti-slop checklist — reject on sight
+
+- Template gravity: rows of three equal cards, hero-icon-grid boilerplate,
+  floating decorative shapes with no content role.
+- One-note palette: a single flood color plus gray, no layered backgrounds,
+  no semantic states.
+- Weak hierarchy: adjacent text sizes doing three jobs, everything at
+  medium weight, headings that do not organize scanning.
+- Arrhythmic spacing: values off the scale, sections that touch, sibling
+  padding that differs for no stated reason.
+- Placeholder gravity: lorem-shaped copy, unrealistic content, empty states
+  never designed.
+- Missing states: any interactive primitive without hover, focus-visible,
+  active, disabled, loading, error, and empty treatments.
+- Motion as decoration: animation that communicates neither state nor
+  causality, or that ignores `prefers-reduced-motion`.
+- CJK as an afterthought: Latin-tuned line-height and truncation applied
+  unchanged to a Korean, Japanese, or Chinese audience.
+
+## Content before chrome
+
+Before laying anything out, list what the surface must say and decide what
+each block is for: draw attention, explain, build trust, support
+comparison, drive the action, or help people find their way. Sequence
+sections in the order a visitor actually decides; visual symmetry never
+outranks that sequence. Review content accuracy and hierarchy before any
+polish — a beautiful wrong page fails first on content.
+
+## Boundary
+
+Taste guidance shapes the prepared direction and contract. It never
+substitutes for observed rendered evidence: the visual-QA owner judges what
+actually shipped.
+
+## Attribution
+
+The idea of pairing a design-system contract file with taste-direction
+material and an evidence-bound critique lane adapts concepts from the
+`frontend` skill of `code-yeongyu/oh-my-openagent@9c62b62` (Sustainable Use
+License 1.0) and its permissively licensed design upstreams:
+`Leonxlnx/taste-skill` (MIT), `nextlevelbuilder/ui-ux-pro-max-skill` (MIT),
+`Owl-Listener/designpowers` (MIT), and `nexu-io/open-design` (Apache-2.0).
+No upstream text is reproduced; the wording here is OMH's own, and OMH keeps
+its deterministic no-render boundary. Product names appear as quality
+analogies only; OMH is not affiliated with, endorsed by, or sponsored by any
+named company.

--- a/src/maintenance/release.py
+++ b/src/maintenance/release.py
@@ -204,7 +204,15 @@ STANDALONE_CAPABILITY_SKILL_ITEM_CHAR_LIMIT = 2200
 # say-not-observed carve-out for directly asked figures (renders into all
 # three handoff-guide skill bodies; the common rail carries the same text but
 # sits outside this metric); warranted growth.
-FULL_PROFILE_SKILL_BODY_CHAR_LIMIT = 716418
+# 716418 -> 717490: the design family gained its named craft bar and the
+# pointers into the new on-demand references (+1072 chars across the
+# frontend, design-quality-gate, and design-orchestration quality bars:
+# the named senior-designer bar with flat-output-fails, the
+# DESIGN.md-before-code contract gate, primary-taste-direction selection,
+# and reference-token extraction). The four reference bodies themselves
+# load on demand and sit outside this always-loaded budget; warranted
+# growth.
+FULL_PROFILE_SKILL_BODY_CHAR_LIMIT = 717490
 FULL_PROFILE_SKILL_BODY_REVIEWED_EXCEPTION_CHARS = 0
 
 

--- a/src/skills/catalog_definitions.py
+++ b/src/skills/catalog_definitions.py
@@ -2642,7 +2642,7 @@ _DEFINITIONS = [
         quality_tier="design-orchestration-gated",
         quality_bar=(
             "Make the design job, context boundary, direction, downstream lane ownership, and visual evidence requirements readable before handoff.",
-            "Reject generic default drift by naming hierarchy, palette, typography, layout, signature element, and avoid patterns deliberately.",
+            "Reject generic default drift by naming hierarchy, palette, typography, layout, signature element, and avoid patterns deliberately — the direction vocabulary and anti-slop patterns live in the frontend skill's `omh-frontend/references/taste-foundations.md`; prepared directions inherit its named bar (technically clean but flat fails).",
             "Require the selected executor and fresh visual evidence separately before any implementation or quality completion claim.",
         ),
         why_this_exists=(
@@ -2743,7 +2743,7 @@ _DEFINITIONS = [
         ),
         quality_tier="design-pro-gated",
         quality_bar=(
-            "Define superior design quality with references, audience, hierarchy, style, and measurable QA gates.",
+            "Define superior design quality with references, audience, hierarchy, style, and measurable QA gates. The bar is named, not relative: what a senior product designer at a top-tier product company (the Linear/Stripe/Supabase class) would sign off on — technically clean but flat output fails it. Load `references/design-critique-rubric.md` and judge every axis with named evidence.",
             "State why the result should be better than ordinary output, including content depth, visual hierarchy, spacing, typography, and interaction or export polish.",
             "Review content accuracy and hierarchy before visual polish.",
             "Use design-system/reference rules for web, deck, PDF, and poster surfaces.",
@@ -2891,8 +2891,9 @@ _DEFINITIONS = [
         quality_tier="frontend-design-gated",
         quality_bar=(
             "Name the product goal, audience, target surfaces, routes, states, and visual quality bar.",
-            "Use references and domain fit to avoid generic AI-looking frontend output.",
-            "Prepare a concrete design-system contract before implementation handoff.",
+            "Hold the named bar: what a senior product designer at a top-tier product company (the Linear/Stripe/Supabase class) would sign off on — technically clean but flat output fails it. Load `references/taste-foundations.md`, name one primary taste direction, and reject the anti-slop patterns it lists.",
+            "Use references and domain fit to avoid generic AI-looking frontend output; when the user supplies a visual reference, load `references/reference-token-extraction.md` and extract tokens into the contract instead of eyeballing.",
+            "Prepare a concrete design-system contract before implementation handoff: load `references/design-system-contract.md` and write DESIGN.md before the first component — no component code before the contract exists.",
             "For first-time UI creation, name the initial generation branch, reference direction, reusable primitives, state coverage, and required visual QA path.",
             "Cover responsive layout, empty/loading/error states, hover/focus/active states, CJK text, accessibility, and performance expectations.",
             "Prefer native UI controls, stable dimensions, and realistic content over decorative cards, blobs, and placeholder-heavy screens.",

--- a/src/skills/packaging.py
+++ b/src/skills/packaging.py
@@ -12,6 +12,7 @@ from .render import (
     context_reference_templates,
     context_skill,
     deep_interview_skill,
+    design_reference_templates,
     jit_learn_skill,
     loop_reference_templates,
     loop_skill,
@@ -38,6 +39,7 @@ def builtin_skill_reference_templates() -> list[SkillReferenceTemplate]:
         *context_reference_templates(),
         *buzz_reference_templates(),
         *loop_reference_templates(),
+        *design_reference_templates(),
     ]
 
 

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -2653,3 +2653,306 @@ the full rule set; this file only covers the reviewee's side.
 Reading a finding is not fixing it. A fix is observed only when the command that
 demonstrated the defect no longer does.
 """
+
+
+def design_reference_templates() -> list[SkillReferenceTemplate]:
+    return list(_design_reference_templates_cached())
+
+
+@lru_cache(maxsize=1)
+def _design_reference_templates_cached() -> tuple[SkillReferenceTemplate, ...]:
+    return (
+        SkillReferenceTemplate(
+            "frontend",
+            "references/design-system-contract.md",
+            _design_system_contract_reference(),
+        ),
+        SkillReferenceTemplate(
+            "frontend",
+            "references/taste-foundations.md",
+            _taste_foundations_reference(),
+        ),
+        SkillReferenceTemplate(
+            "frontend",
+            "references/reference-token-extraction.md",
+            _reference_token_extraction_reference(),
+        ),
+        SkillReferenceTemplate(
+            "design-quality-gate",
+            "references/design-critique-rubric.md",
+            _design_critique_rubric_reference(),
+        ),
+    )
+
+
+# The one sentence every design surface holds the work to. Defined once so a
+# future re-cut of the bar (a brand analogy going stale) is a single edit.
+DESIGN_NAMED_BAR = (
+    "what a senior product designer at a top-tier product company — the "
+    "Linear/Stripe/Supabase class — would sign off on"
+)
+
+# Concept lineage only. The wording in these references is OMH's own — the
+# nearest upstream architecture (oh-my-openagent's frontend skill) is under
+# the Sustainable Use License, so no upstream text is reproduced anywhere in
+# this family; its permissively licensed design upstreams are credited as
+# the idea sources they are.
+_DESIGN_CRAFT_ATTRIBUTION = """## Attribution
+
+The idea of pairing a design-system contract file with taste-direction
+material and an evidence-bound critique lane adapts concepts from the
+`frontend` skill of `code-yeongyu/oh-my-openagent@9c62b62` (Sustainable Use
+License 1.0) and its permissively licensed design upstreams:
+`Leonxlnx/taste-skill` (MIT), `nextlevelbuilder/ui-ux-pro-max-skill` (MIT),
+`Owl-Listener/designpowers` (MIT), and `nexu-io/open-design` (Apache-2.0).
+No upstream text is reproduced; the wording here is OMH's own, and OMH keeps
+its deterministic no-render boundary. Product names appear as quality
+analogies only; OMH is not affiliated with, endorsed by, or sponsored by any
+named company."""
+
+
+def _design_system_contract_reference() -> str:
+    return f"""# Design System Contract (DESIGN.md)
+
+**The gate: no component code before `DESIGN.md` exists.** Design decisions
+that live only in chat evaporate between screens; a contract file makes every
+later component answer to the same tokens. When a project already has one,
+read it and follow it — and when the work introduces a token, primitive,
+interaction state, motion rule, or piece of accepted debt the contract
+lacks, amend the contract before touching the code.
+
+## Structure
+
+`DESIGN.md` carries these sections, in order. An empty section is written as
+an explicit decision ("no elevation system; flat surfaces only") — silence is
+not a decision.
+
+0. **Research Log** (greenfield builds) — an entry for every research lane
+   that ran: the source consulted, what was taken from it (layout rhythm,
+   color logic, type pairing choices), and any skipped lane with its
+   reason. No log entry means the lane did not run.
+1. **Atmosphere & Identity** — three adjectives the surface must read as,
+   the chosen taste direction (primary, plus any deliberately borrowed
+   elements with their reasons), the one signature element a template would
+   not have, and the audience.
+2. **Color** — the full palette as tokens: background layers, text
+   hierarchy, accent budget, semantic states, borders. Name the proportion
+   discipline (for example 60/30/10) and the contrast floor (WCAG AA at
+   minimum).
+3. **Typography** — the pairing (at most two families), a modular scale with
+   named steps, weights in use, and line-height rules for body versus
+   display. When the audience reads CJK: the fallback stacks, CJK
+   line-height and letter-spacing rules, and `word-break`/truncation
+   behavior for the heavy script.
+4. **Spacing & Layout** — the base unit, the spacing scale, container
+   widths, the grid, and which element owns scroll on every screen shape.
+5. **Components** — the reusable primitives (button, input, card, nav,
+   table, ...) with their variants and every interaction state: default,
+   hover, focus-visible, active, disabled, loading, error, empty.
+6. **Motion & Interaction** — duration and easing tokens, what animates and
+   what never does, and the `prefers-reduced-motion` behavior. Motion is
+   punctuation, not decoration.
+7. **Depth & Surface** — the elevation system (shadows, borders, blur) or
+   the explicit decision not to have one.
+8. **Accessibility Constraints & Accepted Debt** — the constraints honored
+   (keyboard paths, focus order, contrast) and the debt knowingly accepted,
+   each with its reason.
+
+## Workflow
+
+- Greenfield: design research is a build step, not optional exploration —
+  consult references and real product surfaces, record each lane in section
+  0, and write the contract BEFORE the first component.
+- Existing UI without a contract: stop and ask the user which path they
+  want — either match the existing visual language and keep new styling
+  local to the code it touches, or pause to extract the contract and shared
+  primitives before continuing. Never decide silently.
+- Every implementation cites the token it uses. A value that appears in
+  code but not in `DESIGN.md` is drift: either the contract or the code is
+  wrong, and one of them gets fixed.
+
+## Boundary
+
+`DESIGN.md` is a prepared contract, not rendered evidence: implementation,
+screenshots, accessibility checks, and visual verdicts stay observed-only
+through the visual-QA and web-QA owners.
+
+{_DESIGN_CRAFT_ATTRIBUTION}
+"""
+
+
+def _taste_foundations_reference() -> str:
+    return f"""# Taste Foundations
+
+**Hold the work to {DESIGN_NAMED_BAR}. Technically clean output that reads
+flat does not clear this bar — flatness is a defect to fix, not a baseline
+to accept.** Generic output is not a neutral outcome; it is the specific
+failure this reference exists to prevent.
+
+## Name one primary direction
+
+Taste directions pull in different directions; blending them by accident
+produces mud. Name ONE primary direction in `DESIGN.md` section 1. An
+element genuinely borrowed from another direction is allowed — named there
+with its reason — so a hybrid brief (a premium marketing shell over an
+operational product) stays expressible without dissolving into no direction
+at all.
+
+- **Operational** — dense internal tools and dashboards where utility
+  leads: information density over drama, native controls, stable
+  dimensions, restrained color. Typical failure: settling here when the
+  brief wants a public, polished surface.
+- **Minimalist / editorial** — briefs that want whitespace-led calm and
+  reading-first structure: generous space, a strict type scale doing the
+  hierarchy work, a single accent, almost no ornament. Typical failure:
+  emptiness without rhythm — minimal is a spacing system, not an absence.
+- **Premium / soft** — surfaces that should feel costly and unhurried:
+  layered depth, soft large-radius shadows, muted-but-saturated palette,
+  slow small motion. Typical failure: gloss layered over weak hierarchy.
+- **Bold / expressive** — statement pages that lead with oversized display
+  type and hard contrast, breaking one grid rule at a time on purpose.
+  Typical failure: every element shouting, so nothing leads.
+
+## Anti-slop checklist — reject on sight
+
+- Template gravity: rows of three equal cards, hero-icon-grid boilerplate,
+  floating decorative shapes with no content role.
+- One-note palette: a single flood color plus gray, no layered backgrounds,
+  no semantic states.
+- Weak hierarchy: adjacent text sizes doing three jobs, everything at
+  medium weight, headings that do not organize scanning.
+- Arrhythmic spacing: values off the scale, sections that touch, sibling
+  padding that differs for no stated reason.
+- Placeholder gravity: lorem-shaped copy, unrealistic content, empty states
+  never designed.
+- Missing states: any interactive primitive without hover, focus-visible,
+  active, disabled, loading, error, and empty treatments.
+- Motion as decoration: animation that communicates neither state nor
+  causality, or that ignores `prefers-reduced-motion`.
+- CJK as an afterthought: Latin-tuned line-height and truncation applied
+  unchanged to a Korean, Japanese, or Chinese audience.
+
+## Content before chrome
+
+Before laying anything out, list what the surface must say and decide what
+each block is for: draw attention, explain, build trust, support
+comparison, drive the action, or help people find their way. Sequence
+sections in the order a visitor actually decides; visual symmetry never
+outranks that sequence. Review content accuracy and hierarchy before any
+polish — a beautiful wrong page fails first on content.
+
+## Boundary
+
+Taste guidance shapes the prepared direction and contract. It never
+substitutes for observed rendered evidence: the visual-QA owner judges what
+actually shipped.
+
+{_DESIGN_CRAFT_ATTRIBUTION}
+"""
+
+
+def _reference_token_extraction_reference() -> str:
+    return f"""# Reference Token Extraction
+
+A user-supplied reference is the visual contract. The work is extraction
+into `DESIGN.md`, not admiration: a reference that is only glanced at
+degrades into a vague mood, the contract inherits none of its precision,
+and the output lands back at generic — which is what the gate exists to
+stop.
+
+## Static reference (screenshot, mockup, Figma export)
+
+Extract into `DESIGN.md`, naming the reference in the Research Log:
+
+- palette samples per background layer, text level, and accent;
+- the type scale as measured ratios (display/heading/body/caption), the
+  weights in play, and how line-height behaves;
+- layout geometry: container width, column rhythm, section spacing values;
+- component anatomy: radii, borders, shadows, and every state treatment the
+  reference shows;
+- copy tone and density — the real shape of the content, not lorem
+  geometry.
+
+## Live URL reference
+
+When the user's selected executor or browser lane can drive a page, extract
+runtime truth instead of guessing from pixels: computed styles for tokens,
+the actual default/hover/focus/active states, transition durations and
+easings, and responsive behavior at the breakpoints that matter. Record
+what was extracted in the Research Log. OMH itself never launches a
+browser, network call, or daemon — extraction happens in the lane the user
+selected, and only its recorded findings enter the contract.
+
+## Fidelity discipline
+
+- Extract tokens and layout grammar; never copy logos, trademarks, or
+  brand copy.
+- Recombine into project-specific primitives — the reference calibrates
+  quality; it does not become the product.
+- Final QA for reference-driven work goes to the visual-QA owner: request a
+  `visual_qa_plan/v1` whose references name the supplied reference, with
+  the visual-fidelity review perspective comparing the rendered result
+  against it side by side — and verify the implementation is a reusable
+  design-system build, not a screenshot-matched one-off.
+
+## Boundary
+
+Extraction produces a prepared contract. Rendered comparisons, screenshots,
+and PASS verdicts belong to the visual-QA owner and stay observed-only.
+
+{_DESIGN_CRAFT_ATTRIBUTION}
+"""
+
+
+def _design_critique_rubric_reference() -> str:
+    return f"""# Design Critique Rubric
+
+The critique lane's question is never "is it correct?" — it is "does this
+clear {DESIGN_NAMED_BAR}?". **Technically clean but flat fails.** Judge each
+axis explicitly; a PASS with no named evidence per axis is not a review.
+
+## Axes
+
+- **Hierarchy** — one glance names what leads, what supports, what recedes.
+  FAIL: adjacent elements competing at equal weight; headings that do not
+  organize scanning.
+- **Type discipline** — a modular scale is in use; display and body behave
+  differently on purpose. FAIL: arbitrary sizes, one step doing three jobs,
+  broken CJK line-height.
+- **Spacing rhythm** — values come from the scale; sibling gaps agree;
+  sections breathe in proportion to their weight. FAIL: off-scale values,
+  touching sections, arrhythmic padding.
+- **Color system** — layered backgrounds, text hierarchy through color, a
+  deliberate accent budget, semantic states. FAIL: one flood color plus
+  gray; decorative gradients with no role; contrast under the floor.
+- **State coverage** — primitives show hover, focus-visible, active,
+  disabled, loading, error, and empty. FAIL: any interactive element with
+  only a default state.
+- **Signature** — at least one deliberate element a template would not
+  have. FAIL: nothing distinguishes this surface from its framework's
+  example app.
+- **Motion restraint** — animation communicates state or causality within
+  duration tokens and respects reduced motion. FAIL: decorative motion,
+  scroll hijacking, ignored `prefers-reduced-motion`.
+- **CJK and localization fit** — when the audience needs it: fallback
+  stacks, line-height, and truncation behave in the heavy script. FAIL:
+  Latin-tuned metrics breaking CJK text.
+
+## Verdict discipline
+
+- Review content accuracy and hierarchy before visual polish; a beautiful
+  wrong page fails first on content.
+- Name the taste direction the work claims — the primary direction
+  (operational, minimalist/editorial, premium/soft, or bold/expressive)
+  declared per the frontend skill's
+  `omh-frontend/references/taste-foundations.md` — then judge inside it: an
+  operational tool is not failed for lacking gloss, and a premium surface
+  is failed for it.
+- Every FAIL names the axis, the evidence, and the smallest change that
+  would flip it.
+- A PASS requires fresh rendered evidence from the visual-QA owner across
+  the declared pages, states, and viewports; the rubric never passes work
+  from description alone.
+
+{_DESIGN_CRAFT_ATTRIBUTION}
+"""

--- a/tests/test_design_craft_references.py
+++ b/tests/test_design_craft_references.py
@@ -1,0 +1,231 @@
+"""Design craft references: the named bar, the contract gate, the rubric.
+
+Live design output through OMH read as generic because the design skills
+stated abstract quality bars with no craft material behind them. These tests
+pin the fix: the always-loaded skill bodies carry a NAMED bar and pointers,
+and the on-demand references carry the material — the DESIGN.md contract
+gate, the taste directions with their anti-slop checklist, the
+reference-token extraction contract, and the critique rubric. The wording is
+OMH's own; the concept lineage (oh-my-openagent's frontend architecture and
+its permissively licensed design upstreams) is credited inside each
+reference with a pinned commit and an explicit no-text-reproduced statement,
+because the nearest upstream is Sustainable-Use-licensed and OMH is MIT.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+from omh.skill_pack import builtin_skill_reference_templates, builtin_skill_templates
+from omh.skills.catalog_types import omh_skill_display_name
+from omh.skills.render import DESIGN_NAMED_BAR, design_reference_templates
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+FLAT_FAILS = "technically clean but flat"
+
+
+def _unwrapped(content: str) -> str:
+    """Soft line wraps collapsed, for phrase assertions that span lines."""
+    return " ".join(content.split())
+
+
+def _reference(skill: str, relative_path: str) -> str:
+    for template in design_reference_templates():
+        if template.skill_name == skill and template.relative_path == relative_path:
+            return template.content
+    raise AssertionError(f"missing design reference {skill}/{relative_path}")
+
+
+def _body(skill: str) -> str:
+    for template in builtin_skill_templates():
+        if template.name == skill:
+            return template.content
+    raise AssertionError(f"missing skill {skill}")
+
+
+class DesignReferenceRegistryTests(unittest.TestCase):
+    def test_all_four_references_are_registered_and_on_disk(self) -> None:
+        expected = {
+            ("frontend", "references/design-system-contract.md"),
+            ("frontend", "references/taste-foundations.md"),
+            ("frontend", "references/reference-token-extraction.md"),
+            ("design-quality-gate", "references/design-critique-rubric.md"),
+        }
+        registered = {
+            (template.skill_name, template.relative_path)
+            for template in builtin_skill_reference_templates()
+        }
+        self.assertLessEqual(expected, registered)
+        for skill, relative_path in expected:
+            path = REPO_ROOT / "skills" / omh_skill_display_name(skill) / relative_path
+            self.assertTrue(path.exists(), path)
+            self.assertEqual(path.read_text(encoding="utf-8"), _reference(skill, relative_path))
+
+    def test_every_reference_carries_the_honest_concept_lineage(self) -> None:
+        # The nearest upstream architecture is Sustainable-Use-licensed and
+        # OMH is MIT, so the attribution must (a) pin the upstream commit,
+        # (b) state that no upstream text is reproduced, (c) credit the
+        # permissive design upstreams the concepts actually come from, and
+        # (d) carry the non-affiliation line for the named brands.
+        for template in design_reference_templates():
+            content = template.content
+            self.assertIn("## Attribution", content, template.relative_path)
+            self.assertRegex(content, r"oh-my-openagent@[0-9a-f]{7,}", template.relative_path)
+            self.assertIn("Sustainable Use", content, template.relative_path)
+            self.assertIn("No upstream text is reproduced", content, template.relative_path)
+            for upstream in ("taste-skill", "ui-ux-pro-max-skill", "designpowers", "open-design"):
+                self.assertIn(upstream, content, f"{template.relative_path}: {upstream}")
+            self.assertIn("not affiliated with", content, template.relative_path)
+            # The retired, incorrect claim must not resurface.
+            self.assertNotIn("Apache-2.0, code-yeongyu", content, template.relative_path)
+
+
+class DesignSystemContractTests(unittest.TestCase):
+    def test_the_gate_is_stated_before_the_structure(self) -> None:
+        content = _reference("frontend", "references/design-system-contract.md")
+        self.assertIn("no component code before `DESIGN.md` exists", content)
+        for heading in (
+            "Research Log",
+            "Atmosphere & Identity",
+            "Color",
+            "Typography",
+            "Spacing & Layout",
+            "Components",
+            "Motion & Interaction",
+            "Depth & Surface",
+            "Accessibility Constraints & Accepted Debt",
+        ):
+            self.assertIn(heading, content, heading)
+        # Empty sections are decisions; existing UI without a contract stops
+        # and asks; a code value outside the contract is drift.
+        self.assertIn("silence is not a decision", _unwrapped(content))
+        self.assertIn("Never decide silently", content)
+        self.assertIn("drift", content)
+        self.assertIn("observed-only", content)
+
+    def test_section_one_carries_the_taste_direction_the_rubric_judges_by(self) -> None:
+        # The rubric judges inside the claimed direction, so the contract
+        # must have a place to declare it — including borrowed elements.
+        content = _reference("frontend", "references/design-system-contract.md")
+        self.assertIn("the chosen taste direction (primary", content)
+        self.assertIn("borrowed", content)
+
+    def test_typography_covers_cjk_metrics_not_just_fallbacks(self) -> None:
+        content = _reference("frontend", "references/design-system-contract.md")
+        self.assertIn("CJK", content)
+        self.assertIn("word-break", content)
+        self.assertIn("truncation", content)
+
+
+class TasteFoundationsTests(unittest.TestCase):
+    def test_the_bar_is_named_and_flatness_fails(self) -> None:
+        content = _reference("frontend", "references/taste-foundations.md")
+        self.assertIn(DESIGN_NAMED_BAR, content)
+        self.assertIn("flatness is a defect", content)
+
+    def test_primary_direction_with_declared_borrowing(self) -> None:
+        # Exactly-one would make a hybrid brief unrepresentable; the rule is
+        # one PRIMARY direction plus named borrowed elements.
+        content = _reference("frontend", "references/taste-foundations.md")
+        self.assertIn("Name one primary direction", content)
+        self.assertIn("borrowed from another direction", content)
+        for direction in ("Operational", "Minimalist", "Premium", "Bold"):
+            self.assertIn(direction, content, direction)
+
+    def test_anti_slop_checklist_names_the_failure_modes(self) -> None:
+        content = _reference("frontend", "references/taste-foundations.md")
+        for marker in (
+            "Anti-slop checklist",
+            "Template gravity",
+            "One-note palette",
+            "Weak hierarchy",
+            "Missing states",
+            "prefers-reduced-motion",
+            "CJK as an afterthought",
+        ):
+            self.assertIn(marker, content, marker)
+
+    def test_content_ordering_beats_visual_symmetry(self) -> None:
+        content = _reference("frontend", "references/taste-foundations.md")
+        self.assertIn("visual symmetry never outranks that sequence", _unwrapped(content))
+
+
+class ReferenceTokenExtractionTests(unittest.TestCase):
+    def test_extraction_covers_static_and_live_references(self) -> None:
+        content = _reference("frontend", "references/reference-token-extraction.md")
+        self.assertIn("Static reference", content)
+        self.assertIn("Live URL reference", content)
+        self.assertIn("OMH itself never launches a browser", _unwrapped(content))
+        self.assertIn("never copy logos", content)
+
+    def test_fidelity_qa_is_stated_in_omh_vocabulary(self) -> None:
+        # "reference-fidelity mode" was a dangling capability name; the QA
+        # request is stated through the artifacts visual-qa actually owns.
+        content = _reference("frontend", "references/reference-token-extraction.md")
+        self.assertIn("visual_qa_plan/v1", content)
+        self.assertIn("visual-fidelity review perspective", content)
+        self.assertNotIn("reference-fidelity mode", content)
+
+
+class DesignCritiqueRubricTests(unittest.TestCase):
+    def test_rubric_axes_each_carry_a_fail_condition(self) -> None:
+        content = _reference("design-quality-gate", "references/design-critique-rubric.md")
+        for axis in (
+            "Hierarchy",
+            "Type discipline",
+            "Spacing rhythm",
+            "Color system",
+            "State coverage",
+            "Signature",
+            "Motion restraint",
+            "CJK",
+        ):
+            self.assertIn(axis, content, axis)
+        self.assertGreaterEqual(content.count("FAIL:"), 8)
+
+    def test_verdicts_name_the_direction_vocabulary_and_its_source(self) -> None:
+        # The rubric judges inside the claimed direction, so it must carry
+        # the four direction names AND the skill-rooted path to their
+        # definitions — design-quality-gate covers deck/PDF/poster surfaces
+        # where the frontend skill would never be consulted first.
+        content = _reference("design-quality-gate", "references/design-critique-rubric.md")
+        self.assertIn("omh-frontend/references/taste-foundations.md", content)
+        for direction in ("operational", "minimalist/editorial", "premium/soft", "bold/expressive"):
+            self.assertIn(direction, content, direction)
+        self.assertIn("judge inside it", content)
+        self.assertIn("smallest change", content)
+        self.assertIn("never passes work", content)
+
+    def test_the_rubric_question_is_the_named_bar(self) -> None:
+        content = _reference("design-quality-gate", "references/design-critique-rubric.md")
+        self.assertIn(DESIGN_NAMED_BAR, content)
+        self.assertIn("Technically clean but flat fails", content)
+
+
+class SkillBodyPointerTests(unittest.TestCase):
+    def test_frontend_body_carries_the_named_bar_and_all_three_pointers(self) -> None:
+        body = _body("frontend")
+        self.assertIn("Linear/Stripe/Supabase class", body)
+        self.assertIn(FLAT_FAILS, body)
+        self.assertIn("references/design-system-contract.md", body)
+        self.assertIn("references/taste-foundations.md", body)
+        self.assertIn("references/reference-token-extraction.md", body)
+        self.assertIn("no component code before the contract exists", body)
+
+    def test_quality_gate_body_points_at_the_rubric(self) -> None:
+        body = _body("design-quality-gate")
+        self.assertIn("references/design-critique-rubric.md", body)
+        self.assertIn(FLAT_FAILS, body)
+
+    def test_orchestration_body_uses_a_skill_rooted_reference_path(self) -> None:
+        # design-orchestration ships no references/ directory of its own, so
+        # a bare relative path would resolve to nothing from its skill root.
+        body = _body("design-orchestration")
+        self.assertIn("omh-frontend/references/taste-foundations.md", body)
+        self.assertIn(FLAT_FAILS, body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Capability

The design skill family (frontend, design-quality-gate, design-orchestration) gains a NAMED craft bar in its always-loaded quality bars — "what a senior product designer at a top-tier product company (the Linear/Stripe/Supabase class) would sign off on; technically clean but flat output fails it" — plus four on-demand references carrying the craft material the bars previously only alluded to:

- `omh-frontend/references/design-system-contract.md` — the DESIGN.md gate (no component code before the contract exists), a nine-section contract including the greenfield Research Log and the declared taste direction, empty-sections-are-decisions, stop-and-ask for existing UI without a contract, and code-vs-contract drift discipline.
- `omh-frontend/references/taste-foundations.md` — the named bar, one PRIMARY taste direction with declared borrowing (hybrid briefs stay representable), four directions each with its typical failure, the anti-slop checklist (including CJK-as-afterthought), and content-before-chrome ordering.
- `omh-frontend/references/reference-token-extraction.md` — static and live reference extraction into the contract, fidelity QA stated in OMH vocabulary (`visual_qa_plan/v1` + the visual-fidelity review perspective), and the restated boundary that OMH never launches a browser.
- `omh-design-quality-gate/references/design-critique-rubric.md` — eight axes each with explicit FAIL conditions, direction-aware verdicts naming the four directions and their skill-rooted source path, evidence-bound PASS.

## Motivation

Owner asked why design output through OMH reads weaker than coding agents' ("디자인이 약한거같은데... 기준을 낮게잡는거같기도하고 그 이유가 뭐야"). Diagnosis: the design skills stated abstract quality bars ("reject generic AI slop") with no craft material behind them — no contract artifact, no taste definitions, no extraction discipline, no judgeable rubric — so the model fell back to its defaults, which is exactly the slop the bars named. The nearest upstream with this architecture solved it with always-loaded bars + on-demand craft references; this PR ports the architecture (not the text) into OMH's catalog/render pipeline.

## Implementation (boundary level)

- `src/skills/render.py`: `design_reference_templates()` producing the four `SkillReferenceTemplate`s; `DESIGN_NAMED_BAR` public constant; a shared trailing `## Attribution` section.
- `src/skills/packaging.py`: references registered in `builtin_skill_reference_templates()`.
- `src/skills/catalog_definitions.py`: the three quality bars gain the named bar and load pointers (design-orchestration uses the skill-rooted `omh-frontend/references/...` path since it ships no references of its own).
- `src/maintenance/release.py`: body budget ratchet 716418 -> 717490 (+1072 chars of pointers; reference bodies load on demand, outside the budget).
- Generated artifacts regenerated: `skills/omh-frontend/**`, `skills/omh-design-quality-gate/**`, `skills/omh-design-orchestration/SKILL.md`, `docs/WORKFLOWS.md`.

## Licensing

Handled on review evidence: the nearest upstream architecture (code-yeongyu/oh-my-openagent, pinned @9c62b62) places its adapted design files under Sustainable Use License 1.0, while OMH is MIT — so no upstream text may be reproduced. Every passage the review flagged was rewritten until an 8-gram overlap scan against the full upstream skill tree shows zero non-boilerplate shared runs. Each reference ends with the repo's Attribution convention: pinned upstream commit + its real license, the four permissively licensed design upstreams the concepts derive from (taste-skill MIT, ui-ux-pro-max-skill MIT, designpowers MIT, open-design Apache-2.0), an explicit no-upstream-text-reproduced statement, and a brand non-affiliation line.

## Verification (observed)

- `PYTHONPATH=tests uv run python -m unittest discover -s tests` — 7336 tests OK on the final tree.
- `tests/test_design_craft_references.py` — 17 contract tests pin the gate line, named bar (via `DESIGN_NAMED_BAR`), directions, anti-slop markers, rubric FAIL counts, OMH-vocabulary fidelity QA, skill-rooted cross-references, attribution invariants (pinned SHA regex, no-text-reproduced line, all four upstreams, the retired Apache claim staying gone), disk/producer byte-parity.
- All five `omh docs * --check` byte gates OK (tap-skills 128 files); ruff; compileall; `git diff --check`.
- 8-gram overlap scan: 0 non-boilerplate hits across all four references.

## Risks

Low — instruction-text surface only; no routing triggers added; reaches machines via `omh update`. Live design output quality through a Hermes run is not directly observable from this repo (prepared_not_observed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKo77o5dTJtLRWfDj4uBtq