### PR TITLE
feat(coding): prescribe capped structural search in the handoff contract

### DIFF
--- a/skills/omh-codebase-onboarding/SKILL.md
+++ b/skills/omh-codebase-onboarding/SKILL.md
@@ -113,7 +113,7 @@ Safety rules:
 
 ## Structural Code Search
 
-When the target is a syntactic shape rather than a string, load `omh-routing/references/structural-code-search.md` before searching. If ast-grep is not on PATH, use grep/ripgrep exactly as today.
+When the target is a syntactic shape rather than a string, load `omh-routing/references/structural-code-search.md` before searching. If ast-grep is not on PATH, use grep/ripgrep exactly as today. Cap exploration to a few bounded, targeted queries before reading a full file, escalate to a wider query only when a bounded pass finds nothing or stays ambiguous, and stop once the target is found.
 
 ## Runtime Evidence
 

--- a/skills/omh-codegraph-refresh/SKILL.md
+++ b/skills/omh-codegraph-refresh/SKILL.md
@@ -114,7 +114,7 @@ Safety rules:
 
 ## Structural Code Search
 
-When the target is a syntactic shape rather than a string, load `omh-routing/references/structural-code-search.md` before searching. If ast-grep is not on PATH, use grep/ripgrep exactly as today.
+When the target is a syntactic shape rather than a string, load `omh-routing/references/structural-code-search.md` before searching. If ast-grep is not on PATH, use grep/ripgrep exactly as today. Cap exploration to a few bounded, targeted queries before reading a full file, escalate to a wider query only when a bounded pass finds nothing or stays ambiguous, and stop once the target is found.
 
 ## Runtime Evidence
 

--- a/src/coding/coding_contracts.py
+++ b/src/coding/coding_contracts.py
@@ -64,6 +64,24 @@ STRUCTURAL_SEARCH_GUIDANCE = (
     "structural query over line-based grep when the target is a syntactic shape rather than a "
     "string; fall back to grep when it is absent. OMH did not check - verify PATH yourself."
 )
+# Capped-search budget: STRUCTURAL_SEARCH_GUIDANCE says WHICH tool to prefer;
+# this says HOW MUCH to search before escalating or stopping, so an executor's
+# own exploration spend is bounded the same way every other handoff discipline
+# is bounded. Deliberately tool- and flag-neutral (no ast-grep option, count,
+# or byte cap is named) — OMH prescribes search discipline, it does not invent
+# or configure tooling. Shared verbatim everywhere STRUCTURAL_SEARCH_GUIDANCE
+# is shared, plus the `executor_prompting_contract/v1` payload
+# (`structural_search_discipline`, below) so the prose and the versioned
+# payload field can never drift apart.
+STRUCTURAL_SEARCH_DISCIPLINE_CONTRACT_SCHEMA_VERSION = "structural_search_discipline/v1"
+STRUCTURAL_SEARCH_DISCIPLINE_GUIDANCE = (
+    "Capped structural search: bound code exploration to a few targeted queries — structural search "
+    "when available, grep otherwise — before reading a full file; start with the narrowest query that "
+    "names the shape or symbol you need. Escalate to a wider query or a full-file read only when a "
+    "bounded pass returns nothing or stays genuinely ambiguous after a second try. Stop searching the "
+    "moment the target is found; a further query for something already located spends tokens without "
+    "adding information."
+)
 PROJECT_GOVERNANCE_PROFILE_SCHEMA_VERSION = "project_governance_profile/v1"
 PROJECT_GOVERNANCE_BLOCKED_SCHEMA_VERSION = "project_governance_blocked/v1"
 PRODUCT_FAMILY_TEMPLATE_SCHEMA_VERSION = "product_family_template/v1"
@@ -90,6 +108,8 @@ __all__ = [
     "LOCAL_CAPABILITY_REPORT_CAPABILITY_FIELDS",
     "LOCAL_CAPABILITY_REPORT_ALLOWED_KINDS",
     "STRUCTURAL_SEARCH_GUIDANCE",
+    "STRUCTURAL_SEARCH_DISCIPLINE_CONTRACT_SCHEMA_VERSION",
+    "STRUCTURAL_SEARCH_DISCIPLINE_GUIDANCE",
     "PROJECT_GOVERNANCE_PROFILE_SCHEMA_VERSION",
     "PROJECT_GOVERNANCE_BLOCKED_SCHEMA_VERSION",
     "PRODUCT_FAMILY_TEMPLATE_SCHEMA_VERSION",

--- a/src/coding/prompting.py
+++ b/src/coding/prompting.py
@@ -7,6 +7,8 @@ from ..coding_contracts import (
     EXECUTOR_PROMPTING_REQUIRED_SECTIONS,
     EXECUTOR_PROMPTING_STRATEGIES,
     EXECUTOR_STEERING_DELTA_CONTRACT_SCHEMA_VERSION,
+    STRUCTURAL_SEARCH_DISCIPLINE_CONTRACT_SCHEMA_VERSION,
+    STRUCTURAL_SEARCH_DISCIPLINE_GUIDANCE,
 )
 from .throughput_prompting import build_throughput_overlay
 
@@ -47,6 +49,10 @@ DOCS_CONSULTED_ARTIFACT_POLICY = (
 # fresh or resumed session rebuilds working state without re-discovering the
 # repository, and so a summary's completeness is checkable by section name
 # instead of read as freeform prose.
+STRUCTURAL_SEARCH_DISCIPLINE_CLAIM_BOUNDARY = (
+    "This is prepared search-discipline guidance only; it is not dispatch, execution, verification, "
+    "review, CI, or merge evidence."
+)
 SESSION_SUMMARY_SHAPE_POLICY = (
     "Session summary shape: when producing a session summary, prepared-handoff brief, or "
     "continuation re-brief, structure it as Goal / Constraints and Preferences / Progress "
@@ -97,6 +103,12 @@ def build_executor_prompting_contract(
             "Report progress, changed files, tests, blockers, evidence refs, local_capabilities_used, local_capability_evidence_refs, and local_capability_fallback_reason; distinguish prepared guidance from observed executor results."
         ),
         "session_summary_policy": SESSION_SUMMARY_SHAPE_POLICY,
+        "structural_search_discipline": {
+            "schema_version": STRUCTURAL_SEARCH_DISCIPLINE_CONTRACT_SCHEMA_VERSION,
+            "status": "prepared_not_observed",
+            "guidance": STRUCTURAL_SEARCH_DISCIPLINE_GUIDANCE,
+            "claim_boundary": STRUCTURAL_SEARCH_DISCIPLINE_CLAIM_BOUNDARY,
+        },
         "steering_delta_contract": {
             "schema_version": EXECUTOR_STEERING_DELTA_CONTRACT_SCHEMA_VERSION,
             "status": "prepared_not_observed",
@@ -157,9 +169,16 @@ def render_executor_prompt_sections(
     strategy = str(contract.get("strategy", "direct_change"))
     task_source = str(contract.get("task_source", "original_message_at_dispatch_time"))
     intent = str(contract.get("intent", "unknown"))
+    structural_search_discipline = contract.get("structural_search_discipline")
+    structural_search_guidance = (
+        str(structural_search_discipline.get("guidance", ""))
+        if isinstance(structural_search_discipline, Mapping)
+        else ""
+    ) or STRUCTURAL_SEARCH_DISCIPLINE_GUIDANCE
     do_items = [
         str(contract.get("repository_first_policy", "Inspect the repository before editing.")),
         str(contract.get("docs_consulted_policy", DOCS_CONSULTED_ARTIFACT_POLICY)),
+        structural_search_guidance,
         _strategy_instruction(strategy),
         "Implement only the requested scope after repository facts confirm it.",
     ]
@@ -276,6 +295,7 @@ def _section(title: str, items: Iterable[str]) -> str:
 __all__ = [
     "DOCS_CONSULTED_ARTIFACT_POLICY",
     "SESSION_SUMMARY_SHAPE_POLICY",
+    "STRUCTURAL_SEARCH_DISCIPLINE_CLAIM_BOUNDARY",
     "build_executor_prompting_contract",
     "render_executor_prompt_sections",
     "select_executor_prompting_strategy",

--- a/src/coding/unit_prompt_protocol.py
+++ b/src/coding/unit_prompt_protocol.py
@@ -1,6 +1,6 @@
 """Verification discipline for prepared fanout unit prompts.
 
-Five deterministic text blocks ride every dispatched unit prompt:
+Six deterministic text blocks ride every dispatched unit prompt:
 
 1. **Goal echo-back** — before any tool use the subagent restates the goal,
    its own deliverable, and the completion criteria, and stops to report (not
@@ -22,10 +22,17 @@ Five deterministic text blocks ride every dispatched unit prompt:
    sidecar is missing the collector parses this block from captured stdout
    and validates it the same way, so collection is parse-then-validate on
    either path and never prose-scraping.
+6. **Capped structural search** — code exploration is bounded the same way
+   verification is: a few targeted structural-search-or-grep passes before a
+   full-file read, escalating only when a bounded pass finds nothing or stays
+   ambiguous, and stopping the moment the target is found. Shared verbatim
+   with the `executor_prompting_contract/v1` payload's
+   `structural_search_discipline` field (`.coding_contracts.
+   STRUCTURAL_SEARCH_DISCIPLINE_GUIDANCE`) so the two cannot drift.
 
 The blocks split across two placement zones for prompt-cache hygiene: the
-goal echo-back, verification-stop, failure-kind, and structured-return
-blocks are unit-invariant,
+goal echo-back, verification-stop, failure-kind, structured-return, and
+capped-search blocks are unit-invariant,
 so `shared_unit_preamble_lines()` places them (with the overall goal) at the
 byte-identical head every sibling prompt of one fanout shares, and
 `unit_protocol_lines()` carries only the unit-varying remainder — numbered
@@ -49,6 +56,8 @@ prompts (subprocess argv), so the total prompt size is policy-gated by
 from __future__ import annotations
 
 from typing import Any, Final, Mapping
+
+from .coding_contracts import STRUCTURAL_SEARCH_DISCIPLINE_GUIDANCE
 
 # Policy ceiling for a fully-assembled unit prompt (bytes of UTF-8). The
 # worst-case combination across roles, owners, and calibration blocks is
@@ -402,6 +411,7 @@ def shared_unit_preamble_lines(goal_text: str) -> list[str]:
         VERIFICATION_STOP_PROTOCOL,
         FAILURE_KIND_PROTOCOL,
         UNIT_RESULT_RETURN_PROTOCOL,
+        STRUCTURAL_SEARCH_DISCIPLINE_GUIDANCE,
     ]
 
 

--- a/src/maintenance/release.py
+++ b/src/maintenance/release.py
@@ -424,7 +424,15 @@ STANDALONE_CAPABILITY_SKILL_ITEM_CHAR_LIMIT = 2200
 # integrity rule above does: it changes the verdict the skill issues, and a
 # gate that reports a lost guard instead of refusing the claim is the failure
 # this rule exists to stop; warranted growth.
-FULL_PROFILE_SKILL_BODY_CHAR_LIMIT = 798042
+# 798042 -> 798440: `codebase-onboarding` and `codegraph-refresh` each gained
+# one sentence (+199 chars x2) in their spliced Structural Code Search section
+# prescribing a capped search budget -- a few bounded, targeted queries before
+# a full-file read, escalate only when a bounded pass finds nothing or stays
+# ambiguous, and stop once the target is found. It belongs in the always-
+# loaded body for the same reason the tool-preference sentence beside it does:
+# it is search discipline the skill states up front, not a fact worth an
+# on-demand reference lookup; warranted growth.
+FULL_PROFILE_SKILL_BODY_CHAR_LIMIT = 798440
 FULL_PROFILE_SKILL_BODY_REVIEWED_EXCEPTION_CHARS = 0
 
 

--- a/src/runtime/records.py
+++ b/src/runtime/records.py
@@ -22,6 +22,7 @@ from ..coding_contracts import (
     LOCAL_CAPABILITY_REPORT_REQUIRED_FIELDS,
     PROMPT_HANDOFF_SCHEMA_VERSION,
     RUNTIME_HANDOFF_SCHEMA_VERSION,
+    STRUCTURAL_SEARCH_DISCIPLINE_CONTRACT_SCHEMA_VERSION,
     TASK_PROMPT_CONTRACT_SCHEMA_VERSION,
     TASK_PROMPT_REQUIRED_SECTIONS,
 )
@@ -473,11 +474,18 @@ CODING_EXECUTOR_PROMPTING_CONTRACT_KEYS = (
     "verification_policy",
     "reporting_policy",
     "session_summary_policy",
+    "structural_search_discipline",
     "steering_delta_contract",
     "steering_delta_template",
     "claim_boundary",
 )
 CODING_EXECUTOR_PROMPTING_CONTRACT_OPTIONAL_KEYS = ("throughput_overlay",)
+CODING_EXECUTOR_STRUCTURAL_SEARCH_DISCIPLINE_KEYS = (
+    "schema_version",
+    "status",
+    "guidance",
+    "claim_boundary",
+)
 CODING_EXECUTOR_THROUGHPUT_OVERLAY_KEYS = (
     "schema_version",
     "status",
@@ -1690,6 +1698,9 @@ def _compact_executor_prompting_contract(value: Any) -> dict[str, Any]:
         "verification_policy": str(value.get("verification_policy", "")),
         "reporting_policy": str(value.get("reporting_policy", "")),
         "session_summary_policy": str(value.get("session_summary_policy", "")),
+        "structural_search_discipline": _compact_structural_search_discipline(
+            value.get("structural_search_discipline")
+        ),
         "steering_delta_contract": _compact_executor_steering_delta_contract(
             value.get("steering_delta_contract")
         ),
@@ -1710,6 +1721,17 @@ def _compact_executor_prompting_contract(value: Any) -> dict[str, Any]:
         if "eval_strategy" in overlay:
             compacted["throughput_overlay"]["eval_strategy"] = str(overlay.get("eval_strategy", ""))
     return compacted
+
+
+def _compact_structural_search_discipline(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    return {
+        "schema_version": str(value.get("schema_version", "")),
+        "status": str(value.get("status", "")),
+        "guidance": str(value.get("guidance", "")),
+        "claim_boundary": str(value.get("claim_boundary", "")),
+    }
 
 
 def _compact_executor_steering_delta_contract(value: Any) -> dict[str, Any]:
@@ -2939,6 +2961,43 @@ def validate_executor_prompting_contract(contract: Any, label: str, *, expected_
         errors,
         f"{label} session_summary_policy must name the structured summary sections and the read-files/modified-files lists",
     )
+    discipline = contract.get("structural_search_discipline")
+    _require(isinstance(discipline, dict), errors, f"{label} structural_search_discipline must be an object")
+    if isinstance(discipline, dict):
+        extra_discipline_keys = sorted(set(discipline) - set(CODING_EXECUTOR_STRUCTURAL_SEARCH_DISCIPLINE_KEYS))
+        missing_discipline_keys = sorted(set(CODING_EXECUTOR_STRUCTURAL_SEARCH_DISCIPLINE_KEYS) - set(discipline))
+        _require(
+            not extra_discipline_keys,
+            errors,
+            f"{label} structural_search_discipline has unsupported keys: {extra_discipline_keys}",
+        )
+        _require(
+            not missing_discipline_keys,
+            errors,
+            f"{label} structural_search_discipline is missing keys: {missing_discipline_keys}",
+        )
+        _require(
+            discipline.get("schema_version") == STRUCTURAL_SEARCH_DISCIPLINE_CONTRACT_SCHEMA_VERSION,
+            errors,
+            f"{label} structural_search_discipline schema_version is invalid",
+        )
+        _require(
+            discipline.get("status") == "prepared_not_observed",
+            errors,
+            f"{label} structural_search_discipline status must be prepared_not_observed",
+        )
+        for key in ("guidance", "claim_boundary"):
+            _require(
+                isinstance(discipline.get(key), str) and bool(str(discipline.get(key))),
+                errors,
+                f"{label} structural_search_discipline {key} must be a non-empty string",
+            )
+        guidance = str(discipline.get("guidance", "")).lower()
+        _require(
+            "capped" in guidance and "stop" in guidance,
+            errors,
+            f"{label} structural_search_discipline guidance must prescribe a capped search budget and a stop condition",
+        )
     template = str(contract.get("steering_delta_template", ""))
     for field in ("changed_constraint", "new_evidence", "required_action", "verification_target_changed"):
         _require("{" + field + "}" in template, errors, f"{label} steering_delta_template must include {{{field}}}")

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -1929,7 +1929,9 @@ _STRUCTURAL_SEARCH_SECTION = (
     "\n"
     "When the target is a syntactic shape rather than a string, load "
     f"`{STRUCTURAL_SEARCH_REFERENCE_PATH}` before searching. "
-    "If ast-grep is not on PATH, use grep/ripgrep exactly as today.\n"
+    "If ast-grep is not on PATH, use grep/ripgrep exactly as today. Cap exploration to a few bounded, "
+    "targeted queries before reading a full file, escalate to a wider query only when a bounded pass "
+    "finds nothing or stays ambiguous, and stop once the target is found.\n"
     "\n"
 )
 

--- a/tests/test_executor_prompting.py
+++ b/tests/test_executor_prompting.py
@@ -425,6 +425,34 @@ class ExecutorPromptingTests(unittest.TestCase):
                     contract["steering_delta_contract"]["action_rule"],
                 )
 
+    def test_structural_search_discipline_is_a_versioned_capped_block_across_handoff_paths(self) -> None:
+        # Given: every prepared-handoff lane that carries the prompting contract.
+        cases = (
+            ("codex", "executor_handoff"),
+            ("claude-code", "prompt_handoff"),
+            ("hermes", "runtime_handoff"),
+        )
+
+        for executor, key in cases:
+            with self.subTest(executor=executor):
+                # When: the handoff is prepared.
+                handoff = build_coding_delegation_payload(
+                    "Implement the exporter flag in src/example.py.",
+                    executor_target=executor,
+                )[key]
+                contract = handoff["executor_prompting_contract"]
+
+                # Then: the payload carries a versioned, prepared-only search-discipline block.
+                discipline = contract["structural_search_discipline"]
+                self.assertEqual(discipline["schema_version"], "structural_search_discipline/v1")
+                self.assertEqual(discipline["status"], "prepared_not_observed")
+                guidance = discipline["guidance"].lower()
+                self.assertIn("capped", guidance)
+                self.assertIn("stop", guidance)
+                self.assertIn("not dispatch", discipline["claim_boundary"].lower())
+                # And the rendered prompt carries the same guidance on every lane.
+                self.assertIn(discipline["guidance"], handoff["prompt_template"])
+
     def test_contract_rejects_missing_or_weakened_session_summary_policy(self) -> None:
         payload = build_coding_delegation_payload(
             "Implement the exporter flag in src/example.py.",
@@ -446,6 +474,38 @@ class ExecutorPromptingTests(unittest.TestCase):
                 for error in errors
             )
         )
+
+    def test_contract_rejects_missing_or_uncapped_structural_search_discipline(self) -> None:
+        payload = build_coding_delegation_payload(
+            "Implement the exporter flag in src/example.py.",
+            executor_target="codex",
+        )
+        contract = dict(payload["executor_handoff"]["executor_prompting_contract"])
+
+        missing = dict(contract)
+        del missing["structural_search_discipline"]
+        errors = validate_executor_prompting_contract(missing, "prompting", expected_profile="codex")
+        self.assertTrue(
+            any("missing keys" in error and "structural_search_discipline" in error for error in errors)
+        )
+
+        uncapped = dict(contract)
+        uncapped["structural_search_discipline"] = dict(contract["structural_search_discipline"])
+        uncapped["structural_search_discipline"]["guidance"] = "Prefer structural search when it is available."
+        errors = validate_executor_prompting_contract(uncapped, "prompting", expected_profile="codex")
+        self.assertTrue(
+            any(
+                "structural_search_discipline guidance must prescribe a capped search budget and a stop condition"
+                in error
+                for error in errors
+            )
+        )
+
+        wrong_version = dict(contract)
+        wrong_version["structural_search_discipline"] = dict(contract["structural_search_discipline"])
+        wrong_version["structural_search_discipline"]["schema_version"] = "structural_search_discipline/v0"
+        errors = validate_executor_prompting_contract(wrong_version, "prompting", expected_profile="codex")
+        self.assertTrue(any("structural_search_discipline schema_version is invalid" in error for error in errors))
 
     def test_contract_rejects_missing_or_advisory_docs_consulted_policy(self) -> None:
         payload = build_coding_delegation_payload(

--- a/tests/test_structural_search_guidance_neutrality.py
+++ b/tests/test_structural_search_guidance_neutrality.py
@@ -6,7 +6,10 @@ from _local_package import load_local_package
 
 load_local_package()
 
-from omh.coding.coding_contracts import STRUCTURAL_SEARCH_GUIDANCE  # noqa: E402
+from omh.coding.coding_contracts import (  # noqa: E402
+    STRUCTURAL_SEARCH_DISCIPLINE_GUIDANCE,
+    STRUCTURAL_SEARCH_GUIDANCE,
+)
 from omh.coding.coding_delegation import (  # noqa: E402
     _executor_local_capability_strategy,
     _local_capability_prompt_block,
@@ -63,6 +66,15 @@ def _lane_b_prompt() -> str:
 class StructuralSearchGuidanceNeutralityTests(unittest.TestCase):
     def test_constant_is_neutral(self) -> None:
         self.assertEqual(guidance_leakage_findings(STRUCTURAL_SEARCH_GUIDANCE), ())
+
+    def test_capped_search_discipline_constant_is_neutral(self) -> None:
+        self.assertEqual(guidance_leakage_findings(STRUCTURAL_SEARCH_DISCIPLINE_GUIDANCE), ())
+        guidance = STRUCTURAL_SEARCH_DISCIPLINE_GUIDANCE.lower()
+        self.assertIn("capped", guidance)
+        self.assertIn("stop", guidance)
+
+    def test_lane_b_carries_capped_search_discipline(self) -> None:
+        self.assertIn(STRUCTURAL_SEARCH_DISCIPLINE_GUIDANCE, _lane_b_prompt())
 
     def test_shapes_carry_only_pre_existing_leakage(self) -> None:
         for shape, text in _lane_a_shapes().items():

--- a/tests/test_unit_prompt_protocol.py
+++ b/tests/test_unit_prompt_protocol.py
@@ -19,6 +19,7 @@ from omh.coding.unit_prompt_protocol import (  # noqa: E402
     MAIN_AGENT_COMPOSITION_CALIBRATIONS,
     PROMPT_CACHE_COMPOSITION_PROTOCOL,
     REVIEW_ROLE_PROTOCOL,
+    STRUCTURAL_SEARCH_DISCIPLINE_GUIDANCE,
     UNIT_PROMPT_MAX_BYTES,
     UNIT_RESULT_RETURN_PROTOCOL,
     VERIFICATION_STOP_PROTOCOL,
@@ -59,7 +60,13 @@ class ProtocolContentTests(unittest.TestCase):
         self.assertIn("remaining work is not blocked", prompt)
         # Every unit prompt instructs the parse-then-validate structured return.
         self.assertIn(UNIT_RESULT_RETURN_PROTOCOL, prompt)
+        # Code exploration is bounded the same way verification is: capped,
+        # escalate-on-need, stop-on-found.
+        self.assertIn(STRUCTURAL_SEARCH_DISCIPLINE_GUIDANCE, prompt)
         self.assertIn("Commit your work; do not merge or push other branches.", prompt)
+
+    def test_structural_search_discipline_rides_the_shared_invariant_preamble(self) -> None:
+        self.assertIn(STRUCTURAL_SEARCH_DISCIPLINE_GUIDANCE, shared_unit_preamble_lines(_GOAL))
 
     def test_structured_return_names_the_shape_and_the_parse_rule(self) -> None:
         """The report must end in a fenced fanout_unit_result/v1 JSON object so


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a versioned, executor-neutral **capped structural search** discipline to the coding-handoff prompting contract, alongside the existing tool-preference guidance (`STRUCTURAL_SEARCH_GUIDANCE`).
- The new `STRUCTURAL_SEARCH_DISCIPLINE_GUIDANCE` constant (`src/coding/coding_contracts.py`) prescribes: a few targeted structural-search-or-grep queries before a full-file read, escalate to a wider query only when a bounded pass finds nothing or stays ambiguous, and stop the moment the target is found.
- `build_executor_prompting_contract()` (`src/coding/prompting.py`) now embeds a versioned `structural_search_discipline` block (`schema_version: structural_search_discipline/v1`, `status`, `guidance`, `claim_boundary`) inside every `executor_prompting_contract/v1` payload, and `render_executor_prompt_sections()` carries its guidance into the rendered "Do" section on every dispatched-prompt lane (codex, claude-code/generic, hermes/runtime).
- The fanout unit-prompt lane's byte-identical shared preamble (`src/coding/unit_prompt_protocol.py`) picks up the same guidance as a sixth unit-invariant block, imported directly from `coding_contracts` so the two lanes' prose can never drift apart.
- `validate_executor_prompting_contract()` and the record compactor (`src/runtime/records.py`) require, shape-check, and carry the new field through `write_coding_delegation()`.
- The spliced "Structural Code Search" section in the `codebase-onboarding` / `codegraph-refresh` skills states the same capped-search rule (source: `src/skills/render.py`, regenerated `skills/omh-codebase-onboarding/SKILL.md` and `skills/omh-codegraph-refresh/SKILL.md`).
- Re-measured the `full_profile_skill_body_chars` release-drift ceiling: `798042 -> 798440` (+398 = +199 chars × 2 skills), with the reasoning documented in `src/maintenance/release.py`.

### Why This Exists

Backlog item **P3-14 "Prescribe capped structural search in the handoff contract"** (`.omc/research/omo-omc-comparison-2026-08-29.md`): OMH's prepared handoffs told an executor WHAT to do but never bounded HOW MUCH exploration to spend getting there. OMH cannot execute ast-grep itself (`src/maintenance/structural_search.py` stays PATH-detection-only, deliberately), but the handoff contract can *prescribe* bounded, structured search discipline so an executor doesn't burn tokens wandering — the same token-efficiency win omo's ast-grep-mcp caps deliver, absorbed as contract text rather than an execution engine.

### User / Operator Impact

Every prepared coding handoff (codex, claude-code, generic, hermes/runtime, and fanout units) now carries an explicit, capped search budget in addition to the existing "prefer structural search when present" guidance. No behavior change for OMH itself — this is prompt/contract text only.

### How It Works

`STRUCTURAL_SEARCH_GUIDANCE` (tool preference: "which tool") and `STRUCTURAL_SEARCH_DISCIPLINE_GUIDANCE` (search budget: "how much") are two separate constants in `coding_contracts.py`, both executor-neutral (no ast-grep flags, counts, or byte caps named — OMH prescribes discipline, it does not configure tooling). They are shared verbatim across:
1. `coding_delegation.py`'s four capability-discovery prompt blocks (unchanged, already carried `STRUCTURAL_SEARCH_GUIDANCE`),
2. `prompting.py`'s `executor_prompting_contract/v1` payload + rendered "Do" section (new: carries both fields now, via the new `structural_search_discipline` block),
3. `unit_prompt_protocol.py` / `fanout_dispatch.py`'s fanout unit prompts (new: `STRUCTURAL_SEARCH_DISCIPLINE_GUIDANCE` added to the byte-identical shared preamble; `STRUCTURAL_SEARCH_GUIDANCE` already rode there separately).

Deliberately did **not** condition the new guidance on `inspect_structural_search().found`, following the precedent already set by `STRUCTURAL_SEARCH_GUIDANCE` ("OMH did not check - verify PATH yourself") — a prepared handoff may dispatch to a different executor environment than the OMH host, so host-side PATH detection is not a valid gate for executor-facing guidance.

### Files And Contracts Touched

- `src/coding/coding_contracts.py` — new `STRUCTURAL_SEARCH_DISCIPLINE_CONTRACT_SCHEMA_VERSION` / `STRUCTURAL_SEARCH_DISCIPLINE_GUIDANCE`
- `src/coding/prompting.py` — `executor_prompting_contract/v1` payload gains `structural_search_discipline`; rendered "Do" section carries the guidance
- `src/coding/unit_prompt_protocol.py` — shared fanout-unit preamble gains the guidance; docstring updated (five → six blocks)
- `src/runtime/records.py` — validator + record compactor updated for the new required key
- `src/skills/render.py` — `_STRUCTURAL_SEARCH_SECTION` splice text gains the capped-search sentence
- `skills/omh-codebase-onboarding/SKILL.md`, `skills/omh-codegraph-refresh/SKILL.md` — regenerated from source
- `src/maintenance/release.py` — `FULL_PROFILE_SKILL_BODY_CHAR_LIMIT` re-measured `798042 -> 798440`
- `tests/test_executor_prompting.py`, `tests/test_unit_prompt_protocol.py`, `tests/test_structural_search_guidance_neutrality.py` — new coverage for payload shape, validator rejection, prompt presence, prompt-cache-preamble membership, and executor-neutrality (leakage-scanner) of the new constant

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [x] Codex
- [x] Claude Code
- [x] Hermes runtime or handoff
- [x] Generic executor
- [ ] Not executor-specific

## Validation

Check only commands that completed successfully. Leave non-applicable checks
unchecked and explain why under **Not Tested / Not Applicable**.

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli release drift` — clean (18 checks passed) after re-measuring the skill-body ceiling
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- `PYTHONPATH=tests uv run python -m unittest discover -s tests` — 8263 tests, `FAILED (failures=21, errors=7)` = exactly the 28 known pre-existing cross-harness `.claude`-path failures (`test_cross_harness_adapters`, `test_cross_harness_adapter_security`), unrelated to this change and reproducible on a clean checkout of this worktree.
- `uv run --group lint ruff check src tests` — `All checks passed!`
- `uv run python -m compileall -q src tests` — clean (only two pre-existing `SyntaxWarning`s in an unrelated Swift-source-embedding test).
- `uv run python -m omh.cli docs workflows --check` — `{"ok":true,...,"tap_skills":{"ok":true,"stale":[]}}`.
- `uv run python -m omh.cli docs roles --check` — `{"ok":true}`.
- `uv run python -m omh.cli docs capability-families --check` — `{"ok":true}` (unaffected, run defensively).
- `uv run python -m omh.cli release drift` — `No drift. 18 checks passed.` after re-measuring `FULL_PROFILE_SKILL_BODY_CHAR_LIMIT`.
- `git diff --check` — clean, no whitespace errors.
- Targeted reruns: `tests/test_executor_prompting.py`, `tests/test_unit_prompt_protocol.py`, `tests/test_structural_search_guidance_neutrality.py`, `tests/test_runtime_artifacts.py`, `tests/test_candidate_handoff.py`, `tests/test_executor_guidance_compatibility.py`, `tests/test_executor_skill_discovery.py`, `tests/test_router_content.py` — all green.

### Not Tested / Not Applicable

- `omh harness validate`, `release checklist --json`, `release hermes-smoke`, and the live `omh` command smokes — this PR changes prompt/contract text and payload shape only, not the harness or release install surfaces they cover.
- No manual Hermes/TUI check — no TUI-facing behavior changed.

## Risk

- Prompt/contract-shape change only; no execution-path or dispatch-mechanism change. `STRUCTURAL_SEARCH_DISCIPLINE_GUIDANCE` is a new required field in `executor_prompting_contract/v1` — any external consumer that hard-pins the prior key set for that contract would need to accept the new key (`validate_executor_prompting_contract` now requires it).

## Compatibility / Rollout

- Additive to `executor_prompting_contract/v1`: the contract still carries `schema_version: executor_prompting_contract/v1` unchanged (no major version bump), but the required-keys set grew by one (`structural_search_discipline`), consistent with how `session_summary_policy` and `docs_consulted_policy` were added previously under the same schema version.
- No migration needed for existing durable artifacts; validation only applies to freshly built contracts.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`) — no release-channel-specific code touched.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap (none run; see Not Tested)

## Follow-Up

- None identified; the two search-discipline constants (tool preference and search budget) are intentionally kept separate so future edits can extend either independently without forking prose across lanes.
