### PR TITLE
feat(quality): denominator hygiene for every rate OMH reports about itself

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,6 +237,27 @@ for shared surfaces and run the full suite before claiming completion.
 For direction, docs, generated skill, wrapper contract, lifecycle, or runtime
 artifact changes, add or update tests that lock the public contract.
 
+### Reporting Our Own Numbers
+
+A rate OMH computes about itself is a claim, so it carries what it divided.
+Every percentage in a payload names the buckets its numerator summed, what its
+denominator counted, and every observation class excluded before either count
+was taken — `src/quality/reported_rate.py` is that shape, and
+`reported_rate_shape_errors()` is what checks it. Two specific traps:
+
+- **An empty denominator is not 0%.** `max(1, count)` in a divisor turns a
+  corpus with nothing in it into a confident zero, which claims that every case
+  was measured and every case failed. Report `percent: null` with basis
+  `no_observations` instead, and let an unmeasured rate fail its target rather
+  than pass it.
+- **A composed numerator says so.** When a rate sums more than one outcome
+  bucket, name them in the payload, not only in a text formatter — every
+  non-human consumer reads the JSON.
+
+The same rule governs prose: a headline number in a commit, PR, or report names
+the arm, the corpus, the selection rule, and the committed artifact it came
+from. A number without those is `prepared_not_observed`, not a result.
+
 ## Repository Maintenance Procedures
 
 Two maintainer sweeps are written down as executor-neutral procedures. Any

--- a/src/quality/common_request_coverage.py
+++ b/src/quality/common_request_coverage.py
@@ -8,6 +8,7 @@ from ..routing.action_copy import next_action_label
 from ..wrapper.contract import build_chat_interaction_payload
 from .common_request_cases import COMMON_REQUEST_COVERAGE_CASES, CommonRequestCoverageCase
 from .popular_plugin_coverage import build_popular_plugin_coverage_demo, popular_plugin_coverage_errors
+from .reported_rate import meets_target, reported_rate
 
 
 COMMON_REQUEST_COVERAGE_SCHEMA_VERSION = "common_request_coverage/v1"
@@ -20,7 +21,13 @@ def build_common_request_coverage_demo(*, source: str = "discord") -> dict[str, 
     rows = [_evaluate_case(case, source=source) for case in COMMON_REQUEST_COVERAGE_CASES]
     passing_count = sum(1 for row in rows if bool(row["passed"]))
     case_count = len(rows)
-    coverage_percent = round((passing_count / max(1, case_count)) * 100, 1)
+    coverage_rate = reported_rate(
+        numerator=passing_count,
+        denominator=case_count,
+        numerator_of=("passing_case",),
+        denominator_of="common request cases",
+    )
+    coverage_percent = coverage_rate.percent
     family_rows = _family_summary(rows)
     popular_plugin_coverage = build_popular_plugin_coverage_demo(cases=rows)
     plugin_summary = _nested(popular_plugin_coverage, "summary")
@@ -33,7 +40,8 @@ def build_common_request_coverage_demo(*, source: str = "discord") -> dict[str, 
             "passing_count": passing_count,
             "failing_count": case_count - passing_count,
             "coverage_percent": coverage_percent,
-            "target_met": coverage_percent >= COMMON_REQUEST_TARGET_PERCENT,
+            "coverage_rate": coverage_rate.to_payload(),
+            "target_met": meets_target(coverage_rate, COMMON_REQUEST_TARGET_PERCENT),
             "family_count": len(family_rows),
             "workflow_count": len({str(row["observed"]["workflow"]) for row in rows}),
             "dispatch_count": sum(1 for row in rows if row["observed"]["route_action"] == "dispatch"),
@@ -206,14 +214,20 @@ def _family_summary(rows: Sequence[Mapping[str, object]]) -> list[dict[str, obje
         family_rows = [row for row in rows if row.get("family") == family]
         passing_count = sum(1 for row in family_rows if bool(row.get("passed")))
         total = len(family_rows)
-        coverage = round((passing_count / max(1, total)) * 100, 1)
+        coverage = reported_rate(
+            numerator=passing_count,
+            denominator=total,
+            numerator_of=("passing_case",),
+            denominator_of=f"common request cases in family {family}",
+        )
         summary.append(
             {
                 "family": family,
                 "case_count": total,
                 "passing_count": passing_count,
-                "coverage_percent": coverage,
-                "target_met": coverage >= COMMON_REQUEST_TARGET_PERCENT,
+                "coverage_percent": coverage.percent,
+                "coverage_rate": coverage.to_payload(),
+                "target_met": meets_target(coverage, COMMON_REQUEST_TARGET_PERCENT),
             }
         )
     return summary

--- a/src/quality/hermes_ux_quality.py
+++ b/src/quality/hermes_ux_quality.py
@@ -9,6 +9,7 @@ from .context_brief_coverage import build_context_brief_coverage_demo
 from .grounded_score import build_grounded_score_demo
 from .localized_chat_copy import build_localized_chat_copy_demo, localized_chat_copy_errors
 from .native_skill_competition import build_native_skill_competition_report, native_skill_competition_errors
+from .reported_rate import reported_rate
 from .route_hint_alignment import build_route_hint_alignment_demo
 from .router_fast_path import build_router_fast_path_demo, router_fast_path_errors
 from .routing_precision import build_routing_precision_demo, routing_precision_errors
@@ -176,6 +177,13 @@ def build_hermes_ux_quality_demo(
     ]
     passing_count = sum(1 for gate in gates if gate["status"] == "passed")
     total = len(gates)
+    score_rate = reported_rate(
+        numerator=passing_count,
+        denominator=total,
+        numerator_of=("passed_gate",),
+        denominator_of="UX quality gates",
+        digits=0,
+    )
     status = "passed" if passing_count == total else "needs_attention"
     grounded_summary = _nested(grounded, "summary")
     chat_summary = _nested(chat_cards, "summary")
@@ -189,7 +197,8 @@ def build_hermes_ux_quality_demo(
         "schema_version": HERMES_UX_QUALITY_SCHEMA_VERSION,
         "source": source,
         "status": status,
-        "score": round((passing_count / max(1, total)) * 100),
+        "score": None if score_rate.percent is None else int(score_rate.percent),
+        "score_rate": score_rate.to_payload(),
         "summary": {
             "gate_count": total,
             "passing_gate_count": passing_count,

--- a/src/quality/reported_rate.py
+++ b/src/quality/reported_rate.py
@@ -1,0 +1,175 @@
+"""One shape for every percentage OMH reports about its own corpora.
+
+A percentage printed without its denominator is a claim nobody can check, and
+the two ways OMH got that wrong are both silent:
+
+- ``max(1, count)`` in a divisor turns an empty corpus into a confident
+  ``0.0%``. That is a stronger claim than the truth: 0% asserts that every
+  case was measured and every case failed, while an empty corpus measured
+  nothing at all. This module reports ``percent = None`` with a named basis
+  instead, the same way the live-lane receipt reports ``pass_rate = None``
+  when nothing was graded.
+- A numerator assembled from more than one outcome bucket reads as if it came
+  from one. ``covered_percent`` folding model-selection handoffs in with
+  resolved routes is fair, but only when the payload says so; explaining it in
+  a text formatter leaves every JSON consumer guessing.
+
+So a reported rate carries four things beside the number: what the numerator
+summed, what the denominator counted, which observations were excluded before
+either was taken, and whether a percentage exists at all.
+
+This is a reporting shape, not a statistic. It computes nothing a caller could
+not compute; it refuses to let a caller report the result without saying what
+it divided.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+REPORTED_RATE_SCHEMA_VERSION = "omh_reported_rate/v1"
+
+# The basis recorded when the denominator is zero. Named rather than blank so a
+# reader can tell "nothing was measured" from "the measurement came out at 0%".
+NO_OBSERVATIONS_BASIS = "no_observations"
+OBSERVATIONS_BASIS = "observed_cases"
+
+
+@dataclass(frozen=True, slots=True)
+class ReportedRate:
+    """A percentage that carries its own denominator and exclusions."""
+
+    numerator: int
+    denominator: int
+    numerator_of: tuple[str, ...]
+    denominator_of: str
+    excluded: tuple[str, ...]
+    percent: float | None
+
+    @property
+    def basis(self) -> str:
+        return OBSERVATIONS_BASIS if self.denominator else NO_OBSERVATIONS_BASIS
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "schema_version": REPORTED_RATE_SCHEMA_VERSION,
+            "percent": self.percent,
+            "numerator": self.numerator,
+            "denominator": self.denominator,
+            "numerator_of": list(self.numerator_of),
+            "denominator_of": self.denominator_of,
+            "excluded": list(self.excluded),
+            "basis": self.basis,
+        }
+
+
+def reported_rate(
+    *,
+    numerator: int,
+    denominator: int,
+    numerator_of: tuple[str, ...] | list[str],
+    denominator_of: str,
+    excluded: tuple[str, ...] | list[str] = (),
+    digits: int = 1,
+) -> ReportedRate:
+    """Build a rate that names what it divided.
+
+    `numerator_of` lists the outcome buckets summed into the numerator, so a
+    composed numerator cannot be mistaken for a single bucket. `denominator_of`
+    names what was counted. `excluded` names every observation class dropped
+    before either count was taken -- an exclusion nobody named is an exclusion
+    nobody can argue with.
+
+    A zero denominator yields `percent = None`, never `0.0`.
+    """
+    if numerator < 0 or denominator < 0:
+        raise ValueError("reported rate counts must be non-negative")
+    if numerator > denominator:
+        raise ValueError("reported rate numerator cannot exceed its denominator")
+    names = tuple(str(name) for name in numerator_of if str(name).strip())
+    if not names:
+        raise ValueError("reported rate must name what its numerator counts")
+    if not str(denominator_of).strip():
+        raise ValueError("reported rate must name what its denominator counts")
+    percent = round(numerator * 100 / denominator, digits) if denominator else None
+    return ReportedRate(
+        numerator=numerator,
+        denominator=denominator,
+        numerator_of=names,
+        denominator_of=str(denominator_of),
+        excluded=tuple(str(name) for name in excluded if str(name).strip()),
+        percent=percent,
+    )
+
+
+def meets_target(rate: ReportedRate, target_percent: float) -> bool:
+    """Return whether a rate clears a target, with an unmeasured rate failing.
+
+    An unmeasured rate is not a met target. The alternative -- treating "no
+    cases" as a pass -- is how an empty corpus silently reports success.
+    """
+    return rate.percent is not None and rate.percent >= target_percent
+
+
+def format_reported_rate(rate: ReportedRate) -> str:
+    """Render a rate as a line that carries its denominator."""
+    numerator_of = " + ".join(rate.numerator_of)
+    if rate.percent is None:
+        head = f"unmeasured ({NO_OBSERVATIONS_BASIS})"
+    else:
+        head = f"{rate.percent}%"
+    line = f"{head} — {rate.numerator}/{rate.denominator} {rate.denominator_of} ({numerator_of})"
+    if rate.excluded:
+        line += f"; excluded: {', '.join(rate.excluded)}"
+    return line
+
+
+def reported_rate_shape_errors(value: object) -> tuple[str, ...]:
+    """Return why a serialized rate payload is not a well-formed reported rate."""
+    expected = {
+        "schema_version", "percent", "numerator", "denominator",
+        "numerator_of", "denominator_of", "excluded", "basis",
+    }
+    if not isinstance(value, dict) or set(value) != expected:
+        return ("reported rate keys are not closed",)
+    errors: list[str] = []
+    if value.get("schema_version") != REPORTED_RATE_SCHEMA_VERSION:
+        errors.append("reported rate schema_version is invalid")
+    for field in ("numerator", "denominator"):
+        count = value.get(field)
+        if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+            errors.append(f"reported rate {field} must be a non-negative integer")
+    names = value.get("numerator_of")
+    if not isinstance(names, list) or not names or not all(isinstance(name, str) and name for name in names):
+        errors.append("reported rate numerator_of must name at least one counted bucket")
+    denominator_of = value.get("denominator_of")
+    if not isinstance(denominator_of, str) or not denominator_of:
+        errors.append("reported rate denominator_of must name what was counted")
+    excluded = value.get("excluded")
+    if not isinstance(excluded, list) or not all(isinstance(name, str) and name for name in excluded):
+        errors.append("reported rate excluded must be a list of named exclusions")
+    percent = value.get("percent")
+    denominator = value.get("denominator")
+    if denominator == 0:
+        if percent is not None:
+            errors.append("reported rate over an empty denominator must report percent null, never a number")
+        if value.get("basis") != NO_OBSERVATIONS_BASIS:
+            errors.append(f"reported rate over an empty denominator must state basis {NO_OBSERVATIONS_BASIS}")
+    else:
+        if isinstance(percent, bool) or not isinstance(percent, (int, float)):
+            errors.append("reported rate percent must be a number when the denominator is non-empty")
+        if value.get("basis") != OBSERVATIONS_BASIS:
+            errors.append(f"reported rate over a non-empty denominator must state basis {OBSERVATIONS_BASIS}")
+    return tuple(errors)
+
+
+__all__ = [
+    "NO_OBSERVATIONS_BASIS",
+    "OBSERVATIONS_BASIS",
+    "REPORTED_RATE_SCHEMA_VERSION",
+    "ReportedRate",
+    "format_reported_rate",
+    "meets_target",
+    "reported_rate",
+    "reported_rate_shape_errors",
+]

--- a/src/quality/routing_accuracy.py
+++ b/src/quality/routing_accuracy.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from ..routing.chat import route_chat_message
+from .reported_rate import ReportedRate, reported_rate
 
 
 ROUTING_ACCURACY_SCHEMA_VERSION = "routing_accuracy/v1"
@@ -141,6 +142,30 @@ def evaluate_routing_accuracy_case(case: RoutingAccuracyCase, *, source: str = "
     }
 
 
+def _resolved_rate(resolved: int, count: int, scope: object) -> ReportedRate:
+    return reported_rate(
+        numerator=resolved,
+        denominator=count,
+        numerator_of=(OUTCOME_RESOLVED,),
+        denominator_of=f"routing accuracy cases ({scope})",
+    )
+
+
+def _covered_rate(covered: int, count: int, scope: object) -> ReportedRate:
+    """Coverage counts model-selection handoffs as covered, so it says so.
+
+    `covered_percent` sums two outcome buckets. The text formatter has always
+    explained that; the JSON payload did not, which left every non-human
+    consumer reading a composed numerator as a single one.
+    """
+    return reported_rate(
+        numerator=covered,
+        denominator=count,
+        numerator_of=(OUTCOME_RESOLVED, OUTCOME_HANDED_OFF),
+        denominator_of=f"routing accuracy cases ({scope})",
+    )
+
+
 def build_routing_accuracy_demo(*, source: str = "generic") -> dict[str, object]:
     rows = [evaluate_routing_accuracy_case(case, source=source) for case in ROUTING_ACCURACY_CASES]
 
@@ -160,14 +185,20 @@ def build_routing_accuracy_demo(*, source: str = "generic") -> dict[str, object]
         count = int(bucket["case_count"])
         resolved = int(bucket["resolved"])
         covered = resolved + int(bucket["handed_off"])
-        bucket["resolved_percent"] = round(resolved * 100 / count, 1)
-        bucket["covered_percent"] = round(covered * 100 / count, 1)
+        resolved_rate = _resolved_rate(resolved, count, bucket["language"])
+        covered_rate = _covered_rate(covered, count, bucket["language"])
+        bucket["resolved_percent"] = resolved_rate.percent
+        bucket["covered_percent"] = covered_rate.percent
+        bucket["resolved_rate"] = resolved_rate.to_payload()
+        bucket["covered_rate"] = covered_rate.to_payload()
 
     total = len(rows)
     resolved_total = sum(1 for row in rows if row["outcome"] == OUTCOME_RESOLVED)
     handed_total = sum(1 for row in rows if row["outcome"] == OUTCOME_HANDED_OFF)
     missed_total = sum(1 for row in rows if row["outcome"] == OUTCOME_MISSED)
     misroute_total = sum(1 for row in rows if row["high_confidence_misroute"])
+    resolved_rate = _resolved_rate(resolved_total, total, "all languages")
+    covered_rate = _covered_rate(resolved_total + handed_total, total, "all languages")
 
     return {
         "schema_version": ROUTING_ACCURACY_SCHEMA_VERSION,
@@ -179,8 +210,10 @@ def build_routing_accuracy_demo(*, source: str = "generic") -> dict[str, object]
             "handed_off": handed_total,
             "missed": missed_total,
             "high_confidence_misroutes": misroute_total,
-            "resolved_percent": round(resolved_total * 100 / total, 1),
-            "covered_percent": round((resolved_total + handed_total) * 100 / total, 1),
+            "resolved_percent": resolved_rate.percent,
+            "covered_percent": covered_rate.percent,
+            "resolved_rate": resolved_rate.to_payload(),
+            "covered_rate": covered_rate.to_payload(),
         },
         "languages": [languages[key] for key in sorted(languages)],
         "cases": rows,

--- a/src/workflows/use_cases.py
+++ b/src/workflows/use_cases.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from ..local_store import atomic_write_json, ensure_dir, read_json_object, read_json_object_result, utc_now
 from ..paths import OmhPaths
+from ..quality.reported_rate import reported_rate
 from ..routing.action_copy import next_action_label
 
 
@@ -719,10 +720,23 @@ def use_case_readiness(paths: OmhPaths | None = None) -> dict[str, Any]:
     if any(gate["id"] == "local_artifact_store" and gate["status"] != "passed" for gate in gates):
         next_actions.append("Optional: write local runbook artifacts with `omh cases artifact --all --write`.")
     next_actions.append("Use `omh cases readiness --json` when a wrapper or release check needs the full payload.")
+    # Non-blocking gates are excluded from BOTH sides of this score, so the
+    # denominator is the blocking gates alone -- not `len(gates)`, which is the
+    # number a reader would otherwise assume. Naming it is the whole point.
+    blocking_gate_count = len(gates) - len(warnings)
+    score_rate = reported_rate(
+        numerator=blocking_gate_count - len(blocking_failures),
+        denominator=blocking_gate_count,
+        numerator_of=("passed_blocking_gate",),
+        denominator_of="blocking readiness gates",
+        excluded=("non_blocking_gate",) if warnings else (),
+        digits=0,
+    )
     return {
         "schema_version": USE_CASE_READINESS_SCHEMA_VERSION,
         "status": "ready" if not blocking_failures else "needs_attention",
-        "score": 100 if not blocking_failures else round(((len(gates) - len(warnings) - len(blocking_failures)) / max(1, len(gates) - len(warnings))) * 100),
+        "score": None if score_rate.percent is None else int(score_rate.percent),
+        "score_rate": score_rate.to_payload(),
         "blocking_failures": len(blocking_failures),
         "warning_count": len(warnings),
         "expected_goals": [case.goal for case in USE_CASES],

--- a/tests/test_reported_rate.py
+++ b/tests/test_reported_rate.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.quality.common_request_coverage import build_common_request_coverage_demo  # noqa: E402
+from omh.quality.hermes_ux_quality import build_hermes_ux_quality_demo  # noqa: E402
+from omh.quality.reported_rate import (  # noqa: E402
+    NO_OBSERVATIONS_BASIS,
+    OBSERVATIONS_BASIS,
+    REPORTED_RATE_SCHEMA_VERSION,
+    format_reported_rate,
+    meets_target,
+    reported_rate,
+    reported_rate_shape_errors,
+)
+from omh.quality.routing_accuracy import build_routing_accuracy_demo  # noqa: E402
+from omh.workflows.use_cases import use_case_readiness  # noqa: E402
+
+
+class ReportedRateContractTests(unittest.TestCase):
+    def test_empty_denominator_reports_unmeasured_never_zero_percent(self) -> None:
+        # Given: a corpus with no cases in it.
+        rate = reported_rate(
+            numerator=0,
+            denominator=0,
+            numerator_of=("passing_case",),
+            denominator_of="demo cases",
+        )
+
+        # Then: the rate is unmeasured, not a confident 0% — 0% would assert
+        # that every case was measured and every case failed.
+        self.assertIsNone(rate.percent)
+        self.assertEqual(rate.basis, NO_OBSERVATIONS_BASIS)
+        self.assertFalse(meets_target(rate, 0.0))
+        self.assertIn(NO_OBSERVATIONS_BASIS, format_reported_rate(rate))
+        self.assertEqual(reported_rate_shape_errors(rate.to_payload()), ())
+
+    def test_measured_rate_names_numerator_denominator_and_exclusions(self) -> None:
+        rate = reported_rate(
+            numerator=3,
+            denominator=4,
+            numerator_of=("resolved", "handed_off"),
+            denominator_of="routing cases",
+            excluded=("infra_error",),
+        )
+
+        payload = rate.to_payload()
+        self.assertEqual(payload["schema_version"], REPORTED_RATE_SCHEMA_VERSION)
+        self.assertEqual(payload["percent"], 75.0)
+        self.assertEqual(payload["numerator_of"], ["resolved", "handed_off"])
+        self.assertEqual(payload["denominator_of"], "routing cases")
+        self.assertEqual(payload["excluded"], ["infra_error"])
+        self.assertEqual(payload["basis"], OBSERVATIONS_BASIS)
+        self.assertEqual(reported_rate_shape_errors(payload), ())
+        self.assertEqual(
+            format_reported_rate(rate),
+            "75.0% — 3/4 routing cases (resolved + handed_off); excluded: infra_error",
+        )
+
+    def test_a_rate_must_name_what_it_divided(self) -> None:
+        for kwargs in (
+            {"numerator_of": ()},
+            {"denominator_of": "  "},
+        ):
+            with self.subTest(kwargs=kwargs):
+                base = {
+                    "numerator": 1,
+                    "denominator": 2,
+                    "numerator_of": ("passing_case",),
+                    "denominator_of": "demo cases",
+                }
+                base.update(kwargs)
+                with self.assertRaises(ValueError):
+                    reported_rate(**base)  # type: ignore[arg-type]
+
+    def test_shape_errors_reject_a_zero_denominator_reported_as_a_number(self) -> None:
+        payload = reported_rate(
+            numerator=0,
+            denominator=0,
+            numerator_of=("passing_case",),
+            denominator_of="demo cases",
+        ).to_payload()
+        payload["percent"] = 0.0
+        self.assertTrue(
+            any("must report percent null" in error for error in reported_rate_shape_errors(payload))
+        )
+
+
+class ReportedRatePayloadDisclosureTests(unittest.TestCase):
+    """Every percentage OMH prints about itself carries its denominator."""
+
+    def _assert_disclosed(self, payload: object, label: str) -> None:
+        self.assertIsInstance(payload, dict)
+        errors = reported_rate_shape_errors(payload)
+        self.assertEqual(errors, (), f"{label}: {errors}")
+
+    def test_common_request_coverage_discloses_its_denominator(self) -> None:
+        summary = build_common_request_coverage_demo()["summary"]
+        rate = summary["coverage_rate"]
+        self._assert_disclosed(rate, "common_request_coverage.summary")
+        self.assertEqual(rate["percent"], summary["coverage_percent"])
+        self.assertEqual(rate["denominator"], summary["case_count"])
+        self.assertEqual(rate["numerator"], summary["passing_count"])
+
+    def test_common_request_family_rows_disclose_their_denominators(self) -> None:
+        payload = build_common_request_coverage_demo()
+        families = payload["families"]
+        self.assertTrue(families)
+        for family in families:
+            with self.subTest(family=family["family"]):
+                self._assert_disclosed(family["coverage_rate"], "family row")
+                self.assertEqual(family["coverage_rate"]["denominator"], family["case_count"])
+
+    def test_ux_quality_score_discloses_its_gate_denominator(self) -> None:
+        payload = build_hermes_ux_quality_demo()
+        rate = payload["score_rate"]
+        self._assert_disclosed(rate, "hermes_ux_quality.score_rate")
+        self.assertEqual(rate["denominator"], payload["summary"]["gate_count"])
+        self.assertEqual(rate["numerator"], payload["summary"]["passing_gate_count"])
+
+    def test_routing_accuracy_names_the_composed_coverage_numerator(self) -> None:
+        payload = build_routing_accuracy_demo()
+        summary = payload["summary"]
+        self._assert_disclosed(summary["resolved_rate"], "routing_accuracy.resolved_rate")
+        self._assert_disclosed(summary["covered_rate"], "routing_accuracy.covered_rate")
+        # Coverage sums two outcome buckets; the payload says which, so a JSON
+        # consumer cannot read it as a single bucket.
+        self.assertEqual(summary["covered_rate"]["numerator_of"], ["resolved", "handed_off"])
+        self.assertEqual(summary["resolved_rate"]["numerator_of"], ["resolved"])
+        self.assertEqual(
+            summary["covered_rate"]["numerator"],
+            summary["resolved"] + summary["handed_off"],
+        )
+        for bucket in payload["languages"]:
+            with self.subTest(language=bucket["language"]):
+                self._assert_disclosed(bucket["resolved_rate"], "language resolved_rate")
+                self._assert_disclosed(bucket["covered_rate"], "language covered_rate")
+
+    def test_use_case_readiness_exposes_its_adjusted_denominator(self) -> None:
+        from omh.paths import OmhPaths
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+
+        with TemporaryDirectory() as tmp:
+            paths = OmhPaths(Path(tmp) / "omh", Path(tmp) / "hermes")
+            payload = use_case_readiness(paths)
+
+        rate = payload["score_rate"]
+        self._assert_disclosed(rate, "use_case_readiness.score_rate")
+        # Non-blocking gates are excluded from both sides, so the denominator is
+        # NOT len(gates) — the payload has to say that, and now does.
+        self.assertEqual(rate["denominator"], len(payload["gates"]) - payload["warning_count"])
+        self.assertEqual(rate["denominator_of"], "blocking readiness gates")
+        if payload["warning_count"]:
+            self.assertEqual(rate["excluded"], ["non_blocking_gate"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New `src/quality/reported_rate.py`: one shape for every percentage OMH reports about its own corpora, carrying the numerator's buckets, the denominator's subject, the exclusions taken before either count, and `percent: null` when the denominator is empty.
- Removed the `max(1, count)` divisor from `common_request_coverage.py` and `hermes_ux_quality.py`, which mapped an empty corpus to a confident `0.0%`.
- `routing_accuracy.py` now names the two outcome buckets its `covered_percent` numerator sums, in the JSON and not only in the text formatter.
- `use_cases.py` readiness score now surfaces its adjusted denominator (`blocking readiness gates`) and its exclusion (`non_blocking_gate`).
- `AGENTS.md` gains a "Reporting Our Own Numbers" rule under Verification, covering both the payload half and the prose half.

### Why This Exists

- A percentage without its denominator is a claim nobody can check, and OMH had two silent versions of the problem.
- `max(1, n)` turns "no cases" into "0% of cases passed". The second is a much stronger claim: it asserts that every case was measured and every case failed. The repo already had the honest answer in one place — the live-lane receipt reports `pass_rate = None` with `pass_rate_denominator: "graded_units_only"` when nothing was graded — but that pattern lived only there.
- A numerator assembled from more than one outcome bucket reads as if it came from one. `covered_percent` folding model-selection handoffs in with resolved routes is fair; leaving that in a text formatter left every JSON consumer guessing. Likewise, the use-case readiness score excludes non-blocking gates from both sides, so its real denominator is `len(gates) - warnings`, a number a reader would not guess.

### User / Operator Impact

- `omh` payloads that report a rate now carry a `*_rate` block naming what was divided. Existing `coverage_percent` / `score` keys keep their names and their values.
- On a hypothetical empty corpus, a rate now reads as unmeasured instead of as a failure, and an unmeasured rate fails its target rather than passing it.

### How It Works

- `reported_rate(numerator=, denominator=, numerator_of=, denominator_of=, excluded=, digits=)` returns a frozen `ReportedRate`; `to_payload()` serializes it under `omh_reported_rate/v1`.
- `meets_target()` treats an unmeasured rate as not meeting the target. `format_reported_rate()` renders the denominator inline. `reported_rate_shape_errors()` is the closed-key validator and rejects a zero denominator reported as a number.
- The five call sites keep their existing keys and add a disclosed rate block beside them, so nothing consuming the old field breaks.

### Files And Contracts Touched

- `src/quality/reported_rate.py` (new) — `omh_reported_rate/v1`.
- `src/quality/common_request_coverage.py` — summary and per-family rows.
- `src/quality/hermes_ux_quality.py` — `score`, new `score_rate`.
- `src/quality/routing_accuracy.py` — summary and per-language buckets.
- `src/workflows/use_cases.py` — readiness `score`, new `score_rate`.
- `AGENTS.md` — new subsection under Verification.
- `tests/test_reported_rate.py` (new) — contract plus a disclosure gate over all five payload sites.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke ... release hermes-smoke ...`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: no learning contract changed.
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli release drift` (No drift, 18 checks passed); `docs ulw-inventory --check`; `docs ulw-site --check`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run — no TUI or chat surface changed; the touched payloads are local quality demos.

### Observed Evidence

- `PYTHONPATH=tests uv run python -m unittest tests.test_reported_rate` -> Ran 9 tests, OK.
- `PYTHONPATH=tests uv run python -m unittest tests.test_routing_accuracy tests.test_hermes_ux_quality tests.test_common_request_coverage tests.test_application_cases` -> Ran 20 tests, OK.
- `PYTHONPATH=tests uv run python -m unittest tests.test_cli tests.test_release_smoke` -> Ran 370 tests, no failures from these modules.
- `PYTHONPATH=tests uv run python -m unittest discover -s tests` -> Ran 8354 tests, failures=21 errors=7. The identical 28 were measured on unmodified `origin/main` in this worktree before any edit; they are the known cross-harness `.claude`-path failures caused by running inside a linked worktree under `.claude/worktrees/`, unrelated to this change.
- `uv run python -m compileall -q src tests` -> clean. `ruff check src tests` -> All checks passed. `git diff --check` -> clean.
- Five `docs ... --check` byte gates and `release drift` -> all ok.

### Not Tested / Not Applicable

- `harness validate`, `release checklist`, `release hermes-smoke`, install smoke: no installer, harness manifest, or release-channel surface changed.
- The empty-corpus branch against a real empty corpus: every corpus in this repo is a non-empty constant, so the branch is covered by direct unit tests of `reported_rate()` instead of by a payload fixture.

## Risk

- Low. Measured values are unchanged on every non-empty corpus, and the corpora here are committed constants, so no reported number moved.
- One deliberate behavior change at an unreachable edge: if `use_case_readiness` ever had zero blocking gates, its score would now report unmeasured rather than 100. The gate list is a fixed literal that always contains blocking gates, so this is not reachable today; reporting 100% of an empty set is the thing the change exists to stop.

## Compatibility / Rollout

- Additive. Existing `coverage_percent`, `score`, `resolved_percent`, and `covered_percent` keys keep their names and values; consumers reading them are unaffected.
- `score` and `coverage_percent` are now typed `int | None` / `float | None` rather than always numeric. Only an empty corpus produces `None`, which no committed corpus does.

## Release / Claims

- [x] Release-channel impact considered (`local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed

## Follow-Up

- `src/quality/paired_run_aggregation.py` was considered and deliberately left alone: it computes no rate (its output is a categorical Pareto outcome), it already separates `infra_error` from `not_observed` as named drop-out buckets, and no CLI surface prints a comparison, so a coverage ratio there would be an unread addition to a digest-bound `paired_run_decision/v1` record. If a comparison ever gains a reporting surface, add the ratio then, through `reported_rate()`.
