### PR TITLE
feat(quality): completion-integrity gate that refuses fake completion

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -3234,6 +3234,7 @@ These surfaces are generated command references, not installed Hermes workflow s
   - Do not collapse build, lint, tests, security, generated docs, review, CI, DCO, merge-readiness, or merge into one claim.
   - Failed or unavailable checks must produce HOLD/BLOCK with a rerun or remediation path.
   - A change touching an authentication, secrets/config, schema/migration, or payment/crypto path escalates to the thorough verification lane regardless of diff size.
+  - Refuse completion, do not merely report it, when the claim carries an unlinked TODO/FIXME/stub marker in changed code, a suppressed test with no linked reason, placeholder or self-referential evidence ('TBD', 'works as expected'), or a proof word ('fixed', 'verified', 'passing') with no observed evidence naming a command; each refusal names its category, the offending excerpt, and the remedy.
 
 ### agent-evaluation
 

--- a/skills/omh-verification-gate/SKILL.md
+++ b/skills/omh-verification-gate/SKILL.md
@@ -108,6 +108,7 @@ Safety rules:
 - Do not collapse build, lint, tests, security, generated docs, review, CI, DCO, merge-readiness, or merge into one claim.
 - Failed or unavailable checks must produce HOLD/BLOCK with a rerun or remediation path.
 - A change touching an authentication, secrets/config, schema/migration, or payment/crypto path escalates to the thorough verification lane regardless of diff size.
+- Refuse completion, do not merely report it, when the claim carries an unlinked TODO/FIXME/stub marker in changed code, a suppressed test with no linked reason, placeholder or self-referential evidence ('TBD', 'works as expected'), or a proof word ('fixed', 'verified', 'passing') with no observed evidence naming a command; each refusal names its category, the offending excerpt, and the remedy.
 
 ## Runtime Evidence
 

--- a/src/maintenance/release.py
+++ b/src/maintenance/release.py
@@ -392,7 +392,15 @@ STANDALONE_CAPABILITY_SKILL_ITEM_CHAR_LIMIT = 2200
 # lookup line (+292 chars: `omh design data --kind palette|font|ux --context`
 # with the rows-inform-DESIGN.md-but-the-contract-gates-the-code boundary);
 # warranted growth.
-FULL_PROFILE_SKILL_BODY_CHAR_LIMIT = 795558
+# 795558 -> 795956: `verification-gate` gained the completion-integrity refusal
+# rule (+398 chars) naming the four things that make a completion claim refuse
+# rather than report -- an unlinked TODO/FIXME/stub marker in changed code, a
+# suppressed test with no linked reason, placeholder or self-referential
+# evidence, and a proof word with no command behind it. It belongs in the
+# always-loaded body because it changes the verdict the skill issues, and a
+# gate that only reports its verdict after the claim is written is the failure
+# this rule exists to stop; warranted growth.
+FULL_PROFILE_SKILL_BODY_CHAR_LIMIT = 795956
 FULL_PROFILE_SKILL_BODY_REVIEWED_EXCEPTION_CHARS = 0
 
 

--- a/src/quality/completion_integrity.py
+++ b/src/quality/completion_integrity.py
@@ -1,0 +1,466 @@
+"""Completion-integrity refusals: a gate that refuses fake completion.
+
+`assess_quality_evidence` reports whether evidence is consistent, and
+`build_goal_completion_gate` reports whether required criteria carry evidence.
+Neither one reads the *claim* itself. A goal can therefore satisfy every
+structural requirement while the work it claims is unfinished ("TODO: wire the
+retry path"), the tests it claims are skipped, and the evidence it names is the
+string "TBD".
+
+This module closes that hole as a pure classifier over a completion claim:
+changed file content, declared evidence entries, and the completion summary in.
+Structured refusals out. It runs no command, reads no file, and upgrades
+nothing -- a refusal is a verdict about the claim as supplied, and the caller
+decides what a refusal blocks.
+
+Two design rules keep the refusals reviewable rather than clever:
+
+* Every rule is a word list or a small predicate over normalized tokens. There
+  is no pattern soup and no rule that only its author can re-derive.
+* Markers are scoped to changed *code* content, never to prose. A `TODO` in a
+  Markdown file or under `docs/` is documentation; a report *about* TODO
+  markers must not refuse itself. Only code files are scanned, and inside them
+  only comment bodies, so a marker word inside a string literal or a variable
+  name is not a placeholder note.
+
+A marker that names a tracked follow-up -- an issue number or a URL on the same
+line -- is a linked reason, not a placeholder, and passes. That is the
+difference between "someone will do this, tracked here" and "this is not done
+and nothing records that".
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Final
+
+COMPLETION_INTEGRITY_SCHEMA_VERSION: Final = "omh_completion_integrity/v1"
+
+REFUSAL_CATEGORIES: Final = (
+    "unfinished_work_marker",
+    "skipped_test_without_linked_reason",
+    "stub_implementation",
+    "empty_evidence",
+    "self_referential_evidence",
+    "prepared_evidence_claimed_as_observed",
+    "unnamed_verification_command",
+    "unproven_claim_word",
+)
+
+CLAIM_BOUNDARY: Final = (
+    "Completion-integrity refusals classify the supplied claim text, changed content, and "
+    "evidence entries only; passing this classifier is not observed execution evidence."
+)
+
+# Only these suffixes are read as code. Everything else -- Markdown, reST,
+# plain text, JSON fixtures -- is prose or data, where a marker word is a
+# legitimate subject rather than an unfinished-work note.
+_CODE_SUFFIXES: Final = (
+    ".c", ".cc", ".cpp", ".cs", ".go", ".h", ".hpp", ".java", ".js", ".jsx",
+    ".kt", ".m", ".mm", ".php", ".py", ".rb", ".rs", ".scala", ".sh", ".sql",
+    ".swift", ".ts", ".tsx", ".zsh",
+)
+
+# A code file living under a documentation tree is still documentation: an
+# example snippet or a doctest fixture is prose about code, not shipped code.
+_PROSE_PATH_PARTS: Final = ("docs", "doc", "examples", "fixtures")
+
+# Comment leads. SQL's `--` is deliberately absent: it collides with every
+# long CLI flag a code line can carry (`--group`, `--check`), and truncating a
+# line there would read the flag name as comment prose.
+_COMMENT_LEADS: Final = ("<!--", "/*", "//", "#")
+
+_UNFINISHED_MARKER_WORDS: Final = ("todo", "fixme", "xxx", "hack", "wip", "tbd")
+
+# Test-suppression markers across the runners OMH's executors actually meet.
+# Matched as literal substrings because each one is already a distinctive,
+# unambiguous token -- `test.skip` never appears by accident.
+_SKIP_MARKERS: Final = (
+    "test.skip(", "test.only(", "it.only(", "it.skip(", "describe.only(",
+    "describe.skip(", "xit(", "xdescribe(", "@unittest.skip", "@pytest.mark.skip",
+    "self.skiptest(", "t.skip(",
+)
+
+# Stub bodies: a function that declares it does nothing.
+_STUB_MARKERS: Final = (
+    "raise notimplementederror", "throw new notimplementederror",
+    "todo!(", "unimplemented!(", "panic(\"not implemented",
+)
+
+# Words that turn a no-op body (`pass`, `...`, `return None`) into a declared
+# stub rather than a deliberate empty implementation.
+_STUB_COMMENT_WORDS: Final = ("stub", "placeholder", "unimplemented", "not implemented")
+_NO_OP_BODIES: Final = ("pass", "...", "return none", "return", "{}", "return null")
+
+# An abstract method raises exactly like a stub does, so the decorator is what
+# separates "this class delegates the body to subclasses" from "nobody wrote
+# this yet". A raise within this many lines of an abstract decorator is read as
+# the former.
+_ABSTRACT_DECORATORS: Final = ("@abstractmethod", "@abc.abstractmethod", "@overload")
+_ABSTRACT_LOOKBACK_LINES: Final = 5
+
+# omo's placeholder set, matched against the whole normalized evidence value so
+# an evidence entry that merely mentions the word "todo" is untouched.
+_PLACEHOLDER_EVIDENCE_VALUES: Final = (
+    "placeholder", "todo", "tbd", "n/a", "na", "none", "nil", "stub", "-", "?", "pending",
+)
+
+# Assertions that describe a feeling about the work instead of a check that
+# ran. Matched as phrases inside the normalized evidence value.
+_SELF_REFERENTIAL_PHRASES: Final = (
+    "works as expected", "worked as expected", "as expected", "should pass",
+    "should work", "should be fine", "looks good", "looks fine", "seems fine",
+    "seems correct", "obviously correct", "no issues found", "nothing to report",
+    "trust me", "it works", "manually verified", "verified manually",
+)
+
+# Words that assert the claim is proven, as opposed to describing what changed.
+# Status words like "done" or "complete" are deliberately absent: they state a
+# position in the workflow, not that a check was run.
+_CLAIM_WORDS: Final = (
+    "verified", "passing", "passed", "fixed", "green", "confirmed", "proven",
+)
+
+# Phrases that specifically claim a suite ran.
+_VERIFICATION_CLAIM_PHRASES: Final = (
+    "tests pass", "tests passing", "tests passed", "test suite passes",
+    "all tests pass", "suite is green", "suite passes", "build passes",
+    "lint passes", "ci is green", "checks pass",
+)
+
+# Command-runner tokens. An evidence entry naming one of these names a command
+# a reader can re-run; an entry naming none is a description of a command.
+_COMMAND_TOKENS: Final = (
+    "pytest", "unittest", "nose", "tox", "jest", "vitest", "mocha", "npm",
+    "pnpm", "yarn", "bun", "cargo", "gradle", "mvn", "make", "ruff", "mypy",
+    "eslint", "tsc", "uv", "python", "python3", "go", "dotnet", "phpunit",
+    "rspec", "swift", "ctest", "bazel", "compileall", "omh",
+)
+
+# Evidence prefixes OMH already uses for a recorded observation. These are
+# observed-class references even when they name no command, because the
+# reference resolves to a stored record rather than to a sentence.
+_OBSERVED_REFERENCE_PREFIXES: Final = ("observed:", "run:", "runtime:", ".omh/", "omh://")
+
+_PREPARED_NOT_OBSERVED: Final = "prepared_not_observed"
+
+_MAX_EXCERPT_CHARS: Final = 160
+
+
+def classify_completion_integrity(
+    *,
+    summary: str = "",
+    changed_files: Sequence[Mapping[str, object]] = (),
+    evidence: Sequence[object] = (),
+) -> dict[str, object]:
+    """Return every completion-integrity refusal the supplied claim earns.
+
+    `changed_files` entries carry `path` and optional `content`; an entry with
+    no content contributes its path only, because a path alone cannot prove
+    anything about what the file now holds. `evidence` entries are either a
+    plain reference string or a mapping with `reference` and an optional
+    `status`, which is how the goal ledger's `evidence_refs` and the richer
+    quality-evidence observations both fit without a conversion step.
+    """
+    refusals: list[dict[str, str]] = []
+    for entry in changed_files:
+        refusals.extend(_changed_file_refusals(entry))
+    normalized_evidence = [_normalized_evidence(entry) for entry in evidence]
+    for index, (reference, status) in enumerate(normalized_evidence):
+        refusals.extend(_evidence_refusals(index, reference, status))
+    refusals.extend(_claim_binding_refusals(summary, normalized_evidence))
+    return {
+        "schema_version": COMPLETION_INTEGRITY_SCHEMA_VERSION,
+        "refused": bool(refusals),
+        "refusals": refusals,
+        "categories": sorted({item["category"] for item in refusals}),
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+
+
+def _changed_file_refusals(entry: Mapping[str, object]) -> list[dict[str, str]]:
+    if not isinstance(entry, Mapping):
+        return []
+    path = entry.get("path")
+    content = entry.get("content")
+    if not isinstance(path, str) or not path.strip():
+        return []
+    if not isinstance(content, str) or not content.strip():
+        return []
+    if not _is_scanned_code_path(path):
+        return []
+    lines = content.splitlines()
+    refusals: list[dict[str, str]] = []
+    for index, line in enumerate(lines):
+        refusal = _line_refusal(path, line, abstract_guarded=_is_abstract_guarded(lines, index))
+        if refusal is not None:
+            refusals.append(refusal)
+    return refusals
+
+
+def _is_abstract_guarded(lines: Sequence[str], index: int) -> bool:
+    window = lines[max(0, index - _ABSTRACT_LOOKBACK_LINES) : index]
+    return any(
+        decorator in line.lower() for line in window for decorator in _ABSTRACT_DECORATORS
+    )
+
+
+def _line_refusal(path: str, line: str, *, abstract_guarded: bool) -> dict[str, str] | None:
+    """The first refusal one code line earns, or None.
+
+    Rules are tried in a fixed order so the same line always reports the same
+    category, and one line reports at most once: a stub body annotated `# TODO`
+    is one unfinished thing, not two.
+
+    A stub marker is refused even when the line links an issue -- a tracked
+    stub is still an unwritten body -- while a skip marker or a placeholder
+    note that links one passes, because there the link is the whole difference
+    between a tracked follow-up and a silently dropped obligation.
+    """
+    lowered = line.lower()
+    if not abstract_guarded:
+        for marker in _STUB_MARKERS:
+            if marker in lowered:
+                return _refusal(
+                    "stub_implementation",
+                    path,
+                    line,
+                    "Implement the branch or record it as a blocker; a declared stub cannot be "
+                    "part of a completion claim.",
+                )
+    if _has_linked_reason(line):
+        return None
+    for marker in _SKIP_MARKERS:
+        if marker in lowered:
+            return _refusal(
+                "skipped_test_without_linked_reason",
+                path,
+                line,
+                f"Remove `{marker.rstrip('(')}` or name the tracked reason on the same line "
+                "(an issue number like #123, or a URL); a suppressed test is not a passing test.",
+            )
+    comment = _comment_body(line)
+    if comment is not None:
+        comment_tokens = _tokens(comment)
+        code_before = _code_before_comment(line)
+        if code_before in _NO_OP_BODIES and any(
+            word in comment.lower() for word in _STUB_COMMENT_WORDS
+        ):
+            return _refusal(
+                "stub_implementation",
+                path,
+                line,
+                "Implement the body or record it as a blocker; a no-op annotated as a stub "
+                "cannot be part of a completion claim.",
+            )
+        for word in _UNFINISHED_MARKER_WORDS:
+            if word in comment_tokens:
+                return _refusal(
+                    "unfinished_work_marker",
+                    path,
+                    line,
+                    f"Resolve the `{word.upper()}` note or link it to a tracked issue "
+                    "(#123 or a URL) on the same line; an unlinked placeholder note is "
+                    "unfinished work, not a completed change.",
+                )
+    return None
+
+
+def _evidence_refusals(index: int, reference: str, status: str) -> list[dict[str, str]]:
+    label = f"evidence[{index}]"
+    normalized = _normalized_text(reference)
+    if not normalized or normalized in _PLACEHOLDER_EVIDENCE_VALUES:
+        return [
+            _refusal(
+                "empty_evidence",
+                label,
+                reference,
+                "Replace the placeholder with the command that ran and where its output is "
+                "recorded; a completion claim cannot check out on an empty evidence field.",
+            )
+        ]
+    for phrase in _SELF_REFERENTIAL_PHRASES:
+        if phrase in normalized:
+            return [
+                _refusal(
+                    "self_referential_evidence",
+                    label,
+                    reference,
+                    f"Replace \"{phrase}\" with the command that ran and its observed result; "
+                    "an assertion about the work is not evidence of the work.",
+                )
+            ]
+    if _PREPARED_NOT_OBSERVED in normalized or status == _PREPARED_NOT_OBSERVED:
+        if _claims_execution(normalized):
+            return [
+                _refusal(
+                    "prepared_evidence_claimed_as_observed",
+                    label,
+                    reference,
+                    "Split the prepared plan from the observed run: keep the prepared entry "
+                    "labelled prepared_not_observed and add a separate entry for the command "
+                    "that actually ran.",
+                )
+            ]
+    if _claims_verification(normalized) and not _names_a_command(normalized):
+        return [
+            _refusal(
+                "unnamed_verification_command",
+                label,
+                reference,
+                "Name the command that produced this result (for example "
+                "`PYTHONPATH=tests uv run python -m unittest discover -s tests`); a claim that "
+                "tests pass without a named command cannot be re-run.",
+            )
+        ]
+    return []
+
+
+def _claim_binding_refusals(
+    summary: str, evidence: Sequence[tuple[str, str]]
+) -> list[dict[str, str]]:
+    """Claim words in the summary require one observed, command-naming entry."""
+    if not isinstance(summary, str) or not summary.strip():
+        return []
+    tokens = _tokens(summary)
+    claimed = [word for word in _CLAIM_WORDS if word in tokens]
+    if not claimed:
+        return []
+    if any(_is_observed_class(reference, status) for reference, status in evidence):
+        return []
+    return [
+        _refusal(
+            "unproven_claim_word",
+            "summary",
+            summary,
+            f"Either drop the word \"{claimed[0]}\" from the summary or add one evidence entry "
+            "naming the command that proves it; a proof word with no observed command-naming "
+            "evidence is an unproven claim.",
+        )
+    ]
+
+
+def _is_observed_class(reference: str, status: str) -> bool:
+    """True when an evidence entry resolves to something a reader can check."""
+    normalized = _normalized_text(reference)
+    if not normalized:
+        return False
+    if status == _PREPARED_NOT_OBSERVED or _PREPARED_NOT_OBSERVED in normalized:
+        return False
+    if any(normalized.startswith(prefix) for prefix in _OBSERVED_REFERENCE_PREFIXES):
+        return True
+    return _names_a_command(normalized)
+
+
+def _normalized_evidence(entry: object) -> tuple[str, str]:
+    """One evidence entry as `(reference, status)`.
+
+    A bare string is a reference with no declared status, which is exactly how
+    the goal ledger stores `evidence_refs`.
+    """
+    if isinstance(entry, str):
+        return entry, ""
+    if isinstance(entry, Mapping):
+        reference = entry.get("reference")
+        if not isinstance(reference, str):
+            reference = entry.get("summary")
+        status = entry.get("status")
+        return (
+            reference if isinstance(reference, str) else "",
+            status.strip().lower() if isinstance(status, str) else "",
+        )
+    return "", ""
+
+
+def _is_scanned_code_path(path: str) -> bool:
+    parts = tuple(part for part in path.replace("\\", "/").split("/") if part not in ("", "."))
+    if not parts:
+        return False
+    if any(part.lower() in _PROSE_PATH_PARTS for part in parts[:-1]):
+        return False
+    basename = parts[-1].lower()
+    return any(basename.endswith(suffix) for suffix in _CODE_SUFFIXES)
+
+
+def _comment_body(line: str) -> str | None:
+    """The comment text on a code line, or None when the line carries none.
+
+    A line whose stripped form starts with `*` is a block-comment continuation.
+    Only the first comment lead is honoured, so a lead appearing later inside
+    the comment text does not restart the scan.
+    """
+    stripped = line.strip()
+    if stripped.startswith("*") and not stripped.startswith("*/"):
+        return stripped[1:]
+    positions = [(line.find(lead), lead) for lead in _COMMENT_LEADS if lead in line]
+    if not positions:
+        return None
+    index, lead = min(positions)
+    return line[index + len(lead):]
+
+
+def _code_before_comment(line: str) -> str:
+    positions = [line.find(lead) for lead in _COMMENT_LEADS if lead in line]
+    if not positions:
+        return line.strip().lower()
+    return line[: min(positions)].strip().lower().rstrip(":;")
+
+
+def _has_linked_reason(line: str) -> bool:
+    """True when the line names a tracked follow-up: an issue number or a URL."""
+    lowered = line.lower()
+    if "http://" in lowered or "https://" in lowered:
+        return True
+    for index, char in enumerate(line):
+        if char == "#" and index + 1 < len(line) and line[index + 1].isdigit():
+            return True
+    return False
+
+
+def _claims_execution(normalized: str) -> bool:
+    return any(
+        word in _tokens(normalized) for word in ("ran", "executed", "observed", "green", "passed")
+    ) or _claims_verification(normalized)
+
+
+def _claims_verification(normalized: str) -> bool:
+    return any(phrase in normalized for phrase in _VERIFICATION_CLAIM_PHRASES)
+
+
+def _names_a_command(normalized: str) -> bool:
+    return any(token in _tokens(normalized) for token in _COMMAND_TOKENS)
+
+
+def _tokens(value: str) -> frozenset[str]:
+    """Lowercased alphanumeric tokens, so marker words match whole words only."""
+    collected: list[str] = []
+    current: list[str] = []
+    for char in value.lower():
+        if char.isalnum():
+            current.append(char)
+        elif current:
+            collected.append("".join(current))
+            current = []
+    if current:
+        collected.append("".join(current))
+    return frozenset(collected)
+
+
+def _normalized_text(value: str) -> str:
+    return " ".join(value.lower().split()) if isinstance(value, str) else ""
+
+
+def _refusal(category: str, path: str, excerpt: str, remedy: str) -> dict[str, str]:
+    return {
+        "category": category,
+        "path": path,
+        "excerpt": _excerpt(excerpt),
+        "remedy": remedy,
+    }
+
+
+def _excerpt(value: str) -> str:
+    collapsed = " ".join(str(value).split())
+    if len(collapsed) <= _MAX_EXCERPT_CHARS:
+        return collapsed
+    return collapsed[: _MAX_EXCERPT_CHARS - 1] + "…"

--- a/src/skills/catalog_definitions.py
+++ b/src/skills/catalog_definitions.py
@@ -4418,6 +4418,7 @@ _DEFINITIONS = [
             "Do not collapse build, lint, tests, security, generated docs, review, CI, DCO, merge-readiness, or merge into one claim.",
             "Failed or unavailable checks must produce HOLD/BLOCK with a rerun or remediation path.",
             "A change touching an authentication, secrets/config, schema/migration, or payment/crypto path escalates to the thorough verification lane regardless of diff size.",
+            "Refuse completion, do not merely report it, when the claim carries an unlinked TODO/FIXME/stub marker in changed code, a suppressed test with no linked reason, placeholder or self-referential evidence ('TBD', 'works as expected'), or a proof word ('fixed', 'verified', 'passing') with no observed evidence naming a command; each refusal names its category, the offending excerpt, and the remedy.",
         ),
         quality_tier="verification-gated",
         quality_bar=(

--- a/src/workflows/goal_ledger.py
+++ b/src/workflows/goal_ledger.py
@@ -9,6 +9,7 @@ from typing import Any, Final, Iterable
 
 from ..hashutil import sha256_text
 from ..local_store import ensure_dir, read_json_object, utc_now
+from ..quality.completion_integrity import classify_completion_integrity
 from ..system.record_revision import (
     DuplicateMutationReplay,
     guarded_record_update,
@@ -687,12 +688,20 @@ def build_goal_completion_gate(paths: OmhPaths, goal_id: str) -> dict[str, Any]:
         status_gaps.append("goal status is failed")
     if goal["status"] == "cancelled":
         status_gaps.append("goal status is cancelled")
-    ready = not missing_required and not active_blockers and not runtime_gaps and not status_gaps
+    integrity_refusals = _completion_integrity_refusals(goal)
+    ready = (
+        not missing_required
+        and not active_blockers
+        and not runtime_gaps
+        and not status_gaps
+        and not integrity_refusals
+    )
     next_action = _completion_next_action(
         missing_required=missing_required,
         active_blockers=active_blockers,
         runtime_gaps=runtime_gaps,
         status_gaps=status_gaps,
+        integrity_refusals=integrity_refusals,
     )
     if goal["status"] == "cancelled":
         # A cancelled goal is terminal: recording blockers or checkpoints is
@@ -708,12 +717,50 @@ def build_goal_completion_gate(paths: OmhPaths, goal_id: str) -> dict[str, Any]:
             active_blockers=active_blockers,
             runtime_gaps=runtime_gaps,
             status_gaps=status_gaps,
+            integrity_refusals=integrity_refusals,
         ),
         "missing_required_criteria": missing_required,
         "active_blockers": active_blockers,
         "linked_runtime_checks": runtime_checks,
+        "integrity_refusals": integrity_refusals,
         "next_action": next_action,
     }
+
+
+def _completion_integrity_refusals(goal: dict[str, Any]) -> list[dict[str, str]]:
+    """Refusals the goal's own completion claim earns, as blocking gaps.
+
+    The ledger stores the claim, not the diff: satisfied criteria and done
+    checkpoints carry the summaries that make the claim and the evidence refs
+    that are supposed to prove it. Those are what get classified here, so a
+    goal cannot pass the gate on the string "TBD" or on a summary asserting
+    "tests passing" with nothing naming a command. Changed-file content is not
+    stored in the ledger and is therefore not scanned at this call site; a
+    caller holding a diff classifies it directly.
+    """
+    claim_lines = [
+        checkpoint["summary"]
+        for checkpoint in goal["checkpoints"]
+        if checkpoint.get("status") == "done"
+    ]
+    claim_lines.extend(
+        checkpoint["notes_summary"]
+        for checkpoint in goal["checkpoints"]
+        if checkpoint.get("status") == "done" and checkpoint.get("notes_summary")
+    )
+    evidence: list[str] = []
+    for criterion in goal["acceptance_criteria"]:
+        if criterion["required"] and criterion["status"] == "satisfied":
+            evidence.extend(criterion["evidence_refs"])
+    for checkpoint in goal["checkpoints"]:
+        if checkpoint.get("status") == "done":
+            evidence.extend(checkpoint.get("evidence_refs", []))
+    verdict = classify_completion_integrity(
+        summary=" ".join(claim_lines),
+        evidence=list(dict.fromkeys(evidence)),
+    )
+    refusals = verdict["refusals"]
+    return refusals if isinstance(refusals, list) else []
 
 
 def complete_goal_ledger(
@@ -973,8 +1020,15 @@ def _completion_gate_summary(
     active_blockers: list[dict[str, Any]],
     runtime_gaps: list[dict[str, Any]],
     status_gaps: list[str],
+    integrity_refusals: list[dict[str, str]],
 ) -> str:
-    if not missing_required and not active_blockers and not runtime_gaps and not status_gaps:
+    if (
+        not missing_required
+        and not active_blockers
+        and not runtime_gaps
+        and not status_gaps
+        and not integrity_refusals
+    ):
         return "Goal is ready for completion."
     parts = []
     if missing_required:
@@ -983,6 +1037,9 @@ def _completion_gate_summary(
         parts.append(f"{len(active_blockers)} active blockers remain")
     if runtime_gaps:
         parts.append(f"{len(runtime_gaps)} linked runtime runs still need observed evidence")
+    if integrity_refusals:
+        categories = ", ".join(sorted({item["category"] for item in integrity_refusals}))
+        parts.append(f"{len(integrity_refusals)} completion-integrity refusals remain ({categories})")
     if status_gaps:
         parts.append("; ".join(status_gaps))
     return "; ".join(parts) + "."
@@ -994,10 +1051,15 @@ def _completion_next_action(
     active_blockers: list[dict[str, Any]],
     runtime_gaps: list[dict[str, Any]],
     status_gaps: list[str],
+    integrity_refusals: list[dict[str, str]],
 ) -> str:
     if active_blockers or status_gaps:
         return "record_blocker"
     if missing_required:
+        return "record_checkpoint"
+    if integrity_refusals:
+        # The claim itself is the gap: a new checkpoint carrying a real command
+        # and a summary that does not outrun it is what clears this.
         return "record_checkpoint"
     if runtime_gaps:
         return "show_status"

--- a/tests/test_completion_integrity.py
+++ b/tests/test_completion_integrity.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.goal_ledger import (
+    build_goal_completion_gate,
+    complete_goal_ledger,
+    create_goal_ledger,
+    record_goal_checkpoint,
+)
+from omh.paths import resolve_paths
+from omh.quality.completion_integrity import (
+    COMPLETION_INTEGRITY_SCHEMA_VERSION,
+    REFUSAL_CATEGORIES,
+    classify_completion_integrity,
+)
+
+
+def _categories(verdict: dict[str, object]) -> list[str]:
+    refusals = verdict["refusals"]
+    assert isinstance(refusals, list)
+    return [str(item["category"]) for item in refusals]
+
+
+class CompletionIntegrityChangedContentTests(unittest.TestCase):
+    def test_unlinked_placeholder_note_in_changed_code_is_refused(self) -> None:
+        verdict = classify_completion_integrity(
+            changed_files=[{"path": "src/coding/retry.py", "content": "def retry():\n    # TODO: wire the retry path\n    return 1\n"}],
+        )
+
+        self.assertTrue(verdict["refused"])
+        self.assertEqual(_categories(verdict), ["unfinished_work_marker"])
+        refusal = verdict["refusals"][0]
+        self.assertEqual(refusal["path"], "src/coding/retry.py")
+        self.assertIn("TODO", refusal["excerpt"])
+        self.assertIn("tracked issue", refusal["remedy"])
+
+    def test_every_unfinished_marker_word_is_refused(self) -> None:
+        for word in ("TODO", "FIXME", "XXX", "HACK", "WIP", "TBD"):
+            with self.subTest(word=word):
+                verdict = classify_completion_integrity(
+                    changed_files=[{"path": "src/a.py", "content": f"x = 1  # {word}: finish this\n"}],
+                )
+                self.assertEqual(_categories(verdict), ["unfinished_work_marker"])
+
+    def test_suppressed_tests_without_a_linked_reason_are_refused(self) -> None:
+        for line in (
+            "    @unittest.skip(\"flaky\")",
+            "    @pytest.mark.skip(reason=\"slow\")",
+            "test.only('renders', () => {})",
+            "describe.skip('parser', () => {})",
+        ):
+            with self.subTest(line=line):
+                verdict = classify_completion_integrity(
+                    changed_files=[{"path": "tests/test_thing.py", "content": line + "\n"}],
+                )
+                self.assertEqual(_categories(verdict), ["skipped_test_without_linked_reason"])
+
+    def test_stub_bodies_and_no_op_stubs_are_refused(self) -> None:
+        for content in (
+            "def parse(text):\n    raise NotImplementedError\n",
+            "def parse(text):\n    pass  # stub until the parser lands\n",
+            "fn parse() { todo!() }\n",
+            "def parse(text):\n    ...  # placeholder\n",
+        ):
+            with self.subTest(content=content):
+                verdict = classify_completion_integrity(
+                    changed_files=[{"path": "src/parser.py", "content": content}],
+                )
+                self.assertEqual(_categories(verdict), ["stub_implementation"])
+
+    def test_a_stub_stays_refused_even_when_it_links_an_issue(self) -> None:
+        # A tracked stub is still an unwritten body, so the linked-reason
+        # escape that clears a skip or a placeholder note does not clear this.
+        verdict = classify_completion_integrity(
+            changed_files=[{"path": "src/parser.py", "content": "    raise NotImplementedError  # tracked in #652\n"}],
+        )
+
+        self.assertEqual(_categories(verdict), ["stub_implementation"])
+
+    def test_one_line_reports_at_most_one_refusal(self) -> None:
+        verdict = classify_completion_integrity(
+            changed_files=[{"path": "src/parser.py", "content": "    raise NotImplementedError  # TODO finish\n"}],
+        )
+
+        self.assertEqual(_categories(verdict), ["stub_implementation"])
+
+
+class CompletionIntegrityNegativeControlTests(unittest.TestCase):
+    def test_a_todo_in_prose_is_not_unfinished_code(self) -> None:
+        for path in ("docs/PLAN.md", "README.md", "notes/backlog.txt"):
+            with self.subTest(path=path):
+                verdict = classify_completion_integrity(
+                    changed_files=[{"path": path, "content": "# TODO: write the migration guide\n"}],
+                )
+                self.assertFalse(verdict["refused"])
+
+    def test_a_report_about_markers_does_not_refuse_itself(self) -> None:
+        # The audit report names every marker word it found. Scanning prose
+        # would make the report that documents unfinished work read as
+        # unfinished work.
+        report = (
+            "# Marker audit\n"
+            "We found TODO, FIXME, XXX, and HACK notes across the retry path.\n"
+            "None of them are linked to an issue.\n"
+        )
+
+        verdict = classify_completion_integrity(
+            summary="Audited every TODO and FIXME marker in the retry path.",
+            changed_files=[{"path": "docs/marker-audit.md", "content": report}],
+            evidence=["rg --line-number TODO src/"],
+        )
+
+        self.assertFalse(verdict["refused"])
+
+    def test_a_code_sample_under_a_docs_tree_is_prose(self) -> None:
+        verdict = classify_completion_integrity(
+            changed_files=[{"path": "docs/examples/snippet.py", "content": "x = 1  # TODO: the reader fills this in\n"}],
+        )
+
+        self.assertFalse(verdict["refused"])
+
+    def test_a_skip_with_a_linked_reason_passes(self) -> None:
+        for line in (
+            "    @unittest.skip(\"blocked on #652\")",
+            "    @pytest.mark.skip(reason=\"https://github.com/rlaope/oh-my-hermes/issues/652\")",
+        ):
+            with self.subTest(line=line):
+                verdict = classify_completion_integrity(
+                    changed_files=[{"path": "tests/test_thing.py", "content": line + "\n"}],
+                )
+                self.assertFalse(verdict["refused"])
+
+    def test_a_marker_note_linked_to_an_issue_passes(self) -> None:
+        verdict = classify_completion_integrity(
+            changed_files=[{"path": "src/a.py", "content": "x = 1  # TODO(#652): enable the broad-exception rule\n"}],
+        )
+
+        self.assertFalse(verdict["refused"])
+
+    def test_an_abstract_method_raise_is_not_a_stub(self) -> None:
+        content = (
+            "class Store:\n"
+            "    @abstractmethod\n"
+            "    def read(self):\n"
+            "        raise NotImplementedError\n"
+        )
+
+        verdict = classify_completion_integrity(changed_files=[{"path": "src/store.py", "content": content}])
+
+        self.assertFalse(verdict["refused"])
+
+    def test_a_marker_word_outside_a_comment_is_not_a_note(self) -> None:
+        content = (
+            "LABEL = \"todo list\"\n"
+            "parser.add_argument(\"--todo-path\")\n"
+            "def hack_around(value):\n"
+            "    return value\n"
+        )
+
+        verdict = classify_completion_integrity(changed_files=[{"path": "src/a.py", "content": content}])
+
+        self.assertFalse(verdict["refused"])
+
+    def test_a_changed_path_with_no_content_contributes_nothing(self) -> None:
+        verdict = classify_completion_integrity(changed_files=[{"path": "src/a.py"}])
+
+        self.assertFalse(verdict["refused"])
+
+
+class CompletionIntegrityEvidenceTests(unittest.TestCase):
+    def test_placeholder_evidence_values_are_refused(self) -> None:
+        for value in ("", "   ", "TBD", "todo", "N/A", "placeholder", "stub", "-"):
+            with self.subTest(value=value):
+                verdict = classify_completion_integrity(evidence=[value])
+                self.assertEqual(_categories(verdict), ["empty_evidence"])
+
+    def test_self_referential_evidence_is_refused(self) -> None:
+        for value in ("works as expected", "should pass", "looks good to me", "manually verified"):
+            with self.subTest(value=value):
+                verdict = classify_completion_integrity(evidence=[value])
+                self.assertEqual(_categories(verdict), ["self_referential_evidence"])
+
+    def test_prepared_evidence_may_not_claim_execution(self) -> None:
+        verdict = classify_completion_integrity(
+            evidence=[{"reference": "the suite ran green", "status": "prepared_not_observed"}],
+        )
+
+        self.assertEqual(_categories(verdict), ["prepared_evidence_claimed_as_observed"])
+        self.assertIn("prepared_not_observed", verdict["refusals"][0]["remedy"])
+
+    def test_a_prepared_entry_that_claims_nothing_is_admissible(self) -> None:
+        verdict = classify_completion_integrity(
+            evidence=[{"reference": "planned unittest discovery", "status": "prepared_not_observed"}],
+        )
+
+        self.assertFalse(verdict["refused"])
+
+    def test_a_tests_pass_claim_without_a_named_command_is_refused(self) -> None:
+        verdict = classify_completion_integrity(evidence=["all tests pass on my machine"])
+
+        self.assertEqual(_categories(verdict), ["unnamed_verification_command"])
+        self.assertIn("unittest", verdict["refusals"][0]["remedy"])
+
+    def test_a_tests_pass_claim_naming_a_command_is_admissible(self) -> None:
+        verdict = classify_completion_integrity(
+            evidence=["PYTHONPATH=tests uv run python -m unittest discover -s tests: all tests pass"],
+        )
+
+        self.assertFalse(verdict["refused"])
+
+
+class CompletionIntegrityClaimBindingTests(unittest.TestCase):
+    def test_a_proof_word_without_observed_command_evidence_is_refused(self) -> None:
+        verdict = classify_completion_integrity(
+            summary="Fixed the parser and verified the retry path.",
+            evidence=["notes/handoff.md"],
+        )
+
+        self.assertEqual(_categories(verdict), ["unproven_claim_word"])
+        self.assertEqual(verdict["refusals"][0]["path"], "summary")
+
+    def test_a_proof_word_backed_by_a_named_command_passes(self) -> None:
+        verdict = classify_completion_integrity(
+            summary="Fixed the parser and verified the retry path.",
+            evidence=["uv run python -m unittest tests/test_parser.py"],
+        )
+
+        self.assertFalse(verdict["refused"])
+
+    def test_a_proof_word_backed_by_a_recorded_observation_passes(self) -> None:
+        verdict = classify_completion_integrity(
+            summary="Fixed the parser.",
+            evidence=["observed:suite-green"],
+        )
+
+        self.assertFalse(verdict["refused"])
+
+    def test_a_status_word_is_not_a_proof_word(self) -> None:
+        # "done" and "complete" state a position in the workflow; only words
+        # that assert the work was checked need a command behind them.
+        verdict = classify_completion_integrity(summary="Done: the retry path is complete.", evidence=["unit"])
+
+        self.assertFalse(verdict["refused"])
+
+    def test_prepared_evidence_never_backs_a_proof_word(self) -> None:
+        verdict = classify_completion_integrity(
+            summary="Verified the retry path.",
+            evidence=[{"reference": "uv run python -m unittest", "status": "prepared_not_observed"}],
+        )
+
+        self.assertEqual(_categories(verdict), ["unproven_claim_word"])
+
+
+class CompletionIntegrityVerdictShapeTests(unittest.TestCase):
+    def test_a_clean_claim_returns_a_bounded_passing_verdict(self) -> None:
+        verdict = classify_completion_integrity(
+            summary="Reworked the retry path and verified it.",
+            changed_files=[{"path": "src/coding/retry.py", "content": "def retry():\n    return 1\n"}],
+            evidence=["uv run python -m unittest tests/test_retry.py"],
+        )
+
+        self.assertEqual(verdict["schema_version"], COMPLETION_INTEGRITY_SCHEMA_VERSION)
+        self.assertFalse(verdict["refused"])
+        self.assertEqual(verdict["refusals"], [])
+        self.assertEqual(verdict["categories"], [])
+        self.assertIn("not observed execution evidence", verdict["claim_boundary"])
+
+    def test_every_shipped_category_is_declared(self) -> None:
+        verdict = classify_completion_integrity(
+            summary="Verified everything.",
+            changed_files=[
+                {
+                    "path": "src/a.py",
+                    "content": (
+                        "x = 1  # TODO: finish\n"
+                        "@unittest.skip(\"flaky\")\n"
+                        "def parse():\n"
+                        "    raise NotImplementedError\n"
+                    ),
+                }
+            ],
+            evidence=[
+                "TBD",
+                "works as expected",
+                {"reference": "the suite ran green", "status": "prepared_not_observed"},
+                "all tests pass",
+            ],
+        )
+
+        self.assertEqual(sorted(REFUSAL_CATEGORIES), verdict["categories"])
+
+
+class CompletionGateIntegrityIntegrationTests(unittest.TestCase):
+    def test_the_completion_gate_refuses_placeholder_evidence(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            create_goal_ledger(paths, "Ship the retry path", ["Criterion one"], goal_id="goal-placeholder")
+            record_goal_checkpoint(
+                paths, "goal-placeholder", "Wired the retry path", criteria_refs=["AC001"], evidence_refs=["TBD"]
+            )
+
+            gate = build_goal_completion_gate(paths, "goal-placeholder")
+
+            self.assertFalse(gate["ready"])
+            self.assertEqual([item["category"] for item in gate["integrity_refusals"]], ["empty_evidence"])
+            self.assertIn("completion-integrity refusals", gate["summary"])
+            self.assertEqual(gate["next_action"], "record_checkpoint")
+            self.assertFalse(complete_goal_ledger(paths, "goal-placeholder", evidence_refs=["TBD"])["completed"])
+
+    def test_the_completion_gate_refuses_an_unproven_proof_word(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            create_goal_ledger(paths, "Ship the retry path", ["Criterion one"], goal_id="goal-unproven")
+            record_goal_checkpoint(
+                paths,
+                "goal-unproven",
+                "Fixed and verified the retry path",
+                criteria_refs=["AC001"],
+                evidence_refs=["notes/handoff.md"],
+            )
+
+            gate = build_goal_completion_gate(paths, "goal-unproven")
+
+            self.assertFalse(gate["ready"])
+            self.assertEqual([item["category"] for item in gate["integrity_refusals"]], ["unproven_claim_word"])
+
+    def test_a_goal_with_command_evidence_still_completes(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            create_goal_ledger(paths, "Ship the retry path", ["Criterion one"], goal_id="goal-clean")
+            record_goal_checkpoint(
+                paths,
+                "goal-clean",
+                "Fixed and verified the retry path",
+                criteria_refs=["AC001"],
+                evidence_refs=["uv run python -m unittest tests/test_retry.py"],
+            )
+
+            gate = build_goal_completion_gate(paths, "goal-clean")
+
+            self.assertTrue(gate["ready"])
+            self.assertEqual(gate["integrity_refusals"], [])
+            completed = complete_goal_ledger(
+                paths, "goal-clean", evidence_refs=["uv run python -m unittest tests/test_retry.py"]
+            )
+            self.assertTrue(completed["completed"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_goal_journey.py
+++ b/tests/test_goal_journey.py
@@ -158,6 +158,11 @@ class GoalJourneyProjectionTests(unittest.TestCase):
         # Acceptance criterion 2. The ledger's own gate accepts a criterion that
         # merely *says* satisfied and carries refs; the journey refuses it,
         # because no done checkpoint ever accepted evidence for it.
+        #
+        # The forged ref has to be one the completion-integrity classifier
+        # admits, or the ledger gate would refuse it for the wrong reason and
+        # the "journey is stricter than the ledger" contract under test would
+        # stop being exercised at all.
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
             paths = _paths(root)
@@ -165,7 +170,7 @@ class GoalJourneyProjectionTests(unittest.TestCase):
             path = goal_ledger_path(paths, "goal-forged")
             stored = json.loads(path.read_text(encoding="utf-8"))
             stored["acceptance_criteria"][0]["status"] = "satisfied"
-            stored["acceptance_criteria"][0]["evidence_refs"] = ["trust me"]
+            stored["acceptance_criteria"][0]["evidence_refs"] = ["observed:suite-green"]
             path.write_text(json.dumps(stored, sort_keys=True), encoding="utf-8")
 
             journey = build_goal_journey(paths, "goal-forged", now=PINNED_NOW)

--- a/tests/test_record_revision.py
+++ b/tests/test_record_revision.py
@@ -1294,9 +1294,13 @@ class GoalLedgerRevisionGuardTests(unittest.TestCase):
                 "goal-guard",
                 "Guard verified",
                 criteria_refs=["AC-guard"],
-                evidence_refs=["tests:green"],
+                # "verified" is a proof word, so the completion gate now wants
+                # one evidence entry naming the command that proves it.
+                evidence_refs=["pytest tests/test_record_revision.py"],
             )
-            completed = complete_goal_ledger(paths, "goal-guard", evidence_refs=["tests:green"])
+            completed = complete_goal_ledger(
+                paths, "goal-guard", evidence_refs=["pytest tests/test_record_revision.py"]
+            )
             self.assertTrue(completed["completed"])
 
             with self.assertRaises(ValueError) as caught:


### PR DESCRIPTION
## Feature Report

### What Changed

- New pure classifier `src/quality/completion_integrity.py`: given a completion claim — changed file paths with optional content, declared evidence entries, and the completion summary — it returns structured refusals under `omh_completion_integrity/v1`.
- Eight refusal categories ship: `unfinished_work_marker`, `skipped_test_without_linked_reason`, `stub_implementation`, `empty_evidence`, `self_referential_evidence`, `prepared_evidence_claimed_as_observed`, `unnamed_verification_command`, `unproven_claim_word`. Each refusal carries its category, the offending path or excerpt, and a paste-ready remedy line.
- One integration point: `build_goal_completion_gate` (`src/workflows/goal_ledger.py`) now classifies the goal's own completion claim and surfaces the result as `integrity_refusals`, which blocks `ready` and feeds the gate summary and next action.
- `verification-gate` gains the matching refusal rule in its always-loaded body (source edit in `src/skills/catalog_definitions.py`, generated `skills/omh-verification-gate/SKILL.md` and `docs/WORKFLOWS.md` regenerated).
- `FULL_PROFILE_SKILL_BODY_CHAR_LIMIT` re-measured 795558 -> 795956 in the same commit, with the reason recorded above the constant.

### Why This Exists

- P2 absorb items 6 and 8 from `.omc/research/omo-omc-comparison-2026-08-29.md`: "completion gate that refuses, rather than reports" and "reject placeholder evidence". OMH's completion surfaces read *structure* — that observations bind to a source (`assess_quality_evidence`), that required criteria carry evidence refs (`build_goal_completion_gate`) — and never read the *claim*.
- The gap that leaves: a goal could satisfy every structural requirement while the work it claims was unfinished (`# TODO: wire the retry path`), the tests it claims were skipped, and the evidence it named was the string "TBD". The gate reported readiness rather than refusing it.
- omc's `validateQualityGate()` throws on that transition and omo's `PLACEHOLDER_PATTERN` rejects placeholder evidence outright. This absorbs both at OMH house size, on top of the prepared/observed vocabulary OMH already owns rather than beside it.

### User / Operator Impact

- A goal whose evidence is a placeholder, whose evidence asserts a feeling instead of a check, or whose summary claims proof no evidence supports now **blocks** at the completion gate instead of passing. The gate names the category, the excerpt, and the remedy, and the next action becomes `record_checkpoint`.
- No new command and no new flag. Existing goals with real command-naming or `observed:`-prefixed evidence refs complete exactly as before.

### How It Works

Boundary-level, in three parts:

1. **Changed-content scan.** Only code-suffixed paths are read, and only paths outside a `docs`/`examples`/`fixtures` tree, so a TODO in `docs/` or a report *about* TODO markers never refuses itself. Inside a code file, marker words are matched as whole tokens in *comment bodies only*, so a marker word inside a string literal or a CLI flag name (`--todo-path`) is not a placeholder note. A skip marker or a placeholder note that links a tracked reason (`#652` or a URL) passes; a stub does not, because a tracked stub is still an unwritten body. An abstract-method raise is guarded by an `@abstractmethod`/`@overload` decorator within five preceding lines, so an ABC is not read as a stub. One line reports at most one refusal, and rules are tried in a fixed order, so the same input always yields the same category.
2. **Evidence scan.** An entry is a bare string (which is exactly how `evidence_refs` are stored) or a mapping with `reference` and an optional `status`. An entry whose whole normalized value is a placeholder (`tbd`, `n/a`, `stub`, empty) is refused; an entry containing a self-referential phrase (`works as expected`, `should pass`) is refused; a `prepared_not_observed` entry that asserts execution is refused; an entry claiming a suite passed while naming no command from the runner token list is refused.
3. **Claim/proof binding.** A proof word in the summary (`verified`, `passing`, `fixed`, `green`, `confirmed`, `proven`) requires at least one observed-class evidence entry — one naming a command, or one carrying an OMH observed-record prefix (`observed:`, `run:`, `.omh/`). Status words (`done`, `complete`) are deliberately **not** proof words: they state a position in the workflow, not that a check ran. A `prepared_not_observed` entry never backs a proof word.

Every rule is a word list or a small predicate over normalized tokens — no regex over whole lines, matching the repo's existing ban on raw substring routing. The module makes no subprocess call, reads no file from disk, and upgrades no supplied assertion into observed evidence.

At the wiring point the ledger supplies what it actually stores: done-checkpoint summaries and notes as the claim text, satisfied-criterion and done-checkpoint evidence refs as the evidence. The ledger holds no diff, so changed-file content is not scanned there; a caller holding one calls the classifier directly.

### Files And Contracts Touched

- `src/quality/completion_integrity.py` (new) — `omh_completion_integrity/v1`, `classify_completion_integrity`, `REFUSAL_CATEGORIES`.
- `src/workflows/goal_ledger.py` — `build_goal_completion_gate` gains `integrity_refusals`; `_completion_gate_summary` / `_completion_next_action` take it as a required keyword; new `_completion_integrity_refusals`. `goal_completion_gate/v1` gains one additive field.
- `src/skills/catalog_definitions.py` — one new `verification-gate` safety rule.
- `skills/omh-verification-gate/SKILL.md`, `docs/WORKFLOWS.md` — regenerated, not hand-edited.
- `src/maintenance/release.py` — skill-body ceiling ratchet raise with its reason line.
- `tests/test_completion_integrity.py` (new, 30 tests); `tests/test_goal_journey.py` and `tests/test_record_revision.py` — two fixtures moved with the contract (a forged ledger used `"trust me"` as an evidence ref; a revision-guard goal claimed `"Guard verified"` behind `"tests:green"`). Both now name something a reader can check, which is the point of the gate.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

Also run, beyond the template list:

- [x] `uv run python -m omh.cli docs ulw-inventory --check`
- [x] `uv run python -m omh.cli docs ulw-site --check`

### Observed Evidence

- `PYTHONPATH=tests uv run python -m unittest discover -s tests` → **8047 tests**, 21 failures + 7 errors, all of them the pre-existing cross-harness-adapter `unsafe_read_root` failures caused by running from a `.claude/worktrees/` path (`test_cross_harness_adapters`, `test_cross_harness_adapter_security`). No goal, quality, skill, docs, drift, or routing test fails. CI is authoritative for those 28.
- `PYTHONPATH=tests uv run python -m unittest tests.test_completion_integrity` → 30 tests, OK.
- `uv run python -m compileall -q src tests` → clean.
- `uv run --group lint ruff check src tests` → `All checks passed!`
- All five `docs ... --check` gates → `{"ok":true}`, with `tap_skills` reporting `checked: 154, expected: 154, missing: [], stale: [], extra: []`.
- `git diff --check` → clean.
- Drift registry: the `full_profile_skill_body_chars` budget tripped at 795956 vs a 795558 limit; the ceiling was raised in the same commit with its reason line, and `test_drift_registry` passes on the re-measured value.

### Not Tested / Not Applicable

- `harness validate`, `release checklist`, `release hermes-smoke`, `omh --help`, and the install smoke: no harness contract, release manifest, installer, or CLI surface changed — the only CLI-visible delta is one additive field inside an existing `goal_completion_gate/v1` payload.
- No manual Hermes/TUI check: the change is a pure classifier plus one in-process gate field; there is no rendered surface to observe, and no runtime or native capability is claimed.
- No diff is fed through the wired call site, because the goal ledger stores none. The changed-content scanners are proven by unit tests over supplied content only, not against a real repository diff.

## Risk

- The gate is deliberately stricter than before, so a goal whose evidence was a placeholder, or whose summary outran its evidence, now blocks where it previously passed. That is the capability rather than a regression, and every refusal names its remedy. Two in-repo fixtures were exactly that shape and moved with the contract.
- False-positive surface, bounded and documented in the module: a `#` inside a Python string literal is read as a comment lead, so a string that both contains `#` and a marker word would refuse. A marker word inside a string with no `#` does not.
- `unproven_claim_word` fires on summary text, so a checkpoint summary using a proof word needs one command-naming or `observed:`-prefixed evidence ref beside it. Status words (`done`, `complete`) were deliberately kept out of the list to keep this from firing on ordinary progress narration.

## Compatibility / Rollout

- Additive: `goal_completion_gate/v1` gains `integrity_refusals`; no schema version bumps, and a reader that ignores the field behaves as before. No stored ledger is migrated, relabelled, or rewritten.
- No new dependency, no new command, no new flag, no network call.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- P2 item 7 (ternary PASS / FAIL / INCONCLUSIVE lane verdict) pairs naturally with this and is not in scope here.
- The remaining half of P2 item 8 — mandating adversarial and regression criterion classes in `extract_stated_acceptance_criteria` — is untouched.
- A caller that holds a real diff (a coding-lane completion report, say) can now feed `changed_files` to the classifier; nothing does yet.
