### PR TITLE
test: make the frontier-admission chaos test race-proof

### DIFF
--- a/tests/test_fanout_chaos.py
+++ b/tests/test_fanout_chaos.py
@@ -189,11 +189,15 @@ class FanoutChaosTests(unittest.TestCase):
         # The frontier property itself — the reason the wave barrier was
         # removed. Under the barrier, u1 (dependent on fast u0) could not
         # start until the unrelated slow sibling drained the wave; under
-        # frontier admission it starts while `slow` is still running. This
-        # deterministic shape needs a real sleep, which the seeded bench
-        # deliberately avoids — hence a separate test.
+        # frontier admission it starts while `slow` is still running.
+        #
+        # `slow` is held on a threading.Event that only opens once `u1` has
+        # been observed starting, so the assertion below cannot lose a race
+        # against wall-clock scheduling noise (this was a real flake on a
+        # loaded Windows CI runner with a fixed 1.0s sleep here). The wait
+        # carries a generous timeout so a genuine frontier-admission
+        # regression still fails the test instead of hanging forever.
         import threading as _threading
-        import time as _time
 
         units = [
             {"unit_id": "slow", "title": "Slow sibling", "owner": "codex", "file_scope": ["src/slow/"]},
@@ -206,6 +210,7 @@ class FanoutChaosTests(unittest.TestCase):
             repo, sha = _make_repo(root)
             contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, units))
             slow_done = _threading.Event()
+            u1_started = _threading.Event()
             events: list[tuple[str, str, bool]] = []
             events_lock = _threading.Lock()
 
@@ -216,8 +221,11 @@ class FanoutChaosTests(unittest.TestCase):
                 unit_id = cwd.rsplit("-fanout-", 1)[-1]
                 with events_lock:
                     events.append(("start", unit_id, slow_done.is_set()))
+                if unit_id == "u1":
+                    u1_started.set()
                 if unit_id == "slow":
-                    _time.sleep(1.0)
+                    started = u1_started.wait(timeout=10.0)
+                    self.assertTrue(started, "u1 never started while slow was still running")
                     slow_done.set()
                 with events_lock:
                     events.append(("end", unit_id, slow_done.is_set()))


### PR DESCRIPTION
## Capability

`test_a_ready_dependent_starts_before_an_unrelated_slow_sibling_finishes` no longer races a real 1.0s sleep against thread-pool and worktree-setup overhead: the fake `slow` unit now blocks on a `threading.Event` that is set only after `u1`'s start has been observed (10s timeout), so the frontier-admission property is asserted deterministically. A genuine regression still fails loudly via the started-assertion rather than hanging.

## Motivation

The test flaked on the Windows CI runner during PR #1158 (u1's admission overhead exceeded the 1s window on a noisy runner, so `slow` finished first) and passed on rerun — recorded then as a watch item, now commissioned. Diagnosis ruled out both product-side suspects: owner gates are an empty dict in this test (no `per_owner_lanes`), and the spawn stagger never applies to a fake runner without `accepts_on_spawn`. The flake was the test's synchronization strategy, not the scheduler.

## Verification (observed)

- Target test looped 30×: 30/30 OK (~0.15–0.23s each, down from a hard 1.0s).
- `tests/test_fanout_chaos` (2) and `tests/test_fanout_dispatch` (110) green; compileall, ruff, all five docs byte gates (zero drift), `git diff --check` clean.
- Full suite in the worktree: only the documented `.claude`-path cross-harness artifact.

## Risks

- Test-only, single file. The property under test is unchanged — the event ordering guarantees `("start","u1",False)` precedes `slow_done` by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)