### PR TITLE
fix(benchmark): normalize Windows snapshot paths

### DIFF
--- a/benchmarks/live-model-tools/v1/lib/runner.py
+++ b/benchmarks/live-model-tools/v1/lib/runner.py
@@ -24,7 +24,7 @@ def _snapshot(root: Path) -> dict[str, bytes]:
         if path.is_symlink():
             continue
         if path.is_file() and "__pycache__" not in path.parts and ".venv" not in path.parts and ".pytest_cache" not in path.parts:
-            snapshot[str(path.relative_to(root))] = path.read_bytes()
+            snapshot[path.relative_to(root).as_posix()] = path.read_bytes()
     return snapshot
 
 

--- a/tests/test_omh_live_model_benchmark.py
+++ b/tests/test_omh_live_model_benchmark.py
@@ -4,6 +4,7 @@ import importlib.util
 import json
 from pathlib import Path
 import stat
+import sys
 from tempfile import TemporaryDirectory
 import unittest
 from unittest.mock import patch
@@ -16,6 +17,10 @@ from omh.coding.unit_prompt_protocol import HIGH_EFFORT_CALIBRATIONS  # noqa: E4
 
 
 BASE = Path(__file__).resolve().parents[1] / "benchmarks" / "live-model-tools" / "v1"
+sys.path.insert(0, str(BASE / "lib"))
+
+from runner import _snapshot  # noqa: E402
+from validation import changed_paths  # noqa: E402
 
 
 def _load_omh_live():
@@ -178,6 +183,20 @@ class OmhLiveAdapterTests(unittest.TestCase):
         self.assertIn("Verify the file exists and parses as JSON", baseline)
         self.assertIn(HIGH_EFFORT_CALIBRATIONS["deepseek"], optimized)
         self.assertEqual(module.task_digest(baseline), module.task_digest(optimized))
+
+    def test_snapshot_and_changed_paths_use_canonical_posix_keys(self) -> None:
+        with TemporaryDirectory() as root_text:
+            root = Path(root_text)
+            target = root / "nested" / "file.txt"
+            target.parent.mkdir()
+            target.write_text("before", encoding="utf-8")
+
+            initial = _snapshot(root)
+            self.assertEqual(initial, {"nested/file.txt": b"before"})
+            self.assertEqual(changed_paths(root, initial), [])
+
+            target.write_text("after", encoding="utf-8")
+            self.assertEqual(changed_paths(root, initial), ["nested/file.txt"])
 
     def test_observation_metrics_never_estimate_missing_usage(self) -> None:
         module = _load_omh_live()


### PR DESCRIPTION
## Summary
Fix the Windows-only benchmark false failure where unchanged files were graded as `mutation_outside_scope`.

## Root cause
`benchmarks/live-model-tools/v1/lib/runner.py::_snapshot()` stored platform-native relative path strings, while `lib/validation.py::changed_paths()` stored POSIX relative paths. On Windows, the key sets differed even when the workspace was unchanged.

## Fix
Store `_snapshot()` keys with `.as_posix()`, matching `changed_paths()` without weakening mutation validation or adding exclusions.

## Regression coverage
Added `test_snapshot_and_changed_paths_use_canonical_posix_keys`, covering an unchanged workspace and a real file modification.

## Verification
- Fake smoke: PASS, no failure codes.
- `tests/test_omh_live_model_benchmark.py`: 14/14.
- Relevant calibration tests: 22/22.
- Pinned Ruff: PASS.
- All required docs `--check` gates: PASS.
- `git diff --check`: PASS.

Full unittest discovery remains blocked on this Windows host by pre-existing symlink-privilege assumptions (`WinError 1314`) in these unrelated tests:
- `tests/test_cli.py::CliTests::test_doctor_warns_about_potential_external_skill_name_collisions_without_claiming_runtime_precedence`
- `tests/test_cli.py::CliTests::test_update_self_update_recognizes_venv_python_symlink_path`
- `tests/test_cli.py::CliTests::test_loop_cli_goal_driver_observe_bounds_json_and_rejects_symlinks`
- `tests/test_cli.py::CliTests::test_uninstall_removes_install_sh_managed_command_package_when_detected`
- `tests/test_cli.py::CliTests::test_uninstall_detects_managed_command_package_when_venv_python_resolves_outside`

No unrelated tests were changed. This PR does not complete issue #1056. No paid/live model calls ran, and the four family calibrations remain pending.