### PR TITLE
feat(hud): truthful liveness — exact in-flight tool tracking and stall-honest dock

### DIFF
--- a/src/capabilities/hooks.py
+++ b/src/capabilities/hooks.py
@@ -103,6 +103,10 @@ def _hook_payload_fields(name: str) -> list[str]:
         ]
     if name == "pre_tool_call":
         return ["context", "action", "message"]
+    if name == "post_tool_call":
+        # A pure observer: it closes the in-flight ledger entry for the HUD
+        # liveness signal and never returns a directive to the host.
+        return []
     if name == "on_session_end":
         return ["session_summary", "metadata_only"]
     if name == "pre_verify":

--- a/src/install/hook_integrity.py
+++ b/src/install/hook_integrity.py
@@ -156,6 +156,16 @@ HOOK_REVIEWS: dict[str, dict[str, Any]] = {
             "unknown-role warning before a Hermes tool call"
         ),
     },
+    "post_tool_call": {
+        "source_path": "hooks/tool_hooks.py",
+        "event_scope": ("post_tool_call",),
+        "reviewed_timeout_ms": 1000,
+        "capability": (
+            "closing the in-flight tool-call ledger entry that backs the OMH "
+            "HUD's liveness signal (open-call count, stalled-todo warning, "
+            "parallel-shot lifetime)"
+        ),
+    },
     "pre_verify": {
         "source_path": "hooks/verify_hooks.py",
         "event_scope": ("pre_verify",),

--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -359,9 +359,13 @@ export default function register(sdk) {
         // by tool_call_id: the only honest answer to "is something actually
         // running right now", as opposed to a lingering active todo item or
         // a ring-saturated parallel-shot count. Renders only while at least
-        // one call is genuinely open; a host without post_tool_call degrades
-        // silently to no segment at all.
-        payload.activity && payload.activity.live
+        // one call is genuinely open AND this install has actually observed
+        // post_tool_call fire at least once (`post_tool_call_observed`) --
+        // on a host `_host_supports_hook` never registered post_tool_call
+        // for, open entries can only expire, never legitimately close, so a
+        // `live` reading there cannot be trusted either way and the segment
+        // stays hidden rather than asserting liveness it cannot back.
+        payload.activity && payload.activity.live && payload.activity.post_tool_call_observed
           ? h(
               Text,
               {},
@@ -369,7 +373,7 @@ export default function register(sdk) {
               h(
                 Text,
                 { color: t.color.warn },
-                `⚙ ${plural(Number(payload.activity.open_call_count) || 0, 'tool')} · ${
+                `${plural(Number(payload.activity.open_call_count) || 0, 'tool')} · ${
                   elapsedText(payload.activity.oldest_open_elapsed_seconds) || '0s'
                 }`,
               ),
@@ -502,12 +506,23 @@ export default function register(sdk) {
     // Stopped-with-incomplete-todo used to look identical to genuinely
     // working -- both showed the same green [•] -- which is the exact
     // complaint this fixes ('todo에 초록색 진행중 텍스트가 있는게 더 문제').
-    const live = !!(payload.activity && payload.activity.live)
+    // When this install has never observed post_tool_call fire, liveness is
+    // unanswerable rather than false -- an unsupported host's ledger can
+    // only expire entries, never legitimately close them, so treating that
+    // silence as "not live" would brand a genuinely working agent stalled
+    // forever. The fallback there is the pre-liveness shape: always live,
+    // no stall hint, same as before this signal existed.
+    const answerable = !!(payload.activity && payload.activity.post_tool_call_observed)
+    const live = answerable ? !!(payload.activity && payload.activity.live) : true
+    // The reader computes this age fresh on every read_omh_hud call (see
+    // `updated_age_seconds` in runtime_reader.py's `_todo_summary`) so it
+    // stays honest even when applySnapshot's byte-identical-payload check
+    // skips a repaint; a Date.now() computed here in render would freeze at
+    // whatever second it last actually rendered on an idle snapshot.
     const stallElapsed = (() => {
       if (live) return ''
-      const updatedAt = Date.parse(safeText(todo.updated_at) || '')
-      if (!Number.isFinite(updatedAt)) return ''
-      return elapsedText(Math.max(0, (Date.now() - updatedAt) / 1000))
+      const seconds = todo.updated_age_seconds
+      return Number.isFinite(seconds) ? elapsedText(Math.max(0, seconds)) : ''
     })()
     const markers = { active: '[•]', done: '[✓]', pending: '[ ]' }
     const budget = Math.max(16, columns - 10)
@@ -622,7 +637,13 @@ export default function register(sdk) {
   // used to read "×40" for as long as the ceiling stayed full regardless of
   // whether the batch was still running. Once every member has closed, the
   // badge either drops (idle) or -- while the shot is still fresh -- renders
-  // dimmed as history with its age, so it never reads as a second live cue.
+  // dimmed as history with its age. The history form reads `peak_open_count`
+  // (the most calls this shot's own members were ever observed open at
+  // once), not `size` (the burst's total member count): Hermes caps
+  // concurrent tool workers well under most burst sizes, so a long chain of
+  // strictly SEQUENTIAL fast calls -- which the 1.5s grouping window still
+  // chains into one burst -- has a `size` that overclaims parallelism the
+  // ledger never actually observed.
   const planShotBadge = (payload, t) => {
     const shot = payload.parallel_shot
     if (!shot || shot.status !== 'observed') return null
@@ -635,7 +656,7 @@ export default function register(sdk) {
     return h(
       Text,
       { color: t.color.muted },
-      ` · parallel shot ×${Number(shot.size) || 0}${age ? ` (${age} ago)` : ''}`,
+      ` · parallel shot ×${Number(shot.peak_open_count) || 0}${age ? ` (${age} ago)` : ''}`,
     )
   }
 
@@ -716,6 +737,10 @@ export default function register(sdk) {
     // purpose -- that boolean flip and count change are structural, and must
     // repaint promptly rather than wait out the metrics throttle.
     'oldest_open_elapsed_seconds',
+    // The reader-computed todo stall age ticks every poll while a plan sits
+    // idle; same reasoning as oldest_open_elapsed_seconds above -- it must
+    // not force a repaint every 2s, only advance on the metrics cadence.
+    'updated_age_seconds',
   ])
   const structuralKey = payload =>
     JSON.stringify(payload, (key, value) => (VOLATILE_KEYS.has(key) ? undefined : value))

--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -355,6 +355,26 @@ export default function register(sdk) {
         h(Text, { color: t.color.border }, SEPARATOR),
         h(Text, { color: active ? t.color.warn : t.color.ok }, hudStateLabel(active, agents)),
         h(Text, { color: t.color.muted }, `${metrics.cost ? ` • ${metrics.cost}` : ''} • ${metrics.ctx}`),
+        // Exact in-flight liveness, paired from pre_tool_call/post_tool_call
+        // by tool_call_id: the only honest answer to "is something actually
+        // running right now", as opposed to a lingering active todo item or
+        // a ring-saturated parallel-shot count. Renders only while at least
+        // one call is genuinely open; a host without post_tool_call degrades
+        // silently to no segment at all.
+        payload.activity && payload.activity.live
+          ? h(
+              Text,
+              {},
+              h(Text, { color: t.color.muted }, ' • '),
+              h(
+                Text,
+                { color: t.color.warn },
+                `⚙ ${plural(Number(payload.activity.open_call_count) || 0, 'tool')} · ${
+                  elapsedText(payload.activity.oldest_open_elapsed_seconds) || '0s'
+                }`,
+              ),
+            )
+          : null,
         // Shift+Tab yolo state: the reader projects the host's persisted
         // surfaces first (the live TUI session row's /yolo flag where the
         // host persists it, config.yaml approvals.mode) so a toggle shows
@@ -477,6 +497,18 @@ export default function register(sdk) {
     // neighbours fold into muted `... (N earlier/later tasks)` lines.
     const shown = Array.isArray(todo.items) ? todo.items : []
     const hasActive = shown.some(item => item.state === 'active')
+    // Truth, not chrome: the active item reads green and animates ONLY while
+    // the HUD's exact in-flight signal says something is actually running.
+    // Stopped-with-incomplete-todo used to look identical to genuinely
+    // working -- both showed the same green [•] -- which is the exact
+    // complaint this fixes ('todo에 초록색 진행중 텍스트가 있는게 더 문제').
+    const live = !!(payload.activity && payload.activity.live)
+    const stallElapsed = (() => {
+      if (live) return ''
+      const updatedAt = Date.parse(safeText(todo.updated_at) || '')
+      if (!Number.isFinite(updatedAt)) return ''
+      return elapsedText(Math.max(0, (Date.now() - updatedAt) / 1000))
+    })()
     const markers = { active: '[•]', done: '[✓]', pending: '[ ]' }
     const budget = Math.max(16, columns - 10)
     const currentPhase = safeText(todo.display_phase)
@@ -503,7 +535,10 @@ export default function register(sdk) {
       `${Object.hasOwn(markers, item.state) ? markers[item.state] : '[ ]'} ${truncateCells(item.text, budget)}`
     const itemProps = item => ({
       bold: item.state === 'active',
-      color: item.state === 'active' ? t.color.ok : item.state === 'done' ? t.color.muted : t.color.text,
+      // A stalled active item (HUD says not-live) is a warning-grade fact,
+      // not progress: the same warn color the route-fallback segment uses
+      // for "this is not what it looks like at a glance" (#1145).
+      color: item.state === 'active' ? (live ? t.color.ok : t.color.warn) : item.state === 'done' ? t.color.muted : t.color.text,
       strikethrough: item.state === 'done',
     })
     const phaseProps = phase => ({
@@ -516,16 +551,25 @@ export default function register(sdk) {
         { key, wrap: 'truncate-end' },
         h(Text, { color: t.color.muted }, `... (${count} ${side} task${count === 1 ? '' : 's'})`),
       )
-    // The active item's text carries the colour wave; its marker, indent and
-    // every other item stay static.
+    // The active item's text carries the colour wave ONLY while live; motion
+    // implies "actually running", so a stalled item renders as static warn
+    // text plus an elapsed hint instead -- the marker and indent stay the
+    // same shape either way, only the state they claim changes.
     const itemNode = (item, indent) =>
       item.state === 'active'
-        ? h(
-            Text,
-            {},
-            h(Text, itemProps(item), `${indent}${markers.active} `),
-            h(ShimmerText, { color: t.color.ok, t, text: truncateCells(item.text, budget) }),
-          )
+        ? live
+          ? h(
+              Text,
+              {},
+              h(Text, itemProps(item), `${indent}${markers.active} `),
+              h(ShimmerText, { color: t.color.ok, t, text: truncateCells(item.text, budget) }),
+            )
+          : h(
+              Text,
+              { wrap: 'truncate-end' },
+              h(Text, itemProps(item), `${indent}${markers.active} ${truncateCells(item.text, budget)}`),
+              stallElapsed ? h(Text, { color: t.color.muted }, ` (stalled ${stallElapsed})`) : null,
+            )
         : h(Text, itemProps(item), `${indent}${itemLabel(item)}`)
     const rows = []
     if (start > 0) rows.push(foldLine('todo-earlier', start, 'earlier'))
@@ -562,7 +606,7 @@ export default function register(sdk) {
         h(Text, { color: t.color.warn }, `${counts.done ?? 0}/${counts.total ?? 0}`),
         phaseCount > 1 ? h(Text, { color: t.color.muted }, ` · ${phaseCount} phases`) : null,
         planShotBadge(payload, t),
-        hasActive ? h(PlanPulse, { t }) : null,
+        hasActive && live ? h(PlanPulse, { t }) : null,
       ),
       ...rows,
       h(Rule, { columns, t }),
@@ -572,18 +616,28 @@ export default function register(sdk) {
   // The parallel-shot badge rides the [Plan] header — the owner moved it
   // here from the frame rule ('parallel shot을 지금 위치에 두지말고 여기
   // 위치 옆에 뜨게'), the line sitting directly under the host status rule.
-  // A fresh concurrent tool-call batch (observed by the pre_tool_call hook)
-  // is the only thing it brands, and the reader's seconds-scale freshness
-  // window makes it vanish right after the batch lands instead of lingering
-  // as standing chrome.
-  const planShotBadge = (payload, t) =>
-    payload.parallel_shot && payload.parallel_shot.status === 'observed'
-      ? h(
-          Text,
-          { color: t.color.label },
-          ` · parallel shot ×${Number(payload.parallel_shot.size) || 0}`,
-        )
-      : null
+  // Its lifetime now ties to open calls, not the ring buffer: while any
+  // member of the batch is still open, the badge shows the TRUE live count
+  // (open_count on the latest shot) instead of the ring-saturated size that
+  // used to read "×40" for as long as the ceiling stayed full regardless of
+  // whether the batch was still running. Once every member has closed, the
+  // badge either drops (idle) or -- while the shot is still fresh -- renders
+  // dimmed as history with its age, so it never reads as a second live cue.
+  const planShotBadge = (payload, t) => {
+    const shot = payload.parallel_shot
+    if (!shot || shot.status !== 'observed') return null
+    const openCount = Number(shot.open_count) || 0
+    if (openCount > 0) {
+      return h(Text, { color: t.color.label }, ` · parallel shot ×${openCount}`)
+    }
+    const observedAt = shot.observed_at ? Date.parse(shot.observed_at) : NaN
+    const age = Number.isFinite(observedAt) ? elapsedText(Math.max(0, (Date.now() - observedAt) / 1000)) : ''
+    return h(
+      Text,
+      { color: t.color.muted },
+      ` · parallel shot ×${Number(shot.size) || 0}${age ? ` (${age} ago)` : ''}`,
+    )
+  }
 
   const sharedInit = () => ({ payload: null, receivedAt: 0, tick: 0 })
   const sharedReduce = (state, input) =>
@@ -657,6 +711,11 @@ export default function register(sdk) {
     'tokens_per_second',
     'tool_count',
     'turn_count',
+    // The exact in-flight age ticks on every poll while live; the liveness
+    // transition itself (open_call_count, live) stays OUT of this set on
+    // purpose -- that boolean flip and count change are structural, and must
+    // repaint promptly rather than wait out the metrics throttle.
+    'oldest_open_elapsed_seconds',
   ])
   const structuralKey = payload =>
     JSON.stringify(payload, (key, value) => (VOLATILE_KEYS.has(key) ? undefined : value))

--- a/src/plugin_bundle/omh/__init__.py
+++ b/src/plugin_bundle/omh/__init__.py
@@ -79,7 +79,7 @@ def register(ctx):
     from .hooks.llm_hooks import pre_llm_call
     from .hooks.result_transforms import transform_tool_result
     from .hooks.session_hooks import on_session_end
-    from .hooks.tool_hooks import pre_tool_call
+    from .hooks.tool_hooks import post_tool_call, pre_tool_call
     from .hooks.verify_hooks import pre_verify
     from .tools.capability_tool import OMH_CAPABILITIES_SCHEMA, omh_capabilities_handler
     from .tools.chat_tool import OMH_INTERACT_SCHEMA, omh_interact_handler
@@ -197,5 +197,6 @@ def register(ctx):
     ctx.register_hook("on_session_end", on_session_end)
     ctx.register_hook("pre_llm_call", pre_llm_call)
     ctx.register_hook("pre_tool_call", pre_tool_call)
+    _register_optional_hook(ctx, "post_tool_call", post_tool_call)
     _register_optional_hook(ctx, "pre_verify", pre_verify)
     _register_optional_hook(ctx, "transform_tool_result", transform_tool_result)

--- a/src/plugin_bundle/omh/hooks/tool_hooks.py
+++ b/src/plugin_bundle/omh/hooks/tool_hooks.py
@@ -5,7 +5,7 @@ import json
 from ..approval_bypass import record_approval_bypass
 from ..host_observation import observe_plugin_hook_call
 from ..omh_roles import extract_role_marker, resolve_role_name, role_aliases, role_names
-from ..tool_bursts import record_tool_call
+from ..tool_bursts import record_tool_call, record_tool_call_close
 from ..toolcall_rules import toolcall_rule_directive
 
 
@@ -33,9 +33,15 @@ def pre_tool_call(**kwargs) -> dict[str, object] | None:
         # parallel-shot burst ledger (its claim boundary is "the host
         # dispatched the calls as one batch").
         return dict(rule_directive)
-    # Tick the parallel-shot ledger: concurrent batch members start within
-    # milliseconds of each other, and this is the only place OMH can see it.
-    record_tool_call(kwargs.get("tool_name"), omh_home=str(kwargs.get("omh_home", "") or ""))
+    # Tick the parallel-shot ledger and, when the host supplies a
+    # tool_call_id, open the in-flight entry post_tool_call closes. This is
+    # the only place OMH can see either fact.
+    record_tool_call(
+        kwargs.get("tool_name"),
+        omh_home=str(kwargs.get("omh_home", "") or ""),
+        tool_call_id=kwargs.get("tool_call_id"),
+        turn_id=kwargs.get("turn_id"),
+    )
     context_parts: list[str] = []
     payload: dict[str, object] = {}
     role_warning = _delegate_role_warning(kwargs)
@@ -46,6 +52,26 @@ def pre_tool_call(**kwargs) -> dict[str, object] | None:
         return None
     payload["context"] = "\n\n".join(context_parts)
     return payload
+
+
+def post_tool_call(**kwargs) -> None:
+    """Close the in-flight ledger entry pre_tool_call opened for this call.
+
+    A supported Hermes observer hook (`install/hook_integrity.py`
+    `HOOK_REVIEWS["post_tool_call"]`), paired with pre_tool_call by
+    tool_call_id. It never blocks or rewrites a tool result -- it only
+    closes the exact in-flight state the HUD's liveness signal reads, which
+    is what tells "stopped with an incomplete todo item" apart from "still
+    running" and keeps the parallel-shot badge from lingering past the ring
+    ceiling. A host that omits tool_call_id is a silent no-op here; the
+    entry pre_tool_call never opened simply never closes early.
+    """
+    observe_plugin_hook_call("post_tool_call", kwargs)
+    record_tool_call_close(
+        kwargs.get("tool_call_id"),
+        omh_home=str(kwargs.get("omh_home", "") or ""),
+    )
+    return None
 
 
 def _delegate_role_warning(kwargs: dict) -> str:

--- a/src/plugin_bundle/omh/metadata.py
+++ b/src/plugin_bundle/omh/metadata.py
@@ -17,8 +17,16 @@ PROVIDED_TOOLS = (
     "omh_todo",
 )
 REQUIRED_HOOKS = ("on_session_end", "pre_llm_call", "pre_tool_call")
-OPTIONAL_HOOKS = ("pre_verify", "transform_tool_result")
-PROVIDED_HOOKS = REQUIRED_HOOKS + OPTIONAL_HOOKS
+# post_tool_call is optional (not every host offers it): it only closes the
+# in-flight ledger pre_tool_call opens for the HUD liveness signal, and a
+# host without it degrades silently to the pre-pairing burst-only behavior.
+OPTIONAL_HOOKS = ("post_tool_call", "pre_verify", "transform_tool_result")
+# Sorted rather than concatenated: several downstream readers (the real
+# loader observation's alphabetized registration report, the plugin.yaml
+# `provides_hooks` conformance check) compare against this tuple's literal
+# order, and required/optional membership stays independently checkable via
+# REQUIRED_HOOKS/OPTIONAL_HOOKS regardless of where a hook sorts.
+PROVIDED_HOOKS = tuple(sorted(REQUIRED_HOOKS + OPTIONAL_HOOKS))
 
 TOOL_FILE_STEMS = {
     "omh_capabilities": "capability_tool",

--- a/src/plugin_bundle/omh/plugin.yaml
+++ b/src/plugin_bundle/omh/plugin.yaml
@@ -21,6 +21,7 @@ provides_tools:
   - omh_todo
 provides_hooks:
   - on_session_end
+  - post_tool_call
   - pre_llm_call
   - pre_tool_call
   - pre_verify

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -13,7 +13,7 @@ from typing import Any, Callable
 
 from .approval_bypass import effective_approval_bypass
 from .hermes_delegation import read_hermes_native_subagents
-from .tool_bursts import latest_parallel_shot, tool_call_activity
+from .tool_bursts import tool_call_projection
 from .metadata import (
     OPTIONAL_HOOKS,
     PROVIDED_HOOKS,
@@ -659,6 +659,10 @@ def read_omh_hud(
     target_registry = _read_hud_json(home / "targets.json", root=home)
     runs = status_payload.get("runs", [])
     latest_run = runs[0] if runs else {}
+    # One ledger read backs both blocks below -- see `tool_call_projection`
+    # for why calling `latest_parallel_shot` and `tool_call_activity`
+    # separately could hand them different snapshots of the same poll.
+    tool_calls = tool_call_projection(str(home))
     payload: dict[str, Any] = {
         "schema_version": HUD_SCHEMA_VERSION,
         "preset": safe_preset,
@@ -675,14 +679,16 @@ def read_omh_hud(
         "todo": _todo_summary(home),
         # Concurrent tool-call batches observed by the pre_tool_call hook;
         # the [OMH] status line brands a fresh batch as a parallel shot.
-        "parallel_shot": latest_parallel_shot(str(home)),
+        "parallel_shot": tool_calls["parallel_shot"],
         # Exact in-flight tool-call state, paired from pre_tool_call and
         # post_tool_call by tool_call_id: open_call_count/live answer "is
         # something actually running right now" -- the question a lingering
         # active todo item and a ring-saturated parallel-shot badge could not.
-        # A host without post_tool_call degrades silently: entries never open,
-        # so live stays False and the widget falls back to today's behavior.
-        "activity": tool_call_activity(str(home)),
+        # A host `_host_supports_hook` never registered post_tool_call for
+        # carries `post_tool_call_observed: false` here; the widget treats
+        # that as liveness being unanswerable rather than trusting entries
+        # that can only expire, never legitimately close.
+        "activity": tool_calls["activity"],
         # Effective approval-bypass (yolo) state, read from the host's own
         # persisted surfaces (session row's /yolo flag, approvals.mode) so a
         # toggle between turns shows on the next widget poll; the hook
@@ -1317,6 +1323,13 @@ def _todo_summary(home: Path) -> dict[str, Any]:
     # hidden done items are already summarized by the header's done/total.
     shown_remaining = sum(1 for item in summary["display_items"] if item["state"] != "done")
     summary["more_count"] = counts["active"] + counts["pending"] - shown_remaining
+    # The reader computes the stall age, not the widget: applySnapshot skips
+    # updateWidget on a byte-identical payload, so a Date.now()-in-render
+    # computation on an idle (unchanging) snapshot never re-runs and sticks
+    # at whatever second it first rendered. `age` is already wall-clock-fresh
+    # on every read_omh_hud call, so shipping it as a field keeps the number
+    # honest; VOLATILE_KEYS carries it forward on the metrics repaint cadence.
+    summary["updated_age_seconds"] = age
     return summary
 
 

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -13,7 +13,7 @@ from typing import Any, Callable
 
 from .approval_bypass import effective_approval_bypass
 from .hermes_delegation import read_hermes_native_subagents
-from .tool_bursts import latest_parallel_shot
+from .tool_bursts import latest_parallel_shot, tool_call_activity
 from .metadata import (
     OPTIONAL_HOOKS,
     PROVIDED_HOOKS,
@@ -676,6 +676,13 @@ def read_omh_hud(
         # Concurrent tool-call batches observed by the pre_tool_call hook;
         # the [OMH] status line brands a fresh batch as a parallel shot.
         "parallel_shot": latest_parallel_shot(str(home)),
+        # Exact in-flight tool-call state, paired from pre_tool_call and
+        # post_tool_call by tool_call_id: open_call_count/live answer "is
+        # something actually running right now" -- the question a lingering
+        # active todo item and a ring-saturated parallel-shot badge could not.
+        # A host without post_tool_call degrades silently: entries never open,
+        # so live stays False and the widget falls back to today's behavior.
+        "activity": tool_call_activity(str(home)),
         # Effective approval-bypass (yolo) state, read from the host's own
         # persisted surfaces (session row's /yolo flag, approvals.mode) so a
         # toggle between turns shows on the next widget poll; the hook

--- a/src/plugin_bundle/omh/tool_bursts.py
+++ b/src/plugin_bundle/omh/tool_bursts.py
@@ -12,14 +12,22 @@ status line.
 
 ``post_tool_call`` (a second supported Hermes observer hook, paired with
 ``pre_tool_call`` by ``tool_call_id``) closes what ``pre_tool_call`` opens.
-Pairing the two gives an exact in-flight count for the main session -- the
-gap the ring-buffer-only design could not see: a stopped turn with an
-incomplete todo item read identically to 40 tool calls genuinely running,
-because nothing distinguished "the ring saturated" from "work is
-happening". A host that omits ``tool_call_id`` degrades silently to the
-pre-pairing behavior: the tick still lands for burst grouping, but no
-in-flight entry opens, and the HUD's liveness signal simply stays quiet
-for that call.
+Pairing the two gives an exact in-flight count -- the gap the
+ring-buffer-only design could not see: a stopped turn with an incomplete
+todo item read identically to 40 tool calls genuinely running, because
+nothing distinguished "the ring saturated" from "work is happening". A
+host that omits ``tool_call_id`` degrades silently to the pre-pairing
+behavior: the tick still lands for burst grouping, but no in-flight entry
+opens, and the HUD's liveness signal simply stays quiet for that call.
+
+Scope: the ledger lives at one path per OMH home
+(``<omh_home>/runtime/tool-bursts.json``), machine-wide and shared by every
+Hermes session pointed at that home -- it is not scoped to one session or
+turn. ``record_tool_call`` accepts a ``turn_id`` and stores it on each open
+entry, but nothing in this module reads it back to filter or attribute
+entries by turn or session; it rides along as inert metadata only. A
+sibling session sharing the same OMH home shows up in this session's
+liveness signal exactly the same as this session's own calls.
 """
 from __future__ import annotations
 
@@ -39,9 +47,14 @@ TOOL_BURSTS_FILE = "tool-bursts.json"
 # Raised from 40 (2026-08, HUD liveness fix): the ring ceiling used to be
 # what the "parallel shot x40" badge actually measured -- a fanout wave of
 # 40+ short calls saturated the ring long before it went idle, so the badge
-# read the buffer filling up, not the truth about what was running. 200
-# covers a large fanout dispatch batch with headroom while keeping the file
-# small (each entry is two-three short fields).
+# read the buffer filling up, not the truth about what was running. 200 is
+# burst HISTORY depth, not a concurrency claim: Hermes caps concurrent tool
+# workers well below this (`_MAX_TOOL_WORKERS` in Hermes'
+# `agent/tool_executor.py`), so no real dispatch ever has 200 calls open at
+# once -- this ceiling exists to keep a long chain of small, fast, strictly
+# SEQUENTIAL calls (which the 1.5s grouping window still chains into one
+# burst) from growing the file without bound, while keeping each entry
+# small (two-three short fields).
 MAX_TOOL_BURST_ENTRIES = 200
 # Same headroom rationale as MAX_TOOL_BURST_ENTRIES, applied to the
 # in-flight ledger: a host that never sends a matching post_tool_call (a
@@ -63,7 +76,11 @@ BURST_FRESH_SECONDS = 8.0
 # An open call with no matching post_tool_call this long is not still
 # running -- it is a process restart, a crashed host, or a lost tick. It is
 # reported as expired rather than kept open forever, and never reported as
-# completed (nothing observed it finishing).
+# completed (nothing observed it finishing). Known limitation, not fixed
+# here: at 100+-way concurrency the file lock `record_tool_call_close`
+# takes can itself time out under contention, which strands that close as a
+# best-effort no-op -- the entry then rides out this same TTL instead of
+# closing promptly, which is an accepted cost of best-effort observation.
 TOOL_CALL_OPEN_TTL_SECONDS = 15 * 60
 TOOL_BURST_CLAIM_BOUNDARY = (
     "Burst grouping observes pre_tool_call start ticks only; it is evidence "
@@ -118,10 +135,17 @@ def record_tool_call(
     try:
         with _awareness_delivery_lock(path):
             record = _read_record(path)
-            entries = record["entries"]
-            entries.append({"tool": name, "ts": tick, "id": call_id})
-            entries = entries[-MAX_TOOL_BURST_ENTRIES:]
             open_calls = _prune_expired_opens(record["open_calls"], now=tick)
+            # How many calls this install already has open the instant this
+            # one starts, counting itself if it opens too. This is the only
+            # honest concurrency evidence available: closed entries carry no
+            # end time (record_tool_call_close only deletes them), so a
+            # group's true peak can only be observed live, at tick time, not
+            # reconstructed afterward from start ticks alone.
+            open_at_tick = len(open_calls) + (1 if call_id else 0)
+            entries = record["entries"]
+            entries.append({"tool": name, "ts": tick, "id": call_id, "open_at_tick": open_at_tick})
+            entries = entries[-MAX_TOOL_BURST_ENTRIES:]
             if call_id:
                 open_calls[call_id] = {
                     "tool": name,
@@ -135,6 +159,7 @@ def record_tool_call(
                     "schema_version": TOOL_BURSTS_SCHEMA_VERSION,
                     "entries": entries,
                     "open_calls": open_calls,
+                    "post_tool_call_observed_at": record["post_tool_call_observed_at"],
                 },
             )
     except (OSError, ValueError, TypeError):
@@ -142,29 +167,37 @@ def record_tool_call(
 
 
 def record_tool_call_close(tool_call_id: object, *, omh_home: str = "", now: float | None = None) -> None:
-    """post_tool_call: close the in-flight entry pre_tool_call opened.
+    """post_tool_call: close the in-flight entry pre_tool_call opened, and
+    record that this install has observed post_tool_call actually fire.
 
-    A tool_call_id with no open entry (already expired, or a host that never
-    sent the matching pre_tool_call tick) is a silent no-op -- there is
-    nothing to close. Best-effort, same as ``record_tool_call``."""
+    The close itself is a no-op when there is nothing to close -- an already
+    expired entry, or a host that never sent the matching pre_tool_call tick
+    (or any tick at all, for a host that omits tool_call_id). But this
+    function running at all is the evidence the HUD's activity block needs:
+    ``_host_supports_hook`` skips registering post_tool_call on hosts whose
+    ``VALID_HOOKS`` predates it, and on such a host this is simply never
+    called. Recording that timestamp unconditionally -- even when there is
+    no entry to close -- is what lets the reader tell "this host never
+    fires post_tool_call, liveness is unanswerable" apart from "this host
+    fires it and nothing happens to be open right now". Best-effort, same
+    as ``record_tool_call``."""
     call_id = _normalized_id(tool_call_id)
-    if not call_id:
-        return
     tick = float(now if now is not None else time.time())
     path = tool_bursts_path(omh_home)
     try:
         with _awareness_delivery_lock(path):
             record = _read_record(path)
             open_calls = _prune_expired_opens(record["open_calls"], now=tick)
-            if call_id not in open_calls:
-                return
-            del open_calls[call_id]
+            if call_id and call_id in open_calls:
+                del open_calls[call_id]
+            observed_at = max(tick, record["post_tool_call_observed_at"])
             _write_delivery_record(
                 path,
                 {
                     "schema_version": TOOL_BURSTS_SCHEMA_VERSION,
                     "entries": record["entries"],
                     "open_calls": open_calls,
+                    "post_tool_call_observed_at": observed_at,
                 },
             )
     except (OSError, ValueError, TypeError):
@@ -178,7 +211,16 @@ def _read_record(path: Path) -> dict[str, Any]:
         raw = {}
     if not isinstance(raw, dict):
         raw = {}
-    return {"entries": _sanitized_entries(raw), "open_calls": _sanitized_open_calls(raw)}
+    return {
+        "entries": _sanitized_entries(raw),
+        "open_calls": _sanitized_open_calls(raw),
+        "post_tool_call_observed_at": _sanitized_observed_at(raw),
+    }
+
+
+def _sanitized_observed_at(raw: dict[str, Any]) -> float:
+    value = raw.get("post_tool_call_observed_at")
+    return float(value) if isinstance(value, (int, float)) and not isinstance(value, bool) else 0.0
 
 
 def _sanitized_entries(raw: dict[str, Any]) -> list[dict[str, Any]]:
@@ -189,12 +231,18 @@ def _sanitized_entries(raw: dict[str, Any]) -> list[dict[str, Any]]:
             continue
         tick = item.get("ts")
         tool = str(item.get("tool", "") or "")
+        open_at_tick = item.get("open_at_tick")
         if isinstance(tick, (int, float)) and not isinstance(tick, bool) and tool:
             entries.append(
                 {
                     "tool": tool[:_MAX_TOOL_NAME_CHARS],
                     "ts": float(tick),
                     "id": _normalized_id(item.get("id")),
+                    "open_at_tick": (
+                        int(open_at_tick)
+                        if isinstance(open_at_tick, (int, float)) and not isinstance(open_at_tick, bool)
+                        else 1
+                    ),
                 }
             )
     entries.sort(key=lambda entry: entry["ts"])
@@ -267,21 +315,77 @@ def _latest_shot_from_entries(
         "observed_at": _iso(last_tick),
         # True in-flight split within this shot's own members, not the ring
         # ceiling: a batch of 40 that saturated the old ring could not tell
-        # "still running" from "buffer full". A member with no tool_call_id
-        # (host degraded to pre-pairing behavior) counts as completed here --
-        # it was never opened, so it cannot be reported open.
+        # "still running" from "buffer full".
         "open_count": open_count,
-        "completed_count": len(latest) - open_count,
+        # NOT a completion claim -- naming it that contradicted
+        # TOOL_CALL_OPEN_TTL_SECONDS's own rule that an expired open entry is
+        # "never reported as completed (nothing observed it finishing)".
+        # This is every member not currently open: a member with no
+        # tool_call_id (host degraded to pre-pairing behavior) was never
+        # opened, and an expired member's close was never observed either --
+        # both land here as "not open", which is the only claim the data
+        # backs, not "finished".
+        "closed_or_unobserved_count": len(latest) - open_count,
+        # The highest open_at_tick observed among this group's own members:
+        # at least this many calls were open simultaneously at some point
+        # during the shot. This is the group's actual measured concurrency,
+        # not `size` -- `size` only proves the host dispatched these calls
+        # inside the grouping window, which a long strictly-sequential chain
+        # can satisfy just as well as a real parallel batch (Hermes caps
+        # concurrent tool workers well under `size` in either case).
+        "peak_open_count": max((entry.get("open_at_tick", 1) for entry in latest), default=0),
         "claim_boundary": TOOL_BURST_CLAIM_BOUNDARY,
+    }
+
+
+def _read_snapshot(omh_home: str, *, now: float) -> dict[str, Any]:
+    """One ledger read, pruned to `now`. The single point every projection
+    below builds from, so a poll that needs more than one projection (the
+    HUD reader wants both the parallel-shot and the activity block) sees one
+    consistent state instead of two reads that can straddle a concurrent
+    writer and disagree about what is currently open."""
+    record = _read_record(tool_bursts_path(omh_home))
+    return {
+        "entries": record["entries"],
+        "open_calls": _prune_expired_opens(record["open_calls"], now=now),
+        "post_tool_call_observed_at": record["post_tool_call_observed_at"],
+    }
+
+
+def _activity_from_snapshot(snapshot: dict[str, Any], shot: dict[str, Any], *, now: float) -> dict[str, Any]:
+    open_calls = snapshot["open_calls"]
+    count = len(open_calls)
+    if count:
+        oldest_id, oldest = min(open_calls.items(), key=lambda item: item[1]["started_at"])
+        oldest_started_at = _iso(oldest["started_at"])
+        oldest_elapsed_seconds: float | None = max(0.0, now - oldest["started_at"])
+    else:
+        oldest_started_at = ""
+        oldest_elapsed_seconds = None
+    return {
+        "schema_version": TOOL_ACTIVITY_SCHEMA_VERSION,
+        "open_call_count": count,
+        "oldest_open_started_at": oldest_started_at,
+        "oldest_open_elapsed_seconds": oldest_elapsed_seconds,
+        "live": count > 0,
+        # Whether this OMH install has ever seen post_tool_call actually
+        # fire (record_tool_call_close ran at least once). False on a host
+        # `_host_supports_hook` skipped registering post_tool_call for: the
+        # ledger's open entries can only expire there, never legitimately
+        # close, so `live`/`oldest_open_elapsed_seconds` cannot be trusted
+        # either way and the HUD must render liveness as unanswerable
+        # rather than inverting silence into a false stall.
+        "post_tool_call_observed": snapshot["post_tool_call_observed_at"] > 0,
+        "latest_shot": shot,
+        "claim_boundary": TOOL_ACTIVITY_CLAIM_BOUNDARY,
     }
 
 
 def latest_parallel_shot(omh_home: str = "", *, now: float | None = None) -> dict[str, Any]:
     """Project the most recent concurrent batch, or an idle marker."""
     current = float(now if now is not None else time.time())
-    record = _read_record(tool_bursts_path(omh_home))
-    open_calls = _prune_expired_opens(record["open_calls"], now=current)
-    return _latest_shot_from_entries(record["entries"], open_calls, now=current)
+    snapshot = _read_snapshot(omh_home, now=current)
+    return _latest_shot_from_entries(snapshot["entries"], snapshot["open_calls"], now=current)
 
 
 def tool_call_activity(omh_home: str = "", *, now: float | None = None) -> dict[str, Any]:
@@ -293,22 +397,21 @@ def tool_call_activity(omh_home: str = "", *, now: float | None = None) -> dict[
     badge and a lingering active todo item could not.
     """
     current = float(now if now is not None else time.time())
-    record = _read_record(tool_bursts_path(omh_home))
-    open_calls = _prune_expired_opens(record["open_calls"], now=current)
-    count = len(open_calls)
-    if count:
-        oldest_id, oldest = min(open_calls.items(), key=lambda item: item[1]["started_at"])
-        oldest_started_at = _iso(oldest["started_at"])
-        oldest_elapsed_seconds: float | None = max(0.0, current - oldest["started_at"])
-    else:
-        oldest_started_at = ""
-        oldest_elapsed_seconds = None
-    return {
-        "schema_version": TOOL_ACTIVITY_SCHEMA_VERSION,
-        "open_call_count": count,
-        "oldest_open_started_at": oldest_started_at,
-        "oldest_open_elapsed_seconds": oldest_elapsed_seconds,
-        "live": count > 0,
-        "latest_shot": _latest_shot_from_entries(record["entries"], open_calls, now=current),
-        "claim_boundary": TOOL_ACTIVITY_CLAIM_BOUNDARY,
-    }
+    snapshot = _read_snapshot(omh_home, now=current)
+    shot = _latest_shot_from_entries(snapshot["entries"], snapshot["open_calls"], now=current)
+    return _activity_from_snapshot(snapshot, shot, now=current)
+
+
+def tool_call_projection(omh_home: str = "", *, now: float | None = None) -> dict[str, Any]:
+    """`{"parallel_shot": ..., "activity": ...}` from one ledger read.
+
+    The HUD reader needs both projections every poll; calling
+    ``latest_parallel_shot`` and ``tool_call_activity`` separately each reads
+    the ledger file on its own, so a write landing between the two reads
+    could hand the two blocks different snapshots of the same poll. This is
+    the single-read equivalent of calling both.
+    """
+    current = float(now if now is not None else time.time())
+    snapshot = _read_snapshot(omh_home, now=current)
+    shot = _latest_shot_from_entries(snapshot["entries"], snapshot["open_calls"], now=current)
+    return {"parallel_shot": shot, "activity": _activity_from_snapshot(snapshot, shot, now=current)}

--- a/src/plugin_bundle/omh/tool_bursts.py
+++ b/src/plugin_bundle/omh/tool_bursts.py
@@ -1,13 +1,25 @@
-"""Parallel tool-call burst observation for the HUD.
+"""Parallel tool-call burst observation and in-flight liveness for the HUD.
 
 Hermes executes a model turn's batched tool calls concurrently (its
 ``_execute_tool_calls_concurrent`` dispatch), but the transcript renders
-only a collapsed "Tool calls (N)" group — nothing tells the user whether
-that batch actually ran as a parallel shot. The ``pre_tool_call`` hook
-fires once per call, so calls whose start ticks land inside one short
-window are the concurrent batch. This module records those ticks (tool
-name and timestamp only, never arguments or results) and projects the
-latest burst for the ``[OMH]`` status line.
+only a collapsed "Tool calls (N)" group -- nothing tells the user whether
+that batch actually ran as a parallel shot, or whether the batch is still
+running at all. The ``pre_tool_call`` hook fires once per call, so calls
+whose start ticks land inside one short window are the concurrent batch;
+this module records those ticks (tool name and timestamp only, never
+arguments or results) and projects the latest burst for the ``[OMH]``
+status line.
+
+``post_tool_call`` (a second supported Hermes observer hook, paired with
+``pre_tool_call`` by ``tool_call_id``) closes what ``pre_tool_call`` opens.
+Pairing the two gives an exact in-flight count for the main session -- the
+gap the ring-buffer-only design could not see: a stopped turn with an
+incomplete todo item read identically to 40 tool calls genuinely running,
+because nothing distinguished "the ring saturated" from "work is
+happening". A host that omits ``tool_call_id`` degrades silently to the
+pre-pairing behavior: the tick still lands for burst grouping, but no
+in-flight entry opens, and the HUD's liveness signal simply stays quiet
+for that call.
 """
 from __future__ import annotations
 
@@ -22,8 +34,21 @@ from typing import Any
 from .awareness_delivery import _awareness_delivery_lock, _write_delivery_record
 
 TOOL_BURSTS_SCHEMA_VERSION = "omh_tool_bursts/v1"
+TOOL_ACTIVITY_SCHEMA_VERSION = "omh_tool_activity/v1"
 TOOL_BURSTS_FILE = "tool-bursts.json"
-MAX_TOOL_BURST_ENTRIES = 40
+# Raised from 40 (2026-08, HUD liveness fix): the ring ceiling used to be
+# what the "parallel shot x40" badge actually measured -- a fanout wave of
+# 40+ short calls saturated the ring long before it went idle, so the badge
+# read the buffer filling up, not the truth about what was running. 200
+# covers a large fanout dispatch batch with headroom while keeping the file
+# small (each entry is two-three short fields).
+MAX_TOOL_BURST_ENTRIES = 200
+# Same headroom rationale as MAX_TOOL_BURST_ENTRIES, applied to the
+# in-flight ledger: a host that never sends a matching post_tool_call (a
+# crash, an unsupported host) must not let open_calls grow without bound.
+# Losing the oldest open entry under pathological load is acceptable --
+# the ledger is best-effort observation, not a correctness-critical store.
+MAX_OPEN_TOOL_CALLS = 200
 # Ticks closer together than this belong to one dispatch burst: Hermes
 # starts a concurrent batch's workers within milliseconds of each other,
 # while consecutive sequential turns are separated by at least one model
@@ -35,12 +60,24 @@ BURST_WINDOW_SECONDS = 1.5
 # and vanishes right after, refreshed continuously through a busy wave by
 # the next batch's ticks.
 BURST_FRESH_SECONDS = 8.0
+# An open call with no matching post_tool_call this long is not still
+# running -- it is a process restart, a crashed host, or a lost tick. It is
+# reported as expired rather than kept open forever, and never reported as
+# completed (nothing observed it finishing).
+TOOL_CALL_OPEN_TTL_SECONDS = 15 * 60
 TOOL_BURST_CLAIM_BOUNDARY = (
     "Burst grouping observes pre_tool_call start ticks only; it is evidence "
     "the host dispatched the calls as one batch, not proof every call "
     "overlapped for its full duration."
 )
+TOOL_ACTIVITY_CLAIM_BOUNDARY = (
+    "In-flight state is the local pairing of this host's pre_tool_call and "
+    "post_tool_call ticks by tool_call_id. It is evidence of calls this OMH "
+    "install observed opening and closing, not a complete accounting of "
+    "every tool call Hermes ran."
+)
 _MAX_TOOL_NAME_CHARS = 48
+_MAX_ID_CHARS = 128
 
 
 def _runtime_dir(omh_home: str = "") -> Path:
@@ -52,49 +89,161 @@ def tool_bursts_path(omh_home: str = "") -> Path:
     return _runtime_dir(omh_home) / TOOL_BURSTS_FILE
 
 
-def record_tool_call(tool_name: object, *, omh_home: str = "", now: float | None = None) -> None:
-    """Append one pre_tool_call tick. Best-effort: losing a tick is acceptable,
-    breaking the hook that feeds the model is not."""
-    name = " ".join(str(tool_name or "").split())[:_MAX_TOOL_NAME_CHARS]
+def _normalized_name(tool_name: object) -> str:
+    return " ".join(str(tool_name or "").split())[:_MAX_TOOL_NAME_CHARS]
+
+
+def _normalized_id(value: object) -> str:
+    return str(value or "").strip()[:_MAX_ID_CHARS]
+
+
+def record_tool_call(
+    tool_name: object,
+    *,
+    omh_home: str = "",
+    now: float | None = None,
+    tool_call_id: object = None,
+    turn_id: object = None,
+) -> None:
+    """Append one pre_tool_call tick and, when the host supplies a
+    tool_call_id, open an in-flight entry post_tool_call will close.
+    Best-effort: losing a tick is acceptable, breaking the hook that feeds
+    the model is not."""
+    name = _normalized_name(tool_name)
     if not name:
         return
     tick = float(now if now is not None else time.time())
+    call_id = _normalized_id(tool_call_id)
     path = tool_bursts_path(omh_home)
     try:
         with _awareness_delivery_lock(path):
-            entries = _read_entries(path)
-            entries.append({"tool": name, "ts": tick})
+            record = _read_record(path)
+            entries = record["entries"]
+            entries.append({"tool": name, "ts": tick, "id": call_id})
             entries = entries[-MAX_TOOL_BURST_ENTRIES:]
+            open_calls = _prune_expired_opens(record["open_calls"], now=tick)
+            if call_id:
+                open_calls[call_id] = {
+                    "tool": name,
+                    "turn_id": _normalized_id(turn_id),
+                    "started_at": tick,
+                }
+                open_calls = _cap_open_calls(open_calls)
             _write_delivery_record(
                 path,
-                {"schema_version": TOOL_BURSTS_SCHEMA_VERSION, "entries": entries},
+                {
+                    "schema_version": TOOL_BURSTS_SCHEMA_VERSION,
+                    "entries": entries,
+                    "open_calls": open_calls,
+                },
             )
     except (OSError, ValueError, TypeError):
         return
 
 
-def _read_entries(path: Path) -> list[dict[str, Any]]:
+def record_tool_call_close(tool_call_id: object, *, omh_home: str = "", now: float | None = None) -> None:
+    """post_tool_call: close the in-flight entry pre_tool_call opened.
+
+    A tool_call_id with no open entry (already expired, or a host that never
+    sent the matching pre_tool_call tick) is a silent no-op -- there is
+    nothing to close. Best-effort, same as ``record_tool_call``."""
+    call_id = _normalized_id(tool_call_id)
+    if not call_id:
+        return
+    tick = float(now if now is not None else time.time())
+    path = tool_bursts_path(omh_home)
     try:
-        record = json.loads(path.read_text(encoding="utf-8"))
+        with _awareness_delivery_lock(path):
+            record = _read_record(path)
+            open_calls = _prune_expired_opens(record["open_calls"], now=tick)
+            if call_id not in open_calls:
+                return
+            del open_calls[call_id]
+            _write_delivery_record(
+                path,
+                {
+                    "schema_version": TOOL_BURSTS_SCHEMA_VERSION,
+                    "entries": record["entries"],
+                    "open_calls": open_calls,
+                },
+            )
+    except (OSError, ValueError, TypeError):
+        return
+
+
+def _read_record(path: Path) -> dict[str, Any]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
-        return []
-    raw = record.get("entries") if isinstance(record, dict) else None
+        raw = {}
+    if not isinstance(raw, dict):
+        raw = {}
+    return {"entries": _sanitized_entries(raw), "open_calls": _sanitized_open_calls(raw)}
+
+
+def _sanitized_entries(raw: dict[str, Any]) -> list[dict[str, Any]]:
+    source = raw.get("entries")
     entries: list[dict[str, Any]] = []
-    for item in raw if isinstance(raw, list) else []:
+    for item in source if isinstance(source, list) else []:
         if not isinstance(item, dict):
             continue
         tick = item.get("ts")
         tool = str(item.get("tool", "") or "")
         if isinstance(tick, (int, float)) and not isinstance(tick, bool) and tool:
-            entries.append({"tool": tool[:_MAX_TOOL_NAME_CHARS], "ts": float(tick)})
+            entries.append(
+                {
+                    "tool": tool[:_MAX_TOOL_NAME_CHARS],
+                    "ts": float(tick),
+                    "id": _normalized_id(item.get("id")),
+                }
+            )
     entries.sort(key=lambda entry: entry["ts"])
     return entries
 
 
-def latest_parallel_shot(omh_home: str = "", *, now: float | None = None) -> dict[str, Any]:
-    """Project the most recent concurrent batch, or an idle marker."""
-    current = float(now if now is not None else time.time())
-    entries = _read_entries(tool_bursts_path(omh_home))
+def _sanitized_open_calls(raw: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    source = raw.get("open_calls")
+    open_calls: dict[str, dict[str, Any]] = {}
+    for call_id, item in (source.items() if isinstance(source, dict) else ()):
+        if not isinstance(item, dict):
+            continue
+        started_at = item.get("started_at")
+        normalized_id = _normalized_id(call_id)
+        if not normalized_id or not isinstance(started_at, (int, float)) or isinstance(started_at, bool):
+            continue
+        open_calls[normalized_id] = {
+            "tool": str(item.get("tool", "") or "")[:_MAX_TOOL_NAME_CHARS],
+            "turn_id": _normalized_id(item.get("turn_id")),
+            "started_at": float(started_at),
+        }
+    return open_calls
+
+
+def _prune_expired_opens(open_calls: dict[str, dict[str, Any]], *, now: float) -> dict[str, dict[str, Any]]:
+    return {
+        call_id: entry
+        for call_id, entry in open_calls.items()
+        if now - float(entry.get("started_at", now)) <= TOOL_CALL_OPEN_TTL_SECONDS
+    }
+
+
+def _cap_open_calls(open_calls: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    if len(open_calls) <= MAX_OPEN_TOOL_CALLS:
+        return open_calls
+    newest_first = sorted(open_calls.items(), key=lambda item: item[1]["started_at"], reverse=True)
+    return dict(newest_first[:MAX_OPEN_TOOL_CALLS])
+
+
+def _iso(tick: float) -> str:
+    return datetime.fromtimestamp(tick, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _latest_shot_from_entries(
+    entries: list[dict[str, Any]],
+    open_calls: dict[str, dict[str, Any]],
+    *,
+    now: float,
+) -> dict[str, Any]:
     idle: dict[str, Any] = {"status": "idle"}
     if not entries:
         return idle
@@ -108,17 +257,58 @@ def latest_parallel_shot(omh_home: str = "", *, now: float | None = None) -> dic
     if latest is None:
         return idle
     last_tick = latest[-1]["ts"]
-    if current - last_tick > BURST_FRESH_SECONDS:
+    if now - last_tick > BURST_FRESH_SECONDS:
         return idle
-    observed_at = (
-        datetime.fromtimestamp(last_tick, tz=timezone.utc)
-        .isoformat()
-        .replace("+00:00", "Z")
-    )
+    open_count = sum(1 for entry in latest if entry.get("id") and entry["id"] in open_calls)
     return {
         "status": "observed",
         "size": len(latest),
         "distinct_tools": len({entry["tool"] for entry in latest}),
-        "observed_at": observed_at,
+        "observed_at": _iso(last_tick),
+        # True in-flight split within this shot's own members, not the ring
+        # ceiling: a batch of 40 that saturated the old ring could not tell
+        # "still running" from "buffer full". A member with no tool_call_id
+        # (host degraded to pre-pairing behavior) counts as completed here --
+        # it was never opened, so it cannot be reported open.
+        "open_count": open_count,
+        "completed_count": len(latest) - open_count,
         "claim_boundary": TOOL_BURST_CLAIM_BOUNDARY,
+    }
+
+
+def latest_parallel_shot(omh_home: str = "", *, now: float | None = None) -> dict[str, Any]:
+    """Project the most recent concurrent batch, or an idle marker."""
+    current = float(now if now is not None else time.time())
+    record = _read_record(tool_bursts_path(omh_home))
+    open_calls = _prune_expired_opens(record["open_calls"], now=current)
+    return _latest_shot_from_entries(record["entries"], open_calls, now=current)
+
+
+def tool_call_activity(omh_home: str = "", *, now: float | None = None) -> dict[str, Any]:
+    """The HUD's liveness signal: exact open tool-call count plus the shot.
+
+    ``live`` is true precisely while at least one tool call this OMH install
+    saw open has not yet closed and has not expired -- it answers "is
+    something actually running right now", the question the ring-buffer-only
+    badge and a lingering active todo item could not.
+    """
+    current = float(now if now is not None else time.time())
+    record = _read_record(tool_bursts_path(omh_home))
+    open_calls = _prune_expired_opens(record["open_calls"], now=current)
+    count = len(open_calls)
+    if count:
+        oldest_id, oldest = min(open_calls.items(), key=lambda item: item[1]["started_at"])
+        oldest_started_at = _iso(oldest["started_at"])
+        oldest_elapsed_seconds: float | None = max(0.0, current - oldest["started_at"])
+    else:
+        oldest_started_at = ""
+        oldest_elapsed_seconds = None
+    return {
+        "schema_version": TOOL_ACTIVITY_SCHEMA_VERSION,
+        "open_call_count": count,
+        "oldest_open_started_at": oldest_started_at,
+        "oldest_open_elapsed_seconds": oldest_elapsed_seconds,
+        "live": count > 0,
+        "latest_shot": _latest_shot_from_entries(record["entries"], open_calls, now=current),
+        "claim_boundary": TOOL_ACTIVITY_CLAIM_BOUNDARY,
     }

--- a/src/plugin_bundle/omh/tools/capability_tool.py
+++ b/src/plugin_bundle/omh/tools/capability_tool.py
@@ -690,6 +690,10 @@ def _standalone_hook_payload_fields(name: str) -> list[str]:
         ]
     if name == "pre_tool_call":
         return ["context", "action", "message"]
+    if name == "post_tool_call":
+        # A pure observer: it closes the in-flight ledger entry for the HUD
+        # liveness signal and never returns a directive to the host.
+        return []
     if name == "on_session_end":
         return ["session_summary", "metadata_only"]
     if name == "pre_verify":

--- a/tests/test_capability_impact.py
+++ b/tests/test_capability_impact.py
@@ -194,11 +194,11 @@ class PreVerifyHookTests(unittest.TestCase):
         context = StrictHermesContext()
         register(context)
 
-        # Only the rejected optional hook is absent; the other optional hook
-        # (transform_tool_result) still registers on this host.
+        # Only the rejected optional hook is absent; the other optional hooks
+        # (post_tool_call, transform_tool_result) still register on this host.
         self.assertEqual(
             set(context.hooks),
-            {"on_session_end", "pre_llm_call", "pre_tool_call", "transform_tool_result"},
+            {"on_session_end", "pre_llm_call", "pre_tool_call", "post_tool_call", "transform_tool_result"},
         )
         self.assertIn("omh_capabilities", context.tools)
 

--- a/tests/test_hook_integrity.py
+++ b/tests/test_hook_integrity.py
@@ -174,12 +174,12 @@ class ReviewedRecordTests(unittest.TestCase):
         with TemporaryDirectory() as tmp:
             status = build_hook_integrity_status(_paths(tmp))
             widened = json.loads(json.dumps(status))
-            _record(widened, "pre_tool_call")["event_scope"] = ["pre_tool_call", "post_tool_call"]
+            _record(widened, "pre_tool_call")["event_scope"] = ["pre_tool_call", "post_verify"]
 
             errors = validate_hook_integrity_status(widened)
 
             self.assertTrue(any("outside VALID_HOOK_EVENTS" in error for error in errors))
-            self.assertTrue(any("post_tool_call" in error for error in errors))
+            self.assertTrue(any("post_verify" in error for error in errors))
 
     def test_the_status_shape_is_pinned(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_hook_manifest.py
+++ b/tests/test_hook_manifest.py
@@ -764,7 +764,11 @@ class HookManifestTests(unittest.TestCase):
                 omh_home=omh_home,
             )
 
-            self.assertTrue(tool_call_activity(omh_home)["live"])
+            activity = tool_call_activity(omh_home)
+            self.assertTrue(activity["live"])
+            # post_tool_call has not fired yet on this install -- liveness
+            # is unanswerable even while an entry happens to be open.
+            self.assertFalse(activity["post_tool_call_observed"])
 
             result = post_tool_call(
                 tool_name="terminal",
@@ -776,16 +780,40 @@ class HookManifestTests(unittest.TestCase):
             )
 
             self.assertIsNone(result)
-            self.assertFalse(tool_call_activity(omh_home)["live"])
+            closed = tool_call_activity(omh_home)
+            self.assertFalse(closed["live"])
+            # post_tool_call firing at all -- regardless of whether this
+            # particular call paired to an open entry -- is what tells the
+            # HUD this host's negative liveness claims can be trusted (P2-1).
+            self.assertTrue(closed["post_tool_call_observed"])
 
-    def test_post_tool_call_with_no_tool_call_id_is_a_silent_no_op(self) -> None:
+    def test_post_tool_call_with_no_tool_call_id_closes_nothing_but_is_still_observed(self) -> None:
         with TemporaryDirectory() as omh_home:
             pre_tool_call(tool_name="terminal", omh_home=omh_home)
 
             result = post_tool_call(tool_name="terminal", omh_home=omh_home)
 
             self.assertIsNone(result)
-            self.assertFalse(tool_call_activity(omh_home)["live"])
+            activity = tool_call_activity(omh_home)
+            self.assertFalse(activity["live"])
+            # No tool_call_id means nothing ever opened to close, but the
+            # hook still fired -- that alone is the observed signal.
+            self.assertTrue(activity["post_tool_call_observed"])
+
+    def test_a_host_that_never_calls_post_tool_call_reports_liveness_unanswerable(self) -> None:
+        with TemporaryDirectory() as omh_home:
+            pre_tool_call(
+                tool_name="terminal",
+                tool_call_id="call-1",
+                turn_id="turn-1",
+                omh_home=omh_home,
+            )
+
+            # post_tool_call is never invoked here -- the host
+            # `_host_supports_hook` skipped registering it for.
+            activity = tool_call_activity(omh_home)
+
+            self.assertFalse(activity["post_tool_call_observed"])
 
     def test_pre_tool_call_preserves_delegate_role_warning(self) -> None:
         result = pre_tool_call(

--- a/tests/test_hook_manifest.py
+++ b/tests/test_hook_manifest.py
@@ -14,7 +14,8 @@ from omh.install.hook_integrity import HOOK_REVIEWS, VALID_HOOK_EVENTS
 from omh.plugin_bundle.omh.awareness import awareness_primer_context, awareness_route_hint
 from omh.plugin_bundle.omh.awareness_delivery import read_awareness_delivery
 from omh.plugin_bundle.omh.hooks.llm_hooks import pre_llm_call
-from omh.plugin_bundle.omh.hooks.tool_hooks import pre_tool_call
+from omh.plugin_bundle.omh.hooks.tool_hooks import post_tool_call, pre_tool_call
+from omh.plugin_bundle.omh.tool_bursts import tool_call_activity
 
 
 def sionic_omh_usage_evaluation_prompt() -> str:
@@ -753,6 +754,38 @@ class HookManifestTests(unittest.TestCase):
                     **extra_kwargs,
                 )
                 self.assertIsNone(result)
+
+    def test_pre_and_post_tool_call_pair_to_close_the_in_flight_entry(self) -> None:
+        with TemporaryDirectory() as omh_home:
+            pre_tool_call(
+                tool_name="terminal",
+                tool_call_id="call-1",
+                turn_id="turn-1",
+                omh_home=omh_home,
+            )
+
+            self.assertTrue(tool_call_activity(omh_home)["live"])
+
+            result = post_tool_call(
+                tool_name="terminal",
+                tool_call_id="call-1",
+                turn_id="turn-1",
+                status="ok",
+                duration_ms=42,
+                omh_home=omh_home,
+            )
+
+            self.assertIsNone(result)
+            self.assertFalse(tool_call_activity(omh_home)["live"])
+
+    def test_post_tool_call_with_no_tool_call_id_is_a_silent_no_op(self) -> None:
+        with TemporaryDirectory() as omh_home:
+            pre_tool_call(tool_name="terminal", omh_home=omh_home)
+
+            result = post_tool_call(tool_name="terminal", omh_home=omh_home)
+
+            self.assertIsNone(result)
+            self.assertFalse(tool_call_activity(omh_home)["live"])
 
     def test_pre_tool_call_preserves_delegate_role_warning(self) -> None:
         result = pre_tool_call(

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -1011,6 +1011,36 @@ class TodoHudTests(unittest.TestCase):
                 ],
             )
             self.assertIn("Todo items are plan declarations", payload["evidence_boundary"])
+            # Fresh write -- the reader-computed stall age is a small,
+            # non-negative number of seconds, not a widget-side clock.
+            self.assertIsNotNone(todo["updated_age_seconds"])
+            self.assertGreaterEqual(todo["updated_age_seconds"], 0)
+            self.assertLess(todo["updated_age_seconds"], 5)
+
+    def test_hud_todo_stall_age_is_computed_fresh_on_every_read(self) -> None:
+        # P1-1 regression: the widget can only ever paint a value handed to
+        # it by the reader (applySnapshot skips an unchanged snapshot, so a
+        # Date.now() computed in render freezes on an idle payload). The
+        # reader must not have that problem -- read_omh_hud recomputes the
+        # age from wall time on every call, even against the exact same
+        # on-disk todo record.
+        from datetime import datetime, timedelta, timezone
+
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            stamp = (datetime.now(timezone.utc) - timedelta(seconds=120)).isoformat().replace("+00:00", "Z")
+            self._write_todo(root / ".omh", self._record(updated_at=stamp))
+
+            first = read_omh_hud(root / ".omh", root / ".hermes")["todo"]["updated_age_seconds"]
+            import time
+
+            time.sleep(1.1)
+            second = read_omh_hud(root / ".omh", root / ".hermes")["todo"]["updated_age_seconds"]
+
+            self.assertGreaterEqual(first, 119)
+            self.assertGreater(second, first)
 
     def test_hud_indents_multiple_tasks_beneath_their_phase_header(self) -> None:
         from omh.plugin_bundle.omh.runtime_reader import read_omh_hud

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -640,6 +640,7 @@ print(json.dumps(observed, ensure_ascii=False))
                 plugin["registered_hooks"],
                 [
                     "on_session_end",
+                    "post_tool_call",
                     "pre_llm_call",
                     "pre_tool_call",
                     "pre_verify",

--- a/tests/test_tool_bursts.py
+++ b/tests/test_tool_bursts.py
@@ -14,10 +14,14 @@ from pathlib import Path
 from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
 from omh.plugin_bundle.omh.tool_bursts import (
     BURST_FRESH_SECONDS,
+    MAX_OPEN_TOOL_CALLS,
     MAX_TOOL_BURST_ENTRIES,
+    TOOL_CALL_OPEN_TTL_SECONDS,
     latest_parallel_shot,
     record_tool_call,
+    record_tool_call_close,
     tool_bursts_path,
+    tool_call_activity,
 )
 
 NOW = 1_787_040_000.0
@@ -62,6 +66,74 @@ class ToolBurstLedgerTest(unittest.TestCase):
         record = json.loads(tool_bursts_path(self.home).read_text(encoding="utf-8"))
         self.assertEqual(len(record["entries"]), MAX_TOOL_BURST_ENTRIES)
 
+    def test_open_call_stays_live_until_a_matching_close(self):
+        record_tool_call("terminal", omh_home=self.home, now=NOW, tool_call_id="call-1", turn_id="turn-1")
+
+        activity = tool_call_activity(self.home, now=NOW + 5)
+
+        self.assertTrue(activity["live"])
+        self.assertEqual(activity["open_call_count"], 1)
+        self.assertEqual(activity["oldest_open_elapsed_seconds"], 5)
+        self.assertTrue(activity["oldest_open_started_at"])
+
+        record_tool_call_close("call-1", omh_home=self.home, now=NOW + 5.5)
+        closed = tool_call_activity(self.home, now=NOW + 6)
+
+        self.assertFalse(closed["live"])
+        self.assertEqual(closed["open_call_count"], 0)
+        self.assertEqual(closed["oldest_open_elapsed_seconds"], None)
+
+    def test_a_call_with_no_tool_call_id_never_opens(self):
+        record_tool_call("terminal", omh_home=self.home, now=NOW)
+
+        activity = tool_call_activity(self.home, now=NOW + 1)
+
+        self.assertFalse(activity["live"])
+        self.assertEqual(activity["open_call_count"], 0)
+
+    def test_an_open_call_expires_after_the_ttl_instead_of_staying_live_forever(self):
+        record_tool_call("terminal", omh_home=self.home, now=NOW, tool_call_id="call-1", turn_id="turn-1")
+
+        still_open = tool_call_activity(self.home, now=NOW + TOOL_CALL_OPEN_TTL_SECONDS - 1)
+        expired = tool_call_activity(self.home, now=NOW + TOOL_CALL_OPEN_TTL_SECONDS + 1)
+
+        self.assertTrue(still_open["live"])
+        self.assertFalse(expired["live"])
+        self.assertEqual(expired["open_call_count"], 0)
+
+    def test_a_close_with_no_matching_open_is_a_silent_no_op(self):
+        record_tool_call_close("never-opened", omh_home=self.home, now=NOW)
+
+        self.assertFalse(tool_bursts_path(self.home).exists())
+
+    def test_the_open_ledger_is_capped_under_pathological_growth(self):
+        for index in range(MAX_OPEN_TOOL_CALLS + 10):
+            record_tool_call(
+                "terminal",
+                omh_home=self.home,
+                now=NOW + index,
+                tool_call_id=f"call-{index}",
+                turn_id="turn-1",
+            )
+
+        activity = tool_call_activity(self.home, now=NOW + MAX_OPEN_TOOL_CALLS + 10)
+
+        self.assertLessEqual(activity["open_call_count"], MAX_OPEN_TOOL_CALLS)
+
+    def test_the_latest_shot_reports_its_open_and_completed_split(self):
+        record_tool_call("read_file", omh_home=self.home, now=NOW, tool_call_id="call-1", turn_id="turn-1")
+        record_tool_call("terminal", omh_home=self.home, now=NOW + 0.1, tool_call_id="call-2", turn_id="turn-1")
+        record_tool_call_close("call-2", omh_home=self.home, now=NOW + 0.2)
+
+        shot = latest_parallel_shot(self.home, now=NOW + 1)
+        activity = tool_call_activity(self.home, now=NOW + 1)
+
+        self.assertEqual(shot["status"], "observed")
+        self.assertEqual(shot["open_count"], 1)
+        self.assertEqual(shot["completed_count"], 1)
+        self.assertEqual(activity["latest_shot"]["open_count"], 1)
+        self.assertTrue(activity["live"])
+
     def test_the_hud_payload_carries_the_latest_shot(self):
         # The reader checks freshness against wall time, so record against
         # wall time here.
@@ -76,6 +148,21 @@ class ToolBurstLedgerTest(unittest.TestCase):
         self.assertEqual(shot["status"], "observed")
         self.assertEqual(shot["size"], 2)
         self.assertEqual(shot["distinct_tools"], 2)
+        self.assertIn("activity", payload)
+        self.assertFalse(payload["activity"]["live"])
+        self.assertEqual(payload["activity"]["open_call_count"], 0)
+
+    def test_the_hud_payload_carries_live_open_call_activity(self):
+        import time
+
+        base = time.time()
+        record_tool_call("terminal", omh_home=self.home, now=base, tool_call_id="call-1", turn_id="turn-1")
+        hermes = str(Path(self._tmp.name) / "hermes")
+
+        payload = read_omh_hud(self.home, hermes)
+
+        self.assertTrue(payload["activity"]["live"])
+        self.assertEqual(payload["activity"]["open_call_count"], 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_tool_bursts.py
+++ b/tests/test_tool_bursts.py
@@ -22,6 +22,7 @@ from omh.plugin_bundle.omh.tool_bursts import (
     record_tool_call_close,
     tool_bursts_path,
     tool_call_activity,
+    tool_call_projection,
 )
 
 NOW = 1_787_040_000.0
@@ -101,10 +102,41 @@ class ToolBurstLedgerTest(unittest.TestCase):
         self.assertFalse(expired["live"])
         self.assertEqual(expired["open_call_count"], 0)
 
-    def test_a_close_with_no_matching_open_is_a_silent_no_op(self):
+    def test_a_close_with_no_matching_open_closes_nothing_but_is_still_observed(self):
         record_tool_call_close("never-opened", omh_home=self.home, now=NOW)
 
-        self.assertFalse(tool_bursts_path(self.home).exists())
+        # Nothing to close, but the file now exists -- post_tool_call firing
+        # at all is the evidence the HUD needs, independent of pairing (P2-1).
+        self.assertTrue(tool_bursts_path(self.home).exists())
+        self.assertTrue(tool_call_activity(self.home, now=NOW)["post_tool_call_observed"])
+
+    def test_liveness_is_unanswerable_until_post_tool_call_is_ever_observed(self):
+        record_tool_call("terminal", omh_home=self.home, now=NOW, tool_call_id="call-1")
+
+        unanswered = tool_call_activity(self.home, now=NOW + 1)
+        self.assertFalse(unanswered["post_tool_call_observed"])
+        # `live` still reports what the ledger has, but the flag beside it
+        # is what tells the widget whether to trust that reading at all.
+        self.assertTrue(unanswered["live"])
+
+        record_tool_call_close("call-1", omh_home=self.home, now=NOW + 2)
+
+        answered = tool_call_activity(self.home, now=NOW + 3)
+        self.assertTrue(answered["post_tool_call_observed"])
+        self.assertFalse(answered["live"])
+
+    def test_tool_call_projection_matches_the_separate_calls_from_one_read(self):
+        record_tool_call("read_file", omh_home=self.home, now=NOW, tool_call_id="call-1")
+        record_tool_call("terminal", omh_home=self.home, now=NOW + 0.1, tool_call_id="call-2")
+        record_tool_call_close("call-2", omh_home=self.home, now=NOW + 0.2)
+
+        projection = tool_call_projection(self.home, now=NOW + 1)
+
+        self.assertEqual(projection["parallel_shot"], latest_parallel_shot(self.home, now=NOW + 1))
+        self.assertEqual(projection["activity"], tool_call_activity(self.home, now=NOW + 1))
+        # The activity block's own latest_shot is the identical object the
+        # top-level parallel_shot key carries -- one computation, not two.
+        self.assertEqual(projection["activity"]["latest_shot"], projection["parallel_shot"])
 
     def test_the_open_ledger_is_capped_under_pathological_growth(self):
         for index in range(MAX_OPEN_TOOL_CALLS + 10):
@@ -120,7 +152,7 @@ class ToolBurstLedgerTest(unittest.TestCase):
 
         self.assertLessEqual(activity["open_call_count"], MAX_OPEN_TOOL_CALLS)
 
-    def test_the_latest_shot_reports_its_open_and_completed_split(self):
+    def test_the_latest_shot_reports_its_open_and_closed_split(self):
         record_tool_call("read_file", omh_home=self.home, now=NOW, tool_call_id="call-1", turn_id="turn-1")
         record_tool_call("terminal", omh_home=self.home, now=NOW + 0.1, tool_call_id="call-2", turn_id="turn-1")
         record_tool_call_close("call-2", omh_home=self.home, now=NOW + 0.2)
@@ -130,9 +162,41 @@ class ToolBurstLedgerTest(unittest.TestCase):
 
         self.assertEqual(shot["status"], "observed")
         self.assertEqual(shot["open_count"], 1)
-        self.assertEqual(shot["completed_count"], 1)
+        # Not "completed" -- an entry with no tool_call_id or an expired
+        # entry lands here too, and neither was observed finishing (P3-1).
+        self.assertEqual(shot["closed_or_unobserved_count"], 1)
         self.assertEqual(activity["latest_shot"]["open_count"], 1)
         self.assertTrue(activity["live"])
+
+    def test_the_latest_shot_reports_peak_concurrency_not_dispatch_size(self):
+        # Four strictly SEQUENTIAL calls, each closing before the next opens,
+        # chained into one burst by the 1.5s grouping window. `size` is 4,
+        # but at no point were more than 1 open at once -- the badge must
+        # read the true peak, not the dispatch count (P1-2).
+        for index in range(4):
+            call_id = f"call-{index}"
+            record_tool_call("terminal", omh_home=self.home, now=NOW + index * 0.3, tool_call_id=call_id)
+            record_tool_call_close(call_id, omh_home=self.home, now=NOW + index * 0.3 + 0.05)
+
+        shot = latest_parallel_shot(self.home, now=NOW + 1)
+
+        self.assertEqual(shot["status"], "observed")
+        self.assertEqual(shot["size"], 4)
+        self.assertEqual(shot["peak_open_count"], 1)
+
+    def test_the_latest_shot_reports_true_overlap_when_calls_genuinely_stack(self):
+        # call-1 opens and is still open when call-2 and call-3 open too --
+        # a real 3-way overlap.
+        record_tool_call("read_file", omh_home=self.home, now=NOW, tool_call_id="call-1")
+        record_tool_call("read_file", omh_home=self.home, now=NOW + 0.1, tool_call_id="call-2")
+        record_tool_call("terminal", omh_home=self.home, now=NOW + 0.2, tool_call_id="call-3")
+        record_tool_call_close("call-1", omh_home=self.home, now=NOW + 0.3)
+        record_tool_call_close("call-2", omh_home=self.home, now=NOW + 0.4)
+        record_tool_call_close("call-3", omh_home=self.home, now=NOW + 0.5)
+
+        shot = latest_parallel_shot(self.home, now=NOW + 1)
+
+        self.assertEqual(shot["peak_open_count"], 3)
 
     def test_the_hud_payload_carries_the_latest_shot(self):
         # The reader checks freshness against wall time, so record against

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -275,6 +275,36 @@ class TuiWidgetPackTests(unittest.TestCase):
         self.assertEqual(widget.count("updateWidget(todoApp, apply)"), 1)
         self.assertEqual(widget.count("openWidget(todoApp, todoApp.init(''))"), 1)
 
+    def test_hud_liveness_signal_drives_the_status_line_todo_and_shot_badge(self) -> None:
+        # 2026-08 HUD liveness fix: exact in-flight tool-call state (paired
+        # from pre_tool_call/post_tool_call by tool_call_id) replaces three
+        # things that used to lie -- a lingering green active todo item, a
+        # parallel-shot badge stuck at the ring ceiling, and no signal at all
+        # while calls were genuinely running.
+        widget = resources.files("omh.tui_widgets").joinpath("omh-status.mjs").read_text(encoding="utf-8")
+
+        # Status line: a live segment renders only while open calls exist.
+        self.assertIn("payload.activity && payload.activity.live", widget)
+        self.assertIn("`⚙ ${plural(Number(payload.activity.open_call_count) || 0, 'tool')}", widget)
+
+        # Todo panel: the active marker is warn-colored and carries a stall
+        # hint when the HUD says not-live, instead of always reading green.
+        self.assertIn("color: item.state === 'active' ? (live ? t.color.ok : t.color.warn)", widget)
+        self.assertIn("stallElapsed ? h(Text, { color: t.color.muted }, ` (stalled ${stallElapsed})`)", widget)
+
+        # Shot badge: tied to open calls while live, dimmed history with age
+        # once every member has closed -- never the saturated ring size.
+        self.assertIn("const openCount = Number(shot.open_count) || 0", widget)
+        self.assertIn("if (openCount > 0) {", widget)
+        self.assertIn("(${age} ago)", widget)
+
+        # The exact in-flight age is the one field allowed to drift every
+        # poll without forcing a repaint; the liveness transition itself
+        # (open_call_count, live) stays out of VOLATILE_KEYS on purpose.
+        self.assertIn("'oldest_open_elapsed_seconds',", widget)
+        self.assertNotIn("'open_call_count',", widget)
+        self.assertNotIn("'live',", widget)
+
     def test_widget_is_bottom_docked_and_omits_host_status_fields(self) -> None:
         widget = resources.files("omh.tui_widgets").joinpath("omh-status.mjs").read_text(encoding="utf-8")
 
@@ -422,7 +452,14 @@ class TuiWidgetPackTests(unittest.TestCase):
         self.assertNotIn(", useShimmerPhase }", widget)
         self.assertIn("ShimmerText", widget)
         self.assertIn("PlanPulse", widget)
-        self.assertIn("hasActive ? h(PlanPulse, { t }) : null", widget)
+        # Changed on purpose (2026-08 HUD liveness fix): the wave and the
+        # walking ellipsis both imply "actually running", so both now gate on
+        # the HUD's exact in-flight signal too, not just an active item's
+        # existence -- a stopped turn with an incomplete todo must not
+        # animate as if work were still happening.
+        self.assertIn("hasActive && live ? h(PlanPulse, { t }) : null", widget)
+        self.assertIn("const live = !!(payload.activity && payload.activity.live)", widget)
+        self.assertIn("stalled ${stallElapsed}", widget)
         self.assertNotIn("Number.MAX_SAFE_INTEGER", widget)
         # Changed on purpose: the parallel-shot badge moved off the bottom
         # status line onto the dock-top frame rule — the transcript's

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -283,25 +283,49 @@ class TuiWidgetPackTests(unittest.TestCase):
         # while calls were genuinely running.
         widget = resources.files("omh.tui_widgets").joinpath("omh-status.mjs").read_text(encoding="utf-8")
 
-        # Status line: a live segment renders only while open calls exist.
-        self.assertIn("payload.activity && payload.activity.live", widget)
-        self.assertIn("`⚙ ${plural(Number(payload.activity.open_call_count) || 0, 'tool')}", widget)
+        # Status line: a live segment renders only while open calls exist AND
+        # this install has actually observed post_tool_call fire -- an
+        # unsupported host's ledger can only expire entries, never
+        # legitimately close them, so a bare `live` reading there is not
+        # trustworthy (P2-1). No ambiguous-width glyph prefixes it (P3-4).
+        self.assertIn(
+            "payload.activity && payload.activity.live && payload.activity.post_tool_call_observed",
+            widget,
+        )
+        self.assertIn("`${plural(Number(payload.activity.open_call_count) || 0, 'tool')}", widget)
+        self.assertNotIn("⚙", widget)
 
         # Todo panel: the active marker is warn-colored and carries a stall
-        # hint when the HUD says not-live, instead of always reading green.
+        # hint when the HUD says not-live, instead of always reading green --
+        # but only once liveness is answerable; an unsupported host falls
+        # back to always-live (P2-1), and the stall age itself comes from
+        # the reader, not a Date.now() computed in render (P1-1).
+        self.assertIn("const answerable = !!(payload.activity && payload.activity.post_tool_call_observed)", widget)
+        self.assertIn(
+            "const live = answerable ? !!(payload.activity && payload.activity.live) : true",
+            widget,
+        )
         self.assertIn("color: item.state === 'active' ? (live ? t.color.ok : t.color.warn)", widget)
         self.assertIn("stallElapsed ? h(Text, { color: t.color.muted }, ` (stalled ${stallElapsed})`)", widget)
+        self.assertIn("const seconds = todo.updated_age_seconds", widget)
+        self.assertNotIn("Date.parse(safeText(todo.updated_at)", widget)
 
         # Shot badge: tied to open calls while live, dimmed history with age
-        # once every member has closed -- never the saturated ring size.
+        # once every member has closed -- never the saturated ring size, and
+        # never the burst's raw dispatch size either (P1-2): the dimmed form
+        # reads the group's measured peak concurrency.
         self.assertIn("const openCount = Number(shot.open_count) || 0", widget)
         self.assertIn("if (openCount > 0) {", widget)
         self.assertIn("(${age} ago)", widget)
+        self.assertIn("parallel shot ×${Number(shot.peak_open_count) || 0}", widget)
+        self.assertNotIn("parallel shot ×${Number(shot.size)", widget)
 
-        # The exact in-flight age is the one field allowed to drift every
-        # poll without forcing a repaint; the liveness transition itself
-        # (open_call_count, live) stays out of VOLATILE_KEYS on purpose.
+        # The exact in-flight age and the reader-computed todo stall age are
+        # the only fields allowed to drift every poll without forcing a
+        # repaint; the liveness transition itself (open_call_count, live)
+        # stays out of VOLATILE_KEYS on purpose.
         self.assertIn("'oldest_open_elapsed_seconds',", widget)
+        self.assertIn("'updated_age_seconds',", widget)
         self.assertNotIn("'open_call_count',", widget)
         self.assertNotIn("'live',", widget)
 
@@ -458,7 +482,10 @@ class TuiWidgetPackTests(unittest.TestCase):
         # existence -- a stopped turn with an incomplete todo must not
         # animate as if work were still happening.
         self.assertIn("hasActive && live ? h(PlanPulse, { t }) : null", widget)
-        self.assertIn("const live = !!(payload.activity && payload.activity.live)", widget)
+        self.assertIn(
+            "const live = answerable ? !!(payload.activity && payload.activity.live) : true",
+            widget,
+        )
         self.assertIn("stalled ${stallElapsed}", widget)
         self.assertNotIn("Number.MAX_SAFE_INTEGER", widget)
         # Changed on purpose: the parallel-shot badge moved off the bottom


### PR DESCRIPTION
## Capability

The OMH TUI dock now tells the truth about whether work is actually running:

- **Exact in-flight tracking**: OMH registers the Hermes `post_tool_call` observer hook (supported hook, pure observer) and pairs it with the existing `pre_tool_call` to keep an open-calls ledger (tool_call_id-keyed, 15-min TTL expiry for crash safety, bounded). The HUD payload gains an `activity` block: open call count, oldest-open elapsed, and a `live` flag.
- **Live activity is visible**: while calls are open, the status line renders a live segment with the true open count and elapsed — previously a 40-wide parallel batch showed nothing.
- **Idle stops looking alive**: the todo panel's active `[•]` item renders green/animated only while live; when the turn has ended with tasks incomplete, it renders warn-colored with a reader-computed `(stalled Ns)` age that keeps advancing (shipped in the payload and VOLATILE_KEYS, so it can't freeze on byte-identical snapshots). The plan header's motion cues gate on the same flag.
- **The shot badge stops lying**: "parallel shot ×N" lifetime is tied to actually-open calls; the dimmed history form reports the observed `peak_open_count` (max simultaneously open) instead of the ring-buffer group size — 60 sequential calls no longer render as "×60 parallel", and the old ×40 was the ring ceiling saturating, not a measurement.
- **Honest degradation**: on a host that never fires `post_tool_call`, liveness is unanswerable — the ledger's observed-at evidence gates the whole feature and the dock falls back to today's rendering instead of showing a working agent as permanently stalled.

## Motivation

Owner-reported incident: a Hermes agent closed its turn early with tasks incomplete, and the dock kept a green active todo item and a stale "parallel shot ×40" indefinitely — stopped-with-incomplete-work was indistinguishable from running ("지금 아무 에이전트도 안 돌고 있었는데 TODO에선 초록색으로 계속 인지하고 있었음"). Conversely, 40 genuinely-running parallel calls showed nothing. Read-only investigation (session-local dossier) confirmed: the agents counter measures delegated children only, the badge freshness was an 8-second heuristic, and the ×40 was the `MAX_TOOL_BURST_ENTRIES` ceiling.

## Implementation (boundary level)

- `plugin.yaml` + `metadata.py` + `hook_integrity.py` + capability mirrors: `post_tool_call` registered as an optional observer (returns nothing; `has_hook`-gated on the host, one dict lookup when absent). Registration is configuration — no Hermes patching.
- `tool_bursts.py`: open/close ledger with atomic temp-rename writes, torn-file degradation, TTL expiry (expired ≠ completed — the count field is named `closed_or_unobserved_count`), per-tick concurrency snapshots for `peak_open_count`, single-read `tool_call_projection()` backing both the badge and the activity block. Docstring states the real scope (machine-wide OMH home, all sessions).
- `runtime_reader.py`: `activity` block + `updated_age_seconds` on the todo summary.
- `omh-status.mjs`: liveness-gated rendering (three surfaces), warn-color stall hint (same color role as the #1145 route-fallback tags), liveness transitions treated as structural for prompt repaint, 30s metric cadence preserved for the drag-copyable dock.
- An independent review pass (2 P1, 2 P2, 4 P3) ran before this PR; every finding was fixed or explicitly documented (`d1ddcbe8` carries the per-finding dispositions in its trailers).

## Verification (observed)

- Full suite on the final tree: **7661 tests, OK**.
- Targeted: tool-bursts/hook-manifest/hud/widget-pack/runtime-reader/broad-except suites (140 tests) plus `node --check` on the widget.
- All five docs byte gates ok (no catalog surfaces touched — proven, not assumed); ruff, compileall, `git diff --check` clean.
- Not observed: a live TUI visual pass on the new segments (no running Hermes session in this environment); the widget renders from the same snapshot contract the tests pin.

## Risks

- Older hosts without `post_tool_call`: feature self-disables via the observed-evidence gate (verified in tests).
- Ledger is machine-scoped: any session's open calls read as live — documented as the real semantics; per-session scoping needs a session-id input the reader doesn't have and is recorded as the follow-up shape.
- Lock contention can strand an open entry only at 100+-way cross-session concurrency (measured); bounded by the 15-min TTL and documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)