### PR TITLE
feat(tui): Claude Code-style aligned token columns on subagent HUD rows

### DIFF
--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -67,6 +67,7 @@ export default function register(sdk) {
       .concat(Array.isArray(payload.maestro?.rows) ? payload.maestro.rows : [])
       .concat(Array.isArray(payload.subagents?.rows) ? payload.subagents.rows : [])
     const cost = rows.reduce((sum, row) => sum + (Number.isFinite(row.cost_usd) ? row.cost_usd : 0), 0)
+    const tokens = rows.reduce((sum, row) => sum + (Number.isFinite(row.tokens) ? row.tokens : 0), 0)
     const approximate = rows.some(row => row.cost_approximate)
     const main = Array.isArray(payload.maestro?.rows) ? payload.maestro.rows[0] : null
     const ctx = main && Number.isFinite(main.context_percentage)
@@ -77,6 +78,14 @@ export default function register(sdk) {
       // token-derived approximation carries a `~`, and a true zero with no
       // approximation renders nothing (a constant $0.000 read as broken).
       cost: cost > 0 ? `${approximate ? '~' : ''}$${cost.toFixed(3)}` : '',
+      // Summed observed subagent tokens in the host gauge's own idiom
+      // (184.8k tokens). Zero renders nothing, same as cost: this is agent
+      // consumption, not the session gauge the host statusline already owns.
+      // Like cost, the sum covers the rows the reader projects (live and
+      // lingering bindings), so it is a live figure that can shrink as rows
+      // age out or fall past the reader's cap — never a monotonic session
+      // total, which the metadata-only projection has no state to carry.
+      tokens: tokens > 0 ? `${tokenCountText(tokens)} tokens` : '',
       ctx: Number.isFinite(ctx) ? `ctx ${ctx}%` : 'ctx --',
     }
   }
@@ -148,6 +157,21 @@ export default function register(sdk) {
   }
   const truncateCells = (value, limit) => truncateTextCells(safeText(value), limit)
 
+  // The host's own gauge idiom (36.4k/272k) and Claude Code's token counter
+  // (184.8k, 2.1m): one decimal, trailing .0 trimmed, bare integers under a
+  // thousand. Subagent tokens are observed usage sums (input+output), so the
+  // count stays exact even on subscription-billed hosts where only the COST
+  // is a token-derived approximation — the owner asked for tokens '근사값으로
+  // 라도' there, and the honest answer is better: the real count.
+  const tokenCountText = value => {
+    if (!Number.isFinite(value) || value < 1) return ''
+    if (value < 1000) return `${Math.floor(value)}`
+    // Unit break sits where one-decimal rounding lands, so 999,950 reads
+    // 1m, never 1000k.
+    const [amount, unit] = value < 999_950 ? [value / 1000, 'k'] : [value / 1_000_000, 'm']
+    return `${amount.toFixed(1).replace(/\.0$/, '')}${unit}`
+  }
+
   const elapsedText = value => {
     if (!Number.isFinite(value)) return ''
     const seconds = Math.max(0, Math.floor(value))
@@ -165,7 +189,7 @@ export default function register(sdk) {
   const observedPercent = (label, value) =>
     Number.isFinite(value) ? `${label} ${value}%` : ''
 
-  const activityLayout = (row, columns, main, extraSeconds) => {
+  const activityLayout = (row, columns, main, extraSeconds, tokensColumn) => {
     const state = safeText(row.state) || 'running'
     const stateText = columns < 100 ? ({ running: 'run', blocked: 'block', failed: 'fail' })[state] || state : state
     const taskId = truncateCells(safeText(row.task_id) || safeText(row.role) || 'agent', 8).padEnd(8)
@@ -203,9 +227,12 @@ export default function register(sdk) {
     const turn = Number.isFinite(row.turn_count) ? `turn ${row.turn_count}` : ''
     const tools = Number.isFinite(row.tool_count) ? `${row.tool_count} tools` : ''
     const turnTools = turn && tools ? `${turn} (${tools})` : turn || tools
+    const tokenText = tokenCountText(row.tokens)
     const optional = [
       dispatchLane ? metricSegment('maestro', dispatchIdentity) : metricSegment(routeKind, route),
       metricSegment('fallback', Number.isFinite(row.fallback_count) && row.fallback_count > 0 ? `fallback:${row.fallback_count}` : ''),
+      metricSegment('cache', observedPercent('cache', row.cache_hit_percentage)),
+      metricSegment('context', observedPercent('ctx', row.context_percentage)),
       metricSegment('turn', turnTools),
       // A subscription-billed host records no per-call cost, so the reader
       // supplies a token-derived approximation flagged cost_approximate —
@@ -219,46 +246,61 @@ export default function register(sdk) {
           : '',
       ),
       metricSegment('rate', Number.isFinite(row.tokens_per_second) ? `${Math.round(row.tokens_per_second)} tok/s` : ''),
-      metricSegment('cache', observedPercent('cache', row.cache_hit_percentage)),
-      metricSegment('context', observedPercent('ctx', row.context_percentage)),
     ].filter(segment => segment.text)
     const running = !row.state || row.state === 'running'
     // A running row's elapsed ticks in real time: the snapshot's value plus
     // the seconds since it arrived, re-rendered by the animation clock.
     // Finished rows keep the frozen precise value.
     const elapsed = running ? (row.elapsed_seconds || 0) + extraSeconds : row.elapsed_seconds
-    const required = [
-      metricSegment('cache', observedPercent('cache', row.cache_hit_percentage)),
-      metricSegment('context', observedPercent('ctx', row.context_percentage)),
-      metricSegment('state', stateText),
-      metricSegment('elapsed', elapsedText(elapsed)),
-    ].filter(segment => segment.text)
-    optional.splice(-2)
+    // Claude Code's task list is the reference the owner pointed at
+    // ('절대위치로 … 클로드코드처럼 정렬', '이런느낌으로'): a grid, not a
+    // sentence. The title is a FIXED column (padded, ~40% of the terminal,
+    // 48 cells at most — '서브에이전트 세션 제목을 좀 축약'), variable
+    // metadata fills the middle, and a fixed-width tail sits flush against
+    // the right edge on every row: `state · elapsed · N tokens`, each piece
+    // padded to a constant cell width so the dots and the tokens column line
+    // up vertically across rows. Tokens anchor the right edge ('tokens로
+    // 해주고 맨 오른쪽에') and are never shed — the middle metadata drops
+    // rate, then cost, then turn before the tail loses anything ('달러
+    // 이런거 나와있긴 한데 … 소모한 토큰도 나왔으면'). A row with no
+    // observed tokens keeps the column as blank cells (only while some row
+    // has tokens to align with), never a fabricated zero.
+    const padCells = (text, width) => `${text}${' '.repeat(Math.max(0, width - cellWidth(text)))}`
+    const stateWidth = columns < 100 ? 5 : 7
+    const tokensWidth = tokensColumn ? 16 : 0
+    const tailWidth = stateWidth + 3 + 7 + tokensWidth
+    const tokensPiece = tokenText
+      ? ` · ${tokenText.padStart(6)} tokens`
+      : ' '.repeat(tokensWidth)
+    const tailState = padCells(stateText, stateWidth)
+    const tailRest = ` · ${padCells(elapsedText(elapsed) || '0s', 7)}${tokensColumn ? tokensPiece : ''}`
     const prefix = `${taskId} `
     const separator = '  ·  '
     const budget = Math.max(24, columns - 4)
-    const minimumAction = columns >= 120 ? 26 : columns >= 90 ? 18 : 10
-    const segments = [...optional, ...required]
-    while (segments.length > required.length) {
+    const actionCap = Math.max(10, Math.min(48, Math.floor(columns * 0.4)))
+    const actionWidth = Math.max(8, Math.min(actionCap, budget - cellWidth(prefix) - tailWidth - 2))
+    const fixedWidth = cellWidth(prefix) + actionWidth + tailWidth
+    const segments = [...optional]
+    while (segments.length) {
       const metadata = segments.map(item => item.text).join(separator)
-      if (cellWidth(prefix) + minimumAction + cellWidth(separator) + cellWidth(metadata) <= budget) break
-      segments.splice(segments.length - required.length - 1, 1)
+      if (fixedWidth + cellWidth(separator) + cellWidth(metadata) + 2 <= budget) break
+      segments.pop()
     }
     const metadata = segments.map(segment => segment.text).join(separator)
-    const actionBudget = Math.max(
-      8,
-      budget - cellWidth(prefix) - cellWidth(metadata) - (metadata ? cellWidth(separator) : 0),
-    )
+    const used = fixedWidth + (metadata ? cellWidth(separator) + cellWidth(metadata) : 0)
     return {
-      action: truncateCells(row.action, actionBudget),
+      action: padCells(truncateCells(row.action, actionWidth), actionWidth),
       metadata,
+      pad: ' '.repeat(Math.max(0, budget - used)),
       segments,
+      tailRest,
+      tailState,
       taskId: main ? 'MAIN'.padEnd(8) : taskId,
     }
   }
 
-  function ActivityRow({ columns, extraSeconds, frame, main, row, t }) {
-    const layout = activityLayout(row, columns, main, extraSeconds)
+  function ActivityRow({ columns, extraSeconds, frame, main, row, t, tokensColumn }) {
+    const layout = activityLayout(row, columns, main, extraSeconds, tokensColumn)
     const blocked = row.state === 'blocked' || row.state === 'failed'
     const done = row.state === 'done'
     const marker = blocked ? '▲' : done ? '✓' : SPINNER_FRAMES[frame % SPINNER_FRAMES.length]
@@ -269,34 +311,42 @@ export default function register(sdk) {
       h(Text, { color: blocked ? t.color.error : done ? t.color.ok : t.color.warn }, `${marker} `),
       h(Text, { color: t.color.muted }, `${layout.taskId} `),
       h(Text, { color: t.color.text }, layout.action),
-      layout.metadata ? h(Text, { color: t.color.muted }, '  ·  ') : null,
       ...layout.segments.map((segment, index) =>
         h(
           Text,
           {
-            color: segment.kind === 'state'
-              ? statusColor
-              : segment.kind === 'route'
-                ? t.color.label
-                // A fallback or exhausted route is a warning-grade fact: the
-                // lane is NOT running the chain head the category names.
-                : segment.kind === 'route-fallback'
-                  // A dispatched-executor identity is warn-colored for the
-                  // same reason as a fallback route: it marks the row as
-                  // something other than the plain Hermes-native default,
-                  // here the Maestro lane's own spawned CLI.
-                  || segment.kind === 'maestro'
-                  ? t.color.warn
-                  : t.color.muted,
+            color: segment.kind === 'route'
+              ? t.color.label
+              // A fallback or exhausted route is a warning-grade fact: the
+              // lane is NOT running the chain head the category names.
+              : segment.kind === 'route-fallback'
+                // A dispatched-executor identity is warn-colored for the
+                // same reason as a fallback route: it marks the row as
+                // something other than the plain Hermes-native default,
+                // here the Maestro lane's own spawned CLI.
+                || segment.kind === 'maestro'
+                ? t.color.warn
+                : t.color.muted,
             key: `${segment.kind}-${index}`,
           },
-          `${index ? '  ·  ' : ''}${segment.text}`,
+          `  ·  ${segment.text}`,
         )
       ),
+      // The fixed tail: state keeps its status color, the elapsed and
+      // tokens columns rest muted, and the pad in front right-anchors the
+      // whole block so every row's columns line up.
+      h(Text, {}, layout.pad),
+      h(Text, { color: statusColor }, layout.tailState),
+      h(Text, { color: t.color.muted }, layout.tailRest),
     )
   }
 
   function ActivityRows({ columns, extraSeconds, frame, mainRows, rows, t }) {
+    // The tokens column exists for the LIST, not per row: one row with an
+    // observed count gives every row the column (blank where unobserved) so
+    // the grid holds; a wave with no counts at all drops the column instead
+    // of wasting sixteen blank cells on every row.
+    const tokensColumn = [...mainRows, ...rows].some(row => tokenCountText(row.tokens))
     return h(
       Box,
       { flexDirection: 'column', width: '100%' },
@@ -309,6 +359,7 @@ export default function register(sdk) {
           main: true,
           row,
           t,
+          tokensColumn,
         })
       ),
       ...rows.map((row, index) =>
@@ -319,6 +370,7 @@ export default function register(sdk) {
           key: `${safeText(row.task_id)}-${index}`,
           row,
           t,
+          tokensColumn,
         })
       ),
     )
@@ -444,8 +496,9 @@ export default function register(sdk) {
         Text,
         { wrap: 'truncate-end' },
         // Always visible: the owner kept the branded status row and asked for
-        // live session metrics on it. Cost and ctx come from sessionMetrics
-        // above -- observed values or "--", never fabricated totals.
+        // live session metrics on it. Tokens, cost and ctx come from
+        // sessionMetrics above -- observed values or "--", never fabricated
+        // totals.
         h(Text, { bold: true, color: t.color.primary }, '⚚ [OMH]'),
         version ? h(Text, { color: t.color.muted }, ` v${version}`) : null,
         h(Text, { color: t.color.border }, SEPARATOR),
@@ -494,6 +547,13 @@ export default function register(sdk) {
                 payload.yolo.enabled ? 'on' : 'off',
               ),
             )
+          : null,
+        // The summed token count anchors the header's right edge, matching
+        // the rows' rightmost tokens column ('맨 오른쪽에 두는게'). The line
+        // has no drop loop, only truncate-end, so below 100 columns it hides
+        // rather than being the segment that pushes everything else off.
+        columns >= 100 && metrics.tokens
+          ? h(Text, { color: t.color.muted }, ` • ${metrics.tokens}`)
           : null,
       ),
       graphActive

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -511,6 +511,49 @@ class TuiWidgetPackTests(unittest.TestCase):
         # per-call cost) render with a `~`; true zeros render nothing.
         self.assertIn("row.cost_approximate ? '~' : ''", widget)
         self.assertIn("cost > 0 ? `${approximate ? '~' : ''}$${cost.toFixed(3)}` : ''", widget)
+        # Claude Code's token-counter idiom (184.8k, 2.1m): observed subagent
+        # token counts render per row and summed on the header, one decimal
+        # with trailing .0 trimmed. The row segment sits BEFORE cost so the
+        # narrow-terminal drop order sheds the dollar figure first and keeps
+        # the token count; a zero renders nothing, exactly like cost.
+        self.assertIn("const tokenCountText", widget)
+        self.assertIn(".toFixed(1).replace(/\\.0$/, '')", widget)
+        # The unit break sits where one-decimal rounding lands (999,950 reads
+        # 1m, never 1000k), sub-thousand counts render bare, and a fractional
+        # or zero value renders nothing rather than a broken-looking "0 tok".
+        self.assertIn("value < 999_950 ?", widget)
+        self.assertIn("if (value < 1000) return", widget)
+        self.assertIn("|| value < 1) return ''", widget)
+        # Claude Code-style grid ('절대위치로 … 클로드코드처럼 정렬'): a
+        # fixed right-anchored tail `state · elapsed · N tokens`, each piece
+        # padded to constant cell widths so the columns line up vertically
+        # across rows; the token count anchors the right edge ('tokens로
+        # 해주고 맨 오른쪽에') and the metadata drop loop sheds rate, cost,
+        # and turn without ever touching the tail.
+        self.assertIn("` · ${tokenText.padStart(6)} tokens`", widget)
+        self.assertIn("h(Text, { color: statusColor }, layout.tailState)", widget)
+        self.assertIn("h(Text, { color: t.color.muted }, layout.tailRest)", widget)
+        # The tokens column exists per LIST: a row with no observed count
+        # holds the grid with blank cells, and a wave with no counts at all
+        # drops the column instead of wasting the width.
+        self.assertIn("' '.repeat(tokensWidth)", widget)
+        self.assertIn(
+            "const tokensColumn = [...mainRows, ...rows].some(row => tokenCountText(row.tokens))",
+            widget,
+        )
+        self.assertIn("tokens: tokens > 0 ? `${tokenCountText(tokens)} tokens` : ''", widget)
+        # The summed count anchors the header's right edge too, and the
+        # header has no drop loop, so the segment hides below 100 columns
+        # instead of pushing ctx and the yolo readout past truncate-end.
+        self.assertIn("columns >= 100 && metrics.tokens", widget)
+        self.assertIn("` • ${metrics.tokens}`", widget)
+        self.assertLess(widget.index("' • yolo mode: '"), widget.index("` • ${metrics.tokens}`"))
+        # Delegate goals (row titles) are a FIXED padded column capped at
+        # ~40% of the terminal, 48 cells at most, and always shrink before
+        # the tail: the metadata column starts aligned and the tail block
+        # keeps its right anchor even on narrow terminals.
+        self.assertIn("Math.min(48, Math.floor(columns * 0.4))", widget)
+        self.assertIn("Math.min(actionCap, budget - cellWidth(prefix) - tailWidth - 2)", widget)
         # The plan panel's liveness cues are the ONE sanctioned animation:
         # a colour wave through the active item's characters plus a walking
         # ellipsis on the [Plan] header, both mounted only while an active


### PR DESCRIPTION
## Feature Report

### What Changed

- The Modern-TUI bottom-dock HUD (`omh-status.mjs`) now renders each subagent delegation row as a grid modeled on Claude Code's task list: a fixed-width title column, variable metadata in the middle, and a right-anchored fixed-width tail — `state · elapsed · N tokens` — with the token count in Claude Code's counter idiom (`184.8k`, `2.1m`) and every column aligned vertically across rows.
- The status header carries the summed token figure at its right end.

### Why This Exists

- The HUD showed each delegation's dollar cost but never its token count — and on subscription-billed hosts the dollar figure is itself only a token-derived approximation (`~$…`), while exact token counts sit unrendered in the payload. The owner asked for token display in Claude Code's `184.8k` / `2.1m` style; since `row.tokens` is observed input+output usage, the count stays exact regardless of billing.
- Rows read as sentences, not a scannable list: sentence-length delegate goals swallowed every spare cell, nothing lined up vertically, and the owner pointed at Claude Code's aligned task list ("절대위치로 … 클로드코드처럼 정렬") as the reference.

### User / Operator Impact

- During a delegation wave the dock reads like Claude Code's task list: titles in one column, and a vertically aligned `elapsed · N tokens` grid flush against the right edge answering "how many tokens has each subagent consumed" at a glance. The header answers it for the wave.
- Long goals no longer bury the metrics: the title is a fixed capped column, and the middle metadata sheds `tok/s`, then `$cost`, then `turn` under width pressure while the right-anchored tail never moves.

### How It Works

- A `tokenCountText` helper formats counts: bare integers under 1k, one decimal with trailing `.0` trimmed above (`36.4k`, `184.8k`, `2.1m`), the k→m unit break placed where one-decimal rounding lands so 999,950 reads `1m`, never `1000k`. Fractional/zero/non-finite values render nothing.
- `activityLayout` builds the grid: title padded to a fixed column (~40% of terminal, 48 cells max, cell-width-aware for CJK), metadata segments dropped from the tail of the optional list when the row is too wide, and a fixed tail (`state` padded to 7 cells, `elapsed` to 7, `count.padStart(6) + " tokens"`) pushed flush right by computed padding — constant widths are what make the columns align.
- The tokens column exists per list, not per row: one observed count gives every row the column (blank cells where unobserved, never a fabricated zero), and a wave with no counts drops the column instead of wasting 16 blank cells per row.
- The header sum covers the rows the reader projects (live and lingering bindings) — a live figure, not a monotonic session total, documented in-code. It renders at the header's right end and hides below 100 columns, since that line has only `truncate-end` and no drop loop.
- No reader or plugin change: `row.tokens` (observed input+output usage from `hermes_delegation.py` / `runtime_reader.py`) was already in the HUD payload and already in the widget's `VOLATILE_KEYS` repaint throttle, so drag-copyable-dock quiescence is untouched.

### Files And Contracts Touched

- `src/omh/tui_widgets/omh-status.mjs` — widget render only (formatter, grid layout, tail rendering, header segment).
- `tests/test_tui_widget_pack.py` — new source-contract assertions: formatter shape and unit break, sub-1 guard, fixed tail pieces and their colors, per-list tokens column, title-column cap, header 100-column gate.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: stub-SDK render harness at 180/120/90/70 columns
- [x] Manual Hermes/TUI check, or explicit reason it was not run: observed — real `hermes` Modern-TUI session in tmux against a throwaway HERMES_HOME carrying this widget and a stubbed HUD reader; grid alignment verified at 150 and 100 columns (owner-shared captures)

### Observed Evidence

- Full suite: `Ran 7824 tests … OK` from a neutral-path detached worktree (validated on the pre-rework tree; the rework re-verified with the targeted suites below — the session worktree's 36 failures are path-environmental: the adapter-sandbox family fail-closes on a `.claude` path segment, and the plan-context-pack family flags the word `token` inside the embedded worktree path as sensitive-looking text; both modules pass from the clean `main` checkout on the same machine and neither reads the files this PR touches).
- Targeted: `tests/test_tui_widget_pack.py` + `tests/test_hermes_tui_preflight.py` + `tests/test_plugin_distribution.py` → 85 tests OK; `node --check` on the widget.
- Live Modern-TUI render (real `hermes` binary, tmux, temp HERMES_HOME, stub payload), 150 columns:
  `⚚ [OMH] v5.4.0 │ 3 agents · 2 running · 1 done • ~$1.288 • ctx 42% • 3 tools · 14s • yolo mode: off • 2.3m tokens`
  `⠸ MAIN     coordinate the delegation wave                    ·  hermes-4.3-large  ·  ctx 42%                       running · 5m 31s  ·   2.1m tokens`
  `⠸ a1b2c3d4 Investigate the runtime reader token projection…  ·  category:explore(kimi-k2:high)  ·  cache 88.1%     running · 1m 44s  · 184.8k tokens`
  `✓ e5f6a7b8 byte-gate sweep                                   ·  glm-5                                              done    · 31s     ·    842 tokens`
  At 100 columns the metadata sheds but the right-anchored tail keeps every column aligned.
- Formatter executed directly: `842→842`, `36400→36.4k`, `184800→184.8k`, `272000→272k`, `999949→999.9k`, `999950→1m`, `2100000→2.1m`.
- Reviewer pass (severity-rated) applied on the first revision: formatter guard, sum-semantics comment, header width gate, test pins for the unit break; the grid rework then re-pinned the layout contracts.

### Not Tested / Not Applicable

- `harness validate`, `release checklist`, `release hermes-smoke`, `omh --help`, install smoke: no CLI, packaging, catalog, or release surface changes — the diff is one widget file plus its source-contract test.
- Live render on the owner's real install: reaches it via `omh update` + TUI restart after merge; the observed TUI evidence above is from an isolated temp home with a stubbed payload, not live delegation state.

## Risk

- Render-only change in one widget file; the HUD payload, reader, and repaint-throttle contracts are untouched. Worst plausible failure is cosmetic (mis-padded column on an unusual width), bounded by `truncate-end`.
- The header sum can shrink as rows age out or fall past the reader's cap — deliberate and documented in-code; a live figure like the cost sum beside it, never a session total.

## Compatibility / Rollout

- Reaches installed machines through `omh update` (widget file refresh) plus a Modern-TUI restart; no config, schema, or plugin-bundle changes, no migration.
- Hosts whose rows carry no `tokens` value render exactly as before — the tokens column only exists when at least one row has an observed count.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- If the reader's row cap ever lifts substantially, consider a `b` tier above `m` in `tokenCountText` (a >1e9 sum currently renders as e.g. `1234.6m`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9F2nbnc7hajqzznXcgLZn
