### PR TITLE
fix(hud): one category(model tag) label shape; exhausted lanes keep their category

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -280,7 +280,9 @@ Next to those two documents, `omh_delegate_route` maintains
 `~/.omh/routing/route-provenance.json` (`delegation_route_provenance/v1`): a
 capped history of the routes it prepared (head, explicit, fallback, chain
 exhaustion, clear) that the HUD uses to label a fallback lane as a fallback
-and an exhausted chain as `category→inherit`. It is written automatically,
+and an exhausted chain as `category(model inherit)` — one `category(model
+tag)` shape for every lane, where the category names the lane and only the
+parenthesized model and state token move. It is written automatically,
 carries its own `claim_boundary` (prepared routes only, never dispatch
 evidence), and is safe to delete — an absent or invalid file only means HUD
 rows fall back to plain category projection.

--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -161,17 +161,22 @@ export default function register(sdk) {
     const taskId = truncateCells(safeText(row.task_id) || safeText(row.role) || 'agent', 8).padEnd(8)
     const model = [safeText(row.model), safeText(row.effort)].filter(Boolean).join(':')
     const category = safeText(row.category)
-    // Prepared-route provenance from the reader: a fallback lane carries a
-    // visible `fallback` token, and an exhausted chain reads
-    // `category→inherit` instead of converging into plain inherit.
+    // Prepared-route provenance from the reader, rendered as one shape:
+    // `category(model tag)`. The category names the LANE and never changes;
+    // only the parenthesized model (and its state token) moves — a fallback
+    // lane reads `category(model fallback)`, and an exhausted chain running
+    // the parent's model reads `category(model inherit)` instead of being
+    // relabeled away from its category.
     const routeOrigin = safeText(row.route_origin)
     const routeCategory = safeText(row.route_category)
-    const routeDetail = [model, routeOrigin === 'fallback' ? 'fallback' : ''].filter(Boolean).join(' ')
-    const route = routeOrigin === 'exhausted_to_inherit' && routeCategory
-      ? `category:${routeCategory}→inherit${model ? `(${model})` : ''}`
-      : category
-        ? `category:${category}${routeDetail ? `(${routeDetail})` : ''}`
-        : model
+    const routeTag = routeOrigin === 'fallback' ? 'fallback'
+      : routeOrigin === 'exhausted_to_inherit' ? 'inherit'
+        : ''
+    const routeDetail = [model, routeTag].filter(Boolean).join(' ')
+    const displayCategory = routeOrigin === 'exhausted_to_inherit' && routeCategory ? routeCategory : category
+    const route = displayCategory
+      ? `category:${displayCategory}${routeDetail ? `(${routeDetail})` : ''}`
+      : model
     const routeKind = routeOrigin === 'fallback' || routeOrigin === 'exhausted_to_inherit' ? 'route-fallback' : 'route'
     const turn = Number.isFinite(row.turn_count) ? `turn ${row.turn_count}` : ''
     const tools = Number.isFinite(row.tool_count) ? `${row.tool_count} tools` : ''

--- a/src/plugin_bundle/omh/hermes_delegation.py
+++ b/src/plugin_bundle/omh/hermes_delegation.py
@@ -311,8 +311,8 @@ def configured_route_for_wire(
 # chain exhaustion clearing back to parent inheritance. omh_delegate_route
 # records each successful route write here so the HUD can label a fallback
 # lane as a fallback instead of rendering it indistinguishable from a head
-# route (and an exhausted chain as `category→inherit` instead of plain
-# inherit). The record is preparation evidence only: a label upgrade for an
+# route (and an exhausted chain as `category(model inherit)` — the category
+# names the lane and never changes — instead of plain inherit). The record is preparation evidence only: a label upgrade for an
 # observed child whose wire identity matches, never execution evidence and
 # never a routing input.
 DELEGATION_ROUTE_PROVENANCE_SCHEMA_VERSION = "delegation_route_provenance/v1"
@@ -965,8 +965,9 @@ def read_hermes_native_subagents(
         # Prepared-route provenance is a best-effort label upgrade, never
         # row identity: when the child's identity matches the newest route
         # prepared before its dispatch, a fallback lane says so and an
-        # exhausted chain reads `category→inherit` instead of converging
-        # into plain inherit. The upgrade carries its own source marker.
+        # exhausted chain keeps its category with an `inherit` model token
+        # (`category(model inherit)`) instead of converging into plain
+        # inherit. The upgrade carries its own source marker.
         provenance = _provenance_for_dispatch(
             route_provenance,
             started_at=child["started_at"],

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -463,8 +463,12 @@ class TuiWidgetPackTests(unittest.TestCase):
         # `category→inherit` instead of converging into plain inherit.
         self.assertIn("route_origin", widget)
         self.assertIn("route-fallback", widget)
-        self.assertIn("routeOrigin === 'fallback' ? 'fallback' : ''", widget)
-        self.assertIn("→inherit", widget)
+        # One label shape for every lane: category(model tag). The category
+        # names the lane and never changes; only the parenthesized model and
+        # its state token (fallback / inherit) move.
+        self.assertIn("routeOrigin === 'fallback' ? 'fallback'", widget)
+        self.assertIn("routeOrigin === 'exhausted_to_inherit' ? 'inherit'", widget)
+        self.assertNotIn("→inherit", widget)
         self.assertIn("row.route_category", widget)
         self.assertIn("tools", widget)
         self.assertIn("tok/s", widget)


### PR DESCRIPTION
## Capability

One HUD label grammar for every delegation lane: `category(model tag)`. The category names the LANE and never changes; only the parenthesized model and its state token move. A fallback lane reads `category:visual-engineering(moonshotai/kimi-k3-ultrafast:high fallback)`; an exhausted chain running the parent's model now reads `category:visual-engineering(gpt-5.6-sol:medium inherit)` instead of the shipped `category:visual-engineering→inherit(gpt-5.6-sol:medium)` second grammar. Both warn-colored.

## Motivation

Owner's format rule, verbatim: "핵심은 category(model)에 표현방식인거임... visual-engineering(gptsol)로 되어야하는거 아닌가 다른 카테고리도 마찬가지고". The arrow form relabeled the lane away from its category on exhaustion; the lane's identity should stay put while the model slot tells the truth.

## Implementation (boundary level)

- `src/omh/tui_widgets/omh-status.mjs`: single label expression — `displayCategory` (route_category on exhaustion, plain category otherwise) + `(model fallback|inherit)` detail. Never-routed lanes keep plain `category:inherit(model)` — they claimed no category, so there is none to keep.
- Reader/tool logic untouched: `route_origin` / `route_category` / `category_source` fields and the one-shot 120s exhaustion matching are exactly as merged in #1145 — the state token appears only on a provenance-matched lane.
- Comments in `hermes_delegation.py` and the `docs/INSTALLATION.md` sentence that quoted the arrow form updated.
- `tests/test_tui_widget_pack.py`: pins the new grammar and asserts the arrow form's absence.

## Verification (observed)

`PYTHONPATH=tests uv run python -m unittest discover -s tests` — 7358 tests OK; targeted widget/reader/preflight suites 70 OK; all five `omh docs * --check` byte gates; ruff; compileall; `git diff --check`.

## Risks

Low — one widget label expression plus wording; no reader, tool, or routing logic. Live TUI rendering is prepared_not_observed (reaches machines via `omh update` + TUI restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKo77o5dTJtLRWfDj4uBtq