### PR TITLE
docs: bring README, site, installation, and agent-install surfaces current with category-maestro

### DIFF
--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -353,6 +353,15 @@ conversation:
    or edit `~/.omh/routing/model-chains.json` directly — both write the same
    `mixture_chain_overrides/v1` document.
 4. Re-run `omh model-chains show` and report the confirmed state.
+5. When a `codex` or `claude` CLI is detected on PATH, offer the Maestro
+   lane's own category table the same way: `omh coding category-maestro show`
+   presents the effective table per dispatchable profile, and
+   `omh coding category-maestro set <profile> <category> <model[:effort]>...`
+   is the scriptable write (`omh coding category-maestro interview` is the
+   human terminal path and refuses non-TTY sessions). This table routes
+   `omh coding run --category <c>` and fanout units that declare a
+   `category`; an explicit `--model` always outranks it, and skipping this
+   step keeps the built-in defaults.
 
 If a chain alias needs a provider-specific wire model, edit the sibling
 `~/.omh/routing/model-providers.json` document:

--- a/README.md
+++ b/README.md
@@ -318,12 +318,23 @@ preferences, not benchmark results. See
 setup, fallback, provider, and ownership rules.
 
 Coding delegation dispatch (`omh coding run` / `omh coding fanout dispatch`)
-reads a separate, operator-set preference, not this file: for the strongest
-Claude Code tier, set `"claude-code": "opus"` in
-`~/.omh/routing/dispatch-models.json`, or pass `--model opus` on one `omh
-coding run` invocation; set an equivalent `codex` entry once you have
-confirmed the model id your account is entitled to. See `docs/FANOUT.md`
-(Dispatch-model preference) for the schema and the full precedence order.
+— the Maestro lane that spawns Claude Code or Codex directly — has the same
+category dial as its own sibling file. Route it per work category with
+
+```sh
+$ omh coding category-maestro set codex ultrabrain gpt-5.6-sol:xhigh
+$ omh coding category-maestro interview   # guided walk, Enter keeps each chain
+$ omh coding run --owner codex --category ultrabrain --goal ...
+```
+
+which edits `~/.omh/routing/category-maestro.json`
+(`omh_category_maestro/v1`); `omh coding category-maestro show` prints the
+effective table with operator overrides marked, and the interactive
+`omh setup` offers the same walk. An explicit `--model` on a run always wins,
+and `~/.omh/routing/dispatch-models.json` remains the per-owner default used
+only when no route resolves at all (for the strongest Claude Code tier, set
+`"claude-code": "opus"` there). See `docs/FANOUT.md` (Category-maestro and
+Dispatch-model preference) for schemas and the full precedence order.
 
 <details>
 <summary><strong>Or paste this into Hermes or another coding agent</strong></summary>

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -288,14 +288,33 @@ evidence), and is safe to delete — an absent or invalid file only means HUD
 rows fall back to plain category projection.
 
 A fourth sibling, `~/.omh/routing/dispatch-models.json`
-(`omh_dispatch_model_preferences/v1`), is operator-edited only — nothing
-seeds or writes it automatically — and applies to a different surface:
+(`omh_dispatch_model_preferences/v1`), applies to a different surface:
 `omh coding fanout dispatch`'s `--model` fallback for a spawned agent CLI,
-used only when a unit's prepared handoff routed no model at all. See
-`docs/FANOUT.md` (Dispatch-model preference) for the schema and the
-`claude-code`/`codex` behavior it fills the gap for; on `omh coding run` it
-sits below that command's own `--model` flag and any routed handoff model,
-above only the executor CLI's own default.
+used only when a unit's prepared handoff routed no model at all. It is
+operator-edited (the interactive `omh setup` maestro question seeds it empty
+on an explicit "yes"; nothing else writes it). See `docs/FANOUT.md`
+(Dispatch-model preference) for the schema and the `claude-code`/`codex`
+behavior it fills the gap for; on `omh coding run` it sits below that
+command's own `--model` flag and any routed handoff model, above only the
+executor CLI's own default.
+
+A fifth sibling, `~/.omh/routing/category-maestro.json`
+(`omh_category_maestro/v1`), is the Maestro lane's own category dial — the
+same category vocabulary as the mixture above, applied to the dispatched
+`codex`/`claude-code` CLIs. `omh coding category-maestro show` prints the
+effective category → model table (operator overrides marked, invalid pieces
+named), `omh coding category-maestro set <profile> <category>
+<model[:effort]>...` is the scriptable write,
+`omh coding category-maestro clear` restores a built-in chain, and
+`omh coding category-maestro interview` walks it guided — the interactive
+`omh setup` offers that walk right after the maestro question. The file's
+presence is the opt-in: machines without it keep byte-identical routes, and
+routes resolved against it record `catalog_kind: "operator_category_config"`
+plus the config fingerprint in the frozen contract. Catalogless profiles
+(for example `omo-runtime`, host CLI `pi`/`senpi`) are deliberately not
+configured here — their categories resolve from the locally-derived model
+catalog (omo config). See `docs/FANOUT.md` (Category-maestro) for the full
+rules.
 
 ### Reaching models through a provider
 
@@ -435,11 +454,22 @@ implicit default.
    `prepared`, not `observed` — the probe actually invokes the CLI (a
    `--version` or no-op call) and reads its configured model before calling it
    ready. Treat a `prepared`-only result as not yet ready.
-3. **Optional: set a dispatch-model preference.** `omh coding fanout
+3. **Optional: route per work category.** The Maestro lane resolves each
+   unit's model from a category → model table (`ultrabrain`, `deep`, `quick`,
+   `writing`, ...). Override it per profile with
+   `omh coding category-maestro set codex ultrabrain gpt-5.6-sol:xhigh`, walk
+   it guided with `omh coding category-maestro interview` (the interactive
+   `omh setup` offers this walk too), and inspect the effective table with
+   `omh coding category-maestro show`. A unit declares its category
+   (`omh coding run --category <c>`, or a `category` field on a fanout unit);
+   an explicit `--model` always wins. See `docs/FANOUT.md`
+   (Category-maestro).
+4. **Optional: set a dispatch-model preference.** `omh coding fanout
    dispatch` spawns each CLI headlessly and falls back to a `--model` value
    only when a unit's prepared handoff routed no model at all. That fallback
-   is operator-edited only — nothing seeds or writes it automatically — at
-   `~/.omh/routing/dispatch-models.json`
+   lives at `~/.omh/routing/dispatch-models.json` — seeded empty only by an
+   explicit "yes" to the interactive setup's maestro question, otherwise
+   operator-edited —
    (`omh_dispatch_model_preferences/v1`, a `profiles` map from owner to model
    string, e.g. `{"schema_version": "omh_dispatch_model_preferences/v1",
    "profiles": {"claude-code": "opus"}}`). Neither profile ships a shipped
@@ -448,7 +478,7 @@ implicit default.
    run can skip this file entirely with `omh coding run --model <id>`, which
    always outranks it. See `docs/FANOUT.md` (Dispatch-model preference) for
    the full schema.
-4. **Check what the CLI's own skills contribute to a handoff prompt.**
+5. **Check what the CLI's own skills contribute to a handoff prompt.**
    ```sh
    omh coding executor-skills --profile claude-code
    omh coding executor-skills --profile codex
@@ -457,7 +487,7 @@ implicit default.
    skills (name, invocation string, role) that the Maestro lane arranges into
    a composed prompt — a discovered `SKILL.md` is evidence the file exists,
    never evidence the receiving agent loads or honors it.
-5. **Know where routing sends the delegation intent.** Once a coding-owner
+6. **Know where routing sends the delegation intent.** Once a coding-owner
    choice for a run is explicit, the handoff is composed by the `ulw-maestro`
    skill — the skill-facing surface of the Maestro lane
    (`src/coding/maestro/`) described under "Hermes-native and Maestro

--- a/site/i18n.js
+++ b/site/i18n.js
@@ -636,10 +636,10 @@ window.OMH_I18N = {
       zh: "其结果是准备好的路由配置，而非提供方可用性、凭据、派发或执行的证据。"
     },
     "chain.edit": {
-      en: 'Every chain is yours to reorder. Edit <code>~/.omh/routing/model-chains.json</code>, then run <code>omh model-chains show</code> to print what is in effect.',
-      ko: '모든 체인은 직접 순서를 바꿀 수 있습니다. <code>~/.omh/routing/model-chains.json</code>을 편집한 뒤 <code>omh model-chains show</code>로 현재 적용된 내용을 출력하세요.',
-      ja: 'どのチェーンも自分で並べ替えられます。<code>~/.omh/routing/model-chains.json</code> を編集し、<code>omh model-chains show</code> で現在有効な内容を出力してください。',
-      zh: '每条链都可以由你重新排序。编辑 <code>~/.omh/routing/model-chains.json</code>，再运行 <code>omh model-chains show</code> 打印当前生效的配置。'
+      en: 'Every chain is yours to reorder. Edit <code>~/.omh/routing/model-chains.json</code>, then run <code>omh model-chains show</code> to print what is in effect. The Maestro lane — dispatched Claude Code and Codex units — has the same dial: <code>omh coding category-maestro interview</code>.',
+      ko: '모든 체인은 직접 순서를 바꿀 수 있습니다. <code>~/.omh/routing/model-chains.json</code>을 편집한 뒤 <code>omh model-chains show</code>로 현재 적용된 내용을 출력하세요. Maestro 레인 — 디스패치되는 Claude Code·Codex 유닛 — 에도 같은 다이얼이 있습니다: <code>omh coding category-maestro interview</code>.',
+      ja: 'どのチェーンも自分で並べ替えられます。<code>~/.omh/routing/model-chains.json</code> を編集し、<code>omh model-chains show</code> で現在有効な内容を出力してください。Maestro レーン — ディスパッチされる Claude Code・Codex ユニット — にも同じダイヤルがあります: <code>omh coding category-maestro interview</code>。',
+      zh: '每条链都可以由你重新排序。编辑 <code>~/.omh/routing/model-chains.json</code>，再运行 <code>omh model-chains show</code> 打印当前生效的配置。Maestro 通道——被派发的 Claude Code 与 Codex 单元——也有同样的旋钮：<code>omh coding category-maestro interview</code>。'
     },
 
     "install.routing.note": {

--- a/site/index.html
+++ b/site/index.html
@@ -357,7 +357,7 @@
         </div>
 
         <p class="ev-note" data-reveal data-i18n="chain.note">The result is prepared routing configuration, not provider availability, credential, dispatch, or execution evidence.</p>
-        <p class="ev-note" data-reveal data-i18n-html="chain.edit">Every chain is yours to reorder. Edit <code>~/.omh/routing/model-chains.json</code>, then run <code>omh model-chains show</code> to print what is in effect.</p>
+        <p class="ev-note" data-reveal data-i18n-html="chain.edit">Every chain is yours to reorder. Edit <code>~/.omh/routing/model-chains.json</code>, then run <code>omh model-chains show</code> to print what is in effect. The Maestro lane — dispatched Claude Code and Codex units — has the same dial: <code>omh coding category-maestro interview</code>.</p>
       </section>
 
       <!-- ======================================================= PLATFORMS -->


### PR DESCRIPTION
## Feature Report

### What Changed

- README, `docs/INSTALLATION.md`, `INSTALL_FOR_AGENTS.md`, and the site now document the Maestro lane's category routing (category-maestro, PRs #1180/#1185/#1192) everywhere the install story previously ended at `dispatch-models.json`.
- README's coding-delegation section leads with `omh coding category-maestro set/interview` and `omh coding run --category`, describing `dispatch-models.json` as the no-route fallback it is.
- `docs/INSTALLATION.md` documents `~/.omh/routing/category-maestro.json` as the fifth routing sibling (schema, editors, the interactive-setup offer, presence-is-opt-in, frozen-contract basis recording, and the pi/omo-runtime exclusion), adds a "route per work category" step to the guided delegation checklist (subsequent items renumbered), and fixes the now-stale "nothing seeds dispatch-models.json" wording to name the setup-question seeding.
- `INSTALL_FOR_AGENTS.md`'s post-setup interview protocol gains a step offering the Maestro category table through the scriptable CLI when a codex/claude CLI is detected.
- `site/index.html` + `site/i18n.js`: the chain-editing note names the Maestro dial in all four locales (en/ko/ja/zh).

### Why This Exists

- Owner directive: bring README, site, docs, and install-related surfaces up to date ("readme, site, docs, install관련된거 다 최신화해줘"). The feature shipped but the onboarding prose still described the lane as dispatch-models-only, so a fresh install would never discover the category dial from the docs.

### User / Operator Impact

- Documentation only: a reader following any install path (README quick view, INSTALLATION deep dive, agent-driven install, or the site) now finds the category table, its editors, and its precedence in the same place the native mixture is explained.

### How It Works

- Prose edits only; all changes sit outside the marked ULW generated regions, so every `docs --check` byte gate stays byte-identical.

### Files And Contracts Touched

- `README.md`, `docs/INSTALLATION.md`, `INSTALL_FOR_AGENTS.md`, `site/index.html`, `site/i18n.js`. No code, schema, or generated artifact touched.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [x] Codex
- [x] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [ ] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- All five docs byte gates green (`workflows`, `roles`, `capability-families`, `ulw-inventory`, `ulw-site`) — the edits sit outside the generated regions.
- `test_distribution_surfaces` / `test_ulw_inventory` / `test_ulw_count_gates` / `test_model_recommendations` (53 tests) OK — the site/i18n surfaces these pin are unaffected.
- Full suite from a neutral-path worktree at this commit: `Ran 8079 tests — OK`.

### Not Tested / Not Applicable

- `compileall` / harness / release / install smoke: no Python or install-surface change (prose only; ruff and the full suite ran as part of the standard gate set anyway).
- Site rendering not eyeballed in a browser — the change is text inside one existing i18n key and its matching default markup.
- ja/zh copy not reviewed by a native speaker.

## Risk

- None functional. Wording risk only; every claim mirrors `docs/FANOUT.md`, which remains the source of the full rules.

## Compatibility / Rollout

- Documentation only; site deploys with the repo, README/docs reach machines via `omh update`.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9F2nbnc7hajqzznXcgLZn
