### PR TITLE
feat(skills): detect and suppress cross-surface duplicate content

### DIFF
--- a/src/skills/duplicate_content.py
+++ b/src/skills/duplicate_content.py
@@ -1,0 +1,242 @@
+"""Cross-surface duplicate-content detection and suppression (backlog item E).
+
+`src/skills/context_cost.py` (#634) already measures duplicate bytes *within
+one surface kind*: byte-identical `##` sections repeated across different
+`SKILL.md` bodies. `tests/test_skill_density_gate.py` (#1201) measures
+repetition *inside a single skill's own body*. Neither answers the question
+this module answers: when Hermes loads more than one OMH surface into the
+same turn -- the always-on awareness primer, the workspace router-profile
+snippet, the selected skill's body, and that skill's on-demand reference
+files -- does the same paragraph get paid for twice *across* those surface
+kinds?
+
+In this codebase, "workflow context cards" (`awareness_workflow_context_markdown`
+in `plugin_bundle/omh/awareness.py`) are rendered directly into each skill
+body rather than delivered as an independently-loaded surface, so they are
+covered here under the ``skill_body`` kind rather than a fifth kind.
+
+Detection and suppression are both normalized-paragraph operations:
+
+- A "block" is a blank-line-delimited paragraph of at least
+  ``MIN_BLOCK_CHARS`` characters (below that, matches are common short
+  phrases rather than owned content).
+- Two blocks are the same content if their whitespace-collapsed text is
+  byte-identical.
+- Surfaces are deduped in the caller-supplied order (first occurrence wins
+  and becomes the block's "owner"); a later surface of a *different* kind
+  that repeats the block is a cross-surface duplicate.
+- A cross-surface duplicate is either suppressed (its text is replaced by a
+  short deterministic pointer line naming the owning surface) or, if its
+  normalized text matches ``ALLOWLISTED_DUPLICATE_BLOCKS``, left untouched
+  because the duplication is intentional and justified there.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from .catalog_types import DELEGATION_TRANSPARENCY_RULES
+from .packaging import builtin_skill_reference_templates, builtin_skill_templates
+
+_BLOCK_SPLIT_RE = re.compile(r"\n\s*\n")
+_WHITESPACE_RE = re.compile(r"\s+")
+
+MIN_BLOCK_CHARS = 40
+POINTER_LINE_PREFIX = "> [duplicate content suppressed; see"
+
+
+@dataclass(frozen=True)
+class Surface:
+    """One independently-loaded (or independently-generated) OMH surface."""
+
+    surface_id: str
+    kind: str
+    content: str
+
+
+@dataclass(frozen=True)
+class CrossSurfaceDuplicate:
+    normalized: str
+    owner_surface: str
+    duplicate_surface: str
+    byte_len: int
+    allowlist_reason: str | None
+
+    @property
+    def allowlisted(self) -> bool:
+        return self.allowlist_reason is not None
+
+
+def normalize_block(text: str) -> str:
+    return _WHITESPACE_RE.sub(" ", text).strip()
+
+
+def _paragraph_spans(content: str) -> list[tuple[int, int, str]]:
+    """Return `(start, end, text)` for each block, positions exact in `content`."""
+    spans: list[tuple[int, int, str]] = []
+    cursor = 0
+    boundaries = [m.span() for m in _BLOCK_SPLIT_RE.finditer(content)]
+    boundaries.append((len(content), len(content)))
+    for boundary_start, boundary_end in boundaries:
+        raw = content[cursor:boundary_start]
+        block = raw.strip()
+        if len(block) >= MIN_BLOCK_CHARS:
+            offset = raw.index(block)
+            start = cursor + offset
+            spans.append((start, start + len(block), block))
+        cursor = boundary_end
+    return spans
+
+
+def paragraph_blocks(content: str) -> list[str]:
+    return [text for _, _, text in _paragraph_spans(content)]
+
+
+def _delegation_transparency_allowlisted_block() -> str:
+    return normalize_block("\n".join(f"- {rule}" for rule in DELEGATION_TRANSPARENCY_RULES))
+
+
+# Blocks that intentionally repeat across surface kinds. Keyed by the block's
+# normalized text; each entry must carry a reason a reviewer can check against
+# the actual duplication, not just a label.
+ALLOWLISTED_DUPLICATE_BLOCKS: dict[str, str] = {
+    _delegation_transparency_allowlisted_block(): (
+        "Delegation transparency rules (commit ad62b9a1) are rendered into both every "
+        "handoff-guide/handoff-gated skill body and the shared skill-common-rail reference "
+        "on purpose: a handoff-gated skill must state its own transparency obligations "
+        "without depending on the agent choosing to fetch the on-demand reference first."
+    ),
+}
+
+
+def detect_cross_surface_duplicates(surfaces: list[Surface]) -> list[CrossSurfaceDuplicate]:
+    """Find blocks repeated verbatim across surfaces of different kinds.
+
+    `surfaces` order is the precedence order: the first surface to emit a
+    given normalized block owns it. Same-kind repeats (e.g. two skill bodies
+    sharing a heading) are out of scope here -- that is `context_cost.py`'s
+    per-heading measurement -- so only a later surface of a *different* kind
+    is reported.
+    """
+    owners: dict[str, tuple[str, str]] = {}  # normalized -> (surface_id, kind)
+    duplicates: list[CrossSurfaceDuplicate] = []
+    for surface in surfaces:
+        for block in paragraph_blocks(surface.content):
+            normalized = normalize_block(block)
+            owner = owners.get(normalized)
+            if owner is None:
+                owners[normalized] = (surface.surface_id, surface.kind)
+                continue
+            owner_id, owner_kind = owner
+            if owner_kind == surface.kind:
+                continue
+            duplicates.append(
+                CrossSurfaceDuplicate(
+                    normalized=normalized,
+                    owner_surface=owner_id,
+                    duplicate_surface=surface.surface_id,
+                    byte_len=len(block),
+                    allowlist_reason=ALLOWLISTED_DUPLICATE_BLOCKS.get(normalized),
+                )
+            )
+    return duplicates
+
+
+def _pointer_line(owner_surface: str) -> str:
+    return f"{POINTER_LINE_PREFIX} `{owner_surface}`.]"
+
+
+def suppress_duplicates(
+    surfaces: list[Surface], duplicates: list[CrossSurfaceDuplicate]
+) -> list[Surface]:
+    """Replace every non-allowlisted duplicate block with a deterministic pointer line.
+
+    Deterministic: same `surfaces` + `duplicates` input always produces the
+    same output, independent of dict/set iteration order, because
+    replacement order is driven by span position within each surface.
+    """
+    owner_by_duplicate_surface: dict[str, dict[str, str]] = {}
+    for duplicate in duplicates:
+        if duplicate.allowlisted:
+            continue
+        owner_by_duplicate_surface.setdefault(duplicate.duplicate_surface, {})[
+            duplicate.normalized
+        ] = duplicate.owner_surface
+
+    suppressed: list[Surface] = []
+    for surface in surfaces:
+        replacements = owner_by_duplicate_surface.get(surface.surface_id)
+        if not replacements:
+            suppressed.append(surface)
+            continue
+        spans = _paragraph_spans(surface.content)
+        new_content = surface.content
+        for start, end, block in sorted(spans, key=lambda span: span[0], reverse=True):
+            owner_surface = replacements.get(normalize_block(block))
+            if owner_surface is None:
+                continue
+            new_content = new_content[:start] + _pointer_line(owner_surface) + new_content[end:]
+        suppressed.append(Surface(surface.surface_id, surface.kind, new_content))
+    return suppressed
+
+
+def assembled_surfaces_for_measurement() -> list[Surface]:
+    """The deterministic, ordered surface set for the real OMH corpus.
+
+    Order matters: it is the precedence order for ownership. The always-on
+    surfaces come first because they load before a skill is ever selected;
+    skill bodies then references, both sorted by name for determinism.
+    """
+    from ..omh.snippet import WORKSPACE_SNIPPET
+    from ..plugin_bundle.omh.awareness import awareness_primer_context, awareness_primer_markdown
+
+    surfaces = [
+        Surface("awareness:primer_context", "awareness_primer", awareness_primer_context()),
+        Surface("awareness:primer_markdown", "awareness_primer", awareness_primer_markdown()),
+        Surface("router:workspace_snippet", "router_profile", WORKSPACE_SNIPPET),
+    ]
+    templates = sorted(builtin_skill_templates(), key=lambda template: template.name)
+    for template in templates:
+        surfaces.append(Surface(f"skill_body:{template.name}", "skill_body", template.content))
+    references = sorted(
+        builtin_skill_reference_templates(),
+        key=lambda template: (template.skill_name, template.relative_path),
+    )
+    for reference in references:
+        surface_id = f"reference:{reference.skill_name}/{reference.relative_path}"
+        surfaces.append(Surface(surface_id, "reference", reference.content))
+    return surfaces
+
+
+def cross_surface_duplicate_profile() -> dict[str, object]:
+    """Measured before/after report for the real assembled corpus."""
+    surfaces = assembled_surfaces_for_measurement()
+    duplicates = detect_cross_surface_duplicates(surfaces)
+    suppressed_surfaces = suppress_duplicates(surfaces, duplicates)
+
+    bytes_before = sum(len(surface.content) for surface in surfaces)
+    bytes_after = sum(len(surface.content) for surface in suppressed_surfaces)
+    allowlisted = [duplicate for duplicate in duplicates if duplicate.allowlisted]
+    suppressible = [duplicate for duplicate in duplicates if not duplicate.allowlisted]
+
+    return {
+        "surface_count": len(surfaces),
+        "surface_kinds": sorted({surface.kind for surface in surfaces}),
+        "bytes_before": bytes_before,
+        "bytes_after": bytes_after,
+        "bytes_saved": bytes_before - bytes_after,
+        "duplicate_count": len(duplicates),
+        "allowlisted_bytes": sum(duplicate.byte_len for duplicate in allowlisted),
+        "suppressible_bytes": sum(duplicate.byte_len for duplicate in suppressible),
+        "duplicates": [
+            {
+                "owner_surface": duplicate.owner_surface,
+                "duplicate_surface": duplicate.duplicate_surface,
+                "byte_len": duplicate.byte_len,
+                "allowlisted": duplicate.allowlisted,
+                "allowlist_reason": duplicate.allowlist_reason,
+            }
+            for duplicate in duplicates
+        ],
+    }

--- a/tests/test_duplicate_content_suppression.py
+++ b/tests/test_duplicate_content_suppression.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.skills.duplicate_content import (
+    ALLOWLISTED_DUPLICATE_BLOCKS,
+    Surface,
+    assembled_surfaces_for_measurement,
+    cross_surface_duplicate_profile,
+    detect_cross_surface_duplicates,
+    normalize_block,
+    paragraph_blocks,
+    suppress_duplicates,
+)
+
+SHARED_PARAGRAPH = (
+    "This is a shared paragraph long enough to clear the minimum block size "
+    "so the detector treats it as owned content rather than a stray phrase."
+)
+
+
+class DuplicateContentSuppressionTests(unittest.TestCase):
+    def test_detects_duplicate_block_across_different_surface_kinds(self) -> None:
+        surfaces = [
+            Surface("primer", "awareness_primer", f"Intro.\n\n{SHARED_PARAGRAPH}\n\nPrimer tail."),
+            Surface("skill_body:x", "skill_body", f"Skill x.\n\n{SHARED_PARAGRAPH}\n\nUnique x content."),
+        ]
+        duplicates = detect_cross_surface_duplicates(surfaces)
+        self.assertEqual(len(duplicates), 1)
+        duplicate = duplicates[0]
+        self.assertEqual(duplicate.owner_surface, "primer")
+        self.assertEqual(duplicate.duplicate_surface, "skill_body:x")
+        self.assertEqual(duplicate.byte_len, len(SHARED_PARAGRAPH))
+        self.assertFalse(duplicate.allowlisted)
+
+    def test_same_kind_repetition_is_not_a_cross_surface_duplicate(self) -> None:
+        # Two skill bodies sharing a paragraph is `context_cost.py`'s per-heading
+        # measurement, not this module's concern -- only a different `kind` counts.
+        surfaces = [
+            Surface("skill_body:a", "skill_body", f"A.\n\n{SHARED_PARAGRAPH}\n\nA tail."),
+            Surface("skill_body:b", "skill_body", f"B.\n\n{SHARED_PARAGRAPH}\n\nB tail."),
+        ]
+        duplicates = detect_cross_surface_duplicates(surfaces)
+        self.assertEqual(duplicates, [])
+
+    def test_blocks_below_minimum_size_are_ignored(self) -> None:
+        surfaces = [
+            Surface("primer", "awareness_primer", "Short.\n\nAlso short."),
+            Surface("skill_body:x", "skill_body", "Short.\n\nAlso short."),
+        ]
+        self.assertEqual(detect_cross_surface_duplicates(surfaces), [])
+
+    def test_pointer_replacement_removes_duplicate_text_and_names_the_owner(self) -> None:
+        surfaces = [
+            Surface("primer", "awareness_primer", f"Intro.\n\n{SHARED_PARAGRAPH}\n\nPrimer tail."),
+            Surface("skill_body:x", "skill_body", f"Skill x.\n\n{SHARED_PARAGRAPH}\n\nUnique x content."),
+        ]
+        duplicates = detect_cross_surface_duplicates(surfaces)
+        suppressed = suppress_duplicates(surfaces, duplicates)
+        by_id = {surface.surface_id: surface for surface in suppressed}
+
+        # The owner keeps its full text untouched.
+        self.assertIn(SHARED_PARAGRAPH, by_id["primer"].content)
+        # The later surface loses the duplicate text and gets a pointer naming the owner.
+        self.assertNotIn(SHARED_PARAGRAPH, by_id["skill_body:x"].content)
+        self.assertIn("`primer`", by_id["skill_body:x"].content)
+        self.assertIn("Unique x content.", by_id["skill_body:x"].content)
+
+        # Exactly one surface still carries the real text: no semantic loss.
+        carriers = [s for s in suppressed if SHARED_PARAGRAPH in s.content]
+        self.assertEqual(len(carriers), 1)
+        self.assertEqual(carriers[0].surface_id, "primer")
+
+    def test_suppression_is_deterministic_across_runs(self) -> None:
+        surfaces = [
+            Surface("primer", "awareness_primer", f"Intro.\n\n{SHARED_PARAGRAPH}\n\nPrimer tail."),
+            Surface("skill_body:x", "skill_body", f"Skill x.\n\n{SHARED_PARAGRAPH}\n\nUnique x content."),
+            Surface("skill_body:y", "skill_body", f"Skill y.\n\n{SHARED_PARAGRAPH}\n\nUnique y content."),
+        ]
+        duplicates = detect_cross_surface_duplicates(surfaces)
+        first = suppress_duplicates(surfaces, duplicates)
+        second = suppress_duplicates(surfaces, duplicates)
+        self.assertEqual(first, second)
+
+    def test_allowlisted_block_is_left_untouched_in_every_surface(self) -> None:
+        allowlisted_normalized = next(iter(ALLOWLISTED_DUPLICATE_BLOCKS))
+        surfaces = [
+            Surface("primer", "awareness_primer", f"Intro.\n\n{allowlisted_normalized}\n\nTail."),
+            Surface("reference:common-rail", "reference", f"Rail.\n\n{allowlisted_normalized}\n\nRail tail."),
+        ]
+        duplicates = detect_cross_surface_duplicates(surfaces)
+        self.assertEqual(len(duplicates), 1)
+        self.assertTrue(duplicates[0].allowlisted)
+        self.assertIsNotNone(duplicates[0].allowlist_reason)
+
+        suppressed = suppress_duplicates(surfaces, duplicates)
+        for surface in suppressed:
+            self.assertIn(allowlisted_normalized, surface.content)
+            self.assertNotIn("duplicate content suppressed", surface.content)
+
+    def test_normalize_and_paragraph_helpers_are_whitespace_insensitive(self) -> None:
+        text = (
+            "first block here that is long enough on its own to clear the minimum block size.\n"
+            "line   two of the first block.\n"
+            "\n\n"
+            "second block here that is also long enough to count as its own block on its own."
+        )
+        blocks = paragraph_blocks(text)
+        self.assertEqual(len(blocks), 2)
+        self.assertEqual(normalize_block("a\n\tb   c"), "a b c")
+
+    def test_real_corpus_has_no_unallowlisted_cross_surface_duplicates(self) -> None:
+        """Standing regression gate for backlog item E.
+
+        If a future change makes the same instruction text appear verbatim in
+        two simultaneously-loaded surfaces (skill body, reference, awareness
+        primer, or the workspace router-profile snippet) without allowlisting
+        it, `suppressible_bytes` goes non-zero here -- the failure names both
+        surfaces so the fix is "move it to the surface that already owns it."
+        """
+        profile = cross_surface_duplicate_profile()
+        self.assertEqual(
+            profile["suppressible_bytes"],
+            0,
+            f"unallowlisted cross-surface duplicates found: {profile['duplicates']}",
+        )
+        # The one known, deliberate duplicate (delegation transparency rules,
+        # commit ad62b9a1) stays allowlisted and accounted for.
+        self.assertEqual(profile["duplicate_count"], 1)
+        self.assertEqual(profile["allowlisted_bytes"], 2466)
+        self.assertEqual(profile["bytes_saved"], 0)
+        self.assertEqual(
+            profile["surface_kinds"],
+            ["awareness_primer", "reference", "router_profile", "skill_body"],
+        )
+
+    def test_real_corpus_measurement_is_stable_across_two_runs(self) -> None:
+        first = cross_surface_duplicate_profile()
+        second = cross_surface_duplicate_profile()
+        self.assertEqual(first, second)
+
+    def test_assembled_surfaces_cover_expected_kinds_and_counts(self) -> None:
+        from omh.skills.packaging import builtin_skill_reference_templates, builtin_skill_templates
+
+        surfaces = assembled_surfaces_for_measurement()
+        kinds = [surface.kind for surface in surfaces]
+        self.assertEqual(kinds.count("awareness_primer"), 2)
+        self.assertEqual(kinds.count("router_profile"), 1)
+        self.assertEqual(kinds.count("skill_body"), len(builtin_skill_templates()))
+        self.assertEqual(kinds.count("reference"), len(builtin_skill_reference_templates()))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- Added `src/skills/duplicate_content.py`: a canonical-block registry that
  detects paragraph-level content repeated verbatim across *different kinds*
  of OMH surfaces (awareness primer, workspace router-profile snippet, skill
  body, on-demand reference file), and suppresses non-allowlisted repeats by
  replacing later occurrences with a short deterministic pointer line naming
  the owning surface.
- Added `tests/test_duplicate_content_suppression.py`: unit tests for
  detection, deterministic pointer replacement, allowlist behavior, no
  semantic loss, and a standing regression gate measured against the real
  corpus.

### Why This Exists

Backlog item E ("Duplicate-content suppression across loaded surfaces",
`.omc/research/ohmypi-optimization-2026-08-29.md` §E) asks: when multiple OMH
surfaces load into one context together, the same content should not be paid
for twice. `src/skills/context_cost.py` (#634) already measures duplication
*within one surface kind* (byte-identical `##` sections across different
`SKILL.md` bodies), and #1201 measures repetition *inside a single skill's own
body*. Neither answers the cross-kind question this item asks.

### User / Operator Impact

None observed today: the measured cross-surface duplicate corpus is
dedup-clean except for one deliberately-doubled, now-allowlisted block. The
real deliverable is the detection mechanism plus a regression gate that
fires the moment a future change introduces real (non-allowlisted)
cross-surface duplication, naming both surfaces so the fix is obvious.

### How It Works

- A "block" is a blank-line-delimited paragraph of at least 40 characters
  (below that, matches are common short phrases, not owned content).
- Two blocks are the same content if their whitespace-collapsed text is
  byte-identical.
- Surfaces are deduped in caller-supplied order; the first surface to emit a
  block owns it. A later surface of a *different* kind repeating the block is
  a cross-surface duplicate (same-kind repeats, e.g. two skill bodies sharing
  a heading, are `context_cost.py`'s territory, not this module's).
- A cross-surface duplicate is either suppressed (pointer line replaces the
  text) or, if its normalized text is in `ALLOWLISTED_DUPLICATE_BLOCKS`, left
  untouched because the repeat is intentional and justified.
- `assembled_surfaces_for_measurement()` builds the real, deterministic
  surface set: the awareness primer (both rendered forms), the workspace
  router-profile snippet (`src/omh/snippet.py`), all 88 skill bodies, and all
  reference files. In this codebase, "workflow context cards" are rendered
  directly into each skill body rather than delivered as an independently
  loaded surface, so they are covered under `skill_body` rather than a fifth
  kind — noted in the module docstring.
- `cross_surface_duplicate_profile()` runs detection + suppression over that
  real corpus and reports measured before/after bytes.

**Measured result:** 157 surfaces, 1,067,403 bytes total. Exactly one
cross-surface-kind duplicate exists: the delegation-transparency rules
(2,466 bytes), which the module allowlists with a citation to commit
`ad62b9a1` — those rules are deliberately rendered into both every
handoff-guide/handoff-gated skill body *and* the shared skill-common-rail
reference, so a handoff-gated skill states its own transparency obligations
without depending on the agent choosing to fetch the on-demand reference
first. Suppressible (non-allowlisted) duplicate bytes: 0. Bytes saved: 0.

Because no generated `SKILL.md`/reference content changed (there is nothing
non-allowlisted to suppress in the current corpus), `FULL_PROFILE_SKILL_BODY_CHAR_LIMIT`
(`src/maintenance/release.py`) is **not** ratcheted in this PR — there is no
real measured drop to ratchet against. The ratchet convention works both
ways (a real measured drop moves the ceiling down with an
`OLD -> NEW: reason` line); this PR's honest finding is a 0-byte drop, so the
ceiling stays put.

Out of scope: the dossier's second suggestion, adopting oh-my-pi's
"shadowing precedence" model (first-wins, loser marked `_shadowed`) for
cases where two sources supply the same named rule. OMH has no live
instance of that collision shape today (unlike oh-my-pi's
native/omp-plugins/agents/cursor/windsurf/cline tiers), so there is nothing
to attach the model to; left for a future item if such a collision point
appears.

### Files And Contracts Touched

- `src/skills/duplicate_content.py` (new)
- `tests/test_duplicate_content_suppression.py` (new)

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli docs ulw-inventory --check`, `uv run python -m omh.cli docs ulw-site --check`, `uv run python -m omh.cli release drift` (no drift, 18 checks)
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- `PYTHONPATH=tests uv run python -m unittest discover -s tests`: 8210 tests,
  21 failures + 7 errors, all in `tests/test_cross_harness_adapters.py` and
  `tests/test_cross_harness_adapter_security.py` — the 28 known cross-harness
  failures caused by the sandbox read-root predicate correctly rejecting this
  checkout's `.claude/worktrees/...` path component; none touch the new
  module or file.
- `PYTHONPATH=tests uv run python -m unittest tests/test_duplicate_content_suppression.py -v`:
  10/10 pass.
- `uv run --group lint ruff check src tests`: clean.
- `uv run python -m compileall -q src tests`: clean (one pre-existing,
  unrelated `SyntaxWarning` in `tests/test_menubar_app.py`).
- `uv run python -m omh.cli docs workflows --check`,
  `docs roles --check`, `docs capability-families --check`,
  `docs ulw-inventory --check`, `docs ulw-site --check`: all `ok: true` (no
  generated artifact changed by this PR).
- `uv run python -m omh.cli release drift`: "No drift. 18 checks passed."
- `git diff --check`: clean.
- Measured cross-surface duplicate profile against the real corpus (see How
  It Works): 157 surfaces / 1,067,403 bytes total; 1 duplicate found, fully
  allowlisted (2,466 bytes); 0 suppressible bytes; 0 bytes saved.

### Not Tested / Not Applicable

- `harness validate`, `release checklist --json`, `release hermes-smoke`,
  `omh --help`, and the live smoke-install command: unrelated to this
  change (no CLI surface, harness definition, or install path touched);
  skipped to keep verification scoped to what changed.
- Manual Hermes/TUI check: this PR ships a detection/measurement module and
  its tests only; no runtime behavior change to observe live (there is
  nothing new suppressed in the shipped corpus to see rendered differently).

## Risk

- Low. New module and new test file only; no changes to `render.py`,
  catalog data, generated `skills/*/SKILL.md` files, or any byte-gated
  artifact. The regression gate is additive (a new failure mode it can
  introduce is a false-positive flag on a future legitimate repeat, fixed by
  adding a justified allowlist entry — the same shape as the one entry
  already shipped here).

## Compatibility / Rollout

- No install-path, CLI, or generated-artifact changes; nothing to roll out
  beyond the code review and merge.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`) — none; no generated artifact or install surface changed.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap — none applicable; no live Hermes-facing surface changed.

## Follow-Up

- If a future dossier item finds a live case in OMH of two data sources
  supplying the same named rule (the shape oh-my-pi's rulebook precedence
  tiers solve), revisit whether `duplicate_content.py`'s allowlist model
  should grow a "shadowed" precedence mode, per §E's second suggestion.
- If a future change legitimately needs a new cross-surface repeat, add the
  entry to `ALLOWLISTED_DUPLICATE_BLOCKS` with a citation the way the
  delegation-transparency entry does, rather than letting the regression
  gate go permanently red.
