### PR TITLE
feat(loop): sticky-rule re-attachment with a bounded repeat policy

### DIFF
--- a/src/commands/loop.py
+++ b/src/commands/loop.py
@@ -5,6 +5,9 @@ import argparse
 from ..goal_loop import (
     LOOP_ACTIONS,
     LOOP_EXECUTOR_OPTION_IDS,
+    LOOP_STICKY_RULE_DEFAULT_GAP,
+    LOOP_STICKY_RULE_DEFAULT_MAX_REPEATS,
+    LOOP_STICKY_RULE_REPEAT_MODES,
     LOOP_WORKFLOW_PATTERNS,
     PERMISSION_PROFILES,
     assess_loopability,
@@ -15,6 +18,7 @@ from ..goal_loop import (
     build_loop_start_card,
     build_loop_status_card,
     create_loop_cycle,
+    declare_sticky_rule,
     dispatch_loop_queue_item,
     inspect_loop_queue_item,
     list_loop_queue,
@@ -180,6 +184,25 @@ def cmd_loop_tick(args: argparse.Namespace) -> int:
             connector_action=args.connector_action or "",
             workflow_pattern=args.workflow_pattern,
             note=args.note or "",
+        )
+        _print_json({"loop": cycle, "status_card": build_loop_status_card(_paths(args), args.loop_id)})
+    except (FileNotFoundError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    return 0
+
+
+def cmd_loop_sticky_rule_declare(args: argparse.Namespace) -> int:
+    try:
+        cycle = declare_sticky_rule(
+            _paths(args),
+            args.loop_id,
+            rule_id=args.rule_id,
+            text=args.text,
+            repeat_mode=args.repeat_mode,
+            repeat_gap=args.repeat_gap,
+            max_repeats=args.max_repeats,
+            expected_revision=args.expected_revision,
+            mutation_id=args.mutation_id or None,
         )
         _print_json({"loop": cycle, "status_card": build_loop_status_card(_paths(args), args.loop_id)})
     except (FileNotFoundError, ValueError) as exc:
@@ -424,6 +447,19 @@ def _add_loop_commands(sub) -> None:
     tick.add_argument("--workflow-pattern", choices=LOOP_WORKFLOW_PATTERNS, default="single_step")
     tick.add_argument("--note", default="")
     tick.set_defaults(func=cmd_loop_tick)
+
+    sticky_rule = loop_sub.add_parser("sticky-rule")
+    sticky_rule_sub = sticky_rule.add_subparsers(dest="sticky_rule_command", required=True)
+
+    sticky_rule_declare = sticky_rule_sub.add_parser("declare")
+    sticky_rule_declare.add_argument("--loop", dest="loop_id", required=True)
+    sticky_rule_declare.add_argument("--rule-id", required=True)
+    sticky_rule_declare.add_argument("--text", required=True)
+    sticky_rule_declare.add_argument("--repeat-mode", choices=LOOP_STICKY_RULE_REPEAT_MODES, default="after_gap")
+    sticky_rule_declare.add_argument("--repeat-gap", type=int, default=LOOP_STICKY_RULE_DEFAULT_GAP)
+    sticky_rule_declare.add_argument("--max-repeats", type=int, default=LOOP_STICKY_RULE_DEFAULT_MAX_REPEATS)
+    add_revision_guard_arguments(sticky_rule_declare)
+    sticky_rule_declare.set_defaults(func=cmd_loop_sticky_rule_declare)
 
     run_once = loop_sub.add_parser("run-once")
     run_once.add_argument("--loop", dest="loop_id", required=True)

--- a/src/workflows/goal_loop.py
+++ b/src/workflows/goal_loop.py
@@ -51,6 +51,8 @@ EXECUTOR_LOOP_CAPABILITY_SCHEMA = "executor_loop_capability/v1"
 LOOP_CYCLE_NARRATION_SCHEMA = "loop_cycle_narration/v1"
 LOOP_INVOCATION_SCHEMA = "loop_invocation/v1"
 LOOP_CONSTRAINT_ASSESSMENT_SCHEMA = "loop_constraint_assessment/v1"
+LOOP_STICKY_RULE_SCHEMA = "loop_sticky_rule/v1"
+LOOP_STICKY_RULE_ATTACHMENT_SCHEMA = "loop_sticky_rule_attachment/v1"
 LOOP_STOP_LADDER_SCHEMA = "loop_stop_ladder/v1"
 
 # The ordered stop ladder evaluated before a tick advances. The tuple order IS
@@ -386,6 +388,37 @@ _LOOP_CONSTRAINT_GUIDANCE: Final[dict[str, dict[str, str]]] = {
         ),
     },
 }
+# Sticky-rule re-attachment: a standing rule (e.g. "never claim completion
+# without observed evidence") that must stay in an executor's attention
+# across a long loop without becoming payload bloat. Modeled on oh-my-pi's
+# TTSR repeat policy (docs/ttsr-injection-lifecycle.md): a rule is declared
+# once with a bounded repeat policy, and the loop re-attaches it at tick
+# boundaries under that policy rather than every tick or never again.
+#
+# - "once": attach the rule exactly one time, at the first tick after it is
+#   declared. `repeat_gap` is not consulted in this mode.
+# - "after_gap": attach the rule again once `heartbeat_count -
+#   last_injected_heartbeat >= repeat_gap` completed ticks have passed since
+#   its last attachment. The gap is measured in `runtime.heartbeat_count`
+#   (completed loop ticks), never in reads of the status card - a card can be
+#   read any number of times between ticks without moving the gap, matching
+#   the oh-my-pi contract that re-attachment is gated on completed turns, not
+#   stream chunks.
+#
+# Every mode is bounded by `max_repeats`, so a long-running loop can never
+# accumulate unbounded repeats of the same reminder; `injected_count >=
+# max_repeats` retires the rule from further attachment regardless of mode
+# or gap. Rules are deduplicated by `rule_id`: declaring an existing id again
+# updates its text and policy in place rather than creating a second entry.
+LOOP_STICKY_RULE_REPEAT_MODES: Final[tuple[str, ...]] = ("once", "after_gap")
+LOOP_STICKY_RULE_DEFAULT_GAP: Final[int] = 10
+LOOP_STICKY_RULE_DEFAULT_MAX_REPEATS: Final[int] = 5
+LOOP_STICKY_RULE_ONCE_MAX_REPEATS: Final[int] = 1
+LOOP_STICKY_RULE_MAX_REPEATS_CEILING: Final[int] = 100
+LOOP_STICKY_RULE_CLAIM_BOUNDARY: Final[str] = (
+    "A sticky-rule attachment restates an already-declared rule at a bounded interval. It is not new "
+    "guidance, it decides no route, and it is not execution, review, CI, merge, or goal completion evidence."
+)
 LOOP_PIPELINE_STEPS = (
     "task_discovery",
     "distribution",
@@ -560,6 +593,8 @@ def create_loop_cycle(
         "goal_driver_observations": [],
         "runtime": _runtime_state(),
         "loop_engineering": _loop_engineering_template(),
+        "sticky_rules": [],
+        "sticky_rule_attachment": _empty_sticky_rule_attachment(),
         "next_action": "continue_loop",
         "completion_claim_allowed": False,
         "claim_boundary": _claim_boundary(),
@@ -1337,6 +1372,15 @@ def tick_loop_runtime(
         runtime.pop("stuck_marker", None)
         runtime.setdefault("queue", []).append(queue_item)
         cycle["runtime"] = runtime
+        # Sticky-rule re-attachment advances only on a tick that actually
+        # incremented heartbeat_count (this branch), never on a stopped tick
+        # (the early `ladder["stop"]` return above) and never on a mere
+        # status-card read. That keeps the repeat gap keyed to completed
+        # loop turns, matching LOOP_STICKY_RULE_REPEAT_MODES's contract.
+        cycle["sticky_rules"] = _sticky_rules_list(cycle.get("sticky_rules"))
+        cycle["sticky_rule_attachment"] = _advance_sticky_rule_attachment(
+            cycle["sticky_rules"], int(runtime["heartbeat_count"])
+        )
         if queue_item["status"] == "prepared_not_observed":
             cycle["wait_reason"] = "none"
             cycle["next_action"] = "observe_runtime_queue"
@@ -2200,6 +2244,7 @@ def build_loop_status_card(paths: OmhPaths, loop_id: str) -> dict[str, Any]:
         "next_action": _next_action(cycle),
         "safe_copy": _safe_status_copy(cycle, envelope),
         "completion_claim_allowed": _completion_claim_allowed(linked_gate),
+        "sticky_rule_attachment": cycle.get("sticky_rule_attachment") or _empty_sticky_rule_attachment(),
         "claim_boundary": _claim_boundary(),
     }
     card["constraint_assessment"] = assess_loop_constraint(card)
@@ -2289,6 +2334,23 @@ def validate_loop_cycle(cycle: dict[str, Any]) -> dict[str, Any]:
     runtime = cycle.get("runtime")
     if runtime is not None:
         errors.extend(_validate_runtime(runtime))
+    sticky_rules = cycle.get("sticky_rules")
+    if sticky_rules is not None:
+        if not isinstance(sticky_rules, list):
+            errors.append("sticky_rules must be a list")
+        else:
+            seen_rule_ids: set[str] = set()
+            for index, rule in enumerate(sticky_rules):
+                for error in validate_loop_sticky_rule(rule):
+                    errors.append(f"sticky_rules[{index}]: {error}")
+                if isinstance(rule, dict):
+                    rule_id = str(rule.get("rule_id", ""))
+                    if rule_id in seen_rule_ids:
+                        errors.append(f"sticky_rules[{index}].rule_id duplicates an earlier entry")
+                    seen_rule_ids.add(rule_id)
+    attachment = cycle.get("sticky_rule_attachment")
+    if attachment is not None:
+        errors.extend(validate_loop_sticky_rule_attachment(attachment))
     errors.extend(validate_loop_phase_history(cycle))
     if cycle.get("completion_claim_allowed") is not False:
         errors.append("loop_cycle cannot directly allow goal completion claims")
@@ -3536,6 +3598,241 @@ def validate_loop_constraint_assessment(value: object) -> list[str]:
     for key in ("claim_boundary", "repeat_note", "next_action_relationship"):
         if not isinstance(value.get(key), str) or not str(value.get(key, "")).strip():
             errors.append(f"constraint_assessment.{key} must be a non-empty string")
+    return errors
+
+
+def declare_sticky_rule(
+    paths: OmhPaths,
+    loop_id: str,
+    *,
+    rule_id: str,
+    text: str,
+    repeat_mode: str = "after_gap",
+    repeat_gap: int = LOOP_STICKY_RULE_DEFAULT_GAP,
+    max_repeats: int = LOOP_STICKY_RULE_DEFAULT_MAX_REPEATS,
+    expected_revision: int | None = None,
+    mutation_id: str | None = None,
+) -> dict[str, Any]:
+    """Declare (or re-declare) a sticky rule for re-attachment on this loop.
+
+    Declaring an existing `rule_id` again updates its text and policy in
+    place - `sticky_rules` is deduplicated by rule id, never a growing list
+    of near-duplicate reminders - and preserves its injected_count and
+    last_injected_heartbeat, so re-declaring the same rule does not reset its
+    bounded repeat budget.
+    """
+    safe_rule_id = _storage_id(rule_id, "rule_id")
+    safe_text = _safe_summary(text, limit=500)
+    if not safe_text:
+        raise ValueError("sticky rule text is required")
+    if repeat_mode not in LOOP_STICKY_RULE_REPEAT_MODES:
+        raise ValueError(f"repeat_mode must be one of {LOOP_STICKY_RULE_REPEAT_MODES}")
+    if isinstance(repeat_gap, bool) or not isinstance(repeat_gap, int) or repeat_gap < 1:
+        raise ValueError("repeat_gap must be a positive integer")
+    if isinstance(max_repeats, bool) or not isinstance(max_repeats, int) or max_repeats < 1:
+        raise ValueError("max_repeats must be a positive integer")
+    if max_repeats > LOOP_STICKY_RULE_MAX_REPEATS_CEILING:
+        raise ValueError(f"max_repeats must not exceed {LOOP_STICKY_RULE_MAX_REPEATS_CEILING}")
+    # "once" is a repeat budget of exactly one by definition; a caller-supplied
+    # max_repeats never widens it, so the mode's own name stays true.
+    effective_max_repeats = LOOP_STICKY_RULE_ONCE_MAX_REPEATS if repeat_mode == "once" else max_repeats
+
+    def mutate(cycle: dict[str, Any]) -> dict[str, Any]:
+        rules = _sticky_rules_list(cycle.get("sticky_rules"))
+        heartbeat_count = int(_runtime_state(cycle.get("runtime")).get("heartbeat_count", 0) or 0)
+        existing = next((rule for rule in rules if rule["rule_id"] == safe_rule_id), None)
+        if existing is not None:
+            existing["text"] = safe_text
+            existing["repeat_mode"] = repeat_mode
+            existing["repeat_gap"] = repeat_gap
+            existing["max_repeats"] = effective_max_repeats
+        else:
+            rules.append(
+                {
+                    "schema_version": LOOP_STICKY_RULE_SCHEMA,
+                    "rule_id": safe_rule_id,
+                    "text": safe_text,
+                    "repeat_mode": repeat_mode,
+                    "repeat_gap": repeat_gap,
+                    "max_repeats": effective_max_repeats,
+                    "declared_at_heartbeat": heartbeat_count,
+                    "injected_count": 0,
+                    "last_injected_heartbeat": None,
+                }
+            )
+        cycle["sticky_rules"] = rules
+        cycle["updated_at"] = utc_now()
+        return cycle
+
+    return _guarded_cycle_update(
+        paths,
+        loop_id,
+        mutate,
+        operation="declare_sticky_rule",
+        expected_revision=expected_revision,
+        mutation_id=mutation_id,
+        mutation_digest=_mutation_digest(
+            "declare_sticky_rule", safe_rule_id, safe_text, repeat_mode, repeat_gap, effective_max_repeats
+        ),
+    )
+
+
+def _sticky_rules_list(value: object) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [dict(rule) for rule in value if isinstance(rule, dict)]
+
+
+def _sticky_rule_due(rule: dict[str, Any], heartbeat_count: int) -> bool:
+    """Whether `rule` is due for attachment at `heartbeat_count` ticks.
+
+    Bounded by max_repeats regardless of mode. "once" fires only before its
+    first injection. "after_gap" fires on the first tick after declaration
+    (no prior injection to measure a gap from), then again only once
+    `heartbeat_count - last_injected_heartbeat >= repeat_gap`.
+    """
+    injected_count = int(rule.get("injected_count", 0) or 0)
+    max_repeats = int(rule.get("max_repeats", LOOP_STICKY_RULE_DEFAULT_MAX_REPEATS) or 0)
+    if injected_count >= max_repeats:
+        return False
+    if rule.get("repeat_mode") == "once":
+        return injected_count == 0
+    last_injected = rule.get("last_injected_heartbeat")
+    if last_injected is None:
+        return True
+    gap = int(rule.get("repeat_gap", LOOP_STICKY_RULE_DEFAULT_GAP) or LOOP_STICKY_RULE_DEFAULT_GAP)
+    return heartbeat_count - int(last_injected) >= gap
+
+
+def _advance_sticky_rule_attachment(rules: list[dict[str, Any]], heartbeat_count: int) -> dict[str, Any]:
+    """Mark every due rule injected at `heartbeat_count` and build this tick's attachment.
+
+    Mutates each due rule in `rules` in place (injected_count, last_injected_heartbeat)
+    so the caller's own `cycle["sticky_rules"]` write carries the advanced state. Rule
+    `text` is copied verbatim from its declaration - never reformatted - so the
+    re-attached block stays byte-identical across repeats and is cache-friendly.
+    """
+    due: list[dict[str, Any]] = []
+    for rule in rules:
+        if not _sticky_rule_due(rule, heartbeat_count):
+            continue
+        rule["injected_count"] = int(rule.get("injected_count", 0) or 0) + 1
+        rule["last_injected_heartbeat"] = heartbeat_count
+        due.append(rule)
+    due.sort(key=lambda rule: str(rule["rule_id"]))
+    return {
+        "schema_version": LOOP_STICKY_RULE_ATTACHMENT_SCHEMA,
+        "heartbeat_count": heartbeat_count,
+        "rules": [
+            {
+                "rule_id": str(rule["rule_id"]),
+                "text": str(rule["text"]),
+                "repeat_mode": str(rule["repeat_mode"]),
+                "injected_count": int(rule["injected_count"]),
+                "max_repeats": int(rule["max_repeats"]),
+            }
+            for rule in due
+        ],
+        "claim_boundary": LOOP_STICKY_RULE_CLAIM_BOUNDARY,
+    }
+
+
+def _empty_sticky_rule_attachment() -> dict[str, Any]:
+    return {
+        "schema_version": LOOP_STICKY_RULE_ATTACHMENT_SCHEMA,
+        "heartbeat_count": 0,
+        "rules": [],
+        "claim_boundary": LOOP_STICKY_RULE_CLAIM_BOUNDARY,
+    }
+
+
+def validate_loop_sticky_rule(value: object) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(value, dict):
+        return ["sticky_rule must be an object"]
+    if value.get("schema_version") != LOOP_STICKY_RULE_SCHEMA:
+        errors.append(f"sticky_rule.schema_version must be {LOOP_STICKY_RULE_SCHEMA}")
+    rule_id = value.get("rule_id")
+    if not isinstance(rule_id, str) or not STORAGE_ID_RE.fullmatch(rule_id):
+        errors.append("sticky_rule.rule_id must be a storage id")
+    if not isinstance(value.get("text"), str) or not str(value.get("text", "")).strip():
+        errors.append("sticky_rule.text must be a non-empty string")
+    if value.get("repeat_mode") not in LOOP_STICKY_RULE_REPEAT_MODES:
+        errors.append("sticky_rule.repeat_mode is unsupported")
+    for key in ("repeat_gap", "max_repeats", "injected_count"):
+        count = value.get(key)
+        if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+            errors.append(f"sticky_rule.{key} must be a non-negative integer")
+    max_repeats = value.get("max_repeats")
+    if value.get("repeat_mode") == "once" and max_repeats != LOOP_STICKY_RULE_ONCE_MAX_REPEATS:
+        errors.append(f"sticky_rule.max_repeats must be {LOOP_STICKY_RULE_ONCE_MAX_REPEATS} when repeat_mode is once")
+    injected_count = value.get("injected_count")
+    if (
+        isinstance(injected_count, int)
+        and not isinstance(injected_count, bool)
+        and isinstance(max_repeats, int)
+        and not isinstance(max_repeats, bool)
+        and injected_count > max_repeats
+    ):
+        errors.append("sticky_rule.injected_count must not exceed max_repeats")
+    declared_at = value.get("declared_at_heartbeat")
+    if isinstance(declared_at, bool) or not isinstance(declared_at, int) or declared_at < 0:
+        errors.append("sticky_rule.declared_at_heartbeat must be a non-negative integer")
+    last_injected = value.get("last_injected_heartbeat")
+    if last_injected is not None and (isinstance(last_injected, bool) or not isinstance(last_injected, int) or last_injected < 0):
+        errors.append("sticky_rule.last_injected_heartbeat must be null or a non-negative integer")
+    return errors
+
+
+def validate_loop_sticky_rule_attachment(value: object) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(value, dict):
+        return ["sticky_rule_attachment must be an object"]
+    if value.get("schema_version") != LOOP_STICKY_RULE_ATTACHMENT_SCHEMA:
+        errors.append(f"sticky_rule_attachment.schema_version must be {LOOP_STICKY_RULE_ATTACHMENT_SCHEMA}")
+    heartbeat_count = value.get("heartbeat_count")
+    if isinstance(heartbeat_count, bool) or not isinstance(heartbeat_count, int) or heartbeat_count < 0:
+        errors.append("sticky_rule_attachment.heartbeat_count must be a non-negative integer")
+    rules = value.get("rules")
+    if not isinstance(rules, list):
+        errors.append("sticky_rule_attachment.rules must be a list")
+        rules = []
+    seen_ids: set[str] = set()
+    previous_id = ""
+    for index, rule in enumerate(rules):
+        if not isinstance(rule, dict):
+            errors.append(f"sticky_rule_attachment.rules[{index}] must be an object")
+            continue
+        rule_id = str(rule.get("rule_id", ""))
+        if not rule_id:
+            errors.append(f"sticky_rule_attachment.rules[{index}].rule_id must be a non-empty string")
+        elif rule_id in seen_ids:
+            errors.append(f"sticky_rule_attachment.rules[{index}].rule_id duplicates an earlier entry")
+        else:
+            seen_ids.add(rule_id)
+        if rule_id < previous_id:
+            errors.append(f"sticky_rule_attachment.rules[{index}] is out of rule_id order")
+        previous_id = rule_id
+        if not isinstance(rule.get("text"), str) or not str(rule.get("text", "")).strip():
+            errors.append(f"sticky_rule_attachment.rules[{index}].text must be a non-empty string")
+        if rule.get("repeat_mode") not in LOOP_STICKY_RULE_REPEAT_MODES:
+            errors.append(f"sticky_rule_attachment.rules[{index}].repeat_mode is unsupported")
+        for key in ("injected_count", "max_repeats"):
+            count = rule.get(key)
+            if isinstance(count, bool) or not isinstance(count, int) or count < 1:
+                errors.append(f"sticky_rule_attachment.rules[{index}].{key} must be a positive integer")
+        injected_count = rule.get("injected_count")
+        max_repeats = rule.get("max_repeats")
+        if (
+            isinstance(injected_count, int)
+            and not isinstance(injected_count, bool)
+            and isinstance(max_repeats, int)
+            and not isinstance(max_repeats, bool)
+            and injected_count > max_repeats
+        ):
+            errors.append(f"sticky_rule_attachment.rules[{index}].injected_count must not exceed max_repeats")
+    if not isinstance(value.get("claim_boundary"), str) or not str(value.get("claim_boundary", "")).strip():
+        errors.append("sticky_rule_attachment.claim_boundary must be a non-empty string")
     return errors
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8936,6 +8936,72 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             self.assertEqual(blocked["loop"]["runtime"]["queue"][0]["blocker_reason"], "Need maintainer approval")
             self.assertEqual(blocked["status_card"]["runtime_summary"]["blocked_queue_count"], 1)
 
+    def test_loop_sticky_rule_declare_and_reattachment_over_cli_ticks(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            home = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+            status, stdout, stderr = run_cli(
+                home
+                + [
+                    "loop",
+                    "start",
+                    "--loop-id",
+                    "loop-sticky",
+                    "--goal-summary",
+                    "Keep a standing rule attached over CLI ticks",
+                    "--goal-reframe",
+                    "Prepare bounded loop slices while a sticky rule stays re-attached under its policy.",
+                    "--criterion",
+                    "The sticky rule re-attaches under its bounded policy",
+                    "--permission-profile",
+                    "handoff_only",
+                ]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+
+            status, stdout, stderr = run_cli(
+                home
+                + [
+                    "loop",
+                    "sticky-rule",
+                    "declare",
+                    "--loop",
+                    "loop-sticky",
+                    "--rule-id",
+                    "never-claim-without-evidence",
+                    "--text",
+                    "Never claim completion without observed evidence.",
+                    "--repeat-mode",
+                    "after_gap",
+                    "--repeat-gap",
+                    "2",
+                    "--max-repeats",
+                    "3",
+                ]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            declared = json.loads(stdout)
+            self.assertEqual(len(declared["loop"]["sticky_rules"]), 1)
+            self.assertEqual(declared["loop"]["sticky_rules"][0]["rule_id"], "never-claim-without-evidence")
+            self.assertEqual(declared["loop"]["sticky_rules"][0]["max_repeats"], 3)
+
+            fired_at: list[int] = []
+            for _ in range(5):
+                status, stdout, stderr = run_cli(home + ["loop", "tick", "--loop", "loop-sticky"])
+                self.assertEqual(stderr, "")
+                self.assertEqual(status, 0)
+                attachment = json.loads(stdout)["status_card"]["sticky_rule_attachment"]
+                self.assertEqual(attachment["schema_version"], "loop_sticky_rule_attachment/v1")
+                if attachment["rules"]:
+                    fired_at.append(attachment["heartbeat_count"])
+
+            # repeat_gap=2 with a bounded max_repeats=3: first tick, then every
+            # second tick, retiring once the repeat budget is spent.
+            self.assertEqual(fired_at, [1, 3, 5])
+
     def test_loop_status_lists_invalid_local_artifacts_without_crashing(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_loop_sticky_rules.py
+++ b/tests/test_loop_sticky_rules.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.goal_ledger import create_goal_ledger  # noqa: E402
+from omh.goal_loop import (  # noqa: E402
+    LOOP_STICKY_RULE_ATTACHMENT_SCHEMA,
+    LOOP_STICKY_RULE_DEFAULT_GAP,
+    LOOP_STICKY_RULE_DEFAULT_MAX_REPEATS,
+    LOOP_STICKY_RULE_ONCE_MAX_REPEATS,
+    LOOP_STICKY_RULE_REPEAT_MODES,
+    LOOP_STICKY_RULE_SCHEMA,
+    build_loop_status_card,
+    create_loop_cycle,
+    declare_sticky_rule,
+    tick_loop_runtime,
+    validate_loop_cycle,
+    validate_loop_sticky_rule_attachment,
+)
+from omh.paths import resolve_paths  # noqa: E402
+
+
+def _paths(tmp: str):
+    return resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+
+
+def _cycle(paths, **overrides):
+    kwargs = {
+        "goal_summary": "Keep a standing rule attached across a long loop",
+        "goal_reframe": "Prepare bounded loop slices while a sticky rule stays re-attached under its policy.",
+        "success_criteria": ["The sticky rule keeps re-attaching under its bounded policy"],
+        "permission_profile": "handoff_only",
+    }
+    kwargs.update(overrides)
+    return create_loop_cycle(paths, **kwargs)
+
+
+class StickyRuleDeclarationTests(unittest.TestCase):
+    def test_declare_creates_a_zero_state_rule(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            cycle = _cycle(paths)
+            declared = declare_sticky_rule(
+                paths,
+                cycle["loop_id"],
+                rule_id="never-claim-without-evidence",
+                text="Never claim completion without observed evidence.",
+            )
+
+        self.assertEqual(len(declared["sticky_rules"]), 1)
+        rule = declared["sticky_rules"][0]
+        self.assertEqual(rule["schema_version"], LOOP_STICKY_RULE_SCHEMA)
+        self.assertEqual(rule["rule_id"], "never-claim-without-evidence")
+        self.assertEqual(rule["repeat_mode"], "after_gap")
+        self.assertEqual(rule["repeat_gap"], LOOP_STICKY_RULE_DEFAULT_GAP)
+        self.assertEqual(rule["max_repeats"], LOOP_STICKY_RULE_DEFAULT_MAX_REPEATS)
+        self.assertEqual(rule["injected_count"], 0)
+        self.assertIsNone(rule["last_injected_heartbeat"])
+        self.assertEqual(validate_loop_cycle(declared), {"ok": True, "errors": []})
+
+    def test_declare_rejects_bad_inputs(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            cycle = _cycle(paths)
+            loop_id = cycle["loop_id"]
+
+            with self.assertRaises(ValueError):
+                declare_sticky_rule(paths, loop_id, rule_id="r1", text="")
+            with self.assertRaises(ValueError):
+                declare_sticky_rule(paths, loop_id, rule_id="r1", text="x", repeat_mode="always")
+            with self.assertRaises(ValueError):
+                declare_sticky_rule(paths, loop_id, rule_id="r1", text="x", repeat_gap=0)
+            with self.assertRaises(ValueError):
+                declare_sticky_rule(paths, loop_id, rule_id="r1", text="x", max_repeats=0)
+            with self.assertRaises(ValueError):
+                declare_sticky_rule(paths, loop_id, rule_id="r1", text="x", max_repeats=10_000)
+
+    def test_once_mode_forces_a_max_repeat_budget_of_one(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            cycle = _cycle(paths)
+            declared = declare_sticky_rule(
+                paths,
+                cycle["loop_id"],
+                rule_id="r1",
+                text="Stated once.",
+                repeat_mode="once",
+                max_repeats=50,
+            )
+
+        # A caller-supplied max_repeats never widens "once" past a budget of one.
+        self.assertEqual(declared["sticky_rules"][0]["max_repeats"], LOOP_STICKY_RULE_ONCE_MAX_REPEATS)
+
+    def test_redeclaring_the_same_rule_id_dedups_and_preserves_injection_state(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            cycle = _cycle(paths)
+            loop_id = cycle["loop_id"]
+            declare_sticky_rule(paths, loop_id, rule_id="r1", text="Original text.", repeat_gap=1)
+            tick_loop_runtime(paths, loop_id)  # injects r1 once, injected_count -> 1
+
+            redeclared = declare_sticky_rule(paths, loop_id, rule_id="r1", text="Updated text.", repeat_gap=5)
+
+        self.assertEqual(len(redeclared["sticky_rules"]), 1)
+        rule = redeclared["sticky_rules"][0]
+        self.assertEqual(rule["text"], "Updated text.")
+        self.assertEqual(rule["repeat_gap"], 5)
+        self.assertEqual(rule["injected_count"], 1)
+        self.assertIsNotNone(rule["last_injected_heartbeat"])
+
+
+class StickyRuleAttachmentPolicyTests(unittest.TestCase):
+    def test_once_mode_attaches_on_the_first_tick_then_never_again(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            cycle = _cycle(paths)
+            loop_id = cycle["loop_id"]
+            declare_sticky_rule(paths, loop_id, rule_id="r1", text="Stated once.", repeat_mode="once")
+
+            attachments = [
+                tick_loop_runtime(paths, loop_id)["sticky_rule_attachment"] for _ in range(5)
+            ]
+
+        rule_ids_per_tick = [[rule["rule_id"] for rule in attachment["rules"]] for attachment in attachments]
+        self.assertEqual(rule_ids_per_tick, [["r1"], [], [], [], []])
+        self.assertEqual(attachments[0]["rules"][0]["injected_count"], 1)
+
+    def test_after_gap_mode_honors_the_interval_and_the_max_repeats_cap(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            cycle = _cycle(paths)
+            loop_id = cycle["loop_id"]
+            declare_sticky_rule(
+                paths, loop_id, rule_id="r1", text="Restated on a gap.", repeat_mode="after_gap",
+                repeat_gap=2, max_repeats=3,
+            )
+
+            attachments = [
+                tick_loop_runtime(paths, loop_id)["sticky_rule_attachment"] for _ in range(8)
+            ]
+
+        fired_at_heartbeat = [a["heartbeat_count"] for a in attachments if a["rules"]]
+        # First tick after declaration attaches immediately; then every 2 ticks
+        # (repeat_gap=2), retiring once injected_count reaches max_repeats=3.
+        self.assertEqual(fired_at_heartbeat, [1, 3, 5])
+        injected_counts = [a["rules"][0]["injected_count"] for a in attachments if a["rules"]]
+        self.assertEqual(injected_counts, [1, 2, 3])
+        # No further attachment even though later ticks satisfy the gap again.
+        self.assertEqual(attachments[7]["rules"], [])
+
+    def test_multiple_rules_are_deduped_by_id_and_emitted_in_sorted_order(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            cycle = _cycle(paths)
+            loop_id = cycle["loop_id"]
+            declare_sticky_rule(paths, loop_id, rule_id="zzz-rule", text="Second rule.", repeat_gap=1)
+            declare_sticky_rule(paths, loop_id, rule_id="aaa-rule", text="First rule.", repeat_gap=1)
+
+            attachment = tick_loop_runtime(paths, loop_id)["sticky_rule_attachment"]
+
+        self.assertEqual([rule["rule_id"] for rule in attachment["rules"]], ["aaa-rule", "zzz-rule"])
+
+    def test_status_card_reads_do_not_advance_the_gap(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            cycle = _cycle(paths)
+            loop_id = cycle["loop_id"]
+            declare_sticky_rule(paths, loop_id, rule_id="r1", text="Stable across reads.", repeat_gap=3)
+            tick_loop_runtime(paths, loop_id)
+
+            reads = [build_loop_status_card(paths, loop_id)["sticky_rule_attachment"] for _ in range(4)]
+
+        # Reading the status card any number of times between ticks changes
+        # nothing: the gap is keyed to runtime.heartbeat_count, not to reads.
+        for read in reads:
+            self.assertEqual(read, reads[0])
+        self.assertEqual(reads[0]["heartbeat_count"], 1)
+
+    def test_a_stopped_tick_does_not_advance_sticky_rule_state(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            goal = create_goal_ledger(paths, "Objective with no recorded progress", ["Criterion"])
+            cycle = _cycle(paths, linked_goal_id=goal["goal_id"])
+            loop_id = cycle["loop_id"]
+            declare_sticky_rule(paths, loop_id, rule_id="r1", text="Held across a stalled tick.", repeat_gap=1)
+
+            first = tick_loop_runtime(paths, loop_id)
+            second = tick_loop_runtime(paths, loop_id)  # stops on no_progress_cap; heartbeat does not advance
+
+        self.assertEqual(first["runtime"]["heartbeat_count"], 1)
+        self.assertEqual(first["sticky_rule_attachment"]["rules"][0]["injected_count"], 1)
+        self.assertEqual(second["runtime"]["stop_ladder"]["stop_reason"], "no_progress_cap")
+        self.assertEqual(second["runtime"]["heartbeat_count"], 1)
+        # A stopped tick recomputes nothing: the attachment carried over from
+        # the last real tick, byte-identical, rather than being re-derived.
+        self.assertEqual(second["sticky_rule_attachment"], first["sticky_rule_attachment"])
+        self.assertEqual(second["sticky_rules"][0]["injected_count"], 1)
+
+
+class StickyRuleAttachmentSchemaTests(unittest.TestCase):
+    def test_empty_attachment_on_a_freshly_started_loop_is_schema_valid(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            cycle = _cycle(paths)
+            card = build_loop_status_card(paths, cycle["loop_id"])
+
+        attachment = card["sticky_rule_attachment"]
+        self.assertEqual(attachment["schema_version"], LOOP_STICKY_RULE_ATTACHMENT_SCHEMA)
+        self.assertEqual(attachment["rules"], [])
+        self.assertEqual(validate_loop_sticky_rule_attachment(attachment), [])
+
+    def test_populated_attachment_round_trips_through_the_validator(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            cycle = _cycle(paths)
+            loop_id = cycle["loop_id"]
+            declare_sticky_rule(paths, loop_id, rule_id="r1", text="Schema-checked rule.", repeat_gap=1)
+            card = build_loop_status_card(paths, loop_id)
+            self.assertEqual(card["sticky_rule_attachment"]["rules"], [])  # no tick yet
+
+            ticked = tick_loop_runtime(paths, loop_id)
+            card_after_tick = build_loop_status_card(paths, loop_id)
+
+        self.assertEqual(validate_loop_sticky_rule_attachment(ticked["sticky_rule_attachment"]), [])
+        self.assertEqual(validate_loop_sticky_rule_attachment(card_after_tick["sticky_rule_attachment"]), [])
+        self.assertEqual(card_after_tick["sticky_rule_attachment"], ticked["sticky_rule_attachment"])
+
+    def test_validator_rejects_duplicate_rule_ids_and_out_of_order_entries(self) -> None:
+        base = {
+            "schema_version": LOOP_STICKY_RULE_ATTACHMENT_SCHEMA,
+            "heartbeat_count": 1,
+            "rules": [
+                {"rule_id": "b", "text": "B.", "repeat_mode": "once", "injected_count": 1, "max_repeats": 1},
+                {"rule_id": "a", "text": "A.", "repeat_mode": "once", "injected_count": 1, "max_repeats": 1},
+            ],
+            "claim_boundary": "x",
+        }
+        errors = validate_loop_sticky_rule_attachment(base)
+        self.assertTrue(any("out of rule_id order" in error for error in errors))
+
+        duplicate = {
+            **base,
+            "rules": [
+                {"rule_id": "a", "text": "A.", "repeat_mode": "once", "injected_count": 1, "max_repeats": 1},
+                {"rule_id": "a", "text": "A2.", "repeat_mode": "once", "injected_count": 1, "max_repeats": 1},
+            ],
+        }
+        errors = validate_loop_sticky_rule_attachment(duplicate)
+        self.assertTrue(any("duplicates an earlier entry" in error for error in errors))
+
+    def test_validator_rejects_wrong_schema_version_and_missing_claim_boundary(self) -> None:
+        errors = validate_loop_sticky_rule_attachment({"schema_version": "wrong/v1", "heartbeat_count": 0, "rules": []})
+        self.assertTrue(any("schema_version" in error for error in errors))
+        self.assertTrue(any("claim_boundary" in error for error in errors))
+
+    def test_repeat_modes_are_the_documented_pair(self) -> None:
+        self.assertEqual(LOOP_STICKY_RULE_REPEAT_MODES, ("once", "after_gap"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New `loop_sticky_rule/v1` declarations on a loop cycle: `declare_sticky_rule(paths, loop_id, *, rule_id, text, repeat_mode, repeat_gap, max_repeats)` (`src/workflows/goal_loop.py`), deduplicated by `rule_id` — re-declaring an existing id updates its text/policy in place and preserves its injection counters.
- A bounded repeat policy per rule: `"once"` (fires exactly once, `max_repeats` forced to 1) or `"after_gap"` (fires again once `heartbeat_count - last_injected_heartbeat >= repeat_gap`), always capped by `max_repeats` regardless of mode.
- Re-attachment advances only inside `tick_loop_runtime`'s real tick branch — never on the stop-ladder's early-return path, and never from a `build_loop_status_card` read — so the gap is keyed to completed loop ticks (`runtime.heartbeat_count`), not to how many times a payload is read.
- The resulting `loop_sticky_rule_attachment/v1` block (sorted by `rule_id`, rule `text` copied verbatim so repeats stay byte-identical) is stored on the cycle and surfaced on `build_loop_status_card`'s `sticky_rule_attachment` field.
- New CLI surface: `omh loop sticky-rule declare --loop <id> --rule-id <id> --text <text> [--repeat-mode once|after_gap] [--repeat-gap N] [--max-repeats N]` (`src/commands/loop.py`), wired with the standard revision-guard flags.
- `validate_loop_cycle` validates `sticky_rules`/`sticky_rule_attachment` when present; new public validators `validate_loop_sticky_rule` and `validate_loop_sticky_rule_attachment`.

### Why This Exists

Backlog item "O. Sticky-rule re-attachment with a bounded repeat policy" (`.omc/research/ohmypi-optimization-2026-08-29.md`). Rules or constraints that must stay in force across a long prepared workflow — "never claim completion without observed evidence," a user's standing constraint — drift out of an executor's attention as loop context grows. oh-my-pi's TTSR system re-attaches such rules at a bounded interval (`once` or `after-gap`, gap measured in completed turns). OMH cannot intercept a stream the way TTSR does, but it can specify and honor the same policy shape in its own prepared payloads.

**Boundary note**: a related owner-side issue ("sticky prompt visibility") was previously judged Hermes-side and the upstream route was rejected by the owner. This PR stays entirely within OMH's own prepared-payload surfaces — the loop cycle record and the status card it already emits per tick — with no Hermes-side change and no stream interception.

### User / Operator Impact

- An operator (or an automation driving the loop) declares a sticky rule once; the loop's own status card then carries a bounded, deduplicated restatement of it at the declared cadence, without the operator having to re-paste it into every prompt or handoff.
- No behavior changes for loops that never declare a sticky rule: `sticky_rules` defaults to `[]` and `sticky_rule_attachment` defaults to an empty, schema-valid block.

### How It Works

- `create_loop_cycle` initializes `cycle["sticky_rules"] = []` and `cycle["sticky_rule_attachment"]` to an empty `loop_sticky_rule_attachment/v1` block.
- `declare_sticky_rule` is a guarded cycle mutation (`_guarded_cycle_update`) that appends or updates one rule record: `{schema_version, rule_id, text, repeat_mode, repeat_gap, max_repeats, declared_at_heartbeat, injected_count, last_injected_heartbeat}`.
- Inside `tick_loop_runtime`'s mutator, right after `runtime["heartbeat_count"]` increments (and only on that branch — never on the stop-ladder's early return), `_advance_sticky_rule_attachment` walks every declared rule, marks the due ones injected (`_sticky_rule_due`), and writes the resulting `loop_sticky_rule_attachment/v1` block back onto the cycle.
- `build_loop_status_card` reads `cycle.get("sticky_rule_attachment")` verbatim — it does not recompute anything, so any number of status-card reads between ticks return the identical block.

### Files And Contracts Touched

- `src/workflows/goal_loop.py`: `LOOP_STICKY_RULE_SCHEMA`, `LOOP_STICKY_RULE_ATTACHMENT_SCHEMA`, `LOOP_STICKY_RULE_REPEAT_MODES`, `LOOP_STICKY_RULE_DEFAULT_GAP`, `LOOP_STICKY_RULE_DEFAULT_MAX_REPEATS`, `LOOP_STICKY_RULE_ONCE_MAX_REPEATS`, `LOOP_STICKY_RULE_MAX_REPEATS_CEILING`, `declare_sticky_rule`, `_sticky_rules_list`, `_sticky_rule_due`, `_advance_sticky_rule_attachment`, `_empty_sticky_rule_attachment`, `validate_loop_sticky_rule`, `validate_loop_sticky_rule_attachment`; `create_loop_cycle`, `tick_loop_runtime`, `build_loop_status_card`, `validate_loop_cycle` updated to carry the new fields.
- `src/commands/loop.py`: `cmd_loop_sticky_rule_declare` and the `loop sticky-rule declare` argparse subcommand.
- `tests/test_loop_sticky_rules.py` (new): declaration validation, dedup/preserve-state on redeclare, `once` vs `after_gap` policy bounds, multi-rule dedup/ordering, status-card reads not advancing the gap, a stopped tick not advancing sticky-rule state, and schema round-trips through `validate_loop_sticky_rule_attachment`.
- `tests/test_cli.py`: end-to-end CLI coverage (`loop start` -> `loop sticky-rule declare` -> five `loop tick` calls) asserting the attachment fires at heartbeat 1, 3, 5 for `repeat_gap=2`, `max_repeats=3`.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

Check only commands that completed successfully. Leave non-applicable checks
unchecked and explain why under **Not Tested / Not Applicable**.

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable, no learning contract touched.
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli docs ulw-inventory --check`, `uv run python -m omh.cli docs ulw-site --check`, `uv run python -m omh.cli release drift --json` (0 drift); manual CLI smoke — `loop start`, `loop sticky-rule declare --repeat-mode after_gap --repeat-gap 2 --max-repeats 3`, five `loop tick` calls — confirmed the attachment fires at `heartbeat_count` 1, 3, 5 then retires.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this change has no TUI or Hermes-runtime surface.

### Observed Evidence

- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`: `Ran 8273 tests ... FAILED (failures=21, errors=7)` — all 28 failures/errors are pre-existing and confined to `test_cross_harness_adapters.py` / `test_cross_harness_adapter_security.py` (unrelated cross-harness `.claude`-path fixtures); every `test_loop_sticky_rules.py` test (14) and the new `test_cli.CliTests.test_loop_sticky_rule_declare_and_reattachment_over_cli_ticks` passed.
- `uv run --group lint ruff check src tests` -> `All checks passed!`
- `uv run python -m compileall -q src tests` -> clean.
- `uv run python -m omh.cli docs workflows --check` / `docs roles --check` / `docs capability-families --check` / `docs ulw-inventory --check` / `docs ulw-site --check` -> all `"ok":true`.
- `uv run python -m omh.cli release drift --json` -> `"drift":[],"drift_count":0,"ok":true`.
- `git diff --check` -> no whitespace errors.
- Manual CLI trace: `omh loop start` -> `omh loop sticky-rule declare --repeat-gap 2 --max-repeats 3` -> five `omh loop tick` calls; `status_card.sticky_rule_attachment.rules` populated at `heartbeat_count` 1, 3, 5 and empty at 2, 4, then empty again at further ticks once `injected_count` reached `max_repeats`.

### Not Tested / Not Applicable

- `omh harness validate`, `release checklist`, `release hermes-smoke`, `omh --help`, and the hermes-smoke install-path command were not run — this change touches only the loop control-plane record and CLI, none of the harness/install/release surfaces those commands check.
- No live Hermes harness run and no manual TUI check — this is a prepared-payload/CLI-only change with no TUI or Hermes-runtime surface.

## Risk

- Additive-only schema change: `sticky_rules` and `sticky_rule_attachment` are new optional/defaulted fields on `loop_cycle/v1`; existing loop cycle records without them validate and default cleanly (`_empty_sticky_rule_attachment()`), and `build_loop_status_card` falls back the same way for any cycle read before this change shipped.
- The only shared function touched is `tick_loop_runtime`'s mutator, and the sticky-rule advance is inserted after the existing heartbeat/queue-item logic, inside the branch that already writes `runtime`; it does not change any existing field's value or the stop-ladder's own behavior.

## Compatibility / Rollout

- No migration needed: existing `cycle.json` records without `sticky_rules`/`sticky_rule_attachment` remain valid (`validate_loop_cycle` only checks these fields when present) and read back with empty defaults.
- No new runtime dependency; pure stdlib.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`) — none; this is additive local control-plane state with no channel-specific behavior.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence — `LOOP_STICKY_RULE_CLAIM_BOUNDARY` states the attachment "is not new guidance... and is not execution, review, CI, merge, or goal completion evidence."
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap — none required for this surface; see Not Tested above.

## Follow-Up

- If a future surface wants sticky rules re-attached at a finer grain than a loop tick (e.g. mid-tick), extend `_advance_sticky_rule_attachment`'s call site deliberately rather than calling it from a read path — calling it from `build_loop_status_card` would start moving the gap on every read.
