### PR TITLE
feat(coding): preflight-block a doomed Hermes child spawn before it starts

### DIFF
--- a/src/coding/hermes_child_dispatch.py
+++ b/src/coding/hermes_child_dispatch.py
@@ -44,6 +44,11 @@ from ._hermes_child_process import (
     terminate_process_group as _terminate_process_group,
     write_stdin_and_close as _write_stdin_and_close,
 )
+from .spawn_preflight import (
+    check_executable_present,
+    check_working_directory,
+    run_spawn_preflight,
+)
 
 MAX_CHILD_DEPTH: Final = 1
 _PARENT_MARKER_ENV: Final = "OMH_ISOLATED_HERMES_PARENT"
@@ -92,6 +97,27 @@ class DispatchConfirmationError(HermesChildDispatchError):
 
 class DispatchRecursionError(HermesChildDispatchError):
     """Raised when an isolated Hermes child attempts another dispatch."""
+
+
+class SpawnPreflightError(HermesChildDispatchError):
+    """Raised when a preflight check blocks the child spawn before anything starts.
+
+    Nothing is spawned to produce this: no scratch directory, no dispatch
+    guard, no subprocess. `verdict` is the full structured payload from
+    `spawn_preflight.run_spawn_preflight`, so a caller that wants more than
+    the rendered message can inspect the failed checks and their remedies
+    directly instead of re-parsing the exception text.
+    """
+
+    def __init__(self, verdict: Mapping[str, object]) -> None:
+        self.verdict = dict(verdict)
+        failed = verdict.get("failed_checks", ())
+        remedies = "; ".join(
+            f"{item.get('check')}: {item.get('detail')} -- {item.get('remedy')}"
+            for item in failed
+            if isinstance(item, Mapping)
+        )
+        super().__init__(f"Hermes child spawn preflight failed: {remedies}")
 
 
 @dataclass(frozen=True, slots=True)
@@ -211,6 +237,9 @@ def dispatch_hermes_child(
     )
     if not request.prompt or not request.model or request.timeout_seconds <= 0:
         raise ValueError("prompt, model, and a positive timeout are required")
+    verdict = _spawn_preflight(request)
+    if not verdict["ready"]:
+        raise SpawnPreflightError(verdict)
     if request.evaluation_context is not None:
         seal_evaluation_binding(
             request.evaluation_context,
@@ -391,6 +420,31 @@ def _dispatch_guarded(
         request, depth, status, process.returncode if process is not None else None,
         stdout, stderr, usage, cleanup, signals,
         stdout_capture.truncated, stderr_capture.truncated, usage_file_exists,
+    )
+
+
+def _spawn_preflight(request: HermesChildRequest) -> dict[str, object]:
+    """Everything about this request that can be checked before any spawn.
+
+    Executable presence covers `request.hermes` exactly as the eventual spawn
+    would resolve it; working directory covers an explicit `request.cwd`
+    override. Both are unconditional prerequisites of a successful spawn on
+    every provider, so blocking on them changes no passing case.
+
+    Provider auth is deliberately NOT preflighted here even though
+    `_PROVIDER_ENV` documents which variables a real provider needs: this
+    dispatch's actual auth contract is "whatever the spawned Hermes CLI
+    itself accepts", which prepare-time cannot fully know (a test double, a
+    provider Hermes resolves outside these variables, a future auth channel).
+    Refusing early on a documented-but-not-actually-required variable would
+    be a behavior change for a spawn that would otherwise have succeeded, so
+    that gap is left for the Hermes CLI itself to report.
+    """
+    return run_spawn_preflight(
+        [
+            check_executable_present(request.hermes),
+            check_working_directory(request.cwd),
+        ]
     )
 
 

--- a/src/coding/spawn_preflight.py
+++ b/src/coding/spawn_preflight.py
@@ -1,0 +1,173 @@
+"""Pure, versioned preflight checks for every OMH boundary that spawns a subprocess.
+
+Backlog item G ("Preflight resolution before any subprocess spawn"): everything
+that CAN be resolved before a subprocess is spawned MUST be, so a doomed spawn
+never happens. Each check here answers one narrow, local question --- does an
+executable resolve, does a working directory exist, is a declared environment
+prerequisite set, does a declared credential file exist --- and never reads
+credential *content*, never makes a network call, and never spawns anything
+itself. A caller composes the checks relevant to its own boundary and passes
+them to `run_spawn_preflight`, which returns one versioned verdict payload a
+caller can cite in a refusal instead of attempting a spawn that was always
+going to fail.
+
+Every failed check carries its own remedy: what a person or wrapper would do
+to make the check pass. A verdict with `ready=False` is a structured refusal,
+not an exception dressed up after the fact --- the whole point is that nothing
+was spawned to produce it.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Final
+
+SPAWN_PREFLIGHT_SCHEMA_VERSION: Final = "omh_spawn_preflight_verdict/v1"
+SPAWN_PREFLIGHT_CLAIM_BOUNDARY: Final = (
+    "A spawn preflight verdict says only whether the checked prerequisites were observed present "
+    "before a subprocess was spawned. It is not dispatch, execution, verification, review, CI, or "
+    "merge evidence, and a ready verdict is not proof the spawned process will succeed."
+)
+
+CHECK_EXECUTABLE_PRESENCE: Final = "executable_presence"
+CHECK_WORKING_DIRECTORY: Final = "working_directory"
+CHECK_ENV_PREREQUISITE: Final = "env_prerequisite"
+CHECK_CREDENTIAL_FILE_PRESENCE: Final = "credential_file_presence"
+
+
+def _check(name: str, passed: bool, detail: str, remedy: str) -> dict[str, object]:
+    return {"check": name, "passed": passed, "detail": detail, "remedy": "" if passed else remedy}
+
+
+def check_executable_present(
+    command: str,
+    *,
+    which: Callable[[str], str | None] = shutil.which,
+) -> dict[str, object]:
+    """Whether `command` resolves to a runnable file before it is ever spawned.
+
+    An absolute path or one carrying a path separator is checked directly
+    (exists, is a file, is executable); a bare name is resolved on PATH the
+    same way the eventual spawn would resolve it, so this reports the
+    identical binary a spawn would use rather than a different PATH entry.
+    """
+    if not command:
+        return _check(
+            CHECK_EXECUTABLE_PRESENCE, False, "no executable was named", "name the executable to spawn"
+        )
+    has_separator = "/" in command or "\\" in command
+    if has_separator or Path(command).is_absolute():
+        candidate = Path(command).expanduser()
+        if not candidate.is_file():
+            return _check(
+                CHECK_EXECUTABLE_PRESENCE,
+                False,
+                f"`{command}` does not exist",
+                f"install the executable, or point at a valid path instead of `{command}`",
+            )
+        if os.name != "nt" and not os.access(candidate, os.X_OK):
+            return _check(
+                CHECK_EXECUTABLE_PRESENCE,
+                False,
+                f"`{command}` exists but is not executable",
+                f"grant execute permission on `{command}` (chmod +x)",
+            )
+        return _check(CHECK_EXECUTABLE_PRESENCE, True, f"`{command}` is a runnable file", "")
+    resolved = which(command)
+    if not resolved:
+        return _check(
+            CHECK_EXECUTABLE_PRESENCE,
+            False,
+            f"`{command}` was not found on PATH",
+            f"install `{command}` or add it to PATH",
+        )
+    return _check(CHECK_EXECUTABLE_PRESENCE, True, f"`{command}` resolves to `{resolved}`", "")
+
+
+def check_working_directory(path: str | Path | None) -> dict[str, object]:
+    """Whether the requested spawn working directory exists and is a directory.
+
+    `None` passes: a spawn with no explicit cwd override inherits the parent
+    process's own working directory, which always exists, so there is nothing
+    to check.
+    """
+    if path is None:
+        return _check(CHECK_WORKING_DIRECTORY, True, "no working directory override was requested", "")
+    candidate = Path(path)
+    if not candidate.exists():
+        return _check(
+            CHECK_WORKING_DIRECTORY,
+            False,
+            f"working directory `{candidate}` does not exist",
+            f"create `{candidate}`, or point the working directory at one that exists",
+        )
+    if not candidate.is_dir():
+        return _check(
+            CHECK_WORKING_DIRECTORY,
+            False,
+            f"`{candidate}` exists but is not a directory",
+            f"point the working directory at a directory, not `{candidate}`",
+        )
+    return _check(CHECK_WORKING_DIRECTORY, True, f"`{candidate}` is a directory", "")
+
+
+def check_env_any_present(names: Sequence[str], *, env: Mapping[str, str]) -> dict[str, object]:
+    """Whether at least one of `names` is set to a non-empty value in `env`.
+
+    An empty `names` sequence means the boundary declared no environment
+    prerequisite for this spawn, and passes -- there is nothing to require.
+    Checking existence only: the value itself is never logged or returned.
+    """
+    if not names:
+        return _check(CHECK_ENV_PREREQUISITE, True, "no environment prerequisite was declared", "")
+    present = [name for name in names if env.get(name)]
+    if present:
+        return _check(CHECK_ENV_PREREQUISITE, True, f"{present[0]} is set", "")
+    joined = ", ".join(names)
+    return _check(
+        CHECK_ENV_PREREQUISITE,
+        False,
+        f"none of the required environment variables are set: {joined}",
+        f"set one of {joined} before dispatching",
+    )
+
+
+def check_credential_file_present(path: str | Path | None) -> dict[str, object]:
+    """Whether a named credential file exists. Existence only -- content is never read.
+
+    `None` or an empty path passes: no credential file was declared for this
+    boundary.
+    """
+    if not path:
+        return _check(CHECK_CREDENTIAL_FILE_PRESENCE, True, "no credential file was declared", "")
+    candidate = Path(path).expanduser()
+    if not candidate.is_file():
+        return _check(
+            CHECK_CREDENTIAL_FILE_PRESENCE,
+            False,
+            f"credential file `{candidate}` does not exist",
+            f"place the credential file at `{candidate}` before dispatching",
+        )
+    return _check(CHECK_CREDENTIAL_FILE_PRESENCE, True, f"`{candidate}` exists", "")
+
+
+def run_spawn_preflight(checks: Sequence[Mapping[str, object]]) -> dict[str, object]:
+    """Combine individual check results into one versioned, citable verdict.
+
+    Every check that ran is carried in `checks` (passed and failed alike), so
+    a caller can show the whole picture; `failed_checks` is the subset a
+    refusal cites. `ready` is the single boolean a spawn boundary gates on.
+    """
+    materialized = [dict(item) for item in checks]
+    failed = [item for item in materialized if not item.get("passed")]
+    return {
+        "schema_version": SPAWN_PREFLIGHT_SCHEMA_VERSION,
+        "status": "blocked" if failed else "ready",
+        "ready": not failed,
+        "checks": materialized,
+        "failed_checks": failed,
+        "claim_boundary": SPAWN_PREFLIGHT_CLAIM_BOUNDARY,
+    }

--- a/tests/test_hermes_child_dispatch.py
+++ b/tests/test_hermes_child_dispatch.py
@@ -24,6 +24,7 @@ from omh.coding.hermes_child_dispatch import (  # noqa: E402
     DispatchRecursionError,
     HermesChildEvaluationContext,
     HermesChildRequest,
+    SpawnPreflightError,
     dispatch_hermes_child,
 )
 from omh.coding.hermes_child_receipts import (  # noqa: E402
@@ -336,6 +337,24 @@ class HermesChildDispatchTests(unittest.TestCase):
         self.assertIsNone(child_env["AWS_SECRET_ACCESS_KEY"])
         self.assertNotIn("UNRELATED_CREDENTIAL", child_env)
 
+    def test_missing_working_directory_is_blocked_by_preflight_before_any_spawn(self) -> None:
+        # Provider auth is deliberately NOT preflighted (see
+        # `_spawn_preflight`'s docstring): only prerequisites unconditional on
+        # every provider -- the executable and the working directory -- are
+        # checked before the spawn.
+        missing_cwd = self.root / "does-not-exist"
+        with patch("omh.coding.hermes_child_dispatch.subprocess.Popen") as popen:
+            with self.assertRaises(SpawnPreflightError) as ctx:
+                dispatch_hermes_child(
+                    self.request(cwd=missing_cwd),
+                    dispatch_policy="ask_before_dispatch",
+                    confirmed=True,
+                )
+        popen.assert_not_called()
+        failed = {item["check"] for item in ctx.exception.verdict["failed_checks"]}
+        self.assertIn("working_directory", failed)
+        self.assertFalse((self.root / "started").exists())
+
     def test_unknown_provider_cannot_project_dynamic_token(self) -> None:
         credential = "github-token-must-not-project"
         result = dispatch_hermes_child(
@@ -399,14 +418,27 @@ class HermesChildDispatchTests(unittest.TestCase):
         self.assertNotIn("SECRET_OUTPUT", result.stdout)
         self.assertNotIn("authorization", result.stderr.lower())
 
-        missing = dispatch_hermes_child(
-            self.request(hermes="/private/SECRET_EXECUTABLE_991/not-there"),
-            dispatch_policy="ask_before_dispatch",
-            confirmed=True,
-        )
-        self.assertEqual(missing.status, "failed")
-        self.assertNotIn("SECRET_EXECUTABLE", missing.stderr)
-        self.assertIn("FileNotFoundError", missing.stderr)
+    def test_missing_hermes_executable_is_blocked_by_preflight_before_any_spawn(self) -> None:
+        # Backlog G: a missing executable is resolved before the spawn is ever
+        # attempted, not discovered by catching the OSError a doomed Popen
+        # call would raise. Popen must never be called.
+        with patch("omh.coding.hermes_child_dispatch.subprocess.Popen") as popen:
+            with self.assertRaises(SpawnPreflightError) as ctx:
+                dispatch_hermes_child(
+                    self.request(hermes="/private/SECRET_EXECUTABLE_991/not-there"),
+                    dispatch_policy="ask_before_dispatch",
+                    confirmed=True,
+                )
+        popen.assert_not_called()
+        verdict = ctx.exception.verdict
+        self.assertEqual(verdict["schema_version"], "omh_spawn_preflight_verdict/v1")
+        self.assertFalse(verdict["ready"])
+        self.assertEqual(verdict["status"], "blocked")
+        failed = {item["check"]: item for item in verdict["failed_checks"]}
+        self.assertIn("executable_presence", failed)
+        self.assertIn("SECRET_EXECUTABLE_991", failed["executable_presence"]["detail"])
+        self.assertTrue(failed["executable_presence"]["remedy"])
+        self.assertFalse((self.root / "started").exists())
 
     def test_exact_100mb_on_both_streams_is_hard_capped_without_deadlock_or_leaks(self) -> None:
         prior_drainers = {

--- a/tests/test_spawn_preflight.py
+++ b/tests/test_spawn_preflight.py
@@ -1,0 +1,191 @@
+"""Positive/negative coverage for backlog G's shared spawn preflight checks.
+
+Each pure check gets one passing case and one failing case, and the failing
+case always names a remedy. `run_spawn_preflight` gets its own contract test
+for the combined verdict shape. Boundary integration (spawn never attempted on
+a failed preflight) lives in `tests/test_hermes_child_dispatch.py`, next to
+the boundary it protects.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.coding.spawn_preflight import (  # noqa: E402
+    CHECK_CREDENTIAL_FILE_PRESENCE,
+    CHECK_ENV_PREREQUISITE,
+    CHECK_EXECUTABLE_PRESENCE,
+    CHECK_WORKING_DIRECTORY,
+    SPAWN_PREFLIGHT_SCHEMA_VERSION,
+    check_credential_file_present,
+    check_env_any_present,
+    check_executable_present,
+    check_working_directory,
+    run_spawn_preflight,
+)
+
+
+class ExecutablePresenceTests(unittest.TestCase):
+    def test_absolute_path_that_exists_and_is_executable_passes(self) -> None:
+        with TemporaryDirectory() as tmp:
+            script = Path(tmp) / "tool"
+            script.write_text("#!/bin/sh\n", encoding="utf-8")
+            script.chmod(0o755)
+            result = check_executable_present(str(script))
+        self.assertEqual(result["check"], CHECK_EXECUTABLE_PRESENCE)
+        self.assertTrue(result["passed"])
+        self.assertEqual(result["remedy"], "")
+
+    def test_absolute_path_that_does_not_exist_fails_with_remedy(self) -> None:
+        result = check_executable_present("/no/such/path/tool-xyz")
+        self.assertFalse(result["passed"])
+        self.assertIn("does not exist", result["detail"])
+        self.assertTrue(result["remedy"])
+
+    def test_absolute_path_that_is_not_executable_fails_with_remedy(self) -> None:
+        if os.name == "nt":
+            self.skipTest("execute-bit check is POSIX-only")
+        with TemporaryDirectory() as tmp:
+            script = Path(tmp) / "tool"
+            script.write_text("not executable\n", encoding="utf-8")
+            script.chmod(0o644)
+            result = check_executable_present(str(script))
+        self.assertFalse(result["passed"])
+        self.assertIn("not executable", result["detail"])
+        self.assertTrue(result["remedy"])
+
+    def test_bare_name_resolves_through_injected_which(self) -> None:
+        result = check_executable_present("tool", which=lambda name: "/usr/bin/tool")
+        self.assertTrue(result["passed"])
+        self.assertIn("/usr/bin/tool", result["detail"])
+
+    def test_bare_name_not_on_path_fails_with_remedy(self) -> None:
+        result = check_executable_present("tool", which=lambda name: None)
+        self.assertFalse(result["passed"])
+        self.assertIn("not found on PATH", result["detail"])
+        self.assertTrue(result["remedy"])
+
+    def test_empty_command_fails(self) -> None:
+        result = check_executable_present("")
+        self.assertFalse(result["passed"])
+
+
+class WorkingDirectoryTests(unittest.TestCase):
+    def test_none_passes(self) -> None:
+        result = check_working_directory(None)
+        self.assertEqual(result["check"], CHECK_WORKING_DIRECTORY)
+        self.assertTrue(result["passed"])
+
+    def test_existing_directory_passes(self) -> None:
+        with TemporaryDirectory() as tmp:
+            result = check_working_directory(tmp)
+        self.assertTrue(result["passed"])
+
+    def test_missing_directory_fails_with_remedy(self) -> None:
+        with TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "does-not-exist"
+            result = check_working_directory(missing)
+        self.assertFalse(result["passed"])
+        self.assertIn("does not exist", result["detail"])
+        self.assertTrue(result["remedy"])
+
+    def test_path_that_is_a_file_not_a_directory_fails(self) -> None:
+        with TemporaryDirectory() as tmp:
+            file_path = Path(tmp) / "not-a-dir"
+            file_path.write_text("x", encoding="utf-8")
+            result = check_working_directory(file_path)
+        self.assertFalse(result["passed"])
+        self.assertIn("not a directory", result["detail"])
+
+
+class EnvPrerequisiteTests(unittest.TestCase):
+    def test_no_names_declared_passes(self) -> None:
+        result = check_env_any_present((), env={})
+        self.assertEqual(result["check"], CHECK_ENV_PREREQUISITE)
+        self.assertTrue(result["passed"])
+
+    def test_one_of_several_present_passes(self) -> None:
+        result = check_env_any_present(
+            ("FIRST_VAR", "SECOND_VAR"), env={"SECOND_VAR": "value"}
+        )
+        self.assertTrue(result["passed"])
+
+    def test_none_present_fails_with_remedy_naming_every_candidate(self) -> None:
+        result = check_env_any_present(("FIRST_VAR", "SECOND_VAR"), env={})
+        self.assertFalse(result["passed"])
+        self.assertIn("FIRST_VAR", result["detail"])
+        self.assertIn("SECOND_VAR", result["detail"])
+        self.assertIn("FIRST_VAR", result["remedy"])
+
+    def test_present_but_empty_value_does_not_count(self) -> None:
+        result = check_env_any_present(("FIRST_VAR",), env={"FIRST_VAR": ""})
+        self.assertFalse(result["passed"])
+
+
+class CredentialFilePresenceTests(unittest.TestCase):
+    def test_no_path_declared_passes(self) -> None:
+        result = check_credential_file_present(None)
+        self.assertEqual(result["check"], CHECK_CREDENTIAL_FILE_PRESENCE)
+        self.assertTrue(result["passed"])
+
+    def test_empty_path_declared_passes(self) -> None:
+        result = check_credential_file_present("")
+        self.assertTrue(result["passed"])
+
+    def test_existing_file_passes_without_reading_content(self) -> None:
+        with TemporaryDirectory() as tmp:
+            credential = Path(tmp) / "service-account.json"
+            credential.write_text("{ this is not valid json ", encoding="utf-8")
+            result = check_credential_file_present(credential)
+        self.assertTrue(result["passed"])
+        self.assertNotIn("this is not valid json", str(result))
+
+    def test_missing_file_fails_with_remedy(self) -> None:
+        with TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "service-account.json"
+            result = check_credential_file_present(missing)
+        self.assertFalse(result["passed"])
+        self.assertIn("does not exist", result["detail"])
+        self.assertTrue(result["remedy"])
+
+
+class RunSpawnPreflightTests(unittest.TestCase):
+    def test_all_checks_passing_yields_ready_verdict(self) -> None:
+        verdict = run_spawn_preflight(
+            [check_working_directory(None), check_credential_file_present(None)]
+        )
+        self.assertEqual(verdict["schema_version"], SPAWN_PREFLIGHT_SCHEMA_VERSION)
+        self.assertEqual(verdict["status"], "ready")
+        self.assertTrue(verdict["ready"])
+        self.assertEqual(verdict["failed_checks"], [])
+        self.assertEqual(len(verdict["checks"]), 2)
+        self.assertTrue(verdict["claim_boundary"])
+
+    def test_one_failing_check_yields_blocked_verdict_naming_it(self) -> None:
+        with TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "gone"
+            verdict = run_spawn_preflight(
+                [check_working_directory(None), check_working_directory(missing)]
+            )
+        self.assertEqual(verdict["status"], "blocked")
+        self.assertFalse(verdict["ready"])
+        self.assertEqual(len(verdict["checks"]), 2)
+        self.assertEqual(len(verdict["failed_checks"]), 1)
+        self.assertEqual(verdict["failed_checks"][0]["check"], CHECK_WORKING_DIRECTORY)
+        self.assertTrue(verdict["failed_checks"][0]["remedy"])
+
+    def test_empty_checks_yields_ready_verdict(self) -> None:
+        verdict = run_spawn_preflight([])
+        self.assertTrue(verdict["ready"])
+        self.assertEqual(verdict["checks"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- Added `src/coding/spawn_preflight.py`: a shared, pure, versioned preflight
  module. Four checks (`check_executable_present`, `check_working_directory`,
  `check_env_any_present`, `check_credential_file_present`) each return a
  `{check, passed, detail, remedy}` row; `run_spawn_preflight` combines any
  set of them into one `omh_spawn_preflight_verdict/v1` payload
  (`schema_version`, `status`, `ready`, `checks`, `failed_checks`,
  `claim_boundary`).
- Wired two of those checks (executable presence, working-directory
  validity) into `src/coding/hermes_child_dispatch.dispatch_hermes_child`
  via a new `_spawn_preflight()` helper and a new
  `SpawnPreflightError(HermesChildDispatchError)`, raised before the scratch
  tempdir, the dispatch guard, or any observer event fires -- nothing is
  spawned to produce the refusal.
- Surveyed every other subprocess-spawn site in `src/` and made no change to
  them: each already resolves what it can before spawning (see "Why This
  Exists" below).

### Why This Exists

Backlog item G ("Preflight resolution before any subprocess spawn"):
everything that can be resolved/validated before spawning a subprocess
should be, so a doomed spawn never happens, and a failed preflight should be
a structured, cited refusal rather than a downstream crash.

Survey of every `subprocess.Popen`/`subprocess.run` call site under `src/`:

| Site | Existing pre-spawn resolution |
| --- | --- |
| `coding/fanout_dispatch.py` (agent-CLI child spawn) | Owner/model/unit schema fully validated (`capability_snapshot`, frozen-route check, `DISPATCH_COMMAND_TEMPLATES`) and executor CLI existence+version probed via `probe_executor_readiness` -- all **before** the worktree is built or `runner` is called. **No gap found.** |
| `coding/hermes_child_dispatch.py` (isolated Hermes child) | **Gap**: `subprocess.Popen` called directly; a missing `request.hermes` or an invalid `request.cwd` was only discovered by catching the resulting `OSError`, after a scratch tempdir and dispatch-guard entry were already paid for. **Fixed by this PR.** |
| `coding/skill_load_process.py` (skill inventory probe) | `resolve_executable` + `snapshot_resolved_tool` resolve, verify regular-file/executable-bit, and snapshot the binary before it is ever probed. No gap. |
| `commands/setup.py` (self-update re-exec/pip install) | `_validated_command_package_launcher` / `_validated_homebrew_commands` resolve and verify every path (`strict=True`, manifest match) before any update command is constructed. No gap. |
| `commands/main.py` (`omh`/`hermes` TUI launch, auto-update re-exec) | `shutil.which("hermes")` gates the TUI launch; the auto-update re-exec uses `sys.executable`, which is always valid. No gap. |
| `quality/cross_harness_adapters.py` | `shutil.which(spec.argv[0])` gates the spawn; a missing backend already reports `executable_not_found` before launch. No gap. |
| `surfaces/menubar_app.py` | `shutil.which("swiftc"/"omh"/"node")` gates each spawn. No gap. |
| `surfaces/hermes_processes.py` | Read-only `ps` observation, not an agent/executor spawn; already handles `OSError`/`SubprocessError` as `ps_unavailable`. Not in scope. |

`hermes_child_dispatch.py` was the only genuine gap, so this PR is scoped to
it plus the shared module the dossier asks for.

### User / Operator Impact

- A `hermes-child dispatch` invocation with a missing/non-executable
  `--hermes` path, or a `--cwd` that does not exist, now fails immediately
  with `omh: Hermes child spawn preflight failed: <check>: <detail> -- <remedy>`
  instead of after a scratch home/tempdir was created and a Hermes spawn was
  attempted and failed with an opaque `OSError`.
- No behavior change for a request whose executable and working directory
  are both valid -- every existing dispatch test still passes unchanged.

### How It Works

`dispatch_hermes_child` now calls `_spawn_preflight(request)` right after its
existing `prompt`/`model`/`timeout` validation and before
`seal_evaluation_binding`/`_enter_dispatch_guard()`. `_spawn_preflight` runs
`check_executable_present(request.hermes)` and
`check_working_directory(request.cwd)` through `run_spawn_preflight`; a
`ready=False` verdict raises `SpawnPreflightError(verdict)`, whose message
renders every failed check's detail and remedy and whose `.verdict` attribute
carries the full structured payload for a caller that wants more than the
rendered text. `SpawnPreflightError` subclasses the same
`HermesChildDispatchError` the CLI (`commands/hermes_child.py`) already
catches broadly and converts to `OmhError(str(exc))` -- no CLI change was
needed for the refusal to surface correctly.

Provider-auth env vars and credential-file existence are implemented in
`spawn_preflight.py` (`check_env_any_present`, `check_credential_file_present`)
per the dossier's fuller check-category list, but are **not** wired at this
boundary -- see Risk below for why, and the commit's `Rejected:` trailer for
the regression that proved it out.

### Files And Contracts Touched

- `src/coding/spawn_preflight.py` (new) -- the shared preflight module;
  `SPAWN_PREFLIGHT_SCHEMA_VERSION = "omh_spawn_preflight_verdict/v1"`.
- `src/coding/hermes_child_dispatch.py` -- `_spawn_preflight()`,
  `SpawnPreflightError`, and the `dispatch_hermes_child` call site.
- `tests/test_spawn_preflight.py` (new) -- positive/negative for every check
  plus the combined verdict shape.
- `tests/test_hermes_child_dispatch.py` -- new missing-executable and
  missing-working-directory preflight tests (Popen-never-called, remedy
  present); the prior missing-executable assertion (observed only via the
  post-hoc `OSError` path) is updated to the new contract.
- `src/coding/fanout_dispatch.py` -- **untouched** (see Why This Exists);
  kept confined per the sibling PR #1199 currently in flight on that file.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

Check only commands that completed successfully. Leave non-applicable checks
unchecked and explain why under **Not Tested / Not Applicable**.

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`: 8223
  tests, 21 failures + 7 errors, all in `test_cross_harness_adapters.py` and
  `test_cross_harness_adapter_security.py` (`unsafe_read_root` reason codes
  from running inside a `.claude/worktrees/...` path). Confirmed
  bit-for-bit identical to a `git stash`-reverted baseline run of this same
  checkout -- pre-existing, unrelated to this change.
- `uv run python -m omh.cli docs workflows --check` / `docs roles --check` /
  `docs capability-families --check` / `docs ulw-inventory --check` /
  `docs ulw-site --check`: all five byte gates `ok: true`.
- `uv run python -m omh.cli release drift`: "No drift. 18 checks passed."
- `uv run python -m compileall -q src tests`: clean.
- `uv run --group lint ruff check src tests`: "All checks passed!"
- `git diff --check`: clean.
- `PYTHONPATH=tests uv run python -m unittest tests/test_broad_exception_policy.py`: 6/6 passed (no new broad `except` introduced).
- Targeted: `tests/test_spawn_preflight.py` (21/21), `tests/test_hermes_child_dispatch.py` (18/18), `tests/test_fanout_dispatch.py` (135/135, unchanged -- confirms the zero-diff decision on that file).
- Regression caught and fixed during this PR: an earlier design also wired
  `check_env_any_present`/`check_credential_file_present` for provider auth
  at this boundary, which broke
  `test_omh_live_model_benchmark.OmhLiveAdapterTests.test_baseline_and_optimized_run_through_real_omh_observation_surface`
  (passes on `origin/main`, confirmed via `git stash`). That wiring was
  removed; the full-suite failure count returned to the pre-existing 28.

### Not Tested / Not Applicable

- `omh --help`, `harness validate`, `release checklist --json`,
  `release hermes-smoke`, the live smoke command: no CLI-surface or release
  contract changed; skipped as out of scope for a two-check internal preflight
  addition.
- Manual Hermes/TUI check: not run -- no live Hermes child process was
  spawned against a real provider in this environment; only the fake/stub
  executable fixtures already in the existing test suite were exercised.
- `spawn_preflight.py`'s `check_env_any_present`/`check_credential_file_present`
  are exercised only as standalone pure functions (`tests/test_spawn_preflight.py`);
  they are not wired at any live boundary in this PR (see Risk).

## Risk

- `fanout_dispatch.py` is untouched (zero-line diff), so there is no risk of
  conflicting with the in-flight sibling PR #1199 on that file.
- The preflight module intentionally implements more check categories
  (env-prerequisite, credential-file) than are wired anywhere yet. This is a
  deliberate, evidence-based scope narrowing, not an oversight: a first
  attempt wired provider-auth env checks into `hermes_child_dispatch.py` and
  it broke a real, currently-passing integration test
  (`test_omh_live_model_benchmark`) that drives the real OMH CLI against a
  stub Hermes executable that never reads credentials -- proof that
  "the spawned CLI needs one of these documented variables" is not something
  preflight can safely assert as fact for every code path this boundary can
  reach. Wiring those two checks anywhere (here or a future boundary) should
  come with the same regression check this PR ran into.
- Low risk otherwise: the two checks that ARE wired (executable presence,
  working-directory validity) are unconditional prerequisites of any
  successful `Popen` call on this boundary, regardless of provider or auth
  strategy, so there is no code path where they can refuse a spawn that would
  otherwise have succeeded.

## Compatibility / Rollout

- No schema/version bump on any existing contract; `SpawnPreflightError`
  subclasses the existing `HermesChildDispatchError`, so any caller that
  already catches that base class (the CLI does) needs no change.
- No config, flag, or CLI surface added or changed.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`) -- none; internal library-level change only.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence -- N/A, no handoff/plan surface touched
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap -- see Not Tested

## Follow-Up

- If a future boundary needs the env-prerequisite or credential-file checks
  already implemented in `spawn_preflight.py`, verify against a real (not
  stub) target CLI first, per the `Directive:` trailer on the commit.
- `fanout_dispatch.py`'s own backlog-G coverage (owner/model/schema
  validation + executor readiness) is already adequate per this survey; no
  follow-up item is opened against it.
