### PR TITLE
feat(fanout): classify unit retries and gate them on replay safety

### DIFF
--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -169,6 +169,30 @@ Rules:
   `spawn_guard` block alongside how much of the budget the run used. Neither
   is verification, review, or merge evidence — a run inside its bounds is not
   thereby correct.
+- **Retries are classified, and never replayed over observed work.** A failed
+  unit is retried only when both answers come back yes, in this order. First,
+  is the failure transient? A provider rate limit, an overload, an HTTP 5xx, a
+  socket reset or hang-up is the executor's transport failing; a real non-zero
+  exit from a test or verification run is the unit's own answer and is
+  **terminal**, never retried. A timeout and a missing executable get their own
+  terminal classes. Second, is the unit replay-safe? Only a unit that has
+  produced **no observed side effect** may be re-dispatched: the recovery probe
+  measures the worktree, and `recovery_available` (files written) or
+  `capture_failed` (unmeasurable) both block the replay — "I could not tell"
+  fails closed. A result sidecar on disk blocks it too. A transient failure
+  that is not replay-safe is surfaced through the existing
+  `recovery_available` path as work to **continue**, with
+  `retry_blocked_by_side_effects` on the unit entry, rather than silently
+  re-run from base — which would destroy exactly the work the failure left
+  behind. Backoff is `min(2s * 2^(attempt-1), 30s)` scaled by 75–100% jitter,
+  bounded at two retries, so a fanout of N units that all hit one rate limit
+  does not retry in lockstep and re-trigger it. Every attempt spends the
+  `run_spawn_ceiling` budget like any other spawn. The unit entry's `retry`
+  block records the attempts and the reason trying stopped — `terminal`,
+  `retries_exhausted`, `surfaced_for_continuation`, `spawn_ceiling_reached`,
+  or `interrupted`; a unit that succeeded first try carries no block at all. A
+  retry is another attempt, not evidence: a unit that passed on attempt three
+  is no more verified than one that passed on attempt one.
 - **Admission is dependency-frontier, not wave-barrier.** A unit starts the
   moment every unit it depends on has completed and a pool slot is free —
   never because a wave boundary was reached — so an unrelated slow sibling

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -9,6 +9,7 @@ from hashlib import sha256
 import json
 import os
 from pathlib import Path
+import random
 import shlex
 import shutil
 import signal
@@ -49,6 +50,13 @@ from .fanout_contracts import (
 )
 from .inflight import InflightMarkerError, clear_inflight_marker, write_inflight_marker
 from .parallelism_policy import FANOUT_MAX_DEPTH_DEFAULT, FANOUT_RUN_SPAWN_CEILING_DEFAULT
+from .fanout_retry import (
+    FANOUT_MAX_RETRIES,
+    RETRY_CLAIM_BOUNDARY,
+    RETRY_POLICY_SCHEMA_VERSION,
+    classify_unit_failure,
+    evaluate_unit_retry,
+)
 from .unit_prompt_protocol import shared_unit_preamble_lines, unit_protocol_lines
 from .fanout_unit_results import validate_check_rows, validate_unit_result
 from .unit_telemetry import parse_unit_telemetry
@@ -991,6 +999,11 @@ def dispatch_fanout(
     max_depth: int | None = None,
     spawn_ceiling: int | None = None,
     env: Mapping[str, str] | None = None,
+    # The retry policy's two impure inputs, injected so the whole ladder is
+    # assertable without a clock and without a single sleep in a test.
+    max_retries: int = FANOUT_MAX_RETRIES,
+    rng: Callable[[], float] = random.random,
+    sleep: Callable[[float], None] = time.sleep,
 ) -> dict[str, Any]:
     # The spawn guard runs before every other check, including the two
     # boundary re-checks below: it is the only one whose whole job is that no
@@ -1200,6 +1213,9 @@ def dispatch_fanout(
                 spawn_ledger=spawn_ledger,
                 dispatch_depth=current_depth,
                 base_env=guard_env,
+                max_retries=max_retries,
+                rng=rng,
+                sleep=sleep,
             )
 
         def _admit_frontier() -> None:
@@ -1699,6 +1715,66 @@ def _close_fanout_progress_binding(
         return
 
 
+def _consider_unit_retry(
+    paths: OmhPaths,
+    *,
+    attempt: int,
+    exit_code: int,
+    output_tail: str,
+    stderr_tail: str,
+    sidecar_path: Path | None,
+    worktree: Path,
+    base_sha: str,
+    runner: Callable[..., Any],
+    max_retries: int,
+    rng: Callable[[], float],
+) -> dict[str, Any]:
+    """Decide whether this failed attempt earns another one, and say why.
+
+    The replay-safety half is measured, not assumed: the SAME recovery probe
+    that reports what a failed unit left behind answers "has this unit produced
+    an observed side effect", and it is called with an empty `fanout_id` so a
+    mid-flight probe never persists an intermediate record over the real one
+    written at the end. The probe only runs for a failure already classified as
+    transient -- a terminal failure is not retried whatever the worktree holds,
+    so measuring it would be work spent on an answer nobody reads.
+    """
+    # Derived once and passed to both calls: the retry verdict and the
+    # persisted provider-limit evidence must never disagree about whether this
+    # failure was limit-shaped.
+    limit_label = _limit_shaped_label(output_tail, stderr_tail)
+    classification = classify_unit_failure(
+        exit_code=exit_code,
+        output_tail=output_tail,
+        stderr_tail=stderr_tail,
+        limit_shaped=limit_label,
+    )
+    recovery: dict[str, Any] | None = None
+    artifact_observed = False
+    if classification["retryable"] and attempt <= max_retries:
+        artifact_observed = sidecar_path is not None and sidecar_path.is_file()
+        if not artifact_observed:
+            recovery = _capture_unit_recovery(
+                paths,
+                fanout_id="",
+                unit_id="",
+                worktree=worktree,
+                base_sha=base_sha,
+                runner=runner,
+            )
+    return evaluate_unit_retry(
+        attempt=attempt,
+        exit_code=exit_code,
+        output_tail=output_tail,
+        stderr_tail=stderr_tail,
+        limit_shaped=limit_label,
+        recovery=recovery,
+        artifact_observed=artifact_observed,
+        max_retries=max_retries,
+        rng=rng,
+    )
+
+
 def _dispatch_unit(
     paths: OmhPaths,
     unit: Mapping[str, Any],
@@ -1720,6 +1796,9 @@ def _dispatch_unit(
     spawn_ledger: _SpawnLedger | None = None,
     dispatch_depth: int = 0,
     base_env: Mapping[str, str] | None = None,
+    max_retries: int = FANOUT_MAX_RETRIES,
+    rng: Callable[[], float] = random.random,
+    sleep: Callable[[float], None] = time.sleep,
 ) -> dict[str, Any]:
     from .model_inventory import catalog_fingerprint_note
 
@@ -1975,6 +2054,10 @@ def _dispatch_unit(
     # up to its freshness window. See _open_fanout_progress_binding.
     progress_binding: dict[str, Any] | None = None
     spawn_kwargs: dict[str, Any] = {}
+    # One entry per FAILED attempt, each carrying why it did or did not lead to
+    # another one. An empty list means the unit succeeded first try.
+    retry_decisions: list[dict[str, Any]] = []
+    attempt = 0
     try:
         progress_binding = _open_fanout_progress_binding(
             paths,
@@ -2010,34 +2093,74 @@ def _dispatch_unit(
                 progress_binding = _record_fanout_progress_pid(paths, progress_binding, process.pid)
 
             spawn_kwargs["on_spawn"] = _record_pid
+        while True:
+            attempt += 1
+            output_tail = ""
+            stdout_text = ""
+            stderr_tail = ""
+            exit_code = 1
             # Real spawns only (the same seam as the pid hook): stagger this
             # unit's start so the first dispatch of the fanout writes the
             # provider prompt cache the byte-identical sibling preambles read.
-            if spawn_stagger is not None:
+            # Inside the loop, so a retry is spaced from its siblings too.
+            if spawn_stagger is not None and "on_spawn" in spawn_kwargs:
                 spawn_stagger.reserve()
-        completed = runner(
-            argv,
-            cwd=str(worktree),
-            # The lineage stamp goes in at the Popen boundary, not into the
-            # dispatcher's own environment: an agent CLI that reads its
-            # instructions and reaches for `omh coding fanout dispatch`
-            # refuses on the depth it inherits here.
-            env=child_env,
-            text=True,
-            capture_output=True,
-            timeout=timeout,
-            **spawn_kwargs,
-        )
-        exit_code = int(getattr(completed, "returncode", 1))
-        stdout_text = str(getattr(completed, "stdout", "") or "")
-        output_tail = stdout_text[-2000:]
-        stderr_tail = str(getattr(completed, "stderr", "") or "")[-2000:]
-    except FileNotFoundError:
-        exit_code, output_tail = 127, f"{argv[0]} not found on PATH"
-    except subprocess.TimeoutExpired:
-        exit_code, output_tail = 124, f"unit timed out after {timeout}s"
-    except OSError as exc:
-        exit_code, output_tail = 1, f"spawn failed: {exc}"
+            try:
+                completed = runner(
+                    argv,
+                    cwd=str(worktree),
+                    # The lineage stamp goes in at the Popen boundary, not into
+                    # the dispatcher's own environment: an agent CLI that reads
+                    # its instructions and reaches for `omh coding fanout
+                    # dispatch` refuses on the depth it inherits here.
+                    env=child_env,
+                    text=True,
+                    capture_output=True,
+                    timeout=timeout,
+                    **spawn_kwargs,
+                )
+                exit_code = int(getattr(completed, "returncode", 1))
+                stdout_text = str(getattr(completed, "stdout", "") or "")
+                output_tail = stdout_text[-2000:]
+                stderr_tail = str(getattr(completed, "stderr", "") or "")[-2000:]
+            except FileNotFoundError:
+                exit_code, output_tail = 127, f"{argv[0]} not found on PATH"
+            except subprocess.TimeoutExpired:
+                exit_code, output_tail = 124, f"unit timed out after {timeout}s"
+            except OSError as exc:
+                exit_code, output_tail = 1, f"spawn failed: {exc}"
+            if exit_code == 0:
+                break
+            decision = _consider_unit_retry(
+                paths,
+                attempt=attempt,
+                exit_code=exit_code,
+                output_tail=output_tail,
+                stderr_tail=stderr_tail,
+                sidecar_path=sidecar_path,
+                worktree=worktree,
+                base_sha=base_sha,
+                runner=runner,
+                max_retries=max_retries,
+                rng=rng,
+            )
+            retry_decisions.append(decision)
+            if not decision.get("retry"):
+                break
+            # A retry is another real spawn and spends the run's budget like
+            # any other; when the budget is gone the unit stops here with its
+            # decision already recorded.
+            if spawn_ledger is not None and not spawn_ledger.claim():
+                decision["retry"] = False
+                decision["decision"] = "spawn_ceiling_reached"
+                break
+            # An interrupted batch must not start a fresh attempt nobody will
+            # collect -- the same rule the pool's own workers follow.
+            if _INTERRUPT_FLAG.is_set():
+                decision["retry"] = False
+                decision["decision"] = "interrupted"
+                break
+            sleep(float(decision["delay_seconds"]))
     finally:
         _clear_inflight(paths, fanout_id, unit_id)
         _close_fanout_progress_binding(
@@ -2144,6 +2267,25 @@ def _dispatch_unit(
     if limit_label:
         result["limit_shaped"] = True
         result["limit_pattern"] = limit_label
+    if retry_decisions:
+        # Only when something actually failed once: a unit that succeeded on
+        # its first attempt carries no retry key at all, so the presence of
+        # this block is itself the signal.
+        final = retry_decisions[-1]
+        result["retry"] = {
+            "schema_version": RETRY_POLICY_SCHEMA_VERSION,
+            "attempts": attempt,
+            "max_retries": max_retries,
+            "final_decision": str(final.get("decision", "")),
+            "decisions": retry_decisions,
+            "claim_boundary": RETRY_CLAIM_BOUNDARY,
+        }
+        if final.get("decision") == "surfaced_for_continuation":
+            # The headline of the replay-safety predicate: this unit COULD
+            # have been retried and deliberately was not, because re-running
+            # it from base would destroy the work its failure left behind.
+            # The recovery record captured just below is how it is continued.
+            result["retry_blocked_by_side_effects"] = True
     if exit_code != 0:
         # A failed unit still owns its worktree, and whatever it managed to
         # write is the only thing standing between the operator and redoing

--- a/src/coding/fanout_retry.py
+++ b/src/coding/fanout_retry.py
@@ -1,0 +1,244 @@
+"""Deterministic retry policy for units dispatched by `omh coding fanout dispatch`.
+
+Two disjoint questions, decided mechanically and in this order:
+
+1. **Is the failure transient?** A rate limit, a provider overload, an HTTP
+   5xx, a socket reset or hang-up is the executor's transport failing, not the
+   unit's work being wrong. A non-zero exit from a real test or verification
+   run is the unit's answer, and re-running it would only produce the same
+   answer more slowly. Only the first class is retryable.
+2. **Is the unit replay-safe?** Even a transient failure must not be replayed
+   once the unit has produced an observed side effect. A unit that wrote files
+   into its worktree or emitted a result artifact has to be CONTINUED or
+   recovered by hand, never silently re-run from base, because a re-dispatch
+   rebuilds the worktree and destroys exactly the work the failure left behind.
+
+Both answers are computed from observed evidence only -- an exit code, the
+bounded output tails already captured, and the recovery probe's own measurement
+of the worktree. Nothing here calls a model, and nothing here decides that a
+retried unit is correct: a retry is another attempt, not evidence.
+
+The backoff is jittered capped exponential so a fanout of N units that all hit
+the same provider limit does not retry in lockstep and re-trigger it. The
+random source and the clock are injected, so the policy is exercised without a
+single sleep in the test suite.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping
+
+RETRY_POLICY_SCHEMA_VERSION = "fanout_retry_policy/v1"
+RETRY_CLAIM_BOUNDARY = (
+    "A retry record states how many times omh started this unit's process and why it stopped trying. "
+    "It is not verification, review, CI, or merge evidence, and a unit that succeeded on a later "
+    "attempt is no more verified than one that succeeded on the first."
+)
+
+# Attempts BEYOND the first, per unit. Deliberately small: each attempt is a
+# whole agent-CLI run costing minutes and provider budget, unlike the
+# single-request retry ladders this formula comes from. Two retries covers the
+# transient window a rate limit or a reset opens without turning one refused
+# unit into a quarter-hour of re-spawning.
+FANOUT_MAX_RETRIES = 2
+# First retry waits ~2s, the second ~4s, before jitter. The cap exists so a
+# raised `FANOUT_MAX_RETRIES` cannot grow the wait without bound.
+RETRY_BASE_DELAY_SECONDS = 2.0
+RETRY_MAX_DELAY_SECONDS = 30.0
+# Jitter spreads each delay across [75%, 100%] of the computed value. Full
+# jitter (0-100%) would let two units collide at ~0s; this floor keeps the
+# spread meaningful while guaranteeing the backoff still grows.
+RETRY_JITTER_FLOOR = 0.75
+
+# Failure classes. Only `transient_*` is ever retryable; every other class is
+# the unit's own answer and is terminal by construction.
+CLASS_PROVIDER_LIMIT = "transient_provider_limit"
+CLASS_TRANSPORT = "transient_transport"
+CLASS_TERMINAL_FAILURE = "terminal_failure"
+CLASS_EXECUTOR_MISSING = "executor_missing"
+CLASS_UNIT_TIMEOUT = "unit_timeout"
+
+# Deterministic transport shapes, matched case-insensitively over the bounded
+# stdout/stderr tails of a FAILED spawn only. Anchored the same way
+# `_LIMIT_SHAPED_PATTERNS` in fanout_dispatch is: a bare "500" or "reset"
+# would match a line number or a git message and retry a unit whose tests
+# simply failed. Provider-limit shapes are NOT repeated here -- the dispatcher
+# already classifies those for the limit-signal record and passes the verdict
+# in, so the two surfaces cannot drift apart.
+_TRANSPORT_PATTERNS: tuple[tuple[str, str], ...] = (
+    ("http_500", "status 500"),
+    ("http_500", "http 500"),
+    ("http_502", "status 502"),
+    ("http_502", "http 502"),
+    ("http_502", "bad gateway"),
+    ("http_503", "status 503"),
+    ("http_503", "http 503"),
+    ("http_503", "service unavailable"),
+    ("http_504", "status 504"),
+    ("http_504", "http 504"),
+    ("http_504", "gateway timeout"),
+    ("provider_overloaded", "overloaded_error"),
+    ("provider_overloaded", "server is overloaded"),
+    ("provider_overloaded", "model is overloaded"),
+    ("provider_error", "internal server error"),
+    ("socket_reset", "connection reset by peer"),
+    ("socket_reset", "econnreset"),
+    ("socket_hang_up", "socket hang up"),
+    ("connection_refused", "connection refused"),
+    ("connection_refused", "econnrefused"),
+    ("connection_closed", "connection closed before"),
+    ("upstream_reset", "upstream connect error"),
+    ("transport_failed", "fetch failed"),
+)
+
+# Replay-safety verdicts, in OMH's evidence vocabulary. `no_observed_side_effect`
+# is the ONLY one that permits a re-dispatch; the other two both mean the unit
+# has to be continued or recovered by hand.
+REPLAY_SAFE = "no_observed_side_effect"
+REPLAY_UNSAFE_SIDE_EFFECTS = "observed_side_effects"
+REPLAY_UNSAFE_UNMEASURED = "side_effects_unmeasured"
+
+
+def transport_failure_label(output_tail: str, stderr_tail: str) -> str:
+    """The transport shape a failed spawn's tails match, or an empty string."""
+    haystack = f"{output_tail}\n{stderr_tail}".lower()
+    for label, needle in _TRANSPORT_PATTERNS:
+        if needle in haystack:
+            return label
+    return ""
+
+
+def classify_unit_failure(
+    *,
+    exit_code: int,
+    output_tail: str,
+    stderr_tail: str,
+    limit_shaped: str = "",
+) -> dict[str, Any]:
+    """Split one observed unit failure into retryable transport vs terminal.
+
+    `limit_shaped` is the dispatcher's own limit-signal label for this failure,
+    passed in rather than re-derived so the retry verdict and the persisted
+    provider-limit evidence can never disagree.
+
+    A timeout and a missing executable get their own terminal classes: both are
+    non-zero exits that are emphatically not transport, and naming them stops a
+    later reader from assuming the terminal bucket is only test failures.
+    """
+    if exit_code == 0:
+        return {"retryable": False, "failure_class": "", "failure_label": ""}
+    if exit_code == 127:
+        return {"retryable": False, "failure_class": CLASS_EXECUTOR_MISSING, "failure_label": ""}
+    if exit_code == 124:
+        # A unit that burned its whole timeout is not a transient transport
+        # blip, and it has almost certainly been writing files the entire time.
+        return {"retryable": False, "failure_class": CLASS_UNIT_TIMEOUT, "failure_label": ""}
+    if limit_shaped:
+        return {"retryable": True, "failure_class": CLASS_PROVIDER_LIMIT, "failure_label": limit_shaped}
+    label = transport_failure_label(output_tail, stderr_tail)
+    if label:
+        return {"retryable": True, "failure_class": CLASS_TRANSPORT, "failure_label": label}
+    # Everything else -- above all a real non-zero exit from a test or
+    # verification run -- is the unit's answer. Retrying it would re-run known
+    # work to reach the same verdict.
+    return {"retryable": False, "failure_class": CLASS_TERMINAL_FAILURE, "failure_label": ""}
+
+
+def replay_safety(
+    recovery: Mapping[str, Any] | None,
+    *,
+    artifact_observed: bool = False,
+) -> dict[str, Any]:
+    """Whether this unit may be re-dispatched, from what was observed of it.
+
+    The predicate is the recovery probe's own measurement, not a guess: it
+    already answers "what did this unit leave in its worktree" with three
+    distinguishable outcomes, and the middle one -- `capture_failed`, "I could
+    not tell" -- is exactly the case that must fail closed. `artifact_observed`
+    covers the other side effect a unit can produce without touching the
+    worktree: a result sidecar the intake path would read.
+    """
+    if artifact_observed:
+        return {"replay_safe": False, "replay_verdict": REPLAY_UNSAFE_SIDE_EFFECTS, "side_effect": "unit_result_artifact"}
+    outcome = str((recovery or {}).get("outcome", "")) if isinstance(recovery, Mapping) else ""
+    if outcome == "no_changes":
+        return {"replay_safe": True, "replay_verdict": REPLAY_SAFE, "side_effect": "none"}
+    if outcome == "recovery_available":
+        return {
+            "replay_safe": False,
+            "replay_verdict": REPLAY_UNSAFE_SIDE_EFFECTS,
+            "side_effect": "worktree_changes",
+        }
+    # No record, or a probe that could not answer: never replay on an
+    # unmeasured worktree.
+    return {"replay_safe": False, "replay_verdict": REPLAY_UNSAFE_UNMEASURED, "side_effect": "unmeasured"}
+
+
+def retry_delay_seconds(
+    attempt: int,
+    *,
+    rng: Callable[[], float],
+    base: float = RETRY_BASE_DELAY_SECONDS,
+    cap: float = RETRY_MAX_DELAY_SECONDS,
+) -> float:
+    """`min(base * 2^(attempt-1), cap)`, scaled by 75-100% jitter.
+
+    `attempt` is the attempt that just failed, so the first retry waits one
+    base delay. `rng` returns a float in [0, 1) -- `random.random` in
+    production, a fixed value in tests, which is what makes the whole ladder
+    assertable without a clock.
+    """
+    step = max(1, int(attempt))
+    capped = min(base * (2 ** (step - 1)), cap)
+    jitter = RETRY_JITTER_FLOOR + (1.0 - RETRY_JITTER_FLOOR) * min(max(rng(), 0.0), 1.0)
+    return round(capped * jitter, 6)
+
+
+def evaluate_unit_retry(
+    *,
+    attempt: int,
+    exit_code: int,
+    output_tail: str,
+    stderr_tail: str,
+    limit_shaped: str = "",
+    recovery: Mapping[str, Any] | None = None,
+    artifact_observed: bool = False,
+    max_retries: int = FANOUT_MAX_RETRIES,
+    rng: Callable[[], float],
+) -> dict[str, Any]:
+    """One retry decision, complete with the reason it went that way.
+
+    The record is the point: a unit that was NOT retried has to say whether it
+    was terminal, out of attempts, or blocked by its own side effects, because
+    those three lead an operator to three different next actions.
+    """
+    decision: dict[str, Any] = {
+        "attempt": int(attempt),
+        "exit_code": int(exit_code),
+        "retry": False,
+        **classify_unit_failure(
+            exit_code=exit_code,
+            output_tail=output_tail,
+            stderr_tail=stderr_tail,
+            limit_shaped=limit_shaped,
+        ),
+    }
+    if not decision["retryable"]:
+        decision["decision"] = "terminal"
+        return decision
+    if int(attempt) > int(max_retries):
+        decision["decision"] = "retries_exhausted"
+        decision["max_retries"] = int(max_retries)
+        return decision
+    safety = replay_safety(recovery, artifact_observed=artifact_observed)
+    decision.update(safety)
+    if not safety["replay_safe"]:
+        # The one outcome this whole module exists for: a transient failure
+        # that must NOT be replayed. It goes out through the recovery path an
+        # operator already reads, as work to continue rather than redo.
+        decision["decision"] = "surfaced_for_continuation"
+        return decision
+    decision["retry"] = True
+    decision["decision"] = "retrying"
+    decision["delay_seconds"] = retry_delay_seconds(attempt, rng=rng)
+    return decision

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -3505,5 +3505,169 @@ class FanoutSpawnGuardTests(unittest.TestCase):
         self.assertEqual(payload["refusal_reason"], "fanout_depth_exceeded")
 
 
+def _flaky_runner(*, failures: dict[str, list[str]], write_units: set[str] | None = None):
+    """A fake agent whose per-unit stdout is scripted attempt by attempt.
+
+    `failures[unit_id]` is the tail each successive FAILED attempt reports; the
+    list running out means the next attempt succeeds. Units in `write_units`
+    write a real file into their worktree on every attempt, which is what makes
+    the replay-safety predicate observe a side effect.
+    """
+    attempts: dict[str, int] = {}
+
+    def owns(prompt: str, unit_id: str) -> bool:
+        return f"agent/{unit_id} in the current worktree" in prompt
+
+    def runner(argv, **kwargs):
+        if argv[0] == "git":
+            return subprocess.run(argv, **kwargs)
+        prompt = " ".join(argv)
+        cwd = Path(str(kwargs.get("cwd", ".")))
+        for unit_id, tails in failures.items():
+            if not owns(prompt, unit_id):
+                continue
+            index = attempts.get(unit_id, 0)
+            attempts[unit_id] = index + 1
+            if unit_id in (write_units or set()):
+                (cwd / f"{unit_id}_partial.py").write_text("value = 1\n", encoding="utf-8")
+            if index < len(tails):
+                return _FakeCompleted(1, tails[index])
+            return _FakeCompleted(0, "done")
+        return _FakeCompleted(0, "done")
+
+    runner.attempts = attempts
+    return runner
+
+
+class FanoutUnitRetryTests(unittest.TestCase):
+    """The retry policy driven through the real dispatch engine.
+
+    No sleeps: the clock and the random source are injected, so a delay is
+    asserted by the value handed to the recorder rather than by waiting for it.
+    """
+
+    _ONE_UNIT = [{"unit_id": "core", "title": "Core work", "owner": "codex", "file_scope": ["src/core/"]}]
+
+    def _setup(self, tmp: str):
+        root = Path(tmp)
+        paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+        repo, sha = _make_repo(root)
+        contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, self._ONE_UNIT))
+        return paths, repo, sha, contract
+
+    def _dispatch(self, paths, repo, sha, contract, runner, delays, **kwargs):
+        return dispatch_fanout(
+            paths,
+            contract,
+            goal_text=_GOAL,
+            repo_root=repo,
+            base_sha=sha,
+            runner=runner,
+            readiness=_ready,
+            # Floor jitter, so the asserted delay is an exact number rather
+            # than a range.
+            rng=lambda: 0.0,
+            sleep=delays.append,
+            **kwargs,
+        )
+
+    def test_a_transient_failure_on_a_clean_worktree_is_retried_with_backoff(self) -> None:
+        delays: list[float] = []
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            runner = _flaky_runner(failures={"core": ["Error: socket hang up", "http 503 service unavailable"]})
+            summary = self._dispatch(paths, repo, sha, contract, runner, delays)
+        entry = summary["units"][0]
+        self.assertEqual(entry["status"], "completed")
+        self.assertEqual(runner.attempts["core"], 3)
+        self.assertEqual(entry["retry"]["attempts"], 3)
+        self.assertEqual(
+            [row["decision"] for row in entry["retry"]["decisions"]], ["retrying", "retrying"]
+        )
+        self.assertEqual(
+            [row["failure_class"] for row in entry["retry"]["decisions"]],
+            ["transient_transport", "transient_transport"],
+        )
+        # min(2 * 2^(n-1), 30) at the 75% jitter floor.
+        self.assertEqual(delays, [1.5, 3.0])
+
+    def test_a_transient_failure_with_observed_side_effects_is_surfaced_not_retried(self) -> None:
+        # The predicate this whole policy exists for: the failure is retryable,
+        # the budget is untouched, and the unit is still not re-run because a
+        # re-dispatch would destroy the work its worktree already holds.
+        delays: list[float] = []
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            runner = _flaky_runner(
+                failures={"core": ["Error: socket hang up"]}, write_units={"core"}
+            )
+            summary = self._dispatch(paths, repo, sha, contract, runner, delays)
+        entry = summary["units"][0]
+        self.assertEqual(entry["status"], "failed")
+        self.assertEqual(runner.attempts["core"], 1)
+        self.assertEqual(delays, [])
+        self.assertTrue(entry["retry_blocked_by_side_effects"])
+        decision = entry["retry"]["decisions"][0]
+        self.assertEqual(decision["decision"], "surfaced_for_continuation")
+        self.assertTrue(decision["retryable"])
+        self.assertEqual(decision["replay_verdict"], "observed_side_effects")
+        # Surfaced through the path an operator already reads, not a new one.
+        self.assertEqual(entry["recovery"]["outcome"], "recovery_available")
+        self.assertEqual(summary["recovery_available_units"], ["core"])
+
+    def test_a_real_test_failure_is_never_retried(self) -> None:
+        delays: list[float] = []
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            runner = _flaky_runner(failures={"core": ["FAILED (failures=2, errors=0)", "done"]})
+            summary = self._dispatch(paths, repo, sha, contract, runner, delays)
+        entry = summary["units"][0]
+        self.assertEqual(entry["status"], "failed")
+        # One attempt, even though a second one would have "succeeded": a
+        # terminal failure is the unit's answer, not a transport blip.
+        self.assertEqual(runner.attempts["core"], 1)
+        self.assertEqual(delays, [])
+        self.assertEqual(entry["retry"]["final_decision"], "terminal")
+        self.assertNotIn("retry_blocked_by_side_effects", entry)
+
+    def test_retries_are_bounded_and_the_exhaustion_is_recorded(self) -> None:
+        delays: list[float] = []
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            runner = _flaky_runner(failures={"core": ["socket hang up"] * 6})
+            summary = self._dispatch(paths, repo, sha, contract, runner, delays, max_retries=2)
+        entry = summary["units"][0]
+        self.assertEqual(entry["status"], "failed")
+        self.assertEqual(runner.attempts["core"], 3)
+        self.assertEqual(len(delays), 2)
+        self.assertEqual(entry["retry"]["final_decision"], "retries_exhausted")
+
+    def test_a_first_try_success_carries_no_retry_record(self) -> None:
+        # The negative control: the presence of the block is itself the signal,
+        # so an untroubled dispatch must not grow one.
+        delays: list[float] = []
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            summary = self._dispatch(paths, repo, sha, contract, _agent_runner(), delays)
+        entry = summary["units"][0]
+        self.assertEqual(entry["status"], "completed")
+        self.assertNotIn("retry", entry)
+        self.assertEqual(delays, [])
+
+    def test_a_retry_spends_the_run_spawn_budget(self) -> None:
+        # A retry is a real spawn. Left uncounted it would let one flaky unit
+        # walk past the ceiling the operator set.
+        delays: list[float] = []
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            runner = _flaky_runner(failures={"core": ["socket hang up"] * 4})
+            summary = self._dispatch(
+                paths, repo, sha, contract, runner, delays, spawn_ceiling=2, max_retries=3
+            )
+        self.assertEqual(runner.attempts["core"], 2)
+        self.assertEqual(summary["spawn_guard"]["spawns_claimed"], 2)
+        self.assertEqual(summary["units"][0]["retry"]["final_decision"], "spawn_ceiling_reached")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_fanout_retry.py
+++ b/tests/test_fanout_retry.py
@@ -1,0 +1,223 @@
+"""Retry taxonomy, replay-safety predicate, and the backoff ladder.
+
+The three properties these hold, in the order the policy decides them:
+
+* A transient transport failure is retryable; a real non-zero exit from a test
+  or verification run is terminal and is NEVER retried. The negative case is
+  the point of the whole classifier -- retrying a genuine failure burns a full
+  agent-CLI run to re-derive an answer already in hand.
+* A unit may only be replayed when nothing observed it doing anything. Files in
+  its worktree or a result artifact both block a replay, and an unmeasurable
+  worktree blocks it too: "I could not tell" must fail closed.
+* The delay is `min(base * 2^(attempt-1), cap)` scaled by 75-100% jitter, with
+  the random source injected so every bound is asserted exactly and no test
+  sleeps.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.coding.fanout_retry import (  # noqa: E402
+    CLASS_EXECUTOR_MISSING,
+    CLASS_PROVIDER_LIMIT,
+    CLASS_TERMINAL_FAILURE,
+    CLASS_TRANSPORT,
+    CLASS_UNIT_TIMEOUT,
+    FANOUT_MAX_RETRIES,
+    REPLAY_SAFE,
+    REPLAY_UNSAFE_SIDE_EFFECTS,
+    REPLAY_UNSAFE_UNMEASURED,
+    RETRY_BASE_DELAY_SECONDS,
+    RETRY_JITTER_FLOOR,
+    RETRY_MAX_DELAY_SECONDS,
+    classify_unit_failure,
+    evaluate_unit_retry,
+    replay_safety,
+    retry_delay_seconds,
+)
+
+
+def _classify(exit_code: int = 1, out: str = "", err: str = "", limit: str = ""):
+    return classify_unit_failure(
+        exit_code=exit_code, output_tail=out, stderr_tail=err, limit_shaped=limit
+    )
+
+
+class FailureTaxonomyTests(unittest.TestCase):
+    def test_transport_shapes_are_retryable(self) -> None:
+        for text in (
+            "openai: http 503 service unavailable",
+            "Error: socket hang up",
+            "read ECONNRESET",
+            "connection reset by peer",
+            "upstream connect error or disconnect/reset before headers",
+            "TypeError: fetch failed",
+            "status 502 bad gateway",
+            "status 504 gateway timeout",
+            '{"type":"overloaded_error"}',
+            "internal server error",
+            "connection refused",
+        ):
+            verdict = _classify(err=text)
+            self.assertTrue(verdict["retryable"], text)
+            self.assertEqual(verdict["failure_class"], CLASS_TRANSPORT, text)
+            self.assertTrue(verdict["failure_label"], text)
+
+    def test_a_limit_shaped_failure_is_retryable_under_its_own_class(self) -> None:
+        # The dispatcher already derives this label for the provider-limit
+        # evidence record; the retry verdict reads that same label rather than
+        # re-matching, so the two surfaces cannot drift apart.
+        verdict = _classify(err="you have hit your rate limit", limit="rate_limit")
+        self.assertTrue(verdict["retryable"])
+        self.assertEqual(verdict["failure_class"], CLASS_PROVIDER_LIMIT)
+        self.assertEqual(verdict["failure_label"], "rate_limit")
+
+    def test_a_real_test_failure_is_terminal(self) -> None:
+        # THE negative case. None of these may ever be retried, however
+        # transient-looking a word in them is.
+        for text in (
+            "FAILED (failures=3, errors=1)",
+            "AssertionError: 2 != 3",
+            "ruff: 4 errors found",
+            "error: could not compile the crate",
+            "ERROR: line 500 of module foo",
+            "reset the branch and try again",
+        ):
+            verdict = _classify(err=text)
+            self.assertFalse(verdict["retryable"], text)
+            self.assertEqual(verdict["failure_class"], CLASS_TERMINAL_FAILURE, text)
+
+    def test_a_missing_executable_and_a_timeout_get_their_own_terminal_classes(self) -> None:
+        self.assertEqual(
+            _classify(exit_code=127, out="codex not found on PATH")["failure_class"],
+            CLASS_EXECUTOR_MISSING,
+        )
+        self.assertFalse(_classify(exit_code=127)["retryable"])
+        # A unit that burned its whole timeout is not a transport blip, and
+        # a transport word in its tail must not make it one.
+        timed_out = _classify(exit_code=124, out="unit timed out after 30s; socket hang up")
+        self.assertEqual(timed_out["failure_class"], CLASS_UNIT_TIMEOUT)
+        self.assertFalse(timed_out["retryable"])
+
+    def test_a_successful_exit_classifies_as_nothing(self) -> None:
+        verdict = _classify(exit_code=0, err="socket hang up")
+        self.assertFalse(verdict["retryable"])
+        self.assertEqual(verdict["failure_class"], "")
+
+
+class ReplaySafetyPredicateTests(unittest.TestCase):
+    def test_a_unit_that_changed_nothing_is_replay_safe(self) -> None:
+        verdict = replay_safety({"outcome": "no_changes"})
+        self.assertTrue(verdict["replay_safe"])
+        self.assertEqual(verdict["replay_verdict"], REPLAY_SAFE)
+
+    def test_observed_worktree_changes_block_a_replay(self) -> None:
+        verdict = replay_safety({"outcome": "recovery_available", "paths_changed": 2})
+        self.assertFalse(verdict["replay_safe"])
+        self.assertEqual(verdict["replay_verdict"], REPLAY_UNSAFE_SIDE_EFFECTS)
+        self.assertEqual(verdict["side_effect"], "worktree_changes")
+
+    def test_a_result_artifact_blocks_a_replay_even_on_a_clean_worktree(self) -> None:
+        verdict = replay_safety({"outcome": "no_changes"}, artifact_observed=True)
+        self.assertFalse(verdict["replay_safe"])
+        self.assertEqual(verdict["side_effect"], "unit_result_artifact")
+
+    def test_an_unmeasurable_worktree_fails_closed(self) -> None:
+        # "The unit left nothing" and "I could not tell" lead an operator to
+        # opposite actions; only the first may be replayed.
+        for recovery in (None, {}, {"outcome": "capture_failed", "reason": "git refused"}):
+            verdict = replay_safety(recovery)
+            self.assertFalse(verdict["replay_safe"], recovery)
+            self.assertEqual(verdict["replay_verdict"], REPLAY_UNSAFE_UNMEASURED, recovery)
+
+
+class BackoffTests(unittest.TestCase):
+    def test_the_ladder_doubles_and_the_floor_is_the_jitter_floor(self) -> None:
+        floor = retry_delay_seconds(1, rng=lambda: 0.0)
+        self.assertAlmostEqual(floor, RETRY_BASE_DELAY_SECONDS * RETRY_JITTER_FLOOR)
+        self.assertAlmostEqual(
+            retry_delay_seconds(2, rng=lambda: 0.0),
+            RETRY_BASE_DELAY_SECONDS * 2 * RETRY_JITTER_FLOOR,
+        )
+        self.assertAlmostEqual(
+            retry_delay_seconds(3, rng=lambda: 0.0),
+            RETRY_BASE_DELAY_SECONDS * 4 * RETRY_JITTER_FLOOR,
+        )
+
+    def test_full_jitter_is_the_undiscounted_delay(self) -> None:
+        self.assertAlmostEqual(retry_delay_seconds(1, rng=lambda: 1.0), RETRY_BASE_DELAY_SECONDS)
+
+    def test_every_delay_stays_inside_75_to_100_percent_of_its_step(self) -> None:
+        import random as _random
+
+        rng = _random.Random(20260830).random
+        for attempt in range(1, 9):
+            step = min(RETRY_BASE_DELAY_SECONDS * (2 ** (attempt - 1)), RETRY_MAX_DELAY_SECONDS)
+            for _ in range(50):
+                delay = retry_delay_seconds(attempt, rng=rng)
+                self.assertGreaterEqual(delay, step * RETRY_JITTER_FLOOR - 1e-6)
+                self.assertLessEqual(delay, step + 1e-6)
+
+    def test_the_cap_bounds_the_ladder(self) -> None:
+        self.assertAlmostEqual(retry_delay_seconds(50, rng=lambda: 1.0), RETRY_MAX_DELAY_SECONDS)
+
+    def test_an_out_of_range_random_source_cannot_escape_the_bounds(self) -> None:
+        # Defensive, not decorative: a caller injecting a bad rng in a test
+        # must not silently produce a negative or oversized sleep.
+        self.assertAlmostEqual(
+            retry_delay_seconds(1, rng=lambda: -5.0), RETRY_BASE_DELAY_SECONDS * RETRY_JITTER_FLOOR
+        )
+        self.assertAlmostEqual(retry_delay_seconds(1, rng=lambda: 5.0), RETRY_BASE_DELAY_SECONDS)
+
+
+class RetryDecisionTests(unittest.TestCase):
+    def _decide(self, **overrides):
+        kwargs = {
+            "attempt": 1,
+            "exit_code": 1,
+            "output_tail": "",
+            "stderr_tail": "socket hang up",
+            "recovery": {"outcome": "no_changes"},
+            "rng": lambda: 0.0,
+        }
+        kwargs.update(overrides)
+        return evaluate_unit_retry(**kwargs)
+
+    def test_transient_plus_clean_worktree_retries_with_a_delay(self) -> None:
+        decision = self._decide()
+        self.assertTrue(decision["retry"])
+        self.assertEqual(decision["decision"], "retrying")
+        self.assertEqual(decision["replay_verdict"], REPLAY_SAFE)
+        self.assertAlmostEqual(
+            decision["delay_seconds"], RETRY_BASE_DELAY_SECONDS * RETRY_JITTER_FLOOR
+        )
+
+    def test_transient_plus_side_effects_is_surfaced_not_retried(self) -> None:
+        decision = self._decide(recovery={"outcome": "recovery_available"})
+        self.assertFalse(decision["retry"])
+        self.assertEqual(decision["decision"], "surfaced_for_continuation")
+        self.assertEqual(decision["replay_verdict"], REPLAY_UNSAFE_SIDE_EFFECTS)
+
+    def test_a_terminal_failure_never_reaches_the_replay_predicate(self) -> None:
+        decision = self._decide(stderr_tail="FAILED (failures=1)")
+        self.assertFalse(decision["retry"])
+        self.assertEqual(decision["decision"], "terminal")
+        # No replay verdict at all: the predicate is not consulted, so the
+        # record cannot imply the worktree was measured.
+        self.assertNotIn("replay_verdict", decision)
+
+    def test_attempts_are_bounded(self) -> None:
+        exhausted = self._decide(attempt=FANOUT_MAX_RETRIES + 1)
+        self.assertFalse(exhausted["retry"])
+        self.assertEqual(exhausted["decision"], "retries_exhausted")
+        self.assertEqual(exhausted["max_retries"], FANOUT_MAX_RETRIES)
+        self.assertTrue(self._decide(attempt=FANOUT_MAX_RETRIES)["retry"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **Stacked PR.** Its base is `claude/fanout-depth-cap` (#1172), not `main`.
> The diff shown here is this branch's own commit only; review #1172 first and
> merge it first, and this PR retargets to `main` automatically.

## Feature Report

### What Changed

- A failed dispatched unit is now classified as retryable-transient or terminal, and a retryable one is re-dispatched only when a replay-safety predicate says nothing observed it doing anything.
- New `src/coding/fanout_retry.py`: the taxonomy, the predicate, the jittered capped-exponential backoff, and the decision record. Pure, no I/O, no LLM.
- Unit entries gained a `retry` block naming the attempts and the reason trying stopped; a unit blocked by its own side effects is additionally flagged `retry_blocked_by_side_effects`.

### Why This Exists

- `omh coding fanout dispatch` spawns local agent CLIs, and those subprocesses fail transiently — rate limits, provider overloads, socket resets. Until now every failure was final: the unit was recorded failed and an operator re-ran it by hand, from base, losing whatever the attempt had already written.
- The naive fix is worse than the bug. A blind retry re-runs a unit that has already edited files, and because a re-dispatch rebuilds the worktree from base it destroys exactly the work the failure left behind. The replay-safety predicate is the precise rule that separates "safe to retry" from "must be continued or surfaced".
- Jitter is not decoration: a fanout of N units all talking to one provider hits one rate limit together, and un-jittered backoff retries them in lockstep and re-triggers it.

### User / Operator Impact

- A unit that fails on a socket hang-up with an untouched worktree now succeeds on its own instead of costing a manual re-run.
- A unit that fails transiently *after* writing files is not retried. It appears exactly where such work already appears — `summary["recovery_available_units"]`, with its `recovery` record and `recover_with` command — plus `retry_blocked_by_side_effects` saying it *could* have been retried and deliberately was not.
- A unit whose tests genuinely failed behaves exactly as before: one attempt, `failed`, with `retry.final_decision: "terminal"` stating the classifier's reason.

### How It Works

Two disjoint questions, in this order.

1. **Classification** (`classify_unit_failure`). Retryable: provider-limit shapes and transport shapes (HTTP 500/502/503/504, `overloaded_error`, `internal server error`, `connection reset by peer` / `ECONNRESET`, `socket hang up`, `connection refused`, `upstream connect error`, `fetch failed`), matched case-insensitively over the bounded tails of a *failed* spawn only and anchored so a bare `500` or `reset` cannot match a line number or a git message. Terminal: everything else, plus `executor_missing` (exit 127) and `unit_timeout` (exit 124) as their own named classes so nobody reads the terminal bucket as "test failures only". The limit-shaped verdict is **passed in** from the dispatcher's existing `_limit_shaped_label` derivation rather than re-matched, so the retry decision and the persisted provider-limit evidence cannot drift apart.
2. **Replay safety** (`replay_safety`). Consulted only for a failure already classified transient and still inside the attempt budget. It reads the *same* `_capture_unit_recovery` probe that already answers "what did this unit leave in its worktree", called with an empty `fanout_id` so a mid-flight probe never persists an intermediate record over the real one written at the end. `no_changes` -> replay-safe. `recovery_available` -> blocked, `observed_side_effects`. `capture_failed` or no record -> blocked, `side_effects_unmeasured`: "the unit left nothing" and "I could not tell" lead an operator to opposite actions, so the second fails closed. A result sidecar on disk blocks a replay too, covering the side effect a unit can produce without touching the worktree.

Backoff is `retry_delay_seconds(attempt) = min(2.0 * 2^(attempt-1), 30.0) * jitter`, jitter uniform in [0.75, 1.0]. Every constant is named and documented at its definition: `FANOUT_MAX_RETRIES = 2` (deliberately small — each attempt is a whole agent-CLI run costing minutes and provider budget, unlike the single-request ladders this formula comes from), `RETRY_BASE_DELAY_SECONDS = 2.0`, `RETRY_MAX_DELAY_SECONDS = 30.0`, `RETRY_JITTER_FLOOR = 0.75` (full 0–100% jitter would let two units collide at ~0s).

The loop lives inside `_dispatch_unit`'s existing progress-binding `try`, so the HUD row and the inflight marker keep their exact lifetime. A retry claims the `run_spawn_ceiling` budget introduced in #1172 like any other spawn, and never starts after `_INTERRUPT_FLAG` is set — both recorded as their own final decisions.

### Files And Contracts Touched

- `src/coding/fanout_retry.py` (new) — `classify_unit_failure`, `replay_safety`, `retry_delay_seconds`, `evaluate_unit_retry`, and the named constants.
- `src/coding/fanout_dispatch.py` — the attempt loop, `_consider_unit_retry`, the `retry` block on the unit result, and `max_retries` / `rng` / `sleep` on `dispatch_fanout` and `_dispatch_unit`.
- `docs/FANOUT.md` — a dispatch-bridge bullet for the policy.
- `tests/test_fanout_retry.py` (new), `tests/test_fanout_dispatch.py`.

`fanout_dispatch_summary/v1` is unchanged in shape for every existing key; `retry` and `retry_blocked_by_side_effects` are new optional keys on a unit entry, and `retry.schema_version` is `fanout_retry_policy/v1`.

### Affected Surfaces

- [x] Codex
- [x] Claude Code
- [x] Generic executor

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `git diff --check`

### Observed Evidence

- Full suite: `Ran 7863 tests` — `FAILED (failures=21, errors=7)`. **Filtering the failure list to anything outside `test_cross_harness_adapter*` returns 0 lines.** All 28 are pre-existing and environment-caused (`unsafe_read_root` — the checkout sits under a path the adapter sandbox rejects); verified against a clean tree in #1172 with byte-identical counts.
- Targeted: `tests.test_fanout_retry` -> `Ran 18 tests ... OK`; `tests.test_fanout_dispatch.FanoutUnitRetryTests` -> `Ran 6 tests ... OK`.
- Regression sweep: `tests.test_fanout_dispatch tests.test_parallelism_policy tests.test_fanout_chaos tests.test_fanout_signal_safety` -> `Ran 152 tests ... OK`.
- `tests/test_broad_exception_policy.py` -> `Ran 6 tests ... OK`, **unchanged**: this branch adds no broad `except`, so `CLASSIFIED_SITES` needed no new verdict. The gate re-derives the live site list from source, so that is a checked fact, not a claim.
- `ruff check src tests` -> `All checks passed!`; all three byte gates `"ok":true`; `git diff --check` clean.

New tests, by what they hold. Policy level (`tests/test_fanout_retry.py`):

- Eleven transport wordings classify retryable with a label; a limit-shaped failure classifies retryable under its own class.
- **The negative case:** six terminal wordings — including `ERROR: line 500 of module foo` and `reset the branch and try again`, which exist precisely to prove the patterns are anchored — are never retryable.
- Exit 127 and exit 124 get their own terminal classes, and a transport word in a timeout's tail does not rescue it.
- Replay safety: clean -> safe; worktree changes -> blocked; artifact -> blocked even on a clean worktree; `None` / `{}` / `capture_failed` -> blocked as unmeasured.
- Backoff: the ladder doubles, the 75% floor and the 100% ceiling are exact, 400 sampled delays across 8 attempts stay inside `[step*0.75, step]`, the cap bounds it, and an out-of-range injected rng cannot escape the bounds.
- A terminal decision carries **no** `replay_verdict` at all, so the record cannot imply a worktree was measured when it was not.

Engine level (`tests/test_fanout_dispatch.py::FanoutUnitRetryTests`), all driven through the real `dispatch_fanout` with `rng` and `sleep` injected — no sleeps:

- Transient failure, clean worktree -> 3 attempts, both decisions `retrying`, delays exactly `[1.5, 3.0]`.
- Transient failure, files written -> **1 attempt, no delay**, `surfaced_for_continuation`, `retryable: true`, `replay_verdict: observed_side_effects`, and it lands in `recovery_available_units` with a `recovery_available` record.
- A real test failure -> 1 attempt and `terminal`, even though the scripted second attempt would have "succeeded".
- Retries bounded: 3 attempts, 2 delays, `retries_exhausted`.
- A first-try success carries **no** `retry` key (negative control — the block's presence is itself the signal).
- A retry spends the `run_spawn_ceiling` budget: ceiling 2 stops at 2 attempts with `spawn_ceiling_reached`.

### Not Tested / Not Applicable

- No live retry against a real provider rate limit or a real socket reset. The taxonomy is exercised against recorded wording, not observed provider output; `prepared_not_observed` for the live path.
- `harness validate`, `release checklist`, `release hermes-smoke`, TUI checks: not applicable — no harness contract, release surface, plugin bundle, or widget is touched.

## Risk

- **Moderate, and concentrated in one place:** the retry is now the only thing that can start a unit's process more than once, so the predicate is load-bearing. It fails closed in all three uncertain directions (unmeasurable worktree, missing record, artifact present), and the `Directive` trailer records the invariant a future side effect must respect.
- A transient-looking word inside a genuine test failure's output could in principle classify as transport. The patterns are anchored against that, and the replay predicate is the second gate — a unit that ran tests has written files, so it is surfaced rather than replayed either way.
- Wall-clock cost of a failing unit rises by up to ~2 backoff waits plus 2 extra agent-CLI runs. Bounded by `FANOUT_MAX_RETRIES = 2` and by the run spawn ceiling, which a retry now spends.

## Compatibility / Rollout

- Additive. `retry` and `retry_blocked_by_side_effects` are new optional keys; a first-try success is byte-identical to before.
- The default behavior change is intentional and narrow: previously every failure was terminal, now a *classified transient* failure on a *provably untouched* worktree is retried twice.

## Release / Claims

- [x] Release-channel impact considered (`local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed

## Follow-Up

- A server-suggested delay (`retry-after`, `x-ratelimit-reset`) is not parsed; agent CLIs do not surface response headers on stdout today. If one starts to, honoring it — and failing immediately rather than sleeping when it exceeds the cap — is the natural next step.
- `FANOUT_MAX_RETRIES` is a named constant, not yet a profile tunable. Promoting it into the `parallelism` block alongside `max_depth` / `run_spawn_ceiling` is a one-line follow-up if operators want to tune it.
