### PR TITLE
fix(skills): give maestro its own Hermes-owner final-checklist line

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -689,8 +689,7 @@ These surfaces are generated command references, not installed Hermes workflow s
   - The selected coding or runtime owner is named before any implementation claim.
   - Prepared handoff, dispatch, execution, verification, review, CI, and merge states are separated.
   - The final status cites observed runtime evidence or keeps the work prepared_not_observed.
-  - When Hermes is the selected coding owner, use `hermes_coding_harness/v1` to keep builder, verifier, reviewer, docs, and PR lanes separate.
-  - Report the current harness stage, owner, next action, and missing evidence without claiming PR creation, review, CI, merge-readiness, or merge until matching runtime observations exist.
+  - When Hermes is the selected coding owner this engine does not apply -- Hermes-native selection uses the Hermes runtime path, never this engine.
 - Recovery notes:
   - If the selected executor is unavailable, ask for Codex, Claude Code, Hermes, or another runtime before retrying.
   - If dispatch or result evidence is missing, keep the handoff prepared_not_observed and expose the next observable action.

--- a/skills/ulw-maestro/SKILL.md
+++ b/skills/ulw-maestro/SKILL.md
@@ -45,8 +45,7 @@ Bad example:
 - The selected coding or runtime owner is named before any implementation claim.
 - Prepared handoff, dispatch, execution, verification, review, CI, and merge states are separated.
 - The final status cites observed runtime evidence or keeps the work prepared_not_observed.
-- When Hermes is the selected coding owner, use `hermes_coding_harness/v1` to keep builder, verifier, reviewer, docs, and PR lanes separate.
-- Report the current harness stage, owner, next action, and missing evidence without claiming PR creation, review, CI, merge-readiness, or merge until matching runtime observations exist.
+- When Hermes is the selected coding owner this engine does not apply -- Hermes-native selection uses the Hermes runtime path, never this engine.
 
 ## Recovery Notes
 

--- a/src/maintenance/release.py
+++ b/src/maintenance/release.py
@@ -288,7 +288,12 @@ STANDALONE_CAPABILITY_SKILL_ITEM_CHAR_LIMIT = 2200
 # node and verification-fan-in contracts, PIN/RED/GREEN/SURFACE/CLEAN evidence
 # discipline, real-surface QA and cleanup receipts, and guarded natural
 # nomination for parallel-then-integrate work (+2301 chars); warranted growth.
-FULL_PROFILE_SKILL_BODY_CHAR_LIMIT = 744243
+# 744243 -> 744060: maestro's own final checklist replaced the generic
+# Hermes-owner harness line -- which told an engine that structurally cannot
+# have Hermes as owner to consult `hermes_coding_harness/v1` -- with one line
+# stating that this engine does not apply when Hermes is the coding owner
+# (-183 chars); warranted correction, not growth.
+FULL_PROFILE_SKILL_BODY_CHAR_LIMIT = 744060
 FULL_PROFILE_SKILL_BODY_REVIEWED_EXCEPTION_CHARS = 0
 
 

--- a/src/skills/catalog_definitions.py
+++ b/src/skills/catalog_definitions.py
@@ -40,9 +40,11 @@ from .catalog_types import (
     ProcedureStep,
     SkillDefinition,
     SkillExample,
+    _HANDOFF_FINAL_CHECKLIST,
     _HERMES_SETUP_FIVE_STEP_BAR,
     _HERMES_SETUP_SKIP_SEMANTICS,
     _HERMES_SETUP_WRITE_BOUNDARY,
+    _MAESTRO_HERMES_OWNER_FINAL_CHECKLIST_NOTE,
 )
 
 _SPECIALIST_DOMAIN_HANDOFF_BOUNDARY = (
@@ -1061,6 +1063,7 @@ _DEFINITIONS = [
             "executing surface.",
         ),
         quality_tier="handoff-gated",
+        final_checklist=_HANDOFF_FINAL_CHECKLIST + (_MAESTRO_HERMES_OWNER_FINAL_CHECKLIST_NOTE,),
         quality_bar=(
             ENGINE_ENTRY_CONFIRMATION_RULE,
             "Require the coding owner to already be chosen for this run -- named in the request, accepted when "

--- a/src/skills/catalog_types.py
+++ b/src/skills/catalog_types.py
@@ -270,6 +270,18 @@ _HERMES_CODING_HARNESS_FINAL_CHECKLIST = (
     "Report the current harness stage, owner, next action, and missing evidence without claiming PR creation, review, CI, merge-readiness, or merge until matching runtime observations exist.",
 )
 
+# maestro cannot reuse the generic Hermes-owner harness line above: its own
+# safety rule ("Never route a Hermes-owned lane through this engine") and its
+# facade's HermesNativeSelectionError mean the engine structurally cannot have
+# Hermes as the selected owner, so `hermes_coding_harness/v1` guidance never
+# applies here. This is the one honest replacement line for maestro's own
+# `final_checklist` override -- see its `SkillDefinition` in
+# catalog_definitions.py.
+_MAESTRO_HERMES_OWNER_FINAL_CHECKLIST_NOTE = (
+    "When Hermes is the selected coding owner this engine does not apply -- Hermes-native selection uses the "
+    "Hermes runtime path, never this engine."
+)
+
 _HANDOFF_RECOVERY_NOTES = (
     "If the selected executor is unavailable, ask for Codex, Claude Code, Hermes, or another runtime before retrying.",
     "If dispatch or result evidence is missing, keep the handoff prepared_not_observed and expose the next observable action.",

--- a/tests/test_maestro_skill.py
+++ b/tests/test_maestro_skill.py
@@ -174,5 +174,39 @@ class MaestroExecutorNeutralityTests(unittest.TestCase):
                 self.assertEqual(overlap, set())
 
 
+class MaestroHermesOwnerChecklistTests(unittest.TestCase):
+    """#1156 review defect, fixed here: `maestro` structurally cannot have
+    Hermes as the selected coding owner (safety rule 3, "Never route a
+    Hermes-owned lane through this engine", plus the facade's
+    `HermesNativeSelectionError`), so its own `final_checklist` must not
+    instruct using `hermes_coding_harness/v1` for a Hermes-owned lane. Other
+    handoff-gated skills that CAN take Hermes as owner keep the original
+    line -- pinned here via `ai-slop-cleaner`.
+    """
+
+    def test_maestro_final_checklist_does_not_instruct_hermes_coding_harness_use(self) -> None:
+        definition = _maestro_definition()
+        checklist = " ".join(definition.final_checklist)
+        self.assertNotIn("use `hermes_coding_harness/v1`", checklist)
+
+    def test_maestro_final_checklist_states_the_engine_does_not_apply_for_hermes_owner(self) -> None:
+        definition = _maestro_definition()
+        checklist = " ".join(definition.final_checklist)
+        self.assertIn(
+            "When Hermes is the selected coding owner this engine does not apply -- "
+            "Hermes-native selection uses the Hermes runtime path, never this engine.",
+            checklist,
+        )
+
+    def test_other_handoff_gated_skill_keeps_the_original_hermes_coding_harness_line(self) -> None:
+        definitions = {item.name: item for item in builtin_definitions()}
+        checklist = " ".join(definitions["ai-slop-cleaner"].final_checklist)
+        self.assertIn(
+            "When Hermes is the selected coding owner, use `hermes_coding_harness/v1` "
+            "to keep builder, verifier, reviewer, docs, and PR lanes separate.",
+            checklist,
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Capability

The `maestro` engine's Completion Checklist no longer instructs the one thing the engine structurally cannot do. The handoff-gated tier's shared line — "When Hermes is the selected coding owner, use `hermes_coding_harness/v1` …" — contradicted maestro's own safety rule ("Never route a Hermes-owned lane through this engine") and the facade's `HermesNativeSelectionError`. Maestro now carries its own line: "When Hermes is the selected coding owner this engine does not apply — Hermes-native selection uses the Hermes runtime path, never this engine."

## Motivation

Deferred consciously in #1156's review ("a tier variant is its own surface change"), now commissioned by the owner. The other handoff-gated members (`omh-executor-runtime-readiness`, `omh-ai-slop-cleaner`) genuinely can take Hermes as owner and keep the original line.

## Implementation (boundary level)

Least-machinery shape: `SkillDefinition.final_checklist` is an existing per-skill override (used by `team`/`ralplan`/`paper-learning`); maestro sets it to the handoff checklist plus the new note — no new tier, enum, or render branch, other members untouched. Regenerated `skills/ulw-maestro/SKILL.md` + `docs/WORKFLOWS.md` (other families verified unchanged via gates); ratchet 744243→744060 (−183). New `MaestroHermesOwnerChecklistTests` pins the new line, the absence of `hermes_coding_harness/v1` guidance on maestro, and that ai-slop-cleaner keeps the original.

## Verification (observed)

Targeted (test_maestro_skill, test_router_content, test_release_smoke, test_drift_registry) green; all five docs byte gates ok; ruff/compileall/`git diff --check` clean; full suite in the worktree shows only the documented `.claude`-path cross-harness artifact.

## Risks

Instruction-text only; one skill's checklist; sibling behavior pinned by test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)