### PR TITLE
fix(hud): yolo reads the host's persisted surfaces, scoped to the live TUI session

### DIFF
--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -355,11 +355,14 @@ export default function register(sdk) {
         h(Text, { color: t.color.border }, SEPARATOR),
         h(Text, { color: active ? t.color.warn : t.color.ok }, hudStateLabel(active, agents)),
         h(Text, { color: t.color.muted }, `${metrics.cost ? ` • ${metrics.cost}` : ''} • ${metrics.ctx}`),
-        // Shift+Tab yolo state, as last observed by the plugin's turn and
-        // tool-call hooks (the host keeps the flag in process memory only).
-        // ON warns in the theme's yellow; OFF rests in the label blue —
-        // colours resolve through the active theme, never literals. An
-        // unobserved or stale ledger renders nothing rather than a guess.
+        // Shift+Tab yolo state: the reader projects the host's persisted
+        // surfaces first (the live TUI session row's /yolo flag where the
+        // host persists it, config.yaml approvals.mode) so a toggle shows
+        // on the next 2s poll, and falls back to the turn/tool-call hook
+        // ledger when neither surface speaks. ON warns in the theme's
+        // yellow; OFF rests in the label blue — colours resolve through
+        // the active theme, never literals. An unobserved or stale state
+        // renders nothing rather than a guess.
         payload.yolo && payload.yolo.status === 'observed'
           ? h(
               Text,

--- a/src/plugin_bundle/omh/approval_bypass.py
+++ b/src/plugin_bundle/omh/approval_bypass.py
@@ -1,13 +1,23 @@
 """Effective approval-bypass (yolo) observation for the HUD.
 
-The Shift+Tab yolo toggle lives only in the host process's
-``tools.approval`` session state — nothing on disk records it — so the
-HUD can only report what the plugin's hooks observe in-process. Both
-``pre_llm_call`` (fires at each turn start, so a toggle shows up on the
-user's next message) and ``pre_tool_call`` tick this ledger with the same
-effective-bypass answer the host's own status surfaces report: global
-``approvals.mode=off``, the process-scoped ``--yolo`` env, or the
-per-session Shift+Tab flag, ORed together. Only the boolean and its
+The Shift+Tab yolo toggle lives in the host process's ``tools.approval``
+session state. Hosts that persist it give the HUD a real-time, on-disk
+signal: the classic CLI writes every ``/yolo`` toggle (both directions)
+and ``--yolo`` launches into the session row's
+``model_config.yolo_mode`` in ``state.db`` so ``--resume`` can restore
+it — the Modern TUI's gateway toggle gains the same persist upstream
+(until then its rows carry no flag and the ledger answers). The reader
+projects that row for the most recently active LIVE TUI session only —
+Hermes's own MRU discipline — inside the same freshness bound as the
+ledger, so a foreign or long-dead row can never answer for the session
+a widget is rendering. ``approvals.mode: off`` is read from
+``config.yaml`` directly and dominates, as it does in the host.
+
+The hook-observed ledger answers when no persisted surface speaks: a
+toggle before the session's first turn (Hermes creates the row lazily),
+a host that does not persist the flag, or a stale row. Both
+``pre_llm_call`` and ``pre_tool_call`` tick it with the effective-bypass
+answer the host's own status surfaces report. Only the boolean and its
 timestamp are recorded — never a session key, command, or prompt.
 """
 from __future__ import annotations
@@ -33,6 +43,12 @@ APPROVAL_BYPASS_CLAIM_BOUNDARY = (
     "Hook-observed effective approval-bypass state; it can lag Shift+Tab "
     "toggles and host restarts until the next turn or tool call, and is "
     "never approval, execution, or safety evidence."
+)
+APPROVAL_BYPASS_HOST_STATE_CLAIM_BOUNDARY = (
+    "Projected from the most recently active live TUI session row's "
+    "persisted /yolo flag and config.yaml approvals.mode — real-time on "
+    "toggles the host persists, but a projection of host state, never "
+    "approval, execution, or safety evidence."
 )
 
 
@@ -70,6 +86,166 @@ def record_approval_bypass(*, omh_home: str = "", now: float | None = None) -> N
             _write_delivery_record(path, record)
     except (OSError, ValueError, TypeError):
         return
+
+
+def _session_yolo_row(
+    hermes_home: str = "", *, now: float | None = None
+) -> tuple[bool, float] | None:
+    """The persisted /yolo flag off the most recently active live TUI session.
+
+    A host that persists the toggle writes ``model_config.yolo_mode`` on
+    every flip, so unlike the hook ledger this sees a toggle the moment it
+    happens — between turns included. The row may only ever answer for the
+    session a TUI widget is plausibly rendering: ``source='tui'``, not
+    ended/archived/hidden, not a delegation child, most recent by the
+    host's own MRU column (``last_activity_at``), and no older than the
+    ledger's freshness bound. Returns ``(enabled, activity_ts)`` or None
+    when no such row speaks (missing DB, older schema, no live TUI session,
+    or a session the host has not stamped) so the caller can fall back.
+    """
+    import json
+    import sqlite3
+    from urllib.parse import quote
+
+    current = float(now if now is not None else time.time())
+    home = Path(hermes_home).expanduser() if hermes_home else Path.home() / ".hermes"
+    path = home / "state.db"
+    if not path.exists():
+        return None
+    try:
+        connection = sqlite3.connect(
+            f"file:{quote(str(path))}?mode=ro", uri=True, timeout=0.2
+        )
+    except sqlite3.Error:
+        return None
+    try:
+        cursor = connection.execute(
+            """
+            SELECT model_config, COALESCE(last_activity_at, started_at)
+            FROM sessions
+            WHERE source = 'tui'
+              AND ended_at IS NULL
+              AND COALESCE(archived, 0) = 0
+              AND COALESCE(hidden, 0) = 0
+              AND (
+                model_config IS NULL
+                OR NOT json_valid(model_config)
+                OR json_extract(model_config, '$._delegate_from') IS NULL
+              )
+            ORDER BY COALESCE(last_activity_at, started_at) DESC
+            LIMIT 32
+            """
+        )
+        for raw_config, activity in cursor.fetchall():
+            try:
+                config = json.loads(raw_config) if raw_config else {}
+            except (ValueError, TypeError):
+                continue
+            if not isinstance(config, dict) or config.get("_delegate_from"):
+                continue
+            if not isinstance(activity, (int, float)) or (
+                current - float(activity) > APPROVAL_BYPASS_FRESH_SECONDS
+            ):
+                # The freshest live TUI row is already too old to describe a
+                # session anyone is looking at; nothing below it is fresher.
+                return None
+            # A row without the key means the host never persisted a toggle
+            # for this session; only the hook ledger can speak for it.
+            if "yolo_mode" not in config:
+                return None
+            return bool(config.get("yolo_mode")), float(activity)
+        return None
+    except (sqlite3.Error, TypeError, ValueError):
+        return None
+    finally:
+        try:
+            connection.close()
+        except sqlite3.Error:
+            pass
+
+
+def _approvals_mode_off(hermes_home: str = "") -> bool:
+    """Whether config.yaml sets the global ``approvals.mode: off`` bypass.
+
+    A minimal text scan in the same spirit as the delegation-route reader:
+    only the top-level ``approvals:`` section's ``mode`` key is inspected,
+    and anything unreadable or oddly shaped reads as False (not bypassed) so
+    this can only ever add a truthful ON, never mask one.
+    """
+    home = Path(hermes_home).expanduser() if hermes_home else Path.home() / ".hermes"
+    try:
+        text = (home / "config.yaml").read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return False
+    in_section = False
+    child_indent: int | None = None
+    for line in text.splitlines():
+        if line and not line[0].isspace() and not line.startswith("#"):
+            in_section = line.split(":", 1)[0].strip() == "approvals"
+            child_indent = None
+            continue
+        if not in_section:
+            continue
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip())
+        # Only the section's DIRECT children are approvals settings; a
+        # deeper `mode:` (e.g. approvals.tools.mode) is a different key and
+        # must never read as the global bypass.
+        if child_indent is None:
+            child_indent = indent
+        if indent != child_indent:
+            continue
+        if stripped.startswith("mode:"):
+            raw_value = stripped.partition(":")[2].split("#", 1)[0].strip()
+            quoted = (
+                len(raw_value) >= 2
+                and raw_value[0] in {"'", '"'}
+                and raw_value[-1] == raw_value[0]
+            )
+            value = raw_value[1:-1] if quoted else raw_value
+            if quoted:
+                # A quoted token is a plain string to YAML: 'false' and 'no'
+                # normalize to "manual" in the host, NOT to the bypass.
+                return value.casefold() == "off"
+            # Bare tokens pass through YAML 1.1 boolean resolution before
+            # the host normalizer maps False back to "off": off, false, and
+            # no all spell the same bypass.
+            return value.casefold() in {"off", "false", "no"}
+    return False
+
+
+def effective_approval_bypass(
+    omh_home: str = "", hermes_home: str = "", *, now: float | None = None
+) -> dict[str, Any]:
+    """Real-time yolo projection: host-persisted state first, ledger fallback.
+
+    ``approvals.mode: off`` dominates (the host's own /yolo refuses to
+    override it), then the session row's persisted toggle; only when neither
+    surface speaks does the hook-observed ledger answer — covering the
+    pre-first-turn toggle and older hosts, at turn latency.
+    """
+    config_off = _approvals_mode_off(hermes_home)
+    row = _session_yolo_row(hermes_home, now=now)
+    if config_off or row is not None:
+        current = float(now if now is not None else time.time())
+        # observed_at carries the row's own activity timestamp, not the
+        # read time: the projection must not restamp old state as fresh.
+        observed_ts = row[1] if row is not None and not config_off else current
+        observed_at = (
+            datetime.fromtimestamp(float(observed_ts), tz=timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+        return {
+            "status": "observed",
+            "enabled": bool(config_off or (row is not None and row[0])),
+            "observed_at": observed_at,
+            "source": "host_state",
+            "claim_boundary": APPROVAL_BYPASS_HOST_STATE_CLAIM_BOUNDARY,
+        }
+    return latest_approval_bypass(omh_home, now=now)
 
 
 def latest_approval_bypass(omh_home: str = "", *, now: float | None = None) -> dict[str, Any]:

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -11,7 +11,7 @@ from functools import partial
 from pathlib import Path
 from typing import Any, Callable
 
-from .approval_bypass import latest_approval_bypass
+from .approval_bypass import effective_approval_bypass
 from .hermes_delegation import read_hermes_native_subagents
 from .tool_bursts import latest_parallel_shot
 from .metadata import (
@@ -676,10 +676,12 @@ def read_omh_hud(
         # Concurrent tool-call batches observed by the pre_tool_call hook;
         # the [OMH] status line brands a fresh batch as a parallel shot.
         "parallel_shot": latest_parallel_shot(str(home)),
-        # Effective approval-bypass (yolo) state observed by the pre_llm_call
-        # and pre_tool_call hooks; the [OMH] status line renders it as
-        # "yolo mode: on/off".
-        "yolo": latest_approval_bypass(str(home)),
+        # Effective approval-bypass (yolo) state, read from the host's own
+        # persisted surfaces (session row's /yolo flag, approvals.mode) so a
+        # toggle between turns shows on the next widget poll; the hook
+        # ledger answers only when neither surface speaks. The [OMH] status
+        # line renders it as "yolo mode: on/off".
+        "yolo": effective_approval_bypass(str(home), str(hermes)),
         "evidence_boundary": (
             "HUD is metadata-only. Prepared handoffs are not execution, review, CI, merge, or token-usage evidence. "
             "Todo items are plan declarations, not execution evidence."

--- a/tests/test_approval_bypass.py
+++ b/tests/test_approval_bypass.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from omh.plugin_bundle.omh.approval_bypass import (
     APPROVAL_BYPASS_FRESH_SECONDS,
     approval_bypass_path,
+    effective_approval_bypass,
     latest_approval_bypass,
     record_approval_bypass,
 )
@@ -115,3 +116,234 @@ class ApprovalBypassLedgerTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class HostStateYoloTest(unittest.TestCase):
+    """The HUD reads the host's persisted /yolo surfaces in real time.
+
+    A host that persists the toggle writes the session row's
+    model_config.yolo_mode (the classic CLI does; the Modern TUI gains the
+    same persist upstream), so the reader projects that row for the most
+    recently active LIVE TUI session — scoped by source, liveness, and the
+    ledger's freshness bound so a foreign or dead row can never answer for
+    the session a widget is rendering ("yolomode onoff 실시간 반영이 안됨").
+    The hook ledger answers whenever no persisted surface speaks.
+    """
+
+    def setUp(self):
+        import sqlite3
+
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.omh_home = str(Path(self._tmp.name) / "omh")
+        self.hermes_home = Path(self._tmp.name) / "hermes"
+        self.hermes_home.mkdir()
+        self._sqlite3 = sqlite3
+
+    def _build_db(self, rows):
+        """rows: (id, config, activity, source='tui', ended_at=None, archived=0, hidden=0)."""
+        connection = self._sqlite3.connect(self.hermes_home / "state.db")
+        connection.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY, source TEXT, model TEXT,
+                model_config TEXT, started_at REAL NOT NULL,
+                last_activity_at REAL, ended_at REAL,
+                archived INTEGER DEFAULT 0, hidden INTEGER DEFAULT 0
+            );
+            """
+        )
+        import json as json_module
+
+        for row in rows:
+            session_id, config, activity = row[0], row[1], row[2]
+            source = row[3] if len(row) > 3 else "tui"
+            ended_at = row[4] if len(row) > 4 else None
+            raw = (
+                config
+                if isinstance(config, (str, int, type(None)))
+                else json_module.dumps(config)
+            )
+            connection.execute(
+                "INSERT INTO sessions (id, source, model, model_config, started_at,"
+                " last_activity_at, ended_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (session_id, source, "gpt-5.6-sol", raw, activity - 100, activity, ended_at),
+            )
+        connection.commit()
+        connection.close()
+
+    def _write_ledger(self, enabled: bool, *, observed_ts: float) -> None:
+        approval_bypass_path(self.omh_home).parent.mkdir(parents=True, exist_ok=True)
+        approval_bypass_path(self.omh_home).write_text(
+            '{"schema_version": "omh_approval_bypass/v1", '
+            f'"enabled": {"true" if enabled else "false"}, '
+            f'"observed_ts": {observed_ts}}}',
+            encoding="utf-8",
+        )
+
+    def _effective(self):
+        return effective_approval_bypass(self.omh_home, str(self.hermes_home), now=NOW)
+
+    def test_a_persisted_toggle_projects_on_without_any_hook_observation(self):
+        self._build_db([("s1", {"yolo_mode": True}, NOW - 60)])
+        state = self._effective()
+        self.assertEqual(state["status"], "observed")
+        self.assertTrue(state["enabled"])
+        self.assertEqual(state["source"], "host_state")
+
+    def test_a_toggle_off_beats_a_stale_hook_observation(self):
+        # The reported bug: the ledger observed ON at the last turn, the
+        # user toggled OFF between turns, and the HUD kept saying on.
+        self._write_ledger(True, observed_ts=NOW - 30)
+        self._build_db([("s1", {"yolo_mode": False}, NOW - 60)])
+        state = self._effective()
+        self.assertEqual(state["status"], "observed")
+        self.assertFalse(state["enabled"])
+
+    def test_only_a_live_tui_row_may_answer(self):
+        # A cron --yolo run and a closed TUI must never flip the display of
+        # the session a widget is actually rendering.
+        self._build_db(
+            [
+                ("cron", {"yolo_mode": True}, NOW - 5, "tool"),
+                ("closed", {"yolo_mode": True}, NOW - 10, "tui", NOW - 9),
+                ("cli", {"yolo_mode": True}, NOW - 15, "cli"),
+                ("live", {"yolo_mode": False}, NOW - 60),
+            ]
+        )
+        state = self._effective()
+        self.assertFalse(state["enabled"])
+        self.assertEqual(state["source"], "host_state")
+
+    def test_an_old_stamped_row_never_dominates_the_ledger(self):
+        # The freshest live TUI row is beyond the freshness bound: a stamp
+        # from a long-dead session says nothing about today.
+        self._build_db([("old", {"yolo_mode": True}, NOW - 7 * 3600)])
+        self._write_ledger(False, observed_ts=NOW - 30)
+        state = self._effective()
+        self.assertFalse(state["enabled"])
+        self.assertNotIn("source", state)
+
+    def test_a_child_row_is_skipped_and_the_next_live_row_answers(self):
+        self._build_db(
+            [
+                ("child", {"yolo_mode": True, "_delegate_from": "main"}, NOW - 5),
+                ("main", {"yolo_mode": False}, NOW - 60),
+            ]
+        )
+        self.assertFalse(self._effective()["enabled"])
+
+    def test_a_crowd_of_live_children_cannot_push_the_main_row_out(self):
+        # Delegate children are source='tui' too; the WHERE-level skip keeps
+        # them from consuming the row limit ahead of the eligible session.
+        rows = [
+            (f"child-{index}", {"yolo_mode": True, "_delegate_from": "main"}, NOW - index)
+            for index in range(40)
+        ]
+        rows.append(("main", {"yolo_mode": False}, NOW - 300))
+        self._build_db(rows)
+        state = self._effective()
+        self.assertFalse(state["enabled"])
+        self.assertEqual(state["source"], "host_state")
+
+    def test_an_undecodable_row_is_skipped_and_the_next_row_answers(self):
+        # A BLOB model_config exercises the decode guard; the eligible row
+        # below it still answers instead of the whole read failing.
+        import sqlite3
+
+        self._build_db([("main", {"yolo_mode": False}, NOW - 60)])
+        connection = self._sqlite3.connect(self.hermes_home / "state.db")
+        connection.execute(
+            "INSERT INTO sessions (id, source, model, model_config, started_at,"
+            " last_activity_at) VALUES (?, 'tui', 'm', ?, ?, ?)",
+            ("blob", sqlite3.Binary(b"\x00\xff\xfe"), NOW - 200, NOW - 5),
+        )
+        connection.commit()
+        connection.close()
+        self.assertFalse(self._effective()["enabled"])
+
+    def test_an_unstamped_newest_session_falls_back_to_the_ledger(self):
+        self._build_db([("s1", {}, NOW - 60)])
+        self._write_ledger(True, observed_ts=NOW - 30)
+        state = self._effective()
+        self.assertEqual(state["status"], "observed")
+        self.assertTrue(state["enabled"])
+        self.assertNotIn("source", state)
+
+    def test_the_row_activity_timestamp_is_carried_not_restamped(self):
+        self._build_db([("s1", {"yolo_mode": True}, NOW - 60)])
+        state = self._effective()
+        from datetime import datetime, timezone
+
+        expected = (
+            datetime.fromtimestamp(NOW - 60, tz=timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+        self.assertEqual(state["observed_at"], expected)
+
+    def test_approvals_mode_off_dominates_a_toggled_off_row(self):
+        # The host's own /yolo refuses to override approvals.mode: off, so
+        # the projection must not either.
+        (self.hermes_home / "config.yaml").write_text(
+            "approvals:\n  mode: off\n", encoding="utf-8"
+        )
+        self._build_db([("s1", {"yolo_mode": False}, NOW - 60)])
+        state = self._effective()
+        self.assertTrue(state["enabled"])
+
+    def test_a_nested_or_manual_mode_never_reads_as_bypass(self):
+        # approvals.tools.mode is a different key; mode: manual is not off;
+        # a QUOTED 'false'/'no' is a plain string the host normalizes to
+        # manual, so it must never read as the bypass.
+        for content in (
+            "approvals:\n  tools:\n    mode: off\n  mode: manual\n",
+            "approvals:\n  mode: manual\n",
+            "approvals:\n  mode: 'false'\n",
+            "approvals:\n  mode: \"no\"\n",
+            "other:\n  mode: off\n",
+            "# approvals:\n#   mode: off\n",
+        ):
+            with self.subTest(content=content):
+                (self.hermes_home / "config.yaml").write_text(content, encoding="utf-8")
+                state = self._effective()
+                self.assertEqual(state["status"], "idle")
+
+    def test_a_bare_yaml_boolean_mode_reads_as_the_bypass_it_is(self):
+        # YAML 1.1 reads bare false/no/off as boolean False and the host
+        # normalizer maps False back to "off" — quoting is what opts out.
+        for content in (
+            "approvals:\n  mode: false\n",
+            "approvals:\n  mode: no\n",
+        ):
+            with self.subTest(content=content):
+                (self.hermes_home / "config.yaml").write_text(content, encoding="utf-8")
+                self.assertTrue(self._effective()["enabled"])
+
+    def test_unreadable_state_never_breaks_the_projection(self):
+        for prepare in (
+            lambda: (self.hermes_home / "state.db").write_bytes(b"not a database"),
+            lambda: self._build_db([("s1", 42, NOW - 60)]),  # non-str model_config
+            lambda: None,  # missing db entirely
+        ):
+            with self.subTest(prepare=prepare):
+                db = self.hermes_home / "state.db"
+                if db.exists():
+                    db.unlink()
+                prepare()
+                state = self._effective()
+                self.assertEqual(state["status"], "idle")
+
+    def test_the_host_state_projection_carries_its_claim_boundary(self):
+        self._build_db([("s1", {"yolo_mode": True}, NOW - 60)])
+        state = self._effective()
+        self.assertIn("never approval, execution", state["claim_boundary"])
+        self.assertIn("real-time", state["claim_boundary"])
+
+    def test_the_hud_payload_reads_the_persisted_toggle(self):
+        # read_omh_hud runs on the wall clock, so the fixture row must be
+        # fresh relative to it (the other cases pin the clock via now=NOW).
+        self._build_db([("s1", {"yolo_mode": True}, time.time() - 60)])
+        payload = read_omh_hud(self.omh_home, str(self.hermes_home))
+        self.assertEqual(payload["yolo"]["status"], "observed")
+        self.assertTrue(payload["yolo"]["enabled"])


### PR DESCRIPTION
## Capability

The HUD's "yolo mode: on/off" reads the host's **persisted** approval-bypass surfaces instead of only echoing what the plugin's hooks observed last turn: `config.yaml` `approvals.mode` (dominates, as in the host) and the session row's `model_config.yolo_mode` — the flag Hermes persists for `--resume` restore. The widget polls every 2s, so a persisted toggle surfaces in at most two seconds instead of waiting for the user's next message.

## Motivation

Owner report: "yolomode onoff 실시간 반영이 안됨" → "되게 해". The state was hook-observed only (`pre_llm_call`/`pre_tool_call` tick a ledger), so a Shift+Tab between turns kept rendering the previous turn's answer.

## Fault domain (review-measured)

The independent reviewer lane falsified the first draft's premise: the **Modern TUI's** gateway toggle flips only the in-memory set — every TUI-source session row on the reporting machine carried zero `yolo_mode` stamps — while the classic CLI persists. The TUI-side persist is fixed upstream in **NousResearch/hermes-agent#96267** (filed with this PR; it also repairs TUI `/yolo` not surviving `--resume`, including the compression-rotation carry the CLI already does). Until the host carries it, TUI toggles keep the ledger's turn latency; `approvals.mode` changes and CLI toggles are real-time now, and TUI toggles become real-time with no further OMH change once the host updates.

## Implementation (boundary level)

- `src/plugin_bundle/omh/approval_bypass.py`: `effective_approval_bypass()` — `approvals.mode` direct-child-indent text scan (quoted `'false'`/`'no'` are strings, never bypass; bare YAML-1.1 booleans `off/false/no` are), and a session-row reader scoped hard before it may answer: `source='tui'` only, not ended/archived/hidden, delegation children excluded at the WHERE level, most recent by the host's own MRU column (`last_activity_at`), inside the ledger's freshness bound, read-only sqlite with quoted URI and fail-open errors. `observed_at` carries the row's activity timestamp, never the read time. The hook ledger answers when no persisted surface speaks.
- `src/plugin_bundle/omh/runtime_reader.py`: the HUD payload swaps to the combined projection.
- `src/omh/tui_widgets/omh-status.mjs`: comment updated to describe the new sourcing (rendering unchanged).

## Review

Two rounds by an independent reviewer lane. Round 1: 2 CRITICAL (unscoped newest-row read — TUI rows never stamped, so the bug was unfixed; stale/foreign rows could dominate indefinitely), 2 HIGH, 3 MEDIUM — full rework plus the upstream fault-domain split. Round 2: no CRITICAL/HIGH remaining; the two residual MEDIUMs (quoted-`'false'` false-ON; upstream rotation-carry gap) fixed and re-verified, including live-machine checks (the scoped WHERE returns exactly the owner's live session; 1.6ms read). Two recorded limitations the reader cannot close (it has no session id): a killed TUI's stamp may answer for a not-yet-stamped new session inside the freshness window, and with two concurrently live TUIs the most recently active answers for both.

## Verification (observed)

- `PYTHONPATH=tests uv run python -m unittest discover -s tests` — full suite OK on the final tree (count in the commit trailer).
- `tests/test_approval_bypass.py` — 22 tests including the review's negative half: cron/tool/closed/cli rows never answer; a stale row never dominates a fresh ledger; a crowd of live delegate children cannot push the eligible row out; nested `approvals.tools.mode`, `mode: manual`, quoted `'false'`/`"no"`, commented-out and foreign sections never read as bypass; bare `false`/`no` do; undecodable rows are skipped; timestamps carried, not restamped.
- ruff; compileall; `git diff --check`; broad-except policy suite; all five docs byte gates.
- Upstream companion: 30/30 gateway yolo+compress tests, 24/24 CLI yolo tests, ruff clean (details in #96267).

## Risks

Low — one plugin module, the reader swap, a widget comment; hooks still tick the ledger. End-to-end TUI Shift+Tab is prepared_not_observed until the host carries #96267 (reaches machines via `omh update`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKo77o5dTJtLRWfDj4uBtq
