### PR TITLE
feat(update): opt-in startup update check with notify/auto modes

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1514,7 +1514,10 @@ delegation flags, and wrapper completion status.
 
 `omh` records runtime metadata only by default:
 
-- setup/install/apply/doctor summaries in `~/.omh/runtime/state.json`
+- setup/install/apply/doctor summaries in `~/.omh/runtime/state.json`,
+  including `release_source_commit` -- the comparable remote `main` identity
+  `omh update-check` compares against, recorded only on the preview channel
+  and only when update-check is not `off`
 - workflow run envelopes in `~/.omh/runtime/runs/<run-id>/run.json`
 - append-only run events in `events.jsonl`
 - append-only lifecycle observations in `~/.omh/runtime/journal/events.jsonl`
@@ -1711,31 +1714,40 @@ storing raw chat prompts.
 By default, `omh`/`hermes` never checks for updates on launch -- OMH's core
 promise is no network calls without an explicit opt-in. `omh update-check`
 turns on a bounded, best-effort comparison against `origin/main` that runs
-right before bare `omh` (or `hermes`, through the same launch door) opens the
-TUI:
+right before bare `omh` opens the TUI. This is `omh`'s own launch door
+(`commands/main.py`); bare `hermes` execs your Hermes install directly and
+never passes through this process, so it never runs this check.
 
 ```sh
 omh update-check status
 omh update-check set --mode notify              # one-line notice when behind
 omh update-check set --mode auto                 # runs `omh update` automatically
 omh update-check set --mode off                  # shipped default
-omh update-check set --interval-hours 12          # default is 24
+omh update-check set --interval-hours 12          # default is 24, 1-8760 accepted
 ```
 
 `notify` prints a single line such as `OMH update available: 3f2a1c9 ->
 9b7e21d; run \`omh update\`` when the preview channel is behind `origin/main`,
-and nothing when it is current. `auto` reuses `omh update` itself (never a
-reimplementation) and reports what it did, including the restart-to-apply
-guidance `omh update` already prints; a non-blocking lock keeps two
-simultaneous launches from auto-updating at once, and a failed attempt is
-never retried before the next interval. Either mode makes at most one
+and nothing when it is current; the line prints only for a launch that
+actually ran a fresh probe, not for every launch that reuses the cache inside
+the same interval. `notify` never blocks or delays the launch either way.
+`auto` is different: it reuses `omh update` itself (never a reimplementation,
+run as a real subprocess so its own re-entry sees a normal `omh update`
+argv), and by design that means the launch waits for that subprocess -- a
+command-package refresh can take minutes on the preview channel, the same
+wait `omh update` always has. A non-blocking lock keeps two simultaneous
+launches from auto-updating at once, and a failed or already-applied attempt
+is never retried before the next interval. Either mode makes at most one
 short-timeout network request per `interval_hours` (a conditional GET against
 the GitHub commits API, ETag-cached in
 `~/.omh/runtime/update-check.json`); a network failure or timeout is a silent
 skip that never blocks or delays the launch. An install that predates a
-recorded comparable identity (or is pinned to a stable/local channel rather
-than the `main`-tracking preview channel) reports the check as inconclusive
-rather than guessing.
+recorded comparable identity reports the check as inconclusive rather than
+guessing, and resolves the next time update-check records one. A `stable` or
+`local` channel install reports inconclusive too, but permanently -- only the
+`preview` channel's `main` source ref ever records a comparable identity, so
+the notice for that case says the comparison does not apply to that channel
+instead of suggesting an `omh update` that cannot resolve it.
 
 ## Reapply
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1706,6 +1706,37 @@ under `~/.omh/runtime/state.json` as `last_setup`, `last_install`,
 count, source metadata, command-package status, and health summaries without
 storing raw chat prompts.
 
+### Startup update check (opt-in)
+
+By default, `omh`/`hermes` never checks for updates on launch -- OMH's core
+promise is no network calls without an explicit opt-in. `omh update-check`
+turns on a bounded, best-effort comparison against `origin/main` that runs
+right before bare `omh` (or `hermes`, through the same launch door) opens the
+TUI:
+
+```sh
+omh update-check status
+omh update-check set --mode notify              # one-line notice when behind
+omh update-check set --mode auto                 # runs `omh update` automatically
+omh update-check set --mode off                  # shipped default
+omh update-check set --interval-hours 12          # default is 24
+```
+
+`notify` prints a single line such as `OMH update available: 3f2a1c9 ->
+9b7e21d; run \`omh update\`` when the preview channel is behind `origin/main`,
+and nothing when it is current. `auto` reuses `omh update` itself (never a
+reimplementation) and reports what it did, including the restart-to-apply
+guidance `omh update` already prints; a non-blocking lock keeps two
+simultaneous launches from auto-updating at once, and a failed attempt is
+never retried before the next interval. Either mode makes at most one
+short-timeout network request per `interval_hours` (a conditional GET against
+the GitHub commits API, ETag-cached in
+`~/.omh/runtime/update-check.json`); a network failure or timeout is a silent
+skip that never blocks or delays the launch. An install that predates a
+recorded comparable identity (or is pinned to a stable/local channel rather
+than the `main`-tracking preview channel) reports the check as inconclusive
+rather than guessing.
+
 ## Reapply
 
 If Hermes does not show the installed skills, reapply the config registration:

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -44,7 +44,7 @@ from .coding import (
     cmd_coding_lifecycle_verify,
 )
 from .codegraph import _add_codegraph_commands, cmd_codegraph_build, cmd_codegraph_handoff, cmd_codegraph_summary
-from .common import set_json_output_pretty
+from .common import _paths, set_json_output_pretty
 from .context import _add_context_commands, cmd_context_brief
 from .model_chains import _add_model_chains_commands
 from .conformance import _add_conformance_commands, cmd_conformance_check
@@ -176,6 +176,7 @@ from .setup import (
     cmd_update,
 )
 from .state import _add_state_commands, cmd_state_clear, cmd_state_finish, cmd_state_start, cmd_state_status
+from .update_check import _add_update_check_commands
 from .use_cases import _add_cases_commands, cmd_cases_inspect, cmd_cases_list, cmd_cases_recommend
 from .visual import _add_visual_commands, cmd_visual_observe, cmd_visual_prompt_card
 from .adapter_quality import _add_adapter_quality_commands
@@ -304,6 +305,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_runtime_commands(sub)
     _add_goal_commands(sub)
     _add_state_commands(sub)
+    _add_update_check_commands(sub)
     return parser
 
 
@@ -371,7 +373,68 @@ Run `omh --help` for the full command list."""
     )
 
 
-def _launch_hermes_tui() -> int | None:
+def _run_startup_update_check(args: argparse.Namespace) -> None:
+    """Compare the local install against `origin/main` and act per `omh update-check`.
+
+    Opt-in only: `update_check.mode` defaults to `off`, which returns before
+    any network attempt. Runs synchronously, right before exec'ing `hermes`,
+    because that exec hands the terminal to a separate process -- there is no
+    "after the TUI paints" moment left in this process to report a result in,
+    so the whole probe has to fit inside its own bounded timeout ahead of the
+    handoff rather than racing it. Any failure here is a silent skip; it must
+    never block, delay beyond that bound, or crash the launch.
+    """
+    from ..maintenance.update_check import evaluate_update_check, format_notice_line
+
+    paths = _paths(args)
+    try:
+        result = evaluate_update_check(paths)
+    except OSError:
+        return
+    if result.get("should_auto_update"):
+        _run_auto_update(args, paths)
+        return
+    notice = format_notice_line(result)
+    if notice:
+        print(notice)
+
+
+def _run_auto_update(args: argparse.Namespace, paths) -> None:
+    """Auto mode: reuse `omh update`'s own code path, never a reimplementation.
+
+    A non-blocking lock keeps two simultaneous launches from auto-updating at
+    once; losing the race is a silent skip, not a retry. A failed update is
+    reported once (so the user is not left guessing) and never retried before
+    the next `evaluate_update_check` interval -- `_run_startup_update_check`
+    only reaches here on a fresh "behind" outcome, so a cached one from
+    within the same interval never re-triggers this.
+    """
+    from ..installer import OmhError
+    from ..local_store import FileLockTimeout
+    from ..maintenance.update_check import acquire_auto_update_lock
+
+    try:
+        with acquire_auto_update_lock(paths):
+            # --omh-home/--hermes-home/--scope are TOP-LEVEL parser options
+            # (defined before `add_subparsers`), so they must precede the
+            # "update" subcommand token, not follow it.
+            update_argv: list[str] = []
+            if getattr(args, "omh_home", None):
+                update_argv += ["--omh-home", str(args.omh_home)]
+            if getattr(args, "hermes_home", None):
+                update_argv += ["--hermes-home", str(args.hermes_home)]
+            if getattr(args, "scope", None):
+                update_argv += ["--scope", str(args.scope)]
+            update_argv += ["update", "--yes", "--no-interactive"]
+            update_args = build_parser().parse_args(update_argv)
+            update_args.func(update_args)
+    except FileLockTimeout:
+        return
+    except OmhError as exc:
+        print(f"omh: update-check auto-update failed: {exc}", file=sys.stderr)
+
+
+def _launch_hermes_tui(args: argparse.Namespace) -> int | None:
     """Open the OH-MY-HERMES terminal: bare `omh` is the same door as `hermes`.
 
     The oh-my-zsh contract, applied here: the wrapper's bare name IS the
@@ -393,6 +456,7 @@ def _launch_hermes_tui() -> int | None:
     hermes = shutil.which("hermes")
     if not hermes:
         return None
+    _run_startup_update_check(args)
     try:
         return int(subprocess.run([hermes]).returncode)
     except (OSError, KeyboardInterrupt):
@@ -408,7 +472,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(raw_argv)
     set_json_output_pretty(bool(getattr(args, "pretty", False)))
     if not getattr(args, "command", None):
-        launched = _launch_hermes_tui()
+        launched = _launch_hermes_tui(args)
         if launched is not None:
             return launched
         _print_welcome()

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import argparse
+import json
+import subprocess
 import sys
 
 from ..version import __version__
@@ -383,35 +385,77 @@ def _run_startup_update_check(args: argparse.Namespace) -> None:
     so the whole probe has to fit inside its own bounded timeout ahead of the
     handoff rather than racing it. Any failure here is a silent skip; it must
     never block, delay beyond that bound, or crash the launch.
+
+    The except clause is deliberately wider than `OSError` alone: it is the
+    same "corrupt on-disk JSON" shape `local_store.read_json_object_result`
+    already classifies, kept here only as a backstop in case a future reader
+    on this path stops going through it -- `evaluate_update_check`'s own
+    readers no longer raise on a corrupt `setup-profile.json`/state/cache
+    file, so a user who never opted into this check must never see a launch
+    traceback from one.
     """
     from ..maintenance.update_check import evaluate_update_check, format_notice_line
 
     paths = _paths(args)
     try:
         result = evaluate_update_check(paths)
-    except OSError:
+    except (OSError, ValueError, json.JSONDecodeError):
         return
     if result.get("should_auto_update"):
         _run_auto_update(args, paths)
         return
-    notice = format_notice_line(result)
-    if notice:
-        print(notice)
+    # Only a fresh probe prints a notice. Reusing the cache inside the same
+    # interval would otherwise reprint the same "behind"/"inconclusive" line
+    # on every launch until the interval elapses -- once per interval is the
+    # documented cadence (docs/INSTALLATION.md, "Startup update check").
+    if result.get("checked"):
+        notice = format_notice_line(result)
+        if notice:
+            print(notice)
+
+
+# `omh update` streams pip/npm/brew output and can take minutes on the
+# preview channel (`commands/setup.py:_run_command_package_self_update`); this
+# bounds that wait instead of letting a hung download block the launch
+# forever.
+_AUTO_UPDATE_SUBPROCESS_TIMEOUT_SECONDS = 600.0
 
 
 def _run_auto_update(args: argparse.Namespace, paths) -> None:
     """Auto mode: reuse `omh update`'s own code path, never a reimplementation.
+
+    Spawns `omh update --no-interactive` as a real subprocess rather than
+    calling `cmd_update()` in-process. `cmd_update()` can re-enter itself via
+    `commands/setup.py:_reentry_argv_with_command_package_updated()`, which
+    reads the real process's `sys.argv[1:]` -- not the synthesized
+    `update_argv` below. Calling it in-process left `sys.argv` at whatever
+    bare `omh` was launched with (empty), so that re-entry became `python -m
+    omh.cli --command-package-updated` with no `update` subcommand, exited 2,
+    and the post-update half (managed skills, plugin bundle, widgets,
+    registration, `release_source_commit`) never ran. A real subprocess gives
+    that re-entry its own correct `sys.argv`.
+
+    Deliberately `--no-interactive` without `--yes`: `--yes` presets the
+    branded-TUI identity choice (`commands/setup.py:_preset_tui_identity_choice`)
+    and would rewrite a user's own `display.interface`/skin choice on every
+    auto-update. `--no-interactive` alone leaves that choice unset --
+    `_update_should_interact()` still skips the prompt (this is a
+    non-interactive background launch), and `_apply_result()` then takes the
+    non-forcing `ensure_tui_interface`/`ensure_omh_skin` path instead of the
+    forcing `activate_*` one, so an existing explicit choice is preserved.
 
     A non-blocking lock keeps two simultaneous launches from auto-updating at
     once; losing the race is a silent skip, not a retry. A failed update is
     reported once (so the user is not left guessing) and never retried before
     the next `evaluate_update_check` interval -- `_run_startup_update_check`
     only reaches here on a fresh "behind" outcome, so a cached one from
-    within the same interval never re-triggers this.
+    within the same interval never re-triggers this. On success, the cache is
+    re-anchored so a launch later in the same interval reads it as resolved
+    instead of still "behind".
     """
     from ..installer import OmhError
     from ..local_store import FileLockTimeout
-    from ..maintenance.update_check import acquire_auto_update_lock
+    from ..maintenance.update_check import acquire_auto_update_lock, refresh_cache_after_auto_update
 
     try:
         with acquire_auto_update_lock(paths):
@@ -425,12 +469,24 @@ def _run_auto_update(args: argparse.Namespace, paths) -> None:
                 update_argv += ["--hermes-home", str(args.hermes_home)]
             if getattr(args, "scope", None):
                 update_argv += ["--scope", str(args.scope)]
-            update_argv += ["update", "--yes", "--no-interactive"]
-            update_args = build_parser().parse_args(update_argv)
-            update_args.func(update_args)
+            update_argv += ["update", "--no-interactive"]
+            # Fail fast on a malformed argv rather than handing it to a
+            # subprocess that can only report it as an opaque exit code.
+            build_parser().parse_args(update_argv)
+            completed = subprocess.run(
+                [sys.executable, "-m", "omh.cli", *update_argv],
+                timeout=_AUTO_UPDATE_SUBPROCESS_TIMEOUT_SECONDS,
+            )
+            if completed.returncode == 0:
+                refresh_cache_after_auto_update(paths)
+            else:
+                print(
+                    f"omh: update-check auto-update failed (exit {completed.returncode})",
+                    file=sys.stderr,
+                )
     except FileLockTimeout:
         return
-    except OmhError as exc:
+    except (OmhError, OSError, subprocess.TimeoutExpired) as exc:
         print(f"omh: update-check auto-update failed: {exc}", file=sys.stderr)
 
 
@@ -449,7 +505,6 @@ def _launch_hermes_tui(args: argparse.Namespace) -> int | None:
     back to the welcome text.
     """
     import shutil
-    import subprocess
 
     if not sys.stdin.isatty() or not sys.stdout.isatty():
         return None

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -308,24 +308,28 @@ def _install_result(args: argparse.Namespace) -> dict[str, object]:
     )
     if not args.dry_run:
         operation_log = _install_operation_log(result, source=source)
-        update_state(
-            paths,
-            {
-                "package": "oh-my-hermes",
-                "version": __version__,
-                "manifest_path": str(paths.manifest_path),
-                "manifest_sha256": sha256_file(paths.manifest_path),
-                "source": source,
-                "release_channel": release.channel,
-                "release_version": release.version,
-                "release_package_url": release.package_url,
-                "release_source_ref": source_ref,
-                "release_update": result["release_update"],
-                "installed_skills": len(result.get("skills", [])),
-                "skills_dir": str(paths.skills_dir),
-                f"last_{operation}": operation_log,
-            },
-        )
+        state_patch: dict[str, object] = {
+            "package": "oh-my-hermes",
+            "version": __version__,
+            "manifest_path": str(paths.manifest_path),
+            "manifest_sha256": sha256_file(paths.manifest_path),
+            "source": source,
+            "release_channel": release.channel,
+            "release_version": release.version,
+            "release_package_url": release.package_url,
+            "release_source_ref": source_ref,
+            "release_update": result["release_update"],
+            "installed_skills": len(result.get("skills", [])),
+            "skills_dir": str(paths.skills_dir),
+            f"last_{operation}": operation_log,
+        }
+        # Only overwrite a previously recorded identity with a freshly
+        # confirmed one; never regress it to "" just because update-check
+        # was off (or the probe failed) on this particular run.
+        release_source_commit = _release_source_commit_for_state(paths, release)
+        if release_source_commit:
+            state_patch["release_source_commit"] = release_source_commit
+        update_state(paths, state_patch)
     return result
 
 
@@ -1129,6 +1133,29 @@ def _release_source_ref(args: argparse.Namespace, release) -> str:
     if explicit:
         return explicit
     return str(getattr(release, "source_label", "") or "").strip()
+
+
+def _release_source_commit_for_state(paths, release) -> str:
+    """Best-effort remote `main` sha, recorded only when update-check is opted in.
+
+    This is the comparable local identity `omh update-check`'s startup probe
+    (`maintenance/update_check.py`) compares against a fresh remote read.
+    Piggybacks on this already-explicit `omh install`/`omh update` invocation
+    rather than adding a second, unscoped network surface (AGENTS.md
+    Implementation Boundaries): a network call rides along only when the user
+    has already opted update-check away from its shipped `off` default.
+    Scoped to the preview channel, the one that actually tracks `main` -- a
+    pinned stable tag or a local source is not meaningfully "behind main".
+    Silent no-op (returns "") on any failure; this metadata must never fail
+    the install/update command it rides along with.
+    """
+    if release.source_label != "main":
+        return ""
+    from ..maintenance.update_check import read_update_check_policy, record_remote_commit_for_install
+
+    if read_update_check_policy(paths)["mode"] == "off":
+        return ""
+    return record_remote_commit_for_install(paths)
 
 
 def _explicit_release_metadata_supplied(args: argparse.Namespace) -> bool:

--- a/src/commands/update_check.py
+++ b/src/commands/update_check.py
@@ -1,0 +1,107 @@
+"""`omh update-check` -- configure and inspect the startup update-availability check.
+
+The check itself runs from the `omh`/`hermes` launch path in `main.py`; this
+module is only the read/write surface over its policy
+(`update_check.mode`, `update_check.interval_hours`, persisted in
+setup-profile.json) and a read-only view of its last cached outcome. `status`
+never makes a network call -- it reports the policy and whatever the launch
+path last recorded, exactly like the check itself does within one interval.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from ..maintenance.update_check import (
+    UPDATE_CHECK_MODES,
+    read_update_check_cache,
+    read_update_check_policy,
+    update_check_cache_path,
+    write_update_check_policy,
+)
+from .common import _paths, _print_json, _wants_json
+
+
+def _status_payload(paths) -> dict[str, object]:
+    return {
+        "schema_version": "omh_update_check_status/v1",
+        "policy": read_update_check_policy(paths),
+        "last_check": read_update_check_cache(paths),
+        "cache_path": str(update_check_cache_path(paths)),
+    }
+
+
+def _print_status(payload: dict[str, object]) -> None:
+    policy = payload.get("policy", {})
+    cache = payload.get("last_check", {})
+    mode = policy.get("mode") if isinstance(policy, dict) else "off"
+    interval = policy.get("interval_hours") if isinstance(policy, dict) else ""
+    print(f"Update-check mode: {mode}")
+    print(f"Interval: every {interval} hour(s)")
+    if isinstance(cache, dict) and cache:
+        print(f"Last checked: {cache.get('last_checked_at', 'never')}")
+        print(f"Last outcome: {cache.get('outcome', 'unknown')}")
+        remote = cache.get("remote_commit")
+        if remote:
+            print(f"Remote main: {remote}")
+    else:
+        print("Last checked: never")
+    print("Change with `omh update-check set --mode off|notify|auto [--interval-hours N]`.")
+
+
+def cmd_update_check_status(args: argparse.Namespace) -> int:
+    payload = _status_payload(_paths(args))
+    if _wants_json(args):
+        _print_json(payload)
+    else:
+        _print_status(payload)
+    return 0
+
+
+def cmd_update_check_set(args: argparse.Namespace) -> int:
+    mode = getattr(args, "mode", None)
+    interval_hours = getattr(args, "interval_hours", None)
+    if mode is None and interval_hours is None:
+        print("omh: update-check set needs --mode and/or --interval-hours", file=sys.stderr)
+        return 2
+    try:
+        policy = write_update_check_policy(_paths(args), mode=mode, interval_hours=interval_hours)
+    except ValueError as exc:
+        print(f"omh: {exc}", file=sys.stderr)
+        return 2
+    if _wants_json(args):
+        _print_json({"schema_version": "omh_update_check_status/v1", "policy": policy})
+        return 0
+    print(f"Update-check mode: {policy['mode']}")
+    print(f"Interval: every {policy['interval_hours']} hour(s)")
+    if policy["mode"] == "off":
+        print("Off: no network attempts are made at Hermes launch (shipped default).")
+    elif policy["mode"] == "notify":
+        print("Notify: a one-line notice prints at launch when main is ahead; run `omh update` to apply it.")
+    else:
+        print("Auto: `omh update` runs automatically at launch when main is ahead.")
+    return 0
+
+
+def _add_update_check_commands(sub) -> None:
+    group = sub.add_parser(
+        "update-check",
+        help="Configure the opt-in startup check that compares this install against origin/main.",
+    )
+    group_sub = group.add_subparsers(dest="update_check_command", required=True)
+
+    status = group_sub.add_parser("status", help="Show the update-check mode, interval, and last known outcome.")
+    status.add_argument("--json", action="store_true", help="Print the machine-readable status payload.")
+    status.set_defaults(func=cmd_update_check_status)
+
+    set_cmd = group_sub.add_parser("set", help="Change the update-check mode and/or interval.")
+    set_cmd.add_argument("--mode", choices=UPDATE_CHECK_MODES, default=None, help="off (shipped default), notify, or auto.")
+    set_cmd.add_argument(
+        "--interval-hours",
+        type=float,
+        default=None,
+        help="Minimum hours between network checks (default 24).",
+    )
+    set_cmd.add_argument("--json", action="store_true", help="Print the machine-readable status payload.")
+    set_cmd.set_defaults(func=cmd_update_check_set)

--- a/src/maintenance/update_check.py
+++ b/src/maintenance/update_check.py
@@ -45,7 +45,7 @@ from pathlib import Path
 import subprocess
 from typing import Any
 
-from ..local_store import atomic_write_json, ensure_dir, file_lock, read_json_object
+from ..local_store import atomic_write_json, ensure_dir, file_lock, read_json_object_result
 from ..paths import OmhPaths
 
 UPDATE_CHECK_POLICY_SCHEMA_VERSION = "omh_update_check_policy/v1"
@@ -55,6 +55,14 @@ UPDATE_CHECK_RESULT_SCHEMA_VERSION = "omh_update_check_result/v1"
 UPDATE_CHECK_MODES = ("off", "notify", "auto")
 DEFAULT_UPDATE_CHECK_MODE = "off"
 DEFAULT_UPDATE_CHECK_INTERVAL_HOURS = 24.0
+
+# `_interval_elapsed` feeds this straight into `timedelta(hours=...)`, which
+# raises `OverflowError` on `inf`/a very large float -- on the launch path,
+# that turns a bad `--interval-hours` value into a crash on every launch
+# instead of a rejected `set`. Bounded to something a human could plausibly
+# mean: at least hourly, at most roughly a year.
+MIN_UPDATE_CHECK_INTERVAL_HOURS = 1.0
+MAX_UPDATE_CHECK_INTERVAL_HOURS = 8760.0
 
 # Bounded probe budget (owner design requirement): the launcher execs `hermes`
 # right after this returns and hands it the terminal, so there is no
@@ -66,20 +74,6 @@ UPDATE_CHECK_NETWORK_TIMEOUT_SECONDS = 1.5
 
 GITHUB_COMMITS_API_URL = "https://api.github.com/repos/rlaope/oh-my-hermes/commits/main"
 
-UPDATE_CHECK_CLAIM_BOUNDARY = (
-    "This check compares a locally recorded install identity against the GitHub API's reported "
-    "HEAD of main; it is not execution, review, CI, or merge evidence, and a missing local "
-    "identity or a network failure is reported as inconclusive or skipped, never as a false "
-    "up-to-date or behind claim."
-)
-
-UPDATE_CHECK_OUTCOMES = (
-    "skipped_off",
-    "up_to_date",
-    "behind",
-    "inconclusive",
-)
-
 
 def update_check_cache_path(paths: OmhPaths) -> Path:
     return paths.runtime_dir / "update-check.json"
@@ -89,8 +83,13 @@ def read_update_check_policy(paths: OmhPaths) -> dict[str, Any]:
     """Read `update_check.{mode,interval_hours}` from setup-profile.json.
 
     Absent or malformed data means the shipped default: off, 24h interval.
+    A corrupt setup-profile.json (bad JSON, or JSON that is not an object)
+    reads the same way as an absent one -- never raises -- because this
+    function sits on the `omh`/`hermes` launch path and a decode error here
+    must never crash a launch that has not even opted into this check.
     """
-    profile = read_json_object(paths.setup_profile_path) or {}
+    profile, _error = read_json_object_result(paths.setup_profile_path)
+    profile = profile or {}
     raw = profile.get("update_check")
     mode = DEFAULT_UPDATE_CHECK_MODE
     interval_hours = DEFAULT_UPDATE_CHECK_INTERVAL_HOURS
@@ -99,7 +98,11 @@ def read_update_check_policy(paths: OmhPaths) -> dict[str, Any]:
         if candidate_mode in UPDATE_CHECK_MODES:
             mode = candidate_mode
         candidate_interval = raw.get("interval_hours")
-        if isinstance(candidate_interval, (int, float)) and not isinstance(candidate_interval, bool) and candidate_interval > 0:
+        if (
+            isinstance(candidate_interval, (int, float))
+            and not isinstance(candidate_interval, bool)
+            and MIN_UPDATE_CHECK_INTERVAL_HOURS <= candidate_interval <= MAX_UPDATE_CHECK_INTERVAL_HOURS
+        ):
             interval_hours = float(candidate_interval)
     return {
         "schema_version": UPDATE_CHECK_POLICY_SCHEMA_VERSION,
@@ -123,22 +126,31 @@ def write_update_check_policy(
         resolved_mode = mode
     resolved_interval = current["interval_hours"]
     if interval_hours is not None:
-        if isinstance(interval_hours, bool) or not (isinstance(interval_hours, (int, float)) and interval_hours > 0):
-            raise ValueError("update-check interval-hours must be a positive number")
+        if isinstance(interval_hours, bool) or not (
+            isinstance(interval_hours, (int, float))
+            and MIN_UPDATE_CHECK_INTERVAL_HOURS <= interval_hours <= MAX_UPDATE_CHECK_INTERVAL_HOURS
+        ):
+            raise ValueError(
+                "update-check interval-hours must be a number between "
+                f"{MIN_UPDATE_CHECK_INTERVAL_HOURS} and {MAX_UPDATE_CHECK_INTERVAL_HOURS}"
+            )
         resolved_interval = float(interval_hours)
     policy = {
         "schema_version": UPDATE_CHECK_POLICY_SCHEMA_VERSION,
         "mode": resolved_mode,
         "interval_hours": resolved_interval,
     }
-    profile = read_json_object(paths.setup_profile_path) or {}
+    profile, _error = read_json_object_result(paths.setup_profile_path)
+    profile = profile or {}
     profile["update_check"] = policy
     atomic_write_json(paths.setup_profile_path, profile, private=True)
     return policy
 
 
 def read_update_check_cache(paths: OmhPaths) -> dict[str, Any]:
-    return read_json_object(update_check_cache_path(paths)) or {}
+    """Read the probe result cache. A corrupt cache file reads as empty, never raises."""
+    cache, _error = read_json_object_result(update_check_cache_path(paths))
+    return cache or {}
 
 
 def _write_cache(paths: OmhPaths, patch: dict[str, Any]) -> dict[str, Any]:
@@ -242,6 +254,12 @@ def fetch_remote_main_identity(
     return RemoteProbeResult(ok=True, sha=sha, etag=response_etag or None, not_modified=False, error=None)
 
 
+def _read_runtime_state(paths: OmhPaths) -> dict[str, Any]:
+    """Read `runtime/state.json`. A corrupt file reads as empty, never raises."""
+    state, _error = read_json_object_result(paths.runtime_state_path)
+    return state or {}
+
+
 def local_installed_commit(paths: OmhPaths) -> str:
     """The comparable remote identity recorded at the last `omh install`/`update`.
 
@@ -249,8 +267,24 @@ def local_installed_commit(paths: OmhPaths) -> str:
     failed / was skipped because update-check was off at that time) -- both
     read as "no comparable identity" by `evaluate_update_check`.
     """
-    state = read_json_object(paths.runtime_state_path) or {}
+    state = _read_runtime_state(paths)
     return str(state.get("release_source_commit", "") or "")
+
+
+def local_installed_channel(paths: OmhPaths) -> str:
+    """The release channel ("stable", "preview", "local", ...) recorded at the
+    last `omh install`/`update`, or "" when nothing has recorded one yet.
+
+    `release_source_commit` is only ever recorded for the `preview` channel's
+    `main` source ref (`commands/setup.py:_release_source_commit_for_state`),
+    so a `stable` or `local` install reports `inconclusive` forever -- there
+    is no future `omh update` that resolves it, unlike a `preview` install
+    that simply has not recorded an identity yet. `format_notice_line` uses
+    this to stop telling a stable/local install to "run `omh update`" for a
+    comparison that channel will never resolve.
+    """
+    state = _read_runtime_state(paths)
+    return str(state.get("release_channel", "") or "")
 
 
 def record_remote_commit_for_install(
@@ -299,6 +333,16 @@ def evaluate_update_check(
     at `update_check_cache_path()`, and any probe failure is a silent skip
     that keeps whatever the cache already knew rather than raising or
     claiming a fresh (possibly wrong) outcome.
+
+    `should_auto_update` is only ever true off a fresh probe in this call --
+    never off a cache reused because the interval has not elapsed yet. A
+    cached "behind" outcome is stale by definition (it is exactly what the
+    previous auto-update either already acted on, or failed to act on);
+    re-triggering `omh update` from it on every launch inside the same
+    interval is what previously made auto mode re-update on every launch.
+    `main.py`'s `_run_auto_update` calls `refresh_cache_after_auto_update()`
+    after a successful auto-update so the cached outcome itself stops
+    claiming "behind" too, rather than relying on this alone.
     """
     policy = read_update_check_policy(paths)
     mode = policy["mode"]
@@ -311,11 +355,13 @@ def evaluate_update_check(
             "should_auto_update": False,
             "local_commit": "",
             "remote_commit": "",
+            "channel": "",
         }
 
     now = now or datetime.now(timezone.utc)
     cache = read_update_check_cache(paths)
     local_commit = local_installed_commit(paths)
+    channel = local_installed_channel(paths)
 
     if not force and not _interval_elapsed(cache, float(policy["interval_hours"]), now):
         outcome = str(cache.get("outcome") or "inconclusive")
@@ -324,9 +370,10 @@ def evaluate_update_check(
             "mode": mode,
             "outcome": outcome,
             "checked": False,
-            "should_auto_update": mode == "auto" and outcome == "behind",
+            "should_auto_update": False,
             "local_commit": local_commit,
             "remote_commit": str(cache.get("remote_commit", "")),
+            "channel": channel,
         }
 
     probe = fetch_remote_main_identity(etag=str(cache.get("remote_etag", "")), timeout=timeout, runner=runner)
@@ -344,6 +391,7 @@ def evaluate_update_check(
             "should_auto_update": False,
             "local_commit": local_commit,
             "remote_commit": str(cache.get("remote_commit", "")),
+            "channel": channel,
         }
 
     remote_commit = probe.sha if not probe.not_modified else str(cache.get("remote_commit", ""))
@@ -373,7 +421,29 @@ def evaluate_update_check(
         "should_auto_update": mode == "auto" and outcome == "behind",
         "local_commit": local_commit,
         "remote_commit": remote_commit,
+        "channel": channel,
     }
+
+
+def refresh_cache_after_auto_update(paths: OmhPaths) -> dict[str, Any]:
+    """Re-anchor the cache to the just-updated local identity.
+
+    Called only from `main.py`'s `_run_auto_update` after `omh update` exits
+    0. Without this, the cache keeps whatever "behind" outcome triggered the
+    auto-update, so the next launch inside the same interval reads a stale
+    claim (fixed separately in `evaluate_update_check` to never re-trigger
+    an auto-update from it, but still wrong for `omh update-check status` and
+    `notify` mode to display). Never probes the network: `omh update` already
+    recorded a fresh `release_source_commit` when it ran, so comparing that
+    against the cache's own `remote_commit` (the identity the auto-update was
+    acting on) is enough to tell "converged" from "still short of it,"
+    without spending another interval-bounded network attempt on it.
+    """
+    cache = read_update_check_cache(paths)
+    local_commit = local_installed_commit(paths)
+    remote_commit = str(cache.get("remote_commit", ""))
+    outcome = "up_to_date" if local_commit and local_commit == remote_commit else "inconclusive"
+    return _write_cache(paths, {"outcome": outcome})
 
 
 def _short_commit(sha: str) -> str:
@@ -390,5 +460,16 @@ def format_notice_line(result: dict[str, Any]) -> str:
         remote = _short_commit(str(result.get("remote_commit", "")))
         return f"OMH update available: {local} -> {remote}; run `omh update`."
     if outcome == "inconclusive":
+        # `release_source_commit` -- the identity this check compares against
+        # `origin/main` -- is only ever recorded for a `preview`-channel
+        # install (`commands/setup.py:_release_source_commit_for_state`). A
+        # `stable` or `local` install is not a temporary gap that the
+        # suggested `omh update` would close; it stays inconclusive forever
+        # because it deliberately is not tracking `main`. An empty/unknown
+        # channel (e.g. an install that predates this field) keeps the
+        # original, actionable wording since that gap really can close.
+        channel = str(result.get("channel", ""))
+        if channel and channel != "preview":
+            return f"OMH update check: not applicable on the {channel} channel (only preview tracks main)."
         return "OMH update check inconclusive -- run `omh update`."
     return ""

--- a/src/maintenance/update_check.py
+++ b/src/maintenance/update_check.py
@@ -1,0 +1,394 @@
+"""Startup update-availability check: compare this install against `origin/main`.
+
+`omh` / `hermes` launch through `_launch_hermes_tui()` in `commands/main.py`,
+which execs the user's own `hermes` binary. This module is the opt-in,
+network-making half of that launch path (AGENTS.md Implementation
+Boundaries): core OMH makes no network calls by default, so every function
+here is inert -- zero network attempts -- until a user explicitly sets
+`update_check.mode` away from its shipped default of ``off`` via
+`omh update-check set`. That keeps this in the same explicit family as
+`omh update` itself (which already makes network calls on explicit
+invocation) rather than adding a second, always-on network surface.
+
+The probe is a single bounded `curl` request against the GitHub commits API
+for `main`, spawned as a subprocess -- never a Python-level network client
+(`tests/test_handoff_safety_contract_enforcement.py` INVARIANT 2 statically
+forbids importing `urllib.request`'s client surface, `socket`, or any other
+network-client module anywhere in `src/`; this module is instead listed in
+that file's INVARIANT 1 `PROCESS_SPAWN_ALLOWLIST`, the same door
+`commands/setup.py` already uses for pip/npm/brew self-update). `curl`
+absent, unreachable, or slow beyond the bounded timeout is a silent skip,
+exactly like a network failure.
+
+Two persisted documents, following the two existing `~/.omh` config
+conventions:
+
+- Policy (mode, interval_hours) lives under the ``update_check`` key in
+  ``setup-profile.json``, the same read-modify-write document
+  `capabilities/toggles.py` uses for capability policy.
+- The probe result cache lives at ``<omh-home>/runtime/update-check.json``
+  (``last_checked_at``, the remote identity, and the outcome), so the
+  configured interval is respected across separate `omh`/`hermes` launches
+  without a fresh network call every time.
+
+A probe failure or timeout is a silent skip, never a blocked or delayed
+launch, and never a false "up to date" or "behind" claim -- an install that
+predates a comparable recorded identity reports as ``inconclusive`` instead.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
+import subprocess
+from typing import Any
+
+from ..local_store import atomic_write_json, ensure_dir, file_lock, read_json_object
+from ..paths import OmhPaths
+
+UPDATE_CHECK_POLICY_SCHEMA_VERSION = "omh_update_check_policy/v1"
+UPDATE_CHECK_CACHE_SCHEMA_VERSION = "omh_update_check_cache/v1"
+UPDATE_CHECK_RESULT_SCHEMA_VERSION = "omh_update_check_result/v1"
+
+UPDATE_CHECK_MODES = ("off", "notify", "auto")
+DEFAULT_UPDATE_CHECK_MODE = "off"
+DEFAULT_UPDATE_CHECK_INTERVAL_HOURS = 24.0
+
+# Bounded probe budget (owner design requirement): the launcher execs `hermes`
+# right after this returns and hands it the terminal, so there is no
+# "after the TUI paints" moment left in this process to report a late result
+# in -- the whole check has to fit before that handoff, and stay small enough
+# it is never a noticeable delay. Passed to `curl --max-time` and doubled as
+# the hard `subprocess.run` timeout backstop below.
+UPDATE_CHECK_NETWORK_TIMEOUT_SECONDS = 1.5
+
+GITHUB_COMMITS_API_URL = "https://api.github.com/repos/rlaope/oh-my-hermes/commits/main"
+
+UPDATE_CHECK_CLAIM_BOUNDARY = (
+    "This check compares a locally recorded install identity against the GitHub API's reported "
+    "HEAD of main; it is not execution, review, CI, or merge evidence, and a missing local "
+    "identity or a network failure is reported as inconclusive or skipped, never as a false "
+    "up-to-date or behind claim."
+)
+
+UPDATE_CHECK_OUTCOMES = (
+    "skipped_off",
+    "up_to_date",
+    "behind",
+    "inconclusive",
+)
+
+
+def update_check_cache_path(paths: OmhPaths) -> Path:
+    return paths.runtime_dir / "update-check.json"
+
+
+def read_update_check_policy(paths: OmhPaths) -> dict[str, Any]:
+    """Read `update_check.{mode,interval_hours}` from setup-profile.json.
+
+    Absent or malformed data means the shipped default: off, 24h interval.
+    """
+    profile = read_json_object(paths.setup_profile_path) or {}
+    raw = profile.get("update_check")
+    mode = DEFAULT_UPDATE_CHECK_MODE
+    interval_hours = DEFAULT_UPDATE_CHECK_INTERVAL_HOURS
+    if isinstance(raw, dict):
+        candidate_mode = str(raw.get("mode", "")).strip()
+        if candidate_mode in UPDATE_CHECK_MODES:
+            mode = candidate_mode
+        candidate_interval = raw.get("interval_hours")
+        if isinstance(candidate_interval, (int, float)) and not isinstance(candidate_interval, bool) and candidate_interval > 0:
+            interval_hours = float(candidate_interval)
+    return {
+        "schema_version": UPDATE_CHECK_POLICY_SCHEMA_VERSION,
+        "mode": mode,
+        "interval_hours": interval_hours,
+    }
+
+
+def write_update_check_policy(
+    paths: OmhPaths,
+    *,
+    mode: str | None = None,
+    interval_hours: float | None = None,
+) -> dict[str, Any]:
+    """Read-modify-write the policy, preserving every other profile field."""
+    current = read_update_check_policy(paths)
+    resolved_mode = current["mode"]
+    if mode is not None:
+        if mode not in UPDATE_CHECK_MODES:
+            raise ValueError(f"unsupported update-check mode: {mode!r}; expected one of {', '.join(UPDATE_CHECK_MODES)}")
+        resolved_mode = mode
+    resolved_interval = current["interval_hours"]
+    if interval_hours is not None:
+        if isinstance(interval_hours, bool) or not (isinstance(interval_hours, (int, float)) and interval_hours > 0):
+            raise ValueError("update-check interval-hours must be a positive number")
+        resolved_interval = float(interval_hours)
+    policy = {
+        "schema_version": UPDATE_CHECK_POLICY_SCHEMA_VERSION,
+        "mode": resolved_mode,
+        "interval_hours": resolved_interval,
+    }
+    profile = read_json_object(paths.setup_profile_path) or {}
+    profile["update_check"] = policy
+    atomic_write_json(paths.setup_profile_path, profile, private=True)
+    return policy
+
+
+def read_update_check_cache(paths: OmhPaths) -> dict[str, Any]:
+    return read_json_object(update_check_cache_path(paths)) or {}
+
+
+def _write_cache(paths: OmhPaths, patch: dict[str, Any]) -> dict[str, Any]:
+    current = read_update_check_cache(paths)
+    merged = {**current, **patch, "schema_version": UPDATE_CHECK_CACHE_SCHEMA_VERSION}
+    path = update_check_cache_path(paths)
+    ensure_dir(path.parent, private=True)
+    atomic_write_json(path, merged, private=True)
+    return merged
+
+
+def acquire_auto_update_lock(paths: OmhPaths):
+    """Non-blocking exclusive lock so two launches never auto-update at once.
+
+    Raises `FileLockTimeout` (from `local_store`) immediately, without
+    polling, when another process already holds it -- the caller's job is to
+    catch that and skip, not to wait.
+    """
+    return file_lock(update_check_cache_path(paths), timeout_seconds=0.0, private=True)
+
+
+@dataclass(frozen=True)
+class RemoteProbeResult:
+    ok: bool
+    sha: str | None
+    etag: str | None
+    not_modified: bool
+    error: str | None
+
+
+def _run_curl(argv: list[str], *, timeout: float) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(argv, capture_output=True, text=True, timeout=timeout)
+
+
+def _parse_http_response(raw: str) -> tuple[int, dict[str, str], str]:
+    """Split `curl -i` output into (status_code, lowercased headers, body)."""
+    normalized = raw.replace("\r\n", "\n")
+    head, _, body = normalized.partition("\n\n")
+    lines = head.split("\n")
+    status = 0
+    if lines:
+        parts = lines[0].split()
+        if len(parts) >= 2 and parts[1].isdigit():
+            status = int(parts[1])
+    headers: dict[str, str] = {}
+    for line in lines[1:]:
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        headers[key.strip().lower()] = value.strip()
+    return status, headers, body
+
+
+def fetch_remote_main_identity(
+    *,
+    etag: str = "",
+    timeout: float = UPDATE_CHECK_NETWORK_TIMEOUT_SECONDS,
+    runner=None,
+) -> RemoteProbeResult:
+    """One conditional GET of `main`'s current commit sha, via `curl`. Never raises.
+
+    `runner` defaults to a small `subprocess.run` wrapper; tests inject a
+    fake `subprocess.CompletedProcess`-shaped stand-in so no unit test ever
+    spawns a real process or reaches a real socket.
+    """
+    runner = runner or _run_curl
+    argv = [
+        "curl",
+        "-sS",
+        "-i",
+        "--max-time",
+        str(timeout),
+        "-H",
+        "Accept: application/vnd.github+json",
+        "-H",
+        "User-Agent: oh-my-hermes-update-check",
+    ]
+    if etag:
+        argv += ["-H", f"If-None-Match: {etag}"]
+    argv.append(GITHUB_COMMITS_API_URL)
+    try:
+        completed = runner(argv, timeout=timeout + 0.5)
+    except (OSError, subprocess.TimeoutExpired, ValueError) as exc:
+        return RemoteProbeResult(ok=False, sha=None, etag=None, not_modified=False, error=str(exc))
+    if completed.returncode != 0:
+        error = (completed.stderr or "").strip() or f"curl exit {completed.returncode}"
+        return RemoteProbeResult(ok=False, sha=None, etag=None, not_modified=False, error=error)
+    status, headers, body = _parse_http_response(completed.stdout or "")
+    if status == 304:
+        return RemoteProbeResult(ok=True, sha=None, etag=etag, not_modified=True, error=None)
+    if status != 200:
+        return RemoteProbeResult(ok=False, sha=None, etag=None, not_modified=False, error=f"http {status}")
+    try:
+        data = json.loads(body)
+    except ValueError as exc:
+        return RemoteProbeResult(ok=False, sha=None, etag=None, not_modified=False, error=str(exc))
+    sha = str(data.get("sha", "")) if isinstance(data, dict) else ""
+    if not sha:
+        return RemoteProbeResult(ok=False, sha=None, etag=None, not_modified=False, error="missing sha in response")
+    response_etag = headers.get("etag", "")
+    return RemoteProbeResult(ok=True, sha=sha, etag=response_etag or None, not_modified=False, error=None)
+
+
+def local_installed_commit(paths: OmhPaths) -> str:
+    """The comparable remote identity recorded at the last `omh install`/`update`.
+
+    Empty when the install predates recording one (or the recording probe
+    failed / was skipped because update-check was off at that time) -- both
+    read as "no comparable identity" by `evaluate_update_check`.
+    """
+    state = read_json_object(paths.runtime_state_path) or {}
+    return str(state.get("release_source_commit", "") or "")
+
+
+def record_remote_commit_for_install(
+    paths: OmhPaths,
+    *,
+    runner=None,
+    timeout: float = UPDATE_CHECK_NETWORK_TIMEOUT_SECONDS,
+) -> str:
+    """Best-effort remote main sha for `omh install`/`omh update` to persist.
+
+    Called only from the already-explicit install/update invocation (never
+    from the startup launch path), and only when update-check is not off, so
+    the piggybacked call stays inside that same explicit-network family.
+    Returns "" on any failure; callers must never let this fail the
+    install/update command it rides along with.
+    """
+    result = fetch_remote_main_identity(timeout=timeout, runner=runner)
+    return result.sha or ""
+
+
+def _interval_elapsed(cache: dict[str, Any], interval_hours: float, now: datetime) -> bool:
+    last_checked_raw = str(cache.get("last_checked_at", ""))
+    if not last_checked_raw:
+        return True
+    try:
+        last_checked = datetime.fromisoformat(last_checked_raw)
+    except ValueError:
+        return True
+    if last_checked.tzinfo is None:
+        last_checked = last_checked.replace(tzinfo=timezone.utc)
+    return (now - last_checked) >= timedelta(hours=interval_hours)
+
+
+def evaluate_update_check(
+    paths: OmhPaths,
+    *,
+    now: datetime | None = None,
+    force: bool = False,
+    runner=None,
+    timeout: float = UPDATE_CHECK_NETWORK_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    """Run (or reuse the cached result of) the startup update-availability check.
+
+    Zero network attempts when `update_check.mode` is `off` (the shipped
+    default). Otherwise respects `interval_hours` across calls via the cache
+    at `update_check_cache_path()`, and any probe failure is a silent skip
+    that keeps whatever the cache already knew rather than raising or
+    claiming a fresh (possibly wrong) outcome.
+    """
+    policy = read_update_check_policy(paths)
+    mode = policy["mode"]
+    if mode == "off":
+        return {
+            "schema_version": UPDATE_CHECK_RESULT_SCHEMA_VERSION,
+            "mode": "off",
+            "outcome": "skipped_off",
+            "checked": False,
+            "should_auto_update": False,
+            "local_commit": "",
+            "remote_commit": "",
+        }
+
+    now = now or datetime.now(timezone.utc)
+    cache = read_update_check_cache(paths)
+    local_commit = local_installed_commit(paths)
+
+    if not force and not _interval_elapsed(cache, float(policy["interval_hours"]), now):
+        outcome = str(cache.get("outcome") or "inconclusive")
+        return {
+            "schema_version": UPDATE_CHECK_RESULT_SCHEMA_VERSION,
+            "mode": mode,
+            "outcome": outcome,
+            "checked": False,
+            "should_auto_update": mode == "auto" and outcome == "behind",
+            "local_commit": local_commit,
+            "remote_commit": str(cache.get("remote_commit", "")),
+        }
+
+    probe = fetch_remote_main_identity(etag=str(cache.get("remote_etag", "")), timeout=timeout, runner=runner)
+    if not probe.ok:
+        # Silent skip: nothing new is claimed. Advancing last_checked_at still
+        # spaces the next attempt by a full interval instead of retrying on
+        # every subsequent launch.
+        _write_cache(paths, {"last_checked_at": now.isoformat(timespec="seconds")})
+        outcome = str(cache.get("outcome") or "inconclusive")
+        return {
+            "schema_version": UPDATE_CHECK_RESULT_SCHEMA_VERSION,
+            "mode": mode,
+            "outcome": outcome,
+            "checked": True,
+            "should_auto_update": False,
+            "local_commit": local_commit,
+            "remote_commit": str(cache.get("remote_commit", "")),
+        }
+
+    remote_commit = probe.sha if not probe.not_modified else str(cache.get("remote_commit", ""))
+    remote_etag = probe.etag if probe.etag else str(cache.get("remote_etag", ""))
+
+    if not local_commit or not remote_commit:
+        outcome = "inconclusive"
+    elif local_commit == remote_commit:
+        outcome = "up_to_date"
+    else:
+        outcome = "behind"
+
+    _write_cache(
+        paths,
+        {
+            "last_checked_at": now.isoformat(timespec="seconds"),
+            "remote_commit": remote_commit,
+            "remote_etag": remote_etag,
+            "outcome": outcome,
+        },
+    )
+    return {
+        "schema_version": UPDATE_CHECK_RESULT_SCHEMA_VERSION,
+        "mode": mode,
+        "outcome": outcome,
+        "checked": True,
+        "should_auto_update": mode == "auto" and outcome == "behind",
+        "local_commit": local_commit,
+        "remote_commit": remote_commit,
+    }
+
+
+def _short_commit(sha: str) -> str:
+    return sha[:7] if sha else "unknown"
+
+
+def format_notice_line(result: dict[str, Any]) -> str:
+    """The one-line notice `notify` mode prints, or `auto` prints when it
+    cannot tell whether an update is needed. Empty string means print nothing.
+    """
+    outcome = result.get("outcome")
+    if outcome == "behind":
+        local = _short_commit(str(result.get("local_commit", "")))
+        remote = _short_commit(str(result.get("remote_commit", "")))
+        return f"OMH update available: {local} -> {remote}; run `omh update`."
+    if outcome == "inconclusive":
+        return "OMH update check inconclusive -- run `omh update`."
+    return ""

--- a/tests/test_handoff_safety_contract_enforcement.py
+++ b/tests/test_handoff_safety_contract_enforcement.py
@@ -180,6 +180,14 @@ PROCESS_SPAWN_ALLOWLIST: dict[str, str] = {
         "`omh doctor` isolated real-Hermes registration probe; reads registered tool/hook names, "
         "dispatches no agent work, and writes only inside a temporary HERMES_HOME."
     ),
+    "src/maintenance/update_check.py": (
+        "opt-in `omh update-check` probe (mode defaults to off): a single bounded `curl` GET of the "
+        "public GitHub commits API for `main`, reached only from the already-allowlisted `omh` "
+        "launch door (commands/main.py) or an explicit `omh install`/`omh update` "
+        "(commands/setup.py) when update-check is not off. The external `curl` process makes the "
+        "connection, never this module -- the same shape as the pip/npm/brew self-update already "
+        "allowlisted for commands/setup.py above."
+    ),
     "src/plugin_bundle/omh/tools/evidence_tool.py": (
         "allowlisted local verification-command runner; its allowlist is itself gated below."
     ),

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -1,0 +1,330 @@
+"""Contracts for the opt-in startup update-availability check.
+
+`evaluate_update_check` is the core of `omh update-check`: zero network
+attempts while `update_check.mode` is `off` (the shipped default), an
+interval-respecting cache once opted in, a bounded timeout on every probe,
+and a silent skip -- never a raised exception, a false claim, or a delayed
+result -- on any network failure.
+
+The probe spawns `curl` as a subprocess (never a Python-level network
+client -- see `tests/test_handoff_safety_contract_enforcement.py` INVARIANT
+2), so every test here fakes the `subprocess.run`-shaped `runner` callable;
+none of them may spawn a real process or reach a real socket.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from omh.local_store import FileLockTimeout, atomic_write_json, read_json_object
+from omh.maintenance.update_check import (
+    DEFAULT_UPDATE_CHECK_INTERVAL_HOURS,
+    DEFAULT_UPDATE_CHECK_MODE,
+    UPDATE_CHECK_MODES,
+    acquire_auto_update_lock,
+    evaluate_update_check,
+    fetch_remote_main_identity,
+    format_notice_line,
+    local_installed_commit,
+    read_update_check_cache,
+    read_update_check_policy,
+    record_remote_commit_for_install,
+    update_check_cache_path,
+    write_update_check_policy,
+)
+from omh.paths import OmhPaths
+
+
+def _paths(root: Path) -> OmhPaths:
+    resolved = root.resolve()
+    return OmhPaths(resolved / ".omh", resolved / ".hermes")
+
+
+def _http_stdout(status: int, *, etag: str = "", sha: str | None = None) -> str:
+    header_lines = [f"HTTP/2 {status}"]
+    if etag:
+        header_lines.append(f"etag: {etag}")
+    body = json.dumps({"sha": sha}) if sha is not None else ""
+    return "\n".join(header_lines) + "\n\n" + body
+
+
+def _ok_runner(sha: str, *, etag: str = '"abc"', calls: list[object] | None = None):
+    def runner(argv, timeout=None):
+        if calls is not None:
+            calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0, stdout=_http_stdout(200, etag=etag, sha=sha), stderr="")
+
+    return runner
+
+
+def _not_modified_runner(etag: str = '"abc"'):
+    def runner(argv, timeout=None):
+        return subprocess.CompletedProcess(argv, 0, stdout=_http_stdout(304, etag=etag), stderr="")
+
+    return runner
+
+
+def _raising_runner(exc: BaseException):
+    def runner(argv, timeout=None):
+        raise exc
+
+    return runner
+
+
+def _refusing_runner():
+    def runner(argv, timeout=None):  # pragma: no cover - fails the test if reached
+        raise AssertionError("no subprocess spawn is allowed here")
+
+    return runner
+
+
+def _write_local_commit(paths: OmhPaths, sha: str) -> None:
+    paths.runtime_dir.mkdir(parents=True, exist_ok=True)
+    atomic_write_json(paths.runtime_state_path, {"release_source_commit": sha})
+
+
+class UpdateCheckPolicyTests(unittest.TestCase):
+    def test_default_policy_is_off_with_the_24h_interval(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            policy = read_update_check_policy(paths)
+            self.assertEqual(policy["mode"], DEFAULT_UPDATE_CHECK_MODE)
+            self.assertEqual(policy["mode"], "off")
+            self.assertEqual(policy["interval_hours"], DEFAULT_UPDATE_CHECK_INTERVAL_HOURS)
+
+    def test_write_then_read_round_trips_and_preserves_other_profile_fields(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            paths.omh_home.mkdir(parents=True, exist_ok=True)
+            atomic_write_json(paths.setup_profile_path, {"unrelated": "kept"})
+            policy = write_update_check_policy(paths, mode="notify", interval_hours=6)
+            self.assertEqual(policy["mode"], "notify")
+            self.assertEqual(policy["interval_hours"], 6.0)
+            self.assertEqual(read_update_check_policy(paths), policy)
+            profile = read_json_object(paths.setup_profile_path)
+            self.assertEqual(profile["unrelated"], "kept")
+
+    def test_write_rejects_unknown_mode_and_non_positive_interval(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            with self.assertRaises(ValueError):
+                write_update_check_policy(paths, mode="sometimes")
+            with self.assertRaises(ValueError):
+                write_update_check_policy(paths, interval_hours=0)
+            with self.assertRaises(ValueError):
+                write_update_check_policy(paths, interval_hours=-4)
+
+    def test_every_mode_is_a_recognized_choice(self) -> None:
+        self.assertEqual(UPDATE_CHECK_MODES, ("off", "notify", "auto"))
+
+
+class FetchRemoteMainIdentityTests(unittest.TestCase):
+    def test_success_returns_sha_and_etag(self) -> None:
+        result = fetch_remote_main_identity(runner=_ok_runner("deadbeef" * 5))
+        self.assertTrue(result.ok)
+        self.assertEqual(result.sha, "deadbeef" * 5)
+        self.assertEqual(result.etag, '"abc"')
+        self.assertFalse(result.not_modified)
+
+    def test_not_modified_304_is_ok_without_a_new_sha(self) -> None:
+        result = fetch_remote_main_identity(etag='"abc"', runner=_not_modified_runner('"abc"'))
+        self.assertTrue(result.ok)
+        self.assertTrue(result.not_modified)
+        self.assertIsNone(result.sha)
+
+    def test_timeout_is_a_clean_failure_not_an_exception(self) -> None:
+        result = fetch_remote_main_identity(
+            runner=_raising_runner(subprocess.TimeoutExpired(cmd=["curl"], timeout=1.5))
+        )
+        self.assertFalse(result.ok)
+        self.assertIsNotNone(result.error)
+
+    def test_curl_missing_is_a_clean_failure(self) -> None:
+        result = fetch_remote_main_identity(runner=_raising_runner(FileNotFoundError("curl not found")))
+        self.assertFalse(result.ok)
+
+    def test_nonzero_exit_is_a_clean_failure(self) -> None:
+        def runner(argv, timeout=None):
+            return subprocess.CompletedProcess(argv, 6, stdout="", stderr="curl: (6) Could not resolve host")
+
+        result = fetch_remote_main_identity(runner=runner)
+        self.assertFalse(result.ok)
+        self.assertIn("resolve host", result.error or "")
+
+    def test_http_error_other_than_304_is_a_clean_failure(self) -> None:
+        def runner(argv, timeout=None):
+            return subprocess.CompletedProcess(argv, 0, stdout=_http_stdout(500), stderr="")
+
+        result = fetch_remote_main_identity(runner=runner)
+        self.assertFalse(result.ok)
+
+    def test_malformed_json_body_is_a_clean_failure(self) -> None:
+        def runner(argv, timeout=None):
+            return subprocess.CompletedProcess(argv, 0, stdout="HTTP/2 200\n\nnot json", stderr="")
+
+        result = fetch_remote_main_identity(runner=runner)
+        self.assertFalse(result.ok)
+
+    def test_missing_sha_field_is_a_clean_failure(self) -> None:
+        def runner(argv, timeout=None):
+            return subprocess.CompletedProcess(argv, 0, stdout="HTTP/2 200\n\n{}", stderr="")
+
+        result = fetch_remote_main_identity(runner=runner)
+        self.assertFalse(result.ok)
+
+    def test_the_argv_invokes_curl_with_the_commits_endpoint(self) -> None:
+        calls: list[object] = []
+        fetch_remote_main_identity(runner=_ok_runner("a" * 40, calls=calls))
+        self.assertEqual(len(calls), 1)
+        argv = calls[0]
+        self.assertEqual(argv[0], "curl")
+        self.assertIn("https://api.github.com/repos/rlaope/oh-my-hermes/commits/main", argv)
+
+
+class EvaluateUpdateCheckTests(unittest.TestCase):
+    def test_off_mode_makes_zero_network_attempts(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            result = evaluate_update_check(paths, runner=_refusing_runner())
+            self.assertEqual(result["mode"], "off")
+            self.assertEqual(result["outcome"], "skipped_off")
+            self.assertFalse(result["checked"])
+            self.assertFalse(result["should_auto_update"])
+
+    def test_no_local_identity_is_inconclusive_not_a_false_claim(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            write_update_check_policy(paths, mode="notify")
+            result = evaluate_update_check(paths, runner=_ok_runner("a" * 40))
+            self.assertEqual(result["outcome"], "inconclusive")
+            self.assertEqual(format_notice_line(result), "OMH update check inconclusive -- run `omh update`.")
+
+    def test_matching_identity_is_up_to_date(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            write_update_check_policy(paths, mode="notify")
+            _write_local_commit(paths, "a" * 40)
+            result = evaluate_update_check(paths, runner=_ok_runner("a" * 40))
+            self.assertEqual(result["outcome"], "up_to_date")
+            self.assertEqual(format_notice_line(result), "")
+
+    def test_differing_identity_is_behind_and_formats_a_short_notice(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            write_update_check_policy(paths, mode="notify")
+            _write_local_commit(paths, "a" * 40)
+            result = evaluate_update_check(paths, runner=_ok_runner("b" * 40))
+            self.assertEqual(result["outcome"], "behind")
+            notice = format_notice_line(result)
+            self.assertIn("OMH update available: aaaaaaa -> bbbbbbb", notice)
+            self.assertIn("omh update", notice)
+
+    def test_auto_mode_flags_should_auto_update_only_when_behind(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            write_update_check_policy(paths, mode="auto")
+            _write_local_commit(paths, "a" * 40)
+            behind = evaluate_update_check(paths, runner=_ok_runner("b" * 40))
+            self.assertTrue(behind["should_auto_update"])
+
+            _write_local_commit(paths, "b" * 40)
+            up_to_date = evaluate_update_check(paths, force=True, runner=_ok_runner("b" * 40))
+            self.assertFalse(up_to_date["should_auto_update"])
+
+    def test_network_failure_is_a_silent_skip_that_keeps_the_previous_outcome(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            write_update_check_policy(paths, mode="notify")
+            _write_local_commit(paths, "a" * 40)
+            first = evaluate_update_check(paths, runner=_ok_runner("b" * 40))
+            self.assertEqual(first["outcome"], "behind")
+
+            second = evaluate_update_check(
+                paths, force=True, runner=_raising_runner(subprocess.TimeoutExpired(cmd=["curl"], timeout=1.5))
+            )
+            self.assertEqual(second["outcome"], "behind")
+            self.assertTrue(second["checked"])
+            cache = read_update_check_cache(paths)
+            self.assertEqual(cache["outcome"], "behind")
+
+    def test_interval_not_elapsed_serves_the_cache_without_a_network_attempt(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            write_update_check_policy(paths, mode="notify", interval_hours=24)
+            _write_local_commit(paths, "a" * 40)
+            first = evaluate_update_check(paths, runner=_ok_runner("b" * 40))
+            self.assertTrue(first["checked"])
+
+            second = evaluate_update_check(paths, runner=_refusing_runner())
+            self.assertFalse(second["checked"])
+            self.assertEqual(second["outcome"], "behind")
+
+    def test_elapsed_interval_triggers_a_fresh_probe(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            write_update_check_policy(paths, mode="notify", interval_hours=1)
+            _write_local_commit(paths, "a" * 40)
+            now = datetime.now(timezone.utc)
+            evaluate_update_check(paths, now=now, runner=_ok_runner("b" * 40))
+            later = now + timedelta(hours=2)
+            result = evaluate_update_check(paths, now=later, runner=_ok_runner("c" * 40))
+            self.assertTrue(result["checked"])
+            self.assertEqual(result["remote_commit"], "c" * 40)
+
+    def test_not_modified_reuses_the_cached_remote_identity(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            write_update_check_policy(paths, mode="notify", interval_hours=1)
+            _write_local_commit(paths, "a" * 40)
+            now = datetime.now(timezone.utc)
+            evaluate_update_check(paths, now=now, runner=_ok_runner("b" * 40))
+
+            later = now + timedelta(hours=2)
+            result = evaluate_update_check(paths, now=later, runner=_not_modified_runner())
+            self.assertEqual(result["remote_commit"], "b" * 40)
+            self.assertEqual(result["outcome"], "behind")
+
+
+class LocalInstalledCommitTests(unittest.TestCase):
+    def test_absent_state_reads_as_empty(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            self.assertEqual(local_installed_commit(paths), "")
+
+    def test_record_remote_commit_for_install_is_best_effort(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            self.assertEqual(
+                record_remote_commit_for_install(
+                    paths, runner=_raising_runner(subprocess.TimeoutExpired(cmd=["curl"], timeout=1.5))
+                ),
+                "",
+            )
+            self.assertEqual(record_remote_commit_for_install(paths, runner=_ok_runner("c" * 40)), "c" * 40)
+
+
+class AutoUpdateLockTests(unittest.TestCase):
+    def test_lock_is_exclusive_and_non_blocking(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            with acquire_auto_update_lock(paths):
+                with self.assertRaises(FileLockTimeout):
+                    with acquire_auto_update_lock(paths):
+                        pass
+
+    def test_lock_path_is_the_cache_sidecar(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            cache_path = update_check_cache_path(paths)
+            with acquire_auto_update_lock(paths):
+                sidecar = cache_path.with_name(f".{cache_path.name}.lock")
+                self.assertTrue(sidecar.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -25,15 +25,19 @@ from omh.local_store import FileLockTimeout, atomic_write_json, read_json_object
 from omh.maintenance.update_check import (
     DEFAULT_UPDATE_CHECK_INTERVAL_HOURS,
     DEFAULT_UPDATE_CHECK_MODE,
+    MAX_UPDATE_CHECK_INTERVAL_HOURS,
+    MIN_UPDATE_CHECK_INTERVAL_HOURS,
     UPDATE_CHECK_MODES,
     acquire_auto_update_lock,
     evaluate_update_check,
     fetch_remote_main_identity,
     format_notice_line,
+    local_installed_channel,
     local_installed_commit,
     read_update_check_cache,
     read_update_check_policy,
     record_remote_commit_for_install,
+    refresh_cache_after_auto_update,
     update_check_cache_path,
     write_update_check_policy,
 )
@@ -236,6 +240,28 @@ class EvaluateUpdateCheckTests(unittest.TestCase):
             up_to_date = evaluate_update_check(paths, force=True, runner=_ok_runner("b" * 40))
             self.assertFalse(up_to_date["should_auto_update"])
 
+    def test_cached_behind_within_the_interval_never_flags_a_repeat_auto_update(self) -> None:
+        # Regression for the "auto mode re-updates every launch" defect: a
+        # cached "behind" outcome served without a fresh probe (interval not
+        # elapsed) must never set should_auto_update on its own -- only a
+        # fresh probe in this same call may.
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            write_update_check_policy(paths, mode="auto", interval_hours=24)
+            _write_local_commit(paths, "a" * 40)
+            first = evaluate_update_check(paths, runner=_ok_runner("b" * 40))
+            self.assertTrue(first["checked"])
+            self.assertTrue(first["should_auto_update"])
+
+            second = evaluate_update_check(paths, runner=_refusing_runner())
+            self.assertFalse(second["checked"])
+            self.assertEqual(second["outcome"], "behind")
+            self.assertFalse(second["should_auto_update"])
+
+            third = evaluate_update_check(paths, runner=_refusing_runner())
+            self.assertFalse(third["checked"])
+            self.assertFalse(third["should_auto_update"])
+
     def test_network_failure_is_a_silent_skip_that_keeps_the_previous_outcome(self) -> None:
         with TemporaryDirectory() as tmp:
             paths = _paths(Path(tmp))
@@ -324,6 +350,130 @@ class AutoUpdateLockTests(unittest.TestCase):
             with acquire_auto_update_lock(paths):
                 sidecar = cache_path.with_name(f".{cache_path.name}.lock")
                 self.assertTrue(sidecar.exists())
+
+
+class LocalInstalledChannelTests(unittest.TestCase):
+    def test_absent_state_reads_as_empty(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            self.assertEqual(local_installed_channel(paths), "")
+
+    def test_reads_the_recorded_channel(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            paths.runtime_dir.mkdir(parents=True, exist_ok=True)
+            atomic_write_json(paths.runtime_state_path, {"release_channel": "stable"})
+            self.assertEqual(local_installed_channel(paths), "stable")
+
+
+class FormatNoticeLineChannelAwarenessTests(unittest.TestCase):
+    def test_inconclusive_on_a_non_preview_channel_names_the_channel_instead_of_suggesting_update(self) -> None:
+        notice = format_notice_line({"outcome": "inconclusive", "channel": "stable"})
+        self.assertIn("stable", notice)
+        self.assertNotIn("omh update", notice)
+
+    def test_inconclusive_with_no_recorded_channel_keeps_the_actionable_wording(self) -> None:
+        notice = format_notice_line({"outcome": "inconclusive", "channel": ""})
+        self.assertEqual(notice, "OMH update check inconclusive -- run `omh update`.")
+
+    def test_inconclusive_on_the_preview_channel_keeps_the_actionable_wording(self) -> None:
+        notice = format_notice_line({"outcome": "inconclusive", "channel": "preview"})
+        self.assertEqual(notice, "OMH update check inconclusive -- run `omh update`.")
+
+
+class RefreshCacheAfterAutoUpdateTests(unittest.TestCase):
+    def test_marks_up_to_date_when_local_commit_now_matches_the_cached_remote(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            write_update_check_policy(paths, mode="auto")
+            _write_local_commit(paths, "a" * 40)
+            evaluate_update_check(paths, runner=_ok_runner("b" * 40))
+
+            _write_local_commit(paths, "b" * 40)  # simulate the auto-update converging
+            refreshed = refresh_cache_after_auto_update(paths)
+            self.assertEqual(refreshed["outcome"], "up_to_date")
+            self.assertEqual(read_update_check_cache(paths)["outcome"], "up_to_date")
+
+    def test_marks_inconclusive_when_the_local_identity_still_does_not_match(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            write_update_check_policy(paths, mode="auto")
+            _write_local_commit(paths, "a" * 40)
+            evaluate_update_check(paths, runner=_ok_runner("b" * 40))
+
+            refreshed = refresh_cache_after_auto_update(paths)  # local commit unchanged
+            self.assertEqual(refreshed["outcome"], "inconclusive")
+
+
+class IntervalHoursBoundsTests(unittest.TestCase):
+    def test_write_rejects_an_interval_below_the_minimum(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            with self.assertRaises(ValueError):
+                write_update_check_policy(paths, interval_hours=MIN_UPDATE_CHECK_INTERVAL_HOURS / 2)
+
+    def test_write_rejects_an_interval_above_the_maximum(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            with self.assertRaises(ValueError):
+                write_update_check_policy(paths, interval_hours=MAX_UPDATE_CHECK_INTERVAL_HOURS * 2)
+
+    def test_write_rejects_an_infinite_interval(self) -> None:
+        # Regression: `timedelta(hours=...)` raises OverflowError on `inf`,
+        # which would otherwise crash `_interval_elapsed` on every launch.
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            with self.assertRaises(ValueError):
+                write_update_check_policy(paths, interval_hours=float("inf"))
+
+    def test_read_ignores_a_stored_out_of_range_interval_and_falls_back_to_default(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            paths.omh_home.mkdir(parents=True, exist_ok=True)
+            atomic_write_json(
+                paths.setup_profile_path,
+                {"update_check": {"mode": "notify", "interval_hours": 1e18}},
+            )
+            policy = read_update_check_policy(paths)
+            self.assertEqual(policy["interval_hours"], DEFAULT_UPDATE_CHECK_INTERVAL_HOURS)
+
+
+class CorruptDiskStateNeverRaisesTests(unittest.TestCase):
+    """Regression for the P0 launch traceback: a corrupt on-disk document must
+    read the same as an absent one everywhere on the update-check path."""
+
+    def test_corrupt_setup_profile_reads_as_the_default_policy(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            paths.omh_home.mkdir(parents=True, exist_ok=True)
+            paths.setup_profile_path.write_text("{not json", encoding="utf-8")
+            policy = read_update_check_policy(paths)
+            self.assertEqual(policy["mode"], DEFAULT_UPDATE_CHECK_MODE)
+            self.assertEqual(policy["interval_hours"], DEFAULT_UPDATE_CHECK_INTERVAL_HOURS)
+
+    def test_corrupt_cache_reads_as_empty(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            paths.runtime_dir.mkdir(parents=True, exist_ok=True)
+            update_check_cache_path(paths).write_text("{not json", encoding="utf-8")
+            self.assertEqual(read_update_check_cache(paths), {})
+
+    def test_state_json_as_a_json_array_reads_as_no_local_identity(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            paths.runtime_dir.mkdir(parents=True, exist_ok=True)
+            paths.runtime_state_path.write_text("[]", encoding="utf-8")
+            self.assertEqual(local_installed_commit(paths), "")
+            self.assertEqual(local_installed_channel(paths), "")
+
+    def test_evaluate_update_check_never_raises_on_a_corrupt_cache(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            write_update_check_policy(paths, mode="notify")
+            paths.runtime_dir.mkdir(parents=True, exist_ok=True)
+            update_check_cache_path(paths).write_text("not json at all", encoding="utf-8")
+            result = evaluate_update_check(paths, runner=_ok_runner("b" * 40))
+            self.assertIn(result["outcome"], ("behind", "up_to_date", "inconclusive"))
 
 
 if __name__ == "__main__":

--- a/tests/test_update_check_command.py
+++ b/tests/test_update_check_command.py
@@ -15,6 +15,14 @@ subprocess call elsewhere in `omh update` (e.g. command-package self-update)
 is never accidentally intercepted. None of these tests may spawn a real
 process or reach a real socket, and the `off`-mode tests assert that too by
 making the fake raise if it is ever called.
+
+Auto mode's `_run_auto_update` spawns `omh update --no-interactive` as a real
+subprocess (so its own command-package-update re-entry sees a normal `omh
+update` `sys.argv`, not the bare-launch argv this process actually started
+with -- see the docstring on `_run_auto_update`). Tests here fake that
+subprocess by patching `omh.commands.main.subprocess.run` directly, the same
+pattern `tests/test_cli.py` already uses for the command-package self-update
+re-entry, rather than letting a real child process spawn.
 """
 
 from __future__ import annotations
@@ -24,6 +32,7 @@ import contextlib
 import io
 import json
 import subprocess
+import sys
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -33,7 +42,12 @@ from _cli_harness import run_cli
 
 from omh.commands import main as main_module
 from omh.local_store import atomic_write_json, read_json_object
-from omh.maintenance.update_check import acquire_auto_update_lock, update_check_cache_path, write_update_check_policy
+from omh.maintenance.update_check import (
+    acquire_auto_update_lock,
+    read_update_check_cache,
+    update_check_cache_path,
+    write_update_check_policy,
+)
 from omh.paths import OmhPaths
 
 _RUN_CURL_TARGET = "omh.maintenance.update_check._run_curl"
@@ -180,6 +194,40 @@ class StartupCheckLaunchIntegrationTests(unittest.TestCase):
                 main_module._run_startup_update_check(args)
             self.assertEqual(buffer.getvalue(), "")
 
+    def test_corrupt_setup_profile_with_the_shipped_off_mode_is_a_silent_launch(self) -> None:
+        # Regression for the P0 defect: a corrupt `setup-profile.json` used to
+        # raise inside `read_update_check_policy` (via `read_json_object`),
+        # and `main.py`'s launch door only caught `OSError` -- a user who
+        # never opted into this check got a launch traceback from a file this
+        # check does not even own. Off mode must stay a silent launch.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = _paths(root)
+            paths.omh_home.mkdir(parents=True, exist_ok=True)
+            paths.setup_profile_path.write_text("{not valid json", encoding="utf-8")
+            args = self._args(root)
+            buffer = io.StringIO()
+            with patch(_RUN_CURL_TARGET, _refusing_curl()), contextlib.redirect_stdout(buffer):
+                main_module._run_startup_update_check(args)  # must not raise
+            self.assertEqual(buffer.getvalue(), "")
+
+    def test_state_json_as_a_json_array_with_notify_mode_is_a_silent_skip(self) -> None:
+        # Regression for the same P0 shape one layer down: `state.json` that
+        # is a JSON array (not an object) used to raise inside
+        # `local_installed_commit`. It must read as "no comparable local
+        # identity" -- inconclusive -- never a raised exception.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = _paths(root)
+            write_update_check_policy(paths, mode="notify")
+            paths.runtime_dir.mkdir(parents=True, exist_ok=True)
+            paths.runtime_state_path.write_text("[]", encoding="utf-8")
+            args = self._args(root)
+            buffer = io.StringIO()
+            with patch(_RUN_CURL_TARGET, _fake_curl("b" * 40)), contextlib.redirect_stdout(buffer):
+                main_module._run_startup_update_check(args)  # must not raise
+            self.assertIn("inconclusive", buffer.getvalue())
+
     def test_notify_mode_prints_the_one_line_notice_when_behind(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -195,7 +243,14 @@ class StartupCheckLaunchIntegrationTests(unittest.TestCase):
             self.assertIn("OMH update available:", output)
             self.assertIn("omh update", output)
 
-    def test_auto_mode_reuses_omh_update_and_records_the_new_identity(self) -> None:
+    def test_auto_mode_spawns_omh_update_no_interactive_as_a_real_subprocess(self) -> None:
+        # Regression for the P1-b defect: `_run_auto_update` used to call
+        # `cmd_update()` in-process, so the command-package self-update
+        # re-entry (`commands/setup.py:_reentry_argv_with_command_package_
+        # updated`) read the real process's `sys.argv[1:]` -- the bare `omh`
+        # launch argv, empty -- instead of the synthesized `update ...` argv,
+        # and exited 2 before the post-update half ever ran. Spawning a real
+        # subprocess gives that re-entry a correct `sys.argv` of its own.
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
             paths = _paths(root)
@@ -204,11 +259,69 @@ class StartupCheckLaunchIntegrationTests(unittest.TestCase):
             atomic_write_json(paths.runtime_state_path, {"release_source_commit": "a" * 40})
             args = self._args(root)
             buffer = io.StringIO()
-            with patch(_RUN_CURL_TARGET, _fake_curl("b" * 40)), contextlib.redirect_stdout(buffer):
+
+            def fake_run(argv, timeout=None):
+                # Simulate a successful `omh update` converging on the remote
+                # identity the auto-update was triggered by.
+                atomic_write_json(
+                    paths.runtime_state_path,
+                    {"release_source_commit": "b" * 40, "last_update": {"status": "ok"}},
+                )
+                return subprocess.CompletedProcess(argv, 0)
+
+            with (
+                patch(_RUN_CURL_TARGET, _fake_curl("b" * 40)),
+                patch.object(main_module.subprocess, "run", side_effect=fake_run) as run,
+                contextlib.redirect_stdout(buffer),
+            ):
                 main_module._run_startup_update_check(args)
+
+            run.assert_called_once()
+            spawned_argv = run.call_args.args[0]
+            self.assertEqual(spawned_argv[0], sys.executable)
+            self.assertEqual(spawned_argv[1:3], ["-m", "omh.cli"])
+            self.assertIn("update", spawned_argv)
+            self.assertIn("--no-interactive", spawned_argv)
+            # `--yes` would preset the branded-TUI identity choice
+            # (`commands/setup.py:_preset_tui_identity_choice`) and rewrite a
+            # user's own `display.interface`/skin choice on every auto-update.
+            self.assertNotIn("--yes", spawned_argv)
+            # The synthesized argv (after the interpreter/module prefix) must
+            # be a valid CLI invocation, not just plausible-looking strings.
+            main_module.build_parser().parse_args(spawned_argv[3:])
+
             state = read_json_object(paths.runtime_state_path) or {}
             self.assertIn("last_update", state)
             self.assertEqual(state["release_source_commit"], "b" * 40)
+            # The cache is re-anchored on success so a launch later in the
+            # same interval reads it as resolved, not still "behind".
+            self.assertEqual(read_update_check_cache(paths)["outcome"], "up_to_date")
+
+    def test_auto_mode_reports_a_failed_subprocess_without_crashing_the_launch(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = _paths(root)
+            write_update_check_policy(paths, mode="auto")
+            paths.runtime_dir.mkdir(parents=True, exist_ok=True)
+            atomic_write_json(paths.runtime_state_path, {"release_source_commit": "a" * 40})
+            args = self._args(root)
+            out_buffer, err_buffer = io.StringIO(), io.StringIO()
+
+            def failing_run(argv, timeout=None):
+                return subprocess.CompletedProcess(argv, 2)
+
+            with (
+                patch(_RUN_CURL_TARGET, _fake_curl("b" * 40)),
+                patch.object(main_module.subprocess, "run", side_effect=failing_run),
+                contextlib.redirect_stdout(out_buffer),
+                contextlib.redirect_stderr(err_buffer),
+            ):
+                main_module._run_startup_update_check(args)
+
+            self.assertIn("update-check auto-update failed", err_buffer.getvalue())
+            cache = read_update_check_cache(paths)
+            # A failed attempt never claims convergence.
+            self.assertNotEqual(cache.get("outcome"), "up_to_date")
 
     def test_auto_mode_skips_silently_when_another_launch_holds_the_lock(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_update_check_command.py
+++ b/tests/test_update_check_command.py
@@ -1,0 +1,236 @@
+"""Contracts for `omh update-check` and its two integration points:
+
+- `omh install`/`omh update` recording a comparable remote identity into
+  `state.json` (`release_source_commit`) only when update-check is opted in.
+- The `omh`/`hermes` launch path (`commands/main.py`) acting on the check:
+  a notice line for `notify`, reusing `omh update`'s own code path for
+  `auto`, and a non-blocking lock so two launches never auto-update at once.
+
+The probe spawns `curl` as a subprocess (never a Python-level network client
+-- see `tests/test_handoff_safety_contract_enforcement.py` INVARIANT 2), so
+every test here patches `omh.maintenance.update_check._run_curl` -- the one
+name `fetch_remote_main_identity` resolves when no `runner` is passed
+explicitly -- rather than the global `subprocess.run`, so a legitimate
+subprocess call elsewhere in `omh update` (e.g. command-package self-update)
+is never accidentally intercepted. None of these tests may spawn a real
+process or reach a real socket, and the `off`-mode tests assert that too by
+making the fake raise if it is ever called.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import subprocess
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from _cli_harness import run_cli
+
+from omh.commands import main as main_module
+from omh.local_store import atomic_write_json, read_json_object
+from omh.maintenance.update_check import acquire_auto_update_lock, update_check_cache_path, write_update_check_policy
+from omh.paths import OmhPaths
+
+_RUN_CURL_TARGET = "omh.maintenance.update_check._run_curl"
+
+
+def _base(root: Path) -> list[str]:
+    return ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+
+def _paths(root: Path) -> OmhPaths:
+    resolved = root.resolve()
+    return OmhPaths(resolved / ".omh", resolved / ".hermes")
+
+
+def _http_stdout(sha: str) -> str:
+    return f'HTTP/2 200\netag: "fake"\n\n{json.dumps({"sha": sha})}'
+
+
+def _fake_curl(sha: str):
+    def runner(argv, timeout=None):
+        return subprocess.CompletedProcess(argv, 0, stdout=_http_stdout(sha), stderr="")
+
+    return runner
+
+
+def _refusing_curl():
+    def runner(argv, timeout=None):  # pragma: no cover - fails the test if reached
+        raise AssertionError("update-check must not spawn curl here")
+
+    return runner
+
+
+class UpdateCheckCliTests(unittest.TestCase):
+    def test_status_reports_the_shipped_default(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            status, stdout, stderr = run_cli(_base(root) + ["update-check", "status"], output_json=False)
+            self.assertEqual((status, stderr), (0, ""))
+            self.assertIn("Update-check mode: off", stdout)
+            self.assertIn("Last checked: never", stdout)
+
+    def test_set_writes_the_policy_and_status_reflects_it(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            status, stdout, stderr = run_cli(
+                _base(root) + ["update-check", "set", "--mode", "notify", "--interval-hours", "6"],
+                output_json=False,
+            )
+            self.assertEqual((status, stderr), (0, ""))
+            self.assertIn("Update-check mode: notify", stdout)
+            self.assertIn("Interval: every 6.0 hour(s)", stdout)
+
+            status, stdout, _ = run_cli(_base(root) + ["update-check", "status"], output_json=False)
+            self.assertEqual(status, 0)
+            self.assertIn("Update-check mode: notify", stdout)
+            self.assertIn("Interval: every 6.0 hour(s)", stdout)
+
+    def test_set_without_arguments_is_refused(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            status, _, stderr = run_cli(_base(root) + ["update-check", "set"], output_json=False)
+            self.assertEqual(status, 2)
+            self.assertIn("--mode", stderr)
+
+    def test_set_rejects_an_unknown_mode(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaises(SystemExit) as raised:
+                run_cli(_base(root) + ["update-check", "set", "--mode", "always"], output_json=False)
+            self.assertEqual(raised.exception.code, 2)
+
+    def test_status_json_reports_the_schema(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            status, stdout, stderr = run_cli(_base(root) + ["update-check", "status", "--json"])
+            self.assertEqual((status, stderr), (0, ""))
+            payload = json.loads(stdout)
+            self.assertEqual(payload["schema_version"], "omh_update_check_status/v1")
+            self.assertEqual(payload["policy"]["mode"], "off")
+
+
+class InstallRecordsRemoteIdentityTests(unittest.TestCase):
+    def _state(self, root: Path) -> dict[str, object]:
+        return read_json_object(_paths(root).runtime_state_path) or {}
+
+    def test_default_off_mode_never_touches_the_network_on_update(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch(_RUN_CURL_TARGET, _refusing_curl()):
+                status, _, stderr = run_cli(_base(root) + ["update", "--yes", "--no-interactive"], output_json=False)
+            self.assertEqual((status, stderr), (0, ""))
+            self.assertNotIn("release_source_commit", self._state(root))
+
+    def test_notify_mode_records_the_remote_commit_on_the_preview_channel(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_cli(_base(root) + ["update-check", "set", "--mode", "notify"], output_json=False)
+            with patch(_RUN_CURL_TARGET, _fake_curl("c" * 40)):
+                status, _, stderr = run_cli(_base(root) + ["update", "--yes", "--no-interactive"], output_json=False)
+            self.assertEqual((status, stderr), (0, ""))
+            self.assertEqual(self._state(root)["release_source_commit"], "c" * 40)
+
+    def test_local_channel_never_records_a_main_commit(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            local_source = root / "local-skills"
+            local_source.mkdir()
+            run_cli(_base(root) + ["update-check", "set", "--mode", "auto"], output_json=False)
+            with patch(_RUN_CURL_TARGET, _refusing_curl()):
+                status, _, stderr = run_cli(
+                    _base(root) + ["install", "--channel", "local", "--from-skills-dir", str(local_source)],
+                    output_json=False,
+                )
+            self.assertEqual((status, stderr), (0, ""))
+            self.assertNotIn("release_source_commit", self._state(root))
+
+    def test_a_failed_probe_never_regresses_a_previously_recorded_identity(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_cli(_base(root) + ["update-check", "set", "--mode", "notify"], output_json=False)
+            with patch(_RUN_CURL_TARGET, _fake_curl("d" * 40)):
+                run_cli(_base(root) + ["update", "--yes", "--no-interactive"], output_json=False)
+            self.assertEqual(self._state(root)["release_source_commit"], "d" * 40)
+
+            def failing(argv, timeout=None):
+                raise subprocess.TimeoutExpired(cmd=argv, timeout=timeout or 1.5)
+
+            with patch(_RUN_CURL_TARGET, failing):
+                status, _, stderr = run_cli(_base(root) + ["update", "--yes", "--no-interactive"], output_json=False)
+            self.assertEqual((status, stderr), (0, ""))
+            self.assertEqual(self._state(root)["release_source_commit"], "d" * 40)
+
+
+class StartupCheckLaunchIntegrationTests(unittest.TestCase):
+    def _args(self, root: Path) -> argparse.Namespace:
+        return argparse.Namespace(omh_home=str(root / ".omh"), hermes_home=str(root / ".hermes"), scope=None)
+
+    def test_off_mode_prints_nothing_and_touches_no_network(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            args = self._args(root)
+            buffer = io.StringIO()
+            with patch(_RUN_CURL_TARGET, _refusing_curl()), contextlib.redirect_stdout(buffer):
+                main_module._run_startup_update_check(args)
+            self.assertEqual(buffer.getvalue(), "")
+
+    def test_notify_mode_prints_the_one_line_notice_when_behind(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = _paths(root)
+            write_update_check_policy(paths, mode="notify")
+            paths.runtime_dir.mkdir(parents=True, exist_ok=True)
+            atomic_write_json(paths.runtime_state_path, {"release_source_commit": "a" * 40})
+            args = self._args(root)
+            buffer = io.StringIO()
+            with patch(_RUN_CURL_TARGET, _fake_curl("b" * 40)), contextlib.redirect_stdout(buffer):
+                main_module._run_startup_update_check(args)
+            output = buffer.getvalue()
+            self.assertIn("OMH update available:", output)
+            self.assertIn("omh update", output)
+
+    def test_auto_mode_reuses_omh_update_and_records_the_new_identity(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = _paths(root)
+            write_update_check_policy(paths, mode="auto")
+            paths.runtime_dir.mkdir(parents=True, exist_ok=True)
+            atomic_write_json(paths.runtime_state_path, {"release_source_commit": "a" * 40})
+            args = self._args(root)
+            buffer = io.StringIO()
+            with patch(_RUN_CURL_TARGET, _fake_curl("b" * 40)), contextlib.redirect_stdout(buffer):
+                main_module._run_startup_update_check(args)
+            state = read_json_object(paths.runtime_state_path) or {}
+            self.assertIn("last_update", state)
+            self.assertEqual(state["release_source_commit"], "b" * 40)
+
+    def test_auto_mode_skips_silently_when_another_launch_holds_the_lock(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = _paths(root)
+            write_update_check_policy(paths, mode="auto")
+            paths.runtime_dir.mkdir(parents=True, exist_ok=True)
+            atomic_write_json(paths.runtime_state_path, {"release_source_commit": "a" * 40})
+            args = self._args(root)
+            buffer = io.StringIO()
+            with acquire_auto_update_lock(paths):
+                with patch(_RUN_CURL_TARGET, _fake_curl("b" * 40)), contextlib.redirect_stdout(buffer):
+                    main_module._run_startup_update_check(args)
+            state = read_json_object(paths.runtime_state_path) or {}
+            self.assertNotIn("last_update", state)
+
+    def test_cache_path_matches_the_documented_runtime_location(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = _paths(root)
+            self.assertEqual(update_check_cache_path(paths), paths.omh_home / "runtime" / "update-check.json")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Capability

`omh` can now notice at launch that the installed OMH is behind open-source main and act on it — strictly opt-in:

- `omh update-check set --mode notify|auto|off` (+ `--interval-hours N`, bounded 1–8760, default 24; `omh update-check status` inspects policy and last outcome). **Shipped default is `off`: zero network attempts** for anyone who never opts in.
- On a bare `omh` launch (the TUI launch door), an opted-in install probes the GitHub commits API once per interval — a `curl` subprocess bounded twice (`--max-time 1.5` + a 2.0s process timeout) — and compares against the `release_source_commit` recorded by `omh install`/`omh update` on the preview channel. Results cache in `~/.omh/runtime/update-check.json`.
- `notify` prints one line only when a fresh probe found the install behind; stable/local channels (which never record a comparable identity) get channel-aware wording instead of an unresolvable nag. `auto` runs a real `omh update --no-interactive` subprocess (correct re-entry argv; no `--yes`, so a user's branded-TUI choice is never re-imposed), guarded by an OS-released flock so concurrent launches cannot double-update, and refreshes the cache on success so it never re-updates within an interval.
- Any failure — corrupt state files, missing curl, DNS stall, rate-limit, torn cache — is a silent skip; the TUI launch cannot be blocked or crashed by this feature.

## Motivation

Owner directive: "omh(혹은 hermes)로 켰을때 open source main과 비교해 커밋이 밀려 있으면 auto update". The repo's core promise is no network calls, so this ships as an explicit member of the update family (the same class as `omh update` itself), off by default, with the network mechanics done the one sanctioned way — an external process (the AST gate in `test_handoff_safety_contract_enforcement.py` forbids in-process network clients; the probe is allowlisted there with its reason).

## Implementation (boundary level)

- `src/maintenance/update_check.py`: policy/cache/identity readers (all through the never-raising `read_json_object_result`), the bounded curl probe with ETag caching, `evaluate_update_check`, the auto-update lock, `refresh_cache_after_auto_update`.
- `src/commands/main.py`: the launch-door hook before the `hermes` exec; `_run_auto_update` spawns `omh update --no-interactive` as a subprocess (600s bound, output surfaced).
- `src/commands/setup.py`: `release_source_commit` recorded into state.json (preview channel, opted-in only); silent no-op on unreadable state.
- `docs/INSTALLATION.md`: new opt-in section with honest budgets (notify never blocks; auto by design updates before launch and can take minutes; bare `hermes` does not pass through this door — recorded boundary).
- An independent review (1 P0, 2 P1, 5 P2, 3 P3) ran before this PR; every finding fixed in `feb15167` — the P0 (a corrupt profile could traceback bare `omh` even in off mode), the auto-loop (cached "behind" re-triggering every launch), and the dead re-entry argv (in-process `cmd_update` under bare `omh` broke the post-update half and never converged) are each covered by regression tests.

## Verification (observed)

- Full suite on the final tree in the main checkout: green on the verbatim rerun (one earlier run showed a single non-reproducing failure; worktree runs show only the known `.claude`-path sandbox artifact). Targeted: 59 update-check tests + safety-contract/broad-except/CLI suites (419 tests) all OK.
- Tests fake the subprocess boundary throughout — off-mode is asserted with runners that raise if invoked; no test can touch the network.
- All five docs byte gates ok; ruff, compileall, `git diff --check` clean.
- Not observed: a live end-to-end launch with a real `hermes` binary and a real GitHub probe (sandboxed).

## Risks

- Auto mode intentionally trades launch latency for freshness — the update runs before the TUI opens; documented plainly.
- The comparison anchor only exists for installs updated after this lands (preview channel, opted in); older installs get the explicit inconclusive line until their first `omh update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)