### PR TITLE
feat(coding): deterministic request-complexity scorer feeding a model recommendation

### DIFF
--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -450,6 +450,27 @@ Rules:
   deliberately not configurable here — the local-inventory catalog remains
   their single override source, so "which basis resolved this route" always
   has one answer.
+- **Request complexity (advisory).** `omh coding complexity "<request>"`
+  scores a request deterministically — no model, no network — and returns a
+  tier (`light` / `standard` / `deep`) with every contributing signal named,
+  weighted, and carrying its own evidence. The score is exactly the sum of the
+  listed signals, so a tier is always explainable from the payload alone.
+  Signals: `architecture_keywords` (+3), `impact_system_wide` (+3),
+  `subtasks_many` (+4), `risk_keywords` (+2), `debugging_keywords` (+2),
+  `fanout_intent` (+2), `cross_file` (+2), `message_length` (+1/+2),
+  `routed_skill_class` (+1/+2), and `simple_request` (−2, the only signal that
+  subtracts). The tier names a model *class* — a `MODEL_CATEGORIES` member —
+  which resolves through the user's own
+  `<omh-home>/routing/model-chains.json` chains, so no model id is ever
+  hardcoded; a class the user's chains do not cover is named as
+  `class_not_in_chains` rather than substituted. `--model` / `--effort` record
+  an explicit choice, which supersedes the recommendation (still printed, so
+  what was set aside stays visible). The same two blocks
+  (`request_complexity/v1` and `complexity_model_recommendation/v1`) ride every
+  prepared handoff from `omh coding delegate`. This is a recommendation, never
+  a route: the declared `role` / `depth` / `category` / `scale` dials that
+  `resolve_model_route` reads stay declared by the caller, never inferred from
+  phrasing.
 - **Model inventory (reporting-only).** `omh coding model-inventory` reports
   which coding models the user has locally activated before any split or
   delegation is proposed: agent CLIs on PATH (codex, claude, opencode,
@@ -684,6 +705,7 @@ omh coding category-maestro set <profile> <category> <model[:effort]>...
 omh coding category-maestro clear <profile> <category>
 omh coding category-maestro interview          # guided per-profile walk (terminal only)
 omh coding model-inventory [--json]
+omh coding complexity <request> [--skill <workflow>] [--model <id>] [--effort <level>] [--json]
 omh coding composition-guide [--model <id>] [--json]
 ```
 

--- a/src/coding/coding_delegation.py
+++ b/src/coding/coding_delegation.py
@@ -6,7 +6,7 @@ from functools import lru_cache
 import hashlib
 from pathlib import Path
 import re
-from typing import Any
+from typing import Any, Mapping
 
 from ..coding_contracts import (
     CLAUDE_CODE_SESSION_OBSERVATION_CONTRACT_SCHEMA_VERSION,
@@ -363,6 +363,9 @@ def build_coding_delegation_payload(
     live_safety_profile_revision: str | None = None,
     requested_authority_actions: tuple[str, ...] | list[str] | None = None,
     model_recommendation: dict[str, object] | None = None,
+    model_chains: Mapping[str, Sequence[tuple[str, str]]] | None = None,
+    requested_model: str = "",
+    requested_effort: str = "",
 ) -> dict[str, object]:
     """Prepare coding work through Maestro for external owners and natively for Hermes."""
 
@@ -407,6 +410,9 @@ def build_coding_delegation_payload(
                 live_safety_profile_revision=live_safety_profile_revision,
                 requested_authority_actions=requested_authority_actions,
                 model_recommendation=model_recommendation,
+                model_chains=dict(model_chains) if model_chains is not None else None,
+                requested_model=requested_model,
+                requested_effort=requested_effort,
             )
         try:
             return maestro_facade.build_external_handoff(request).payload
@@ -445,6 +451,9 @@ def build_coding_delegation_payload(
         live_safety_profile_revision=live_safety_profile_revision,
         requested_authority_actions=requested_authority_actions,
         model_recommendation=model_recommendation,
+        model_chains=model_chains,
+        requested_model=requested_model,
+        requested_effort=requested_effort,
     )
 
 
@@ -476,6 +485,9 @@ def _build_coding_delegation_payload_native(
     live_safety_profile_revision: str | None = None,
     requested_authority_actions: tuple[str, ...] | list[str] | None = None,
     model_recommendation: dict[str, object] | None = None,
+    model_chains: Mapping[str, Sequence[tuple[str, str]]] | None = None,
+    requested_model: str = "",
+    requested_effort: str = "",
 ) -> dict[str, object]:
     message = message.strip()
     if not message:
@@ -807,6 +819,14 @@ def _build_coding_delegation_payload_native(
         category=model_route_category,
         recommendation=model_recommendation,
     )
+    _attach_request_complexity(
+        payload,
+        message,
+        routed_skill=delegation.recommended_workflow,
+        chains=model_chains,
+        requested_model=requested_model,
+        requested_effort=requested_effort,
+    )
     specialist_work_quality = build_specialist_work_quality_contract(
         delegation.recommended_workflow,
         phase="implementation" if delegation.action == "delegate" else "planning",
@@ -838,6 +858,35 @@ def _build_coding_delegation_payload_native(
     if agentic_playbook:
         payload["agentic_playbook"] = agentic_playbook
     return payload
+
+
+def _attach_request_complexity(
+    payload: dict[str, object],
+    message: str,
+    *,
+    routed_skill: str,
+    chains: Mapping[str, Sequence[tuple[str, str]]] | None,
+    requested_model: str,
+    requested_effort: str,
+) -> None:
+    """Attach the deterministic complexity read and the model-class recommendation.
+
+    Both blocks are advisory: nothing here changes `model_route_category`, the
+    resolved recommendation, or any handoff field. The complexity block carries
+    only derived values — signal names from this repo's own closed vocabulary
+    plus counts — so no user request text crosses into the payload through it,
+    which keeps `include_message` the single gate on raw content.
+    """
+    from .request_complexity import recommend_model_for_complexity, score_request_complexity
+
+    complexity = score_request_complexity(message, routed_skill=routed_skill)
+    payload["request_complexity"] = complexity
+    payload["complexity_model_recommendation"] = recommend_model_for_complexity(
+        complexity,
+        chains=chains,
+        requested_model=requested_model,
+        requested_effort=requested_effort,
+    )
 
 
 def _attach_model_routing_metadata(

--- a/src/coding/maestro/contracts.py
+++ b/src/coding/maestro/contracts.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, Mapping, Protocol, TypeAlias
+from typing import Literal, Mapping, Protocol, Sequence, TypeAlias
 
 
 ExternalProfile: TypeAlias = Literal[
@@ -57,6 +57,13 @@ class ExternalHandoffRequest:
     live_safety_profile_revision: str | None = None
     requested_authority_actions: tuple[str, ...] | list[str] | None = None
     model_recommendation: dict[str, object] | None = None
+    # The user's effective category -> chain mapping, already read by the
+    # caller so this contract stays I/O-free, plus the explicit per-request
+    # model/effort. All three feed the advisory complexity recommendation
+    # only; none of them route.
+    model_chains: dict[str, Sequence[tuple[str, str]]] | None = None
+    requested_model: str = ""
+    requested_effort: str = ""
 
 
 @dataclass(frozen=True)

--- a/src/coding/maestro/facade.py
+++ b/src/coding/maestro/facade.py
@@ -76,6 +76,9 @@ def build_external_handoff(request: ExternalHandoffRequest) -> PreparedExternalH
         live_safety_profile_revision=request.live_safety_profile_revision,
         requested_authority_actions=request.requested_authority_actions,
         model_recommendation=request.model_recommendation,
+        model_chains=request.model_chains,
+        requested_model=request.requested_model,
+        requested_effort=request.requested_effort,
     )
     selected_profile = payload.get("selected_executor_profile")
     if selected_profile == "hermes" or payload.get("work_owner_mode") == "retained_hermes":

--- a/src/coding/request_complexity.py
+++ b/src/coding/request_complexity.py
@@ -1,0 +1,527 @@
+"""Deterministic request-complexity scoring (`request_complexity/v1`).
+
+`score_request_complexity` is a pure function over the request text and the
+routed skill name: same inputs, byte-identical payload, no I/O, no clock, no
+environment reads, no network, no model. It reports how much work a request
+looks like, so a prepared handoff can RECOMMEND a model class and reasoning
+effort with every input disclosed.
+
+Three boundaries hold this module honest:
+
+- **Advisory only.** The tier never becomes a route. `model_routing` keeps its
+  documented contract that role/depth/scale are DECLARED by the caller and
+  never inferred from phrasing; this scorer produces a separate recommendation
+  block that a human or a caller may then declare. Nothing here is imported by
+  `resolve_model_route`, and a test pins that direction.
+- **Explainable from the payload alone.** Every point in `score` comes from a
+  named signal in `signals`, each carrying its weight and the evidence that
+  fired it. `score == sum(signal["weight"] for signal in signals)` is an
+  invariant, not a coincidence, so a tier can always be traced back to words.
+- **The user outranks the score.** An explicit `--model`/`--effort` (or a
+  configured equivalent) supersedes the recommendation, and the payload says
+  so in `status` rather than quietly dropping the suggestion.
+
+Model names are never written here. A tier maps to a model *class* — a member
+of `MODEL_CATEGORIES` — which resolves against the user's own configured
+chains (`<omh-home>/routing/model-chains.json` merged over the shipped
+defaults). A user who rewrote a chain gets their own models back.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Final, Mapping, Sequence
+
+from ..routing.localization import normalized_phrase
+from .model_routing import MODEL_CATEGORIES, REASONING_EFFORT_LADDER
+
+REQUEST_COMPLEXITY_SCHEMA_VERSION: Final[str] = "request_complexity/v1"
+COMPLEXITY_MODEL_RECOMMENDATION_SCHEMA_VERSION: Final[str] = "complexity_model_recommendation/v1"
+
+# Weakest to strongest. Order is load-bearing: consumers compare positions.
+COMPLEXITY_TIERS: Final[tuple[str, ...]] = ("light", "standard", "deep")
+
+# Inclusive lower bounds, strongest first. A score below every bound is the
+# weakest tier. Thresholds and signal weights are deliberately small integers
+# so a reader can add them up by hand from the payload.
+COMPLEXITY_TIER_THRESHOLDS: Final[tuple[tuple[str, int], ...]] = (
+    ("deep", 8),
+    ("standard", 4),
+)
+
+COMPLEXITY_CLAIM_BOUNDARY: Final[str] = (
+    "A complexity score is a deterministic reading of the request text and the routed skill name. "
+    "It is a recommendation input, not a route, not a model choice, and not execution, review, CI, "
+    "or merge evidence. omh never calls a model to produce it and never applies it without the "
+    "caller declaring the dial themselves; an explicit user model or effort always wins."
+)
+
+# Message length bands, in characters of the stripped request. Long requests
+# carry more scope than short ones often enough to be worth a point, and never
+# more than two — length is corroboration, never a tier on its own.
+COMPLEXITY_LENGTH_BANDS: Final[tuple[tuple[str, int, int], ...]] = (
+    ("brief", 0, 0),
+    ("medium", 200, 1),
+    ("long", 600, 2),
+)
+
+# Routed-skill class weights over the capability-family vocabulary. The family
+# id is OMH's own closed taxonomy for what a workflow does, so this table
+# cannot drift into a parallel domain vocabulary. Families absent from the
+# table weigh nothing, as does an unrouted request.
+COMPLEXITY_SKILL_CLASS_WEIGHTS: Final[dict[str, int]] = {
+    "delegate_coding_and_ship": 2,
+    "plan_and_decide": 1,
+    "operate_and_observe": 1,
+    "learn_and_gather": 1,
+}
+
+# Tier -> model class. Values are members of `MODEL_CATEGORIES`, which is also
+# the key vocabulary of the user's chain-override document, so a recommendation
+# resolves through the user's config instead of naming a model.
+COMPLEXITY_TIER_MODEL_CLASSES: Final[dict[str, str]] = {
+    "light": "quick",
+    "standard": "unspecified-high",
+    "deep": "deep",
+}
+
+# Tier -> reasoning-effort suggestion, as rungs of `REASONING_EFFORT_LADDER`.
+COMPLEXITY_TIER_EFFORTS: Final[dict[str, str]] = {
+    "light": "low",
+    "standard": "medium",
+    "deep": "high",
+}
+
+COMPLEXITY_RECOMMENDATION_STATUSES: Final[tuple[str, ...]] = (
+    "recommended",
+    "superseded_by_user_override",
+)
+
+COMPLEXITY_CHAIN_STATUSES: Final[tuple[str, ...]] = (
+    "resolved",
+    "class_not_in_chains",
+    "no_chain_config",
+)
+
+# Caps borrowed from the surveyed prior art: an extractor that counts without a
+# ceiling lets one pathological paste dominate every other signal.
+_MAX_COUNTED_PATHS: Final[int] = 20
+_MAX_COUNTED_SUBTASKS: Final[int] = 10
+
+_PATH_RE: Final[re.Pattern[str]] = re.compile(r"(?<![\w./-])[\w][\w./-]*/[\w./-]*\.[a-z]{1,6}(?![\w])|(?<![\w./-])[\w][\w.-]*\.(?:py|ts|tsx|js|jsx|go|rs|java|rb|md|json|yaml|yml|toml|sh|sql|css|html)(?![\w])")
+_ORDERED_STEP_RE: Final[re.Pattern[str]] = re.compile(r"(?m)^\s*(?:\d+[.)]|[-*+])\s+\S")
+
+
+@dataclass(frozen=True)
+class ComplexitySignal:
+    """One named, weighted contribution to a complexity score.
+
+    `phrases` are matched against the accent-folded, case-folded request text
+    through `normalized_phrase`, the same folding the router uses, so a signal
+    cannot fire on casing or diacritics alone. Signals whose evidence is
+    counted rather than phrased carry an empty `phrases` and are computed in
+    `_derived_signals`.
+    """
+
+    name: str
+    weight: int
+    describe: str
+    phrases: tuple[str, ...] = ()
+
+
+# The only negative signal is `simple_request`. Everything else adds, so a
+# score can be read as "how many reasons to spend more", and a trivial request
+# has to earn its way up from below zero.
+COMPLEXITY_SIGNALS: Final[tuple[ComplexitySignal, ...]] = (
+    ComplexitySignal(
+        "architecture_keywords",
+        3,
+        "Design-level work: the shape of the system changes, not just its lines.",
+        (
+            "architecture",
+            "architectural",
+            "rearchitect",
+            "re-architect",
+            "redesign",
+            "restructure",
+            "refactor",
+            "rewrite",
+            "migration",
+            "migrate",
+            "schema change",
+            "data model",
+            "design doc",
+            "decouple",
+        ),
+    ),
+    ComplexitySignal(
+        "impact_system_wide",
+        3,
+        "Blast radius is stated as the whole surface rather than one place.",
+        (
+            "system-wide",
+            "system wide",
+            "across the codebase",
+            "across the repo",
+            "across every",
+            "across all",
+            "entire codebase",
+            "entire repo",
+            "whole codebase",
+            "every module",
+            "every service",
+            "every caller",
+            "all callers",
+            "all services",
+            "end-to-end",
+            "end to end",
+            "everywhere",
+        ),
+    ),
+    ComplexitySignal(
+        "risk_keywords",
+        2,
+        "Failure here is expensive: security, concurrency, or data-integrity work.",
+        (
+            "security",
+            "vulnerability",
+            "authentication",
+            "authorization",
+            "credential",
+            "secret",
+            "injection",
+            "concurrency",
+            "concurrent",
+            "race condition",
+            "deadlock",
+            "thread safety",
+            "thread-safe",
+            "data loss",
+            "corruption",
+            "rollback",
+            "backwards compatibility",
+            "backward compatibility",
+        ),
+    ),
+    ComplexitySignal(
+        "debugging_keywords",
+        2,
+        "Investigation before repair: the cause is not yet known.",
+        (
+            "root cause",
+            "root-cause",
+            "regression",
+            "stack trace",
+            "traceback",
+            "reproduce",
+            "reproduction",
+            "flaky",
+            "intermittent",
+            "why does it fail",
+            "why is it failing",
+            "bisect",
+            "heisenbug",
+        ),
+    ),
+    ComplexitySignal(
+        "fanout_intent",
+        2,
+        "The request asks for parallel or split execution, not a single pass.",
+        (
+            "in parallel",
+            "parallelize",
+            "parallelise",
+            "fanout",
+            "fan out",
+            "fan-out",
+            "concurrently",
+            "multiple agents",
+            "several agents",
+            "split the work",
+            "split it up",
+            "at the same time",
+        ),
+    ),
+    ComplexitySignal(
+        "simple_request",
+        -2,
+        "Stated as a one-liner or a lookup; the only signal that subtracts.",
+        (
+            "typo",
+            "one-liner",
+            "one liner",
+            "single line",
+            "one line",
+            "rename",
+            "bump the version",
+            "bump version",
+            "quick question",
+            "just tell me",
+            "what is",
+            "what does",
+            "where is",
+            "print the",
+            "list the files",
+            "add a comment",
+            "fix the spelling",
+        ),
+    ),
+)
+
+# Derived signals are computed, not phrase-matched, and are named here so the
+# full signal vocabulary is one closed list a test can assert against.
+COMPLEXITY_DERIVED_SIGNAL_NAMES: Final[tuple[str, ...]] = (
+    "subtasks_many",
+    "cross_file",
+    "message_length",
+    "routed_skill_class",
+)
+
+COMPLEXITY_SIGNAL_NAMES: Final[tuple[str, ...]] = tuple(
+    [signal.name for signal in COMPLEXITY_SIGNALS] + list(COMPLEXITY_DERIVED_SIGNAL_NAMES)
+)
+
+
+def score_request_complexity(
+    message: str,
+    *,
+    routed_skill: str = "",
+) -> dict[str, object]:
+    """Score one request and return its tier with every contributing signal named.
+
+    `routed_skill` is a workflow name from the skill catalog; it is resolved to
+    a capability-family id and weighted by class. An unknown or empty name
+    contributes nothing rather than guessing.
+    """
+    text = str(message or "")
+    folded = normalized_phrase(text)
+    skill = str(routed_skill or "").strip()
+    skill_class = complexity_class_for_skill(skill)
+
+    signals: list[dict[str, object]] = []
+    for signal in COMPLEXITY_SIGNALS:
+        evidence = _matched_phrases(folded, signal.phrases)
+        if evidence:
+            signals.append(_signal_payload(signal.name, signal.weight, signal.describe, evidence))
+    signals.extend(_derived_signals(text, folded, skill, skill_class))
+
+    score = sum(int(entry["weight"]) for entry in signals)
+    return {
+        "schema_version": REQUEST_COMPLEXITY_SCHEMA_VERSION,
+        "score": score,
+        "tier": tier_for_score(score),
+        "signals": signals,
+        "routed_skill": skill,
+        "routed_skill_class": skill_class,
+        "thresholds": [{"tier": tier, "min_score": bound} for tier, bound in COMPLEXITY_TIER_THRESHOLDS],
+        "claim_boundary": COMPLEXITY_CLAIM_BOUNDARY,
+    }
+
+
+def tier_for_score(score: int) -> str:
+    """Return the tier for one score using the inclusive lower bounds."""
+    for tier, bound in COMPLEXITY_TIER_THRESHOLDS:
+        if score >= bound:
+            return tier
+    return COMPLEXITY_TIERS[0]
+
+
+def complexity_class_for_skill(routed_skill: str) -> str:
+    """Return the capability-family id for one workflow name, or an empty sentinel.
+
+    The capability-family projection is imported lazily on purpose: `src/coding`
+    has no import-time edge into the skill catalog today, and a scorer is not a
+    reason to add one.
+    """
+    name = str(routed_skill or "").strip()
+    if not name:
+        return ""
+    from ..capabilities.families import family_id_for_workflow
+
+    return family_id_for_workflow(name)
+
+
+def recommend_model_for_complexity(
+    complexity: Mapping[str, object],
+    *,
+    chains: Mapping[str, Sequence[tuple[str, str]]] | None = None,
+    requested_model: str = "",
+    requested_effort: str = "",
+) -> dict[str, object]:
+    """Prepare the model-class recommendation for one scored request.
+
+    `chains` is the user's effective category -> chain mapping (shipped
+    defaults with `<omh-home>/routing/model-chains.json` merged over them).
+    Passing `None` means no chain config was read; the class and effort are
+    still reported, the concrete model is not invented.
+
+    Effort precedence matches `model_routing`: requested effort > chain-entry
+    effort > the tier suggestion. An explicit requested model or effort makes
+    the whole block `superseded_by_user_override` — the recommendation is still
+    disclosed so the reader can see what was set aside, never applied.
+    """
+    tier = str(complexity.get("tier") or COMPLEXITY_TIERS[0])
+    if tier not in COMPLEXITY_TIER_MODEL_CLASSES:
+        tier = COMPLEXITY_TIERS[0]
+    model_class = COMPLEXITY_TIER_MODEL_CLASSES[tier]
+    tier_effort = COMPLEXITY_TIER_EFFORTS[tier]
+
+    chain_entries: list[dict[str, str]] = []
+    chain_status = "no_chain_config"
+    if chains is not None:
+        chain_status = "class_not_in_chains"
+        for model, effort in chains.get(model_class, ()) or ():
+            chain_entries.append({"model": str(model), "reasoning_effort": str(effort)})
+        if chain_entries:
+            chain_status = "resolved"
+
+    model = str(requested_model or "").strip()
+    effort = str(requested_effort or "").strip()
+    overridden = bool(model or effort)
+
+    head = chain_entries[0] if chain_entries else {}
+    resolved_effort = effort or head.get("reasoning_effort", "") or tier_effort
+    resolved: dict[str, str] = {}
+    if head:
+        resolved = {"model": head["model"], "reasoning_effort": resolved_effort}
+
+    payload: dict[str, object] = {
+        "schema_version": COMPLEXITY_MODEL_RECOMMENDATION_SCHEMA_VERSION,
+        "status": "superseded_by_user_override" if overridden else "recommended",
+        "tier": tier,
+        "score": int(complexity.get("score") or 0),
+        "model_class": model_class,
+        "reasoning_effort": resolved_effort,
+        "chain_status": chain_status,
+        "chain": chain_entries,
+        "resolved": resolved,
+        "signals": [
+            {"name": entry.get("name", ""), "weight": entry.get("weight", 0)}
+            for entry in _signal_entries(complexity)
+        ],
+        "claim_boundary": COMPLEXITY_CLAIM_BOUNDARY,
+    }
+    if overridden:
+        payload["user_override"] = {"model": model, "reasoning_effort": effort}
+        payload["override_note"] = (
+            "An explicit model or reasoning effort was requested; it wins over this recommendation, "
+            "which is reported for disclosure only."
+        )
+    return payload
+
+
+def _signal_entries(complexity: Mapping[str, object]) -> list[Mapping[str, object]]:
+    raw = complexity.get("signals")
+    if not isinstance(raw, list):
+        return []
+    return [entry for entry in raw if isinstance(entry, Mapping)]
+
+
+def _signal_payload(name: str, weight: int, describe: str, evidence: Sequence[str]) -> dict[str, object]:
+    return {
+        "name": name,
+        "weight": weight,
+        "describe": describe,
+        "evidence": list(evidence),
+    }
+
+
+def _matched_phrases(folded: str, phrases: Sequence[str]) -> list[str]:
+    return sorted({phrase for phrase in phrases if normalized_phrase(phrase) in folded})
+
+
+def _derived_signals(text: str, folded: str, skill: str, skill_class: str) -> list[dict[str, object]]:
+    signals: list[dict[str, object]] = []
+
+    subtasks = _subtask_count(folded, text)
+    if subtasks >= 3:
+        signals.append(
+            _signal_payload(
+                "subtasks_many",
+                # Weighted one point above the surveyed prior art, and this is
+                # the only place we deviate. Reason: a caller who enumerated
+                # three or more steps has already told us the request is more
+                # than one task, which is the plainest evidence of scope this
+                # scorer ever gets. It is the one signal allowed to cross the
+                # `standard` boundary alone; `simple_request` still pulls a
+                # list of three trivial edits back down.
+                4,
+                "Three or more enumerated or chained steps were requested at once.",
+                [f"subtask_estimate={subtasks}"],
+            )
+        )
+
+    paths = _path_count(text)
+    if paths >= 2:
+        signals.append(
+            _signal_payload(
+                "cross_file",
+                2,
+                "Two or more distinct files are named, so the change spans a seam.",
+                [f"path_count={paths}"],
+            )
+        )
+
+    band, band_weight = _length_band(text)
+    if band_weight:
+        signals.append(
+            _signal_payload(
+                "message_length",
+                band_weight,
+                "Longer requests carry more stated scope; length corroborates, never decides.",
+                [f"length_band={band}", f"characters={len(text.strip())}"],
+            )
+        )
+
+    class_weight = COMPLEXITY_SKILL_CLASS_WEIGHTS.get(skill_class, 0)
+    if class_weight:
+        signals.append(
+            _signal_payload(
+                "routed_skill_class",
+                class_weight,
+                "The routed skill belongs to a capability family whose work is typically heavier.",
+                [f"routed_skill={skill}", f"routed_skill_class={skill_class}"],
+            )
+        )
+    return signals
+
+
+def _subtask_count(folded: str, text: str) -> int:
+    """Estimate enumerated or chained steps, capped so one paste cannot dominate.
+
+    ` then ` also covers ` and then `, which contains it, so each chained step
+    is counted exactly once.
+    """
+    count = len(_ORDERED_STEP_RE.findall(text)) + folded.count(" then ")
+    return min(count, _MAX_COUNTED_SUBTASKS)
+
+
+def _path_count(text: str) -> int:
+    """Count distinct file-path-shaped tokens, capped."""
+    return min(len({match.casefold() for match in _PATH_RE.findall(text)}), _MAX_COUNTED_PATHS)
+
+
+def _length_band(text: str) -> tuple[str, int]:
+    length = len(text.strip())
+    band, weight = COMPLEXITY_LENGTH_BANDS[0][0], COMPLEXITY_LENGTH_BANDS[0][2]
+    for name, minimum, band_weight in COMPLEXITY_LENGTH_BANDS:
+        if length >= minimum:
+            band, weight = name, band_weight
+    return band, weight
+
+
+def _validate_module_tables() -> None:
+    """Fail at import time if the tier tables leave the shared vocabularies.
+
+    Cheap, and it means a rename in `model_routing` cannot leave this module
+    quietly recommending a class or an effort rung that no longer exists.
+    """
+    for tier in COMPLEXITY_TIERS:
+        if COMPLEXITY_TIER_MODEL_CLASSES[tier] not in MODEL_CATEGORIES:
+            raise ValueError(f"model class for tier {tier!r} is not a MODEL_CATEGORIES member")
+        if COMPLEXITY_TIER_EFFORTS[tier] not in REASONING_EFFORT_LADDER:
+            raise ValueError(f"effort for tier {tier!r} is not a REASONING_EFFORT_LADDER rung")
+
+
+_validate_module_tables()

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -33,6 +33,8 @@ from ..memory import memory_recall_pack_for_handoff, read_handoff_context_pack_f
 from ..coding.product_family_templates import PRODUCT_FAMILIES, product_family_template
 from ..coding.product_quality_harnesses import product_quality_harness
 from ..coding.project_governance import discover_project_governance
+from ..coding.request_complexity import recommend_model_for_complexity, score_request_complexity
+from ..plugin_bundle.omh.hermes_delegation import effective_mixture_category_chains
 from ..routing.intent import META_OR_FEEDBACK_INTENTS, classify_workflow_intent
 from ..routing.localization import normalized_phrase, routing_tokens
 from ..runtime.artifacts import append_journal_observation, create_prepared_coding_delegation_run, write_coding_delegation
@@ -123,6 +125,12 @@ def cmd_coding_delegate(args: argparse.Namespace) -> int:
             project_root=args.project_root or None,
             governance_default=args.governance_default,
             product_family=args.product_family or None,
+            # The user's own chains, so the advisory complexity recommendation
+            # resolves to models they configured rather than to a name this
+            # repo hardcoded. Reading stays here; the builder stays pure.
+            model_chains=effective_mixture_category_chains(paths.omh_home),
+            requested_model=getattr(args, "model", None) or "",
+            requested_effort=getattr(args, "effort", None) or "",
         )
         record_attached_recall_usage(paths, payload)
         if plan_artifact:
@@ -1267,6 +1275,45 @@ def _confirmed_active_models(inventory: dict[str, object]) -> list[dict[str, obj
             }
         )
     return active
+
+
+def cmd_coding_complexity(args: argparse.Namespace) -> int:
+    """Score one request and print the advisory model-class recommendation."""
+    message = " ".join(args.message).strip() if args.message else (sys.stdin.read().strip() if args.stdin else "")
+    if not message:
+        raise OmhError("coding complexity requires a request description or --stdin")
+    paths = _paths(args)
+    complexity = score_request_complexity(message, routed_skill=args.skill or "")
+    recommendation = recommend_model_for_complexity(
+        complexity,
+        chains=effective_mixture_category_chains(paths.omh_home),
+        requested_model=args.model or "",
+        requested_effort=args.effort or "",
+    )
+    payload = {
+        "schema_version": "coding_complexity_report/v1",
+        "complexity": complexity,
+        "recommendation": recommendation,
+    }
+    if _wants_json(args):
+        _print_json(payload)
+        return 0
+    print(f"Complexity: {complexity['tier']} (score {complexity['score']})")
+    print("Signals (score is their sum; no other input moves the tier):")
+    for signal in complexity["signals"]:
+        print(f"  {signal['weight']:+d}  {signal['name']}: {', '.join(signal['evidence'])}")
+    if not complexity["signals"]:
+        print("  (none fired; the score is 0)")
+    resolved = recommendation["resolved"]
+    print(f"Recommended model class: {recommendation['model_class']} at effort {recommendation['reasoning_effort']}")
+    if resolved:
+        print(f"  Your chain head for that class: {resolved['model']} [{recommendation['chain_status']}]")
+    else:
+        print(f"  No model resolved from your chains [{recommendation['chain_status']}]")
+    if recommendation["status"] == "superseded_by_user_override":
+        override = recommendation["user_override"]
+        print(f"Your explicit choice wins: model={override['model'] or '-'} effort={override['reasoning_effort'] or '-'}")
+    return 0
 
 
 def cmd_coding_composition_guide(args: argparse.Namespace) -> int:
@@ -2698,6 +2745,26 @@ def _add_coding_commands(sub) -> None:
     model_inventory.add_argument("--json", action="store_true", help="Emit the machine payload instead of plain text.")
     model_inventory.set_defaults(func=cmd_coding_model_inventory)
 
+    complexity = coding_sub.add_parser(
+        "complexity",
+        help="Score a request's complexity and show the advisory model-class recommendation.",
+    )
+    complexity.add_argument("message", nargs="*", help="Request text to score.")
+    complexity.add_argument("--stdin", action="store_true", help="Read the request text from standard input.")
+    complexity.add_argument("--skill", default=None, help="Routed workflow name, so its capability family can weigh in.")
+    complexity.add_argument(
+        "--model",
+        default=None,
+        help="Explicit model id; supersedes the recommendation, which is still printed for disclosure.",
+    )
+    complexity.add_argument(
+        "--effort",
+        default=None,
+        help="Explicit reasoning effort; supersedes the recommended effort.",
+    )
+    complexity.add_argument("--json", action="store_true", help="Emit the machine payload instead of plain text.")
+    complexity.set_defaults(func=cmd_coding_complexity)
+
     composition_guide = coding_sub.add_parser(
         "composition-guide",
         help="Composition calibration for the MAIN agent's own model family (how to compose splits and unit prompts).",
@@ -2786,6 +2853,21 @@ def _add_coding_commands(sub) -> None:
         help="Explicit advisory-default decision for a project without discovered governance.",
     )
     delegate.add_argument("--product-family", choices=PRODUCT_FAMILIES, default="", help="Optional prepared product-family template.")
+    # These two annotate the prepared handoff's advisory complexity
+    # recommendation and nothing else: they record that the caller already
+    # chose, so the recommendation is reported as superseded rather than
+    # silently dropped. They do not route -- `omh coding run --model/--effort`
+    # is the flag pair that reaches a dispatch argv.
+    delegate.add_argument(
+        "--model",
+        default=None,
+        help="Model already chosen for this request; supersedes the prepared complexity recommendation.",
+    )
+    delegate.add_argument(
+        "--effort",
+        default=None,
+        help="Reasoning effort already chosen for this request; supersedes the recommended effort.",
+    )
     delegate.set_defaults(func=cmd_coding_delegate)
 
     governance = coding_sub.add_parser("governance", help="Discover explicit-root project governance for prepared handoffs.")

--- a/src/quality/complexity_precision.py
+++ b/src/quality/complexity_precision.py
@@ -1,0 +1,259 @@
+"""Guard corpus for the deterministic request-complexity scorer.
+
+Written in the `routing_precision` idiom and for the same reason: a scorer
+without negative controls is an unguarded trigger. Two corpora, each with a
+name worth grepping for and a failure metric of its own.
+
+* `COMPLEXITY_PRECISION_CASES` is the **negative-control** corpus — ordinary
+  small requests that must NOT escalate. Its failure metric is
+  `overscore_count`.
+* `COMPLEXITY_INTERVENTION_CASES` is the **positive** corpus — genuinely heavy
+  requests that must reach at least the stated tier. Its failure metric is
+  `missed_escalation_count`.
+
+Grepping for "underscore" finds nothing; the positive guard lives under the
+intervention name, exactly as the routing corpora do.
+
+Every case names a `max_tier`/`min_tier` rather than an exact tier, so adding a
+signal that moves a score within its band is a deliberate edit rather than a
+fixture rewrite. Cases that DO pin an exact boundary live in the tier-boundary
+tests, where a one-point change is supposed to be loud.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..coding.request_complexity import COMPLEXITY_TIERS, score_request_complexity
+
+COMPLEXITY_PRECISION_SCHEMA_VERSION = "complexity_precision/v1"
+
+
+@dataclass(frozen=True)
+class ComplexityPrecisionCase:
+    """A request that must stay at or below `max_tier`."""
+
+    id: str
+    title: str
+    message: str
+    max_tier: str
+    routed_skill: str = ""
+
+
+@dataclass(frozen=True)
+class ComplexityInterventionCase:
+    """A request that must reach at least `min_tier`, for the named reason."""
+
+    id: str
+    title: str
+    message: str
+    min_tier: str
+    expected_signals: tuple[str, ...]
+    routed_skill: str = ""
+
+
+# Negative controls. A one-liner, a lookup, a rename, or a single narrow fix
+# must never buy a frontier model. Several of these deliberately contain a word
+# that ALSO appears in a heavy signal ("security header", "migrate one import")
+# so the corpus proves the scorer needs more than one keyword to escalate.
+COMPLEXITY_PRECISION_CASES: tuple[ComplexityPrecisionCase, ...] = (
+    ComplexityPrecisionCase(
+        "typo-fix",
+        "A typo fix never scores deep",
+        "fix a typo in README.md",
+        "light",
+    ),
+    ComplexityPrecisionCase(
+        "one-line-change",
+        "A stated one-liner never scores deep",
+        "one line change: bump the version in pyproject.toml",
+        "light",
+    ),
+    ComplexityPrecisionCase(
+        "concept-question",
+        "A concept question never scores deep",
+        "what does reasoning effort mean in this report?",
+        "light",
+    ),
+    ComplexityPrecisionCase(
+        "file-lookup",
+        "A file lookup never scores deep",
+        "where is the router implemented?",
+        "light",
+    ),
+    ComplexityPrecisionCase(
+        "single-rename",
+        "A rename in one file never scores deep",
+        "rename the helper in src/routing/chat.py",
+        "light",
+    ),
+    ComplexityPrecisionCase(
+        "single-security-header",
+        "One security header edit does not become deep on the word alone",
+        "add a security header to the response in src/server.py",
+        "standard",
+    ),
+    ComplexityPrecisionCase(
+        "narrow-migration-import",
+        "Migrating one import is not a migration project",
+        "migrate one import in src/cli.py to the new module path",
+        "standard",
+    ),
+    ComplexityPrecisionCase(
+        "add-a-comment",
+        "A comment request never scores deep",
+        "add a comment explaining why this branch exists",
+        "light",
+    ),
+    ComplexityPrecisionCase(
+        "print-a-value",
+        "A print/debug-line request never scores deep",
+        "print the resolved config path at startup",
+        "light",
+    ),
+    ComplexityPrecisionCase(
+        "two-files-simple",
+        "Two named files alone do not reach deep",
+        "update the copyright year in src/a.py and src/b.py",
+        "standard",
+    ),
+    ComplexityPrecisionCase(
+        "long-but-simple",
+        "A long request that is still a one-liner stays light",
+        (
+            "quick question, and sorry for the wall of text: I was reading through the installer "
+            "yesterday and noticed that the help string for the scope flag reads a little oddly to me, "
+            "it says 'scope' twice in a row which I think is just a copy-paste slip, so if you agree "
+            "could you fix the spelling there? that is the whole ask, nothing else needs to change and "
+            "I do not need any tests for it, it is a single line and I just kept typing to explain."
+        ),
+        "standard",
+    ),
+    ComplexityPrecisionCase(
+        "enumerated-trivia",
+        "An enumerated list of trivial edits stays light despite the step count",
+        "1. fix the typo in the help text\n2. bump the version\n3. rename the flag",
+        "light",
+    ),
+    ComplexityPrecisionCase(
+        "routed-coding-skill-alone",
+        "Routing to a coding skill alone does not make a small request deep",
+        "rename the flag in src/commands/coding.py",
+        "standard",
+        routed_skill="code-review",
+    ),
+)
+
+
+# Positive interventions. Each names the signals it expects to fire, so a case
+# that passes for the wrong reason is still a failure.
+COMPLEXITY_INTERVENTION_CASES: tuple[ComplexityInterventionCase, ...] = (
+    ComplexityInterventionCase(
+        "auth-rearchitecture",
+        "A cross-service auth rearchitecture reaches deep",
+        (
+            "Refactor the authentication layer across every service, migrate the session schema, "
+            "and keep backwards compatibility for existing tokens."
+        ),
+        "deep",
+        ("architecture_keywords", "impact_system_wide", "risk_keywords"),
+    ),
+    ComplexityInterventionCase(
+        "race-condition-investigation",
+        "A multi-file race-condition investigation reaches deep",
+        (
+            "Investigate the intermittent race condition in the dispatcher: reproduce it, find the "
+            "root cause, then fix src/coding/fanout_dispatch.py and src/coding/fanout_reap.py."
+        ),
+        "deep",
+        ("risk_keywords", "debugging_keywords", "cross_file"),
+        routed_skill="build-failure-triage",
+    ),
+    # Deliberately stops at `standard`. Two heavy-scope signals are six points
+    # and the deep bound is eight, so scope-and-shape alone never buys the top
+    # tier: deep needs a third independent reason (risk, cross-file span, an
+    # enumerated plan, a heavy routed skill). Recorded as a case rather than a
+    # comment because it is the boundary most likely to be tuned by accident.
+    ComplexityInterventionCase(
+        "system-wide-rewrite",
+        "A system-wide rewrite reaches standard; deep still needs a third signal",
+        "Rewrite the error handling system-wide so every caller reports a typed failure instead of a bare string.",
+        "standard",
+        ("architecture_keywords", "impact_system_wide"),
+    ),
+    ComplexityInterventionCase(
+        "parallel-split",
+        "An explicit parallel split reaches at least standard",
+        "Split the work up and run the migration in parallel across the four packages.",
+        "standard",
+        ("architecture_keywords", "fanout_intent"),
+    ),
+    ComplexityInterventionCase(
+        "enumerated-plan",
+        "Three or more enumerated steps reach at least standard",
+        (
+            "Please do the following:\n"
+            "1. add the new flag to the parser\n"
+            "2. thread it into the payload builder\n"
+            "3. cover it with a unit test\n"
+            "4. update the help text"
+        ),
+        "standard",
+        ("subtasks_many",),
+    ),
+    ComplexityInterventionCase(
+        "concurrency-redesign",
+        "A concurrency redesign reaches deep",
+        (
+            "Redesign the worker pool to remove the deadlock: the current thread safety story is wrong "
+            "and we risk data loss on shutdown across the whole codebase."
+        ),
+        "deep",
+        ("architecture_keywords", "impact_system_wide", "risk_keywords"),
+    ),
+    ComplexityInterventionCase(
+        "coding-skill-heavy",
+        "A heavy request routed to a coding skill reaches deep",
+        "Refactor the dispatch layer end-to-end and prove the rollback path still works.",
+        "deep",
+        ("architecture_keywords", "impact_system_wide", "risk_keywords", "routed_skill_class"),
+        routed_skill="maestro",
+    ),
+)
+
+
+def complexity_precision_report() -> dict[str, object]:
+    """Run both corpora and report the two failure metrics with their offenders."""
+    tier_index = {tier: index for index, tier in enumerate(COMPLEXITY_TIERS)}
+
+    overscored: list[dict[str, object]] = []
+    for case in COMPLEXITY_PRECISION_CASES:
+        result = score_request_complexity(case.message, routed_skill=case.routed_skill)
+        if tier_index[str(result["tier"])] > tier_index[case.max_tier]:
+            overscored.append({"id": case.id, "tier": result["tier"], "max_tier": case.max_tier, "score": result["score"]})
+
+    missed: list[dict[str, object]] = []
+    for case in COMPLEXITY_INTERVENTION_CASES:
+        result = score_request_complexity(case.message, routed_skill=case.routed_skill)
+        fired = {str(signal["name"]) for signal in result["signals"]}
+        missing = sorted(set(case.expected_signals) - fired)
+        if tier_index[str(result["tier"])] < tier_index[case.min_tier] or missing:
+            missed.append(
+                {
+                    "id": case.id,
+                    "tier": result["tier"],
+                    "min_tier": case.min_tier,
+                    "score": result["score"],
+                    "missing_signals": missing,
+                }
+            )
+
+    return {
+        "schema_version": COMPLEXITY_PRECISION_SCHEMA_VERSION,
+        "precision_case_count": len(COMPLEXITY_PRECISION_CASES),
+        "intervention_case_count": len(COMPLEXITY_INTERVENTION_CASES),
+        "overscore_count": len(overscored),
+        "overscored": overscored,
+        "missed_escalation_count": len(missed),
+        "missed_escalations": missed,
+    }

--- a/tests/test_request_complexity.py
+++ b/tests/test_request_complexity.py
@@ -1,0 +1,410 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from _cli_harness import run_cli
+from omh.coding.coding_delegation import build_coding_delegation_payload
+from omh.coding.model_routing import MODEL_CATEGORIES, REASONING_EFFORT_LADDER
+from omh.coding.request_complexity import (
+    COMPLEXITY_CHAIN_STATUSES,
+    COMPLEXITY_MODEL_RECOMMENDATION_SCHEMA_VERSION,
+    COMPLEXITY_RECOMMENDATION_STATUSES,
+    COMPLEXITY_SIGNAL_NAMES,
+    COMPLEXITY_SIGNALS,
+    COMPLEXITY_TIER_EFFORTS,
+    COMPLEXITY_TIER_MODEL_CLASSES,
+    COMPLEXITY_TIER_THRESHOLDS,
+    COMPLEXITY_TIERS,
+    REQUEST_COMPLEXITY_SCHEMA_VERSION,
+    recommend_model_for_complexity,
+    score_request_complexity,
+    tier_for_score,
+)
+from omh.quality.complexity_precision import (
+    COMPLEXITY_INTERVENTION_CASES,
+    COMPLEXITY_PRECISION_CASES,
+    complexity_precision_report,
+)
+
+# A stand-in for the user's configured chains. Deliberately NOT the shipped
+# table: a test that asserted the shipped model names would turn an editorial
+# chain edit into a test failure, and would also quietly bless hardcoding.
+_USER_CHAINS = {
+    "quick": (("user-small", "low"),),
+    "unspecified-high": (("user-mid", ""),),
+    "deep": (("user-large", "xhigh"), ("user-large-backup", "high")),
+}
+
+
+class SignalTests(unittest.TestCase):
+    def test_score_is_exactly_the_sum_of_its_named_signals(self) -> None:
+        for case in COMPLEXITY_PRECISION_CASES + COMPLEXITY_INTERVENTION_CASES:
+            with self.subTest(case=case.id):
+                result = score_request_complexity(case.message, routed_skill=case.routed_skill)
+                total = sum(int(signal["weight"]) for signal in result["signals"])
+                self.assertEqual(result["score"], total)
+                self.assertEqual(result["tier"], tier_for_score(total))
+
+    def test_every_signal_name_is_in_the_closed_vocabulary(self) -> None:
+        for case in COMPLEXITY_PRECISION_CASES + COMPLEXITY_INTERVENTION_CASES:
+            result = score_request_complexity(case.message, routed_skill=case.routed_skill)
+            for signal in result["signals"]:
+                self.assertIn(signal["name"], COMPLEXITY_SIGNAL_NAMES, case.id)
+
+    def test_every_signal_carries_its_own_evidence_and_description(self) -> None:
+        result = score_request_complexity(
+            "Refactor the auth layer across every service and fix the race condition in src/a.py and src/b.py",
+        )
+        self.assertTrue(result["signals"])
+        for signal in result["signals"]:
+            self.assertTrue(signal["describe"], signal["name"])
+            self.assertTrue(signal["evidence"], signal["name"])
+
+    def test_simple_request_is_the_only_negative_signal(self) -> None:
+        negatives = [signal.name for signal in COMPLEXITY_SIGNALS if signal.weight < 0]
+        self.assertEqual(negatives, ["simple_request"])
+
+    def test_an_empty_request_scores_zero_with_no_signals(self) -> None:
+        result = score_request_complexity("")
+        self.assertEqual(result["score"], 0)
+        self.assertEqual(result["signals"], [])
+        self.assertEqual(result["tier"], "light")
+        self.assertEqual(result["schema_version"], REQUEST_COMPLEXITY_SCHEMA_VERSION)
+
+    def test_scoring_is_deterministic_byte_for_byte(self) -> None:
+        message = "Migrate the schema across every service, then reproduce the deadlock in src/a.py and src/b.py."
+        first = json.dumps(score_request_complexity(message, routed_skill="maestro"), sort_keys=True)
+        second = json.dumps(score_request_complexity(message, routed_skill="maestro"), sort_keys=True)
+        self.assertEqual(first, second)
+
+    def test_case_and_accent_folding_does_not_change_the_score(self) -> None:
+        lowered = score_request_complexity("refactor the architecture across every service")
+        shouted = score_request_complexity("REFACTOR the ARCHITECTURE across EVERY service")
+        self.assertEqual(lowered["score"], shouted["score"])
+
+    def test_the_routed_skill_class_is_a_named_signal_with_its_family(self) -> None:
+        result = score_request_complexity("ship the change", routed_skill="maestro")
+        classes = [signal for signal in result["signals"] if signal["name"] == "routed_skill_class"]
+        self.assertEqual(len(classes), 1)
+        self.assertEqual(classes[0]["weight"], 2)
+        self.assertIn("routed_skill_class=delegate_coding_and_ship", classes[0]["evidence"])
+        self.assertEqual(result["routed_skill_class"], "delegate_coding_and_ship")
+
+    def test_an_unknown_routed_skill_contributes_nothing(self) -> None:
+        result = score_request_complexity("ship the change", routed_skill="not-a-real-workflow")
+        self.assertEqual(result["routed_skill_class"], "")
+        self.assertNotIn("routed_skill_class", [signal["name"] for signal in result["signals"]])
+
+    def test_path_and_subtask_counts_report_counts_not_user_text(self) -> None:
+        result = score_request_complexity(
+            "1. edit src/secret_project/a.py\n2. edit src/secret_project/b.py\n3. edit src/secret_project/c.py",
+        )
+        rendered = json.dumps(result)
+        self.assertNotIn("secret_project", rendered)
+
+
+class TierBoundaryTests(unittest.TestCase):
+    def test_thresholds_are_inclusive_lower_bounds_in_descending_order(self) -> None:
+        bounds = [bound for _, bound in COMPLEXITY_TIER_THRESHOLDS]
+        self.assertEqual(bounds, sorted(bounds, reverse=True))
+        for tier, bound in COMPLEXITY_TIER_THRESHOLDS:
+            self.assertEqual(tier_for_score(bound), tier)
+            self.assertNotEqual(tier_for_score(bound - 1), tier)
+
+    def test_the_weakest_tier_absorbs_zero_and_negative_scores(self) -> None:
+        for score in (-99, -2, 0, 3):
+            self.assertEqual(tier_for_score(score), COMPLEXITY_TIERS[0])
+
+    def test_every_tier_maps_to_a_shared_vocabulary_class_and_effort(self) -> None:
+        for tier in COMPLEXITY_TIERS:
+            self.assertIn(COMPLEXITY_TIER_MODEL_CLASSES[tier], MODEL_CATEGORIES)
+            self.assertIn(COMPLEXITY_TIER_EFFORTS[tier], REASONING_EFFORT_LADDER)
+
+    def test_tier_efforts_never_weaken_as_the_tier_rises(self) -> None:
+        rungs = [REASONING_EFFORT_LADDER.index(COMPLEXITY_TIER_EFFORTS[tier]) for tier in COMPLEXITY_TIERS]
+        self.assertEqual(rungs, sorted(rungs))
+
+
+class ExplainabilityTests(unittest.TestCase):
+    def test_every_tier_change_traces_to_a_named_signal(self) -> None:
+        """Remove one signal's points and the tier must move only when the arithmetic says so."""
+        message = (
+            "Refactor the authentication layer across every service, migrate the session schema, "
+            "and keep backwards compatibility for existing tokens."
+        )
+        result = score_request_complexity(message)
+        self.assertEqual(result["tier"], "deep")
+        for signal in result["signals"]:
+            without = result["score"] - int(signal["weight"])
+            expected = tier_for_score(without)
+            self.assertEqual(
+                tier_for_score(result["score"] - int(signal["weight"])),
+                expected,
+                f"{signal['name']} does not account for its own {signal['weight']} points",
+            )
+        # The payload alone is sufficient: nothing outside `signals` moved the score.
+        self.assertEqual(result["score"], sum(int(signal["weight"]) for signal in result["signals"]))
+
+    def test_the_thresholds_travel_with_the_payload(self) -> None:
+        result = score_request_complexity("fix a typo in README.md")
+        self.assertEqual(
+            result["thresholds"],
+            [{"tier": tier, "min_score": bound} for tier, bound in COMPLEXITY_TIER_THRESHOLDS],
+        )
+
+
+class ChainResolutionTests(unittest.TestCase):
+    def test_a_deep_tier_resolves_the_users_own_chain_head(self) -> None:
+        complexity = score_request_complexity(
+            "Refactor the auth layer across every service, migrate the schema, keep backwards compatibility.",
+        )
+        recommendation = recommend_model_for_complexity(complexity, chains=_USER_CHAINS)
+        self.assertEqual(recommendation["schema_version"], COMPLEXITY_MODEL_RECOMMENDATION_SCHEMA_VERSION)
+        self.assertEqual(recommendation["model_class"], "deep")
+        self.assertEqual(recommendation["chain_status"], "resolved")
+        self.assertEqual(recommendation["resolved"], {"model": "user-large", "reasoning_effort": "xhigh"})
+        self.assertEqual(
+            recommendation["chain"],
+            [
+                {"model": "user-large", "reasoning_effort": "xhigh"},
+                {"model": "user-large-backup", "reasoning_effort": "high"},
+            ],
+        )
+
+    def test_a_chain_entry_without_an_effort_falls_back_to_the_tier_suggestion(self) -> None:
+        complexity = score_request_complexity("Split the work up and migrate the four packages in parallel.")
+        recommendation = recommend_model_for_complexity(complexity, chains=_USER_CHAINS)
+        self.assertEqual(recommendation["model_class"], "unspecified-high")
+        self.assertEqual(recommendation["reasoning_effort"], COMPLEXITY_TIER_EFFORTS["standard"])
+        self.assertEqual(recommendation["resolved"]["model"], "user-mid")
+
+    def test_no_chain_config_reports_the_class_without_inventing_a_model(self) -> None:
+        complexity = score_request_complexity("fix a typo in README.md")
+        recommendation = recommend_model_for_complexity(complexity)
+        self.assertEqual(recommendation["chain_status"], "no_chain_config")
+        self.assertEqual(recommendation["chain"], [])
+        self.assertEqual(recommendation["resolved"], {})
+        self.assertEqual(recommendation["model_class"], "quick")
+
+    def test_a_class_missing_from_the_users_chains_is_named_not_substituted(self) -> None:
+        complexity = score_request_complexity("fix a typo in README.md")
+        recommendation = recommend_model_for_complexity(complexity, chains={"deep": (("user-large", "high"),)})
+        self.assertEqual(recommendation["chain_status"], "class_not_in_chains")
+        self.assertEqual(recommendation["resolved"], {})
+
+    def test_every_reported_status_is_in_its_closed_vocabulary(self) -> None:
+        complexity = score_request_complexity("fix a typo in README.md")
+        for chains in (None, _USER_CHAINS, {}):
+            recommendation = recommend_model_for_complexity(complexity, chains=chains)
+            self.assertIn(recommendation["chain_status"], COMPLEXITY_CHAIN_STATUSES)
+            self.assertIn(recommendation["status"], COMPLEXITY_RECOMMENDATION_STATUSES)
+
+    def test_no_shipped_model_name_is_written_into_the_module(self) -> None:
+        from omh.coding import request_complexity
+        from omh.plugin_bundle.omh.hermes_delegation import HERMES_MIXTURE_CATEGORY_CHAINS
+
+        source = Path(request_complexity.__file__).read_text(encoding="utf-8")
+        shipped = {model for chain in HERMES_MIXTURE_CATEGORY_CHAINS.values() for model, _ in chain}
+        for model in shipped:
+            self.assertNotIn(model, source, "the scorer must resolve models from config, never name one")
+
+
+class OverridePrecedenceTests(unittest.TestCase):
+    def test_an_explicit_model_supersedes_the_recommendation_and_says_so(self) -> None:
+        complexity = score_request_complexity("fix a typo in README.md")
+        recommendation = recommend_model_for_complexity(
+            complexity,
+            chains=_USER_CHAINS,
+            requested_model="operator-choice",
+        )
+        self.assertEqual(recommendation["status"], "superseded_by_user_override")
+        self.assertEqual(recommendation["user_override"], {"model": "operator-choice", "reasoning_effort": ""})
+        self.assertIn("wins over this recommendation", recommendation["override_note"])
+        # The set-aside advice is still disclosed rather than dropped.
+        self.assertEqual(recommendation["model_class"], "quick")
+
+    def test_an_explicit_effort_outranks_both_the_chain_and_the_tier(self) -> None:
+        complexity = score_request_complexity(
+            "Refactor the auth layer across every service, migrate the schema, keep backwards compatibility.",
+        )
+        recommendation = recommend_model_for_complexity(
+            complexity,
+            chains=_USER_CHAINS,
+            requested_effort="minimal",
+        )
+        self.assertEqual(recommendation["status"], "superseded_by_user_override")
+        self.assertEqual(recommendation["reasoning_effort"], "minimal")
+        self.assertEqual(recommendation["resolved"]["reasoning_effort"], "minimal")
+
+    def test_no_override_leaves_the_block_a_plain_recommendation(self) -> None:
+        complexity = score_request_complexity("fix a typo in README.md")
+        recommendation = recommend_model_for_complexity(complexity, chains=_USER_CHAINS)
+        self.assertEqual(recommendation["status"], "recommended")
+        self.assertNotIn("user_override", recommendation)
+        self.assertNotIn("override_note", recommendation)
+
+
+class GuardCorpusTests(unittest.TestCase):
+    def test_the_negative_controls_never_overscore(self) -> None:
+        report = complexity_precision_report()
+        self.assertEqual(report["overscore_count"], 0, report["overscored"])
+        self.assertEqual(report["precision_case_count"], 13)
+
+    def test_the_intervention_cases_all_escalate_for_their_named_reasons(self) -> None:
+        report = complexity_precision_report()
+        self.assertEqual(report["missed_escalation_count"], 0, report["missed_escalations"])
+        self.assertEqual(report["intervention_case_count"], 7)
+
+    def test_a_trivial_one_liner_never_scores_deep(self) -> None:
+        for message in (
+            "fix a typo",
+            "rename this variable",
+            "what is the default scope?",
+            "add a comment here",
+            "one line change to bump the version",
+        ):
+            with self.subTest(message=message):
+                self.assertEqual(score_request_complexity(message)["tier"], "light")
+
+    def test_every_case_id_is_unique_across_both_corpora(self) -> None:
+        ids = [case.id for case in COMPLEXITY_PRECISION_CASES] + [case.id for case in COMPLEXITY_INTERVENTION_CASES]
+        self.assertEqual(len(ids), len(set(ids)))
+
+
+class PurityTests(unittest.TestCase):
+    def test_model_routing_does_not_import_the_scorer(self) -> None:
+        """The declared role/depth/scale dials stay declared; the scorer never routes."""
+        from omh.coding import model_routing
+
+        source = Path(model_routing.__file__).read_text(encoding="utf-8")
+        self.assertNotIn("request_complexity", source)
+
+
+class DelegationPayloadTests(unittest.TestCase):
+    def test_the_prepared_handoff_carries_the_versioned_recommendation_block(self) -> None:
+        payload = build_coding_delegation_payload(
+            "Refactor the authentication layer across every service and migrate the session schema.",
+            executor_target="codex",
+            explicit_owner_choice=True,
+            model_chains=_USER_CHAINS,
+        )
+        complexity = payload["request_complexity"]
+        recommendation = payload["complexity_model_recommendation"]
+        self.assertEqual(complexity["schema_version"], REQUEST_COMPLEXITY_SCHEMA_VERSION)
+        self.assertEqual(recommendation["schema_version"], COMPLEXITY_MODEL_RECOMMENDATION_SCHEMA_VERSION)
+        self.assertEqual(complexity["tier"], "deep")
+        self.assertEqual(recommendation["model_class"], "deep")
+        self.assertEqual(recommendation["resolved"]["model"], "user-large")
+        self.assertEqual(recommendation["status"], "recommended")
+
+    def test_an_explicit_choice_in_the_handoff_supersedes_the_recommendation(self) -> None:
+        payload = build_coding_delegation_payload(
+            "Refactor the authentication layer across every service and migrate the session schema.",
+            executor_target="codex",
+            explicit_owner_choice=True,
+            model_chains=_USER_CHAINS,
+            requested_model="operator-choice",
+            requested_effort="max",
+        )
+        recommendation = payload["complexity_model_recommendation"]
+        self.assertEqual(recommendation["status"], "superseded_by_user_override")
+        self.assertEqual(recommendation["user_override"]["model"], "operator-choice")
+        self.assertEqual(recommendation["reasoning_effort"], "max")
+
+    def test_the_block_carries_no_user_request_text(self) -> None:
+        payload = build_coding_delegation_payload(
+            "Refactor the authentication layer in src/hushhush/private_thing.py across every service.",
+            executor_target="codex",
+            explicit_owner_choice=True,
+        )
+        rendered = json.dumps(payload["request_complexity"]) + json.dumps(payload["complexity_model_recommendation"])
+        self.assertNotIn("hushhush", rendered)
+        self.assertNotIn("private_thing", rendered)
+
+    def test_the_routed_skill_reaches_the_scorer_from_the_delegation(self) -> None:
+        payload = build_coding_delegation_payload(
+            "Refactor the authentication layer across every service and migrate the session schema.",
+            executor_target="codex",
+            explicit_owner_choice=True,
+        )
+        self.assertEqual(
+            payload["request_complexity"]["routed_skill"],
+            payload["delegation"]["recommended_workflow"],
+        )
+
+    def test_a_delegation_without_chains_still_reports_the_class(self) -> None:
+        payload = build_coding_delegation_payload(
+            "fix a typo in README.md",
+            executor_target="codex",
+            explicit_owner_choice=True,
+        )
+        recommendation = payload["complexity_model_recommendation"]
+        self.assertEqual(recommendation["chain_status"], "no_chain_config")
+        self.assertEqual(recommendation["model_class"], "quick")
+
+
+_HEAVY_REQUEST = "Refactor the authentication layer across every service and migrate the session schema."
+
+
+class ComplexityCliTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # An empty home means no override document, so the shipped chains
+        # answer and the run does not depend on the developer's own config.
+        self._home = TemporaryDirectory()
+        self.addCleanup(self._home.cleanup)
+        self.omh_home = ["--omh-home", self._home.name]
+
+    def test_the_cli_reports_the_tier_its_signals_and_the_recommendation(self) -> None:
+        status, stdout, stderr = run_cli([*self.omh_home, "coding", "complexity", _HEAVY_REQUEST, "--json"])
+        self.assertEqual(status, 0, stderr)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["schema_version"], "coding_complexity_report/v1")
+        self.assertEqual(payload["complexity"]["tier"], "deep")
+        self.assertEqual(payload["recommendation"]["model_class"], "deep")
+        self.assertEqual(payload["recommendation"]["chain_status"], "resolved")
+
+    def test_the_cli_marks_an_explicit_model_as_the_winner(self) -> None:
+        status, stdout, stderr = run_cli(
+            [*self.omh_home, "coding", "complexity", "fix a typo in README.md", "--model", "operator-choice", "--json"]
+        )
+        self.assertEqual(status, 0, stderr)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["recommendation"]["status"], "superseded_by_user_override")
+        self.assertEqual(payload["recommendation"]["user_override"]["model"], "operator-choice")
+
+    def test_the_cli_reads_the_users_own_chain_override(self) -> None:
+        overrides = Path(self._home.name) / "routing" / "model-chains.json"
+        overrides.parent.mkdir(parents=True, exist_ok=True)
+        overrides.write_text(
+            json.dumps(
+                {
+                    "schema_version": "mixture_chain_overrides/v1",
+                    "categories": {"deep": [{"model": "my-own-model", "reasoning_effort": "high"}]},
+                }
+            ),
+            encoding="utf-8",
+        )
+        status, stdout, stderr = run_cli([*self.omh_home, "coding", "complexity", _HEAVY_REQUEST, "--json"])
+        self.assertEqual(status, 0, stderr)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["recommendation"]["resolved"]["model"], "my-own-model")
+
+    def test_the_plain_text_output_names_every_contributing_signal(self) -> None:
+        status, stdout, stderr = run_cli(
+            [*self.omh_home, "coding", "complexity", _HEAVY_REQUEST], output_json=False
+        )
+        self.assertEqual(status, 0, stderr)
+        self.assertIn("Complexity: deep", stdout)
+        self.assertIn("architecture_keywords", stdout)
+        self.assertIn("impact_system_wide", stdout)
+
+    def test_the_cli_refuses_an_empty_request(self) -> None:
+        status, _, _ = run_cli([*self.omh_home, "coding", "complexity"])
+        self.assertNotEqual(status, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New pure-Python scorer `src/coding/request_complexity.py` reads a request's text plus its routed skill and emits `{score, tier, signals[]}` as `request_complexity/v1`. Ten named additive signals; `simple_request` (-2) is the only one that subtracts.
- `recommend_model_for_complexity()` turns a tier into a model **class** and a reasoning-effort suggestion (`complexity_model_recommendation/v1`), resolved against the user's own `<omh-home>/routing/model-chains.json` chains.
- Both blocks now ride every prepared handoff built by `build_coding_delegation_payload`.
- New read-only surface `omh coding complexity "<request>" [--skill] [--model] [--effort] [--json]`; `omh coding delegate` gains `--model`/`--effort` to record an explicit choice.
- New guard corpus `src/quality/complexity_precision.py` in the `routing_precision` idiom: 13 negative controls (`overscore_count`) and 7 positive interventions (`missed_escalation_count`).

### Why This Exists

Backlog item **P1-5** from `.omc/research/omo-omc-comparison-2026-08-29.md`. OMH selects a model from a category the caller already **declared**. That is a lookup table, not routing: a one-line typo fix and a forty-file auth rearchitecture reach `resolve_model_route` identically unless a human remembers to type a dial. This adds the missing half — a deterministic read of how much work a request looks like — and hands it to the handoff as advice with its inputs disclosed.

The whole mechanism is regex extraction plus weighted integer arithmetic. No LLM, no network, no clock, no filesystem read inside the scorer.

### User / Operator Impact

```
$ omh coding complexity "Refactor the auth layer across every service and migrate the schema, keeping backwards compatibility." --skill maestro
Complexity: deep (score 10)
Signals (score is their sum; no other input moves the tier):
  +3  architecture_keywords: migrate, refactor
  +3  impact_system_wide: across every, every service
  +2  risk_keywords: backwards compatibility
  +2  routed_skill_class: routed_skill=maestro, routed_skill_class=delegate_coding_and_ship
Recommended model class: deep at effort high
  Your chain head for that class: gpt-5.6-terra [resolved]
```

`gpt-5.6-terra` came from the operator's own `deep` chain, not from anything written into this repo. An operator who rewrote that chain sees their own model.

### How It Works

**Signal table (`request_complexity/v1`)**

| Weight | Signal | Fires on |
| --- | --- | --- |
| +3 | `architecture_keywords` | design-level work: the system's shape changes |
| +3 | `impact_system_wide` | blast radius stated as the whole surface |
| +4 | `subtasks_many` | 3+ enumerated or chained steps (capped at 10) |
| +2 | `risk_keywords` | security, concurrency, data integrity |
| +2 | `debugging_keywords` | cause not yet known; investigation first |
| +2 | `fanout_intent` | explicit parallel/split execution |
| +2 | `cross_file` | 2+ distinct file paths named (capped at 20) |
| +1/+2 | `message_length` | length band; corroborates, never decides |
| +1/+2 | `routed_skill_class` | capability-family weight of the routed skill |
| **-2** | `simple_request` | stated as a one-liner or a lookup |

Tiers `light` / `standard` / `deep` at inclusive bounds **4** and **8**.

**Explainability is an invariant, not a docstring.** `score == sum(signal["weight"] for signal in signals)` is asserted across every corpus case, and each signal carries its name, weight, one-line description, and the evidence that fired it. A reader can add the numbers up by hand and get the tier back.

**Tier examples**

| Request | Score | Tier | Why |
| --- | --- | --- | --- |
| `fix a typo in README.md` | -2 | light | `simple_request` only |
| `debug the flaky test` | 2 | light | `debugging_keywords` only |
| `Split the work up and run the migration in parallel across the four packages.` | 5 | standard | architecture + fanout |
| `Rewrite the error handling system-wide so every caller reports a typed failure.` | 6 | standard | two heavy signals; deep needs a third |
| `Investigate the intermittent race condition: reproduce it, find the root cause, then fix src/coding/fanout_dispatch.py and src/coding/fanout_reap.py.` | 8 | deep | risk + debugging + cross_file + skill class |
| `Refactor the authentication layer across every service, migrate the session schema, keep backwards compatibility.` | 10 | deep | architecture + system-wide + risk + skill class |

**One deliberate deviation from the surveyed prior art**, documented at the site: `subtasks_many` is weighted 4 rather than 3. A caller who enumerated three or more steps has already told us the request is more than one task — the plainest evidence of scope this scorer ever gets. It is the one signal allowed to cross the `standard` boundary alone, and `simple_request` still pulls a list of three trivial edits back down (the `enumerated-trivia` negative control pins that).

**Two boundaries carry the design.**

1. *Recommend, never route.* `model_routing` documents that role, research depth, and task scale are **declared** by the caller and never inferred from phrasing, precisely so model cost cannot depend on wording. This change does not touch that. The scorer produces a separate advisory block a human or caller may then declare; `resolve_model_route` is unchanged, and `PurityTests.test_model_routing_does_not_import_the_scorer` pins the direction.
2. *The user outranks the score.* An explicit `--model`/`--effort` marks the block `superseded_by_user_override` with a `user_override` sub-dict and an `override_note`. The recommendation is still reported, so what was set aside stays visible rather than silently dropped. Effort precedence matches `model_routing`: requested > chain-entry > tier suggestion.

**No model name is written into the module.** A tier maps to a `MODEL_CATEGORIES` member; that class resolves through the user's chain document merged over the shipped defaults. A class the user's chains do not cover is reported as `class_not_in_chains` rather than substituted, and no chain config at all reports `no_chain_config` rather than inventing a head. `test_no_shipped_model_name_is_written_into_the_module` greps the module source for every shipped model id to keep it that way. A module-level table check raises at import if a tier's class leaves `MODEL_CATEGORIES` or its effort leaves `REASONING_EFFORT_LADDER`.

**No user request text crosses into the payload.** Evidence entries are phrases from this repo's own closed vocabulary plus counts (`path_count=2`, `subtask_estimate=4`), never echoed input — so `include_message` stays the single gate on raw content. Pinned by `test_the_block_carries_no_user_request_text`.

### Files And Contracts Touched

- `src/coding/request_complexity.py` **(new, 400 lines)** — the scorer, the recommendation, `request_complexity/v1` and `complexity_model_recommendation/v1`. The capability-family lookup is imported lazily on purpose: `src/coding` has no import-time edge into the skill catalog today and a scorer is not a reason to add one.
- `src/quality/complexity_precision.py` **(new)** — the guard corpus and `complexity_precision_report()`.
- `src/coding/coding_delegation.py` — `_attach_request_complexity` adds two top-level self-versioned blocks, attached in the **native** builder so `test_facade_preserves_builder_payload_bytes_and_handoff_field`'s byte-equality contract holds. Three new defaulted kwargs: `model_chains`, `requested_model`, `requested_effort`.
- `src/coding/maestro/contracts.py`, `src/coding/maestro/facade.py` — the same three fields threaded through `ExternalHandoffRequest`.
- `src/commands/coding.py` — `cmd_coding_complexity` and its subparser; `omh coding delegate` gains `--model`/`--effort` and passes `effective_mixture_category_chains(paths.omh_home)`. Chain I/O stays in the command layer so the builder stays pure.
- `docs/FANOUT.md` — the signal table, the config-resolution rule, and the command, beside its `model-inventory` / `composition-guide` siblings.
- `tests/test_request_complexity.py` **(new, 40 tests)**.

Neither new payload key is persisted: `coding_delegation_record_payload` copies an explicit field list, so `CODING_DELEGATION_RECORD_KEYS` and the three handoff allowlists are untouched and `omh coding delegate --record` is unaffected.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

The two blocks are executor-neutral and ride whichever handoff the payload builds.

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli release checklist --json`
- [x] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [x] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke ... release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `omh coding complexity ... --skill maestro` against the real `~/.omh` chain document (output quoted above)
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- `PYTHONPATH=tests uv run python -m unittest discover -s tests` — **8201 tests**, green except the pre-existing **21 failures / 7 errors** in `test_cross_harness_adapters` and `test_cross_harness_adapter_security`. Those are this worktree's `.claude`-path `unsafe_read_root` failures; confirmed **bit-for-bit identical** on a clean `origin/main` tree via `git stash push -u` (same 21/7, same reason codes) and unrelated to this change.
- `PYTHONPATH=tests uv run python -m unittest tests.test_request_complexity` — 40 tests, OK.
- `PYTHONPATH=tests uv run python -m unittest tests.test_coding_delegation tests.test_maestro_contracts tests.test_maestro_integration tests.test_conformance tests.test_data_boundary` — 134 tests, OK (the facade byte-equality and record-validator suites specifically).
- `PYTHONPATH=tests uv run python -m unittest tests.test_cli` — 381 tests, OK.
- `uv run python -m omh.cli release drift` — `No drift. 17 checks passed.`
- All five docs byte gates green, including `ulw-inventory` and `ulw-site`.
- `uv run python -m omh.cli harness validate` — `{"counts":{"harnesses":75,"skills":113},"errors":[],"ok":true}`.
- `complexity_precision_report()` — `overscore_count: 0`, `missed_escalation_count: 0` across 13 negative and 7 positive cases.

Two cases in the first corpus run genuinely failed and were resolved by looking at the arithmetic rather than by editing the fixture: `system-wide-rewrite` scored 6 (two heavy signals, deep bound is 8), which is now recorded as a deliberate boundary case asserting `standard`; and `enumerated-plan` scored 3, which is what motivated the documented `subtasks_many` weight change above.

### Not Tested / Not Applicable

- **Installed-command and wheel smokes**: this change adds no new packaging surface — both new modules live inside existing `src/coding` and `src/quality` packages already covered by `[tool.setuptools]`. The plan-mode `release hermes-smoke` and `omh --help` were run instead.
- **Localized request text (ko/ja/zh)**: the phrase vocabulary is English-only by design and by scope. A localized cue pack is separate work and is deliberately not attempted here.
- **Live Hermes chat session**: no chat turn exercised the two new payload blocks end to end; the CLI delegate path and direct builder calls were exercised instead.
- **Wrapper call sites**: `src/wrapper/contract.py` still calls the builder without `model_chains`, so chat-lane handoffs currently report `chain_status: no_chain_config` (the class and effort are still named). Wiring that is deliberate follow-up, not silently missing.
- **Manual TUI check**: no TUI surface renders these blocks yet.

## Risk

Low. Two new payload keys that no record allowlist persists, one new read-only subcommand, three defaulted kwargs, and two new modules. No schema migration, no validator change, and no change to `resolve_model_route` or any dispatch path.

The one real risk is **editorial**: the phrase lists and weights are judgment, and a 20-case corpus is thin against real traffic. That is why nothing consumes the tier automatically — it is disclosed advice, the user's explicit choice always wins, and the guard corpus is the place to grow.

Secondary: `subtasks_many` at +4 crosses the `standard` boundary alone. `simple_request` is the counterweight and `enumerated-trivia` pins it, but a heavily-enumerated trivial request is the shape most likely to over-score.

## Compatibility / Rollout

Fully backward compatible. All three new kwargs default such that an unchanged caller gets the same behavior plus two additive, self-describing payload keys. Frozen contracts and persisted records are untouched. `local` channel; no runtime or install surface changes.

## Release / Claims

- [x] Release-channel impact considered (`local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence — both new blocks carry their own claim boundary naming them a recommendation input, never a route
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data — the no-user-text property is asserted by a test
- [x] Known manual Hermes checks are listed, including the `omh release hermes-smoke --live` gap

## Follow-Up

- Wire `model_chains` into the two `src/wrapper/contract.py` call sites so chat-lane handoffs resolve a concrete head instead of reporting `no_chain_config`.
- Grow the negative-control corpus against real traffic before any surface consumes the tier without a human in the loop.
- Consider the surveyed **confidence value** and rule-table cross-check (P1-5 also describes lowering confidence and preferring the higher tier on divergence). Deliberately deferred: OMH has no rule table to cross-check against yet, and a confidence number with nothing to disagree with would be decoration.
- A localized cue pack, coordinated with the trigger-language-pack work rather than duplicated here.
