### PR TITLE
fix(routing): normalize Hangul trigger-token hold-backs before subtraction

### DIFF
--- a/src/routing/recommend.py
+++ b/src/routing/recommend.py
@@ -1784,13 +1784,13 @@ _WHOLE_PHRASE_ONLY_TRIGGER_TOKENS = {
     # inside a complete trigger phrase, which the phrase match and the
     # `direct:llm_app_dev` boost cover.
     #
-    # English only, deliberately. `routing_tokens` decomposes Hangul, so a
-    # Korean entry written here in composed form never matches the decomposed
-    # token and is a silent no-op -- the same already-shipped shape as
-    # `adversarial-consensus`'s Korean entries. The Korean triggers do not need
-    # the hold-back: measured on "앱 개발 시작하자", "기능 개발 계획 세워줘",
-    # "버전 관리 어떻게 해?", "출력 형식 바꿔줘", and "프롬프트 좀 고쳐줘", their
-    # token credit tops out at 6, which stays in clarify and never dispatches.
+    # English only -- not because a composed Korean entry here would be a
+    # no-op (entries are normalized through `routing_tokens` before use, same
+    # as `adversarial-consensus`'s Korean entries below), but because the
+    # Korean triggers do not need the hold-back at all: measured on "앱 개발
+    # 시작하자", "기능 개발 계획 세워줘", "버전 관리 어떻게 해?", "출력 형식
+    # 바꿔줘", and "프롬프트 좀 고쳐줘", their token credit tops out at 6, which
+    # stays in clarify and never dispatches.
     "llm-app-dev": frozenset(
         {
             "app",
@@ -1819,6 +1819,32 @@ _WHOLE_PHRASE_ONLY_TRIGGER_TOKENS = {
 }
 
 
+def _normalized_trigger_token_holdback(entries: frozenset[str]) -> frozenset[str]:
+    # `trigger_tokens` below is built from `_tokens(...)`, which folds every
+    # token through `routing_tokens` -- NFKD normalization that decomposes
+    # precomposed Hangul syllables into their component jamo. Subtracting the
+    # *raw* `_WHOLE_PHRASE_ONLY_TRIGGER_TOKENS` entries would compare an
+    # as-written composed Korean word against decomposed tokens it can never
+    # equal, so the hold-back would silently remove nothing for Korean
+    # entries (see `tests/test_trigger_holdback_reachability.py`). Running
+    # each entry through the same `_tokens` pipeline before subtracting keeps
+    # this a set difference over a shared representation, so authors can
+    # write entries -- Korean or English -- in ordinary composed form.
+    # `_tokens` itself is defined later in this module (it is only a thin
+    # `routing_tokens(value, stopwords=_STOPWORDS)` wrapper), and this table
+    # is built at import time, so call `routing_tokens` directly here rather
+    # than forward-reference `_tokens`.
+    normalized: set[str] = set()
+    for entry in entries:
+        normalized.update(routing_tokens(entry, stopwords=_STOPWORDS))
+    return frozenset(normalized)
+
+
+_NORMALIZED_WHOLE_PHRASE_ONLY_TRIGGER_TOKENS = {
+    name: _normalized_trigger_token_holdback(entries) for name, entries in _WHOLE_PHRASE_ONLY_TRIGGER_TOKENS.items()
+}
+
+
 def _prepare_definition(definition: SkillDefinition) -> _PreparedDefinition:
     trigger_phrases = tuple(normalized_phrase(trigger) for trigger in definition.triggers)
     metadata_tokens = frozenset(
@@ -1831,7 +1857,7 @@ def _prepare_definition(definition: SkillDefinition) -> _PreparedDefinition:
         command_trigger_phrases=tuple(trigger for trigger in trigger_phrases if trigger in _COMMAND_TRIGGER_PHRASES),
         plain_trigger_phrases=tuple(trigger for trigger in trigger_phrases if trigger and trigger not in _COMMAND_TRIGGER_PHRASES),
         trigger_tokens=frozenset(_tokens(" ".join(definition.triggers)))
-        - _WHOLE_PHRASE_ONLY_TRIGGER_TOKENS.get(definition.name, frozenset()),
+        - _NORMALIZED_WHOLE_PHRASE_ONLY_TRIGGER_TOKENS.get(definition.name, frozenset()),
         name_phrase=normalized_phrase(definition.name),
         description_phrase=normalized_phrase(definition.description),
         use_when_phrase=normalized_phrase(definition.use_when),

--- a/tests/test_trigger_holdback_reachability.py
+++ b/tests/test_trigger_holdback_reachability.py
@@ -1,0 +1,56 @@
+"""Reachability gate for `_WHOLE_PHRASE_ONLY_TRIGGER_TOKENS`.
+
+`_WHOLE_PHRASE_ONLY_TRIGGER_TOKENS` holds back specific words from a skill's
+scored trigger-token pool because, split from their trigger phrase, they are
+too generic to credit on their own (see the comments beside the dict in
+`src/routing/recommend.py`). The hold-back is a set difference applied at
+definition-prepare time: `_tokens(triggers) - holdback_entries`.
+
+`routing_tokens` (imported as `_tokens` in that module) folds every token
+through NFKD normalization, which decomposes precomposed Hangul syllables into
+their component jamo. A holdback entry written in ordinary composed Korean
+(e.g. `"검토"`, codepoint U+AC80) is therefore a different string from the
+decomposed token `_tokens` actually produces for that same word, so the set
+subtraction silently removes nothing — the entry still gets scored even though
+the comment says it is held back. `adversarial-consensus` shipped five such
+dead rows (검토, 계획, 관점에서, 여러, 찾아).
+
+This test proves the hold-back is real: none of the words an entry names may
+still surface in the skill's actual scored `trigger_tokens`.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from omh.routing.recommend import (
+    _WHOLE_PHRASE_ONLY_TRIGGER_TOKENS,
+    _prepared_routable_definitions,
+    _tokens,
+)
+
+
+class WholePhraseOnlyTriggerHoldbackReachabilityTests(unittest.TestCase):
+    def test_every_holdback_entry_is_actually_absent_from_scored_trigger_tokens(self) -> None:
+        prepared_by_name = {prepared.definition.name: prepared for prepared in _prepared_routable_definitions()}
+
+        leaked: list[str] = []
+        for skill, entries in _WHOLE_PHRASE_ONLY_TRIGGER_TOKENS.items():
+            prepared = prepared_by_name[skill]
+            for entry in entries:
+                still_scored = _tokens(entry) & prepared.trigger_tokens
+                if still_scored:
+                    leaked.append(f"{skill}: {entry!r} still scored as {sorted(still_scored)}")
+
+        self.assertEqual(
+            leaked,
+            [],
+            "Dead _WHOLE_PHRASE_ONLY_TRIGGER_TOKENS entries in src/routing/recommend.py -- "
+            "these words are documented as held back but are still scored on their own "
+            "because the hold-back set subtraction never removed them (composed vs. "
+            "NFKD-decomposed Hangul is the usual cause): " + "; ".join(leaked),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- Fixed the mechanism behind `_WHOLE_PHRASE_ONLY_TRIGGER_TOKENS` in `src/routing/recommend.py`: hold-back entries are now run through the same `routing_tokens` NFKD-normalization pipeline used to build a skill's scored `trigger_tokens` before the set subtraction that is supposed to remove them.
- Corrected the now-stale `llm-app-dev` comment that cited the decomposition bug as a live reason to keep that hold-back table English-only.
- Added `tests/test_trigger_holdback_reachability.py`, a permanent contract test that fails with a paste-ready per-entry list whenever a hold-back entry is still scored on its own.

### Why This Exists

`routing_tokens` folds every token through NFKD normalization, which decomposes precomposed Hangul syllables (e.g. `검토`, U+AC80) into their component conjoining jamo. `_WHOLE_PHRASE_ONLY_TRIGGER_TOKENS` entries were written as ordinary composed Korean literals and subtracted directly against the decomposed `trigger_tokens` set, so `entry in decomposed_set` was always `False` for Korean entries — the subtraction silently removed nothing. The already-shipped `adversarial-consensus` entry shipped five such dead rows (`검토`, `계획`, `관점에서`, `여러`, `찾아`): the comments say these words are held back to a whole-phrase-only credit, but they were still individually creditable, discovered during #1182 development.

### User / Operator Impact

Before this fix, a message containing only the held-back bare words (e.g. "여러 관점에서 봐줘") scored `adversarial-consensus` a nonzero 6 via `trigger:관점에서`/`trigger:여러` even with no other adversarial-consensus vocabulary present. After the fix, that same message no longer surfaces `adversarial-consensus` in the candidate list at all, while the full documented trigger phrases ("여러 관점에서 검토", "적대적 검토", "허점 찾아", etc.) continue to route to `adversarial-consensus` at high confidence exactly as before.

### How It Works

- New `_normalized_trigger_token_holdback()` runs each raw entry through `routing_tokens(entry, stopwords=_STOPWORDS)` (the same fold used to build a skill's `trigger_tokens`) and flattens the results.
- New module-level `_NORMALIZED_WHOLE_PHRASE_ONLY_TRIGGER_TOKENS` precomputes this once per skill from the existing `_WHOLE_PHRASE_ONLY_TRIGGER_TOKENS` table at import time.
- `_prepare_definition()`'s trigger-token subtraction now uses the normalized dict instead of the raw literal one.
- Mechanism fix chosen over hand-correcting the five dead rows to their decomposed literal forms: it keeps the source table readable (authors write ordinary composed Korean or English) and self-heals any future entry instead of requiring contributors to know they must paste in jamo-decomposed strings. See the commit's `Rejected:` trailer for the alternative considered.

### Files And Contracts Touched

- `src/routing/recommend.py` — `_WHOLE_PHRASE_ONLY_TRIGGER_TOKENS` consumption site in `_prepare_definition`; no trigger data changed.
- `tests/test_trigger_holdback_reachability.py` — new permanent contract test.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

Check only commands that completed successfully. Leave non-applicable checks
unchecked and explain why under **Not Tested / Not Applicable**.

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [x] Manual Hermes/TUI check, or explicit reason it was not run: live `omh chat route` probes below stand in for the manual Hermes/TUI check for this routing-only change.

### Observed Evidence

- Targeted tests, commands, CI checks, and manual behavior actually observed:
- `PYTHONPATH=tests uv run python -m unittest tests/test_trigger_holdback_reachability.py -v` — new contract test: fails pre-fix listing the five `adversarial-consensus` dead rows, passes post-fix.
- `PYTHONPATH=tests uv run python -m unittest tests/test_routing_precision.py tests/test_routing_scoring.py tests/test_routing_language_policy.py tests/test_cli.py tests/test_hermes_ux_quality.py tests/test_release_smoke.py -v` — 396 tests, all pass; `ROUTING_PRECISION_CASES`/`ROUTING_INTERVENTION_CASES` exact-count corpora unchanged.
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 8018 tests; 28 failures/errors, all in `test_cross_harness_adapter_security.py`/`test_cross_harness_adapters.py`, the pre-existing cross-harness `.claude`-path failures allowed by this task; none in routing. `test_reserve_spaces_consecutive_slots` did not appear as a failure this run.
- `uv run python -m compileall -q src tests` — clean.
- `uv run python -m omh.cli docs workflows --check`, `docs roles --check`, `docs capability-families --check`, `docs ulw-inventory --check`, `docs ulw-site --check` — all five byte-exact gates `"ok": true`.
- `uv run --group lint ruff check src tests` — `All checks passed!`.
- `git diff --check` — clean, no whitespace errors.
- Live `omh chat route` probes (git-stashed the fix to compare pre/post):
  - `"여러 관점에서 봐줘"` (bare held-back words only, no other adversarial-consensus vocabulary): pre-fix `adversarial-consensus` score 6 (`trigger:관점에서`, `trigger:여러`); post-fix `adversarial-consensus` absent from candidates entirely.
  - `"여러 관점에서 검토"` (the documented full trigger phrase): routes to `adversarial-consensus` at `high` confidence both before and after — unchanged.
  - `"이거 검토해줘"` / `"계획 세워줘"` (unrelated ordinary requests): stay low-confidence/clarify, do not surface `adversarial-consensus` — unchanged.

### Not Tested / Not Applicable

- Skipped checks and the concrete reason each one does not apply:
- `harness validate`, `release checklist --json`, `release hermes-smoke`, `omh --help`, and the full install/hermes-smoke command are unrelated to this routing-scoring-only change and were not run.
- No live probe of the `llm-app-dev` hold-back table's Korean-language reasoning specifically — that table carries no Korean entries either before or after this change, so its behavior is unchanged by construction; only its explanatory comment was corrected.

## Risk

- Narrow: the change touches one private module-level mapping and its single consumption site in `_prepare_definition`. It can only ever *remove* fewer tokens than before for skills that already had Korean entries in `_WHOLE_PHRASE_ONLY_TRIGGER_TOKENS` (currently only `adversarial-consensus`), and does not add, remove, or reorder any trigger phrase.

## Compatibility / Rollout

- No schema, CLI, or generated-artifact changes. No migration needed.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`) — none; internal routing-scorer fix only.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap — none needed for this change; live `omh chat route` probes cover the behavioral claim.

## Follow-Up

- None identified. The new `tests/test_trigger_holdback_reachability.py` gate will catch any future dead entry across every skill that uses `_WHOLE_PHRASE_ONLY_TRIGGER_TOKENS`, not just `adversarial-consensus`.
