### PR TITLE
feat(coding): resumable fanout via a terminal-state run journal

### DIFF
--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -524,6 +524,28 @@ Rules:
   and `duration_seconds`, and the full dispatch summary persists to
   `~/.omh/coding/fanout/<id>/dispatch_summary.json` (latest wins,
   metadata only, skipped on `--dry-run`).
+- **Run journal and resume.** Alongside the summary, every non-dry-run
+  dispatch writes `~/.omh/coding/fanout/<id>/run_journal.json`
+  (`fanout_run_journal/v1`): one row per unit holding the terminal state it
+  reached (`succeeded`, `failed`, `skipped_by_dependency`, `not_attempted`),
+  the failure class read off the retry decision, the replay-safety verdict,
+  and what it was blocked on. The write is temp-then-rename, so a dispatch
+  interrupted mid-write leaves the previous journal intact rather than a
+  truncated document. Passing it back as `omh coding fanout dispatch
+  <id> --resume-journal <path>` re-dispatches only what is eligible: a unit
+  that already succeeded is never re-run and still clears its dependents; a
+  failure with no observed side effect is re-run; a failure that left changes
+  in its worktree, wrote a result artifact, or could not be measured is
+  **held**, with the reason named, and continued through the recovery record
+  instead; and a dependent skipped behind a blocker is un-skipped exactly when
+  that blocker is being attempted again. The plan is reported under the
+  summary's `resume` key and per unit under `resume`, and a journal that
+  cannot be read as this schema is refused with a `reason_code`
+  (`journal_corrupt`, `journal_schema_unsupported`, `journal_fanout_mismatch`)
+  rather than treated as an empty prior run. The resume decides eligibility
+  only — it does not remove anything, so a unit whose earlier attempt left its
+  worktree in place still meets the existing `worktree_path_already_exists`
+  refusal until that worktree and branch are cleared by hand.
 - **Failed-unit recovery.** A unit that exits non-zero — including a
   timeout — still owns its worktree, and whatever it wrote is the only
   thing between the operator and redoing the work. Before the summary
@@ -645,7 +667,8 @@ omh coding fanout migrate-legacy <fanout-id> \
   [--confirm-contract-sha256 <digest>]  # operator/maintenance only
 omh coding fanout dispatch <fanout-id> --goal-file goal.txt \
   [--repo-root .] [--base-ref HEAD] [--concurrency N] [--timeout 1800] \
-  [--unit <id> ...] [--dry-run] [--run-verification]
+  [--unit <id> ...] [--dry-run] [--run-verification] \
+  [--resume-journal ~/.omh/coding/fanout/<fanout-id>/run_journal.json]
 omh coding run --owner <profile> (--goal <words...> | --goal-file goal.txt) \
   [--unit-id run] [--file-scope <path> ...] [--repo-root .] [--base-ref HEAD] \
   [--timeout 1800] [--dry-run] [--run-verification] [--source discord] \

--- a/src/coding/fanout_artifacts.py
+++ b/src/coding/fanout_artifacts.py
@@ -55,6 +55,11 @@ def fanout_dispatch_summary_path(paths: OmhPaths, fanout_id: str) -> Path:
     return _managed_fanout_dir(paths, _validated_fanout_id(fanout_id)) / "dispatch_summary.json"
 
 
+def fanout_run_journal_path(paths: OmhPaths, fanout_id: str) -> Path:
+    """Validated run-journal path for one fanout (id pattern + containment)."""
+    return _managed_fanout_dir(paths, _validated_fanout_id(fanout_id)) / "run_journal.json"
+
+
 def fanout_contract_provenance_path(paths: OmhPaths, fanout_id: str) -> Path:
     return _managed_fanout_dir(
         paths,

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -48,6 +48,14 @@ from .fanout_contracts import (
     FanoutContractError,
     verification_command_argv,
 )
+from .fanout_journal import (
+    RESUME_HOLD_ACTIONS,
+    RESUME_HOLD_SUCCEEDED,
+    build_fanout_run_journal,
+    plan_fanout_resume,
+    resume_counts,
+    write_fanout_run_journal,
+)
 from .inflight import InflightMarkerError, clear_inflight_marker, write_inflight_marker
 from .parallelism_policy import FANOUT_MAX_DEPTH_DEFAULT, FANOUT_RUN_SPAWN_CEILING_DEFAULT
 from .fanout_retry import (
@@ -1102,6 +1110,10 @@ def dispatch_fanout(
     max_depth: int | None = None,
     spawn_ceiling: int | None = None,
     env: Mapping[str, str] | None = None,
+    # A prior run's terminal-state journal. Present, it decides per unit
+    # whether this dispatch attempts it again; absent, every selected unit is
+    # attempted exactly as before.
+    resume_journal: Mapping[str, Any] | None = None,
     # The retry policy's two impure inputs, injected so the whole ladder is
     # assertable without a clock and without a single sleep in a test.
     max_retries: int = FANOUT_MAX_RETRIES,
@@ -1169,6 +1181,26 @@ def dispatch_fanout(
         else _owner_skill_discoveries(capability_valid_units, project_root=repo_root)
     )
     results: dict[str, dict[str, Any]] = {}
+    # Read once, before any unit is considered: the plan is a pure function of
+    # the prior journal and the contract's own dependency edges, so it is the
+    # same plan on every machine and can be printed before anything spawns.
+    resume_plan = (
+        None
+        if resume_journal is None
+        else plan_fanout_resume(
+            resume_journal,
+            order=order,
+            depends_on={
+                unit_id: [str(dep) for dep in (unit.get("depends_on") or [])]
+                for unit_id, unit in units.items()
+            },
+        )
+    )
+    resume_decisions: dict[str, Mapping[str, Any]] = (
+        {}
+        if resume_plan is None
+        else {str(decision["unit_id"]): decision for decision in resume_plan["decisions"]}
+    )
 
     if selected_capability_invalid:
         invalid_reason = (
@@ -1177,6 +1209,10 @@ def dispatch_fanout(
         )
         for unit_id in order:
             unit = units[unit_id]
+            held = _resume_hold(paths, unit, resume_decisions.get(unit_id))
+            if held is not None:
+                results[unit_id] = held
+                continue
             if _already_completed(paths, unit):
                 results[unit_id] = _skipped(
                     unit,
@@ -1217,7 +1253,13 @@ def dispatch_fanout(
 
     for unit_id in order if not selected_capability_invalid else ():
         unit = units[unit_id]
-        if _already_completed(paths, unit):
+        # The resume verdict is read BEFORE the completion probe on purpose: a
+        # unit the journal held as replay-unsafe must stay held even where the
+        # run journal it would be probed against has since been pruned.
+        held = _resume_hold(paths, unit, resume_decisions.get(unit_id))
+        if held is not None:
+            results[unit_id] = held
+        elif _already_completed(paths, unit):
             # Completed units satisfy dependencies whether or not they are in
             # the current selection, so partial re-dispatch of downstream
             # units works after an earlier run (or manual recovery) finished
@@ -1405,6 +1447,13 @@ def dispatch_fanout(
             signal.signal(signal.SIGTERM, previous_term)
 
     summary_units = [results[unit_id] for unit_id in order]
+    for entry in summary_units:
+        decision = resume_decisions.get(str(entry.get("unit_id", "")))
+        if decision is not None and "resume" not in entry:
+            # A re-dispatched unit says which resume rule admitted it, so the
+            # summary answers "why did this run again" without the reader
+            # having to join it back against the plan.
+            entry["resume"] = _resume_note(decision)
     _apply_integration_readiness(summary_units)
     summary = {
         "schema_version": FANOUT_DISPATCH_SCHEMA_VERSION,
@@ -1441,13 +1490,15 @@ def dispatch_fanout(
         "spawns_claimed": spawn_ledger.claimed,
         "claim_boundary": FANOUT_SPAWN_GUARD_CLAIM_BOUNDARY,
     }
+    if resume_plan is not None:
+        summary["resume"] = {**resume_plan, "counts": resume_counts(resume_plan["decisions"])}
     if interrupted_by is not None:
         # A cut-short batch says so; units that never started carry the
         # `interrupted` status rather than silently vanishing from the
         # rollup as if they were never planned.
         summary["interrupted"] = True
     if not dry_run and fanout_id:
-        from .fanout_artifacts import fanout_dispatch_summary_path
+        from .fanout_artifacts import fanout_dispatch_summary_path, fanout_run_journal_path
 
         # Metadata-only persistence so `omh coding fanout brief` can join
         # observed telemetry without replaying the journal. The validated
@@ -1467,6 +1518,15 @@ def dispatch_fanout(
         # so `already_completed` still means "I did not re-run this".
         summary["units"] = _with_carried_recovery(summary["units"], stored.get("units", []))
         summary["recovery_available_units"] = _recovery_available(summary["units"])
+        # Written last, from the carried-forward view: the replay-safety
+        # verdict a later resume reads is the recovery record's own answer,
+        # and a unit whose recovery was carried rather than re-captured must
+        # not be journalled as unmeasured. The write is temp-then-rename, so
+        # an interrupted resume still leaves the previous journal intact.
+        journal = build_fanout_run_journal(summary)
+        summary["run_journal_path"] = str(
+            write_fanout_run_journal(fanout_run_journal_path(paths, fanout_id), journal)
+        )
     if isinstance(interrupted_by, SystemExit):
         # The summary is written; now honor the termination that was asked
         # for, so a supervisor still observes the death it requested (OMO's
@@ -3169,6 +3229,54 @@ def _skipped(
             unit_verification_observed=unit_verification_observed,
         ),
     }
+
+
+def _resume_note(decision: Mapping[str, Any]) -> dict[str, Any]:
+    note: dict[str, Any] = {
+        "action": str(decision.get("action", "")),
+        "prior_state": str(decision.get("prior_state", "")),
+        "reason": str(decision.get("reason", "")),
+    }
+    carried = decision.get("carry_forward")
+    if isinstance(carried, Mapping):
+        # A held unit is recorded in THIS run's summary as a skip, which on its
+        # own would journal as "never attempted" and make the next resume
+        # re-dispatch exactly what this one refused to. The prior journal row
+        # rides along so the verdict survives every further resume.
+        note["carry_forward"] = dict(carried)
+    return note
+
+
+def _resume_hold(
+    paths: OmhPaths,
+    unit: Mapping[str, Any],
+    decision: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    """The skip entry for a unit a resume plan holds back, or None to dispatch.
+
+    Held units reuse the existing skip vocabulary rather than inventing a
+    status: a succeeded unit reads `already_completed` so it keeps satisfying
+    its dependents, and a refused replay reads `not_selected` so its dependents
+    stay blocked. The `resume` block is what says which of the two it was and
+    why. Nothing else runs for a held unit -- no readiness probe, no worktree,
+    no spawn, and above all no progress binding, so the live telemetry reporter
+    never reports a unit this run did not actually run.
+    """
+    if decision is None or str(decision.get("action", "")) not in RESUME_HOLD_ACTIONS:
+        return None
+    if str(decision.get("action", "")) == RESUME_HOLD_SUCCEEDED:
+        entry = _skipped(
+            unit,
+            "already_completed",
+            process_succeeded=True,
+            unit_verification_observed=_unit_verification_is_observed(
+                paths, str(unit.get("run_ref", unit.get("unit_id", "")))
+            ),
+        )
+    else:
+        entry = _skipped(unit, "not_selected")
+    entry["resume"] = _resume_note(decision)
+    return entry
 
 
 def _worktree_path(repo_root: Path, unit_id: str) -> Path:

--- a/src/coding/fanout_journal.py
+++ b/src/coding/fanout_journal.py
@@ -1,0 +1,470 @@
+"""Terminal-state journal for one fanout run, and the resume plan read off it.
+
+A dispatch summary answers "what happened", in full, for a human and for `omh
+coding fanout brief`. It is not a resume input: it carries per-unit telemetry,
+capability snapshots, bounded output tails, and a merge view, and deciding what
+to re-run by re-deriving all of that on every resume would couple the resume
+rule to every field any of those surfaces later adds.
+
+The journal is the narrow projection instead: one row per unit, holding only
+the four things a resume decision needs.
+
+1. **What terminally happened** -- succeeded, failed, skipped because a
+   dependency did not clear, or never attempted at all.
+2. **How it failed**, in the classification vocabulary `fanout_retry` already
+   owns, read off the retry decision the dispatcher recorded rather than
+   re-derived from tails the summary does not keep.
+3. **Whether it may be replayed.** Same predicate, same three verdicts, plus
+   the one case an in-flight retry never has to consider: a unit that never
+   spawned in the prior run left nothing behind, so it is trivially safe.
+4. **What it was blocked on**, so a dependent can be un-skipped when its
+   blocker is going to be attempted again.
+
+The resume rule is replay-safety, not transience. An automatic retry inside a
+run declines terminal failures because re-running them would spend a whole
+agent-CLI run to re-derive an answer already in hand; an operator asking to
+resume an interrupted fanout has already decided that answer is worth
+re-deriving. What stays refused in both places is a replay that would destroy
+observed work: a unit whose failure left changes in its worktree, wrote a
+result artifact, or could not be measured at all is held, with the reason
+named, and continued by hand through the recovery path.
+
+Writes go through `atomic_write_json` -- serialize, write a sibling temp,
+rename over -- so an interrupted write leaves the previous journal exactly as
+it was rather than a truncated document nothing can resume from. A journal
+that cannot be read as this schema raises `FanoutJournalError` carrying a
+machine-readable `reason_code`; a resume must refuse loudly rather than treat
+an unreadable prior run as "nothing happened" and re-dispatch everything.
+
+A plan decides eligibility, not outcome, and it deliberately does not reach
+into the repository: a unit whose earlier attempt left its worktree in place
+is still selected here, and still meets the dispatcher's existing
+`worktree_path_already_exists` refusal, which already names its own remedy.
+Nothing in this module removes a worktree -- deleting an operator's directory
+is a much larger claim than deciding what is eligible to run.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from ..system.local_store import atomic_write_json, utc_now
+from .fanout_retry import (
+    REPLAY_SAFE,
+    REPLAY_UNSAFE_SIDE_EFFECTS,
+    classify_unit_failure,
+    replay_safety,
+)
+
+FANOUT_RUN_JOURNAL_SCHEMA_VERSION = "fanout_run_journal/v1"
+FANOUT_RESUME_PLAN_SCHEMA_VERSION = "fanout_resume_plan/v1"
+
+JOURNAL_CLAIM_BOUNDARY = (
+    "A run journal records the terminal state each unit reached in one dispatch and whether "
+    "re-running it would destroy observed work. It is not verification, review, CI, or merge "
+    "evidence, and a resumed unit that succeeds is no more verified than one that succeeded first time."
+)
+RESUME_CLAIM_BOUNDARY = (
+    "A resume plan states which units a prior journal makes eligible for another dispatch and why "
+    "the rest are held. Deciding a unit is eligible is not a claim that re-running it will succeed, "
+    "and holding one is not a claim that its work is complete."
+)
+
+# Terminal states. Every unit in a dispatch lands in exactly one of them.
+TERMINAL_SUCCEEDED = "succeeded"
+TERMINAL_FAILED = "failed"
+TERMINAL_SKIPPED_BY_DEPENDENCY = "skipped_by_dependency"
+TERMINAL_NOT_ATTEMPTED = "not_attempted"
+
+# Resume actions. The three `hold_*` actions mean "not re-dispatched", each for
+# a different reason an operator acts on differently.
+RESUME_RERUN_FAILED = "rerun_replay_safe_failure"
+RESUME_RERUN_NOT_ATTEMPTED = "rerun_not_attempted"
+RESUME_UNSKIP_DEPENDENT = "unskip_dependent"
+RESUME_HOLD_SUCCEEDED = "hold_succeeded"
+RESUME_HOLD_REPLAY_UNSAFE = "hold_replay_unsafe"
+RESUME_HOLD_BLOCKED_DEPENDENCY = "hold_blocked_dependency"
+
+RESUME_HOLD_ACTIONS = frozenset(
+    {RESUME_HOLD_SUCCEEDED, RESUME_HOLD_REPLAY_UNSAFE, RESUME_HOLD_BLOCKED_DEPENDENCY}
+)
+RESUME_RERUN_ACTIONS = frozenset(
+    {RESUME_RERUN_FAILED, RESUME_RERUN_NOT_ATTEMPTED, RESUME_UNSKIP_DEPENDENT}
+)
+
+# Reason codes for an unreadable journal, in OMH's `reason_code` idiom so a
+# wrapper branches on a code rather than on prose.
+JOURNAL_MISSING = "journal_missing"
+JOURNAL_CORRUPT = "journal_corrupt"
+JOURNAL_SCHEMA_UNSUPPORTED = "journal_schema_unsupported"
+JOURNAL_FANOUT_MISMATCH = "journal_fanout_mismatch"
+
+# Statuses a unit can carry without any process ever having started for it.
+# They are failures of the batch around the unit, not answers from the unit,
+# so a resume re-attempts them -- an executor that was not ready then may be
+# ready now, and a worktree that could not be created may create cleanly.
+_NEVER_SPAWNED_STATUSES = frozenset(
+    {
+        "not_selected",
+        "interrupted",
+        "model_choice_required",
+        "spawn_ceiling_reached",
+    }
+)
+_SUCCEEDED_STATUSES = frozenset({"completed", "already_completed", "dry_run_planned"})
+
+_JOURNAL_UNIT_KEYS = (
+    "unit_id",
+    "run_ref",
+    "owner",
+    "terminal_state",
+    "status",
+    "failure_class",
+    "failure_label",
+    "replay_safe",
+    "replay_verdict",
+    "side_effect",
+    "blocked_on",
+)
+
+
+class FanoutJournalError(ValueError):
+    """A stored run journal could not be read as `fanout_run_journal/v1`."""
+
+    def __init__(self, message: str, *, reason_code: str) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+
+
+def journal_unit_entry(entry: Mapping[str, Any]) -> dict[str, Any]:
+    """Project one dispatch-summary unit entry into its journal row.
+
+    Carried-forward rows come back unchanged: a unit held by an earlier resume
+    is recorded in that run's summary as a skip, and re-deriving its state from
+    the skip would lose exactly the verdict that held it -- a unit refused as
+    replay-unsafe would read as `not_attempted` on the next resume and be
+    re-dispatched, which is the one outcome the hold exists to prevent.
+    """
+    carried = _carried_forward(entry)
+    if carried is not None:
+        return carried
+    state = _terminal_state(entry)
+    row: dict[str, Any] = {
+        "unit_id": str(entry.get("unit_id", "")),
+        "run_ref": str(entry.get("run_ref", "")),
+        "owner": str(entry.get("owner") or "choose"),
+        "terminal_state": state,
+        "status": str(entry.get("status", "")),
+        **_failure_classification(entry),
+        **_entry_replay_safety(entry, succeeded=state == TERMINAL_SUCCEEDED),
+        "blocked_on": [str(dep) for dep in entry.get("blocked_on", []) or []],
+    }
+    exit_code = entry.get("exit_code")
+    if isinstance(exit_code, int) and not isinstance(exit_code, bool):
+        row["exit_code"] = exit_code
+    return row
+
+
+def build_fanout_run_journal(summary: Mapping[str, Any]) -> dict[str, Any]:
+    """The journal for one completed dispatch, built from its own summary."""
+    order = [str(unit_id) for unit_id in summary.get("merge_order", []) or []]
+    rows = {
+        str(entry.get("unit_id", "")): journal_unit_entry(entry)
+        for entry in summary.get("units", []) or []
+        if isinstance(entry, Mapping)
+    }
+    journal: dict[str, Any] = {
+        "schema_version": FANOUT_RUN_JOURNAL_SCHEMA_VERSION,
+        "fanout_id": str(summary.get("fanout_id", "")),
+        "observed_at": utc_now(),
+        "base_sha": str(summary.get("base_sha", "")),
+        "merge_order": order,
+        "units": [rows[unit_id] for unit_id in order if unit_id in rows],
+        "privacy": "metadata_only",
+        "claim_boundary": JOURNAL_CLAIM_BOUNDARY,
+    }
+    if summary.get("interrupted"):
+        # The state that makes a resume worth having: this run was cut short,
+        # so units reading `not_attempted` were never asked the question.
+        journal["interrupted"] = True
+    return journal
+
+
+def write_fanout_run_journal(path: Path, journal: Mapping[str, Any]) -> Path:
+    """Persist one run journal crash-consistently and return its path.
+
+    `atomic_write_json` writes a sibling temp file and renames it over the
+    target, so a write interrupted at any point leaves the previous journal
+    byte-identical instead of a half-document a resume would misread.
+    """
+    atomic_write_json(path, dict(journal), private=True)
+    return path
+
+
+def read_fanout_run_journal(path: Path, *, expected_fanout_id: str = "") -> dict[str, Any]:
+    """Load one run journal, refusing anything this schema cannot resume from."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise FanoutJournalError(f"run journal not found: {path}", reason_code=JOURNAL_MISSING) from exc
+    except OSError as exc:
+        raise FanoutJournalError(f"run journal unreadable: {exc}", reason_code=JOURNAL_CORRUPT) from exc
+    try:
+        journal = json.loads(raw)
+    except (json.JSONDecodeError, RecursionError) as exc:
+        raise FanoutJournalError(f"run journal is not valid JSON: {exc}", reason_code=JOURNAL_CORRUPT) from exc
+    if not isinstance(journal, dict):
+        raise FanoutJournalError("run journal must be a JSON object", reason_code=JOURNAL_CORRUPT)
+    if journal.get("schema_version") != FANOUT_RUN_JOURNAL_SCHEMA_VERSION:
+        raise FanoutJournalError(
+            f"unsupported run journal schema_version: {journal.get('schema_version') or 'missing'}",
+            reason_code=JOURNAL_SCHEMA_UNSUPPORTED,
+        )
+    units = journal.get("units")
+    if not isinstance(units, list) or not all(isinstance(row, Mapping) for row in units):
+        raise FanoutJournalError("run journal units must be a list of objects", reason_code=JOURNAL_CORRUPT)
+    for row in units:
+        missing = [key for key in _JOURNAL_UNIT_KEYS if key not in row]
+        if missing:
+            raise FanoutJournalError(
+                f"run journal unit {row.get('unit_id') or '?'} is missing {', '.join(missing)}",
+                reason_code=JOURNAL_CORRUPT,
+            )
+    if expected_fanout_id and str(journal.get("fanout_id", "")) != expected_fanout_id:
+        raise FanoutJournalError(
+            f"run journal is for fanout {journal.get('fanout_id') or '?'}, not {expected_fanout_id}",
+            reason_code=JOURNAL_FANOUT_MISMATCH,
+        )
+    return journal
+
+
+def plan_fanout_resume(
+    journal: Mapping[str, Any],
+    *,
+    order: Sequence[str],
+    depends_on: Mapping[str, Sequence[str]],
+) -> dict[str, Any]:
+    """Decide, per unit, whether a resume re-dispatches it and say why.
+
+    Walked in `merge_order`, which the contract validator already guarantees
+    names every unit exactly once and which a prepared fanout emits in
+    dependency order, so a unit's blockers are always decided before it is.
+    """
+    rows = {str(row.get("unit_id", "")): row for row in journal.get("units", []) or [] if isinstance(row, Mapping)}
+    decisions: list[dict[str, Any]] = []
+    selected: list[str] = []
+    resumable: set[str] = set()
+    for unit_id in (str(value) for value in order):
+        row = rows.get(unit_id)
+        blockers = [str(dep) for dep in depends_on.get(unit_id, []) or []]
+        unresolved = [dep for dep in blockers if dep not in resumable]
+        decision = _unit_resume_decision(unit_id, row, unresolved)
+        decisions.append(decision)
+        if decision["action"] in RESUME_RERUN_ACTIONS:
+            selected.append(unit_id)
+            resumable.add(unit_id)
+        elif decision["action"] == RESUME_HOLD_SUCCEEDED:
+            # A succeeded unit is not re-dispatched and still clears the way
+            # for its dependents: that pairing is the whole point of a resume.
+            resumable.add(unit_id)
+    return {
+        "schema_version": FANOUT_RESUME_PLAN_SCHEMA_VERSION,
+        "fanout_id": str(journal.get("fanout_id", "")),
+        "resumed_from": {
+            "journal_schema_version": str(journal.get("schema_version", "")),
+            "observed_at": str(journal.get("observed_at", "")),
+            "interrupted": bool(journal.get("interrupted")),
+        },
+        "selected_units": selected,
+        "held_units": [entry["unit_id"] for entry in decisions if entry["action"] in RESUME_HOLD_ACTIONS],
+        "decisions": decisions,
+        "claim_boundary": RESUME_CLAIM_BOUNDARY,
+    }
+
+
+def _unit_resume_decision(
+    unit_id: str,
+    row: Mapping[str, Any] | None,
+    unresolved: Sequence[str],
+) -> dict[str, Any]:
+    if row is None:
+        # In the contract, absent from the journal: the prior run never
+        # reached it, so there is nothing to preserve and nothing to hold.
+        return _decision(
+            unit_id,
+            prior_state=TERMINAL_NOT_ATTEMPTED,
+            action=RESUME_RERUN_NOT_ATTEMPTED,
+            reason="no prior journal entry: the unit was never recorded",
+        )
+    prior_state = str(row.get("terminal_state", ""))
+    if prior_state == TERMINAL_SUCCEEDED:
+        return _decision(
+            unit_id,
+            prior_state=prior_state,
+            action=RESUME_HOLD_SUCCEEDED,
+            reason="the prior run observed this unit's process succeed; a resume never re-runs it",
+            row=row,
+        )
+    if not bool(row.get("replay_safe")):
+        return _decision(
+            unit_id,
+            prior_state=prior_state,
+            action=RESUME_HOLD_REPLAY_UNSAFE,
+            reason=(
+                f"replay refused ({row.get('replay_verdict') or 'unknown'}, "
+                f"side effect: {row.get('side_effect') or 'unknown'}): re-dispatching rebuilds the "
+                "worktree and destroys the work the failure left behind; continue it through the recovery record"
+            ),
+            row=row,
+        )
+    if unresolved:
+        return _decision(
+            unit_id,
+            prior_state=prior_state,
+            action=RESUME_HOLD_BLOCKED_DEPENDENCY,
+            reason=(
+                "held because "
+                + ", ".join(unresolved)
+                + " is not being re-dispatched, so this unit would only block again"
+            ),
+            row=row,
+        )
+    if prior_state == TERMINAL_SKIPPED_BY_DEPENDENCY:
+        return _decision(
+            unit_id,
+            prior_state=prior_state,
+            action=RESUME_UNSKIP_DEPENDENT,
+            reason="every unit it was blocked on is being attempted again, so it is no longer skipped",
+            row=row,
+        )
+    if prior_state == TERMINAL_NOT_ATTEMPTED:
+        return _decision(
+            unit_id,
+            prior_state=prior_state,
+            action=RESUME_RERUN_NOT_ATTEMPTED,
+            reason=f"never attempted in the prior run (status {row.get('status') or 'unknown'})",
+            row=row,
+        )
+    return _decision(
+        unit_id,
+        prior_state=prior_state,
+        action=RESUME_RERUN_FAILED,
+        reason=(
+            f"failed as {row.get('failure_class') or 'unclassified'} with no observed side effect, "
+            "so re-dispatching it destroys nothing"
+        ),
+        row=row,
+    )
+
+
+def _decision(
+    unit_id: str,
+    *,
+    prior_state: str,
+    action: str,
+    reason: str,
+    row: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    decision: dict[str, Any] = {
+        "unit_id": unit_id,
+        "prior_state": prior_state,
+        "action": action,
+        "reason": reason,
+    }
+    if action in RESUME_HOLD_ACTIONS and row is not None:
+        # A held unit is not dispatched, so the resumed run's own summary can
+        # only record a skip for it. Its prior verdict rides along so the next
+        # journal restates it instead of downgrading a refused replay to
+        # "never attempted".
+        decision["carry_forward"] = {key: row[key] for key in _JOURNAL_UNIT_KEYS if key in row}
+    return decision
+
+
+def _carried_forward(entry: Mapping[str, Any]) -> dict[str, Any] | None:
+    resume = entry.get("resume")
+    if not isinstance(resume, Mapping):
+        return None
+    carried = resume.get("carry_forward")
+    if not isinstance(carried, Mapping):
+        return None
+    if any(key not in carried for key in _JOURNAL_UNIT_KEYS):
+        return None
+    return {key: value for key, value in carried.items()}
+
+
+def _terminal_state(entry: Mapping[str, Any]) -> str:
+    if entry.get("status") in _SUCCEEDED_STATUSES or bool(entry.get("process_succeeded")):
+        return TERMINAL_SUCCEEDED
+    if entry.get("status") == "blocked_by_dependency":
+        return TERMINAL_SKIPPED_BY_DEPENDENCY
+    if "exit_code" not in entry and entry.get("status") in _NEVER_SPAWNED_STATUSES:
+        return TERMINAL_NOT_ATTEMPTED
+    return TERMINAL_FAILED
+
+
+def _failure_classification(entry: Mapping[str, Any]) -> dict[str, str]:
+    """The failure class in `fanout_retry`'s vocabulary, read not re-derived.
+
+    The dispatcher already classified any failure it considered retrying, from
+    the output tails it had in hand; the summary does not keep those tails, so
+    re-matching here would be guessing. Only a failure the retry ladder never
+    saw falls back to the exit-code-only classification.
+    """
+    retry = entry.get("retry")
+    if isinstance(retry, Mapping):
+        decisions = retry.get("decisions")
+        if isinstance(decisions, list) and decisions and isinstance(decisions[-1], Mapping):
+            final = decisions[-1]
+            return {
+                "failure_class": str(final.get("failure_class", "")),
+                "failure_label": str(final.get("failure_label", "")),
+            }
+    exit_code = entry.get("exit_code")
+    if not isinstance(exit_code, int) or isinstance(exit_code, bool) or exit_code == 0:
+        return {"failure_class": "", "failure_label": ""}
+    verdict = classify_unit_failure(
+        exit_code=exit_code,
+        output_tail="",
+        stderr_tail="",
+        limit_shaped=str(entry.get("limit_pattern", "")),
+    )
+    return {
+        "failure_class": str(verdict["failure_class"]),
+        "failure_label": str(verdict["failure_label"]),
+    }
+
+
+def _entry_replay_safety(entry: Mapping[str, Any], *, succeeded: bool) -> dict[str, Any]:
+    """Whether a resume may re-dispatch this unit, from what was observed.
+
+    The recovery-probe predicate is reused unchanged for a unit that ran and
+    failed. Two cases it does not model, because an in-flight retry only ever
+    asks about a spawn that just failed:
+
+    * A unit that never spawned. No process means no side effect, and the
+      absent exit code is the observation that says so.
+    * A unit that succeeded. Its work IS the side effect, and no recovery
+      probe was ever run against it because nothing failed -- reading that
+      absence as "unmeasured" would file the strongest possible reason not to
+      replay under the vocabulary for "I could not tell".
+    """
+    if succeeded:
+        return {
+            "replay_safe": False,
+            "replay_verdict": REPLAY_UNSAFE_SIDE_EFFECTS,
+            "side_effect": "succeeded_unit_work",
+        }
+    if "exit_code" not in entry:
+        return {"replay_safe": True, "replay_verdict": REPLAY_SAFE, "side_effect": "no_spawn_observed"}
+    return replay_safety(entry.get("recovery"), artifact_observed="unit_result" in entry)
+
+
+def resume_counts(decisions: Iterable[Mapping[str, Any]]) -> dict[str, int]:
+    """How many units each resume action covers, for the summary rollup."""
+    counts: dict[str, int] = {}
+    for decision in decisions:
+        action = str(decision.get("action", ""))
+        counts[action] = counts.get(action, 0) + 1
+    return dict(sorted(counts.items()))

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -1903,6 +1903,7 @@ def cmd_coding_fanout_dispatch(args: argparse.Namespace) -> int:
         read_fanout_contract_provenance,
     )
     from ..coding.fanout_dispatch import dispatch_fanout, fanout_dispatch_preflight
+    from ..coding.fanout_journal import FanoutJournalError, read_fanout_run_journal
     from ..coding.parallelism_policy import read_parallelism_policy, resolve_fanout_concurrency
 
     paths = _paths(args)
@@ -1917,6 +1918,18 @@ def cmd_coding_fanout_dispatch(args: argparse.Namespace) -> int:
         )
     except (OSError, ValueError) as exc:
         raise OmhError(f"fanout contract not found: {exc}") from exc
+    resume_journal = None
+    if args.resume_journal:
+        # Refused loudly rather than treated as an empty prior run: reading an
+        # unusable journal as "nothing happened" would re-dispatch every unit,
+        # including the ones a replay would destroy.
+        try:
+            resume_journal = read_fanout_run_journal(
+                Path(args.resume_journal).expanduser(),
+                expected_fanout_id=str(args.fanout_id),
+            )
+        except FanoutJournalError as exc:
+            raise OmhError(f"{exc} ({exc.reason_code})") from exc
     goal_text = sys.stdin.read() if args.goal_file == "-" else Path(args.goal_file).expanduser().read_text(encoding="utf-8")
     repo_root = Path(args.repo_root).expanduser().resolve()
     try:
@@ -1944,6 +1957,7 @@ def cmd_coding_fanout_dispatch(args: argparse.Namespace) -> int:
             only_units=args.unit,
             dry_run=bool(args.dry_run),
             run_verification=bool(args.run_verification),
+            resume_journal=resume_journal,
         )
         _print_json(summary)
         return _fanout_dispatch_exit_code(summary)
@@ -1976,6 +1990,7 @@ def cmd_coding_fanout_dispatch(args: argparse.Namespace) -> int:
             only_units=args.unit,
             dry_run=bool(args.dry_run),
             run_verification=bool(args.run_verification),
+            resume_journal=resume_journal,
         )
     except ValueError as exc:
         raise OmhError(str(exc)) from exc
@@ -2420,6 +2435,15 @@ def _add_coding_commands(sub) -> None:
         "--run-verification",
         action="store_true",
         help="Run each unit's contract verification_commands in its worktree after its sidecar validates.",
+    )
+    fanout_dispatch.add_argument(
+        "--resume-journal",
+        default="",
+        help=(
+            "Resume from a prior run's run_journal.json: re-dispatch only units that "
+            "failed with no observed side effect, un-skip their dependents, and never "
+            "re-run a unit that already succeeded."
+        ),
     )
     fanout_dispatch.set_defaults(func=cmd_coding_fanout_dispatch)
 

--- a/tests/test_fanout_journal.py
+++ b/tests/test_fanout_journal.py
@@ -1,0 +1,643 @@
+"""Run journal, crash-consistent write, and the resume rule read off it.
+
+Four properties, in the order a resume depends on them:
+
+* One dispatch summary projects to one journal row per unit, and the row's
+  terminal state is derived from what was observed -- not from the status
+  string alone, which cannot tell a unit that never spawned from one that
+  spawned and failed.
+* A write that dies mid-flight leaves the PREVIOUS journal byte-identical.
+  The whole surface is worthless otherwise: a resume that reads a truncated
+  journal is a resume that re-dispatches units it should have held.
+* The resume matrix. A succeeded unit is never re-run; a failure with no
+  observed side effect is; a failure that left work behind is NOT, with the
+  reason named; and a dependent skipped behind a blocker is un-skipped exactly
+  when that blocker is being attempted again.
+* The verdict survives being carried through a run that did not re-run the
+  unit, and a held unit costs nothing at dispatch time -- no spawn, and no
+  telemetry event, so the live reporter cannot double-report it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+from tempfile import TemporaryDirectory
+import unittest
+from unittest import mock
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.coding.fanout import build_fanout_contract  # noqa: E402
+from omh.coding.fanout_artifacts import (  # noqa: E402
+    fanout_run_journal_path,
+    write_fanout_contract,
+)
+from omh.coding.fanout_dispatch import dispatch_fanout  # noqa: E402
+from omh.coding.fanout_journal import (  # noqa: E402
+    FANOUT_RESUME_PLAN_SCHEMA_VERSION,
+    FANOUT_RUN_JOURNAL_SCHEMA_VERSION,
+    JOURNAL_CORRUPT,
+    JOURNAL_FANOUT_MISMATCH,
+    JOURNAL_MISSING,
+    JOURNAL_SCHEMA_UNSUPPORTED,
+    RESUME_HOLD_BLOCKED_DEPENDENCY,
+    RESUME_HOLD_REPLAY_UNSAFE,
+    RESUME_HOLD_SUCCEEDED,
+    RESUME_RERUN_FAILED,
+    RESUME_RERUN_NOT_ATTEMPTED,
+    RESUME_UNSKIP_DEPENDENT,
+    TERMINAL_FAILED,
+    TERMINAL_NOT_ATTEMPTED,
+    TERMINAL_SKIPPED_BY_DEPENDENCY,
+    TERMINAL_SUCCEEDED,
+    FanoutJournalError,
+    build_fanout_run_journal,
+    plan_fanout_resume,
+    read_fanout_run_journal,
+    write_fanout_run_journal,
+)
+from omh.coding.fanout_retry import (  # noqa: E402
+    CLASS_TERMINAL_FAILURE,
+    REPLAY_SAFE,
+    REPLAY_UNSAFE_SIDE_EFFECTS,
+)
+from omh.runtime.artifacts import show_run  # noqa: E402
+from omh.system.paths import OmhPaths  # noqa: E402
+
+_GOAL = "split the sample feature across agents"
+_UNITS = [
+    {"unit_id": "core", "title": "Core work", "owner": "codex", "file_scope": ["src/core/"]},
+    {"unit_id": "docs", "title": "Docs work", "owner": "claude-code", "file_scope": ["docs/"]},
+    {
+        "unit_id": "tests",
+        "title": "Test work",
+        "owner": "codex",
+        "file_scope": ["tests/"],
+        "depends_on": ["core"],
+    },
+]
+_ORDER = ["core", "docs", "tests"]
+_DEPENDS_ON = {"core": [], "docs": [], "tests": ["core"]}
+
+
+def _summary(*units: dict[str, object], **overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "fanout_id": "fanout-1",
+        "base_sha": "abc123",
+        "merge_order": [str(unit["unit_id"]) for unit in units],
+        "units": list(units),
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _succeeded(unit_id: str) -> dict[str, object]:
+    return {
+        "unit_id": unit_id,
+        "run_ref": f"run-{unit_id}",
+        "owner": "codex",
+        "status": "completed",
+        "exit_code": 0,
+        "process_succeeded": True,
+        "unit_result": {"unit_id": unit_id},
+    }
+
+
+def _failed(unit_id: str, *, recovery: str | None = "no_changes") -> dict[str, object]:
+    entry: dict[str, object] = {
+        "unit_id": unit_id,
+        "run_ref": f"run-{unit_id}",
+        "owner": "codex",
+        "status": "failed",
+        "exit_code": 1,
+        "process_succeeded": False,
+    }
+    if recovery is not None:
+        entry["recovery"] = {"outcome": recovery}
+    return entry
+
+
+def _blocked(unit_id: str, *, blocked_on: list[str]) -> dict[str, object]:
+    return {
+        "unit_id": unit_id,
+        "run_ref": f"run-{unit_id}",
+        "owner": "codex",
+        "status": "blocked_by_dependency",
+        "process_succeeded": False,
+        "blocked_on": blocked_on,
+    }
+
+
+def _interrupted(unit_id: str) -> dict[str, object]:
+    return {
+        "unit_id": unit_id,
+        "run_ref": f"run-{unit_id}",
+        "owner": "codex",
+        "status": "interrupted",
+        "process_succeeded": False,
+    }
+
+
+def _rows(journal: dict) -> dict[str, dict]:
+    return {row["unit_id"]: row for row in journal["units"]}
+
+
+def _actions(plan: dict) -> dict[str, str]:
+    return {entry["unit_id"]: entry["action"] for entry in plan["decisions"]}
+
+
+def _reason(plan: dict, unit_id: str) -> str:
+    return next(entry["reason"] for entry in plan["decisions"] if entry["unit_id"] == unit_id)
+
+
+class JournalProjectionTests(unittest.TestCase):
+    def test_each_terminal_state_is_derived_from_what_was_observed(self) -> None:
+        journal = build_fanout_run_journal(
+            _summary(
+                _succeeded("core"),
+                _failed("docs"),
+                _blocked("tests", blocked_on=["docs"]),
+                _interrupted("lint"),
+            )
+        )
+        rows = _rows(journal)
+        self.assertEqual(rows["core"]["terminal_state"], TERMINAL_SUCCEEDED)
+        self.assertEqual(rows["docs"]["terminal_state"], TERMINAL_FAILED)
+        self.assertEqual(rows["tests"]["terminal_state"], TERMINAL_SKIPPED_BY_DEPENDENCY)
+        self.assertEqual(rows["tests"]["blocked_on"], ["docs"])
+        self.assertEqual(rows["lint"]["terminal_state"], TERMINAL_NOT_ATTEMPTED)
+
+    def test_a_unit_that_never_spawned_is_replay_safe_and_one_that_wrote_is_not(self) -> None:
+        journal = build_fanout_run_journal(
+            _summary(
+                _interrupted("core"),
+                _failed("docs", recovery="recovery_available"),
+                _failed("tests", recovery=None),
+            )
+        )
+        rows = _rows(journal)
+        # No exit code means no process, so there is nothing a replay destroys.
+        self.assertTrue(rows["core"]["replay_safe"])
+        self.assertEqual(rows["core"]["side_effect"], "no_spawn_observed")
+        self.assertEqual(rows["core"]["replay_verdict"], REPLAY_SAFE)
+        # A worktree the probe found changes in blocks the replay ...
+        self.assertFalse(rows["docs"]["replay_safe"])
+        self.assertEqual(rows["docs"]["replay_verdict"], REPLAY_UNSAFE_SIDE_EFFECTS)
+        # ... and so does a worktree nobody could measure at all.
+        self.assertFalse(rows["tests"]["replay_safe"])
+
+    def test_a_result_artifact_blocks_a_replay_even_with_a_clean_worktree(self) -> None:
+        entry = _failed("core")
+        entry["unit_result"] = {"unit_id": "core"}
+        row = _rows(build_fanout_run_journal(_summary(entry)))["core"]
+        self.assertFalse(row["replay_safe"])
+        self.assertEqual(row["replay_verdict"], REPLAY_UNSAFE_SIDE_EFFECTS)
+
+    def test_the_failure_class_is_read_from_the_retry_decision_not_re_derived(self) -> None:
+        entry = _failed("core")
+        entry["retry"] = {
+            "decisions": [
+                {"failure_class": "transient_transport", "failure_label": "socket_hang_up"},
+            ]
+        }
+        row = _rows(build_fanout_run_journal(_summary(entry)))["core"]
+        self.assertEqual(row["failure_class"], "transient_transport")
+        self.assertEqual(row["failure_label"], "socket_hang_up")
+
+    def test_a_failure_the_retry_ladder_never_saw_falls_back_to_the_exit_code(self) -> None:
+        row = _rows(build_fanout_run_journal(_summary(_failed("core"))))["core"]
+        self.assertEqual(row["failure_class"], CLASS_TERMINAL_FAILURE)
+
+    def test_an_interrupted_batch_is_recorded_on_the_journal(self) -> None:
+        journal = build_fanout_run_journal(_summary(_interrupted("core"), interrupted=True))
+        self.assertTrue(journal["interrupted"])
+
+
+class JournalRoundTripTests(unittest.TestCase):
+    def test_a_written_journal_reads_back_identically(self) -> None:
+        journal = build_fanout_run_journal(
+            _summary(_succeeded("core"), _failed("docs"), _blocked("tests", blocked_on=["docs"]))
+        )
+        with TemporaryDirectory() as tmp:
+            path = write_fanout_run_journal(Path(tmp) / "run_journal.json", journal)
+            self.assertEqual(read_fanout_run_journal(path), journal)
+            self.assertEqual(journal["schema_version"], FANOUT_RUN_JOURNAL_SCHEMA_VERSION)
+            self.assertEqual(journal["merge_order"], ["core", "docs", "tests"])
+
+    def test_reading_refuses_every_unusable_journal_with_a_reason_code(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cases = [
+                (root / "absent.json", None, JOURNAL_MISSING),
+                (root / "garbage.json", "{not json", JOURNAL_CORRUPT),
+                (root / "array.json", "[]", JOURNAL_CORRUPT),
+                (
+                    root / "old.json",
+                    json.dumps({"schema_version": "fanout_run_journal/v0", "units": []}),
+                    JOURNAL_SCHEMA_UNSUPPORTED,
+                ),
+                (
+                    root / "shape.json",
+                    json.dumps(
+                        {
+                            "schema_version": FANOUT_RUN_JOURNAL_SCHEMA_VERSION,
+                            "units": [{"unit_id": "core"}],
+                        }
+                    ),
+                    JOURNAL_CORRUPT,
+                ),
+            ]
+            for path, text, reason_code in cases:
+                if text is not None:
+                    path.write_text(text, encoding="utf-8")
+                with self.assertRaises(FanoutJournalError) as caught:
+                    read_fanout_run_journal(path)
+                self.assertEqual(caught.exception.reason_code, reason_code, str(path))
+
+    def test_a_journal_from_another_fanout_is_refused(self) -> None:
+        journal = build_fanout_run_journal(_summary(_succeeded("core")))
+        with TemporaryDirectory() as tmp:
+            path = write_fanout_run_journal(Path(tmp) / "run_journal.json", journal)
+            with self.assertRaises(FanoutJournalError) as caught:
+                read_fanout_run_journal(path, expected_fanout_id="fanout-2")
+            self.assertEqual(caught.exception.reason_code, JOURNAL_FANOUT_MISMATCH)
+
+
+class JournalCrashConsistencyTests(unittest.TestCase):
+    def test_a_write_that_dies_before_the_rename_leaves_the_prior_journal_intact(self) -> None:
+        first = build_fanout_run_journal(_summary(_succeeded("core"), _failed("docs")))
+        second = build_fanout_run_journal(_summary(_succeeded("core"), _succeeded("docs")))
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "run_journal.json"
+            write_fanout_run_journal(path, first)
+            before = path.read_bytes()
+            with mock.patch.object(Path, "replace", side_effect=OSError("crash mid-write")):
+                with self.assertRaises(OSError):
+                    write_fanout_run_journal(path, second)
+            # The point of temp-then-rename: not a truncated document, not a
+            # merged one -- exactly the bytes that were there before.
+            self.assertEqual(path.read_bytes(), before)
+            self.assertEqual(read_fanout_run_journal(path), first)
+            # And no half-written sibling left behind for a later reader to find.
+            self.assertEqual(sorted(child.name for child in path.parent.iterdir()), ["run_journal.json"])
+
+
+class ResumeMatrixTests(unittest.TestCase):
+    def _plan(self, *units: dict[str, object]) -> dict:
+        return plan_fanout_resume(
+            build_fanout_run_journal(_summary(*units)),
+            order=_ORDER,
+            depends_on=_DEPENDS_ON,
+        )
+
+    def test_a_succeeded_unit_is_never_re_run_and_still_clears_its_dependent(self) -> None:
+        plan = self._plan(_succeeded("core"), _succeeded("docs"), _failed("tests"))
+        actions = _actions(plan)
+        self.assertEqual(actions["core"], RESUME_HOLD_SUCCEEDED)
+        self.assertEqual(actions["docs"], RESUME_HOLD_SUCCEEDED)
+        # `tests` depends on `core`, which succeeded: the dependency is clear
+        # without `core` running again.
+        self.assertEqual(actions["tests"], RESUME_RERUN_FAILED)
+        self.assertEqual(plan["selected_units"], ["tests"])
+        self.assertEqual(sorted(plan["held_units"]), ["core", "docs"])
+
+    def test_a_replay_safe_failure_is_re_run_and_un_skips_its_dependent(self) -> None:
+        plan = self._plan(
+            _failed("core"),
+            _succeeded("docs"),
+            _blocked("tests", blocked_on=["core"]),
+        )
+        actions = _actions(plan)
+        self.assertEqual(actions["core"], RESUME_RERUN_FAILED)
+        self.assertEqual(actions["docs"], RESUME_HOLD_SUCCEEDED)
+        self.assertEqual(actions["tests"], RESUME_UNSKIP_DEPENDENT)
+        self.assertEqual(plan["selected_units"], ["core", "tests"])
+        self.assertIn("no longer skipped", _reason(plan, "tests"))
+
+    def test_a_replay_unsafe_failure_is_held_and_its_dependent_stays_skipped(self) -> None:
+        plan = self._plan(
+            _failed("core", recovery="recovery_available"),
+            _succeeded("docs"),
+            _blocked("tests", blocked_on=["core"]),
+        )
+        actions = _actions(plan)
+        self.assertEqual(actions["core"], RESUME_HOLD_REPLAY_UNSAFE)
+        self.assertEqual(actions["tests"], RESUME_HOLD_BLOCKED_DEPENDENCY)
+        self.assertEqual(plan["selected_units"], [])
+        self.assertIn("destroys the work the failure left behind", _reason(plan, "core"))
+        self.assertIn("core", _reason(plan, "tests"))
+
+    def test_an_unmeasured_worktree_is_held_the_same_way(self) -> None:
+        plan = self._plan(_failed("core", recovery=None), _succeeded("docs"), _succeeded("tests"))
+        self.assertEqual(_actions(plan)["core"], RESUME_HOLD_REPLAY_UNSAFE)
+
+    def test_units_the_interrupt_never_started_are_re_run(self) -> None:
+        plan = self._plan(_succeeded("core"), _interrupted("docs"), _interrupted("tests"))
+        actions = _actions(plan)
+        self.assertEqual(actions["docs"], RESUME_RERUN_NOT_ATTEMPTED)
+        self.assertEqual(actions["tests"], RESUME_RERUN_NOT_ATTEMPTED)
+
+    def test_a_unit_absent_from_the_journal_is_re_run(self) -> None:
+        plan = self._plan(_succeeded("core"))
+        actions = _actions(plan)
+        self.assertEqual(actions["docs"], RESUME_RERUN_NOT_ATTEMPTED)
+        self.assertIn("never recorded", _reason(plan, "docs"))
+
+    def test_the_plan_names_its_schema_and_what_it_resumed_from(self) -> None:
+        journal = build_fanout_run_journal(_summary(_failed("core"), interrupted=True))
+        plan = plan_fanout_resume(journal, order=_ORDER, depends_on=_DEPENDS_ON)
+        self.assertEqual(plan["schema_version"], FANOUT_RESUME_PLAN_SCHEMA_VERSION)
+        self.assertEqual(plan["resumed_from"]["journal_schema_version"], FANOUT_RUN_JOURNAL_SCHEMA_VERSION)
+        self.assertTrue(plan["resumed_from"]["interrupted"])
+
+
+class ResumeVerdictCarryForwardTests(unittest.TestCase):
+    def test_a_held_replay_unsafe_unit_stays_held_across_a_second_resume(self) -> None:
+        # The regression this exists for: a held unit is recorded in the
+        # resumed run's summary as a plain skip. Re-deriving its state from
+        # that skip would read "never attempted", and the NEXT resume would
+        # re-dispatch exactly the unit the first one refused to.
+        first = build_fanout_run_journal(
+            _summary(_failed("core", recovery="recovery_available"), _succeeded("docs"))
+        )
+        plan = plan_fanout_resume(first, order=_ORDER, depends_on=_DEPENDS_ON)
+        held = next(entry for entry in plan["decisions"] if entry["unit_id"] == "core")
+        resumed_entry = {
+            "unit_id": "core",
+            "run_ref": "run-core",
+            "owner": "codex",
+            "status": "not_selected",
+            "process_succeeded": False,
+            "resume": {
+                "action": held["action"],
+                "prior_state": held["prior_state"],
+                "reason": held["reason"],
+                "carry_forward": held["carry_forward"],
+            },
+        }
+        second = build_fanout_run_journal(_summary(resumed_entry, _succeeded("docs")))
+        row = _rows(second)["core"]
+        self.assertEqual(row["terminal_state"], TERMINAL_FAILED)
+        self.assertFalse(row["replay_safe"])
+        again = plan_fanout_resume(second, order=_ORDER, depends_on=_DEPENDS_ON)
+        self.assertEqual(_actions(again)["core"], RESUME_HOLD_REPLAY_UNSAFE)
+
+
+def _git(repo: Path, *argv: str) -> None:
+    subprocess.run(["git", *argv], cwd=str(repo), check=True, capture_output=True, text=True)
+
+
+def _make_repo(root: Path) -> tuple[Path, str]:
+    repo = root / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+    _git(repo, "add", "seed.txt")
+    _git(repo, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "init")
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=str(repo), capture_output=True, text=True, check=True
+    ).stdout.strip()
+    return repo, sha
+
+
+class _FakeCompleted:
+    def __init__(self, returncode: int, stdout: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = ""
+
+
+def _runner(*, fail_units: set[str] | None = None, write_units: set[str] | None = None):
+    """Fake agent CLI; `write_units` leave real files for the recovery probe."""
+    spawned: list[str] = []
+
+    def owns(prompt: str, unit_id: str) -> bool:
+        return f"agent/{unit_id} in the current worktree" in prompt
+
+    def runner(argv, **kwargs):
+        if argv[0] == "git":
+            return subprocess.run(argv, **kwargs)
+        prompt = " ".join(argv)
+        cwd = Path(str(kwargs.get("cwd", ".")))
+        for unit_id in _ORDER:
+            if owns(prompt, unit_id):
+                spawned.append(unit_id)
+        for unit_id in write_units or set():
+            if owns(prompt, unit_id):
+                (cwd / f"{unit_id}_partial.py").write_text("value = 1\n", encoding="utf-8")
+        for unit_id in fail_units or set():
+            if owns(prompt, unit_id):
+                return _FakeCompleted(1, f"unit {unit_id} failed")
+        return _FakeCompleted(0, "done")
+
+    runner.spawned = spawned
+    return runner
+
+
+def _ready(paths, profile, **kwargs):
+    return {"status": "ready", "profile": profile}
+
+
+def _clear_unit_worktree(repo: Path, unit_id: str) -> None:
+    """The remedy the dispatcher's own refusals name, applied by hand.
+
+    OMH never removes a worktree or a branch for the operator, so a resume of a
+    unit whose earlier attempt left both behind only proceeds once they are
+    cleared. Doing it explicitly here is the honest fixture.
+    """
+    _git(repo, "worktree", "remove", "--force", str(repo.parent / f"{repo.name}-fanout-{unit_id}"))
+    _git(repo, "branch", "-D", f"agent/{unit_id}")
+
+
+def _worker_results(paths: OmhPaths, run_ref: str) -> int:
+    shown = show_run(paths, run_ref)
+    return sum(
+        1
+        for event in shown.get("journal_events", []) or []
+        if str(event.get("event", "")) == "worker_result"
+    )
+
+
+class ResumeDispatchIntegrationTests(unittest.TestCase):
+    def _setup(self, tmp: str):
+        root = Path(tmp)
+        paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+        repo, sha = _make_repo(root)
+        contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, _UNITS))
+        return paths, repo, sha, contract
+
+    def _dispatch(self, paths, repo, sha, contract, runner, resume_journal=None, only_units=None):
+        return dispatch_fanout(
+            paths,
+            contract,
+            goal_text=_GOAL,
+            repo_root=repo,
+            base_sha=sha,
+            runner=runner,
+            readiness=_ready,
+            only_units=only_units,
+            resume_journal=resume_journal,
+        )
+
+    def _journal(self, paths, contract) -> dict:
+        return read_fanout_run_journal(fanout_run_journal_path(paths, contract["fanout_id"]))
+
+    def _run_ref(self, contract, unit_id: str) -> str:
+        return next(
+            str(unit["run_ref"]) for unit in contract["units"] if unit["unit_id"] == unit_id
+        )
+
+    def test_a_dispatch_writes_a_run_journal_next_to_its_summary(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            summary = self._dispatch(paths, repo, sha, contract, _runner(fail_units={"core"}))
+            path = fanout_run_journal_path(paths, contract["fanout_id"])
+            self.assertEqual(summary["run_journal_path"], str(path))
+            rows = _rows(read_fanout_run_journal(path, expected_fanout_id=contract["fanout_id"]))
+            self.assertEqual(rows["core"]["terminal_state"], TERMINAL_FAILED)
+            self.assertEqual(rows["docs"]["terminal_state"], TERMINAL_SUCCEEDED)
+            self.assertEqual(rows["tests"]["terminal_state"], TERMINAL_SKIPPED_BY_DEPENDENCY)
+
+    def test_a_resume_runs_only_what_the_cut_short_run_never_reached(self) -> None:
+        # The headline case: a run that stopped before every unit was tried.
+        # Nothing was started for `core` or `tests`, so they have no worktree
+        # and no side effect, and the resume simply picks them up.
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            self._dispatch(paths, repo, sha, contract, _runner(), only_units=["docs"])
+            journal = self._journal(paths, contract)
+            docs_before = _worker_results(paths, self._run_ref(contract, "docs"))
+
+            resumed = _runner()
+            summary = self._dispatch(
+                paths, repo, sha, contract, resumed, resume_journal=journal
+            )
+
+            self.assertEqual(sorted(resumed.spawned), ["core", "tests"])
+            units = {entry["unit_id"]: entry for entry in summary["units"]}
+            self.assertEqual(units["core"]["resume"]["action"], RESUME_RERUN_NOT_ATTEMPTED)
+            self.assertEqual(units["tests"]["resume"]["action"], RESUME_RERUN_NOT_ATTEMPTED)
+            self.assertEqual(units["docs"]["resume"]["action"], RESUME_HOLD_SUCCEEDED)
+            self.assertEqual(units["docs"]["status"], "already_completed")
+            self.assertEqual(summary["resume"]["counts"][RESUME_HOLD_SUCCEEDED], 1)
+            # A held unit is never dispatched, so no second `worker_result` is
+            # appended for it and the live telemetry reporter -- which only
+            # exists inside a dispatch -- cannot report it a second time.
+            self.assertEqual(_worker_results(paths, self._run_ref(contract, "docs")), docs_before)
+
+    def test_a_replay_safe_failure_is_selected_and_still_meets_the_worktree_refusal(self) -> None:
+        # The plan decides eligibility; it does not reach into the repository.
+        # A unit whose earlier attempt left its worktree in place is selected
+        # and then meets the dispatcher's own long-standing refusal -- OMH
+        # never auto-deletes a worktree, and a resume is not the place to start.
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            self._dispatch(paths, repo, sha, contract, _runner(fail_units={"core"}))
+            journal = self._journal(paths, contract)
+            self.assertTrue(_rows(journal)["core"]["replay_safe"])
+
+            summary = self._dispatch(paths, repo, sha, contract, _runner(), resume_journal=journal)
+            units = {entry["unit_id"]: entry for entry in summary["units"]}
+            self.assertEqual(units["core"]["resume"]["action"], RESUME_RERUN_FAILED)
+            self.assertEqual(units["core"]["status"], "worktree_failed")
+            self.assertIn("remove it", units["core"]["reason"])
+
+    def test_once_the_leftover_worktree_is_cleared_the_resume_re_runs_and_un_skips(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            self._dispatch(paths, repo, sha, contract, _runner(fail_units={"core"}))
+            journal = self._journal(paths, contract)
+            self.assertEqual(_rows(journal)["tests"]["terminal_state"], TERMINAL_SKIPPED_BY_DEPENDENCY)
+            _clear_unit_worktree(repo, "core")
+
+            resumed = _runner()
+            summary = self._dispatch(paths, repo, sha, contract, resumed, resume_journal=journal)
+
+            self.assertEqual(sorted(resumed.spawned), ["core", "tests"])
+            units = {entry["unit_id"]: entry for entry in summary["units"]}
+            self.assertEqual(units["core"]["resume"]["action"], RESUME_RERUN_FAILED)
+            self.assertEqual(units["core"]["status"], "completed")
+            # The blocker cleared, so the dependent the first run skipped runs.
+            self.assertEqual(units["tests"]["resume"]["action"], RESUME_UNSKIP_DEPENDENT)
+            self.assertEqual(units["tests"]["status"], "completed")
+            self.assertEqual(units["docs"]["resume"]["action"], RESUME_HOLD_SUCCEEDED)
+
+    def test_a_resume_refuses_to_replay_a_failure_that_left_work_behind(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            self._dispatch(
+                paths,
+                repo,
+                sha,
+                contract,
+                _runner(fail_units={"core"}, write_units={"core"}),
+            )
+            journal = self._journal(paths, contract)
+            self.assertFalse(_rows(journal)["core"]["replay_safe"])
+
+            resumed = _runner()
+            summary = self._dispatch(paths, repo, sha, contract, resumed, resume_journal=journal)
+
+            self.assertEqual(resumed.spawned, [])
+            units = {entry["unit_id"]: entry for entry in summary["units"]}
+            self.assertEqual(units["core"]["resume"]["action"], RESUME_HOLD_REPLAY_UNSAFE)
+            self.assertIn("recovery record", units["core"]["resume"]["reason"])
+            self.assertEqual(units["tests"]["resume"]["action"], RESUME_HOLD_BLOCKED_DEPENDENCY)
+            self.assertEqual(summary["resume"]["selected_units"], [])
+            # And the refusal survives into the journal this resume writes.
+            again = self._journal(paths, contract)
+            self.assertFalse(_rows(again)["core"]["replay_safe"])
+            self.assertEqual(_rows(again)["core"]["terminal_state"], TERMINAL_FAILED)
+
+    def test_a_dispatch_without_a_journal_is_unchanged(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            runner = _runner()
+            summary = self._dispatch(paths, repo, sha, contract, runner)
+            self.assertEqual(sorted(runner.spawned), ["core", "docs", "tests"])
+            self.assertNotIn("resume", summary)
+            self.assertTrue(all("resume" not in entry for entry in summary["units"]))
+
+
+class ResumeCliTests(unittest.TestCase):
+    def test_an_unreadable_journal_is_refused_with_its_reason_code(self) -> None:
+        from _cli_harness import run_cli
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            repo, _sha = _make_repo(root)
+            contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, _UNITS))
+            goal_file = root / "goal.txt"
+            goal_file.write_text(_GOAL, encoding="utf-8")
+            journal = root / "run_journal.json"
+            journal.write_text("{not json", encoding="utf-8")
+            code, _out, err = run_cli(
+                [
+                    "--omh-home",
+                    str(paths.omh_home),
+                    "--hermes-home",
+                    str(paths.hermes_home),
+                    "coding",
+                    "fanout",
+                    "dispatch",
+                    str(contract["fanout_id"]),
+                    "--goal-file",
+                    str(goal_file),
+                    "--repo-root",
+                    str(repo),
+                    "--resume-journal",
+                    str(journal),
+                    "--dry-run",
+                ]
+            )
+            self.assertNotEqual(code, 0)
+            self.assertIn(JOURNAL_CORRUPT, err)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New `src/coding/fanout_journal.py`: a versioned terminal-state journal for one fanout run (`fanout_run_journal/v1`) and the pure resume plan (`fanout_resume_plan/v1`) derived from it.
- Every non-dry-run `dispatch_fanout` now writes `~/.omh/coding/fanout/<id>/run_journal.json` next to `dispatch_summary.json`, and returns its path as `run_journal_path`.
- New CLI option `omh coding fanout dispatch <id> --resume-journal <path>`: re-dispatch only what a prior journal makes eligible.
- `docs/FANOUT.md` gains a "Run journal and resume" bullet and the flag in the command synopsis.

### Why This Exists

Backlog item **P2 — 9. Resumable fanout: journal + retry that un-skips dependents** from `.omc/research/omo-omc-comparison-2026-08-29.md`. OMH already recorded `interrupted` and supported a manual merged re-dispatch (`_merged_dispatch_summary`, `_recovery_available`); what was missing was a machine-readable record of *what terminally happened per unit* and a rule that turns it back into a next dispatch without re-running finished work or replaying units whose failure left work behind.

The dossier item is implemented as the **delta on top of shipped code**, not a re-implementation:

- Depth caps and the spawn ledger (#1172) are untouched — the resume path spawns through the same guarded loop.
- Retry classification and the replay-safety predicate (#1179) are **reused, not duplicated**: the journal reads `failure_class` off the retry decision the dispatcher already recorded, and calls `fanout_retry.replay_safety()` for the recovery-mapping cases.
- The injectable clock/rng seam (#1187) is unchanged; nothing in this change sleeps or reads a clock beyond the existing `utc_now()` stamp.
- Deliberately **not** implemented from the dossier text: the append-only event stream with `checkpointSeq`, the per-run lock, `dag.stream.overflow` / `recoverAfterSeq` for reconnecting watchers, and the optional omo `amend` (fingerprint unit definitions, re-run changed units). Those are stream-watcher and re-planning surfaces; this PR ships the resume half the item is named for.

### User / Operator Impact

An interrupted or partly-failed fanout can be picked back up with one flag instead of a hand-assembled `--unit a --unit b`. The plan is printed before anything spawns, and the reasons are the operator-facing part: a held unit says *why* it is held, so "continue this by hand through its recovery record" and "this will run again" are distinguishable without reading the summary's telemetry.

Behaviour is unchanged when the flag is absent: no `resume` key on the summary, no `resume` block on any unit, same unit selection. The journal file is new on every non-dry-run dispatch.

### How It Works

**Journal (`fanout_run_journal/v1`).** One narrow row per unit, in `merge_order`:

- `terminal_state`: `succeeded` | `failed` | `skipped_by_dependency` | `not_attempted`.
- `failure_class` / `failure_label`: read off the last retry decision the dispatcher recorded; only a failure the retry ladder never saw falls back to an exit-code-only `classify_unit_failure`. The summary does not keep output tails, so re-matching them here would be guessing.
- `replay_safe` / `replay_verdict` / `side_effect`: `fanout_retry.replay_safety()` for a unit that ran and failed, plus the two cases an in-flight retry never has to consider — a unit that never spawned (no exit code ⇒ no side effect ⇒ safe) and a unit that succeeded (its work *is* the side effect ⇒ never replayable).
- `blocked_on`, `status`, `run_ref`, `owner`, `exit_code`.

**Resume rule.** The gate is **replay-safety, not transience**. An in-run retry declines a terminal failure because re-running it burns an agent-CLI run to re-derive an answer already in hand; an operator asking to resume has already decided that answer is worth re-deriving. What stays refused in both places is a replay that destroys observed work.

Walking `merge_order` (dependency-ordered by contract validation), per unit:

| prior state | verdict | action |
| --- | --- | --- |
| `succeeded` | — | `hold_succeeded` — never re-run, still clears dependents |
| `failed` | replay-safe | `rerun_replay_safe_failure` |
| `failed` | replay-unsafe (worktree changes / result artifact / unmeasured) | `hold_replay_unsafe`, reason names the side effect |
| `skipped_by_dependency` | blockers all resumable | `unskip_dependent` |
| any | a blocker is held | `hold_blocked_dependency`, reason names the blocker |
| `not_attempted` / absent from journal | — | `rerun_not_attempted` |

**Crash consistency.** Writes go through `atomic_write_json` (serialize → sibling temp → rename). A write that dies before the rename leaves the previous journal byte-identical and removes its own temp file, so an interrupted resume never produces a half-document a later resume would misread. A journal that cannot be read as this schema raises `FanoutJournalError` with a `reason_code` (`journal_missing`, `journal_corrupt`, `journal_schema_unsupported`, `journal_fanout_mismatch`) and the CLI refuses — treating an unreadable prior run as "nothing happened" would re-dispatch every unit, including the ones a replay would destroy.

**No new status vocabulary.** A held unit reuses the existing skip statuses: `already_completed` for a succeeded hold (so it keeps satisfying dependents through `_dependency_satisfied`) and `not_selected` for a refused replay (so its dependents stay blocked through `_dependency_failed`). The new `resume` block carries the distinction. That keeps summary merging, `fanout brief`, `fanout status`, integration-readiness folding, and the dispatch exit code working unchanged. A held unit's prior journal row rides in `resume.carry_forward`, so a refused replay is not downgraded to "never attempted" by the next resume.

**Telemetry.** A held unit never enters `_dispatch_unit`: no readiness probe, no worktree, no spawn, no progress binding, and therefore no `on_output` live-telemetry reporter — the reporter only exists inside a dispatch. A resumed run appends no second `worker_result` for a held unit, which is asserted directly.

### Files And Contracts Touched

- `src/coding/fanout_journal.py` (new) — `fanout_run_journal/v1`, `fanout_resume_plan/v1`, `FanoutJournalError`.
- `src/coding/fanout_artifacts.py` — `fanout_run_journal_path()`, same id-pattern + containment validation as the summary path.
- `src/coding/fanout_dispatch.py` — `resume_journal=` parameter, resume hold in both result pre-passes, `summary["resume"]`, journal write after the carried-recovery merge, `_resume_hold` / `_resume_note`.
- `src/commands/coding.py` — `--resume-journal` on the dispatch parser, journal read with fanout-id check, threaded into both `dispatch_fanout` call sites.
- `docs/FANOUT.md` — hand-written doc, not a generated artifact.
- `tests/test_fanout_journal.py` (new) — 25 cases.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli docs ulw-inventory --check`, `uv run python -m omh.cli docs ulw-site --check`, `uv run python -m omh.cli release drift`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: this change touches no Hermes-facing surface — no skill catalog, router, card, or plugin artifact is modified, and all five generated-artifact byte gates are unchanged.

### Observed Evidence

- `uv run python -m compileall -q src tests` → clean.
- `PYTHONPATH=tests uv run python -m unittest discover -s tests` → **Ran 8125 tests**, `FAILED (failures=21, errors=7)`. All 28 are the known cross-harness `.claude`-path failures in `test_cross_harness_adapters` / `test_cross_harness_adapter_security` (`reason_code == 'unsafe_read_root'` because the worktree lives under `.claude/`). Enumerated and confirmed to be exactly that set; no other module fails.
- `PYTHONPATH=tests uv run python -m unittest tests/test_fanout_journal.py` → **Ran 25 tests, OK**.
- `PYTHONPATH=tests uv run python -m unittest tests/test_fanout_dispatch.py tests/test_fanout_retry.py tests/test_cli.py` → **499 tests, OK** (no regression in the surfaces this builds on).
- Byte gates, all `ok:true`: `docs workflows --check` (tap-skills 154/154, no missing/stale/extra), `docs roles --check`, `docs capability-families --check`, `docs ulw-inventory --check`, `docs ulw-site --check`.
- `uv run python -m omh.cli release drift` → `No drift. 17 checks passed.`
- `uv run python -m omh.cli harness validate` → `ok:true`, 75 harnesses / 113 skills, no errors or warnings.
- `uv run python -m omh.cli release checklist --json` → `ok:true` (plan mode, 35 required items, nothing observed by the checklist itself).
- `uv run --group lint ruff check src tests` → `All checks passed!`
- `git diff --check` → clean.

**Resume matrix, as asserted (`tests/test_fanout_journal.py`):**

| case | test | observed |
| --- | --- | --- |
| succeeded unit never re-run, still clears its dependent | `test_a_succeeded_unit_is_never_re_run_and_still_clears_its_dependent` | `hold_succeeded`; dependent selected |
| replay-safe failure re-run, dependent un-skipped | `test_a_replay_safe_failure_is_re_run_and_un_skips_its_dependent` | `selected_units == ["core", "tests"]` |
| replay-unsafe failure NOT re-run, with reason | `test_a_replay_unsafe_failure_is_held_and_its_dependent_stays_skipped` | `hold_replay_unsafe` + `hold_blocked_dependency`; `selected_units == []` |
| unmeasured worktree fails closed the same way | `test_an_unmeasured_worktree_is_held_the_same_way` | `hold_replay_unsafe` |
| never-started units resume | `test_units_the_interrupt_never_started_are_re_run` | `rerun_not_attempted` |
| verdict survives a second resume | `test_a_held_replay_unsafe_unit_stays_held_across_a_second_resume` | still `hold_replay_unsafe` |
| crash-consistency | `test_a_write_that_dies_before_the_rename_leaves_the_prior_journal_intact` | prior bytes identical, no stray temp file |
| corrupt / unsupported / mismatched journal | `test_reading_refuses_every_unusable_journal_with_a_reason_code`, `test_a_journal_from_another_fanout_is_refused` | all four reason codes |
| end-to-end resume of a cut-short run | `test_a_resume_runs_only_what_the_cut_short_run_never_reached` | only the 2 unreached units spawn; held unit's `worker_result` count unchanged |
| end-to-end un-skip after the blocker clears | `test_once_the_leftover_worktree_is_cleared_the_resume_re_runs_and_un_skips` | `core` + `tests` both `completed` |
| replay-unsafe end-to-end | `test_a_resume_refuses_to_replay_a_failure_that_left_work_behind` | nothing spawned; refusal survives into the next journal |
| no journal ⇒ no behaviour change | `test_a_dispatch_without_a_journal_is_unchanged` | all 3 units spawn, no `resume` key anywhere |

### Not Tested / Not Applicable

- `release hermes-smoke`, `omh --help`, the installed-command smoke, and the manual Hermes/TUI check: this change adds no skill, router trigger, card, or plugin artifact, so no Hermes-facing surface moved. All five generated-artifact gates are byte-identical.
- Workflow-learning review queue smoke: no learning contract changed.
- No real agent CLI was spawned. Dispatch integration tests use injected fake runners, matching the existing `tests/test_fanout_dispatch.py` convention; `git` calls in those tests are real.
- No concurrent or multi-machine resume was exercised — one dispatch per process is the supported shape, unchanged by this PR.
- The CLI path is exercised only for the refusal case (`journal_corrupt`); the resume behaviour itself is asserted at the `dispatch_fanout` boundary, which the CLI calls directly.

## Risk

- **Every non-dry-run dispatch now writes one more small metadata-only file.** It is written after the summary and cannot change the summary's contents; a write failure raises where the summary is already on disk. Bounded: one row per unit, no tails, no diffs.
- **A held unit reuses `not_selected`.** A consumer that reads `not_selected` as "the operator did not ask for this" now also sees units a resume refused. The `resume` block disambiguates, and the alternative — a new status — would have needed changes in dependency satisfaction, summary merging, brief, status projection, and the exit code.
- **A replay-safe re-run still meets the pre-existing worktree refusal.** OMH never auto-deletes a worktree (`worktree_creator`'s cleanup receipt says so in as many words), so a unit whose earlier attempt left its worktree in place is *selected* by the plan and then refused as `worktree_path_already_exists` until the operator clears it. This is deliberate — deleting an operator's directory is a much larger claim than deciding what is eligible — and it is asserted as a test, not left as a surprise. The interrupted-run case, which the dossier item is actually named for, needs no manual step.

## Compatibility / Rollout

- Additive. `dispatch_fanout(resume_journal=...)` defaults to `None`; `--resume-journal` defaults to empty. Without it, the summary shape is byte-comparable to before apart from the new `run_journal_path` key.
- `fanout_run_journal/v1` is a new file in an existing per-fanout directory. An older OMH ignores it; a newer OMH reading a directory without one simply has nothing to resume from.
- The schema is version-pinned and read strictly: a future `v2` is refused with `journal_schema_unsupported` rather than misread.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`) — no channel or install artifact touched.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence — the journal and resume plan both carry explicit claim boundaries stating they are not verification, review, CI, or merge evidence.
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data — the journal is metadata only: ids, statuses, classes, verdicts. No tails, no diffs, no paths beyond `run_ref`.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- The dossier's stream half is still open: append-only events with a monotonic `checkpointSeq`, `store.withRunLock`, and `dag.stream.overflow` / `recoverAfterSeq` for a watcher reconnecting mid-run.
- omo's `amend` (fingerprint the unit definitions, re-run only changed units plus their dependents) is a separate re-planning surface that would sit on top of this journal.
- Whether a resume should offer to clear a worktree it has *measured* as containing no changes is a real question, but it is a new destructive capability and deserves its own decision, not a side effect of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1Tue9T3YhWLT5mT8bo9Ke
