### PR TITLE
fix(coding): name where catalogless profiles route categories in category-maestro show

### DIFF
--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -897,12 +897,21 @@ def cmd_coding_category_maestro(args: argparse.Namespace) -> int:
             lines.append(f"  {marker} {category:18s} {chain_text or '-'}")
         report_profiles[profile] = categories
     rejected = list(config.get("rejected", [])) if isinstance(config, dict) else []
+    # Catalogless profiles are deliberately absent from this table (#1180's
+    # one-basis rule); naming where THEIR categories come from keeps a pi/omo
+    # operator from reading this as "pi has no category routing".
+    catalogless_note = (
+        "omo-runtime (host CLI: pi/senpi) and other catalogless profiles are not configured here: "
+        "their categories resolve from the locally-derived model catalog (omo config) — see "
+        "`omh coding model-route --executor omo-runtime --from-inventory`."
+    )
     payload = {
         "schema_version": "omh_category_maestro_report/v1",
         "path": str(category_maestro_path(paths.omh_home)),
         "configured": config is not None,
         "profiles": report_profiles,
         "rejected": rejected,
+        "catalogless_note": catalogless_note,
         "claim_boundary": (
             "This table is prepared routing metadata only; it is not dispatch, execution, "
             "entitlement, or provider availability evidence."
@@ -915,6 +924,7 @@ def cmd_coding_category_maestro(args: argparse.Namespace) -> int:
         lines.append("rejected config pieces:")
         lines.extend(f"  ! {note}" for note in rejected)
     lines.append("* = operator override from category-maestro.json; others are built-in defaults.")
+    lines.append(catalogless_note)
     print("\n".join(lines))
     return 0
 

--- a/tests/test_category_maestro.py
+++ b/tests/test_category_maestro.py
@@ -433,6 +433,26 @@ class CategoryMaestroCliTests(unittest.TestCase):
             self.assertNotEqual(status, 0)
             self.assertIn("no-such", stderr)
 
+    def test_show_names_where_catalogless_profiles_route_categories(self) -> None:
+        # pi/omo-runtime is deliberately absent from this table (one-basis
+        # rule); show must say where its categories DO come from instead of
+        # reading as "no category routing there".
+        with TemporaryDirectory() as tmp:
+            base = ["--omh-home", str(Path(tmp) / ".omh")]
+            status, stdout, stderr = run_cli(
+                base + ["coding", "category-maestro", "show"], output_json=False
+            )
+            self.assertEqual((status, stderr), (0, ""))
+            self.assertIn("omo-runtime (host CLI: pi/senpi)", stdout)
+            self.assertIn("--from-inventory", stdout)
+            status, stdout, stderr = run_cli(
+                base + ["coding", "category-maestro", "show", "--json"], output_json=False
+            )
+            self.assertEqual((status, stderr), (0, ""))
+            note = json.loads(stdout)["catalogless_note"]
+            self.assertIn("omo-runtime", note)
+            self.assertIn("omo config", note)
+
     def test_interview_refuses_without_a_terminal_and_names_the_scriptable_path(self) -> None:
         with TemporaryDirectory() as tmp:
             base = ["--omh-home", str(Path(tmp) / ".omh")]


### PR DESCRIPTION
## Feature Report

### What Changed

- `omh coding category-maestro show` now ends with one line naming where catalogless profiles route their categories: `omo-runtime (host CLI: pi/senpi)` resolves from the locally-derived model catalog (omo config), previewable via `omh coding model-route --executor omo-runtime --from-inventory`. The JSON report gains the same text as an additive `catalogless_note` field.

### Why This Exists

- Owner asked whether pi needs category-maestro support ("pi도 지원해야하나") and then asked for this pointer line ("그 안내 한줄도 추가해줘"). pi/omo-runtime already has category routing through its omo-config-derived local catalog — the #1180 one-basis rule deliberately keeps it out of category-maestro — but `show` said nothing, so the table read as "pi has no category routing".

### User / Operator Impact

- `show` output (text and `--json`) now tells a pi/omo operator where their category table actually lives and the command that previews a route from it. No routing behavior changes.

### How It Works

- One string appended to the text output and included in the `omh_category_maestro_report/v1` payload as `catalogless_note` (additive field, no schema bump).

### Files And Contracts Touched

- `src/commands/coding.py`, `tests/test_category_maestro.py` (32→33 cases). `omh_category_maestro_report/v1` gains one additive field.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [x] Codex
- [x] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [ ] `uv run python -m omh.cli docs workflows --check`
- [ ] `uv run python -m omh.cli docs roles --check`
- [ ] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- Full suite from a neutral-path worktree at this commit: `Ran 8079 tests — OK`.
- New test pins the note in both text and JSON output; the whole category-maestro suite (33 cases) passes.

### Not Tested / Not Applicable

- Docs byte gates / harness / release / install smoke: no generated-doc, harness, release, or install surface touched (one CLI string + one report field).
- No live pi/senpi CLI invocation — presence-only claims, as everywhere in this lane.

## Risk

- None beyond `omh_category_maestro_report/v1` consumers seeing one additive field.

## Compatibility / Rollout

- Additive only; reaches a live machine via `omh update`.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9F2nbnc7hajqzznXcgLZn
