### PR TITLE
feat(quality): adversarial-regression rule before a guard deletion

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -3235,6 +3235,7 @@ These surfaces are generated command references, not installed Hermes workflow s
   - Failed or unavailable checks must produce HOLD/BLOCK with a rerun or remediation path.
   - A change touching an authentication, secrets/config, schema/migration, or payment/crypto path escalates to the thorough verification lane regardless of diff size.
   - Refuse completion, do not merely report it, when the claim carries an unlinked TODO/FIXME/stub marker in changed code, a suppressed test with no linked reason, placeholder or self-referential evidence ('TBD', 'works as expected'), or a proof word ('fixed', 'verified', 'passing') with no observed evidence naming a command; each refusal names its category, the offending excerpt, and the remedy.
+  - Before a diff deletes a validation/refusal/sanitization/permission/allowlist check at a trust boundary, or a negative test named for it ('refuses', 'rejects', 'denies', 'blocks', 'invalid'), require a named adversarial or regression case proving the boundary still refuses what it should; a guard that only moves elsewhere in the same diff is not a deletion, but a deletion with no negative case behind it -- in the diff or named in evidence -- earns no completion claim.
 
 ### agent-evaluation
 

--- a/skills/omh-verification-gate/SKILL.md
+++ b/skills/omh-verification-gate/SKILL.md
@@ -109,6 +109,7 @@ Safety rules:
 - Failed or unavailable checks must produce HOLD/BLOCK with a rerun or remediation path.
 - A change touching an authentication, secrets/config, schema/migration, or payment/crypto path escalates to the thorough verification lane regardless of diff size.
 - Refuse completion, do not merely report it, when the claim carries an unlinked TODO/FIXME/stub marker in changed code, a suppressed test with no linked reason, placeholder or self-referential evidence ('TBD', 'works as expected'), or a proof word ('fixed', 'verified', 'passing') with no observed evidence naming a command; each refusal names its category, the offending excerpt, and the remedy.
+- Before a diff deletes a validation/refusal/sanitization/permission/allowlist check at a trust boundary, or a negative test named for it ('refuses', 'rejects', 'denies', 'blocks', 'invalid'), require a named adversarial or regression case proving the boundary still refuses what it should; a guard that only moves elsewhere in the same diff is not a deletion, but a deletion with no negative case behind it -- in the diff or named in evidence -- earns no completion claim.
 
 ## Runtime Evidence
 

--- a/src/maintenance/release.py
+++ b/src/maintenance/release.py
@@ -416,7 +416,15 @@ STANDALONE_CAPABILITY_SKILL_ITEM_CHAR_LIMIT = 2200
 # language the skill cannot be asked for. The number grows with languages
 # rather than with prose -- no skill's own contract changed by a character;
 # warranted growth.
-FULL_PROFILE_SKILL_BODY_CHAR_LIMIT = 797568
+# 797568 -> 798042: `verification-gate` gained the guard-deletion regression
+# rule (+474 chars) requiring a named adversarial or regression case before a
+# diff that deletes a validation/refusal/sanitization/permission/allowlist
+# check, or the negative test that proved it, can be claimed complete. It
+# belongs in the always-loaded body for the same reason the completion-
+# integrity rule above does: it changes the verdict the skill issues, and a
+# gate that reports a lost guard instead of refusing the claim is the failure
+# this rule exists to stop; warranted growth.
+FULL_PROFILE_SKILL_BODY_CHAR_LIMIT = 798042
 FULL_PROFILE_SKILL_BODY_REVIEWED_EXCEPTION_CHARS = 0
 
 

--- a/src/quality/completion_integrity.py
+++ b/src/quality/completion_integrity.py
@@ -27,6 +27,18 @@ A marker that names a tracked follow-up -- an issue number or a URL on the same
 line -- is a linked reason, not a placeholder, and passes. That is the
 difference between "someone will do this, tracked here" and "this is not done
 and nothing records that".
+
+A ninth rule reads a diff rather than post-change content: `guard_deletion_
+without_adversarial_regression` fires when a changed file's `diff` entry
+*removes* a validation/refusal/sanitization/permission/allowlist line, or a
+test function whose name carries negative-case vocabulary ("refuses",
+"rejects", "denies", "blocks", "invalid"), and the same idiom does not
+reappear as an *added* line anywhere in the supplied diffs. A guard that moves
+elsewhere in the same change (the identical line reappears added) is not a
+deletion. The refusal is waived for the whole claim, not line by line, the
+moment any diff adds a negative-case-named test or an evidence entry names
+"adversarial"/"regression" -- a boundary that loses its guard without a
+regression proving it still refuses is the exact hole this rule closes.
 """
 
 from __future__ import annotations
@@ -35,6 +47,8 @@ from collections.abc import Mapping, Sequence
 from typing import Final
 
 COMPLETION_INTEGRITY_SCHEMA_VERSION: Final = "omh_completion_integrity/v1"
+
+GUARD_DELETION_CATEGORY: Final = "guard_deletion_without_adversarial_regression"
 
 REFUSAL_CATEGORIES: Final = (
     "unfinished_work_marker",
@@ -45,6 +59,7 @@ REFUSAL_CATEGORIES: Final = (
     "prepared_evidence_claimed_as_observed",
     "unnamed_verification_command",
     "unproven_claim_word",
+    GUARD_DELETION_CATEGORY,
 )
 
 CLAIM_BOUNDARY: Final = (
@@ -144,6 +159,33 @@ _OBSERVED_REFERENCE_PREFIXES: Final = ("observed:", "run:", "runtime:", ".omh/",
 
 _PREPARED_NOT_OBSERVED: Final = "prepared_not_observed"
 
+# House vocabulary for a trust-boundary guard: a removed line carrying one of
+# these tokens is read as a validation/refusal/sanitization/permission/
+# allowlist check, whether it is a `raise`, a `return`/`refuse` verdict, or an
+# allowlist assignment (OMH's own `DAEMON_ENV_ALLOWLIST`-style identifiers
+# tokenize to exactly this word).
+_GUARD_VOCABULARY_WORDS: Final = frozenset((
+    "raise", "refuse", "refuses", "refused", "refusal",
+    "deny", "denies", "denied", "validate", "validates", "validated", "validation",
+    "sanitize", "sanitizes", "sanitized", "sanitise", "sanitises", "sanitised",
+    "permission", "allowlist", "forbid", "forbids", "forbidden",
+    "disallow", "disallows", "disallowed", "guard", "reject", "rejects", "rejected",
+))
+
+# omo's `ULW_LOOP_SUCCESS_CRITERION_USER_MODELS` negative-case naming
+# convention, matched against a test definition's name or description.
+_NEGATIVE_CASE_VOCABULARY_WORDS: Final = frozenset((
+    "refuse", "refuses", "refused", "refusal",
+    "reject", "rejects", "rejected", "rejection",
+    "deny", "denies", "denied", "denial",
+    "block", "blocks", "blocked",
+    "invalid", "invalidates", "invalidated",
+))
+
+# The criterion classes a claim can name in its evidence to prove a guard
+# deletion is covered, mirroring `ULW_LOOP_SUCCESS_CRITERION_USER_MODELS`.
+_REGRESSION_CRITERION_WORDS: Final = frozenset(("adversarial", "regression"))
+
 _MAX_EXCERPT_CHARS: Final = 160
 
 
@@ -169,6 +211,7 @@ def classify_completion_integrity(
     for index, (reference, status) in enumerate(normalized_evidence):
         refusals.extend(_evidence_refusals(index, reference, status))
     refusals.extend(_claim_binding_refusals(summary, normalized_evidence))
+    refusals.extend(_guard_deletion_refusals(changed_files, normalized_evidence))
     return {
         "schema_version": COMPLETION_INTEGRITY_SCHEMA_VERSION,
         "refused": bool(refusals),
@@ -263,6 +306,118 @@ def _line_refusal(path: str, line: str, *, abstract_guarded: bool) -> dict[str, 
                     "(#123 or a URL) on the same line; an unlinked placeholder note is "
                     "unfinished work, not a completed change.",
                 )
+    return None
+
+
+def _guard_deletion_refusals(
+    changed_files: Sequence[Mapping[str, object]], normalized_evidence: Sequence[tuple[str, str]]
+) -> list[dict[str, str]]:
+    """Refusals for a guard deleted with no adversarial/regression case behind it.
+
+    Each `changed_files` entry may carry an optional `diff` -- unified-diff
+    text for that path, `-`/`+`/context-prefixed lines -- alongside `content`.
+    Entries with no `diff` contribute nothing here; `content`-only entries are
+    already covered by `_changed_file_refusals`.
+    """
+    parsed: list[tuple[str, list[str], list[str]]] = []
+    for entry in changed_files:
+        if not isinstance(entry, Mapping):
+            continue
+        path = entry.get("path")
+        diff = entry.get("diff")
+        if not isinstance(path, str) or not path.strip():
+            continue
+        if not isinstance(diff, str) or not diff.strip():
+            continue
+        if not _is_scanned_code_path(path):
+            continue
+        removed, added = _diff_removed_and_added(diff)
+        parsed.append((path, removed, added))
+    if not parsed:
+        return []
+
+    added_normalized: set[str] = set()
+    added_negative_test = False
+    for _, _, added in parsed:
+        for line in added:
+            added_normalized.add(_normalized_text(line))
+            test_name = _test_definition_name(line)
+            if test_name and _tokens(test_name) & _NEGATIVE_CASE_VOCABULARY_WORDS:
+                added_negative_test = True
+
+    candidates: list[dict[str, str]] = []
+    for path, removed, _ in parsed:
+        for line in removed:
+            if not line.strip():
+                continue
+            if _normalized_text(line) in added_normalized:
+                continue  # the identical line reappears added: moved, not deleted
+            test_name = _test_definition_name(line)
+            if test_name and _tokens(test_name) & _NEGATIVE_CASE_VOCABULARY_WORDS:
+                candidates.append(
+                    _refusal(
+                        GUARD_DELETION_CATEGORY,
+                        path,
+                        line,
+                        "Restore the deleted negative-case test or add a named adversarial/"
+                        "regression test proving the boundary still refuses what it should; a "
+                        "deleted negative case with no replacement earns no completion claim.",
+                    )
+                )
+                continue
+            if _tokens(line) & _GUARD_VOCABULARY_WORDS:
+                candidates.append(
+                    _refusal(
+                        GUARD_DELETION_CATEGORY,
+                        path,
+                        line,
+                        "Add a named adversarial/regression test proving the boundary still "
+                        "refuses what it should, or restore the guard; a removed validation/"
+                        "refusal/sanitization/permission/allowlist check with no adversarial "
+                        "regression behind it earns no completion claim.",
+                    )
+                )
+
+    if not candidates or added_negative_test:
+        return []
+    if any(_tokens(reference) & _REGRESSION_CRITERION_WORDS for reference, _ in normalized_evidence):
+        return []
+    return candidates
+
+
+def _diff_removed_and_added(diff_text: str) -> tuple[list[str], list[str]]:
+    """`(-, +)` line bodies from unified-diff text, headers and hunks skipped."""
+    removed: list[str] = []
+    added: list[str] = []
+    for raw_line in diff_text.splitlines():
+        if raw_line.startswith(("---", "+++", "@@")):
+            continue
+        if raw_line.startswith("-"):
+            removed.append(raw_line[1:])
+        elif raw_line.startswith("+"):
+            added.append(raw_line[1:])
+    return removed, added
+
+
+def _test_definition_name(line: str) -> str | None:
+    """The test name/description a line declares, or None.
+
+    Covers Python's `def test_x(...)` / `async def test_x(...)` and the
+    JS/TS `it("...", ...)` / `test("...", ...)` description-string idiom.
+    """
+    stripped = line.strip()
+    for prefix in ("def ", "async def "):
+        if stripped.startswith(prefix):
+            name = stripped[len(prefix):].split("(", 1)[0].strip()
+            return name if name.lower().startswith("test") else None
+    for caller in ("it(", "test(", "it.each(", "test.each("):
+        if stripped.startswith(caller):
+            after = stripped[len(caller):].lstrip()
+            if after[:1] in ("\"", "'", "`"):
+                quote = after[0]
+                end = after.find(quote, 1)
+                if end != -1:
+                    return after[1:end]
     return None
 
 

--- a/src/skills/catalog_definitions.py
+++ b/src/skills/catalog_definitions.py
@@ -4096,6 +4096,7 @@ _DEFINITIONS = [
             "Failed or unavailable checks must produce HOLD/BLOCK with a rerun or remediation path.",
             "A change touching an authentication, secrets/config, schema/migration, or payment/crypto path escalates to the thorough verification lane regardless of diff size.",
             "Refuse completion, do not merely report it, when the claim carries an unlinked TODO/FIXME/stub marker in changed code, a suppressed test with no linked reason, placeholder or self-referential evidence ('TBD', 'works as expected'), or a proof word ('fixed', 'verified', 'passing') with no observed evidence naming a command; each refusal names its category, the offending excerpt, and the remedy.",
+            "Before a diff deletes a validation/refusal/sanitization/permission/allowlist check at a trust boundary, or a negative test named for it ('refuses', 'rejects', 'denies', 'blocks', 'invalid'), require a named adversarial or regression case proving the boundary still refuses what it should; a guard that only moves elsewhere in the same diff is not a deletion, but a deletion with no negative case behind it -- in the diff or named in evidence -- earns no completion claim.",
         ),
         quality_tier="verification-gated",
         quality_bar=(

--- a/tests/test_completion_integrity.py
+++ b/tests/test_completion_integrity.py
@@ -283,6 +283,7 @@ class CompletionIntegrityVerdictShapeTests(unittest.TestCase):
                         "def parse():\n"
                         "    raise NotImplementedError\n"
                     ),
+                    "diff": "@@\n-    raise PermissionError(\"denied\")\n+    pass\n",
                 }
             ],
             evidence=[
@@ -294,6 +295,167 @@ class CompletionIntegrityVerdictShapeTests(unittest.TestCase):
         )
 
         self.assertEqual(sorted(REFUSAL_CATEGORIES), verdict["categories"])
+
+
+class CompletionIntegrityGuardDeletionTests(unittest.TestCase):
+    _GUARD_DIFF = (
+        "@@\n"
+        "-    if not is_allowed(user):\n"
+        "-        raise PermissionError(\"denied\")\n"
+        "+    pass\n"
+    )
+
+    def test_a_deleted_refusal_line_with_no_new_negative_case_is_refused(self) -> None:
+        verdict = classify_completion_integrity(
+            changed_files=[{"path": "src/security/gate.py", "diff": self._GUARD_DIFF}],
+        )
+
+        self.assertEqual(_categories(verdict), ["guard_deletion_without_adversarial_regression"])
+        remedy = verdict["refusals"][0]["remedy"]
+        self.assertIn("adversarial", remedy)
+
+    def test_a_deleted_negative_test_with_no_replacement_is_refused(self) -> None:
+        verdict = classify_completion_integrity(
+            changed_files=[
+                {
+                    "path": "tests/test_gate.py",
+                    "diff": (
+                        "@@\n"
+                        "-def test_gate_refuses_unauthorized_user():\n"
+                        "-    assert not gate.allow(bad_user)\n"
+                        "+\n"
+                    ),
+                }
+            ],
+        )
+
+        self.assertEqual(_categories(verdict), ["guard_deletion_without_adversarial_regression"])
+
+    def test_a_widened_allowlist_with_no_new_negative_case_is_refused(self) -> None:
+        verdict = classify_completion_integrity(
+            changed_files=[
+                {
+                    "path": "src/security/allowlist.py",
+                    "diff": (
+                        "@@\n"
+                        '-ALLOWLIST = ("a.example.com", "b.example.com")\n'
+                        '+ALLOWLIST = ("a.example.com", "b.example.com", "evil.example.com")\n'
+                    ),
+                }
+            ],
+        )
+
+        self.assertEqual(_categories(verdict), ["guard_deletion_without_adversarial_regression"])
+
+    def test_a_guard_moved_not_deleted_is_not_refused(self) -> None:
+        # The identical removed line reappears added elsewhere in the same
+        # change: the guard moved, it was not dropped.
+        verdict = classify_completion_integrity(
+            changed_files=[
+                {"path": "src/security/gate.py", "diff": "@@\n-        raise PermissionError(\"denied\")\n"},
+                {"path": "src/security/gate_helpers.py", "diff": "@@\n+        raise PermissionError(\"denied\")\n"},
+            ],
+        )
+
+        self.assertFalse(verdict["refused"])
+
+    def test_a_renamed_test_that_keeps_the_negative_case_is_not_refused(self) -> None:
+        # A refactor renames the test function; the negative-case vocabulary
+        # in the new name still proves the boundary is exercised.
+        verdict = classify_completion_integrity(
+            changed_files=[
+                {
+                    "path": "tests/test_gate.py",
+                    "diff": (
+                        "@@\n"
+                        "-def test_gate_refuses_unauthorized_user():\n"
+                        "-    assert not gate.allow(bad_user)\n"
+                        "+def test_gate_rejects_bad_credentials():\n"
+                        "+    assert not gate.allow(bad_user)\n"
+                    ),
+                }
+            ],
+        )
+
+        self.assertFalse(verdict["refused"])
+
+    def test_a_deletion_with_a_new_adversarial_test_in_the_diff_is_not_refused(self) -> None:
+        verdict = classify_completion_integrity(
+            changed_files=[
+                {"path": "src/security/gate.py", "diff": self._GUARD_DIFF},
+                {
+                    "path": "tests/test_gate.py",
+                    "diff": (
+                        "@@\n"
+                        "+def test_gate_still_refuses_unauthorized_user_without_the_inline_check():\n"
+                        "+    assert not gate.allow(bad_user)\n"
+                    ),
+                },
+            ],
+        )
+
+        self.assertFalse(verdict["refused"])
+
+    def test_a_deletion_with_evidence_naming_an_adversarial_regression_is_not_refused(self) -> None:
+        verdict = classify_completion_integrity(
+            changed_files=[{"path": "src/security/gate.py", "diff": self._GUARD_DIFF}],
+            evidence=["uv run python -m unittest tests/test_gate_adversarial_regression.py"],
+        )
+
+        self.assertFalse(verdict["refused"])
+
+    def test_a_changed_file_with_no_diff_contributes_nothing(self) -> None:
+        verdict = classify_completion_integrity(
+            changed_files=[{"path": "src/security/gate.py", "content": "def allow(user):\n    return True\n"}],
+        )
+
+        self.assertFalse(verdict["refused"])
+
+
+class CompletionIntegrityGuardDeletionGateIntegrationTests(unittest.TestCase):
+    _GUARD_DIFF = (
+        "@@\n"
+        "-    if not is_allowed(user):\n"
+        "-        raise PermissionError(\"denied\")\n"
+        "+    pass\n"
+    )
+
+    def test_a_caller_holding_a_diff_blocks_what_the_ledger_alone_misses(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            create_goal_ledger(paths, "Simplify the gate", ["Criterion one"], goal_id="goal-guard-deletion")
+            record_goal_checkpoint(
+                paths,
+                "goal-guard-deletion",
+                "Simplified the permission gate",
+                criteria_refs=["AC001"],
+                evidence_refs=["uv run python -m unittest tests/test_gate.py"],
+            )
+
+            gate = build_goal_completion_gate(paths, "goal-guard-deletion")
+            # The ledger stores no diff (see `_completion_integrity_refusals`),
+            # so the gate alone is blind to the deleted guard.
+            self.assertTrue(gate["ready"])
+
+            # A caller holding the diff -- the seam the goal-ledger docstring
+            # names -- classifies it directly and must refuse before this
+            # completion claim stands, exactly as content scanning already
+            # does for a caller holding changed-file content.
+            diff_verdict = classify_completion_integrity(
+                changed_files=[{"path": "src/security/gate.py", "diff": self._GUARD_DIFF}],
+                evidence=["uv run python -m unittest tests/test_gate.py"],
+            )
+
+            self.assertTrue(diff_verdict["refused"])
+            self.assertEqual(diff_verdict["categories"], ["guard_deletion_without_adversarial_regression"])
+
+    def test_evidence_naming_a_regression_criterion_clears_the_same_diff(self) -> None:
+        diff_verdict = classify_completion_integrity(
+            changed_files=[{"path": "src/security/gate.py", "diff": self._GUARD_DIFF}],
+            evidence=["uv run python -m unittest tests/test_gate_regression.py"],
+        )
+
+        self.assertFalse(diff_verdict["refused"])
 
 
 class CompletionGateIntegrityIntegrationTests(unittest.TestCase):


### PR DESCRIPTION
## Feature Report

### What Changed

- `completion_integrity.py` gains a ninth completion-integrity refusal category, `guard_deletion_without_adversarial_regression`: it fires when a supplied diff deletes a validation/refusal/sanitization/permission/allowlist check at a trust boundary, or the negative test that proved it, with no adversarial/regression case behind the deletion.
- `changed_files` entries accept an optional `diff` field (unified-diff text) alongside the existing `content` field; the new detector reads only `diff`.
- `verification-gate`'s always-loaded safety rules gain the matching sentence (`src/skills/catalog_definitions.py` → regenerated `skills/omh-verification-gate/SKILL.md` and `docs/WORKFLOWS.md`); `FULL_PROFILE_SKILL_BODY_CHAR_LIMIT` re-measured 797568 -> 798042 (+474 chars).

### Why This Exists

Combines two related backlog items from `.omc/research/omo-omc-comparison-2026-08-29.md`: P2-11 ("adversarial-regression rule before deleting a trust-boundary guard") and the un-shipped half of P2-8 ("mandate adversarial/regression criteria", the sibling of the placeholder-evidence half already shipped in PR #1191). `completion_integrity.py` already refuses a claim carrying an unlinked TODO or placeholder evidence, but it never read a diff — a change that quietly deleted a permission check, or the negative test proving it, or widened an allowlist, checked out clean as long as its evidence named a command that ran. Nothing asked whether the boundary the deleted guard protected could still be shown to refuse what it should.

### User / Operator Impact

A caller holding a diff (an executor, a cleanup pass, a fanout unit report) that classifies a completion claim through `classify_completion_integrity` now gets refused when it deletes a guard with no adversarial/regression case behind it — before the claim is allowed to stand — with a paste-ready remedy naming the excerpt. No wired call site changes behavior today: the goal ledger stores no diff (same limitation PR #1191 documented for `content`), so `build_goal_completion_gate` is unaffected until a caller supplies one directly.

### How It Works

`_guard_deletion_refusals` parses every `changed_files[].diff` into removed/added line sets (skipping `---`/`+++`/`@@` diff plumbing). Two signals produce a candidate refusal per removed line:
1. A removed line whose tokens intersect house guard vocabulary (`raise`, `refuse(s/d/al)`, `deny/denies/denied`, `validate(s/d)`/`validation`, `sanitize(s/d)`/`sanitise(s/d)`, `permission`, `allowlist`, `forbid(s)`/`forbidden`, `disallow(s/ed)`, `guard`, `reject(s/ed)`).
2. A removed test-function definition (`def test_x`, `it("...")`, `test("...")`) whose name/description tokens intersect negative-case vocabulary (`refuse(s/d/al)`, `reject(s/ed/ion)`, `deny/denies/denied/denial`, `block(s/ed)`, `invalid(ates/ated)`).

A removed line that reappears, normalized-identical, as an added line anywhere in the supplied diffs is read as **moved**, not deleted, and is skipped. Once candidates exist, the whole set is waived — not filtered line by line — the moment any diff **adds** a negative-case-named test, or an evidence entry's tokens name `adversarial` or `regression` (mirroring omo's `ULW_LOOP_SUCCESS_CRITERION_USER_MODELS`). Otherwise every candidate is returned as a `guard_deletion_without_adversarial_regression` refusal.

### Files And Contracts Touched

- `src/quality/completion_integrity.py` — new category, vocabulary word lists, `_guard_deletion_refusals`, `_diff_removed_and_added`, `_test_definition_name`; wired into `classify_completion_integrity`.
- `tests/test_completion_integrity.py` — positive detections (deleted guard line, deleted negative test, widened allowlist), negative controls (guard moved not deleted, test renamed but negative case kept), escape-hatch cases (new adversarial test in-diff, evidence naming adversarial/regression), a no-diff no-op case, and an integration test showing the gate misses a diff-only deletion while a caller holding the diff still refuses it; `test_every_shipped_category_is_declared` updated to trip the new category too.
- `src/skills/catalog_definitions.py` / `skills/omh-verification-gate/SKILL.md` / `docs/WORKFLOWS.md` — regenerated skill text.
- `src/maintenance/release.py` — `FULL_PROFILE_SKILL_BODY_CHAR_LIMIT` re-measured with the `OLD -> NEW` comment convention.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [x] Generic executor
- [x] Not executor-specific

## Validation

Check only commands that completed successfully. Leave non-applicable checks unchecked and explain why under **Not Tested / Not Applicable**.

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

Also ran and passing: `uv run python -m omh.cli docs ulw-inventory --check`, `uv run python -m omh.cli docs ulw-site --check`, `uv run python -m omh.cli release drift` (17 checks passed, 0 drift).

### Observed Evidence

- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`: 8171 tests, 28 failures/errors, all in `test_cross_harness_adapters.py` and `test_cross_harness_adapter_security.py` (the pre-existing `.claude`-path worktree `unsafe_read_root` artifact class documented in prior PRs, e.g. #1191) — no failure in any file this PR touches.
- `uv run --group lint ruff check src tests`: all checks passed.
- `uv run python -m compileall -q src tests`: clean (two pre-existing unrelated `SyntaxWarning`s in `test_menubar_app.py`).
- Five docs `--check` gates (`workflows`, `roles`, `capability-families`, `ulw-inventory`, `ulw-site`): all `ok: true`.
- `uv run python -m omh.cli release drift`: "No drift. 17 checks passed."
- `git diff --check`: clean.

### Not Tested / Not Applicable

- `harness validate`, `release checklist --json`, `release hermes-smoke`, `omh --help`, and the full hermes-smoke command: not run — no harness/manifest/CLI-surface contract changed, only a pure-classifier module, its tests, and generated skill text.
- No diff is fed through the wired call site (`build_goal_completion_gate`), because the goal ledger stores no diff — the new detector is proven by unit tests over supplied diff text only, matching PR #1191's stated precedent for `content` scanning.

## Risk

- Narrow: the new refusal category only fires when a caller explicitly supplies a `changed_files[].diff` entry. No production call site does that yet, so no existing behavior changes. Once a caller does supply diffs, the category is stricter than before by design — a guard deletion with no adversarial/regression case now refuses where it previously passed silently; that is the capability.

## Compatibility / Rollout

- Purely additive to `classify_completion_integrity`'s optional-field contract; no signature change (still keyword-only `summary`, `changed_files`, `evidence`). Existing callers passing only `content`/`evidence`/`summary` are unaffected.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`) — no release-channel-specific behavior; pure classifier addition.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap — none applicable; no Hermes-facing runtime surface changed.

## Follow-Up

- None. If a future PR wires diffs into a real call site (e.g. `fanout dispatch` unit reports or an executor's own diff-reading tool), it can pass `changed_files[].diff` directly through this same seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1Tue9T3YhWLT5mT8bo9Ke