### PR TITLE
feat(coding): symlink shared build artifacts into fanout unit worktrees

### DIFF
--- a/src/coding/fanout_artifact_sharing.py
+++ b/src/coding/fanout_artifact_sharing.py
@@ -11,20 +11,29 @@ starts warm.
 The MUST NOT is the interesting half of that precedent, and it drives every
 guard here: never symlink a directory that holds tracked sources, because a
 folder-level link would shadow real files a unit is supposed to see and edit.
-Three independent guards enforce that, in order, and any one of them failing
-falls back silently-but-recorded to the cold behavior that already exists:
+Four independent guards enforce that, checked in this order for each
+allowlist entry, and any one of them failing falls back silently-but-recorded
+to the cold behavior that already exists:
 
 1. The name must be on `SHAREABLE_ARTIFACT_ALLOWLIST` -- a small, named set,
    not an open pattern.
 2. The parent checkout must itself report the path `git check-ignore`d.
-3. AFTER the symlink is created, the unit worktree must ALSO report the same
-   path ignored. This second check exists because a directory-only gitignore
-   pattern (`node_modules/`, the common shape) matches a real directory but
-   NOT a symlink of the same name -- git's dir-only match uses the on-disk
-   type, and a symlink is never a directory to it. Skipping this re-check
-   would let a shared artifact masquerade as a unit-authored change and
-   corrupt `fanout_retry`'s worktree-side-effect detection for a unit that
-   never touched it.
+3. The platform must support symlinks (`os.name != "nt"`). This check is
+   deliberately LAST, immediately before the `os.symlink` call, rather than a
+   single up-front skip for every entry: an entry that would have refused
+   anyway (missing source, not gitignored, or a tracked path already in the
+   worktree) reports THAT reason on every platform, including Windows, so the
+   guard order stays exercised and testable without a real symlink syscall.
+   Only an entry that has cleared every other guard reports
+   `platform_unsupported`.
+4. AFTER the symlink is created, the unit worktree must ALSO report the same
+   path ignored. This second gitignore check exists because a directory-only
+   gitignore pattern (`node_modules/`, the common shape) matches a real
+   directory but NOT a symlink of the same name -- git's dir-only match uses
+   the on-disk type, and a symlink is never a directory to it. Skipping this
+   re-check would let a shared artifact masquerade as a unit-authored change
+   and corrupt `fanout_retry`'s worktree-side-effect detection for a unit
+   that never touched it.
 
 Nothing here raises. A unit worktree that cannot be warmed still gets created
 cold, and every allowlist entry's outcome -- linked, or skipped with a named
@@ -117,22 +126,6 @@ def plan_and_link_shared_artifacts(
             "entries": [],
             "linked": [],
         }
-    if os.name == "nt" or not hasattr(os, "symlink"):
-        # Windows CI runs this path. The safest available mechanism here is to
-        # skip and record why, rather than reach for a junction/copy strategy
-        # that would need its own correctness rails this feature has not
-        # earned yet.
-        entries = [
-            {"name": allowed["name"], "rationale": allowed["rationale"], "action": "skipped", "reason": "platform_unsupported"}
-            for allowed in SHAREABLE_ARTIFACT_ALLOWLIST
-        ]
-        return {
-            "schema_version": SHARED_ARTIFACT_SCHEMA_VERSION,
-            "claim_boundary": SHARED_ARTIFACT_CLAIM_BOUNDARY,
-            "opted_out": False,
-            "entries": entries,
-            "linked": [],
-        }
     entries = []
     linked: list[str] = []
     for allowed in SHAREABLE_ARTIFACT_ALLOWLIST:
@@ -176,6 +169,14 @@ def _link_one(
         return {**entry, "action": "skipped", "reason": "source_missing"}
     if not _path_is_gitignored(runner, repo_root, name):
         return {**entry, "action": "skipped", "reason": "source_not_gitignored"}
+    if not _symlinks_supported():
+        # Windows CI runs this path. The safest available mechanism here is to
+        # skip and record why, rather than reach for a junction/copy strategy
+        # that would need its own correctness rails this feature has not
+        # earned yet. Checked last, immediately before the syscall, so every
+        # guard above it stays exercised (and its own reason reported) on
+        # every platform.
+        return {**entry, "action": "skipped", "reason": "platform_unsupported"}
     try:
         os.symlink(source, target, target_is_directory=True)
     except OSError as exc:
@@ -219,3 +220,13 @@ def _exit_code(value: Any) -> int:
         return int(value)
     except (TypeError, ValueError):
         return 1
+
+
+def _symlinks_supported() -> bool:
+    """Whether this platform can create a directory symlink at all.
+
+    A plain function, not an inlined condition, so a test can monkeypatch it
+    directly to exercise the `platform_unsupported` branch on any host
+    without needing an actual Windows runner.
+    """
+    return os.name != "nt" and hasattr(os, "symlink")

--- a/src/coding/fanout_artifact_sharing.py
+++ b/src/coding/fanout_artifact_sharing.py
@@ -1,0 +1,221 @@
+"""Symlink read-only-ish build artifacts into fresh fanout unit worktrees.
+
+Each `omh coding fanout dispatch` unit gets its own `git worktree add`, which
+starts cold: dependency directories and build caches the parent checkout
+already paid for (`node_modules`, `.venv`, `target`, ...) have to be rebuilt
+from scratch inside every unit worktree. This module absorbs the precedent
+documented in oh-my-pi's `.omp/commands/fix-issues.md:64-81`: symlink those
+directories in from the parent checkout instead of rebuilding them, so a unit
+starts warm.
+
+The MUST NOT is the interesting half of that precedent, and it drives every
+guard here: never symlink a directory that holds tracked sources, because a
+folder-level link would shadow real files a unit is supposed to see and edit.
+Three independent guards enforce that, in order, and any one of them failing
+falls back silently-but-recorded to the cold behavior that already exists:
+
+1. The name must be on `SHAREABLE_ARTIFACT_ALLOWLIST` -- a small, named set,
+   not an open pattern.
+2. The parent checkout must itself report the path `git check-ignore`d.
+3. AFTER the symlink is created, the unit worktree must ALSO report the same
+   path ignored. This second check exists because a directory-only gitignore
+   pattern (`node_modules/`, the common shape) matches a real directory but
+   NOT a symlink of the same name -- git's dir-only match uses the on-disk
+   type, and a symlink is never a directory to it. Skipping this re-check
+   would let a shared artifact masquerade as a unit-authored change and
+   corrupt `fanout_retry`'s worktree-side-effect detection for a unit that
+   never touched it.
+
+Nothing here raises. A unit worktree that cannot be warmed still gets created
+cold, and every allowlist entry's outcome -- linked, or skipped with a named
+reason -- rides into the caller's returned record so a run stays explainable.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+from typing import Any, Callable, Mapping
+
+SHARED_ARTIFACT_SCHEMA_VERSION = "fanout_shared_artifacts/v1"
+SHARED_ARTIFACT_CLAIM_BOUNDARY = (
+    "A shared_artifacts record states which parent-checkout directories a fanout unit worktree "
+    "started with a symlink instead of a cold rebuild, and why any allowlisted entry was skipped. "
+    "It is not a claim that the linked content is correct, complete, fresh, or safe to trust blindly."
+)
+
+# Opt-out only: `OMH_FANOUT_SHARE_ARTIFACTS=0` disables linking entirely and a
+# unit worktree starts exactly as it did before this feature. Same shape as
+# the existing `OMH_MENUBAR` / `OMH_PROGRESS` toggles -- default on, explicit
+# `0` to turn off.
+OPT_OUT_ENV_VAR = "OMH_FANOUT_SHARE_ARTIFACTS"
+
+# Every name this feature MAY symlink from the parent checkout into a fanout
+# unit worktree, with the rationale for including it. This list is not a
+# guarantee any entry gets linked in a given repo: `_link_one` still requires
+# the parent checkout to report the path gitignored before it ever touches a
+# unit worktree, so a repo that tracks a directory with one of these names
+# never has it linked.
+SHAREABLE_ARTIFACT_ALLOWLIST: tuple[dict[str, str], ...] = (
+    {
+        "name": "node_modules",
+        "rationale": (
+            "JS/TS dependency install, reproducible from lockfiles; one of the two directories "
+            "the oh-my-pi fix-issues.md precedent names explicitly."
+        ),
+    },
+    {
+        "name": "target",
+        "rationale": (
+            "Rust/Cargo build cache; the other directory the oh-my-pi precedent names, expensive "
+            "to rebuild per worktree."
+        ),
+    },
+    {
+        "name": ".venv",
+        "rationale": (
+            "Python virtualenv created by uv/venv, reproducible from lockfiles; this repo's own "
+            "tooling convention (see CLAUDE.md Build & Test)."
+        ),
+    },
+    {
+        "name": "build",
+        "rationale": (
+            "Generic build output directory used by many toolchains; only ever shared when the "
+            "parent checkout itself gitignores it."
+        ),
+    },
+)
+
+
+def shared_artifacts_opted_out(env: Mapping[str, str] | None = None) -> bool:
+    """Whether `OMH_FANOUT_SHARE_ARTIFACTS=0` disabled this feature for this dispatch."""
+    source = env if env is not None else os.environ
+    return str(source.get(OPT_OUT_ENV_VAR, "1")) == "0"
+
+
+def plan_and_link_shared_artifacts(
+    *,
+    repo_root: Path,
+    worktree_path: Path,
+    runner: Callable[..., Any] = subprocess.run,
+    env: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Symlink allowlisted, gitignored artifact directories into a fresh unit worktree.
+
+    Called once, right after `git worktree add` creates `worktree_path` and
+    before the unit's process spawns. Every allowlist entry is independent and
+    best-effort: one entry failing never blocks another, and never blocks the
+    dispatch -- a unit whose warm start did not work out still runs cold.
+    """
+    if shared_artifacts_opted_out(env):
+        return {
+            "schema_version": SHARED_ARTIFACT_SCHEMA_VERSION,
+            "claim_boundary": SHARED_ARTIFACT_CLAIM_BOUNDARY,
+            "opted_out": True,
+            "entries": [],
+            "linked": [],
+        }
+    if os.name == "nt" or not hasattr(os, "symlink"):
+        # Windows CI runs this path. The safest available mechanism here is to
+        # skip and record why, rather than reach for a junction/copy strategy
+        # that would need its own correctness rails this feature has not
+        # earned yet.
+        entries = [
+            {"name": allowed["name"], "rationale": allowed["rationale"], "action": "skipped", "reason": "platform_unsupported"}
+            for allowed in SHAREABLE_ARTIFACT_ALLOWLIST
+        ]
+        return {
+            "schema_version": SHARED_ARTIFACT_SCHEMA_VERSION,
+            "claim_boundary": SHARED_ARTIFACT_CLAIM_BOUNDARY,
+            "opted_out": False,
+            "entries": entries,
+            "linked": [],
+        }
+    entries = []
+    linked: list[str] = []
+    for allowed in SHAREABLE_ARTIFACT_ALLOWLIST:
+        entry = _link_one(
+            runner,
+            repo_root=repo_root,
+            worktree_path=worktree_path,
+            name=allowed["name"],
+            rationale=allowed["rationale"],
+        )
+        entries.append(entry)
+        if entry["action"] == "linked":
+            linked.append(allowed["name"])
+    return {
+        "schema_version": SHARED_ARTIFACT_SCHEMA_VERSION,
+        "claim_boundary": SHARED_ARTIFACT_CLAIM_BOUNDARY,
+        "opted_out": False,
+        "entries": entries,
+        "linked": linked,
+    }
+
+
+def _link_one(
+    runner: Callable[..., Any],
+    *,
+    repo_root: Path,
+    worktree_path: Path,
+    name: str,
+    rationale: str,
+) -> dict[str, str]:
+    entry = {"name": name, "rationale": rationale}
+    source = repo_root / name
+    target = worktree_path / name
+    if target.exists() or target.is_symlink():
+        # A fresh `git worktree add` checkout contains only tracked paths, so
+        # a non-empty path here means a TRACKED file or directory of this name
+        # already lives in the checkout -- exactly what the dossier's MUST NOT
+        # warns against displacing.
+        return {**entry, "action": "skipped", "reason": "path_exists_in_worktree"}
+    if not source.is_dir():
+        return {**entry, "action": "skipped", "reason": "source_missing"}
+    if not _path_is_gitignored(runner, repo_root, name):
+        return {**entry, "action": "skipped", "reason": "source_not_gitignored"}
+    try:
+        os.symlink(source, target, target_is_directory=True)
+    except OSError as exc:
+        return {**entry, "action": "skipped", "reason": f"symlink_failed:{exc}"}
+    if not _path_is_gitignored(runner, worktree_path, name):
+        # Re-checked from INSIDE the worktree, after the symlink now exists.
+        # A dir-only gitignore pattern does not match a symlink of the same
+        # name, so this can fail even though the source check above passed.
+        # Undo rather than leave a link that would show up as an untracked
+        # change and corrupt replay-safety detection.
+        try:
+            target.unlink()
+        except OSError:
+            pass
+        return {**entry, "action": "skipped", "reason": "symlink_not_recognized_ignored"}
+    return {**entry, "action": "linked", "reason": ""}
+
+
+def _path_is_gitignored(runner: Callable[..., Any], cwd: Path, relative_name: str) -> bool:
+    """Whether `relative_name` is gitignored, queried from `cwd` via `git check-ignore`.
+
+    Read-only, and never raises: a runner that cannot answer is treated as
+    "not ignored," which is the fail-closed direction -- it skips linking
+    rather than risk sharing tracked content.
+    """
+    try:
+        completed = runner(
+            ["git", "check-ignore", "-q", "--", relative_name],
+            cwd=str(cwd),
+            text=True,
+            capture_output=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError, ValueError, TypeError):
+        return False
+    return _exit_code(getattr(completed, "returncode", 1)) == 0
+
+
+def _exit_code(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 1

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -41,6 +41,7 @@ from .executor_progress import (
     write_progress_binding,
 )
 from .executor_readiness import probe_executor_readiness
+from .fanout_artifact_sharing import plan_and_link_shared_artifacts
 from .fanout_contracts import (
     FANOUT_CLAIM_BOUNDARY,
     FANOUT_CONTRACT_SCHEMA_VERSION,
@@ -2311,6 +2312,16 @@ def _dispatch_unit(
             **_dispatch_status_ladder(),
         }
     worktree = Path(str(worktree_record["worktree_path"]))
+    # After the worktree exists and before anything else touches it: a linked
+    # artifact must be in place before the unit's process spawns to be worth
+    # anything, and re-checking from inside the worktree (see
+    # fanout_artifact_sharing) requires the worktree's own git metadata, which
+    # `git worktree add` has just finished writing.
+    shared_artifacts = plan_and_link_shared_artifacts(
+        repo_root=repo_root,
+        worktree_path=worktree,
+        runner=runner,
+    )
     if fanout_id:
         # Before the spawn, like the in-flight marker below. A record from an
         # earlier attempt describes a worktree that has just been rebuilt from
@@ -2326,6 +2337,12 @@ def _dispatch_unit(
         ensure_dir(sidecar_path.parent, private=True)
         sidecar_path.unlink(missing_ok=True)
     _ensure_unit_run(paths, unit, owner)
+    dispatch_summary = f"local dispatch of unit {unit_id} to {owner}"
+    if shared_artifacts.get("linked"):
+        # Named in the journal, not just the eventual result dict, so a run
+        # stays explainable from the journal alone: the observation schema
+        # carries only fixed fields, so the note rides in free-text summary.
+        dispatch_summary = f"{dispatch_summary} (shared_artifacts: {', '.join(shared_artifacts['linked'])})"
     append_journal_observation(
         paths,
         {
@@ -2334,7 +2351,7 @@ def _dispatch_unit(
             "run_id": run_ref,
             "event": "worker_dispatch",
             "status": "observed",
-            "summary": f"local dispatch of unit {unit_id} to {owner}",
+            "summary": dispatch_summary,
             "worker_ref": unit_id,
             "worktree_ref": str(worktree),
             # The schema has carried this field all along and nothing set it,
@@ -2635,6 +2652,7 @@ def _dispatch_unit(
         "status": "completed" if exit_code == 0 else "failed",
         "exit_code": exit_code,
         "worktree_path": str(worktree),
+        "shared_artifacts": shared_artifacts,
         **_dispatch_status_ladder(
             process_succeeded=exit_code == 0,
             result_schema_valid=bool(unit_result.get("result_schema_valid")),

--- a/tests/test_fanout_artifact_sharing.py
+++ b/tests/test_fanout_artifact_sharing.py
@@ -1,0 +1,369 @@
+"""Tests for symlinking shared build artifacts into fanout unit worktrees.
+
+Covers the module directly (`fanout_artifact_sharing`) and its wiring into
+`dispatch_fanout` / the observation journal / `fanout_retry`'s replay-safety
+predicate, per the backlog item "Symlink build artifacts into fanout
+worktrees."
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+from tempfile import TemporaryDirectory
+import unittest
+from unittest import mock
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.coding.fanout import build_fanout_contract  # noqa: E402
+from omh.coding.fanout_artifact_sharing import (  # noqa: E402
+    OPT_OUT_ENV_VAR,
+    SHAREABLE_ARTIFACT_ALLOWLIST,
+    SHARED_ARTIFACT_SCHEMA_VERSION,
+    plan_and_link_shared_artifacts,
+    shared_artifacts_opted_out,
+)
+from omh.coding.fanout_artifacts import write_fanout_contract  # noqa: E402
+from omh.coding.fanout_dispatch import dispatch_fanout  # noqa: E402
+from omh.runtime.artifacts import read_observation_events_result  # noqa: E402
+from omh.system.paths import OmhPaths  # noqa: E402
+
+
+def _git(repo: Path, *argv: str) -> None:
+    subprocess.run(["git", *argv], cwd=str(repo), check=True, capture_output=True, text=True)
+
+
+def _make_repo(root: Path, *, gitignore_lines: list[str] | None = None) -> tuple[Path, str]:
+    repo = root / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+    _git(repo, "add", "seed.txt")
+    if gitignore_lines:
+        (repo / ".gitignore").write_text("\n".join(gitignore_lines) + "\n", encoding="utf-8")
+        _git(repo, "add", ".gitignore")
+    _git(repo, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "init")
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=str(repo), capture_output=True, text=True, check=True
+    ).stdout.strip()
+    return repo, sha
+
+
+def _commit_all(repo: Path, message: str) -> str:
+    _git(repo, "add", "-A")
+    _git(repo, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", message)
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=str(repo), capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def _add_worktree(repo: Path, branch: str, base_sha: str, worktree_path: Path) -> None:
+    subprocess.run(
+        ["git", "worktree", "add", str(worktree_path), "-b", branch, base_sha],
+        cwd=str(repo),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+class _FakeCompleted:
+    def __init__(self, returncode: int, stdout: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = ""
+
+
+def _agent_runner(*, fail_units: set[str] | None = None):
+    """Route git commands to the real subprocess; fake agent CLI spawns."""
+
+    def runner(argv, **kwargs):
+        if argv[0] == "git":
+            return subprocess.run(argv, **kwargs)
+        prompt = " ".join(argv)
+        for unit_id in fail_units or set():
+            if unit_id in prompt:
+                return _FakeCompleted(1, f"unit {unit_id} failed")
+        return _FakeCompleted(0, "done")
+
+    return runner
+
+
+def _ready(paths, profile, **kwargs):
+    return {"status": "ready", "profile": profile}
+
+
+class SharedArtifactAllowlistTests(unittest.TestCase):
+    """`plan_and_link_shared_artifacts` called directly against real git worktrees."""
+
+    def test_allowlist_entries_carry_a_rationale(self) -> None:
+        for entry in SHAREABLE_ARTIFACT_ALLOWLIST:
+            self.assertTrue(entry["name"])
+            self.assertTrue(entry["rationale"])
+
+    def test_links_an_allowlisted_gitignored_directory(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo, sha = _make_repo(root, gitignore_lines=["node_modules"])
+            (repo / "node_modules").mkdir()
+            (repo / "node_modules" / "pkg.js").write_text("module.exports = 1;\n", encoding="utf-8")
+            worktree = root / "unit-worktree"
+            _add_worktree(repo, "agent/unit-a", sha, worktree)
+
+            result = plan_and_link_shared_artifacts(repo_root=repo, worktree_path=worktree, runner=subprocess.run)
+
+            self.assertEqual(result["schema_version"], SHARED_ARTIFACT_SCHEMA_VERSION)
+            self.assertFalse(result["opted_out"])
+            self.assertIn("node_modules", result["linked"])
+            entry = next(e for e in result["entries"] if e["name"] == "node_modules")
+            self.assertEqual(entry["action"], "linked")
+            self.assertEqual(entry["reason"], "")
+            self.assertTrue(entry["rationale"])
+            self.assertTrue((worktree / "node_modules").is_symlink())
+            self.assertEqual(
+                (worktree / "node_modules" / "pkg.js").read_text(encoding="utf-8"),
+                "module.exports = 1;\n",
+            )
+
+    def test_gitignore_guard_never_links_a_tracked_directory(self) -> None:
+        # "build" is TRACKED in the parent checkout (never gitignored). A
+        # fresh unit worktree therefore already contains it as a real
+        # directory, and the guard must never displace real, checked-out
+        # source with a symlink -- the exact MUST NOT the absorbed precedent
+        # names.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo, sha = _make_repo(root)
+            (repo / "build").mkdir()
+            (repo / "build" / "tracked_source.py").write_text("value = 1\n", encoding="utf-8")
+            sha2 = _commit_all(repo, "track build/")
+            worktree = root / "unit-worktree"
+            _add_worktree(repo, "agent/unit-b", sha2, worktree)
+
+            result = plan_and_link_shared_artifacts(repo_root=repo, worktree_path=worktree, runner=subprocess.run)
+
+            self.assertNotIn("build", result["linked"])
+            entry = next(e for e in result["entries"] if e["name"] == "build")
+            self.assertEqual(entry["action"], "skipped")
+            self.assertEqual(entry["reason"], "path_exists_in_worktree")
+            self.assertFalse((worktree / "build").is_symlink())
+            self.assertEqual(
+                (worktree / "build" / "tracked_source.py").read_text(encoding="utf-8"), "value = 1\n"
+            )
+
+    def test_present_but_not_gitignored_source_is_never_linked(self) -> None:
+        # Untracked in the parent AND not covered by any .gitignore rule: the
+        # guard must refuse on the gitignore check alone.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo, sha = _make_repo(root)
+            (repo / "target").mkdir()
+            (repo / "target" / "f.bin").write_bytes(b"x")
+            worktree = root / "unit-worktree"
+            _add_worktree(repo, "agent/unit-c", sha, worktree)
+
+            result = plan_and_link_shared_artifacts(repo_root=repo, worktree_path=worktree, runner=subprocess.run)
+
+            self.assertNotIn("target", result["linked"])
+            entry = next(e for e in result["entries"] if e["name"] == "target")
+            self.assertEqual(entry["reason"], "source_not_gitignored")
+            self.assertFalse((worktree / "target").exists())
+
+    def test_missing_source_falls_back_for_every_entry(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            names = [entry["name"] for entry in SHAREABLE_ARTIFACT_ALLOWLIST]
+            repo, sha = _make_repo(root, gitignore_lines=names)
+            worktree = root / "unit-worktree"
+            _add_worktree(repo, "agent/unit-d", sha, worktree)
+
+            result = plan_and_link_shared_artifacts(repo_root=repo, worktree_path=worktree, runner=subprocess.run)
+
+            self.assertEqual(result["linked"], [])
+            for entry in result["entries"]:
+                self.assertEqual(entry["reason"], "source_missing")
+
+    def test_opt_out_env_var_disables_linking_entirely(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo, sha = _make_repo(root, gitignore_lines=["node_modules"])
+            (repo / "node_modules").mkdir()
+            (repo / "node_modules" / "pkg.js").write_text("x\n", encoding="utf-8")
+            worktree = root / "unit-worktree"
+            _add_worktree(repo, "agent/unit-e", sha, worktree)
+
+            result = plan_and_link_shared_artifacts(
+                repo_root=repo,
+                worktree_path=worktree,
+                runner=subprocess.run,
+                env={OPT_OUT_ENV_VAR: "0"},
+            )
+
+            self.assertTrue(result["opted_out"])
+            self.assertEqual(result["entries"], [])
+            self.assertEqual(result["linked"], [])
+            self.assertFalse((worktree / "node_modules").exists())
+
+    def test_shared_artifacts_opted_out_helper(self) -> None:
+        self.assertFalse(shared_artifacts_opted_out({}))
+        self.assertFalse(shared_artifacts_opted_out({OPT_OUT_ENV_VAR: "1"}))
+        self.assertTrue(shared_artifacts_opted_out({OPT_OUT_ENV_VAR: "0"}))
+
+    def test_dir_only_gitignore_pattern_is_recognized_and_refused_after_linking(self) -> None:
+        # The empirically-verified hazard this module's second guard exists
+        # for: a trailing-slash, dir-only gitignore pattern (`node_modules/`)
+        # matches a real directory but NOT a symlink of the same name, because
+        # git's dir-only match uses the on-disk type from lstat and a symlink
+        # is never a directory to it. Left unguarded, the freshly created
+        # symlink would show up as an untracked change in the unit worktree.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo, sha = _make_repo(root, gitignore_lines=["node_modules/"])
+            (repo / "node_modules").mkdir()
+            (repo / "node_modules" / "pkg.js").write_text("x\n", encoding="utf-8")
+            worktree = root / "unit-worktree"
+            _add_worktree(repo, "agent/unit-f", sha, worktree)
+
+            result = plan_and_link_shared_artifacts(repo_root=repo, worktree_path=worktree, runner=subprocess.run)
+
+            entry = next(e for e in result["entries"] if e["name"] == "node_modules")
+            self.assertEqual(entry["action"], "skipped")
+            self.assertEqual(entry["reason"], "symlink_not_recognized_ignored")
+            self.assertNotIn("node_modules", result["linked"])
+            # The undo actually ran: nothing left behind for the unit to trip on.
+            self.assertFalse((worktree / "node_modules").exists())
+
+    def test_platform_unsupported_records_every_entry(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo, sha = _make_repo(root, gitignore_lines=["node_modules"])
+            (repo / "node_modules").mkdir()
+            worktree = root / "unit-worktree"
+            _add_worktree(repo, "agent/unit-g", sha, worktree)
+
+            from omh.coding import fanout_artifact_sharing as sharing_module
+
+            with mock.patch.object(sharing_module.os, "name", "nt"):
+                result = plan_and_link_shared_artifacts(
+                    repo_root=repo, worktree_path=worktree, runner=subprocess.run
+                )
+
+            self.assertEqual(result["linked"], [])
+            for entry in result["entries"]:
+                self.assertEqual(entry["reason"], "platform_unsupported")
+            self.assertFalse((worktree / "node_modules").exists())
+
+
+class FanoutDispatchSharedArtifactsIntegrationTests(unittest.TestCase):
+    """Wiring into `dispatch_fanout`: the unit result and journal both note it."""
+
+    def _setup(self, tmp: str):
+        root = Path(tmp)
+        paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+        repo, sha = _make_repo(root, gitignore_lines=["node_modules"])
+        (repo / "node_modules").mkdir()
+        (repo / "node_modules" / "pkg.js").write_text("x\n", encoding="utf-8")
+        goal = "warm-start a fanout unit"
+        units = [{"unit_id": "core", "title": "Core work", "owner": "codex", "file_scope": ["src/core/"]}]
+        contract = write_fanout_contract(paths, build_fanout_contract(goal, units))
+        return paths, repo, sha, contract, goal
+
+    def test_completed_unit_result_carries_shared_artifacts(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract, goal = self._setup(tmp)
+
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=goal,
+                repo_root=repo,
+                base_sha=sha,
+                runner=_agent_runner(),
+                readiness=_ready,
+            )
+
+            core = {entry["unit_id"]: entry for entry in summary["units"]}["core"]
+            self.assertIn("shared_artifacts", core)
+            self.assertEqual(core["shared_artifacts"]["schema_version"], SHARED_ARTIFACT_SCHEMA_VERSION)
+            self.assertIn("node_modules", core["shared_artifacts"]["linked"])
+            worktree = Path(core["worktree_path"])
+            self.assertTrue((worktree / "node_modules").is_symlink())
+
+    def test_journal_worker_dispatch_event_notes_shared_artifacts(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract, goal = self._setup(tmp)
+
+            dispatch_fanout(
+                paths,
+                contract,
+                goal_text=goal,
+                repo_root=repo,
+                base_sha=sha,
+                runner=_agent_runner(),
+                readiness=_ready,
+            )
+
+            events, errors = read_observation_events_result(paths)
+            self.assertEqual(errors, [])
+            dispatch_events = [
+                event
+                for event in events
+                if event.get("event") == "executor_dispatch_observed" and event.get("worker_ref") == "core"
+            ]
+            self.assertTrue(dispatch_events)
+            self.assertIn("shared_artifacts: node_modules", dispatch_events[-1]["summary"])
+
+    def test_opted_out_dispatch_carries_no_linked_artifacts(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract, goal = self._setup(tmp)
+
+            with mock.patch.dict(os.environ, {OPT_OUT_ENV_VAR: "0"}):
+                summary = dispatch_fanout(
+                    paths,
+                    contract,
+                    goal_text=goal,
+                    repo_root=repo,
+                    base_sha=sha,
+                    runner=_agent_runner(),
+                    readiness=_ready,
+                )
+
+            core = {entry["unit_id"]: entry for entry in summary["units"]}["core"]
+            self.assertTrue(core["shared_artifacts"]["opted_out"])
+            self.assertEqual(core["shared_artifacts"]["linked"], [])
+            worktree = Path(core["worktree_path"])
+            self.assertFalse((worktree / "node_modules").exists())
+
+    def test_replay_safety_is_unaffected_by_a_linked_artifact(self) -> None:
+        # The rail this whole task is really about: a unit that fails
+        # transiently but touches nothing of its own must still classify as
+        # replay-safe (`recovery.outcome == "no_changes"`) even though its
+        # worktree holds a live symlink into the parent's node_modules. If the
+        # symlinked directory leaked into git's diff/status view, this would
+        # misreport `recovery_available` for a unit that did nothing.
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract, goal = self._setup(tmp)
+
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=goal,
+                repo_root=repo,
+                base_sha=sha,
+                runner=_agent_runner(fail_units={"core"}),
+                readiness=_ready,
+            )
+
+            core = {entry["unit_id"]: entry for entry in summary["units"]}["core"]
+            self.assertIn("node_modules", core["shared_artifacts"]["linked"])
+            self.assertEqual(core["status"], "failed")
+            self.assertEqual(core["recovery"]["outcome"], "no_changes")
+            self.assertEqual(summary["recovery_available_units"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fanout_artifact_sharing.py
+++ b/tests/test_fanout_artifact_sharing.py
@@ -16,6 +16,7 @@ import unittest
 from unittest import mock
 
 from _local_package import load_local_package
+from _platform_support import requires_symlinks
 
 load_local_package()
 
@@ -105,6 +106,7 @@ class SharedArtifactAllowlistTests(unittest.TestCase):
             self.assertTrue(entry["name"])
             self.assertTrue(entry["rationale"])
 
+    @requires_symlinks
     def test_links_an_allowlisted_gitignored_directory(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -213,6 +215,7 @@ class SharedArtifactAllowlistTests(unittest.TestCase):
         self.assertFalse(shared_artifacts_opted_out({OPT_OUT_ENV_VAR: "1"}))
         self.assertTrue(shared_artifacts_opted_out({OPT_OUT_ENV_VAR: "0"}))
 
+    @requires_symlinks
     def test_dir_only_gitignore_pattern_is_recognized_and_refused_after_linking(self) -> None:
         # The empirically-verified hazard this module's second guard exists
         # for: a trailing-slash, dir-only gitignore pattern (`node_modules/`)
@@ -238,16 +241,28 @@ class SharedArtifactAllowlistTests(unittest.TestCase):
             self.assertFalse((worktree / "node_modules").exists())
 
     def test_platform_unsupported_records_every_entry(self) -> None:
+        # Runnable on every platform, including a real Windows CI host: it
+        # exercises the DECISION only, never an actual symlink syscall, by
+        # monkeypatching `_symlinks_supported` directly rather than gating on
+        # POSIX. Every allowlist directory is real and gitignored here so each
+        # one clears every earlier guard and reaches the platform check --
+        # otherwise an entry with no source would report `source_missing`
+        # instead, the same way it does on a platform that DOES support
+        # symlinks.
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
-            repo, sha = _make_repo(root, gitignore_lines=["node_modules"])
-            (repo / "node_modules").mkdir()
+            names = [entry["name"] for entry in SHAREABLE_ARTIFACT_ALLOWLIST]
+            repo, sha = _make_repo(root, gitignore_lines=names)
+            for name in names:
+                artifact_dir = repo / name
+                artifact_dir.mkdir()
+                (artifact_dir / "f.txt").write_text("x\n", encoding="utf-8")
             worktree = root / "unit-worktree"
             _add_worktree(repo, "agent/unit-g", sha, worktree)
 
             from omh.coding import fanout_artifact_sharing as sharing_module
 
-            with mock.patch.object(sharing_module.os, "name", "nt"):
+            with mock.patch.object(sharing_module, "_symlinks_supported", return_value=False):
                 result = plan_and_link_shared_artifacts(
                     repo_root=repo, worktree_path=worktree, runner=subprocess.run
                 )
@@ -255,7 +270,8 @@ class SharedArtifactAllowlistTests(unittest.TestCase):
             self.assertEqual(result["linked"], [])
             for entry in result["entries"]:
                 self.assertEqual(entry["reason"], "platform_unsupported")
-            self.assertFalse((worktree / "node_modules").exists())
+            for name in names:
+                self.assertFalse((worktree / name).exists())
 
 
 class FanoutDispatchSharedArtifactsIntegrationTests(unittest.TestCase):
@@ -272,6 +288,7 @@ class FanoutDispatchSharedArtifactsIntegrationTests(unittest.TestCase):
         contract = write_fanout_contract(paths, build_fanout_contract(goal, units))
         return paths, repo, sha, contract, goal
 
+    @requires_symlinks
     def test_completed_unit_result_carries_shared_artifacts(self) -> None:
         with TemporaryDirectory() as tmp:
             paths, repo, sha, contract, goal = self._setup(tmp)
@@ -293,6 +310,7 @@ class FanoutDispatchSharedArtifactsIntegrationTests(unittest.TestCase):
             worktree = Path(core["worktree_path"])
             self.assertTrue((worktree / "node_modules").is_symlink())
 
+    @requires_symlinks
     def test_journal_worker_dispatch_event_notes_shared_artifacts(self) -> None:
         with TemporaryDirectory() as tmp:
             paths, repo, sha, contract, goal = self._setup(tmp)
@@ -338,6 +356,7 @@ class FanoutDispatchSharedArtifactsIntegrationTests(unittest.TestCase):
             worktree = Path(core["worktree_path"])
             self.assertFalse((worktree / "node_modules").exists())
 
+    @requires_symlinks
     def test_replay_safety_is_unaffected_by_a_linked_artifact(self) -> None:
         # The rail this whole task is really about: a unit that fails
         # transiently but touches nothing of its own must still classify as

--- a/tests/test_handoff_safety_contract_enforcement.py
+++ b/tests/test_handoff_safety_contract_enforcement.py
@@ -133,6 +133,12 @@ PROCESS_SPAWN_ALLOWLIST: dict[str, str] = {
     "src/coding/worktree_creator.py": (
         "`git worktree add` for isolated executor workspaces; local, non-remote (see INVARIANT 3)."
     ),
+    "src/coding/fanout_artifact_sharing.py": (
+        "reached only from `_dispatch_unit` inside the `omh coding fanout dispatch` bridge above, "
+        "right after `ensure_fanout_unit_worktree`; runs `git check-ignore` to decide whether a "
+        "parent-checkout directory may be symlinked into the fresh unit worktree, and spawns no "
+        "executor of its own."
+    ),
     "src/coding/executor_readiness.py": (
         "probes `<executor> --version` on PATH to report which agent CLIs are installed; "
         "reads a version line, dispatches no work."
@@ -518,6 +524,12 @@ GIT_ARGV_ALLOWLIST: dict[tuple[str, tuple[str, ...]], str] = {
         "recorded against, so assessment can later tell evidence about the current tracked content "
         "from evidence about older content; read-only local object lookup, names no remote, and it "
         "resolves no ref the caller supplied"
+    ),
+    ("src/coding/fanout_artifact_sharing.py", ("check-ignore",)): (
+        "`git check-ignore -q --` against the parent checkout, then again inside the fresh unit "
+        "worktree after a symlink is created, to decide whether an allowlisted artifact directory "
+        "may be shared; read-only, names no remote, and never runs against anything but the "
+        "dispatching repo or the unit worktree it just created"
     ),
 }
 


### PR DESCRIPTION
## Feature Report

### What Changed

- New module `src/coding/fanout_artifact_sharing.py`: symlinks a small named allowlist of build-artifact directories (`node_modules`, `target`, `.venv`, `build`) from the parent checkout into each freshly created `omh coding fanout dispatch` unit worktree, so the unit starts warm instead of paying a cold dependency/build-cache rebuild.
- `src/coding/fanout_dispatch.py`: calls the new module right after `ensure_fanout_unit_worktree` creates the unit worktree and before the unit's process spawns; records the outcome in the unit's dispatch result (`shared_artifacts`) and, when anything was linked, appends a short note to the `worker_dispatch` journal event's summary.
- `tests/test_handoff_safety_contract_enforcement.py`: adds the new module's `git check-ignore` call to `GIT_ARGV_ALLOWLIST` and its `subprocess` import to `PROCESS_SPAWN_ALLOWLIST`, both with a reason naming the command that reaches it.
- `tests/test_fanout_artifact_sharing.py` (new): 13 test cases covering the allowlist directly against real git worktrees, plus dispatch-level integration.

### Why This Exists

Backlog item "I. Symlink build artifacts into fanout worktrees" from
`.omc/research/ohmypi-optimization-2026-08-29.md`. Each fanout unit gets its
own `git worktree add`, which starts cold: dependency directories and build
caches the parent checkout already paid for have to be rebuilt from scratch
inside every unit worktree. The dossier names the OMH absorption of a
precedent from oh-my-pi's `.omp/commands/fix-issues.md:64-81`: symlink the
expensive, gitignored build outputs in; never link a directory that contains
tracked sources.

### User / Operator Impact

A fanout unit whose owner uses one of the allowlisted directories (JS/TS via
`node_modules`, Rust via `target`, Python via `.venv`, or a generic `build`
output) starts with that directory already populated instead of rebuilding it,
when the parent checkout has that directory present and gitignored. No
behavior changes for a unit worktree that has nothing to share -- it dispatches
exactly as before. `OMH_FANOUT_SHARE_ARTIFACTS=0` opts out entirely.

### How It Works

Three independent guards, each failing closed to the pre-existing cold
behavior:

1. **Named allowlist only.** `SHAREABLE_ARTIFACT_ALLOWLIST` in
   `fanout_artifact_sharing.py` is a small, explicit set, each entry carrying
   its rationale -- not an open pattern match over every gitignored directory.
2. **Pre-link gitignore guard.** The parent checkout must itself report the
   path `git check-ignore`d before anything is touched. A tracked directory of
   the same name is never linked; a fresh `git worktree add` checkout would
   already contain it as a real file/directory, and the module's first check
   (`target.exists()`) refuses to displace it regardless.
3. **Post-link re-check (the hazard this task called out).** Confirmed
   empirically before writing this module: a trailing-slash, dir-only
   gitignore pattern (`node_modules/`, the common shape) matches a real
   directory but **not** a symlink of the same name -- git's dir-only match
   uses the on-disk type from `lstat`, and a symlink is never a directory to
   it. So after the symlink is created, the module re-runs `git check-ignore`
   from *inside* the worktree; if the symlink is not recognized as ignored
   there, it is undone and the entry falls back to cold. Skipping this step
   would let a shared artifact masquerade as a unit-authored change and
   corrupt `fanout_retry`'s replay-safety predicate (`_capture_unit_recovery`
   in `fanout_dispatch.py`, which drives `evaluate_unit_retry` in
   `fanout_retry.py`) for a unit that never touched it -- confirmed directly by
   `test_replay_safety_is_unaffected_by_a_linked_artifact`.

Windows (`os.name == "nt"`) records every allowlist entry as
`platform_unsupported` and skips symlinking entirely, rather than reach for a
junction/copy strategy that would need its own correctness rails this feature
has not earned. `OMH_FANOUT_SHARE_ARTIFACTS=0` opts out entirely, following the
existing `OMH_MENUBAR`/`OMH_PROGRESS` default-on toggle convention (`os.environ.get(..., "1") != "0"`).

Every entry's outcome (`linked`, or `skipped` with a machine-readable reason:
`path_exists_in_worktree`, `source_missing`, `source_not_gitignored`,
`symlink_failed:<detail>`, `symlink_not_recognized_ignored`, or
`platform_unsupported`) rides into the unit's dispatch result under
`shared_artifacts`, and a short `(shared_artifacts: ...)` note is appended to
the `worker_dispatch` journal event's free-text summary when anything was
linked -- the observation-event schema (`workflows/observation_journal.py`)
carries only fixed fields, so the note rides in `summary` rather than a new
schema field.

### Files And Contracts Touched

- `src/coding/fanout_artifact_sharing.py` (new) -- the allowlist, the
  gitignore guards, and `plan_and_link_shared_artifacts`.
- `src/coding/fanout_dispatch.py` -- wires the call into `_dispatch_unit`,
  adds `shared_artifacts` to the unit result, and notes it in the
  `worker_dispatch` journal summary.
- `tests/test_handoff_safety_contract_enforcement.py` -- allowlists the new
  module's `subprocess` import and `git check-ignore` argv.
- `tests/test_fanout_artifact_sharing.py` (new).

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [x] Generic executor
- [ ] Not executor-specific

## Validation

Check only commands that completed successfully. Leave non-applicable checks
unchecked and explain why under **Not Tested / Not Applicable**.

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- `uv run --group lint ruff check src tests` -- `All checks passed!`
- `PYTHONPATH=tests uv run python -m unittest discover -s tests` -- `Ran 8271 tests`, `FAILED (failures=21, errors=7)`; all 28 failures/errors are in `test_cross_harness_adapters*` / `test_cross_harness_adapter_security*`, the pre-existing known cross-harness `.claude`-path failures named in the task brief -- none in fanout, worktree, or handoff-safety surfaces.
- `PYTHONPATH=tests uv run python -m unittest tests/test_fanout_artifact_sharing.py -v` -- 13/13 passed.
- `PYTHONPATH=tests uv run python -m unittest tests/test_fanout_dispatch.py tests/test_fanout_retry.py tests/test_fanout_journal.py tests/test_fanout_status.py tests/test_broad_exception_policy.py tests/test_handoff_safety_contract_enforcement.py -v` -- all passed (206 tests before adding the standalone `test_handoff_safety_contract_enforcement.py` run; 18/18 on the handoff-safety file alone after the allowlist edits).
- `uv run python -m compileall -q src tests` -- clean.
- `uv run python -m omh.cli docs workflows --check` / `docs roles --check` / `docs capability-families --check` / `docs ulw-inventory --check` / `docs ulw-site --check` -- all five `{"ok": true, ...}`.
- `uv run python -m omh.cli release drift` -- `No drift. 18 checks passed.`
- `git diff --check` -- clean (exit 0).
- Direct git experiment (scratch repo, not part of the diff) confirming the dir-only-gitignore-pattern hazard before writing the post-link re-check: a `node_modules/` pattern matches a real directory (`git check-ignore` exit 0) but not a symlink of the same name (`git check-ignore` exit 1) -- this is what `test_dir_only_gitignore_pattern_is_recognized_and_refused_after_linking` exercises.

### Not Tested / Not Applicable

- `harness validate`, `release checklist --json`, `release hermes-smoke`, `omh --help`, and the install-path smoke were not run -- out of scope for this change (no CLI surface, harness contract, or install path touched) and not named in the task's verification list.
- No real agent CLI was spawned; `dispatch_fanout` in the new tests uses the same injected-fake-runner pattern as the existing `tests/test_fanout_dispatch.py` suite (git commands run for real, agent-CLI spawns are stubbed).
- No Windows CI run; the `platform_unsupported` fallback path is exercised only by mocking `os.name` to `"nt"` in `test_platform_unsupported_records_every_entry`.
- No real `node_modules`/`.venv`/`target`-sized directory; fixtures use a single small file per directory, since the behavior under test is the symlink/gitignore mechanics, not directory size.

## Risk

- Narrow: the new code path only runs from inside the already opt-in
  `omh coding fanout dispatch` local-dispatch bridge, after the unit worktree
  is created and before the unit's process spawns. Every failure mode (missing
  source, not gitignored, symlink creation error, post-link recognition
  failure, unsupported platform, or the env opt-out) falls back to exactly the
  pre-existing cold-worktree behavior; nothing here can make a unit fail that
  would otherwise have succeeded, and nothing here touches the operator's own
  checkout.
- The one correctness risk this task exists to close -- a shared artifact
  leaking into `fanout_retry`'s side-effect detection -- is covered by the
  post-link `git check-ignore` re-check and by
  `test_replay_safety_is_unaffected_by_a_linked_artifact`.

## Compatibility / Rollout

- Additive and on by default (`OMH_FANOUT_SHARE_ARTIFACTS` defaults to `"1"`,
  i.e. enabled); a fanout run that touches no allowlisted directory in the
  parent checkout dispatches identically to before this PR. No schema version
  bump: `shared_artifacts` is a new, optional key on the unit dispatch result,
  and the journal note is free text inside the existing `summary` field.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`) -- no release-channel gating touched; this is a local dispatch-path behavior change only.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap -- none run; see Not Tested above.

## Follow-Up

- Consider extending the allowlist (e.g. `.tox`, `.mypy_cache`, `.next`,
  `vendor`) once this conservative set has run in real fanout dispatches; each
  addition is still gated by both `git check-ignore` checks, so growing the
  list is low-risk.
