### PR TITLE
fix(tests): deflake spawn-stagger test with an injected clock

### DIFF
--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -284,24 +284,36 @@ class _SpawnStagger:
     provider prompt cache the siblings read; parallel identical requests
     would each pay a full cache write."""
 
-    def __init__(self, interval: float) -> None:
+    def __init__(
+        self,
+        interval: float,
+        *,
+        # The clock and sleep are injected, same seam as the retry policy's
+        # `sleep` parameter below, so the reservation schedule this class
+        # computes is assertable without a real clock and without a single
+        # wall-clock sleep in a test.
+        monotonic: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
         self._interval = max(0.0, interval)
         self._lock = threading.Lock()
         self._next = 0.0
+        self._monotonic = monotonic
+        self._sleep = sleep
 
     def reserve(self) -> None:
         with self._lock:
-            now = time.monotonic()
+            now = self._monotonic()
             slot = max(now, self._next)
             self._next = slot + self._interval
         # time.sleep can wake up to a timer tick early on Windows waitable
         # timers, which would collapse the spacing; loop until the slot is
         # actually reached on the monotonic clock.
         while True:
-            now = time.monotonic()
+            now = self._monotonic()
             if now >= slot:
                 return
-            time.sleep(slot - now)
+            self._sleep(slot - now)
 
 
 # Lineage stamp carried into every child environment this module spawns.

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -3139,18 +3139,38 @@ class SpawnStaggerTests(unittest.TestCase):
     staggered while injected test runners stay untouched."""
 
     def test_reserve_spaces_consecutive_slots(self) -> None:
-        import time as _time
-
+        # A real wall-clock sleep here is inherently racy under CPU
+        # contention: the assertion has been observed failing on loaded
+        # machines when the scheduler delivers a slightly-short gap. Inject
+        # a fake clock/sleep instead — same seam as the retry policy's
+        # `sleep` parameter elsewhere in this module — and assert on the
+        # reservation schedule the code actually computed, which is
+        # deterministic regardless of real scheduling.
         from omh.coding.fanout_dispatch import _SpawnStagger
 
-        stagger = _SpawnStagger(0.05)
+        class _FakeClock:
+            def __init__(self) -> None:
+                self.now = 0.0
+                self.slept: list[float] = []
+
+            def monotonic(self) -> float:
+                return self.now
+
+            def sleep(self, seconds: float) -> None:
+                self.slept.append(seconds)
+                self.now += seconds
+
+        clock = _FakeClock()
+        stagger = _SpawnStagger(0.05, monotonic=clock.monotonic, sleep=clock.sleep)
         starts: list[float] = []
         for _ in range(3):
             stagger.reserve()
-            starts.append(_time.monotonic())
-        # Scheduler slack tolerance downward: sleeps may wake a hair early.
+            starts.append(clock.now)
         self.assertGreaterEqual(starts[1] - starts[0], 0.045)
         self.assertGreaterEqual(starts[2] - starts[1], 0.045)
+        # The fake sleep advances the clock by exactly the requested delay,
+        # so the reserved slots land exactly one interval apart.
+        self.assertEqual(clock.slept, [0.05, 0.05])
 
     def test_injected_runner_without_marker_never_staggers(self) -> None:
         import time as _time


### PR DESCRIPTION
## Feature Report

### What Changed

- Gave `_SpawnStagger` (in `src/coding/fanout_dispatch.py`) an injectable
  `monotonic`/`sleep` clock seam, defaulting to the real `time.monotonic`
  and `time.sleep` — same injection pattern `dispatch_fanout`'s retry
  policy already uses for its `sleep: Callable[[float], None] = time.sleep`
  parameter.
- Rewrote `SpawnStaggerTests.test_reserve_spaces_consecutive_slots` in
  `tests/test_fanout_dispatch.py` to inject a fake clock/sleep and assert on
  the reservation schedule `reserve()` computed, instead of measuring real
  wall-clock elapsed time between calls.

### Why This Exists

- `test_reserve_spaces_consecutive_slots` asserted a wall-clock spawn gap
  `>= 0.045s` against a 0.05s stagger interval. Under CPU contention
  (parallel test suites on one loaded machine) the OS scheduler occasionally
  delivered a 0.041–0.043s gap and the assertion failed, even though
  `_SpawnStagger` had correctly scheduled the next slot exactly one interval
  later. The flake was in *observing* the schedule through real wall-clock
  time under scheduler jitter, not in the schedule itself. Observed failing
  twice on loaded machines during unrelated PRs, passing in isolation every
  time.

### User / Operator Impact

- None. `_SpawnStagger` is an internal primitive of the `omh coding fanout
  dispatch` real-spawn cache-warm path; its default behavior (real
  `time.monotonic`/`time.sleep`) is unchanged, and no call site passes the
  new keyword-only parameters. This is a test-reliability fix only.

### How It Works

- `_SpawnStagger.__init__` now accepts keyword-only `monotonic: Callable[[],
  float] = time.monotonic` and `sleep: Callable[[float], None] = time.sleep`,
  stored as `self._monotonic`/`self._sleep` and used inside `reserve()` in
  place of the module-level `time.monotonic()`/`time.sleep()` calls. Slot
  arithmetic and the Windows-early-wake retry loop are byte-for-byte
  unchanged — only the two clock reads are now indirected through the
  seam.
- The test constructs a small in-test `_FakeClock` (a `monotonic()` reader
  and a `sleep(seconds)` that advances `now` by exactly `seconds`), injects
  it into `_SpawnStagger(0.05, monotonic=clock.monotonic, sleep=clock.sleep)`,
  and asserts the resulting slot gaps and the exact sequence of requested
  sleep durations. Because the fake clock only advances when `reserve()`
  asks it to sleep, the assertions are deterministic under any real
  scheduling pressure.

### Files And Contracts Touched

- `src/coding/fanout_dispatch.py`: `_SpawnStagger.__init__`/`reserve` — new
  keyword-only `monotonic`/`sleep` params, both defaulted to the real clock;
  no behavior change for existing callers (`dispatch_fanout` constructs
  `_SpawnStagger(CACHE_WARM_SPAWN_STAGGER_SECONDS)` unchanged).
- `tests/test_fanout_dispatch.py`: `SpawnStaggerTests.test_reserve_spaces_consecutive_slots`
  rewritten to use the injected fake clock. The other two `SpawnStaggerTests`
  methods (`test_injected_runner_without_marker_never_staggers`,
  `test_marked_runner_spawns_are_spaced`) are untouched.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

Check only commands that completed successfully. Leave non-applicable checks
unchecked and explain why under **Not Tested / Not Applicable**.

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [ ] `uv run python -m omh.cli docs roles --check`
- [ ] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- `uv run python -m compileall -q src tests` — clean (one pre-existing,
  unrelated `SyntaxWarning` in `tests/test_menubar_app.py`).
- `uv run --group lint ruff check src tests` — `All checks passed!`.
- `git diff --check` — clean, exit 0.
- `uv run python -m omh.cli docs workflows --check` — `"ok":true`, no drift,
  `tap_skills` 154/154, no missing/stale/extra.
- `PYTHONPATH=tests uv run python -m unittest tests.test_fanout_dispatch.SpawnStaggerTests -v`
  — 10/10 runs green (at rest).
- `PYTHONPATH=tests uv run python -m unittest tests.test_fanout_dispatch -v`
  — 10/10 runs green, run concurrently with an artificial all-core CPU-burn
  load (`multiprocessing.cpu_count()` busy-loop processes for 25s), 0
  failures — reproduces and clears the loaded-machine condition the flake
  report described.
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 8017
  tests, green except 21 failures / 7 errors, all in
  `test_cross_harness_adapters` / `test_cross_harness_adapter_security`
  (the known 28 cross-harness `.claude`-path failures pre-existing in this
  sandboxed worktree checkout, unrelated to this change).

### Not Tested / Not Applicable

- `docs roles --check`, `docs capability-families --check`, `harness
  validate`, `release checklist --json`, `release hermes-smoke`, `omh
  --help`, and the `release hermes-smoke` install-path smoke were not run:
  this change touches only `_SpawnStagger`'s internal clock seam and its
  unit test, none of which are inputs to those generated-doc, harness, or
  release surfaces.
- No live multi-process fanout dispatch with real agent CLIs was exercised
  — out of scope for a test-determinism fix to the stagger primitive.

## Risk

- Low. The clock/sleep parameters are keyword-only and default to the real
  `time.monotonic`/`time.sleep`, so every existing call site
  (`dispatch_fanout`'s `_SpawnStagger(CACHE_WARM_SPAWN_STAGGER_SECONDS)`)
  is unaffected. Only the flaky test's own construction now supplies a fake
  clock. `_marked_runner_spawns_are_spaced` (which exercises the real
  wall-clock stagger through `dispatch_fanout`) is untouched and still
  passed in the full suite run.

## Compatibility / Rollout

- No compatibility impact; internal test-only change plus a backward-
  compatible constructor default on a private (`_SpawnStagger`) class.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`) —
      none; no release-channel-visible behavior changed.
- [x] Runtime/native capability claims are backed by evidence or marked as
      not observed
- [ ] Prepared handoffs or plans are labeled `prepared_not_observed`, never
      as execution, review, CI, or merge evidence — not applicable, no
      handoffs in this change
- [x] Evidence contains no credentials, raw prompts, raw platform events,
      transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release
      hermes-smoke --live` gap — none required for this change

## Follow-Up

- None.
