### PR TITLE
fix(routing): vanilla configs route again, and fallback lanes say so

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -276,6 +276,15 @@ walks, and HUD category labels alike — until the user removes it. An invalid
 document is ignored whole (defaults apply) and reported by
 `omh_delegate_route` `action=status` as `chain_overrides: invalid: ...`.
 
+Next to those two documents, `omh_delegate_route` maintains
+`~/.omh/routing/route-provenance.json` (`delegation_route_provenance/v1`): a
+capped history of the routes it prepared (head, explicit, fallback, chain
+exhaustion, clear) that the HUD uses to label a fallback lane as a fallback
+and an exhausted chain as `category→inherit`. It is written automatically,
+carries its own `claim_boundary` (prepared routes only, never dispatch
+evidence), and is safe to delete — an absent or invalid file only means HUD
+rows fall back to plain category projection.
+
 ### Reaching models through a provider
 
 Chains name models the way a person says them (`glm-5.2`, `kimi-k3`). A host

--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -161,12 +161,23 @@ export default function register(sdk) {
     const taskId = truncateCells(safeText(row.task_id) || safeText(row.role) || 'agent', 8).padEnd(8)
     const model = [safeText(row.model), safeText(row.effort)].filter(Boolean).join(':')
     const category = safeText(row.category)
-    const route = category ? `category:${category}${model ? `(${model})` : ''}` : model
+    // Prepared-route provenance from the reader: a fallback lane carries a
+    // visible `fallback` token, and an exhausted chain reads
+    // `category→inherit` instead of converging into plain inherit.
+    const routeOrigin = safeText(row.route_origin)
+    const routeCategory = safeText(row.route_category)
+    const routeDetail = [model, routeOrigin === 'fallback' ? 'fallback' : ''].filter(Boolean).join(' ')
+    const route = routeOrigin === 'exhausted_to_inherit' && routeCategory
+      ? `category:${routeCategory}→inherit${model ? `(${model})` : ''}`
+      : category
+        ? `category:${category}${routeDetail ? `(${routeDetail})` : ''}`
+        : model
+    const routeKind = routeOrigin === 'fallback' || routeOrigin === 'exhausted_to_inherit' ? 'route-fallback' : 'route'
     const turn = Number.isFinite(row.turn_count) ? `turn ${row.turn_count}` : ''
     const tools = Number.isFinite(row.tool_count) ? `${row.tool_count} tools` : ''
     const turnTools = turn && tools ? `${turn} (${tools})` : turn || tools
     const optional = [
-      metricSegment('route', route),
+      metricSegment(routeKind, route),
       metricSegment('fallback', Number.isFinite(row.fallback_count) && row.fallback_count > 0 ? `fallback:${row.fallback_count}` : ''),
       metricSegment('turn', turnTools),
       // A subscription-billed host records no per-call cost, so the reader
@@ -240,7 +251,11 @@ export default function register(sdk) {
               ? statusColor
               : segment.kind === 'route'
                 ? t.color.label
-                : t.color.muted,
+                // A fallback or exhausted route is a warning-grade fact: the
+                // lane is NOT running the chain head the category names.
+                : segment.kind === 'route-fallback'
+                  ? t.color.warn
+                  : t.color.muted,
             key: `${segment.kind}-${index}`,
           },
           `${index ? '  ·  ' : ''}${segment.text}`,

--- a/src/plugin_bundle/omh/delegation_routing.py
+++ b/src/plugin_bundle/omh/delegation_routing.py
@@ -76,7 +76,12 @@ def _read_delegation_route_text(text: str) -> dict[str, str]:
                 value = _yaml_string_token(raw)
                 if value is None:
                     return {}
-                values[key] = value
+                # An empty value is Hermes's stock "inherit" spelling for the
+                # key; last occurrence wins, so it unsets an earlier value.
+                if value:
+                    values[key] = value
+                else:
+                    values.pop(key, None)
     return values
 
 
@@ -118,7 +123,11 @@ def write_delegation_route(
     if _has_unsupported_delegation(lines):
         return {
             "status": "error",
-            "error": "unsupported delegation mapping; refusing to rewrite it",
+            "error": (
+                "unsupported delegation mapping; refusing to rewrite it — "
+                "no route was written, so the next delegate_task dispatch "
+                "inherits the parent model"
+            ),
         }
     child_indents = _delegation_child_indents(lines)
     output: list[str] = []
@@ -280,6 +289,24 @@ def _has_unsupported_delegation(lines: list[str]) -> bool:
         _, _, raw = line.partition(":")
         if _yaml_string_token(raw) is None:
             return True
+        # A plain scalar (null, ~, or an ordinary token) continues onto a
+        # more-indented following line in YAML: OMH would read one value
+        # while Hermes resolves the continuation, and the writer would drop
+        # the key line and orphan that continuation into unparseable YAML.
+        # Refuse any routable key whose next content line sits deeper — the
+        # guard is about whether a continuation follows, not which token
+        # appeared.
+        if _continuation_follows(lines, index, child_indent):
+            return True
+    return False
+
+
+def _continuation_follows(lines: list[str], index: int, indent: int) -> bool:
+    for following in lines[index + 1 :]:
+        stripped = following.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        return len(following) - len(stripped) > indent
     return False
 
 
@@ -314,12 +341,28 @@ def _yaml_string_token(raw: str) -> str | None:
         and value[-1] == value[0]
     ):
         token = value[1:-1]
+        if not token:
+            # `model: ''` is Hermes's own stock config shape for "no route,
+            # inherit the parent". It is an absent value, not an unsupported
+            # mapping — refusing it locked routing out of every vanilla
+            # install (observed live: all category sets refused, lanes
+            # silently dispatched as inherit).
+            return ""
         return token if _VALUE_RE.fullmatch(token) else None
     lowered = value.casefold()
+    if lowered in {"~", "null"}:
+        # Same inherit family. These are PLAIN scalars, which YAML continues
+        # onto a more-indented following line — that continuation case is
+        # refused by the lookahead in _has_unsupported_delegation, not here.
+        return ""
+    if not lowered:
+        # A BARE empty value is different: `model:` with nothing after the
+        # colon may be a block-mapping header whose children live on the next,
+        # more-indented lines. Treating it as an empty scalar would let the
+        # writer drop the header and orphan those children into unparseable
+        # YAML, so it stays refused.
+        return None
     if lowered in {
-        "",
-        "~",
-        "null",
         "true",
         "false",
         "yes",

--- a/src/plugin_bundle/omh/hermes_delegation.py
+++ b/src/plugin_bundle/omh/hermes_delegation.py
@@ -25,8 +25,10 @@ mixture routing is visible as such instead of masquerading as a routed one.
 from __future__ import annotations
 
 import json
+import os
 import re
 import sqlite3
+import tempfile
 import time
 from collections.abc import Mapping
 from pathlib import Path
@@ -302,6 +304,203 @@ def configured_route_for_wire(
         if model == wire_model
     }
     return next(iter(matches)) if len(matches) == 1 else (model, "")
+
+
+# Prepared-route provenance. Hermes persists which model a child ran, but not
+# WHY that model was chosen — chain head, fallback after a dead candidate, or
+# chain exhaustion clearing back to parent inheritance. omh_delegate_route
+# records each successful route write here so the HUD can label a fallback
+# lane as a fallback instead of rendering it indistinguishable from a head
+# route (and an exhausted chain as `category→inherit` instead of plain
+# inherit). The record is preparation evidence only: a label upgrade for an
+# observed child whose wire identity matches, never execution evidence and
+# never a routing input.
+DELEGATION_ROUTE_PROVENANCE_SCHEMA_VERSION = "delegation_route_provenance/v1"
+_PROVENANCE_RECORD_LIMIT = 32
+# A route write immediately precedes its dispatch (the tool contract is
+# set → dispatch per lane). A record this much older than a child's start
+# no longer describes that dispatch, so it stops upgrading labels.
+_PROVENANCE_FRESHNESS_SECONDS = 900.0
+# An exhaustion record describes only the immediate re-dispatch after the
+# chain cleared — the agent retries within seconds, and every inherit child
+# beyond this window is an ordinary unrouted lane, so the claim window is
+# much tighter than the routed one.
+_EXHAUSTION_FRESHNESS_SECONDS = 120.0
+_PROVENANCE_ORIGINS = (
+    "head",
+    "explicit",
+    "fallback",
+    "exhausted_to_inherit",
+    "cleared",
+)
+
+
+def delegation_route_provenance_path(omh_home: str | Path | None = None) -> Path:
+    root = Path(omh_home).expanduser() if omh_home else Path.home() / ".omh"
+    return root / "routing" / "route-provenance.json"
+
+
+def _valid_provenance_record(record: object) -> dict[str, Any] | None:
+    if not isinstance(record, dict):
+        return None
+    origin = record.get("origin")
+    if origin not in _PROVENANCE_ORIGINS:
+        return None
+    written_at = record.get("written_at")
+    if (
+        isinstance(written_at, bool)
+        or not isinstance(written_at, (int, float))
+        or not written_at == written_at
+    ):
+        return None
+    cleaned: dict[str, Any] = {"origin": origin, "written_at": float(written_at)}
+    for field in ("category", "alias", "wire_model", "provider", "reasoning_effort", "from_alias"):
+        value = record.get(field, "")
+        if not isinstance(value, str) or len(value) > 160:
+            return None
+        cleaned[field] = value
+    return cleaned
+
+
+def load_delegation_route_provenance(
+    omh_home: str | Path | None = None,
+) -> list[dict[str, Any]]:
+    """Read prepared-route records, oldest first; absent or invalid is empty.
+
+    Provenance only ever upgrades a HUD label — it never gates routing — so
+    every failure mode reads as "no provenance" rather than an error.
+    """
+    path = delegation_route_provenance_path(omh_home)
+    try:
+        raw = _strict_json_loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return []
+    except (OSError, UnicodeDecodeError, ValueError):
+        return []
+    if not isinstance(raw, dict):
+        return []
+    if raw.get("schema_version") != DELEGATION_ROUTE_PROVENANCE_SCHEMA_VERSION:
+        return []
+    records = raw.get("records")
+    if not isinstance(records, list):
+        return []
+    cleaned: list[dict[str, Any]] = []
+    for record in records:
+        valid = _valid_provenance_record(record)
+        if valid is None:
+            return []
+        cleaned.append(valid)
+    return cleaned
+
+
+def append_delegation_route_provenance(
+    record: dict[str, Any],
+    omh_home: str | Path | None = None,
+) -> str:
+    """Append one prepared-route record; returns ``recorded`` or ``unrecorded: <reason>``."""
+    valid = _valid_provenance_record(record)
+    if valid is None:
+        return "unrecorded: invalid record"
+    records = load_delegation_route_provenance(omh_home)
+    records.append(valid)
+    records = records[-_PROVENANCE_RECORD_LIMIT:]
+    payload = {
+        "schema_version": DELEGATION_ROUTE_PROVENANCE_SCHEMA_VERSION,
+        "records": records,
+    }
+    payload["claim_boundary"] = (
+        "Prepared routes only: each record says what omh_delegate_route wrote "
+        "into delegation.* before a dispatch, not that any dispatch ran, "
+        "which model a child actually used, or that the lane completed. The "
+        "history is read-modify-write without a lock; concurrent appends may "
+        "drop a record, which degrades to a missing HUD label."
+    )
+    path = delegation_route_provenance_path(omh_home)
+    temp_name = ""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        descriptor, temp_name = tempfile.mkstemp(
+            prefix=".omh-route-provenance-", dir=str(path.parent)
+        )
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, sort_keys=True)
+        os.replace(temp_name, path)
+    except OSError:
+        if temp_name:
+            try:
+                os.unlink(temp_name)
+            except OSError:
+                pass
+        return "unrecorded: provenance write failed"
+    return "recorded"
+
+
+def _child_is_inherit(
+    child: Mapping[str, Any],
+    parent_models: Mapping[str, str],
+    provider_routes: Mapping[str, tuple[str, str]],
+) -> bool:
+    """Mirror the projection's inherit test: child alias == parent model."""
+    parent_model = _text(parent_models.get(child.get("parent_id", ""), ""))
+    if not parent_model:
+        return False
+    alias, _ = configured_route_for_wire(child["model"], provider_routes)
+    return _text(alias).casefold() == parent_model.casefold()
+
+
+def _provenance_for_dispatch(
+    records: list[dict[str, Any]],
+    *,
+    started_at: float,
+    wire_model: str,
+    alias: str,
+    is_inherit: bool,
+    session_id: str = "",
+    exhaustion_claims: Mapping[int, str] | None = None,
+) -> dict[str, Any] | None:
+    """Best-effort pairing of a child with the route prepared before it.
+
+    Like the manifest/task pairing above, this is best-effort context, never
+    row identity: only the newest record written before the child's start is
+    considered (later writes replaced it for later lanes), the child must
+    still match the record's identity, and every ambiguity degrades to "no
+    record" — a missing label is acceptable, a wrong one is not.
+    """
+    for index in range(len(records) - 1, -1, -1):
+        record = records[index]
+        # written_at and the child's started_at come from the same machine
+        # clock, and the tool contract writes the route BEFORE dispatching
+        # the lane, so a record stamped after the child started cannot be
+        # the route that dispatch read.
+        if record["written_at"] > started_at:
+            continue
+        if started_at - record["written_at"] > _PROVENANCE_FRESHNESS_SECONDS:
+            return None
+        if record["origin"] == "cleared":
+            # The route was explicitly cleared before this dispatch: the
+            # child inherited on purpose, and no older record describes it.
+            return None
+        if record["origin"] == "exhausted_to_inherit":
+            # An exhaustion record describes exactly one dispatch — the
+            # next inherit child after the chain cleared. The caller
+            # precomputes that claim, the window is tight, and every other
+            # inherit child is an ordinary unrouted lane.
+            if not is_inherit:
+                return None
+            if started_at - record["written_at"] > _EXHAUSTION_FRESHNESS_SECONDS:
+                return None
+            claimed = (exhaustion_claims or {}).get(index, "")
+            return record if session_id and session_id == claimed else None
+        if is_inherit:
+            # `inherit` wins over any chain match (the projection's
+            # documented invariant): a child on the parent session's own
+            # model was not routed, whatever the prepared route said.
+            return None
+        matched = (wire_model and wire_model == record["wire_model"]) or (
+            alias and alias == record["alias"]
+        )
+        return record if matched else None
+    return None
 
 
 def _strict_json_loads(text: str) -> object:
@@ -617,6 +816,7 @@ def read_hermes_native_subagents(
     # overrides so a customized chain labels its children like a shipped one.
     active_chains = effective_mixture_category_chains(omh_home)
     provider_routes, _ = load_model_provider_routes(omh_home)
+    route_provenance = load_delegation_route_provenance(omh_home)
     payload: dict[str, Any] = {
         "status": "idle",
         "rows": [],
@@ -651,6 +851,27 @@ def read_hermes_native_subagents(
         for task, child in zip(manifest["tasks"], window_children):
             matched_tasks[child["session_id"]] = task
             matched_delegations[child["session_id"]] = manifest["delegation_id"]
+
+    # One-shot exhaustion claims: an exhaustion record describes exactly the
+    # next dispatch after its chain cleared, so only the EARLIEST inherit
+    # child started after the record may carry its label (best-effort
+    # pairing, never row identity — same discipline as the manifest match).
+    parent_models = state.get("parent_models", {})
+    exhaustion_claims: dict[int, str] = {}
+    for index, record in enumerate(route_provenance):
+        if record["origin"] != "exhausted_to_inherit":
+            continue
+        candidates = [
+            child
+            for child in children
+            if 0.0
+            <= child["started_at"] - record["written_at"]
+            <= _EXHAUSTION_FRESHNESS_SECONDS
+            and _child_is_inherit(child, parent_models, provider_routes)
+        ]
+        if candidates:
+            claimed = min(candidates, key=lambda item: item["started_at"])
+            exhaustion_claims[index] = claimed["session_id"]
 
     rows: list[dict[str, Any]] = []
     running = 0
@@ -741,6 +962,32 @@ def read_hermes_native_subagents(
         }
         if route_provider:
             row["provider_source"] = "model_provider_routes"
+        # Prepared-route provenance is a best-effort label upgrade, never
+        # row identity: when the child's identity matches the newest route
+        # prepared before its dispatch, a fallback lane says so and an
+        # exhausted chain reads `category→inherit` instead of converging
+        # into plain inherit. The upgrade carries its own source marker.
+        provenance = _provenance_for_dispatch(
+            route_provenance,
+            started_at=child["started_at"],
+            wire_model=child["model"],
+            alias=route_alias,
+            is_inherit=row["category"] == "inherit",
+            session_id=child["session_id"],
+            exhaustion_claims=exhaustion_claims,
+        )
+        if provenance is not None:
+            if provenance["origin"] == "exhausted_to_inherit":
+                if provenance["category"]:
+                    row["route_origin"] = "exhausted_to_inherit"
+                    row["route_category"] = provenance["category"]
+                    row["category_source"] = "route_provenance"
+            else:
+                if provenance["category"]:
+                    row["category"] = provenance["category"]
+                    row["category_source"] = "route_provenance"
+                if provenance["origin"] == "fallback":
+                    row["route_origin"] = "fallback"
         if failure_hint:
             row["failure_hint"] = failure_hint
         api_calls = usage.get("api_calls")

--- a/src/plugin_bundle/omh/tools/delegate_route_tool.py
+++ b/src/plugin_bundle/omh/tools/delegate_route_tool.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import json
+import time
 from typing import Any
 
 from ..delegation_routing import read_delegation_route, write_delegation_route
 from ..hermes_delegation import (
     HERMES_MIXTURE_CATEGORY_CHAINS,
+    append_delegation_route_provenance,
     chain_alias_for,
     load_mixture_chain_overrides,
     load_model_provider_routes,
@@ -173,6 +175,14 @@ def omh_delegate_route_handler(args: dict[str, Any], **kwargs) -> str:
 
     if action == "clear":
         result = write_delegation_route(hermes_home, clear=True)
+        if result.get("status") == "cleared":
+            # A cleared route must supersede the head/fallback record that
+            # preceded it, or a later child on a coincidentally matching
+            # model would still inherit that record's label.
+            result["route_provenance"] = append_delegation_route_provenance(
+                {"origin": "cleared", "written_at": time.time()},
+                omh_home,
+            )
         result["evidence_boundary"] = _EVIDENCE_BOUNDARY
         return json.dumps(attach_public_observation(result, observation), sort_keys=True)
 
@@ -279,6 +289,15 @@ def omh_delegate_route_handler(args: dict[str, Any], **kwargs) -> str:
             )
             if result.get("status") == "cleared":
                 result["status"] = "exhausted_to_inherit"
+                result["route_provenance"] = append_delegation_route_provenance(
+                    {
+                        "origin": "exhausted_to_inherit",
+                        "category": category,
+                        "from_alias": current_alias,
+                        "written_at": time.time(),
+                    },
+                    omh_home,
+                )
             result["category"] = category
             result["from"] = current_model
             result["evidence_boundary"] = _EVIDENCE_BOUNDARY
@@ -308,6 +327,19 @@ def omh_delegate_route_handler(args: dict[str, Any], **kwargs) -> str:
             result["applied"]["alias"] = next_model
             result["category"] = category
             result["from"] = current_model
+            result["route_provenance"] = append_delegation_route_provenance(
+                {
+                    "origin": "fallback",
+                    "category": category,
+                    "alias": next_model,
+                    "wire_model": wire_model,
+                    "provider": next_provider,
+                    "reasoning_effort": next_effort,
+                    "from_alias": current_alias,
+                    "written_at": time.time(),
+                },
+                omh_home,
+            )
             result["fallback_candidates"] = [
                 _chain_entry(alias, chain_effort, provider_routes)
                 for alias, chain_effort in chain[index + 2 :]
@@ -374,6 +406,18 @@ def omh_delegate_route_handler(args: dict[str, Any], **kwargs) -> str:
     if result.get("status") == "routed":
         result["applied"]["alias"] = alias
         result["category"] = category
+        result["route_provenance"] = append_delegation_route_provenance(
+            {
+                "origin": "head" if category and not model else "explicit",
+                "category": category,
+                "alias": alias,
+                "wire_model": wire_model,
+                "provider": provider,
+                "reasoning_effort": effort,
+                "written_at": time.time(),
+            },
+            omh_home,
+        )
         chain = chains.get(category, ())
         result["fallback_candidates"] = [
             _chain_entry(alias, chain_effort, provider_routes)

--- a/tests/test_delegate_route_tool.py
+++ b/tests/test_delegate_route_tool.py
@@ -19,6 +19,7 @@ from omh.plugin_bundle.omh.delegation_routing import (
     read_delegation_route,
     write_delegation_route,
 )
+from omh.plugin_bundle.omh.hermes_delegation import load_delegation_route_provenance
 from omh.plugin_bundle.omh.tools.delegate_route_tool import omh_delegate_route_handler
 
 
@@ -650,3 +651,169 @@ class DelegateRouteToolTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class StockConfigRouteTest(unittest.TestCase):
+    """Hermes's own stock config spells "inherit" as empty delegation values.
+
+    Observed live: a vanilla install ships `model: ''` / `provider: ''`, the
+    old reader classified the empty quoted string as an unsupported mapping,
+    every category set was refused, and the lanes silently dispatched as
+    inherit while the HUD had no route to explain why.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.home = Path(self._tmp.name)
+        self.config = self.home / "config.yaml"
+
+    def test_stock_empty_values_read_as_no_route_and_are_writable(self):
+        self.config.write_text(
+            "delegation:\n"
+            "  model: ''\n"
+            "  reasoning_effort: medium\n"
+            "  max_iterations: 250\n"
+            "  provider: ''\n",
+            encoding="utf-8",
+        )
+        self.assertEqual(read_delegation_route(self.home), {"reasoning_effort": "medium"})
+
+        result = write_delegation_route(
+            self.home, model="kimi", reasoning_effort="high", provider="og"
+        )
+
+        self.assertEqual(result["status"], "routed")
+        text = self.config.read_text(encoding="utf-8")
+        self.assertIn("max_iterations: 250", text)
+        self.assertIn("model: 'kimi'", text)
+        self.assertNotIn("model: ''", text)
+
+    def test_null_values_are_the_same_inherit_family(self):
+        for value in (" null", " ~"):
+            with self.subTest(value=value):
+                self.config.write_text(
+                    f"delegation:\n  model:{value}\n  provider: og\n", encoding="utf-8"
+                )
+                self.assertEqual(read_delegation_route(self.home), {"provider": "og"})
+                self.assertEqual(
+                    write_delegation_route(self.home, model="kimi")["status"], "routed"
+                )
+
+    def test_a_bare_empty_value_stays_refused_because_it_may_head_a_block(self):
+        # `model:` with nothing after the colon may be a block-mapping header;
+        # treating it as an empty scalar would let the writer drop the header
+        # and orphan its more-indented children into unparseable YAML.
+        content = (
+            "delegation:\n"
+            "  model:\n"
+            "    primary: 'gpt-5'\n"
+            "    secondary: 'kimi'\n"
+            "  provider: og\n"
+        )
+        self.config.write_text(content, encoding="utf-8")
+        before = self.config.read_bytes()
+
+        self.assertEqual(read_delegation_route(self.home), {})
+        result = write_delegation_route(self.home, model="sonnet")
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("unsupported delegation mapping", result["error"])
+        self.assertEqual(self.config.read_bytes(), before)
+
+    def test_a_plain_scalar_with_a_deeper_continuation_line_is_refused(self):
+        # null, ~, and ordinary tokens are PLAIN scalars, which YAML
+        # continues onto a more-indented following line: OMH would read one
+        # value while Hermes resolves the continuation, and the writer would
+        # orphan that continuation. The lookahead refuses all three shapes.
+        for value in ("null", "~", "sonnet"):
+            with self.subTest(value=value):
+                content = f"delegation:\n  model: {value}\n    junk line\n"
+                self.config.write_text(content, encoding="utf-8")
+                before = self.config.read_bytes()
+
+                self.assertEqual(read_delegation_route(self.home), {})
+                result = write_delegation_route(self.home, model="kimi")
+
+                self.assertEqual(result["status"], "error")
+                self.assertIn("unsupported delegation mapping", result["error"])
+                self.assertEqual(self.config.read_bytes(), before)
+
+    def test_a_deeper_comment_after_a_null_value_is_not_a_continuation(self):
+        self.config.write_text(
+            "delegation:\n  model: null\n    # a comment, not a value\n  provider: og\n",
+            encoding="utf-8",
+        )
+        self.assertEqual(read_delegation_route(self.home), {"provider": "og"})
+        self.assertEqual(write_delegation_route(self.home, model="kimi")["status"], "routed")
+
+    def test_an_empty_last_occurrence_unsets_the_earlier_value(self):
+        self.config.write_text(
+            "delegation:\n  model: first\n  model: ''\n", encoding="utf-8"
+        )
+        self.assertEqual(read_delegation_route(self.home), {})
+
+    def test_the_refusal_names_the_inherit_consequence(self):
+        # A refused write is exactly the moment a lane silently inherits; the
+        # error must say so, so the calling agent never labels the lane with
+        # the category it asked for.
+        self.config.write_text("delegation:\n  model: true\n", encoding="utf-8")
+        result = write_delegation_route(self.home, model="kimi")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("unsupported delegation mapping", result["error"])
+        self.assertIn("inherits the parent model", result["error"])
+
+
+class RouteProvenanceRecordingTest(unittest.TestCase):
+    """Every successful route write records why the next dispatch runs what it runs."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.home = Path(self._tmp.name)
+        self.config = self.home / "config.yaml"
+        self.omh_home = self.home / ".omh"
+
+    def _call(self, **args) -> dict:
+        return json.loads(
+            omh_delegate_route_handler(
+                {"hermes_home": str(self.home), "omh_home": str(self.omh_home), **args}
+            )
+        )
+
+    def test_set_fallback_and_exhaustion_each_record_their_origin(self):
+        first = self._call(action="set", category="quick")
+        self.assertEqual(first["route_provenance"], "recorded")
+        self._call(action="fallback", category="quick")
+        self._call(action="fallback", category="quick")
+        self._call(action="fallback", category="quick")
+        last = self._call(action="fallback", category="quick")
+        self.assertEqual(last["status"], "exhausted_to_inherit")
+        self.assertEqual(last["route_provenance"], "recorded")
+
+        records = load_delegation_route_provenance(self.omh_home)
+        self.assertEqual(
+            [record["origin"] for record in records],
+            ["head", "fallback", "fallback", "fallback", "exhausted_to_inherit"],
+        )
+        self.assertEqual(records[0]["alias"], "glm-5.2-ultrafast")
+        self.assertEqual(records[1]["from_alias"], "glm-5.2-ultrafast")
+        self.assertEqual(records[1]["alias"], "kimi-k3")
+        self.assertEqual(records[-1]["category"], "quick")
+        self.assertEqual(records[-1]["from_alias"], "claude-fable-5")
+
+    def test_clear_records_a_superseding_cleared_origin(self):
+        # Without this record, a later child on a coincidentally matching
+        # model would still inherit the pre-clear record's label.
+        self._call(action="set", category="quick")
+        result = self._call(action="clear")
+        self.assertEqual(result["route_provenance"], "recorded")
+        records = load_delegation_route_provenance(self.omh_home)
+        self.assertEqual([record["origin"] for record in records], ["head", "cleared"])
+
+    def test_an_explicit_model_override_records_explicit_origin(self):
+        self._call(action="set", category="quick", model="my-model")
+        records = load_delegation_route_provenance(self.omh_home)
+        self.assertEqual(records[-1]["origin"], "explicit")
+        self.assertEqual(records[-1]["category"], "quick")
+        self.assertEqual(records[-1]["wire_model"], "my-model")

--- a/tests/test_plugin_hermes_delegation.py
+++ b/tests/test_plugin_hermes_delegation.py
@@ -17,10 +17,13 @@ from pathlib import Path
 
 from omh.plugin_bundle.omh.hermes_delegation import (
     COMPLETED_LINGER_SECONDS,
+    DELEGATION_ROUTE_PROVENANCE_SCHEMA_VERSION,
     HERMES_MIXTURE_CATEGORY_CHAINS,
     MIXTURE_CHAIN_OVERRIDES_SCHEMA_VERSION,
     RECENT_ACTIVITY_SECONDS,
+    append_delegation_route_provenance,
     effective_mixture_category_chains,
+    load_delegation_route_provenance,
     load_mixture_chain_overrides,
     mixture_category_for,
     mixture_chain_overrides_path,
@@ -729,3 +732,253 @@ class HudMergeTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+def _write_provenance(omh_home: Path, records: list[dict]) -> None:
+    path = omh_home / "routing" / "route-provenance.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": DELEGATION_ROUTE_PROVENANCE_SCHEMA_VERSION,
+                "records": records,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _record(**overrides) -> dict:
+    record = {
+        "origin": "fallback",
+        "category": "visual-engineering",
+        "alias": "glm-5.2-ultrafast",
+        "wire_model": "z-ai/glm-5.2-ultrafast",
+        "provider": "gateway",
+        "reasoning_effort": "low",
+        "from_alias": "claude-fable-5",
+        "written_at": NOW - 120,
+    }
+    record.update(overrides)
+    return record
+
+
+class RouteProvenanceStoreTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.home = Path(self._tmp.name)
+
+    def test_append_roundtrips_and_caps_history(self):
+        for index in range(40):
+            status = append_delegation_route_provenance(
+                _record(alias=f"m{index}", written_at=1000.0 + index), self.home
+            )
+            self.assertEqual(status, "recorded")
+        records = load_delegation_route_provenance(self.home)
+        self.assertEqual(len(records), 32)
+        self.assertEqual(records[-1]["alias"], "m39")
+        self.assertEqual(records[0]["alias"], "m8")
+
+    def test_an_invalid_record_is_refused_not_written(self):
+        self.assertEqual(
+            append_delegation_route_provenance(_record(origin="nope"), self.home),
+            "unrecorded: invalid record",
+        )
+        self.assertEqual(load_delegation_route_provenance(self.home), [])
+
+    def test_an_invalid_document_reads_empty_whole(self):
+        path = self.home / "routing" / "route-provenance.json"
+        path.parent.mkdir(parents=True)
+        for document in (
+            "not json",
+            json.dumps({"schema_version": "wrong/v9", "records": []}),
+            json.dumps(
+                {
+                    "schema_version": DELEGATION_ROUTE_PROVENANCE_SCHEMA_VERSION,
+                    "records": [{"origin": "nope", "written_at": 1.0}],
+                }
+            ),
+        ):
+            with self.subTest(document=document[:30]):
+                path.write_text(document, encoding="utf-8")
+                self.assertEqual(load_delegation_route_provenance(self.home), [])
+
+
+class RouteProvenanceProjectionTest(unittest.TestCase):
+    """Prepared-route provenance upgrades HUD labels for matching children."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.home = Path(self._tmp.name)
+        route_path = self.home / "routing" / "model-providers.json"
+        route_path.parent.mkdir(parents=True)
+        route_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "model_provider_routes/v1",
+                    "models": {
+                        "glm-5.2-ultrafast": {
+                            "provider": "gateway",
+                            "model": "z-ai/glm-5.2-ultrafast",
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def _row(self, child_model: str) -> dict:
+        _build_state_db(
+            self.home,
+            [
+                {
+                    "id": "20260818_100200_lane",
+                    "model": child_model,
+                    "effort": "low",
+                    "started_at": NOW - 60,
+                    "usage": {"last_seen": NOW - 5, "output_tokens": 10},
+                }
+            ],
+        )
+        return read_hermes_native_subagents(self.home, now=NOW, omh_home=self.home)["rows"][0]
+
+    def test_a_fallback_route_labels_its_child_with_category_and_origin(self):
+        _write_provenance(self.home, [_record()])
+        row = self._row("z-ai/glm-5.2-ultrafast")
+        self.assertEqual(row["category"], "visual-engineering")
+        self.assertEqual(row["route_origin"], "fallback")
+        self.assertEqual(row["category_source"], "route_provenance")
+
+    def test_an_exhausted_chain_child_reads_route_category_to_inherit(self):
+        # The child runs the parent model, so the plain projection says
+        # inherit; the provenance says WHY — the category chain exhausted.
+        _write_provenance(
+            self.home,
+            [_record(origin="exhausted_to_inherit", alias="", wire_model="", provider="")],
+        )
+        row = self._row("gpt-5.6-sol")
+        self.assertEqual(row["category"], "inherit")
+        self.assertEqual(row["route_origin"], "exhausted_to_inherit")
+        self.assertEqual(row["route_category"], "visual-engineering")
+
+    def _rows(self, children: list[dict]) -> dict:
+        _build_state_db(self.home, children)
+        payload = read_hermes_native_subagents(self.home, now=NOW, omh_home=self.home)
+        return {row["task_id"]: row for row in payload["rows"]}
+
+    def test_an_exhaustion_record_labels_only_the_earliest_inherit_child(self):
+        # The record describes exactly one dispatch — the next inherit child
+        # after the chain cleared. A later inherit lane is an ordinary
+        # unrouted delegation and must NOT be claimed.
+        _write_provenance(
+            self.home,
+            [_record(origin="exhausted_to_inherit", alias="", wire_model="", provider="")],
+        )
+        rows = self._rows(
+            [
+                {
+                    "id": "20260818_100300_first",
+                    "model": "gpt-5.6-sol",
+                    "effort": "medium",
+                    "started_at": NOW - 90,
+                    "usage": {"last_seen": NOW - 5, "output_tokens": 10},
+                },
+                {
+                    "id": "20260818_100400_second",
+                    "model": "gpt-5.6-sol",
+                    "effort": "medium",
+                    "started_at": NOW - 40,
+                    "usage": {"last_seen": NOW - 5, "output_tokens": 10},
+                },
+            ]
+        )
+        self.assertEqual(rows["first"]["route_origin"], "exhausted_to_inherit")
+        self.assertNotIn("route_origin", rows["second"])
+        self.assertEqual(rows["second"]["category"], "inherit")
+
+    def test_an_exhaustion_record_beyond_its_tight_window_claims_nothing(self):
+        # 800s after the chain cleared, an inherit lane is an ordinary
+        # unrouted delegation, not the exhausted chain's re-dispatch.
+        _write_provenance(
+            self.home,
+            [
+                _record(
+                    origin="exhausted_to_inherit",
+                    alias="",
+                    wire_model="",
+                    provider="",
+                    written_at=NOW - 860,
+                )
+            ],
+        )
+        row = self._row("gpt-5.6-sol")
+        self.assertEqual(row["category"], "inherit")
+        self.assertNotIn("route_origin", row)
+
+    def test_a_cleared_route_supersedes_the_record_before_it(self):
+        _write_provenance(
+            self.home,
+            [
+                _record(written_at=NOW - 300),
+                {"origin": "cleared", "written_at": NOW - 200},
+            ],
+        )
+        row = self._row("z-ai/glm-5.2-ultrafast")
+        self.assertNotIn("route_origin", row)
+        self.assertNotIn("category_source", row)
+        self.assertEqual(row["category"], "quick")
+
+    def test_inherit_wins_over_a_matching_routed_record(self):
+        # The parent's own model can also be a chain member; a child that
+        # inherited it was NOT routed, whatever the prepared route said.
+        _write_provenance(
+            self.home,
+            [_record(alias="gpt-5.6-sol", wire_model="gpt-5.6-sol", provider="")],
+        )
+        row = self._row("gpt-5.6-sol")
+        self.assertEqual(row["category"], "inherit")
+        self.assertNotIn("route_origin", row)
+        self.assertNotIn("category_source", row)
+
+    def test_a_newer_unrelated_record_blocks_an_older_matching_one(self):
+        # Only the newest record written before the dispatch describes it;
+        # an older matching record was already replaced for this lane.
+        _write_provenance(
+            self.home,
+            [
+                _record(written_at=NOW - 300),
+                _record(
+                    origin="head",
+                    category="ultrabrain",
+                    alias="gpt-5.6-sol",
+                    wire_model="gpt-5.6-sol",
+                    provider="",
+                    written_at=NOW - 100,
+                ),
+            ],
+        )
+        row = self._row("z-ai/glm-5.2-ultrafast")
+        self.assertNotIn("route_origin", row)
+        self.assertEqual(row["category"], "quick")
+
+    def test_the_written_document_carries_a_claim_boundary(self):
+        append_delegation_route_provenance(_record(), self.home)
+        document = json.loads(
+            (self.home / "routing" / "route-provenance.json").read_text(encoding="utf-8")
+        )
+        self.assertIn("Prepared routes only", document["claim_boundary"])
+
+    def test_stale_or_mismatched_provenance_never_upgrades_a_label(self):
+        for records in (
+            [_record(written_at=NOW - 2000)],           # older than freshness
+            [_record(written_at=NOW - 10)],             # written after dispatch
+            [_record(wire_model="other/model", alias="other")],  # different route
+        ):
+            with self.subTest(records=records):
+                _write_provenance(self.home, records)
+                (self.home / "state.db").unlink(missing_ok=True)
+                row = self._row("z-ai/glm-5.2-ultrafast")
+                self.assertNotIn("route_origin", row)
+                self.assertEqual(row["category"], "quick")

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -458,6 +458,14 @@ class TuiWidgetPackTests(unittest.TestCase):
         self.assertIn("ActivityRow", widget)
         self.assertIn("truncateCells", widget)
         self.assertIn("category:", widget)
+        # Prepared-route provenance renders: a fallback lane carries a
+        # warning-colored `fallback` token, and an exhausted chain reads
+        # `category→inherit` instead of converging into plain inherit.
+        self.assertIn("route_origin", widget)
+        self.assertIn("route-fallback", widget)
+        self.assertIn("routeOrigin === 'fallback' ? 'fallback' : ''", widget)
+        self.assertIn("→inherit", widget)
+        self.assertIn("row.route_category", widget)
         self.assertIn("tools", widget)
         self.assertIn("tok/s", widget)
         self.assertIn("cache_hit_percentage", widget)


### PR DESCRIPTION
## Capability

Two coupled fixes on the delegation-route surface, from one live incident:

1. **Vanilla Hermes configs route again.** Hermes's stock config spells "no route, inherit" as empty quoted values (`delegation.model: ''`, `provider: ''`). OMH's route reader classified the empty quoted string as an unsupported scalar, fail-closed the whole section, and refused every `omh_delegate_route` set/fallback with "unsupported delegation mapping" — on the config shape every vanilla install ships. The refused lane then dispatched as plain `inherit` with nothing explaining why. Empty-quoted, `null`, and `~` now read as "key present, no route"; the refusal error names its consequence (no route written → next dispatch inherits) so a calling agent never labels a lane with a category that was not applied.

2. **Fallback lanes say so.** `omh_delegate_route` records every successful set/fallback/exhaustion/clear into `~/.omh/routing/route-provenance.json` (`delegation_route_provenance/v1`, capped 32 records, atomic write, fail-open reads, claim_boundary in the document). The HUD reader upgrades a matching child's row — marked `category_source: route_provenance` — so a fallback lane renders `category:visual-engineering(moonshotai/kimi-k3-ultrafast:high fallback)` in warn color, and an exhausted chain renders `category:visual-engineering→inherit(...)` instead of converging into plain `inherit`.

## Motivation

Observed live: a visual-engineering category set was refused ("unsupported delegation mapping; refusing to rewrite it" — three refusals logged 11:31–11:59), the lane silently ran as `inherit(gpt-5.6-sol)`, and the session misread the screen because nothing distinguished a refused route from a chosen one. After the config was cleaned, the chain worked (fable head → HTTP 400 → fallback to kimi via og) but the fallback lane was indistinguishable from a head route in the HUD. Owner directive: fix it as OMH product capability ("fallback모델로 들어간거면 fallback됐다는 표시도 해줘야지... 최종 폴백이 inherit로 다 수렴해버리면 안되는거잖"), not machine settings.

## Implementation (boundary level)

- `src/plugin_bundle/omh/delegation_routing.py`: empty-value family reads as unset (last-wins unsetting); BARE empty stays refused (may head a block mapping); a new continuation lookahead refuses any routable key whose next content line sits deeper — plain scalars continue onto deeper lines in YAML, so this guards the actual safety property and also closes a pre-existing hole where an ordinary value with a continuation was writable; refusal message carries the inherit consequence.
- `src/plugin_bundle/omh/hermes_delegation.py`: provenance store (path/load/append with validation, cap, atomic write + temp cleanup, claim_boundary) and best-effort dispatch pairing — newest record strictly before the child's start, 900s freshness, `inherit` wins over any routed record, exhaustion records claim only the EARLIEST inherit child inside a 120s window, `cleared` records supersede.
- `src/plugin_bundle/omh/tools/delegate_route_tool.py`: set/fallback/exhaustion/clear record their origin; results disclose `route_provenance: recorded`.
- `src/omh/tui_widgets/omh-status.mjs`: `fallback` token and `category→inherit` rendering, warn-colored via a `route-fallback` segment kind.
- `docs/INSTALLATION.md`: the provenance file documented next to its two routing siblings.

## Review

Independent reviewer lane (two rounds): 1 CRITICAL (bare-empty acceptance would let the writer orphan block children into unparseable YAML — reproduced, refused instead), 2 HIGH (exhaustion records over-claiming unrelated inherit lanes; missing `cleared` supersede + inherit-wins), 4 MEDIUM (timing tolerance, evidence marking/claim_boundary, temp-file leak, plain-scalar continuation), all fixed and re-verified against the reviewer's own repro scripts. Verdict: approve. Named residual on the record: within the 120s exhaustion window an unrelated inherit lane that starts before the real retry can steal the one-shot claim — best-effort pairing, never row identity (same discipline as the manifest/task pairing). Declared follow-up: widget cell-width/truncation for the new route strings on narrow terminals.

## Verification (observed)

- `PYTHONPATH=tests uv run python -m unittest discover -s tests` — full suite OK on the final tree (count in the commit trailer).
- 90 tests across `tests/test_delegate_route_tool.py`, `tests/test_plugin_hermes_delegation.py`, `tests/test_tui_widget_pack.py`, including negative cases: block child / sequence / plain continuation under a routable key refused byte-identically; exhaustion one-shot and 120s window; cleared supersede; inherit-wins; newer-record precedence; claim_boundary pin.
- The previously-refusing stock shape verified routed end-to-end through the installed handler; the reviewer's three corruption repros verified refused.
- All five `omh docs * --check` byte gates; ruff; compileall; `git diff --check`.

## Risks

Moderate: route reader/predicate semantics change for empty values (fail-closed → read-as-absent, with the new lookahead making continuation shapes strictly safer than HEAD); HUD row schema gains `route_origin`/`route_category`/`category_source`. No routing triggers, skills, or generated artifacts change. A live Hermes dispatch consuming the label is prepared_not_observed (reaches machines via `omh update` + TUI restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKo77o5dTJtLRWfDj4uBtq
