### PR TITLE
fix(coding): spell out the sidecar's closed enums in the executor-facing prompt

### DIFF
--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -58,7 +58,12 @@ from .fanout_retry import (
     evaluate_unit_retry,
 )
 from .unit_prompt_protocol import shared_unit_preamble_lines, unit_protocol_lines
-from .fanout_unit_results import validate_check_rows, validate_unit_result
+from .fanout_unit_results import (
+    FANOUT_UNIT_RESULT_CHECK_STATUSES,
+    FANOUT_UNIT_RESULT_PROCESS_STATUSES,
+    validate_check_rows,
+    validate_unit_result,
+)
 from .unit_telemetry import parse_unit_telemetry
 
 FANOUT_DISPATCH_SCHEMA_VERSION = "fanout_dispatch_summary/v1"
@@ -638,7 +643,18 @@ def build_unit_prompt(
 
 
 def _unit_result_prompt_lines(contract: Mapping[str, Any]) -> list[str]:
-    """Executor-neutral, typed sidecar contract appended to a live unit prompt."""
+    """Executor-neutral, typed sidecar contract appended to a live unit prompt.
+
+    The closed enums are spelled out with their exact literals — imported from
+    the validator's own tuples so prompt and validation can never drift. The
+    validator deliberately never infers or aliases (a "success" it normalized
+    into "process_succeeded" would launder an executor claim), so this prompt
+    is the ONLY channel that tells a foreign executor which values validate;
+    omitting them produced real `unit_result_invalid` outcomes on work that
+    had succeeded (#1190).
+    """
+    process_values = " or ".join(f'"{value}"' for value in FANOUT_UNIT_RESULT_PROCESS_STATUSES)
+    check_values = ", ".join(f'"{value}"' for value in FANOUT_UNIT_RESULT_CHECK_STATUSES)
     return [
         "Before exiting, write one fanout_unit_result/v1 JSON sidecar to exactly "
         f"{contract.get('path', '')}.",
@@ -648,8 +664,10 @@ def _unit_result_prompt_lines(contract: Mapping[str, Any]) -> list[str]:
         f"schema_version=fanout_unit_result/v1, unit_id={contract.get('unit_id', '')}, "
         f"run_id={contract.get('run_id', '')}, fanout_id={contract.get('fanout_id', '')}, "
         f"base_sha={contract.get('base_sha', '')}; head_sha is the git HEAD you leave behind.",
+        f"process_status must be exactly {process_values} — no other value validates.",
         "Each checks row fields: command, status, evidence_ref, reported_by, observed_by, "
         "observation_source.",
+        f"Each checks row status must be exactly one of {check_values} — no other value validates.",
         "For every executor-authored checks row, set reported_by=executor. observed_by and "
         "observation_source are dispatcher-owned; leave both null. Sidecar validation records "
         "only a report and never verification.",

--- a/tests/test_fanout_unit_results.py
+++ b/tests/test_fanout_unit_results.py
@@ -74,6 +74,38 @@ def _payload_with_check(**check_overrides: object) -> dict[str, object]:
 
 
 class FanoutUnitResultTests(unittest.TestCase):
+    def test_prompt_names_every_enum_literal_the_validator_demands(self) -> None:
+        # #1190: the validator never infers ("success" is rejected, correctly),
+        # so the executor-facing prompt is the ONLY channel that communicates
+        # the closed vocabularies. Every literal must appear verbatim, sourced
+        # from the validator's own tuples so the two can never drift.
+        from omh.coding.fanout_dispatch import _unit_result_prompt_lines
+        from omh.coding.fanout_unit_results import (
+            FANOUT_UNIT_RESULT_CHECK_STATUSES,
+            FANOUT_UNIT_RESULT_PROCESS_STATUSES,
+        )
+
+        prompt = "\n".join(
+            _unit_result_prompt_lines(
+                {
+                    "path": "/tmp/unit-result.json",
+                    "unit_id": "core",
+                    "run_id": "run-1",
+                    "fanout_id": "fanout-0123456789ab",
+                    "base_sha": "0" * 40,
+                }
+            )
+        )
+        for literal in FANOUT_UNIT_RESULT_PROCESS_STATUSES + FANOUT_UNIT_RESULT_CHECK_STATUSES:
+            self.assertIn(f'"{literal}"', prompt)
+
+    def test_natural_language_process_status_is_rejected_with_the_enum_named(self) -> None:
+        with self.assertRaises(ValueError) as caught:
+            validate_unit_result({**VALID_PAYLOAD, "process_status": "success"})
+        message = str(caught.exception)
+        self.assertIn("process_succeeded", message)
+        self.assertIn("'success'", message)
+
     def test_valid_payload_normalizes(self) -> None:
         result = validate_unit_result(VALID_PAYLOAD)
 


### PR DESCRIPTION
## Feature Report

### What Changed

- The executor-facing unit prompt (`_unit_result_prompt_lines`) now states the sidecar's closed enums with their exact literals: `process_status must be exactly "process_succeeded" or "process_failed"`, and `checks[].status` must be one of `"passed", "failed", "skipped"`. Both lines interpolate the validator's own tuples (`FANOUT_UNIT_RESULT_PROCESS_STATUSES` / `FANOUT_UNIT_RESULT_CHECK_STATUSES`) so prompt and validation can never drift.

### Why This Exists

- Fixes #1190. The dispatcher validates `fanout_unit_result/v1` against exact closed vocabularies and deliberately never infers or aliases (normalizing `"success"` into `"process_succeeded"` would launder an executor claim). The prompt named the fields but never their allowed values, and it is the ONLY channel a foreign executor CLI has — the issue's real run (claude-code, exit 0, work done) was recorded `unit_result_invalid` for writing the natural `process_status: "success"`.

### User / Operator Impact

- Executors dispatched by `omh coding fanout dispatch` / `omh coding run` now receive the exact literals; a succeeded unit no longer degrades to `unit_result_invalid` for guessing natural vocabulary. The validator is untouched — no relaxation, no aliasing.

### How It Works

- Two added prompt lines in `src/coding/fanout_dispatch.py`, values imported from `fanout_unit_results` (the issue verified via grep that no other channel communicated the enum).

### Files And Contracts Touched

- `src/coding/fanout_dispatch.py`, `tests/test_fanout_unit_results.py`. No schema or validator change.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [x] Codex
- [x] Claude Code
- [ ] Hermes runtime or handoff
- [x] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [ ] `uv run python -m omh.cli docs workflows --check`
- [ ] `uv run python -m omh.cli docs roles --check`
- [ ] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- Full suite from a neutral-path worktree at this commit: `Ran 8102 tests — OK`.
- New tests implement the issue's repro contract: the prompt must contain every enum literal (the issue's "defect assertion" inverted — it starts passing exactly when the fix lands), and `"success"` is rejected with the enum named in the error. Fanout/unit-prompt suites (261 tests) green.
- Verified no existing test pinned the previous prompt text byte-exactly (grep before edit), so the two added lines break no byte-identity contract.

### Not Tested / Not Applicable

- Docs byte gates: no generated docs touched.
- No live executor dispatch was spawned — the failure mode is fully reproduced by the validator + prompt assertions; a routed prompt remains prepared metadata.

## Risk

- Unit prompts grow two lines. Executors already following the enum see no behavioral difference.

## Compatibility / Rollout

- Prompt-only; reaches machines via `omh update`. Frozen contracts and recorded results are unaffected.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- None; the issue's optional suggestion (check-row statuses) is included in this PR.

Fixes #1190

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9F2nbnc7hajqzznXcgLZn
