### PR TITLE
feat(coding): operator category->model chains for the Maestro lane (category-maestro)

### DIFF
--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -420,6 +420,33 @@ Rules:
   recommended value either (no local `codex` CLI in this repo to confirm its
   `--model` value space against). An operator profile entry, including an
   explicit empty string, always overrides an unset default.
+- **Category-maestro (operator category chains).** The Hermes-native
+  delegation lane routes per work category through an editable mixture
+  (`omh model-chains`); `<omh_home>/routing/category-maestro.json`
+  (`omh_category_maestro/v1`) is the same dial for the Maestro lane. It
+  overrides individual categories of the built-in category → model table for
+  the dispatchable profiles (`codex`, `claude-code`); unmentioned categories
+  keep the built-in chain, and the merged table feeds every path that
+  consults categories — a unit's explicit `category` (ulw-\* aliases
+  accepted), role chains, the research `depth` dial, and the task `scale`
+  dial. A route resolved against the merged table records
+  `catalog_kind: "operator_category_config"` plus the config's fingerprint,
+  so a frozen contract names the exact basis it was resolved from; the
+  file's presence is the opt-in, and codex/claude-only contracts stay
+  byte-identical across machines that have not created it. Edit it with
+  `omh coding category-maestro set <profile> <category> <model[:effort]>...`
+  (the tail after the last colon is the effort only when it is a known level
+  — off/minimal/low/medium/high/xhigh/max/auto — so colon-tagged model ids
+  like `qwen2.5-coder:7b` stay intact), inspect the effective table with
+  `omh coding category-maestro show` (operator overrides are marked, invalid
+  config pieces are named, a broken file reads as absent and never blocks a
+  dispatch), and restore a built-in chain with
+  `omh coding category-maestro clear <profile> <category>`. `omh coding run
+  --category <category>` routes one run through the same table; an explicit
+  `--model` still wins (requested > chain head). Catalogless profiles are
+  deliberately not configurable here — the local-inventory catalog remains
+  their single override source, so "which basis resolved this route" always
+  has one answer.
 - **Model inventory (reporting-only).** `omh coding model-inventory` reports
   which coding models the user has locally activated before any split or
   delegation is proposed: agent CLIs on PATH (codex, claude, opencode,
@@ -619,13 +646,16 @@ omh coding fanout dispatch <fanout-id> --goal-file goal.txt \
 omh coding run --owner <profile> (--goal <words...> | --goal-file goal.txt) \
   [--unit-id run] [--file-scope <path> ...] [--repo-root .] [--base-ref HEAD] \
   [--timeout 1800] [--dry-run] [--run-verification] [--source discord] \
-  [--model <id>] [--effort <level>]
+  [--model <id>] [--effort <level>] [--category <category>]
   # single-invocation: builds and dispatches a one-unit fanout_contract/v2 through
   # the same engine as `fanout dispatch`; see "Single-run entry" above
 omh coding fanout reap <fanout-id> [--pid N ...]  # terminate marker-named
   # unit process groups (verify the dispatcher is dead first); refuses any
   # pid the inflight markers do not name — never kills by process name
 omh coding model-route [--executor <profile>] [--role <role>] [--model <id>] [--effort <level>] [--domain <name>] [--explain] [--from-inventory] [--json]
+omh coding category-maestro show [--json]      # effective category table, operator overrides marked
+omh coding category-maestro set <profile> <category> <model[:effort]>...
+omh coding category-maestro clear <profile> <category>
 omh coding model-inventory [--json]
 omh coding composition-guide [--model <id>] [--json]
 ```

--- a/src/coding/category_maestro.py
+++ b/src/coding/category_maestro.py
@@ -1,0 +1,276 @@
+"""Operator-configured category->model chains for the Maestro dispatch lane.
+
+The Hermes-native delegation lane already routes per work category through an
+editable mixture (`omh_delegate_route`). This module gives the Maestro lane
+the same dial: `~/.omh/routing/category-maestro.json` overrides individual
+categories of `BUILTIN_CATEGORY_MODELS` for the dispatchable CLI profiles, and
+`resolve_model_route` consults the merged table wherever it would consult the
+built-in one — explicit categories, role chains, research depth, task scale.
+
+Presence of the file IS the opt-in. The built-in table is a package default
+that must stay byte-identical across machines; this file is the one sanctioned
+per-machine divergence, and every route resolved against it records
+`catalog_kind: "operator_category_config"` plus the config fingerprint so a
+frozen contract names the exact basis it was resolved from.
+
+Reading never raises: a missing, unreadable, or malformed document reads the
+same as an absent one (mirroring the dispatch-model preference file), because
+a broken config must not block a prepare or dispatch. Invalid pieces are
+dropped and named in `rejected` so `omh coding category-maestro show` can
+report them instead of silently swallowing a typo.
+"""
+
+from __future__ import annotations
+
+import json
+from hashlib import sha256
+from pathlib import Path
+from typing import Final, Mapping
+
+from ..system.local_store import atomic_write_json, read_json_object_result
+from .model_routing import (
+    BUILTIN_CATEGORY_MODELS,
+    MODEL_CATEGORIES,
+    canonical_model_category,
+)
+
+CATEGORY_MAESTRO_SCHEMA_VERSION: Final[str] = "omh_category_maestro/v1"
+
+# Only profiles with a built-in category table are configurable here: the
+# catalogless profiles already have the local-inventory path, and layering a
+# second override source over that one would make "which basis resolved this
+# route" unanswerable.
+CATEGORY_MAESTRO_PROFILES: Final[tuple[str, ...]] = tuple(sorted(BUILTIN_CATEGORY_MODELS))
+
+# Effort values are embedded into executor argv composites, so they get the
+# same closed shape gate the resolver applies to requested efforts.
+_EFFORT_CHARSET: Final[frozenset[str]] = frozenset("abcdefghijklmnopqrstuvwxyz0123456789-")
+_MAX_CHAIN_ENTRIES: Final[int] = 8
+_MAX_MODEL_ID_CHARS: Final[int] = 120
+_MAX_EFFORT_CHARS: Final[int] = 32
+
+
+def category_maestro_path(omh_home: Path) -> Path:
+    return Path(omh_home) / "routing" / "category-maestro.json"
+
+
+def _config_fingerprint(profiles: Mapping[str, object]) -> dict[str, str]:
+    canonical = json.dumps(profiles, sort_keys=True, separators=(",", ":"))
+    return {
+        "source": "category-maestro.json",
+        "digest": sha256(canonical.encode("utf-8")).hexdigest()[:16],
+    }
+
+
+def _validated_entry(entry: object, *, where: str, rejected: list[str]) -> dict[str, str] | None:
+    if not isinstance(entry, Mapping):
+        rejected.append(f"{where}: chain entry must be an object with model_id")
+        return None
+    model_id = str(entry.get("model_id", "") or "").strip()
+    # A leading `-` is rejected because selected_model lands in the spawned
+    # CLI's argv as its own token: never allow a "model id" that would parse
+    # as a flag there.
+    if (
+        not model_id
+        or len(model_id) > _MAX_MODEL_ID_CHARS
+        or model_id.startswith("-")
+        or any(char.isspace() for char in model_id)
+    ):
+        rejected.append(
+            f"{where}: model_id must be a non-empty token without whitespace or a leading '-'"
+        )
+        return None
+    effort = str(entry.get("reasoning_effort", "") or "").strip().casefold()
+    if effort and (len(effort) > _MAX_EFFORT_CHARS or not set(effort) <= _EFFORT_CHARSET):
+        rejected.append(f"{where}: reasoning_effort {effort!r} is not an effort-shaped value")
+        return None
+    return {"model_id": model_id, "reasoning_effort": effort}
+
+
+def read_category_maestro_config(omh_home: Path) -> dict[str, object] | None:
+    """Return the validated operator category config, or None when absent.
+
+    The returned payload carries only validated data: `profiles` maps a
+    dispatchable profile to canonical categories with non-empty entry chains,
+    `fingerprint` names the exact accepted basis, and `rejected` lists every
+    dropped piece by name. A document that validates down to nothing returns
+    None so callers treat it exactly like an absent file.
+    """
+    document, _error = read_json_object_result(category_maestro_path(omh_home))
+    if not isinstance(document, dict):
+        return None
+    if document.get("schema_version") != CATEGORY_MAESTRO_SCHEMA_VERSION:
+        return None
+    raw_profiles = document.get("profiles")
+    if not isinstance(raw_profiles, Mapping):
+        return None
+    rejected: list[str] = []
+    profiles: dict[str, dict[str, tuple[dict[str, str], ...]]] = {}
+    for raw_profile, raw_categories in raw_profiles.items():
+        profile = str(raw_profile or "").strip().casefold()
+        if profile not in CATEGORY_MAESTRO_PROFILES:
+            rejected.append(
+                f"profile {raw_profile!r} is not configurable here; expected one of "
+                f"{', '.join(CATEGORY_MAESTRO_PROFILES)}"
+            )
+            continue
+        if not isinstance(raw_categories, Mapping):
+            rejected.append(f"profile {profile!r}: categories must be an object")
+            continue
+        categories: dict[str, tuple[dict[str, str], ...]] = {}
+        for raw_category, raw_entries in raw_categories.items():
+            category = canonical_model_category(raw_category)
+            if not category:
+                rejected.append(
+                    f"profile {profile!r}: category {raw_category!r} is not one of "
+                    f"{', '.join(MODEL_CATEGORIES)}"
+                )
+                continue
+            if not isinstance(raw_entries, (list, tuple)):
+                rejected.append(f"profile {profile!r} category {category!r}: chain must be a list")
+                continue
+            if len(raw_entries) > _MAX_CHAIN_ENTRIES:
+                rejected.append(
+                    f"profile {profile!r} category {category!r}: chain longer than "
+                    f"{_MAX_CHAIN_ENTRIES} entries"
+                )
+                continue
+            entries = [
+                validated
+                for position, raw_entry in enumerate(raw_entries)
+                if (
+                    validated := _validated_entry(
+                        raw_entry,
+                        where=f"profile {profile!r} category {category!r} entry {position}",
+                        rejected=rejected,
+                    )
+                )
+                is not None
+            ]
+            if not entries:
+                # An empty (or fully-rejected) chain is treated as unset, not
+                # as "no chain": clearing a category back to the built-in is
+                # `clear`, and a typo must not silently disable a category.
+                rejected.append(
+                    f"profile {profile!r} category {category!r}: no valid entries; built-in chain kept"
+                )
+                continue
+            categories[category] = tuple(entries)
+        if categories:
+            profiles[profile] = categories
+    if not profiles:
+        return None
+    return {
+        "schema_version": CATEGORY_MAESTRO_SCHEMA_VERSION,
+        "profiles": profiles,
+        "fingerprint": _config_fingerprint(profiles),
+        "rejected": rejected,
+    }
+
+
+def _raw_document(omh_home: Path) -> dict[str, object]:
+    """Return the on-disk document for editing; raise on one this code does not own.
+
+    An existing file the writers do not recognize (different schema_version,
+    non-object profiles, unparseable JSON) is never overwritten — losing a
+    hand-written or future-versioned config on a `set`/`clear` would be silent
+    data loss, and the dispatch-preference seeder next door already documents
+    the same stance ("an existing file, however it got there, is never
+    overwritten"). Only the READ path is never-raise; editing is an explicit
+    operator action that can and should refuse loudly.
+    """
+    path = category_maestro_path(omh_home)
+    if not path.exists():
+        return {"schema_version": CATEGORY_MAESTRO_SCHEMA_VERSION, "profiles": {}}
+    document, error = read_json_object_result(path)
+    if (
+        isinstance(document, dict)
+        and document.get("schema_version") == CATEGORY_MAESTRO_SCHEMA_VERSION
+        and isinstance(document.get("profiles"), dict)
+    ):
+        return document
+    raise ValueError(
+        f"refusing to edit {path}: the existing file is not a recognized "
+        f"{CATEGORY_MAESTRO_SCHEMA_VERSION} document"
+        + (f" ({error})" if error else "")
+        + "; fix or remove it first"
+    )
+
+
+def set_category_maestro_chain(
+    omh_home: Path,
+    profile: str,
+    category: str,
+    entries: list[Mapping[str, str]],
+) -> dict[str, object]:
+    """Write one category's chain for one profile; raises ValueError on bad input."""
+    normalized_profile = str(profile or "").strip().casefold()
+    if normalized_profile not in CATEGORY_MAESTRO_PROFILES:
+        raise ValueError(
+            f"profile {profile!r} is not configurable; expected one of "
+            f"{', '.join(CATEGORY_MAESTRO_PROFILES)}"
+        )
+    normalized_category = canonical_model_category(category)
+    if not normalized_category:
+        raise ValueError(
+            f"category {category!r} is not one of {', '.join(MODEL_CATEGORIES)}"
+        )
+    if not entries or len(entries) > _MAX_CHAIN_ENTRIES:
+        raise ValueError(f"a chain needs 1..{_MAX_CHAIN_ENTRIES} entries")
+    rejected: list[str] = []
+    validated = [
+        _validated_entry(entry, where=f"entry {position}", rejected=rejected)
+        for position, entry in enumerate(entries)
+    ]
+    if any(entry is None for entry in validated):
+        raise ValueError("; ".join(rejected))
+    document = _raw_document(omh_home)
+    profiles = document["profiles"]
+    assert isinstance(profiles, dict)
+    profile_categories = profiles.setdefault(normalized_profile, {})
+    if not isinstance(profile_categories, dict):
+        profile_categories = {}
+        profiles[normalized_profile] = profile_categories
+    profile_categories[normalized_category] = [dict(entry) for entry in validated if entry]
+    atomic_write_json(category_maestro_path(omh_home), document)
+    return {
+        "profile": normalized_profile,
+        "category": normalized_category,
+        "chain": profile_categories[normalized_category],
+        "path": str(category_maestro_path(omh_home)),
+    }
+
+
+def clear_category_maestro_chain(omh_home: Path, profile: str, category: str) -> dict[str, object]:
+    """Remove one category override (back to the built-in chain)."""
+    normalized_profile = str(profile or "").strip().casefold()
+    if normalized_profile not in CATEGORY_MAESTRO_PROFILES:
+        raise ValueError(
+            f"profile {profile!r} is not configurable; expected one of "
+            f"{', '.join(CATEGORY_MAESTRO_PROFILES)}"
+        )
+    normalized_category = canonical_model_category(category)
+    if not normalized_category:
+        raise ValueError(
+            f"category {category!r} is not one of {', '.join(MODEL_CATEGORIES)}"
+        )
+    document = _raw_document(omh_home)
+    profiles = document["profiles"]
+    assert isinstance(profiles, dict)
+    profile_categories = profiles.get(normalized_profile)
+    removed = False
+    if isinstance(profile_categories, dict) and normalized_category in profile_categories:
+        del profile_categories[normalized_category]
+        removed = True
+        if not profile_categories:
+            del profiles[normalized_profile]
+    if removed:
+        # A no-op clear writes nothing: it must not create the config file
+        # (whose presence is the routing opt-in) as a side effect.
+        atomic_write_json(category_maestro_path(omh_home), document)
+    return {
+        "profile": normalized_profile,
+        "category": normalized_category,
+        "removed": removed,
+        "path": str(category_maestro_path(omh_home)),
+    }

--- a/src/coding/fanout.py
+++ b/src/coding/fanout.py
@@ -27,7 +27,7 @@ from .executor_capability_snapshots import (
     complete_executor_capability_snapshot,
     prepared_executor_capability_snapshot,
 )
-from .model_routing import model_route_for_unit
+from .model_routing import MODEL_CATEGORIES, canonical_model_category, model_route_for_unit
 
 _UNIT_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
 _FROZEN_CAPABILITY_SNAPSHOT_POLICY = "frozen_required"
@@ -40,6 +40,7 @@ def build_fanout_contract(
     source: str = "generic",
     source_metadata: Mapping[str, object] | None = None,
     local_catalogs: Mapping[str, Mapping[str, object]] | None = None,
+    category_config: Mapping[str, object] | None = None,
     capability_snapshots: Mapping[str, Mapping[str, object]] | None = None,
     spawn_plan: Mapping[str, object] | None = None,
 ) -> dict[str, object]:
@@ -70,6 +71,7 @@ def build_fanout_contract(
             sibling_scopes=_sibling_scopes(normalized_units, str(unit["unit_id"])),
             fanout_id=fanout_id,
             local_catalogs=local_catalogs,
+            category_config=category_config,
             capability_snapshots=validated_capability_snapshots,
         )
         for unit in normalized_units
@@ -200,6 +202,11 @@ def validate_fanout_units(units: Sequence[Mapping[str, object]]) -> None:
         file_scope = unit.get("file_scope", [])
         if not isinstance(file_scope, (list, tuple)) or not [str(path) for path in file_scope if str(path).strip()]:
             raise FanoutContractError(f"unit {unit_id} requires a non-empty file_scope boundary")
+        category = str(unit.get("category", "") or "").strip()
+        if category and not canonical_model_category(category):
+            raise FanoutContractError(
+                f"unit {unit_id} category {category!r} is not one of {', '.join(MODEL_CATEGORIES)}"
+            )
         for dependency in unit.get("depends_on", []) or []:
             if str(dependency) not in known:
                 raise FanoutContractError(f"unit {unit_id} depends on unknown unit {dependency!r}")
@@ -382,6 +389,11 @@ def _normalized_unit(unit: Mapping[str, object], index: int) -> dict[str, object
         "model": str(unit.get("model", "") or "").strip(),
         "reasoning_effort": str(unit.get("reasoning_effort", "") or "").strip(),
         "role": str(unit.get("role", "") or "").strip(),
+        # `category` accepts the OMO/ULW ulw-* aliases the resolver already
+        # normalizes; validate_fanout_units rejects unknown vocabulary so a
+        # typo fails the freeze instead of silently routing by role only.
+        "category": str(unit.get("category", unit.get("model_category", "")) or "").strip(),
+        "scale": str(unit.get("scale", "") or "").strip(),
         "domain": str(unit.get("domain", "") or "").strip(),
         "depth": str(unit.get("depth", "") or "").strip(),
         # None (key absent) and [] (declared empty) are different answers: absent
@@ -477,13 +489,14 @@ def _contract_unit(
     sibling_scopes: list[str],
     fanout_id: str,
     local_catalogs: Mapping[str, Mapping[str, object]] | None = None,
+    category_config: Mapping[str, object] | None = None,
     capability_snapshots: Mapping[str, Mapping[str, object]] | None = None,
 ) -> dict[str, object]:
     unit_id = str(unit["unit_id"])
     own_scope = set(str(path) for path in unit.get("file_scope", []))
     executor_target = str(unit.get("owner")) if unit.get("owner") else "choose"
     local_catalog = (local_catalogs or {}).get(executor_target)
-    model_route = model_route_for_unit(unit, executor_target, local_catalog)
+    model_route = model_route_for_unit(unit, executor_target, local_catalog, category_config)
     handoff: dict[str, object] = {
         "schema_version": "fanout_unit_handoff/v1",
         "executor_target": executor_target,

--- a/src/coding/model_routing.py
+++ b/src/coding/model_routing.py
@@ -123,6 +123,10 @@ MODEL_CATALOG_KINDS: Final[tuple[str, ...]] = (
     "built_in_defaults",
     "local_inventory",
     "editorial_recommendations",
+    # The operator's category-maestro config merged over the built-in table
+    # (`~/.omh/routing/category-maestro.json`); such routes also carry the
+    # config's fingerprint so a frozen record names its exact basis.
+    "operator_category_config",
 )
 
 EXECUTOR_MODEL_OPTIONS: Final[dict[str, tuple[dict[str, object], ...]]] = {
@@ -460,6 +464,7 @@ def resolve_model_route(
     requested_scale: str = "",
     requested_category: str = "",
     chains: Mapping[str, Mapping[str, tuple[Mapping[str, str], ...]]] | None = None,
+    category_config: Mapping[str, object] | None = None,
     local_catalog: Mapping[str, object] | None = None,
     active_models: Iterable[str | Mapping[str, object]] | None = None,
     recommendation_overrides: Mapping[str, object] | None = None,
@@ -471,9 +476,19 @@ def resolve_model_route(
     to its chain head; a role whose chain is missing is an explicit choice;
     no data leaves the executor CLI default in place as a named outcome.
 
-    Injection precedence — the two parameters never apply to the same profile:
-    `chains` (tests only) overrides role chains for profiles WITH a built-in
-    catalog; `local_catalog` (a `local_model_catalog/v1` payload derived by
+    Injection precedence — the injected sources never apply to the same
+    profile: `chains` (tests only) overrides role chains for profiles WITH a
+    built-in catalog and wins over `category_config`; `category_config` (the
+    validated `omh_category_maestro/v1` payload read by the caller — I/O stays
+    in the caller) merges the operator's per-category chains over the built-in
+    table for built-in-catalog profiles only, feeding every path that consults
+    that table (explicit category, role, research depth, task scale) and
+    recording `catalog_kind: "operator_category_config"` plus the config
+    fingerprint — the kind names which TABLE was consulted for this profile,
+    not that the override changed the outcome: a route whose chain happens to
+    match the built-in one, or that a requested model won over, still records
+    the operator basis because that is the table that would have adjudicated;
+    `local_catalog` (a `local_model_catalog/v1` payload derived by
     the caller from an observed inventory — I/O stays in the caller, this
     function remains pure) is consulted ONLY when the profile has no built-in
     catalog and the payload names this profile. A route resolved from a local
@@ -557,19 +572,60 @@ def resolve_model_route(
             role_reasons.append(
                 "A local model catalog was offered but carried no usable options; it was not consulted."
             )
+    # The operator's category-maestro config applies only to profiles WITH a
+    # built-in category table (the dispatchable CLIs); catalogless profiles
+    # keep the local-inventory path as their single override source. `chains`
+    # stays the tests-only injection and wins over the operator table.
+    operator_categories: Mapping[str, object] | None = None
+    if (
+        category_config is not None
+        and chains is None
+        and catalog_kind == MODEL_CATALOG_KIND
+        and profile in BUILTIN_CATEGORY_MODELS
+    ):
+        config_profiles = category_config.get("profiles") if isinstance(category_config, Mapping) else None
+        raw_operator = config_profiles.get(profile) if isinstance(config_profiles, Mapping) else None
+        if isinstance(raw_operator, Mapping) and raw_operator:
+            operator_categories = raw_operator
+            catalog_kind = "operator_category_config"
+            raw_config_fingerprint = category_config.get("fingerprint")
+            if isinstance(raw_config_fingerprint, Mapping):
+                catalog_fingerprint = dict(raw_config_fingerprint)
+    effective_categories: Mapping[str, object] = (
+        {**BUILTIN_CATEGORY_MODELS.get(profile, {}), **dict(operator_categories)}
+        if operator_categories is not None
+        else BUILTIN_CATEGORY_MODELS.get(profile, {})
+    )
     candidates = [dict(option) for option in options]
     if catalog_kind == "local_inventory":
         role_chain = tuple(local_chains.get(normalized_role, ())) if normalized_role else ()
+    elif operator_categories is not None:
+        role_chain = (
+            merged_category_chain(effective_categories, CATEGORY_ROLE_SOURCES.get(normalized_role, ()))
+            if normalized_role
+            else ()
+        )
     else:
         chain_table = ROLE_MODEL_CHAINS if chains is None else chains
         role_chain = tuple(chain_table.get(profile, {}).get(normalized_role, ())) if normalized_role else ()
     attempted: list[dict[str, str]] = []
+    if operator_categories is not None:
+        attempted.append(
+            {
+                "stage": "category_config",
+                "outcome": "applied",
+                "reason": (
+                    "operator category-maestro config overrides categories "
+                    f"({', '.join(sorted(str(name) for name in operator_categories))}) for `{profile}`"
+                ),
+            }
+        )
     if category:
         if catalog_kind == "local_inventory":
             raw_categories = local_catalog.get("categories", {}) if isinstance(local_catalog, Mapping) else {}
             category_chain = raw_categories.get(category, ()) if isinstance(raw_categories, Mapping) else ()
         else:
-            category_chain = BUILTIN_CATEGORY_MODELS.get(profile, {}).get(category, ())
+            category_chain = effective_categories.get(category, ())
         role_chain = tuple(entry for entry in category_chain if isinstance(entry, Mapping))
         attempted.append(
             {
@@ -578,9 +634,16 @@ def resolve_model_route(
                 "reason": f"explicit category `{category}` selects its chain independently of role `{normalized_role or 'none'}`",
             }
         )
+    operator_table = effective_categories if operator_categories is not None else None
     if depth and not category:
         role_chain = _depth_selected_chain(
-            depth, normalized_role, profile, role_chain, local_chains if catalog_kind == "local_inventory" else None, attempted
+            depth,
+            normalized_role,
+            profile,
+            role_chain,
+            local_chains if catalog_kind == "local_inventory" else None,
+            attempted,
+            operator_table=operator_table,
         )
     if scale and not category:
         role_chain = _scale_selected_chain(
@@ -591,6 +654,7 @@ def resolve_model_route(
             local_chains if catalog_kind == "local_inventory" else None,
             depth,
             attempted,
+            operator_table=operator_table,
         )
     if domain:
         role_chain = _domain_ordered_chain(
@@ -771,11 +835,13 @@ def model_route_for_unit(
     unit: Mapping[str, object],
     executor_target: str,
     local_catalog: Mapping[str, object] | None = None,
+    category_config: Mapping[str, object] | None = None,
 ) -> dict[str, object] | None:
     """Return the prepared model route for a fanout unit, or None when unrouted.
 
-    `local_catalog` is passed through verbatim; this function stays pure and
-    the resolver's precedence rules decide whether it applies.
+    `local_catalog` and `category_config` are passed through verbatim; this
+    function stays pure and the resolver's precedence rules decide whether
+    either applies.
     """
     model = str(unit.get("model", "") or "").strip()
     effort = str(unit.get("reasoning_effort", "") or "").strip()
@@ -794,6 +860,7 @@ def model_route_for_unit(
         requested_depth=str(unit.get("depth", "") or "").strip(),
         requested_scale=str(unit.get("scale", "") or "").strip(),
         requested_category=category,
+        category_config=category_config,
         local_catalog=local_catalog,
     )
 
@@ -1173,6 +1240,8 @@ def _scale_selected_chain(
     local_chains: Mapping[str, object] | None,
     depth: str,
     attempted: list[dict[str, str]],
+    *,
+    operator_table: Mapping[str, object] | None = None,
 ) -> tuple[Mapping[str, str], ...]:
     """Swap in the declared task-scale chain, recording the outcome.
 
@@ -1227,7 +1296,10 @@ def _scale_selected_chain(
             }
         )
         return role_chain
-    scale_chain = TASK_SCALE_CHAINS.get(profile, {}).get(scale, ())
+    if operator_table is not None:
+        scale_chain = merged_category_chain(operator_table, CATEGORY_SCALE_SOURCES.get(scale, ()))
+    else:
+        scale_chain = TASK_SCALE_CHAINS.get(profile, {}).get(scale, ())
     if scale_chain:
         attempted.append(
             {
@@ -1254,6 +1326,8 @@ def _depth_selected_chain(
     role_chain: tuple[Mapping[str, str], ...],
     local_chains: Mapping[str, object] | None,
     attempted: list[dict[str, str]],
+    *,
+    operator_table: Mapping[str, object] | None = None,
 ) -> tuple[Mapping[str, str], ...]:
     """Swap in the declared research-depth chain, recording the outcome.
 
@@ -1303,7 +1377,10 @@ def _depth_selected_chain(
             }
         )
         return role_chain
-    depth_chain = RESEARCH_DEPTH_CHAINS.get(profile, {}).get(depth, ())
+    if operator_table is not None:
+        depth_chain = merged_category_chain(operator_table, CATEGORY_ROLE_SOURCES.get(f"research:{depth}", ()))
+    else:
+        depth_chain = RESEARCH_DEPTH_CHAINS.get(profile, {}).get(depth, ())
     if depth_chain:
         attempted.append(
             {

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -706,6 +706,120 @@ def _payload_choice_required(payload: dict[str, object]) -> bool:
     return isinstance(selection, dict) and bool(selection.get("choice_required"))
 
 
+def _parsed_chain_entry(raw: str) -> dict[str, str]:
+    """Split one `model[:effort]` CLI token, only when the tail IS an effort.
+
+    Model ids legitimately carry colon tags (`qwen2.5-coder:7b`,
+    `openai/gpt-4o:2024-08-06`), so an unconditional last-colon split would
+    silently tear the tag off into a bogus reasoning effort. The tail is
+    treated as an effort only when it names a known effort level; anything
+    else keeps the whole token as the model id.
+    """
+    from ..coding.model_routing import REASONING_EFFORT_LADDER
+
+    text = str(raw or "").strip()
+    if ":" in text:
+        model_id, tail = text.rsplit(":", 1)
+        effort = tail.strip().casefold()
+        if model_id.strip() and effort in (*REASONING_EFFORT_LADDER, "auto"):
+            return {"model_id": model_id.strip(), "reasoning_effort": effort}
+    return {"model_id": text, "reasoning_effort": ""}
+
+
+def cmd_coding_category_maestro(args: argparse.Namespace) -> int:
+    from ..coding.category_maestro import (
+        CATEGORY_MAESTRO_PROFILES,
+        category_maestro_path,
+        clear_category_maestro_chain,
+        read_category_maestro_config,
+        set_category_maestro_chain,
+    )
+    from ..coding.model_routing import BUILTIN_CATEGORY_MODELS, MODEL_CATEGORIES
+
+    paths = _paths(args)
+    command = args.category_maestro_command
+    if command == "set":
+        try:
+            result = set_category_maestro_chain(
+                paths.omh_home,
+                args.profile,
+                args.category,
+                [_parsed_chain_entry(entry) for entry in args.chain],
+            )
+        except ValueError as exc:
+            raise OmhError(str(exc)) from exc
+        if _wants_json(args):
+            _print_json(result)
+            return 0
+        chain_text = " > ".join(
+            str(entry["model_id"]) + (f" {entry['reasoning_effort']}" if entry.get("reasoning_effort") else "")
+            for entry in result["chain"]
+        )
+        print(
+            f"category-maestro: {result['profile']} {result['category']} -> {chain_text}\n"
+            f"written to {result['path']}"
+        )
+        return 0
+    if command == "clear":
+        try:
+            result = clear_category_maestro_chain(paths.omh_home, args.profile, args.category)
+        except ValueError as exc:
+            raise OmhError(str(exc)) from exc
+        if _wants_json(args):
+            _print_json(result)
+            return 0
+        state = "cleared (built-in chain applies)" if result["removed"] else "was not set (built-in chain already applies)"
+        print(f"category-maestro: {result['profile']} {result['category']} {state}")
+        return 0
+    # show (the default subcommand): the effective merged table per profile,
+    # each category labeled with which basis supplies its chain.
+    config = read_category_maestro_config(paths.omh_home)
+    operator_profiles = config.get("profiles", {}) if isinstance(config, dict) else {}
+    report_profiles: dict[str, object] = {}
+    lines = [f"Category-maestro table ({category_maestro_path(paths.omh_home)}):"]
+    for profile in CATEGORY_MAESTRO_PROFILES:
+        operator_categories = operator_profiles.get(profile, {})
+        categories: dict[str, object] = {}
+        lines.append(f"- {profile}:")
+        for category in MODEL_CATEGORIES:
+            operator_chain = operator_categories.get(category) if isinstance(operator_categories, dict) else None
+            chain = operator_chain if operator_chain else BUILTIN_CATEGORY_MODELS[profile].get(category, ())
+            source = "operator" if operator_chain else "built_in"
+            entries = [
+                {"model_id": str(entry.get("model_id", "")), "reasoning_effort": str(entry.get("reasoning_effort", ""))}
+                for entry in chain
+            ]
+            categories[category] = {"chain": entries, "source": source}
+            chain_text = " > ".join(
+                entry["model_id"] + (f" {entry['reasoning_effort']}" if entry["reasoning_effort"] else "")
+                for entry in entries
+            )
+            marker = "*" if source == "operator" else " "
+            lines.append(f"  {marker} {category:18s} {chain_text or '-'}")
+        report_profiles[profile] = categories
+    rejected = list(config.get("rejected", [])) if isinstance(config, dict) else []
+    payload = {
+        "schema_version": "omh_category_maestro_report/v1",
+        "path": str(category_maestro_path(paths.omh_home)),
+        "configured": config is not None,
+        "profiles": report_profiles,
+        "rejected": rejected,
+        "claim_boundary": (
+            "This table is prepared routing metadata only; it is not dispatch, execution, "
+            "entitlement, or provider availability evidence."
+        ),
+    }
+    if _wants_json(args):
+        _print_json(payload)
+        return 0
+    if rejected:
+        lines.append("rejected config pieces:")
+        lines.extend(f"  ! {note}" for note in rejected)
+    lines.append("* = operator override from category-maestro.json; others are built-in defaults.")
+    print("\n".join(lines))
+    return 0
+
+
 def cmd_coding_model_route(args: argparse.Namespace) -> int:
     from ..coding.executors import EXECUTOR_PROFILES
     from ..coding.model_routing import (
@@ -715,6 +829,7 @@ def cmd_coding_model_route(args: argparse.Namespace) -> int:
         route_provenance,
     )
 
+    category_config = _operator_category_config(_paths(args))
     if getattr(args, "explain", False):
         profiles = [args.executor] if args.executor else list(EXECUTOR_MODEL_OPTIONS)
         unknown = [profile for profile in profiles if profile not in EXECUTOR_MODEL_OPTIONS]
@@ -724,7 +839,7 @@ def cmd_coding_model_route(args: argparse.Namespace) -> int:
         cell_lines = []
         for profile in profiles:
             for role in MODEL_ROLES:
-                route = resolve_model_route(profile, role=role)
+                route = resolve_model_route(profile, role=role, category_config=category_config)
                 provenance, _vocabulary = route_provenance(route)
                 chain = route.get("chain", [])
                 cells.append(
@@ -805,6 +920,7 @@ def cmd_coding_model_route(args: argparse.Namespace) -> int:
         requested_domain=getattr(args, "domain", None) or "",
         requested_depth=getattr(args, "depth", None) or "",
         requested_category=getattr(args, "category", None) or "",
+        category_config=category_config,
         local_catalog=local_catalog,
         active_models=active_models,
         recommendation_overrides=recommendation_overrides,
@@ -978,6 +1094,23 @@ def cmd_coding_model_inventory(args: argparse.Namespace) -> int:
     return 0
 
 
+def _operator_category_config(paths) -> dict[str, object] | None:
+    """Read the category-maestro override table; the file's presence is the opt-in.
+
+    Dropped config pieces are surfaced on stderr here — the loader names them
+    precisely so a typo'd category is visible during the prepare/route/run
+    that ignored it, not only in `category-maestro show`. stdout stays clean
+    for the JSON contracts these commands print.
+    """
+    from ..coding.category_maestro import read_category_maestro_config
+
+    config = read_category_maestro_config(paths.omh_home)
+    if isinstance(config, dict):
+        for note in config.get("rejected", []):
+            print(f"omh: category-maestro: ignored {note}", file=sys.stderr)
+    return config
+
+
 def _local_model_catalogs() -> dict[str, dict[str, object]]:
     """Observe the local inventory once and key its derived catalog by profile.
 
@@ -1129,6 +1262,7 @@ def cmd_coding_fanout_prepare(args: argparse.Namespace) -> int:
             source=args.source,
             source_metadata=_explicit_source_metadata(args),
             local_catalogs=_local_model_catalogs() if needs_inventory else {},
+            category_config=_operator_category_config(paths),
             capability_snapshots=capability_snapshots,
             spawn_plan=spawn_plan,
         )
@@ -1805,6 +1939,10 @@ def cmd_coding_run(args: argparse.Namespace) -> int:
         # --model`.
         "model": args.model or "",
         "reasoning_effort": args.effort or "",
+        # A declared work category routes through the category-maestro merged
+        # table exactly like a fanout unit's `category` field; `--model` still
+        # wins (requested > category chain head).
+        "category": getattr(args, "category", None) or "",
     }
     needs_inventory = args.owner not in EXECUTOR_MODEL_OPTIONS
     try:
@@ -1820,6 +1958,7 @@ def cmd_coding_run(args: argparse.Namespace) -> int:
             source=args.source,
             source_metadata=_explicit_source_metadata(args),
             local_catalogs=_local_model_catalogs() if needs_inventory else {},
+            category_config=_operator_category_config(paths),
             capability_snapshots=capability_snapshots,
         )
     except (FanoutContractError, ExecutorCapabilitySnapshotError) as exc:
@@ -2271,6 +2410,15 @@ def _add_coding_commands(sub) -> None:
         ),
     )
     run_cmd.add_argument("--effort", default=None, help="Reasoning effort for profiles that support one.")
+    run_cmd.add_argument(
+        "--category",
+        default=None,
+        help=(
+            "OMO/ULW model category for this run (ultrabrain, deep, architect, quick, writing, "
+            "visual-engineering, artistry, unspecified-high, unspecified-low); resolved through the "
+            "category-maestro table when one is configured. --model still wins."
+        ),
+    )
     run_cmd.set_defaults(func=cmd_coding_run)
 
     model_route = coding_sub.add_parser(
@@ -2327,6 +2475,49 @@ def _add_coding_commands(sub) -> None:
     )
     model_route.add_argument("--json", action="store_true", help="Emit the machine payload instead of plain text.")
     model_route.set_defaults(func=cmd_coding_model_route)
+
+    category_maestro = coding_sub.add_parser(
+        "category-maestro",
+        help=(
+            "Operator category->model chains for the Maestro dispatch lane "
+            "(the same category mixture the Hermes-native delegation lane routes by)."
+        ),
+    )
+    category_maestro_sub = category_maestro.add_subparsers(dest="category_maestro_command", required=True)
+    category_maestro_show = category_maestro_sub.add_parser(
+        "show",
+        help="Render the effective category table per dispatchable profile, operator overrides marked.",
+    )
+    category_maestro_show.add_argument("--json", action="store_true", help="Emit the machine payload instead of plain text.")
+    category_maestro_show.set_defaults(func=cmd_coding_category_maestro)
+    category_maestro_set = category_maestro_sub.add_parser(
+        "set",
+        help="Override one category's model chain for one profile (written to ~/.omh/routing/category-maestro.json).",
+    )
+    category_maestro_set.add_argument("profile", help="Dispatchable profile: codex or claude-code.")
+    category_maestro_set.add_argument(
+        "category",
+        help="Model category (ultrabrain, deep, architect, quick, writing, visual-engineering, artistry, unspecified-high, unspecified-low).",
+    )
+    category_maestro_set.add_argument(
+        "chain",
+        nargs="+",
+        help=(
+            "Chain entries in order, each `model[:effort]`, e.g. gpt-5.6-sol:xhigh. The tail after the "
+            "last colon is taken as the effort only when it is a known level (off, minimal, low, medium, "
+            "high, xhigh, max, auto); other colon tags stay part of the model id."
+        ),
+    )
+    category_maestro_set.add_argument("--json", action="store_true", help="Emit the machine payload instead of plain text.")
+    category_maestro_set.set_defaults(func=cmd_coding_category_maestro)
+    category_maestro_clear = category_maestro_sub.add_parser(
+        "clear",
+        help="Remove one category override so the built-in chain applies again.",
+    )
+    category_maestro_clear.add_argument("profile", help="Dispatchable profile: codex or claude-code.")
+    category_maestro_clear.add_argument("category", help="Model category to clear.")
+    category_maestro_clear.add_argument("--json", action="store_true", help="Emit the machine payload instead of plain text.")
+    category_maestro_clear.set_defaults(func=cmd_coding_category_maestro)
 
     model_routing = coding_sub.add_parser(
         "model-routing",

--- a/src/system/local_store.py
+++ b/src/system/local_store.py
@@ -111,9 +111,14 @@ def read_json_object(path: Path) -> dict[str, Any] | None:
 
 
 def read_json_object_result(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    # RecursionError: a pathologically nested document (e.g. 60k open
+    # brackets) overflows the JSON decoder's recursion before it can raise
+    # JSONDecodeError. Callers use this reader on never-raise config paths
+    # (dispatch model preferences, category-maestro), so that shape must read
+    # as malformed, not abort a prepare or dispatch with a traceback.
     try:
         return read_json_object(path), None
-    except (OSError, JSONDecodeError, ValueError) as exc:
+    except (OSError, JSONDecodeError, RecursionError, ValueError) as exc:
         return None, str(exc)
 
 

--- a/tests/test_category_maestro.py
+++ b/tests/test_category_maestro.py
@@ -1,0 +1,450 @@
+"""Contracts for category-maestro — operator category->model chains for the
+Maestro dispatch lane.
+
+The Hermes-native delegation lane routes per work category through an editable
+mixture (`omh model-chains`); `~/.omh/routing/category-maestro.json` is the
+same dial for the Maestro lane's dispatchable CLI profiles. The loader never
+raises and drops invalid pieces by name; the resolver merges the operator
+table over `BUILTIN_CATEGORY_MODELS` for every path that consults it (explicit
+category, role, research depth, task scale) and records the basis as
+`catalog_kind: "operator_category_config"` plus the config fingerprint; an
+absent config leaves every route byte-identical to the built-in resolution.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.coding.category_maestro import (
+    CATEGORY_MAESTRO_PROFILES,
+    category_maestro_path,
+    clear_category_maestro_chain,
+    read_category_maestro_config,
+    set_category_maestro_chain,
+)
+from omh.coding.fanout import build_fanout_contract
+from omh.coding.fanout_contracts import FanoutContractError
+from omh.coding.model_routing import (
+    BUILTIN_CATEGORY_MODELS,
+    MODEL_CATALOG_KINDS,
+    resolve_model_route,
+)
+
+_CONFIG = {
+    "schema_version": "omh_category_maestro/v1",
+    "profiles": {
+        "codex": {
+            "ultrabrain": ({"model_id": "gpt-5.6-sol", "reasoning_effort": "xhigh"},),
+            "deep": ({"model_id": "gpt-5.6-sol", "reasoning_effort": "high"},),
+            "quick": ({"model_id": "gpt-5.6-luna", "reasoning_effort": "low"},),
+        }
+    },
+    "fingerprint": {"source": "category-maestro.json", "digest": "feedfacefeedface"},
+}
+
+
+def _write_config(omh_home: Path, profiles: dict) -> Path:
+    path = category_maestro_path(omh_home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"schema_version": "omh_category_maestro/v1", "profiles": profiles}),
+        encoding="utf-8",
+    )
+    return path
+
+
+class CategoryMaestroLoaderTests(unittest.TestCase):
+    def test_profiles_cover_exactly_the_builtin_catalog_profiles(self) -> None:
+        self.assertEqual(CATEGORY_MAESTRO_PROFILES, tuple(sorted(BUILTIN_CATEGORY_MODELS)))
+
+    def test_missing_and_malformed_documents_read_as_absent(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            self.assertIsNone(read_category_maestro_config(home))
+            path = category_maestro_path(home)
+            path.parent.mkdir(parents=True)
+            path.write_text("{not json", encoding="utf-8")
+            self.assertIsNone(read_category_maestro_config(home))
+            path.write_text(json.dumps({"schema_version": "wrong/v9", "profiles": {}}), encoding="utf-8")
+            self.assertIsNone(read_category_maestro_config(home))
+
+    def test_valid_config_reads_with_fingerprint_and_alias_normalization(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            # `brain` is the ulw alias for ultrabrain; the stored table must
+            # come back canonical so the resolver's lookup hits it.
+            _write_config(
+                home,
+                {"codex": {"brain": [{"model_id": "gpt-5.6-sol", "reasoning_effort": "xhigh"}]}},
+            )
+            config = read_category_maestro_config(home)
+            self.assertIsNotNone(config)
+            self.assertEqual(
+                config["profiles"]["codex"]["ultrabrain"],
+                ({"model_id": "gpt-5.6-sol", "reasoning_effort": "xhigh"},),
+            )
+            fingerprint = config["fingerprint"]
+            self.assertEqual(fingerprint["source"], "category-maestro.json")
+            self.assertEqual(len(fingerprint["digest"]), 16)
+            self.assertEqual(config["rejected"], [])
+
+    def test_invalid_pieces_are_dropped_and_named(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            _write_config(
+                home,
+                {
+                    "codex": {
+                        "ultrabrain": [{"model_id": "gpt-5.6-sol"}],
+                        "no-such-category": [{"model_id": "x"}],
+                        "quick": [],
+                        "deep": [{"model_id": "bad model id"}],
+                    },
+                    "not-a-profile": {"quick": [{"model_id": "x"}]},
+                },
+            )
+            config = read_category_maestro_config(home)
+            self.assertIsNotNone(config)
+            self.assertEqual(list(config["profiles"]), ["codex"])
+            self.assertEqual(list(config["profiles"]["codex"]), ["ultrabrain"])
+            rejected_text = "\n".join(config["rejected"])
+            self.assertIn("no-such-category", rejected_text)
+            self.assertIn("not-a-profile", rejected_text)
+            self.assertIn("'quick'", rejected_text)
+            self.assertIn("'deep'", rejected_text)
+
+    def test_config_that_validates_to_nothing_reads_as_absent(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            _write_config(home, {"codex": {"quick": []}})
+            self.assertIsNone(read_category_maestro_config(home))
+
+
+class CategoryMaestroWriterTests(unittest.TestCase):
+    def test_set_then_read_round_trips_and_clear_restores_builtin(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            result = set_category_maestro_chain(
+                home,
+                "codex",
+                "ultrabrain",
+                [{"model_id": "gpt-5.6-sol", "reasoning_effort": "xhigh"}],
+            )
+            self.assertEqual(result["category"], "ultrabrain")
+            config = read_category_maestro_config(home)
+            self.assertEqual(
+                config["profiles"]["codex"]["ultrabrain"][0]["model_id"], "gpt-5.6-sol"
+            )
+            cleared = clear_category_maestro_chain(home, "codex", "ultrabrain")
+            self.assertTrue(cleared["removed"])
+            self.assertIsNone(read_category_maestro_config(home))
+            again = clear_category_maestro_chain(home, "codex", "ultrabrain")
+            self.assertFalse(again["removed"])
+
+    def test_set_rejects_bad_profile_category_and_entries(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            with self.assertRaises(ValueError):
+                set_category_maestro_chain(home, "hermes", "quick", [{"model_id": "x"}])
+            with self.assertRaises(ValueError):
+                set_category_maestro_chain(home, "codex", "no-such", [{"model_id": "x"}])
+            with self.assertRaises(ValueError):
+                set_category_maestro_chain(home, "codex", "quick", [])
+            with self.assertRaises(ValueError):
+                set_category_maestro_chain(home, "codex", "quick", [{"model_id": "has space"}])
+            with self.assertRaises(ValueError):
+                set_category_maestro_chain(
+                    home, "codex", "quick", [{"model_id": "ok", "reasoning_effort": "Bad Effort"}]
+                )
+            # A "model id" with a leading dash would parse as a flag in the
+            # spawned CLI's argv; an unbounded effort has no honest shape.
+            with self.assertRaises(ValueError):
+                set_category_maestro_chain(
+                    home, "codex", "quick", [{"model_id": "--dangerously-skip-permissions"}]
+                )
+            with self.assertRaises(ValueError):
+                set_category_maestro_chain(
+                    home, "codex", "quick", [{"model_id": "ok", "reasoning_effort": "a" * 33}]
+                )
+
+    def test_writers_refuse_an_unrecognized_existing_file(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            path = category_maestro_path(home)
+            path.parent.mkdir(parents=True)
+            original = json.dumps(
+                {
+                    "schema_version": "omh_category_maestro/v2",
+                    "profiles": {"codex": {"quick": [{"model_id": "keepme"}]}},
+                    "notes": "hand written",
+                }
+            )
+            path.write_text(original, encoding="utf-8")
+            with self.assertRaises(ValueError):
+                set_category_maestro_chain(home, "codex", "quick", [{"model_id": "x"}])
+            with self.assertRaises(ValueError):
+                clear_category_maestro_chain(home, "codex", "quick")
+            self.assertEqual(path.read_text(encoding="utf-8"), original)
+
+    def test_clear_validates_profile_and_a_noop_creates_no_file(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            with self.assertRaises(ValueError):
+                clear_category_maestro_chain(home, "no-such-profile", "quick")
+            result = clear_category_maestro_chain(home, "codex", "quick")
+            self.assertFalse(result["removed"])
+            # The file's presence is the routing opt-in; a no-op clear must
+            # not create it as a side effect.
+            self.assertFalse(category_maestro_path(home).exists())
+
+    def test_pathologically_nested_json_reads_as_absent_not_a_crash(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            path = category_maestro_path(home)
+            path.parent.mkdir(parents=True)
+            path.write_text("[" * 60000 + "]" * 60000, encoding="utf-8")
+            self.assertIsNone(read_category_maestro_config(home))
+
+
+class CategoryMaestroResolverTests(unittest.TestCase):
+    def test_vocabulary_includes_the_operator_catalog_kind(self) -> None:
+        self.assertIn("operator_category_config", MODEL_CATALOG_KINDS)
+
+    def test_explicit_category_selects_operator_chain_and_records_basis(self) -> None:
+        route = resolve_model_route("codex", requested_category="ultrabrain", category_config=_CONFIG)
+        self.assertEqual(route["selected_model"], "gpt-5.6-sol")
+        self.assertEqual(route["selected_reasoning_effort"], "xhigh")
+        self.assertEqual(route["provenance"], "category_chain_head")
+        self.assertEqual(route["catalog_kind"], "operator_category_config")
+        self.assertEqual(route["catalog_fingerprint"]["digest"], "feedfacefeedface")
+        stages = [entry["stage"] for entry in route["attempted"]]
+        self.assertIn("category_config", stages)
+
+    def test_role_chain_derives_from_the_merged_table(self) -> None:
+        # brain = (deep, unspecified-low); deep is overridden, the tail is not.
+        route = resolve_model_route("codex", role="brain", category_config=_CONFIG)
+        self.assertEqual(route["selected_model"], "gpt-5.6-sol")
+        self.assertEqual(route["selected_reasoning_effort"], "high")
+        self.assertEqual(route["provenance"], "role_chain_head")
+        chain_models = [entry["model_id"] for entry in route["chain"]]
+        self.assertEqual(chain_models, ["gpt-5.6-sol", "gpt-5"])
+
+    def test_depth_and_scale_chains_derive_from_the_merged_table(self) -> None:
+        deep = resolve_model_route(
+            "codex", role="research", requested_depth="deep", category_config=_CONFIG
+        )
+        self.assertEqual(deep["selected_model"], "gpt-5.6-sol")
+        self.assertEqual(deep["selected_reasoning_effort"], "xhigh")
+        small = resolve_model_route(
+            "codex", role="implementation", requested_scale="small", category_config=_CONFIG
+        )
+        self.assertEqual(small["selected_model"], "gpt-5.6-luna")
+        self.assertEqual(small["selected_reasoning_effort"], "low")
+
+    def test_requested_model_still_wins_over_the_operator_chain(self) -> None:
+        route = resolve_model_route(
+            "codex",
+            requested_model="explicit-model",
+            requested_category="ultrabrain",
+            category_config=_CONFIG,
+        )
+        self.assertEqual(route["selected_model"], "explicit-model")
+        self.assertEqual(route["provenance"], "request_named_model")
+
+    def test_unconfigured_profile_keeps_the_builtin_basis(self) -> None:
+        route = resolve_model_route("claude-code", role="brain", category_config=_CONFIG)
+        self.assertEqual(route["selected_model"], "opus")
+        self.assertEqual(route["catalog_kind"], "built_in_defaults")
+        self.assertNotIn("catalog_fingerprint", route)
+
+    def test_absent_config_is_byte_identical_to_todays_resolution(self) -> None:
+        for profile in CATEGORY_MAESTRO_PROFILES:
+            for kwargs in (
+                {"role": "brain"},
+                {"requested_category": "quick"},
+                {"role": "research", "requested_depth": "deep"},
+                {"role": "implementation", "requested_scale": "large"},
+                {"requested_model": "explicit", "requested_effort": "high"},
+            ):
+                with self.subTest(profile=profile, kwargs=kwargs):
+                    self.assertEqual(
+                        json.dumps(resolve_model_route(profile, **kwargs), sort_keys=True),
+                        json.dumps(
+                            resolve_model_route(profile, category_config=None, **kwargs),
+                            sort_keys=True,
+                        ),
+                    )
+
+    def test_tests_only_chains_injection_wins_over_operator_config(self) -> None:
+        chains = {"codex": {"brain": ({"model_id": "injected", "reasoning_effort": ""},)}}
+        route = resolve_model_route("codex", role="brain", chains=chains, category_config=_CONFIG)
+        self.assertEqual(route["selected_model"], "injected")
+        self.assertEqual(route["catalog_kind"], "built_in_defaults")
+
+
+class CategoryMaestroFanoutTests(unittest.TestCase):
+    def _unit(self, **extra: object) -> dict[str, object]:
+        return {
+            "unit_id": "core",
+            "title": "core unit",
+            "owner": "codex",
+            "file_scope": ["src/"],
+            "depends_on": [],
+            **extra,
+        }
+
+    def test_unit_category_freezes_the_operator_routed_model(self) -> None:
+        contract = build_fanout_contract(
+            "route by category",
+            [self._unit(category="ultrabrain")],
+            category_config=_CONFIG,
+        )
+        route = contract["units"][0]["handoff"]["model_route"]
+        self.assertEqual(route["selected_model"], "gpt-5.6-sol")
+        self.assertEqual(route["selected_reasoning_effort"], "xhigh")
+        self.assertEqual(route["catalog_kind"], "operator_category_config")
+
+    def test_unit_category_routes_the_builtin_chain_without_config(self) -> None:
+        contract = build_fanout_contract(
+            "route by category",
+            [self._unit(category="ultrabrain")],
+        )
+        route = contract["units"][0]["handoff"]["model_route"]
+        self.assertEqual(route["selected_model"], "gpt-5-codex")
+        self.assertEqual(route["catalog_kind"], "built_in_defaults")
+
+    def test_unit_scale_survives_normalization_into_routing(self) -> None:
+        contract = build_fanout_contract(
+            "route by scale",
+            [self._unit(role="implementation", scale="small")],
+            category_config=_CONFIG,
+        )
+        route = contract["units"][0]["handoff"]["model_route"]
+        self.assertEqual(route["selected_model"], "gpt-5.6-luna")
+
+    def test_unknown_unit_category_fails_the_freeze_by_name(self) -> None:
+        with self.assertRaises(FanoutContractError) as caught:
+            build_fanout_contract("bad category", [self._unit(category="no-such")])
+        self.assertIn("no-such", str(caught.exception))
+
+
+class CategoryMaestroCliTests(unittest.TestCase):
+    def test_set_show_route_clear_round_trip(self) -> None:
+        with TemporaryDirectory() as tmp:
+            base = ["--omh-home", str(Path(tmp) / ".omh")]
+            status, stdout, stderr = run_cli(
+                base + ["coding", "category-maestro", "set", "codex", "ultrabrain", "gpt-5.6-sol:xhigh"],
+                output_json=False,
+            )
+            self.assertEqual((status, stderr), (0, ""))
+            self.assertIn("gpt-5.6-sol xhigh", stdout)
+
+            status, stdout, stderr = run_cli(
+                base + ["coding", "category-maestro", "show", "--json"], output_json=False
+            )
+            self.assertEqual((status, stderr), (0, ""))
+            report = json.loads(stdout)
+            self.assertTrue(report["configured"])
+            cell = report["profiles"]["codex"]["ultrabrain"]
+            self.assertEqual(cell["source"], "operator")
+            self.assertEqual(cell["chain"][0]["model_id"], "gpt-5.6-sol")
+            self.assertEqual(report["profiles"]["codex"]["deep"]["source"], "built_in")
+
+            status, stdout, stderr = run_cli(
+                base + ["coding", "model-route", "--executor", "codex", "--category", "ultrabrain", "--json"],
+                output_json=False,
+            )
+            self.assertEqual((status, stderr), (0, ""))
+            route = json.loads(stdout)
+            self.assertEqual(route["selected_model"], "gpt-5.6-sol")
+            self.assertEqual(route["catalog_kind"], "operator_category_config")
+
+            status, stdout, stderr = run_cli(
+                base + ["coding", "category-maestro", "clear", "codex", "ultrabrain"],
+                output_json=False,
+            )
+            self.assertEqual((status, stderr), (0, ""))
+            status, stdout, stderr = run_cli(
+                base + ["coding", "model-route", "--executor", "codex", "--category", "ultrabrain", "--json"],
+                output_json=False,
+            )
+            self.assertEqual((status, stderr), (0, ""))
+            self.assertEqual(json.loads(stdout)["selected_model"], "gpt-5-codex")
+
+    def test_colon_tagged_model_ids_stay_intact_and_efforts_still_split(self) -> None:
+        with TemporaryDirectory() as tmp:
+            base = ["--omh-home", str(Path(tmp) / ".omh")]
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "coding", "category-maestro", "set", "codex", "quick",
+                    "qwen2.5-coder:7b", "gpt-5.6-luna:low",
+                ],
+                output_json=False,
+            )
+            self.assertEqual((status, stderr), (0, ""))
+            status, stdout, stderr = run_cli(
+                base + ["coding", "category-maestro", "show", "--json"], output_json=False
+            )
+            self.assertEqual((status, stderr), (0, ""))
+            chain = json.loads(stdout)["profiles"]["codex"]["quick"]["chain"]
+            self.assertEqual(
+                chain,
+                [
+                    {"model_id": "qwen2.5-coder:7b", "reasoning_effort": ""},
+                    {"model_id": "gpt-5.6-luna", "reasoning_effort": "low"},
+                ],
+            )
+
+    def test_rejected_config_pieces_reach_stderr_on_route_commands(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp) / ".omh"
+            _write_config(
+                home,
+                {
+                    "codex": {
+                        "ultrabrain": [{"model_id": "gpt-5.6-sol"}],
+                        "no-such-category": [{"model_id": "x"}],
+                    }
+                },
+            )
+            status, _stdout, stderr = run_cli(
+                ["--omh-home", str(home), "coding", "model-route", "--executor", "codex", "--role", "brain", "--json"],
+                output_json=False,
+            )
+            self.assertEqual(status, 0)
+            self.assertIn("no-such-category", stderr)
+
+    def test_set_rejects_unknown_vocabulary_with_a_named_error(self) -> None:
+        with TemporaryDirectory() as tmp:
+            base = ["--omh-home", str(Path(tmp) / ".omh")]
+            status, _stdout, stderr = run_cli(
+                base + ["coding", "category-maestro", "set", "codex", "no-such", "model-x"],
+                output_json=False,
+            )
+            self.assertNotEqual(status, 0)
+            self.assertIn("no-such", stderr)
+
+    def test_run_exposes_the_category_flag(self) -> None:
+        from contextlib import redirect_stdout
+        from io import StringIO
+
+        from omh.cli import main
+
+        buffer = StringIO()
+        with redirect_stdout(buffer), self.assertRaises(SystemExit) as caught:
+            main(["coding", "run", "--help"])
+        self.assertEqual(caught.exception.code, 0)
+        self.assertIn("--category", buffer.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- The Maestro dispatch lane gains the operator category dial the Hermes-native delegation lane already has: `~/.omh/routing/category-maestro.json` (`omh_category_maestro/v1`) overrides individual categories of the built-in category → model table for the dispatchable profiles (`codex`, `claude-code`).
- New CLI editor mirroring the native lane's `omh model-chains`: `omh coding category-maestro show | set <profile> <category> <model[:effort]>... | clear <profile> <category>`.
- `omh coding run --category <category>` routes one run through the same table; fanout units' `category` / `model_category` / `scale` fields now actually reach routing (the unit normalizer previously dropped them silently), and unknown category vocabulary fails the freeze by name.
- `read_json_object_result` additionally catches `RecursionError` so a pathologically nested JSON config reads as malformed on the never-raise config paths (this reader also backs `dispatch-models.json`) instead of aborting a prepare/dispatch with a traceback.

### Why This Exists

- Owner directive: Maestro should be usable per work category like the subagent routing mixture, and it should be configurable ("maestro도 subagent routing mixture model처럼 작업 카테고리별로 쓰이게 해줘", "설정되게 해주고", "category-maestro 이런걸 만들어서").
- The category engine (`BUILTIN_CATEGORY_MODELS`) already existed but was fixed at package defaults, and the local-inventory override path is deliberately gated away from profiles with a built-in catalog — there was no sanctioned way to say "on this machine, `ultrabrain` on codex means `gpt-5.6-sol:xhigh`".

### User / Operator Impact

- `omh coding category-maestro set codex ultrabrain gpt-5.6-sol:xhigh` then every explicit-category, role, depth, and scale resolution that consults `ultrabrain` on codex selects that chain; `clear` restores the built-in. `show` renders the effective merged table with operator overrides marked and invalid config pieces named.
- Requested models keep absolute precedence (`--model` > category chain head). A broken config file reads as absent and never blocks a prepare or dispatch; dropped config pieces are surfaced on stderr during `model-route`, `fanout prepare`, and `run`.
- The file's presence is the opt-in: machines without it keep byte-identical routes and contracts.

### How It Works

- `src/coding/category_maestro.py`: never-raising validated loader (canonical categories incl. `ulw-*` aliases, argv-shape gates on model ids/efforts, `rejected` notes, config fingerprint), plus `set`/`clear` writers that refuse to edit an existing file they do not recognize (never silent data loss) and skip no-op writes.
- `resolve_model_route(..., category_config=...)` merges the operator table over the built-in per category and feeds every path that consults it (explicit category, role chains via `merged_category_chain`, research depth, task scale). Such routes record `catalog_kind: "operator_category_config"` + the config fingerprint; the kind names which table was consulted for the profile, documented explicitly. The tests-only `chains` injection still wins; catalogless profiles keep `local_inventory` as their single override source.
- I/O stays at the command layer (`_operator_category_config`); the resolver and contract builder remain pure. `_normalized_unit` carries `category`/`scale`; `validate_fanout_units` rejects unknown category vocabulary at freeze time.
- The CLI `model[:effort]` token splits only when the tail is a known effort level (off/minimal/low/medium/high/xhigh/max/auto), so colon-tagged model ids (`qwen2.5-coder:7b`) stay intact.

### Files And Contracts Touched

- `src/coding/category_maestro.py` (new), `src/coding/model_routing.py`, `src/coding/fanout.py`, `src/commands/coding.py`, `src/system/local_store.py`, `tests/test_category_maestro.py` (new, 27 cases), `docs/FANOUT.md`.
- Contract: `coding_model_route/v2` gains one `catalog_kind` value (`operator_category_config`, additive); new document schema `omh_category_maestro/v1`; report schema `omh_category_maestro_report/v1`.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [x] Codex
- [x] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [x] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- Full suite from a neutral-path worktree at this commit: `Ran 7966 tests — OK` (second run; a third run under heavy parallel load showed one failure in `test_fanout_dispatch.SpawnStaggerTests.test_reserve_spaces_consecutive_slots`, a wall-clock stagger timing test untouched by this change that passes standalone on the same commit — load flake, not a regression).
- `tests/test_category_maestro.py`: 27 cases — loader (incl. the deep-nesting `RecursionError` shape), writers (incl. unrecognized-file refusal with the original bytes proven untouched, and no-op `clear` creating no file), resolver paths (explicit category / role / depth / scale, requested-model precedence, `chains` injection precedence, byte-identity with `category_config=None` across profiles and dials), fanout freeze (operator-routed and built-in-routed units, unknown-category refusal), CLI round-trips (set → show → model-route → clear, colon-tagged ids, stderr surfacing of rejected pieces).
- Manual CLI smoke against a scratch `OMH_HOME`: `category-maestro set codex ultrabrain gpt-5.6-sol:xhigh gpt-5.6-terra:high` → `model-route --executor codex --category ultrabrain` selected `gpt-5.6-sol xhigh` (`category_chain_head`, `operator_category_config`); `clear` restored `gpt-5-codex xhigh`.
- Separate-lane code review produced 9 findings (3 blocking: silent config-file data loss on set/clear, loader `RecursionError` crash shape, colon-tag misparse) — all addressed in this commit, each with a regression test.
- In-place worktree runs show exactly one known environmental failure (this worktree's path contains "token", tripping the plan-context-pack sensitive-text detector) — pre-existing, which is why the full-suite proof runs from a neutral path.

### Not Tested / Not Applicable

- `harness validate` / `release checklist` / `release hermes-smoke` / install smoke: no harness, release-channel, or install-surface change in this PR.
- Manual Hermes/TUI check: no TUI or plugin-bundle surface changes here.
- No live codex/claude CLI dispatch with an overridden model was spawned — model availability and entitlement are provider truth this repo does not observe; a routed model remains prepared metadata (`prepared_not_observed`), never execution evidence.

## Risk

- Fanout units that ALREADY carry `category`, `model_category`, or `scale` change behavior with no config present: those fields previously vanished before routing and now route (an explicit category outranks the role chain) or fail the freeze by name when unknown. Re-preparing an existing unit file is where an operator feels this; declared in the commit's Scope-risk trailer.
- Readers pinning the closed `catalog_kind` vocabulary must accept the additive `operator_category_config` value.

## Compatibility / Rollout

- No config file → byte-identical routes and contracts (asserted by test across profiles and dials). Frozen v1/v2 routes are read verbatim, unchanged. Reaches a live machine only via `omh update`; no TUI restart needed (no widget change).

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- HUD maestro row identity shows the routed model but not effort/category; a small reader+widget follow-up could render `(codex/maestro gpt-5.6-sol:xhigh)` once dispatch rows carry the routed effort.
- The `claude --output-format stream-json` dispatch-argv follow-up (live claude token counts) noted on PR #1178 remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9F2nbnc7hajqzznXcgLZn
