### PR TITLE
feat(coding): live mid-run token telemetry for Maestro-lane HUD rows

### DIFF
--- a/src/coding/executor_progress.py
+++ b/src/coding/executor_progress.py
@@ -1330,6 +1330,13 @@ def transition_fingerprint(event: dict[str, Any]) -> str:
                 "latest_progress_event_type",
                 "progress_snapshot_hash",
                 "codex_artifact_sha256",
+                # A moved token counter IS a transition: without it, a unit's
+                # mid-run token updates (identical type, status, and summary)
+                # collapse into `duplicate_transition` after the first one and
+                # the HUD row's count freezes. Lanes that do not want
+                # token-drift cadence are still gated by their binding's
+                # `minimum_repeat_interval_seconds`.
+                "tokens_total",
             )
             if signal.get(key) not in (None, "")
         },

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -118,6 +118,7 @@ def signal_safe_unit_runner(
     capture_output: bool = False,
     timeout: float | None = None,
     on_spawn: Callable[[subprocess.Popen], None] | None = None,
+    on_output: Callable[[str], None] | None = None,
 ) -> subprocess.CompletedProcess:
     """Drop-in for `subprocess.run` that owns each child as a process group.
 
@@ -127,6 +128,12 @@ def signal_safe_unit_runner(
     timeout, and its pid is real state the fanout reaper can verify against
     the inflight marker. `on_spawn` hands the live process to the caller
     (the dispatch path records the pid in the unit's inflight marker).
+
+    `on_output` receives the stdout captured SO FAR, at a fixed poll cadence
+    while the child runs — the seam the dispatch path uses to read a unit's
+    cumulative token telemetry mid-run instead of only after exit. It only
+    engages for text-mode captured output (the dispatch path's shape); any
+    other shape keeps the plain blocking `communicate` exactly as before.
     """
     pipe = subprocess.PIPE if capture_output else None
     process = subprocess.Popen(
@@ -154,7 +161,15 @@ def signal_safe_unit_runner(
                 # A raising hook must not leak the child it was handed.
                 terminate_process_group(process, UNIT_TERMINATE_GRACE_SECONDS, signal.SIGTERM)
                 raise
-            stdout, stderr = process.communicate(timeout=timeout)
+            if on_output is not None and capture_output and text:
+                stdout, stderr = _communicate_with_output_polls(
+                    process,
+                    timeout=timeout,
+                    on_output=on_output,
+                    poll_seconds=UNIT_OUTPUT_POLL_SECONDS,
+                )
+            else:
+                stdout, stderr = process.communicate(timeout=timeout)
         except subprocess.TimeoutExpired:
             # The whole group dies with the leader — a timed-out unit must
             # not leave grandchildren running against the worktree.
@@ -169,6 +184,82 @@ def signal_safe_unit_runner(
 # retry decorator) can propagate it so the dispatch path keeps recording the
 # reapable pid instead of silently dropping it.
 signal_safe_unit_runner.accepts_on_spawn = True  # type: ignore[attr-defined]
+# Same marker pattern for the mid-run stdout seam: injected test runners keep
+# the plain protocol unless they opt in, exactly like `accepts_on_spawn`.
+signal_safe_unit_runner.accepts_on_output = True  # type: ignore[attr-defined]
+
+# Cadence of mid-run stdout snapshots handed to `on_output`. Also the upper
+# bound the poll loop waits between liveness checks, so timeout precision is
+# never worse than one poll step.
+UNIT_OUTPUT_POLL_SECONDS = 5.0
+
+
+def _drain_stream(stream: Any, chunks: list[str]) -> None:
+    # Line-at-a-time on purpose: a text stream's `read(n)` blocks until n
+    # characters accumulate, which starves the mid-run snapshots of
+    # everything until EOF. `readline` returns as each line lands — the
+    # exact granularity of the JSONL telemetry the snapshots exist to carry.
+    try:
+        while True:
+            line = stream.readline()
+            if not line:
+                return
+            chunks.append(line)
+    except (OSError, ValueError):
+        # A pipe closing mid-read (interrupt, group kill) ends the drain; the
+        # chunks captured before that still return to the caller.
+        return
+
+
+def _snapshot_output(on_output: Callable[[str], None], chunks: list[str]) -> None:
+    try:
+        on_output("".join(chunks))
+    except Exception:
+        # A raising snapshot hook is telemetry-only narration; unlike a
+        # raising on_spawn hook it must never kill the unit it observes.
+        return
+
+
+def _communicate_with_output_polls(
+    process: subprocess.Popen,
+    *,
+    timeout: float | None,
+    on_output: Callable[[str], None],
+    poll_seconds: float,
+) -> tuple[str, str]:
+    """`communicate()` with periodic mid-run stdout snapshots.
+
+    Reader threads drain both pipes continuously (the same deadlock guard
+    `communicate` provides), while the waiting thread wakes every poll step
+    to hand `on_output` the stdout collected so far. The overall timeout
+    keeps `communicate`'s contract: `TimeoutExpired` raises to the caller,
+    who terminates the group.
+    """
+    collected: dict[str, list[str]] = {"stdout": [], "stderr": []}
+    threads: list[threading.Thread] = []
+    for name, stream in (("stdout", process.stdout), ("stderr", process.stderr)):
+        if stream is None:
+            continue
+        thread = threading.Thread(target=_drain_stream, args=(stream, collected[name]), daemon=True)
+        thread.start()
+        threads.append(thread)
+    deadline = None if timeout is None else time.monotonic() + float(timeout)
+    step = max(0.2, float(poll_seconds))
+    while True:
+        wait_for = step
+        if deadline is not None:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise subprocess.TimeoutExpired(process.args, float(timeout or 0))
+            wait_for = min(step, remaining)
+        try:
+            process.wait(timeout=wait_for)
+            break
+        except subprocess.TimeoutExpired:
+            _snapshot_output(on_output, collected["stdout"])
+    for thread in threads:
+        thread.join(timeout=UNIT_TERMINATE_GRACE_SECONDS)
+    return "".join(collected["stdout"]), "".join(collected["stderr"])
 
 
 # Spacing between real agent-CLI spawn starts of one fanout. Providers cache
@@ -1451,6 +1542,13 @@ def _open_fanout_progress_binding(
             now=started_at,
             worktree=str(worktree),
             source=_FANOUT_PROGRESS_SOURCE,
+            # The default 120s repeat interval would suppress the mid-run
+            # token updates `_live_unit_telemetry_reporter` posts (same event
+            # type each time) down to two-minute granularity on the HUD row.
+            # A unit binding is short-lived and its reporter only writes when
+            # the count moved, so the journal cadence matches the reporter's
+            # own throttle instead.
+            minimum_repeat_interval_seconds=int(LIVE_UNIT_TELEMETRY_MIN_INTERVAL_SECONDS),
         )
         binding = write_progress_binding(paths, binding)
         signal = build_safe_progress_signal(
@@ -1510,7 +1608,6 @@ def _close_fanout_progress_binding(
         return
     try:
         telemetry = parse_unit_telemetry(owner, stdout_text)
-        tokens_total = telemetry.get("tokens_total")
         cost_usd = telemetry.get("cost_usd")
         signal = build_safe_progress_signal(
             executor_profile=str(binding.get("executor_profile", "")),
@@ -1518,12 +1615,96 @@ def _close_fanout_progress_binding(
             routed_model=routed_model,
             routed_reasoning_effort=routed_effort,
             explicit_summary=title,
-            tokens_total=tokens_total if isinstance(tokens_total, int) else None,
+            tokens_total=_reported_unit_tokens(telemetry),
             cost_usd=cost_usd if isinstance(cost_usd, (int, float)) and not isinstance(cost_usd, bool) else None,
         )
         observe_executor_progress(paths, binding, signal)
     except (ExecutorProgressError, OSError):
         return
+
+
+def _reported_unit_tokens(telemetry: Mapping[str, Any]) -> int | None:
+    """The one display count a unit's reported telemetry supports.
+
+    `tokens_total` when the CLI itself stated a total (codex's cumulative
+    `total_token_usage` carries one); otherwise the sum of the reported input
+    and output counts — the same input+output convention the Hermes-native
+    HUD rows already use, and aggregation of stated values in the
+    `tokens_billable` sense, never an estimate. Claude's result object states
+    input and output but no total, so without this fallback its rows carried
+    no count at all. Absent counts stay absent: None, never zero.
+    """
+    total = telemetry.get("tokens_total")
+    if isinstance(total, int) and not isinstance(total, bool):
+        return total
+    parts = (telemetry.get("input_tokens"), telemetry.get("output_tokens"))
+    counts = [part for part in parts if isinstance(part, int) and not isinstance(part, bool)]
+    return sum(counts) if counts else None
+
+
+# Minimum spacing between mid-run telemetry parses of one unit's stdout.
+# The runner snapshots every UNIT_OUTPUT_POLL_SECONDS; parsing (bounded but
+# not free) and journal writes throttle further, and a write only happens
+# when the reported count actually moved.
+LIVE_UNIT_TELEMETRY_MIN_INTERVAL_SECONDS = 10.0
+
+
+def _live_unit_telemetry_reporter(
+    paths: OmhPaths,
+    *,
+    owner: str,
+    routed_model: str,
+    routed_effort: str,
+    title: str,
+    binding_ref: Callable[[], dict[str, Any] | None],
+    binding_set: Callable[[dict[str, Any]], None],
+) -> Callable[[str], None]:
+    """Best-effort mid-run token reporting for a unit's HUD row.
+
+    Before this seam existed, a Maestro-lane row showed no token count until
+    the process exited — and the closed binding dropped the row on the next
+    poll, so the count was never visible live at all ('maestro세션은 어캐
+    tokens 측정함?'). The runner hands this hook the stdout captured so far;
+    it parses the same `omh_unit_telemetry/v1` surface the terminal close
+    already uses (codex's cumulative token events mid-run; claude reports
+    usage only in its terminal result, so its live rows stay honestly blank)
+    and reports the count as a `running` progress signal on the unit's
+    binding. Reporting only — never execution or result evidence, and a
+    failure here never disturbs the dispatch.
+    """
+    throttle: dict[str, Any] = {"next_at": 0.0, "count": None}
+
+    def report(stdout_snapshot: str) -> None:
+        binding = binding_ref()
+        if binding is None or not stdout_snapshot:
+            return
+        now = time.monotonic()
+        if now < throttle["next_at"]:
+            return
+        throttle["next_at"] = now + LIVE_UNIT_TELEMETRY_MIN_INTERVAL_SECONDS
+        tokens = _reported_unit_tokens(parse_unit_telemetry(owner, stdout_snapshot))
+        if tokens is None or tokens == throttle["count"]:
+            return
+        try:
+            signal = build_safe_progress_signal(
+                executor_profile=str(binding.get("executor_profile", "")),
+                process_status="running",
+                routed_model=routed_model,
+                routed_reasoning_effort=routed_effort,
+                explicit_summary=title,
+                tokens_total=tokens,
+            )
+            observation = observe_executor_progress(paths, binding, signal)
+        except (ExecutorProgressError, OSError):
+            return
+        throttle["count"] = tokens
+        # Hand the caller the updated binding so the later pid/close calls
+        # carry this observation's reporter state instead of a stale copy.
+        updated = observation.get("binding")
+        if isinstance(updated, dict):
+            binding_set(updated)
+
+    return report
 
 
 def _dispatch_unit(
@@ -1817,6 +1998,23 @@ def _dispatch_unit(
             # provider prompt cache the byte-identical sibling preambles read.
             if spawn_stagger is not None:
                 spawn_stagger.reserve()
+        if getattr(runner, "accepts_on_output", False):
+            # Mid-run token telemetry for the unit's HUD row, from the stdout
+            # captured so far. Same opt-in marker pattern as accepts_on_spawn:
+            # injected plain-protocol test runners never see the kwarg.
+            def _replace_binding(updated: dict[str, Any]) -> None:
+                nonlocal progress_binding
+                progress_binding = updated
+
+            spawn_kwargs["on_output"] = _live_unit_telemetry_reporter(
+                paths,
+                owner=owner,
+                routed_model=routed_model,
+                routed_effort=routed_effort,
+                title=unit_title,
+                binding_ref=lambda: progress_binding,
+                binding_set=_replace_binding,
+            )
         completed = runner(
             argv, cwd=str(worktree), text=True, capture_output=True, timeout=timeout, **spawn_kwargs
         )

--- a/tests/test_broad_exception_policy.py
+++ b/tests/test_broad_exception_policy.py
@@ -78,6 +78,16 @@ CLASSIFIED_SITES: tuple[ClassifiedSite, ...] = (
         "orphan behind.",
     ),
     ClassifiedSite(
+        "src/coding/fanout_dispatch.py",
+        "_snapshot_output",
+        INTENTIONAL,
+        "The mid-run stdout snapshot hook is telemetry-only narration for a unit's HUD row: a "
+        "raising hook must never kill or time out the unit it observes, so the handler returns "
+        "and the poll loop keeps waiting on the process. Nothing is relabeled — no count is "
+        "reported for that snapshot (an absent count, never a zero), the next poll retries, and "
+        "the terminal close still parses the full stdout independently of every snapshot.",
+    ),
+    ClassifiedSite(
         "src/workflows/domain_intelligence_store_security.py",
         "_open_store_lock_descriptor",
         INTENTIONAL,
@@ -237,8 +247,8 @@ CLASSIFIED_SITES: tuple[ClassifiedSite, ...] = (
 # function. `_write_candidate_batch`, `_is_catalog_question`, `pre_llm_call`,
 # and `_resume_unlocked` each hold two handlers, so the handler count is four
 # above the anchor count.
-EXPECTED_HANDLER_COUNT = 23
-EXPECTED_ANCHOR_COUNT = 19
+EXPECTED_HANDLER_COUNT = 24
+EXPECTED_ANCHOR_COUNT = 20
 
 
 class DerivedSite(NamedTuple):

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -3217,5 +3217,184 @@ class SpawnStaggerTests(unittest.TestCase):
             self.assertGreaterEqual(spawn_times[1] - spawn_times[0], 0.25)
 
 
+def _live_output_runner(snapshots_by_unit: dict[str, list[str]]):
+    """Like `_agent_runner`, but opts into the mid-run stdout seam: for a
+    matching unit it hands the dispatch's `on_output` hook each snapshot in
+    order before returning, with the last snapshot as the final stdout —
+    the same cumulative-stream shape the signal-safe runner produces."""
+
+    spawned: list[list[str]] = []
+
+    def runner(argv, **kwargs):
+        if argv[0] == "git":
+            return subprocess.run(argv, **kwargs)
+        spawned.append(list(argv))
+        prompt = " ".join(argv)
+        on_output = kwargs.get("on_output")
+        stdout = "done"
+        for unit_id, snapshots in snapshots_by_unit.items():
+            if unit_id in prompt and snapshots:
+                for snapshot in snapshots:
+                    if on_output is not None:
+                        on_output(snapshot)
+                stdout = snapshots[-1]
+        return _FakeCompleted(0, stdout)
+
+    runner.accepts_on_output = True
+    runner.spawned = spawned
+    return runner
+
+
+class FanoutDispatchLiveUnitTelemetryTests(unittest.TestCase):
+    """Mid-run token telemetry for Maestro-lane HUD rows: the runner hands the
+    dispatch periodic stdout snapshots, the reporter parses the same
+    `omh_unit_telemetry/v1` surface the terminal close uses, and the unit's
+    binding journal carries `running` events whose signal holds the count —
+    which is what lets the TUI row show tokens while the process still runs
+    instead of only in the instant before the closed row disappears."""
+
+    def _setup(self, tmp: str, units=None):
+        root = Path(tmp)
+        paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+        repo, sha = _make_repo(root)
+        contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, units or _UNITS))
+        return paths, repo, sha, contract
+
+    def _codex_usage_line(self, input_tokens: int, output_tokens: int, total: int) -> str:
+        return (
+            json.dumps(
+                {
+                    "type": "token_count",
+                    "total_token_usage": {
+                        "input_tokens": input_tokens,
+                        "output_tokens": output_tokens,
+                        "total_tokens": total,
+                    },
+                }
+            )
+            + "\n"
+        )
+
+    def test_mid_run_codex_token_updates_surface_as_running_events(self) -> None:
+        from omh.coding import fanout_dispatch as dispatch_module
+
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            core = {entry["unit_id"]: entry for entry in contract["units"]}["core"]
+            run_ref = core["run_ref"]
+            first = self._codex_usage_line(900, 100, 1000)
+            second = first + self._codex_usage_line(2000, 500, 2500)
+            # Three snapshots: the middle repeats the first count, proving the
+            # reporter writes only when the reported count actually moved.
+            runner = _live_output_runner({"core": [first, first, second]})
+
+            interval = dispatch_module.LIVE_UNIT_TELEMETRY_MIN_INTERVAL_SECONDS
+            dispatch_module.LIVE_UNIT_TELEMETRY_MIN_INTERVAL_SECONDS = 0.0
+            try:
+                dispatch_fanout(
+                    paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                    only_units=["core"], runner=runner, readiness=_ready,
+                )
+            finally:
+                dispatch_module.LIVE_UNIT_TELEMETRY_MIN_INTERVAL_SECONDS = interval
+
+            events = _progress_events(paths, run_ref)
+            running = [event for event in events if event["event_type"] == "running_no_diff_observed"]
+            self.assertEqual(
+                [event["signal"]["tokens_total"] for event in running], [1000, 2500]
+            )
+            completed = next(event for event in events if event["event_type"] == "executor_completed")
+            # The terminal close re-parses the full stdout independently of
+            # every snapshot, so the closing event carries the final count.
+            self.assertEqual(completed["signal"]["tokens_total"], 2500)
+
+    def test_live_reports_throttle_to_the_minimum_parse_interval(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            core = {entry["unit_id"]: entry for entry in contract["units"]}["core"]
+            run_ref = core["run_ref"]
+            first = self._codex_usage_line(900, 100, 1000)
+            second = first + self._codex_usage_line(2000, 500, 2500)
+            # Default 10s interval, two immediate snapshots with different
+            # counts: the second parse is throttled, so only one live event
+            # lands and the moved count still arrives via the terminal close.
+            runner = _live_output_runner({"core": [first, second]})
+
+            dispatch_fanout(
+                paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                only_units=["core"], runner=runner, readiness=_ready,
+            )
+
+            events = _progress_events(paths, run_ref)
+            running = [event for event in events if event["event_type"] == "running_no_diff_observed"]
+            self.assertEqual([event["signal"]["tokens_total"] for event in running], [1000])
+            completed = next(event for event in events if event["event_type"] == "executor_completed")
+            self.assertEqual(completed["signal"]["tokens_total"], 2500)
+
+    def test_plain_protocol_runner_sees_no_on_output_kwarg(self) -> None:
+        """An injected runner without the capability marker keeps the plain
+        protocol — the dispatch must not hand it a kwarg it never accepted."""
+        seen_kwargs: list[set[str]] = []
+
+        def runner(argv, **kwargs):
+            if argv[0] == "git":
+                return subprocess.run(argv, **kwargs)
+            seen_kwargs.append(set(kwargs))
+            return _FakeCompleted(0, "done")
+
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            dispatch_fanout(
+                paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                only_units=["core"], runner=runner, readiness=_ready,
+            )
+        self.assertTrue(seen_kwargs)
+        for kwargs in seen_kwargs:
+            self.assertNotIn("on_output", kwargs)
+            self.assertNotIn("on_spawn", kwargs)
+
+    def test_claude_result_usage_sums_input_and_output_at_close(self) -> None:
+        """Claude's result object states input and output but no total; the
+        close path now reports their sum (the Hermes-native input+output
+        convention) instead of leaving the row's count absent forever."""
+
+        stdout = json.dumps(
+            {
+                "result": "done",
+                "session_id": "sess_x",
+                "usage": {"input_tokens": 2, "output_tokens": 4, "cache_read_input_tokens": 100},
+            }
+        )
+
+        def runner(argv, **kwargs):
+            if argv[0] == "git":
+                return subprocess.run(argv, **kwargs)
+            return _FakeCompleted(0, stdout)
+
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            docs = {entry["unit_id"]: entry for entry in contract["units"]}["docs"]
+            run_ref = docs["run_ref"]
+            dispatch_fanout(
+                paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                only_units=["docs"], runner=runner, readiness=_ready,
+            )
+            completed = next(
+                event for event in _progress_events(paths, run_ref)
+                if event["event_type"] == "executor_completed"
+            )
+            self.assertEqual(completed["signal"]["tokens_total"], 6)
+
+    def test_reported_unit_tokens_prefers_stated_total_and_sums_reported_parts(self) -> None:
+        from omh.coding.fanout_dispatch import _reported_unit_tokens
+
+        self.assertEqual(_reported_unit_tokens({"tokens_total": 1000, "input_tokens": 1}), 1000)
+        self.assertEqual(_reported_unit_tokens({"input_tokens": 2, "output_tokens": 4}), 6)
+        self.assertEqual(_reported_unit_tokens({"output_tokens": 4}), 4)
+        # Absent counts stay absent, and bools never read as counts.
+        self.assertIsNone(_reported_unit_tokens({}))
+        self.assertIsNone(_reported_unit_tokens({"tokens_total": True}))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_fanout_signal_safety.py
+++ b/tests/test_fanout_signal_safety.py
@@ -20,6 +20,7 @@ from tempfile import TemporaryDirectory
 
 from omh.coding.fanout import build_fanout_contract
 from omh.coding.fanout_artifacts import fanout_dispatch_summary_path, write_fanout_contract
+from omh.coding import fanout_dispatch as fanout_dispatch_module
 from omh.coding.fanout_dispatch import (
     dispatch_fanout,
     signal_safe_unit_runner,
@@ -122,6 +123,88 @@ class SignalSafeRunnerTests(unittest.TestCase):
             time.sleep(0.05)
         with self.assertRaises(ProcessLookupError):
             os.killpg(seen["pid"], 0)
+
+    def test_on_output_hands_mid_run_stdout_snapshots_and_final_output_is_complete(self) -> None:
+        """The mid-run stdout seam: every snapshot is a prefix of the final
+        stdout (the reader drains continuously, the hook only ever sees what
+        was captured so far), at least one snapshot arrives while the child
+        still runs, and the returned CompletedProcess is byte-complete."""
+        script = (
+            "import time\n"
+            "print('line-a', flush=True)\n"
+            "time.sleep(2)\n"
+            "print('line-b', flush=True)\n"
+        )
+        snapshots: list[str] = []
+        poll = fanout_dispatch_module.UNIT_OUTPUT_POLL_SECONDS
+        fanout_dispatch_module.UNIT_OUTPUT_POLL_SECONDS = 0.2
+        try:
+            completed = signal_safe_unit_runner(
+                [sys.executable, "-c", script],
+                text=True,
+                capture_output=True,
+                timeout=30,
+                on_output=snapshots.append,
+            )
+        finally:
+            fanout_dispatch_module.UNIT_OUTPUT_POLL_SECONDS = poll
+        self.assertEqual(completed.returncode, 0)
+        self.assertIn("line-a", completed.stdout)
+        self.assertIn("line-b", completed.stdout)
+        self.assertTrue(snapshots)
+        for snapshot in snapshots:
+            self.assertTrue(completed.stdout.startswith(snapshot))
+        self.assertTrue(any("line-a" in snapshot and "line-b" not in snapshot for snapshot in snapshots))
+
+    @posix_only
+    def test_timeout_with_on_output_still_raises_and_kills_the_group(self) -> None:
+        seen: dict[str, int] = {}
+
+        def on_spawn(process) -> None:
+            seen["pid"] = process.pid
+
+        poll = fanout_dispatch_module.UNIT_OUTPUT_POLL_SECONDS
+        fanout_dispatch_module.UNIT_OUTPUT_POLL_SECONDS = 0.2
+        try:
+            with self.assertRaises(subprocess.TimeoutExpired):
+                signal_safe_unit_runner(
+                    [sys.executable, "-c", "import time; time.sleep(60)"],
+                    text=True,
+                    capture_output=True,
+                    timeout=0.5,
+                    on_spawn=on_spawn,
+                    on_output=lambda text: None,
+                )
+        finally:
+            fanout_dispatch_module.UNIT_OUTPUT_POLL_SECONDS = poll
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            try:
+                os.killpg(seen["pid"], 0)
+            except ProcessLookupError:
+                break
+            time.sleep(0.05)
+        with self.assertRaises(ProcessLookupError):
+            os.killpg(seen["pid"], 0)
+
+    def test_raising_on_output_hook_never_kills_the_unit(self) -> None:
+        def raising_hook(text: str) -> None:
+            raise RuntimeError("telemetry-only hook must be swallowed")
+
+        poll = fanout_dispatch_module.UNIT_OUTPUT_POLL_SECONDS
+        fanout_dispatch_module.UNIT_OUTPUT_POLL_SECONDS = 0.2
+        try:
+            completed = signal_safe_unit_runner(
+                [sys.executable, "-c", "import time; print('ok', flush=True); time.sleep(1)"],
+                text=True,
+                capture_output=True,
+                timeout=30,
+                on_output=raising_hook,
+            )
+        finally:
+            fanout_dispatch_module.UNIT_OUTPUT_POLL_SECONDS = poll
+        self.assertEqual(completed.returncode, 0)
+        self.assertIn("ok", completed.stdout)
 
     @posix_only
     def test_terminate_live_unit_groups_reaps_a_registered_unit(self) -> None:


### PR DESCRIPTION
## Feature Report

### What Changed

- Maestro-lane (fanout dispatch / `omh coding run`) unit rows in the TUI HUD now update their token count **while the spawned CLI runs**, instead of showing nothing until the instant the row disappears: the signal-safe runner gained a mid-run stdout seam, and the dispatch path posts throttled `running` progress signals carrying the CLI's own cumulative token counts.
- Claude-code units, whose result object states no total, now get a token count at close too — the sum of reported input+output, matching the Hermes-native display convention.

### Why This Exists

- Follow-up to #1171 asked directly by the owner ("maestro세션은 어캐 tokens 측정함?"): Maestro rows render in the subagent section, but their token column stayed blank for the whole run. The runner collected stdout with a blocking `communicate()`, telemetry was parsed only at process exit, and the closed binding drops off the HUD on the next 2s poll — so live visibility was structurally impossible. Worse, the close path read only `tokens_total`, which neither codex-terminal nor claude events name for every owner, so claude rows never showed a count at all.

### User / Operator Impact

- During `omh coding fanout dispatch` / `omh coding run`, a codex unit's HUD row ticks like a Hermes-native row (`1.0k → 2.5k → 3.9k tokens`), using codex's own cumulative `total_token_usage` events. A claude unit's live row stays honestly blank (its CLI reports usage only in the terminal result) and its closing event now carries input+output.
- No behavior change for anything else: the seam is opt-in via an `accepts_on_output` capability marker (mirroring `accepts_on_spawn`), so injected/plain-protocol runners and every non-fanout progress lane are untouched.

### How It Works

- `signal_safe_unit_runner` accepts `on_output`: reader threads drain both pipes line-at-a-time (a text stream's `read(n)` blocks until n chars accumulate, which starved snapshots until EOF — found by the new prefix-property test), while the waiting thread hands the hook the stdout captured so far each poll (`UNIT_OUTPUT_POLL_SECONDS`), preserving `communicate()`'s timeout/group-termination contract. A raising hook is swallowed (`_snapshot_output`, classified in the broad-exception policy): telemetry must never kill the unit it observes.
- `_live_unit_telemetry_reporter` parses each snapshot with the same `omh_unit_telemetry/v1` parser the terminal close uses, throttled to `LIVE_UNIT_TELEMETRY_MIN_INTERVAL_SECONDS`, and writes a `running` signal only when the reported count moved. The shared `_reported_unit_tokens` helper prefers a CLI-stated total, else sums reported input+output — reported values only, never estimates, absent stays absent.
- Two suppression fixes make the updates actually surface on the HUD row (which projects the latest *appended* journal event): fanout unit bindings set `minimum_repeat_interval_seconds` to the live cadence instead of the 120s default, and `transition_fingerprint` now includes `tokens_total` so a moved counter is a meaningful transition, not a `duplicate_transition`. Other lanes keep their 120s repeat gate.

### Files And Contracts Touched

- `src/coding/fanout_dispatch.py` — runner seam, drain/poll helpers, live reporter, `_reported_unit_tokens`, close-path fallback, binding repeat interval.
- `src/coding/executor_progress.py` — one-line fingerprint composition change (`tokens_total` participates).
- `tests/test_fanout_signal_safety.py` — real-subprocess runner tests (snapshot prefix property, timeout still kills the group, raising hook never kills the unit).
- `tests/test_fanout_dispatch.py` — dispatch-level live-event tests, throttle test, plain-protocol protection, claude close fallback, `_reported_unit_tokens` units.
- `tests/test_broad_exception_policy.py` — classification for `_snapshot_output` (handler count 23→24).

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [x] Codex
- [x] Claude Code
- [ ] Hermes runtime or handoff
- [x] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [ ] `uv run python -m omh.cli docs workflows --check`
- [ ] `uv run python -m omh.cli docs roles --check`
- [ ] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: end-to-end proof with a real subprocess spawn (see Observed Evidence)
- [x] Manual Hermes/TUI check, or explicit reason it was not run: not run — the HUD projection path this feeds (`row.tokens_total` → `subagents/maestro` rows → widget tokens column) is the exact surface merged and TUI-verified in #1171; this PR changes only what the journal carries

### Observed Evidence

- Full suite: `Ran 7832 tests … OK` from a neutral-path detached worktree of this commit (the session worktree's known path-environmental failures — `.claude` segment fail-close, "token" in the path tripping the sensitive-text detector — are pre-existing and unrelated; both families pass from the clean checkout).
- End-to-end through the REAL `signal_safe_unit_runner` (fake `codex` shim on PATH emitting cumulative JSONL over ~5s, real process group, real journal):
  `executor_dispatched None` → `running_no_diff_observed 1000` → `running_no_diff_observed 2500` → `executor_completed 3900`
- New tests observed green: snapshot-prefix property (every mid-run snapshot is a prefix of the final stdout; caught the text-mode `read(n)` starvation bug during development), timeout-with-hook still kills the whole group, raising hook never kills the unit, codex live events carry moving counts, second identical count writes nothing, default throttle collapses rapid updates to one live event, plain-protocol runners receive no new kwargs, claude close sums input+output (2+4=6, cache excluded).
- Targeted suites green: fanout (dispatch/signal-safety/chaos/status/unit-results), executor-progress (binding/projection/suppression/chat-reporting/omo/quality-floor), HUD, coding status board, routing observation, unit telemetry, broad-exception policy.

### Not Tested / Not Applicable

- Docs byte gates, harness/release/install smokes, `omh --help`: no catalog, docs, CLI-surface, or packaging changes (they were run and green on the #1171 branch this builds on; the diff here touches no generated source).
- A real codex/claude CLI spawn end-to-end: dispatch is operator-invoked and billed; the shim proof exercises the identical process/journal path.
- Windows poll-loop timing beyond CI's `test-windows` run.

## Risk

- The seam is additive and opt-in: without `on_output` the runner executes the exact `communicate()` path as before, and only the fanout dispatch passes the hook (only to runners advertising `accepts_on_output`).
- The fingerprint change slightly widens what counts as a distinct progress event for ANY signal carrying `tokens_total`; other lanes stay bounded by their 120s repeat interval, and the full progress-suppression suite passes unchanged.
- Journal growth is bounded: writes happen only when a unit's reported count moves, at ≥10s spacing.

## Compatibility / Rollout

- Reaches installed machines through `omh update` (plugin bundle unchanged; this is core `omh` dispatch code) — live rows appear on the next dispatch after update, no config or schema migration.
- Owners with no structured stdout (omo-runtime hosts, generic) keep honest absence: no live events, no fabricated zeros.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Claude live counts would need `--output-format stream-json` on the spawned CLI to exist mid-run; worth considering when the dispatch argv builder next changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9F2nbnc7hajqzznXcgLZn
