### PR TITLE
feat(security): named strict security posture via OMH_SECURITY

### DIFF
--- a/src/coding/coding_delegation.py
+++ b/src/coding/coding_delegation.py
@@ -74,6 +74,7 @@ from .context_safety import (
 from ..harness_quality import with_wrapper_actions
 from ..quality.specialist_work import build_specialist_work_quality_contract
 from ..quality.verification_tiering import sensitive_path_escalation
+from ..system.security_posture import STRICT_POSTURE, resolve_security_posture
 from ..ingress import CHAT_SOURCES, extract_message_text, extract_source_metadata
 from ..isolation import build_isolation_plan
 from ..memory import validate_handoff_context_blocked, validate_handoff_context_pack, validate_project_memory_recall_pack
@@ -1683,6 +1684,15 @@ def _verification(intent: str, action: str, workflow: str, target_paths: Sequenc
     escalation = sensitive_path_escalation(target_paths)
     if escalation is not None:
         checks = (*checks, f"Escalate to the thorough verification lane: {escalation['reason']}")
+    elif resolve_security_posture() == STRICT_POSTURE:
+        # Strict posture (`security_posture.POSTURE_MAPPING`, key
+        # `verification_escalate_always`): every request escalates, not only
+        # the ones the sensitive-path classifier recognizes by pattern.
+        checks = (
+            *checks,
+            "Escalate to the thorough verification lane: OMH_SECURITY=strict escalates every "
+            "request regardless of touched path.",
+        )
     return checks
 
 

--- a/src/coding/parallelism_policy.py
+++ b/src/coding/parallelism_policy.py
@@ -14,12 +14,19 @@ The same block also carries the spawn guard — `max_depth` and
 `run_spawn_ceiling` — because both bound the same one subprocess exception
 from a different direction: the pool width bounds how many units run at once,
 the ceiling bounds how many are ever started, and the depth cap bounds whether
-a dispatched agent CLI may dispatch again at all.
+a dispatched agent CLI may dispatch again at all. `max_retries` rides along
+for the same reason, sized by `fanout_retry.FANOUT_MAX_RETRIES`.
+
+`read_parallelism_policy` applies the active `OMH_SECURITY` posture last, on
+top of the stored profile: `default` changes nothing, `strict` clamps every
+tunable here (and `max_retries`) to the ceiling named in
+`system.security_posture.POSTURE_MAPPING`, disclosed the same
+clamp-and-name way an out-of-range profile value already is.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Mapping
 
 from ..profiles.setup import (
     PARALLELISM_DEFAULTS,
@@ -27,6 +34,13 @@ from ..profiles.setup import (
     read_setup_profile,
 )
 from ..system.paths import OmhPaths
+from ..system.security_posture import (
+    DEFAULT_POSTURE,
+    STRICT_POSTURE,
+    resolve_security_posture,
+    strict_override,
+)
+from .fanout_retry import FANOUT_MAX_RETRIES
 
 # One config typo must not turn the fanout pool into a fork bomb: 32 is far
 # above any real local agent-CLI fleet while still catching a stray 500.
@@ -89,13 +103,25 @@ def build_parallelism_policy() -> dict[str, Any]:
     }
 
 
-def read_parallelism_policy(paths: OmhPaths) -> dict[str, Any]:
-    """The effective policy: stored `parallelism` overrides on the defaults."""
+def read_parallelism_policy(paths: OmhPaths, *, env: Mapping[str, str] | None = None) -> dict[str, Any]:
+    """The effective policy: stored `parallelism` overrides on the defaults,
+    then the active security posture's ceilings.
+
+    `env` is injected the same way `dispatch_fanout`'s own spawn-guard read
+    is, so the posture resolution is exercised without mutating process
+    environment in a test. Posture resolution can raise `ValueError` for an
+    unrecognized `OMH_SECURITY` value; unlike an invalid stored profile value
+    (which falls back and is named in `ignored_keys`), an invalid posture is
+    a loud refusal, not a silent fallback -- callers that reach this from a
+    CLI command must catch it and convert it to a clean CLI error.
+    """
     policy = build_parallelism_policy()
+    policy["max_retries"] = FANOUT_MAX_RETRIES
+    posture = resolve_security_posture(env)
     setup = read_setup_profile(paths)
     stored = setup.get("parallelism") if isinstance(setup, dict) else None
     if not isinstance(stored, dict):
-        return policy
+        return _apply_security_posture(policy, posture)
     ignored: list[str] = []
     for key in _BOUNDED_KEYS:
         if key not in stored:
@@ -133,6 +159,39 @@ def read_parallelism_policy(paths: OmhPaths) -> dict[str, Any]:
         policy["default_concurrency_clamped_from"] = policy["default_concurrency"]
         policy["default_concurrency"] = policy["global_concurrency"]
     policy["ignored_keys"] = ignored
+    return _apply_security_posture(policy, posture)
+
+
+# Every numeric tunable the strict posture ceilings apply to, paired with its
+# `security_posture` mapping-table key. Order matches the cascade above so a
+# clamp report reads in the same "width, then guard, then retries" order an
+# operator already sees the rest of this policy in.
+_SECURITY_CLAMPED_KEYS: tuple[tuple[str, str], ...] = (
+    ("default_concurrency", "fanout_default_concurrency"),
+    ("global_concurrency", "fanout_global_concurrency"),
+    ("lane_budget_default", "fanout_lane_budget_default"),
+    ("max_depth", "fanout_max_depth"),
+    ("run_spawn_ceiling", "fanout_run_spawn_ceiling"),
+    ("max_retries", "fanout_max_retries"),
+)
+
+
+def _apply_security_posture(policy: dict[str, Any], posture: str) -> dict[str, Any]:
+    """Tighten `policy` to the active posture's ceilings, in place.
+
+    `default` posture returns `policy` completely unchanged beyond recording
+    the label -- every strict ceiling in `_SECURITY_CLAMPED_KEYS` is defined
+    to be at or below its surface's own default, so the clamp is a no-op
+    against a default-posture read and only ever lowers a strict one.
+    """
+    policy["security_posture"] = posture
+    if posture != STRICT_POSTURE:
+        return policy
+    for key, mapping_key in _SECURITY_CLAMPED_KEYS:
+        ceiling = strict_override(mapping_key, posture, policy[key])
+        if policy[key] > ceiling:
+            policy[f"{key}_security_clamped_from"] = policy[key]
+            policy[key] = ceiling
     return policy
 
 
@@ -166,6 +225,8 @@ def resolve_fanout_concurrency(policy: dict[str, Any], requested: int | None) ->
         # "how wide", "how deep", and "how many in total" together.
         "max_depth": int(policy.get("max_depth", FANOUT_MAX_DEPTH_DEFAULT)),
         "run_spawn_ceiling": int(policy.get("run_spawn_ceiling", FANOUT_RUN_SPAWN_CEILING_DEFAULT)),
+        "max_retries": int(policy.get("max_retries", FANOUT_MAX_RETRIES)),
+        "security_posture": str(policy.get("security_posture", DEFAULT_POSTURE)),
     }
     global_clamped_from = policy.get("global_concurrency_clamped_from")
     if global_clamped_from is not None:

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -1906,7 +1906,10 @@ def cmd_coding_fanout_dispatch(args: argparse.Namespace) -> int:
     from ..coding.parallelism_policy import read_parallelism_policy, resolve_fanout_concurrency
 
     paths = _paths(args)
-    parallelism = read_parallelism_policy(paths)
+    try:
+        parallelism = read_parallelism_policy(paths)
+    except ValueError as exc:
+        raise OmhError(str(exc)) from exc
     concurrency = resolve_fanout_concurrency(parallelism, args.concurrency)
     try:
         contract = read_fanout_contract(paths, args.fanout_id)
@@ -1940,6 +1943,7 @@ def cmd_coding_fanout_dispatch(args: argparse.Namespace) -> int:
             concurrency_policy=concurrency,
             max_depth=parallelism["max_depth"],
             spawn_ceiling=parallelism["run_spawn_ceiling"],
+            max_retries=parallelism["max_retries"],
             timeout=args.timeout,
             only_units=args.unit,
             dry_run=bool(args.dry_run),
@@ -1972,6 +1976,7 @@ def cmd_coding_fanout_dispatch(args: argparse.Namespace) -> int:
             concurrency_policy=concurrency,
             max_depth=parallelism["max_depth"],
             spawn_ceiling=parallelism["run_spawn_ceiling"],
+            max_retries=parallelism["max_retries"],
             timeout=args.timeout,
             only_units=args.unit,
             dry_run=bool(args.dry_run),
@@ -2087,7 +2092,10 @@ def cmd_coding_run(args: argparse.Namespace) -> int:
     )
     if resolved.returncode != 0:
         raise OmhError(f"could not resolve --base-ref {args.base_ref!r} in {repo_root}: {resolved.stderr.strip()}")
-    parallelism = read_parallelism_policy(paths)
+    try:
+        parallelism = read_parallelism_policy(paths)
+    except ValueError as exc:
+        raise OmhError(str(exc)) from exc
     concurrency = resolve_fanout_concurrency(parallelism, None)
     try:
         summary = dispatch_fanout(
@@ -2102,6 +2110,7 @@ def cmd_coding_run(args: argparse.Namespace) -> int:
             concurrency_policy=concurrency,
             max_depth=parallelism["max_depth"],
             spawn_ceiling=parallelism["run_spawn_ceiling"],
+            max_retries=parallelism["max_retries"],
             timeout=args.timeout,
             dry_run=bool(args.dry_run),
             run_verification=bool(args.run_verification),

--- a/src/maintenance/doctor.py
+++ b/src/maintenance/doctor.py
@@ -36,6 +36,7 @@ from ..plugin_observations import (
 from ..plugin_pack import PLUGIN_NAME, inspect_plugin_bundle
 from ..runtime.artifacts import read_state, read_state_error
 from ..skill_pack import CORE_SKILLS, builtin_skill_templates
+from ..system.security_posture import SECURITY_POSTURE_ENV_VAR, STRICT_POSTURE, resolve_security_posture
 from ..version import __version__
 from ..targets import read_target_registry_result, summarize_target_registry
 from ..workflow_state import list_workflow_states
@@ -347,7 +348,40 @@ def run_doctor(paths: OmhPaths) -> list[Check]:
         )
     checks.append(_structural_search_check())
     checks.append(_trigger_language_pack_check(paths))
+    checks.append(_security_posture_check())
     return checks
+
+
+def _security_posture_check() -> Check:
+    """Surface the active `OMH_SECURITY` posture (`P3 -- named strict security posture`).
+
+    Same shape as `_structural_search_check`: this is informational, not a
+    health gate, so both branches stay `ok=True`/`severity="ok"` -- `strict`
+    is opt-in, not a recommended state, and `default` is not a warning. An
+    unrecognized `OMH_SECURITY` value is the one case doctor reports as a
+    failing check, since a security knob that fails open on a typo must be
+    loud, and a health check is the surface an operator reads for exactly
+    that kind of misconfiguration.
+    """
+    try:
+        posture = resolve_security_posture()
+    except ValueError as exc:
+        return Check(
+            "security_posture",
+            False,
+            str(exc),
+            severity="warning",
+            next_action=f"Set {SECURITY_POSTURE_ENV_VAR} to `default` or `strict`, or unset it.",
+        )
+    if posture == STRICT_POSTURE:
+        message = f"active security posture: {posture} ({SECURITY_POSTURE_ENV_VAR}=strict)"
+    else:
+        message = (
+            f"active security posture: {posture} "
+            f"(set {SECURITY_POSTURE_ENV_VAR}=strict to tighten fanout concurrency, retries, "
+            "verification escalation, and the loop stop ladder together)"
+        )
+    return Check("security_posture", True, message, severity="ok", next_action="")
 
 
 def _trigger_language_pack_check(paths: OmhPaths) -> Check:

--- a/src/system/security_posture.py
+++ b/src/system/security_posture.py
@@ -1,0 +1,178 @@
+"""Named strict security posture: one switch that bundles the tightened end of
+OMH's already-existing safety knobs, instead of an operator hand-tuning each
+one across the setup profile.
+
+`OMH_SECURITY=strict` follows the same env-resolution idiom `OMH_LANG` and
+`OMH_HOME` already use: unset or blank reads as the safe, unchanged default,
+and an unrecognized value is a loud `ValueError` naming the valid choices --
+never a silent fallback, because a security knob that fails open on a typo is
+worse than no knob at all.
+
+`POSTURE_MAPPING` is the single table every tightened surface reads through.
+Each row names the surface module, the value strict applies there, and a
+short rationale -- it deliberately does NOT carry the default value: every
+consuming surface already owns its default as a pre-existing constant, and
+asking this module to restate it would create a second copy that could drift
+from the original. `default` posture therefore changes nothing anywhere:
+every surface's own constant is untouched, and this module is never consulted
+for a value beyond the posture label itself.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Mapping, NamedTuple
+
+SECURITY_POSTURE_SCHEMA_VERSION = "omh_security_posture/v1"
+SECURITY_POSTURE_ENV_VAR = "OMH_SECURITY"
+
+DEFAULT_POSTURE = "default"
+STRICT_POSTURE = "strict"
+VALID_POSTURES: tuple[str, ...] = (DEFAULT_POSTURE, STRICT_POSTURE)
+
+
+class PostureRow(NamedTuple):
+    key: str
+    surface: str
+    strict_value: Any
+    rationale: str
+
+
+# One row per tightened surface. `key` is the lookup a surface module passes
+# to `strict_override`/`security_posture_value`; `surface` is the file that
+# reads it, for the doctor/status projection; `strict_value` is what
+# `strict` applies -- the default lives only in the surface's own constant.
+# Two rows (`completion_integrity_refusal_overridable`,
+# `dispatch_confirmation_required`) tighten nothing: both gates are already
+# non-overridable/always-required in `default` posture, and the row exists so
+# the mapping table documents the invariant instead of leaving it unstated.
+POSTURE_MAPPING: tuple[PostureRow, ...] = (
+    PostureRow(
+        "fanout_default_concurrency",
+        "src/coding/parallelism_policy.py",
+        2,
+        "Fewer fanout units run at once by default, so a misjudged contract burns less "
+        "provider budget before an operator notices.",
+    ),
+    PostureRow(
+        "fanout_global_concurrency",
+        "src/coding/parallelism_policy.py",
+        3,
+        "The pool-wide ceiling shrinks alongside the per-lane default and clamps any "
+        "setup-profile override that would otherwise reopen the width strict just closed.",
+    ),
+    PostureRow(
+        "fanout_lane_budget_default",
+        "src/coding/parallelism_policy.py",
+        2,
+        "The advisory Hermes-native lane budget matches the tightened dispatch pool so the "
+        "two numbers an operator reads never disagree.",
+    ),
+    PostureRow(
+        "fanout_max_depth",
+        "src/coding/parallelism_policy.py",
+        1,
+        "Already the minimum that permits one dispatch at all; strict pins it as a hard "
+        "ceiling a setup-profile override cannot raise.",
+    ),
+    PostureRow(
+        "fanout_run_spawn_ceiling",
+        "src/coding/parallelism_policy.py",
+        10,
+        "One dispatch run may start far fewer real agent-CLI processes in total, bounding "
+        "the worst case of a misjudged contract regardless of pool width.",
+    ),
+    PostureRow(
+        "fanout_max_retries",
+        "src/coding/fanout_retry.py",
+        0,
+        "Zero retries on transient (ambiguous) classifications: a strict operator wants a "
+        "surfaced failure, not an automatic second attempt.",
+    ),
+    PostureRow(
+        "verification_escalate_always",
+        "src/quality/verification_tiering.py",
+        True,
+        "Every request escalates to the thorough verification lane, not only ones that "
+        "touch a recognized sensitive-path pattern the classifier already knows.",
+    ),
+    PostureRow(
+        "loop_no_progress_cap",
+        "src/workflows/goal_loop.py",
+        1,
+        "The stop ladder's no-progress rung fires after one stalled tick instead of two, so "
+        "a stuck loop surfaces sooner.",
+    ),
+    PostureRow(
+        "completion_integrity_refusal_overridable",
+        "src/quality/completion_integrity.py",
+        False,
+        "No override path exists in either posture -- completion-integrity refusals are "
+        "already non-overridable; the row documents the invariant rather than changing it.",
+    ),
+    PostureRow(
+        "dispatch_confirmation_required",
+        "src/coding/hermes_child_dispatch.py",
+        True,
+        "Explicit `ask_before_dispatch` confirmation is already required in both postures "
+        "(`require_hermes_child_dispatch_boundary`); the row documents the invariant.",
+    ),
+)
+
+_POSTURE_MAPPING_BY_KEY: dict[str, PostureRow] = {row.key: row for row in POSTURE_MAPPING}
+
+
+def resolve_security_posture(env: Mapping[str, str] | None = None) -> str:
+    """The active posture: `OMH_SECURITY` normalized, or `default` when unset.
+
+    Matches the `OMH_LANG`/`normalize_language` idiom: an unset or blank
+    value reads as the safe default, and an unrecognized value is a loud
+    refusal naming the valid choices rather than a silent fallback.
+    """
+    source = os.environ if env is None else env
+    raw = str(source.get(SECURITY_POSTURE_ENV_VAR, "") or "").strip().lower()
+    if not raw:
+        return DEFAULT_POSTURE
+    if raw in VALID_POSTURES:
+        return raw
+    valid = ", ".join(VALID_POSTURES)
+    raise ValueError(f"unsupported {SECURITY_POSTURE_ENV_VAR} value: {raw!r}; expected one of {valid}")
+
+
+def security_posture_value(key: str) -> Any:
+    """The `strict` value mapped for `key`. Raises `KeyError` for an unknown key."""
+    return _POSTURE_MAPPING_BY_KEY[key].strict_value
+
+
+def strict_override(key: str, posture: str, default: Any) -> Any:
+    """`default` unless `posture` is `strict`, in which case the mapped strict value.
+
+    Each surface passes its OWN pre-existing default constant in; this
+    module never states that default itself, so `default` posture can never
+    diverge from the value the surface already had -- there is no second
+    copy of the number to drift out of sync.
+    """
+    if posture != STRICT_POSTURE:
+        return default
+    return security_posture_value(key)
+
+
+def describe_security_posture(env: Mapping[str, str] | None = None) -> dict[str, Any]:
+    """The active posture plus the full mapping table, for a status/doctor surface."""
+    posture = resolve_security_posture(env)
+    return {
+        "schema_version": SECURITY_POSTURE_SCHEMA_VERSION,
+        "env_var": SECURITY_POSTURE_ENV_VAR,
+        "posture": posture,
+        "valid_postures": list(VALID_POSTURES),
+        "rows": [
+            {
+                "key": row.key,
+                "surface": row.surface,
+                "strict_value": row.strict_value,
+                "active_when_strict": posture == STRICT_POSTURE,
+                "rationale": row.rationale,
+            }
+            for row in POSTURE_MAPPING
+        ],
+    }

--- a/src/workflows/goal_loop.py
+++ b/src/workflows/goal_loop.py
@@ -19,6 +19,7 @@ from ..local_store import ensure_dir, read_json_object, utc_now
 from ..system.record_revision import DuplicateMutationReplay, guarded_record_update, revision_field_errors
 from ..loopability import LOOPABILITY_ASSESSMENT_SCHEMA, assess_loopability, validate_loopability_assessment
 from ..paths import OmhPaths
+from ..system.security_posture import resolve_security_posture, strict_override
 from .goal_quality_coaching import UPSTREAM_GOAL_DEFAULT_MAX_TURNS
 from .loop_phase_transitions import (
     LOOP_GOAL_DRIVER_OBSERVATION_SCHEMA,
@@ -1010,13 +1011,17 @@ def assess_loop_stop_ladder(
     ledger_entry_count: int = 0,
     limit_signal: Mapping[str, Any] | None = None,
     auth_signal: Mapping[str, Any] | None = None,
+    no_progress_cap: int = LOOP_NO_PROGRESS_TICK_CAP,
 ) -> dict[str, Any]:
     """Walk LOOP_STOP_REASONS in order and name the first rung that stops the tick.
 
     Pure policy over signals the caller already read, in the idiom
     `build_account_authorization` uses: the ladder never probes, so the same
     verdict is reproducible from a recorded snapshot. `read_loop_stop_ladder`
-    is the reading half.
+    is the reading half -- it also resolves `no_progress_cap` from the active
+    security posture (`system.security_posture`, key `loop_no_progress_cap`)
+    before calling in; the default here stays the unposture-adjusted
+    constant so a direct caller sees the same behavior as before.
     """
     runtime = _runtime_state(cycle.get("runtime"))
     executor_profile = _preferred_executor(_dict_value(cycle, "authority_envelope"))
@@ -1032,7 +1037,7 @@ def assess_loop_stop_ladder(
         _stop_rung_explicit_cancel(goal_linked, goal_status),
         _stop_rung_rate_limit(executor_profile, limit_signal),
         _stop_rung_auth_failure(executor_profile, planned_action, auth_signal),
-        _stop_rung_no_progress(goal_linked, no_progress_ticks),
+        _stop_rung_no_progress(goal_linked, no_progress_ticks, no_progress_cap),
     ]
 
     rungs: list[dict[str, Any]] = []
@@ -1068,7 +1073,7 @@ def assess_loop_stop_ladder(
         "next_action": _LOOP_STOP_NEXT_ACTIONS.get(stop_reason, ""),
         "ledger_entry_count": ledger_entry_count if goal_linked else previous_count,
         "no_progress_ticks": no_progress_ticks,
-        "no_progress_cap": LOOP_NO_PROGRESS_TICK_CAP,
+        "no_progress_cap": no_progress_cap,
         "rungs": rungs,
         "claim_boundary": LOOP_STOP_LADDER_CLAIM_BOUNDARY,
     }
@@ -1124,19 +1129,21 @@ def _stop_rung_auth_failure(
     return ("clear", f"The `{executor_profile}` login marker reads `{marker}`.")
 
 
-def _stop_rung_no_progress(goal_linked: bool, no_progress_ticks: int) -> tuple[str, str]:
+def _stop_rung_no_progress(
+    goal_linked: bool, no_progress_ticks: int, no_progress_cap: int = LOOP_NO_PROGRESS_TICK_CAP
+) -> tuple[str, str]:
     if not goal_linked:
         return ("not_applicable", "Without a linked goal ledger there are no records to key progress to.")
-    if no_progress_ticks >= LOOP_NO_PROGRESS_TICK_CAP:
+    if no_progress_ticks >= no_progress_cap:
         return (
             "fired",
             f"{no_progress_ticks} consecutive ticks wrote no new goal-ledger record "
-            f"(cap {LOOP_NO_PROGRESS_TICK_CAP}).",
+            f"(cap {no_progress_cap}).",
         )
     return (
         "clear",
         f"{no_progress_ticks} consecutive ticks without a new goal-ledger record, under the "
-        f"{LOOP_NO_PROGRESS_TICK_CAP} cap.",
+        f"{no_progress_cap} cap.",
     )
 
 
@@ -1146,13 +1153,24 @@ def read_loop_stop_ladder(
     *,
     planned_action: str = "",
     home: Path | None = None,
+    env: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
     """Read the ladder's inputs, then hand them to the pure assessment.
 
     The auth marker is read only when the tick plans `executor_dispatch`: the
     marker file is the potentially large `~/.claude.json`, and a research or
     planning tick has no executor CLI to confirm.
+
+    `no_progress_cap` is resolved from the active security posture here, not
+    inside the pure assessment: `strict` fires the no-progress rung after one
+    stalled tick instead of two (`security_posture.POSTURE_MAPPING`, key
+    `loop_no_progress_cap`). `default` posture resolves to the unchanged
+    `LOOP_NO_PROGRESS_TICK_CAP`. `resolve_security_posture` raises
+    `ValueError` for an unrecognized `OMH_SECURITY`; the CLI tick/run-once
+    commands already convert that to a clean error.
     """
+    posture = resolve_security_posture(env)
+    no_progress_cap = strict_override("loop_no_progress_cap", posture, LOOP_NO_PROGRESS_TICK_CAP)
     linked_goal_id = str(cycle.get("linked_goal_id", ""))
     goal_linked = False
     goal_status = ""
@@ -1184,6 +1202,7 @@ def read_loop_stop_ladder(
         ledger_entry_count=ledger_entry_count,
         limit_signal=limit_signal,
         auth_signal=auth_signal,
+        no_progress_cap=no_progress_cap,
     )
 
 

--- a/tests/test_coding_delegation.py
+++ b/tests/test_coding_delegation.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import os
 import unittest
+from unittest.mock import patch
 
 from _local_package import load_local_package
 
@@ -293,6 +295,61 @@ class VerificationPathEscalationTests(unittest.TestCase):
         self.assertEqual(delegation["action"], "delegate")
         verification = delegation["verification"]
         self.assertFalse(any("thorough verification lane" in line for line in verification), verification)
+
+
+class StrictSecurityPostureVerificationTests(unittest.TestCase):
+    """`OMH_SECURITY=strict` escalates every request's verification, not only
+    the ones `sensitive_path_escalation` recognizes by path pattern -- the
+    `verification_escalate_always` row in `system.security_posture.POSTURE_MAPPING`.
+    """
+
+    def test_default_posture_leaves_an_ordinary_path_unescalated(self) -> None:
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("OMH_SECURITY", None)
+            payload = build_coding_delegation_payload(
+                "fix src/foo.py to log the response body",
+                executor_target="claude-code",
+                explicit_owner_choice=True,
+            )
+        verification = payload["delegation"]["verification"]
+        self.assertFalse(any("thorough verification lane" in line for line in verification), verification)
+
+    def test_strict_posture_escalates_an_ordinary_path_too(self) -> None:
+        with patch.dict(os.environ, {"OMH_SECURITY": "strict"}):
+            payload = build_coding_delegation_payload(
+                "fix src/foo.py to log the response body",
+                executor_target="claude-code",
+                explicit_owner_choice=True,
+            )
+        verification = payload["delegation"]["verification"]
+        self.assertTrue(
+            any("thorough verification lane" in line for line in verification),
+            verification,
+        )
+
+    def test_strict_posture_does_not_duplicate_an_already_escalated_path(self) -> None:
+        with patch.dict(os.environ, {"OMH_SECURITY": "strict"}):
+            payload = build_coding_delegation_payload(
+                "fix src/auth/login.py to validate tokens correctly",
+                executor_target="claude-code",
+                explicit_owner_choice=True,
+            )
+        verification = payload["delegation"]["verification"]
+        escalations = [line for line in verification if "thorough verification lane" in line]
+        self.assertEqual(len(escalations), 1, verification)
+        self.assertIn("src/auth/login.py", escalations[0])
+
+    def test_an_unrecognized_posture_value_is_rejected_loudly(self) -> None:
+        with patch.dict(os.environ, {"OMH_SECURITY": "paranoid"}):
+            with self.assertRaises(ValueError) as ctx:
+                build_coding_delegation_payload(
+                    "fix src/foo.py to log the response body",
+                    executor_target="claude-code",
+                    explicit_owner_choice=True,
+                )
+        self.assertIn("OMH_SECURITY", str(ctx.exception))
+        self.assertIn("default", str(ctx.exception))
+        self.assertIn("strict", str(ctx.exception))
 
 
 class CategoryPropagationTests(unittest.TestCase):

--- a/tests/test_loop_stop_ladder.py
+++ b/tests/test_loop_stop_ladder.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import json
+import os
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from _local_package import load_local_package
 
@@ -212,6 +214,51 @@ class StopLadderRungTests(unittest.TestCase):
         self.assertEqual(resumed["runtime"]["last_stop_reason"], "none")
         self.assertNotIn("stuck_marker", resumed["runtime"])
         self.assertEqual(len(resumed["runtime"]["queue"]), 2)
+
+
+class StrictSecurityPostureStopLadderTests(unittest.TestCase):
+    """`OMH_SECURITY=strict` fires the no-progress rung after one stalled
+    tick instead of two (`security_posture.POSTURE_MAPPING`, key
+    `loop_no_progress_cap`); `default` (unset) is unchanged.
+    """
+
+    def test_strict_posture_stops_on_the_first_stalled_tick(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            goal = create_goal_ledger(paths, "Objective with no recorded progress", ["Criterion"])
+            cycle = _cycle(paths, linked_goal_id=goal["goal_id"])
+
+            with patch.dict(os.environ, {"OMH_SECURITY": "strict"}):
+                first = tick_loop_runtime(paths, cycle["loop_id"])
+
+        ladder = first["runtime"]["stop_ladder"]
+        self.assertEqual(ladder["stop_reason"], "no_progress_cap")
+        self.assertEqual(ladder["no_progress_cap"], 1)
+        self.assertEqual(ladder["no_progress_ticks"], 1)
+
+    def test_default_posture_still_needs_two_stalled_ticks(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            goal = create_goal_ledger(paths, "Objective with no recorded progress", ["Criterion"])
+            cycle = _cycle(paths, linked_goal_id=goal["goal_id"])
+
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("OMH_SECURITY", None)
+                first = tick_loop_runtime(paths, cycle["loop_id"])
+                second = tick_loop_runtime(paths, cycle["loop_id"])
+
+        self.assertFalse(first["runtime"]["stop_ladder"]["stop"])
+        self.assertEqual(first["runtime"]["stop_ladder"]["no_progress_cap"], LOOP_NO_PROGRESS_TICK_CAP)
+        self.assertEqual(second["runtime"]["stop_ladder"]["stop_reason"], "no_progress_cap")
+
+    def test_an_unrecognized_posture_value_is_rejected_loudly(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            cycle = _cycle(paths)
+            with patch.dict(os.environ, {"OMH_SECURITY": "paranoid"}):
+                with self.assertRaises(ValueError) as ctx:
+                    tick_loop_runtime(paths, cycle["loop_id"])
+        self.assertIn("OMH_SECURITY", str(ctx.exception))
 
 
 class StopLadderNegativeTests(unittest.TestCase):

--- a/tests/test_parallelism_policy.py
+++ b/tests/test_parallelism_policy.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 import unittest
 
+from omh.coding.fanout_retry import FANOUT_MAX_RETRIES
 from omh.coding.parallelism_policy import (
     FANOUT_MAX_DEPTH_DEFAULT,
     FANOUT_RUN_SPAWN_CEILING_DEFAULT,
@@ -237,6 +238,70 @@ class SpawnGuardPolicyTests(unittest.TestCase):
         self.assertEqual(resolution["global_concurrency_clamped_from"], 8)
 
 
+class SecurityPostureTests(unittest.TestCase):
+    """`OMH_SECURITY=strict` tightens the fanout pool, spawn guard, and retry
+    ceiling together (`security_posture.POSTURE_MAPPING`); `default` (unset)
+    reads byte-for-byte the same numbers this module's own constants name.
+    """
+
+    def test_default_posture_matches_todays_constants_exactly(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            policy = read_parallelism_policy(paths, env={})
+            self.assertEqual(policy["default_concurrency"], PARALLELISM_DEFAULTS["default_concurrency"])
+            self.assertEqual(policy["global_concurrency"], PARALLELISM_DEFAULTS["global_concurrency"])
+            self.assertEqual(policy["lane_budget_default"], PARALLELISM_DEFAULTS["lane_budget_default"])
+            self.assertEqual(policy["max_depth"], FANOUT_MAX_DEPTH_DEFAULT)
+            self.assertEqual(policy["run_spawn_ceiling"], FANOUT_RUN_SPAWN_CEILING_DEFAULT)
+            self.assertEqual(policy["max_retries"], FANOUT_MAX_RETRIES)
+            self.assertEqual(policy["security_posture"], "default")
+            self.assertNotIn("default_concurrency_security_clamped_from", policy)
+
+    def test_strict_posture_tightens_every_bundled_tunable(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            policy = read_parallelism_policy(paths, env={"OMH_SECURITY": "strict"})
+            self.assertEqual(policy["security_posture"], "strict")
+            self.assertLess(policy["default_concurrency"], PARALLELISM_DEFAULTS["default_concurrency"])
+            self.assertLess(policy["global_concurrency"], PARALLELISM_DEFAULTS["global_concurrency"])
+            self.assertLess(policy["lane_budget_default"], PARALLELISM_DEFAULTS["lane_budget_default"])
+            self.assertLess(policy["run_spawn_ceiling"], FANOUT_RUN_SPAWN_CEILING_DEFAULT)
+            self.assertEqual(policy["max_retries"], 0)
+            self.assertEqual(policy["max_depth"], FANOUT_MAX_DEPTH_DEFAULT)
+
+    def test_strict_posture_clamps_a_setup_profile_override_and_discloses_it(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            profile = build_setup_profile()
+            profile["parallelism"] = {"default_concurrency": 5, "global_concurrency": 8, "max_depth": 3}
+            paths.setup_profile_path.parent.mkdir(parents=True, exist_ok=True)
+            atomic_write_json(paths.setup_profile_path, profile, private=True)
+            policy = read_parallelism_policy(paths, env={"OMH_SECURITY": "strict"})
+            self.assertLess(policy["default_concurrency"], 5)
+            self.assertEqual(policy["default_concurrency_security_clamped_from"], 5)
+            self.assertLess(policy["global_concurrency"], 8)
+            self.assertEqual(policy["global_concurrency_security_clamped_from"], 8)
+            # A profile that asked for deeper nesting is pinned back to the
+            # floor strict pins as a hard ceiling.
+            self.assertEqual(policy["max_depth"], FANOUT_MAX_DEPTH_DEFAULT)
+            self.assertEqual(policy["max_depth_security_clamped_from"], 3)
+
+    def test_an_unrecognized_posture_value_is_rejected_loudly(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            with self.assertRaises(ValueError) as ctx:
+                read_parallelism_policy(paths, env={"OMH_SECURITY": "paranoid"})
+            self.assertIn("OMH_SECURITY", str(ctx.exception))
+
+    def test_the_resolution_carries_max_retries_and_posture(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            policy = read_parallelism_policy(paths, env={"OMH_SECURITY": "strict"})
+            resolution = resolve_fanout_concurrency(policy, None)
+            self.assertEqual(resolution["max_retries"], 0)
+            self.assertEqual(resolution["security_posture"], "strict")
+
+
 class CliWiringTests(unittest.TestCase):
     def test_parser_default_is_none_and_dispatch_receives_the_policy_width(self) -> None:
         # The headline behavior of this change is the CLI moving from a
@@ -301,6 +366,88 @@ class CliWiringTests(unittest.TestCase):
             self.assertEqual(captured["concurrency"], 5)
             self.assertEqual(captured["per_owner_lanes"], {})
             self.assertEqual(captured["concurrency_policy"]["source"], "policy_default")
+
+    def _fanout_dispatch_args(self, paths, repo, contract, goal):
+        import subprocess
+
+        from omh.commands.main import build_parser
+
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=str(repo), check=True)
+        (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+        subprocess.run(["git", "add", "seed.txt"], cwd=str(repo), check=True)
+        subprocess.run(
+            ["git", "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "init"],
+            cwd=str(repo),
+            check=True,
+        )
+        return build_parser().parse_args(
+            [
+                "--omh-home",
+                str(paths.omh_home),
+                "--hermes-home",
+                str(paths.hermes_home),
+                "coding",
+                "fanout",
+                "dispatch",
+                contract["fanout_id"],
+                "--goal-file",
+                str(goal),
+                "--repo-root",
+                str(repo),
+            ]
+        )
+
+    def test_strict_posture_passes_the_tightened_max_retries_to_dispatch(self) -> None:
+        import contextlib
+        import io
+        import os
+        from unittest.mock import patch
+
+        from omh.coding.fanout import build_fanout_contract
+        from omh.coding.fanout_artifacts import write_fanout_contract
+
+        goal_text = "split the sample feature across agents"
+        units = [{"unit_id": "core", "title": "Core work", "owner": "codex", "file_scope": ["src/core/"]}]
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            contract = write_fanout_contract(paths, build_fanout_contract(goal_text, units))
+            goal = Path(tmp) / "goal.txt"
+            goal.write_text(goal_text, encoding="utf-8")
+            args = self._fanout_dispatch_args(paths, Path(tmp) / "repo", contract, goal)
+            captured: dict[str, object] = {}
+
+            def _capture(*call_args, **kwargs):
+                captured.update(kwargs)
+                return {"schema_version": "fanout_dispatch_summary/v1", "units": []}
+
+            with patch.dict(os.environ, {"OMH_SECURITY": "strict"}):
+                with patch("omh.coding.fanout_dispatch.dispatch_fanout", new=_capture):
+                    with contextlib.redirect_stdout(io.StringIO()):
+                        args.func(args)
+            self.assertEqual(captured["max_retries"], 0)
+            self.assertLess(captured["concurrency"], 5)
+
+    def test_an_unrecognized_posture_value_is_a_clean_cli_error(self) -> None:
+        import os
+        from unittest.mock import patch
+
+        from omh.coding.fanout import build_fanout_contract
+        from omh.coding.fanout_artifacts import write_fanout_contract
+        from omh.installer import OmhError
+
+        goal_text = "split the sample feature across agents"
+        units = [{"unit_id": "core", "title": "Core work", "owner": "codex", "file_scope": ["src/core/"]}]
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            contract = write_fanout_contract(paths, build_fanout_contract(goal_text, units))
+            goal = Path(tmp) / "goal.txt"
+            goal.write_text(goal_text, encoding="utf-8")
+            args = self._fanout_dispatch_args(paths, Path(tmp) / "repo", contract, goal)
+            with patch.dict(os.environ, {"OMH_SECURITY": "paranoid"}):
+                with self.assertRaises(OmhError) as ctx:
+                    args.func(args)
+            self.assertIn("OMH_SECURITY", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/tests/test_security_posture.py
+++ b/tests/test_security_posture.py
@@ -1,0 +1,181 @@
+"""Named strict security posture: the resolver, the mapping table, and the
+`OMH_SECURITY` env-var contract (`OMH_LANG`/`normalize_language` idiom).
+
+`P3 -- 15. Named strict security posture`: a single `OMH_SECURITY=strict`
+switch bundles the conservative end of OMH's already-existing safety knobs.
+These tests pin the resolver in isolation; the per-surface wiring (fanout
+concurrency/retries, verification escalation, the loop stop ladder) is
+covered where each surface already has its own test module.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import patch
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.coding.hermes_child_dispatch import (  # noqa: E402
+    DispatchConfirmationError,
+    require_hermes_child_dispatch_boundary,
+)
+from omh.maintenance.doctor import _security_posture_check  # noqa: E402
+from omh.quality.completion_integrity import classify_completion_integrity  # noqa: E402
+from omh.system.security_posture import (  # noqa: E402
+    DEFAULT_POSTURE,
+    POSTURE_MAPPING,
+    SECURITY_POSTURE_ENV_VAR,
+    SECURITY_POSTURE_SCHEMA_VERSION,
+    STRICT_POSTURE,
+    VALID_POSTURES,
+    describe_security_posture,
+    resolve_security_posture,
+    security_posture_value,
+    strict_override,
+)
+
+
+class ResolvePostureTests(unittest.TestCase):
+    def test_env_var_name_and_valid_choices(self) -> None:
+        self.assertEqual(SECURITY_POSTURE_ENV_VAR, "OMH_SECURITY")
+        self.assertEqual(VALID_POSTURES, (DEFAULT_POSTURE, STRICT_POSTURE))
+
+    def test_unset_reads_as_default(self) -> None:
+        self.assertEqual(resolve_security_posture({}), DEFAULT_POSTURE)
+
+    def test_blank_reads_as_default(self) -> None:
+        self.assertEqual(resolve_security_posture({"OMH_SECURITY": "  "}), DEFAULT_POSTURE)
+
+    def test_strict_is_recognized_case_and_whitespace_insensitively(self) -> None:
+        self.assertEqual(resolve_security_posture({"OMH_SECURITY": "strict"}), STRICT_POSTURE)
+        self.assertEqual(resolve_security_posture({"OMH_SECURITY": " STRICT "}), STRICT_POSTURE)
+
+    def test_explicit_default_is_recognized(self) -> None:
+        self.assertEqual(resolve_security_posture({"OMH_SECURITY": "default"}), DEFAULT_POSTURE)
+
+    def test_an_unrecognized_value_is_rejected_loudly(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            resolve_security_posture({"OMH_SECURITY": "paranoid"})
+        message = str(ctx.exception)
+        self.assertIn("OMH_SECURITY", message)
+        self.assertIn("paranoid", message)
+        self.assertIn("default", message)
+        self.assertIn("strict", message)
+
+
+class MappingTableTests(unittest.TestCase):
+    """The mapping table lives in exactly one place, with a rationale per row."""
+
+    def test_every_row_names_a_surface_and_a_non_empty_rationale(self) -> None:
+        self.assertTrue(POSTURE_MAPPING)
+        keys = [row.key for row in POSTURE_MAPPING]
+        self.assertEqual(len(keys), len(set(keys)), "mapping-table keys must be unique")
+        for row in POSTURE_MAPPING:
+            self.assertTrue(row.surface.startswith("src/"), row)
+            self.assertTrue(row.rationale.strip(), row)
+
+    def test_security_posture_value_looks_up_the_strict_value(self) -> None:
+        self.assertEqual(security_posture_value("fanout_max_retries"), 0)
+
+    def test_security_posture_value_rejects_an_unknown_key(self) -> None:
+        with self.assertRaises(KeyError):
+            security_posture_value("not_a_real_key")
+
+
+class StrictOverrideTests(unittest.TestCase):
+    def test_default_posture_returns_the_callers_own_default_unchanged(self) -> None:
+        self.assertEqual(strict_override("fanout_max_retries", DEFAULT_POSTURE, 2), 2)
+        self.assertEqual(strict_override("loop_no_progress_cap", DEFAULT_POSTURE, 2), 2)
+
+    def test_strict_posture_returns_the_mapped_value_regardless_of_default(self) -> None:
+        self.assertEqual(strict_override("fanout_max_retries", STRICT_POSTURE, 2), 0)
+        self.assertEqual(strict_override("loop_no_progress_cap", STRICT_POSTURE, 2), 1)
+
+
+class DescribeSecurityPostureTests(unittest.TestCase):
+    def test_schema_and_row_count_match_the_mapping_table(self) -> None:
+        report = describe_security_posture({})
+        self.assertEqual(report["schema_version"], SECURITY_POSTURE_SCHEMA_VERSION)
+        self.assertEqual(report["posture"], DEFAULT_POSTURE)
+        self.assertEqual(len(report["rows"]), len(POSTURE_MAPPING))
+        self.assertFalse(any(row["active_when_strict"] for row in report["rows"]))
+
+    def test_strict_report_flags_every_row_active(self) -> None:
+        report = describe_security_posture({"OMH_SECURITY": "strict"})
+        self.assertEqual(report["posture"], STRICT_POSTURE)
+        self.assertTrue(all(row["active_when_strict"] for row in report["rows"]))
+
+    def test_an_invalid_env_value_raises_before_building_the_report(self) -> None:
+        with self.assertRaises(ValueError):
+            describe_security_posture({"OMH_SECURITY": "bogus"})
+
+
+class InvariantRowTests(unittest.TestCase):
+    """Two `POSTURE_MAPPING` rows tighten nothing: `completion_integrity_refusal_overridable`
+    and `dispatch_confirmation_required` are already non-overridable/always-required in
+    `default` posture, and the row exists to document the invariant rather than change it.
+    These are the closest thing to an equivalence proof a no-op row can carry: neither
+    consuming function accepts a posture, an override, or a bypass argument at all.
+    """
+
+    def test_completion_integrity_has_no_override_or_bypass_argument(self) -> None:
+        import inspect
+
+        params = inspect.signature(classify_completion_integrity).parameters
+        self.assertNotIn("override", params)
+        self.assertNotIn("bypass", params)
+        self.assertNotIn("posture", params)
+
+    def test_completion_integrity_refuses_a_placeholder_evidence_entry_regardless_of_posture(self) -> None:
+        for env in ({}, {"OMH_SECURITY": "strict"}):
+            with patch.dict(os.environ, env, clear=False):
+                if not env:
+                    os.environ.pop("OMH_SECURITY", None)
+                result = classify_completion_integrity(evidence=["TBD"])
+            self.assertTrue(result["refused"])
+            self.assertIn("empty_evidence", result["categories"])
+
+    def test_dispatch_confirmation_is_required_regardless_of_posture(self) -> None:
+        for env in ({}, {"OMH_SECURITY": "strict"}):
+            with patch.dict(os.environ, env, clear=False):
+                if not env:
+                    os.environ.pop("OMH_SECURITY", None)
+                with self.assertRaises(DispatchConfirmationError):
+                    require_hermes_child_dispatch_boundary(dispatch_policy="prepare_only", confirmed=False)
+                with self.assertRaises(DispatchConfirmationError):
+                    require_hermes_child_dispatch_boundary(dispatch_policy="ask_before_dispatch", confirmed=False)
+                # No exception: explicit confirmation with the required policy passes.
+                require_hermes_child_dispatch_boundary(dispatch_policy="ask_before_dispatch", confirmed=True)
+
+
+class DoctorSecurityPostureCheckTests(unittest.TestCase):
+    """`omh doctor` surfaces the active posture (`_security_posture_check`)."""
+
+    def test_default_posture_is_an_ok_informational_check(self) -> None:
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("OMH_SECURITY", None)
+            check = _security_posture_check()
+        self.assertTrue(check.ok)
+        self.assertEqual(check.severity, "ok")
+        self.assertIn("default", check.message)
+
+    def test_strict_posture_is_named_in_the_message(self) -> None:
+        with patch.dict(os.environ, {"OMH_SECURITY": "strict"}):
+            check = _security_posture_check()
+        self.assertTrue(check.ok)
+        self.assertIn("strict", check.message)
+
+    def test_an_unrecognized_value_fails_the_check_with_the_valid_choices(self) -> None:
+        with patch.dict(os.environ, {"OMH_SECURITY": "paranoid"}):
+            check = _security_posture_check()
+        self.assertFalse(check.ok)
+        self.assertIn("paranoid", check.message)
+        self.assertIn("default", check.message)
+        self.assertIn("strict", check.message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- Adds `src/system/security_posture.py`: a pure resolver for `OMH_SECURITY` (`default` | `strict`, unset/blank -> `default`, unrecognized value -> loud `ValueError` naming the valid choices) plus `POSTURE_MAPPING`, a single table naming every tightened surface, the value `strict` applies there, and a short rationale per row.
- Wires the resolver into four real surfaces (see mapping table below) and adds an `omh doctor` check that surfaces the active posture.
- `default` posture (unset `OMH_SECURITY`) is provably unchanged: every wired surface has a test asserting its resolved defaults equal today's pre-existing constants byte-for-byte.

### Why This Exists

Backlog item "P3 — 15. Named strict security posture" (`.omc/research/omo-omc-comparison-2026-08-29.md`). An operator who wants OMH's conservative safety knobs tightened today has to hand-tune fanout concurrency, retry counts, verification escalation, and the loop stop ladder separately across the setup profile, and reason about how they interact. A single named posture asserts that intent in one place.

### User / Operator Impact

- Nothing changes for anyone who does not set `OMH_SECURITY`.
- `OMH_SECURITY=strict` tightens fanout dispatch concurrency/lane-budget/spawn-ceiling/retries (as a hard ceiling even over a setup-profile override), always escalates coding-delegate verification to the thorough lane, and trips the loop stop ladder's no-progress rung after one stalled tick instead of two.
- `OMH_SECURITY=<anything else>` is a loud, immediate refusal (a clean `omh: ...` CLI error, or a failing `omh doctor` check) naming the two valid values — never a silent fallback.
- `omh doctor` now reports the active posture as an informational (`severity=ok`) check.

### How It Works

`POSTURE_MAPPING` deliberately does **not** restate any surface's own default constant. `strict_override(key, posture, default)` takes the caller's own pre-existing default in and only substitutes the mapped strict value when posture is `strict` — so there is no second copy of a number that could silently drift from its source of truth, which is exactly the class of drift this repo's own gates (`src/maintenance/drift.py`) exist to catch elsewhere.

**Mapping table** (`src/system/security_posture.POSTURE_MAPPING`):

| key | surface | strict value | rationale |
| --- | --- | --- | --- |
| `fanout_default_concurrency` | `src/coding/parallelism_policy.py` | `2` (default `5`) | Fewer fanout units run at once by default, so a misjudged contract burns less provider budget before an operator notices. |
| `fanout_global_concurrency` | `src/coding/parallelism_policy.py` | `3` (default `8`) | The pool-wide ceiling shrinks alongside the per-lane default and clamps any setup-profile override that would otherwise reopen the width strict just closed. |
| `fanout_lane_budget_default` | `src/coding/parallelism_policy.py` | `2` (default `5`) | The advisory Hermes-native lane budget matches the tightened dispatch pool so the two numbers an operator reads never disagree. |
| `fanout_max_depth` | `src/coding/parallelism_policy.py` | `1` (default `1`) | Already the minimum that permits one dispatch at all; strict pins it as a hard ceiling a setup-profile override cannot raise. |
| `fanout_run_spawn_ceiling` | `src/coding/parallelism_policy.py` | `10` (default `60`) | One dispatch run may start far fewer real agent-CLI processes in total, bounding the worst case of a misjudged contract regardless of pool width. |
| `fanout_max_retries` | `src/coding/fanout_retry.py` | `0` (default `2`) | Zero retries on transient (ambiguous) classifications: a strict operator wants a surfaced failure, not an automatic second attempt. |
| `verification_escalate_always` | `src/quality/verification_tiering.py` | `True` (default: sensitive-path match only) | Every request escalates to the thorough verification lane, not only ones touching a recognized sensitive-path pattern the classifier already knows. |
| `loop_no_progress_cap` | `src/workflows/goal_loop.py` | `1` (default `2`) | The stop ladder's no-progress rung fires after one stalled tick instead of two, so a stuck loop surfaces sooner. |
| `completion_integrity_refusal_overridable` | `src/quality/completion_integrity.py` | `False` (both postures) | **Invariant row, no code change.** No override path exists in either posture already; the row documents this rather than changing it. |
| `dispatch_confirmation_required` | `src/coding/hermes_child_dispatch.py` | `True` (both postures) | **Invariant row, no code change.** Explicit `ask_before_dispatch` confirmation is already required in both postures (`require_hermes_child_dispatch_boundary`). |

The two invariant rows are verified by tests that inspect the consuming functions' own signatures (no `override`/`bypass`/`posture` parameter exists at all) and exercise both postures against identical behavior.

### Files And Contracts Touched

- `src/system/security_posture.py` (new) — resolver, `POSTURE_MAPPING`, `strict_override`, `describe_security_posture`.
- `src/coding/parallelism_policy.py` — `read_parallelism_policy` gains an `env` override param and applies strict ceilings (with `<key>_security_clamped_from` disclosure, matching the existing clamp-and-name idiom) after the setup-profile read; adds `max_retries`/`security_posture` to the policy dict and `resolve_fanout_concurrency`'s resolution record.
- `src/commands/coding.py` — `cmd_coding_fanout_dispatch` (both dispatch paths) and `cmd_coding_run` now catch `ValueError` from `read_parallelism_policy` and convert to `OmhError`; pass `max_retries=parallelism["max_retries"]` through to `dispatch_fanout`.
- `src/coding/coding_delegation.py` — `_verification` escalates unconditionally under strict posture when the sensitive-path classifier did not already escalate.
- `src/workflows/goal_loop.py` — `assess_loop_stop_ladder`/`_stop_rung_no_progress` take an explicit `no_progress_cap` (default unchanged); `read_loop_stop_ladder` resolves it from the active posture and threads it through.
- `src/maintenance/doctor.py` — new `_security_posture_check`, appended to `run_doctor`.
- Tests: `tests/test_security_posture.py` (new), plus strict-posture test classes added to `tests/test_parallelism_policy.py`, `tests/test_coding_delegation.py`, `tests/test_loop_stop_ladder.py`.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [x] Codex
- [x] Claude Code
- [ ] Hermes runtime or handoff
- [x] Generic executor
- [ ] Not executor-specific

(`omh coding fanout dispatch` / `omh coding run` dispatch to any of the templated coding-owner executor CLIs, so the tightened concurrency/retry ceiling applies regardless of which owner is dispatched.)

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run — this change has no TUI-facing surface; `omh doctor`'s new check was exercised as a unit (`_security_posture_check()`), not through the terminal renderer.

### Observed Evidence

- `uv run python -m compileall -q src tests` — clean (pre-existing unrelated `SyntaxWarning` in `tests/test_menubar_app.py`).
- `uv run --group lint ruff check src tests` — `All checks passed!`.
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — **Ran 8134 tests, 21 failures + 7 errors = 28 total**, all confined to `test_cross_harness_adapters.py` / `test_cross_harness_adapter_security.py` (the repo's known pre-existing `.claude`-path cross-harness failures per the task brief's 28-failure allowance); zero failures in any touched module or test file.
- `uv run python -m omh.cli docs workflows --check` / `docs roles --check` / `docs capability-families --check` / `docs ulw-inventory --check` / `docs ulw-site --check` — all `"ok":true`.
- `uv run python -m omh.cli release drift` — `No drift. 17 checks passed.`
- `git diff --check` — clean.
- Targeted reruns during development: `tests/test_parallelism_policy.py` (26 tests), `tests/test_coding_delegation.py` (34 tests), `tests/test_loop_stop_ladder.py` (23 tests), `tests/test_security_posture.py` (20 tests), `tests/test_doctor_advisory.py` (40 tests), `tests/test_fanout_dispatch.py` + `tests/test_fanout_retry.py` (150 tests) — all passing.

### Not Tested / Not Applicable

- `harness validate`, `release checklist --json`, `release hermes-smoke`, `omh --help`, and the live install-path smoke were not run — none is part of this task's stated verification set (`compileall`; full suite; five docs `--check` gates; `release drift`; ruff; `git diff --check`), and this change makes no install/packaging/harness-catalog change.
- No live Hermes TUI check — `omh doctor`'s new check has no TUI rendering path beyond the existing `Check` object shape other checks already use.

## Risk

- **Scope-risk: moderate.** Touches five production modules across coding/quality/workflows/maintenance, but every change is additive and backward-compatible: new optional parameters default to prior behavior, and `resolve_security_posture()` returns `"default"` (a no-op) whenever `OMH_SECURITY` is unset — which is the case for every existing user and CI run today.
- The two `ValueError`-raising call sites added at the CLI boundary (`cmd_coding_fanout_dispatch`, `cmd_coding_run`) are explicitly wrapped to `OmhError` for a clean CLI message; `_verification()` (deep in `coding_delegation.py`) and `read_loop_stop_ladder` (via `tick_loop_runtime`) rely on their existing, pre-existing `except (..., ValueError)` boundaries at `cmd_coding_delegate` / `cmd_loop_tick` / `cmd_loop_run_once` — same posture as `normalize_language`'s existing `ValueError` contract elsewhere in this codebase.
- **Known limitation, disclosed rather than silently left out:** `goal_loop._runtime_summary`'s display-only `no_progress_cap` field still reports the un-posture-adjusted constant (it has no `paths`/`env` to resolve posture from, and is a general runtime summary, not the enforcement point — `assess_loop_stop_ladder`/`read_loop_stop_ladder` are fully wired and correctly enforce the tightened cap).

## Compatibility / Rollout

- No config migration, no schema version bump on any existing artifact. `OMH_SECURITY` is a brand-new, previously-unused env var (verified no prior occurrence in `src/`, `tests/`, or `docs/`).
- Fully opt-in; no default-path behavior change.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`) — none; pure additive library/CLI behavior gated behind an unset-by-default env var.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap — none run; no TUI-facing surface.

## Follow-Up

- Thread posture into `goal_loop._runtime_summary`'s display-only `no_progress_cap` field if a future consumer needs live-value visibility there beyond `omh doctor` and the stop-ladder record itself.
- Consider documenting `OMH_SECURITY` in `docs/INSTALLATION.md` alongside `OMH_LANG`/`OMH_HOME` if/when that doc grows a dedicated environment-variable reference section (none exists today).
