### PR TITLE
feat(loop): ordered stop ladder before a goal-loop tick advances

### DIFF
--- a/src/workflows/goal_loop.py
+++ b/src/workflows/goal_loop.py
@@ -7,6 +7,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Final, Iterable, Mapping
 
+from ..coding.executor_auth_signals import (
+    AUTH_SIGNAL_PROFILES,
+    auth_signal_for_profile,
+    last_limit_signal_for_profile,
+)
 from ..codex_progress import summarize_codex_jsonl_text
 from ..goal_ledger import build_goal_completion_gate, read_goal_ledger
 from ..hashutil import sha256_text
@@ -45,6 +50,61 @@ EXECUTOR_LOOP_CAPABILITY_SCHEMA = "executor_loop_capability/v1"
 LOOP_CYCLE_NARRATION_SCHEMA = "loop_cycle_narration/v1"
 LOOP_INVOCATION_SCHEMA = "loop_invocation/v1"
 LOOP_CONSTRAINT_ASSESSMENT_SCHEMA = "loop_constraint_assessment/v1"
+LOOP_STOP_LADDER_SCHEMA = "loop_stop_ladder/v1"
+
+# The ordered stop ladder evaluated before a tick advances. The tuple order IS
+# the ladder: assess_loop_stop_ladder walks it top to bottom, the first rung
+# that fires stops the tick, and every rung below it is recorded
+# `not_evaluated` rather than `clear` - a lower rung that was never consulted
+# must never read as a rung that passed. Per-rung rationale:
+# - Rung 1, explicit_cancel: a human already said stop. Nothing below it can
+#   outrank an explicit decision, and a cancelled linked goal refuses every
+#   ledger mutation anyway, so any work the loop prepared under it is
+#   unrecordable by construction.
+# - Rung 2, rate_limit_signal: an observed limit-shaped dispatch failure for
+#   the active executor profile. Above auth because a rate limit is the
+#   cheaper, more common, and self-clearing of the two, and because a loop
+#   that keeps iterating into a limit window is the single most expensive
+#   failure mode a persistence loop has.
+# - Rung 3, auth_failure_signal: no local login marker for the executor
+#   profile this tick is about to hand work to. Gated on the planned action
+#   being executor_dispatch on purpose - `executor_auth_signals` states that
+#   markers rank candidates and never veto one, because an API-key or
+#   environment-token install legitimately reads `absent`. This rung does not
+#   veto a candidate: it stops the loop at the one moment its own next act is
+#   to hand work to a CLI for which omh can see no login at all.
+# - Rung 4, no_progress_cap: the loop is running but nothing is being written
+#   down. Last because it is the only rung whose evidence is the loop's own
+#   history rather than an external signal, so it must not pre-empt a stop
+#   whose cause is already known and named.
+LOOP_STOP_REASONS: Final[tuple[str, ...]] = (
+    "explicit_cancel",
+    "rate_limit_signal",
+    "auth_failure_signal",
+    "no_progress_cap",
+)
+LOOP_STOP_RUNG_STATES: Final[tuple[str, ...]] = ("clear", "fired", "not_applicable", "not_evaluated")
+# Two consecutive ticks that write no new goal-ledger record. Keyed to records
+# written rather than ticks attempted: attempts are what a stuck loop produces
+# in abundance, so counting them measures the symptom instead of the progress.
+LOOP_NO_PROGRESS_TICK_CAP: Final[int] = 2
+LOOP_STOP_LADDER_CLAIM_BOUNDARY: Final[str] = (
+    "A stop-ladder verdict is local policy over already-recorded signals. A stop is a stop with a "
+    "named reason - it is not a completion, a failure verdict on the goal, provider quota truth, or "
+    "evidence that any provider rejected a request."
+)
+_LOOP_STOP_NEXT_ACTIONS: Final[dict[str, str]] = {
+    "explicit_cancel": "show_loop_status",
+    "rate_limit_signal": "wait_for_executor_limit_reset",
+    "auth_failure_signal": "confirm_executor_login_or_retarget",
+    "no_progress_cap": "record_goal_blocker_for_stuck_loop",
+}
+_LOOP_STOP_EVIDENCE_SOURCES: Final[dict[str, str]] = {
+    "explicit_cancel": "goal_ledger.status",
+    "rate_limit_signal": "executor_auth_signals.last_limit_signal_for_profile",
+    "auth_failure_signal": "executor_auth_signals.auth_signal_for_profile",
+    "no_progress_cap": "runtime.no_progress_ticks",
+}
 
 _INNER_TIER_EXPECTED_SIGNAL = (
     "Cheap focused evidence such as syntax, compile, schema validation, command smoke, "
@@ -924,6 +984,253 @@ def update_loop_permission(
     )
 
 
+def goal_ledger_entry_count(goal: Mapping[str, Any] | None) -> int:
+    """Records written into one goal ledger: checkpoints, blockers, quality gates.
+
+    The three lists a loop can actually append to. Acceptance criteria are
+    declared at creation and only change status, so counting them would make a
+    loop that writes nothing look like a loop that started well.
+    """
+    if not isinstance(goal, Mapping):
+        return 0
+    total = 0
+    for key in ("checkpoints", "blockers", "quality_gates"):
+        entries = goal.get(key)
+        if isinstance(entries, list):
+            total += len(entries)
+    return total
+
+
+def assess_loop_stop_ladder(
+    cycle: dict[str, Any],
+    *,
+    planned_action: str = "",
+    goal_linked: bool = False,
+    goal_status: str = "",
+    ledger_entry_count: int = 0,
+    limit_signal: Mapping[str, Any] | None = None,
+    auth_signal: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Walk LOOP_STOP_REASONS in order and name the first rung that stops the tick.
+
+    Pure policy over signals the caller already read, in the idiom
+    `build_account_authorization` uses: the ladder never probes, so the same
+    verdict is reproducible from a recorded snapshot. `read_loop_stop_ladder`
+    is the reading half.
+    """
+    runtime = _runtime_state(cycle.get("runtime"))
+    executor_profile = _preferred_executor(_dict_value(cycle, "authority_envelope"))
+    previous_count = int(runtime["ledger_entry_count"])
+    if not goal_linked:
+        no_progress_ticks = 0
+    elif ledger_entry_count > previous_count:
+        no_progress_ticks = 0
+    else:
+        no_progress_ticks = int(runtime["no_progress_ticks"]) + 1
+
+    verdicts: list[tuple[str, str]] = [
+        _stop_rung_explicit_cancel(goal_linked, goal_status),
+        _stop_rung_rate_limit(executor_profile, limit_signal),
+        _stop_rung_auth_failure(executor_profile, planned_action, auth_signal),
+        _stop_rung_no_progress(goal_linked, no_progress_ticks),
+    ]
+
+    rungs: list[dict[str, Any]] = []
+    stop_reason = "none"
+    stop_rung = 0
+    detail = "No stop-ladder rung fired; the tick may advance."
+    for index, reason in enumerate(LOOP_STOP_REASONS):
+        state, rung_detail = verdicts[index]
+        if stop_reason != "none":
+            state, rung_detail = "not_evaluated", "A higher rung already stopped this tick."
+        rungs.append(
+            {
+                "rung": index + 1,
+                "reason": reason,
+                "state": state,
+                "detail": rung_detail,
+                "evidence_source": _LOOP_STOP_EVIDENCE_SOURCES[reason],
+            }
+        )
+        if state == "fired":
+            stop_reason = reason
+            stop_rung = index + 1
+            detail = rung_detail
+    return {
+        "schema_version": LOOP_STOP_LADDER_SCHEMA,
+        "loop_id": str(cycle.get("loop_id", "")),
+        "stop": stop_reason != "none",
+        "stop_reason": stop_reason,
+        "stop_rung": stop_rung,
+        "executor_profile": executor_profile,
+        "planned_action": str(planned_action),
+        "detail": detail,
+        "next_action": _LOOP_STOP_NEXT_ACTIONS.get(stop_reason, ""),
+        "ledger_entry_count": ledger_entry_count if goal_linked else previous_count,
+        "no_progress_ticks": no_progress_ticks,
+        "no_progress_cap": LOOP_NO_PROGRESS_TICK_CAP,
+        "rungs": rungs,
+        "claim_boundary": LOOP_STOP_LADDER_CLAIM_BOUNDARY,
+    }
+
+
+def _stop_rung_explicit_cancel(goal_linked: bool, goal_status: str) -> tuple[str, str]:
+    if not goal_linked:
+        return ("not_applicable", "This loop carries no linked goal ledger to cancel.")
+    if goal_status == "cancelled":
+        return (
+            "fired",
+            "The linked goal ledger is cancelled; it refuses every checkpoint, blocker, and gate.",
+        )
+    return ("clear", f"The linked goal ledger status is `{goal_status or 'unknown'}`.")
+
+
+def _stop_rung_rate_limit(executor_profile: str, limit_signal: Mapping[str, Any] | None) -> tuple[str, str]:
+    if executor_profile not in AUTH_SIGNAL_PROFILES:
+        return ("not_applicable", f"`{executor_profile}` records no limit signals.")
+    if not isinstance(limit_signal, Mapping) or not limit_signal:
+        return ("clear", f"No limit-shaped dispatch failure is recorded for `{executor_profile}`.")
+    if limit_signal.get("stale") is not False:
+        # Missing freshness means the stored stamp did not parse. Same
+        # direction `_stamp_age_seconds` takes: what cannot be shown fresh is
+        # not treated as fresh, so an unreadable stamp never fabricates a stop.
+        return ("clear", "The recorded limit signal is stale or undatable, so it is history rather than state.")
+    label = str(limit_signal.get("pattern_label", "") or "unlabelled")
+    return (
+        "fired",
+        f"A `{label}` limit-shaped dispatch failure was observed for `{executor_profile}` "
+        "inside the freshness horizon.",
+    )
+
+
+def _stop_rung_auth_failure(
+    executor_profile: str, planned_action: str, auth_signal: Mapping[str, Any] | None
+) -> tuple[str, str]:
+    if planned_action != "executor_dispatch":
+        return (
+            "not_applicable",
+            f"This tick plans `{planned_action or 'nothing'}`, so it hands no work to an executor CLI.",
+        )
+    marker = str((auth_signal or {}).get("login_marker", "") or "")
+    if marker in {"", "not_applicable"}:
+        return ("not_applicable", f"`{executor_profile}` carries no local login marker to read.")
+    if marker == "absent":
+        return (
+            "fired",
+            f"This tick would dispatch to `{executor_profile}` and omh sees no local login marker for it. "
+            "An absent marker is file presence only - an API-key or environment-token install reads absent "
+            "while working, and no provider rejected anything here.",
+        )
+    return ("clear", f"The `{executor_profile}` login marker reads `{marker}`.")
+
+
+def _stop_rung_no_progress(goal_linked: bool, no_progress_ticks: int) -> tuple[str, str]:
+    if not goal_linked:
+        return ("not_applicable", "Without a linked goal ledger there are no records to key progress to.")
+    if no_progress_ticks >= LOOP_NO_PROGRESS_TICK_CAP:
+        return (
+            "fired",
+            f"{no_progress_ticks} consecutive ticks wrote no new goal-ledger record "
+            f"(cap {LOOP_NO_PROGRESS_TICK_CAP}).",
+        )
+    return (
+        "clear",
+        f"{no_progress_ticks} consecutive ticks without a new goal-ledger record, under the "
+        f"{LOOP_NO_PROGRESS_TICK_CAP} cap.",
+    )
+
+
+def read_loop_stop_ladder(
+    paths: OmhPaths,
+    cycle: dict[str, Any],
+    *,
+    planned_action: str = "",
+    home: Path | None = None,
+) -> dict[str, Any]:
+    """Read the ladder's inputs, then hand them to the pure assessment.
+
+    The auth marker is read only when the tick plans `executor_dispatch`: the
+    marker file is the potentially large `~/.claude.json`, and a research or
+    planning tick has no executor CLI to confirm.
+    """
+    linked_goal_id = str(cycle.get("linked_goal_id", ""))
+    goal_linked = False
+    goal_status = ""
+    ledger_entry_count = 0
+    if linked_goal_id:
+        try:
+            goal = read_goal_ledger(paths, linked_goal_id)
+        except (FileNotFoundError, ValueError):
+            # An unreadable link is a setup gap, not a stop reason. Reporting
+            # it as `not_applicable` keeps the ladder from inventing a cancel
+            # or a stuck marker out of a missing file.
+            goal = None
+        if isinstance(goal, dict):
+            goal_linked = True
+            goal_status = str(goal.get("status", ""))
+            ledger_entry_count = goal_ledger_entry_count(goal)
+    executor_profile = _preferred_executor(_dict_value(cycle, "authority_envelope"))
+    limit_signal: dict[str, object] = {}
+    if executor_profile in AUTH_SIGNAL_PROFILES:
+        limit_signal = last_limit_signal_for_profile(paths, executor_profile)
+    auth_signal: dict[str, object] = {}
+    if planned_action == "executor_dispatch":
+        auth_signal = auth_signal_for_profile(executor_profile, home=home)
+    return assess_loop_stop_ladder(
+        cycle,
+        planned_action=planned_action,
+        goal_linked=goal_linked,
+        goal_status=goal_status,
+        ledger_entry_count=ledger_entry_count,
+        limit_signal=limit_signal,
+        auth_signal=auth_signal,
+    )
+
+
+def validate_loop_stop_ladder(value: object) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(value, dict):
+        return ["stop_ladder must be an object"]
+    if value.get("schema_version") != LOOP_STOP_LADDER_SCHEMA:
+        errors.append(f"stop_ladder.schema_version must be {LOOP_STOP_LADDER_SCHEMA}")
+    stop_reason = str(value.get("stop_reason", ""))
+    if stop_reason not in set(LOOP_STOP_REASONS) | {"none"}:
+        errors.append("stop_ladder.stop_reason is unsupported")
+    if value.get("stop") is not (stop_reason != "none"):
+        errors.append("stop_ladder.stop must agree with stop_reason")
+    for key in ("no_progress_ticks", "no_progress_cap", "stop_rung", "ledger_entry_count"):
+        count = value.get(key)
+        if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+            errors.append(f"stop_ladder.{key} must be a non-negative integer")
+    rungs = value.get("rungs")
+    if not isinstance(rungs, list) or len(rungs) != len(LOOP_STOP_REASONS):
+        errors.append(f"stop_ladder.rungs must hold {len(LOOP_STOP_REASONS)} entries")
+        return errors
+    for index, rung in enumerate(rungs):
+        if not isinstance(rung, dict):
+            errors.append(f"stop_ladder.rungs[{index}] must be an object")
+            continue
+        if rung.get("reason") != LOOP_STOP_REASONS[index]:
+            errors.append(f"stop_ladder.rungs[{index}].reason must be {LOOP_STOP_REASONS[index]}")
+        if rung.get("rung") != index + 1:
+            errors.append(f"stop_ladder.rungs[{index}].rung must be {index + 1}")
+        if rung.get("state") not in LOOP_STOP_RUNG_STATES:
+            errors.append(f"stop_ladder.rungs[{index}].state is unsupported")
+    return errors
+
+
+def _loop_stuck_marker(ladder: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "recorded_at": utc_now(),
+        "reason": str(ladder["stop_reason"]),
+        "no_progress_ticks": int(ladder["no_progress_ticks"]),
+        "ledger_entry_count": int(ladder["ledger_entry_count"]),
+        "summary": str(ladder["detail"]),
+        "next_action": str(ladder["next_action"]),
+        "claim_boundary": LOOP_STOP_LADDER_CLAIM_BOUNDARY,
+    }
+
+
 def tick_loop_runtime(
     paths: OmhPaths,
     loop_id: str,
@@ -939,6 +1246,7 @@ def tick_loop_runtime(
     note: str = "",
     expected_revision: int | None = None,
     mutation_id: str | None = None,
+    home: Path | None = None,
 ) -> dict[str, Any]:
     def mutate(cycle: dict[str, Any]) -> dict[str, Any]:
         # The plan and the queue item are derived from the cycle read inside
@@ -946,6 +1254,26 @@ def tick_loop_runtime(
         # computed against permissions or a queue that had already moved on.
         envelope = _dict_value(cycle, "authority_envelope")
         plan = _next_runtime_plan(cycle, envelope)
+        # The stop ladder runs before the queue item is built, on the plan this
+        # tick would actually carry out. A stop appends nothing, raises no
+        # heartbeat, and names its own reason: a refused tick has to be
+        # distinguishable from a tick that ran and found nothing to do.
+        ladder = read_loop_stop_ladder(
+            paths, cycle, planned_action=str(plan["planned_action"]), home=home
+        )
+        if ladder["stop"]:
+            runtime = _runtime_state(cycle.get("runtime"))
+            runtime["ledger_entry_count"] = int(ladder["ledger_entry_count"])
+            runtime["no_progress_ticks"] = int(ladder["no_progress_ticks"])
+            runtime["last_stop_reason"] = str(ladder["stop_reason"])
+            runtime["last_stop_at"] = utc_now()
+            runtime["stop_ladder"] = ladder
+            if ladder["stop_reason"] == "no_progress_cap":
+                runtime["stuck_marker"] = _loop_stuck_marker(ladder)
+            cycle["runtime"] = runtime
+            cycle["next_action"] = str(ladder["next_action"])
+            cycle["updated_at"] = utc_now()
+            return cycle
         queue_item = _runtime_queue_item(
             cycle,
             envelope,
@@ -966,6 +1294,11 @@ def tick_loop_runtime(
         runtime["last_trigger"] = queue_item["trigger"]
         runtime["last_planned_action"] = queue_item["planned_action"]
         runtime["last_queue_id"] = queue_item["queue_id"]
+        runtime["ledger_entry_count"] = int(ladder["ledger_entry_count"])
+        runtime["no_progress_ticks"] = int(ladder["no_progress_ticks"])
+        runtime["last_stop_reason"] = "none"
+        runtime["stop_ladder"] = ladder
+        runtime.pop("stuck_marker", None)
         runtime.setdefault("queue", []).append(queue_item)
         cycle["runtime"] = runtime
         if queue_item["status"] == "prepared_not_observed":
@@ -1050,6 +1383,13 @@ def run_loop_once_result(paths: OmhPaths, loop_id: str) -> dict[str, Any]:
         advanced = created_queue_count > 0
         outcome = "created_tick" if advanced else "no_eligible_tick"
         queue_id = str(queue[-1].get("queue_id", "")) if queue else ""
+    stop_reason = str(runtime.get("last_stop_reason", "") or "none")
+    if outcome == "no_eligible_tick" and stop_reason != "none":
+        # A refused tick reports the ladder rung that refused it. Collapsing it
+        # into no_eligible_tick would report a stop as an absence of work.
+        # `pending_queue_exists` keeps its own name: that call never ticked, so
+        # the stored reason belongs to an earlier tick, not to this one.
+        outcome = "stopped_by_ladder"
     return {
         "loop": cycle,
         "run_once": {
@@ -1060,6 +1400,7 @@ def run_loop_once_result(paths: OmhPaths, loop_id: str) -> dict[str, Any]:
             "created_queue_count": created_queue_count,
             "queue_id": queue_id,
             "pending_queue_count": sum(1 for item in queue if item.get("status") == "prepared_not_observed"),
+            "stop_reason": stop_reason,
             "next_action": str(cycle.get("next_action", "")),
             "claim_boundary": _runtime_claim_boundary(),
         },
@@ -2430,20 +2771,36 @@ def _runtime_state(value: object | None = None) -> dict[str, Any]:
     queue = runtime.get("queue", [])
     if not isinstance(queue, list):
         queue = []
-    try:
-        heartbeat_count = int(runtime.get("heartbeat_count", 0) or 0)
-    except (TypeError, ValueError):
-        heartbeat_count = 0
-    return {
+    state: dict[str, Any] = {
         "schema_version": LOOP_RUNTIME_SCHEMA,
-        "heartbeat_count": heartbeat_count,
+        "heartbeat_count": _non_negative_count(runtime.get("heartbeat_count")),
         "last_tick_at": str(runtime.get("last_tick_at", "")),
         "last_trigger": _safe_summary(str(runtime.get("last_trigger", "")), limit=80),
         "last_planned_action": _safe_summary(str(runtime.get("last_planned_action", "")), limit=80),
         "last_queue_id": _safe_summary(str(runtime.get("last_queue_id", "")), limit=140),
+        # Stop-ladder accounting. `ledger_entry_count` is the goal-ledger record
+        # count observed at the last tick, and `no_progress_ticks` counts the
+        # consecutive ticks since that number last moved - the pair is what
+        # keys the cap to records written rather than ticks attempted.
+        "ledger_entry_count": _non_negative_count(runtime.get("ledger_entry_count")),
+        "no_progress_ticks": _non_negative_count(runtime.get("no_progress_ticks")),
+        "last_stop_reason": str(runtime.get("last_stop_reason", "") or "none"),
+        "last_stop_at": str(runtime.get("last_stop_at", "")),
         "queue": queue,
         "claim_boundary": _runtime_claim_boundary(),
     }
+    for key in ("stop_ladder", "stuck_marker"):
+        carried = runtime.get(key)
+        if isinstance(carried, dict):
+            state[key] = carried
+    return state
+
+
+def _non_negative_count(value: object) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
 
 
 def _next_runtime_plan(cycle: dict[str, Any], envelope: dict[str, Any]) -> dict[str, str]:
@@ -2814,6 +3171,9 @@ def _runtime_summary(cycle: dict[str, Any]) -> dict[str, Any]:
         "last_queue_reason": str(last.get("reason", "")),
         "blocked_queue_count": sum(1 for item in queue if item.get("status") in {"blocked", "blocked_by_permission", "blocked_by_wait"}),
         "observed_queue_count": sum(1 for item in queue if item.get("status") == "observed" and item.get("observed") is True),
+        "last_stop_reason": runtime["last_stop_reason"],
+        "no_progress_ticks": runtime["no_progress_ticks"],
+        "no_progress_cap": LOOP_NO_PROGRESS_TICK_CAP,
         "claim_boundary": _runtime_claim_boundary(),
     }
 
@@ -3357,6 +3717,16 @@ def _validate_runtime(runtime: object) -> list[str]:
         return ["runtime must be an object"]
     if runtime.get("schema_version") != LOOP_RUNTIME_SCHEMA:
         errors.append(f"runtime.schema_version must be {LOOP_RUNTIME_SCHEMA}")
+    for key in ("heartbeat_count", "ledger_entry_count", "no_progress_ticks"):
+        count = runtime.get(key)
+        if count is not None and (isinstance(count, bool) or not isinstance(count, int) or count < 0):
+            errors.append(f"runtime.{key} must be a non-negative integer")
+    last_stop_reason = runtime.get("last_stop_reason")
+    if last_stop_reason is not None and last_stop_reason not in set(LOOP_STOP_REASONS) | {"none", ""}:
+        errors.append("runtime.last_stop_reason is unsupported")
+    stop_ladder = runtime.get("stop_ladder")
+    if stop_ladder is not None:
+        errors.extend(f"runtime.{error}" for error in validate_loop_stop_ladder(stop_ladder))
     queue = runtime.get("queue", [])
     if not isinstance(queue, list):
         errors.append("runtime.queue must be a list")

--- a/tests/test_loop_stop_ladder.py
+++ b/tests/test_loop_stop_ladder.py
@@ -1,0 +1,420 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.goal_ledger import (  # noqa: E402
+    cancel_goal_ledger,
+    create_goal_ledger,
+    record_goal_blocker,
+    record_goal_checkpoint,
+)
+from omh.goal_loop import (  # noqa: E402
+    LOOP_NO_PROGRESS_TICK_CAP,
+    LOOP_STOP_LADDER_SCHEMA,
+    LOOP_STOP_REASONS,
+    assess_loop_stop_ladder,
+    create_loop_cycle,
+    goal_ledger_entry_count,
+    observe_loop_queue_item,
+    read_loop_cycle,
+    run_loop_once_result,
+    tick_loop_runtime,
+    validate_loop_cycle,
+    validate_loop_stop_ladder,
+)
+from omh.paths import resolve_paths  # noqa: E402
+from omh.system.local_store import atomic_write_json, utc_now  # noqa: E402
+
+
+def _paths(tmp: str) -> object:
+    return resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+
+
+def _cycle(paths, **overrides):
+    kwargs = {
+        "goal_summary": "Keep the loop stop ladder honest about why it stopped",
+        "goal_reframe": "Prepare bounded loop slices and stop with a named reason when a signal says so.",
+        "success_criteria": ["Every stop carries a reason code"],
+        "permission_profile": "handoff_only",
+    }
+    kwargs.update(overrides)
+    return create_loop_cycle(paths, **kwargs)
+
+
+def _seed_limit_signal(paths, profile: str, *, observed_at: str) -> None:
+    atomic_write_json(
+        paths.executor_limit_signals_path,
+        {
+            "schema_version": "executor_limit_signals/v1",
+            "profiles": {
+                profile: {
+                    "last_limit_shaped_at": observed_at,
+                    "run_ref": "run-1",
+                    "unit_id": "unit-1",
+                    "pattern_label": "http_429",
+                }
+            },
+        },
+        private=True,
+    )
+
+
+def _seed_codex_login(home: Path) -> None:
+    auth = home / ".codex" / "auth.json"
+    auth.parent.mkdir(parents=True, exist_ok=True)
+    auth.write_text(json.dumps({"tokens": "redacted"}), encoding="utf-8")
+
+
+def _advance_to_handoff_phase(paths, loop_id: str, home: Path) -> None:
+    """Tick and observe until the next planned action is `executor_dispatch`.
+
+    Phases advance on observed queue evidence, so reaching the dispatch phase
+    means walking interview -> plan -> research -> handoff the same way the
+    loop does in production.
+    """
+    for index in range(3):
+        item = tick_loop_runtime(paths, loop_id, home=home)["runtime"]["queue"][-1]
+        observe_loop_queue_item(
+            paths, loop_id, str(item["queue_id"]), evidence_refs=[f"wrapper:phase-observation:{index}"]
+        )
+
+
+class StopLadderOrderingTests(unittest.TestCase):
+    def test_ladder_reason_codes_are_the_declared_order(self) -> None:
+        self.assertEqual(
+            LOOP_STOP_REASONS,
+            ("explicit_cancel", "rate_limit_signal", "auth_failure_signal", "no_progress_cap"),
+        )
+
+    def test_cancel_outranks_a_rate_limit_that_is_also_present(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            goal = create_goal_ledger(paths, "Cancelled objective", ["Criterion"])
+            cancel_goal_ledger(paths, goal["goal_id"], reason="operator stopped this")
+            cycle = _cycle(paths, allowed_executors=["codex"], linked_goal_id=goal["goal_id"])
+            _seed_limit_signal(paths, "codex", observed_at=utc_now())
+
+            stopped = tick_loop_runtime(paths, cycle["loop_id"])
+
+        ladder = stopped["runtime"]["stop_ladder"]
+        self.assertTrue(ladder["stop"])
+        self.assertEqual(ladder["stop_reason"], "explicit_cancel")
+        self.assertEqual(ladder["stop_rung"], 1)
+        self.assertEqual(ladder["rungs"][0]["state"], "fired")
+        # The rate-limit rung was real, but a higher rung already answered:
+        # recording it as `clear` would claim a check that never ran.
+        self.assertEqual(ladder["rungs"][1]["state"], "not_evaluated")
+        self.assertEqual(ladder["rungs"][2]["state"], "not_evaluated")
+        self.assertEqual(ladder["rungs"][3]["state"], "not_evaluated")
+        self.assertEqual(stopped["runtime"]["heartbeat_count"], 0)
+        self.assertEqual(stopped["runtime"]["queue"], [])
+        self.assertEqual(stopped["next_action"], "show_loop_status")
+        self.assertEqual(validate_loop_stop_ladder(ladder), [])
+        self.assertEqual(validate_loop_cycle(stopped), {"ok": True, "errors": []})
+
+
+class StopLadderRungTests(unittest.TestCase):
+    def test_cancelled_linked_goal_stops_the_tick(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            goal = create_goal_ledger(paths, "Cancelled objective", ["Criterion"])
+            cancel_goal_ledger(paths, goal["goal_id"], reason="operator stopped this")
+            cycle = _cycle(paths, linked_goal_id=goal["goal_id"])
+
+            stopped = tick_loop_runtime(paths, cycle["loop_id"])
+
+        self.assertEqual(stopped["runtime"]["last_stop_reason"], "explicit_cancel")
+        self.assertEqual(stopped["runtime"]["queue"], [])
+        self.assertIn("cancelled", stopped["runtime"]["stop_ladder"]["detail"])
+
+    def test_fresh_rate_limit_signal_stops_the_tick(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            cycle = _cycle(paths, allowed_executors=["codex"])
+            _seed_limit_signal(paths, "codex", observed_at=utc_now())
+
+            stopped = tick_loop_runtime(paths, cycle["loop_id"])
+
+        ladder = stopped["runtime"]["stop_ladder"]
+        self.assertEqual(ladder["stop_reason"], "rate_limit_signal")
+        self.assertEqual(ladder["stop_rung"], 2)
+        self.assertEqual(ladder["executor_profile"], "codex")
+        self.assertIn("http_429", ladder["detail"])
+        self.assertEqual(stopped["next_action"], "wait_for_executor_limit_reset")
+        self.assertEqual(stopped["runtime"]["heartbeat_count"], 0)
+
+    def test_missing_login_marker_stops_a_tick_that_would_dispatch(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            home = Path(tmp) / "home"
+            home.mkdir()
+            cycle = _cycle(paths, permission_profile="full_loop", allowed_executors=["codex"])
+            _advance_to_handoff_phase(paths, cycle["loop_id"], home)
+
+            stopped = tick_loop_runtime(paths, cycle["loop_id"], home=home)
+
+        ladder = stopped["runtime"]["stop_ladder"]
+        self.assertEqual(ladder["planned_action"], "executor_dispatch")
+        self.assertEqual(ladder["stop_reason"], "auth_failure_signal")
+        self.assertEqual(ladder["stop_rung"], 3)
+        self.assertEqual(stopped["next_action"], "confirm_executor_login_or_retarget")
+        # The stop names the marker for what it is and claims nothing about
+        # the provider, which is the whole reason the rung is allowed to fire.
+        self.assertIn("no provider rejected anything here", ladder["detail"])
+        self.assertEqual(stopped["runtime"]["heartbeat_count"], 3)
+
+    def test_no_progress_cap_stops_and_records_a_stuck_marker(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            goal = create_goal_ledger(paths, "Objective with no recorded progress", ["Criterion"])
+            cycle = _cycle(paths, linked_goal_id=goal["goal_id"])
+
+            first = tick_loop_runtime(paths, cycle["loop_id"])
+            second = tick_loop_runtime(paths, cycle["loop_id"])
+
+        self.assertEqual(first["runtime"]["no_progress_ticks"], 1)
+        self.assertEqual(first["runtime"]["last_stop_reason"], "none")
+        ladder = second["runtime"]["stop_ladder"]
+        self.assertEqual(ladder["stop_reason"], "no_progress_cap")
+        self.assertEqual(ladder["stop_rung"], 4)
+        self.assertEqual(ladder["no_progress_ticks"], LOOP_NO_PROGRESS_TICK_CAP)
+        marker = second["runtime"]["stuck_marker"]
+        self.assertEqual(marker["reason"], "no_progress_cap")
+        self.assertEqual(marker["no_progress_ticks"], LOOP_NO_PROGRESS_TICK_CAP)
+        self.assertEqual(marker["next_action"], "record_goal_blocker_for_stuck_loop")
+        self.assertIn("not a completion", marker["claim_boundary"])
+        self.assertEqual(len(second["runtime"]["queue"]), 1)
+        self.assertEqual(second["runtime"]["heartbeat_count"], 1)
+
+    def test_recording_the_stuck_blocker_clears_the_no_progress_stop(self) -> None:
+        # The stop's own next_action is the way out of it: a blocker is a
+        # ledger record, so writing one is progress by the cap's own measure.
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            goal = create_goal_ledger(paths, "Objective that gets unstuck", ["Criterion"])
+            cycle = _cycle(paths, linked_goal_id=goal["goal_id"])
+
+            tick_loop_runtime(paths, cycle["loop_id"])
+            stopped = tick_loop_runtime(paths, cycle["loop_id"])
+            record_goal_blocker(paths, goal["goal_id"], "Loop stalled without recorded progress")
+            resumed = tick_loop_runtime(paths, cycle["loop_id"])
+
+        self.assertEqual(stopped["runtime"]["stop_ladder"]["stop_reason"], "no_progress_cap")
+        self.assertFalse(resumed["runtime"]["stop_ladder"]["stop"])
+        self.assertEqual(resumed["runtime"]["no_progress_ticks"], 0)
+        self.assertEqual(resumed["runtime"]["last_stop_reason"], "none")
+        self.assertNotIn("stuck_marker", resumed["runtime"])
+        self.assertEqual(len(resumed["runtime"]["queue"]), 2)
+
+
+class StopLadderNegativeTests(unittest.TestCase):
+    def test_healthy_signals_let_the_loop_advance(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            goal = create_goal_ledger(paths, "Healthy objective", ["Criterion"])
+            cycle = _cycle(paths, allowed_executors=["codex"], linked_goal_id=goal["goal_id"])
+
+            ticked = tick_loop_runtime(paths, cycle["loop_id"])
+
+        ladder = ticked["runtime"]["stop_ladder"]
+        self.assertFalse(ladder["stop"])
+        self.assertEqual(ladder["stop_reason"], "none")
+        self.assertEqual(ladder["stop_rung"], 0)
+        self.assertEqual(ladder["next_action"], "")
+        self.assertEqual([rung["state"] for rung in ladder["rungs"]], ["clear", "clear", "not_applicable", "clear"])
+        self.assertEqual(ticked["runtime"]["heartbeat_count"], 1)
+        self.assertEqual(len(ticked["runtime"]["queue"]), 1)
+        self.assertNotIn("stuck_marker", ticked["runtime"])
+
+    def test_one_no_progress_tick_below_the_cap_still_advances(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            goal = create_goal_ledger(paths, "Objective under the cap", ["Criterion"])
+            cycle = _cycle(paths, linked_goal_id=goal["goal_id"])
+
+            ticked = tick_loop_runtime(paths, cycle["loop_id"])
+
+        self.assertFalse(ticked["runtime"]["stop_ladder"]["stop"])
+        self.assertEqual(ticked["runtime"]["no_progress_ticks"], 1)
+        self.assertLess(ticked["runtime"]["no_progress_ticks"], LOOP_NO_PROGRESS_TICK_CAP)
+        self.assertEqual(len(ticked["runtime"]["queue"]), 1)
+
+    def test_a_new_ledger_record_resets_the_no_progress_count(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            goal = create_goal_ledger(paths, "Objective that records progress", ["Criterion"])
+            cycle = _cycle(paths, linked_goal_id=goal["goal_id"])
+
+            first = tick_loop_runtime(paths, cycle["loop_id"])
+            record_goal_checkpoint(paths, goal["goal_id"], "Recorded one real step", status="in_progress")
+            second = tick_loop_runtime(paths, cycle["loop_id"])
+            third = tick_loop_runtime(paths, cycle["loop_id"])
+
+        self.assertEqual(first["runtime"]["no_progress_ticks"], 1)
+        self.assertEqual(second["runtime"]["no_progress_ticks"], 0)
+        self.assertEqual(second["runtime"]["ledger_entry_count"], 1)
+        self.assertEqual(len(second["runtime"]["queue"]), 2)
+        # The count restarts rather than resuming: the cap measures consecutive
+        # ticks since the last record, not ticks since the loop began.
+        self.assertEqual(third["runtime"]["no_progress_ticks"], 1)
+        self.assertEqual(len(third["runtime"]["queue"]), 3)
+
+    def test_a_stale_limit_signal_does_not_stop_the_loop(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            cycle = _cycle(paths, allowed_executors=["codex"])
+            _seed_limit_signal(paths, "codex", observed_at="2020-01-01T00:00:00Z")
+
+            ticked = tick_loop_runtime(paths, cycle["loop_id"])
+
+        ladder = ticked["runtime"]["stop_ladder"]
+        self.assertFalse(ladder["stop"])
+        self.assertEqual(ladder["rungs"][1]["state"], "clear")
+        self.assertIn("stale", ladder["rungs"][1]["detail"])
+        self.assertEqual(len(ticked["runtime"]["queue"]), 1)
+
+    def test_an_absent_login_marker_does_not_stop_a_tick_that_never_dispatches(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            home = Path(tmp) / "home"
+            home.mkdir()
+            cycle = _cycle(paths, permission_profile="full_loop", allowed_executors=["codex"])
+
+            ticked = tick_loop_runtime(paths, cycle["loop_id"], home=home)
+
+        ladder = ticked["runtime"]["stop_ladder"]
+        self.assertFalse(ladder["stop"])
+        self.assertEqual(ladder["planned_action"], "planning")
+        self.assertEqual(ladder["rungs"][2]["state"], "not_applicable")
+        self.assertEqual(len(ticked["runtime"]["queue"]), 1)
+
+    def test_a_present_login_marker_lets_a_dispatch_tick_advance(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            home = Path(tmp) / "home"
+            home.mkdir()
+            _seed_codex_login(home)
+            cycle = _cycle(paths, permission_profile="full_loop", allowed_executors=["codex"])
+            _advance_to_handoff_phase(paths, cycle["loop_id"], home)
+
+            ticked = tick_loop_runtime(paths, cycle["loop_id"], home=home)
+
+        ladder = ticked["runtime"]["stop_ladder"]
+        self.assertEqual(ladder["planned_action"], "executor_dispatch")
+        self.assertFalse(ladder["stop"])
+        self.assertEqual(ladder["rungs"][2]["state"], "clear")
+        self.assertEqual(ticked["runtime"]["heartbeat_count"], 4)
+
+    def test_an_unlinked_loop_never_fires_the_ledger_keyed_rungs(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            cycle = _cycle(paths)
+
+            ticks = [tick_loop_runtime(paths, cycle["loop_id"]) for _ in range(4)]
+
+        for ticked in ticks:
+            ladder = ticked["runtime"]["stop_ladder"]
+            self.assertFalse(ladder["stop"])
+            self.assertEqual(ladder["rungs"][0]["state"], "not_applicable")
+            self.assertEqual(ladder["rungs"][3]["state"], "not_applicable")
+        self.assertEqual(ticks[-1]["runtime"]["heartbeat_count"], 4)
+
+
+class StopLadderContractTests(unittest.TestCase):
+    def test_ledger_entry_count_counts_written_records_only(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            goal = create_goal_ledger(paths, "Counted objective", ["First", "Second"])
+            self.assertEqual(goal_ledger_entry_count(goal), 0)
+            goal = record_goal_checkpoint(paths, goal["goal_id"], "One step", status="in_progress")
+
+        self.assertEqual(goal_ledger_entry_count(goal), 1)
+        self.assertEqual(goal_ledger_entry_count(None), 0)
+
+    def test_assessment_is_pure_over_handed_in_signals(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            cycle = _cycle(paths, allowed_executors=["codex"])
+
+        ladder = assess_loop_stop_ladder(
+            cycle,
+            planned_action="executor_dispatch",
+            goal_linked=True,
+            goal_status="active",
+            ledger_entry_count=0,
+            limit_signal={"stale": True, "pattern_label": "rate_limit"},
+            auth_signal={"login_marker": "absent"},
+        )
+
+        self.assertEqual(ladder["schema_version"], LOOP_STOP_LADDER_SCHEMA)
+        self.assertEqual(ladder["stop_reason"], "auth_failure_signal")
+        self.assertEqual(ladder["rungs"][1]["state"], "clear")
+        self.assertEqual(validate_loop_stop_ladder(ladder), [])
+
+    def test_validator_rejects_a_disagreeing_stop_flag_and_short_ladder(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            cycle = _cycle(paths)
+
+        ladder = assess_loop_stop_ladder(cycle, planned_action="planning")
+        disagreeing = {**ladder, "stop": True}
+        short = {**ladder, "rungs": ladder["rungs"][:2]}
+        renamed = {
+            **ladder,
+            "rungs": [{**ladder["rungs"][0], "reason": "made_up"}, *ladder["rungs"][1:]],
+        }
+
+        self.assertEqual(validate_loop_stop_ladder(ladder), [])
+        self.assertIn("stop_ladder.stop must agree with stop_reason", validate_loop_stop_ladder(disagreeing))
+        self.assertIn("stop_ladder.rungs must hold 4 entries", validate_loop_stop_ladder(short))
+        self.assertIn("stop_ladder.rungs[0].reason must be explicit_cancel", validate_loop_stop_ladder(renamed))
+        self.assertEqual(validate_loop_stop_ladder("not a ladder"), ["stop_ladder must be an object"])
+
+    def test_a_stored_stop_survives_a_read_and_stays_valid(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            cycle = _cycle(paths, allowed_executors=["codex"])
+            _seed_limit_signal(paths, "codex", observed_at=utc_now())
+            tick_loop_runtime(paths, cycle["loop_id"])
+
+            stored = read_loop_cycle(paths, cycle["loop_id"])
+
+        self.assertEqual(stored["runtime"]["stop_ladder"]["stop_reason"], "rate_limit_signal")
+        self.assertEqual(validate_loop_cycle(stored), {"ok": True, "errors": []})
+
+
+class StopLadderRunOnceTests(unittest.TestCase):
+    def test_run_once_reports_the_stop_rung_instead_of_an_empty_tick(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            cycle = _cycle(paths, allowed_executors=["codex"])
+            _seed_limit_signal(paths, "codex", observed_at=utc_now())
+
+            result = run_loop_once_result(paths, cycle["loop_id"])["run_once"]
+
+        self.assertEqual(result["outcome"], "stopped_by_ladder")
+        self.assertEqual(result["stop_reason"], "rate_limit_signal")
+        self.assertFalse(result["advanced"])
+        self.assertEqual(result["created_queue_count"], 0)
+
+    def test_run_once_still_reports_a_created_tick_when_no_rung_fires(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            cycle = _cycle(paths, allowed_executors=["codex"])
+
+            result = run_loop_once_result(paths, cycle["loop_id"])["run_once"]
+
+        self.assertEqual(result["outcome"], "created_tick")
+        self.assertEqual(result["stop_reason"], "none")
+        self.assertTrue(result["advanced"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- `src/workflows/goal_loop.py` evaluates an ordered stop ladder before a goal-loop tick advances, and writes a `loop_stop_ladder/v1` verdict into the loop's runtime record on every tick, whether it stops or advances.
- Four named reason codes in `LOOP_STOP_REASONS`, and the tuple order *is* the ladder: `explicit_cancel` → `rate_limit_signal` → `auth_failure_signal` → `no_progress_cap`.
- A stop appends no queue item and raises no heartbeat. `omh loop run-once` reports it as `stopped_by_ladder` with the reason, instead of collapsing it into `no_eligible_tick`.
- `tests/test_loop_stop_ladder.py` — 20 tests: every rung firing with its own reason code, ladder ordering, and the mandatory negative controls.

### Why This Exists

- `tick_loop_runtime` prepared a queue item on every call. A grep of `goal_loop.py` and `loopability.py` for rate-limit, auth, 401, 403, or 429 handling returned nothing, so the loop had no way to refuse an iteration.
- Meanwhile `src/coding/executor_auth_signals.py` already computes `auth_signal_for_profile` and `last_limit_signal_for_profile`. The ingredients existed; nothing wired them into the loop's stop contract.
- A loop pointed at a rate-limited or unauthenticated executor kept preparing work it could never convert, and a loop whose linked goal ledger was recording nothing kept ticking with no marker saying so. Both competitor harnesses paid for these lessons in production (omc issues #777 and #1308 for the two exemptions; omo's `RESUME_CAP = 2` keyed to ledger lines with a `.stuck` marker).
- Absorbed from `.omc/research/omo-omc-comparison-2026-08-29.md`, section "P1 — 2. Loop stop ladder with error-class exemptions".

### User / Operator Impact

- A loop that cannot make progress now stops and says why, in a reason code an operator or a wrapper can read, instead of accumulating prepared handoffs.
- Each stop carries its own way forward: `show_loop_status`, `wait_for_executor_limit_reset`, `confirm_executor_login_or_retarget`, `record_goal_blocker_for_stuck_loop`.
- The no-progress stop is self-clearing by design: recording the blocker it asks for is itself a goal-ledger record, so the next tick advances.
- No behaviour change for a loop with no linked goal ledger and no recorded executor signals — the ladder reports `clear`/`not_applicable` and the tick advances exactly as before.

### How It Works

- `assess_loop_stop_ladder(cycle, ...)` is pure policy over signals the caller already read, in the `build_account_authorization` idiom — it never probes, so the verdict is reproducible from a recorded snapshot. `read_loop_stop_ladder(paths, cycle, ...)` is the reading half and is the only part that touches disk.
- The ladder short-circuits: the first rung that fires stops the tick, and every rung below it is recorded `not_evaluated` rather than `clear`. A rung that was never consulted must never read as a rung that passed.
- **Rung 1 `explicit_cancel`** — the linked goal ledger is `cancelled`. A cancelled ledger refuses every checkpoint, blocker, and gate, so any work prepared under it is unrecordable by construction. A cancel and a fresh rate-limit signal present together stop as `explicit_cancel`, with rung 2 recorded `not_evaluated`.
- **Rung 2 `rate_limit_signal`** — a non-stale entry from `last_limit_signal_for_profile` for the loop's active executor profile. Freshness comes from the signal's own `stale` field; a signal whose stamp did not parse is treated as history rather than state, in the direction `_stamp_age_seconds` already takes, so an unreadable stamp never fabricates a stop.
- **Rung 3 `auth_failure_signal`** — `auth_signal_for_profile(...)["login_marker"] == "absent"`, gated on the tick actually planning `executor_dispatch`. That gate is the reconciliation with `executor_auth_signals`' own boundary, which states that markers rank candidates and never veto one because an API-key or environment-token install legitimately reads absent. The rung does not veto a candidate: it stops the loop at the one moment its own next act is to hand work to a CLI omh can see no login for, and the stop text says plainly that no provider rejected anything.
- **Rung 4 `no_progress_cap`** — `LOOP_NO_PROGRESS_TICK_CAP = 2` consecutive ticks that wrote no new goal-ledger record. Keyed to records written (checkpoints + blockers + quality gates) rather than ticks attempted: attempts are what a stuck loop produces in abundance, so counting them measures the symptom instead of the progress. Fires only on a linked ledger; without one there are no records to key to. Its stop writes a `stuck_marker` into the runtime record.

### Files And Contracts Touched

- `src/workflows/goal_loop.py`
  - New: `LOOP_STOP_LADDER_SCHEMA` (`loop_stop_ladder/v1`), `LOOP_STOP_REASONS`, `LOOP_STOP_RUNG_STATES`, `LOOP_NO_PROGRESS_TICK_CAP`, `LOOP_STOP_LADDER_CLAIM_BOUNDARY`, `goal_ledger_entry_count`, `assess_loop_stop_ladder`, `read_loop_stop_ladder`, `validate_loop_stop_ladder`.
  - `tick_loop_runtime` gains a `home` parameter (mirroring `auth_signal_for_profile(profile, home=...)`) so the marker probe is injectable; it evaluates the ladder inside the same locked transaction that already derives the plan.
  - `_runtime_state` carries `ledger_entry_count`, `no_progress_ticks`, `last_stop_reason`, `last_stop_at`, and the optional `stop_ladder` / `stuck_marker` blocks; `_validate_runtime` validates them, and `_runtime_summary` surfaces the stop reason and the no-progress counters on the status card.
  - `run_loop_once_result` gains `stop_reason` and the `stopped_by_ladder` outcome. `pending_queue_exists` keeps its own name: that call never ticked, so a stored reason belongs to an earlier tick.
- `tests/test_loop_stop_ladder.py` — new.
- `src/workflows/loopability.py` — deliberately untouched. The start gate answers whether a request is loop-shaped; these four reasons are runtime signals about an already-started loop, and none of them is knowable at start.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [x] Codex
- [x] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

Executor-neutral in wording and schema; the two named profiles appear only because `AUTH_SIGNAL_PROFILES` is the set that carries local login and limit markers at all.

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke ...`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- `PYTHONPATH=tests uv run python -m unittest discover -s tests` → `Ran 7844 tests`, `FAILED (failures=21, errors=7)`. Every one of those 28 is pre-existing and confined to `tests/test_cross_harness_adapters.py` and `tests/test_cross_harness_adapter_security.py`, failing with `unsafe_read_root` because this worktree lives under `.claude/worktrees/`. Baselined by stashing the branch changes and re-running those two files on the clean tree in the same worktree: `Ran 32 tests ... FAILED (failures=21, errors=7)` — the identical set, byte-for-byte on a sorted `FAIL:`/`ERROR:` diff before and after.
- `PYTHONPATH=tests uv run python -m unittest tests/test_loop_stop_ladder.py -v` → 20 passed.
- `PYTHONPATH=tests uv run python -m unittest tests/test_loop_stop_ladder.py tests/test_loop_cycle.py tests/test_cli.py tests/test_record_revision.py tests/test_router_content.py` → `Ran 598 tests ... OK` (the first run, before the final `run_once` refinement; the three-file rerun after it was `Ran 416 tests ... OK`).
- `uv run python -m compileall -q src tests` → clean.
- `uv run python -m omh.cli docs workflows --check` → `{"ok":true, ... "tap_skills":{"checked":140,"expected":140,...,"ok":true}}`.
- `uv run python -m omh.cli docs roles --check` → `{"ok":true}`.
- `docs capability-families --check`, `docs ulw-inventory --check`, `docs ulw-site --check` → all exit 0.
- `uv run --group lint ruff check src tests` → `All checks passed!`.
- `git diff --check` → clean.

Negative controls observed, per the guard-pattern rule:

- healthy signals → tick advances, `stop_reason == "none"`, rung states `["clear","clear","not_applicable","clear"]`, one queue item appended;
- one no-progress tick below the cap → advances with `no_progress_ticks == 1`;
- a new ledger record between ticks → count resets to 0, and restarts at 1 on the following tick rather than resuming;
- a stale limit signal → rung 2 `clear`, tick advances;
- an absent login marker on a tick that plans `planning` → rung 3 `not_applicable`, tick advances;
- a present login marker on a tick that plans `executor_dispatch` → rung 3 `clear`, tick advances;
- an unlinked loop → four consecutive ticks all advance, rungs 1 and 4 `not_applicable` throughout;
- recording the blocker the stuck marker asks for → the next tick advances with `no_progress_ticks == 0` and no `stuck_marker`.

### Not Tested / Not Applicable

- `harness validate`, `release checklist`, `release hermes-smoke`, `omh --help`, and the install-path smoke: no harness contract, release surface, CLI argument, or installed artifact changed. `omh loop tick` and `omh loop run-once` call through unchanged signatures; the new `home` parameter is keyword-only with a `None` default and is not exposed as a flag.
- No manual Hermes/TUI check: nothing in this change reaches a widget, the HUD, or Hermes state.
- No live rate-limited or unauthenticated executor was driven end to end. The limit signal is seeded as the exact fixture `_record_limit_signal` writes in the dispatch path; the login marker is a real file-presence probe against a temporary home rather than a mock, but no provider was contacted.
- The loop skill body and `site/docs/loop/index.html` still enumerate only `created_tick` and `pending_queue_exists`; adding `stopped_by_ladder` there is a catalog change with its own regeneration gates, listed under Follow-Up.

## Risk

- **A false stop is the risk that matters.** Rung 3 is the one that could fire on a healthy machine, because an API-key install legitimately shows an absent login marker. It is narrowed to ticks that plan `executor_dispatch`, so a research, planning, or handoff tick is never affected, and the stop text says explicitly that an absent marker is file presence only and that no provider rejected anything. An operator who hits it can relax the executor or log in; the loop is stopped, not failed.
- Rung 2 stops a loop whose active executor recorded a limit-shaped dispatch failure within the six-hour horizon, even for a tick that would only do research. That is the intended strong reading — never iterate against an observed limit — but it means one recent `omh coding fanout dispatch` failure can pause an unrelated loop pointed at the same profile for up to six hours.
- Rung 4 changes behaviour for loops that carry a linked goal ledger: two ticks without a recorded checkpoint, blocker, or gate now stop. No test in the suite linked a ledger and then ticked, so nothing regressed, but a live loop that ticks without writing to its ledger will now hit the cap. That is the point of the rung, and the recorded blocker clears it.
- The ladder reads the goal ledger from inside the cycle's locked transaction. Different records, different locks, and `read_goal_ledger` takes no lock of its own, so no ordering hazard is introduced.

## Compatibility / Rollout

- Records written before this change carry none of the new runtime keys. `_runtime_state` fills defaults on read, and `_validate_runtime` skips each new check when the key is absent, so an existing `cycle.json` reads, validates, and ticks unchanged.
- Additive on every payload: `loop_runtime/v1`, `loop_status_card/v1`, and `loop_run_once_result/v1` all gain fields and keep every existing one. `stopped_by_ladder` is a new outcome value in a field that already carried three.
- Local state only; no release-channel or installed-artifact impact.

## Release / Claims

- [x] Release-channel impact considered (`local` — no packaged artifact changes)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

The ladder's own claim boundary is carried on every verdict: *"A stop-ladder verdict is local policy over already-recorded signals. A stop is a stop with a named reason — it is not a completion, a failure verdict on the goal, provider quota truth, or evidence that any provider rejected a request."*

## Follow-Up

- Surface `stopped_by_ladder` and the four reason codes in the loop skill body and `site/docs/loop/index.html`. That is a `src/skills/catalog.py` / `render.py` change with the tap-skills, `docs workflows`, and `docs roles` byte gates, so it belongs in its own PR rather than riding along here.
- Rung 3 currently has one input, the login marker. If the dispatch path ever learns to classify auth-shaped failures the way `_LIMIT_SHAPED_PATTERNS` classifies limit-shaped ones, the rung should read that observed failure first and treat the marker as corroboration — which would also let the rung fire outside a dispatch-planning tick.
- The remaining `.claude/worktrees/` sandbox-root failures in the two cross-harness adapter test files are an environment fault, not repo work; they reproduce on a clean tree in this worktree and are not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1Tue9T3YhWLT5mT8bo9Ke
