### PR TITLE
fix(plugin_bundle): honest-unknown elapsed time in run summary

### DIFF
--- a/src/plugin_bundle/omh/tools/run_summary_tool.py
+++ b/src/plugin_bundle/omh/tools/run_summary_tool.py
@@ -29,13 +29,22 @@ RUN_SUMMARY_CLAIM_BOUNDARY = (
     "recorded them; this is not billing-exact provider evidence."
 )
 
-# Labels only — numbers are always rendered with thousands separators.
+# Labels only — numbers are always rendered with thousands separators. The
+# elapsed placeholder carries its own unit suffix (see _ELAPSED_UNITS) so an
+# unmeasured elapsed time can render the bare word "unknown" instead of
+# "unknowns" / "unknown초".
 _SUMMARY_LABELS: dict[str, tuple[str, str, str]] = {
-    "en": ("Elapsed time: {elapsed}s", "Tokens used: {tokens}", "Models used: {models}"),
-    "ko": ("소요 시간: {elapsed}초", "토큰 사용량: {tokens}", "사용 모델: {models}"),
-    "ja": ("所要時間: {elapsed}秒", "トークン使用量: {tokens}", "使用モデル: {models}"),
-    "zh": ("耗时: {elapsed}秒", "Token 使用量: {tokens}", "使用模型: {models}"),
+    "en": ("Elapsed time: {elapsed}", "Tokens used: {tokens}", "Models used: {models}"),
+    "ko": ("소요 시간: {elapsed}", "토큰 사용량: {tokens}", "사용 모델: {models}"),
+    "ja": ("所要時間: {elapsed}", "トークン使用量: {tokens}", "使用モデル: {models}"),
+    "zh": ("耗时: {elapsed}", "Token 使用量: {tokens}", "使用模型: {models}"),
 }
+
+# Unit suffix appended to a *measured* elapsed value only. Left in English
+# ("unknown") when the value is unmeasured, matching the sentinel word used
+# elsewhere in OMH's status renderers (e.g. `src/coding/status_board.py`).
+_ELAPSED_UNITS: dict[str, str] = {"en": "s", "ko": "초", "ja": "秒", "zh": "秒"}
+_ELAPSED_UNKNOWN: str = "unknown"
 
 OMH_RUN_SUMMARY_SCHEMA = {
     "name": "omh_run_summary",
@@ -137,6 +146,20 @@ def _number(value: Any) -> float:
     return float(value)
 
 
+def _optional_number(value: Any) -> float | None:
+    """Like `_number`, but preserves "never recorded" as `None`.
+
+    `started_at` is the one field in this row that can genuinely be absent
+    (a session row without a start time was never observed starting).
+    Collapsing that into `0.0` — as `_number` deliberately does for token and
+    cost columns, which really do default to zero — would make an unmeasured
+    elapsed time indistinguishable from a run that took no time at all.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
 def omh_run_summary_handler(args: dict[str, Any], **kwargs) -> str:
     observation = observe_plugin_tool_call("omh_run_summary", args, kwargs)
     language = str(args.get("language", "") or "en").strip().lower()
@@ -164,9 +187,13 @@ def omh_run_summary_handler(args: dict[str, Any], **kwargs) -> str:
         payload["error"] = f"no session row observed for {session_id!r}"
         return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
 
-    started = _number(session.get("started_at"))
-    ended = _number(session.get("ended_at")) or time.time()
-    elapsed = max(0, int(round(ended - started))) if started else 0
+    started = _optional_number(session.get("started_at"))
+    ended_raw = _optional_number(session.get("ended_at"))
+    ended = ended_raw if ended_raw is not None else time.time()
+    # A session row with no recorded start time never observed starting: an
+    # honest "unknown" beats a fabricated 0s that would read as a run that
+    # took no time at all.
+    elapsed: int | None = max(0, int(round(ended - started))) if started is not None else None
     scope = [session, *children]
     input_tokens = int(sum(_number(row.get("input_tokens")) for row in scope))
     output_tokens = int(sum(_number(row.get("output_tokens")) for row in scope))
@@ -177,9 +204,10 @@ def omh_run_summary_handler(args: dict[str, Any], **kwargs) -> str:
         _number(row.get("actual_cost_usd")) or _number(row.get("estimated_cost_usd"))
         for row in scope
     )
+    elapsed_text = f"{elapsed:,}{_ELAPSED_UNITS[language]}" if elapsed is not None else _ELAPSED_UNKNOWN
     elapsed_line, tokens_line, models_line = _SUMMARY_LABELS[language]
     lines = [
-        elapsed_line.format(elapsed=f"{elapsed:,}"),
+        elapsed_line.format(elapsed=elapsed_text),
         tokens_line.format(tokens=f"{tokens_used:,}"),
     ]
     if models:

--- a/tests/test_run_summary_tool.py
+++ b/tests/test_run_summary_tool.py
@@ -155,5 +155,64 @@ class RunSummaryToolTest(unittest.TestCase):
         self.assertIn("claim_boundary", result)
 
 
+class RunSummaryUnmeasuredElapsedTest(unittest.TestCase):
+    """A session row with no recorded start time never observed starting.
+
+    `started_at` is the one field on the row that can genuinely be absent.
+    The summary must say "unknown" for it -- never a fabricated `0s` that
+    reads as a run that took no time at all.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.home = Path(self._tmp.name) / "hermes"
+        _build_state_db(
+            self.home,
+            [
+                {
+                    "id": "20260830_100000_nostart",
+                    "started_at": None,
+                    "input_tokens": 1_234,
+                    "output_tokens": 567,
+                    "usage_models": ["gpt-5.6-sol"],
+                },
+            ],
+        )
+
+    def _call(self, **args) -> dict:
+        return json.loads(
+            omh_run_summary_handler(
+                {"hermes_home": str(self.home), **args},
+                session_id="20260830_100000_nostart",
+            )
+        )
+
+    def test_elapsed_seconds_is_none_not_a_fabricated_zero(self):
+        result = self._call(language="en")
+        self.assertEqual(result["status"], "observed")
+        self.assertIsNone(result["elapsed_seconds"])
+
+    def test_summary_text_renders_the_word_unknown(self):
+        result = self._call(language="en")
+        self.assertEqual(
+            result["summary_text"],
+            "Elapsed time: unknown\nTokens used: 1,801\nModels used: gpt-5.6-sol",
+        )
+
+    def test_unknown_elapsed_is_not_localized_but_labels_still_are(self):
+        result = self._call(language="ko")
+        self.assertEqual(
+            result["summary_text"],
+            "소요 시간: unknown\n토큰 사용량: 1,801\n사용 모델: gpt-5.6-sol",
+        )
+
+    def test_measured_tokens_are_unaffected_by_unmeasured_elapsed(self):
+        result = self._call(language="en")
+        self.assertEqual(result["tokens_used"], 1_801)
+        self.assertEqual(result["breakdown"]["input_tokens"], 1_234)
+        self.assertEqual(result["breakdown"]["output_tokens"], 567)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- `omh_run_summary_handler` (`src/plugin_bundle/omh/tools/run_summary_tool.py`) no longer
  fabricates `elapsed_seconds: 0` / `"Elapsed time: 0s"` when a session row has no recorded
  `started_at`. A new `_optional_number` helper preserves `None` for that field, and the
  renderer now emits the literal word `unknown` in `summary_text` for every supported
  language (en/ko/ja/zh) and JSON `null` for `elapsed_seconds` in the payload.

### Why This Exists

Backlog item **J. Honest-unknown as a display contract**
(`.omc/research/ohmypi-optimization-2026-08-29.md`, section J): everywhere OMH renders a
value it does not actually know, the display must say "unknown" honestly — never a
fabricated `0`, empty string, or guessed value presented as a measurement.
`omh_run_summary_handler` renders the owner-watched end-of-run closing block
(`소요 시간: 2,741초` / `토큰 사용량: ...`). Its elapsed-time computation was
`elapsed = max(0, int(round(ended - started))) if started else 0` — a session row with no
recorded start time collapsed straight into a fabricated zero, indistinguishable from a run
that genuinely took no time.

### User / Operator Impact

The owner-watched closing summary now says `Elapsed time: unknown` instead of
`Elapsed time: 0s` on the (rare) session row that never recorded a start time, instead of
silently lying about a zero-second run. No change to the common path: every existing test
for the measured case renders byte-identical `summary_text`.

### How It Works

- `_optional_number(value)` returns `None` for anything that is not a real, non-bool
  `int`/`float` (mirrors the existing `_number` helper's type guard, but returns `None`
  instead of `0.0`).
- `started`/`ended` are read with `_optional_number`; `elapsed` is computed only when
  `started is not None`, otherwise stays `None` end to end.
- The per-language label templates (`_SUMMARY_LABELS`) were restructured so the elapsed
  unit suffix (`s`/`초`/`秒`, in `_ELAPSED_UNITS`) is appended only to a real measured
  value — the bare word `unknown` is substituted whole, never glued to a unit letter
  (`unknowns` / `unknown초`).
- `_number` (which still collapses missing token/cost columns to `0.0`) is left untouched;
  see Deferred below.

### Files And Contracts Touched

- `src/plugin_bundle/omh/tools/run_summary_tool.py` — `_optional_number` helper;
  `elapsed_seconds` is now `int | None`; `_SUMMARY_LABELS`/`_ELAPSED_UNITS` restructured.
- `tests/test_run_summary_tool.py` — new `RunSummaryUnmeasuredElapsedTest` covering
  `elapsed_seconds is None`, the `unknown` summary line in en and ko, and that
  unmeasured elapsed does not affect the (separately measured) token totals.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [x] Generic executor
- [x] Not executor-specific

`omh_run_summary` is a Hermes plugin tool invoked by any host calling the OMH plugin
bundle, not tied to a specific coding executor.

## Survey (item J's "survey first")

Inventoried every rendering surface the task named — HUD widget data producer, `omh coding
fanout brief`/`status` renderers, receipt/summary formatters, doctor output — for the
`or 0` / `.get(..., 0)` / `default=0` / ternary-collapse-to-0 pattern applied to a
telemetry-shaped value (duration, tokens, cost), as distinct from a legitimate count/length
(which is always a real, known zero, not a missing measurement).

**Already compliant (surveyed, no change needed):**

- `src/plugin_bundle/omh/hermes_delegation.py` (feeds `src/omh/tui_widgets/omh-status.mjs`,
  the HUD widget) — `"tokens": tokens_total if tokens_total else None`, cost/rate/cache-hit
  all conditionally omitted rather than zero-filled.
- `src/omh/tui_widgets/omh-status.mjs` — explicit code comments describing this exact
  discipline; cost/tokens render as blank rather than a fabricated `$0.000`/`0 tokens`.
- `src/coding/status_board.py` — an explicit `UNKNOWN = "unknown"` sentinel plus
  `elapsed_text_for`/`tokens_text_for`, already the reference implementation.
- `src/coding/unit_telemetry.py` — module docstring states the rule verbatim ("Never
  fabricate. A value the CLI did not report is an ABSENT KEY, never a zero").
- `src/coding/fanout_status.py` / `commands/coding.py` fanout brief — `"unknown"` literal
  for `elapsed_seconds`/`tokens_total` when not observed.
- `src/coding/routing_observation.py` — `_metric()` drops a field entirely (empty string)
  rather than rendering a fabricated `0`; backed by `_observed_integer`/`_observed_number`.
- `src/coding/executor_progress.py` — `_observed_count`/`_observed_number` helpers, with a
  code comment on the exact "defaulted 0 read back as observed zero" failure mode this PR
  fixes elsewhere.
- `src/coding/codex_progress.py` — `finding_count` defaults to `0` but carries a sibling
  `finding_count_observed` boolean, preserving the distinction at the data level.
- `commands/setup.py::cmd_doctor` — surveyed; renders install/skill counts (real,
  always-known list lengths), no telemetry-shaped values.

**Fixed in this PR:** `run_summary_tool.py`'s `elapsed_seconds` — the one surface with a
provable fabricated-zero bug.

**Deferred (listed, not fixed):**

- `run_summary_tool.py`'s `input_tokens`/`output_tokens`/`cost_usd` still collapse a NULL
  DB column to `0.0` via the pre-existing `_number` helper. Left alone: Hermes'
  `sessions` table is an external, undocumented-to-OMH schema, and these columns plausibly
  default to a real `0` (an accounting total) rather than ever being NULL for an observed
  session — unlike `started_at`, a timestamp that is unambiguously either set or absent.
  Fixing this without evidence of the column's real NULL semantics would be a guess.
- `omh-status.mjs`'s `elapsedText(elapsed) || '0s'` (line 276) and the running-row
  `(row.elapsed_seconds || 0) + extraSeconds` (line 254) are defensive JS-side fallbacks
  for a field the Python producer (`hermes_delegation.py`) always supplies today; not
  reachable in practice, and outside the "Python-side producer" scope this item names.
- A repo-wide shared `format_measured()` helper unifying the three independently-tested
  implementations already in the coding/HUD lane (`_observed_count`/`_observed_number`,
  `_observed_integer`/`_observed_number`, `UNKNOWN`/`elapsed_text_for`) — real refactor
  work with its own regression surface, out of scope for a one-file bug fix.

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli release checklist --json`
- [x] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [x] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- `PYTHONPATH=tests uv run python -m unittest tests/test_run_summary_tool.py -v` → 10
  passed (6 existing unchanged, 4 new for the None-`started_at` path).
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` → 8204 tests; 21
  failures + 7 errors, all in `test_cross_harness_adapters*` /
  `test_cross_harness_adapter_security*` — the documented 28 known cross-harness
  `.claude`-worktree-path failures, unrelated to this change.
- `uv run python -m compileall -q src tests` → clean (unrelated pre-existing
  `SyntaxWarning` in `tests/test_menubar_app.py`).
- `uv run python -m omh.cli docs workflows --check` / `docs roles --check` /
  `docs capability-families --check` / `docs ulw-inventory --check` /
  `docs ulw-site --check` → all `"ok": true`.
- `uv run python -m omh.cli release drift` → "No drift. 18 checks passed."
- `uv run --group lint ruff check src tests` → "All checks passed!"
- `git diff --check` → clean.
- `uv run python -m omh.cli harness validate` → `{"ok": true, "errors": [], "warnings": []}`.
- `uv run python -m omh.cli release checklist --json` → `"ok": true`, `"mode": "plan"`.
- `uv run python -m omh.cli release hermes-smoke` → plan mode, `Status: ok`, `observed: no`
  (unchanged pre-existing plan-mode boundary; no live Hermes profile available here).
- `omh --help` → exit 0.
- Additional `omh --omh-home ... --include-command-smoke` variant not run (requires a
  writable `/tmp` install target outside this task's isolated worktree scope; the plain
  `release hermes-smoke` plan-mode run above already exercises the same command).

### Not Tested / Not Applicable

- No live Hermes host available to confirm real-world `started_at`-NULL sessions occur;
  the fixed path is proven by a synthetic sqlite fixture only, matching this tool's
  existing test convention.
- Workflow-learning review queue smoke — no learning contracts touched.
- Manual Hermes/TUI check — no TUI-visible surface changed (the HUD widget producer was
  surveyed and found already compliant; nothing there changed).

## Risk

- Narrow: one function in one plugin tool, additive `_optional_number` helper, no changed
  behavior on the measured path (verified byte-identical `summary_text` for all existing
  tests). The only behavior change is on a row with `started_at` genuinely absent, which
  previously rendered a wrong zero and now renders `unknown`.

## Compatibility / Rollout

- `elapsed_seconds` in the tool's JSON payload changes type from always-`int` to
  `int | None` on the (previously mishandled) missing-`started_at` case. Any caller
  currently assuming `elapsed_seconds` is always an integer and reading it into arithmetic
  should already be doing so defensively (this was previously a silent wrong `0`, not a
  documented guarantee); no known caller in this repo consumes `elapsed_seconds` beyond
  printing `summary_text` verbatim, per the tool's own schema description.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`) — no release
      surface touched; this is a plugin-tool bug fix.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution,
      review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or
      unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live`
      gap (see Not Tested)

## Follow-Up

- If Hermes' `sessions.input_tokens`/`output_tokens` are ever confirmed to leave NULL for a
  session with no recorded usage (as opposed to defaulting to `0`), extend
  `_optional_number` to those columns too — do not guess at that without evidence.
- A shared cross-module `format_measured()` helper, if the three existing independent
  implementations of this discipline (`executor_progress.py`, `routing_observation.py`,
  `status_board.py`) are ever consolidated — separate refactor, not bundled here.
