### PR TITLE
feat(quality): measured instruction-density gate for skill bodies

### DIFF
--- a/docs/ADDING-A-SKILL.md
+++ b/docs/ADDING-A-SKILL.md
@@ -82,7 +82,10 @@ repeated section in `workflow_skill`:
 
 ```sh
 uv run python -m omh.cli docs skill-context-cost
+uv run python -m omh.cli release drift
 ```
+
+Density is the other half of that number; see §6.
 
 ```sh
 uv run python -m compileall -q src tests
@@ -92,6 +95,40 @@ uv run python -m omh.cli docs capability-families --check
 git diff --check
 PYTHONPATH=tests uv run python -m unittest discover -s tests
 ```
+
+## 6. Authoring doctrine: the body carries instruction, the trigger carries phrasing
+
+`FULL_PROFILE_SKILL_BODY_CHAR_LIMIT` bounds what the whole pack costs. It cannot
+tell a body that grew a rule from a body that grew adjectives, so
+`tests/test_skill_density.py` measures instruction density per skill from the
+catalog producer. It fails naming the skill, the measured value, the threshold,
+and the offending excerpt. Thresholds and the reviewed lists live in
+`src/quality/skill_density.py`; `omh release drift` reports the filler count
+alongside the byte budgets.
+
+What it measures, and what each one asks of you:
+
+| Signal | Threshold | What passes it |
+| --- | --- | --- |
+| `filler_hits` | 0 | No phrase from the reviewed `FILLER_PHRASES` list. Each is a connective whose deletion leaves the claim intact. |
+| `repeated_share_percent` | < 5.0 | A body does not repeat its own sentences. The margin exists so the one most important rule may be restated at the end of a long body. |
+| `payload_markers_per_1k` | > 9.0 | Prose that instructs: modals, negations and exceptions, conditionals, numeric bounds with units, and exact strings in backticks. |
+
+Two rules the gate cannot check for you:
+
+- **Never compress the trigger.** The frontmatter `description` and the routing
+  signal list are retrieval surface matched against the user's own phrasing by
+  `src/routing/`, so keyword-redundant alternatives are payload there even where
+  a human reader needs one. The density measurement excludes both on purpose;
+  trimming triggers to look tidy costs routing coverage, and
+  `ROUTING_PRECISION_CASES` / `ROUTING_INTERVENTION_CASES` are what notice.
+- **Declare what a rewrite drops.** Before compressing an existing body, run
+  `compression_verdict(skill, before, after)`. It returns `keep_original` when
+  the measured token delta is under 10%, when the retrieval surface moved, or
+  when the draft dropped a never-delete marker — and it names each dropped
+  claim, bound, or exact string rather than counting them. On already-dense
+  text the remaining words are the payload; an undeclared loss is a silent
+  regression, and a single-digit win is not worth re-reading every rule for.
 
 ## Acknowledgements
 

--- a/src/maintenance/drift.py
+++ b/src/maintenance/drift.py
@@ -259,7 +259,14 @@ def count_metrics() -> tuple[CountMetric, ...]:
     )
 
 
+def _skill_density_filler_hits() -> int:
+    from ..quality.skill_density import catalog_filler_hit_total
+
+    return catalog_filler_hit_total()
+
+
 def budget_metrics() -> tuple[BudgetMetric, ...]:
+    from ..quality.skill_density import DENSITY_FILLER_HIT_CEILING
     from .release import (
         AWARENESS_PRIMER_MARKDOWN_CHAR_LIMIT,
         FULL_CAPABILITY_SKILL_SECTION_CHAR_LIMIT,
@@ -297,6 +304,19 @@ def budget_metrics() -> tuple[BudgetMetric, ...]:
             limit=FULL_PROFILE_SKILL_BODY_CHAR_LIMIT,
             limit_site="src/maintenance/release.py",
             reviewed_exception=FULL_PROFILE_SKILL_BODY_REVIEWED_EXCEPTION_CHARS,
+        ),
+        # The byte budget above says how much the pack costs; this says whether
+        # the characters carry instruction. A hit is a reviewed filler phrase
+        # that an install pays for in every context window without changing
+        # what a reader does, so the ceiling is zero on a corpus measured at
+        # zero. The other two density signals are floats and stay in
+        # `tests/test_skill_density.py`.
+        BudgetMetric(
+            name="skill_density_filler_hits",
+            describe="Reviewed filler phrases across all catalog skill bodies",
+            live=_skill_density_filler_hits,
+            limit=DENSITY_FILLER_HIT_CEILING,
+            limit_site="src/quality/skill_density.py",
         ),
     )
 

--- a/src/quality/skill_density.py
+++ b/src/quality/skill_density.py
@@ -1,0 +1,431 @@
+"""Per-skill instruction density for the catalog-rendered skill bodies.
+
+`FULL_PROFILE_SKILL_BODY_CHAR_LIMIT` already ratchets how many bytes the whole
+generated pack costs. It cannot tell a body that grew because a workflow gained
+a rule from a body that grew because someone wrote three sentences where one
+carried the instruction. This module measures the second thing: how much of a
+skill body is payload a reader would act on.
+
+Three signals, measured on the catalog producer (`builtin_skill_templates()`),
+never on the committed `skills/*/SKILL.md` copies:
+
+- ``filler_hits``: occurrences of the reviewed `FILLER_PHRASES` list. Each entry
+  is a connective that can be deleted without losing a claim, a bound, or a
+  condition.
+- ``repeated_share_percent``: the share of a body's own sentence characters
+  spent on the second and later copies of a sentence it already contains. This
+  is intra-skill repetition; cross-skill repetition is a different cost and is
+  already reported by `skills.context_cost`.
+- ``payload_markers_per_1k``: never-delete payload per 1,000 prose characters.
+  The marker list is the floor, not a style preference -- RFC 2119 modals,
+  negation and exception words, conditionals, numeric bounds, and exact strings
+  (identifiers, flags, paths) are the parts of an instruction that change what
+  a reader does. Prose carrying few of them per character is prose that is
+  describing rather than instructing.
+
+Two surfaces are excluded from the prose on purpose. The frontmatter
+`description` and the "Strong routing signals" list are *retrieval* surface:
+they are matched against the user's own phrasing by `src/routing/`, so
+keyword-redundant alternatives are payload there even where a human reader
+needs only one. The body compresses; the trigger never does.
+`compression_verdict()` enforces the same split for a proposed rewrite.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from dataclasses import dataclass
+
+from ..skills.context_cost import CHARS_PER_TOKEN_ESTIMATE
+
+SKILL_DENSITY_SCHEMA_VERSION = "omh_skill_density/v1"
+
+SKILL_DENSITY_RULE_IDS = (
+    "SKILL_DENSITY_FILLER",
+    "SKILL_DENSITY_PAYLOAD_FLOOR",
+    "SKILL_DENSITY_REPEATED_CONTENT",
+)
+
+# Reviewed list. Every entry is a phrase whose deletion leaves the surrounding
+# claim intact, so a hit is a character an install pays for in every context
+# window without changing what a reader does. Keep it short and arguable-free:
+# a phrase that sometimes carries meaning ("note that", "make sure") does not
+# belong here, because a gate nobody trusts gets exempted rather than fixed.
+FILLER_PHRASES: tuple[str, ...] = (
+    "as mentioned above",
+    "as mentioned earlier",
+    "as you can see",
+    "at the end of the day",
+    "at this point in time",
+    "basically",
+    "due to the fact that",
+    "each and every",
+    "first and foremost",
+    "for the purpose of",
+    "in order to",
+    "in terms of",
+    "in the event that",
+    "it goes without saying",
+    "it is important to note",
+    "it should be noted",
+    "keep in mind that",
+    "needless to say",
+    "please note",
+    "simply put",
+    "the fact that",
+    "with regard to",
+    "with respect to",
+)
+
+# The never-delete payload list, in match order. `exact_string` runs first so a
+# backticked flag such as `--limit 3` counts once as one exact string rather
+# than twice as a string plus a bound.
+PAYLOAD_MARKER_PATTERNS: tuple[tuple[str, str], ...] = (
+    ("exact_string", r"`[^`\n]+`"),
+    ("modal", r"\b(?:must|shall|should|may|required|requires|never|always|only)\b"),
+    ("negation", r"\b(?:not|no|none|without|except|unless|neither|cannot|avoid|refuse)\b"),
+    ("conditional", r"\b(?:if|when|before|after|until|while|otherwise|instead)\b"),
+    ("bound", r"\d+(?:\.\d+)?%?"),
+)
+
+# A sentence shorter than this is a structural label ("Good example:", "Why:"),
+# not content, and counting those as repetition would flag the rendered skill
+# shape rather than the prose an author wrote.
+REPEATED_SENTENCE_MIN_CHARS = 40
+
+# Thresholds. See `tests/test_skill_density.py` for the measured distribution
+# they were set from and for what each one buys.
+DENSITY_FILLER_HIT_CEILING = 0
+DENSITY_REPEATED_SHARE_CEILING_PERCENT = 5.0
+DENSITY_PAYLOAD_MARKERS_PER_1K_FLOOR = 9.0
+
+# Named exemptions with a reason each, never a silent skip. Empty today: the
+# thresholds above were set from the measured corpus so that no skill needs
+# one. A new entry is a review decision, not a way past a red gate.
+DENSITY_REVIEWED_EXEMPTIONS: dict[str, str] = {}
+
+# A compression pass whose measured token delta is under this keeps the
+# original. On already-dense text the remaining words are the payload, and a
+# rewrite that trades a single-digit percentage for a re-read of every rule is
+# a bad trade even when nothing is lost.
+COMPRESSION_KEEP_ORIGINAL_DELTA_PERCENT = 10.0
+
+_FRONTMATTER = re.compile(r"\A---\n.*?\n---\n", re.DOTALL)
+_ROUTING_SIGNALS_LINE = re.compile(r"^[ \t]*Strong routing signals:.*$", re.MULTILINE)
+_FILLER_RE = re.compile(
+    "|".join(rf"\b{re.escape(phrase)}\b" for phrase in FILLER_PHRASES), re.IGNORECASE
+)
+_PAYLOAD_RE = re.compile(
+    "|".join(f"(?P<{name}>{pattern})" for name, pattern in PAYLOAD_MARKER_PATTERNS),
+    re.IGNORECASE,
+)
+_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
+
+
+@dataclass(frozen=True)
+class SkillDensityMeasurement:
+    skill: str
+    prose_chars: int
+    filler_hits: int
+    filler_excerpts: tuple[str, ...]
+    repeated_share_percent: float
+    repeated_excerpts: tuple[str, ...]
+    payload_markers: int
+    payload_markers_per_1k: float
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "skill": self.skill,
+            "prose_chars": self.prose_chars,
+            "filler_hits": self.filler_hits,
+            "filler_excerpts": list(self.filler_excerpts),
+            "repeated_share_percent": self.repeated_share_percent,
+            "repeated_excerpts": list(self.repeated_excerpts),
+            "payload_markers": self.payload_markers,
+            "payload_markers_per_1k": self.payload_markers_per_1k,
+        }
+
+
+def trigger_surface(content: str) -> str:
+    """Return the retrieval surface of a rendered body: frontmatter + signals.
+
+    This is the text a compression pass may never touch. It is returned as one
+    string so a before/after comparison is a single equality check.
+    """
+    frontmatter = _FRONTMATTER.match(content)
+    head = frontmatter.group(0) if frontmatter is not None else ""
+    signals = "\n".join(match.strip() for match in _ROUTING_SIGNALS_LINE.findall(content))
+    return f"{head}{signals}"
+
+
+def instruction_prose(content: str) -> str:
+    """Return the compressible part of a rendered body.
+
+    Frontmatter and the routing-signal list are removed, because both are
+    matched against user phrasing rather than read as instructions.
+    """
+    return _ROUTING_SIGNALS_LINE.sub("", _FRONTMATTER.sub("", content))
+
+
+def _sentence_units(prose: str) -> list[str]:
+    units: list[str] = []
+    for line in prose.splitlines():
+        stripped = line.strip().lstrip("-*# ").strip()
+        if not stripped:
+            continue
+        for part in _SENTENCE_SPLIT.split(stripped):
+            normalized = re.sub(r"\s+", " ", part).strip().lower()
+            if len(normalized) >= REPEATED_SENTENCE_MIN_CHARS:
+                units.append(normalized)
+    return units
+
+
+def payload_markers(text: str) -> Counter[str]:
+    """Count never-delete markers as `category:matched-text` keys.
+
+    The key keeps the matched text so a before/after difference names the exact
+    claim, bound, or identifier a rewrite dropped instead of only how many.
+
+    Filler spans are blanked first. "It should be noted" carries an RFC 2119
+    modal by accident, and counting it would both flatter a wordy body's
+    density and make deleting the filler look like a payload loss.
+    """
+    found: Counter[str] = Counter()
+    for match in _PAYLOAD_RE.finditer(_FILLER_RE.sub(" ", text)):
+        name = match.lastgroup or "payload"
+        found[f"{name}:{match.group(0).strip().lower()}"] += 1
+    return found
+
+
+def _excerpt(prose: str, start: int, end: int) -> str:
+    line_start = prose.rfind("\n", 0, start) + 1
+    line_end = prose.find("\n", end)
+    line = prose[line_start : line_end if line_end != -1 else len(prose)].strip()
+    return line if len(line) <= 160 else f"{line[:157]}..."
+
+
+def measure_skill_density(skill: str, content: str) -> SkillDensityMeasurement:
+    prose = instruction_prose(content)
+    prose_chars = len(prose)
+
+    filler_matches = list(_FILLER_RE.finditer(prose))
+    filler_excerpts = tuple(
+        dict.fromkeys(_excerpt(prose, match.start(), match.end()) for match in filler_matches)
+    )[:3]
+
+    units = _sentence_units(prose)
+    counts = Counter(units)
+    unit_chars = sum(len(unit) * total for unit, total in counts.items())
+    repeated_chars = sum(len(unit) * (total - 1) for unit, total in counts.items() if total > 1)
+    repeated_excerpts = tuple(
+        unit if len(unit) <= 160 else f"{unit[:157]}..."
+        for unit, total in sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+        if total > 1
+    )[:3]
+
+    markers = sum(payload_markers(prose).values())
+    return SkillDensityMeasurement(
+        skill=skill,
+        prose_chars=prose_chars,
+        filler_hits=len(filler_matches),
+        filler_excerpts=filler_excerpts,
+        repeated_share_percent=round(repeated_chars * 100 / unit_chars, 2) if unit_chars else 0.0,
+        repeated_excerpts=repeated_excerpts,
+        payload_markers=markers,
+        payload_markers_per_1k=round(markers * 1000 / prose_chars, 2) if prose_chars else 0.0,
+    )
+
+
+def skill_density_measurements() -> list[SkillDensityMeasurement]:
+    from ..skills.packaging import builtin_skill_templates
+
+    return [
+        measure_skill_density(template.name, template.content)
+        for template in sorted(builtin_skill_templates(), key=lambda item: item.name)
+    ]
+
+
+def _violation(
+    rule: str,
+    measurement: SkillDensityMeasurement,
+    measured: float,
+    threshold: float,
+    detail: str,
+    excerpts: tuple[str, ...],
+) -> dict[str, object]:
+    return {
+        "rule": rule,
+        "skill": measurement.skill,
+        "measured": measured,
+        "threshold": threshold,
+        "detail": detail,
+        "excerpts": list(excerpts),
+    }
+
+
+def skill_density_violations(
+    measurements: list[SkillDensityMeasurement] | None = None,
+) -> list[dict[str, object]]:
+    """Return every threshold breach, exemptions applied by name."""
+    resolved = skill_density_measurements() if measurements is None else measurements
+    found: list[dict[str, object]] = []
+    for measurement in resolved:
+        if measurement.skill in DENSITY_REVIEWED_EXEMPTIONS:
+            continue
+        if measurement.filler_hits > DENSITY_FILLER_HIT_CEILING:
+            found.append(
+                _violation(
+                    "SKILL_DENSITY_FILLER",
+                    measurement,
+                    measurement.filler_hits,
+                    DENSITY_FILLER_HIT_CEILING,
+                    f"{measurement.filler_hits} reviewed filler phrase(s) in the always-loaded body; "
+                    "delete the phrase and keep the claim",
+                    measurement.filler_excerpts,
+                )
+            )
+        if measurement.repeated_share_percent > DENSITY_REPEATED_SHARE_CEILING_PERCENT:
+            found.append(
+                _violation(
+                    "SKILL_DENSITY_REPEATED_CONTENT",
+                    measurement,
+                    measurement.repeated_share_percent,
+                    DENSITY_REPEATED_SHARE_CEILING_PERCENT,
+                    f"{measurement.repeated_share_percent}% of this body's sentence characters are "
+                    "second-and-later copies of its own sentences; keep one copy or move the shared "
+                    "text to a reference",
+                    measurement.repeated_excerpts,
+                )
+            )
+        if measurement.payload_markers_per_1k < DENSITY_PAYLOAD_MARKERS_PER_1K_FLOOR:
+            found.append(
+                _violation(
+                    "SKILL_DENSITY_PAYLOAD_FLOOR",
+                    measurement,
+                    measurement.payload_markers_per_1k,
+                    DENSITY_PAYLOAD_MARKERS_PER_1K_FLOOR,
+                    f"{measurement.payload_markers} never-delete markers across "
+                    f"{measurement.prose_chars} prose chars; the body describes more than it "
+                    "instructs -- state the rule, the bound, or the exact string, or cut the prose",
+                    (),
+                )
+            )
+    return found
+
+
+def catalog_filler_hit_total() -> int:
+    return sum(measurement.filler_hits for measurement in skill_density_measurements())
+
+
+def _distribution(values: list[float]) -> dict[str, float]:
+    ordered = sorted(values)
+    if not ordered:
+        return {"count": 0, "min": 0.0, "median": 0.0, "max": 0.0}
+    return {
+        "count": len(ordered),
+        "min": ordered[0],
+        "median": ordered[len(ordered) // 2],
+        "max": ordered[-1],
+    }
+
+
+def skill_density_payload() -> dict[str, object]:
+    measurements = skill_density_measurements()
+    violations = skill_density_violations(measurements)
+    return {
+        "schema_version": SKILL_DENSITY_SCHEMA_VERSION,
+        "description": (
+            "Per-skill instruction density for catalog-rendered skill bodies. Frontmatter and the "
+            "routing-signal list are excluded as retrieval surface. Token figures elsewhere in this "
+            "repo use a chars/4 estimate, not tokenizer output."
+        ),
+        "ok": not violations,
+        "rules": list(SKILL_DENSITY_RULE_IDS),
+        "thresholds": {
+            "filler_hit_ceiling": DENSITY_FILLER_HIT_CEILING,
+            "repeated_share_ceiling_percent": DENSITY_REPEATED_SHARE_CEILING_PERCENT,
+            "payload_markers_per_1k_floor": DENSITY_PAYLOAD_MARKERS_PER_1K_FLOOR,
+        },
+        "reviewed_exemptions": dict(DENSITY_REVIEWED_EXEMPTIONS),
+        "skill_count": len(measurements),
+        "distribution": {
+            "filler_hits": _distribution([float(item.filler_hits) for item in measurements]),
+            "repeated_share_percent": _distribution([item.repeated_share_percent for item in measurements]),
+            "payload_markers_per_1k": _distribution([item.payload_markers_per_1k for item in measurements]),
+        },
+        "violations": violations,
+        "skills": [measurement.to_payload() for measurement in measurements],
+    }
+
+
+def format_skill_density_violations(violations: list[dict[str, object]]) -> str:
+    """Render violations as a paste-ready failure message."""
+    if not violations:
+        return ""
+    lines = [f"{len(violations)} skill density violation(s):"]
+    for finding in violations:
+        lines.append(
+            f"  [{finding['rule']}] {finding['skill']}: measured {finding['measured']}, "
+            f"threshold {finding['threshold']}"
+        )
+        lines.append(f"    {finding['detail']}")
+        for excerpt in finding["excerpts"]:  # type: ignore[union-attr]
+            lines.append(f"    > {excerpt}")
+    lines.append(
+        "  Thresholds and the reviewed exemption list live in src/quality/skill_density.py; "
+        "the authoring doctrine is docs/ADDING-A-SKILL.md."
+    )
+    return "\n".join(lines)
+
+
+def compression_verdict(skill: str, before: str, after: str) -> dict[str, object]:
+    """Judge a proposed rewrite of one rendered skill body.
+
+    The verdict says `keep_original` when the rewrite is not worth its risk:
+    the measured token delta is under `COMPRESSION_KEEP_ORIGINAL_DELTA_PERCENT`,
+    the rewrite touched the retrieval surface, or it dropped never-delete
+    payload. `dropped_payload` is the declared-loss list -- every claim, bound,
+    or exact string present before and missing after, named rather than
+    counted, because an undeclared loss is a silent regression.
+    """
+    before_prose = instruction_prose(before)
+    after_prose = instruction_prose(after)
+    before_tokens = -(-len(before_prose) // CHARS_PER_TOKEN_ESTIMATE)
+    after_tokens = -(-len(after_prose) // CHARS_PER_TOKEN_ESTIMATE)
+    delta_percent = (
+        round((before_tokens - after_tokens) * 100 / before_tokens, 2) if before_tokens else 0.0
+    )
+    dropped = payload_markers(before_prose) - payload_markers(after_prose)
+    trigger_changed = trigger_surface(before) != trigger_surface(after)
+
+    reasons: list[str] = []
+    if trigger_changed:
+        reasons.append(
+            "the rewrite changed the retrieval surface (frontmatter description or routing "
+            "signals); the body compresses, the trigger never does"
+        )
+    if dropped:
+        reasons.append(
+            "the rewrite dropped never-delete payload: "
+            + ", ".join(sorted(dropped.elements()))
+        )
+    if delta_percent < COMPRESSION_KEEP_ORIGINAL_DELTA_PERCENT:
+        reasons.append(
+            f"measured delta {delta_percent}% is under the "
+            f"{COMPRESSION_KEEP_ORIGINAL_DELTA_PERCENT}% floor; on already-dense text the "
+            "remaining words are the payload"
+        )
+    return {
+        "schema_version": SKILL_DENSITY_SCHEMA_VERSION,
+        "skill": skill,
+        "verdict": "keep_original" if reasons else "accept_draft",
+        "before_estimated_tokens": before_tokens,
+        "after_estimated_tokens": after_tokens,
+        "delta_percent": delta_percent,
+        "trigger_changed": trigger_changed,
+        "dropped_payload": sorted(dropped.elements()),
+        "reasons": reasons,
+        "before": measure_skill_density(skill, before).to_payload(),
+        "after": measure_skill_density(skill, after).to_payload(),
+    }

--- a/tests/test_skill_density.py
+++ b/tests/test_skill_density.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.quality.skill_density import (  # noqa: E402
+    COMPRESSION_KEEP_ORIGINAL_DELTA_PERCENT,
+    DENSITY_FILLER_HIT_CEILING,
+    DENSITY_PAYLOAD_MARKERS_PER_1K_FLOOR,
+    DENSITY_REPEATED_SHARE_CEILING_PERCENT,
+    DENSITY_REVIEWED_EXEMPTIONS,
+    SKILL_DENSITY_RULE_IDS,
+    SKILL_DENSITY_SCHEMA_VERSION,
+    compression_verdict,
+    format_skill_density_violations,
+    instruction_prose,
+    measure_skill_density,
+    skill_density_measurements,
+    skill_density_payload,
+    skill_density_violations,
+    trigger_surface,
+)
+from omh.skills.packaging import builtin_skill_templates  # noqa: E402
+
+
+class SkillDensityGateTests(unittest.TestCase):
+    """Standing density gate for the always-loaded skill bodies.
+
+    `FULL_PROFILE_SKILL_BODY_CHAR_LIMIT` (src/maintenance/release.py) ratchets
+    the pack's total bytes. It cannot separate a body that grew because a
+    workflow gained a rule from one that grew because the prose got wordier.
+    This gate measures the second thing per skill.
+
+    Measured distribution over all 108 catalog skills at the time these
+    thresholds were set (`omh.quality.skill_density.skill_density_payload()`):
+
+    | signal | min | median | max |
+    | --- | --- | --- | --- |
+    | `filler_hits` | 0 | 0 | 0 |
+    | `repeated_share_percent` | 0.0 | 0.0 | 0.0 |
+    | `payload_markers_per_1k` | 10.03 | 13.17 | 21.3 |
+
+    Thresholds follow from those three rows:
+
+    - Filler ceiling 0. The corpus carries zero hits from the reviewed phrase
+      list today, so the gate is a ratchet on a clean corpus rather than a
+      cleanup target. A non-zero tolerance here would only buy the first
+      author who wants one.
+    - Repeated-share ceiling 5.0%. Intra-skill repetition is also zero today,
+      but the ceiling is deliberately not 0: repeating the single most
+      important rule at the end of a long body is a positioning decision, not
+      bloat, and a hard zero would forbid it. 5.0% leaves room for exactly one
+      such repeat in a median-length body while still failing a section
+      pasted twice.
+    - Payload floor 9.0 markers per 1,000 prose chars, about 10% below the
+      measured worst legitimate case (`llm-app-dev`, 10.03 -- the largest body
+      with the most narrative framing). Set at today's worst it would fail on
+      the next rounding; set at the median it would fail a third of the
+      catalog for style.
+
+    Nothing is exempted: `DENSITY_REVIEWED_EXEMPTIONS` is empty and the gate
+    passes on today's corpus.
+    """
+
+    def test_catalog_passes_the_density_gate(self) -> None:
+        violations = skill_density_violations()
+        self.assertEqual(violations, [], format_skill_density_violations(violations))
+
+    def test_no_skill_is_silently_exempted(self) -> None:
+        self.assertEqual(DENSITY_REVIEWED_EXEMPTIONS, {})
+        catalog = {template.name for template in builtin_skill_templates()}
+        for skill, reason in DENSITY_REVIEWED_EXEMPTIONS.items():
+            with self.subTest(skill=skill):
+                self.assertIn(skill, catalog)
+                self.assertTrue(reason.strip(), "an exemption without a reason is a silent skip")
+
+    def test_measured_distribution_still_matches_the_recorded_thresholds(self) -> None:
+        """The thresholds are only defensible while the distribution behind them holds."""
+        payload = skill_density_payload()
+        self.assertEqual(payload["schema_version"], SKILL_DENSITY_SCHEMA_VERSION)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["skill_count"], len(builtin_skill_templates()))
+        self.assertEqual(list(payload["rules"]), sorted(SKILL_DENSITY_RULE_IDS))
+
+        distribution = payload["distribution"]
+        self.assertEqual(distribution["filler_hits"]["max"], 0.0)
+        self.assertEqual(distribution["repeated_share_percent"]["max"], 0.0)
+        # Headroom, not a second ratchet: the floor stays meaningfully under the
+        # worst measured body and the median stays well clear of the floor.
+        self.assertGreater(distribution["payload_markers_per_1k"]["min"], DENSITY_PAYLOAD_MARKERS_PER_1K_FLOOR)
+        self.assertGreater(distribution["payload_markers_per_1k"]["median"], 12.0)
+
+    def test_failure_message_names_skill_value_threshold_and_excerpt(self) -> None:
+        wordy = (
+            '---\nname: "omh-demo"\ndescription: "[omh] demo"\n---\n\n'
+            "# Demo\n\n"
+            "In order to run the workflow the operator opens the workflow and then the "
+            "workflow proceeds through the workflow stages of the workflow run.\n"
+        )
+        measurement = measure_skill_density("demo", wordy)
+        violations = skill_density_violations([measurement])
+        rules = {str(finding["rule"]) for finding in violations}
+        self.assertIn("SKILL_DENSITY_FILLER", rules)
+        self.assertIn("SKILL_DENSITY_PAYLOAD_FLOOR", rules)
+
+        message = format_skill_density_violations(violations)
+        self.assertIn("demo", message)
+        self.assertIn("SKILL_DENSITY_FILLER", message)
+        self.assertIn(f"threshold {DENSITY_FILLER_HIT_CEILING}", message)
+        self.assertIn("In order to run the workflow", message)
+        self.assertIn("src/quality/skill_density.py", message)
+        self.assertIn("docs/ADDING-A-SKILL.md", message)
+
+    def test_repeated_content_rule_fires_on_a_body_that_repeats_itself(self) -> None:
+        sentence = "Record the accepted decision before any executor handoff is prepared."
+        body = "---\nname: \"omh-demo\"\n---\n\n# Demo\n\n" + "\n\n".join([sentence] * 4) + "\n"
+        measurement = measure_skill_density("demo", body)
+        self.assertGreater(measurement.repeated_share_percent, DENSITY_REPEATED_SHARE_CEILING_PERCENT)
+        rules = {str(finding["rule"]) for finding in skill_density_violations([measurement])}
+        self.assertIn("SKILL_DENSITY_REPEATED_CONTENT", rules)
+
+
+class TriggerSurfaceIsNotCompressibleTests(unittest.TestCase):
+    """The description and routing signals are matched against user phrasing.
+
+    `src/routing/` reads catalog triggers, so keyword-redundant alternatives are
+    payload on the retrieval surface even where a human reader needs one. The
+    density measurement must therefore never see them, or a wide trigger list
+    would read as repetition and pressure an author to trim routing coverage.
+    """
+
+    def test_prose_excludes_frontmatter_and_routing_signals(self) -> None:
+        template = next(item for item in builtin_skill_templates() if item.name == "plan")
+        prose = instruction_prose(template.content)
+        self.assertNotIn("Strong routing signals:", prose)
+        self.assertNotIn("description:", prose)
+        self.assertIn("Completion Checklist", prose)
+
+        surface = trigger_surface(template.content)
+        self.assertIn("Strong routing signals:", surface)
+        self.assertIn("`implementation plan`", surface)
+
+
+class CompressionDeltaGateTests(unittest.TestCase):
+    """The gate that can say "stop" to a compression pass.
+
+    A rewrite is only worth its re-review when it wins real tokens and loses
+    nothing. Three refusals: an under-threshold delta, a touched trigger, and a
+    dropped never-delete claim.
+    """
+
+    ORIGINAL = (
+        '---\nname: "omh-demo"\ndescription: "[omh] demo. Use when the user says: demo, demo run."\n---\n\n'
+        "# Demo\n\n"
+        "The run must stop after 3 failed attempts and never reports prepared work as observed.\n"
+        "Pass `--limit 3` when the batch exceeds the default.\n"
+        "If the batch is empty, say so and stop instead of writing an empty report.\n"
+        "Record the stop reason in the run summary before handing back to the caller.\n"
+    )
+
+    def test_small_delta_keeps_the_original(self) -> None:
+        trimmed = self.ORIGINAL.replace("exceeds the default", "exceeds default")
+        verdict = compression_verdict("demo", self.ORIGINAL, trimmed)
+        self.assertEqual(verdict["verdict"], "keep_original")
+        self.assertLess(verdict["delta_percent"], COMPRESSION_KEEP_ORIGINAL_DELTA_PERCENT)
+        self.assertEqual(verdict["dropped_payload"], [])
+        self.assertIn("under the", " ".join(verdict["reasons"]))
+
+    def test_dropped_payload_is_named_not_counted(self) -> None:
+        lossy = (
+            '---\nname: "omh-demo"\ndescription: "[omh] demo. Use when the user says: demo, demo run."\n---\n\n'
+            "# Demo\n\nThe run stops after failures.\n"
+        )
+        verdict = compression_verdict("demo", self.ORIGINAL, lossy)
+        self.assertEqual(verdict["verdict"], "keep_original")
+        self.assertGreater(verdict["delta_percent"], COMPRESSION_KEEP_ORIGINAL_DELTA_PERCENT)
+        self.assertIn("modal:must", verdict["dropped_payload"])
+        self.assertIn("modal:never", verdict["dropped_payload"])
+        self.assertIn("exact_string:`--limit 3`", verdict["dropped_payload"])
+        self.assertFalse(verdict["trigger_changed"])
+
+    def test_touching_the_trigger_keeps_the_original(self) -> None:
+        retriggered = self.ORIGINAL.replace(", demo run.", ".")
+        verdict = compression_verdict("demo", self.ORIGINAL, retriggered)
+        self.assertEqual(verdict["verdict"], "keep_original")
+        self.assertTrue(verdict["trigger_changed"])
+        self.assertIn("the trigger never does", " ".join(verdict["reasons"]))
+
+    def test_a_real_win_that_loses_nothing_is_accepted(self) -> None:
+        original = (
+            '---\nname: "omh-demo"\ndescription: "[omh] demo."\n---\n\n'
+            "# Demo\n\n"
+            "It is important to note that, in order to keep things consistent across the board, "
+            "and basically as you can see, at the end of the day the run must stop after 3 failed "
+            "attempts, and with regard to prepared work, needless to say, it should be noted that "
+            "prepared work is never reported as observed.\n"
+        )
+        tightened = (
+            '---\nname: "omh-demo"\ndescription: "[omh] demo."\n---\n\n'
+            "# Demo\n\n"
+            "The run must stop after 3 failed attempts. Prepared work is never reported as "
+            "observed.\n"
+        )
+        verdict = compression_verdict("demo", original, tightened)
+        self.assertEqual(verdict["verdict"], "accept_draft")
+        self.assertEqual(verdict["dropped_payload"], [])
+        self.assertGreater(verdict["delta_percent"], COMPRESSION_KEEP_ORIGINAL_DELTA_PERCENT)
+        self.assertGreater(
+            verdict["after"]["payload_markers_per_1k"], verdict["before"]["payload_markers_per_1k"]
+        )
+
+
+class DensityMeasurementSourceTests(unittest.TestCase):
+    def test_measurement_reads_the_catalog_producer_not_the_committed_files(self) -> None:
+        """The generated `skills/*/SKILL.md` copies can be stale; the producer cannot."""
+        measurements = {item.skill: item for item in skill_density_measurements()}
+        self.assertEqual(set(measurements), {item.name for item in builtin_skill_templates()})
+        for template in builtin_skill_templates():
+            with self.subTest(skill=template.name):
+                self.assertEqual(
+                    measurements[template.name].prose_chars,
+                    len(instruction_prose(template.content)),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New pure measurement module `src/quality/skill_density.py`: per-skill instruction density for every catalog-rendered skill body, measured on the producer (`builtin_skill_templates()`), never on the committed `skills/*/SKILL.md` copies.
- New standing gate `tests/test_skill_density.py` (11 tests) that fails with a paste-ready message naming the rule id, the skill, the measured value, the threshold, and up to three offending excerpts.
- `omh release drift` gains one `skill_density_filler_hits` budget metric (ceiling 0). Drift now reports 18 checks instead of 17.
- `docs/ADDING-A-SKILL.md` gains section 6, the authoring doctrine: what the gate measures, and the two rules it cannot check for you.

### Why This Exists

OMH already ratchets what the generated pack costs in bytes
(`FULL_PROFILE_SKILL_BODY_CHAR_LIMIT`, currently 797,568). A byte budget is
blind to the difference that matters: a body that grew because a workflow
gained a rule versus a body that grew because the prose got wordier. Both
read the same to the ratchet, and only one is a cost worth paying in every
install's context window, on every turn.

Density is the missing half. It also refuses the opposite failure: a
compression pass that wins a few percent while quietly deleting a safety
rule. That is what makes "trim the skill" a decidable operation instead of
a taste argument.

### User / Operator Impact

- Skill authors: a new gate in the suite, plus a doctrine section telling them what it measures before they write. No behavior change to any installed skill; not a single generated byte moved.
- Maintainers: `omh release drift` now surfaces filler density next to the byte budgets, so a wordy body shows up in the same one-shot report as everything else a catalog change knocks out of sync.

### How It Works

Three signals, computed from the rendered body with the retrieval surface removed:

| Signal | Threshold | What passes |
| --- | --- | --- |
| `filler_hits` | 0 | No phrase from the reviewed 23-entry `FILLER_PHRASES` list. Each entry is a connective whose deletion leaves the surrounding claim intact. |
| `repeated_share_percent` | < 5.0 | A body does not repeat its own sentences (>= 40 chars, so structural labels like "Good example:" are not counted). Cross-skill repetition is a different cost, already reported by `skills.context_cost`. |
| `payload_markers_per_1k` | > 9.0 | Never-delete payload per 1,000 prose chars: RFC 2119 modals, negation and exception words, conditionals, numeric bounds, and exact strings in backticks. |

**Measured distribution over all 108 catalog skills** (recorded in the
gate's class docstring, the way the byte budgets record theirs):

| signal | min | median | max |
| --- | --- | --- | --- |
| `filler_hits` | 0 | 0 | 0 |
| `repeated_share_percent` | 0.0 | 0.0 | 0.0 |
| `payload_markers_per_1k` | 10.03 | 13.17 | 21.30 |

Thresholds follow from those rows, not from taste:

- **Filler ceiling 0.** The corpus carries zero hits today, so this is a ratchet on a clean corpus rather than a cleanup target. A non-zero tolerance would only buy the first author who wants one.
- **Repeated-share ceiling 5.0%.** Intra-skill repetition is also zero today, but the ceiling is deliberately not 0: restating the single most important rule at the end of a long body is a positioning decision, not bloat, and a hard zero would forbid it. 5.0% leaves room for one such repeat in a median-length body while still failing a section pasted twice.
- **Payload floor 9.0.** About 10% below today's worst legitimate case, `llm-app-dev` at 10.03 (the largest body with the most narrative framing). Set at 10.03 the gate would fail on the next rounding; set at the median it would fail a third of the catalog for style.

The gate passes on today's corpus with **`DENSITY_REVIEWED_EXEMPTIONS`
empty** — nothing is exempted, silently or otherwise. A future entry is a
named skill with a written reason, and the test asserts both that the skill
exists and that the reason is non-empty.

Two rules that a size gate cannot express are encoded alongside the metrics:

- **Never compress the trigger.** The frontmatter `description` and the "Strong routing signals" list are retrieval surface, matched against the user's own phrasing by `src/routing/`. `instruction_prose()` excludes both, so a wide trigger list can never read as repetition and pressure an author into trimming routing coverage that `ROUTING_PRECISION_CASES` / `ROUTING_INTERVENTION_CASES` depend on.
- **A delta gate that can say stop.** `compression_verdict(skill, before, after)` returns `keep_original` when the proposed rewrite wins under 10% estimated tokens, when it moved the retrieval surface, or when it dropped a never-delete marker — and it *names* each dropped claim, bound, or exact string (`modal:must`, `exact_string:\`--limit 3\``) rather than counting them. A declared loss is a decision a reader can audit; an undeclared one is a silent regression.

One implementation detail worth calling out: filler spans are blanked
before marker counting, because "it should be noted" carries an RFC 2119
modal by accident. Without the mask it would both flatter a wordy body's
density score and make deleting the filler look like a payload loss.

### Files And Contracts Touched

- `src/quality/skill_density.py` (new): `SKILL_DENSITY_SCHEMA_VERSION = "omh_skill_density/v1"`, `FILLER_PHRASES`, `PAYLOAD_MARKER_PATTERNS`, the three thresholds, `DENSITY_REVIEWED_EXEMPTIONS`, `measure_skill_density()`, `skill_density_violations()`, `skill_density_payload()`, `format_skill_density_violations()`, `compression_verdict()`.
- `tests/test_skill_density.py` (new): the gate, the recorded distribution, negative fixtures for each rule, and the trigger-surface exclusion contract.
- `src/maintenance/drift.py`: one `BudgetMetric` (`skill_density_filler_hits`, `limit_site` `src/quality/skill_density.py`) plus its live producer.
- `docs/ADDING-A-SKILL.md`: section 6 (hand-authored doc; not generated, no byte gate).

No catalog data changed, so no generated artifact moved and no exact-count fixture shifted.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli release drift`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

Also run, beyond the template list:

- [x] `uv run python -m omh.cli docs ulw-inventory --check`
- [x] `uv run python -m omh.cli docs ulw-site --check`

### Observed Evidence

- `PYTHONPATH=tests uv run python -m unittest discover -s tests` — 8172 tests, 21 failures + 7 errors. All 28 are the pre-existing `test_cross_harness_adapters` / `test_cross_harness_adapter_security` `unsafe_read_root` failures caused by running from a `.claude/worktrees/...` path; none touch this change. No other test moved.
- `PYTHONPATH=tests uv run python -m unittest tests/test_skill_density.py tests/test_drift_registry.py tests/test_efficiency.py tests/test_router_content.py` — 214 tests, OK.
- `uv run python -m omh.cli release drift` — `No drift. 18 checks passed.` (17 before this branch; the new check is `skill_density_filler_hits`).
- `uv run python -m omh.cli docs workflows --check` — ok, `tap_skills` 154/154, 0 missing/stale/extra.
- `uv run python -m omh.cli docs roles --check`, `docs capability-families --check`, `docs ulw-inventory --check`, `docs ulw-site --check` — all `"ok":true`.
- `uv run python -m compileall -q src tests` — exit 0.
- `uv run --group lint ruff check src tests` — All checks passed.
- `git diff --check` — clean.
- Measurement run over the live catalog: 108 skills, `ok: true`, 0 violations, distribution as tabled above.

### Not Tested / Not Applicable

- `harness validate`, `release checklist`, `release hermes-smoke`, the `--include-command-smoke` install smoke, and `omh --help`: this branch adds a quality module, a test, one drift metric, and a doc section. It touches no harness definition, no release channel or artifact, no installer path, and no CLI surface, so none of those commands can observe anything this change affects.
- Manual Hermes/TUI check: no user-facing runtime surface changed; the only new output path is `release drift`, which was run.
- Workflow-learning review queue smoke: no learning contract changed.
- `compression_verdict()` against a real historical compression of an OMH skill body: the fixtures are synthetic, because the repo holds no committed before/after pair of a rendered body to replay.

## Risk

- The thresholds are set from one measured snapshot. The two zero-valued ceilings are the sharp ones: an author who legitimately wants a phrase from `FILLER_PHRASES` will hit a red gate. That is the intended trade — the list is deliberately narrow and excludes every phrase that sometimes carries meaning ("note that", "make sure"), because a gate nobody trusts gets exempted rather than fixed. The escape hatch is a named exemption with a reason, never a silent skip.
- The payload floor is a heuristic over a marker regex, not a semantic judgement. It can be satisfied by prose that is dense but wrong. It is a floor against description-instead-of-instruction, not a correctness check, and the docstring says so.
- The chars/4 token figure in `compression_verdict()` is an estimate, matching `CHARS_PER_TOKEN_ESTIMATE` used elsewhere in the repo — a comparison unit for before/after work, not tokenizer output.
- Blast radius is one new module, one new test file, one drift metric, and a doc section. No catalog data, no generated artifact, no routing fixture.

## Compatibility / Rollout

- No runtime, install, or wire-format change. `omh release drift` output gains one line only when the new metric is over budget, which it is not today; the check count in its summary moves 17 -> 18.
- No new dependency; the module is stdlib-only (`re`, `collections`, `dataclasses`) and makes no network or LLM call, consistent with the deterministic core boundary.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`) — none; no packaged artifact changes.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- The remaining mechanically-testable half of the source doctrine is a *differential* never-delete lint in `src/skills/structure_lint.py`: fail when a body loses an RFC 2119 modal, a numeric bound with its unit, or an exact identifier **relative to its previous committed version**. `compression_verdict()` already computes that difference for a supplied before/after pair; wiring it to git history is a separate change with its own failure modes (rename detection, first-commit bodies) and does not belong in this one.
- If a future skill legitimately lands under the payload floor, the decision is a reviewed exemption with a reason, not a floor bump — re-measuring the distribution and moving the floor should require the same explicit argument the byte ratchet's comment history carries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1Tue9T3YhWLT5mT8bo9Ke
