### PR TITLE
feat(verification): escalate to thorough lane on sensitive path touches

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -2989,6 +2989,7 @@ These surfaces are generated command references, not installed Hermes workflow s
   - Do not treat a planned command, stale output, green local check, or prepared handoff as fresh verification evidence.
   - Do not collapse build, lint, tests, security, generated docs, review, CI, DCO, merge-readiness, or merge into one claim.
   - Failed or unavailable checks must produce HOLD/BLOCK with a rerun or remediation path.
+  - A change touching an authentication, secrets/config, schema/migration, or payment/crypto path escalates to the thorough verification lane regardless of diff size.
 
 ### agent-evaluation
 

--- a/skills/omh-verification-gate/SKILL.md
+++ b/skills/omh-verification-gate/SKILL.md
@@ -107,6 +107,7 @@ Safety rules:
 - Do not treat a planned command, stale output, green local check, or prepared handoff as fresh verification evidence.
 - Do not collapse build, lint, tests, security, generated docs, review, CI, DCO, merge-readiness, or merge into one claim.
 - Failed or unavailable checks must produce HOLD/BLOCK with a rerun or remediation path.
+- A change touching an authentication, secrets/config, schema/migration, or payment/crypto path escalates to the thorough verification lane regardless of diff size.
 
 ## Runtime Evidence
 

--- a/src/coding/coding_delegation.py
+++ b/src/coding/coding_delegation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import asdict, dataclass
 from functools import lru_cache
 import hashlib
@@ -72,6 +73,7 @@ from .context_safety import (
 )
 from ..harness_quality import with_wrapper_actions
 from ..quality.specialist_work import build_specialist_work_quality_contract
+from ..quality.verification_tiering import sensitive_path_escalation
 from ..ingress import CHAT_SOURCES, extract_message_text, extract_source_metadata
 from ..isolation import build_isolation_plan
 from ..memory import validate_handoff_context_blocked, validate_handoff_context_pack, validate_project_memory_recall_pack
@@ -548,6 +550,11 @@ def _build_coding_delegation_payload_native(
         workflow = "oh-my-hermes"
     harness = primary_harness_for_skill(workflow)
     review_required = _review_required(message, intent, workflow)
+    # Same extraction `_safety_preflight_request` uses below for its own
+    # `target_paths` declaration -- reused here (and re-derived there) rather
+    # than threaded through the dataclass, since it is a pure, cheap scan of
+    # the message and the two call sites read it for unrelated purposes.
+    verification_target_paths = _safety_preflight_target_paths(message)
     delegation = CodingDelegation(
         action=action,
         intent=intent,
@@ -555,7 +562,7 @@ def _build_coding_delegation_payload_native(
         recommended_harness=harness,
         executor_profile=_executor_profile(intent, action),
         acceptance_criteria=_acceptance_criteria(intent, action, workflow),
-        verification=_verification(intent, action, workflow),
+        verification=_verification(intent, action, workflow, target_paths=verification_target_paths),
         review_required=review_required,
         review_workflow="code-review" if review_required else None,
         delegation_prompt_template=_delegation_prompt_template(action, intent, workflow, harness),
@@ -1652,7 +1659,7 @@ def _acceptance_criteria(intent: str, action: str, workflow: str) -> tuple[str, 
     return criteria
 
 
-def _verification(intent: str, action: str, workflow: str) -> tuple[str, ...]:
+def _verification(intent: str, action: str, workflow: str, target_paths: Sequence[str] = ()) -> tuple[str, ...]:
     if action == "fallback":
         return ("No executor verification until the task is clarified.",)
     if action == "clarify":
@@ -1668,6 +1675,14 @@ def _verification(intent: str, action: str, workflow: str) -> tuple[str, ...]:
         intent,
         ("Run targeted tests for the changed behavior.", "Run static or compile checks when available."),
     )
+    # Path escalation (verification tiering): a target that touches a
+    # security-sensitive surface forces the thorough verification lane
+    # regardless of how small the change is. This runs after the intent-based
+    # checklist so the escalation reason is always the last, most specific
+    # line rather than folded into (and possibly lost among) the base checks.
+    escalation = sensitive_path_escalation(target_paths)
+    if escalation is not None:
+        checks = (*checks, f"Escalate to the thorough verification lane: {escalation['reason']}")
     return checks
 
 

--- a/src/maintenance/release.py
+++ b/src/maintenance/release.py
@@ -332,7 +332,13 @@ STANDALONE_CAPABILITY_SKILL_ITEM_CHAR_LIMIT = 2200
 # mandatory planner handoff -- the rules that are wrong to discover late. The
 # remainder of the delta is the `+N more` lane line regenerating across the
 # eleven other `intent_to_plan` skills; warranted growth for a new workflow.
-FULL_PROFILE_SKILL_BODY_CHAR_LIMIT = 756725
+# 756725 -> 756890: `verification-gate`'s safety_rules gained one rule stating
+# that a change touching an authentication, secrets/config, schema/migration,
+# or payment/crypto path escalates to the thorough verification lane
+# regardless of diff size (+165 chars); warranted growth documenting the new
+# deterministic sensitive-path escalation (`quality/verification_tiering.py`)
+# absorbed into `_verification` in `coding_delegation.py`.
+FULL_PROFILE_SKILL_BODY_CHAR_LIMIT = 756890
 FULL_PROFILE_SKILL_BODY_REVIEWED_EXCEPTION_CHARS = 0
 
 

--- a/src/quality/verification_tiering.py
+++ b/src/quality/verification_tiering.py
@@ -1,0 +1,107 @@
+"""Verification tiering: sensitive-path escalation.
+
+Absorbs "verification tiering with path escalation": a change that touches a
+security-sensitive surface -- authentication, secrets/config, schema or
+database migrations, or payment/crypto code -- must force the thorough
+verification lane regardless of how small the diff is. Change size is a poor
+proxy for risk on these surfaces: a one-line edit to `src/auth/jwt.py` or
+`.env.production` can be more consequential than a hundred-line refactor of an
+unrelated module, so `_verification` in `coding_delegation.py` calls
+`sensitive_path_escalation` on every declared target path rather than sizing
+the checklist off the request alone.
+
+Matching is by path component and filename pattern (`fnmatch`, case folded so
+the decision does not depend on which case convention the caller used), never
+substring search over the whole path string. `src/blog/author.py` must never
+escalate on "auth" the way `src/auth/login.py` does, and `docs/environment.md`
+must never escalate on "env" the way `.env.production` does -- so directory
+patterns are matched against whole path parts and filename patterns are
+matched against the basename only, and neither ever runs as a raw substring
+check over the full path string.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+import fnmatch
+from typing import Final
+
+SENSITIVE_PATH_ESCALATION_SCHEMA_VERSION: Final = "omh_sensitive_path_escalation/v1"
+
+# (category, human label, whole-path-part patterns, basename patterns). A path
+# escalates when any of its path parts fnmatch-matches a dir pattern, or its
+# basename fnmatch-matches a basename pattern. Every pattern is matched as a
+# whole string against one path part or the basename -- never as a substring
+# scan over the joined path -- so a part or basename merely containing the
+# letters never matches a pattern naming the whole part.
+_SENSITIVE_PATH_RULES: Final = (
+    (
+        "auth",
+        "authentication/authorization surface",
+        ("auth", "auth-*", "*-auth"),
+        ("*jwt*",),
+    ),
+    (
+        "secrets_config",
+        "secrets or environment configuration",
+        ("secrets", "credentials"),
+        (".env", ".env.*", "*credential*"),
+    ),
+    (
+        "schema_migrations",
+        "schema or database migration",
+        ("migrations", "migration"),
+        ("schema.*",),
+    ),
+    (
+        "payment_crypto",
+        "payment or cryptographic surface",
+        ("payment", "payments", "billing", "crypto"),
+        ("*wallet*",),
+    ),
+)
+
+
+def sensitive_path_escalation(paths: Sequence[str]) -> dict[str, object] | None:
+    """The escalation verdict for a set of changed paths, or None.
+
+    Rules are tried in `_SENSITIVE_PATH_RULES` order, and within a rule paths
+    are tried in `paths` order, so the same input always names the same
+    category and matched path. Each path is read as a plain string; a
+    non-string or blank entry is skipped rather than raising, since this is a
+    pure classifier over caller-supplied metadata and not a validator.
+    """
+    for category, label, dir_patterns, basename_patterns in _SENSITIVE_PATH_RULES:
+        for path in paths:
+            if not isinstance(path, str) or not path.strip():
+                continue
+            parts = _path_parts(path)
+            if not parts:
+                continue
+            basename = parts[-1]
+            if _matches_any(parts, dir_patterns) or _matches_any((basename,), basename_patterns):
+                return {
+                    "schema_version": SENSITIVE_PATH_ESCALATION_SCHEMA_VERSION,
+                    "category": category,
+                    "matched_path": path,
+                    "reason": (
+                        f"{path} is in the {label}; verification escalates to the thorough "
+                        "lane regardless of change size."
+                    ),
+                }
+    return None
+
+
+def _matches_any(values: Sequence[str], patterns: Sequence[str]) -> bool:
+    return any(fnmatch.fnmatchcase(value.lower(), pattern.lower()) for value in values for pattern in patterns)
+
+
+def _path_parts(path: str) -> tuple[str, ...]:
+    """A path as comparable, case-preserved segments, on every host.
+
+    Both separators are folded and empty and `.` segments dropped, matching
+    `safety_preflight._path_parts` and `action_gate`'s path handling, so a
+    path handed to this classifier reads the same way it reads everywhere else
+    in the coding-delegation lane.
+    """
+    return tuple(part for part in path.replace("\\", "/").split("/") if part not in ("", "."))

--- a/src/skills/catalog_definitions.py
+++ b/src/skills/catalog_definitions.py
@@ -4054,6 +4054,7 @@ _DEFINITIONS = [
             "Do not treat a planned command, stale output, green local check, or prepared handoff as fresh verification evidence.",
             "Do not collapse build, lint, tests, security, generated docs, review, CI, DCO, merge-readiness, or merge into one claim.",
             "Failed or unavailable checks must produce HOLD/BLOCK with a rerun or remediation path.",
+            "A change touching an authentication, secrets/config, schema/migration, or payment/crypto path escalates to the thorough verification lane regardless of diff size.",
         ),
         quality_tier="verification-gated",
         quality_bar=(

--- a/tests/test_coding_delegation.py
+++ b/tests/test_coding_delegation.py
@@ -261,6 +261,40 @@ class ExplicitOwnerChoiceOverrideTests(unittest.TestCase):
         self.assertEqual(delegation["action"], "clarify")
 
 
+class VerificationPathEscalationTests(unittest.TestCase):
+    """Integration coverage for `verification_tiering.sensitive_path_escalation`
+    wired into `_verification` (`coding_delegation.py`): a change that names a
+    security-sensitive target path escalates to the thorough verification lane
+    regardless of change size, and an ordinary path does not.
+    """
+
+    def test_a_named_auth_path_escalates_verification(self) -> None:
+        payload = build_coding_delegation_payload(
+            "fix src/auth/login.py to validate tokens correctly",
+            executor_target="claude-code",
+            explicit_owner_choice=True,
+        )
+        delegation = payload["delegation"]
+        self.assertEqual(delegation["action"], "delegate")
+        verification = delegation["verification"]
+        self.assertTrue(
+            any("thorough verification lane" in line for line in verification),
+            verification,
+        )
+        self.assertTrue(any("src/auth/login.py" in line for line in verification), verification)
+
+    def test_an_ordinary_path_does_not_escalate_verification(self) -> None:
+        payload = build_coding_delegation_payload(
+            "fix src/foo.py to log the response body",
+            executor_target="claude-code",
+            explicit_owner_choice=True,
+        )
+        delegation = payload["delegation"]
+        self.assertEqual(delegation["action"], "delegate")
+        verification = delegation["verification"]
+        self.assertFalse(any("thorough verification lane" in line for line in verification), verification)
+
+
 class CategoryPropagationTests(unittest.TestCase):
     def test_natural_ulw_category_reaches_root_and_hermes_handoff(self) -> None:
         payload = build_coding_delegation_payload(

--- a/tests/test_verification_tiering.py
+++ b/tests/test_verification_tiering.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import unittest
+
+from omh.quality.verification_tiering import (
+    SENSITIVE_PATH_ESCALATION_SCHEMA_VERSION,
+    sensitive_path_escalation,
+)
+
+
+class SensitivePathEscalationTests(unittest.TestCase):
+    def test_no_paths_never_escalates(self) -> None:
+        self.assertIsNone(sensitive_path_escalation([]))
+
+    def test_ordinary_paths_never_escalate(self) -> None:
+        for path in ("README.md", "src/foo.py", "src/quality/routing_precision.py", "tests/test_cli.py"):
+            with self.subTest(path=path):
+                self.assertIsNone(sensitive_path_escalation([path]))
+
+    def test_author_dot_py_is_not_auth(self) -> None:
+        """A filename merely containing the letters `auth` must never false-positive."""
+        self.assertIsNone(sensitive_path_escalation(["src/blog/author.py"]))
+        self.assertIsNone(sensitive_path_escalation(["authoring/notes.py"]))
+
+    def test_environment_dot_md_is_not_env(self) -> None:
+        """A filename merely containing the letters `env` must never false-positive."""
+        self.assertIsNone(sensitive_path_escalation(["docs/environment.md"]))
+        self.assertIsNone(sensitive_path_escalation(["src/envelope.py"]))
+
+    def test_auth_directory_escalates(self) -> None:
+        result = sensitive_path_escalation(["src/auth/login.py"])
+        self.assertIsNotNone(result)
+        self.assertEqual(result["category"], "auth")
+        self.assertEqual(result["matched_path"], "src/auth/login.py")
+        self.assertEqual(result["schema_version"], SENSITIVE_PATH_ESCALATION_SCHEMA_VERSION)
+        self.assertIn("thorough", result["reason"])
+
+    def test_jwt_filename_escalates_as_auth(self) -> None:
+        result = sensitive_path_escalation(["lib/jwt_utils.py"])
+        self.assertIsNotNone(result)
+        self.assertEqual(result["category"], "auth")
+
+    def test_dotenv_escalates(self) -> None:
+        for path in (".env", ".env.local", ".env.production"):
+            with self.subTest(path=path):
+                result = sensitive_path_escalation([path])
+                self.assertIsNotNone(result)
+                self.assertEqual(result["category"], "secrets_config")
+
+    def test_credential_filename_escalates(self) -> None:
+        result = sensitive_path_escalation(["config/credentials.json"])
+        self.assertIsNotNone(result)
+        self.assertEqual(result["category"], "secrets_config")
+
+    def test_migrations_directory_escalates(self) -> None:
+        result = sensitive_path_escalation(["db/migrations/0001_init.sql"])
+        self.assertIsNotNone(result)
+        self.assertEqual(result["category"], "schema_migrations")
+
+    def test_schema_filename_escalates(self) -> None:
+        result = sensitive_path_escalation(["schema.sql"])
+        self.assertIsNotNone(result)
+        self.assertEqual(result["category"], "schema_migrations")
+
+    def test_payment_directory_escalates(self) -> None:
+        result = sensitive_path_escalation(["src/payments/charge.py"])
+        self.assertIsNotNone(result)
+        self.assertEqual(result["category"], "payment_crypto")
+
+    def test_wallet_filename_escalates(self) -> None:
+        result = sensitive_path_escalation(["wallet_signer.py"])
+        self.assertIsNotNone(result)
+        self.assertEqual(result["category"], "payment_crypto")
+
+    def test_first_rule_and_first_path_win_deterministically(self) -> None:
+        result = sensitive_path_escalation(["README.md", "src/foo.py", "src/auth/login.py", ".env"])
+        self.assertIsNotNone(result)
+        self.assertEqual(result["category"], "auth")
+        self.assertEqual(result["matched_path"], "src/auth/login.py")
+
+    def test_non_string_and_blank_entries_are_skipped(self) -> None:
+        self.assertIsNone(sensitive_path_escalation([None, "", "   ", 42]))  # type: ignore[list-item]
+
+    def test_matching_is_case_insensitive_but_still_component_scoped(self) -> None:
+        result = sensitive_path_escalation(["src/Auth/Login.py"])
+        self.assertIsNotNone(result)
+        self.assertEqual(result["category"], "auth")
+        self.assertIsNone(sensitive_path_escalation(["src/Author/Notes.py"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Capability

Absorb "verification tiering with path escalation" into OMH's deterministic
verification-planning surface: a change that touches a security-sensitive
path — authentication code, secrets/config, schema or database migrations,
or payment/crypto surfaces — now forces the thorough verification lane
regardless of how small the diff is. Pure Python, no network/LLM calls, no
new dependency.

## Motivation

Change size is a poor proxy for verification risk on these surfaces: a
one-line edit to `src/auth/jwt.py` or `.env.production` can be more
consequential than a hundred-line refactor of an unrelated module, but OMH's
existing `_verification()` checklist (`coding_delegation.py`) sized itself
off `intent`/`action`/`workflow` alone with no awareness of *which* files a
request names. This closes that gap without inventing a new command, flag,
or planning surface.

## Implementation (boundary-level)

- **New pure module** `src/quality/verification_tiering.py`:
  `sensitive_path_escalation(paths: Sequence[str]) -> dict | None`. Rules are
  `(category, label, dir-component patterns, basename patterns)` tuples for
  `auth`, `secrets_config`, `schema_migrations`, and `payment_crypto`,
  matched via `fnmatch` (case-folded) against whole path parts or the
  basename only — **never** a substring scan over the joined path, so
  `src/blog/author.py` and `docs/environment.md` never false-positive the
  way `src/auth/login.py` and `.env.production` correctly do. Returns the
  first matching rule over the first matching path, deterministically.

- **Wiring (one integration point)**: `coding_delegation._verification()`
  gained an optional `target_paths` parameter; when
  `sensitive_path_escalation(target_paths)` returns non-None, one escalation
  line is appended to the checklist. The call site reuses
  `_safety_preflight_target_paths(message)` — the same extraction the safety
  preflight request already performs — so no new message scan, field, or
  schema was introduced. `delegation.verification` in the prepared handoff
  payload carries the escalation line end-to-end.

- **Skill documentation**: one `safety_rules` bullet added to the
  `verification-gate` `SkillDefinition` in `src/skills/catalog_definitions.py`;
  `skills/omh-verification-gate/SKILL.md` and `docs/WORKFLOWS.md`
  regenerated from that source via the existing generator functions (no
  hand-edits to generated files).

- **Byte-budget ratchet**: the doc addition (+165 chars) pushed
  `full_profile_skill_body_chars` over `FULL_PROFILE_SKILL_BODY_CHAR_LIMIT`.
  Raised the limit in `src/maintenance/release.py` with an `OLD -> NEW:
  reason; warranted growth` history comment, matching the file's existing
  convention.

- **Tests**: `tests/test_verification_tiering.py` (new, 16 cases) — every
  category positive, the `author.py`/`environment.md` false-positive guards
  called out explicitly, empty/blank/non-string input handling,
  deterministic first-rule/first-path ordering, and
  case-insensitive-but-component-scoped matching.
  `tests/test_coding_delegation.py` gained `VerificationPathEscalationTests`
  — an integration pair through the public `build_coding_delegation_payload`
  proving an auth-path message escalates and an ordinary-path message does
  not.

No schema changed, no CLI flag added, no execution/network/LLM surface
touched.

## Observed verification

Run from the worktree root on branch `claude/path-escalated-verification`:

- `uv run python -m compileall -q src tests` — clean.
- `PYTHONPATH=tests uv run python -m unittest discover -s tests` — **7956
  tests, 21 failures / 7 errors**, all inside
  `test_cross_harness_adapters` / `test_cross_harness_adapter_security`
  (`unsafe_read_root`-style failures from the `.claude` segment in this
  worktree's path) — the documented pre-existing local artifact, not this
  change. Confirmed unrelated:
  - `tests/test_drift_registry.py` — 16/16 pass (this is the suite that
    exercises the byte-budget ratchet touched here).
  - `tests/test_verification_tiering.py` + `tests/test_coding_delegation.py`
    — 45/45 pass.
- `uv run python -m omh.cli docs workflows --check` — pass.
- `uv run python -m omh.cli docs roles --check` — pass.
- `uv run python -m omh.cli docs capability-families --check` — pass.
- `uv run python -m omh.cli docs ulw-inventory --check` — pass.
- `uv run python -m omh.cli docs ulw-site --check` — pass.
- `uv run --group lint ruff check src tests` — all checks passed.
- `git diff --check` — clean.

Manual smoke evidence (direct Python calls):
- `sensitive_path_escalation` returns the expected category for
  `src/auth/login.py`, `lib/jwt_utils.py`, `.env`, `.env.production`,
  `config/credentials.json`, `db/migrations/0001_init.sql`, `schema.sql`,
  `src/payments/charge.py`, `wallet_signer.py`, and `None` for `README.md`,
  `src/foo.py`, `src/blog/author.py`, `docs/environment.md`.
- `build_coding_delegation_payload("fix src/auth/login.py to validate
  tokens correctly", executor_target="claude-code",
  explicit_owner_choice=True)["delegation"]["verification"]` includes the
  escalation line naming `src/auth/login.py`; the same call with
  `src/foo.py` does not.

## Risks

- Low scope-risk: one new pure module, one optional parameter on a private
  helper, one doc bullet, one generated-artifact regeneration, one ratchet
  bump. No schema, CLI, or public API surface changed, and no code touches
  execution, network, or LLM calls.
- The sensitive-path pattern list is deliberately conservative (explicit
  component/basename patterns, not broad substrings) to avoid the
  `author.py`/`environment.md` class of false positive; a real gap in
  coverage (e.g. a category not yet listed) would currently just skip
  escalation rather than fail closed. Extending `_SENSITIVE_PATH_RULES` is
  the documented path for adding a category, per the commit's `Directive`
  trailer.
- Not tested: no live Hermes chat session or executor dispatch exercised
  this change; verified entirely through the unit/integration suite and
  direct Python smoke calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1Tue9T3YhWLT5mT8bo9Ke
