### PR TITLE
feat(benchmark): ternary live verdicts and baseline comparison

### DIFF
--- a/benchmarks/cross-harness/live/README.md
+++ b/benchmarks/cross-harness/live/README.md
@@ -7,9 +7,9 @@ and then submits only what it observed. It emits two artifacts:
 
 1. an ordinary `cross_harness_benchmark_cli_input/v1` envelope, scored by the
    same production parser, evaluator, and scorer as any mailed-in file; and
-2. a `cross_harness_live_receipt/v1` receipt binding that envelope's digest to
-   the observations behind it, an authenticity tier, and the run's efficiency
-   facts.
+2. a `cross_harness_live_receipt/v2` receipt binding that envelope's digest to
+   the observations behind it, an authenticity tier, the run's efficiency facts,
+   a ternary per-unit verdict, and an optional baseline comparison.
 
 `cross_harness_benchmark/v1` is untouched. The corpus, the submission schema,
 the scoring semantics, and both production trust anchors are unchanged; this
@@ -67,6 +67,68 @@ Ordered weakest to strongest:
 report a stronger tier only for results it executed, and the receipt validator
 rejects a tier that outruns its own coverage lists.
 
+## Verdicts are ternary
+
+Every one of the fifteen corpus fixtures is a *unit* of the task set, and the
+receipt grades each one `PASS`, `FAIL`, or `INCONCLUSIVE`. The task set is the
+whole corpus, not the submitted subset, so two runs of different coverage still
+compare unit for unit.
+
+`INCONCLUSIVE` is a statement about the controller, never about the harness: it
+means this controller could not grade the unit at all. A unit that ran and
+produced a wrong observed result is `FAIL`. The reason codes are:
+
+| Reason | Raised when |
+| --- | --- |
+| `no_controller_observation` | nothing was executed for this unit (fake, carried, or unsupported) |
+| `execution_launch_failed` | the process could not be started |
+| `timed_out_before_output` | the timeout elapsed before any gradeable output |
+| `artifact_unreadable` | the observation artifact was missing or would not parse |
+| `telemetry_channel_absent` | the graded channel reported nothing |
+
+`verdict_summary` counts all three verdicts, and `graded_total` is
+`pass_count + fail_count` only. `pass_rate` divides by `graded_total`, so an
+ungraded unit never counts as a failure and never dilutes a rate. The receipt
+says this in the artifact rather than leaving it to a reader:
+`pass_rate_denominator: "graded_units_only"` and
+`inconclusive_excluded_from_pass_rate: true`. When nothing was graded,
+`pass_rate` is `null` — never `0`.
+
+When a unit binds several observations, an observed failure outranks an
+ungradeable sibling: positive evidence of a wrong result is a `FAIL` even when
+another channel of the same unit went dark.
+
+## Baselines
+
+`--baseline RECEIPT` compares this run against a prior receipt and writes a
+`cross_harness_live_baseline_comparison/v1` block into the emitted receipt. Both
+receipts must be `cross_harness_live_receipt/v2`, carry the same
+`corpus_digest`, and cover the same task set; anything else is a hard refusal
+with a reason code, never a silent intersection over whichever units happened to
+appear in both.
+
+Per-unit labels are verdict transitions:
+
+| Baseline → current | Label |
+| --- | --- |
+| same verdict | `STABLE` |
+| `FAIL` → `PASS` | `IMPROVED` |
+| `PASS` → `FAIL` | `REGRESSED` |
+| either side `INCONCLUSIVE` | `not_comparable` |
+
+An ungraded side is never a direction. `INCONCLUSIVE` is not ranked between
+`FAIL` and `PASS`, because losing the ability to grade a unit is neither a win
+nor a loss — it is missing information, and labelling it `not_comparable` says
+so. The aggregate `summary.label` is worst-direction-wins: any regression makes
+the run `REGRESSED`, otherwise any improvement makes it `IMPROVED`.
+
+`efficiency_delta` subtracts `tokens` and `cost_usd` only where **both** sides
+observed the figure; otherwise `delta` stays `null` and the field is labelled
+`not_comparable`. A delta is never estimated from one side, and the receipt
+validator rejects one that is. Deltas are aggregate-only: a single observation
+feeds several units, so a per-unit split would count the same tokens more than
+once.
+
 ## Efficiency is not quality
 
 The receipt's `efficiency` block reports `duration_ms`, `tokens`, and `cost_usd`
@@ -91,6 +153,15 @@ PYTHONPATH=. python3 benchmarks/cross-harness/live/bench.py run \
   --receipt-output artifacts/live-receipt.json
 
 python3 -m omh.cli benchmark report --input artifacts/live-envelope.json
+```
+
+Compare a run against a retained earlier receipt:
+
+```sh
+PYTHONPATH=. python3 benchmarks/cross-harness/live/bench.py run \
+  --mode probe \
+  --baseline artifacts/live-receipt.json \
+  --receipt-output artifacts/live-receipt-next.json
 ```
 
 Live dispatch, explicit on every axis:
@@ -120,3 +191,9 @@ Controller observation covers only the fixtures listed in
 and a `mixed_controller_and_submitted` receipt does not make its carried results
 observed. Report the level and coverage with the receipt's tier beside the
 score's `evidence_authenticity` and `execution_verified`; never merge them.
+
+A verdict is likewise bounded: `PASS` covers exactly the unit the controller
+observed, and an `INCONCLUSIVE` unit is ungraded, not passing and not failing. A
+baseline comparison reports transitions between two receipts and re-grades
+nothing; `IMPROVED` means one unit's verdict moved, not that the harness got
+better in general.

--- a/benchmarks/cross-harness/live/bench.py
+++ b/benchmarks/cross-harness/live/bench.py
@@ -49,6 +49,14 @@ def build_parser() -> argparse.ArgumentParser:
         type=Path,
         help="Existing cross_harness_benchmark_cli_input/v1 envelope supplying unobserved fixture results.",
     )
+    run_parser.add_argument(
+        "--baseline",
+        type=Path,
+        help=(
+            "Prior cross_harness_live_receipt/v2 receipt of the same task set; the "
+            "emitted receipt then carries the verdict transitions against it."
+        ),
+    )
     run_parser.add_argument("--envelope-output", type=Path)
     run_parser.add_argument("--receipt-output", type=Path)
     run_parser.add_argument("--omh-executable", default="omh")
@@ -74,6 +82,7 @@ def main(argv: list[str] | None = None) -> int:
                 mode=args.mode,
                 repository_root=args.repository_root,
                 base_path=args.base,
+                baseline_path=args.baseline,
                 omh_executable=args.omh_executable,
                 hermes_executable=args.hermes_executable,
                 model=args.model,

--- a/benchmarks/cross-harness/live/lib/controller.py
+++ b/benchmarks/cross-harness/live/lib/controller.py
@@ -44,13 +44,21 @@ from omh.quality.cross_harness_benchmark_values import JsonValue, corpus_digest
 
 from receipt import (
     CLAIM_BOUNDARY,
+    COMPARISON_LABELS,
+    COMPARISON_SCHEMA,
     DOCTOR_SCHEMA,
+    INCONCLUSIVE_REASONS,
     RECEIPT_SCHEMA,
     RUN_SCHEMA,
+    VERDICTS,
+    BaselineComparisonError,
     aggregate_efficiency,
     authenticity_tier,
+    compare_to_baseline,
     envelope_digest,
+    unit_verdicts,
     validate_receipt,
+    verdict_summary,
 )
 
 
@@ -130,7 +138,11 @@ def doctor(corpus_path: Path) -> dict[str, JsonValue]:
         "dispatch_boundary": "omh coding hermes-child dispatch --confirm-dispatch",
         "observation_schema": "routing_observation/v1",
         "receipt_schema": RECEIPT_SCHEMA,
+        "comparison_schema": COMPARISON_SCHEMA,
         "envelope_schema": INPUT_SCHEMA,
+        "verdict_values": list(VERDICTS),
+        "inconclusive_reason_codes": list(INCONCLUSIVE_REASONS),
+        "comparison_labels": list(COMPARISON_LABELS),
         "v1_corpus_mutated": False,
         "claim_boundary": CLAIM_BOUNDARY,
     }
@@ -175,12 +187,29 @@ def load_base_results(path: Path, corpus: Corpus) -> dict[str, JsonValue]:
     return carried
 
 
+def load_baseline_receipt(path: Path) -> dict[str, JsonValue]:
+    """Read a prior receipt to compare against; refuse anything not valid."""
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as error:
+        raise ControllerError("baseline_unavailable") from error
+    except json.JSONDecodeError as error:
+        raise ControllerError("baseline_invalid_json") from error
+    if not isinstance(raw, dict):
+        raise ControllerError("baseline_must_be_object")
+    reasons = validate_receipt(raw)
+    if reasons:
+        raise ControllerError("baseline_receipt_invalid:" + ",".join(reasons))
+    return raw
+
+
 def run(
     *,
     corpus_path: Path,
     mode: str = "fake",
     repository_root: Path,
     base_path: Path | None = None,
+    baseline_path: Path | None = None,
     omh_executable: str = "omh",
     hermes_executable: str = "hermes",
     model: str | None = None,
@@ -209,6 +238,7 @@ def run(
     corpus, corpus_raw = load_corpus(corpus_path)
     command = _single_command(corpus)
     carried = load_base_results(base_path, corpus) if base_path is not None else {}
+    baseline = load_baseline_receipt(baseline_path) if baseline_path is not None else None
     observations: list[Observation] = []
 
     if mode != "fake":
@@ -252,6 +282,11 @@ def run(
         observations=observations,
         bindings=bindings,
     )
+    if baseline is not None:
+        try:
+            receipt["baseline_comparison"] = compare_to_baseline(receipt, baseline)
+        except BaselineComparisonError as error:
+            raise ControllerError(str(error)) from error
     reasons = validate_receipt(receipt)
     if reasons:
         raise ControllerError("invalid_receipt:" + ",".join(reasons))
@@ -637,6 +672,7 @@ def _receipt(
     submitted = {str(item["fixture_id"]) for item in bindings}
     unsupported = [item.id for item in corpus.fixtures if item.id not in submitted]
     payloads = [item.payload() for item in observations]
+    verdicts = unit_verdicts([item.id for item in corpus.fixtures], bindings, payloads)
     return {
         "schema_version": RECEIPT_SCHEMA,
         "mode": mode,
@@ -653,6 +689,9 @@ def _receipt(
         "fixture_bindings": [dict(item) for item in bindings],
         "observations": payloads,
         "efficiency": aggregate_efficiency(payloads),
+        "verdicts": verdicts,
+        "verdict_summary": verdict_summary(verdicts),
+        "baseline_comparison": None,
         "claim_boundary": CLAIM_BOUNDARY,
     }
 

--- a/benchmarks/cross-harness/live/lib/receipt.py
+++ b/benchmarks/cross-harness/live/lib/receipt.py
@@ -1,24 +1,42 @@
-"""`cross_harness_live_receipt/v1`: controller provenance for the live lane.
+"""`cross_harness_live_receipt/v2`: controller provenance for the live lane.
 
 The receipt is a separate artifact from the `cross_harness_benchmark_cli_input/v1`
 envelope the controller emits. `cross_harness_benchmark/v1` fixtures, schemas,
 scoring semantics, and trust anchors stay untouched: the receipt adds no field to
-the v1 submission and changes no v1 outcome. It records two things v1 cannot
+the v1 submission and changes no v1 outcome. It records four things v1 cannot
 express, alongside the digest of the exact envelope it describes:
 
 * which submitted fixture results this controller observed itself, and which were
   carried from an outside submission, as an ordered authenticity tier;
 * the efficiency facts of the run (duration, tokens, cost), kept strictly outside
-  the quality score.
+  the quality score;
+* a ternary per-unit verdict (`PASS` / `FAIL` / `INCONCLUSIVE`) plus the
+  aggregate that excludes `INCONCLUSIVE` units from the pass-rate denominator;
+* an optional `cross_harness_live_baseline_comparison/v1` block naming the
+  verdict transitions against a prior receipt of the same task set.
 
 Efficiency never earns points, never changes a level, and never turns a
 `partial` into a `pass`. A fast run and a cheap run are separate facts from a
 correct run.
+
+`INCONCLUSIVE` is a statement about the controller, never about the harness: it
+means this controller could not grade the unit at all (nothing was executed for
+it, the launch failed, the timeout elapsed before any output, the observation
+artifact was unreadable, or the graded telemetry channel reported nothing). A
+unit that ran and produced a wrong observed result is `FAIL`, never
+`INCONCLUSIVE`. Because an ungraded unit is not a passing unit and not a failing
+one either, it is counted separately and left out of the pass-rate denominator,
+which the summary states in the artifact rather than leaving to a reader.
+
+Schema history: `v1` (PR #1173) carried the coverage lists, observations, and
+efficiency block. `v2` adds `verdicts`, `verdict_summary`, and
+`baseline_comparison`. Only `v2` is emitted and only `v2` validates, so a `v1`
+receipt handed in as a baseline is refused rather than silently half-compared.
 """
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Final
 
 from omh.quality.cross_harness_benchmark_values import (
@@ -29,7 +47,8 @@ from omh.quality.cross_harness_benchmark_values import (
 )
 
 
-RECEIPT_SCHEMA: Final = "cross_harness_live_receipt/v1"
+RECEIPT_SCHEMA: Final = "cross_harness_live_receipt/v2"
+COMPARISON_SCHEMA: Final = "cross_harness_live_baseline_comparison/v1"
 RUN_SCHEMA: Final = "cross_harness_live_run/v1"
 DOCTOR_SCHEMA: Final = "cross_harness_live_doctor/v1"
 
@@ -54,11 +73,31 @@ FAILURE_CODES: Final = (
     "observation_unavailable",
     "observation_invalid",
 )
+#: Ternary per-unit outcome. `INCONCLUSIVE` marks controller-side inability to
+#: grade, never a graded-but-failing unit.
+VERDICTS: Final = ("PASS", "FAIL", "INCONCLUSIVE")
+#: Why the controller could not grade a unit. One of these is required on every
+#: `INCONCLUSIVE` verdict and forbidden on every graded one.
+INCONCLUSIVE_REASONS: Final = (
+    "no_controller_observation",
+    "execution_launch_failed",
+    "timed_out_before_output",
+    "artifact_unreadable",
+    "telemetry_channel_absent",
+)
+#: Baseline transition labels. `not_comparable` is the honest label whenever one
+#: side of a comparison is not a graded value; it is never folded into `STABLE`.
+COMPARISON_LABELS: Final = ("IMPROVED", "REGRESSED", "STABLE", "not_comparable")
+DELTA_LABELS: Final = ("comparable", "not_comparable")
+#: Named in the artifact so a reader never has to infer which units were counted.
+PASS_RATE_DENOMINATOR: Final = "graded_units_only"
 CLAIM_BOUNDARY: Final = (
     "Controller observation covers only the listed controller_observed fixtures "
     "and is not general live executor quality proof. Carried results stay "
     "unverified submissions. Efficiency facts are reported outside the quality "
-    "score and never earn points."
+    "score and never earn points. INCONCLUSIVE units are ungraded, not failing, "
+    "and are excluded from the pass-rate denominator. A baseline comparison "
+    "reports verdict transitions between two receipts and re-grades nothing."
 )
 
 _RECEIPT_FIELDS: Final = frozenset(
@@ -76,10 +115,52 @@ _RECEIPT_FIELDS: Final = frozenset(
         "fixture_bindings",
         "observations",
         "efficiency",
+        "verdicts",
+        "verdict_summary",
+        "baseline_comparison",
         "claim_boundary",
     }
 )
 _BINDING_FIELDS: Final = frozenset({"fixture_id", "provenance", "observation_ids"})
+_VERDICT_FIELDS: Final = frozenset({"fixture_id", "verdict", "reason_code"})
+_VERDICT_SUMMARY_FIELDS: Final = frozenset(
+    {
+        "units_total",
+        "pass_count",
+        "fail_count",
+        "inconclusive_count",
+        "graded_total",
+        "pass_rate",
+        "pass_rate_denominator",
+        "inconclusive_excluded_from_pass_rate",
+    }
+)
+_COMPARISON_FIELDS: Final = frozenset(
+    {
+        "schema_version",
+        "baseline_mode",
+        "baseline_corpus_digest",
+        "baseline_envelope_digest",
+        "units",
+        "summary",
+        "efficiency_delta",
+    }
+)
+_COMPARISON_UNIT_FIELDS: Final = frozenset(
+    {"fixture_id", "baseline_verdict", "current_verdict", "label"}
+)
+_COMPARISON_SUMMARY_FIELDS: Final = frozenset(
+    {
+        "label",
+        "improved_count",
+        "regressed_count",
+        "stable_count",
+        "not_comparable_count",
+        "baseline_pass_rate",
+        "current_pass_rate",
+    }
+)
+_DELTA_FIELDS: Final = frozenset({"baseline", "current", "delta", "label"})
 _OBSERVATION_FIELDS: Final = frozenset(
     {
         "observation_id",
@@ -152,6 +233,236 @@ def aggregate_efficiency(observations: list[Mapping[str, JsonValue]]) -> dict[st
     }
 
 
+class BaselineComparisonError(ValueError):
+    """A refusal to compare two receipts that do not describe the same run shape."""
+
+
+def observation_inconclusive_reason(observation: Mapping[str, JsonValue]) -> str | None:
+    """Return why this observation cannot be graded, or None when it can be.
+
+    A process that ran and exited wrong is gradeable and grades to `FAIL`; only
+    the controller's own inability to see a result lands here.
+    """
+    status = observation.get("status")
+    failure_code = observation.get("failure_code")
+    if status == "not_executed":
+        return "no_controller_observation"
+    if status == "timed_out":
+        return "timed_out_before_output"
+    if failure_code == "command_launch_failed":
+        return "execution_launch_failed"
+    if failure_code in {"observation_invalid", "observation_unavailable"}:
+        return "artifact_unreadable"
+    if status == "completed":
+        semantic = observation.get("observed_semantic_result")
+        if semantic is None:
+            return "telemetry_channel_absent"
+        if semantic == "unvalidated":
+            return "artifact_unreadable"
+    return None
+
+
+def unit_verdicts(
+    fixture_ids: Sequence[str],
+    bindings: Sequence[Mapping[str, JsonValue]],
+    observations: Sequence[Mapping[str, JsonValue]],
+) -> list[dict[str, JsonValue]]:
+    """Grade every unit of the task set from the observations bound to it.
+
+    The task set is the whole corpus, not the submitted subset, so two runs of
+    different coverage still compare unit for unit. Observed failure outranks an
+    ungradeable sibling observation: positive evidence of a wrong result is a
+    `FAIL` even when another channel of the same unit went dark.
+    """
+    by_id = {str(item["observation_id"]): item for item in observations}
+    bound = {
+        str(item["fixture_id"]): [str(value) for value in item["observation_ids"]]
+        for item in bindings
+        if isinstance(item.get("observation_ids"), list)
+    }
+    verdicts: list[dict[str, JsonValue]] = []
+    for fixture_id in fixture_ids:
+        blocked: list[str] = []
+        failed = False
+        identifiers = bound.get(fixture_id) or []
+        for observation_id in identifiers:
+            observation = by_id.get(observation_id)
+            if observation is None:
+                blocked.append("no_controller_observation")
+                continue
+            reason = observation_inconclusive_reason(observation)
+            if reason is not None:
+                blocked.append(reason)
+            elif observation.get("status") != "completed":
+                failed = True
+        if not identifiers:
+            verdict, reason_code = "INCONCLUSIVE", "no_controller_observation"
+        elif failed:
+            verdict, reason_code = "FAIL", None
+        elif blocked:
+            verdict, reason_code = "INCONCLUSIVE", blocked[0]
+        else:
+            verdict, reason_code = "PASS", None
+        verdicts.append(
+            {"fixture_id": fixture_id, "verdict": verdict, "reason_code": reason_code}
+        )
+    return verdicts
+
+
+def verdict_summary(verdicts: Sequence[Mapping[str, JsonValue]]) -> dict[str, JsonValue]:
+    """Count all three verdicts and rate only the graded ones."""
+    counts = {value: 0 for value in VERDICTS}
+    for item in verdicts:
+        verdict = item.get("verdict")
+        if isinstance(verdict, str) and verdict in counts:
+            counts[verdict] += 1
+    graded = counts["PASS"] + counts["FAIL"]
+    return {
+        "units_total": len(verdicts),
+        "pass_count": counts["PASS"],
+        "fail_count": counts["FAIL"],
+        "inconclusive_count": counts["INCONCLUSIVE"],
+        "graded_total": graded,
+        "pass_rate": round(counts["PASS"] / graded, 6) if graded else None,
+        "pass_rate_denominator": PASS_RATE_DENOMINATOR,
+        "inconclusive_excluded_from_pass_rate": True,
+    }
+
+
+def transition_label(baseline_verdict: str, current_verdict: str) -> str:
+    """Label one verdict transition; an ungraded side is never a direction."""
+    if baseline_verdict not in VERDICTS or current_verdict not in VERDICTS:
+        raise BaselineComparisonError("baseline_verdict_unknown")
+    if baseline_verdict == current_verdict:
+        return "STABLE"
+    if "INCONCLUSIVE" in (baseline_verdict, current_verdict):
+        return "not_comparable"
+    return "IMPROVED" if current_verdict == "PASS" else "REGRESSED"
+
+
+def compare_to_baseline(
+    current: Mapping[str, JsonValue], baseline: Mapping[str, JsonValue]
+) -> dict[str, JsonValue]:
+    """Compare two receipts of the same task set; refuse anything else.
+
+    Refusal is deliberate: silently intersecting two different task sets would
+    report a pass rate over units the reader never chose.
+    """
+    if baseline.get("schema_version") != RECEIPT_SCHEMA:
+        raise BaselineComparisonError("baseline_schema_unsupported")
+    if baseline.get("corpus_digest") != current.get("corpus_digest"):
+        raise BaselineComparisonError("baseline_corpus_mismatch")
+    current_verdicts = _verdict_map(current.get("verdicts"), "current")
+    baseline_verdicts = _verdict_map(baseline.get("verdicts"), "baseline")
+    only_current = sorted(set(current_verdicts) - set(baseline_verdicts))
+    only_baseline = sorted(set(baseline_verdicts) - set(current_verdicts))
+    if only_current or only_baseline:
+        raise BaselineComparisonError(
+            "baseline_task_set_mismatch:only_in_current="
+            + ",".join(only_current)
+            + ";only_in_baseline="
+            + ",".join(only_baseline)
+        )
+    units: list[JsonValue] = []
+    counts = {label: 0 for label in COMPARISON_LABELS}
+    for fixture_id in current_verdicts:
+        before, after = baseline_verdicts[fixture_id], current_verdicts[fixture_id]
+        label = transition_label(before, after)
+        counts[label] += 1
+        units.append(
+            {
+                "fixture_id": fixture_id,
+                "baseline_verdict": before,
+                "current_verdict": after,
+                "label": label,
+            }
+        )
+    return {
+        "schema_version": COMPARISON_SCHEMA,
+        "baseline_mode": baseline.get("mode"),
+        "baseline_corpus_digest": baseline.get("corpus_digest"),
+        "baseline_envelope_digest": baseline.get("envelope_digest"),
+        "units": units,
+        "summary": {
+            "label": _aggregate_label(counts),
+            "improved_count": counts["IMPROVED"],
+            "regressed_count": counts["REGRESSED"],
+            "stable_count": counts["STABLE"],
+            "not_comparable_count": counts["not_comparable"],
+            "baseline_pass_rate": _pass_rate(baseline.get("verdict_summary")),
+            "current_pass_rate": _pass_rate(current.get("verdict_summary")),
+        },
+        "efficiency_delta": _efficiency_delta(
+            current.get("efficiency"), baseline.get("efficiency")
+        ),
+    }
+
+
+def _aggregate_label(counts: Mapping[str, int]) -> str:
+    """Worst direction wins: one regression is the headline, not an average."""
+    if counts["REGRESSED"]:
+        return "REGRESSED"
+    if counts["IMPROVED"]:
+        return "IMPROVED"
+    if counts["STABLE"]:
+        return "STABLE"
+    return "not_comparable"
+
+
+def _efficiency_delta(
+    current: JsonValue, baseline: JsonValue
+) -> dict[str, JsonValue]:
+    """Subtract telemetry only where both sides observed it; never estimate."""
+    current_map = current if isinstance(current, dict) else {}
+    baseline_map = baseline if isinstance(baseline, dict) else {}
+    block: dict[str, JsonValue] = {}
+    for field in ("tokens", "cost_usd"):
+        before = _number(baseline_map.get(field))
+        after = _number(current_map.get(field))
+        comparable = before is not None and after is not None
+        delta: JsonValue = None
+        if comparable:
+            delta = round(after - before, 6) if field == "cost_usd" else after - before
+        block[field] = {
+            "baseline": before,
+            "current": after,
+            "delta": delta,
+            "label": "comparable" if comparable else "not_comparable",
+        }
+    return block
+
+
+def _pass_rate(summary: JsonValue) -> JsonValue:
+    if not isinstance(summary, dict):
+        raise BaselineComparisonError("baseline_verdict_summary_missing")
+    value = summary.get("pass_rate")
+    if value is not None and _number(value) is None:
+        raise BaselineComparisonError("baseline_pass_rate_invalid")
+    return value
+
+
+def _number(value: JsonValue) -> int | float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return value
+
+
+def _verdict_map(raw: JsonValue, side: str) -> dict[str, str]:
+    if not isinstance(raw, list) or not raw:
+        raise BaselineComparisonError(f"{side}_verdicts_missing")
+    mapped: dict[str, str] = {}
+    for item in raw:
+        if not isinstance(item, dict):
+            raise BaselineComparisonError(f"{side}_verdict_invalid")
+        fixture_id, verdict = item.get("fixture_id"), item.get("verdict")
+        if not isinstance(fixture_id, str) or not fixture_id or verdict not in VERDICTS:
+            raise BaselineComparisonError(f"{side}_verdict_invalid")
+        if fixture_id in mapped:
+            raise BaselineComparisonError(f"{side}_verdict_duplicate")
+        mapped[fixture_id] = str(verdict)
+    return mapped
+
+
 def validate_receipt(raw: JsonValue) -> tuple[str, ...]:
     """Return ordered reason codes; an empty tuple means the receipt is valid."""
     if not isinstance(raw, dict):
@@ -171,7 +482,10 @@ def validate_receipt(raw: JsonValue) -> tuple[str, ...]:
     observation_ids = _check_observations(raw["observations"], reasons)
     _check_bindings(raw["fixture_bindings"], observation_ids, reasons)
     _check_efficiency(raw["efficiency"], reasons)
-    _check_coverage(raw, reasons)
+    verdicts = _check_verdicts(raw["verdicts"], reasons)
+    _check_verdict_summary(raw["verdict_summary"], verdicts, reasons)
+    _check_comparison(raw["baseline_comparison"], set(verdicts), reasons)
+    _check_coverage(raw, set(verdicts), reasons)
     try:
         safe(dict(raw))
     except BenchmarkValidationError:
@@ -265,7 +579,157 @@ def _check_efficiency(raw: JsonValue, reasons: list[str]) -> None:
         reasons.append("invalid_efficiency_complete")
 
 
-def _check_coverage(raw: Mapping[str, JsonValue], reasons: list[str]) -> None:
+def _check_verdicts(raw: JsonValue, reasons: list[str]) -> dict[str, str]:
+    """A reason code is required on every INCONCLUSIVE unit and only on those."""
+    verdicts: dict[str, str] = {}
+    if not isinstance(raw, list):
+        reasons.append("invalid_verdicts")
+        return verdicts
+    for item in raw:
+        if not isinstance(item, dict):
+            reasons.append("invalid_verdict")
+            continue
+        before = len(reasons)
+        _check_shape(item, _VERDICT_FIELDS, "verdict", reasons)
+        if len(reasons) != before:
+            continue
+        fixture_id = item["fixture_id"]
+        _text(fixture_id, "invalid_verdict_fixture_id", reasons)
+        _member(item["verdict"], VERDICTS, "invalid_verdict_value", reasons)
+        reason_code = item["reason_code"]
+        if item["verdict"] == "INCONCLUSIVE":
+            _member(reason_code, INCONCLUSIVE_REASONS, "invalid_inconclusive_reason", reasons)
+        elif reason_code is not None:
+            reasons.append("graded_verdict_claims_inconclusive_reason")
+        if isinstance(fixture_id, str) and fixture_id:
+            if fixture_id in verdicts:
+                reasons.append("duplicate_verdict_fixture_id")
+            verdicts[fixture_id] = str(item["verdict"])
+    return verdicts
+
+
+def _check_verdict_summary(
+    raw: JsonValue, verdicts: Mapping[str, str], reasons: list[str]
+) -> None:
+    """The aggregate must restate the verdict list and exclude INCONCLUSIVE units."""
+    if not isinstance(raw, dict):
+        reasons.append("invalid_verdict_summary")
+        return
+    before = len(reasons)
+    _check_shape(raw, _VERDICT_SUMMARY_FIELDS, "verdict_summary", reasons)
+    if len(reasons) != before:
+        return
+    for field in ("units_total", "pass_count", "fail_count", "inconclusive_count", "graded_total"):
+        if type(raw[field]) is not int or raw[field] < 0:
+            reasons.append("invalid_verdict_count")
+            return
+    if raw["pass_rate_denominator"] != PASS_RATE_DENOMINATOR:
+        reasons.append("invalid_pass_rate_denominator")
+    if raw["inconclusive_excluded_from_pass_rate"] is not True:
+        reasons.append("inconclusive_not_excluded_from_pass_rate")
+    if raw["graded_total"] != raw["pass_count"] + raw["fail_count"]:
+        reasons.append("invalid_graded_total")
+    if raw["units_total"] != raw["graded_total"] + raw["inconclusive_count"]:
+        reasons.append("invalid_units_total")
+    expected = verdict_summary([{"fixture_id": key, "verdict": value} for key, value in verdicts.items()])
+    if any(raw[field] != expected[field] for field in ("units_total", "pass_count", "fail_count", "inconclusive_count")):
+        reasons.append("verdict_summary_mismatch")
+    rate = raw["pass_rate"]
+    if raw["graded_total"] == 0:
+        if rate is not None:
+            reasons.append("pass_rate_without_graded_units")
+    elif _number(rate) is None or not 0 <= float(rate) <= 1:  # type: ignore[arg-type]
+        reasons.append("invalid_pass_rate")
+
+
+def _check_comparison(raw: JsonValue, fixture_ids: set[str], reasons: list[str]) -> None:
+    """Validate the optional baseline block against this receipt's own task set."""
+    if raw is None:
+        return
+    if not isinstance(raw, dict):
+        reasons.append("invalid_baseline_comparison")
+        return
+    before = len(reasons)
+    _check_shape(raw, _COMPARISON_FIELDS, "baseline_comparison", reasons)
+    if len(reasons) != before:
+        return
+    _member(raw["schema_version"], (COMPARISON_SCHEMA,), "unknown_comparison_schema", reasons)
+    _member(raw["baseline_mode"], MODES, "invalid_baseline_mode", reasons)
+    _digest(raw["baseline_corpus_digest"], "invalid_baseline_corpus_digest", reasons)
+    _digest(raw["baseline_envelope_digest"], "invalid_baseline_envelope_digest", reasons)
+    compared = _check_comparison_units(raw["units"], reasons)
+    if compared is not None and compared != fixture_ids:
+        reasons.append("comparison_task_set_mismatch")
+    _check_comparison_summary(raw["summary"], reasons)
+    _check_efficiency_delta(raw["efficiency_delta"], reasons)
+
+
+def _check_comparison_units(raw: JsonValue, reasons: list[str]) -> set[str] | None:
+    if not isinstance(raw, list):
+        reasons.append("invalid_comparison_units")
+        return None
+    seen: set[str] = set()
+    for item in raw:
+        if not isinstance(item, dict):
+            reasons.append("invalid_comparison_unit")
+            return None
+        before = len(reasons)
+        _check_shape(item, _COMPARISON_UNIT_FIELDS, "comparison_unit", reasons)
+        if len(reasons) != before:
+            return None
+        _text(item["fixture_id"], "invalid_comparison_fixture_id", reasons)
+        _member(item["baseline_verdict"], VERDICTS, "invalid_comparison_verdict", reasons)
+        _member(item["current_verdict"], VERDICTS, "invalid_comparison_verdict", reasons)
+        _member(item["label"], COMPARISON_LABELS, "invalid_comparison_label", reasons)
+        if isinstance(item["fixture_id"], str):
+            seen.add(item["fixture_id"])
+    return seen
+
+
+def _check_comparison_summary(raw: JsonValue, reasons: list[str]) -> None:
+    if not isinstance(raw, dict):
+        reasons.append("invalid_comparison_summary")
+        return
+    before = len(reasons)
+    _check_shape(raw, _COMPARISON_SUMMARY_FIELDS, "comparison_summary", reasons)
+    if len(reasons) != before:
+        return
+    _member(raw["label"], COMPARISON_LABELS, "invalid_comparison_label", reasons)
+    for field in ("improved_count", "regressed_count", "stable_count", "not_comparable_count"):
+        if type(raw[field]) is not int or raw[field] < 0:
+            reasons.append("invalid_comparison_count")
+    for field in ("baseline_pass_rate", "current_pass_rate"):
+        value = raw[field]
+        if value is not None and (_number(value) is None or not 0 <= float(value) <= 1):
+            reasons.append("invalid_comparison_pass_rate")
+
+
+def _check_efficiency_delta(raw: JsonValue, reasons: list[str]) -> None:
+    """A delta exists only where both sides observed the figure."""
+    if not isinstance(raw, dict) or set(raw) != {"tokens", "cost_usd"}:
+        reasons.append("invalid_efficiency_delta")
+        return
+    for field, block in raw.items():
+        if not isinstance(block, dict):
+            reasons.append("invalid_efficiency_delta")
+            return
+        before = len(reasons)
+        _check_shape(block, _DELTA_FIELDS, "efficiency_delta", reasons)
+        if len(reasons) != before:
+            return
+        _member(block["label"], DELTA_LABELS, "invalid_delta_label", reasons)
+        both = _number(block["baseline"]) is not None and _number(block["current"]) is not None
+        if both != (block["label"] == "comparable"):
+            reasons.append("invalid_delta_label")
+        if both and _number(block["delta"]) is None:
+            reasons.append("missing_delta")
+        if not both and block["delta"] is not None:
+            reasons.append("estimated_delta")
+        if field == "tokens" and block["delta"] is not None and type(block["delta"]) is not int:
+            reasons.append("invalid_token_delta")
+
+
+def _check_coverage(raw: Mapping[str, JsonValue], fixture_ids: set[str], reasons: list[str]) -> None:
     """The four coverage lists partition the corpus; the tier may not outrun them."""
     lists: dict[str, list[str]] = {}
     for field in (
@@ -282,6 +746,8 @@ def _check_coverage(raw: Mapping[str, JsonValue], reasons: list[str]) -> None:
     flattened = [item for value in lists.values() for item in value]
     if len(flattened) != len(set(flattened)):
         reasons.append("overlapping_fixture_coverage")
+    if set(flattened) != fixture_ids:
+        reasons.append("verdict_coverage_mismatch")
     observed = lists["controller_observed_fixture_ids"]
     if raw["evidence_authenticity"] == "controller_observed" and lists["carried_fixture_ids"]:
         reasons.append("authenticity_tier_overclaims")

--- a/tests/test_cross_harness_live_lane.py
+++ b/tests/test_cross_harness_live_lane.py
@@ -358,6 +358,354 @@ class EfficiencyTests(unittest.TestCase):
             self.assertNotIn(marker, serialized)
 
 
+def _verdicts(receipt: object) -> dict[str, str]:
+    return {item["fixture_id"]: item["verdict"] for item in receipt["verdicts"]}  # type: ignore[index]
+
+
+def _reasons(receipt: object) -> dict[str, object]:
+    return {item["fixture_id"]: item["reason_code"] for item in receipt["verdicts"]}  # type: ignore[index]
+
+
+def _probe(**overrides: object) -> dict[str, object]:
+    """Run probe mode with a stubbed command observation, patched per test."""
+    observation = overrides.pop("observation", _fake_command_observation())
+    with patch.object(controller, "execute_command_binding", return_value=observation):
+        return _run(mode="probe", **overrides)
+
+
+def _dispatch(**overrides: object) -> dict[str, object]:
+    command = overrides.pop("command_observation", _fake_command_observation())
+    child = overrides.pop("dispatch_observation", _fake_dispatch_observation())
+    with (
+        patch.object(controller, "execute_command_binding", return_value=command),
+        patch.object(controller, "execute_child_dispatch", return_value=child),
+    ):
+        return _run(mode="dispatch", model="m", provider="p", allow_paid_live=True, max_paid_calls=1, **overrides)
+
+
+class _BaselineFile:
+    """Write a receipt to disk so the controller reads it the way an operator would."""
+
+    def __init__(self, receipt: object) -> None:
+        self._directory = TemporaryDirectory()
+        self.path = Path(self._directory.name) / "baseline-receipt.json"
+        self.path.write_text(json.dumps(receipt, sort_keys=True), encoding="utf-8")
+
+    def __enter__(self) -> Path:
+        return self.path
+
+    def __exit__(self, *_: object) -> None:
+        self._directory.cleanup()
+
+
+class VerdictTests(unittest.TestCase):
+    def test_fake_mode_grades_nothing_and_rates_nothing(self) -> None:
+        receipt = _run()["receipt"]
+        summary = receipt["verdict_summary"]  # type: ignore[index]
+        self.assertEqual(summary["units_total"], 15)
+        self.assertEqual(summary["inconclusive_count"], 15)
+        self.assertEqual(summary["graded_total"], 0)
+        self.assertIsNone(summary["pass_rate"])
+        self.assertEqual(set(_verdicts(receipt).values()), {"INCONCLUSIVE"})
+        self.assertEqual(set(_reasons(receipt).values()), {"no_controller_observation"})
+
+    def test_observed_run_grades_only_the_units_it_observed(self) -> None:
+        receipt = _dispatch()["receipt"]
+        verdicts = _verdicts(receipt)
+        observable = (*controller.COMMAND_FIXTURES, *controller.DISPATCH_FIXTURES)
+        for fixture_id in observable:
+            self.assertEqual(verdicts[fixture_id], "PASS")
+        summary = receipt["verdict_summary"]  # type: ignore[index]
+        self.assertEqual(summary["pass_count"], len(observable))
+        self.assertEqual(summary["graded_total"], len(observable))
+        self.assertEqual(summary["inconclusive_count"], 15 - len(observable))
+        self.assertEqual(summary["pass_rate"], 1.0)
+
+    def test_a_graded_failure_is_fail_and_never_inconclusive(self) -> None:
+        failed = _fake_dispatch_observation(
+            status="failed", observed_exit=1, observed_semantic_result=None, failure_code="nonzero_exit"
+        )
+        receipt = _dispatch(dispatch_observation=failed)["receipt"]
+        verdicts = _verdicts(receipt)
+        for fixture_id in controller.DISPATCH_FIXTURES:
+            self.assertEqual(verdicts[fixture_id], "FAIL")
+        self.assertEqual(verdicts["evidence-command-binding"], "PASS")
+        summary = receipt["verdict_summary"]  # type: ignore[index]
+        self.assertEqual(summary["fail_count"], 3)
+        self.assertEqual(summary["graded_total"], 4)
+        self.assertEqual(summary["pass_rate"], 0.25)
+
+    def test_launch_failure_is_inconclusive(self) -> None:
+        observation = _fake_command_observation(
+            status="failed", observed_exit=None, observed_semantic_result=None, failure_code="command_launch_failed"
+        )
+        receipt = _probe(observation=observation)["receipt"]
+        self.assertEqual(_verdicts(receipt)["evidence-command-binding"], "INCONCLUSIVE")
+        self.assertEqual(_reasons(receipt)["evidence-command-binding"], "execution_launch_failed")
+
+    def test_timeout_before_output_is_inconclusive(self) -> None:
+        observation = _fake_command_observation(
+            status="timed_out", observed_exit=None, observed_semantic_result=None, failure_code="timeout"
+        )
+        receipt = _probe(observation=observation)["receipt"]
+        self.assertEqual(_verdicts(receipt)["evidence-command-binding"], "INCONCLUSIVE")
+        self.assertEqual(_reasons(receipt)["evidence-command-binding"], "timed_out_before_output")
+
+    def test_unreadable_observation_artifact_is_inconclusive(self) -> None:
+        unreadable = _fake_dispatch_observation(
+            status="failed", observed_semantic_result=None, failure_code="observation_invalid"
+        )
+        receipt = _dispatch(dispatch_observation=unreadable)["receipt"]
+        for fixture_id in controller.DISPATCH_FIXTURES:
+            self.assertEqual(_verdicts(receipt)[fixture_id], "INCONCLUSIVE")
+            self.assertEqual(_reasons(receipt)[fixture_id], "artifact_unreadable")
+
+    def test_a_crashed_validator_is_inconclusive_not_a_pass(self) -> None:
+        observation = _fake_command_observation(observed_semantic_result="unvalidated")
+        receipt = _probe(observation=observation)["receipt"]
+        self.assertEqual(_verdicts(receipt)["evidence-command-binding"], "INCONCLUSIVE")
+        self.assertEqual(_reasons(receipt)["evidence-command-binding"], "artifact_unreadable")
+
+    def test_absent_telemetry_channel_is_inconclusive(self) -> None:
+        observation = _fake_command_observation(observed_semantic_result=None)
+        receipt = _probe(observation=observation)["receipt"]
+        self.assertEqual(_verdicts(receipt)["evidence-command-binding"], "INCONCLUSIVE")
+        self.assertEqual(_reasons(receipt)["evidence-command-binding"], "telemetry_channel_absent")
+
+    def test_inconclusive_units_stay_out_of_the_pass_rate_denominator(self) -> None:
+        summary = _probe()["receipt"]["verdict_summary"]  # type: ignore[index]
+        self.assertEqual(summary["pass_count"], 1)
+        self.assertEqual(summary["inconclusive_count"], 14)
+        self.assertEqual(summary["graded_total"], 1)
+        self.assertEqual(summary["pass_rate"], 1.0)
+        self.assertEqual(summary["pass_rate_denominator"], "graded_units_only")
+        self.assertIs(summary["inconclusive_excluded_from_pass_rate"], True)
+
+    def test_verdicts_cover_the_whole_task_set_not_only_the_submission(self) -> None:
+        receipt = _probe()["receipt"]
+        coverage = {
+            item
+            for field in (
+                "controller_observed_fixture_ids",
+                "carried_fixture_ids",
+                "simulated_fixture_ids",
+                "unsupported_fixture_ids",
+            )
+            for item in receipt[field]  # type: ignore[index]
+        }
+        self.assertEqual(set(_verdicts(receipt)), coverage)
+
+
+class BaselineComparisonTests(unittest.TestCase):
+    def test_unchanged_verdicts_are_stable(self) -> None:
+        with _BaselineFile(_probe()["receipt"]) as path:
+            comparison = _probe(baseline_path=path)["receipt"]["baseline_comparison"]  # type: ignore[index]
+        self.assertEqual(comparison["schema_version"], "cross_harness_live_baseline_comparison/v1")
+        self.assertEqual(comparison["summary"]["label"], "STABLE")
+        self.assertEqual(comparison["summary"]["stable_count"], 15)
+        self.assertEqual(comparison["summary"]["regressed_count"], 0)
+
+    def test_a_recovered_unit_is_improved(self) -> None:
+        failing = _fake_command_observation(
+            status="failed", observed_exit=1, observed_semantic_result="unvalidated", failure_code="nonzero_exit"
+        )
+        with _BaselineFile(_probe(observation=failing)["receipt"]) as path:
+            comparison = _probe(baseline_path=path)["receipt"]["baseline_comparison"]  # type: ignore[index]
+        unit = next(item for item in comparison["units"] if item["fixture_id"] == "evidence-command-binding")
+        self.assertEqual(unit["baseline_verdict"], "FAIL")
+        self.assertEqual(unit["current_verdict"], "PASS")
+        self.assertEqual(unit["label"], "IMPROVED")
+        self.assertEqual(comparison["summary"]["label"], "IMPROVED")
+        self.assertEqual(comparison["summary"]["baseline_pass_rate"], 0.0)
+        self.assertEqual(comparison["summary"]["current_pass_rate"], 1.0)
+
+    def test_a_broken_unit_is_regressed(self) -> None:
+        failing = _fake_command_observation(
+            status="failed", observed_exit=1, observed_semantic_result="unvalidated", failure_code="nonzero_exit"
+        )
+        with _BaselineFile(_probe()["receipt"]) as path:
+            comparison = _probe(observation=failing, baseline_path=path)["receipt"]["baseline_comparison"]  # type: ignore[index]
+        unit = next(item for item in comparison["units"] if item["fixture_id"] == "evidence-command-binding")
+        self.assertEqual(unit["label"], "REGRESSED")
+        self.assertEqual(comparison["summary"]["label"], "REGRESSED")
+        self.assertEqual(comparison["summary"]["regressed_count"], 1)
+
+    def test_an_ungraded_side_is_not_comparable_rather_than_a_direction(self) -> None:
+        with _BaselineFile(_probe()["receipt"]) as path:
+            comparison = _run(baseline_path=path)["receipt"]["baseline_comparison"]  # type: ignore[index]
+        unit = next(item for item in comparison["units"] if item["fixture_id"] == "evidence-command-binding")
+        self.assertEqual(unit["baseline_verdict"], "PASS")
+        self.assertEqual(unit["current_verdict"], "INCONCLUSIVE")
+        self.assertEqual(unit["label"], "not_comparable")
+        self.assertEqual(comparison["summary"]["not_comparable_count"], 1)
+        self.assertIsNone(comparison["summary"]["current_pass_rate"])
+
+    def test_observed_telemetry_on_both_sides_yields_a_delta(self) -> None:
+        with _BaselineFile(_dispatch()["receipt"]) as path:
+            richer = _fake_dispatch_observation(tokens=1524, cost_usd=0.0051)
+            comparison = _dispatch(dispatch_observation=richer, baseline_path=path)["receipt"][  # type: ignore[index]
+                "baseline_comparison"
+            ]
+        tokens = comparison["efficiency_delta"]["tokens"]
+        self.assertEqual(tokens["label"], "comparable")
+        self.assertEqual(tokens["baseline"], 1024)
+        self.assertEqual(tokens["delta"], 500)
+        self.assertEqual(comparison["efficiency_delta"]["cost_usd"]["delta"], 0.002)
+
+    def test_a_null_telemetry_side_yields_no_delta(self) -> None:
+        silent = _fake_dispatch_observation(tokens=None, cost_usd=None)
+        with _BaselineFile(_dispatch(dispatch_observation=silent)["receipt"]) as path:
+            comparison = _dispatch(baseline_path=path)["receipt"]["baseline_comparison"]  # type: ignore[index]
+        for field in ("tokens", "cost_usd"):
+            delta = comparison["efficiency_delta"][field]
+            self.assertIsNone(delta["baseline"])
+            self.assertIsNone(delta["delta"])
+            self.assertEqual(delta["label"], "not_comparable")
+
+    def test_a_different_task_set_is_a_hard_error_listing_the_mismatch(self) -> None:
+        receipt = dict(_probe()["receipt"])  # type: ignore[arg-type]
+        receipt["verdicts"] = [
+            {**item, "fixture_id": "renamed-unit"} if item["fixture_id"] == "model-neutral-fallback" else item
+            for item in receipt["verdicts"]
+        ]
+        receipt["unsupported_fixture_ids"] = [
+            "renamed-unit" if item == "model-neutral-fallback" else item
+            for item in receipt["unsupported_fixture_ids"]
+        ]
+        self.assertEqual(receipt_module.validate_receipt(receipt), ())
+        with _BaselineFile(receipt) as path:
+            with self.assertRaises(controller.ControllerError) as caught:
+                _probe(baseline_path=path)
+        message = str(caught.exception)
+        self.assertTrue(message.startswith("baseline_task_set_mismatch:"))
+        self.assertIn("only_in_current=model-neutral-fallback", message)
+        self.assertIn("only_in_baseline=renamed-unit", message)
+
+    def test_mismatched_task_sets_are_never_silently_intersected(self) -> None:
+        current = {
+            "schema_version": receipt_module.RECEIPT_SCHEMA,
+            "corpus_digest": "a" * 64,
+            "verdicts": [{"fixture_id": "kept", "verdict": "PASS", "reason_code": None}],
+            "verdict_summary": {"pass_rate": 1.0},
+            "efficiency": {},
+        }
+        baseline = {
+            **current,
+            "verdicts": [
+                {"fixture_id": "kept", "verdict": "PASS", "reason_code": None},
+                {"fixture_id": "extra", "verdict": "FAIL", "reason_code": None},
+            ],
+        }
+        with self.assertRaises(receipt_module.BaselineComparisonError) as caught:
+            receipt_module.compare_to_baseline(current, baseline)
+        self.assertEqual(
+            str(caught.exception),
+            "baseline_task_set_mismatch:only_in_current=;only_in_baseline=extra",
+        )
+
+    def test_a_foreign_corpus_baseline_is_refused(self) -> None:
+        receipt = dict(_probe()["receipt"])  # type: ignore[arg-type]
+        receipt["corpus_digest"] = "f" * 64
+        with _BaselineFile(receipt) as path:
+            with self.assertRaises(controller.ControllerError) as caught:
+                _probe(baseline_path=path)
+        self.assertEqual(str(caught.exception), "baseline_corpus_mismatch")
+
+    def test_a_v1_baseline_receipt_is_refused_rather_than_half_compared(self) -> None:
+        receipt = dict(_probe()["receipt"])  # type: ignore[arg-type]
+        receipt["schema_version"] = "cross_harness_live_receipt/v1"
+        with _BaselineFile(receipt) as path:
+            with self.assertRaises(controller.ControllerError) as caught:
+                _probe(baseline_path=path)
+        self.assertEqual(str(caught.exception), "baseline_receipt_invalid:unknown_receipt_schema")
+
+    def test_an_unreadable_baseline_is_refused_before_comparison(self) -> None:
+        with TemporaryDirectory() as root:
+            path = Path(root) / "baseline.json"
+            path.write_text("{not json", encoding="utf-8")
+            with self.assertRaises(controller.ControllerError) as caught:
+                _probe(baseline_path=path)
+        self.assertEqual(str(caught.exception), "baseline_invalid_json")
+
+    def test_a_receipt_with_a_comparison_round_trips_through_json(self) -> None:
+        with _BaselineFile(_probe()["receipt"]) as path:
+            receipt = _probe(baseline_path=path)["receipt"]
+            reloaded = json.loads(json.dumps(receipt, sort_keys=True))
+        self.assertEqual(reloaded, receipt)
+        self.assertEqual(receipt_module.validate_receipt(reloaded), ())
+
+
+class VerdictSchemaTests(unittest.TestCase):
+    @staticmethod
+    def _receipt() -> dict[str, object]:
+        return dict(_probe()["receipt"])  # type: ignore[arg-type]
+
+    def test_a_graded_verdict_may_not_carry_an_inconclusive_reason(self) -> None:
+        payload = self._receipt()
+        payload["verdicts"] = [
+            {**item, "reason_code": "artifact_unreadable"} if item["verdict"] == "PASS" else item
+            for item in payload["verdicts"]  # type: ignore[attr-defined]
+        ]
+        self.assertIn(
+            "graded_verdict_claims_inconclusive_reason", receipt_module.validate_receipt(payload)
+        )
+
+    def test_an_inconclusive_verdict_requires_a_known_reason(self) -> None:
+        payload = self._receipt()
+        payload["verdicts"] = [
+            {**item, "reason_code": None} if item["verdict"] == "INCONCLUSIVE" else item
+            for item in payload["verdicts"]  # type: ignore[attr-defined]
+        ]
+        self.assertIn("invalid_inconclusive_reason", receipt_module.validate_receipt(payload))
+
+    def test_a_summary_that_contradicts_the_verdicts_is_rejected(self) -> None:
+        payload = self._receipt()
+        summary = dict(payload["verdict_summary"])  # type: ignore[arg-type]
+        summary["pass_count"] = 2
+        summary["graded_total"] = 2
+        summary["units_total"] = 16
+        payload["verdict_summary"] = summary
+        self.assertIn("verdict_summary_mismatch", receipt_module.validate_receipt(payload))
+
+    def test_a_pass_rate_over_zero_graded_units_is_rejected(self) -> None:
+        payload = dict(_run()["receipt"])  # type: ignore[arg-type]
+        summary = dict(payload["verdict_summary"])  # type: ignore[arg-type]
+        summary["pass_rate"] = 1.0
+        payload["verdict_summary"] = summary
+        self.assertIn("pass_rate_without_graded_units", receipt_module.validate_receipt(payload))
+
+    def test_a_summary_may_not_fold_inconclusive_units_into_the_denominator(self) -> None:
+        payload = self._receipt()
+        summary = dict(payload["verdict_summary"])  # type: ignore[arg-type]
+        summary["graded_total"] = 15
+        payload["verdict_summary"] = summary
+        self.assertIn("invalid_graded_total", receipt_module.validate_receipt(payload))
+
+    def test_a_delta_without_both_sides_observed_is_rejected(self) -> None:
+        silent = _fake_dispatch_observation(tokens=None, cost_usd=None)
+        with _BaselineFile(_dispatch(dispatch_observation=silent)["receipt"]) as path:
+            payload = dict(_dispatch(baseline_path=path)["receipt"])  # type: ignore[arg-type]
+        comparison = dict(payload["baseline_comparison"])  # type: ignore[arg-type]
+        delta = dict(comparison["efficiency_delta"])  # type: ignore[index]
+        delta["tokens"] = {**delta["tokens"], "delta": 1024}
+        comparison["efficiency_delta"] = delta
+        payload["baseline_comparison"] = comparison
+        self.assertIn("estimated_delta", receipt_module.validate_receipt(payload))
+
+    def test_a_comparison_over_foreign_units_is_rejected(self) -> None:
+        with _BaselineFile(_probe()["receipt"]) as path:
+            payload = dict(_probe(baseline_path=path)["receipt"])  # type: ignore[arg-type]
+        comparison = dict(payload["baseline_comparison"])  # type: ignore[arg-type]
+        comparison["units"] = [{**item, "fixture_id": "foreign-unit"} for item in comparison["units"]]  # type: ignore[index]
+        payload["baseline_comparison"] = comparison
+        self.assertIn("comparison_task_set_mismatch", receipt_module.validate_receipt(payload))
+
+    def test_verdict_vocabulary_is_ternary_and_ordered(self) -> None:
+        self.assertEqual(receipt_module.VERDICTS, ("PASS", "FAIL", "INCONCLUSIVE"))
+        self.assertIn("not_comparable", receipt_module.COMPARISON_LABELS)
+        self.assertEqual(receipt_module.RECEIPT_SCHEMA, "cross_harness_live_receipt/v2")
+
+
 class BenchEntryPointTests(unittest.TestCase):
     @staticmethod
     def _bench() -> object:


### PR DESCRIPTION
## Feature Report

### What Changed

- The live cross-harness lane now grades every unit of the task set `PASS` / `FAIL` / `INCONCLUSIVE` instead of a binary "observation completed or it did not", with a required reason code on every `INCONCLUSIVE`.
- `verdict_summary` counts all three verdicts and rates only the graded ones: `graded_total = pass + fail`, `pass_rate` divides by `graded_total`, and the artifact states the exclusion itself via `pass_rate_denominator: "graded_units_only"` and `inconclusive_excluded_from_pass_rate: true`.
- New `--baseline RECEIPT` option compares a run against a retained earlier receipt and writes a versioned `cross_harness_live_baseline_comparison/v1` block into the emitted receipt: per-unit and aggregate `IMPROVED` / `REGRESSED` / `STABLE` transitions plus null-safe token and cost deltas.
- Receipt schema bumped to `cross_harness_live_receipt/v2`.

### Why This Exists

- `.omc/research/benchmark-methodology-survey-2026-08-29.md` names two gaps this closes. Gap 7: a fixture outcome carried no decomposition beyond a boolean, so "the harness answered wrong" and "the controller could not see an answer" were the same non-pass. Gap 10 (and the OMC `--save-baseline` / `--compare` precedent it cites): the lane had no way to say whether this run is better or worse than the last one.
- A binary result quietly charges controller-side blindness against the harness. A launch failure, a timeout before any output, an unparseable observation artifact, or a silent telemetry channel are all facts about the controller, and folding them into a failure count produces a pass rate nobody should act on.

### User / Operator Impact

- A maintainer reading a receipt can now separate "four units failed" from "four units could not be graded", and see the denominator the rate was computed over without inferring it.
- Retaining a receipt turns the lane into a longitudinal instrument: run again with `--baseline` and the receipt names which units moved and in which direction.
- Behaviour with no new flag is unchanged apart from the added receipt blocks; the scored envelope is byte-identical to before.

### How It Works

- `observation_inconclusive_reason()` maps one observation onto the ungradeable reasons `no_controller_observation`, `execution_launch_failed`, `timed_out_before_output`, `artifact_unreadable`, `telemetry_channel_absent`, returning `None` when the observation is gradeable.
- `unit_verdicts()` grades every corpus fixture (the whole task set, not the submitted subset, so runs of different coverage still compare unit for unit) from the observations bound to it. Observed failure outranks an ungradeable sibling observation: positive evidence of a wrong result is a `FAIL` even when another channel of the same unit went dark. A unit with no bound observation is `INCONCLUSIVE`, never a failure.
- `compare_to_baseline()` refuses a baseline that is not `v2`, whose `corpus_digest` differs, or whose task set differs — the last raising `baseline_task_set_mismatch:only_in_current=…;only_in_baseline=…` so the refusal names both sides. Transitions with an `INCONCLUSIVE` side are labelled `not_comparable` rather than ranked between `FAIL` and `PASS`; the aggregate label is worst-direction-wins.
- `_efficiency_delta()` subtracts `tokens` and `cost_usd` only where both sides observed the figure; otherwise `delta` stays `null` and the field is `not_comparable`. Deltas are aggregate-only because one observation feeds several units and a per-unit split would count the same tokens more than once.
- `validate_receipt()` enforces the contract rather than trusting the producer: a reason code is required on `INCONCLUSIVE` and forbidden on graded verdicts, the summary must restate the verdict list, `pass_rate` must be `null` when nothing was graded, a delta may not exist without both sides, and the comparison's unit set must equal the receipt's own.

### Files And Contracts Touched

- `benchmarks/cross-harness/live/lib/receipt.py` — schema bumped to `cross_harness_live_receipt/v2`; new `verdicts`, `verdict_summary`, `baseline_comparison` fields; verdict/comparison vocabulary; comparison builder and validators; extended `CLAIM_BOUNDARY`.
- `benchmarks/cross-harness/live/lib/controller.py` — `load_baseline_receipt()`, `baseline_path` on `run()`, verdicts in the receipt builder, verdict/comparison vocabulary in `doctor`.
- `benchmarks/cross-harness/live/bench.py` — `--baseline` option.
- `benchmarks/cross-harness/live/README.md` — verdict and baseline sections, extended claim boundary.
- `tests/test_cross_harness_live_lane.py` — 30 new tests.
- Untouched by design: `src/commands/cross_harness_benchmark.py` and the frozen `cross_harness_benchmark/v1` corpus, submission schema, evaluator, scorer, and trust anchors. No skill, routing, or count-fixture changes.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `bench.py run --mode probe --baseline …`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- Full suite: `PYTHONPATH=tests uv run python -m unittest discover -s tests` → `Ran 8047 tests`, `FAILED (failures=21, errors=7)`. All 28 are the known `.claude`-worktree-path failures in `test_cross_harness_adapters` and `test_cross_harness_adapter_security` (reason code `unsafe_read_root` in place of the expected adapter reason codes); none are in a file this PR touches.
- Targeted: `PYTHONPATH=tests uv run python -m unittest tests/test_cross_harness_live_lane.py` → `Ran 65 tests … OK` (35 pre-existing plus 30 new).
- Extra gates run beyond the template list: `uv run python -m omh.cli docs ulw-inventory --check` → `ok:true`; `uv run python -m omh.cli docs ulw-site --check` → `ok:true`.
- End-to-end operator path, real local execution (no paid call): `bench.py run --mode probe --receipt-output r1.json` → exit 0; `bench.py run --mode probe --baseline r1.json --receipt-output r2.json` → exit 0, `verdict_summary` `{pass_count: 1, fail_count: 0, inconclusive_count: 14, graded_total: 1, pass_rate: 1.0}`, comparison `label: STABLE`, `stable_count: 15`, and both efficiency deltas `not_comparable` with `delta: null` because neither side observed tokens or cost.
- Refusal path: a baseline receipt with a foreign `corpus_digest` → `{"ok": false, "reason_code": "baseline_corpus_mismatch"}`, exit 2.
- Not observed: `dispatch` mode against a live Hermes child. It is a paid call and was deliberately not run; its verdict and telemetry paths are covered by tests with stubbed observations only.

### Not Tested / Not Applicable

- `harness validate`, `release checklist`, `release hermes-smoke`, `omh --help`, and the install smoke: this PR touches only `benchmarks/cross-harness/live/` and its test file, adds no CLI surface to `omh` itself, and changes no install manifest, skill, or routing table.
- Workflow-learning review queue smoke: no learning contract changed.
- Manual Hermes/TUI check: no TUI, widget, or plugin surface changed.

## Risk

- The receipt schema bump is a breaking change for any consumer pinned to `cross_harness_live_receipt/v1`. The lane is new (PR #1173), emits only `v2`, and commits no receipt artifacts, so the blast radius is any receipt an operator retained locally in the last few days; such a file is refused as a baseline with `baseline_receipt_invalid:unknown_receipt_schema` rather than half-compared.
- The `INCONCLUSIVE` mapping is a judgement about which failure codes are ungradeable. If a future failure code is added to the observation vocabulary without a mapping, it falls through to gradeable and would read as `FAIL`; the reason table in the README and the per-trigger tests are where that gets corrected.
- No new dependency, no network call, no change to what the controller executes or to the emitted envelope.

## Compatibility / Rollout

- Default behaviour unchanged: `bench.py run` with no new flag still defaults to `fake` mode, still starts no process, and still emits the same envelope. The receipt simply carries three more fields, with `baseline_comparison: null` when no baseline is given.
- `--baseline` is opt-in and read-only; it never changes what is executed or submitted.
- No release-channel or install-manifest impact.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- The survey's Gap 2 (repetitions, pass^k, a `flaky` status distinct from pass and fail) is the natural next step now that a unit has a ternary verdict to repeat.
- Retaining dated reference receipts under a `baselines/` directory, so the comparison has a committed anchor rather than whatever the operator happened to keep, is Gap 10's remaining half.
