### PR TITLE
fix(routing): make the sole-owner delegation carve-out executor-neutral

### DIFF
--- a/src/coding/coding_delegation.py
+++ b/src/coding/coding_delegation.py
@@ -26,6 +26,7 @@ from ..coding_contracts import (
 from .action_gate import evaluate_action_gate, split_handoff_safety_contract
 from .prompting import build_executor_prompting_contract, render_executor_prompt_sections
 from ..executors import (
+    EXTERNAL_CLI_PROFILES,
     HERMES_CODING_TEAM_WRAPPER_ACTIONS,
     denied_executor_selection,
     executor_label,
@@ -297,6 +298,18 @@ _CODING_STATUS_REQUEST_TERMS = (
     "완료",
     "끝났",
 )
+# Same status/diagnostic vocabulary as `_CODING_STATUS_REQUEST_TERMS`, minus
+# "session"/"세션" plus "broken": naming a sole external CLI executor
+# (`_names_sole_external_executor`) should reach the retained-workflow delegate
+# outcome only for an imperative delivery request, not a status/health question
+# about that executor -- "is codex broken" and "코덱스가 지금 뭐하고있는지
+# 알려줘" ask about the executor, they do not hand it work. "session"/"세션" is
+# excluded on purpose: it also appears in genuine delegate imperatives such as
+# "claude code 작업 세션 열어줘" and "codex 세션 켜서 작업 시작하게 해줘", where
+# the noun names the object of the command rather than a status question.
+_EXECUTOR_STATUS_QUERY_TERMS = tuple(
+    term for term in _CODING_STATUS_REQUEST_TERMS if term not in {"session", "세션"}
+) + ("broken",)
 
 
 @dataclass(frozen=True)
@@ -508,11 +521,11 @@ def _build_coding_delegation_payload_native(
         and (
             plan_artifact is not None
             or _has_code_reference(message)
-            or _names_claude_code_as_sole_executor(message)
+            or _names_sole_external_executor(message)
         )
     ):
         workflow = "plan"
-    action = _action_for(intent, score, workflow, named_coding_agent=_names_claude_code_as_sole_executor(message))
+    action = _action_for(intent, score, workflow, named_coding_agent=_names_sole_external_executor(message))
     if force_coding_handoff and action == "clarify" and intent in {"coding", "review"} and score >= 4:
         action = "delegate"
     if action == "fallback":
@@ -1416,25 +1429,37 @@ def _inline_coding_policy_applies(lowered_message: str, intent: str, action: str
     return action != "delegate" or choice_required
 
 
-def _names_claude_code_as_sole_executor(message: str) -> bool:
-    """True when the message names the Claude Code executor, and only that one.
+def _names_sole_external_executor(message: str) -> bool:
+    """True when the message names exactly one external coding CLI executor.
 
     This is the delegation path's own detection of that executor name,
-    independent of any catalog trigger score: a request that names Claude Code
-    is coding-shaped even when it carries no other coding verb or file
+    independent of any catalog trigger score: a request that names an
+    external coding CLI (Claude Code or Codex -- `EXTERNAL_CLI_PROFILES`) is
+    coding-shaped even when it carries no other coding verb or file
     reference. It is the one family `ask`'s retired bare `claude` trigger used
     to catch as an accidental delegation-path side effect.
 
     Detection goes through `routing.coding_route_actions.named_executor_owners`
     -- the same owner resolver the coding-owner route decision uses -- rather
-    than a bare phrase check, and only counts when Claude Code is the *sole*
-    named owner. Every other named executor (Codex, Hermes coding, the
-    omo-runtime family) already reached the correct retained-workflow clarify
-    outcome on its own, and a message naming more than one owner is a genuine
-    owner-comparison question; broadening this detection to either case
-    regresses those clarifications.
+    than a bare phrase check, and only counts when a single `EXTERNAL_CLI_PROFILES`
+    member is the *sole* named owner. A user who names one external CLI with an
+    imperative has already made the explicit owner choice, so the delegation
+    path yields the same delegate outcome for Codex that it always has for
+    Claude Code. Hermes coding and the omo-runtime family are runtime owners,
+    not external CLIs, and stay on the retained-workflow clarify outcome; a
+    message naming more than one owner is a genuine owner-comparison question.
+    Broadening this detection to either case regresses those clarifications.
+
+    A message that only asks about the named executor's status, progress, or
+    health ("is codex broken", "코덱스가 지금 뭐하고있는지 알려줘") is excluded
+    even when it is the sole named owner: it is a diagnostic question, not an
+    imperative delivery request, and must keep reaching the retained-workflow
+    clarify outcome (`_EXECUTOR_STATUS_QUERY_TERMS`).
     """
-    return named_executor_owners(normalized_phrase(message)) == ("claude-code",)
+    owners = named_executor_owners(normalized_phrase(message))
+    if len(owners) != 1 or owners[0] not in EXTERNAL_CLI_PROFILES:
+        return False
+    return not _has_any(message.lower(), _EXECUTOR_STATUS_QUERY_TERMS)
 
 
 def _intent_for(message: str, workflow: str, score: int) -> str:
@@ -1444,7 +1469,7 @@ def _intent_for(message: str, workflow: str, score: int) -> str:
     if _coding_status_request_applies(lowered, workflow):
         return "coding"
     if workflow in _CATALOG_INTENT_RETAINED_WORKFLOWS:
-        if _has_any(lowered, coding_terms_for_intent("coding")) or _names_claude_code_as_sole_executor(message):
+        if _has_any(lowered, coding_terms_for_intent("coding")) or _names_sole_external_executor(message):
             return "coding"
         return coding_intent_for_skill(workflow)
     for intent in CODING_INTENT_PRIORITY:
@@ -1469,15 +1494,23 @@ def _action_for(intent: str, score: int, workflow: str, *, named_coding_agent: b
     if intent == "unknown":
         return "fallback"
     if workflow in _RETAINED_HERMES_WORKFLOWS:
-        # A message that names the Claude Code executor still reaches a coding
-        # handoff even when the top catalog match is a retained Hermes workflow.
-        # This mirrors the unconditional delegate outcome `ask`'s retired bare
+        # A message that names a sole external CLI executor (Claude Code or
+        # Codex -- `EXTERNAL_CLI_PROFILES`) still reaches a coding handoff even
+        # when the top catalog match is a retained Hermes workflow. This
+        # mirrors the unconditional delegate outcome `ask`'s retired bare
         # `claude`/`gemini` triggers used to produce, and it applies regardless
         # of `prefer_direct_coding_handoff`: callers that evaluate the
         # retained-workflow contract directly (with that flag off) must observe
         # the same delegate outcome the direct-handoff redirect above gives
-        # callers that leave it on.
-        if named_coding_agent and intent == "coding" and score >= 4:
+        # callers that leave it on. The score threshold is intentionally not
+        # applied here: naming the sole external executor is independent of the
+        # generic catalog trigger score by design (see
+        # `_names_sole_external_executor`'s docstring), and some equally
+        # coding-shaped Codex phrasings score lower on this catalog than their
+        # Claude Code equivalents. `named_coding_agent` already screens out
+        # status/diagnostic questions about the executor, so no separate score
+        # floor is needed here.
+        if named_coding_agent and intent == "coding":
             return "delegate"
         return "clarify"
     if score < 4:

--- a/src/quality/grounded_score.py
+++ b/src/quality/grounded_score.py
@@ -444,8 +444,8 @@ GROUNDED_SCENARIOS: tuple[GroundedScenario, ...] = (
         "executor-runtime-readiness",
         "executor_runtime_readiness",
         "prepare_executor_runtime_readiness",
-        "clarify",
-        False,
+        "delegate",
+        True,
         expected_playbook="executor-runtime-readiness",
     ),
     GroundedScenario(

--- a/src/skills/catalog_definitions.py
+++ b/src/skills/catalog_definitions.py
@@ -5456,12 +5456,12 @@ _DEFINITIONS = [
             # Bare `claude`/`gemini` used to live here as ambiguous advisor-vs-executor
             # tokens. They were retired once `coding_delegation.build_coding_delegation_payload`
             # learned to detect a named coding executor directly through
-            # `routing/coding_route_actions.named_executor_owners` -- and only when Claude
-            # Code is the sole named owner (see `_names_claude_code_as_sole_executor` and its
-            # use in `_intent_for` and the retained-workflow-to-`plan` redirect), so
-            # "Claude Code로 바로 열어줘" and its siblings no longer need this trigger's score to
-            # reach action=delegate. The phrase triggers below still carry every real advisor
-            # intent without them.
+            # `routing/coding_route_actions.named_executor_owners` -- and only when a single
+            # external CLI executor (Claude Code or Codex -- see `_names_sole_external_executor`
+            # and its use in `_intent_for` and the retained-workflow-to-`plan` redirect) is the
+            # sole named owner, so "Claude Code로 바로 열어줘", "Codex로 바로 열어줘", and their
+            # siblings no longer need this trigger's score to reach action=delegate. The phrase
+            # triggers below still carry every real advisor intent without them.
             "ask claude",
             "ask gemini",
             "consult claude",

--- a/tests/test_coding_delegation.py
+++ b/tests/test_coding_delegation.py
@@ -60,7 +60,7 @@ class CodingStatusAgentTermTests(unittest.TestCase):
 
 
 class NamedCodingAgentDelegationTests(unittest.TestCase):
-    """The ask bare-token retirement's prerequisite fix.
+    """The ask bare-token retirement's prerequisite fix, now executor-neutral.
 
     `ask`'s bare `claude`/`gemini` catalog triggers used to be the only reason a
     request naming Claude Code outranked the retained `executor-runtime-readiness`
@@ -68,17 +68,58 @@ class NamedCodingAgentDelegationTests(unittest.TestCase):
     replacement would silently downgrade "Claude Code로 바로 열어줘" to
     action=clarify. The delegation path now detects the named executor directly
     through `routing.coding_route_actions.named_executor_owners` -- and only
-    when Claude Code is the sole named owner -- independent of any catalog
-    trigger score.
+    when a single `EXTERNAL_CLI_PROFILES` member (Claude Code or Codex) is the
+    sole named owner -- independent of any catalog trigger score. A user who
+    names one external CLI with an imperative has already made the explicit
+    owner choice, so Codex now reaches the same delegate outcome Claude Code
+    always has (#1163's Directive). Naming two owners, a runtime owner such as
+    Hermes coding or the omo-runtime family (pi/senpi/opencode), or asking a
+    status/diagnostic question about the named executor all keep the clarify
+    outcome.
     """
 
-    def test_naming_codex_still_clarifies(self) -> None:
-        payload = build_coding_delegation_payload("Codex\ub85c \ubc14\ub85c \uc5f4\uc5b4\uc918")
-        self.assertEqual(payload["delegation"]["action"], "clarify")
+    def test_naming_codex_now_delegates(self) -> None:
+        # Renamed from `test_naming_codex_still_clarifies`: naming Codex alone
+        # with an imperative now reaches the same delegate outcome naming
+        # Claude Code alone always has.
+        payload = build_coding_delegation_payload("Codex로 바로 열어줘")
+        delegation = payload["delegation"]
+        self.assertEqual(delegation["action"], "delegate")
+        self.assertEqual(delegation["intent"], "coding")
+
+    def test_naming_codex_with_a_coding_verb_now_delegates(self) -> None:
+        payload = build_coding_delegation_payload("codex로 구현해줘")
+        delegation = payload["delegation"]
+        self.assertEqual(delegation["action"], "delegate")
+        self.assertEqual(delegation["intent"], "coding")
 
     def test_naming_two_owners_still_clarifies(self) -> None:
-        payload = build_coding_delegation_payload("claude code\ub791 codex \uc911\uc5d0 \uace8\ub77c\uc11c \uc5f4\uc5b4\uc918")
+        payload = build_coding_delegation_payload("claude code랑 codex 중에 골라서 열어줘")
         self.assertEqual(payload["delegation"]["action"], "clarify")
+
+    def test_naming_runtime_owner_still_clarifies(self) -> None:
+        # Runtime owners (Hermes coding, the omo-runtime family) are not
+        # external CLIs -- `EXTERNAL_CLI_PROFILES` is only `("claude-code",
+        # "codex")` -- so naming one alone keeps the retained-workflow clarify
+        # outcome even with an identical imperative shape to the Codex/Claude
+        # Code cases above.
+        hermes_payload = build_coding_delegation_payload("Hermes coding으로 구현해줘")
+        self.assertEqual(hermes_payload["delegation"]["action"], "clarify")
+        omo_runtime_payload = build_coding_delegation_payload("omo runtime으로 구현해줘")
+        self.assertEqual(omo_runtime_payload["delegation"]["action"], "clarify")
+
+    def test_status_question_about_named_codex_still_clarifies(self) -> None:
+        # A status/diagnostic question about the named executor is not an
+        # imperative delivery request, so it must not gain the delegate
+        # outcome the imperative cases above now get.
+        for message in (
+            "is codex broken",
+            "codex 상태 어때",
+            "코덱스가 지금 어디까지 했는지 알려줘",
+        ):
+            with self.subTest(message=message):
+                payload = build_coding_delegation_payload(message)
+                self.assertEqual(payload["delegation"]["action"], "clarify")
 
     def test_naming_claude_code_without_a_code_reference_still_delegates(self) -> None:
         payload = build_coding_delegation_payload("Claude Code로 바로 열어줘")


### PR DESCRIPTION
## Capability

Naming exactly one external coding CLI with an imperative now yields the delegate outcome for **both** external CLIs, not just Claude Code: "Codex로 바로 열어줘" / "codex로 구현해줘" / "codex 세션 켜서 작업 시작하게 해줘" delegate (were clarify). `_names_claude_code_as_sole_executor`'s hardcoded `== ("claude-code",)` becomes `_names_sole_external_executor` over `EXTERNAL_CLI_PROFILES` — executing the Directive recorded on #1163's commit.

Two defects surfaced and fixed during verification: (1) naive generalization made Codex status/diagnostic questions start delegating — a new executor-status-query guard keeps "is codex broken" / "코덱스가 지금 뭐하고 있는지" on clarify (three grounded-score pins preserved byte-identical); (2) "Codex로 바로 열어줘" scored below the retained-workflow `score>=4` gate that the Claude Code phrasing happened to clear — the floor is dropped once the sole-external-executor check (independent of catalog score by design) has passed, so the two CLIs get identical treatment.

## Motivation

Owner delegated the usability judgment; ruling: a user who names a CLI with an imperative has already made the explicit owner choice — asking "which executor?" back is zero-information friction, and CONTEXT.md's doctrine says naming a CLI is an owner-choice signal. The single-vendor carve-out also brushed AGENTS.md executor neutrality.

## Boundaries preserved (all probed before/after)

Two-owner and comparison shapes clarify; runtime owners (hermes coding, omo family) stay on retained-workflow clarify — they are runtime handoffs, not external CLIs (pinned by a new test); advisor intents unchanged; #1165 boundary hygiene (claudecode-notes/codex-ish filenames) unchanged; bare one-word names unchanged. One `GROUNDED_SCENARIOS` entry flips consciously (the codex session-open imperative — the change's very target); scenario count stays 50.

## Verification (observed)

Full suite green outside the documented worktree-path artifact (identical set reproduced via stash on the unmodified tip). Targeted: coding-delegation (22), route-actions, routing precision, router content, ux/release smoke, named-executor precedence, orchestration vocabulary, owner invariant, ulw equivalence/retirement — all green. No corpus count changes. Five docs byte gates ok; ruff/compileall/`git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)