### PR TITLE
feat(hud): live maestro rows for fanout-dispatched CLI units

### DIFF
--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -145,9 +145,19 @@ Rules:
   HUD's active-executor projection on the next read. The HUD reader labels
   these rows `(<executor>/maestro <model>)`, alongside Hermes-native
   delegate_task rows, because a fanout unit IS the Maestro lane spawning an
-  external CLI directly. Every write here is best-effort: an
-  `ExecutorProgressError` or `OSError` never blocks or fails the dispatch,
-  the same rule the inflight marker already holds.
+  external CLI directly, and derives the row's `elapsed_seconds` from the
+  binding's own opened timestamp against wall-clock now so a live row shows
+  real running time instead of the widget's snapshot-age fallback. Cost is
+  NOT a live figure for this lane: the spawned CLI reports it only in its
+  terminal result object, so `cost_usd` never has a value until the unit's
+  binding closes on exit, and a closed binding drops out of the active-row
+  projection before the next read — a finished unit's cost still surfaces
+  wherever closed rows are reported (the dispatch summary, `omh coding
+  fanout brief`), just never on a still-running row. Every write here is
+  best-effort: an `ExecutorProgressError` or `OSError` never blocks or fails
+  the dispatch, the same rule the inflight marker already holds; the binding
+  now opens and closes inside the same `try`/`finally` so a Ctrl-C or other
+  interruption during the spawn cannot orphan a live row with no closer.
 - **Spawnability is data.** `DISPATCH_COMMAND_TEMPLATES` in
   `src/coding/fanout_dispatch.py` maps profiles with a local headless CLI to
   fixed argv templates — currently codex (`codex exec`), claude-code
@@ -306,15 +316,19 @@ Rules:
   handoff routed no model at all — it never overrides a resolved
   `coding_model_route/v2`/`v1`, and a frozen `choice_required` route still
   fails closed before this is ever read. Editing the JSON file directly is
-  the supported surface; there is no dedicated CLI editor. Shipped default:
-  `claude-code` defaults to `"opus"` (`claude --help` documents `--model` as
-  accepting a short alias — `fable`, `opus`, `sonnet` — alongside a full model
-  id, and `opus` is the strongest published alias), so a claude-code unit with
-  no other route dispatches on the strongest tier rather than silently taking
-  whatever the CLI defaults to. `codex` ships no default (no local `codex` CLI
-  in this repo to confirm its `--model` value space against) — an unset entry
-  means the spawned CLI's own default. An operator profile entry, including an
-  explicit empty string, always overrides the shipped default.
+  the supported surface; there is no dedicated CLI editor. No profile ships a
+  default: a model an account is not entitled to is an observed exit failure
+  with no fallback walk, so an unset entry — meaning the spawned CLI's own
+  default — is the out-of-the-box behavior for every profile, including
+  `claude-code`. **Recommended**, not shipped: an operator who wants the
+  strongest claude-code tier and knows their account carries it can set
+  `"claude-code": "opus"` themselves (this codebase's own model-family alias
+  set, `_CLAUDE_TIER_ALIASES` in `src/coding/model_routing.py`, recognizes
+  `opus` as a claude-family model id; whether `claude --help` documents it as
+  a `--model` alias on a given install is unverified here). `codex` has no
+  recommended value either (no local `codex` CLI in this repo to confirm its
+  `--model` value space against). An operator profile entry, including an
+  explicit empty string, always overrides an unset default.
 - **Model inventory (reporting-only).** `omh coding model-inventory` reports
   which coding models the user has locally activated before any split or
   delegation is proposed: agent CLIs on PATH (codex, claude, opencode,

--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -132,6 +132,22 @@ Rules:
   not name is refused whatever its process name. The reaper does not check
   that the dispatcher is dead — verify that first; a live dispatcher's
   running units are equally marker-named.
+- **Each spawned unit opens an executor-progress row.** Before the spawn,
+  dispatch opens an `omh_executor_progress_binding/v1` on the unit's run
+  (`target_type: run, target_id: <run_ref>`) tagged `delivery.source:
+  fanout_dispatch`, reports an `executor_dispatched` event carrying the
+  unit's title and its routed (or preference-filled) model, and updates the
+  binding's pid once the real spawn hands one back — the same seam the
+  inflight marker above uses. On exit it reports `executor_completed` or
+  `executor_failed`, carrying whatever tokens/cost the spawned CLI's own
+  stdout reported (`unit_telemetry`, never estimated) and closing the
+  binding, which is what stops the row — a closed binding drops out of the
+  HUD's active-executor projection on the next read. The HUD reader labels
+  these rows `(<executor>/maestro <model>)`, alongside Hermes-native
+  delegate_task rows, because a fanout unit IS the Maestro lane spawning an
+  external CLI directly. Every write here is best-effort: an
+  `ExecutorProgressError` or `OSError` never blocks or fails the dispatch,
+  the same rule the inflight marker already holds.
 - **Spawnability is data.** `DISPATCH_COMMAND_TEMPLATES` in
   `src/coding/fanout_dispatch.py` maps profiles with a local headless CLI to
   fixed argv templates — currently codex (`codex exec`), claude-code
@@ -275,14 +291,30 @@ Rules:
   `effort_change` record; for models the catalog has not met the request
   passes through untouched (the catalog is a default candidate list, not an
   allowlist, and it never adjudicates a model it does not know). No route
-  means the argv stays byte-identical to the base template and the executor
-  CLI default model applies. Model availability and entitlement are provider
-  truth; a routed model that the CLI rejects surfaces as a normal observed
-  exit failure. `omh coding model-route` previews a single route;
+  means the argv stays byte-identical to the base template *unless* the
+  operator's dispatch-model preference fills the gap (below); with neither, the
+  executor CLI default model applies. Model availability and entitlement are
+  provider truth; a routed model that the CLI rejects surfaces as a normal
+  observed exit failure. `omh coding model-route` previews a single route;
   `omh coding model-route --explain` renders the full profile × role
   resolution matrix with chains and provenance. Contracts frozen before the
   v2 bump may embed `coding_model_route/v1` routes — they are read verbatim
   (the brief annotates them `[schema v1]`), never rewritten.
+- **Dispatch-model preference (fallback only).** `<omh_home>/routing/dispatch-models.json`
+  (`omh_dispatch_model_preferences/v1`, `{"schema_version": ..., "profiles": {"codex": "...", "claude-code": "..."}}`)
+  names a per-owner `--model` value dispatch uses only when a unit's prepared
+  handoff routed no model at all — it never overrides a resolved
+  `coding_model_route/v2`/`v1`, and a frozen `choice_required` route still
+  fails closed before this is ever read. Editing the JSON file directly is
+  the supported surface; there is no dedicated CLI editor. Shipped default:
+  `claude-code` defaults to `"opus"` (`claude --help` documents `--model` as
+  accepting a short alias — `fable`, `opus`, `sonnet` — alongside a full model
+  id, and `opus` is the strongest published alias), so a claude-code unit with
+  no other route dispatches on the strongest tier rather than silently taking
+  whatever the CLI defaults to. `codex` ships no default (no local `codex` CLI
+  in this repo to confirm its `--model` value space against) — an unset entry
+  means the spawned CLI's own default. An operator profile entry, including an
+  explicit empty string, always overrides the shipped default.
 - **Model inventory (reporting-only).** `omh coding model-inventory` reports
   which coding models the user has locally activated before any split or
   delegation is proposed: agent CLIs on PATH (codex, claude, opencode,

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -287,6 +287,14 @@ carries its own `claim_boundary` (prepared routes only, never dispatch
 evidence), and is safe to delete — an absent or invalid file only means HUD
 rows fall back to plain category projection.
 
+A fourth sibling, `~/.omh/routing/dispatch-models.json`
+(`omh_dispatch_model_preferences/v1`), is operator-edited only — nothing
+seeds or writes it automatically — and applies to a different surface:
+`omh coding fanout dispatch`'s `--model` fallback for a spawned agent CLI,
+used only when a unit's prepared handoff routed no model at all. See
+`docs/FANOUT.md` (Dispatch-model preference) for the schema and the
+`claude-code`/`codex` behavior it fills the gap for.
+
 ### Reaching models through a provider
 
 Chains name models the way a person says them (`glm-5.2`, `kimi-k3`). A host

--- a/src/coding/executor_progress.py
+++ b/src/coding/executor_progress.py
@@ -1418,6 +1418,15 @@ def _project_binding_row(
         "linked_bindings": linked,
         "claim_boundary": CLAIM_BOUNDARY,
     }
+    # Who opened the binding, projected from `delivery.source` -- absent for
+    # every binding source that predates this field. `fanout_dispatch` is the
+    # one value the HUD reader currently keys off of, to tell a fanout-unit
+    # binding apart from a Hermes-native or wrapper-session one that happens
+    # to share the same executor profile.
+    delivery = primary.get("delivery")
+    source = str(delivery.get("source", "")) if isinstance(delivery, dict) else ""
+    if source:
+        row["source"] = source
     # Promoted to the row itself, not left nested in `latest_event`: the status
     # board renders one line per executor and had no way to say which model was
     # running, because the profile alone does not identify it.

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -1371,18 +1371,25 @@ DISPATCH_MODEL_PREFERENCE_SCHEMA_VERSION = "omh_dispatch_model_preferences/v1"
 # Owners that spawn a headless coding CLI directly accept a `--model` string
 # (see DISPATCH_MODEL_OPTION_TEMPLATES); this is the operator preference read
 # when a unit's prepared handoff carries no routed model at all -- it never
-# overrides a frozen route, only fills the gap when there is none. Shipped
-# default covers claude-code only: `claude --help` documents `--model` as
-# accepting a short alias ("fable", "opus", "sonnet") in addition to a full
-# model id, and "opus" is the strongest published alias, so it degrades to a
-# real, CLI-recognized model rather than a guessed full id (owner directive,
-# 2026-08: "웬만해서는 fable-5 opus 쓰게"). Codex ships no default here: this
-# repo has no local `codex` CLI to confirm its `--model` value space against,
-# so an unset entry -- meaning the spawned CLI's own default -- is the
-# conservative choice until that is verified. An operator can override or
-# clear either entry in `dispatch-models.json`; an explicit empty string
-# clears the shipped default back to unset.
-_SHIPPED_DISPATCH_MODEL_DEFAULTS: dict[str, str] = {"claude-code": "opus"}
+# overrides a frozen route, only fills the gap when there is none. No profile
+# ships a default here: a model the account is not entitled to is an observed
+# exit failure with no fallback walk, and a user who never opted into a
+# specific model choice should not be defaulted into that failure. The unset
+# entry -- meaning the spawned CLI's own default -- is therefore the honest
+# out-of-the-box behavior for every profile, including claude-code.
+# `docs/FANOUT.md` documents "opus" as the recommended claude-code value for
+# an operator who wants the strongest tier and knows their account carries
+# it (this codebase's own model-family alias set, `_CLAUDE_TIER_ALIASES` in
+# `src/coding/model_routing.py`, recognizes "opus" as a claude-family model
+# id; whether `claude --help` itself documents "opus" as a `--model` alias on
+# a given install is unverified here). One operator's own preference for it
+# (2026-08 directive: "use fable-5 opus wherever reasonably possible") is set
+# the same way, in that operator's own `dispatch-models.json`, not as a
+# package-wide default. Codex ships no default either: this repo has no
+# local `codex` CLI to confirm its `--model` value space against. An
+# operator sets either profile in `dispatch-models.json`; an explicit empty
+# string clears an entry back to unset.
+_SHIPPED_DISPATCH_MODEL_DEFAULTS: dict[str, str] = {}
 
 
 def dispatch_model_preferences_path(omh_home: Path) -> Path:
@@ -1482,7 +1489,8 @@ def _close_fanout_progress_binding(
     routed_model: str,
     routed_effort: str,
     title: str,
-    telemetry: Mapping[str, object],
+    owner: str,
+    stdout_text: str,
 ) -> None:
     """Best-effort: report the unit's terminal state and close its row.
 
@@ -1490,12 +1498,20 @@ def _close_fanout_progress_binding(
     very next read, which is what stops the row the moment the process ends —
     the same lifecycle every other executor-progress binding already has, not
     a bespoke lingering rule invented for this lane.
+
+    Telemetry parsing lives INSIDE this guard rather than being handed in
+    already-parsed: a caller evaluating `parse_unit_telemetry(...)` as an
+    argument to this function runs it outside any try/except of its own --
+    from inside a `finally`, that would propagate straight out and mask
+    whatever the dispatch itself was doing, which is exactly the failure mode
+    this whole binding lifecycle is "best-effort" to avoid.
     """
     if binding is None:
         return
-    tokens_total = telemetry.get("tokens_total")
-    cost_usd = telemetry.get("cost_usd")
     try:
+        telemetry = parse_unit_telemetry(owner, stdout_text)
+        tokens_total = telemetry.get("tokens_total")
+        cost_usd = telemetry.get("cost_usd")
         signal = build_safe_progress_signal(
             executor_profile=str(binding.get("executor_profile", "")),
             process_status="completed" if exit_code == 0 else "failed",
@@ -1753,50 +1769,54 @@ def _dispatch_unit(
             "started_at": started_at,
         },
     )
-    # Best-effort HUD row for this unit: opened before the spawn, next to the
-    # inflight marker above, and closed in `finally` below so the row can
-    # never outlive the process it describes. See _open_fanout_progress_binding.
-    progress_binding = _open_fanout_progress_binding(
-        paths,
-        run_ref=run_ref,
-        owner=owner,
-        worktree=worktree,
-        started_at=started_at,
-        routed_model=routed_model,
-        routed_effort=routed_effort,
-        title=unit_title,
-    )
+    # Best-effort HUD row for this unit: opened inside the same try whose
+    # finally below closes it, so the row can never outlive the process it
+    # describes -- opening it BEFORE the try left a window (a Ctrl-C during
+    # the stagger sleep just below, in particular) where the binding was on
+    # disk but the finally that closes it never ran, orphaning a live row for
+    # up to its freshness window. See _open_fanout_progress_binding.
+    progress_binding: dict[str, Any] | None = None
     spawn_kwargs: dict[str, Any] = {}
-    if getattr(runner, "accepts_on_spawn", False):
-        # The signal-safe runner hands back the live process so the marker
-        # carries the real group-leader pid the fanout reaper verifies
-        # against; injected test runners keep the plain protocol.
-        def _record_pid(process: subprocess.Popen) -> None:
-            nonlocal progress_binding
-            _write_inflight(
-                paths,
-                fanout_id,
-                unit_id,
-                {
-                    "owner": owner,
-                    "owner_host": owner_host,
-                    "model": routed_model,
-                    "reasoning_effort": routed_effort,
-                    "run_ref": run_ref,
-                    "worktree": str(worktree),
-                    "started_at": started_at,
-                    "pid": str(process.pid),
-                },
-            )
-            progress_binding = _record_fanout_progress_pid(paths, progress_binding, process.pid)
-
-        spawn_kwargs["on_spawn"] = _record_pid
-        # Real spawns only (the same seam as the pid hook): stagger this
-        # unit's start so the first dispatch of the fanout writes the
-        # provider prompt cache the byte-identical sibling preambles read.
-        if spawn_stagger is not None:
-            spawn_stagger.reserve()
     try:
+        progress_binding = _open_fanout_progress_binding(
+            paths,
+            run_ref=run_ref,
+            owner=owner,
+            worktree=worktree,
+            started_at=started_at,
+            routed_model=routed_model,
+            routed_effort=routed_effort,
+            title=unit_title,
+        )
+        if getattr(runner, "accepts_on_spawn", False):
+            # The signal-safe runner hands back the live process so the marker
+            # carries the real group-leader pid the fanout reaper verifies
+            # against; injected test runners keep the plain protocol.
+            def _record_pid(process: subprocess.Popen) -> None:
+                nonlocal progress_binding
+                _write_inflight(
+                    paths,
+                    fanout_id,
+                    unit_id,
+                    {
+                        "owner": owner,
+                        "owner_host": owner_host,
+                        "model": routed_model,
+                        "reasoning_effort": routed_effort,
+                        "run_ref": run_ref,
+                        "worktree": str(worktree),
+                        "started_at": started_at,
+                        "pid": str(process.pid),
+                    },
+                )
+                progress_binding = _record_fanout_progress_pid(paths, progress_binding, process.pid)
+
+            spawn_kwargs["on_spawn"] = _record_pid
+            # Real spawns only (the same seam as the pid hook): stagger this
+            # unit's start so the first dispatch of the fanout writes the
+            # provider prompt cache the byte-identical sibling preambles read.
+            if spawn_stagger is not None:
+                spawn_stagger.reserve()
         completed = runner(
             argv, cwd=str(worktree), text=True, capture_output=True, timeout=timeout, **spawn_kwargs
         )
@@ -1819,7 +1839,8 @@ def _dispatch_unit(
             routed_model=routed_model,
             routed_effort=routed_effort,
             title=unit_title,
-            telemetry=parse_unit_telemetry(owner, stdout_text),
+            owner=owner,
+            stdout_text=stdout_text,
         )
     finished_at = utc_now()
     duration_seconds = round(time.monotonic() - started_clock, 3)

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -19,7 +19,7 @@ import time
 from typing import Any, Callable, Iterable, Mapping, Sequence
 
 from ..runtime.artifacts import append_journal_observation, create_run, show_run
-from ..system.local_store import atomic_write_json, ensure_dir, locked_json_update, utc_now
+from ..system.local_store import atomic_write_json, ensure_dir, locked_json_update, read_json_object_result, utc_now
 from ..system.metadata_safety import redact_metadata_text
 from ..system.paths import OmhPaths
 from ._hermes_child_process import terminate_process_group
@@ -30,6 +30,14 @@ from .executor_capability_snapshots import (
     validate_executor_capability_snapshot,
 )
 from .executor_capabilities import legacy_executor_capability_projection
+from .executor_progress import (
+    ExecutorProgressError,
+    build_progress_binding,
+    build_safe_progress_signal,
+    normalize_executor_profile,
+    observe_executor_progress,
+    write_progress_binding,
+)
 from .executor_readiness import probe_executor_readiness
 from .fanout_contracts import (
     FANOUT_CLAIM_BOUNDARY,
@@ -1333,6 +1341,7 @@ _TELEMETRY_RESULT_KEYS: tuple[str, ...] = (
     "cache_read_tokens",
     "cache_write_tokens",
     "reasoning_tokens",
+    "cost_usd",
     "session_ref",
 )
 
@@ -1354,6 +1363,150 @@ def _clear_inflight(paths: OmhPaths, fanout_id: str, unit_id: str) -> None:
     try:
         clear_inflight_marker(paths, fanout_id, unit_id)
     except (InflightMarkerError, OSError):
+        return
+
+
+DISPATCH_MODEL_PREFERENCE_SCHEMA_VERSION = "omh_dispatch_model_preferences/v1"
+
+# Owners that spawn a headless coding CLI directly accept a `--model` string
+# (see DISPATCH_MODEL_OPTION_TEMPLATES); this is the operator preference read
+# when a unit's prepared handoff carries no routed model at all -- it never
+# overrides a frozen route, only fills the gap when there is none. Shipped
+# default covers claude-code only: `claude --help` documents `--model` as
+# accepting a short alias ("fable", "opus", "sonnet") in addition to a full
+# model id, and "opus" is the strongest published alias, so it degrades to a
+# real, CLI-recognized model rather than a guessed full id (owner directive,
+# 2026-08: "웬만해서는 fable-5 opus 쓰게"). Codex ships no default here: this
+# repo has no local `codex` CLI to confirm its `--model` value space against,
+# so an unset entry -- meaning the spawned CLI's own default -- is the
+# conservative choice until that is verified. An operator can override or
+# clear either entry in `dispatch-models.json`; an explicit empty string
+# clears the shipped default back to unset.
+_SHIPPED_DISPATCH_MODEL_DEFAULTS: dict[str, str] = {"claude-code": "opus"}
+
+
+def dispatch_model_preferences_path(omh_home: Path) -> Path:
+    return Path(omh_home) / "routing" / "dispatch-models.json"
+
+
+def _dispatch_model_preference(paths: OmhPaths, owner: str) -> str:
+    """The operator's preferred `--model` value for `owner`, or "" for the CLI default.
+
+    Never raises: a missing, unreadable, or malformed document reads the same
+    as an absent one, and the shipped default still applies -- a broken
+    preference file must not block a dispatch or silently downgrade the
+    model choice below the shipped default.
+    """
+    document, _error = read_json_object_result(dispatch_model_preferences_path(paths.omh_home))
+    if isinstance(document, dict) and document.get("schema_version") == DISPATCH_MODEL_PREFERENCE_SCHEMA_VERSION:
+        profiles = document.get("profiles")
+        if isinstance(profiles, dict) and owner in profiles:
+            value = profiles.get(owner)
+            return value.strip() if isinstance(value, str) else ""
+    return _SHIPPED_DISPATCH_MODEL_DEFAULTS.get(owner, "")
+
+
+# `source` on the progress binding this lane opens. The HUD reader keys off
+# this exact string (`_hud_subagent_summary` in runtime_reader.py) to label a
+# row `(<executor>/maestro)` instead of rendering it like a Hermes-native
+# delegate_task child -- `omh coding fanout dispatch` spawning an external CLI
+# directly IS the Maestro lane (CONTEXT.md "Maestro" / "Fanout dispatch").
+_FANOUT_PROGRESS_SOURCE = "fanout_dispatch"
+
+
+def _open_fanout_progress_binding(
+    paths: OmhPaths,
+    *,
+    run_ref: str,
+    owner: str,
+    worktree: Path,
+    started_at: str,
+    routed_model: str,
+    routed_effort: str,
+    title: str,
+) -> dict[str, Any] | None:
+    """Best-effort: open and report the initial live row for one dispatched unit.
+
+    Returns None when the owner has no progress lane (never raises) so the
+    caller's later pid/close calls become no-ops rather than every dispatch
+    growing a try/except of its own -- observability must never fail a
+    dispatch, the same rule `_write_inflight` already holds for markers.
+    """
+    try:
+        profile = normalize_executor_profile(owner)
+    except ExecutorProgressError:
+        return None
+    try:
+        binding = build_progress_binding(
+            target_type="run",
+            target_id=run_ref,
+            executor_profile=profile,
+            now=started_at,
+            worktree=str(worktree),
+            source=_FANOUT_PROGRESS_SOURCE,
+        )
+        binding = write_progress_binding(paths, binding)
+        signal = build_safe_progress_signal(
+            executor_profile=profile,
+            process_status="dispatched",
+            routed_model=routed_model,
+            routed_reasoning_effort=routed_effort,
+            explicit_summary=title,
+        )
+        observation = observe_executor_progress(paths, binding, signal, observed_at=started_at)
+        return observation["binding"]
+    except (ExecutorProgressError, OSError):
+        return None
+
+
+def _record_fanout_progress_pid(
+    paths: OmhPaths,
+    binding: dict[str, Any] | None,
+    pid: int,
+) -> dict[str, Any] | None:
+    if binding is None:
+        return None
+    try:
+        updated = dict(binding)
+        updated["process"] = {**binding.get("process", {}), "pid": pid}
+        return write_progress_binding(paths, updated)
+    except (ExecutorProgressError, OSError):
+        return binding
+
+
+def _close_fanout_progress_binding(
+    paths: OmhPaths,
+    binding: dict[str, Any] | None,
+    *,
+    exit_code: int,
+    routed_model: str,
+    routed_effort: str,
+    title: str,
+    telemetry: Mapping[str, object],
+) -> None:
+    """Best-effort: report the unit's terminal state and close its row.
+
+    A closed binding drops out of the HUD's active-executor projection on the
+    very next read, which is what stops the row the moment the process ends —
+    the same lifecycle every other executor-progress binding already has, not
+    a bespoke lingering rule invented for this lane.
+    """
+    if binding is None:
+        return
+    tokens_total = telemetry.get("tokens_total")
+    cost_usd = telemetry.get("cost_usd")
+    try:
+        signal = build_safe_progress_signal(
+            executor_profile=str(binding.get("executor_profile", "")),
+            process_status="completed" if exit_code == 0 else "failed",
+            routed_model=routed_model,
+            routed_reasoning_effort=routed_effort,
+            explicit_summary=title,
+            tokens_total=tokens_total if isinstance(tokens_total, int) else None,
+            cost_usd=cost_usd if isinstance(cost_usd, (int, float)) and not isinstance(cost_usd, bool) else None,
+        )
+        observe_executor_progress(paths, binding, signal)
+    except (ExecutorProgressError, OSError):
         return
 
 
@@ -1462,7 +1615,19 @@ def _dispatch_unit(
             else None
         ),
     )
-    argv = build_dispatch_argv(owner, prompt, model_route)
+    # The unit's prepared handoff routes a model whenever the contract
+    # resolved one; when it did not (no route at all, or a route that
+    # resolved with no model), the operator's dispatch-model preference fills
+    # the gap so the spawn — and the row it opens — never silently falls back
+    # to "whatever the CLI defaults to" without a recorded reason. A frozen
+    # `choice_required` route already returned above and never reaches here.
+    effective_model_route = model_route
+    if not routed_model:
+        preference = _dispatch_model_preference(paths, owner)
+        if preference:
+            routed_model = preference
+            effective_model_route = {**(model_route or {}), "selected_model": preference}
+    argv = build_dispatch_argv(owner, prompt, effective_model_route)
     worktree = _worktree_path(repo_root, unit_id)
     if dry_run:
         from .executor_skill_discovery import skill_selection_card, suggested_skill_sequence
@@ -1567,7 +1732,9 @@ def _dispatch_unit(
     started_clock = time.monotonic()
     stderr_tail = ""
     stdout_text = ""
+    exit_code = 1
     owner_host = omo_runtime_host() or "" if owner == "omo-runtime" else ""
+    unit_title = str(unit.get("title") or unit.get("unit_id", unit_id))
     # Written BEFORE the spawn and cleared in `finally`. This call blocks for
     # the whole unit, so the dispatching process cannot report on itself; the
     # marker is what lets ANOTHER session see that this unit is running and
@@ -1586,12 +1753,26 @@ def _dispatch_unit(
             "started_at": started_at,
         },
     )
+    # Best-effort HUD row for this unit: opened before the spawn, next to the
+    # inflight marker above, and closed in `finally` below so the row can
+    # never outlive the process it describes. See _open_fanout_progress_binding.
+    progress_binding = _open_fanout_progress_binding(
+        paths,
+        run_ref=run_ref,
+        owner=owner,
+        worktree=worktree,
+        started_at=started_at,
+        routed_model=routed_model,
+        routed_effort=routed_effort,
+        title=unit_title,
+    )
     spawn_kwargs: dict[str, Any] = {}
     if getattr(runner, "accepts_on_spawn", False):
         # The signal-safe runner hands back the live process so the marker
         # carries the real group-leader pid the fanout reaper verifies
         # against; injected test runners keep the plain protocol.
         def _record_pid(process: subprocess.Popen) -> None:
+            nonlocal progress_binding
             _write_inflight(
                 paths,
                 fanout_id,
@@ -1607,6 +1788,7 @@ def _dispatch_unit(
                     "pid": str(process.pid),
                 },
             )
+            progress_binding = _record_fanout_progress_pid(paths, progress_binding, process.pid)
 
         spawn_kwargs["on_spawn"] = _record_pid
         # Real spawns only (the same seam as the pid hook): stagger this
@@ -1630,6 +1812,15 @@ def _dispatch_unit(
         exit_code, output_tail = 1, f"spawn failed: {exc}"
     finally:
         _clear_inflight(paths, fanout_id, unit_id)
+        _close_fanout_progress_binding(
+            paths,
+            progress_binding,
+            exit_code=exit_code,
+            routed_model=routed_model,
+            routed_effort=routed_effort,
+            title=unit_title,
+            telemetry=parse_unit_telemetry(owner, stdout_text),
+        )
     finished_at = utc_now()
     duration_seconds = round(time.monotonic() - started_clock, 3)
     limit_label = _limit_shaped_label(output_tail, stderr_tail) if exit_code != 0 else ""

--- a/src/coding/unit_telemetry.py
+++ b/src/coding/unit_telemetry.py
@@ -2,9 +2,10 @@
 
 `omh coding fanout dispatch` spawns a local agent CLI per unit and keeps only a
 bounded stdout tail in memory. When that CLI was asked for a structured stream,
-the tail carries the two numbers a fanout status board otherwise has to print as
-"unknown": how many tokens the run consumed, and which provider-side session it
-belongs to. This module lifts exactly those out and nothing else.
+the tail carries the numbers a fanout status board otherwise has to print as
+"unknown": how many tokens the run consumed, which provider-side session it
+belongs to, and -- for the one owner that reports it -- what the call cost.
+This module lifts exactly those out and nothing else.
 
 Relationship to `codex_progress` (read this before "fixing" either module):
 
@@ -48,6 +49,7 @@ Boundaries, in order of importance:
 from __future__ import annotations
 
 import json
+import math
 from typing import Any, Final, Mapping
 
 UNIT_TELEMETRY_SCHEMA_VERSION: Final[str] = "omh_unit_telemetry/v1"
@@ -75,8 +77,20 @@ UNIT_TELEMETRY_VALUE_KEYS: Final[tuple[str, ...]] = (
     "cache_read_tokens",
     "cache_write_tokens",
     "reasoning_tokens",
+    "cost_usd",
     "session_ref",
 )
+
+# Owners whose structured stdout reports a per-call cost, and the top-level key
+# it reports it under. `claude -p --output-format json` returns one `result`
+# object carrying `total_cost_usd` alongside `usage` -- confirmed from this
+# CLI's own `--help` documentation of `--output-format json`, not from a
+# stream captured in this repo (same provenance caveat as the claude-code
+# token shape above). Codex reports none: `codex exec`'s `turn.completed`
+# usage event has no cost field, and this module never estimates one from
+# tokens -- an omitted owner here means "no reported cost", read as an absent
+# key, exactly like every other unreported count.
+_COST_KEY_BY_SOURCE: Final[dict[str, str]] = {"claude_json": "total_cost_usd"}
 
 # Owners with a structured stdout surface. Every other owner -- omo-runtime and
 # its pi/senpi/opencode hosts, hermes, the omx/omc runtimes, generic --
@@ -211,6 +225,7 @@ def _observed_values(objects: list[dict[str, Any]], source: str) -> dict[str, ob
     """
     observed: dict[str, object] = {}
     session_keys = _SESSION_KEYS_BY_SOURCE.get(source, ())
+    cost_key = _COST_KEY_BY_SOURCE.get(source, "")
     for item in objects:
         usage = _token_usage(item)
         if usage:
@@ -221,6 +236,10 @@ def _observed_values(objects: list[dict[str, Any]], source: str) -> dict[str, ob
             observed.update(usage)
             if "tokens_billable" in usage:
                 observed["tokens_billable_source"] = "summed_reported_components"
+        if cost_key:
+            cost = _reported_cost(item.get(cost_key))
+            if cost is not None:
+                observed["cost_usd"] = cost
         if "session_ref" not in observed:
             session_ref = _session_ref(item, session_keys)
             if session_ref:
@@ -320,6 +339,22 @@ def _token_count(value: Any) -> int | None:
     if isinstance(value, bool) or not isinstance(value, int):
         return None
     return value if value >= 0 else None
+
+
+def _reported_cost(value: Any) -> float | None:
+    """Accept a reported non-negative finite cost only -- never an estimate.
+
+    `bool` is excluded for the same reason as `_token_count`: it is an `int`
+    subclass and would otherwise read `"total_cost_usd": true` as a real
+    number. This module sums or rounds only what a CLI already reported; it
+    never derives a cost from token counts.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    number = float(value)
+    if not math.isfinite(number) or number < 0:
+        return None
+    return number
 
 
 def _session_ref(item: Mapping[str, Any], session_keys: tuple[str, ...]) -> str:

--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -32,6 +32,11 @@ export default function register(sdk) {
   // (` ─ ready │ gpt 5.6 sol │ … `) and like oh-my-claudecode's HUD -- dense
   // text in the TUI's idiom, not a boxed widget that announces itself.
   // Colours still resolve only through the active theme, never literals.
+  // `omh coding fanout dispatch` spawns these local CLIs directly (executor
+  // profile names from executor_progress.ALLOWED_EXECUTOR_PROFILES); the
+  // short forms match how the rest of the row grammar already abbreviates —
+  // one bare word, lower case, no provider suffix.
+  const MAESTRO_EXECUTOR_SHORT_NAMES = { codex: 'codex', claude_code: 'claude', omo_runtime: 'omo', hermes_local: 'hermes' }
   const SEPARATOR = ' │ '
   // The classic REPL frames the composer with horizontal rules; the modern
   // TUI draws none. An interim single-dock design put both rules AND the
@@ -165,6 +170,18 @@ export default function register(sdk) {
     const stateText = columns < 100 ? ({ running: 'run', blocked: 'block', failed: 'fail' })[state] || state : state
     const taskId = truncateCells(safeText(row.task_id) || safeText(row.role) || 'agent', 8).padEnd(8)
     const model = [safeText(row.model), safeText(row.effort)].filter(Boolean).join(':')
+    // A row `omh coding fanout dispatch` opened (the Maestro lane spawning an
+    // external CLI directly, not a Hermes-native delegate_task child) carries
+    // `dispatch_lane` from the reader. It renders like every other row in
+    // this list — same truncation, dots, and state colors — except its
+    // identity segment reads `(<executor>/maestro <model>)` instead of the
+    // category:model route, so the dispatched executor and lane are visible
+    // at a glance and warn-colored to stand apart from Hermes-native rows.
+    const dispatchLane = safeText(row.dispatch_lane)
+    const dispatchExecutor = safeText(row.executor_profile)
+    const dispatchIdentity = dispatchLane
+      ? `(${MAESTRO_EXECUTOR_SHORT_NAMES[dispatchExecutor] || dispatchExecutor}/${dispatchLane}${safeText(row.model) ? ` ${truncateCells(row.model, 20)}` : ''})`
+      : ''
     const category = safeText(row.category)
     // Prepared-route provenance from the reader, rendered as one shape:
     // `category(model tag)`. The category names the LANE and never changes;
@@ -187,7 +204,7 @@ export default function register(sdk) {
     const tools = Number.isFinite(row.tool_count) ? `${row.tool_count} tools` : ''
     const turnTools = turn && tools ? `${turn} (${tools})` : turn || tools
     const optional = [
-      metricSegment(routeKind, route),
+      dispatchLane ? metricSegment('maestro', dispatchIdentity) : metricSegment(routeKind, route),
       metricSegment('fallback', Number.isFinite(row.fallback_count) && row.fallback_count > 0 ? `fallback:${row.fallback_count}` : ''),
       metricSegment('turn', turnTools),
       // A subscription-billed host records no per-call cost, so the reader
@@ -264,6 +281,11 @@ export default function register(sdk) {
                 // A fallback or exhausted route is a warning-grade fact: the
                 // lane is NOT running the chain head the category names.
                 : segment.kind === 'route-fallback'
+                  // A dispatched-executor identity is warn-colored for the
+                  // same reason as a fallback route: it marks the row as
+                  // something other than the plain Hermes-native default,
+                  // here the Maestro lane's own spawned CLI.
+                  || segment.kind === 'maestro'
                   ? t.color.warn
                   : t.color.muted,
             key: `${segment.kind}-${index}`,

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -1559,6 +1559,23 @@ def _hud_subagent_summary(status: dict[str, Any]) -> dict[str, Any]:
             value = _hud_percentage(row.get(key))
             if value is not None:
                 projected[key] = value
+        # `omh coding fanout dispatch` spawns an external CLI directly, which
+        # is the Maestro lane by definition (CONTEXT.md "Maestro" /
+        # "Fanout dispatch") -- the binding it opens carries
+        # `delivery.source: fanout_dispatch`, projected onto the active-
+        # executor row as `source` by `_project_binding_row`. The widget reads
+        # `dispatch_lane` to label the row `(<executor>/maestro)` instead of
+        # rendering it like a Hermes-native delegate_task child; absent for
+        # every other source, exactly like every other unreported field here.
+        if str(row.get("source", "")) == "fanout_dispatch":
+            projected["dispatch_lane"] = "maestro"
+            projected["executor_profile"] = str(row.get("executor_profile", ""))
+            # The row's own cost, when present, is a rounded pass-through of
+            # what the spawned CLI itself reported (`unit_telemetry`) -- never
+            # a token-derived guess -- so it always renders with the `~`
+            # approximate marker the widget already uses for that meaning.
+            if projected.get("cost_usd") is not None:
+                projected["cost_approximate"] = True
         if (
             str(row.get("executor_profile", "")).casefold() == "maestro"
             or str(row.get("target_id", "")) in maestro_run_ids

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -1570,12 +1570,15 @@ def _hud_subagent_summary(status: dict[str, Any]) -> dict[str, Any]:
         if str(row.get("source", "")) == "fanout_dispatch":
             projected["dispatch_lane"] = "maestro"
             projected["executor_profile"] = str(row.get("executor_profile", ""))
-            # The row's own cost, when present, is a rounded pass-through of
-            # what the spawned CLI itself reported (`unit_telemetry`) -- never
-            # a token-derived guess -- so it always renders with the `~`
-            # approximate marker the widget already uses for that meaning.
-            if projected.get("cost_usd") is not None:
-                projected["cost_approximate"] = True
+            # No live-cost claim here: the spawned CLI reports cost only in
+            # its terminal result object, so `cost_usd` never has a real
+            # value until the unit's binding closes -- and a closed binding
+            # drops out of `active_executors` on the very next read, before
+            # this loop ever sees it. A structurally-impossible-to-populate
+            # `cost_approximate` marker would be dead code implying a live
+            # estimate this lane cannot honestly produce. A finished unit's
+            # cost still surfaces wherever closed rows are reported, e.g. the
+            # fanout dispatch summary.
         if (
             str(row.get("executor_profile", "")).casefold() == "maestro"
             or str(row.get("target_id", "")) in maestro_run_ids
@@ -2347,6 +2350,16 @@ def _progress_row(primary: dict[str, Any], group: list[dict[str, Any]], event: d
         "linked_bindings": linked,
         "claim_boundary": binding.get("claim_boundary", ""),
     }
+    # Who opened the binding, projected from `delivery.source` -- mirrors
+    # `_project_binding_row` in `src/coding/executor_progress.py`. Without
+    # this, `_hud_subagent_summary` below (which keys off `row["source"]` to
+    # label a fanout-dispatch unit `dispatch_lane: maestro`) never sees the
+    # field: `read_omh_hud` reads through THIS mirror, not the core
+    # projection, so the core-side fix alone left every real HUD row plain.
+    delivery = binding.get("delivery")
+    source = str(delivery.get("source", "")) if isinstance(delivery, dict) else ""
+    if source:
+        row["source"] = source
     signal = event.get("signal", {}) if event else {}
     if isinstance(signal, dict):
         for key in (
@@ -2366,6 +2379,19 @@ def _progress_row(primary: dict[str, Any], group: list[dict[str, Any]], event: d
             value = signal.get(key)
             if value not in (None, ""):
                 row[key] = value
+    # A fanout-dispatch unit reports process metrics (tokens/cost) only on
+    # its terminal event, never its own elapsed time -- so without this, a
+    # live row's `elapsed_seconds` stayed unset and the widget fell back to
+    # rendering snapshot age instead of the unit's actual running time.
+    # Derived here from the binding's own opened timestamp against wall-clock
+    # now (`_seconds_since`, already used for staleness above), the same
+    # "since observed" shape as `_elapsed_since` in status_board.py, applied
+    # only when the signal did not already report a real elapsed value.
+    if "elapsed_seconds" not in row:
+        opened_at = str(binding.get("created_at") or row.get("latest_observed_at") or "")
+        elapsed = _seconds_since(opened_at)
+        if elapsed is not None and elapsed >= 0:
+            row["elapsed_seconds"] = int(elapsed)
     return row
 
 

--- a/tests/test_executor_progress_projection.py
+++ b/tests/test_executor_progress_projection.py
@@ -148,6 +148,54 @@ class ExecutorProgressProjectionTests(unittest.TestCase):
             self.assertEqual(plugin_status["stale_executors"], [])
             self.assertEqual(plugin_status["latest_progress_events"], [])
 
+    def test_binding_delivery_source_is_projected_onto_the_active_executor_row(self) -> None:
+        """`omh coding fanout dispatch` opens its binding with
+        `source="fanout_dispatch"` (the delivery field this binding builder
+        already carries); the HUD reader keys off the projected `source` to
+        label a fanout unit's row `(<executor>/maestro)` instead of rendering
+        it like a Hermes-native delegate_task child."""
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            run = create_run(paths, {"skill": "oh-my-hermes", "harness": "coding-handling", "status": "started"})
+            binding = write_progress_binding(
+                paths,
+                build_progress_binding(
+                    target_type="run",
+                    target_id=run["run_id"],
+                    executor_profile="claude_code",
+                    source="fanout_dispatch",
+                    now="2026-06-24T00:00:00Z",
+                ),
+            )
+            signal = build_safe_progress_signal(executor_profile="claude_code", process_status="dispatched")
+            observe_executor_progress(paths, binding, signal, observed_at="2026-06-24T00:00:30Z")
+
+            projection = project_active_executor_status(paths, now="2026-06-24T00:01:00Z")
+
+            self.assertEqual(len(projection["active_executors"]), 1)
+            self.assertEqual(projection["active_executors"][0]["source"], "fanout_dispatch")
+
+    def test_binding_without_a_delivery_source_projects_no_source_key(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            run = create_run(paths, {"skill": "oh-my-hermes", "harness": "coding-handling", "status": "started"})
+            binding = write_progress_binding(
+                paths,
+                build_progress_binding(
+                    target_type="run",
+                    target_id=run["run_id"],
+                    executor_profile="codex",
+                    codex_session_ref="codex-session-1",
+                    now="2026-06-24T00:00:00Z",
+                ),
+            )
+            signal = build_safe_progress_signal(executor_profile="codex", process_status="dispatched")
+            observe_executor_progress(paths, binding, signal, observed_at="2026-06-24T00:00:30Z")
+
+            projection = project_active_executor_status(paths, now="2026-06-24T00:01:00Z")
+
+            self.assertNotIn("source", projection["active_executors"][0])
+
     def test_worktree_branch_only_bindings_project_as_separate_instances(self) -> None:
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -39,8 +39,10 @@ from omh.coding.fanout_dispatch import (  # noqa: E402
     _stdout_fenced_json_blocks,
     _unit_verification_is_observed,
     dispatch_fanout,
+    dispatch_model_preferences_path,
     verify_goal_matches_contract,
 )
+from omh.coding.executor_progress import read_progress_binding  # noqa: E402
 from omh.runtime.artifacts import append_journal_observation, create_run, show_run  # noqa: E402
 from omh.system.local_store import atomic_write_json  # noqa: E402
 from omh.system.paths import OmhPaths  # noqa: E402
@@ -1031,9 +1033,21 @@ class FanoutDispatchEngineTests(unittest.TestCase):
             self.assertIn(("codex", "exec"), heads)
             claude_argv = next(argv for argv in runner.spawned if argv[0] == "claude")
             self.assertEqual(claude_argv[1], "-p")
+            # No unit here routes a model, so the base template shows through
+            # except for one appended pair: claude-code's shipped dispatch-
+            # model default (`opus`, see _SHIPPED_DISPATCH_MODEL_DEFAULTS)
+            # fills the gap. codex ships no such default (see
+            # test_codex_dispatch_model_ships_with_no_default).
             self.assertEqual(
                 claude_argv[3:],
-                ["--permission-mode", "acceptEdits", "--allowedTools", "Bash(git add:*),Bash(git commit:*)"],
+                [
+                    "--permission-mode",
+                    "acceptEdits",
+                    "--allowedTools",
+                    "Bash(git add:*),Bash(git commit:*)",
+                    "--model",
+                    "opus",
+                ],
             )
             self.assertIn("Work unit:", claude_argv[2])
 
@@ -2272,6 +2286,231 @@ class FanoutDispatchTelemetryTests(unittest.TestCase):
             self.assertIn("opus", spawned["claude"])
             by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
             self.assertEqual(by_unit["ui"]["model"], "opus")
+
+
+def _progress_events(paths: OmhPaths, run_ref: str) -> list[dict[str, object]]:
+    events_path = paths.runtime_runs_dir / run_ref / "executor_progress" / "events.jsonl"
+    if not events_path.is_file():
+        return []
+    return [json.loads(line) for line in events_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+class FanoutDispatchMaestroProgressRowTests(unittest.TestCase):
+    """`omh coding fanout dispatch` spawns local CLIs directly, which is the
+    Maestro lane by definition; this class covers the executor-progress
+    binding lifecycle those units open so the HUD's active-executor
+    projection can label and drop the row, and the operator's dispatch-model
+    preference that fills a gap a unit's prepared handoff left unrouted."""
+
+    def _setup(self, tmp: str, units=None):
+        root = Path(tmp)
+        paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+        repo, sha = _make_repo(root)
+        contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, units or _UNITS))
+        return paths, repo, sha, contract
+
+    def test_completed_unit_opens_a_maestro_binding_and_closes_it(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            core = {entry["unit_id"]: entry for entry in contract["units"]}["core"]
+            run_ref = core["run_ref"]
+
+            dispatch_fanout(
+                paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                only_units=["core"], runner=_agent_runner(), readiness=_ready,
+            )
+
+            binding = read_progress_binding(paths, "run", run_ref)
+            self.assertIsNotNone(binding)
+            self.assertEqual(binding["executor_profile"], "codex")
+            self.assertEqual(binding["delivery"]["source"], "fanout_dispatch")
+            # Closed the moment the process ended: a closed binding drops out
+            # of the HUD's active-executor projection on the next read, which
+            # is what stops the row -- never a lingering live row for a
+            # finished process.
+            self.assertEqual(binding["state"], "closed")
+            events = [event["event_type"] for event in _progress_events(paths, run_ref)]
+            self.assertIn("executor_dispatched", events)
+            self.assertIn("executor_completed", events)
+
+    def test_failed_unit_also_closes_its_maestro_binding(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            core = {entry["unit_id"]: entry for entry in contract["units"]}["core"]
+            run_ref = core["run_ref"]
+
+            dispatch_fanout(
+                paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                only_units=["core"], runner=_agent_runner(fail_units={"core"}), readiness=_ready,
+            )
+
+            binding = read_progress_binding(paths, "run", run_ref)
+            self.assertEqual(binding["state"], "closed")
+            events = [event["event_type"] for event in _progress_events(paths, run_ref)]
+            self.assertIn("executor_failed", events)
+
+    def test_dispatched_event_carries_the_unit_title_and_routed_model(self) -> None:
+        with TemporaryDirectory() as tmp:
+            units = [
+                {"unit_id": "core", "title": "Core work", "owner": "codex", "file_scope": ["src/core/"]},
+                {"unit_id": "docs", "title": "Docs work", "owner": "claude-code", "file_scope": ["docs/"]},
+            ]
+            paths, repo, sha, contract = self._setup(tmp, units=units)
+            core = {entry["unit_id"]: entry for entry in contract["units"]}["core"]
+            run_ref = core["run_ref"]
+
+            dispatch_fanout(
+                paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                only_units=["core"], runner=_agent_runner(), readiness=_ready,
+            )
+
+            dispatched = next(
+                event for event in _progress_events(paths, run_ref) if event["event_type"] == "executor_dispatched"
+            )
+            self.assertEqual(dispatched["summary"], "Core work")
+
+    def test_claude_code_unit_defaults_to_the_opus_dispatch_model(self) -> None:
+        """Owner directive (2026-08): dispatch mostly uses the strongest
+        claude-code tier by default when nothing routed a model, because
+        `claude --model` documents `opus` as a recognized alias."""
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            docs = {entry["unit_id"]: entry for entry in contract["units"]}["docs"]
+            run_ref = docs["run_ref"]
+            runner = _agent_runner()
+
+            summary = dispatch_fanout(
+                paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                only_units=["docs"], runner=runner, readiness=_ready,
+            )
+
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            self.assertEqual(by_unit["docs"]["model"], "opus")
+            spawned = next(argv for argv in runner.spawned if argv[0] == "claude")
+            self.assertIn("--model", spawned)
+            self.assertIn("opus", spawned)
+            binding = read_progress_binding(paths, "run", run_ref)
+            self.assertEqual(binding["executor_profile"], "claude_code")
+
+    def test_dispatch_model_preference_config_overrides_the_shipped_default(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            config_path = dispatch_model_preferences_path(paths.omh_home)
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            atomic_write_json(
+                config_path,
+                {
+                    "schema_version": "omh_dispatch_model_preferences/v1",
+                    "profiles": {"claude-code": "claude-fable-5"},
+                },
+            )
+            runner = _agent_runner()
+
+            summary = dispatch_fanout(
+                paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                only_units=["docs"], runner=runner, readiness=_ready,
+            )
+
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            self.assertEqual(by_unit["docs"]["model"], "claude-fable-5")
+            spawned = next(argv for argv in runner.spawned if argv[0] == "claude")
+            self.assertIn("claude-fable-5", spawned)
+
+    def test_dispatch_model_preference_can_be_cleared_to_the_cli_default(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            config_path = dispatch_model_preferences_path(paths.omh_home)
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            atomic_write_json(
+                config_path,
+                {"schema_version": "omh_dispatch_model_preferences/v1", "profiles": {"claude-code": ""}},
+            )
+            runner = _agent_runner()
+
+            summary = dispatch_fanout(
+                paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                only_units=["docs"], runner=runner, readiness=_ready,
+            )
+
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            self.assertEqual(by_unit["docs"]["model"], "")
+            spawned = next(argv for argv in runner.spawned if argv[0] == "claude")
+            self.assertNotIn("--model", spawned)
+
+    def test_dispatch_model_preference_never_overrides_a_routed_model(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            docs = {entry["unit_id"]: entry for entry in contract["units"]}["docs"]
+            docs["handoff"]["model_route"] = {
+                "schema_version": "coding_model_route/v2",
+                "status": "resolved",
+                "provenance": "explicit",
+                "selected_model": "claude-sonnet-5",
+                "selected_reasoning_effort": "medium",
+            }
+            runner = _agent_runner()
+
+            summary = dispatch_fanout(
+                paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                only_units=["docs"], runner=runner, readiness=_ready,
+            )
+
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            self.assertEqual(by_unit["docs"]["model"], "claude-sonnet-5")
+            spawned = next(argv for argv in runner.spawned if argv[0] == "claude")
+            self.assertIn("claude-sonnet-5", spawned)
+            self.assertNotIn("opus", spawned)
+
+    def test_codex_dispatch_model_ships_with_no_default(self) -> None:
+        """No local codex CLI to confirm its `--model` value space against in
+        this repo, so the conservative choice (unset = CLI default) stands
+        until that is verified."""
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            runner = _agent_runner()
+
+            summary = dispatch_fanout(
+                paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                only_units=["core"], runner=runner, readiness=_ready,
+            )
+
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            self.assertEqual(by_unit["core"]["model"], "")
+            spawned = next(argv for argv in runner.spawned if argv[0] == "codex")
+            self.assertNotIn("--model", spawned)
+
+    def test_reported_cost_and_tokens_reach_the_terminal_progress_event(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            docs = {entry["unit_id"]: entry for entry in contract["units"]}["docs"]
+            run_ref = docs["run_ref"]
+            claude_result = json.dumps(
+                {
+                    "type": "result",
+                    "subtype": "success",
+                    "session_id": "sess-cost-1",
+                    "total_cost_usd": 0.4213,
+                    "usage": {"input_tokens": 100, "output_tokens": 40},
+                }
+            )
+
+            def runner(argv, **kwargs):
+                if argv[0] == "git":
+                    return subprocess.run(argv, **kwargs)
+                return _FakeCompleted(0, claude_result)
+
+            dispatch_fanout(
+                paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                only_units=["docs"], runner=runner, readiness=_ready,
+            )
+
+            completed = next(
+                event for event in _progress_events(paths, run_ref) if event["event_type"] == "executor_completed"
+            )
+            self.assertEqual(completed["signal"]["cost_usd"], 0.4213)
+            # Never estimated from tokens: the reported total is a rounded
+            # pass-through, not a derivation from input/output token counts.
+            self.assertNotEqual(completed["signal"]["cost_usd"], 100 + 40)
 
 
 def _write_skill(root: Path, name: str, description: str) -> None:

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -1033,11 +1033,12 @@ class FanoutDispatchEngineTests(unittest.TestCase):
             self.assertIn(("codex", "exec"), heads)
             claude_argv = next(argv for argv in runner.spawned if argv[0] == "claude")
             self.assertEqual(claude_argv[1], "-p")
-            # No unit here routes a model, so the base template shows through
-            # except for one appended pair: claude-code's shipped dispatch-
-            # model default (`opus`, see _SHIPPED_DISPATCH_MODEL_DEFAULTS)
-            # fills the gap. codex ships no such default (see
-            # test_codex_dispatch_model_ships_with_no_default).
+            # No unit here routes a model, and neither profile ships a
+            # dispatch-model default (see _SHIPPED_DISPATCH_MODEL_DEFAULTS
+            # and test_codex_dispatch_model_ships_with_no_default /
+            # test_claude_code_unit_ships_with_no_default_dispatch_model), so
+            # the base template shows through byte-identical with no
+            # appended `--model`.
             self.assertEqual(
                 claude_argv[3:],
                 [
@@ -1045,8 +1046,6 @@ class FanoutDispatchEngineTests(unittest.TestCase):
                     "acceptEdits",
                     "--allowedTools",
                     "Bash(git add:*),Bash(git commit:*)",
-                    "--model",
-                    "opus",
                 ],
             )
             self.assertIn("Work unit:", claude_argv[2])
@@ -2369,10 +2368,15 @@ class FanoutDispatchMaestroProgressRowTests(unittest.TestCase):
             )
             self.assertEqual(dispatched["summary"], "Core work")
 
-    def test_claude_code_unit_defaults_to_the_opus_dispatch_model(self) -> None:
-        """Owner directive (2026-08): dispatch mostly uses the strongest
-        claude-code tier by default when nothing routed a model, because
-        `claude --model` documents `opus` as a recognized alias."""
+    def test_claude_code_unit_ships_with_no_default_dispatch_model(self) -> None:
+        """A rejected model is an observed exit failure with no fallback
+        walk, and no user opted into a specific model choice by dispatching a
+        unit -- so, like every other profile, claude-code ships with no
+        dispatch-model default (see _SHIPPED_DISPATCH_MODEL_DEFAULTS).
+        `docs/FANOUT.md` documents `opus` as the recommended value an
+        operator can opt into via `dispatch-models.json`
+        (test_dispatch_model_preference_config_overrides_the_shipped_default
+        covers that opt-in path)."""
         with TemporaryDirectory() as tmp:
             paths, repo, sha, contract = self._setup(tmp)
             docs = {entry["unit_id"]: entry for entry in contract["units"]}["docs"]
@@ -2385,10 +2389,9 @@ class FanoutDispatchMaestroProgressRowTests(unittest.TestCase):
             )
 
             by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
-            self.assertEqual(by_unit["docs"]["model"], "opus")
+            self.assertEqual(by_unit["docs"]["model"], "")
             spawned = next(argv for argv in runner.spawned if argv[0] == "claude")
-            self.assertIn("--model", spawned)
-            self.assertIn("opus", spawned)
+            self.assertNotIn("--model", spawned)
             binding = read_progress_binding(paths, "run", run_ref)
             self.assertEqual(binding["executor_profile"], "claude_code")
 

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -603,13 +603,15 @@ class HudCliTests(unittest.TestCase):
         self.assertEqual(len(payload["subagents"]["rows"]), 1)
 
     def test_hud_labels_a_fanout_dispatch_unit_as_a_maestro_row_in_the_agent_list(self) -> None:
-        """`omh coding fanout dispatch` opens its executor-progress binding
-        with `delivery.source: fanout_dispatch`, projected onto the active-
-        executor row as `source` (see _project_binding_row). Unlike the
-        single-slot `payload.maestro.rows` main row above -- which can only
-        ever hold one entry -- a fanout unit belongs in the agent list next
-        to Hermes-native rows, so several can run at once and each gets its
-        own row; the widget tells the two apart with `dispatch_lane`."""
+        """Exercises `_hud_subagent_summary`'s own labeling logic in
+        isolation: given a row that already carries `source: fanout_dispatch`
+        (however it got there), the summary must label it `dispatch_lane:
+        maestro` and route it to the agent list rather than the single-slot
+        `payload.maestro.rows` main row, which can only ever hold one entry.
+        This synthetic `status=` dict bypasses the reader's OWN binding-to-row
+        projection (`_progress_row`), so it cannot catch a gap there -- see
+        `test_hud_projects_a_real_fanout_dispatch_binding_with_live_elapsed`
+        below for the disk-backed regression that covers that seam."""
         from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
 
         status = {
@@ -622,7 +624,6 @@ class HudCliTests(unittest.TestCase):
                     "executor_profile": "claude_code",
                     "source": "fanout_dispatch",
                     "routed_model": "opus",
-                    "cost_usd": 0.4213,
                     "latest_event": {
                         "event_type": "executor_dispatched",
                         "status": "running",
@@ -642,11 +643,81 @@ class HudCliTests(unittest.TestCase):
         self.assertEqual(row["dispatch_lane"], "maestro")
         self.assertEqual(row["executor_profile"], "claude_code")
         self.assertEqual(row["model"], "opus")
-        self.assertEqual(row["cost_usd"], 0.4213)
-        # A cost this lane surfaces is always a rounded pass-through of what
-        # the spawned CLI itself reported, never a token-derived guess, so it
-        # always carries the widget's `~` approximate marker.
-        self.assertTrue(row["cost_approximate"])
+        # No live-cost claim for this lane: the spawned CLI reports cost only
+        # in its terminal result object, so a still-running row never carries
+        # a real `cost_usd` (the projection always pre-declares the key, but
+        # unset stays `None`), and `cost_approximate` is never fabricated.
+        self.assertIsNone(row["cost_usd"])
+        self.assertNotIn("cost_approximate", row)
+
+    def test_hud_projects_a_real_fanout_dispatch_binding_with_live_elapsed(self) -> None:
+        """Regression: the reader's active-executor projection (`_progress_row`
+        in the plugin-bundle mirror `read_omh_hud` actually reads through) did
+        not project `delivery.source` at all -- only the separate core
+        projection (`_project_binding_row` in `src/coding/executor_progress.py`)
+        did -- so a real fanout-dispatch binding on disk never reached the HUD
+        as a maestro row; the synthetic `status=` dict test above injects the
+        row directly and cannot see that gap. This writes a REAL
+        `omh_executor_progress_binding/v1` to a temp `omh_home` and drives
+        `read_omh_hud` from it end to end, the same path the TUI dock reads.
+        It also covers `elapsed_seconds`, which this lane never self-reports
+        in its signal (only tokens/cost, and only at closing) -- the reader
+        must derive it from the binding's own opened timestamp against
+        wall-clock now rather than leaving the widget to fall back to
+        snapshot age."""
+        from datetime import datetime, timedelta, timezone
+
+        from omh.executor_progress import (
+            build_progress_binding,
+            build_safe_progress_signal,
+            observe_executor_progress,
+            write_progress_binding,
+        )
+        from omh.paths import resolve_paths
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+        from omh.runtime_artifacts import create_run
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            run = create_run(paths, {"skill": "oh-my-hermes", "harness": "coding-handling", "status": "started"})
+            opened_at = (datetime.now(timezone.utc) - timedelta(seconds=45)).strftime("%Y-%m-%dT%H:%M:%SZ")
+            binding = write_progress_binding(
+                paths,
+                build_progress_binding(
+                    target_type="run",
+                    target_id=run["run_id"],
+                    executor_profile="claude_code",
+                    source="fanout_dispatch",
+                    now=opened_at,
+                ),
+            )
+            signal = build_safe_progress_signal(
+                executor_profile="claude_code",
+                process_status="dispatched",
+                routed_model="opus",
+                explicit_summary="Docs work",
+            )
+            observe_executor_progress(paths, binding, signal, observed_at=opened_at)
+
+            payload = read_omh_hud(paths.omh_home, paths.hermes_home)
+
+            self.assertEqual(payload["maestro"]["rows"], [])
+            self.assertEqual(len(payload["subagents"]["rows"]), 1)
+            row = payload["subagents"]["rows"][0]
+            self.assertEqual(row["dispatch_lane"], "maestro")
+            self.assertEqual(row["executor_profile"], "claude_code")
+            self.assertEqual(row["model"], "opus")
+            # Derived from the ~45s-old opened timestamp against wall-clock
+            # now, not the widget's snapshot-age fallback (which would read 0
+            # here since the binding was never re-observed after opening).
+            self.assertGreaterEqual(row["elapsed_seconds"], 40)
+            self.assertLessEqual(row["elapsed_seconds"], 120)
+            # Still dispatched, not closed: no live cost claim (the
+            # projection always pre-declares the `cost_usd` key; unset stays
+            # `None` rather than a fabricated `cost_approximate` estimate).
+            self.assertIsNone(row["cost_usd"])
+            self.assertNotIn("cost_approximate", row)
 
     def test_hud_bounds_workflow_within_allowed_file_size(self) -> None:
         from omh.plugin_bundle.omh.runtime_reader import read_omh_hud

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -602,6 +602,52 @@ class HudCliTests(unittest.TestCase):
         self.assertEqual(payload["maestro"]["rows"][0]["context_percentage"], 41.5)
         self.assertEqual(len(payload["subagents"]["rows"]), 1)
 
+    def test_hud_labels_a_fanout_dispatch_unit_as_a_maestro_row_in_the_agent_list(self) -> None:
+        """`omh coding fanout dispatch` opens its executor-progress binding
+        with `delivery.source: fanout_dispatch`, projected onto the active-
+        executor row as `source` (see _project_binding_row). Unlike the
+        single-slot `payload.maestro.rows` main row above -- which can only
+        ever hold one entry -- a fanout unit belongs in the agent list next
+        to Hermes-native rows, so several can run at once and each gets its
+        own row; the widget tells the two apart with `dispatch_lane`."""
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+        status = {
+            "runtime_state_present": True,
+            "runs": [],
+            "active_executors": [
+                {
+                    "target_type": "run",
+                    "target_id": "fanout-0123456789ab-docs",
+                    "executor_profile": "claude_code",
+                    "source": "fanout_dispatch",
+                    "routed_model": "opus",
+                    "cost_usd": 0.4213,
+                    "latest_event": {
+                        "event_type": "executor_dispatched",
+                        "status": "running",
+                        "summary": "Docs work",
+                    },
+                },
+            ],
+            "stale_executors": [],
+            "latest_progress_events": [],
+        }
+
+        payload = read_omh_hud(status=status)
+
+        self.assertEqual(payload["maestro"]["rows"], [])
+        self.assertEqual(len(payload["subagents"]["rows"]), 1)
+        row = payload["subagents"]["rows"][0]
+        self.assertEqual(row["dispatch_lane"], "maestro")
+        self.assertEqual(row["executor_profile"], "claude_code")
+        self.assertEqual(row["model"], "opus")
+        self.assertEqual(row["cost_usd"], 0.4213)
+        # A cost this lane surfaces is always a rounded pass-through of what
+        # the spawned CLI itself reported, never a token-derived guess, so it
+        # always carries the widget's `~` approximate marker.
+        self.assertTrue(row["cost_approximate"])
+
     def test_hud_bounds_workflow_within_allowed_file_size(self) -> None:
         from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
 

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -300,6 +300,27 @@ class TuiWidgetPackTests(unittest.TestCase):
         self.assertNotIn("useInput", widget)
         self.assertNotIn("useKeypress", widget)
 
+    def test_fanout_dispatch_rows_render_a_warn_colored_maestro_identity(self) -> None:
+        # `omh coding fanout dispatch` spawns a local CLI directly (the
+        # Maestro lane by definition), and the reader tags that row
+        # `dispatch_lane` so it renders in the same agent list as Hermes-
+        # native delegate_task rows -- same truncation, dots, and state
+        # colors -- but with `(<executor>/maestro <model>)` in place of the
+        # category:model route, warn-colored to stand apart from the default
+        # Hermes-native lane.
+        widget = resources.files("omh.tui_widgets").joinpath("omh-status.mjs").read_text(encoding="utf-8")
+
+        self.assertIn(
+            "const MAESTRO_EXECUTOR_SHORT_NAMES = { codex: 'codex', claude_code: 'claude', omo_runtime: 'omo', hermes_local: 'hermes' }",
+            widget,
+        )
+        self.assertIn("const dispatchLane = safeText(row.dispatch_lane)", widget)
+        self.assertIn(
+            "dispatchLane ? metricSegment('maestro', dispatchIdentity) : metricSegment(routeKind, route),",
+            widget,
+        )
+        self.assertIn("|| segment.kind === 'maestro'", widget)
+
     def test_hud_liveness_signal_drives_the_status_line_todo_and_shot_badge(self) -> None:
         # 2026-08 HUD liveness fix: exact in-flight tool-call state (paired
         # from pre_tool_call/post_tool_call by tool_call_id) replaces three

--- a/tests/test_unit_telemetry.py
+++ b/tests/test_unit_telemetry.py
@@ -172,6 +172,31 @@ class ClaudeCodeOwnerTests(unittest.TestCase):
         self.assertEqual(payload["input_tokens"], 7)
         self.assertEqual(payload["output_tokens"], 3)
 
+    def test_claude_result_total_cost_usd_is_read_as_the_reported_cost(self) -> None:
+        event = {**CLAUDE_RESULT_EVENT, "total_cost_usd": 0.4213}
+        payload = parse_unit_telemetry("claude-code", jsonl(event))
+
+        self.assertEqual(payload["cost_usd"], 0.4213)
+
+    def test_claude_result_without_total_cost_usd_reports_no_cost(self) -> None:
+        payload = parse_unit_telemetry("claude-code", jsonl(CLAUDE_RESULT_EVENT))
+
+        self.assertNotIn("cost_usd", payload)
+
+    def test_negative_or_non_numeric_reported_cost_is_rejected(self) -> None:
+        for bad_cost in (-0.5, "0.42", True):
+            with self.subTest(bad_cost=bad_cost):
+                event = {**CLAUDE_RESULT_EVENT, "total_cost_usd": bad_cost}
+                payload = parse_unit_telemetry("claude-code", jsonl(event))
+                self.assertNotIn("cost_usd", payload)
+
+
+class CodexCostTests(unittest.TestCase):
+    def test_codex_never_reports_a_cost_because_none_is_estimated_from_tokens(self) -> None:
+        payload = parse_unit_telemetry("codex", jsonl(CODEX_SESSION_CONFIGURED_EVENT, CODEX_TOKEN_COUNT_EVENT))
+
+        self.assertNotIn("cost_usd", payload)
+
 
 class UnstructuredOwnerTests(unittest.TestCase):
     def test_owners_without_a_structured_surface_report_honest_absence(self) -> None:


### PR DESCRIPTION
## Capability

Fanout-dispatched external CLI units (the maestro lane) now appear in the TUI dock like subagent rows, live while they run:

- Each dispatched unit opens an executor-progress binding (existing lifecycle reused) at spawn and closes it on success/failure/interrupt/SIGTERM — a closed binding drops from the dock on the next read, so no stale live rows.
- The row renders in the existing delegation-row grammar with a **warn-colored identity segment** `(claude/maestro opus)` / `(codex/maestro)` — executor short name, the maestro lane tag, and the model actually passed to the CLI.
- **Real elapsed time** derived in the reader from the binding's opened timestamp (not snapshot age), so a unit running for minutes reads minutes.
- **Honest cost**: `claude -p` reports cost only in its final result object, so a live approximate cost is structurally impossible for this lane — the live row makes no cost claim (documented in FANOUT.md); reported cost still flows into the terminal telemetry.
- New optional `~/.omh/routing/dispatch-models.json` maps executor profile → dispatch `--model`. **Shipped default is empty** (the CLI's own default applies); `opus` is documented as the recommended value — a rejected model surfaces as an observed exit failure with no fallback walk, so forcing a tier on non-entitled accounts is not a safe product default.

## Motivation

Owner-reported: maestro-lane dispatches were invisible in the dock ("maestro 돌리면 TUI subagent에서 뜨는 것처럼 (claude/maestro) 이렇게"), with the follow-ups: match the existing row style, orange identity with the model, approximate cost/time, both executors, and a fable/opus preference (delivered as the config mechanism + documented recommendation; the shipped default stays neutral).

## Implementation (boundary level)

- `src/coding/fanout_dispatch.py`: binding open moved inside the try whose finally closes it (an interrupt during the spawn stagger can no longer orphan a live row for the 15-minute freshness window); telemetry parse computed inside the close's own guard; dispatch-model preference injection.
- `src/coding/executor_progress.py` + `src/plugin_bundle/omh/runtime_reader.py`: `delivery.source` projected in **both** row projections — the independent review's P0 caught the first commit projecting only the core path while the HUD reads the plugin-bundle mirror, leaving the feature inert on a real machine; the regression test now writes a real binding to disk and drives `read_omh_hud` end-to-end.
- `src/omh/tui_widgets/omh-status.mjs`: identity segment via the theme's warn color role, existing truncation/separator grammar, #1155 liveness rules respected.
- `src/coding/unit_telemetry.py`: `total_cost_usd` pass-through parsing (strict: rejects bool/negative/non-finite; never token-derived).

## Verification (observed)

- Full suite on the final tree in the main checkout: **7680 tests — OK** (worktree runs show only the known `.claude`-path sandbox artifact, reproduced identically on clean main).
- Targeted: fanout-dispatch/unit-telemetry/executor-progress/hud/widget-pack/broad-except suites (220 tests) + `node --check`.
- All five docs byte gates ok; ruff, compileall, `git diff --check` clean.
- Independent review (1 P0, 3 P1, 2 P2, 4 P3) ran before this PR; every finding fixed in `5ee0604c` with per-finding dispositions in its trailers.
- Not observed: a live dispatch against an authenticated `claude`/`codex` CLI (sandboxed); the spawn seams are faked in tests.

## Risks

- Fanout rows share the dock's 5-row active bound with Hermes-native rows; a wide fanout can push native rows into the disclosed `hidden_rows` overflow.
- Cost renders only post-terminal by design — an operator wanting live spend must look at the dispatch summary, not the dock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)