### PR TITLE
feat(benchmark): live cross-harness lane that executes what it submits

### DIFF
--- a/benchmarks/cross-harness/live/README.md
+++ b/benchmarks/cross-harness/live/README.md
@@ -1,0 +1,122 @@
+# Cross-harness live lane
+
+AUDIENCE: agent/maintainer. This is not the normal human OMH workflow.
+
+The live lane is a controller that **executes** `cross_harness_benchmark/v1` work
+and then submits only what it observed. It emits two artifacts:
+
+1. an ordinary `cross_harness_benchmark_cli_input/v1` envelope, scored by the
+   same production parser, evaluator, and scorer as any mailed-in file; and
+2. a `cross_harness_live_receipt/v1` receipt binding that envelope's digest to
+   the observations behind it, an authenticity tier, and the run's efficiency
+   facts.
+
+`cross_harness_benchmark/v1` is untouched. The corpus, the submission schema,
+the scoring semantics, and both production trust anchors are unchanged; this
+directory adds a producer, not a contract. The v1 scorer still returns
+`evidence_authenticity: "unverified_submission"` and `execution_verified: false`
+for every envelope the controller emits, because those fields describe what the
+offline evaluator can prove. Controller provenance lives only in the receipt.
+
+## Modes
+
+| Mode | Executes | Requires | Tier it can reach |
+| --- | --- | --- | --- |
+| `fake` (default) | nothing | — | `fake_adapter` |
+| `probe` | the corpus command binding (`python3 -m omh.cli harness validate`), locally and free | — | `controller_observed` |
+| `dispatch` | the command binding plus one isolated Hermes child | `--allow-paid-live` **and** `--max-paid-calls N` | `controller_observed` |
+
+`fake` mode starts no process. Its fixture results are simulated, and they are
+submitted with `evidence_class: "prepared"`, which is below every fixture's
+required class. A fake run therefore cannot produce a passing fixture, a level
+above 1, or a certification — that property is a test, not a promise.
+
+`dispatch` mode runs exactly one child through the approved explicit boundary,
+`omh coding hermes-child dispatch --confirm-dispatch`, with the prompt on stdin
+only. It refuses before any subprocess when the paid flags are absent, when the
+budget is below the scheduled call count, or when model/provider metadata is
+missing. Passing `--allow-paid-live` outside `dispatch` mode is also refused, so
+the flag can never be left set by habit.
+
+## Observable fixtures
+
+The controller submits a fixture result only when it observed that fixture's
+predicate value itself. Four of the fifteen v1 fixtures are observable:
+
+| Fixture | Predicate | Observed from |
+| --- | --- | --- |
+| `evidence-command-binding` | `actual_machine.semantic_result` | the executed command binding's exit and machine result |
+| `ultrawork-child-propagation` | `actual_machine.parent_exit` | the dispatch process exit |
+| `ultrawork-observed-runtime` | `facts.dispatch_state` | the `routing_observation/v1` status |
+| `evidence-runtime-observation` | `facts.observation_state` | whether a valid routing observation was produced |
+
+The other eleven are offline metadata facts this controller does not execute.
+They are simply absent from the submission, so the v1 evaluator reports them
+`unsupported` — a visible coverage gap, never a pass. `--base ENVELOPE` fills
+them from an existing submission; the receipt then records each carried fixture
+as `carried_from_base` with no observation ids and downgrades the tier to
+`mixed_controller_and_submitted`.
+
+## Authenticity tiers
+
+Ordered weakest to strongest:
+
+`fake_adapter` → `unverified_submission` → `mixed_controller_and_submitted` → `controller_observed`
+
+`unverified_submission` is exactly the claim v1 always makes. The controller may
+report a stronger tier only for results it executed, and the receipt validator
+rejects a tier that outruns its own coverage lists.
+
+## Efficiency is not quality
+
+The receipt's `efficiency` block reports `duration_ms`, `tokens`, and `cost_usd`
+for the run. It never earns points, never changes a level, and never turns a
+`partial` into a `pass`; it is not part of the envelope at all. Telemetry the
+child did not report stays `null` and is never estimated, and
+`observations_reporting_tokens` / `observations_reporting_cost_usd` say how many
+observations actually supplied each figure.
+
+## Commands
+
+Run from the repository root.
+
+```sh
+PYTHONPATH=. python3 benchmarks/cross-harness/live/bench.py doctor
+
+PYTHONPATH=. python3 benchmarks/cross-harness/live/bench.py run --mode fake
+
+PYTHONPATH=. python3 benchmarks/cross-harness/live/bench.py run \
+  --mode probe \
+  --envelope-output artifacts/live-envelope.json \
+  --receipt-output artifacts/live-receipt.json
+
+python3 -m omh.cli benchmark report --input artifacts/live-envelope.json
+```
+
+Live dispatch, explicit on every axis:
+
+```sh
+PYTHONPATH=. python3 benchmarks/cross-harness/live/bench.py run \
+  --mode dispatch --allow-paid-live --max-paid-calls 1 \
+  --model <model-alias> --provider <provider-alias>
+```
+
+Exit status: `0` when every observation completed, `1` when an observation
+failed, `2` for a refusal or contract error (the payload carries the reason
+code). Scoring exit status comes from `omh.cli benchmark score/report` as usual.
+
+## Privacy
+
+Artifacts are metadata-only: stable ids, digests, reason codes, and bounded
+machine facts. The dispatch task text is passed on stdin and never persisted;
+command stdout is read for the machine result and then discarded; workspace and
+home paths never enter an artifact. Runtime homes are redirected into a
+temporary root for the duration of the run.
+
+## Claim boundary
+
+Controller observation covers only the fixtures listed in
+`controller_observed_fixture_ids`. It is not general live executor quality proof,
+and a `mixed_controller_and_submitted` receipt does not make its carried results
+observed. Report the level and coverage with the receipt's tier beside the
+score's `evidence_authenticity` and `execution_verified`; never merge them.

--- a/benchmarks/cross-harness/live/bench.py
+++ b/benchmarks/cross-harness/live/bench.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Live cross-harness benchmark controller entry point.
+
+AUDIENCE: agent/maintainer. Offline `fake` mode is the default and starts no
+process. `probe` executes only the free local `cross_harness_benchmark/v1`
+command binding. `dispatch` additionally starts one isolated Hermes child and
+therefore requires both `--allow-paid-live` and `--max-paid-calls`.
+
+Run from the repository root:
+
+    PYTHONPATH=. python3 benchmarks/cross-harness/live/bench.py run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+BASE = Path(__file__).resolve().parent
+REPOSITORY_ROOT = BASE.parents[2]
+sys.path.insert(0, str(BASE / "lib"))
+
+from controller import ControllerError, doctor, run  # noqa: E402
+from receipt import RECEIPT_SCHEMA  # noqa: E402
+
+DEFAULT_CORPUS = REPOSITORY_ROOT / "benchmarks" / "cross-harness" / "v1" / "manifest.json"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="cross-harness-live",
+        description=(
+            "Execute cross_harness_benchmark/v1 work through the approved explicit "
+            "dispatch boundary and emit a v1 envelope plus a controller receipt. "
+            "The v1 corpus, schemas, and trust anchors are never modified."
+        ),
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+    doctor_parser = sub.add_parser("doctor", help="Describe the lane; executes nothing.")
+    doctor_parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS)
+    run_parser = sub.add_parser("run", help="Run the selected mode and emit envelope plus receipt.")
+    run_parser.add_argument("--mode", choices=("fake", "probe", "dispatch"), default="fake")
+    run_parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS)
+    run_parser.add_argument("--repository-root", type=Path, default=REPOSITORY_ROOT)
+    run_parser.add_argument(
+        "--base",
+        type=Path,
+        help="Existing cross_harness_benchmark_cli_input/v1 envelope supplying unobserved fixture results.",
+    )
+    run_parser.add_argument("--envelope-output", type=Path)
+    run_parser.add_argument("--receipt-output", type=Path)
+    run_parser.add_argument("--omh-executable", default="omh")
+    run_parser.add_argument("--hermes-executable", default="hermes")
+    run_parser.add_argument("--model", help="Hermes model alias metadata; required for --mode dispatch.")
+    run_parser.add_argument("--provider", help="Provider alias metadata; required for --mode dispatch.")
+    run_parser.add_argument("--reasoning", default="medium")
+    run_parser.add_argument("--timeout", type=int, default=300)
+    run_parser.add_argument("--allow-paid-live", action="store_true")
+    run_parser.add_argument("--max-paid-calls", type=int, default=0)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "doctor":
+            result = doctor(args.corpus)
+        else:
+            result = run(
+                corpus_path=args.corpus,
+                mode=args.mode,
+                repository_root=args.repository_root,
+                base_path=args.base,
+                omh_executable=args.omh_executable,
+                hermes_executable=args.hermes_executable,
+                model=args.model,
+                provider=args.provider,
+                reasoning=args.reasoning,
+                timeout=args.timeout,
+                allow_paid_live=args.allow_paid_live,
+                max_paid_calls=args.max_paid_calls,
+            )
+            _write(args.envelope_output, result["envelope"])
+            _write(args.receipt_output, result["receipt"])
+    except ControllerError as error:
+        _emit({"schema_version": "cross_harness_live_error/v1", "ok": False, "reason_code": str(error)})
+        return 2
+    _emit(result)
+    return 0 if result.get("ok", True) else 1
+
+
+def _write(path: Path | None, value: object) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+
+def _emit(value: object) -> None:
+    print(json.dumps(value, sort_keys=True, indent=2))
+
+
+__all__ = ["RECEIPT_SCHEMA", "build_parser", "main"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/cross-harness/live/lib/controller.py
+++ b/benchmarks/cross-harness/live/lib/controller.py
@@ -1,0 +1,675 @@
+"""Live cross-harness benchmark controller: execute, then submit only what it saw.
+
+The controller executes the `cross_harness_benchmark/v1` command binding and, in
+`dispatch` mode, one isolated Hermes child through the approved
+`omh coding hermes-child dispatch --confirm-dispatch` boundary. It then emits a
+`cross_harness_benchmark_cli_input/v1` envelope whose fixture results carry only
+observed values, plus a `cross_harness_live_receipt/v1` receipt binding that
+envelope to the observations and their efficiency facts.
+
+The v1 corpus, schemas, evaluator, and trust anchors are immutable and untouched.
+The controller is a producer of ordinary v1 submissions: every envelope it emits
+is scored by the same parser, evaluator, and scorer as a mailed-in file, and the
+scorer still returns `evidence_authenticity: "unverified_submission"`. Provenance
+lives only in the separate receipt.
+
+Fixtures the controller cannot observe are simply absent from the submission, so
+the v1 evaluator reports them `unsupported` (a coverage gap, never a pass). A
+`--base` envelope may supply those results; the receipt then records them as
+`carried_from_base` and downgrades the authenticity tier accordingly.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import subprocess
+from tempfile import TemporaryDirectory
+import time
+from typing import Any, Final
+import uuid
+
+from omh.coding.routing_observation import validate_routing_observation
+from omh.quality.cross_harness_benchmark import (
+    CommandBinding,
+    Corpus,
+    Fixture,
+    evaluate_submission,
+    parse_corpus,
+)
+from omh.quality.cross_harness_benchmark_values import JsonValue, corpus_digest
+
+from receipt import (
+    CLAIM_BOUNDARY,
+    DOCTOR_SCHEMA,
+    RECEIPT_SCHEMA,
+    RUN_SCHEMA,
+    aggregate_efficiency,
+    authenticity_tier,
+    envelope_digest,
+    validate_receipt,
+)
+
+
+INPUT_SCHEMA: Final = "cross_harness_benchmark_cli_input/v1"
+SUBMISSION_SCHEMA: Final = "cross_harness_benchmark_submission/v1"
+
+#: Fixtures whose predicate values the executed command binding itself supplies.
+COMMAND_FIXTURES: Final = ("evidence-command-binding",)
+#: Fixtures whose predicate values one observed Hermes child dispatch supplies.
+DISPATCH_FIXTURES: Final = (
+    "evidence-runtime-observation",
+    "ultrawork-child-propagation",
+    "ultrawork-observed-runtime",
+)
+#: The bounded task sent to the child on stdin only. Never persisted.
+DISPATCH_TASK: Final = (
+    "Cross-harness benchmark liveness probe. Do not modify any file. "
+    "Reply with the single word READY and stop."
+)
+MAX_TIMEOUT_SECONDS: Final = 3600
+
+
+class ControllerError(ValueError):
+    """A refusal or contract failure raised before any effect is claimed."""
+
+
+@dataclass(frozen=True, slots=True)
+class Observation:
+    """One controller-observed execution, with efficiency kept beside quality."""
+
+    observation_id: str
+    kind: str
+    cwd_class: str
+    argv_digest: str
+    status: str
+    observed_exit: int | None = None
+    observed_semantic_result: str | None = None
+    failure_code: str | None = None
+    duration_ms: int | None = None
+    tokens: int | None = None
+    cost_usd: float | None = None
+    tools: int | None = None
+
+    @property
+    def succeeded(self) -> bool:
+        return self.status == "completed"
+
+    def payload(self) -> dict[str, JsonValue]:
+        return {
+            "observation_id": self.observation_id,
+            "kind": self.kind,
+            "cwd_class": self.cwd_class,
+            "argv_digest": self.argv_digest,
+            "status": self.status,
+            "observed_exit": self.observed_exit,
+            "observed_semantic_result": self.observed_semantic_result,
+            "failure_code": self.failure_code,
+            "duration_ms": self.duration_ms,
+            "tokens": self.tokens,
+            "cost_usd": self.cost_usd,
+            "tools": self.tools,
+        }
+
+
+def doctor(corpus_path: Path) -> dict[str, JsonValue]:
+    """Describe the lane without executing anything."""
+    corpus, _ = load_corpus(corpus_path)
+    return {
+        "schema_version": DOCTOR_SCHEMA,
+        "ok": True,
+        "corpus_id": corpus.corpus_id,
+        "corpus_digest": corpus.digest,
+        "default_mode": "fake",
+        "modes": ["fake", "probe", "dispatch"],
+        "observable_fixture_ids": sorted((*COMMAND_FIXTURES, *DISPATCH_FIXTURES)),
+        "command_binding_ids": sorted(item.command_id for item in corpus.commands),
+        "dispatch_boundary": "omh coding hermes-child dispatch --confirm-dispatch",
+        "observation_schema": "routing_observation/v1",
+        "receipt_schema": RECEIPT_SCHEMA,
+        "envelope_schema": INPUT_SCHEMA,
+        "v1_corpus_mutated": False,
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+
+
+def load_corpus(path: Path) -> tuple[Corpus, dict[str, JsonValue]]:
+    """Load the frozen corpus and re-parse it through the production parser."""
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as error:
+        raise ControllerError("corpus_unavailable") from error
+    except json.JSONDecodeError as error:
+        raise ControllerError("corpus_invalid_json") from error
+    if not isinstance(raw, dict):
+        raise ControllerError("corpus_must_be_object")
+    return parse_corpus(raw), raw
+
+
+def load_base_results(path: Path, corpus: Corpus) -> dict[str, JsonValue]:
+    """Read carried fixture results from an existing CLI-input envelope."""
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as error:
+        raise ControllerError("base_unavailable") from error
+    except json.JSONDecodeError as error:
+        raise ControllerError("base_invalid_json") from error
+    if not isinstance(raw, dict) or raw.get("schema_version") != INPUT_SCHEMA:
+        raise ControllerError("base_not_cli_input")
+    submission = raw.get("submission")
+    if not isinstance(submission, dict):
+        raise ControllerError("base_missing_submission")
+    if submission.get("corpus_digest") != corpus.digest:
+        raise ControllerError("base_corpus_mismatch")
+    results = submission.get("results")
+    if not isinstance(results, list):
+        raise ControllerError("base_missing_results")
+    carried: dict[str, JsonValue] = {}
+    for item in results:
+        if not isinstance(item, dict) or not isinstance(item.get("fixture_id"), str):
+            raise ControllerError("base_result_invalid")
+        carried[str(item["fixture_id"])] = item
+    return carried
+
+
+def run(
+    *,
+    corpus_path: Path,
+    mode: str = "fake",
+    repository_root: Path,
+    base_path: Path | None = None,
+    omh_executable: str = "omh",
+    hermes_executable: str = "hermes",
+    model: str | None = None,
+    provider: str | None = None,
+    reasoning: str = "medium",
+    timeout: int = 300,
+    allow_paid_live: bool = False,
+    max_paid_calls: int = 0,
+) -> dict[str, JsonValue]:
+    """Execute the selected mode and return the envelope with its receipt."""
+    if mode not in {"fake", "probe", "dispatch"}:
+        raise ControllerError("unknown_mode")
+    if not isinstance(timeout, int) or isinstance(timeout, bool) or not 1 <= timeout <= MAX_TIMEOUT_SECONDS:
+        raise ControllerError("invalid_timeout")
+    scheduled_paid_calls = 1 if mode == "dispatch" else 0
+    if scheduled_paid_calls:
+        if not allow_paid_live:
+            raise ControllerError("paid_live_not_allowed")
+        if max_paid_calls < scheduled_paid_calls:
+            raise ControllerError("paid_call_budget_exceeded")
+        if not model or not provider:
+            raise ControllerError("dispatch_requires_model_and_provider")
+    elif allow_paid_live:
+        raise ControllerError("paid_live_flag_without_dispatch")
+
+    corpus, corpus_raw = load_corpus(corpus_path)
+    command = _single_command(corpus)
+    carried = load_base_results(base_path, corpus) if base_path is not None else {}
+    observations: list[Observation] = []
+
+    if mode != "fake":
+        with TemporaryDirectory(prefix="omh-cross-harness-live-") as root_text:
+            root = Path(root_text)
+            home = root / "home"
+            home.mkdir()
+            observations.append(
+                execute_command_binding(
+                    command,
+                    repository_root=repository_root,
+                    home_root=home,
+                    timeout=timeout,
+                )
+            )
+            if mode == "dispatch":
+                workspace = root / "workspace"
+                workspace.mkdir()
+                observations.append(
+                    execute_child_dispatch(
+                        omh_executable=omh_executable,
+                        hermes_executable=hermes_executable,
+                        workspace=workspace,
+                        home_root=home,
+                        model=str(model),
+                        provider=str(provider),
+                        reasoning=reasoning,
+                        timeout=timeout,
+                        confirmed=allow_paid_live,
+                    )
+                )
+
+    results, bindings = _fixture_results(corpus, mode, observations, carried)
+    envelope = _envelope(corpus, corpus_raw, results)
+    evaluate_submission(envelope["submission"], corpus)  # self-check via the real evaluator
+    receipt = _receipt(
+        mode=mode,
+        corpus=corpus,
+        command=command,
+        envelope=envelope,
+        observations=observations,
+        bindings=bindings,
+    )
+    reasons = validate_receipt(receipt)
+    if reasons:
+        raise ControllerError("invalid_receipt:" + ",".join(reasons))
+    return {
+        "schema_version": RUN_SCHEMA,
+        "ok": all(item.succeeded for item in observations),
+        "mode": mode,
+        "paid_calls_launched": scheduled_paid_calls if observations else 0,
+        "envelope": envelope,
+        "receipt": receipt,
+    }
+
+
+def execute_command_binding(
+    command: CommandBinding,
+    *,
+    repository_root: Path,
+    home_root: Path,
+    timeout: int,
+) -> Observation:
+    """Run the corpus command binding verbatim in its declared working directory."""
+    argv = list(command.argv)
+    observation = {
+        "observation_id": "obs-command-binding",
+        "kind": "command_binding",
+        "cwd_class": command.cwd_class,
+        "argv_digest": corpus_digest(argv),
+    }
+    started = time.monotonic()
+    try:
+        completed = subprocess.run(
+            argv,
+            cwd=repository_root,
+            env=_environment(home_root),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return Observation(**observation, status="timed_out", failure_code="timeout", duration_ms=_elapsed_ms(started))
+    except OSError:
+        return Observation(**observation, status="failed", failure_code="command_launch_failed")
+    duration_ms = _elapsed_ms(started)
+    semantic = _semantic_result(completed.returncode, completed.stdout, command)
+    return Observation(
+        **observation,
+        status="completed" if completed.returncode == command.expected_exit else "failed",
+        observed_exit=completed.returncode,
+        observed_semantic_result=semantic,
+        failure_code=None if completed.returncode == command.expected_exit else "nonzero_exit",
+        duration_ms=duration_ms,
+    )
+
+
+def child_dispatch_argv(
+    omh_executable: str,
+    *,
+    hermes_executable: str,
+    workspace: Path,
+    model: str,
+    provider: str,
+    reasoning: str,
+    parent_run_id: str,
+    run_id: str,
+    timeout: int,
+) -> list[str]:
+    """Build the approved explicit dispatch argv. The prompt never appears here."""
+    return [
+        omh_executable,
+        "coding",
+        "hermes-child",
+        "dispatch",
+        "--confirm-dispatch",
+        "--model",
+        model,
+        "--provider",
+        provider,
+        "--reasoning",
+        reasoning,
+        "--parent-run-id",
+        parent_run_id,
+        "--run-id",
+        run_id,
+        "--hermes",
+        hermes_executable,
+        "--cwd",
+        str(workspace),
+        "--timeout",
+        str(timeout),
+        "--json",
+    ]
+
+
+def execute_child_dispatch(
+    *,
+    omh_executable: str,
+    hermes_executable: str,
+    workspace: Path,
+    home_root: Path,
+    model: str,
+    provider: str,
+    reasoning: str,
+    timeout: int,
+    confirmed: bool = False,
+) -> Observation:
+    """Dispatch one isolated Hermes child through the approved explicit boundary."""
+    if not confirmed:
+        raise ControllerError("paid_live_not_allowed")
+    argv = child_dispatch_argv(
+        omh_executable,
+        hermes_executable=hermes_executable,
+        workspace=workspace,
+        model=model,
+        provider=provider,
+        reasoning=reasoning,
+        parent_run_id=f"xh-live-parent-{uuid.uuid4().hex}",
+        run_id=f"xh-live-child-{uuid.uuid4().hex}",
+        timeout=timeout,
+    )
+    observation = {
+        "observation_id": "obs-hermes-child-dispatch",
+        "kind": "hermes_child_dispatch",
+        "cwd_class": "isolated_temporary",
+        # The workspace path is a local absolute path and is deliberately not
+        # part of the digested argv, which stays metadata-only.
+        "argv_digest": corpus_digest([item for item in argv if not item.startswith("/")]),
+    }
+    started = time.monotonic()
+    try:
+        completed = subprocess.run(
+            argv,
+            input=DISPATCH_TASK,
+            cwd=workspace,
+            env=_environment(home_root),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout + 30,
+        )
+    except subprocess.TimeoutExpired:
+        return Observation(**observation, status="timed_out", failure_code="timeout", duration_ms=_elapsed_ms(started))
+    except OSError:
+        return Observation(**observation, status="failed", failure_code="command_launch_failed")
+    duration_ms = _elapsed_ms(started)
+    if completed.returncode:
+        return Observation(
+            **observation,
+            status="failed",
+            observed_exit=completed.returncode,
+            failure_code="nonzero_exit",
+            duration_ms=duration_ms,
+        )
+    metrics = _routing_observation_metrics(completed.stdout)
+    if metrics is None:
+        return Observation(
+            **observation,
+            status="failed",
+            observed_exit=completed.returncode,
+            failure_code="observation_invalid",
+            duration_ms=duration_ms,
+        )
+    return Observation(
+        **observation,
+        status="completed",
+        observed_exit=completed.returncode,
+        observed_semantic_result=str(metrics["status"]),
+        duration_ms=duration_ms,
+        tokens=metrics["tokens"],
+        cost_usd=metrics["cost_usd"],
+        tools=metrics["tools"],
+    )
+
+
+def _routing_observation_metrics(stdout: str) -> dict[str, Any] | None:
+    """Read only the allowlisted scalars from a validated routing observation."""
+    try:
+        raw = json.loads(stdout)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(raw, dict) or validate_routing_observation(raw):
+        return None
+    return {
+        "claim": "observed" if raw.get("claim") == "observed" else "prepared_not_observed",
+        "status": str(raw.get("status") or "failed"),
+        "tokens": raw["tokens"] if type(raw.get("tokens")) is int else None,
+        "tools": raw["tools"] if type(raw.get("tools")) is int else None,
+        "cost_usd": raw["cost_usd"]
+        if isinstance(raw.get("cost_usd"), (int, float)) and not isinstance(raw.get("cost_usd"), bool)
+        else None,
+    }
+
+
+def _semantic_result(exit_code: int, stdout: str, command: CommandBinding) -> str:
+    """Derive the observed semantic result; stdout itself is never retained."""
+    if exit_code != command.expected_exit:
+        return "unvalidated"
+    try:
+        raw = json.loads(stdout)
+    except json.JSONDecodeError:
+        return "unvalidated"
+    if isinstance(raw, dict) and raw.get("ok") is True and raw.get("errors") == []:
+        return command.expected_semantic_result
+    return "unvalidated"
+
+
+def _fixture_results(
+    corpus: Corpus,
+    mode: str,
+    observations: Sequence[Observation],
+    carried: Mapping[str, JsonValue],
+) -> tuple[list[JsonValue], list[dict[str, JsonValue]]]:
+    by_kind = {item.kind: item for item in observations}
+    command_observation = by_kind.get("command_binding")
+    dispatch_observation = by_kind.get("hermes_child_dispatch")
+    results: list[JsonValue] = []
+    bindings: list[dict[str, JsonValue]] = []
+    for fixture in corpus.fixtures:
+        if mode == "fake":
+            if fixture.id not in (*COMMAND_FIXTURES, *DISPATCH_FIXTURES):
+                built = None
+            else:
+                built = _simulated_result(fixture, corpus)
+            provenance, bound = "fake_adapter", []
+        elif fixture.id in COMMAND_FIXTURES and command_observation is not None:
+            built = _observed_result(fixture, corpus, command_observation, command_observation)
+            provenance, bound = "controller_observed", [command_observation.observation_id]
+        elif fixture.id in DISPATCH_FIXTURES and dispatch_observation is not None and command_observation is not None:
+            built = _observed_result(fixture, corpus, command_observation, dispatch_observation)
+            provenance = "controller_observed"
+            bound = [command_observation.observation_id, dispatch_observation.observation_id]
+        else:
+            built, provenance, bound = None, "carried_from_base", []
+        if built is None:
+            built = carried.get(fixture.id)
+            provenance, bound = "carried_from_base", []
+        if built is None:
+            continue
+        results.append(built)
+        bindings.append({"fixture_id": fixture.id, "provenance": provenance, "observation_ids": list(bound)})
+    return results, bindings
+
+
+def _simulated_result(fixture: Fixture, corpus: Corpus) -> dict[str, JsonValue]:
+    """Offline simulation: satisfies the predicate but never claims observation.
+
+    `prepared` evidence is below every fixture's required class, so a fake run
+    can never produce a passing fixture, a level, or a certification.
+    """
+    actual, facts = _predicate_values(fixture)
+    return _result(
+        fixture,
+        corpus,
+        actual=actual,
+        facts=facts,
+        evidence_class="prepared",
+        runtime_observation="prepared_not_observed",
+        command_exit=corpus.commands[0].expected_exit,
+        command_semantic=corpus.commands[0].expected_semantic_result,
+        child_result="pass",
+    )
+
+
+def _observed_result(
+    fixture: Fixture,
+    corpus: Corpus,
+    command_observation: Observation,
+    source: Observation,
+) -> dict[str, JsonValue]:
+    actual, facts = _observed_values(fixture, source)
+    return _result(
+        fixture,
+        corpus,
+        actual=actual,
+        facts=facts,
+        evidence_class="runtime",
+        runtime_observation="observed",
+        command_exit=command_observation.observed_exit if command_observation.observed_exit is not None else -1,
+        command_semantic=command_observation.observed_semantic_result or "unvalidated",
+        child_result="pass" if source.succeeded else "fail",
+    )
+
+
+def _observed_values(fixture: Fixture, source: Observation) -> tuple[dict[str, JsonValue], dict[str, JsonValue]]:
+    """Map one observation onto the fixture's predicate keys, observed values only."""
+    if fixture.id == "evidence-command-binding":
+        return {"semantic_result": source.observed_semantic_result or "unvalidated"}, {}
+    if fixture.id == "evidence-runtime-observation":
+        return {}, {"observation_state": "observed" if source.succeeded else "prepared_not_observed"}
+    if fixture.id == "ultrawork-child-propagation":
+        return {"parent_exit": source.observed_exit if source.observed_exit is not None else -1}, {}
+    if fixture.id == "ultrawork-observed-runtime":
+        return {}, {"dispatch_state": source.observed_semantic_result or "failed"}
+    raise ControllerError("fixture_not_observable")
+
+
+def _predicate_values(fixture: Fixture) -> tuple[dict[str, JsonValue], dict[str, JsonValue]]:
+    actual: dict[str, JsonValue] = {}
+    facts: dict[str, JsonValue] = {}
+    for predicate in fixture.predicates:
+        target = actual if predicate.scope == "actual_machine" else facts
+        target[predicate.key] = predicate.value
+    return actual, facts
+
+
+def _result(
+    fixture: Fixture,
+    corpus: Corpus,
+    *,
+    actual: dict[str, JsonValue],
+    facts: dict[str, JsonValue],
+    evidence_class: str,
+    runtime_observation: str,
+    command_exit: int,
+    command_semantic: str,
+    child_result: str,
+) -> dict[str, JsonValue]:
+    source = next(item for item in corpus.sources if item.source_id == fixture.source_id)
+    command = next(item for item in corpus.commands if item.command_id == fixture.command_binding_id)
+    source_base: dict[str, JsonValue] = {
+        "source_id": source.source_id,
+        "commit": source.commit,
+        "license": source.license,
+        "path_metadata": source.path_metadata,
+    }
+    command_base: dict[str, JsonValue] = {
+        "command_id": command.command_id,
+        "harness": command.harness,
+        "argv": list(command.argv),
+        "cwd_class": command.cwd_class,
+        "source_id": command.source_id,
+        "source_commit": command.source_commit,
+        "expected_exit": command.expected_exit,
+        "expected_semantic_result": command.expected_semantic_result,
+    }
+    return {
+        "fixture_id": fixture.id,
+        "adapter_id": fixture.adapter_id,
+        "capability_id": fixture.capability_id,
+        "evidence_class": evidence_class,
+        "runtime_observation": runtime_observation,
+        "actual_machine": dict(actual),
+        "facts": dict(facts),
+        "source_binding": {**source_base, "source_digest": corpus_digest(source_base)},
+        "command_evidence": {
+            **command_base,
+            "binding_digest": corpus_digest(command_base),
+            "observed_exit": command_exit,
+            "observed_semantic_result": command_semantic,
+        },
+        "child_results": [{"id": "primary", "result": child_result}],
+    }
+
+
+def _envelope(corpus: Corpus, corpus_raw: Mapping[str, JsonValue], results: list[JsonValue]) -> dict[str, JsonValue]:
+    return {
+        "schema_version": INPUT_SCHEMA,
+        "corpus": dict(corpus_raw),
+        "submission": {
+            "schema_version": SUBMISSION_SCHEMA,
+            "corpus_digest": corpus.digest,
+            "harness_id": corpus.commands[0].harness,
+            "results": results,
+        },
+    }
+
+
+def _receipt(
+    *,
+    mode: str,
+    corpus: Corpus,
+    command: CommandBinding,
+    envelope: Mapping[str, JsonValue],
+    observations: Sequence[Observation],
+    bindings: Sequence[Mapping[str, JsonValue]],
+) -> dict[str, JsonValue]:
+    def selected(provenance: str) -> list[JsonValue]:
+        return [str(item["fixture_id"]) for item in bindings if item["provenance"] == provenance]
+
+    observed = selected("controller_observed")
+    carried = selected("carried_from_base")
+    simulated = selected("fake_adapter")
+    submitted = {str(item["fixture_id"]) for item in bindings}
+    unsupported = [item.id for item in corpus.fixtures if item.id not in submitted]
+    payloads = [item.payload() for item in observations]
+    return {
+        "schema_version": RECEIPT_SCHEMA,
+        "mode": mode,
+        "harness_id": command.harness,
+        "corpus_digest": corpus.digest,
+        "envelope_digest": envelope_digest(envelope),
+        "evidence_authenticity": authenticity_tier(
+            mode=mode, observed_count=len(observed), carried_count=len(carried)
+        ),
+        "controller_observed_fixture_ids": observed,
+        "carried_fixture_ids": carried,
+        "simulated_fixture_ids": simulated,
+        "unsupported_fixture_ids": unsupported,
+        "fixture_bindings": [dict(item) for item in bindings],
+        "observations": payloads,
+        "efficiency": aggregate_efficiency(payloads),
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+
+
+def _single_command(corpus: Corpus) -> CommandBinding:
+    if len(corpus.commands) != 1:
+        raise ControllerError("unsupported_command_binding_count")
+    return corpus.commands[0]
+
+
+def _environment(home_root: Path) -> dict[str, str]:
+    """Inherit PATH and credentials but redirect every runtime home to a temp root."""
+    environment = dict(os.environ)
+    environment["OMH_HOME"] = str(home_root / "omh")
+    environment["HERMES_HOME"] = str(home_root / "hermes")
+    return environment
+
+
+def _elapsed_ms(started: float) -> int:
+    return max(0, int((time.monotonic() - started) * 1000))

--- a/benchmarks/cross-harness/live/lib/receipt.py
+++ b/benchmarks/cross-harness/live/lib/receipt.py
@@ -1,0 +1,337 @@
+"""`cross_harness_live_receipt/v1`: controller provenance for the live lane.
+
+The receipt is a separate artifact from the `cross_harness_benchmark_cli_input/v1`
+envelope the controller emits. `cross_harness_benchmark/v1` fixtures, schemas,
+scoring semantics, and trust anchors stay untouched: the receipt adds no field to
+the v1 submission and changes no v1 outcome. It records two things v1 cannot
+express, alongside the digest of the exact envelope it describes:
+
+* which submitted fixture results this controller observed itself, and which were
+  carried from an outside submission, as an ordered authenticity tier;
+* the efficiency facts of the run (duration, tokens, cost), kept strictly outside
+  the quality score.
+
+Efficiency never earns points, never changes a level, and never turns a
+`partial` into a `pass`. A fast run and a cheap run are separate facts from a
+correct run.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Final
+
+from omh.quality.cross_harness_benchmark_values import (
+    BenchmarkValidationError,
+    JsonValue,
+    corpus_digest,
+    safe,
+)
+
+
+RECEIPT_SCHEMA: Final = "cross_harness_live_receipt/v1"
+RUN_SCHEMA: Final = "cross_harness_live_run/v1"
+DOCTOR_SCHEMA: Final = "cross_harness_live_doctor/v1"
+
+MODES: Final = ("fake", "probe", "dispatch")
+#: Ordered weakest to strongest. `unverified_submission` is the same claim the
+#: v1 scorer always returns; the controller may only ever report a stronger tier
+#: for results it executed itself.
+AUTHENTICITY_TIERS: Final = (
+    "fake_adapter",
+    "unverified_submission",
+    "mixed_controller_and_submitted",
+    "controller_observed",
+)
+PROVENANCE: Final = ("fake_adapter", "carried_from_base", "controller_observed")
+OBSERVATION_KINDS: Final = ("command_binding", "hermes_child_dispatch")
+OBSERVATION_STATUSES: Final = ("completed", "failed", "timed_out", "not_executed")
+CWD_CLASSES: Final = ("repository_root", "isolated_temporary")
+FAILURE_CODES: Final = (
+    "command_launch_failed",
+    "timeout",
+    "nonzero_exit",
+    "observation_unavailable",
+    "observation_invalid",
+)
+CLAIM_BOUNDARY: Final = (
+    "Controller observation covers only the listed controller_observed fixtures "
+    "and is not general live executor quality proof. Carried results stay "
+    "unverified submissions. Efficiency facts are reported outside the quality "
+    "score and never earn points."
+)
+
+_RECEIPT_FIELDS: Final = frozenset(
+    {
+        "schema_version",
+        "mode",
+        "harness_id",
+        "corpus_digest",
+        "envelope_digest",
+        "evidence_authenticity",
+        "controller_observed_fixture_ids",
+        "carried_fixture_ids",
+        "simulated_fixture_ids",
+        "unsupported_fixture_ids",
+        "fixture_bindings",
+        "observations",
+        "efficiency",
+        "claim_boundary",
+    }
+)
+_BINDING_FIELDS: Final = frozenset({"fixture_id", "provenance", "observation_ids"})
+_OBSERVATION_FIELDS: Final = frozenset(
+    {
+        "observation_id",
+        "kind",
+        "cwd_class",
+        "argv_digest",
+        "status",
+        "observed_exit",
+        "observed_semantic_result",
+        "failure_code",
+        "duration_ms",
+        "tokens",
+        "cost_usd",
+        "tools",
+    }
+)
+_EFFICIENCY_FIELDS: Final = frozenset(
+    {
+        "duration_ms",
+        "tokens",
+        "cost_usd",
+        "observations_total",
+        "observations_reporting_tokens",
+        "observations_reporting_cost_usd",
+        "complete",
+    }
+)
+_HEX_64_DIGITS: Final = frozenset("0123456789abcdef")
+
+
+def envelope_digest(envelope: Mapping[str, JsonValue]) -> str:
+    """Return the canonical digest binding a receipt to one emitted envelope."""
+    return corpus_digest(dict(envelope))
+
+
+def authenticity_tier(
+    *, mode: str, observed_count: int, carried_count: int
+) -> str:
+    """Derive the honest tier from what the controller actually executed."""
+    if mode not in MODES:
+        raise ValueError("mode must be one of " + ", ".join(MODES))
+    if mode == "fake":
+        return "fake_adapter"
+    if not observed_count:
+        return "unverified_submission"
+    if carried_count:
+        return "mixed_controller_and_submitted"
+    return "controller_observed"
+
+
+def aggregate_efficiency(observations: list[Mapping[str, JsonValue]]) -> dict[str, JsonValue]:
+    """Sum reported telemetry only; missing telemetry stays null, never estimated."""
+    durations = [item["duration_ms"] for item in observations if isinstance(item["duration_ms"], int)]
+    tokens = [item["tokens"] for item in observations if isinstance(item["tokens"], int)]
+    costs = [
+        item["cost_usd"]
+        for item in observations
+        if isinstance(item["cost_usd"], (int, float)) and not isinstance(item["cost_usd"], bool)
+    ]
+    return {
+        "duration_ms": sum(durations) if durations else None,
+        "tokens": sum(tokens) if tokens else None,
+        "cost_usd": round(sum(costs), 6) if costs else None,
+        "observations_total": len(observations),
+        "observations_reporting_tokens": len(tokens),
+        "observations_reporting_cost_usd": len(costs),
+        "complete": bool(observations)
+        and len(tokens) == len(observations)
+        and len(costs) == len(observations),
+    }
+
+
+def validate_receipt(raw: JsonValue) -> tuple[str, ...]:
+    """Return ordered reason codes; an empty tuple means the receipt is valid."""
+    if not isinstance(raw, dict):
+        return ("receipt_not_object",)
+    reasons: list[str] = []
+    _check_shape(raw, _RECEIPT_FIELDS, "receipt", reasons)
+    if reasons:
+        return tuple(reasons)
+    _member(raw["schema_version"], (RECEIPT_SCHEMA,), "unknown_receipt_schema", reasons)
+    _member(raw["mode"], MODES, "invalid_mode", reasons)
+    _member(raw["evidence_authenticity"], AUTHENTICITY_TIERS, "invalid_authenticity_tier", reasons)
+    _text(raw["harness_id"], "invalid_harness_id", reasons)
+    _digest(raw["corpus_digest"], "invalid_corpus_digest", reasons)
+    _digest(raw["envelope_digest"], "invalid_envelope_digest", reasons)
+    if raw["claim_boundary"] != CLAIM_BOUNDARY:
+        reasons.append("invalid_claim_boundary")
+    observation_ids = _check_observations(raw["observations"], reasons)
+    _check_bindings(raw["fixture_bindings"], observation_ids, reasons)
+    _check_efficiency(raw["efficiency"], reasons)
+    _check_coverage(raw, reasons)
+    try:
+        safe(dict(raw))
+    except BenchmarkValidationError:
+        reasons.append("unsafe_metadata")
+    return tuple(reasons)
+
+
+def _check_observations(raw: JsonValue, reasons: list[str]) -> set[str]:
+    ids: set[str] = set()
+    if not isinstance(raw, list):
+        reasons.append("invalid_observations")
+        return ids
+    for item in raw:
+        if not isinstance(item, dict):
+            reasons.append("invalid_observation")
+            continue
+        before = len(reasons)
+        _check_shape(item, _OBSERVATION_FIELDS, "observation", reasons)
+        if len(reasons) != before:
+            continue
+        identifier = item["observation_id"]
+        _text(identifier, "invalid_observation_id", reasons)
+        if isinstance(identifier, str):
+            if identifier in ids:
+                reasons.append("duplicate_observation_id")
+            ids.add(identifier)
+        _member(item["kind"], OBSERVATION_KINDS, "invalid_observation_kind", reasons)
+        _member(item["cwd_class"], CWD_CLASSES, "invalid_cwd_class", reasons)
+        _member(item["status"], OBSERVATION_STATUSES, "invalid_observation_status", reasons)
+        _digest(item["argv_digest"], "invalid_argv_digest", reasons)
+        _optional_int(item["observed_exit"], "invalid_observed_exit", reasons)
+        _optional_text(item["observed_semantic_result"], "invalid_semantic_result", reasons)
+        _optional_member(item["failure_code"], FAILURE_CODES, "invalid_failure_code", reasons)
+        for field, code in (
+            ("duration_ms", "invalid_duration_ms"),
+            ("tokens", "invalid_tokens"),
+            ("tools", "invalid_tools"),
+        ):
+            _optional_int(item[field], code, reasons, non_negative=True)
+        _optional_number(item["cost_usd"], "invalid_cost_usd", reasons)
+    return ids
+
+
+def _check_bindings(raw: JsonValue, observation_ids: set[str], reasons: list[str]) -> None:
+    if not isinstance(raw, list):
+        reasons.append("invalid_fixture_bindings")
+        return
+    seen: set[str] = set()
+    for item in raw:
+        if not isinstance(item, dict):
+            reasons.append("invalid_fixture_binding")
+            continue
+        before = len(reasons)
+        _check_shape(item, _BINDING_FIELDS, "fixture_binding", reasons)
+        if len(reasons) != before:
+            continue
+        fixture_id = item["fixture_id"]
+        _text(fixture_id, "invalid_fixture_id", reasons)
+        if isinstance(fixture_id, str):
+            if fixture_id in seen:
+                reasons.append("duplicate_fixture_binding")
+            seen.add(fixture_id)
+        _member(item["provenance"], PROVENANCE, "invalid_provenance", reasons)
+        bound = item["observation_ids"]
+        if not isinstance(bound, list) or any(not isinstance(value, str) for value in bound):
+            reasons.append("invalid_binding_observation_ids")
+            continue
+        if any(value not in observation_ids for value in bound):
+            reasons.append("unknown_binding_observation_id")
+        if item["provenance"] == "controller_observed" and not bound:
+            reasons.append("unbound_controller_observation")
+        if item["provenance"] == "carried_from_base" and bound:
+            reasons.append("carried_result_claims_observation")
+
+
+def _check_efficiency(raw: JsonValue, reasons: list[str]) -> None:
+    if not isinstance(raw, dict):
+        reasons.append("invalid_efficiency")
+        return
+    before = len(reasons)
+    _check_shape(raw, _EFFICIENCY_FIELDS, "efficiency", reasons)
+    if len(reasons) != before:
+        return
+    _optional_int(raw["duration_ms"], "invalid_duration_ms", reasons, non_negative=True)
+    _optional_int(raw["tokens"], "invalid_tokens", reasons, non_negative=True)
+    _optional_number(raw["cost_usd"], "invalid_cost_usd", reasons)
+    for field in ("observations_total", "observations_reporting_tokens", "observations_reporting_cost_usd"):
+        if type(raw[field]) is not int or raw[field] < 0:
+            reasons.append("invalid_efficiency_count")
+    if not isinstance(raw["complete"], bool):
+        reasons.append("invalid_efficiency_complete")
+
+
+def _check_coverage(raw: Mapping[str, JsonValue], reasons: list[str]) -> None:
+    """The four coverage lists partition the corpus; the tier may not outrun them."""
+    lists: dict[str, list[str]] = {}
+    for field in (
+        "controller_observed_fixture_ids",
+        "carried_fixture_ids",
+        "simulated_fixture_ids",
+        "unsupported_fixture_ids",
+    ):
+        value = raw[field]
+        if not isinstance(value, list) or any(not isinstance(item, str) or not item for item in value):
+            reasons.append("invalid_fixture_id_list")
+            return
+        lists[field] = [item for item in value if isinstance(item, str)]
+    flattened = [item for value in lists.values() for item in value]
+    if len(flattened) != len(set(flattened)):
+        reasons.append("overlapping_fixture_coverage")
+    observed = lists["controller_observed_fixture_ids"]
+    if raw["evidence_authenticity"] == "controller_observed" and lists["carried_fixture_ids"]:
+        reasons.append("authenticity_tier_overclaims")
+    if raw["evidence_authenticity"] in {"controller_observed", "mixed_controller_and_submitted"} and not observed:
+        reasons.append("authenticity_tier_overclaims")
+    if raw["mode"] == "fake" and observed:
+        reasons.append("fake_mode_claims_observation")
+    if raw["mode"] != "fake" and lists["simulated_fixture_ids"]:
+        reasons.append("live_mode_reports_simulated_result")
+
+
+def _check_shape(raw: Mapping[str, JsonValue], fields: frozenset[str], label: str, reasons: list[str]) -> None:
+    if set(raw) != fields:
+        reasons.append(f"invalid_{label}_shape")
+
+
+def _member(value: JsonValue, allowed: tuple[str, ...], code: str, reasons: list[str]) -> None:
+    if value not in allowed:
+        reasons.append(code)
+
+
+def _optional_member(value: JsonValue, allowed: tuple[str, ...], code: str, reasons: list[str]) -> None:
+    if value is not None and value not in allowed:
+        reasons.append(code)
+
+
+def _text(value: JsonValue, code: str, reasons: list[str]) -> None:
+    if not isinstance(value, str) or not value:
+        reasons.append(code)
+
+
+def _optional_text(value: JsonValue, code: str, reasons: list[str]) -> None:
+    if value is not None and (not isinstance(value, str) or not value):
+        reasons.append(code)
+
+
+def _optional_int(value: JsonValue, code: str, reasons: list[str], *, non_negative: bool = False) -> None:
+    if value is None:
+        return
+    if type(value) is not int or (non_negative and value < 0):
+        reasons.append(code)
+
+
+def _optional_number(value: JsonValue, code: str, reasons: list[str]) -> None:
+    if value is None:
+        return
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
+        reasons.append(code)
+
+
+def _digest(value: JsonValue, code: str, reasons: list[str]) -> None:
+    if not isinstance(value, str) or len(value) != 64 or set(value) - _HEX_64_DIGITS:
+        reasons.append(code)

--- a/docs/CROSS_HARNESS_BENCHMARK.md
+++ b/docs/CROSS_HARNESS_BENCHMARK.md
@@ -114,6 +114,65 @@ python3 -m omh.cli benchmark score --stdin \
   < benchmarks/cross-harness/v1/example-passing-submission.json
 ```
 
+## Live lane (agent/maintainer)
+
+AUDIENCE: agent/maintainer. The `benchmark` command above never executes
+anything. [benchmarks/cross-harness/live](../benchmarks/cross-harness/live) is a
+separate controller that does: it executes the corpus command binding, and on
+explicit request one isolated Hermes child through
+`omh coding hermes-child dispatch --confirm-dispatch`, then emits an ordinary
+`cross_harness_benchmark_cli_input/v1` envelope alongside a
+`cross_harness_live_receipt/v1` receipt. The lane adds a producer, not a
+contract: the `v1` corpus, submission schema, scoring semantics, and both
+production trust anchors are unchanged, and every envelope it emits is scored by
+the same parser, evaluator, and scorer as a mailed-in file.
+
+Because the offline scorer describes only what it can prove, a controller-run
+envelope still scores `evidence_authenticity: "unverified_submission"` and
+`execution_verified: false`. Controller provenance therefore lives in the
+separate receipt, which binds the envelope digest to its observation ids and
+carries two facts `v1` cannot express: an ordered authenticity tier
+(`fake_adapter`, `unverified_submission`, `mixed_controller_and_submitted`,
+`controller_observed`) and an `efficiency` block. Efficiency is reported outside
+the quality score: it earns no points, changes no level, and is absent from the
+envelope entirely. Telemetry the child did not report stays null and is never
+estimated.
+
+The controller submits a fixture result only for a predicate it observed itself.
+Four fixtures qualify: `evidence-command-binding` from the executed binding's
+machine result, `ultrawork-child-propagation` from the dispatch process exit,
+`ultrawork-observed-runtime` from the `routing_observation/v1` status, and
+`evidence-runtime-observation` from whether a valid observation was produced.
+The other eleven are absent, so the evaluator reports them `unsupported` — a
+visible coverage gap, never a pass. `--base` fills them from an existing
+submission; those results are recorded as `carried_from_base` with no
+observation ids and the tier drops to `mixed_controller_and_submitted`.
+
+Nothing runs by default. `--mode fake` is the default, starts no process, and
+submits simulated results as `prepared` evidence, which is below every fixture's
+required class, so a fake run cannot pass a fixture or certify. `--mode probe`
+executes only the free local binding. `--mode dispatch` requires both
+`--allow-paid-live` and `--max-paid-calls N`, and refuses before any subprocess
+otherwise; `--allow-paid-live` outside dispatch mode is refused as well.
+
+```sh
+PYTHONPATH=. python3 benchmarks/cross-harness/live/bench.py doctor
+PYTHONPATH=. python3 benchmarks/cross-harness/live/bench.py run --mode fake
+PYTHONPATH=. python3 benchmarks/cross-harness/live/bench.py run --mode probe \
+  --envelope-output artifacts/live-envelope.json \
+  --receipt-output artifacts/live-receipt.json
+python3 -m omh.cli benchmark report --input artifacts/live-envelope.json
+```
+
+Controller observation is still not general live-quality proof. Report the
+receipt's tier beside the score's `evidence_authenticity` and
+`execution_verified`; never merge them, and never read a
+`mixed_controller_and_submitted` receipt as making its carried results observed.
+[benchmarks/cross-harness/live/README.md](../benchmarks/cross-harness/live/README.md)
+holds the operator detail;
+[tests/test_cross_harness_live_lane.py](../tests/test_cross_harness_live_lane.py)
+asserts the machine behaviour.
+
 ## Manual QA
 
 Run from the repository root.
@@ -126,6 +185,10 @@ Run from the repository root.
 6. Report the unsupported input; confirm unsupported coverage and exit 1. Do not report it as pass.
 7. Score the partial input; confirm partial status and exit 1.
 8. Run `python3 -m omh.cli harness validate`; it remains a separate generated-harness validation surface.
+9. Run the live lane's `doctor`; confirm `default_mode: "fake"` and that no process started.
+10. Run the live lane with `--mode fake`; confirm the receipt reports `fake_adapter`, an empty `controller_observed_fixture_ids`, and that scoring the emitted envelope is not contract-certified.
+11. Run the live lane with `--mode dispatch` and no paid flags; confirm exit 2 and `reason_code: "paid_live_not_allowed"` before any subprocess.
+12. Run the live lane with `--mode probe`; confirm `evidence-command-binding` passes, the receipt reports `controller_observed`, and the score still reports `evidence_authenticity: "unverified_submission"`.
 
 The benchmark command must create no `.omh` directory or runtime artifact in an isolated directory. It is pure input-to-output evaluation: no network calls, subprocess dispatch, executor launch, persistent runtime state, skill-body loading, or production-routing mutation belongs here.
 

--- a/tests/test_cross_harness_live_lane.py
+++ b/tests/test_cross_harness_live_lane.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+from contextlib import redirect_stdout
+import importlib.util
+import io
+import json
+from pathlib import Path
+import sys
+from tempfile import TemporaryDirectory
+import unittest
+from unittest.mock import patch
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.quality.cross_harness_benchmark import (  # noqa: E402
+    evaluate_submission,
+    parse_corpus,
+    score_submission,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+LIVE_BASE = ROOT / "benchmarks" / "cross-harness" / "live"
+CORPUS_PATH = ROOT / "benchmarks" / "cross-harness" / "v1" / "manifest.json"
+PASSING_INPUT_PATH = ROOT / "benchmarks" / "cross-harness" / "v1" / "example-passing-submission.json"
+sys.path.insert(0, str(LIVE_BASE / "lib"))
+
+import controller  # noqa: E402
+import receipt as receipt_module  # noqa: E402
+
+
+def _fake_command_observation(**overrides: object) -> controller.Observation:
+    fields: dict[str, object] = {
+        "observation_id": "obs-command-binding",
+        "kind": "command_binding",
+        "cwd_class": "repository_root",
+        "argv_digest": "0" * 64,
+        "status": "completed",
+        "observed_exit": 0,
+        "observed_semantic_result": "validated",
+        "duration_ms": 12,
+    }
+    fields.update(overrides)
+    return controller.Observation(**fields)  # type: ignore[arg-type]
+
+
+def _fake_dispatch_observation(**overrides: object) -> controller.Observation:
+    fields: dict[str, object] = {
+        "observation_id": "obs-hermes-child-dispatch",
+        "kind": "hermes_child_dispatch",
+        "cwd_class": "isolated_temporary",
+        "argv_digest": "1" * 64,
+        "status": "completed",
+        "observed_exit": 0,
+        "observed_semantic_result": "completed",
+        "duration_ms": 4200,
+        "tokens": 1024,
+        "cost_usd": 0.0031,
+        "tools": 3,
+    }
+    fields.update(overrides)
+    return controller.Observation(**fields)  # type: ignore[arg-type]
+
+
+def _run(**overrides: object) -> dict[str, object]:
+    arguments: dict[str, object] = {
+        "corpus_path": CORPUS_PATH,
+        "repository_root": ROOT,
+        "mode": "fake",
+    }
+    arguments.update(overrides)
+    return controller.run(**arguments)  # type: ignore[arg-type]
+
+
+def _evaluate(envelope: dict[str, object]) -> object:
+    corpus = parse_corpus(envelope["corpus"])  # type: ignore[arg-type]
+    return evaluate_submission(envelope["submission"], corpus)  # type: ignore[arg-type]
+
+
+class LiveLaneDefaultsTests(unittest.TestCase):
+    def test_doctor_reports_offline_default_and_untouched_v1_corpus(self) -> None:
+        report = controller.doctor(CORPUS_PATH)
+        self.assertEqual(report["default_mode"], "fake")
+        self.assertIs(report["v1_corpus_mutated"], False)
+        self.assertEqual(
+            report["dispatch_boundary"], "omh coding hermes-child dispatch --confirm-dispatch"
+        )
+        on_disk = json.loads(CORPUS_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(report["corpus_digest"], on_disk["corpus_digest"])
+
+    def test_emitted_envelope_carries_the_corpus_verbatim(self) -> None:
+        envelope = _run()["envelope"]
+        self.assertEqual(envelope["corpus"], json.loads(CORPUS_PATH.read_text(encoding="utf-8")))
+        self.assertEqual(
+            set(envelope), {"schema_version", "corpus", "submission"}
+        )
+        self.assertEqual(envelope["schema_version"], "cross_harness_benchmark_cli_input/v1")
+
+
+class FakeModeTests(unittest.TestCase):
+    def test_fake_mode_envelope_passes_the_real_v1_parser_and_evaluator(self) -> None:
+        result = _run()
+        report = _evaluate(result["envelope"])  # type: ignore[arg-type]
+        statuses = {outcome.fixture_id: outcome.status for outcome in report.outcomes}
+        self.assertEqual(len(statuses), 15)
+        for fixture_id in (*controller.COMMAND_FIXTURES, *controller.DISPATCH_FIXTURES):
+            self.assertEqual(statuses[fixture_id], "partial")
+
+    def test_fake_mode_can_never_pass_a_fixture_or_certify(self) -> None:
+        result = _run()
+        corpus = parse_corpus(result["envelope"]["corpus"])  # type: ignore[index, arg-type]
+        score = score_submission(result["envelope"]["submission"], corpus)  # type: ignore[index, arg-type]
+        self.assertFalse(score.contract_certified)
+        self.assertEqual(score.evidence_authenticity, "unverified_submission")
+        self.assertFalse(score.execution_verified)
+        report = _evaluate(result["envelope"])  # type: ignore[arg-type]
+        self.assertNotIn("pass", {outcome.status for outcome in report.outcomes})
+
+    def test_fake_mode_receipt_declares_the_fake_tier_and_no_observation(self) -> None:
+        receipt = _run()["receipt"]
+        self.assertEqual(receipt["evidence_authenticity"], "fake_adapter")
+        self.assertEqual(receipt["controller_observed_fixture_ids"], [])
+        self.assertEqual(receipt["observations"], [])
+        self.assertEqual(
+            sorted(receipt["simulated_fixture_ids"]),  # type: ignore[arg-type]
+            sorted((*controller.COMMAND_FIXTURES, *controller.DISPATCH_FIXTURES)),
+        )
+
+    def test_fake_mode_starts_no_subprocess(self) -> None:
+        with patch.object(controller.subprocess, "run") as spawn:
+            _run()
+        spawn.assert_not_called()
+
+    def test_fake_mode_is_reproducible(self) -> None:
+        first, second = _run(), _run()
+        self.assertEqual(first["envelope"], second["envelope"])
+        self.assertEqual(first["receipt"]["envelope_digest"], second["receipt"]["envelope_digest"])  # type: ignore[index]
+
+
+class RefusalTests(unittest.TestCase):
+    def test_dispatch_without_allow_paid_live_refuses(self) -> None:
+        with self.assertRaises(controller.ControllerError) as caught:
+            _run(mode="dispatch", model="m", provider="p")
+        self.assertEqual(str(caught.exception), "paid_live_not_allowed")
+
+    def test_dispatch_without_paid_budget_refuses(self) -> None:
+        with self.assertRaises(controller.ControllerError) as caught:
+            _run(mode="dispatch", model="m", provider="p", allow_paid_live=True, max_paid_calls=0)
+        self.assertEqual(str(caught.exception), "paid_call_budget_exceeded")
+
+    def test_dispatch_without_model_metadata_refuses(self) -> None:
+        with self.assertRaises(controller.ControllerError) as caught:
+            _run(mode="dispatch", allow_paid_live=True, max_paid_calls=1)
+        self.assertEqual(str(caught.exception), "dispatch_requires_model_and_provider")
+
+    def test_paid_flag_outside_dispatch_refuses(self) -> None:
+        with self.assertRaises(controller.ControllerError) as caught:
+            _run(mode="probe", allow_paid_live=True, max_paid_calls=1)
+        self.assertEqual(str(caught.exception), "paid_live_flag_without_dispatch")
+
+    def test_refusal_happens_before_any_subprocess(self) -> None:
+        with patch.object(controller.subprocess, "run") as spawn:
+            with self.assertRaises(controller.ControllerError):
+                _run(mode="dispatch", model="m", provider="p")
+        spawn.assert_not_called()
+
+    def test_child_dispatch_requires_explicit_confirmation(self) -> None:
+        with TemporaryDirectory() as workspace, patch.object(controller.subprocess, "run") as spawn:
+            with self.assertRaises(controller.ControllerError):
+                controller.execute_child_dispatch(
+                    omh_executable="omh",
+                    hermes_executable="hermes",
+                    workspace=Path(workspace),
+                    home_root=Path(workspace),
+                    model="m",
+                    provider="p",
+                    reasoning="medium",
+                    timeout=5,
+                )
+        spawn.assert_not_called()
+
+    def test_invalid_timeout_refuses(self) -> None:
+        with self.assertRaises(controller.ControllerError) as caught:
+            _run(timeout=0)
+        self.assertEqual(str(caught.exception), "invalid_timeout")
+
+
+class DispatchBoundaryTests(unittest.TestCase):
+    def test_dispatch_argv_uses_the_approved_explicit_boundary(self) -> None:
+        argv = controller.child_dispatch_argv(
+            "omh",
+            hermes_executable="hermes",
+            workspace=Path("/tmp/workspace"),
+            model="qwen3-coder-next",
+            provider="ultrafast",
+            reasoning="high",
+            parent_run_id="parent",
+            run_id="child",
+            timeout=120,
+        )
+        self.assertEqual(argv[:5], ["omh", "coding", "hermes-child", "dispatch", "--confirm-dispatch"])
+        self.assertIn("--json", argv)
+        self.assertNotIn(controller.DISPATCH_TASK, argv)
+
+    def test_observed_run_reports_controller_tier_and_efficiency(self) -> None:
+        with (
+            patch.object(controller, "execute_command_binding", return_value=_fake_command_observation()),
+            patch.object(controller, "execute_child_dispatch", return_value=_fake_dispatch_observation()),
+        ):
+            result = _run(mode="dispatch", model="m", provider="p", allow_paid_live=True, max_paid_calls=1)
+        receipt = result["receipt"]
+        self.assertEqual(receipt["evidence_authenticity"], "controller_observed")
+        self.assertEqual(
+            sorted(receipt["controller_observed_fixture_ids"]),  # type: ignore[arg-type]
+            sorted((*controller.COMMAND_FIXTURES, *controller.DISPATCH_FIXTURES)),
+        )
+        self.assertEqual(receipt["efficiency"]["tokens"], 1024)  # type: ignore[index]
+        self.assertEqual(receipt["efficiency"]["duration_ms"], 4212)  # type: ignore[index]
+        self.assertEqual(result["paid_calls_launched"], 1)
+        report = _evaluate(result["envelope"])  # type: ignore[arg-type]
+        observed = {
+            outcome.fixture_id: outcome.status
+            for outcome in report.outcomes
+            if outcome.fixture_id in set(receipt["controller_observed_fixture_ids"])  # type: ignore[arg-type]
+        }
+        self.assertEqual(set(observed.values()), {"pass"})
+
+    def test_failed_dispatch_becomes_an_observed_failure_not_a_pass(self) -> None:
+        failed = _fake_dispatch_observation(
+            status="failed", observed_exit=1, observed_semantic_result=None, failure_code="nonzero_exit"
+        )
+        with (
+            patch.object(controller, "execute_command_binding", return_value=_fake_command_observation()),
+            patch.object(controller, "execute_child_dispatch", return_value=failed),
+        ):
+            result = _run(mode="dispatch", model="m", provider="p", allow_paid_live=True, max_paid_calls=1)
+        self.assertFalse(result["ok"])
+        report = _evaluate(result["envelope"])  # type: ignore[arg-type]
+        statuses = {outcome.fixture_id: outcome.status for outcome in report.outcomes}
+        for fixture_id in controller.DISPATCH_FIXTURES:
+            self.assertEqual(statuses[fixture_id], "fail")
+
+    def test_routing_observation_metrics_reject_an_unvalidated_payload(self) -> None:
+        self.assertIsNone(controller._routing_observation_metrics("not json"))
+        self.assertIsNone(controller._routing_observation_metrics(json.dumps({"schema_version": "wrong"})))
+
+
+class BaseEnvelopeTests(unittest.TestCase):
+    def test_carried_results_downgrade_the_tier_and_claim_no_observation(self) -> None:
+        with patch.object(controller, "execute_command_binding", return_value=_fake_command_observation()):
+            result = _run(mode="probe", base_path=PASSING_INPUT_PATH)
+        receipt = result["receipt"]
+        self.assertEqual(receipt["evidence_authenticity"], "mixed_controller_and_submitted")
+        self.assertEqual(receipt["controller_observed_fixture_ids"], ["evidence-command-binding"])
+        self.assertEqual(len(receipt["carried_fixture_ids"]), 14)  # type: ignore[arg-type]
+        self.assertEqual(receipt["unsupported_fixture_ids"], [])
+        for binding in receipt["fixture_bindings"]:  # type: ignore[attr-defined]
+            if binding["provenance"] == "carried_from_base":
+                self.assertEqual(binding["observation_ids"], [])
+
+    def test_certified_carried_envelope_still_scores_as_unverified(self) -> None:
+        with patch.object(controller, "execute_command_binding", return_value=_fake_command_observation()):
+            result = _run(mode="probe", base_path=PASSING_INPUT_PATH)
+        corpus = parse_corpus(result["envelope"]["corpus"])  # type: ignore[index, arg-type]
+        score = score_submission(result["envelope"]["submission"], corpus)  # type: ignore[index, arg-type]
+        self.assertTrue(score.contract_certified)
+        self.assertEqual(score.evidence_authenticity, "unverified_submission")
+        self.assertFalse(score.execution_verified)
+
+    def test_base_from_a_foreign_corpus_is_refused(self) -> None:
+        with TemporaryDirectory() as root:
+            path = Path(root) / "base.json"
+            payload = json.loads(PASSING_INPUT_PATH.read_text(encoding="utf-8"))
+            payload["submission"]["corpus_digest"] = "f" * 64
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            with self.assertRaises(controller.ControllerError) as caught:
+                _run(base_path=path)
+        self.assertEqual(str(caught.exception), "base_corpus_mismatch")
+
+
+class ReceiptSchemaTests(unittest.TestCase):
+    def test_emitted_receipt_validates(self) -> None:
+        self.assertEqual(receipt_module.validate_receipt(_run()["receipt"]), ())
+
+    def test_unknown_field_is_rejected(self) -> None:
+        payload = dict(_run()["receipt"])  # type: ignore[arg-type]
+        payload["extra"] = 1
+        self.assertIn("invalid_receipt_shape", receipt_module.validate_receipt(payload))
+
+    def test_fake_mode_may_not_claim_controller_observation(self) -> None:
+        payload = dict(_run()["receipt"])  # type: ignore[arg-type]
+        payload["controller_observed_fixture_ids"] = ["evidence-command-binding"]
+        payload["simulated_fixture_ids"] = []
+        payload["evidence_authenticity"] = "controller_observed"
+        self.assertIn("fake_mode_claims_observation", receipt_module.validate_receipt(payload))
+
+    def test_observed_tier_requires_an_observed_fixture(self) -> None:
+        payload = dict(_run()["receipt"])  # type: ignore[arg-type]
+        payload["evidence_authenticity"] = "mixed_controller_and_submitted"
+        self.assertIn("authenticity_tier_overclaims", receipt_module.validate_receipt(payload))
+
+    def test_carried_result_may_not_reference_an_observation(self) -> None:
+        with patch.object(controller, "execute_command_binding", return_value=_fake_command_observation()):
+            payload = dict(_run(mode="probe", base_path=PASSING_INPUT_PATH)["receipt"])  # type: ignore[arg-type]
+        bindings = [dict(item) for item in payload["fixture_bindings"]]
+        for binding in bindings:
+            if binding["provenance"] == "carried_from_base":
+                binding["observation_ids"] = ["obs-command-binding"]
+                break
+        payload["fixture_bindings"] = bindings
+        self.assertIn("carried_result_claims_observation", receipt_module.validate_receipt(payload))
+
+    def test_binding_must_reference_a_recorded_observation(self) -> None:
+        with patch.object(controller, "execute_command_binding", return_value=_fake_command_observation()):
+            payload = dict(_run(mode="probe")["receipt"])  # type: ignore[arg-type]
+        payload["observations"] = []
+        self.assertIn("unknown_binding_observation_id", receipt_module.validate_receipt(payload))
+
+    def test_authenticity_tiers_are_ordered_weakest_first(self) -> None:
+        self.assertEqual(receipt_module.AUTHENTICITY_TIERS[0], "fake_adapter")
+        self.assertEqual(receipt_module.AUTHENTICITY_TIERS[-1], "controller_observed")
+        self.assertIn("unverified_submission", receipt_module.AUTHENTICITY_TIERS)
+
+
+class EfficiencyTests(unittest.TestCase):
+    def test_missing_telemetry_stays_null_and_is_never_estimated(self) -> None:
+        payloads = [
+            _fake_command_observation().payload(),
+            _fake_dispatch_observation(tokens=None, cost_usd=None).payload(),
+        ]
+        efficiency = receipt_module.aggregate_efficiency(payloads)
+        self.assertIsNone(efficiency["tokens"])
+        self.assertIsNone(efficiency["cost_usd"])
+        self.assertEqual(efficiency["duration_ms"], 4212)
+        self.assertEqual(efficiency["observations_reporting_tokens"], 0)
+        self.assertFalse(efficiency["complete"])
+
+    def test_partially_reported_telemetry_exposes_its_reporting_count(self) -> None:
+        payloads = [
+            _fake_command_observation().payload(),
+            _fake_dispatch_observation().payload(),
+        ]
+        efficiency = receipt_module.aggregate_efficiency(payloads)
+        self.assertEqual(efficiency["tokens"], 1024)
+        self.assertEqual(efficiency["observations_total"], 2)
+        self.assertEqual(efficiency["observations_reporting_tokens"], 1)
+        self.assertFalse(efficiency["complete"])
+
+    def test_efficiency_is_absent_from_the_scored_envelope(self) -> None:
+        with (
+            patch.object(controller, "execute_command_binding", return_value=_fake_command_observation()),
+            patch.object(controller, "execute_child_dispatch", return_value=_fake_dispatch_observation()),
+        ):
+            result = _run(mode="dispatch", model="m", provider="p", allow_paid_live=True, max_paid_calls=1)
+        serialized = json.dumps(result["envelope"])
+        for marker in ("duration_ms", "tokens", "cost_usd", "efficiency"):
+            self.assertNotIn(marker, serialized)
+
+
+class BenchEntryPointTests(unittest.TestCase):
+    @staticmethod
+    def _bench() -> object:
+        spec = importlib.util.spec_from_file_location("cross_harness_live_bench", LIVE_BASE / "bench.py")
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def _invoke(self, argv: list[str]) -> tuple[int, dict[str, object]]:
+        stream = io.StringIO()
+        with redirect_stdout(stream):
+            status = self._bench().main(argv)  # type: ignore[attr-defined]
+        return status, json.loads(stream.getvalue())
+
+    def test_fake_run_is_the_default_and_exits_zero(self) -> None:
+        status, payload = self._invoke(["run"])
+        self.assertEqual(status, 0)
+        self.assertEqual(payload["mode"], "fake")
+        self.assertEqual(payload["paid_calls_launched"], 0)
+        self.assertEqual(payload["receipt"]["evidence_authenticity"], "fake_adapter")  # type: ignore[index]
+
+    def test_dispatch_without_explicit_flags_exits_two_with_a_reason_code(self) -> None:
+        status, payload = self._invoke(["run", "--mode", "dispatch", "--model", "m", "--provider", "p"])
+        self.assertEqual(status, 2)
+        self.assertEqual(payload["reason_code"], "paid_live_not_allowed")
+
+    def test_written_envelope_scores_through_the_production_command(self) -> None:
+        with TemporaryDirectory() as root:
+            envelope_path = Path(root) / "envelope.json"
+            status, _ = self._invoke(["run", "--envelope-output", str(envelope_path)])
+            self.assertEqual(status, 0)
+            envelope = json.loads(envelope_path.read_text(encoding="utf-8"))
+        corpus = parse_corpus(envelope["corpus"])
+        self.assertFalse(score_submission(envelope["submission"], corpus).contract_certified)
+
+
+class PrivacyTests(unittest.TestCase):
+    def test_run_payload_holds_no_prompt_body_or_absolute_path(self) -> None:
+        with (
+            patch.object(controller, "execute_command_binding", return_value=_fake_command_observation()),
+            patch.object(controller, "execute_child_dispatch", return_value=_fake_dispatch_observation()),
+        ):
+            result = _run(mode="dispatch", model="m", provider="p", allow_paid_live=True, max_paid_calls=1)
+        serialized = json.dumps(result)
+        self.assertNotIn(controller.DISPATCH_TASK, serialized)
+        self.assertNotIn(str(ROOT), serialized)
+        self.assertNotIn("/Users/", serialized)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New `benchmarks/cross-harness/live/` controller (`bench.py` + `lib/controller.py` + `lib/receipt.py` + operator `README.md`) that **executes** `cross_harness_benchmark/v1` work and emits a v1-compatible envelope plus a separate `cross_harness_live_receipt/v1` receipt.
- New `tests/test_cross_harness_live_lane.py` (35 tests) covering envelope validity through the real v1 parser/evaluator/scorer, the receipt schema, every refusal path, and fake-mode end to end.
- New audience-labeled "Live lane (agent/maintainer)" section and four manual-QA steps in `docs/CROSS_HARNESS_BENCHMARK.md`.
- `benchmarks/cross-harness/v1/` is **byte-identical**. No `src/` module, schema, validator, or trust anchor changed.

### Why This Exists

`cross_harness_benchmark/v1` can only evaluate facts somebody else typed. File and stdin submissions are unauthenticated, so `benchmark score` always returns `evidence_authenticity: "unverified_submission"` and `execution_verified: false` — correctly, because the offline command observes nothing. That leaves no way for OMH to say "I ran this myself" without weakening the honest offline default.

This adds a lane that runs the work first and then submits only what it observed, so a controller-observed record becomes distinguishable from a mailed-in one **without changing anything about the offline lane**.

### User / Operator Impact

Operators and agents get a third benchmark surface beside `benchmark validate|score|report`. Nothing runs by default: `--mode fake` is the default and starts no process. Normal human OMH users are unaffected; this is not the normal Hermes workflow.

### How It Works

**The controller is a producer, not a contract.** Every envelope it emits is an ordinary `cross_harness_benchmark_cli_input/v1` object, parsed, evaluated, and scored by exactly the same production code as any hand-written file — and it still scores `unverified_submission` / `execution_verified: false`, because those fields describe what the *offline evaluator* can prove.

**Provenance lives in a sidecar receipt.** `cross_harness_live_receipt/v1` binds the emitted envelope's digest to its observation ids and carries the two facts v1 cannot express:

1. An ordered authenticity tier: `fake_adapter` < `unverified_submission` < `mixed_controller_and_submitted` < `controller_observed`. The validator rejects a tier that outruns its own coverage lists (four lists — observed / carried / simulated / unsupported — partition the fifteen fixtures).
2. An `efficiency` block (`duration_ms`, `tokens`, `cost_usd`) that is **absent from the envelope entirely**, earns no points, and changes no level. Missing telemetry stays `null` and is never estimated; `observations_reporting_tokens` / `observations_reporting_cost_usd` state how many observations actually supplied each figure.

**It submits only what it observed.** Four of the fifteen fixtures have predicates the controller can observe:

| Fixture | Predicate | Observed from |
| --- | --- | --- |
| `evidence-command-binding` | `actual_machine.semantic_result` | the executed binding's exit and machine result |
| `ultrawork-child-propagation` | `actual_machine.parent_exit` | the dispatch process exit |
| `ultrawork-observed-runtime` | `facts.dispatch_state` | the `routing_observation/v1` status |
| `evidence-runtime-observation` | `facts.observation_state` | whether a valid routing observation was produced |

The other eleven are offline metadata facts this controller does not execute. They are simply **absent** from the submission, so the evaluator reports them `unsupported` — a visible coverage gap, never a pass. `--base ENVELOPE` fills them from an existing submission; those results are recorded as `carried_from_base` with no observation ids and the tier drops to `mixed_controller_and_submitted`, so a certified carried envelope can never read as controller-observed.

**Modes and the refusal ladder:**

| Mode | Executes | Requires | Tier it can reach |
| --- | --- | --- | --- |
| `fake` (default) | nothing | — | `fake_adapter` |
| `probe` | the corpus binding (`python3 -m omh.cli harness validate`), local and free | — | `controller_observed` |
| `dispatch` | the binding plus one isolated Hermes child | `--allow-paid-live` **and** `--max-paid-calls N` | `controller_observed` |

Fake-mode results are submitted as `prepared` evidence, which is below every fixture's required class, so a fake run **structurally cannot** pass a fixture or certify — that is a test, not a promise. `dispatch` refuses before any subprocess when the paid flags are missing, when the budget is below the scheduled call count, or when model/provider metadata is absent; `--allow-paid-live` outside dispatch mode is refused too, so the flag cannot be left set by habit.

**Boundary discipline.** All execution goes through the existing explicit `omh coding hermes-child dispatch --confirm-dispatch` surface, with the prompt on stdin only, following `benchmarks/live-model-tools/v1`'s posture. Core `omh` still makes no LLM or network calls. The command binding runs verbatim in its declared `repository_root` cwd with `OMH_HOME`/`HERMES_HOME` redirected into a temporary root; the child runs in an isolated temporary workspace.

**Privacy.** Artifacts are metadata-only: stable ids, digests, reason codes, bounded machine facts. The dispatch task text is never persisted; command stdout is read for the machine result and discarded; workspace and home paths never enter an artifact. A dedicated test asserts the run payload contains no prompt body and no absolute path.

### Files And Contracts Touched

- `benchmarks/cross-harness/live/bench.py` — `doctor` (executes nothing) and `run`, mirroring live-model-tools' entry-point shape.
- `benchmarks/cross-harness/live/lib/controller.py` — mode selection, refusal ladder, command-binding execution, child dispatch, envelope assembly self-checked through the real `parse_corpus`/`evaluate_submission`.
- `benchmarks/cross-harness/live/lib/receipt.py` — `cross_harness_live_receipt/v1` schema, validator, tier derivation, telemetry aggregation.
- `benchmarks/cross-harness/live/README.md`, `docs/CROSS_HARNESS_BENCHMARK.md` — audience-labeled operator sections.
- `tests/test_cross_harness_live_lane.py` — machine behaviour.

New contract: `cross_harness_live_receipt/v1` (plus `cross_harness_live_run/v1`, `cross_harness_live_doctor/v1`, `cross_harness_live_error/v1` output envelopes). No existing contract modified.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli release checklist --json`
- [x] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `bench.py doctor`, `run --mode fake`, `run --mode probe`, `run --mode probe --base example-passing-submission.json`, and all three refusal paths
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: no TUI or Hermes-chat surface changed; the lane is a source-tree operator script

### Observed Evidence

- `PYTHONPATH=tests uv run python -m unittest discover -s tests` — 7859 tests. Green except 21 failures / 7 errors confined to `test_cross_harness_adapters` and `test_cross_harness_adapter_security`. Those are pre-existing and environmental: on a `git stash -u` clean tree in the same worktree, those two files reproduce **exactly** 12F+6E and 9F+1E (21F+7E total, identical to the run with this change). The same pre-existing counts are recorded in the previous merged PR's `Tested:` trailer.
- `PYTHONPATH=tests uv run python -m unittest tests/test_cross_harness_live_lane.py -v` — 35 tests, all green.
- `uv run --group lint ruff check src tests` and `... benchmarks/cross-harness/live` — "All checks passed!" for both.
- `uv run python -m compileall -q src tests` and `... benchmarks/cross-harness/live` — exit 0.
- All five generated-artifact byte gates (`docs workflows`, `docs roles`, `docs capability-families`, `docs ulw-inventory`, `docs ulw-site`) `--check` — `ok: true`; tap-skills 140/140, no missing/stale/extra.
- `git diff --check` — clean.
- `bench.py doctor` — `default_mode: "fake"`, `v1_corpus_mutated: false`, `corpus_digest` equal to the on-disk manifest anchor, no process started.
- `bench.py run --mode fake` → `omh.cli benchmark validate` exit 0 / `valid: true`; `benchmark score` exit 1, `total: 10`, `level: 1`, `contract_certified: false`, `coverage_supported: 4/15`. The four simulated fixtures evaluate `partial`; no fixture evaluates `pass`.
- `bench.py run --mode probe` → observation `obs-command-binding`, `observed_exit: 0`, `observed_semantic_result: "validated"`, `duration_ms: 274`, receipt tier `controller_observed`. `omh.cli benchmark report` shows `evidence-command-binding` with `status: "pass"` and `submission_claims_runtime_observed: true`, coverage `1/15` supported, and the score still reporting `evidence_authenticity: "unverified_submission"` / `execution_verified: false`.
- `bench.py run --mode probe --base benchmarks/cross-harness/v1/example-passing-submission.json` → receipt tier `mixed_controller_and_submitted`, 1 observed / 14 carried / 0 unsupported; `benchmark score` exit 0 with `total: 100`, `level: 5`, `contract_certified: true`, and still `evidence_authenticity: "unverified_submission"` / `execution_verified: false`. This is the intended separation: v1 certification of carried facts never becomes controller observation.
- Refusals, each exit 2 with a reason code and no subprocess: `--mode dispatch` alone → `paid_live_not_allowed`; `--mode dispatch --allow-paid-live --max-paid-calls 0` → `paid_call_budget_exceeded`; `--mode fake --allow-paid-live` → `paid_live_flag_without_dispatch`.
- `git status` confirms `benchmarks/cross-harness/v1/` untouched; the diff adds only new files plus one documentation section.

### Not Tested / Not Applicable

- **No live Hermes child was dispatched.** `--mode dispatch` has never been exercised against a real provider. Its argv shape, budget refusals, observation parsing, failure classification, and efficiency aggregation are unit-tested with a patched subprocess boundary only. This is `prepared_not_observed` for the paid path.
- `omh --help` and the installed-command release smoke: no installer, packaging manifest, CLI parser, or command registration changed. `MANIFEST.in` was deliberately left alone — `benchmarks/cross-harness/v1/` is not shipped in the sdist either, and the live lane is a source-tree operator surface consistent with its sibling.
- Workflow-learning review queue smoke: no learning contract touched.
- Manual Hermes/TUI check: no TUI or chat surface changed.

## Risk

Low. Entirely new files under `benchmarks/` and `tests/`, plus one documentation section. No `src/` module, schema, validator, evaluator, scorer, or trust anchor is modified, so no existing benchmark behaviour can change.

The residual risk is interpretive, not mechanical: a reader could conflate the receipt's `evidence_authenticity` with the score's identically named field. They answer different questions — the score field is always `unverified_submission` by design. The receipt's `claim_boundary`, the doc section, and the README all state the separation explicitly, and the receipt validator refuses a tier that outruns its coverage lists.

Second residual risk: `--mode dispatch` is unproven against a real provider. It is opt-in behind two explicit flags and refuses by default, so an untested path cannot run by accident.

## Compatibility / Rollout

Fully additive and backward compatible. `omh.cli benchmark validate|score|report` behave identically; the checked-in v1 examples, digests, and anchors are unchanged. Nothing new runs unless an operator invokes `bench.py` explicitly, and even then the default mode starts no process.

## Release / Claims

- [x] Release-channel impact considered (`local` — source-tree operator surface, not shipped in the sdist)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including the live-dispatch gap

## Follow-Up

- Exercise `--mode dispatch` against a real provider once, and record the observed receipt (tier `controller_observed`, non-null `tokens`/`cost_usd`) as the first genuine live-lane evidence.
- Consider a CI step running `bench.py run --mode fake` and scoring the emitted envelope, so the lane's offline contract is gated rather than only unit-tested.
- If more fixtures become observable, extend `COMMAND_FIXTURES` / `DISPATCH_FIXTURES` rather than widening what a single observation is claimed to prove.

### Design Decisions Worth Reviewing

**Why a sidecar receipt rather than `cross_harness_benchmark/v2`.** The two new facts — authenticity tier and efficiency — describe the *producer* of a submission, not the benchmark. A v2 would have required a new corpus directory, new example envelopes, and newly reviewed production trust anchors to carry fields that say nothing about what the fixtures measure. The receipt is the smaller honest design: v1 stays frozen, the envelope stays scoreable by unmodified production code, and provenance is a separate artifact that can be read or ignored independently.

**Why eleven fixtures stay unsupported.** Overlaying observed-looking values onto all fifteen would have produced a better-looking score and would have been laundering. Eleven predicates are offline metadata this controller does not execute; claiming them would convert a coverage gap into a fabricated pass. The `unsupported` outcome is the contract's own vocabulary for exactly this, and using it keeps the coverage separation the corpus was designed around.

**Why the binding runs verbatim.** The corpus pins the argv `python3 -m omh.cli harness validate`. Running it under `sys.executable` for robustness would make the observed evidence describe a different command than the one the binding names, so the binding is executed exactly as declared and a missing or too-old `python3` surfaces as an observed failure rather than a silent substitution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1Tue9T3YhWLT5mT8bo9Ke
