### PR TITLE
feat(quality): bind evidence freshness to the git tree hash

### DIFF
--- a/src/commands/goal.py
+++ b/src/commands/goal.py
@@ -17,6 +17,7 @@ from ..goal_ledger import (
     record_goal_checkpoint,
 )
 from ..installer import OmhError
+from ..quality.evidence_records import current_git_tree_hash
 from ..system.local_store import utc_now
 from ..workflows.coordination_board import (
     DEFAULT_LIMIT as COORDINATION_BOARD_DEFAULT_LIMIT,
@@ -64,6 +65,12 @@ def _mutation_payload(paths, goal_id: str, goal: dict, outcome: dict) -> dict:
 def cmd_goal_checkpoint(args: argparse.Namespace) -> int:
     paths = _paths(args)
     outcome: dict = {}
+    # Read rather than accept: the observed tree is the one thing in a
+    # checkpoint that must describe the working tree at record time, so a flag
+    # letting the caller name any tree would forge exactly the freshness the
+    # stamp exists to prove. Outside a repository the read answers None and the
+    # checkpoint is recorded with no tree, as before.
+    observed_tree = current_git_tree_hash() or ""
     try:
         goal = record_goal_checkpoint(
             paths,
@@ -74,6 +81,7 @@ def cmd_goal_checkpoint(args: argparse.Namespace) -> int:
             evidence_refs=args.evidence_ref or [],
             notes_summary=args.notes_summary or "",
             linked_runtime_run_id=args.linked_runtime_run or "",
+            observed_tree=observed_tree,
             expected_revision=args.expected_revision,
             mutation_id=args.mutation_id or None,
             outcome=outcome,

--- a/src/quality/evidence_records.py
+++ b/src/quality/evidence_records.py
@@ -6,13 +6,19 @@ upgrades a supplied assertion into observed execution evidence.
 
 from __future__ import annotations
 
+import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Mapping, Sequence
+from typing import Any, Callable, Mapping, Sequence
 
 from ..local_store import read_json_object_result
 
 QUALITY_EVIDENCE_PACKAGE_SCHEMA = "quality_evidence_package/v1"
+# `observed_tree` was added to the observation as an optional field and the
+# schema stayed at v1 on purpose: a bump would turn every stored v1 observation
+# into `unknown_schema`, which is a mass invalidation of existing evidence
+# rather than a freshness verdict about it. A reader that does not know the
+# field ignores it and behaves exactly as before.
 QUALITY_EVIDENCE_OBSERVATION_SCHEMA = "quality_evidence_observation/v1"
 QUALITY_EVIDENCE_ASSESSMENT_SCHEMA = "quality_evidence_assessment/v1"
 PREPARED_NOT_OBSERVED = "prepared_not_observed"
@@ -21,6 +27,41 @@ EVIDENCE_KINDS = frozenset({"test", "visual", "performance", "review", "ci", "pr
 RESULTS = frozenset({"passed", "failed", "unknown"})
 DIMENSION_STATES = frozenset({"satisfied", "unsatisfied", "unknown", "not_applicable"})
 _PACKAGE_FIELDS = frozenset({"schema_version", "status", "subject", "qa_scenarios", "review_requirements", "claim_requirements", "self_critique_questions", "claim_boundary"})
+_TREE_HASH_TIMEOUT_SECONDS = 15
+
+
+def current_git_tree_hash(
+    repo_root: str | Path | None = None,
+    *,
+    runner: Callable[..., Any] = subprocess.run,
+) -> str | None:
+    """Return the short tree hash of the checkout at `repo_root`, or None.
+
+    Read-only local git plumbing: no network call, nothing written, no ref
+    moved.  The tree hash is what makes freshness answerable at all -- it
+    survives a rebase or an amend that leaves tracked content identical, and
+    changes the moment that content differs, which a commit sha does not.
+
+    An absent git binary, a path outside a repository, a repository with no
+    commit, and a query that times out all return None.  That is the "the
+    question could not be answered" outcome and is deliberately distinct from
+    a known tree: only a caller holding a real hash may stamp one.
+    """
+    root = Path(repo_root).expanduser() if repo_root is not None else Path.cwd()
+    try:
+        completed = runner(
+            ["git", "rev-parse", "--short", "HEAD^{tree}"],
+            cwd=str(root),
+            text=True,
+            capture_output=True,
+            timeout=_TREE_HASH_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if getattr(completed, "returncode", 1) != 0:
+        return None
+    tree = str(getattr(completed, "stdout", "") or "").strip()
+    return tree or None
 
 
 def source_identity(repository_id: str, commit_sha: str, tree_sha: str) -> dict[str, str]:
@@ -113,8 +154,15 @@ def build_quality_evidence_observation(
     reference: str, observed_at: str, reporter: str, provenance: str = "supplied_unverified",
     record_ref: str | None = None, scenario_ids: Sequence[str] = (),
     review_requirement_ids: Sequence[str] = (), claim_ids: Sequence[str] = (), independence: str | None = None,
+    observed_tree: str | None = None,
 ) -> dict[str, object]:
-    """Build an observation bound to the package's canonical source identity."""
+    """Build an observation bound to the package's canonical source identity.
+
+    `observed_tree` is the git tree hash the observation was actually taken
+    against.  It is optional: an observation that omits it is complete and
+    assessed exactly as before, because a caller that cannot answer "which
+    tree" must not be made to guess one.
+    """
     observation = {"schema_version": QUALITY_EVIDENCE_OBSERVATION_SCHEMA, "evidence_id": evidence_id,
         "evidence_kind": evidence_kind, "result": result, "reference": reference,
         "observed_at": observed_at, "reporter": reporter, "source": _source_from_package(package),
@@ -122,6 +170,8 @@ def build_quality_evidence_observation(
         "review_requirement_ids": list(review_requirement_ids), "claim_ids": list(claim_ids)}
     if independence is not None:
         observation["independence"] = independence
+    if observed_tree is not None:
+        observation["observed_tree"] = observed_tree
     errors = validate_quality_evidence_observation(observation, package)
     if errors:
         raise ValueError("invalid quality evidence observation: " + ", ".join(errors))
@@ -162,6 +212,10 @@ def validate_quality_evidence_observation(
         errors.append("missing_observed_record_ref")
     if kind == "review" and observation.get("independence") not in {"independent", "self_review_only"}:
         errors.append("missing_review_independence")
+    if "observed_tree" in observation:
+        observed_tree = observation.get("observed_tree")
+        if not isinstance(observed_tree, str) or not observed_tree.strip():
+            errors.append("invalid_observed_tree")
     valid_ids = _package_ids(package)
     for field in ("scenario_ids", "review_requirement_ids", "claim_ids"):
         values = observation.get(field, [])
@@ -175,9 +229,21 @@ def validate_quality_evidence_observation(
 
 def assess_quality_evidence(
     package: Mapping[str, object], observations: Sequence[Mapping[str, object]] = (), *, now: datetime | None = None,
-    omh_home: str | Path | None = None,
+    omh_home: str | Path | None = None, current_tree: str | None = None,
 ) -> dict[str, object]:
-    """Derive independent dimensions and fail closed on drift or self-review."""
+    """Derive independent dimensions and fail closed on drift or self-review.
+
+    When `current_tree` is supplied, an observation stamped with a different
+    `observed_tree` is classified `stale_tree`: it was observed against content
+    that is no longer the tracked content, so it cannot speak for the current
+    tree.  Staleness is an assessment outcome only.  Nothing here relabels a
+    record, rewrites a stamp, or regenerates evidence; the stale observation is
+    left exactly as recorded and simply stops counting.
+
+    The parameter is explicit rather than probed: assessment stays a pure
+    function of what it is handed, and a caller that wants the live tree reads
+    it with `current_git_tree_hash()` first.
+    """
     package_errors = validate_quality_evidence_package(package)
     if package_errors:
         raise ValueError("invalid quality evidence package: " + ", ".join(package_errors))
@@ -188,6 +254,9 @@ def assess_quality_evidence(
         errors = validate_quality_evidence_observation(item, package)
         if errors:
             reasons.extend(errors)
+            continue
+        if _observed_tree_is_stale(item, current_tree):
+            reasons.append("stale_tree")
             continue
         if item.get("independence") == "self_review_only":
             reasons.append("self_review_only_not_admissible")
@@ -213,6 +282,10 @@ def assess_quality_evidence(
         reasons.append("contradictory_observations")
         scenario_state = "unsatisfied"
     freshness = "satisfied" if valid and all(dict(item.get("source", {})) == source for item in valid) else "unsatisfied" if "source_mismatch" in reasons else "unknown"
+    if "stale_tree" in reasons:
+        # A dropped stale observation must not leave freshness reading
+        # "satisfied" off the observations that survived beside it.
+        freshness = "unsatisfied"
     reviews = _package_ids(package)["review_requirement_ids"]
     independent = {rid for item in valid if item.get("evidence_kind") == "review" and item.get("independence") == "independent" and item.get("result") == "passed" for rid in item.get("review_requirement_ids", [])}
     review_state = "not_applicable" if not reviews else "satisfied" if independent >= reviews else "unknown" if not valid else "unsatisfied"
@@ -233,6 +306,21 @@ def assess_quality_evidence(
     dimensions = {name: _dimension(state, reasons, evidence_ids[name]) for name, state in states.items()}
     complete = all(item["status"] in {"satisfied", "not_applicable"} for item in dimensions.values())
     return {"schema_version": QUALITY_EVIDENCE_ASSESSMENT_SCHEMA, "source": source, "dimensions": dimensions, "ready_for_completion": complete, "next_action": "record_source_bound_observations" if not complete else "none", "reasons": list(dict.fromkeys(reasons)), "claim_boundary": "Assessment validates evidence consistency only; it does not prove external execution."}
+
+
+def _observed_tree_is_stale(observation: Mapping[str, object], current_tree: str | None) -> bool:
+    """True only when both trees are known and they differ.
+
+    An observation carrying no `observed_tree`, or an assessment given no
+    `current_tree`, is never stale here: the question was not asked, and an
+    unasked question must not become a staleness verdict.
+    """
+    if not isinstance(current_tree, str) or not current_tree.strip():
+        return False
+    observed_tree = observation.get("observed_tree")
+    if not isinstance(observed_tree, str) or not observed_tree.strip():
+        return False
+    return observed_tree.strip() != current_tree.strip()
 
 
 def _source_from_package(package: Mapping[str, object]) -> dict[str, str]:
@@ -313,6 +401,11 @@ def _record_is_admissible(
         if record.get(key) != observation.get(key):
             return False
     if "independence" in observation and record.get("independence") != observation.get("independence"):
+        return False
+    # A stamped observed tree is a claim about the underlying record, so the
+    # record has to carry the same one. An observation that stamps no tree
+    # keeps the pre-existing binding untouched.
+    if "observed_tree" in observation and record.get("observed_tree") != observation.get("observed_tree"):
         return False
     return True
 

--- a/src/workflows/goal_ledger.py
+++ b/src/workflows/goal_ledger.py
@@ -375,10 +375,18 @@ def record_goal_checkpoint(
     evidence_refs: Iterable[str] | None = None,
     notes_summary: str = "",
     linked_runtime_run_id: str = "",
+    observed_tree: str = "",
     expected_revision: int | None = None,
     mutation_id: str | None = None,
     outcome: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
+    """Append one checkpoint to a goal ledger.
+
+    `observed_tree` is the git tree hash the checkpoint's work was observed
+    against, read by the caller (see `current_git_tree_hash`). It is stamped as
+    recorded and never re-derived later: a checkpoint that carries no tree
+    stores the empty string, exactly as before, and stays readable as such.
+    """
     if status not in CHECKPOINT_STATUSES:
         raise ValueError(f"unsupported checkpoint status: {status}")
     if not summary.strip():
@@ -386,6 +394,7 @@ def record_goal_checkpoint(
     checkpoint_id = _mutation_item_id(mutation_id, "checkpoint")
     refs = [str(ref).strip() for ref in criteria_refs or [] if str(ref).strip()]
     evidence = _evidence_refs(evidence_refs)
+    observed_tree_ref = _safe_summary(observed_tree, limit=64)
     linked_runtime_ref = (
         _storage_id(linked_runtime_run_id, "linked_runtime_run_id") if linked_runtime_run_id.strip() else ""
     )
@@ -419,6 +428,7 @@ def record_goal_checkpoint(
             "evidence_refs": evidence,
             "notes_summary": _safe_summary(notes_summary) if notes_summary.strip() else "",
             "linked_runtime_run_id": linked_runtime_ref,
+            "observed_tree": observed_tree_ref,
         }
         goal["checkpoints"].append(checkpoint)
         goal["current_checkpoint"] = checkpoint["checkpoint_id"]
@@ -440,8 +450,12 @@ def record_goal_checkpoint(
         operation="record_goal_checkpoint",
         expected_revision=expected_revision,
         mutation_id=mutation_id,
+        # The observed tree is part of the checkpoint's content, so a retry
+        # reusing this mutation_id against a different tree is a content
+        # conflict to refuse, not a replay to serve from the stored record.
         mutation_digest=_mutation_digest(
-            "record_goal_checkpoint", summary, status, refs, evidence, notes_summary, linked_runtime_ref
+            "record_goal_checkpoint", summary, status, refs, evidence, notes_summary, linked_runtime_ref,
+            observed_tree_ref,
         ),
     )
     _record_goal_outcome(
@@ -1123,6 +1137,10 @@ def _validate_checkpoints(checkpoints: Any, errors: list[str]) -> None:
             errors.append(f"checkpoints[{index}].criteria_refs must be a list")
         if not isinstance(checkpoint.get("evidence_refs"), list):
             errors.append(f"checkpoints[{index}].evidence_refs must be a list")
+        # Optional, so a checkpoint written before the field existed stays
+        # valid; a present value still has to be a string.
+        if not isinstance(checkpoint.get("observed_tree", ""), str):
+            errors.append(f"checkpoints[{index}].observed_tree must be a string")
 
 
 def _validate_blockers(blockers: Any, errors: list[str]) -> None:

--- a/tests/test_goal_ledger.py
+++ b/tests/test_goal_ledger.py
@@ -27,7 +27,11 @@ from omh.goal_ledger import (
     validate_goal_ledger,
 )
 from omh.paths import resolve_paths
-from omh.record_revision import APPLIED_MUTATIONS_LIMIT, applied_mutation_key
+from omh.record_revision import (
+    APPLIED_MUTATIONS_LIMIT,
+    ConflictingMutationReplay,
+    applied_mutation_key,
+)
 
 
 class GoalLedgerTests(unittest.TestCase):
@@ -80,6 +84,75 @@ class GoalLedgerTests(unittest.TestCase):
             self.assertEqual(updated["acceptance_criteria"][0]["evidence_refs"], ["tests/test_goal_ledger.py"])
             self.assertEqual(updated["linked_runtime_runs"], ["run-42"])
             self.assertEqual(read_goal_ledger(paths, "goal-checkpoint")["checkpoints"][0]["status"], "done")
+
+    def test_checkpoint_stamps_the_tree_the_work_was_observed_against(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            create_goal_ledger(
+                paths, "Stamp the observed tree", [{"id": "AC-tree", "summary": "Tree is stamped"}], goal_id="goal-tree"
+            )
+
+            updated = record_goal_checkpoint(
+                paths,
+                "goal-tree",
+                "Ran the suite",
+                criteria_refs=["AC-tree"],
+                evidence_refs=["tests/test_goal_ledger.py"],
+                observed_tree="abc1234",
+            )
+
+            self.assertEqual(updated["checkpoints"][0]["observed_tree"], "abc1234")
+            stored = read_goal_ledger(paths, "goal-tree")
+            self.assertEqual(stored["checkpoints"][0]["observed_tree"], "abc1234")
+
+    def test_a_checkpoint_without_an_observed_tree_records_no_tree(self) -> None:
+        # The stamp is optional: a caller that cannot answer "which tree" must
+        # keep recording checkpoints exactly as before rather than guess one.
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            create_goal_ledger(
+                paths, "Skip the observed tree", [{"id": "AC-none", "summary": "No tree"}], goal_id="goal-no-tree"
+            )
+
+            updated = record_goal_checkpoint(paths, "goal-no-tree", "Drafted the notes", status="in_progress")
+
+            self.assertEqual(updated["checkpoints"][0]["observed_tree"], "")
+            self.assertTrue(validate_goal_ledger(read_goal_ledger(paths, "goal-no-tree"))["ok"])
+
+    def test_a_checkpoint_written_before_the_field_existed_stays_valid(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            create_goal_ledger(
+                paths, "Read an older ledger", [{"id": "AC-old", "summary": "Old shape"}], goal_id="goal-old"
+            )
+            record_goal_checkpoint(paths, "goal-old", "Recorded earlier", status="in_progress")
+            path = goal_ledger_path(paths, "goal-old")
+            goal = json.loads(path.read_text(encoding="utf-8"))
+            goal["checkpoints"][0].pop("observed_tree")
+            path.write_text(json.dumps(goal), encoding="utf-8")
+
+            self.assertTrue(validate_goal_ledger(read_goal_ledger(paths, "goal-old"))["ok"])
+
+    def test_a_retry_stamping_a_different_tree_is_refused_not_replayed(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            create_goal_ledger(
+                paths, "Refuse a divergent retry", [{"id": "AC-retry", "summary": "Retry is guarded"}], goal_id="goal-retry-tree"
+            )
+            record_goal_checkpoint(
+                paths, "goal-retry-tree", "Ran the suite", status="in_progress",
+                mutation_id="cp-tree-1", observed_tree="abc1234",
+            )
+
+            with self.assertRaises(ConflictingMutationReplay):
+                record_goal_checkpoint(
+                    paths, "goal-retry-tree", "Ran the suite", status="in_progress",
+                    mutation_id="cp-tree-1", observed_tree="def5678",
+                )
+
+            stored = read_goal_ledger(paths, "goal-retry-tree")
+            self.assertEqual(len(stored["checkpoints"]), 1)
+            self.assertEqual(stored["checkpoints"][0]["observed_tree"], "abc1234")
 
     def test_completion_gate_rejects_pending_criteria_with_summary_only_output(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_handoff_safety_contract_enforcement.py
+++ b/tests/test_handoff_safety_contract_enforcement.py
@@ -198,6 +198,12 @@ PROCESS_SPAWN_ALLOWLIST: dict[str, str] = {
         "explicit `omh menubar status --observe-local-processes` (also invoked by the opted-in "
         "native helper); reads local process status, spawns no agent."
     ),
+    "src/quality/evidence_records.py": (
+        "`current_git_tree_hash()`, reached from `omh goal checkpoint`, runs one bounded local "
+        "read-only `git rev-parse --short HEAD^{tree}` so a recorded observation carries the tree "
+        "it was observed against. It reads a hash and nothing else: no ref moves, no work starts, "
+        "and a machine with no git or no repository answers None instead of a stamp."
+    ),
 }
 
 # Alternative spawn routes. No allowlist: `subprocess` is the only sanctioned
@@ -506,6 +512,12 @@ GIT_ARGV_ALLOWLIST: dict[tuple[str, tuple[str, ...]], str] = {
         "`rev-parse --show-toplevel`, run BEFORE the `add -N` above, to prove the recovery probe is "
         "standing in the unit's own worktree and not in whatever repository encloses it; read-only, "
         "and the reason the `add` entry's containment claim is checked rather than asserted"
+    ),
+    ("src/quality/evidence_records.py", ("rev-parse", "HEAD^{tree}")): (
+        "`rev-parse --short HEAD^{tree}` reads the tree hash a quality-evidence observation is "
+        "recorded against, so assessment can later tell evidence about the current tracked content "
+        "from evidence about older content; read-only local object lookup, names no remote, and it "
+        "resolves no ref the caller supplied"
     ),
 }
 

--- a/tests/test_quality_evidence_records.py
+++ b/tests/test_quality_evidence_records.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import unittest
 import json
+import subprocess
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -10,9 +11,19 @@ from omh.quality.evidence_records import (
     assess_quality_evidence,
     build_quality_evidence_observation,
     build_quality_evidence_package,
+    current_git_tree_hash,
     validate_quality_evidence_observation,
     validate_quality_evidence_package,
 )
+
+
+class _CompletedProcess:
+    """Minimal stand-in for the `subprocess.run` result the helper reads."""
+
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
 
 
 class QualityEvidenceRecordsTests(unittest.TestCase):
@@ -73,6 +84,7 @@ class QualityEvidenceRecordsTests(unittest.TestCase):
             "review_requirement_ids": observation.get("review_requirement_ids", []),
             "claim_ids": observation.get("claim_ids", []),
             **({"independence": observation["independence"]} if "independence" in observation else {}),
+            **({"observed_tree": observation["observed_tree"]} if "observed_tree" in observation else {}),
             "executor_target": self.package["subject"]["executor_target"],
             "observed": True,
             "provenance": "omh_observed_record",
@@ -278,6 +290,132 @@ class QualityEvidenceRecordsTests(unittest.TestCase):
         for item in observations:
             self._write_record(item)
         self.assertEqual(assess_quality_evidence(package, observations, omh_home=self.omh_home)["dimensions"]["ci_status"]["status"], "unsatisfied")
+
+    def test_evidence_observed_against_the_current_tree_stays_fresh(self) -> None:
+        observation = self._observation(observed_tree="tree-aaa")
+        self.assertEqual(validate_quality_evidence_observation(observation, self.package), [])
+
+        assessment = assess_quality_evidence(
+            self.package, [observation], omh_home=self.omh_home, current_tree="tree-aaa"
+        )
+
+        self.assertEqual(assessment["dimensions"]["source_freshness"]["status"], "satisfied")
+        self.assertEqual(assessment["dimensions"]["scenario_coverage"]["status"], "satisfied")
+        self.assertNotIn("stale_tree", assessment["reasons"])
+
+    def test_evidence_observed_against_another_tree_is_stale(self) -> None:
+        observation = self._observation(observed_tree="tree-aaa")
+
+        assessment = assess_quality_evidence(
+            self.package, [observation], omh_home=self.omh_home, current_tree="tree-bbb"
+        )
+
+        self.assertIn("stale_tree", assessment["reasons"])
+        self.assertEqual(assessment["dimensions"]["source_freshness"]["status"], "unsatisfied")
+        self.assertEqual(assessment["dimensions"]["scenario_coverage"]["status"], "unknown")
+        self.assertFalse(assessment["ready_for_completion"])
+
+    def test_stale_evidence_is_classified_and_never_rewritten(self) -> None:
+        observation = self._observation(observed_tree="tree-aaa")
+        record = self.omh_home / str(observation["record_ref"])
+        before = record.read_text(encoding="utf-8")
+
+        assess_quality_evidence(
+            self.package, [observation], omh_home=self.omh_home, current_tree="tree-bbb"
+        )
+
+        self.assertEqual(observation["observed_tree"], "tree-aaa")
+        self.assertEqual(record.read_text(encoding="utf-8"), before)
+
+    def test_a_fresh_observation_beside_a_stale_one_does_not_restore_freshness(self) -> None:
+        fresh = self._observation(evidence_id="fresh", observed_tree="tree-bbb")
+        stale = self._observation(evidence_id="stale", observed_tree="tree-aaa")
+
+        assessment = assess_quality_evidence(
+            self.package, [fresh, stale], omh_home=self.omh_home, current_tree="tree-bbb"
+        )
+
+        self.assertEqual(assessment["dimensions"]["source_freshness"]["status"], "unsatisfied")
+        self.assertEqual(assessment["dimensions"]["source_freshness"]["evidence_ids"], ["fresh"])
+
+    def test_evidence_without_an_observed_tree_is_assessed_exactly_as_before(self) -> None:
+        observation = self._observation()
+        self.assertNotIn("observed_tree", observation)
+
+        baseline = assess_quality_evidence(self.package, [observation], omh_home=self.omh_home)
+        with_current_tree = assess_quality_evidence(
+            self.package, [observation], omh_home=self.omh_home, current_tree="tree-bbb"
+        )
+
+        self.assertEqual(with_current_tree, baseline)
+        self.assertNotIn("stale_tree", with_current_tree["reasons"])
+        self.assertEqual(with_current_tree["dimensions"]["scenario_coverage"]["status"], "satisfied")
+
+    def test_an_unknown_current_tree_never_becomes_a_staleness_verdict(self) -> None:
+        observation = self._observation(observed_tree="tree-aaa")
+
+        assessment = assess_quality_evidence(self.package, [observation], omh_home=self.omh_home)
+
+        self.assertNotIn("stale_tree", assessment["reasons"])
+        self.assertEqual(assessment["dimensions"]["scenario_coverage"]["status"], "satisfied")
+
+    def test_observed_tree_must_be_a_nonblank_string_and_match_the_record(self) -> None:
+        blank = self._observation(observed_tree="  ")
+        self.assertIn("invalid_observed_tree", validate_quality_evidence_observation(blank, self.package))
+
+        observation = self._observation(observed_tree="tree-aaa")
+        record = self.omh_home / str(observation["record_ref"])
+        payload = json.loads(record.read_text(encoding="utf-8"))
+        payload["observed_tree"] = "tree-bbb"
+        record.write_text(json.dumps(payload), encoding="utf-8")
+
+        assessment = assess_quality_evidence(
+            self.package, [observation], omh_home=self.omh_home, current_tree="tree-aaa"
+        )
+        self.assertIn("unresolved_observed_record", assessment["reasons"])
+
+    def test_builder_stamps_the_observed_tree_only_when_one_is_supplied(self) -> None:
+        stamped = build_quality_evidence_observation(
+            self.package, evidence_id="stamped", evidence_kind="test", result="passed", reference="tests",
+            observed_at="2026-07-16T00:00:00Z", reporter="executor", provenance="omh_observed_record",
+            record_ref="runtime/stamped.json", scenario_ids=["scenario-pass"], observed_tree="tree-aaa",
+        )
+        unstamped = build_quality_evidence_observation(
+            self.package, evidence_id="unstamped", evidence_kind="test", result="passed", reference="tests",
+            observed_at="2026-07-16T00:00:00Z", reporter="executor", provenance="omh_observed_record",
+            record_ref="runtime/unstamped.json", scenario_ids=["scenario-pass"],
+        )
+
+        self.assertEqual(stamped["observed_tree"], "tree-aaa")
+        self.assertNotIn("observed_tree", unstamped)
+
+    def test_current_git_tree_hash_reads_the_short_tree_and_fails_soft(self) -> None:
+        calls: list[dict[str, object]] = []
+
+        def runner(argv: list[str], **kwargs: object) -> _CompletedProcess:
+            calls.append({"argv": argv, **kwargs})
+            return _CompletedProcess(0, stdout="abc1234\n")
+
+        self.assertEqual(current_git_tree_hash(self.omh_home, runner=runner), "abc1234")
+        self.assertEqual(calls[0]["argv"], ["git", "rev-parse", "--short", "HEAD^{tree}"])
+        self.assertEqual(calls[0]["cwd"], str(self.omh_home))
+
+        def failing(argv: list[str], **kwargs: object) -> _CompletedProcess:
+            return _CompletedProcess(128, stderr="not a git repository")
+
+        def blank(argv: list[str], **kwargs: object) -> _CompletedProcess:
+            return _CompletedProcess(0, stdout="\n")
+
+        def missing_binary(argv: list[str], **kwargs: object) -> _CompletedProcess:
+            raise FileNotFoundError("git")
+
+        def timed_out(argv: list[str], **kwargs: object) -> _CompletedProcess:
+            raise subprocess.TimeoutExpired(cmd=argv, timeout=15)
+
+        self.assertIsNone(current_git_tree_hash(self.omh_home, runner=failing))
+        self.assertIsNone(current_git_tree_hash(self.omh_home, runner=blank))
+        self.assertIsNone(current_git_tree_hash(self.omh_home, runner=missing_binary))
+        self.assertIsNone(current_git_tree_hash(self.omh_home, runner=timed_out))
 
     def test_self_review_never_counts_with_independent_review(self) -> None:
         reviews = [


### PR DESCRIPTION
## Feature Report

### What Changed

- Quality-evidence observations can now carry `observed_tree`, the git tree hash the observation was actually taken against, and `assess_quality_evidence()` accepts the current tree and classifies a mismatch as a new `stale_tree` reason that drops `source_freshness` to `unsatisfied`.
- New `current_git_tree_hash()` helper in `src/quality/evidence_records.py`: one bounded, read-only `git rev-parse --short "HEAD^{tree}"` with an injectable runner.
- Goal-ledger checkpoints stamp `observed_tree`, and `omh goal checkpoint` reads the live tree itself so the stamp is an observation rather than a caller's claim.
- Both handoff safety-contract allowlists (`PROCESS_SPAWN_ALLOWLIST`, `GIT_ARGV_ALLOWLIST`) carry the new process boundary with a written reason.

### Why This Exists

OMH's differentiator is evidence discipline — the prepared/observed axis, the provenance taxonomy, the per-payload claim boundaries. But it had no answer at all to the question that decides whether any of that still means anything: **is this evidence about the code that is here now?**

A `unit_verification_observed` record written before an amend was byte-indistinguishable from one written after it. Nothing in the assessment could tell them apart, so "ready_for_completion" could be true about content that no longer existed.

The design is absorbed from omo (`ulw-loop`), which binds evidence to `git rev-parse --short "HEAD^{tree}"`: valid across a rebase or amend that keeps the tree identical, invalid the instant tracked content differs, never relabelled and never regenerated. It is strictly better than the alternative in the field (omc's 5-minute wall clock), which expires evidence that is still true and keeps evidence that is already false. The comparison that motivated this is in `.omc/research/omo-omc-comparison-2026-08-29.md`, P1 item 1.

### User / Operator Impact

- An operator running `omh goal checkpoint` now gets the working tree hash recorded on the checkpoint automatically — no flag, nothing to remember.
- A caller assessing evidence can pass `current_tree=` and get `stale_tree` back for every observation that was taken against different content, instead of an assessment that silently counts it.
- Evidence recorded before a rebase or an amend that changed nothing tracked stays valid, which is the case the naive "compare the commit sha" approach gets wrong.

### How It Works

**Staleness is an assessment outcome, never a mutation.** `assess_quality_evidence()` drops a stale observation from the admissible set and appends the `stale_tree` reason. It does not rewrite the stamp, relabel the record, or regenerate anything — the observation on disk is untouched, which a test asserts by byte-comparing the record file before and after an assessment that finds it stale. `source_freshness` is forced to `unsatisfied` whenever any observation was stale, so a fresh observation sitting beside a stale one cannot restore the dimension.

**Backward compatibility is the default, not an option.** The observation schema stays at `quality_evidence_observation/v1`. Bumping it would turn every stored v1 observation into `unknown_schema` — a mass invalidation of existing evidence rather than a freshness verdict about it, which is exactly the mutation this feature exists to avoid. An observation with no `observed_tree`, and an assessment given no `current_tree`, produce a byte-identical assessment to before; there is a test that asserts equality of the two full assessment payloads. An unasked question must not become a staleness verdict.

**The process boundary is real and is written down.** `current_git_tree_hash()` is the only new spawn. It moves no ref, writes nothing, names no remote, and returns `None` — not a guess — when the question cannot be answered (no git binary, no repository, no commit, timeout). `src/quality/evidence_records.py` and the `("rev-parse", "HEAD^{tree}")` argv are both added to the INVARIANT 1 / INVARIANT 3 allowlists in `tests/test_handoff_safety_contract_enforcement.py` with the reason spelled out, per that module's rule that "adding an entry is a decision someone has to write down".

**The stamp is read, not accepted.** `omh goal checkpoint` calls the helper instead of exposing an `--observed-tree` flag: a caller-named tree is a claim, and a flag would let anyone forge precisely the freshness the stamp exists to prove. The tree is part of the checkpoint's content, so it joins `_mutation_digest(...)` — a retry reusing a `mutation_id` against a different tree is a content conflict to refuse, not a replay to serve from the stored record.

### Files And Contracts Touched

- `src/quality/evidence_records.py` — `current_git_tree_hash()`, optional `observed_tree` on the observation builder and validator (`invalid_observed_tree`), `current_tree=` on `assess_quality_evidence()`, the `stale_tree` reason and its freshness effect, and the observed-record binding check so a stamped tree must match the underlying record.
- `src/workflows/goal_ledger.py` — `observed_tree` parameter on `record_goal_checkpoint`, stamped on the checkpoint, included in the mutation digest, and validated as an optional string so ledgers written before the field stay valid.
- `src/commands/goal.py` — `omh goal checkpoint` reads the tree.
- `tests/test_handoff_safety_contract_enforcement.py` — two allowlist entries with reasons.
- `tests/test_quality_evidence_records.py`, `tests/test_goal_ledger.py` — coverage below.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke ... release hermes-smoke ...`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed
- [x] Relevant dry-run or smoke command: `omh goal create` + `omh goal checkpoint` against a temporary OMH home
- [ ] Manual Hermes/TUI check

### Observed Evidence

- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` → **7837 tests, 21 failures / 7 errors**, all of them in `tests/test_cross_harness_adapters.py` (18) and `tests/test_cross_harness_adapter_security.py` (10). **These reproduce identically on the unmodified tree**: stashing this branch's changes and running those two files alone on `origin/main` gives the same 21 failures / 7 errors, so they are a pre-existing sandbox-environment failure on this machine and not a regression from this PR. Every other test in the suite passes.
- `PYTHONPATH=tests uv run python -m unittest tests/test_quality_evidence_records.py -v` → 28 passed (21 pre-existing + 7 new).
- `PYTHONPATH=tests uv run python -m unittest tests/test_goal_ledger.py -v` → 34 passed (30 pre-existing + 4 new).
- `PYTHONPATH=tests uv run python -m unittest tests/test_handoff_safety_contract_enforcement.py tests/test_goal_cli.py tests/test_quality_evidence_records.py tests/test_goal_ledger.py` → 92 passed.
- `uv run python -m compileall -q src tests` → clean.
- `uv run python -m omh.cli docs workflows --check` → `ok: true`, tap-skills 140/140, no missing/stale/extra.
- `uv run python -m omh.cli docs roles --check` → `ok: true`.
- `uv run python -m omh.cli docs capability-families --check` → `ok: true`. Also ran `docs ulw-inventory --check` and `docs ulw-site --check` → both `ok: true`.
- `uv run --group lint ruff check src tests` → All checks passed.
- `git diff --check` → clean.
- Manual smoke against a temporary OMH home: `omh goal create --goal-id smoke-tree ...` then `omh goal checkpoint --goal smoke-tree --summary "Ran the targeted suite" --criterion AC001 --evidence-ref ...` recorded `observed_tree: 8b1fbdac`, byte-equal to `git rev-parse --short "HEAD^{tree}"` in the same worktree.

New test coverage, positive and negative in pairs:

| Case | Expected |
| --- | --- |
| observation tree == current tree | `source_freshness` satisfied, no `stale_tree` |
| observation tree != current tree | `stale_tree` reason, freshness unsatisfied, scenario coverage back to unknown |
| stale observation assessed | record file byte-identical before and after; stamp unchanged |
| fresh observation beside a stale one | freshness still unsatisfied; only the fresh id listed |
| no `observed_tree` on the observation | assessment payload equal to the no-`current_tree` baseline |
| `observed_tree` present, no `current_tree` given | no `stale_tree`; assessed as before |
| blank / non-string `observed_tree` | `invalid_observed_tree` |
| stamped tree disagrees with the resolved OMH record | `unresolved_observed_record` |
| helper: exit 0 with a hash / exit 128 / blank stdout / no git binary / timeout | hash, then `None` four times |
| checkpoint with and without a tree | stamped hash; empty string |
| checkpoint written before the field existed | still validates |
| retry reusing a `mutation_id` with a different tree | `ConflictingMutationReplay`, one checkpoint, original tree kept |

### Not Tested / Not Applicable

- `harness validate`, `release checklist`, `release hermes-smoke`, and the install-path smoke: this PR changes no harness contract, no release surface, and no installed artifact.
- Manual Hermes/TUI check: no Hermes-facing surface, skill catalog entry, or HUD projection changed; no generated artifact family was touched, which the five `--check` gates confirm.
- The cross-harness adapter sandbox lane could not be exercised on this machine either before or after the change (see Observed Evidence).

## Risk

- `omh goal checkpoint` now shells out to `git` once per invocation. It is read-only and bounded (15s timeout), and a machine with no git or outside a repository records the checkpoint with an empty tree exactly as before — but it is a new process spawn on a command that previously had none, which is why it is allowlisted with a written reason rather than left implicit.
- Including the observed tree in the checkpoint mutation digest changes digest values. A `mutation_id` that was first recorded before this change and is retried after it will be refused as a conflicting replay instead of served from the stored record. Refusal is the conservative direction — nothing is written and nothing is silently discarded — and the window is one in-flight retry across the upgrade.

## Compatibility / Rollout

- Observation schema stays `quality_evidence_observation/v1`; goal ledger stays `goal_ledger/v1`. Both fields are additive and optional.
- Records written by an older version read and assess identically: a checkpoint with no `observed_tree` key still validates, and an observation with no stamp is assessed exactly as before.
- `assess_quality_evidence(current_tree=...)` is keyword-only with a `None` default, so every existing call site is unaffected.

## Release / Claims

- [x] Release-channel impact considered (`local`; no installed artifact or release surface changes)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence — the assessment claim boundary is unchanged and still reads "Assessment validates evidence consistency only; it does not prove external execution."
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed

## Follow-Up

- **Stamp the fanout dispatch status ladder.** `src/coding/fanout_dispatch.py` was deliberately left untouched here because a parallel PR owns that file. Its `unit_verification_observed` and `integration_ready` promotions are the highest-value place for this binding and still carry no tree; wire `current_git_tree_hash()` into `_dispatch_status_ladder` there.
- **Operator-facing assessment.** `omh quality-evidence assess` does not yet expose `--current-tree`, so the staleness verdict is currently reachable through the library and through what stamping records, not from that command. Worth adding once the dispatch-ladder consumer above lands and there is a real end-to-end operator flow to shape the flag around.
- **Blockers and quality gates.** Only checkpoints stamp a tree today; `record_goal_blocker` and `record_goal_quality_gate` are the obvious next records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1Tue9T3YhWLT5mT8bo9Ke
