### PR TITLE
chore(release): cut v2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "oh-my-hermes"
-version = "1.0.10"
+version = "2.0.0"
 description = "Install a Hermes-native skill workflow pack."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/omh/version.py
+++ b/src/omh/version.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "1.0.10"
+__version__ = "2.0.0"

--- a/src/plugin_bundle/omh/plugin.yaml
+++ b/src/plugin_bundle/omh/plugin.yaml
@@ -1,6 +1,6 @@
 name: omh
 kind: standalone
-version: "1.0.10"
+version: "2.0.0"
 description: "Oh My Hermes native bridge for metadata-only runtime status, HUD, role context, bounded evidence probes, evidence-boundary context, and a deterministic file-backed memory provider."
 author: oh-my-hermes maintainers
 provides_memory_provider: omh


### PR DESCRIPTION
## Capability

Version bump 1.0.10 → **2.0.0** across the three parity-gated surfaces (`pyproject.toml`, `src/omh/version.py`, `src/plugin_bundle/omh/plugin.yaml`).

## Motivation

Owner-directed major cut. This week's capability wave ships as one public step: the ulw-maestro external-owner handoff engine (+ `omh coding executor-skills`), the P1–P7 coding-harness upgrades (TDD lane, TUI craft, cache hygiene, docs-consulted artifact, debug bars, screenshot loop, structured summaries/fanout returns), the greenfield project-bootstrap pass, HUD liveness + live maestro dispatch rows, the opt-in startup update check, and the routing honesty fixes (advisor filename shield, Korean delivery underroutes, bare advisor-token retirement). Requested `1.0.9.1` was refused by the repo's own version gate (X.Y.Z tag/npm semver contract); 1.0.10 went out as the mechanical patch cut, so the intended visible release lands as 2.0.0.

## Verification (observed)

`tests/test_release_smoke.py` green including `VersionSurfaceParityTests`; all five docs byte gates ok; ruff; `git diff --check` clean. After merge: tag `v2.0.0` on the merge commit dispatches the distribution workflow (npm approval already authorized by the owner).

## Risks

Version metadata only; distribution mechanics identical to the v1.0.10 run that just completed its gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)