### PR TITLE
feat(system): one truncation contract with spill-to-artifact back-references

### DIFF
--- a/src/coding/_hermes_child_process.py
+++ b/src/coding/_hermes_child_process.py
@@ -16,12 +16,12 @@ import time
 from typing import BinaryIO, Final
 
 from ..system.metadata_safety import is_sensitive_metadata_text
+from ..system.output_truncation import truncation_notice, truncation_record
 
 _MAX_USAGE_BYTES: Final = 65_536
 _FORCE_KILL_SIGNAL: Final = getattr(signal, "SIGKILL", signal.SIGTERM)
 MAX_CAPTURE_BYTES: Final = 16_384
 _READ_CHUNK_BYTES: Final = 64 * 1024
-_OUTPUT_TRUNCATED_MARKER: Final = "\n[output truncated at 16384-byte capture limit]\n"
 _USAGE_KEYS: Final = frozenset(
     {
         "estimated_cost_usd", "cost_status", "cost_source", "input_tokens",
@@ -38,6 +38,11 @@ class BoundedStreamCapture:
 
     data: bytes
     truncated: bool
+    # Total bytes the drainer read before discarding, counted rather than
+    # retained, so a truncation record can state the real original size instead
+    # of reporting it as unknown. Zero means "not counted by this producer",
+    # which the record renders as unknown rather than as an empty stream.
+    seen_bytes: int = 0
 
 
 class PipeDrainer:
@@ -47,6 +52,7 @@ class PipeDrainer:
         self._pipe = pipe
         self._parts: list[bytes] = []
         self._retained = 0
+        self._seen = 0
         self._truncated = False
         self._error = False
         self.done = Event()
@@ -56,7 +62,9 @@ class PipeDrainer:
         self.thread.start()
 
     def capture(self) -> BoundedStreamCapture:
-        return BoundedStreamCapture(b"".join(self._parts), self._truncated or self._error)
+        return BoundedStreamCapture(
+            b"".join(self._parts), self._truncated or self._error, self._seen
+        )
 
     def close(self) -> None:
         try:
@@ -70,6 +78,9 @@ class PipeDrainer:
                 chunk = self._pipe.read(_READ_CHUNK_BYTES)
                 if not chunk:
                     break
+                # Counted, never retained: this is what lets the truncation
+                # record name the real original size at zero memory cost.
+                self._seen += len(chunk)
                 remaining = MAX_CAPTURE_BYTES - self._retained
                 if remaining > 0:
                     kept = chunk[:remaining]
@@ -281,19 +292,38 @@ def read_usage(path: Path) -> Mapping[str, object]:
     return usage
 
 
+def capture_truncation_record(
+    captured: BoundedStreamCapture | bytes | str | object,
+    *,
+    source: str,
+) -> dict[str, object]:
+    """The `omh_output_truncation/v1` record for one bounded stream capture.
+
+    Nothing spills here, and that is not an omission: the drainer enforces the
+    cap while reading, so the discarded bytes never existed in this process to
+    write anywhere. The record says exactly that (`content_not_retained`)
+    rather than implying a pointer that could never be produced.
+    """
+    raw, truncated, seen = _capture_parts(captured)
+    return truncation_record(
+        source=source,
+        reason_code="capture_cap" if truncated else "not_truncated",
+        limit_bytes=MAX_CAPTURE_BYTES,
+        kept_bytes=len(raw),
+        original_bytes=seen if seen >= len(raw) else None,
+        keep="head",
+        spill_status="content_not_retained" if truncated else "not_attempted",
+    )
+
+
 def bounded_redacted_output(
     captured: BoundedStreamCapture | bytes | str | object,
     *,
     secrets: Iterable[str],
+    source: str = "hermes child stream capture",
 ) -> str:
-    """Redact a byte-bounded diagnostic and attach a content-free truncation marker."""
-    if isinstance(captured, BoundedStreamCapture):
-        raw, truncated = captured.data, captured.truncated
-    elif isinstance(captured, bytes):
-        raw, truncated = captured[:MAX_CAPTURE_BYTES], len(captured) > MAX_CAPTURE_BYTES
-    else:
-        raw_value = str(captured or "").encode("utf-8", errors="replace")
-        raw, truncated = raw_value[:MAX_CAPTURE_BYTES], len(raw_value) > MAX_CAPTURE_BYTES
+    """Redact a byte-bounded diagnostic and attach a content-free continuation notice."""
+    raw, truncated, _seen = _capture_parts(captured)
     value = raw.decode("utf-8", errors="replace")
     known_secrets = sorted({item for item in secrets if len(item) >= 4}, key=len, reverse=True)
     for secret in known_secrets:
@@ -308,7 +338,22 @@ def bounded_redacted_output(
         "[redacted]\n" if is_sensitive_metadata_text(line) else line
         for line in value.splitlines(keepends=True)
     )
-    return value + (_OUTPUT_TRUNCATED_MARKER if truncated else "")
+    if not truncated:
+        return value
+    notice = truncation_notice(capture_truncation_record(captured, source=source))
+    return f"{value}\n{notice}\n"
+
+
+def _capture_parts(
+    captured: BoundedStreamCapture | bytes | str | object,
+) -> tuple[bytes, bool, int]:
+    """Normalize the three capture shapes to (retained bytes, truncated, bytes seen)."""
+    if isinstance(captured, BoundedStreamCapture):
+        return captured.data, captured.truncated, captured.seen_bytes
+    if isinstance(captured, bytes):
+        return captured[:MAX_CAPTURE_BYTES], len(captured) > MAX_CAPTURE_BYTES, len(captured)
+    raw_value = str(captured or "").encode("utf-8", errors="replace")
+    return raw_value[:MAX_CAPTURE_BYTES], len(raw_value) > MAX_CAPTURE_BYTES, len(raw_value)
 
 
 def _suffix_prefix_overlap(value: str, secret: str) -> int:

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -22,6 +22,7 @@ from typing import Any, Callable, Iterable, Mapping, Sequence
 from ..runtime.artifacts import append_journal_observation, create_run, show_run
 from ..system.local_store import atomic_write_json, ensure_dir, locked_json_update, read_json_object_result, utc_now
 from ..system.metadata_safety import redact_metadata_text
+from ..system.output_truncation import spill_evidence_ref, truncate_output, truncation_notice
 from ..system.paths import OmhPaths
 from ._hermes_child_process import terminate_process_group
 from .action_gate import recheck_safety_profile_revision
@@ -418,6 +419,15 @@ UNIT_VERIFICATION_CLAIM_BOUNDARY = (
 # command cannot hold a whole dispatch open.
 _VERIFICATION_COMMAND_TIMEOUT = 600
 _MAX_VERIFICATION_OUTPUT_TAIL = 300
+# What a dispatched unit's stdout/stderr keeps in memory for the summary and
+# the journal. Everything above it spills, so the bound costs context rather
+# than evidence.
+_MAX_UNIT_OUTPUT_TAIL = 2000
+# The journal's own `summary` field is capped at 500 characters upstream, so
+# this second bound over an already-bounded tail leaves room for the rest of
+# the line. The resolvable pointer rides in `evidence_refs`, which has no such
+# ceiling, rather than in prose a bare slice could cut in half.
+_MAX_UNIT_SUMMARY_TAIL = 300
 EXECUTOR_LIMIT_SIGNALS_SCHEMA_VERSION = "executor_limit_signals/v1"
 EXECUTOR_LIMIT_SIGNALS_CLAIM_BOUNDARY = (
     "A limit signal records that one observed local dispatch failure matched a rate/usage-limit shape. "
@@ -968,17 +978,24 @@ def _run_verification_command(
     worktree: Path,
     runner: Callable[..., Any],
     child_env: Mapping[str, str] | None = None,
-) -> tuple[str, str]:
-    """Run one command in the unit worktree; return its status and a bounded tail.
+    spill_dir: Path | None = None,
+) -> tuple[str, str, dict[str, Any] | None]:
+    """Run one command in the unit worktree; return status, bounded tail, truncation record.
 
     Never raises: a command that cannot start is a failed check, not a failed
     dispatch. `shell=False`, so the argv comes from the contract's own frozen
     split and nothing in the command string is reinterpreted here.
+
+    The third element is the `omh_output_truncation/v1` record for the captured
+    output, present whenever output was actually captured -- including when it
+    fit, so a reader can tell "this is the whole failure output" from "the tail
+    of a longer one". It is `None` for the paths that never ran a command and
+    so have a constructed message rather than captured output.
     """
     try:
         env_overrides, argv = verification_command_argv(command)
     except FanoutContractError as exc:
-        return "failed", str(exc)
+        return "failed", str(exc), None
     try:
         completed = runner(
             argv,
@@ -996,17 +1013,28 @@ def _run_verification_command(
             f"{getattr(completed, 'stdout', '') or ''}{getattr(completed, 'stderr', '') or ''}"
         )
     except FileNotFoundError:
-        return "failed", f"{argv[0]} not found on PATH"
+        return "failed", f"{argv[0]} not found on PATH", None
     except subprocess.TimeoutExpired:
-        return "failed", f"timed out after {_VERIFICATION_COMMAND_TIMEOUT}s"
+        return "failed", f"timed out after {_VERIFICATION_COMMAND_TIMEOUT}s", None
     except (OSError, subprocess.SubprocessError, TypeError, ValueError) as exc:
-        return "failed", f"could not run: {exc}"
+        return "failed", f"could not run: {exc}", None
     if exit_code == 0:
-        return "passed", ""
-    tail = redact_metadata_text(
-        combined[-_MAX_VERIFICATION_OUTPUT_TAIL:], limit=_MAX_VERIFICATION_OUTPUT_TAIL
+        return "passed", "", None
+    # The bound is the same 300 it always was; what changed is that the bytes it
+    # drops are now written whole to a content-addressed spill and the row
+    # carries a pointer to them, so a reader chasing a failure is not left with
+    # the last 300 bytes of a build log and no way back to the rest.
+    bounded = truncate_output(
+        combined,
+        limit_bytes=_MAX_VERIFICATION_OUTPUT_TAIL,
+        source=f"fanout unit verification command: {command}",
+        keep="tail",
+        spill_dir=spill_dir,
     )
-    return "failed", f"exit {exit_code}: {tail}"
+    tail = redact_metadata_text(bounded.kept_text, limit=_MAX_VERIFICATION_OUTPUT_TAIL)
+    notice = truncation_notice(bounded.record)
+    detail = f"exit {exit_code}: {tail}"
+    return "failed", f"{detail} {notice}" if notice else detail, bounded.record
 
 
 def _run_unit_verification(
@@ -1034,8 +1062,17 @@ def _run_unit_verification(
         return {}
     rows: list[dict[str, object]] = []
     failures: list[str] = []
+    truncations: list[dict[str, Any]] = []
     for command in commands:
-        status, detail = _run_verification_command(command, worktree, runner, child_env)
+        status, detail, truncation = _run_verification_command(
+            command,
+            worktree,
+            runner,
+            child_env,
+            spill_dir=paths.runtime_output_spills_dir,
+        )
+        if truncation is not None:
+            truncations.append(truncation)
         rows.append(
             {
                 "command": command,
@@ -1076,6 +1113,11 @@ def _run_unit_verification(
     }
     if failures:
         verification["verification_failures"] = failures
+    # Carried whenever a command produced captured output, truncated or not.
+    # The failure strings already read the notice inline; this is the same
+    # thing in a form a consumer can branch on without parsing prose.
+    if truncations:
+        verification["verification_output_truncation"] = truncations
     return verification
 
 
@@ -2311,6 +2353,8 @@ def _dispatch_unit(
             output_tail = ""
             stdout_text = ""
             stderr_tail = ""
+            output_truncation: dict[str, Any] | None = None
+            stderr_truncation: dict[str, Any] | None = None
             exit_code = 1
             # Real spawns only (the same seam as the pid hook): stagger this
             # unit's start so the first dispatch of the fanout writes the
@@ -2334,8 +2378,28 @@ def _dispatch_unit(
                 )
                 exit_code = int(getattr(completed, "returncode", 1))
                 stdout_text = str(getattr(completed, "stdout", "") or "")
-                output_tail = stdout_text[-2000:]
-                stderr_tail = str(getattr(completed, "stderr", "") or "")[-2000:]
+                # The tails are what rides into the summary and the journal; the
+                # bytes above them used to be dropped on the floor. They now go
+                # to a content-addressed spill, and the records below carry a
+                # pointer a later step can resolve.
+                bounded_stdout = truncate_output(
+                    stdout_text,
+                    limit_bytes=_MAX_UNIT_OUTPUT_TAIL,
+                    source=f"fanout unit {unit_id} stdout",
+                    keep="tail",
+                    spill_dir=paths.runtime_output_spills_dir,
+                )
+                bounded_stderr = truncate_output(
+                    str(getattr(completed, "stderr", "") or ""),
+                    limit_bytes=_MAX_UNIT_OUTPUT_TAIL,
+                    source=f"fanout unit {unit_id} stderr",
+                    keep="tail",
+                    spill_dir=paths.runtime_output_spills_dir,
+                )
+                output_tail = bounded_stdout.kept_text
+                stderr_tail = bounded_stderr.kept_text
+                output_truncation = bounded_stdout.record
+                stderr_truncation = bounded_stderr.record
             except FileNotFoundError:
                 exit_code, output_tail = 127, f"{argv[0]} not found on PATH"
             except subprocess.TimeoutExpired:
@@ -2397,12 +2461,43 @@ def _dispatch_unit(
         # down-ranking the executor forever.
         _clear_limit_signal(paths, owner)
     status = "observed" if exit_code == 0 else "failed"
+    # A second cap over an already-bounded tail. It goes through the shared
+    # contract too, so the journal line says which of the two it is: the whole
+    # tail, or a cut of it whose full text the evidence ref below resolves.
+    unit_output_spilled = output_truncation is not None and bool(output_truncation.get("truncated"))
+    summary_bound = truncate_output(
+        output_tail,
+        limit_bytes=_MAX_UNIT_SUMMARY_TAIL,
+        source=f"fanout unit {unit_id} journal summary",
+        keep="tail",
+        # Spilled only when the unit-level cap did not already spill this text.
+        # Otherwise the journal would point at a 2000-byte tail while a pointer
+        # to the whole output already exists.
+        spill_dir=None if unit_output_spilled else paths.runtime_output_spills_dir,
+    )
     summary = (
         f"unit {unit_id} exit {exit_code} after {duration_seconds}s: "
-        f"{redact_metadata_text(output_tail[-300:], limit=300)}"
+        f"{redact_metadata_text(summary_bound.kept_text, limit=_MAX_UNIT_SUMMARY_TAIL)}"
     )
+    # The unit-level record wins when it has one: it is the truncation that
+    # actually holds a spill pointer. The summary's own cap is reported only
+    # when the unit output fit and this second bound was what cut it.
+    journal_truncation = output_truncation if unit_output_spilled else summary_bound.record
+    journal_notice = truncation_notice(journal_truncation, compact=True)
+    if journal_notice:
+        summary = f"{summary} {journal_notice}"
     if limit_label:
         summary = f"limit-shaped failure ({limit_label}); {summary}"
+    # The compact notice above says "continuation=evidence_refs"; these are the
+    # refs it means. Uncapped by the journal, so the pointer arrives whole.
+    spill_refs = [
+        ref
+        for ref in (
+            spill_evidence_ref(journal_truncation or {}),
+            spill_evidence_ref(stderr_truncation or {}),
+        )
+        if ref
+    ]
     append_journal_observation(
         paths,
         {
@@ -2412,6 +2507,7 @@ def _dispatch_unit(
             "event": "worker_result",
             "status": status,
             "summary": summary,
+            "evidence_refs": spill_refs,
             "worker_ref": unit_id,
             "worktree_ref": str(worktree),
             "runtime_profile": owner,
@@ -2466,6 +2562,13 @@ def _dispatch_unit(
     }
     if owner_host:
         result["owner_host"] = owner_host
+    # Present whenever a spawn actually produced captured output, truncated or
+    # not, so the dispatch summary distinguishes "this is the whole tail" from
+    # "the tail of a longer output, spilled to <path>" without parsing prose.
+    if output_truncation is not None:
+        result["output_truncation"] = output_truncation
+    if stderr_truncation is not None:
+        result["stderr_truncation"] = stderr_truncation
     result["executor_capability_snapshot"] = capability_snapshot
     result["executor_capability"] = legacy_executor_capability_projection(capability_snapshot)
     # `tokens_total` and `session_ref` were READ by `omh coding fanout brief`

--- a/src/coding/hermes_child_dispatch.py
+++ b/src/coding/hermes_child_dispatch.py
@@ -23,6 +23,7 @@ import sys
 import tempfile
 from threading import Event, Lock, Thread
 import time
+from types import MappingProxyType
 from typing import Final
 
 from .hermes_child_evaluation import (
@@ -35,6 +36,7 @@ from ._hermes_child_process import (
     await_pipe_threads as _await_pipe_threads,
     block_relay_signals as _block_relay_signals,
     bounded_redacted_output as _bounded_redacted_output,
+    capture_truncation_record as _capture_truncation_record,
     install_signal_relays as _install_signal_relays,
     merge_signals as _merge_signals,
     read_usage as _read_usage,
@@ -151,6 +153,12 @@ class HermesChildResult:
     termination_signals: tuple[int, ...]
     stdout_truncated: bool
     stderr_truncated: bool
+    # The machine-readable form of the two booleans above: reason code, byte
+    # counts, kept ranges, and why no spill pointer exists for a cap the
+    # drainer applied while reading. Empty only for a result built before any
+    # capture happened.
+    stdout_truncation: Mapping[str, object] = MappingProxyType({})
+    stderr_truncation: Mapping[str, object] = MappingProxyType({})
 
 
 class CancellationToken:
@@ -372,8 +380,18 @@ def _dispatch_guarded(
             cancellation._remove(cancel_child)
         _restore_signal_mask(old_mask)
         _restore_signal_handlers(handlers)
-        stdout = _bounded_redacted_output(stdout_capture, secrets=redaction_values)
-        stderr = _bounded_redacted_output(stderr_capture, secrets=redaction_values)
+        stdout = _bounded_redacted_output(
+            stdout_capture, secrets=redaction_values, source="hermes child stdout capture"
+        )
+        stderr = _bounded_redacted_output(
+            stderr_capture, secrets=redaction_values, source="hermes child stderr capture"
+        )
+        stdout_truncation = _capture_truncation_record(
+            stdout_capture, source="hermes child stdout capture"
+        )
+        stderr_truncation = _capture_truncation_record(
+            stderr_capture, source="hermes child stderr capture"
+        )
         try:
             scratch.cleanup()
         except OSError:
@@ -391,6 +409,7 @@ def _dispatch_guarded(
         request, depth, status, process.returncode if process is not None else None,
         stdout, stderr, usage, cleanup, signals,
         stdout_capture.truncated, stderr_capture.truncated, usage_file_exists,
+        stdout_truncation, stderr_truncation,
     )
 
 
@@ -501,9 +520,13 @@ def _result(
     signals: tuple[int, ...], stdout_truncated: bool = False,
     stderr_truncated: bool = False,
     usage_file_exists: bool = False,
+    stdout_truncation: Mapping[str, object] | None = None,
+    stderr_truncation: Mapping[str, object] | None = None,
 ) -> HermesChildResult:
     return HermesChildResult(
         status, request.parent_run_id, request.run_id, depth, request.model, exit_code,
         stdout, stderr, usage, cleanup, usage_file_exists, signals,
         stdout_truncated, stderr_truncated,
+        MappingProxyType(dict(stdout_truncation or {})),
+        MappingProxyType(dict(stderr_truncation or {})),
     )

--- a/src/coding/hermes_child_dispatch.py
+++ b/src/coding/hermes_child_dispatch.py
@@ -9,7 +9,7 @@ provider call; the spawned local Hermes CLI owns that call.
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 import hashlib
 import hmac
@@ -23,7 +23,6 @@ import sys
 import tempfile
 from threading import Event, Lock, Thread
 import time
-from types import MappingProxyType
 from typing import Final
 
 from .hermes_child_evaluation import (
@@ -157,8 +156,8 @@ class HermesChildResult:
     # counts, kept ranges, and why no spill pointer exists for a cap the
     # drainer applied while reading. Empty only for a result built before any
     # capture happened.
-    stdout_truncation: Mapping[str, object] = MappingProxyType({})
-    stderr_truncation: Mapping[str, object] = MappingProxyType({})
+    stdout_truncation: Mapping[str, object] = field(default_factory=dict)
+    stderr_truncation: Mapping[str, object] = field(default_factory=dict)
 
 
 class CancellationToken:
@@ -527,6 +526,6 @@ def _result(
         status, request.parent_run_id, request.run_id, depth, request.model, exit_code,
         stdout, stderr, usage, cleanup, usage_file_exists, signals,
         stdout_truncated, stderr_truncated,
-        MappingProxyType(dict(stdout_truncation or {})),
-        MappingProxyType(dict(stderr_truncation or {})),
+        dict(stdout_truncation or {}),
+        dict(stderr_truncation or {}),
     )

--- a/src/install/release_smoke_core.py
+++ b/src/install/release_smoke_core.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import subprocess
 from typing import Callable, Mapping, Sequence
 
+from ..system.output_truncation import truncate_output
+
 
 @dataclass(frozen=True)
 class CommandResult:
@@ -59,10 +61,16 @@ def _run_subprocess(command: Sequence[str], timeout_seconds: int, run_env: Mappi
     return CommandResult(command, completed.returncode, completed.stdout, completed.stderr)
 
 
-def bounded_text(value: str, limit: int = 1200) -> str:
-    if len(value) <= limit:
-        return value
-    return value[: limit - 15].rstrip() + "\n...[truncated]"
+def bounded_text(value: str, limit: int = 1200, *, source: str = "release smoke command output") -> str:
+    """Bound one smoke-step excerpt and say what was cut, not just that something was.
+
+    The old marker was a bare `"...[truncated]"`, which is indistinguishable
+    from an ellipsis the command printed itself and names no way back to the
+    rest. No spill store is offered here: the smoke runner holds the full
+    `CommandResult` in memory for the life of the report, so the record says
+    the cap was not spilled rather than pointing at a file that does not exist.
+    """
+    return truncate_output(value, limit_bytes=limit, source=source, keep="head").text
 
 
 def expand_home(value: str | Path | None, env_key: str, default: str) -> str:

--- a/src/system/output_truncation.py
+++ b/src/system/output_truncation.py
@@ -1,0 +1,361 @@
+"""One versioned contract for every place OMH caps captured output.
+
+Each cap used to invent its own marker: ``"\\n...[truncated]"`` in the release
+smoke report, ``"[output truncated at 16384-byte capture limit]"`` in the
+Hermes-child stream drainer, and a bare tail slice with no marker at all in the
+fanout verification runner. All three tell a reader that something was lost;
+none of them says *why*, *how much*, or *where the rest is*. A consumer
+therefore cannot tell "this is the whole output" from "more exists, capped
+here", and a follow-up step has nothing to resolve.
+
+Every truncation built here carries a machine-readable record instead: a reason
+code from a closed vocabulary, the original byte count, the byte ranges that
+were kept, and a continuation hint. When a spill store is offered the full
+content is written whole to a content-addressed path and the record gains a
+resolvable back-reference (path + sha256 + byte length), so a later step can
+fetch exactly what was cut. The pointer is emitted only when the write actually
+succeeded -- this repo's `prepared_not_observed` discipline applied to
+artifacts.
+
+No notice this module renders contains an ellipsis. A bare "..." is the shape
+that started the problem: it is indistinguishable from an ellipsis the producer
+wrote itself, and it carries no recovery path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+from pathlib import Path
+import re
+from typing import Any, Mapping
+
+from .local_store import atomic_write_text
+
+OUTPUT_TRUNCATION_SCHEMA_VERSION = "omh_output_truncation/v1"
+OUTPUT_SPILL_REF_SCHEMA_VERSION = "omh_output_spill_ref/v1"
+
+# Closed vocabulary. `not_truncated` is a real member, not a filler: recording
+# it is what lets a reader distinguish "nothing more to show" from "capped".
+TRUNCATION_REASON_CODES: tuple[str, ...] = (
+    "not_truncated",
+    "output_cap",
+    "capture_cap",
+    "match_limit",
+    "redacted",
+)
+# `kept_ranges` is a list rather than a single range so a head+tail keep can be
+# added later without a schema bump. Only the two single-range keeps are
+# implemented, because those are the only shapes any current cap site uses.
+KEPT_RANGE_POSITIONS: tuple[str, ...] = ("head", "tail")
+SPILL_STATUSES: tuple[str, ...] = (
+    "written",
+    "not_attempted",
+    "content_not_retained",
+    "store_unavailable",
+)
+
+OUTPUT_SPILL_DIR_NAME = "output-spills"
+
+_SHA256_RE = re.compile(r"[0-9a-f]{64}")
+_MAX_SOURCE_CHARS = 120
+_CONTINUATION_HINTS: dict[str, str] = {
+    "not_attempted": (
+        "no spill store was offered for this cap; re-run the producing command to see the discarded bytes"
+    ),
+    "content_not_retained": (
+        "the discarded bytes were never retained in memory; re-run with a larger capture bound to see them"
+    ),
+    "store_unavailable": (
+        "the spill write did not succeed, so the discarded bytes are not recoverable from this record"
+    ),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class TruncatedOutput:
+    """A bounded payload plus the contract record describing what was cut."""
+
+    kept_text: str
+    record: dict[str, Any]
+
+    @property
+    def truncated(self) -> bool:
+        return bool(self.record.get("truncated"))
+
+    @property
+    def text(self) -> str:
+        """The bounded payload with its continuation notice attached."""
+        notice = truncation_notice(self.record)
+        return f"{self.kept_text}\n{notice}\n" if notice else self.kept_text
+
+
+def truncation_record(
+    *,
+    source: str,
+    reason_code: str,
+    limit_bytes: int,
+    kept_bytes: int,
+    original_bytes: int | None,
+    keep: str = "tail",
+    spill: Mapping[str, Any] | None = None,
+    spill_status: str = "not_attempted",
+) -> dict[str, Any]:
+    """Build one truncation contract record.
+
+    `original_bytes` is `None` when the cap was applied upstream and the total
+    is genuinely unknowable -- recorded as unknown rather than guessed, because
+    a fabricated size is worse than an absent one.
+    """
+    normalized_reason = reason_code if reason_code in TRUNCATION_REASON_CODES else "output_cap"
+    truncated = normalized_reason != "not_truncated"
+    status = spill_status if spill_status in SPILL_STATUSES else "not_attempted"
+    if not truncated:
+        status = "not_attempted"
+    record: dict[str, Any] = {
+        "schema_version": OUTPUT_TRUNCATION_SCHEMA_VERSION,
+        "truncated": truncated,
+        "reason_code": normalized_reason,
+        "source": _bounded_source(source),
+        "limit_bytes": max(0, int(limit_bytes)),
+        "original_bytes": None if original_bytes is None else max(0, int(original_bytes)),
+        "kept_bytes": max(0, int(kept_bytes)),
+        "kept_ranges": _kept_ranges(
+            keep=keep,
+            kept_bytes=max(0, int(kept_bytes)),
+            original_bytes=original_bytes,
+        ),
+        "spill_status": status,
+    }
+    # Emit-only-on-success: a pointer exists in the record only when a write
+    # was actually observed to land, never because one was attempted.
+    if truncated and status == "written" and isinstance(spill, Mapping):
+        record["spill"] = dict(spill)
+    record["continuation_hint"] = _continuation_hint(record)
+    return record
+
+
+def truncate_output(
+    value: object,
+    *,
+    limit_bytes: int,
+    source: str,
+    reason_code: str = "output_cap",
+    keep: str = "tail",
+    spill_dir: Path | None = None,
+) -> TruncatedOutput:
+    """Cap `value` at `limit_bytes` and describe the cut in the contract.
+
+    The bound is a byte bound, and the kept slice is aligned to a UTF-8
+    character boundary so a cap can never emit a half-decoded character. Text
+    exactly at the bound is not truncated: the record then carries the
+    `not_truncated` reason so a consumer reads "this is the whole output"
+    rather than having to infer it from an absent marker.
+    """
+    text = value if isinstance(value, str) else str(value or "")
+    encoded = text.encode("utf-8")
+    original_bytes = len(encoded)
+    limit = max(0, int(limit_bytes))
+    if original_bytes <= limit:
+        return TruncatedOutput(
+            text,
+            truncation_record(
+                source=source,
+                reason_code="not_truncated",
+                limit_bytes=limit,
+                kept_bytes=original_bytes,
+                original_bytes=original_bytes,
+                keep="head",
+            ),
+        )
+
+    position = keep if keep in KEPT_RANGE_POSITIONS else "tail"
+    if position == "head":
+        kept = _align_head(encoded[:limit])
+    else:
+        kept = _align_tail(encoded[original_bytes - limit :])
+
+    spill: Mapping[str, Any] | None = None
+    spill_status = "not_attempted"
+    if spill_dir is not None:
+        spill = write_output_spill(spill_dir, text)
+        spill_status = "written" if spill else "store_unavailable"
+
+    return TruncatedOutput(
+        kept.decode("utf-8", errors="replace"),
+        truncation_record(
+            source=source,
+            reason_code=reason_code,
+            limit_bytes=limit,
+            kept_bytes=len(kept),
+            original_bytes=original_bytes,
+            keep=position,
+            spill=spill,
+            spill_status=spill_status,
+        ),
+    )
+
+
+def write_output_spill(spill_dir: Path, text: str) -> dict[str, Any]:
+    """Write the full text to a content-addressed path; return its back-reference.
+
+    Content addressing is what makes the path deterministic *and* resume-safe:
+    identical content re-spills onto the same file, different content can never
+    land on an existing one, so a resumed or re-reaped dispatch cannot clobber
+    an earlier run's spill. That is the property the scan-then-allocate counter
+    rule buys elsewhere, without a counter to keep consistent across processes.
+
+    Returns `{}` when the write did not succeed, so the caller emits no pointer
+    at all rather than one nothing can resolve.
+    """
+    encoded = text.encode("utf-8")
+    digest = sha256(encoded).hexdigest()
+    path = spill_dir / f"{digest}.txt"
+    try:
+        # Temp-then-rename, so a crash mid-write leaves either the previous
+        # file or no file -- never a half-written one a digest check would
+        # later reject.
+        atomic_write_text(path, text, private=True)
+    except OSError:
+        return {}
+    return {
+        "schema_version": OUTPUT_SPILL_REF_SCHEMA_VERSION,
+        "path": str(path),
+        "sha256": digest,
+        "byte_count": len(encoded),
+    }
+
+
+def resolve_spill_reference(spill: Mapping[str, Any]) -> str:
+    """Read back exactly what a spill pointer promised, or raise.
+
+    Digest and byte length are re-checked against the file, so a pointer into a
+    rewritten, truncated, or partially written file fails loudly instead of
+    returning content that is not what was cut.
+    """
+    if str(spill.get("schema_version", "")) != OUTPUT_SPILL_REF_SCHEMA_VERSION:
+        raise ValueError("output spill reference schema is unsupported")
+    digest = str(spill.get("sha256", ""))
+    if not _SHA256_RE.fullmatch(digest):
+        raise ValueError("output spill reference digest is invalid")
+    path = Path(str(spill.get("path", "")))
+    if path.is_symlink():
+        raise ValueError("output spill file must not be a symlink")
+    text = path.read_text(encoding="utf-8")
+    encoded = text.encode("utf-8")
+    if len(encoded) != int(spill.get("byte_count", -1)):
+        raise ValueError("output spill file length does not match its reference")
+    if sha256(encoded).hexdigest() != digest:
+        raise ValueError("output spill file digest does not match its reference")
+    return text
+
+
+def truncation_notice(record: Mapping[str, Any], *, compact: bool = False) -> str:
+    """One rendered line saying truncated, why, how much, and where the rest lives.
+
+    Empty for an untruncated record: a reader gets a notice only when there is
+    something to continue from.
+
+    `compact` is for surfaces that impose their own character ceiling on prose
+    -- the observation journal caps `summary` at 500 -- where a full notice
+    would itself be cut and leave a half-written pointer nothing can resolve.
+    It drops the schema and source fields and, when the record has a spill,
+    points at `evidence_refs` instead of inlining the path: such a surface is
+    expected to carry `spill_evidence_ref(record)` in that uncapped field.
+    """
+    if not record.get("truncated"):
+        return ""
+    original = record.get("original_bytes")
+    fields = [
+        f"reason={record.get('reason_code', 'output_cap')}",
+        f"original_bytes={'unknown' if original is None else original}",
+        f"kept_bytes={record.get('kept_bytes', 0)}",
+        f"kept_ranges={_rendered_ranges(record.get('kept_ranges'))}",
+    ]
+    if compact:
+        spilled = isinstance(record.get("spill"), Mapping)
+        fields.append(
+            f"continuation={'evidence_refs' if spilled else record.get('spill_status', 'not_attempted')}"
+        )
+    else:
+        fields.insert(0, f"schema={record.get('schema_version', OUTPUT_TRUNCATION_SCHEMA_VERSION)}")
+        fields.insert(2, f"source={record.get('source', '')}")
+        fields.append(f"continuation={record.get('continuation_hint', '')}")
+    return "[output truncated: " + "; ".join(fields) + "]"
+
+
+def spill_evidence_ref(record: Mapping[str, Any]) -> str:
+    """A one-string evidence ref for a spilled truncation, or "" when none spilled.
+
+    For surfaces that carry `evidence_refs` and cap their prose: the pointer
+    stays whole in a field with no character ceiling, instead of riding in a
+    summary line a bare slice could cut in half and leave unresolvable.
+    """
+    spill = record.get("spill") if isinstance(record, Mapping) else None
+    if not isinstance(spill, Mapping):
+        return ""
+    return (
+        f"output_spill:{spill.get('path', '')}"
+        f":sha256:{spill.get('sha256', '')}:{spill.get('byte_count', 0)}"
+    )
+
+
+def _kept_ranges(*, keep: str, kept_bytes: int, original_bytes: int | None) -> list[dict[str, Any]]:
+    position = keep if keep in KEPT_RANGE_POSITIONS else "tail"
+    if position == "tail" and original_bytes is not None:
+        start = max(0, original_bytes - kept_bytes)
+        return [{"position": "tail", "start_byte": start, "end_byte": start + kept_bytes}]
+    # A tail keep whose original size is unknown cannot name an absolute
+    # offset, so it is reported as the head of what survived rather than as an
+    # invented range.
+    return [{"position": "head", "start_byte": 0, "end_byte": kept_bytes}]
+
+
+def _rendered_ranges(value: Any) -> str:
+    if not isinstance(value, (list, tuple)) or not value:
+        return "none"
+    parts = []
+    for entry in value:
+        if not isinstance(entry, Mapping):
+            continue
+        parts.append(
+            f"{entry.get('position', 'head')} {entry.get('start_byte', 0)}-{entry.get('end_byte', 0)}"
+        )
+    return ",".join(parts) if parts else "none"
+
+
+def _continuation_hint(record: Mapping[str, Any]) -> str:
+    if not record.get("truncated"):
+        return ""
+    spill = record.get("spill")
+    if isinstance(spill, Mapping):
+        return (
+            f"read {spill.get('path', '')} "
+            f"(sha256 {spill.get('sha256', '')}, {spill.get('byte_count', 0)} bytes) for the full output"
+        )
+    return _CONTINUATION_HINTS.get(str(record.get("spill_status", "")), _CONTINUATION_HINTS["not_attempted"])
+
+
+def _bounded_source(value: object) -> str:
+    text = " ".join(str(value or "").split())
+    return text[:_MAX_SOURCE_CHARS]
+
+
+def _align_head(chunk: bytes) -> bytes:
+    """Drop a trailing partial UTF-8 sequence so the kept prefix decodes whole."""
+    for back in range(1, min(4, len(chunk)) + 1):
+        byte = chunk[-back]
+        if byte < 0x80:
+            return chunk
+        if byte >= 0xC0:
+            width = 2 if byte < 0xE0 else 3 if byte < 0xF0 else 4
+            return chunk if back == width else chunk[: len(chunk) - back]
+    return chunk
+
+
+def _align_tail(chunk: bytes) -> bytes:
+    """Drop leading continuation bytes so the kept suffix decodes whole."""
+    index = 0
+    while index < len(chunk) and index < 4 and 0x80 <= chunk[index] < 0xC0:
+        index += 1
+    return chunk[index:]

--- a/src/system/paths.py
+++ b/src/system/paths.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from .local_store import atomic_write_text
+from .output_truncation import OUTPUT_SPILL_DIR_NAME
 
 
 @dataclass(frozen=True)
@@ -40,6 +41,16 @@ class OmhPaths:
     @property
     def runtime_efficiency_reports_dir(self) -> Path:
         return self.runtime_dir / "efficiency-reports"
+
+    @property
+    def runtime_output_spills_dir(self) -> Path:
+        """Where a capped output spills its full content, content-addressed.
+
+        Flat and keyed by sha256 rather than by run: the same output spilled
+        twice is one file, and a resumed or re-reaped dispatch can never write
+        over an earlier run's spill.
+        """
+        return self.runtime_dir / OUTPUT_SPILL_DIR_NAME
 
     @property
     def runtime_wrapper_sessions_dir(self) -> Path:

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -51,6 +51,7 @@ from omh.coding.parallelism_policy import (  # noqa: E402
 from omh.coding.executor_progress import read_progress_binding  # noqa: E402
 from omh.runtime.artifacts import append_journal_observation, create_run, show_run  # noqa: E402
 from omh.system.local_store import atomic_write_json  # noqa: E402
+from omh.system.output_truncation import resolve_spill_reference  # noqa: E402
 from omh.system.paths import OmhPaths  # noqa: E402
 
 _GOAL = "split the sample feature across agents"
@@ -2922,6 +2923,9 @@ _PY = shlex.quote(sys.executable)
 _PASSING_COMMAND = f"{_PY} -c pass"
 _FAILING_COMMAND = f"{_PY} -c 'import sys; sys.stdout.write(\"boom\"); sys.exit(3)'"
 _ENV_COMMAND = f"OMH_VERIFY=1 {_PY} -c 'import os,sys; sys.exit(0 if os.environ.get(\"OMH_VERIFY\") else 1)'"
+# Well over the 300-byte verification tail, so the dispatcher has to spill.
+_FLOODING_COMMAND = f"{_PY} -c 'import sys; sys.stdout.write(\"flood\" * 900); sys.exit(4)'"
+_FLOODING_OUTPUT = "flood" * 900
 
 
 def _verification_runner(script: Path, sidecar: Path, payload: dict[str, object], *, mode: str = "valid"):
@@ -2951,6 +2955,66 @@ def _verification_runner(script: Path, sidecar: Path, payload: dict[str, object]
 
     runner.verified = verified
     return runner
+
+
+class FanoutUnitOutputSpillTests(unittest.TestCase):
+    def test_a_flooding_unit_spills_and_the_journal_line_stays_resolvable(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            repo, sha = _make_repo(root)
+            contract = write_fanout_contract(
+                paths, build_fanout_contract(_GOAL, [dict(unit) for unit in _UNITS])
+            )
+            sidecar = unit_result_path(paths, contract["fanout_id"], "core")
+            payload = _unit_result_payload(contract, sha)
+            flood = "flood-line\n" * 900
+
+            def runner(argv, **kwargs):
+                if argv[0] == "git":
+                    return subprocess.run(argv, **kwargs)
+                sidecar.parent.mkdir(parents=True, exist_ok=True)
+                sidecar.write_text(json.dumps(payload), encoding="utf-8")
+                return subprocess.CompletedProcess(argv, 0, flood, "")
+
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                only_units=["core"],
+                runner=runner,
+                readiness=_ready,
+            )
+            core = {entry["unit_id"]: entry for entry in summary["units"]}["core"]
+
+            record = core["output_truncation"]
+            self.assertTrue(record["truncated"])
+            self.assertEqual(record["reason_code"], "output_cap")
+            self.assertEqual(record["original_bytes"], len(flood))
+            self.assertEqual(record["kept_bytes"], 2000)
+            self.assertEqual(record["spill_status"], "written")
+            self.assertEqual(resolve_spill_reference(record["spill"]), flood)
+            self.assertFalse(core["stderr_truncation"]["truncated"])
+
+            events = show_run(paths, core["run_ref"])["journal_events"]
+            worker = [event for event in events if event["event"] == "executor_result_observed"][-1]
+            # The journal caps `summary` at 500 characters, so the notice it
+            # carries is the compact one and the resolvable pointer rides in
+            # `evidence_refs` where nothing can cut it in half.
+            self.assertIn("[output truncated:", worker["summary"])
+            self.assertIn("continuation=evidence_refs", worker["summary"])
+            self.assertTrue(worker["summary"].endswith("]"))
+            self.assertLess(len(worker["summary"]), 500)
+            self.assertNotIn("...", worker["summary"])
+            self.assertEqual(
+                worker["evidence_refs"],
+                [
+                    f"output_spill:{record['spill']['path']}"
+                    f":sha256:{record['spill']['sha256']}:{record['spill']['byte_count']}"
+                ],
+            )
 
 
 class FanoutDispatchVerificationTests(unittest.TestCase):
@@ -3022,6 +3086,41 @@ class FanoutDispatchVerificationTests(unittest.TestCase):
             # The unit's own process still succeeded; only verification failed.
             self.assertTrue(core["process_succeeded"])
             self.assertTrue(core["result_schema_valid"])
+
+    def test_a_short_failure_records_that_its_output_was_not_truncated(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract, runner = self._setup(tmp, [_FAILING_COMMAND])
+
+            core = self._dispatch(paths, repo, sha, contract, runner, run_verification=True)
+
+            records = core["verification_output_truncation"]
+            self.assertEqual(len(records), 1)
+            self.assertFalse(records[0]["truncated"])
+            self.assertEqual(records[0]["reason_code"], "not_truncated")
+            self.assertNotIn("[output truncated:", core["verification_failures"][0])
+
+    def test_a_flooding_failure_spills_and_the_failure_row_names_the_spill(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract, runner = self._setup(tmp, [_FLOODING_COMMAND])
+
+            core = self._dispatch(paths, repo, sha, contract, runner, run_verification=True)
+
+            records = core["verification_output_truncation"]
+            self.assertEqual(len(records), 1)
+            record = records[0]
+            self.assertTrue(record["truncated"])
+            self.assertEqual(record["reason_code"], "output_cap")
+            self.assertEqual(record["original_bytes"], len(_FLOODING_OUTPUT))
+            self.assertEqual(record["kept_bytes"], 300)
+            self.assertEqual(record["spill_status"], "written")
+            # The rendered row -- the surface a reader actually sees -- says
+            # truncated, why, and where the rest lives.
+            detail = core["verification_failures"][0]
+            self.assertIn("[output truncated:", detail)
+            self.assertIn("reason=output_cap", detail)
+            self.assertIn(record["spill"]["path"], detail)
+            self.assertNotIn("...", detail)
+            self.assertEqual(resolve_spill_reference(record["spill"]), _FLOODING_OUTPUT)
 
     def test_a_command_that_cannot_start_is_a_failed_check_not_a_failed_dispatch(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_hermes_child_dispatch.py
+++ b/tests/test_hermes_child_dispatch.py
@@ -428,11 +428,25 @@ class HermesChildDispatchTests(unittest.TestCase):
         self.assertEqual((result.status, result.exit_code), ("failed", 9))
         self.assertTrue(result.stdout_truncated)
         self.assertTrue(result.stderr_truncated)
-        marker = "[output truncated at 16384-byte capture limit]"
+        marker = "[output truncated:"
         self.assertEqual(result.stdout.count(marker), 1)
         self.assertEqual(result.stderr.count(marker), 1)
-        self.assertLessEqual(len(result.stdout.encode("utf-8")), 16_500)
-        self.assertLessEqual(len(result.stderr.encode("utf-8")), 16_500)
+        # The notice replaced a bare marker, so the payload says which cap fired
+        # and how much it dropped -- and, because the drainer counts what it
+        # discards, the real original size rather than "unknown".
+        for stream, record in (
+            (result.stdout, result.stdout_truncation),
+            (result.stderr, result.stderr_truncation),
+        ):
+            self.assertEqual(record["reason_code"], "capture_cap")
+            self.assertEqual(record["kept_bytes"], 16_384)
+            self.assertGreaterEqual(record["original_bytes"], 100 * 1024 * 1024)
+            self.assertEqual(record["spill_status"], "content_not_retained")
+            self.assertNotIn("spill", record)
+            self.assertIn(f"original_bytes={record['original_bytes']}", stream)
+            self.assertNotIn("...", stream)
+        self.assertLessEqual(len(result.stdout.encode("utf-8")), 17_000)
+        self.assertLessEqual(len(result.stderr.encode("utf-8")), 17_000)
         self.assertTrue(result.cleanup_verified)
         pid = int((self.root / "flood.pid").read_text(encoding="utf-8"))
         self.assertTrue(process_absent(pid))

--- a/tests/test_output_truncation.py
+++ b/tests/test_output_truncation.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from hashlib import sha256
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.coding._hermes_child_process import (  # noqa: E402
+    BoundedStreamCapture,
+    MAX_CAPTURE_BYTES,
+    bounded_redacted_output,
+    capture_truncation_record,
+)
+from omh.install.release_smoke_core import bounded_text  # noqa: E402
+from omh.system.output_truncation import (  # noqa: E402
+    OUTPUT_SPILL_REF_SCHEMA_VERSION,
+    OUTPUT_TRUNCATION_SCHEMA_VERSION,
+    SPILL_STATUSES,
+    TRUNCATION_REASON_CODES,
+    resolve_spill_reference,
+    spill_evidence_ref,
+    truncate_output,
+    truncation_notice,
+    write_output_spill,
+)
+from omh.system.paths import OmhPaths  # noqa: E402
+
+
+class OutputTruncationContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = TemporaryDirectory(prefix="omh-output-truncation-")
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.paths = OmhPaths(omh_home=self.root / ".omh", hermes_home=self.root / ".hermes")
+
+    def test_record_round_trips_every_contract_field(self) -> None:
+        bounded = truncate_output(
+            "x" * 5000,
+            limit_bytes=100,
+            source="unit test capture",
+            keep="tail",
+            spill_dir=self.paths.runtime_output_spills_dir,
+        )
+        record = bounded.record
+        self.assertEqual(record["schema_version"], OUTPUT_TRUNCATION_SCHEMA_VERSION)
+        self.assertTrue(record["truncated"])
+        self.assertIn(record["reason_code"], TRUNCATION_REASON_CODES)
+        self.assertEqual(record["reason_code"], "output_cap")
+        self.assertEqual(record["source"], "unit test capture")
+        self.assertEqual(record["limit_bytes"], 100)
+        self.assertEqual(record["original_bytes"], 5000)
+        self.assertEqual(record["kept_bytes"], 100)
+        self.assertEqual(
+            record["kept_ranges"],
+            [{"position": "tail", "start_byte": 4900, "end_byte": 5000}],
+        )
+        self.assertIn(record["spill_status"], SPILL_STATUSES)
+        self.assertEqual(record["spill_status"], "written")
+        self.assertTrue(record["continuation_hint"])
+        self.assertEqual(bounded.kept_text, "x" * 100)
+
+    def test_exactly_at_the_cap_is_not_truncated(self) -> None:
+        at_cap = truncate_output("y" * 300, limit_bytes=300, source="boundary")
+        over_cap = truncate_output("y" * 301, limit_bytes=300, source="boundary")
+        self.assertFalse(at_cap.truncated)
+        self.assertEqual(at_cap.record["reason_code"], "not_truncated")
+        self.assertEqual(at_cap.text, "y" * 300)
+        self.assertEqual(truncation_notice(at_cap.record), "")
+        self.assertTrue(over_cap.truncated)
+        self.assertEqual(over_cap.record["reason_code"], "output_cap")
+
+    def test_spill_file_digest_and_length_match_the_back_reference(self) -> None:
+        full = "line\n" * 4000
+        bounded = truncate_output(
+            full,
+            limit_bytes=200,
+            source="spill digest",
+            spill_dir=self.paths.runtime_output_spills_dir,
+        )
+        spill = bounded.record["spill"]
+        self.assertEqual(spill["schema_version"], OUTPUT_SPILL_REF_SCHEMA_VERSION)
+        self.assertEqual(spill["sha256"], sha256(full.encode("utf-8")).hexdigest())
+        self.assertEqual(spill["byte_count"], len(full.encode("utf-8")))
+        spill_path = Path(spill["path"])
+        self.assertTrue(spill_path.is_file())
+        self.assertEqual(spill_path.read_text(encoding="utf-8"), full)
+        # Deterministic and content-addressed: the same output re-spills onto
+        # the same file rather than allocating a second one.
+        again = write_output_spill(self.paths.runtime_output_spills_dir, full)
+        self.assertEqual(again["path"], spill["path"])
+
+    def test_back_reference_resolves_exactly_what_was_cut(self) -> None:
+        full = "".join(f"row {index}\n" for index in range(3000))
+        bounded = truncate_output(
+            full,
+            limit_bytes=120,
+            source="back reference",
+            keep="tail",
+            spill_dir=self.paths.runtime_output_spills_dir,
+        )
+        spill = bounded.record["spill"]
+        self.assertEqual(resolve_spill_reference(spill), full)
+        # The kept tail is the exact suffix of the resolved content, so a
+        # reader can splice the two without guessing where the cut fell.
+        self.assertTrue(full.endswith(bounded.kept_text))
+        self.assertEqual(
+            spill_evidence_ref(bounded.record),
+            f"output_spill:{spill['path']}:sha256:{spill['sha256']}:{spill['byte_count']}",
+        )
+
+    def test_resolution_refuses_a_reference_whose_file_changed(self) -> None:
+        bounded = truncate_output(
+            "z" * 4000,
+            limit_bytes=50,
+            source="tamper",
+            spill_dir=self.paths.runtime_output_spills_dir,
+        )
+        spill = dict(bounded.record["spill"])
+        Path(spill["path"]).write_text("z" * 3999, encoding="utf-8")
+        with self.assertRaises(ValueError):
+            resolve_spill_reference(spill)
+
+    def test_no_pointer_is_emitted_when_the_spill_write_failed(self) -> None:
+        blocked = self.root / "blocked"
+        blocked.write_text("not a directory", encoding="utf-8")
+        bounded = truncate_output(
+            "q" * 4000, limit_bytes=40, source="failed spill", spill_dir=blocked / "spills"
+        )
+        self.assertNotIn("spill", bounded.record)
+        self.assertEqual(bounded.record["spill_status"], "store_unavailable")
+        self.assertIn("not recoverable", bounded.record["continuation_hint"])
+
+    def test_notices_are_ellipsis_free_and_name_the_recovery_path(self) -> None:
+        bounded = truncate_output(
+            "e" * 9000,
+            limit_bytes=64,
+            source="ellipsis guarantee",
+            spill_dir=self.paths.runtime_output_spills_dir,
+        )
+        self.assertNotIn("...", bounded.text)
+        self.assertNotIn("…", bounded.text)
+        notice = truncation_notice(bounded.record)
+        self.assertIn("reason=output_cap", notice)
+        self.assertIn("original_bytes=9000", notice)
+        self.assertIn("kept_bytes=64", notice)
+        self.assertIn("kept_ranges=tail 8936-9000", notice)
+        self.assertIn(bounded.record["spill"]["path"], notice)
+        self.assertIn(bounded.record["spill"]["sha256"], notice)
+
+    def test_compact_notice_defers_the_pointer_to_evidence_refs(self) -> None:
+        bounded = truncate_output(
+            "c" * 9000,
+            limit_bytes=64,
+            source="compact",
+            spill_dir=self.paths.runtime_output_spills_dir,
+        )
+        compact = truncation_notice(bounded.record, compact=True)
+        self.assertIn("continuation=evidence_refs", compact)
+        self.assertNotIn(bounded.record["spill"]["path"], compact)
+        self.assertNotIn("...", compact)
+        # Short enough to survive the observation journal's 500-character
+        # summary bound alongside a 300-byte tail and the run prefix.
+        self.assertLess(len(compact), 160)
+
+    def test_multibyte_output_never_keeps_a_partial_character(self) -> None:
+        text = "한글" * 400
+        tail = truncate_output(text, limit_bytes=101, source="utf8 tail", keep="tail")
+        head = truncate_output(text, limit_bytes=101, source="utf8 head", keep="head")
+        self.assertTrue(text.endswith(tail.kept_text))
+        self.assertTrue(text.startswith(head.kept_text))
+        self.assertNotIn("�", tail.kept_text)
+        self.assertNotIn("�", head.kept_text)
+        self.assertEqual(tail.record["kept_bytes"], len(tail.kept_text.encode("utf-8")))
+        self.assertEqual(head.record["kept_bytes"], len(head.kept_text.encode("utf-8")))
+
+
+class BoundedCaptureContractTests(unittest.TestCase):
+    def test_capture_cap_reports_the_counted_original_and_no_spill(self) -> None:
+        capture = BoundedStreamCapture(b"k" * MAX_CAPTURE_BYTES, True, 1_048_576)
+        record = capture_truncation_record(capture, source="hermes child stdout capture")
+        self.assertEqual(record["reason_code"], "capture_cap")
+        self.assertEqual(record["original_bytes"], 1_048_576)
+        self.assertEqual(record["kept_bytes"], MAX_CAPTURE_BYTES)
+        self.assertEqual(record["spill_status"], "content_not_retained")
+        self.assertNotIn("spill", record)
+
+    def test_uncounted_capture_reports_the_original_as_unknown(self) -> None:
+        record = capture_truncation_record(
+            BoundedStreamCapture(b"partial", True), source="hermes child stderr capture"
+        )
+        self.assertIsNone(record["original_bytes"])
+        self.assertIn("original_bytes=unknown", truncation_notice(record))
+
+    def test_bounded_output_renders_the_notice_instead_of_a_bare_marker(self) -> None:
+        rendered = bounded_redacted_output(
+            BoundedStreamCapture(b"m" * MAX_CAPTURE_BYTES, True, 999_999),
+            secrets=set(),
+            source="hermes child stdout capture",
+        )
+        self.assertNotIn("...", rendered)
+        self.assertIn("[output truncated:", rendered)
+        self.assertIn("reason=capture_cap", rendered)
+        self.assertIn("original_bytes=999999", rendered)
+        self.assertIn("never retained", rendered)
+
+    def test_untruncated_capture_renders_no_notice(self) -> None:
+        rendered = bounded_redacted_output(
+            BoundedStreamCapture(b"short", False, 5), secrets=set()
+        )
+        self.assertEqual(rendered, "short")
+
+
+class ReleaseSmokeExcerptTests(unittest.TestCase):
+    def test_excerpt_under_the_bound_is_returned_verbatim(self) -> None:
+        self.assertEqual(bounded_text("ok\n"), "ok\n")
+
+    def test_excerpt_over_the_bound_carries_a_reason_code_not_an_ellipsis(self) -> None:
+        rendered = bounded_text("v" * 4000, 100)
+        self.assertNotIn("...[truncated]", rendered)
+        self.assertNotIn("...", rendered)
+        self.assertIn("reason=output_cap", rendered)
+        self.assertIn("original_bytes=4000", rendered)
+        self.assertIn("kept_bytes=100", rendered)
+        self.assertIn("kept_ranges=head 0-100", rendered)
+        self.assertTrue(rendered.startswith("v" * 100))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New `src/system/output_truncation.py`: one versioned truncation contract
  (`omh_output_truncation/v1`) plus a content-addressed spill store and its
  resolvable back-reference (`omh_output_spill_ref/v1`).
- Every truncation now carries a reason code from a closed vocabulary, the
  original byte count, the kept byte ranges, a spill status, and a
  continuation hint. `not_truncated` is a real member of that vocabulary, so
  "this is the whole output" is a stated fact rather than an inference from
  an absent marker.
- When a spill store is offered, the full content is written whole to
  `~/.omh/runtime/output-spills/<sha256>.txt` (temp-then-rename) and the
  record gains a `path` + `sha256` + `byte_count` pointer.
  `resolve_spill_reference` re-verifies both digest and length on read.
- Wired at the sites that actually truncate captured output today.
- No notice this module renders contains an ellipsis.

### Why This Exists

Each output cap in the repo invented its own marker:

| Site | Old marker |
| --- | --- |
| `src/install/release_smoke_core.py` | `"\n...[truncated]"` |
| `src/coding/_hermes_child_process.py` | `"[output truncated at 16384-byte capture limit]"` |
| `src/coding/fanout_dispatch.py` verification | `combined[-300:]`, no marker at all |
| `src/coding/fanout_dispatch.py` unit stdout | `stdout_text[-2000:]`, no marker at all |

All four tell a reader that something was lost. None says *why*, *how much*,
or *where the rest is*. A consumer cannot distinguish "nothing more to show"
from "more exists, capped here", and a follow-up step has nothing to resolve —
a truncated build-log tail is a dead end that costs a wasted turn.

This absorbs three backlog items into one capability:
`.omc/research/ohmypi-optimization-2026-08-29.md` section B (the truncation
contract, not just the limits) and section C (spill-to-artifact with a
resolvable back-reference), and
`.omc/research/omo-omc-comparison-2026-08-29.md` P3-13 (machine-readable
truncation reasons).

### User / Operator Impact

- A fanout unit that floods stdout no longer loses everything above the
  2000-byte tail. The dispatch summary row says how much was cut and names a
  file holding the whole thing.
- A failing verification command's row names the spill for its full output
  instead of ending at the last 300 bytes of a build log.
- The observation journal's `worker_result` line says truncated, why, and how
  much, with the resolvable pointer in `evidence_refs`.
- The Hermes-child capture notice now names the real original stream size
  (the drainer counts what it discards) and states honestly that no spill
  exists because the bytes were never retained.
- No behavior change when nothing exceeds a cap.

### How It Works

`truncate_output(value, limit_bytes=..., source=..., keep="head"|"tail", spill_dir=...)`
returns a `TruncatedOutput` carrying the bounded text and the record.

- The bound is a **byte** bound, and the kept slice is aligned to a UTF-8
  character boundary, so a cap can never emit a half-decoded character.
- Text exactly at the bound is **not** truncated; the record then carries
  `reason_code: "not_truncated"` and `truncation_notice()` returns `""`.
- `kept_ranges` is a list of `{position, start_byte, end_byte}` so a future
  head+tail keep needs no schema bump. Only single-range `head` and `tail`
  are implemented, because those are the only shapes any current cap uses.
- Spill paths are **content-addressed**, which is what makes them
  deterministic *and* resume-safe: identical content re-spills onto the same
  file, different content can never land on an existing one, so a resumed or
  re-reaped dispatch cannot clobber an earlier run's spill.
- **Emit-only-on-success**: `write_output_spill` returns `{}` when the write
  did not land, and the record then says `store_unavailable` and carries no
  `spill` key at all — the `prepared_not_observed` discipline applied to
  artifacts.

`truncation_notice(record, compact=True)` exists for surfaces with their own
hard character ceiling. The observation journal caps `summary` at 500
characters with a bare slice; a full notice inline would itself be cut and
leave a half-written pointer nothing can resolve. The compact form drops the
schema and source fields and says `continuation=evidence_refs`, and the
dispatcher puts `spill_evidence_ref(record)` in that uncapped field.

### Files And Contracts Touched

- `src/system/output_truncation.py` (new): `omh_output_truncation/v1`,
  `omh_output_spill_ref/v1`, `truncate_output`, `truncation_record`,
  `write_output_spill`, `resolve_spill_reference`, `truncation_notice`,
  `spill_evidence_ref`.
- `src/system/paths.py`: `OmhPaths.runtime_output_spills_dir`.
- `src/coding/fanout_dispatch.py`: unit stdout/stderr capture and declared
  verification commands both go through the contract and spill; the dispatch
  summary gains `output_truncation`, `stderr_truncation`, and
  `verification_output_truncation`; the `worker_result` journal event gains
  the compact notice plus spill `evidence_refs`.
- `src/coding/_hermes_child_process.py`: `PipeDrainer` counts discarded bytes
  (`BoundedStreamCapture.seen_bytes`); `bounded_redacted_output` renders the
  contract notice; new `capture_truncation_record`.
- `src/coding/hermes_child_dispatch.py`: `HermesChildResult` gains
  `stdout_truncation` / `stderr_truncation`.
- `src/install/release_smoke_core.py`: `bounded_text` goes through the shared
  helper.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke ...`
- [ ] Relevant workflow-learning review queue smoke: not applicable, no learning contract changed
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli release drift`,
      `uv run python -m omh.cli docs ulw-inventory --check`,
      `uv run python -m omh.cli docs ulw-site --check`
- [ ] Manual Hermes/TUI check: not run; this change touches no chat, router,
      skill catalog, or TUI surface

### Observed Evidence

- `PYTHONPATH=tests uv run python -m unittest discover -s tests` — **8118
  tests, 21 failures + 7 errors, all 28 in `test_cross_harness_adapters` /
  `test_cross_harness_adapter_security`** (the known pre-existing
  `.claude`-worktree-path failures). Filtering the failure list for anything
  outside `test_cross_harness` returns **zero** lines.
- `tests/test_output_truncation.py` — 15 new tests, all passing: contract
  round-trip over every field; threshold boundary (exactly-at-cap is *not*
  truncated, one byte over is); spill file digest and byte length match the
  back-reference; deterministic re-spill lands on the same path; back-reference
  resolution returns exactly what was cut and the kept tail is its exact
  suffix; resolution refuses a reference whose file changed; no pointer is
  emitted when the spill write failed; ellipsis-free guarantee on the rendered
  notice; compact notice defers to `evidence_refs` and stays under 160 chars;
  multibyte input never keeps a partial character; capture-cap record reports
  the counted original and `content_not_retained`; release-smoke excerpt
  carries a reason code instead of `...[truncated]`.
- `tests/test_fanout_dispatch.py::FanoutUnitOutputSpillTests` — a flooding
  unit spills 9900 bytes, `resolve_spill_reference` returns them byte-exact,
  and the journal line carries the compact notice (under the 500-character
  bound, ellipsis-free) with the resolvable ref in `evidence_refs`.
- `tests/test_fanout_dispatch.py::FanoutDispatchVerificationTests` — a short
  failure records `not_truncated`; a flooding failure spills and the rendered
  `verification_failures` row names the spill path. All 11 tests in the class
  pass.
- `tests/test_hermes_child_dispatch.py` — the 100 MB dual-stream flood test
  now asserts the notice, `reason=capture_cap`, the counted `original_bytes`
  (at least 100 MiB, previously unknowable), `spill_status:
  content_not_retained`, and absence of any ellipsis. All 17 tests pass.
- `uv run python -m omh.cli release drift` — `No drift. 17 checks passed.`
- All five `docs --check` byte gates — `ok: true`.

### Not Tested / Not Applicable

- `harness validate`, `release checklist`, `release hermes-smoke`, `omh --help`,
  manual Hermes/TUI: this change touches no skill catalog, router, handoff
  template, or CLI surface — the five generated-artifact byte gates and
  `release drift` are the relevant proof, and all pass.
- No live fanout dispatch against a real agent CLI. The dispatch path is
  exercised through the existing subprocess-runner seam the suite already uses.
- The 28 cross-harness failures are pre-existing on this checkout and unrelated
  (`.claude` worktree path handling in the adapter sandbox).

## Risk

- The observation journal's `worker_result` summary grows by the compact
  notice (about 90 characters) when output was truncated. Measured to stay
  under the upstream 500-character bound alongside the 300-byte tail and the
  run prefix; asserted in `FanoutUnitOutputSpillTests`.
- `~/.omh/runtime/output-spills/` grows without a reaper. Files are
  content-addressed and deduped, and written `0o600`, but retention is a
  follow-up.
- `HermesChildResult` gained two fields with defaults; it is constructed only
  in `hermes_child_dispatch.py`, so no external caller breaks.

## Compatibility / Rollout

- Additive. New keys appear on dispatch summary rows and unit results only
  when a spawn actually produced captured output; consumers that ignore
  unknown keys are unaffected.
- The two markers this replaces (`"...[truncated]"` and `"[output truncated
  at 16384-byte capture limit]"`) had no consumers outside their own tests,
  both updated here.
- Nothing in `omh` core makes a network call; the spill store is a local
  file under the existing OMH home.

## Release / Claims

- [x] Release-channel impact considered (`local` — no installed-artifact change)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including the `omh release hermes-smoke --live` gap

## Follow-Up

Deltas against the dossiers, stated rather than silently skipped:

- **Section B point 3 (interpolate the limits into the prompt/handoff text
  from the same constants)** is not implemented. It belongs in
  `src/coding/unit_prompt_protocol.py` / `prompting.py` and is a separate
  contract change to what dispatched units are told; this PR is the enforcing
  side only.
- **Section B's `bounded_prompt_preview` extension** is deliberately not done.
  That `... [truncated, N chars total]` shape is byte-gated into 154 generated
  `skills/*/SKILL.md` files via `DELEGATE_PROMPT_DISPLAY_RULE`, and it is a
  chat preview of a composed *prompt*, not captured output — a different
  contract that should move with its own generated-artifact regeneration.
- **Section C's scan-then-allocate integer ids** is answered differently
  rather than copied: content addressing gives the same resume/re-reap safety
  with no counter to keep consistent across concurrent dispatch processes. The
  two independently-tunable inline-materialization caps (8 MiB / 50 KiB) have
  no OMH equivalent yet because nothing materializes a spill inline.
- **P3-13's `redacted` reason code** is in the vocabulary but not yet emitted:
  `redact_metadata_text` returns `"[redacted]"` without a record. Wiring it is
  a follow-up in `src/system/metadata_safety.py`.
- Head+tail keeps are representable in `kept_ranges` but not implemented; no
  current cap site needs one.
- A retention/reaper policy for `~/.omh/runtime/output-spills/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1Tue9T3YhWLT5mT8bo9Ke
