### PR TITLE
feat(coding,workflows): negative-conclusive terminal statuses

### DIFF
--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -68,6 +68,7 @@ from .fanout_retry import (
 from .unit_prompt_protocol import shared_unit_preamble_lines, unit_protocol_lines
 from .fanout_unit_results import (
     FANOUT_UNIT_RESULT_CHECK_STATUSES,
+    FANOUT_UNIT_RESULT_DECLINE_REASONS,
     FANOUT_UNIT_RESULT_PROCESS_STATUSES,
     validate_check_rows,
     validate_unit_result,
@@ -662,17 +663,24 @@ def _unit_result_prompt_lines(contract: Mapping[str, Any]) -> list[str]:
     had succeeded (#1190).
     """
     process_values = " or ".join(f'"{value}"' for value in FANOUT_UNIT_RESULT_PROCESS_STATUSES)
+    decline_values = ", ".join(f'"{value}"' for value in FANOUT_UNIT_RESULT_DECLINE_REASONS)
     check_values = ", ".join(f'"{value}"' for value in FANOUT_UNIT_RESULT_CHECK_STATUSES)
     return [
         "Before exiting, write one fanout_unit_result/v1 JSON sidecar to exactly "
         f"{contract.get('path', '')}.",
         "Top-level fields: schema_version, unit_id, run_id, fanout_id, base_sha, head_sha, "
-        "process_status, changed_paths, checks, findings, schema_error (optional).",
+        "process_status, decline_reason (required only with process_status process_declined), "
+        "changed_paths, checks, findings, schema_error (optional).",
         "Use these dispatch-bound values: "
         f"schema_version=fanout_unit_result/v1, unit_id={contract.get('unit_id', '')}, "
         f"run_id={contract.get('run_id', '')}, fanout_id={contract.get('fanout_id', '')}, "
         f"base_sha={contract.get('base_sha', '')}; head_sha is the git HEAD you leave behind.",
         f"process_status must be exactly {process_values} — no other value validates.",
+        "process_declined is a conclusive negative answer (the target does not exist, the request "
+        "is refused by policy, or the acceptance criteria are infeasible as specified), never a "
+        "retry candidate — do not report process_failed for it. When you report process_declined, "
+        f"decline_reason is required and must be exactly {decline_values} — omit decline_reason for "
+        "every other process_status.",
         "Each checks row fields: command, status, evidence_ref, reported_by, observed_by, "
         "observation_source.",
         f"Each checks row status must be exactly one of {check_values} — no other value validates.",
@@ -2603,6 +2611,7 @@ _UNIT_RESULT_TOP_LEVEL_KEYS = (
     "base_sha",
     "head_sha",
     "process_status",
+    "decline_reason",
 )
 _UNIT_RESULT_CHECK_KEYS = (
     "command",

--- a/src/coding/fanout_journal.py
+++ b/src/coding/fanout_journal.py
@@ -9,8 +9,13 @@ rule to every field any of those surfaces later adds.
 The journal is the narrow projection instead: one row per unit, holding only
 the four things a resume decision needs.
 
-1. **What terminally happened** -- succeeded, failed, skipped because a
-   dependency did not clear, or never attempted at all.
+1. **What terminally happened** -- succeeded, failed, declined by the unit's
+   own conclusive negative answer, skipped because a dependency did not
+   clear, or never attempted at all. `declined` is not a shade of `failed`:
+   the unit itself reported (in a validated `fanout_unit_result/v1` sidecar)
+   that the work cannot be done at all -- the target does not exist, the
+   request is refused by policy, or the criteria are infeasible as
+   specified -- which a retry cannot answer differently.
 2. **How it failed**, in the classification vocabulary `fanout_retry` already
    owns, read off the retry decision the dispatcher recorded rather than
    re-derived from tails the summary does not keep.
@@ -28,6 +33,14 @@ re-deriving. What stays refused in both places is a replay that would destroy
 observed work: a unit whose failure left changes in its worktree, wrote a
 result artifact, or could not be measured at all is held, with the reason
 named, and continued by hand through the recovery path.
+
+A declined unit is refused a third way, unconditionally: replay-safety is
+about whether re-dispatching would destroy something, and a decline holds
+regardless of that answer, because re-dispatching would not produce a
+different verdict either way. `RESUME_HOLD_DECLINED` is checked ahead of
+replay-unsafe side effects for exactly that reason -- the unit's own
+conclusive negative answer is why it is held, not what it may have touched
+on the way to reaching it.
 
 Writes go through `atomic_write_json` -- serialize, write a sibling temp,
 rename over -- so an interrupted write leaves the previous journal exactly as
@@ -75,10 +88,19 @@ RESUME_CLAIM_BOUNDARY = (
 # Terminal states. Every unit in a dispatch lands in exactly one of them.
 TERMINAL_SUCCEEDED = "succeeded"
 TERMINAL_FAILED = "failed"
+TERMINAL_DECLINED = "declined"
 TERMINAL_SKIPPED_BY_DEPENDENCY = "skipped_by_dependency"
 TERMINAL_NOT_ATTEMPTED = "not_attempted"
 
-# Resume actions. The three `hold_*` actions mean "not re-dispatched", each for
+# The journal's own name for a decline in `failure_class`, kept apart from
+# every class `fanout_retry` owns: a decline was never classified by the
+# retry ladder's transport-vs-terminal question (`fanout_retry` only asks
+# "is this the unit's own answer", and a decline always is), so it earns its
+# own label rather than borrowing `terminal_failure` and reading as an
+# ordinary bug the retry ladder happened to give up on.
+FAILURE_CLASS_DECLINED_CONCLUSIVE = "declined_conclusive"
+
+# Resume actions. The four `hold_*` actions mean "not re-dispatched", each for
 # a different reason an operator acts on differently.
 RESUME_RERUN_FAILED = "rerun_replay_safe_failure"
 RESUME_RERUN_NOT_ATTEMPTED = "rerun_not_attempted"
@@ -86,9 +108,10 @@ RESUME_UNSKIP_DEPENDENT = "unskip_dependent"
 RESUME_HOLD_SUCCEEDED = "hold_succeeded"
 RESUME_HOLD_REPLAY_UNSAFE = "hold_replay_unsafe"
 RESUME_HOLD_BLOCKED_DEPENDENCY = "hold_blocked_dependency"
+RESUME_HOLD_DECLINED = "hold_declined_conclusive"
 
 RESUME_HOLD_ACTIONS = frozenset(
-    {RESUME_HOLD_SUCCEEDED, RESUME_HOLD_REPLAY_UNSAFE, RESUME_HOLD_BLOCKED_DEPENDENCY}
+    {RESUME_HOLD_SUCCEEDED, RESUME_HOLD_REPLAY_UNSAFE, RESUME_HOLD_BLOCKED_DEPENDENCY, RESUME_HOLD_DECLINED}
 )
 RESUME_RERUN_ACTIONS = frozenset(
     {RESUME_RERUN_FAILED, RESUME_RERUN_NOT_ATTEMPTED, RESUME_UNSKIP_DEPENDENT}
@@ -123,6 +146,7 @@ _JOURNAL_UNIT_KEYS = (
     "status",
     "failure_class",
     "failure_label",
+    "decline_reason",
     "replay_safe",
     "replay_verdict",
     "side_effect",
@@ -157,7 +181,8 @@ def journal_unit_entry(entry: Mapping[str, Any]) -> dict[str, Any]:
         "owner": str(entry.get("owner") or "choose"),
         "terminal_state": state,
         "status": str(entry.get("status", "")),
-        **_failure_classification(entry),
+        **_failure_classification(entry, state=state),
+        "decline_reason": _decline_reason(entry) if state == TERMINAL_DECLINED else "",
         **_entry_replay_safety(entry, succeeded=state == TERMINAL_SUCCEEDED),
         "blocked_on": [str(dep) for dep in entry.get("blocked_on", []) or []],
     }
@@ -307,6 +332,24 @@ def _unit_resume_decision(
             reason="the prior run observed this unit's process succeed; a resume never re-runs it",
             row=row,
         )
+    if prior_state == TERMINAL_DECLINED:
+        # Checked ahead of replay-safety and `unresolved` on purpose: the
+        # unit already answered this question, conclusively and negatively,
+        # and a resume re-asking it would spend a whole agent-CLI run to
+        # relearn what the journal already states -- regardless of whether
+        # replaying it would also be safe, and regardless of whether its
+        # blockers have since cleared.
+        return _decision(
+            unit_id,
+            prior_state=prior_state,
+            action=RESUME_HOLD_DECLINED,
+            reason=(
+                f"the unit reported a negative-conclusive outcome ({row.get('decline_reason') or 'unspecified'}): "
+                "resuming does not re-dispatch it because a retry cannot answer the question differently; "
+                "act on the recorded reason or supersede it by hand"
+            ),
+            row=row,
+        )
     if not bool(row.get("replay_safe")):
         return _decision(
             unit_id,
@@ -401,17 +444,53 @@ def _terminal_state(entry: Mapping[str, Any]) -> str:
         return TERMINAL_SKIPPED_BY_DEPENDENCY
     if "exit_code" not in entry and entry.get("status") in _NEVER_SPAWNED_STATUSES:
         return TERMINAL_NOT_ATTEMPTED
+    if _unit_result_declined(entry):
+        return TERMINAL_DECLINED
     return TERMINAL_FAILED
 
 
-def _failure_classification(entry: Mapping[str, Any]) -> dict[str, str]:
+def _unit_result_declined(entry: Mapping[str, Any]) -> bool:
+    """Whether the dispatcher's own observation validated a decline.
+
+    Gated on `result_schema_valid`, the dispatcher's own record that it
+    validated the sidecar's shape -- not on the executor's claim alone, the
+    same rule `fanout_unit_results` states for every field on this contract.
+    A unit that succeeded is caught by the earlier `TERMINAL_SUCCEEDED` branch
+    regardless of what a stray `process_declined` sidecar might claim: the
+    dispatcher's own exit-code observation always outranks a self-report.
+    """
+    if not bool(entry.get("result_schema_valid")):
+        return False
+    unit_result = entry.get("unit_result")
+    if not isinstance(unit_result, Mapping):
+        return False
+    return str(unit_result.get("process_status", "")) == "process_declined"
+
+
+def _decline_reason(entry: Mapping[str, Any]) -> str:
+    unit_result = entry.get("unit_result")
+    if isinstance(unit_result, Mapping):
+        return str(unit_result.get("decline_reason", ""))
+    return ""
+
+
+def _failure_classification(entry: Mapping[str, Any], *, state: str = "") -> dict[str, str]:
     """The failure class in `fanout_retry`'s vocabulary, read not re-derived.
 
     The dispatcher already classified any failure it considered retrying, from
     the output tails it had in hand; the summary does not keep those tails, so
     re-matching here would be guessing. Only a failure the retry ladder never
     saw falls back to the exit-code-only classification.
+
+    A declined unit skips both: its class is the journal's own
+    `FAILURE_CLASS_DECLINED_CONCLUSIVE`, never `fanout_retry`'s
+    `terminal_failure`, because the retry ladder never asked "is this
+    conclusive" -- only "is this the unit's own answer", which is true of
+    every non-transient failure and would erase the distinction this module
+    exists to keep.
     """
+    if state == TERMINAL_DECLINED:
+        return {"failure_class": FAILURE_CLASS_DECLINED_CONCLUSIVE, "failure_label": ""}
     retry = entry.get("retry")
     if isinstance(retry, Mapping):
         decisions = retry.get("decisions")

--- a/src/coding/fanout_unit_results.py
+++ b/src/coding/fanout_unit_results.py
@@ -35,11 +35,27 @@ from .fanout_contracts import FANOUT_ID_PATTERN
 
 
 FANOUT_UNIT_RESULT_SCHEMA_VERSION = "fanout_unit_result/v1"
-# Exit-code shaped, and deliberately only that. Anything richer (schema
-# validity, observed verification, integration eligibility) is the
-# dispatcher's to decide from its own observations, never the executor's to
-# assert here.
-FANOUT_UNIT_RESULT_PROCESS_STATUSES = ("process_succeeded", "process_failed")
+# Exit-code shaped, and deliberately only that -- with one deliberate
+# exception. `process_declined` is not a shade of `process_failed`: it is the
+# unit's own conclusive negative answer ("the target does not exist", "this
+# is refused by policy", "the criteria are infeasible as specified"), which a
+# retry cannot turn into a different answer. Everything else this schema
+# rejects (schema validity, observed verification, integration eligibility)
+# stays the dispatcher's to decide from its own observations, never the
+# executor's to assert here -- a decline is reportable precisely because it is
+# not a claim of success or of a bug, so there is nothing here for the
+# dispatcher to launder.
+FANOUT_UNIT_RESULT_PROCESS_STATUSES = ("process_succeeded", "process_failed", "process_declined")
+# The closed reasons a decline may cite. `decline_reason` is required exactly
+# when `process_status` is `process_declined` and refused otherwise, enforced
+# by `_validated_process_status_and_decline_reason` below.
+FANOUT_UNIT_RESULT_DECLINE_REASONS = (
+    "target_not_found",
+    "infeasible_as_specified",
+    "refused_by_policy",
+    "superseded_by_existing_work",
+    "other_declared",
+)
 FANOUT_UNIT_RESULT_CHECK_STATUSES = ("passed", "failed", "skipped")
 FANOUT_UNIT_RESULT_REPORTERS = ("executor", "dispatcher")
 # Only the dispatcher observes. An executor claiming to have observed itself
@@ -82,6 +98,7 @@ def validate_unit_result(payload: Mapping[str, object]) -> dict[str, object]:
     result["process_status"] = _validated_choice(
         payload.get("process_status"), "process_status", FANOUT_UNIT_RESULT_PROCESS_STATUSES
     )
+    _validate_decline_reason(payload, result)
     result["changed_paths"] = _validated_changed_paths(payload.get("changed_paths"))
     result["checks"] = _validated_checks(payload.get("checks"))
     result["findings"] = _validated_findings(payload.get("findings"))
@@ -137,6 +154,30 @@ def _validated_choice(value: object, field: str, allowed: Sequence[str]) -> str:
     if not isinstance(value, str) or value not in allowed:
         raise ValueError(f"{field} must be one of {', '.join(allowed)}; got {value!r}")
     return value
+
+
+def _validate_decline_reason(payload: Mapping[str, object], result: dict[str, object]) -> None:
+    """Require a structured reason on a decline, and refuse one everywhere else.
+
+    A `process_declined` result with no reason is exactly as unbacked as the
+    `process_failed` reports this schema already refuses to let mean anything
+    beyond an exit code -- so the reason is mandatory here, not optional. A
+    reason present on a non-declined result is refused too: it would be a
+    stray field an unrelated report never asked for, and a validator that
+    quietly dropped it would let a decline hide behind a status that reads as
+    ordinary failure.
+    """
+    declined = result["process_status"] == "process_declined"
+    reason = payload.get("decline_reason")
+    if declined:
+        result["decline_reason"] = _validated_choice(
+            reason, "decline_reason", FANOUT_UNIT_RESULT_DECLINE_REASONS
+        )
+    elif "decline_reason" in payload:
+        raise ValueError(
+            f"decline_reason is only valid when process_status is process_declined; "
+            f"process_status is {result['process_status']!r}"
+        )
 
 
 def _validated_optional_choice(value: object, field: str, allowed: Sequence[str]) -> str | None:

--- a/src/coding/unit_prompt_protocol.py
+++ b/src/coding/unit_prompt_protocol.py
@@ -78,7 +78,10 @@ FAILURE_KIND_PROTOCOL: Final[str] = (
     "not retry it through another tool or route; record the denial and continue with what the boundary "
     "allows, or report it. Report blocked only when the same concrete condition still holds after the "
     "bounded fix-and-verify cycles, and name that condition; difficulty, uncertainty, or useful "
-    "remaining work is not blocked."
+    "remaining work is not blocked. When the unit's whole objective is unreachable for a reason a retry "
+    "cannot change — the target does not exist, the request is refused by policy, or the acceptance "
+    "criteria are infeasible as specified — report process_status process_declined with a decline_reason "
+    "instead of process_failed: a decline is a conclusive negative answer, never a bug to retry."
 )
 
 # The sidecar file is the primary machine-read return

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -1540,6 +1540,23 @@ _FANOUT_BRIEF_CLAIM_BOUNDARY = (
 )
 
 
+def _brief_decline_reason(dispatched: dict) -> str:
+    """The unit's own negative-conclusive reason, when it validly reported one.
+
+    Empty for every ordinary failure: an exit code alone reports `failed`
+    already, and that is not this. Set only when the executor's own validated
+    `fanout_unit_result/v1` sidecar named `process_status` `process_declined` --
+    a distinct, structured claim that the work cannot be done at all, never a
+    retry candidate.
+    """
+    unit_result = dispatched.get("unit_result")
+    if not isinstance(unit_result, dict):
+        return ""
+    if str(unit_result.get("process_status", "")) != "process_declined":
+        return ""
+    return str(unit_result.get("decline_reason", ""))
+
+
 def _brief_recovery(dispatched: dict) -> dict[str, object]:
     """The salvage line for one unit: outcome, size, and how to get the patch.
 
@@ -1673,6 +1690,7 @@ def cmd_coding_fanout_brief(args: argparse.Namespace) -> int:
                 # can recreate it, and destroys the work the recovery record
                 # exists to preserve.
                 "recovery": _brief_recovery(dispatched),
+                "decline_reason": _brief_decline_reason(dispatched),
                 "summary": latest_summary,
             }
         )

--- a/src/commands/goal.py
+++ b/src/commands/goal.py
@@ -4,12 +4,14 @@ import argparse
 
 from ..goal_ledger import (
     CHECKPOINT_STATUSES,
+    GOAL_FAILURE_REASON_CODES,
     build_goal_completion_gate,
     build_goal_continuation,
     build_goal_status_card,
     cancel_goal_ledger,
     complete_goal_ledger,
     create_goal_ledger,
+    fail_goal_ledger,
     list_goal_ledgers,
     read_goal_ledger,
     render_goal_status_text,
@@ -145,6 +147,36 @@ def cmd_goal_cancel(args: argparse.Namespace) -> int:
         raise OmhError(str(exc)) from exc
     payload = _mutation_payload(paths, args.goal_id, goal, outcome)
     payload["cancelled"] = bool(outcome.get("applied"))
+    _print_json(payload)
+    return 0 if outcome.get("applied") else 1
+
+
+def cmd_goal_fail(args: argparse.Namespace) -> int:
+    """Terminally fail a goal: a negative but CONCLUSIVE verdict on the objective.
+
+    Distinct from `goal cancel` (an operator decision) and `goal blocker`
+    (a recoverable obstacle, resumable once cleared): a failure states that
+    the objective cannot be met at all, with a required, closed
+    `--reason-code`, and is terminal in the same way `goal cancel` is --
+    later checkpoints, blockers, and gates all refuse.
+    """
+    paths = _paths(args)
+    outcome: dict = {}
+    try:
+        goal = fail_goal_ledger(
+            paths,
+            args.goal_id,
+            args.summary,
+            reason_code=args.reason_code,
+            evidence_refs=args.evidence_ref or [],
+            expected_revision=args.expected_revision,
+            mutation_id=args.mutation_id or None,
+            outcome=outcome,
+        )
+    except (FileNotFoundError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    payload = _mutation_payload(paths, args.goal_id, goal, outcome)
+    payload["failed"] = bool(outcome.get("applied"))
     _print_json(payload)
     return 0 if outcome.get("applied") else 1
 
@@ -287,6 +319,17 @@ def _add_goal_commands(sub) -> None:
     goal_cancel.add_argument("--reason", default="")
     add_revision_guard_arguments(goal_cancel)
     goal_cancel.set_defaults(func=cmd_goal_cancel)
+
+    goal_fail = goal_sub.add_parser(
+        "fail",
+        help="Terminally fail a goal: the objective cannot be met at all (distinct from cancel or blocker).",
+    )
+    goal_fail.add_argument("--goal", dest="goal_id", required=True)
+    goal_fail.add_argument("--summary", required=True)
+    goal_fail.add_argument("--reason-code", required=True, choices=sorted(GOAL_FAILURE_REASON_CODES))
+    goal_fail.add_argument("--evidence-ref", action="append")
+    add_revision_guard_arguments(goal_fail)
+    goal_fail.set_defaults(func=cmd_goal_fail)
 
     goal_status = goal_sub.add_parser("status")
     goal_status.add_argument("--goal", dest="goal_id", default="")

--- a/src/workflows/goal_ledger.py
+++ b/src/workflows/goal_ledger.py
@@ -31,7 +31,24 @@ GOAL_CONTINUATION_SCHEMA = "goal_continuation/v1"
 GOAL_STATUS_CARD_SCHEMA = "goal_status_card/v1"
 
 GOAL_STATUSES = {"active", "blocked", "failed", "complete", "cancelled"}
-GOAL_TERMINAL_STATUSES = ("complete", "cancelled")
+# `failed` is terminal alongside `complete` and `cancelled`: it is a negative
+# but CONCLUSIVE verdict on the objective itself (the target does not exist,
+# the request is refused by policy, the acceptance criteria are infeasible as
+# specified), reached via `fail_goal_ledger`, and a retry cannot answer the
+# same question differently. It is distinct from `blocked`, which stays
+# non-terminal on purpose: a blocker is recoverable, and clearing it is
+# exactly what further checkpoints on the goal are for.
+GOAL_TERMINAL_STATUSES = ("complete", "cancelled", "failed")
+# Closed reasons a failure verdict may cite. Required on every call to
+# `fail_goal_ledger`, mirroring how `record_goal_blocker` requires a summary --
+# a negative-conclusive verdict earns no less structure than a recoverable one.
+GOAL_FAILURE_REASON_CODES = (
+    "target_not_found",
+    "infeasible_as_specified",
+    "refused_by_policy",
+    "superseded_by_existing_work",
+    "other_declared",
+)
 CRITERION_STATUSES = {"pending", "satisfied"}
 CHECKPOINT_STATUSES = {"pending", "in_progress", "done", "blocked", "failed"}
 BLOCKER_STATUSES = {"active", "resolved"}
@@ -623,6 +640,64 @@ def cancel_goal_ledger(
     return goal
 
 
+def fail_goal_ledger(
+    paths: OmhPaths,
+    goal_id: str,
+    summary: str,
+    *,
+    reason_code: str,
+    evidence_refs: Iterable[str] | None = None,
+    expected_revision: int | None = None,
+    mutation_id: str | None = None,
+    outcome: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Terminally fail a goal: the objective was evaluated and cannot be met.
+
+    Distinct from `cancel_goal_ledger` (an operator decided to stop, for any
+    reason or none) and from `record_goal_blocker` (a recoverable obstacle
+    that further checkpoints can clear): a failure is a negative but
+    CONCLUSIVE verdict on the objective itself, reached because the target
+    does not exist, the request is refused by policy, or the acceptance
+    criteria are infeasible as specified. It is never a claim that the goal
+    ran out of budget or attempts -- `record_goal_blocker` or a loop's own
+    `wait_reason` cover that case, and stay recoverable.
+
+    Terminal like `cancel_goal_ledger`: later checkpoints, blockers, and gates
+    refuse via `require_not_terminal`, and a linked loop's stop ladder must
+    not schedule further ticks against this goal (`_stop_rung_explicit_cancel`
+    in `goal_loop` fires on `failed` for the same reason it fires on
+    `cancelled`).
+    """
+    if reason_code not in GOAL_FAILURE_REASON_CODES:
+        raise ValueError(f"unsupported goal failure reason_code: {reason_code}")
+    if not summary.strip():
+        raise ValueError("failure summary is required")
+    evidence = _evidence_refs(evidence_refs)
+
+    def mutate(goal: dict[str, Any]) -> dict[str, Any]:
+        require_not_terminal(goal, "status", GOAL_TERMINAL_STATUSES, "fail this goal")
+        goal["status"] = "failed"
+        goal["failure_reason_code"] = reason_code
+        goal["failure_summary"] = _safe_summary(summary)
+        goal["failure_evidence_refs"] = evidence
+        return goal
+
+    goal, replayed = _guarded_goal_update(
+        paths,
+        goal_id,
+        mutate,
+        operation="fail_goal_ledger",
+        expected_revision=expected_revision,
+        mutation_id=mutation_id,
+        mutation_digest=_mutation_digest("fail_goal_ledger", reason_code, summary, evidence),
+    )
+    # Re-derived from the persisted status, the same rule `cancel_goal_ledger`
+    # follows: a mutation replayed away leaves an unfailed goal, and reporting
+    # that as success is how a discarded failure verdict looks like a real one.
+    _record_goal_outcome(outcome, goal, replayed=replayed, applied=goal.get("status") == "failed")
+    return goal
+
+
 def validate_goal_ledger(goal: dict[str, Any]) -> dict[str, Any]:
     errors: list[str] = []
     if goal.get("schema_version") != GOAL_LEDGER_SCHEMA:
@@ -640,6 +715,7 @@ def validate_goal_ledger(goal: dict[str, Any]) -> dict[str, Any]:
         errors.append("status must be active, blocked, failed, complete, or cancelled")
     if "cancel_reason" in goal and not isinstance(goal.get("cancel_reason"), str):
         errors.append("cancel_reason must be a string")
+    errors.extend(_failure_fields_errors(goal))
     objective_hash = str(goal.get("objective_hash", ""))
     if len(objective_hash) != 64 or not re.fullmatch(r"[0-9a-f]+", objective_hash):
         errors.append("objective_hash must be a sha256 hex digest")
@@ -703,9 +779,12 @@ def build_goal_completion_gate(paths: OmhPaths, goal_id: str) -> dict[str, Any]:
         status_gaps=status_gaps,
         integrity_refusals=integrity_refusals,
     )
-    if goal["status"] == "cancelled":
-        # A cancelled goal is terminal: recording blockers or checkpoints is
-        # refused, so the only safe next action is showing status.
+    if goal["status"] in ("cancelled", "failed"):
+        # Both are terminal: recording blockers or checkpoints on either is
+        # refused (`require_not_terminal`), so the only safe next action is
+        # showing status. Without this a `failed` goal fell through to
+        # `_completion_next_action`'s `status_gaps` branch and suggested
+        # `record_blocker`, which the goal would then refuse.
         next_action = "show_status"
     return {
         "schema_version": GOAL_COMPLETION_GATE_SCHEMA,
@@ -889,7 +968,7 @@ def build_goal_status_card(paths: OmhPaths, goal_id: str) -> dict[str, Any]:
     goal = read_goal_ledger(paths, goal_id)
     gate = build_goal_completion_gate(paths, goal_id)
     progress = _goal_progress(goal)
-    return {
+    card: dict[str, Any] = {
         "schema_version": GOAL_STATUS_CARD_SCHEMA,
         "goal_id": goal_id,
         "goal_status": goal["status"],
@@ -908,6 +987,13 @@ def build_goal_status_card(paths: OmhPaths, goal_id: str) -> dict[str, Any]:
             "Never render a markdown table: messenger surfaces (Slack, Telegram) drop tables."
         ),
     }
+    # Additive, and only on a failed goal: a negative-conclusive verdict
+    # carries its own structured reason, distinct from `active_blockers`
+    # (recoverable) or a bare `goal_status` string a caller might miss.
+    if goal["status"] == "failed":
+        card["failure_reason_code"] = str(goal.get("failure_reason_code", ""))
+        card["failure_summary"] = str(goal.get("failure_summary", ""))
+    return card
 
 
 GOAL_STATUS_CLAIM_BOUNDARY: Final[str] = (
@@ -1084,8 +1170,10 @@ def _goal_progress(goal: dict[str, Any]) -> dict[str, Any]:
 
 
 def _allowed_goal_actions(gate: dict[str, Any]) -> list[str]:
-    if gate.get("goal_status") == "cancelled":
-        # Terminal cancellation: checkpoints, blockers, and completion refuse.
+    if gate.get("goal_status") in ("cancelled", "failed"):
+        # Both terminal: checkpoints, blockers, and completion all refuse via
+        # `require_not_terminal`. A `failed` goal offered `record_blocker`
+        # here would advertise an action the ledger is about to raise on.
         return ["show_status"]
     actions = ["continue_goal", "show_status"]
     if gate["missing_required_criteria"]:
@@ -1101,6 +1189,13 @@ def _goal_safe_copy(goal: dict[str, Any], gate: dict[str, Any], progress: dict[s
         next_step = "Record completion with the final verification evidence."
     elif gate["active_blockers"] or goal["status"] == "blocked":
         next_step = "Resolve or update the active blocker before claiming completion."
+    elif goal["status"] == "failed":
+        # Terminal and negative-conclusive: unlike a blocker, there is nothing
+        # left on this goal to clear. The reason lives on the record.
+        reason = str(goal.get("failure_reason_code", "") or "unspecified")
+        next_step = f"This goal failed conclusively ({reason}); no further checkpoint or blocker applies."
+    elif goal["status"] == "cancelled":
+        next_step = "This goal was cancelled; no further checkpoint or blocker applies."
     elif gate["missing_required_criteria"]:
         ids = ", ".join(item["id"] for item in gate["missing_required_criteria"])
         next_step = f"Record a checkpoint for the missing acceptance criteria: {ids}."
@@ -1220,6 +1315,25 @@ def _validate_blockers(blockers: Any, errors: list[str]) -> None:
             errors.append(f"blockers[{index}].summary is required")
         if not isinstance(blocker.get("evidence_refs"), list):
             errors.append(f"blockers[{index}].evidence_refs must be a list")
+
+
+def _failure_fields_errors(goal: dict[str, Any]) -> list[str]:
+    """The `fail_goal_ledger` fields, checked the way `cancel_reason` is: loosely
+    typed when present, and required together once the status they explain is on
+    the record -- a `failed` goal with no reason is the exact gap #H exists to close.
+    """
+    errors: list[str] = []
+    if "failure_reason_code" in goal and goal.get("failure_reason_code") not in GOAL_FAILURE_REASON_CODES:
+        errors.append("failure_reason_code is unsupported")
+    if "failure_summary" in goal and not isinstance(goal.get("failure_summary"), str):
+        errors.append("failure_summary must be a string")
+    if "failure_evidence_refs" in goal and not isinstance(goal.get("failure_evidence_refs"), list):
+        errors.append("failure_evidence_refs must be a list")
+    if goal.get("status") == "failed" and (
+        "failure_reason_code" not in goal or not str(goal.get("failure_summary", "")).strip()
+    ):
+        errors.append("a failed goal must carry failure_reason_code and a non-empty failure_summary")
+    return errors
 
 
 def _validate_quality_gates(quality_gates: Any, errors: list[str]) -> None:

--- a/src/workflows/goal_loop.py
+++ b/src/workflows/goal_loop.py
@@ -58,10 +58,15 @@ LOOP_STOP_LADDER_SCHEMA = "loop_stop_ladder/v1"
 # that fires stops the tick, and every rung below it is recorded
 # `not_evaluated` rather than `clear` - a lower rung that was never consulted
 # must never read as a rung that passed. Per-rung rationale:
-# - Rung 1, explicit_cancel: a human already said stop. Nothing below it can
-#   outrank an explicit decision, and a cancelled linked goal refuses every
-#   ledger mutation anyway, so any work the loop prepared under it is
-#   unrecordable by construction.
+# - Rung 1, explicit_cancel: a human already said stop, OR the linked goal
+#   reached its own negative-conclusive verdict (`fail_goal_ledger`: the
+#   target does not exist, the request is refused by policy, the criteria
+#   are infeasible as specified). Both share the rung because both leave a
+#   goal ledger that refuses every checkpoint, blocker, and gate
+#   (`GOAL_TERMINAL_STATUSES` covers `cancelled` and `failed` alike), so any
+#   work the loop prepared under either is unrecordable by construction --
+#   the `detail` text still names which of the two actually fired. Nothing
+#   below this rung can outrank either kind of terminal verdict.
 # - Rung 2, rate_limit_signal: an observed limit-shaped dispatch failure for
 #   the active executor profile. Above auth because a rate limit is the
 #   cheaper, more common, and self-clearing of the two, and because a loop
@@ -1086,6 +1091,18 @@ def _stop_rung_explicit_cancel(goal_linked: bool, goal_status: str) -> tuple[str
         return (
             "fired",
             "The linked goal ledger is cancelled; it refuses every checkpoint, blocker, and gate.",
+        )
+    if goal_status == "failed":
+        # A negative but CONCLUSIVE verdict on the objective itself, reached
+        # through `fail_goal_ledger` -- not an operator's explicit cancel, but
+        # the same downstream fact: the ledger refuses every mutation, so a
+        # tick that proceeded would only fail loudly on its first write.
+        # Named distinctly from `cancelled` in `detail` on purpose: an
+        # operator reading this stop should not mistake a conclusive failure
+        # for someone having stopped the loop by hand.
+        return (
+            "fired",
+            "The linked goal ledger failed conclusively; it refuses every checkpoint, blocker, and gate.",
         )
     return ("clear", f"The linked goal ledger status is `{goal_status or 'unknown'}`.")
 

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -31,6 +31,12 @@ from omh.coding.fanout_artifacts import write_fanout_contract  # noqa: E402
 from omh.coding.fanout_artifacts import fanout_dispatch_summary_path  # noqa: E402
 from omh.coding.fanout_artifacts import fanout_unit_recovery_path  # noqa: E402
 from omh.coding.fanout_artifacts import unit_result_path  # noqa: E402
+from omh.coding.fanout_journal import (  # noqa: E402
+    RESUME_HOLD_DECLINED,
+    TERMINAL_DECLINED,
+    build_fanout_run_journal,
+    plan_fanout_resume,
+)
 from omh.coding.fanout_dispatch import (  # noqa: E402
     FANOUT_DEPTH_ENV_VAR,
     FANOUT_LINEAGE_ENV_VAR,
@@ -276,6 +282,41 @@ class FanoutUnitResultIntakeTests(unittest.TestCase):
             self.assertIn("observation_source", prompt)
             events = [event["event"] for event in show_run(paths, core["run_ref"])["journal_events"]]
             self.assertIn("unit_result_validated", events)
+
+    def test_a_declined_unit_reaches_the_journal_distinctly_and_resume_holds_it(self) -> None:
+        # #H end-to-end: a unit that validly reports `process_declined` must
+        # (a) never be selected by a resume plan and (b) land in the journal
+        # under its own terminal state, not folded into `failed`.
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract, sidecar, script = self._setup(tmp)
+            payload = _unit_result_payload(
+                contract, sha, process_status="process_declined", decline_reason="target_not_found"
+            )
+
+            def runner(argv, **kwargs):
+                if argv[0] == "git":
+                    return subprocess.run(argv, **kwargs)
+                sidecar.parent.mkdir(parents=True, exist_ok=True)
+                sidecar.write_text(json.dumps(payload), encoding="utf-8")
+                return _FakeCompleted(3, "cannot be done: target not found")
+
+            summary = self._dispatch(paths, repo, sha, contract, runner)
+
+            core = {entry["unit_id"]: entry for entry in summary["units"]}["core"]
+            self.assertFalse(core["process_succeeded"])
+            self.assertTrue(core["result_schema_valid"])
+            self.assertEqual(core["unit_result"]["process_status"], "process_declined")
+            self.assertEqual(core["unit_result"]["decline_reason"], "target_not_found")
+
+            journal = build_fanout_run_journal(summary)
+            row = {entry["unit_id"]: entry for entry in journal["units"]}["core"]
+            self.assertEqual(row["terminal_state"], TERMINAL_DECLINED)
+            self.assertEqual(row["decline_reason"], "target_not_found")
+
+            plan = plan_fanout_resume(journal, order=["core"], depends_on={"core": []})
+            self.assertEqual(plan["decisions"][0]["action"], RESUME_HOLD_DECLINED)
+            self.assertEqual(plan["selected_units"], [])
+            self.assertIn("core", plan["held_units"])
 
     def test_missing_sidecar_is_explicit_without_erasing_process_success(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -2692,6 +2733,60 @@ class FanoutDispatchSkillDiscoveryTests(unittest.TestCase):
 
 
 class FanoutBriefCliTests(unittest.TestCase):
+    def test_brief_surfaces_a_declined_units_reason_distinctly_from_failed(self) -> None:
+        # #H requirement (c): a reporting surface must render a
+        # negative-conclusive outcome distinctly from an ordinary failure.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            repo, sha = _make_repo(root)
+            units = [
+                {"unit_id": "core", "title": "Core", "owner": "codex", "file_scope": ["src/core/"]},
+            ]
+            contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, units))
+            sidecar = unit_result_path(paths, contract["fanout_id"], "core")
+            payload = _unit_result_payload(
+                contract, sha, process_status="process_declined", decline_reason="refused_by_policy"
+            )
+
+            def runner(argv, **kwargs):
+                if argv[0] == "git":
+                    return subprocess.run(argv, **kwargs)
+                sidecar.parent.mkdir(parents=True, exist_ok=True)
+                sidecar.write_text(json.dumps(payload), encoding="utf-8")
+                return _FakeCompleted(3, "refused")
+
+            dispatch_fanout(
+                paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                runner=runner, readiness=_ready,
+            )
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            status, stdout, stderr = run_cli(base + ["coding", "fanout", "brief", str(contract["fanout_id"])])
+            self.assertEqual(status, 0, stderr)
+            brief = json.loads(stdout)
+            core = {entry["unit_id"]: entry for entry in brief["units"]}["core"]
+            self.assertEqual(core["status"], "failed")
+            self.assertEqual(core["decline_reason"], "refused_by_policy")
+
+    def test_brief_leaves_decline_reason_empty_for_an_ordinary_failure(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            repo, sha = _make_repo(root)
+            units = [{"unit_id": "core", "title": "Core", "owner": "codex", "file_scope": ["src/core/"]}]
+            contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, units))
+            dispatch_fanout(
+                paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                runner=_agent_runner(fail_units={"core"}), readiness=_ready,
+            )
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            status, stdout, stderr = run_cli(base + ["coding", "fanout", "brief", str(contract["fanout_id"])])
+            self.assertEqual(status, 0, stderr)
+            brief = json.loads(stdout)
+            core = {entry["unit_id"]: entry for entry in brief["units"]}["core"]
+            self.assertEqual(core["status"], "failed")
+            self.assertEqual(core["decline_reason"], "")
+
     def test_brief_joins_contract_journal_and_dispatch_summary(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_fanout_journal.py
+++ b/tests/test_fanout_journal.py
@@ -40,16 +40,19 @@ from omh.coding.fanout_dispatch import dispatch_fanout  # noqa: E402
 from omh.coding.fanout_journal import (  # noqa: E402
     FANOUT_RESUME_PLAN_SCHEMA_VERSION,
     FANOUT_RUN_JOURNAL_SCHEMA_VERSION,
+    FAILURE_CLASS_DECLINED_CONCLUSIVE,
     JOURNAL_CORRUPT,
     JOURNAL_FANOUT_MISMATCH,
     JOURNAL_MISSING,
     JOURNAL_SCHEMA_UNSUPPORTED,
     RESUME_HOLD_BLOCKED_DEPENDENCY,
+    RESUME_HOLD_DECLINED,
     RESUME_HOLD_REPLAY_UNSAFE,
     RESUME_HOLD_SUCCEEDED,
     RESUME_RERUN_FAILED,
     RESUME_RERUN_NOT_ATTEMPTED,
     RESUME_UNSKIP_DEPENDENT,
+    TERMINAL_DECLINED,
     TERMINAL_FAILED,
     TERMINAL_NOT_ATTEMPTED,
     TERMINAL_SKIPPED_BY_DEPENDENCY,
@@ -130,6 +133,30 @@ def _blocked(unit_id: str, *, blocked_on: list[str]) -> dict[str, object]:
         "process_succeeded": False,
         "blocked_on": blocked_on,
     }
+
+
+def _declined(
+    unit_id: str, *, reason: str = "target_not_found", recovery: str | None = "no_changes"
+) -> dict[str, object]:
+    """A unit whose validated sidecar reported a conclusive negative answer.
+
+    `result_schema_valid` is set because only the dispatcher's own observation
+    that the sidecar validated -- never the raw claim alone -- may promote a
+    unit to `declined`; see `_unit_result_declined`.
+    """
+    entry: dict[str, object] = {
+        "unit_id": unit_id,
+        "run_ref": f"run-{unit_id}",
+        "owner": "codex",
+        "status": "failed",
+        "exit_code": 3,
+        "process_succeeded": False,
+        "result_schema_valid": True,
+        "unit_result": {"unit_id": unit_id, "process_status": "process_declined", "decline_reason": reason},
+    }
+    if recovery is not None:
+        entry["recovery"] = {"outcome": recovery}
+    return entry
 
 
 def _interrupted(unit_id: str) -> dict[str, object]:
@@ -215,6 +242,37 @@ class JournalProjectionTests(unittest.TestCase):
     def test_an_interrupted_batch_is_recorded_on_the_journal(self) -> None:
         journal = build_fanout_run_journal(_summary(_interrupted("core"), interrupted=True))
         self.assertTrue(journal["interrupted"])
+
+    def test_a_declined_unit_gets_its_own_terminal_state_distinct_from_failed(self) -> None:
+        # #H: a negative but CONCLUSIVE outcome ("the target does not exist")
+        # must not be shoehorned into `failed`, which implies a retry might
+        # help. The journal's own `declined_conclusive` class is used instead
+        # of `fanout_retry`'s `terminal_failure`, because the retry ladder
+        # never asked whether the answer was conclusive -- it only asked
+        # whether it was transient.
+        row = _rows(build_fanout_run_journal(_summary(_declined("core"))))["core"]
+        self.assertEqual(row["terminal_state"], TERMINAL_DECLINED)
+        self.assertNotEqual(row["terminal_state"], TERMINAL_FAILED)
+        self.assertEqual(row["failure_class"], FAILURE_CLASS_DECLINED_CONCLUSIVE)
+        self.assertEqual(row["decline_reason"], "target_not_found")
+
+    def test_a_declined_unit_is_never_promoted_from_an_unvalidated_self_report(self) -> None:
+        # Mirrors `fanout_unit_results`' own rule: only the dispatcher's own
+        # observation that a sidecar validated may promote a claim. A stray
+        # `process_declined` sitting under an entry the dispatcher never
+        # validated must not read as a decline.
+        entry = _failed("core")
+        entry["unit_result"] = {"unit_id": "core", "process_status": "process_declined", "decline_reason": "x"}
+        row = _rows(build_fanout_run_journal(_summary(entry)))["core"]
+        self.assertEqual(row["terminal_state"], TERMINAL_FAILED)
+        self.assertEqual(row["decline_reason"], "")
+
+    def test_a_succeeded_exit_outranks_a_stray_declined_self_report(self) -> None:
+        entry = _succeeded("core")
+        entry["result_schema_valid"] = True
+        entry["unit_result"] = {"unit_id": "core", "process_status": "process_declined", "decline_reason": "x"}
+        row = _rows(build_fanout_run_journal(_summary(entry)))["core"]
+        self.assertEqual(row["terminal_state"], TERMINAL_SUCCEEDED)
 
 
 class JournalRoundTripTests(unittest.TestCase):
@@ -334,6 +392,30 @@ class ResumeMatrixTests(unittest.TestCase):
     def test_an_unmeasured_worktree_is_held_the_same_way(self) -> None:
         plan = self._plan(_failed("core", recovery=None), _succeeded("docs"), _succeeded("tests"))
         self.assertEqual(_actions(plan)["core"], RESUME_HOLD_REPLAY_UNSAFE)
+
+    def test_a_declined_unit_is_held_and_never_selected_for_rerun(self) -> None:
+        # #H requirement (a): retry/resume must not select a negative-
+        # conclusive unit. Held even though it is replay-safe (no side
+        # effect): resuming it would not answer the question any differently.
+        plan = self._plan(
+            _declined("core", reason="refused_by_policy"),
+            _succeeded("docs"),
+            _blocked("tests", blocked_on=["core"]),
+        )
+        actions = _actions(plan)
+        self.assertEqual(actions["core"], RESUME_HOLD_DECLINED)
+        self.assertNotIn("core", plan["selected_units"])
+        self.assertIn("core", plan["held_units"])
+        self.assertIn("refused_by_policy", _reason(plan, "core"))
+        # Its dependent stays blocked, exactly like a replay-unsafe blocker:
+        # a decline never clears the way for downstream work either.
+        self.assertEqual(actions["tests"], RESUME_HOLD_BLOCKED_DEPENDENCY)
+
+    def test_a_declined_unit_is_held_even_when_replay_would_be_unsafe_too(self) -> None:
+        # A decline is unconditional: it is held for its own answer, not for
+        # what it may have touched on the way to reaching it.
+        plan = self._plan(_declined("core", recovery="recovery_available"))
+        self.assertEqual(_actions(plan)["core"], RESUME_HOLD_DECLINED)
 
     def test_units_the_interrupt_never_started_are_re_run(self) -> None:
         plan = self._plan(_succeeded("core"), _interrupted("docs"), _interrupted("tests"))

--- a/tests/test_fanout_unit_results.py
+++ b/tests/test_fanout_unit_results.py
@@ -18,6 +18,7 @@ load_local_package()
 
 from omh.coding.fanout_unit_results import (  # noqa: E402
     FANOUT_UNIT_RESULT_CHECK_STATUSES,
+    FANOUT_UNIT_RESULT_DECLINE_REASONS,
     FANOUT_UNIT_RESULT_PROCESS_STATUSES,
     FANOUT_UNIT_RESULT_SCHEMA_VERSION,
     validate_check_rows,
@@ -82,6 +83,7 @@ class FanoutUnitResultTests(unittest.TestCase):
         from omh.coding.fanout_dispatch import _unit_result_prompt_lines
         from omh.coding.fanout_unit_results import (
             FANOUT_UNIT_RESULT_CHECK_STATUSES,
+            FANOUT_UNIT_RESULT_DECLINE_REASONS,
             FANOUT_UNIT_RESULT_PROCESS_STATUSES,
         )
 
@@ -96,8 +98,17 @@ class FanoutUnitResultTests(unittest.TestCase):
                 }
             )
         )
-        for literal in FANOUT_UNIT_RESULT_PROCESS_STATUSES + FANOUT_UNIT_RESULT_CHECK_STATUSES:
+        for literal in (
+            FANOUT_UNIT_RESULT_PROCESS_STATUSES
+            + FANOUT_UNIT_RESULT_CHECK_STATUSES
+            + FANOUT_UNIT_RESULT_DECLINE_REASONS
+        ):
             self.assertIn(f'"{literal}"', prompt)
+        # #H: the prompt must steer a conclusively-unreachable unit toward
+        # `process_declined` rather than the generic `process_failed`, which
+        # implies a retry might help.
+        self.assertIn("decline_reason", prompt)
+        self.assertIn("process_declined", prompt)
 
     def test_natural_language_process_status_is_rejected_with_the_enum_named(self) -> None:
         with self.assertRaises(ValueError) as caught:
@@ -140,10 +151,50 @@ class FanoutUnitResultTests(unittest.TestCase):
         self.assertIn("process_status", str(caught.exception))
 
     def test_accepts_every_declared_process_status(self) -> None:
-        self.assertEqual(FANOUT_UNIT_RESULT_PROCESS_STATUSES, ("process_succeeded", "process_failed"))
+        self.assertEqual(
+            FANOUT_UNIT_RESULT_PROCESS_STATUSES,
+            ("process_succeeded", "process_failed", "process_declined"),
+        )
         for status in FANOUT_UNIT_RESULT_PROCESS_STATUSES:
             with self.subTest(status=status):
-                self.assertEqual(validate_unit_result(_payload(process_status=status))["process_status"], status)
+                overrides: dict[str, object] = {"process_status": status}
+                if status == "process_declined":
+                    overrides["decline_reason"] = "target_not_found"
+                self.assertEqual(validate_unit_result(_payload(**overrides))["process_status"], status)
+
+    def test_process_declined_requires_a_closed_decline_reason(self) -> None:
+        self.assertEqual(
+            FANOUT_UNIT_RESULT_DECLINE_REASONS,
+            (
+                "target_not_found",
+                "infeasible_as_specified",
+                "refused_by_policy",
+                "superseded_by_existing_work",
+                "other_declared",
+            ),
+        )
+        for reason in FANOUT_UNIT_RESULT_DECLINE_REASONS:
+            with self.subTest(reason=reason):
+                validated = validate_unit_result(
+                    _payload(process_status="process_declined", decline_reason=reason)
+                )
+                self.assertEqual(validated["decline_reason"], reason)
+        with self.assertRaises(ValueError) as missing:
+            validate_unit_result(_payload(process_status="process_declined"))
+        self.assertIn("decline_reason", str(missing.exception))
+        with self.assertRaises(ValueError) as unclosed:
+            validate_unit_result(_payload(process_status="process_declined", decline_reason="because"))
+        self.assertIn("decline_reason", str(unclosed.exception))
+
+    def test_decline_reason_is_refused_outside_a_decline(self) -> None:
+        for status in ("process_succeeded", "process_failed"):
+            with self.subTest(status=status):
+                with self.assertRaises(ValueError) as caught:
+                    validate_unit_result(
+                        _payload(process_status=status, decline_reason="target_not_found")
+                    )
+                self.assertIn("decline_reason", str(caught.exception))
+                self.assertIn("process_declined", str(caught.exception))
 
     def test_rejects_non_dict_payload(self) -> None:
         for payload in ([], "fanout_unit_result/v1", None, 7):

--- a/tests/test_goal_cli.py
+++ b/tests/test_goal_cli.py
@@ -51,6 +51,7 @@ class GoalCliRevisionGuardTests(unittest.TestCase):
             ("blocker", ["--summary", "s"]),
             ("complete", []),
             ("cancel", []),
+            ("fail", ["--summary", "s", "--reason-code", "target_not_found"]),
         ):
             with self.subTest(subcommand=subcommand):
                 args = parser.parse_args(
@@ -88,6 +89,56 @@ class GoalCliRevisionGuardTests(unittest.TestCase):
             self.assertIn("cancelled", stderr)
             self.assertIn("terminal", stderr)
             self.assertNotIn("Traceback", stderr)
+
+    def test_fail_reports_the_terminal_state_and_refuses_later_checkpoints(self) -> None:
+        # #H: `goal fail` reaches a negative-conclusive verdict distinct from
+        # `goal cancel` (operator decision) and `goal blocker` (recoverable).
+        with TemporaryDirectory() as tmp:
+            base = _base(Path(tmp))
+            _create(base)
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "goal", "fail", "--goal", "goal-cli-guard",
+                    "--summary", "The target does not exist in this environment.",
+                    "--reason-code", "target_not_found",
+                ]
+            )
+
+            self.assertEqual(status, 0, stderr)
+            payload = json.loads(stdout)
+            self.assertTrue(payload["failed"])
+            self.assertTrue(payload["applied"])
+            self.assertFalse(payload["replayed"])
+            self.assertEqual(payload["goal"]["status"], "failed")
+            self.assertEqual(payload["goal"]["failure_reason_code"], "target_not_found")
+            self.assertEqual(payload["completion_gate"]["next_action"], "show_status")
+
+            status, stdout, stderr = run_cli(
+                base + ["goal", "checkpoint", "--goal", "goal-cli-guard", "--summary", "After failure"]
+            )
+
+            self.assertEqual(status, 2)
+            self.assertEqual(stdout, "")
+            self.assertTrue(stderr.startswith("omh: "), stderr)
+            self.assertIn("failed", stderr)
+            self.assertIn("terminal", stderr)
+            self.assertNotIn("Traceback", stderr)
+
+    def test_fail_rejects_an_unsupported_reason_code_at_the_parser(self) -> None:
+        with TemporaryDirectory() as tmp:
+            base = _base(Path(tmp))
+            _create(base)
+
+            with self.assertRaises(SystemExit):
+                run_cli(
+                    base
+                    + [
+                        "goal", "fail", "--goal", "goal-cli-guard",
+                        "--summary", "s", "--reason-code", "not_a_real_code",
+                    ]
+                )
 
     def test_stale_expected_revision_exits_non_zero_with_a_readable_message(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_goal_ledger.py
+++ b/tests/test_goal_ledger.py
@@ -11,14 +11,17 @@ load_local_package()
 from omh.goal_ledger import (
     GOAL_COMPLETION_GATE_SCHEMA,
     GOAL_CONTINUATION_SCHEMA,
+    GOAL_FAILURE_REASON_CODES,
     GOAL_LEDGER_SCHEMA,
     GOAL_STATUS_CARD_SCHEMA,
+    GOAL_TERMINAL_STATUSES,
     build_goal_completion_gate,
     build_goal_continuation,
     build_goal_status_card,
     cancel_goal_ledger,
     complete_goal_ledger,
     create_goal_ledger,
+    fail_goal_ledger,
     goal_ledger_path,
     read_goal_ledger,
     record_goal_blocker,
@@ -316,6 +319,83 @@ class GoalLedgerTests(unittest.TestCase):
             self.assertEqual(blocked["blockers"][0]["status"], "active")
             self.assertEqual(gated["quality_gates"][0]["status"], "passed")
             self.assertTrue(validate_goal_ledger(gated)["ok"])
+
+    def test_fail_goal_ledger_records_a_negative_conclusive_terminal_status(self) -> None:
+        # #H: a goal that cannot be met at all (the target does not exist, the
+        # request is refused by policy) gets its own terminal status, distinct
+        # from `blocked` (recoverable) and `cancelled` (an operator decision).
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            create_goal_ledger(paths, "Migrate a table that turns out not to exist", ["Table migrated"], goal_id="goal-fail")
+
+            failed = fail_goal_ledger(
+                paths,
+                "goal-fail",
+                "The target table was never created in this environment.",
+                reason_code="target_not_found",
+                evidence_refs=["psql -c dt"],
+            )
+
+            self.assertEqual(failed["status"], "failed")
+            self.assertEqual(failed["failure_reason_code"], "target_not_found")
+            self.assertIn("target table", failed["failure_summary"])
+            self.assertEqual(failed["failure_evidence_refs"], ["psql -c dt"])
+            self.assertIn("failed", GOAL_TERMINAL_STATUSES)
+            self.assertTrue(validate_goal_ledger(failed)["ok"])
+
+    def test_fail_goal_ledger_requires_a_closed_reason_code(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            create_goal_ledger(paths, "Goal with an unsupported failure reason", ["AC"], goal_id="goal-bad-reason")
+
+            with self.assertRaises(ValueError):
+                fail_goal_ledger(paths, "goal-bad-reason", "because", reason_code="not_a_real_code")
+
+    def test_a_failed_goal_is_terminal_and_refuses_further_mutations(self) -> None:
+        # Requirement (a): terminal means retry/resume-shaped paths must not
+        # select it -- here, no further checkpoint, blocker, or gate applies.
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            create_goal_ledger(paths, "Goal that will conclusively fail", ["AC"], goal_id="goal-terminal")
+            fail_goal_ledger(paths, "goal-terminal", "Refused by policy.", reason_code="refused_by_policy")
+
+            with self.assertRaises(ValueError):
+                record_goal_checkpoint(paths, "goal-terminal", "Trying anyway")
+            with self.assertRaises(ValueError):
+                record_goal_blocker(paths, "goal-terminal", "Some blocker")
+            with self.assertRaises(ValueError):
+                fail_goal_ledger(paths, "goal-terminal", "Again", reason_code="refused_by_policy")
+
+    def test_a_failed_goals_completion_gate_and_status_card_render_distinctly(self) -> None:
+        # Requirement (c): reporting surfaces render the outcome distinctly
+        # from an ordinary in-progress or blocked goal.
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            create_goal_ledger(paths, "Goal that cannot be met as specified", ["AC"], goal_id="goal-render")
+            fail_goal_ledger(
+                paths, "goal-render", "Criteria are infeasible as specified.",
+                reason_code="infeasible_as_specified",
+            )
+
+            gate = build_goal_completion_gate(paths, "goal-render")
+            self.assertFalse(gate["ready"])
+            self.assertEqual(gate["next_action"], "show_status")
+            self.assertIn("goal status is failed", gate["summary"])
+
+            card = build_goal_status_card(paths, "goal-render")
+            self.assertEqual(card["goal_status"], "failed")
+            self.assertEqual(card["failure_reason_code"], "infeasible_as_specified")
+            self.assertIn("failed conclusively", card["safe_copy"]["next_step"])
+            self.assertIn("infeasible_as_specified", card["safe_copy"]["next_step"])
+            self.assertEqual(card["allowed_actions"], ["show_status"])
+
+    def test_reason_codes_are_closed_and_exhaustively_round_trip(self) -> None:
+        for reason in GOAL_FAILURE_REASON_CODES:
+            with self.subTest(reason=reason), TemporaryDirectory() as tmp:
+                paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+                create_goal_ledger(paths, f"Goal for {reason}", ["AC"], goal_id="goal-reason")
+                failed = fail_goal_ledger(paths, "goal-reason", "because", reason_code=reason)
+                self.assertEqual(failed["failure_reason_code"], reason)
 
     def test_validation_flags_raw_objective_and_bad_shape(self) -> None:
         validation = validate_goal_ledger(

--- a/tests/test_loop_stop_ladder.py
+++ b/tests/test_loop_stop_ladder.py
@@ -14,6 +14,7 @@ load_local_package()
 from omh.goal_ledger import (  # noqa: E402
     cancel_goal_ledger,
     create_goal_ledger,
+    fail_goal_ledger,
     record_goal_blocker,
     record_goal_checkpoint,
 )
@@ -135,6 +136,28 @@ class StopLadderRungTests(unittest.TestCase):
         self.assertEqual(stopped["runtime"]["last_stop_reason"], "explicit_cancel")
         self.assertEqual(stopped["runtime"]["queue"], [])
         self.assertIn("cancelled", stopped["runtime"]["stop_ladder"]["detail"])
+
+    def test_a_conclusively_failed_linked_goal_also_stops_the_tick(self) -> None:
+        # #H: `fail_goal_ledger`'s negative-conclusive verdict makes the ledger
+        # refuse every mutation exactly like `cancelled` does, so the loop must
+        # not proceed into a doomed write -- but the stop `detail` must name
+        # the failure distinctly from an operator's explicit cancel.
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            goal = create_goal_ledger(paths, "Objective that turns out infeasible", ["Criterion"])
+            fail_goal_ledger(
+                paths, goal["goal_id"], "Criteria are infeasible as specified.",
+                reason_code="infeasible_as_specified",
+            )
+            cycle = _cycle(paths, linked_goal_id=goal["goal_id"])
+
+            stopped = tick_loop_runtime(paths, cycle["loop_id"])
+
+        self.assertEqual(stopped["runtime"]["last_stop_reason"], "explicit_cancel")
+        self.assertEqual(stopped["runtime"]["queue"], [])
+        detail = stopped["runtime"]["stop_ladder"]["detail"]
+        self.assertIn("failed conclusively", detail)
+        self.assertNotIn("cancelled", detail)
 
     def test_fresh_rate_limit_signal_stops_the_tick(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Feature Report

### What Changed

- `fanout_unit_results`: a new `process_declined` value for `process_status`, gated by a required closed `decline_reason` (`target_not_found`, `infeasible_as_specified`, `refused_by_policy`, `superseded_by_existing_work`, `other_declared`). An executor reports this instead of `process_failed` when the work is conclusively impossible, not merely broken.
- `fanout_dispatch`: the prompt contract now names `process_declined`/`decline_reason` explicitly (and `FAILURE_KIND_PROTOCOL` in `unit_prompt_protocol` steers toward it); `_UNIT_RESULT_TOP_LEVEL_KEYS` carries `decline_reason` through to the persisted `unit_result`; `omh coding fanout brief` surfaces a `decline_reason` field per unit, empty for an ordinary failure.
- `fanout_journal`: a new terminal state `declined` (distinct from `failed`), derived only from a **dispatcher-validated** sidecar (`result_schema_valid`), never a bare executor claim — matching the module's existing "never launder a self-report" rule. A new resume action `hold_declined_conclusive` holds the unit unconditionally, checked ahead of replay-safety, so a resume never re-dispatches it even when replay would otherwise be safe. Its dependents stay blocked, exactly like a replay-unsafe blocker.
- `goal_ledger`: `GOAL_STATUSES` already declared `failed`, but nothing could ever reach it — no minting function existed, and it was missing from `GOAL_TERMINAL_STATUSES`. Added `fail_goal_ledger()` (mirrors `cancel_goal_ledger`), a required closed `--reason-code` vocabulary (`GOAL_FAILURE_REASON_CODES`), and made `failed` terminal alongside `complete`/`cancelled` so `require_not_terminal` refuses further checkpoints/blockers/gates. Fixed two `cancelled`-only branches that would otherwise have advertised now-refused actions on a failed goal: `_allowed_goal_actions` and the completion gate's `next_action` override (`_completion_next_action`'s `status_gaps` branch used to suggest `record_blocker`, which the ledger would then refuse).
- `commands/goal.py`: new `omh goal fail --goal ID --summary ... --reason-code ...` CLI command, wired the same way as `goal cancel` (revision guard flags, mutation-id replay semantics).
- `goal_loop`: the stop ladder's rung 1 (`explicit_cancel`) now also fires when the linked goal is `failed`, with its own `detail` line distinct from a human cancel, so a loop does not proceed into a tick that would raise on its first ledger write.

### Why This Exists

Backlog item H ("Negative outcomes as first-class terminal statuses", `.omc/research/ohmypi-optimization-2026-08-29.md`): an operation that ends in a conclusive **negative** outcome ("cannot be done because X") was being shoehorned into either `failed` (implies a retry might help) or `succeeded` (implies the goal was achieved). Neither claim is honest. Two real gaps existed in the tree:

1. A fanout unit that concludes its task is impossible had no way to say so — it could only report `process_failed`, and a resumed dispatch would blindly re-run it.
2. `goal_ledger.GOAL_STATUSES` already contained `failed` as a value, and downstream code (`goal_loop`'s `goal_status_gap` constraint, `build_goal_completion_gate`'s `status_gaps`) already anticipated it — but no code path could ever produce it. It was dead vocabulary.

### User / Operator Impact

- A fanout executor can now report "this cannot be done" distinctly, with a structured reason, and that unit will never be silently re-dispatched by `omh coding fanout dispatch --resume`.
- An operator (or a loop) can now record that a goal failed conclusively, with a reason, via `omh goal fail`; the goal ledger and any linked loop stop cleanly instead of either looping forever or crashing on the next mutation attempt.
- `omh coding fanout brief` reports a distinct `decline_reason` per unit.

### How It Works

- **Terminal, not retryable (requirement a).** `fanout_journal._unit_resume_decision` checks `TERMINAL_DECLINED` before the replay-safety check, so a decline is held unconditionally — replay-safe or not. `goal_ledger.fail_goal_ledger` sets `status="failed"`, which is now in `GOAL_TERMINAL_STATUSES`, so `require_not_terminal` refuses every later checkpoint/blocker/gate/re-fail the same way `cancelled` already does.
- **Structured reason (requirement b).** `decline_reason` (fanout) and `--reason-code` (goal) are both required, closed vocabularies — never free text — following the pattern the rest of the tree uses (`blocked_work_records.reason_code`, `fanout_retry`'s failure classes).
- **Rendered distinctly (requirement c).** `fanout_journal` gives a decline its own `terminal_state` (`declined`) and `failure_class` (`declined_conclusive`, not `fanout_retry`'s `terminal_failure`); `omh coding fanout brief` and the resume plan's `reason` text both name it explicitly. `goal_ledger`'s status card carries `failure_reason_code`/`failure_summary` and a distinct `safe_copy.next_step` line; `goal_loop`'s stop-ladder `detail` names "failed conclusively" distinctly from "cancelled".
- **The INCONCLUSIVE boundary, documented not touched.** `paired_run_model.PairedRunVerdict.INCONCLUSIVE` (#1189, live-benchmark) is a different concept — a grader's inability to compare baseline vs. candidate — not a unit's own conclusive negative answer about its task. Nothing there changes.

### Files And Contracts Touched

- `src/coding/fanout_unit_results.py` — `fanout_unit_result/v1` contract: `process_declined`, `FANOUT_UNIT_RESULT_DECLINE_REASONS`.
- `src/coding/fanout_journal.py` — `fanout_run_journal/v1` and `fanout_resume_plan/v1`: `TERMINAL_DECLINED`, `FAILURE_CLASS_DECLINED_CONCLUSIVE`, `RESUME_HOLD_DECLINED`, `decline_reason` journal key.
- `src/coding/fanout_dispatch.py` — prompt contract text, `_UNIT_RESULT_TOP_LEVEL_KEYS`.
- `src/coding/unit_prompt_protocol.py` — `FAILURE_KIND_PROTOCOL` (shared prompt preamble; verified still under `UNIT_PROMPT_MAX_BYTES`).
- `src/commands/coding.py` — `fanout_briefing/v1`: `decline_reason` field on `omh coding fanout brief`.
- `src/workflows/goal_ledger.py` — `goal_ledger/v1`: `GOAL_TERMINAL_STATUSES`, `GOAL_FAILURE_REASON_CODES`, `fail_goal_ledger()`, `_allowed_goal_actions`, `_completion_next_action` override, `_goal_safe_copy`, `build_goal_status_card`.
- `src/workflows/goal_loop.py` — `loop_stop_ladder/v1`: `_stop_rung_explicit_cancel`.
- `src/commands/goal.py` — new `omh goal fail` subcommand.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [x] Codex
- [x] Claude Code
- [ ] Hermes runtime or handoff
- [x] Generic executor
- [ ] Not executor-specific

(Any agent CLI dispatched as a fanout unit is the "executor" that reports `process_declined`; this is executor-neutral by construction — the contract lives in `fanout_unit_result/v1`, not in any one CLI's adapter.)

## Validation

Check only commands that completed successfully. Leave non-applicable checks
unchecked and explain why under **Not Tested / Not Applicable**.

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli release checklist --json`
- [x] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [x] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- `uv run --group lint ruff check src tests` → `All checks passed!`
- `uv run python -m compileall -q src tests` → clean (only a pre-existing, unrelated `SyntaxWarning` in `tests/test_menubar_app.py`).
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` → `Ran 8179 tests ... FAILED (failures=21, errors=7)`, 28 total, every one of them in `test_cross_harness_adapters.py` / `test_cross_harness_adapter_security.py` with `reason_code == "unsafe_read_root"` — the known cross-harness `.claude`-worktree-path failures, present before this change and unrelated to any file this PR touches. No failure appears in `test_fanout_dispatch`, `test_fanout_journal`, `test_fanout_unit_results`, `test_unit_prompt_protocol`, `test_goal_ledger`, `test_goal_cli`, `test_loop_stop_ladder`, or `test_broad_exception_policy` (all ran green, including every new test added by this PR).
- Five docs `--check` gates (`docs workflows`, `docs roles`, `docs capability-families`, `docs ulw-inventory`, `docs ulw-site`) each returned `"ok":true`.
- `uv run python -m omh.cli release drift` → `No drift. 17 checks passed.`
- `git diff --check` → exit 0, no whitespace errors.
- `uv run python -m omh.cli harness validate` → `"ok":true`.
- `omh --help`, `uv run python -m omh.cli release checklist --json`, `uv run python -m omh.cli release hermes-smoke` all ran successfully (plan mode; no profile mutation).
- New/updated tests exercising this PR's contract directly: `tests/test_fanout_unit_results.py` (`process_declined` round-trip, `decline_reason` required/forbidden), `tests/test_fanout_journal.py` (declined terminal state, `declined_conclusive` failure class, resume hold ahead of replay-safety), `tests/test_fanout_dispatch.py` (end-to-end dispatch → journal → resume-plan for a declined unit; `fanout brief` distinct rendering), `tests/test_goal_ledger.py` (`fail_goal_ledger`, terminal refusal, rendering), `tests/test_goal_cli.py` (`omh goal fail` CLI), `tests/test_loop_stop_ladder.py` (stop ladder fires on a failed linked goal with a distinct detail line).

### Not Tested / Not Applicable

- `--include-command-smoke` full installed-command smoke: not run (requires an isolated `/tmp` install path and takes several minutes beyond what this feature PR's surface needs; the plan-mode `release hermes-smoke` and `omh --help` already cover console-script importability).
- No live Hermes tap smoke: requires release authority and mutates a target profile; out of scope for a feature PR, and this PR's `merge` protocol says not to merge, only to open the PR for review.
- `hermes-child dispatch` negative-conclusive status: **deferred, see Follow-Up** — not implemented in this PR, so there is nothing to test.

## Risk

- Narrow and additive. `GOAL_TERMINAL_STATUSES` gained one member (`failed`); `GOAL_TERMINAL_STATUSES` has exactly one consumer in the tree (`goal_ledger.py` itself, confirmed by grep), so the blast radius is contained to that file plus the two `cancelled`-only branches this PR also fixed.
- `fanout_journal`'s resume-decision ordering changed (a `TERMINAL_DECLINED` check now runs before the replay-safety check) — this only changes behavior for units carrying a validated `process_declined` sidecar, which did not exist before this PR, so no prior behavior changes for any existing unit.
- The shared unit prompt preamble (`FAILURE_KIND_PROTOCOL`, `unit_prompt_protocol.py`) grew by one sentence; `tests/test_unit_prompt_protocol.py::PromptBudgetPolicyTests::test_worst_case_prompt_stays_under_budget` still passes under `UNIT_PROMPT_MAX_BYTES` (8000 bytes).

## Compatibility / Rollout

- Backward compatible. Existing `fanout_unit_result/v1` sidecars with `process_status` of `process_succeeded`/`process_failed` are unaffected; `decline_reason` is refused (not silently ignored) outside a decline, so a stray field cannot appear unnoticed.
- Existing goal ledgers with `status` other than `failed` are unaffected. A goal ledger record that somehow already carries `status: "failed"` from before this PR (should not exist, since nothing could write it) would now correctly become terminal rather than silently accepting further mutations — this is a fix, not a regression, and `validate_goal_ledger` now also requires `failure_reason_code`/`failure_summary` on any `failed` record.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`) — pure library/CLI addition, no channel-specific behavior.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap (see Not Tested)

## Follow-Up

- **hermes-child dispatch observations** (`src/coding/hermes_child_dispatch.py`, `hermes_child_receipts.py`): status vocabulary is `prepared`/`completed`/`failed`/`timed_out`/`cancelled`, with no structured self-report contract analogous to `fanout_unit_result/v1`. Adding a negative-conclusive status there needs a new typed contract (what would report the decline reason?), not a reuse of this PR's mechanism — deliberately deferred rather than forced.
- **`blocked_work_records`** (`src/workflows/blocked_work_records.py`) already expresses a closely related but distinct concept: its `blocked` outcome is a *pre-flight* denial (permission/safety gate refuses before any run exists), already terminal-shaped (`OUTCOME_LIFECYCLE["blocked"] = "paused"`, with a required `recovery_action`). It is not extended here because it already satisfies (a)/(b)/(c) for its own lane; no gap was found.
- Consider whether `fanout_retry`'s `CLASS_TERMINAL_FAILURE` should eventually be split further (e.g. distinguishing "real test failure" from other non-retryable shapes) — out of scope here; this PR only carves out the `declined_conclusive` case the dossier specifically calls for.
