### PR TITLE
feat(security): approval-tier resolver centralizes confirm/refuse decisions

### DIFF
--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -20,7 +20,9 @@ import time
 from typing import Any, Callable, Iterable, Mapping, Sequence
 
 from ..runtime.artifacts import append_journal_observation, create_run, show_run
+from ..system.approval_tier import TIER_AUTO_ALLOWED, resolve_approval_tier
 from ..system.local_store import atomic_write_json, ensure_dir, locked_json_update, read_json_object_result, utc_now
+from ..system.security_posture import resolve_security_posture
 from ..system.metadata_safety import redact_metadata_text
 from ..system.output_truncation import spill_evidence_ref, truncate_output, truncation_notice
 from ..system.paths import OmhPaths
@@ -1196,14 +1198,18 @@ def dispatch_fanout(
     effective_max_depth = FANOUT_MAX_DEPTH_DEFAULT if max_depth is None else max(1, int(max_depth))
     current_depth = read_fanout_depth(guard_env)
     if current_depth >= effective_max_depth:
-        return _depth_refusal_summary(
-            contract,
-            dry_run=dry_run,
-            base_sha=base_sha,
-            depth=current_depth,
-            max_depth=effective_max_depth,
-            lineage=str(guard_env.get(FANOUT_LINEAGE_ENV_VAR, "") or ""),
+        depth_decision = resolve_approval_tier(
+            "fanout_recursion_depth", posture=resolve_security_posture(guard_env)
         )
+        if depth_decision.tier != TIER_AUTO_ALLOWED:
+            return _depth_refusal_summary(
+                contract,
+                dry_run=dry_run,
+                base_sha=base_sha,
+                depth=current_depth,
+                max_depth=effective_max_depth,
+                lineage=str(guard_env.get(FANOUT_LINEAGE_ENV_VAR, "") or ""),
+            )
     spawn_ledger = _SpawnLedger(
         FANOUT_RUN_SPAWN_CEILING_DEFAULT if spawn_ceiling is None else spawn_ceiling
     )

--- a/src/coding/hermes_child_dispatch.py
+++ b/src/coding/hermes_child_dispatch.py
@@ -25,6 +25,8 @@ from threading import Event, Lock, Thread
 import time
 from typing import Final
 
+from ..system.approval_tier import TIER_AUTO_ALLOWED, resolve_approval_tier
+from ..system.security_posture import resolve_security_posture
 from .hermes_child_evaluation import (
     HermesChildEvaluationContext,
     seal_evaluation_binding,
@@ -195,13 +197,27 @@ class CancellationToken:
 def require_hermes_child_dispatch_boundary(
     *, dispatch_policy: str, confirmed: bool, depth: int = 0
 ) -> None:
-    """Enforce the shared confirmation and depth-one child boundary."""
-    if dispatch_policy != "ask_before_dispatch" or not confirmed:
+    """Enforce the shared confirmation and depth-one child boundary.
+
+    Both checks ask `resolve_approval_tier` for the DECISION and keep the
+    enforcement (which error, which message) here: the confirmation check
+    folds `dispatch_policy`/`confirmed` into the single `hermes_child_dispatch`
+    operation class the resolver's table already documents as
+    non-tightenable-by-posture; the depth check consults the structurally
+    `refused` `hermes_child_recursion_depth` class only once the site's own
+    trigger (`depth >= MAX_CHILD_DEPTH or` a child environment) fires.
+    """
+    posture = resolve_security_posture()
+    is_confirmed = dispatch_policy == "ask_before_dispatch" and confirmed
+    decision = resolve_approval_tier("hermes_child_dispatch", confirmed=is_confirmed, posture=posture)
+    if decision.tier != TIER_AUTO_ALLOWED:
         raise DispatchConfirmationError(
             "isolated Hermes dispatch requires ask_before_dispatch and explicit confirmation"
         )
     if depth >= MAX_CHILD_DEPTH or _environment_is_child():
-        raise DispatchRecursionError("isolated Hermes child dispatch depth is limited to one")
+        depth_decision = resolve_approval_tier("hermes_child_recursion_depth", posture=posture)
+        if depth_decision.tier != TIER_AUTO_ALLOWED:
+            raise DispatchRecursionError("isolated Hermes child dispatch depth is limited to one")
 
 
 def dispatch_hermes_child(

--- a/src/commands/hermes_child.py
+++ b/src/commands/hermes_child.py
@@ -10,6 +10,8 @@ import secrets
 import signal
 
 from ..coding.hermes_child_dispatch import DispatchConfirmationError, DispatchRecursionError, HermesChildDispatchError, HermesChildObservation, HermesChildRequest, dispatch_hermes_child
+from ..system.approval_tier import TIER_AUTO_ALLOWED, resolve_approval_tier
+from ..system.security_posture import resolve_security_posture
 from ..coding.hermes_child_receipts import ReceiptVerificationError, hermes_child_run_dir, observation_key_open_flags, observation_signature_valid, read_hermes_child_observation, write_signed_observation
 from ..coding.routing_observation import JsonValue, authenticate_child_observation, build_routing_observation, render_routing_status_rows, validate_routing_observation
 from ..core.errors import OmhError
@@ -43,7 +45,10 @@ def cmd_hermes_child_prepare(args: argparse.Namespace) -> int:
 
 
 def cmd_hermes_child_dispatch(args: argparse.Namespace) -> int:
-    if not args.confirm_dispatch:
+    decision = resolve_approval_tier(
+        "hermes_child_dispatch", confirmed=bool(args.confirm_dispatch), posture=resolve_security_posture()
+    )
+    if decision.tier != TIER_AUTO_ALLOWED:
         raise OmhError("Hermes child dispatch requires --confirm-dispatch; prepare is the safe default")
     _validate_metadata_args(args)
     prompt = _read_prompt(args.prompt_file)

--- a/src/commands/hermes_child_skill_load.py
+++ b/src/commands/hermes_child_skill_load.py
@@ -23,7 +23,9 @@ from ..coding.skill_load_observation import (
     validate_skill_load_observation,
 )
 from ..core.errors import OmhError
+from ..system.approval_tier import TIER_AUTO_ALLOWED, resolve_approval_tier
 from ..system.local_store import atomic_write_json, read_json_object
+from ..system.security_posture import resolve_security_posture
 from .common import _paths, _print_json, _wants_json
 
 _AUDIENCE = "agent/maintainer"
@@ -31,7 +33,10 @@ _ObservationValue = TypeVar("_ObservationValue")
 
 
 def cmd_hermes_child_skill_load_probe(args: argparse.Namespace) -> int:
-    if not args.confirm_dispatch:
+    decision = resolve_approval_tier(
+        "hermes_child_dispatch", confirmed=bool(args.confirm_dispatch), posture=resolve_security_posture()
+    )
+    if decision.tier != TIER_AUTO_ALLOWED:
         raise OmhError("Hermes skill-load probe requires --confirm-dispatch")
     run_dir = _run_dir(args)
     run_dir.mkdir(mode=0o700, exist_ok=True)

--- a/src/install/installer.py
+++ b/src/install/installer.py
@@ -24,6 +24,8 @@ from ..skill_pack import (
     builtin_skill_reference_templates,
     builtin_skill_templates,
 )
+from ..system.approval_tier import TIER_AUTO_ALLOWED, resolve_approval_tier
+from ..system.security_posture import resolve_security_posture
 
 SKILL_PROFILES = ("core", "full")
 # The full catalog is the default: installing OMH means getting OMH, ULW
@@ -86,9 +88,9 @@ def skill_install_relative_dir(canonical: str) -> Path:
 def _write_skill(skills_dir: Path, template: SkillTemplate, force: bool = False, managed: bool = False) -> None:
     target_dir = skills_dir / skill_install_relative_dir(template.name)
     target_file = target_dir / "SKILL.md"
-    if target_file.exists() and not force and not managed:
+    if target_file.exists() and not managed:
         existing = target_file.read_text(encoding="utf-8")
-        if existing != template.content:
+        if existing != template.content and not _overwrite_allowed(force):
             raise OmhError(f"local skill differs, refusing to overwrite without --force: {target_file}")
     atomic_write_text(target_file, template.content)
 
@@ -100,11 +102,25 @@ def _write_skill_reference(
     managed: bool = False,
 ) -> None:
     target_file = skills_dir / skill_install_relative_dir(template.skill_name) / template.relative_path
-    if target_file.exists() and not force and not managed:
+    if target_file.exists() and not managed:
         existing = target_file.read_text(encoding="utf-8")
-        if existing != template.content:
+        if existing != template.content and not _overwrite_allowed(force):
             raise OmhError(f"local skill reference differs, refusing to overwrite without --force: {target_file}")
     atomic_write_text(target_file, template.content)
+
+
+def _overwrite_allowed(force: bool) -> bool:
+    """The DECISION for every installer overwrite/removal guard in this module.
+
+    `force` is the caller's confirmation; `resolve_approval_tier` also folds
+    in the active security posture, so `--force` stops overriding a local
+    modification at all once `OMH_SECURITY=strict` is set
+    (`installer_confirmation_override_available` in security_posture.py).
+    """
+    decision = resolve_approval_tier(
+        "installer_overwrite_local_modification", confirmed=force, posture=resolve_security_posture()
+    )
+    return decision.tier == TIER_AUTO_ALLOWED
 
 
 def install_skill_pack(
@@ -164,7 +180,7 @@ def install_skill_pack(
         ]
     manifest = read_manifest(paths.manifest_path)
     modified = local_modifications(manifest, paths.skills_dir)
-    if modified and not force:
+    if modified and not _overwrite_allowed(force):
         raise OmhError("local modifications detected; rerun with --force or resolve: " + ", ".join(modified))
     context_cost_warning = (
         _context_cost_warning(core_count=len(CORE_PROFILE_SKILLS), full_count=len(builtin_skill_templates()))
@@ -849,9 +865,13 @@ def _collect_removal(
 ) -> None:
     if not path.exists() and not path.is_symlink():
         return
-    if managed_plugin and not force and not _looks_like_managed_plugin(path):
-        kept.append({"path": str(path), "reason": "plugin dir is not an OMH-managed bundle; rerun with --force to remove it"})
-        return
+    if managed_plugin and not _looks_like_managed_plugin(path):
+        decision = resolve_approval_tier(
+            "installer_remove_unowned_plugin_dir", confirmed=force, posture=resolve_security_posture()
+        )
+        if decision.tier != TIER_AUTO_ALLOWED:
+            kept.append({"path": str(path), "reason": "plugin dir is not an OMH-managed bundle; rerun with --force to remove it"})
+            return
     if dry_run:
         would_remove.append(str(path))
         return

--- a/src/system/approval_tier.py
+++ b/src/system/approval_tier.py
@@ -1,0 +1,177 @@
+"""A pure, testable resolver from a proposed OMH operation to an approval tier.
+
+Before this module, the same shape -- "if not confirmed: raise", "kept unless
+--force" -- was written out separately at each dispatch and install boundary:
+`require_hermes_child_dispatch_boundary` (`coding/hermes_child_dispatch.py`),
+the two `--confirm-dispatch` CLI guards (`commands/hermes_child.py`,
+`commands/hermes_child_skill_load.py`), the fanout spawn-depth guard
+(`coding/fanout_dispatch.py`), and the installer's overwrite/removal guards
+(`install/installer.py`). Each copy had its own wording and its own chance to
+drift from the others. `resolve_approval_tier` is the one DECISION function
+those sites now ask; every one of them still does its own enforcement (raising
+its own error, returning its own refusal payload) because the tier alone does
+not know how a given call site should fail.
+
+Three tiers, closed vocabulary: `auto_allowed`, `needs_confirmation`,
+`refused`. Two absorbed rules, both from `docs/approval-mode.md`'s six-step
+precedence for tool-call tiers (`oh-my-pi`; OMH absorption, P3):
+
+- **Unknown defaults to most-restrictive.** An `operation_class` this table has
+  never seen resolves to `refused`, mirroring "tools without an approval
+  declaration ... are treated as exec" -- OMH's most restrictive tier is
+  `refused`, not `auto_allowed`.
+- **Headless rejects rather than hangs.** `needs_confirmation` without
+  `confirmed=True` resolves straight to `refused`. This module has no live
+  prompt loop to wait on; a caller that cannot supply confirmation now gets a
+  refusal now, never a pending state.
+
+Strict security posture (`security_posture.py`, #1196) composes through the
+same `POSTURE_MAPPING` / `strict_override` pattern every other tightened
+surface already uses: a rule's `posture_key`, when set, names a
+`POSTURE_MAPPING` row whose strict value answers "is the confirmation override
+even available here". `default` posture always reads `True` (unchanged
+behavior); `strict` can read `False`, which turns `needs_confirmation` into
+`refused` regardless of `confirmed` -- a strict operator gets no override path
+at all for that operation class.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from .security_posture import DEFAULT_POSTURE, strict_override
+
+APPROVAL_TIER_SCHEMA_VERSION = "omh_approval_tier/v1"
+
+TIER_AUTO_ALLOWED = "auto_allowed"
+TIER_NEEDS_CONFIRMATION = "needs_confirmation"
+TIER_REFUSED = "refused"
+APPROVAL_TIERS: tuple[str, ...] = (TIER_AUTO_ALLOWED, TIER_NEEDS_CONFIRMATION, TIER_REFUSED)
+
+UNKNOWN_OPERATION_REASON = "unknown_operation_class"
+
+
+class ApprovalRule(NamedTuple):
+    operation_class: str
+    base_tier: str
+    # A `security_posture.POSTURE_MAPPING` key whose strict value is a bool:
+    # whether the confirmation override is available at all in that posture.
+    # None means posture never changes this row's tier.
+    posture_key: str | None
+    rationale: str
+
+
+# One row per decision this resolver answers for. `operation_class` is the
+# lookup every enforcement site passes; `base_tier` is what the table assigns
+# before any posture or confirmation input is applied.
+APPROVAL_RULE_TABLE: tuple[ApprovalRule, ...] = (
+    ApprovalRule(
+        "hermes_child_dispatch",
+        TIER_NEEDS_CONFIRMATION,
+        None,
+        "Isolated local Hermes dispatch requires the fixed ask_before_dispatch policy plus an explicit "
+        "operator confirmation (--confirm-dispatch). security_posture.py's dispatch_confirmation_required "
+        "row documents that this requirement is already non-tightenable: both postures require it.",
+    ),
+    ApprovalRule(
+        "hermes_child_recursion_depth",
+        TIER_REFUSED,
+        None,
+        "A dispatched agent CLI must never start another isolated Hermes child (the depth-one boundary). "
+        "Structural: no confirmation lifts it.",
+    ),
+    ApprovalRule(
+        "fanout_recursion_depth",
+        TIER_REFUSED,
+        None,
+        "Mirrors hermes_child_recursion_depth for the fanout spawn guard: a dispatched agent CLI must not "
+        "start another fanout dispatch. Structural: no confirmation lifts it.",
+    ),
+    ApprovalRule(
+        "installer_overwrite_managed_file",
+        TIER_AUTO_ALLOWED,
+        None,
+        "A file OMH already manages is rewritten on every normal install/update; that is what 'managed' "
+        "means, so no confirmation is asked for it.",
+    ),
+    ApprovalRule(
+        "installer_overwrite_local_modification",
+        TIER_NEEDS_CONFIRMATION,
+        "installer_confirmation_override_available",
+        "A local edit under a managed skill path is overwritten only with the operator's explicit --force.",
+    ),
+    ApprovalRule(
+        "installer_remove_unowned_plugin_dir",
+        TIER_NEEDS_CONFIRMATION,
+        "installer_confirmation_override_available",
+        "A plugin directory OMH cannot prove it manages is kept unless --force explicitly claims it.",
+    ),
+)
+
+_RULES_BY_CLASS: dict[str, ApprovalRule] = {rule.operation_class: rule for rule in APPROVAL_RULE_TABLE}
+
+
+def known_operation_classes() -> tuple[str, ...]:
+    """Every `operation_class` the table can resolve, in table order."""
+    return tuple(rule.operation_class for rule in APPROVAL_RULE_TABLE)
+
+
+class ApprovalDecision(NamedTuple):
+    operation_class: str
+    tier: str
+    reason_code: str
+    posture: str
+
+
+def resolve_approval_tier(
+    operation_class: str,
+    *,
+    confirmed: bool = False,
+    posture: str = DEFAULT_POSTURE,
+) -> ApprovalDecision:
+    """The DECISION only: which tier `operation_class` resolves to right now.
+
+    Pure and side-effect free -- this never raises, writes, or spawns. A call
+    site compares `decision.tier` against `TIER_AUTO_ALLOWED` and enforces its
+    own refusal (its own exception type, its own message, its own refusal
+    payload shape); this function only ever answers "what tier".
+    """
+    rule = _RULES_BY_CLASS.get(operation_class)
+    if rule is None:
+        return ApprovalDecision(operation_class, TIER_REFUSED, UNKNOWN_OPERATION_REASON, posture)
+
+    if rule.base_tier == TIER_REFUSED:
+        return ApprovalDecision(operation_class, TIER_REFUSED, "structural_refusal", posture)
+
+    if rule.base_tier == TIER_AUTO_ALLOWED:
+        return ApprovalDecision(operation_class, TIER_AUTO_ALLOWED, "table_default", posture)
+
+    # base_tier is needs_confirmation.
+    override_available = (
+        True if rule.posture_key is None else strict_override(rule.posture_key, posture, True)
+    )
+    if not override_available:
+        return ApprovalDecision(operation_class, TIER_REFUSED, "strict_posture_override_disabled", posture)
+    if confirmed:
+        return ApprovalDecision(operation_class, TIER_AUTO_ALLOWED, "confirmed", posture)
+    # Headless-rejects-rather-than-hangs: no confirmation channel exists
+    # inside a pure function, so an unconfirmed needs_confirmation operation
+    # is refused now rather than left pending.
+    return ApprovalDecision(operation_class, TIER_REFUSED, "unconfirmed", posture)
+
+
+def describe_approval_tier_table() -> dict[str, object]:
+    """The full rule table, for a status/doctor surface (mirrors `describe_security_posture`)."""
+    return {
+        "schema_version": APPROVAL_TIER_SCHEMA_VERSION,
+        "tiers": list(APPROVAL_TIERS),
+        "rows": [
+            {
+                "operation_class": rule.operation_class,
+                "base_tier": rule.base_tier,
+                "posture_key": rule.posture_key,
+                "rationale": rule.rationale,
+            }
+            for rule in APPROVAL_RULE_TABLE
+        ],
+    }

--- a/src/system/output_truncation.py
+++ b/src/system/output_truncation.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import Path
 import re
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 
 from .local_store import atomic_write_text
 
@@ -37,12 +37,17 @@ OUTPUT_SPILL_REF_SCHEMA_VERSION = "omh_output_spill_ref/v1"
 
 # Closed vocabulary. `not_truncated` is a real member, not a filler: recording
 # it is what lets a reader distinguish "nothing more to show" from "capped".
+# `fabricated_boundary` is `truncate_at_fabricated_boundary`'s reason: a caller-
+# named authority marker turned up inside content a dispatched unit does not
+# get to author, so everything from the marker onward was cut rather than
+# trusted.
 TRUNCATION_REASON_CODES: tuple[str, ...] = (
     "not_truncated",
     "output_cap",
     "capture_cap",
     "match_limit",
     "redacted",
+    "fabricated_boundary",
 )
 # `kept_ranges` is a list rather than a single range so a head+tail keep can be
 # added later without a schema bump. Only the two single-range keeps are
@@ -194,6 +199,79 @@ def truncate_output(
             spill_status=spill_status,
         ),
     )
+
+
+def truncate_at_fabricated_boundary(
+    value: object,
+    *,
+    markers: Sequence[str],
+    source: str,
+    spill_dir: Path | None = None,
+) -> TruncatedOutput:
+    """Cap `value` at the first occurrence of any string in `markers`.
+
+    OMH's analogue of `tools.abortOnFabricatedResult`
+    (`docs/toolconv/xml.md:188` in oh-my-pi; OMH absorption, P3 item Q): a
+    dispatched unit's own captured output is not a trusted source for the
+    markers named here -- only OMH's own dispatcher legitimately writes them.
+    The first occurrence of any marker, wherever it falls, is a hard boundary:
+    everything before it is kept as this capture's real content; everything
+    from the marker onward is cut under the `fabricated_boundary` reason code
+    and never parsed as if it were genuine, mirroring "content before the
+    fabricated block is preserved, generation stops".
+
+    `markers` is caller-supplied rather than a fixed OMH vocabulary: which
+    strings count as an unforgeable authority marker is a property of the
+    call site (what only ITS OWN dispatcher ever legitimately writes), not of
+    this generic contract. No marker found is not truncation -- `value`
+    passes through unchanged with the `not_truncated` reason, exactly like
+    `truncate_output` at or under its limit.
+    """
+    text = value if isinstance(value, str) else str(value or "")
+    original_bytes = len(text.encode("utf-8"))
+    boundary = _first_marker_offset(text, markers)
+    if boundary is None:
+        return TruncatedOutput(
+            text,
+            truncation_record(
+                source=source,
+                reason_code="not_truncated",
+                limit_bytes=original_bytes,
+                kept_bytes=original_bytes,
+                original_bytes=original_bytes,
+                keep="head",
+            ),
+        )
+
+    kept = text[:boundary]
+    kept_bytes = len(kept.encode("utf-8"))
+    spill: Mapping[str, Any] | None = None
+    spill_status = "not_attempted"
+    if spill_dir is not None:
+        # The full, unredacted text spills -- including the fabricated
+        # portion -- so a reviewer can inspect exactly what was cut, the same
+        # discipline `truncate_output` already applies to a length cap.
+        spill = write_output_spill(spill_dir, text)
+        spill_status = "written" if spill else "store_unavailable"
+
+    return TruncatedOutput(
+        kept,
+        truncation_record(
+            source=source,
+            reason_code="fabricated_boundary",
+            limit_bytes=kept_bytes,
+            kept_bytes=kept_bytes,
+            original_bytes=original_bytes,
+            keep="head",
+            spill=spill,
+            spill_status=spill_status,
+        ),
+    )
+
+
+def _first_marker_offset(text: str, markers: Sequence[str]) -> int | None:
+    offsets = [text.index(marker) for marker in markers if marker and marker in text]
+    return min(offsets) if offsets else None
 
 
 def write_output_spill(spill_dir: Path, text: str) -> dict[str, Any]:

--- a/src/system/security_posture.py
+++ b/src/system/security_posture.py
@@ -117,6 +117,14 @@ POSTURE_MAPPING: tuple[PostureRow, ...] = (
         "Explicit `ask_before_dispatch` confirmation is already required in both postures "
         "(`require_hermes_child_dispatch_boundary`); the row documents the invariant.",
     ),
+    PostureRow(
+        "installer_confirmation_override_available",
+        "src/install/installer.py",
+        False,
+        "A strict operator gets no `--force` override path at all for overwriting a "
+        "locally-modified managed file or reclaiming an unowned plugin directory; only "
+        "default posture honors the flag (`approval_tier.resolve_approval_tier`).",
+    ),
 )
 
 _POSTURE_MAPPING_BY_KEY: dict[str, PostureRow] = {row.key: row for row in POSTURE_MAPPING}

--- a/tests/test_approval_tier.py
+++ b/tests/test_approval_tier.py
@@ -1,0 +1,288 @@
+"""The approval-tier resolver: one pure DECISION function every dispatch and
+install confirmation guard now asks (`P3 -- P. Approval-tier resolution as a
+pure function`), plus the enforcement-site integration that replaced their own
+scattered "if not confirmed: raise" copies.
+
+Coverage in this module:
+
+- Every `APPROVAL_RULE_TABLE` row is exercised for both its confirmed and
+  unconfirmed shape (`ResolveApprovalTierTests`).
+- The unknown-defaults-to-most-restrictive and headless-rejects-rather-than-
+  hangs rules absorbed from `docs/approval-mode.md` (P3, item P).
+- Posture composition through `security_posture.strict_override`
+  (`installer_confirmation_override_available`).
+- Enforcement-site integration for the two installer guards this resolver now
+  drives (`_write_skill`/`install_skill_pack`'s local-modification refusal,
+  `_collect_removal`'s unowned-plugin-dir refusal): strict posture disables
+  `--force` for both, default posture is unchanged from before this resolver
+  existed. The hermes-child-dispatch and fanout-recursion-depth sites'
+  default-posture behavior is already pinned by
+  `tests/test_security_posture.py::InvariantRowTests`,
+  `tests/test_hermes_child_cli.py`, and `tests/test_fanout_dispatch.py`
+  (`FanoutSpawnGuardTests`) -- this module does not duplicate those.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+from unittest.mock import patch
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.core.errors import OmhError  # noqa: E402
+from omh.install.installer import _collect_removal, install_skill_pack, uninstall_profile_plugin  # noqa: E402
+from omh.manifest import new_manifest, skill_records, write_manifest  # noqa: E402
+from omh.paths import resolve_paths  # noqa: E402
+from omh.system.approval_tier import (  # noqa: E402
+    APPROVAL_RULE_TABLE,
+    APPROVAL_TIER_SCHEMA_VERSION,
+    APPROVAL_TIERS,
+    TIER_AUTO_ALLOWED,
+    TIER_NEEDS_CONFIRMATION,
+    TIER_REFUSED,
+    UNKNOWN_OPERATION_REASON,
+    describe_approval_tier_table,
+    known_operation_classes,
+    resolve_approval_tier,
+)
+from omh.system.security_posture import DEFAULT_POSTURE, POSTURE_MAPPING, STRICT_POSTURE  # noqa: E402
+
+
+class RuleTableIntegrityTests(unittest.TestCase):
+    def test_every_row_has_a_unique_class_a_valid_tier_and_a_rationale(self) -> None:
+        self.assertTrue(APPROVAL_RULE_TABLE)
+        classes = [rule.operation_class for rule in APPROVAL_RULE_TABLE]
+        self.assertEqual(len(classes), len(set(classes)), "operation_class values must be unique")
+        for rule in APPROVAL_RULE_TABLE:
+            self.assertIn(rule.base_tier, APPROVAL_TIERS, rule)
+            self.assertTrue(rule.rationale.strip(), rule)
+
+    def test_every_posture_key_names_a_real_security_posture_mapping_row(self) -> None:
+        posture_keys = {row.key for row in POSTURE_MAPPING}
+        for rule in APPROVAL_RULE_TABLE:
+            if rule.posture_key is not None:
+                self.assertIn(rule.posture_key, posture_keys, rule)
+
+    def test_only_needs_confirmation_rows_carry_a_posture_key(self) -> None:
+        # auto_allowed and refused rows are already the most/least permissive
+        # tier; nothing for posture to tighten toward.
+        for rule in APPROVAL_RULE_TABLE:
+            if rule.posture_key is not None:
+                self.assertEqual(rule.base_tier, TIER_NEEDS_CONFIRMATION, rule)
+
+    def test_known_operation_classes_matches_the_table_order(self) -> None:
+        self.assertEqual(known_operation_classes(), tuple(rule.operation_class for rule in APPROVAL_RULE_TABLE))
+
+
+class ResolveApprovalTierTests(unittest.TestCase):
+    """Every table row, exercised for both its confirmed and unconfirmed shape."""
+
+    def test_unknown_operation_class_defaults_to_refused(self) -> None:
+        decision = resolve_approval_tier("some_operation_nobody_declared")
+        self.assertEqual(decision.tier, TIER_REFUSED)
+        self.assertEqual(decision.reason_code, UNKNOWN_OPERATION_REASON)
+
+    def test_auto_allowed_rows_are_allowed_regardless_of_confirmation(self) -> None:
+        for rule in APPROVAL_RULE_TABLE:
+            if rule.base_tier != TIER_AUTO_ALLOWED:
+                continue
+            for confirmed in (True, False):
+                decision = resolve_approval_tier(rule.operation_class, confirmed=confirmed)
+                self.assertEqual(decision.tier, TIER_AUTO_ALLOWED, rule)
+
+    def test_structural_refusal_rows_stay_refused_regardless_of_confirmation(self) -> None:
+        for rule in APPROVAL_RULE_TABLE:
+            if rule.base_tier != TIER_REFUSED:
+                continue
+            for confirmed in (True, False):
+                decision = resolve_approval_tier(rule.operation_class, confirmed=confirmed)
+                self.assertEqual(decision.tier, TIER_REFUSED, rule)
+                self.assertEqual(decision.reason_code, "structural_refusal")
+
+    def test_needs_confirmation_rows_allow_only_when_confirmed_in_default_posture(self) -> None:
+        for rule in APPROVAL_RULE_TABLE:
+            if rule.base_tier != TIER_NEEDS_CONFIRMATION:
+                continue
+            allowed = resolve_approval_tier(rule.operation_class, confirmed=True, posture=DEFAULT_POSTURE)
+            self.assertEqual(allowed.tier, TIER_AUTO_ALLOWED, rule)
+            self.assertEqual(allowed.reason_code, "confirmed")
+
+            refused = resolve_approval_tier(rule.operation_class, confirmed=False, posture=DEFAULT_POSTURE)
+            self.assertEqual(refused.tier, TIER_REFUSED, rule)
+            self.assertEqual(refused.reason_code, "unconfirmed")
+
+    def test_headless_rejects_rather_than_hangs_unconfirmed_never_returns_needs_confirmation(self) -> None:
+        # The resolver never hands a call site a pending state to wait on:
+        # every decision is a final tier.
+        for rule in APPROVAL_RULE_TABLE:
+            for confirmed in (True, False):
+                for posture in (DEFAULT_POSTURE, STRICT_POSTURE):
+                    decision = resolve_approval_tier(rule.operation_class, confirmed=confirmed, posture=posture)
+                    self.assertNotEqual(decision.tier, TIER_NEEDS_CONFIRMATION, rule)
+
+    def test_decision_carries_the_operation_class_and_posture_back(self) -> None:
+        decision = resolve_approval_tier("hermes_child_dispatch", confirmed=True, posture=STRICT_POSTURE)
+        self.assertEqual(decision.operation_class, "hermes_child_dispatch")
+        self.assertEqual(decision.posture, STRICT_POSTURE)
+
+
+class PostureCompositionTests(unittest.TestCase):
+    """Strict posture tightens exactly the rows with a `posture_key`, through
+    `security_posture.strict_override` -- the same mapping-table pattern every
+    other tightened surface (#1196) already uses."""
+
+    def test_strict_posture_disables_the_installer_confirmation_override(self) -> None:
+        for operation_class in ("installer_overwrite_local_modification", "installer_remove_unowned_plugin_dir"):
+            decision = resolve_approval_tier(operation_class, confirmed=True, posture=STRICT_POSTURE)
+            self.assertEqual(decision.tier, TIER_REFUSED, operation_class)
+            self.assertEqual(decision.reason_code, "strict_posture_override_disabled", operation_class)
+
+    def test_default_posture_still_honors_the_installer_confirmation_override(self) -> None:
+        for operation_class in ("installer_overwrite_local_modification", "installer_remove_unowned_plugin_dir"):
+            decision = resolve_approval_tier(operation_class, confirmed=True, posture=DEFAULT_POSTURE)
+            self.assertEqual(decision.tier, TIER_AUTO_ALLOWED, operation_class)
+
+    def test_rows_with_no_posture_key_are_posture_invariant(self) -> None:
+        # hermes_child_dispatch, hermes_child_recursion_depth, and
+        # fanout_recursion_depth all document (in security_posture.py's own
+        # `dispatch_confirmation_required` row, and by construction here) that
+        # posture never changes their tier.
+        for rule in APPROVAL_RULE_TABLE:
+            if rule.posture_key is not None:
+                continue
+            for confirmed in (True, False):
+                default_decision = resolve_approval_tier(
+                    rule.operation_class, confirmed=confirmed, posture=DEFAULT_POSTURE
+                )
+                strict_decision = resolve_approval_tier(
+                    rule.operation_class, confirmed=confirmed, posture=STRICT_POSTURE
+                )
+                self.assertEqual(default_decision.tier, strict_decision.tier, rule)
+
+    def test_installer_confirmation_override_row_exists_and_defaults_true(self) -> None:
+        row = next(row for row in POSTURE_MAPPING if row.key == "installer_confirmation_override_available")
+        self.assertEqual(row.strict_value, False)
+        self.assertTrue(row.rationale.strip())
+
+
+class DescribeApprovalTierTableTests(unittest.TestCase):
+    def test_schema_and_row_count_match_the_table(self) -> None:
+        report = describe_approval_tier_table()
+        self.assertEqual(report["schema_version"], APPROVAL_TIER_SCHEMA_VERSION)
+        self.assertEqual(report["tiers"], list(APPROVAL_TIERS))
+        self.assertEqual(len(report["rows"]), len(APPROVAL_RULE_TABLE))
+        self.assertEqual(
+            {row["operation_class"] for row in report["rows"]},
+            {rule.operation_class for rule in APPROVAL_RULE_TABLE},
+        )
+
+
+def _strict_env():
+    return patch.dict(os.environ, {"OMH_SECURITY": "strict"}, clear=False)
+
+
+class InstallerEnforcementSiteIntegrationTests(unittest.TestCase):
+    """`install/installer.py`'s overwrite and removal guards now ask the
+    resolver. Default posture reproduces the pre-resolver behavior exactly
+    (golden); strict posture is new: `--force` no longer overrides either
+    guard."""
+
+    def test_default_posture_force_still_overrides_a_locally_edited_skill(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            install_skill_pack(paths, profile="core")
+            # Edit one installed SKILL.md, then re-freeze the manifest so the
+            # edit predates it -- the same shape as the existing installer
+            # golden test (`test_a_locally_edited_flat_directory_blocks_the_install`).
+            skill_md = next(paths.skills_dir.glob("**/SKILL.md"))
+            write_manifest(
+                paths.manifest_path,
+                new_manifest("builtin", paths.skills_dir, skill_records(paths.skills_dir, "builtin")),
+            )
+            skill_md.write_text("edited after the manifest froze\n", encoding="utf-8")
+
+            with self.assertRaises(OmhError):
+                install_skill_pack(paths, profile="core")
+
+            # Golden: force still overrides in default posture, exactly as it
+            # did before this resolver existed.
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("OMH_SECURITY", None)
+                install_skill_pack(paths, profile="core", force=True)
+            self.assertNotEqual(skill_md.read_text(encoding="utf-8"), "edited after the manifest froze\n")
+
+    def test_strict_posture_refuses_the_same_edit_even_with_force(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            install_skill_pack(paths, profile="core")
+            skill_md = next(paths.skills_dir.glob("**/SKILL.md"))
+            write_manifest(
+                paths.manifest_path,
+                new_manifest("builtin", paths.skills_dir, skill_records(paths.skills_dir, "builtin")),
+            )
+            skill_md.write_text("edited after the manifest froze\n", encoding="utf-8")
+
+            with _strict_env():
+                with self.assertRaises(OmhError):
+                    install_skill_pack(paths, profile="core", force=True)
+            self.assertEqual(skill_md.read_text(encoding="utf-8"), "edited after the manifest froze\n")
+
+    def test_default_posture_force_still_removes_an_unowned_plugin_dir(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            paths.hermes_plugin_dir.mkdir(parents=True, exist_ok=True)
+            (paths.hermes_plugin_dir / "unrelated.txt").write_text("not an OMH manifest\n", encoding="utf-8")
+
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("OMH_SECURITY", None)
+                kept_without_force = uninstall_profile_plugin(paths, force=False)
+                self.assertTrue(kept_without_force["kept_paths"])
+                self.assertTrue(paths.hermes_plugin_dir.exists())
+
+                removed_with_force = uninstall_profile_plugin(paths, force=True)
+                self.assertIn(str(paths.hermes_plugin_dir), removed_with_force["removed_paths"])
+            self.assertFalse(paths.hermes_plugin_dir.exists())
+
+    def test_strict_posture_keeps_the_unowned_plugin_dir_even_with_force(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            paths.hermes_plugin_dir.mkdir(parents=True, exist_ok=True)
+            (paths.hermes_plugin_dir / "unrelated.txt").write_text("not an OMH manifest\n", encoding="utf-8")
+
+            with _strict_env():
+                result = uninstall_profile_plugin(paths, force=True)
+            self.assertTrue(result["kept_paths"])
+            self.assertTrue(paths.hermes_plugin_dir.exists())
+
+    def test_collect_removal_directly_traces_to_the_resolver_for_a_managed_plugin(self) -> None:
+        # A dir that DOES carry the manifest is never gated by this rule at
+        # all -- unaffected by force or posture.
+        with TemporaryDirectory() as tmp:
+            plugin_dir = Path(tmp) / "plugin"
+            plugin_dir.mkdir()
+            (plugin_dir / ".omh-plugin-manifest.json").write_text("{}\n", encoding="utf-8")
+            removed: list[str] = []
+            would_remove: list[str] = []
+            kept: list[dict[str, str]] = []
+            with _strict_env():
+                _collect_removal(
+                    plugin_dir,
+                    removed=removed,
+                    would_remove=would_remove,
+                    kept=kept,
+                    dry_run=False,
+                    force=False,
+                    managed_plugin=True,
+                )
+            self.assertEqual(kept, [])
+            self.assertIn(str(plugin_dir), removed)
+            self.assertFalse(plugin_dir.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -3573,6 +3573,29 @@ class FanoutSpawnGuardTests(unittest.TestCase):
             # never going to start.
             self.assertEqual(runner.spawned, [])
             self.assertEqual(sorted(p.name for p in Path(tmp).glob("*core*")), [])
+
+    def test_the_depth_refusal_traces_to_the_approval_tier_resolver_and_is_posture_invariant(self) -> None:
+        # `dispatch_fanout`'s depth guard now asks
+        # `resolve_approval_tier("fanout_recursion_depth", ...)` instead of
+        # refusing unconditionally; that operation class carries no
+        # `posture_key` (`system.approval_tier.APPROVAL_RULE_TABLE`), so the
+        # same refusal must fire in strict posture too.
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            runner = _agent_runner()
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                runner=runner,
+                readiness=_ready,
+                env={FANOUT_DEPTH_ENV_VAR: "1", "OMH_SECURITY": "strict"},
+            )
+            self.assertTrue(summary["refused"])
+            self.assertEqual(summary["refusal_reason"], "fanout_depth_exceeded")
+            self.assertEqual(runner.spawned, [])
             # And nothing was persisted: a refusal must not overwrite the
             # stored summary of the run that is actually in flight.
             self.assertFalse(fanout_dispatch_summary_path(paths, contract["fanout_id"]).exists())

--- a/tests/test_output_truncation.py
+++ b/tests/test_output_truncation.py
@@ -23,6 +23,7 @@ from omh.system.output_truncation import (  # noqa: E402
     TRUNCATION_REASON_CODES,
     resolve_spill_reference,
     spill_evidence_ref,
+    truncate_at_fabricated_boundary,
     truncate_output,
     truncation_notice,
     write_output_spill,
@@ -176,6 +177,107 @@ class OutputTruncationContractTests(unittest.TestCase):
         self.assertNotIn("�", head.kept_text)
         self.assertEqual(tail.record["kept_bytes"], len(tail.kept_text.encode("utf-8")))
         self.assertEqual(head.record["kept_bytes"], len(head.kept_text.encode("utf-8")))
+
+
+class FabricatedBoundaryContractTests(unittest.TestCase):
+    """`truncate_at_fabricated_boundary` -- OMH's analogue of oh-my-pi's
+    `tools.abortOnFabricatedResult` (P3, item Q): a dispatched unit's captured
+    output is cut at the first occurrence of a caller-named authority marker,
+    the content before it kept and reported real, the marker onward reported
+    under the `fabricated_boundary` reason code and never parsed as genuine.
+    """
+
+    def setUp(self) -> None:
+        self.temp = TemporaryDirectory(prefix="omh-fabricated-boundary-")
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.paths = OmhPaths(omh_home=self.root / ".omh", hermes_home=self.root / ".hermes")
+
+    def test_no_marker_present_passes_through_unchanged(self) -> None:
+        bounded = truncate_at_fabricated_boundary(
+            "ordinary unit output, nothing suspicious here\n",
+            markers=("v1.deadbeef.cafef00d",),
+            source="unit test capture",
+        )
+        self.assertFalse(bounded.truncated)
+        self.assertEqual(bounded.record["reason_code"], "not_truncated")
+        self.assertEqual(bounded.text, "ordinary unit output, nothing suspicious here\n")
+
+    def test_a_marker_mid_stream_keeps_only_what_precedes_it(self) -> None:
+        genuine = "real progress output before the boundary\n"
+        fabricated = "v1.deadbeef.cafef00d fake authority claim\nmore fabricated text\n"
+        bounded = truncate_at_fabricated_boundary(
+            genuine + fabricated,
+            markers=("v1.deadbeef.cafef00d",),
+            source="unit test capture",
+        )
+        self.assertTrue(bounded.truncated)
+        self.assertEqual(bounded.kept_text, genuine)
+        self.assertEqual(bounded.record["reason_code"], "fabricated_boundary")
+        self.assertIn(bounded.record["reason_code"], TRUNCATION_REASON_CODES)
+        self.assertEqual(bounded.record["kept_bytes"], len(genuine.encode("utf-8")))
+        self.assertEqual(
+            bounded.record["original_bytes"], len((genuine + fabricated).encode("utf-8"))
+        )
+
+    def test_the_earliest_of_several_markers_wins(self) -> None:
+        text = "keep-me BETA_MARKER discard-from-here ALPHA_MARKER discard-more"
+        bounded = truncate_at_fabricated_boundary(
+            text, markers=("ALPHA_MARKER", "BETA_MARKER"), source="marker order"
+        )
+        self.assertEqual(bounded.kept_text, "keep-me ")
+
+    def test_a_marker_at_the_very_start_keeps_nothing(self) -> None:
+        bounded = truncate_at_fabricated_boundary(
+            "v1.marker rest of a fully fabricated stream",
+            markers=("v1.marker",),
+            source="all fabricated",
+        )
+        self.assertTrue(bounded.truncated)
+        self.assertEqual(bounded.kept_text, "")
+        self.assertEqual(bounded.record["kept_bytes"], 0)
+
+    def test_full_original_content_spills_including_the_fabricated_part(self) -> None:
+        genuine = "trusted prefix\n"
+        fabricated = "MARKER poisoned suffix\n"
+        bounded = truncate_at_fabricated_boundary(
+            genuine + fabricated,
+            markers=("MARKER",),
+            source="spill coverage",
+            spill_dir=self.paths.runtime_output_spills_dir,
+        )
+        spill = bounded.record["spill"]
+        self.assertEqual(resolve_spill_reference(spill), genuine + fabricated)
+        self.assertEqual(spill_evidence_ref(bounded.record), f"output_spill:{spill['path']}:sha256:{spill['sha256']}:{spill['byte_count']}")
+
+    def test_no_spill_dir_means_not_attempted_and_no_pointer(self) -> None:
+        bounded = truncate_at_fabricated_boundary(
+            "prefix MARKER suffix", markers=("MARKER",), source="no spill"
+        )
+        self.assertNotIn("spill", bounded.record)
+        self.assertEqual(bounded.record["spill_status"], "not_attempted")
+
+    def test_multibyte_content_before_the_marker_is_kept_whole(self) -> None:
+        text = "한글" * 50 + "MARKER" + "tail"
+        bounded = truncate_at_fabricated_boundary(text, markers=("MARKER",), source="utf8")
+        self.assertEqual(bounded.kept_text, "한글" * 50)
+        self.assertNotIn("�", bounded.kept_text)
+
+    def test_empty_marker_list_never_truncates(self) -> None:
+        bounded = truncate_at_fabricated_boundary("anything at all", markers=(), source="no markers")
+        self.assertFalse(bounded.truncated)
+
+    def test_notice_names_the_reason_and_carries_no_ellipsis(self) -> None:
+        bounded = truncate_at_fabricated_boundary(
+            "kept part MARKER cut part",
+            markers=("MARKER",),
+            source="notice",
+            spill_dir=self.paths.runtime_output_spills_dir,
+        )
+        notice = truncation_notice(bounded.record)
+        self.assertIn("reason=fabricated_boundary", notice)
+        self.assertNotIn("...", notice)
+        self.assertNotIn("…", notice)
 
 
 class BoundedCaptureContractTests(unittest.TestCase):


### PR DESCRIPTION
## Feature Report

### What Changed

- New `src/system/approval_tier.py`: a pure, testable `resolve_approval_tier(operation_class, *, confirmed, posture)` function backed by one explicit rule table (`APPROVAL_RULE_TABLE`), answering `auto_allowed` / `needs_confirmation` / `refused` for six named operation classes. Absorbs two rules from `docs/approval-mode.md` (oh-my-pi; dossier item P): unknown operation classes default to `refused` (most restrictive, never `auto_allowed`), and an unconfirmed `needs_confirmation` operation resolves straight to `refused` rather than a pending state (no live prompt loop exists inside a pure function to wait on).
- Six enforcement sites now ask the resolver instead of repeating their own `if not confirmed: raise` / `kept unless --force` shape:
  - `src/coding/hermes_child_dispatch.py`: `require_hermes_child_dispatch_boundary` (confirmation + recursion-depth checks).
  - `src/commands/hermes_child.py`: `cmd_hermes_child_dispatch`'s `--confirm-dispatch` CLI guard.
  - `src/commands/hermes_child_skill_load.py`: `cmd_hermes_child_skill_load_probe`'s `--confirm-dispatch` CLI guard.
  - `src/coding/fanout_dispatch.py`: `dispatch_fanout`'s spawn-depth refusal.
  - `src/install/installer.py`: `_write_skill`, `_write_skill_reference`, `install_skill_pack`'s local-modification refusal (via a new shared `_overwrite_allowed(force)` helper), and `_collect_removal`'s unowned-plugin-directory refusal.
  Every site keeps its own enforcement -- its own exception type, its own message, its own refusal payload shape. Only the DECISION moved.
- Strict security posture (#1196) composes through the table: a new `installer_confirmation_override_available` row in `security_posture.POSTURE_MAPPING` (default `True`, strict `False`) lets `OMH_SECURITY=strict` drop `--force`'s override path entirely for the two installer guards. Every other rule (hermes-child dispatch, both recursion-depth guards) is posture-invariant, matching the already-documented `dispatch_confirmation_required` invariant row.
- New `output_truncation.truncate_at_fabricated_boundary` (dossier item Q, mechanism 1): OMH's analogue of oh-my-pi's `tools.abortOnFabricatedResult`. Given caller-supplied authority markers, content is kept up to the first marker occurrence; everything from there is cut and reported under a new `fabricated_boundary` reason code, never parsed as genuine. New reason code added to the closed `TRUNCATION_REASON_CODES` vocabulary.

### Why This Exists

`.omc/research/ohmypi-optimization-2026-08-29.md` items P and Q. P: OMH's confirm/refuse decisions for the hermes-child dispatch boundary, fanout dispatch confirmation, and installer guards were each hand-written at their own call site with no single source of truth, and no posture-tightening path. Q: two smaller mechanisms from the same source material -- one (fabricated-result boundary) was a genuine gap; the other (an FS-scan cache) turned out not to apply.

### User / Operator Impact

- Default posture: no behavior change anywhere (golden tests below).
- `OMH_SECURITY=strict`: `omh install --force` / `omh setup --force` no longer overwrite a locally-modified managed skill file, and `--force` no longer reclaims a plugin directory OMH cannot prove it manages. Both now refuse outright in strict posture; default posture is unaffected.
- `truncate_at_fabricated_boundary` ships as a tested library function; no existing dispatch path is rewired onto it in this PR (see Risk).

### How It Works

`resolve_approval_tier` never raises, writes, or spawns -- it only returns an `ApprovalDecision(operation_class, tier, reason_code, posture)`. A call site compares `decision.tier` against `TIER_AUTO_ALLOWED` and does its own enforcement. `needs_confirmation` rows carry an optional `posture_key` naming a `security_posture.POSTURE_MAPPING` row; `strict_override` (already used by `parallelism_policy.py`, `goal_loop.py`, `coding_delegation.py`) resolves whether the confirmation override is even available in the active posture before `confirmed` is considered.

### Files And Contracts Touched

- `src/system/approval_tier.py` (new)
- `src/system/security_posture.py` (`POSTURE_MAPPING` +1 row)
- `src/coding/hermes_child_dispatch.py`, `src/coding/fanout_dispatch.py`
- `src/commands/hermes_child.py`, `src/commands/hermes_child_skill_load.py`
- `src/install/installer.py`
- `src/system/output_truncation.py` (`TRUNCATION_REASON_CODES` +1 member, `truncate_at_fabricated_boundary` new)
- `tests/test_approval_tier.py` (new), `tests/test_fanout_dispatch.py`, `tests/test_output_truncation.py`

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [x] `uv run python -m omh.cli docs ulw-inventory --check`
- [x] `uv run python -m omh.cli docs ulw-site --check`
- [x] `uv run python -m omh.cli release drift`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: no live Hermes install in this environment.

### Observed Evidence

- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`: 8288 tests, 21 failures + 7 errors = 28, all in `test_cross_harness_adapters.py` / `test_cross_harness_adapter_security.py` (the documented pre-existing cross-harness `.claude`-path baseline; verified none touch a file this PR changed).
- `uv run python -m compileall -q src tests`: clean.
- All five docs `--check` gates (workflows, roles, capability-families, ulw-inventory, ulw-site): `"ok": true`.
- `uv run python -m omh.cli release drift`: "No drift. 18 checks passed."
- `uv run --group lint ruff check src tests`: "All checks passed!"
- `git diff --check`: no output (clean).
- `tests/test_broad_exception_policy.py` run standalone: 6/6 pass (no new broad `except` sites introduced).
- New/changed test files run standalone and green: `tests/test_approval_tier.py` (20 tests), `tests/test_output_truncation.py` (24 tests), `tests/test_fanout_dispatch.py` (all, including the new posture-invariance case), `tests/test_security_posture.py`, `tests/test_hermes_child_dispatch.py`, `tests/test_hermes_child_cli.py`, `tests/test_installer_skill_profile.py`, `tests/test_skill_load_replay_boundary.py`, `tests/test_handoff_safety_contract_enforcement.py`.

### Not Tested / Not Applicable

- `harness validate`, `release checklist --json`, `release hermes-smoke`, `omh --help`, and the live smoke command: this change touches no harness-validation, release-checklist, or smoke-relevant surface; not run to keep the PR's own verification loop tight, per repo convention for a non-release-shaped change.
- No live Hermes install was available to exercise the CLI guards (`--confirm-dispatch`, `--force`) against a real `hermes` binary; coverage is unit/integration only (fake CLI fixtures), matching the rest of this test suite's pattern for these commands.

## Risk

- `truncate_at_fabricated_boundary` is new, tested library code with zero existing call sites in this PR. The one place OMH currently treats a dispatched unit's own stdout as ground truth -- fanout's fenced ` ```json ` fallback intake in `fanout_dispatch.py` (`_stdout_fenced_json_blocks` / `_intake_stdout_unit_result`) -- is a heavily tested (30+ tests), documented wire-format contract ("the final report ENDS with the block, so the last one is the return"). Rewiring fabricated-boundary detection into that parsing path is a real design decision (what counts as an unforgeable marker for a fenced-block protocol) that belongs in its own reviewed change, not folded into a "P3, small" item. Left as a documented follow-up.
- Q's second mechanism (an FS-scan cache with TTL/eviction/prefix-invalidation) does not apply: neither `src/maintenance/structural_search.py` (a PATH-only presence probe, no filesystem walk) nor `src/codegraph/scanner.py` (`os.walk` once per call, no caching) caches a scan today. Per the dossier's own conditional framing ("relevant only if ... ever caches scans"), there is nothing to retrofit a cache-key discipline into. No code change made for this half of Q.
- Installer strict-posture behavior change is new and only takes effect under an explicit opt-in env var (`OMH_SECURITY=strict`); default posture is unchanged (golden-tested).

## Compatibility / Rollout

- Additive: new module, new `POSTURE_MAPPING` row, new truncation reason code. No public function signature removed or narrowed. `install/installer.py`'s public `install_skill_pack`/`uninstall_profile_plugin`/`uninstall_skill_pack` signatures are unchanged.
- No migration needed; strict-posture installer behavior is opt-in via the existing `OMH_SECURITY` env var.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`) -- no release-channel-specific logic touched.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence -- n/a, no handoff/plan surface touched.
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap -- listed above under Not Tested.

## Follow-Up

- Consider wiring `truncate_at_fabricated_boundary` into a real dispatch call site once a provably-unforgeable marker set is chosen for that site (see Risk above and the commit's `Directive` trailer).
- If OMH ever adds caching to `structural_search.py` or `codegraph/scanner.py`, compose the cache key from the canonicalized root plus the complete effective walk options (Q's transferable rule), not a partial key.
