### PR TITLE
feat(coding): foveated history layout policy on the prompting contract

### DIFF
--- a/src/coding/prompting.py
+++ b/src/coding/prompting.py
@@ -61,6 +61,22 @@ SESSION_SUMMARY_SHAPE_POLICY = (
     "across successive summaries. A summary in this shape remains a report; it is never "
     "execution, verification, review, CI, or merge evidence."
 )
+# The layout half of the same problem. SESSION_SUMMARY_SHAPE_POLICY says which
+# sections a summary carries; it says nothing about what survives when the
+# history does not fit the budget. Foveation answers that with arithmetic
+# rather than taste: both temporal edges verbatim, the middle degraded,
+# oldest-middle dropped first, the drop stated, and every summary re-planned
+# from the original source so lossy layers never stack.
+HISTORY_FOVEATION_POLICY = (
+    "History foveation: when the history does not fit the budget of a summary, prepared-handoff "
+    "brief, or continuation re-brief, keep both temporal edges verbatim -- the oldest turns that "
+    "set the goal, constraints, and decisions, and the newest turns that hold current working "
+    "state -- and compress the middle instead. When the compressed middle still exceeds the "
+    "budget, drop the oldest part of the middle first and state what was dropped, naming the "
+    "dropped span and how much of it was dropped. Re-plan every summary from the original "
+    "source, never from an earlier summary, so successive re-briefs do not stack lossy layers. "
+    "An unstated drop is missing evidence, not a shorter summary."
+)
 
 
 def build_executor_prompting_contract(
@@ -103,6 +119,7 @@ def build_executor_prompting_contract(
             "Report progress, changed files, tests, blockers, evidence refs, local_capabilities_used, local_capability_evidence_refs, and local_capability_fallback_reason; distinguish prepared guidance from observed executor results."
         ),
         "session_summary_policy": SESSION_SUMMARY_SHAPE_POLICY,
+        "history_foveation_policy": HISTORY_FOVEATION_POLICY,
         "structural_search_discipline": {
             "schema_version": STRUCTURAL_SEARCH_DISCIPLINE_CONTRACT_SCHEMA_VERSION,
             "status": "prepared_not_observed",
@@ -232,6 +249,7 @@ def render_executor_prompt_sections(
                 (
                     str(contract.get("reporting_policy", "")),
                     str(contract.get("session_summary_policy", SESSION_SUMMARY_SHAPE_POLICY)),
+                    str(contract.get("history_foveation_policy", HISTORY_FOVEATION_POLICY)),
                 ),
             ),
             _section("Evidence boundary", (str(contract.get("claim_boundary", "")),)),
@@ -294,6 +312,7 @@ def _section(title: str, items: Iterable[str]) -> str:
 
 __all__ = [
     "DOCS_CONSULTED_ARTIFACT_POLICY",
+    "HISTORY_FOVEATION_POLICY",
     "SESSION_SUMMARY_SHAPE_POLICY",
     "STRUCTURAL_SEARCH_DISCIPLINE_CLAIM_BOUNDARY",
     "build_executor_prompting_contract",

--- a/src/runtime/records.py
+++ b/src/runtime/records.py
@@ -474,6 +474,7 @@ CODING_EXECUTOR_PROMPTING_CONTRACT_KEYS = (
     "verification_policy",
     "reporting_policy",
     "session_summary_policy",
+    "history_foveation_policy",
     "structural_search_discipline",
     "steering_delta_contract",
     "steering_delta_template",
@@ -1698,6 +1699,7 @@ def _compact_executor_prompting_contract(value: Any) -> dict[str, Any]:
         "verification_policy": str(value.get("verification_policy", "")),
         "reporting_policy": str(value.get("reporting_policy", "")),
         "session_summary_policy": str(value.get("session_summary_policy", "")),
+        "history_foveation_policy": str(value.get("history_foveation_policy", "")),
         "structural_search_discipline": _compact_structural_search_discipline(
             value.get("structural_search_discipline")
         ),
@@ -2942,6 +2944,7 @@ def validate_executor_prompting_contract(contract: Any, label: str, *, expected_
         "verification_policy",
         "reporting_policy",
         "session_summary_policy",
+        "history_foveation_policy",
         "steering_delta_template",
         "claim_boundary",
     ):
@@ -2960,6 +2963,15 @@ def validate_executor_prompting_contract(contract: Any, label: str, *, expected_
         and "modified-files" in summary_policy,
         errors,
         f"{label} session_summary_policy must name the structured summary sections and the read-files/modified-files lists",
+    )
+    foveation_policy = str(contract.get("history_foveation_policy", "")).lower()
+    _require(
+        "oldest" in foveation_policy
+        and "newest" in foveation_policy
+        and "state what was dropped" in foveation_policy
+        and "never from an earlier summary" in foveation_policy,
+        errors,
+        f"{label} history_foveation_policy must keep both temporal edges, drop the oldest middle first with the drop stated, and re-plan from the original source",
     )
     discipline = contract.get("structural_search_discipline")
     _require(isinstance(discipline, dict), errors, f"{label} structural_search_discipline must be an object")

--- a/tests/test_executor_prompting.py
+++ b/tests/test_executor_prompting.py
@@ -475,6 +475,64 @@ class ExecutorPromptingTests(unittest.TestCase):
             )
         )
 
+    def test_history_foveation_policy_rides_every_handoff_path(self) -> None:
+        # Given: every prepared-handoff lane that carries the prompting contract.
+        cases = (
+            ("codex", "executor_handoff"),
+            ("claude-code", "prompt_handoff"),
+            ("hermes", "runtime_handoff"),
+        )
+
+        for executor, key in cases:
+            with self.subTest(executor=executor):
+                # When: the handoff is prepared.
+                handoff = build_coding_delegation_payload(
+                    "Implement the exporter flag in src/example.py.",
+                    executor_target=executor,
+                )[key]
+                contract = handoff["executor_prompting_contract"]
+
+                # Then: the layout policy states all four rules — both temporal
+                # edges verbatim, the middle degraded, oldest-middle dropped
+                # first with the drop stated, and no summary of a summary.
+                policy = contract["history_foveation_policy"]
+                self.assertIn("keep both temporal edges verbatim", policy)
+                self.assertIn("the oldest turns that set the goal", policy)
+                self.assertIn("the newest turns that hold current working state", policy)
+                self.assertIn("compress the middle", policy)
+                self.assertIn("drop the oldest part of the middle first", policy)
+                self.assertIn("state what was dropped", policy)
+                self.assertIn("never from an earlier summary", policy)
+                self.assertIn("An unstated drop is missing evidence", policy)
+                # And the rendered prompt carries it on every lane.
+                self.assertIn(policy, handoff["prompt_template"])
+
+    def test_contract_rejects_missing_or_weakened_history_foveation_policy(self) -> None:
+        payload = build_coding_delegation_payload(
+            "Implement the exporter flag in src/example.py.",
+            executor_target="codex",
+        )
+        contract = dict(payload["executor_handoff"]["executor_prompting_contract"])
+
+        missing = dict(contract)
+        del missing["history_foveation_policy"]
+        errors = validate_executor_prompting_contract(missing, "prompting", expected_profile="codex")
+        self.assertTrue(
+            any("missing keys" in error and "history_foveation_policy" in error for error in errors)
+        )
+
+        # A policy that keeps the edges but drops the anti-stacking rule is the
+        # regression this gate exists for: summarizing a summary is where long
+        # sessions actually lose their early constraints.
+        weakened = dict(contract)
+        weakened["history_foveation_policy"] = (
+            "Keep the oldest and newest turns and compress the middle; state what was dropped."
+        )
+        errors = validate_executor_prompting_contract(weakened, "prompting", expected_profile="codex")
+        self.assertTrue(
+            any("history_foveation_policy must keep both temporal edges" in error for error in errors)
+        )
+
     def test_contract_rejects_missing_or_uncapped_structural_search_discipline(self) -> None:
         payload = build_coding_delegation_payload(
             "Implement the exporter flag in src/example.py.",


### PR DESCRIPTION
## Feature Report

### What Changed

- Added `HISTORY_FOVEATION_POLICY` to the executor prompting contract as a new required field, `history_foveation_policy`, carried on every prepared handoff lane and rendered into the prompt text next to the session-summary shape.
- The validator in `src/runtime/records.py` now rejects a missing field and rejects weakened text that keeps the temporal edges but drops the drop-statement or the never-summarize-a-summary rule.

### Why This Exists

- `SESSION_SUMMARY_SHAPE_POLICY` (#shipped earlier) says which sections a summary carries. It says nothing about what survives when the history does not fit the budget, and that is the half where long sessions actually lose their early constraints.
- Without a layout rule, an executor asked to "summarize" drops whichever region it reaches last, and a re-brief built from the previous re-brief stacks lossy layers until the goal is a paraphrase of a paraphrase.
- The policy is arithmetic rather than taste, so a reviewer can check a summary against it: both temporal edges verbatim, middle compressed, oldest-middle dropped first with the drop stated, and every summary re-planned from the original source.

### User / Operator Impact

- Every prepared handoff (executor, prompt, runtime) now carries the layout rule in its prompt text, so a long-running executor has a stated policy for what to keep instead of an implicit one.
- No CLI surface changes, no new flags, no behavior change for short sessions.

### How It Works

- `src/coding/prompting.py`: new module-level constant; added to the contract dict beside `session_summary_policy`; rendered in the Progress-and-blockers section of the prompt template.
- `src/runtime/records.py`: the field joins `CODING_EXECUTOR_PROMPTING_CONTRACT_KEYS`, the compacted durable record, and the required-non-empty key list, plus a vocabulary assertion mirroring the existing `session_summary_policy` and `docs_consulted_policy` gates.
- OMH holds no transcript of its own, so the foveation arithmetic itself has no input here; only the policy ships.

### Files And Contracts Touched

- `src/coding/prompting.py` — `HISTORY_FOVEATION_POLICY`, contract field, prompt rendering.
- `src/runtime/records.py` — contract key tuple, compaction, required keys, validator rule.
- `tests/test_executor_prompting.py` — two new tests (all three handoff lanes; missing and weakened field).
- Contract: `executor_prompting_contract` gains one required key. Schema version is unchanged, matching the precedent set when `docs_consulted_policy` was added (4ee4bf74).

### Affected Surfaces

- [x] Hermes chat or wrapper
- [x] Codex
- [x] Claude Code
- [x] Hermes runtime or handoff
- [x] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke ... release hermes-smoke ...`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli release drift` (No drift, 18 checks passed); `uv run python -m omh.cli docs ulw-inventory --check`; `uv run python -m omh.cli docs ulw-site --check`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run — this change adds prepared prompt text and a validator rule; no TUI or runtime surface moved.

### Observed Evidence

- `PYTHONPATH=tests uv run python -m unittest tests.test_executor_prompting` -> Ran 18 tests, OK.
- `PYTHONPATH=tests uv run python -m unittest tests.test_runtime_artifacts tests.test_coding_lifecycle tests.test_runtime_lifecycle_invariants tests.test_context_safety tests.test_prompt_compatibility tests.test_release_smoke tests.test_hermes_ux_quality` -> Ran 127 tests, OK.
- `PYTHONPATH=tests uv run python -m unittest discover -s tests` -> Ran 8274 tests, failures=21 errors=7. The same 28 failures were measured on unmodified `origin/main` in this worktree before any edit (Ran 8272 tests, failures=21 errors=7); they are the known cross-harness `.claude`-path failures caused by running inside a linked worktree under `.claude/worktrees/`, and are unrelated to this change.
- `uv run python -m compileall -q src tests` -> clean. `uv run --group lint ruff check src tests` -> All checks passed. `git diff --check` -> clean.
- Five `docs ... --check` byte gates and `release drift` -> all ok, output quoted above.

### Not Tested / Not Applicable

- `harness validate`, `release checklist`, `release hermes-smoke`, and the install smoke: no installer, harness manifest, or release-channel surface changed.
- Live executor behavior against the new prompt text: OMH prepares prompts and observes no executor runs, so any claim about how a model follows the policy would be `prepared_not_observed`.
- No before/after measurement of summary quality: OMH holds no transcript to measure.

## Risk

- Low. One added contract key on a surface whose producer and validator are both updated in the same commit; the vocabulary gate is a substring assertion over text this repo owns.
- The added field lengthens every prepared prompt by roughly 630 bytes. That cost is paid on the handoff lane, not on the byte-ceilinged skill pack, and no byte ceiling was tripped (`release drift`: no drift).

## Compatibility / Rollout

- A durable runtime record written before this change lacks the key and will fail `validate_executor_prompting_contract`, the same way records predating `docs_consulted_policy` did. Contracts are regenerated per handoff, so this affects replay of stored artifacts only.
- No schema-version bump, following the `docs_consulted_policy` precedent for an additive required field.

## Release / Claims

- [x] Release-channel impact considered (`local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed

## Follow-Up

- If fanout unit prompts later gain a history or re-brief instruction, reuse `HISTORY_FOVEATION_POLICY` verbatim so the dispatch lane and the handoff lane cannot drift apart.
