### PR TITLE
feat(quality): classify prompt/schema overlap on the omh tool surface

### DIFF
--- a/docs/ADDING-A-SKILL.md
+++ b/docs/ADDING-A-SKILL.md
@@ -130,6 +130,40 @@ Two rules the gate cannot check for you:
   text the remaining words are the payload; an undeclared loss is a silent
   regression, and a single-digit win is not worth re-reading every rule for.
 
+## 7. Tool-facing text: a prune candidate is never a delete
+
+The same question applies to the `src/plugin_bundle/omh/tools/` descriptions,
+with a sharper test available: a JSON schema sits beside each one, so text a
+reader could reconstruct from `(name, schema, blank outline)` is measurable
+rather than argued. `tests/test_schema_overlap.py` runs that measurement over
+every registered tool; the rules and the reviewed verdicts live in
+`src/quality/schema_overlap.py`.
+
+What the probe finds is a **prune candidate**, never an automatic delete:
+
+| Bucket | Examples |
+| --- | --- |
+| Prune candidate | Parameter names and types. `required`. Value examples that only restate an enum. Clamp ranges already declared as `minimum` / `maximum`. |
+| Keep, always | Defaults **and their direction** — `gitignore: true` does not say "respects gitignore". Routing and escalation rules. Exact output shape. Worked anti-patterns. Constraints the type system cannot express, such as a field required only for one action. |
+
+Three rules the measurement cannot apply for you:
+
+- **`git blame` the line before cutting it.** Much of what restates a schema is
+  incident scar tissue: somebody added that sentence because a model got it
+  wrong once, and the schema has not started saying it since.
+- **One sample is noise.** A single overlap hit is a question for review, not a
+  finding. The gate is that every hit carries a verdict, not that the count is
+  zero.
+- **Decide what ships before you compress it.** Scope first, density second; a
+  tighter description of a parameter that should not exist is still a worse
+  tool.
+
+The gate fails when a finding has no reviewed verdict, and it fails with the
+finding id and paste-ready instructions. Add the id to
+`REVIEWED_OVERLAP_DECISIONS` with `keep — <which bucket>` or
+`prune candidate — <what git blame showed>`. Self-documenting flag-style tools
+prune heavily; DSL and capability tools barely, so most verdicts are `keep`.
+
 ## Acknowledgements
 
 Domain taxonomy adapted from revfactory/harness (https://github.com/revfactory/harness), Apache License 2.0, Copyright 2025 robin.

--- a/src/plugin_bundle/omh/tools/__init__.py
+++ b/src/plugin_bundle/omh/tools/__init__.py
@@ -1,1 +1,68 @@
 from __future__ import annotations
+
+from typing import Any
+
+# Every tool name registered by `register()` in the parent package, in
+# registration order. Kept as data so a check can walk the tool surface
+# without importing the Hermes registration context; parity with the
+# `register()` body is a test, not a convention.
+BUILTIN_TOOL_NAMES: tuple[str, ...] = (
+    "omh_capabilities",
+    "omh_context",
+    "omh_delegate_route",
+    "omh_gather_evidence",
+    "omh_hud",
+    "omh_interact",
+    "omh_memory",
+    "omh_probe",
+    "omh_recommend",
+    "omh_role",
+    "omh_run_summary",
+    "omh_source_trust",
+    "omh_status",
+    "omh_todo",
+)
+
+
+def builtin_tool_schemas() -> tuple[dict[str, Any], ...]:
+    """Return every registered omh tool schema, name-sorted.
+
+    Imports live inside the function for the same reason `register()` does it:
+    the plugin bundle is loaded by Hermes, and a module-level import graph here
+    would pull every tool module in on package import.
+    """
+    from .capability_tool import OMH_CAPABILITIES_SCHEMA
+    from .chat_tool import OMH_INTERACT_SCHEMA
+    from .context_tool import OMH_CONTEXT_SCHEMA
+    from .delegate_route_tool import OMH_DELEGATE_ROUTE_SCHEMA
+    from .evidence_tool import OMH_EVIDENCE_SCHEMA
+    from .hud_tool import OMH_HUD_SCHEMA
+    from .memory_tool import OMH_MEMORY_SCHEMA
+    from .probe_tool import OMH_PROBE_SCHEMA
+    from .recommend_tool import OMH_RECOMMEND_SCHEMA
+    from .role_tool import OMH_ROLE_SCHEMA
+    from .run_summary_tool import OMH_RUN_SUMMARY_SCHEMA
+    from .source_trust_tool import OMH_SOURCE_TRUST_SCHEMA
+    from .status_tool import OMH_STATUS_SCHEMA
+    from .todo_tool import OMH_TODO_SCHEMA
+
+    schemas = (
+        OMH_CAPABILITIES_SCHEMA,
+        OMH_CONTEXT_SCHEMA,
+        OMH_DELEGATE_ROUTE_SCHEMA,
+        OMH_EVIDENCE_SCHEMA,
+        OMH_HUD_SCHEMA,
+        OMH_INTERACT_SCHEMA,
+        OMH_MEMORY_SCHEMA,
+        OMH_PROBE_SCHEMA,
+        OMH_RECOMMEND_SCHEMA,
+        OMH_ROLE_SCHEMA,
+        OMH_RUN_SUMMARY_SCHEMA,
+        OMH_SOURCE_TRUST_SCHEMA,
+        OMH_STATUS_SCHEMA,
+        OMH_TODO_SCHEMA,
+    )
+    return tuple(sorted(schemas, key=lambda schema: str(schema.get("name", ""))))
+
+
+__all__ = ["BUILTIN_TOOL_NAMES", "builtin_tool_schemas"]

--- a/src/quality/schema_overlap.py
+++ b/src/quality/schema_overlap.py
@@ -1,0 +1,411 @@
+"""Prompt/schema overlap probing for the omh tool surface: a candidate is never a delete.
+
+A tool description is paid for in every context window that loads the toolset,
+and part of it is often already carried by the JSON schema sitting beside it: a
+parameter's type, its enum members, its clamp range, its default, whether it is
+required. Text a reader could reconstruct from `(name, schema, blank outline)`
+is a **prune candidate**. It is never an automatic delete, and this module
+never removes anything -- it reports.
+
+The bucketing, which is the actual doctrine:
+
+**Prune candidates.** Parameter names and types. `required`. Value examples
+that only restate an enum. Clamp ranges already declared as `minimum` /
+`maximum`.
+
+**Keep, always.** Defaults *and their direction* -- `gitignore: true` does not
+say "respects gitignore", and the schema cannot say which way the boolean
+points. Routing and escalation rules. Exact output shape. Worked anti-patterns.
+Constraints the type system cannot express, such as a field required only for
+one action.
+
+Three caveats travel with the bucketing, and they are why the probe reports
+rather than edits:
+
+1. **One sample is noise.** A single overlap hit is a question, not a finding.
+2. **`git blame` each line before cutting it.** Much of what looks redundant is
+   incident scar tissue: someone added that sentence because a model got it
+   wrong once.
+3. **Memorization is not inference.** A model reconstructing text from a public
+   repository may be reciting it. That caveat bounds the *model-based* probe the
+   upstream audit describes; this module does not run one. It matches the
+   schema against its own description deterministically, which is a narrower
+   question with no recitation risk -- and a correspondingly narrower answer.
+
+So the gate here is not "no overlap". It is **every overlap is classified**:
+each finding must appear in `REVIEWED_OVERLAP_DECISIONS` with a verdict and a
+reason, so a new tool description that restates its schema gets a human
+decision rather than sliding in unread. Self-documenting flag-style tools prune
+heavily; DSL and capability tools barely -- expect most verdicts to be `keep`.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+SCHEMA_OVERLAP_SCHEMA_VERSION = "omh_schema_overlap/v1"
+
+OVERLAP_RULE_IDS = (
+    "OVERLAP_BOUND_RESTATED",
+    "OVERLAP_DEFAULT_RESTATED",
+    "OVERLAP_ENUM_RESTATED",
+    "OVERLAP_REQUIRED_RESTATED",
+    "OVERLAP_TYPE_RESTATED",
+)
+
+VERDICT_PRUNE_CANDIDATE = "prune_candidate"
+VERDICT_KEEP = "keep"
+
+# Keep reasons, one per bucket the doctrine names. A finding classified `keep`
+# always carries one of these, so "we looked and decided to keep it" is
+# distinguishable from "nobody looked".
+KEEP_REASONS = (
+    "member_semantics",
+    "bound_meaning",
+    "default_direction",
+    "conditional_requirement",
+)
+
+# A description that names every enum member is only a restatement when it
+# stops there. Measured against the current tool surface: the two descriptions
+# that teach what each member DOES carry 62 and 287 characters of text beyond
+# the member names, while the one that merely lists them carries 35. The floor
+# sits between, so "list the members" is a candidate and "say what each member
+# does" is payload.
+ENUM_SEMANTIC_RESIDUE_MIN_CHARS = 40
+
+# A description is a bare type restatement when the whole of it is a type word.
+_TYPE_ONLY = re.compile(
+    r"\A\s*(?:an?\s+)?(?:optional\s+)?"
+    r"(?:string|integer|number|boolean|bool|object|array|list|flag)\b[^.]{0,20}\.?\s*\Z",
+    re.IGNORECASE,
+)
+# Direction: text that says what a value MEANS rather than what it IS.
+_DIRECTION = re.compile(
+    r"(?:=|->|\bmeans\b|\bso that\b|\brenders?\b|\bapplies\b|\bwins over\b|\bfalls? back\b"
+    r"|\bdefaults? to the\b|\bhighest\b|\blowest\b|\btop-level\b|\bindent)",
+    re.IGNORECASE,
+)
+# A requirement the type system cannot express: required only under a condition.
+_CONDITIONAL = re.compile(r"\b(?:if|when|unless|only|except|for action)\b", re.IGNORECASE)
+_WORDS = re.compile(r"[^a-z0-9]+")
+
+
+@dataclass(frozen=True, slots=True)
+class OverlapFinding:
+    """One place a description restates something its schema already declares."""
+
+    rule: str
+    tool: str
+    path: str
+    verdict: str
+    keep_reason: str
+    detail: str
+    excerpt: str
+
+    @property
+    def id(self) -> str:
+        return f"{self.tool}.{self.path}:{self.rule}"
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "rule": self.rule,
+            "tool": self.tool,
+            "path": self.path,
+            "verdict": self.verdict,
+            "keep_reason": self.keep_reason,
+            "detail": self.detail,
+            "excerpt": self.excerpt,
+        }
+
+
+# The reviewed verdict for every overlap the probe finds today. A finding that
+# is not listed here fails the gate: the point is that somebody classified it,
+# not that the count stayed the same. Each entry is `<finding id>: <reason>`.
+REVIEWED_OVERLAP_DECISIONS: dict[str, str] = {
+    "omh_delegate_route.action:OVERLAP_ENUM_RESTATED": (
+        "keep — the description says what each of set/clear/status/fallback does to the route, "
+        "including that fallback advances the category chain and clears to parent inheritance "
+        "when exhausted. None of that is in the enum."
+    ),
+    "omh_todo.action:OVERLAP_ENUM_RESTATED": (
+        "keep — set/clear/show are named with their effect on the stored list and the rendered "
+        "projection, which is output shape, not member names."
+    ),
+    "omh_todo.items[].depth:OVERLAP_BOUND_RESTATED": (
+        "keep — the numerals carry meaning the clamp cannot: 0 is a top-level task and 1-3 render "
+        "indented beneath their parent. Cutting them leaves a range with no semantics."
+    ),
+    "omh_role.action:OVERLAP_ENUM_RESTATED": (
+        "prune candidate — 'List available roles or read one role context.' restates list/read "
+        "with only the object each acts on. Left in place pending `git blame`: it predates the "
+        "role catalog split and may be scar tissue from a model calling read without a role."
+    ),
+}
+
+
+def _text(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _residue(description: str, members: Sequence[str]) -> int:
+    lowered = description.casefold()
+    for member in members:
+        lowered = lowered.replace(str(member).casefold(), " ")
+    return len(_WORDS.sub(" ", lowered).strip())
+
+
+def _excerpt(description: str) -> str:
+    single = " ".join(description.split())
+    return single if len(single) <= 160 else f"{single[:157]}..."
+
+
+def _finding(
+    rule: str,
+    tool: str,
+    path: str,
+    description: str,
+    *,
+    keep_reason: str,
+    detail: str,
+) -> OverlapFinding:
+    return OverlapFinding(
+        rule=rule,
+        tool=tool,
+        path=path,
+        verdict=VERDICT_KEEP if keep_reason else VERDICT_PRUNE_CANDIDATE,
+        keep_reason=keep_reason,
+        detail=detail,
+        excerpt=_excerpt(description),
+    )
+
+
+def _property_findings(
+    tool: str,
+    name: str,
+    path: str,
+    spec: Mapping[str, Any],
+    required: Sequence[str],
+) -> list[OverlapFinding]:
+    description = _text(spec.get("description"))
+    if not description:
+        return []
+    findings: list[OverlapFinding] = []
+
+    if _TYPE_ONLY.match(description):
+        findings.append(
+            _finding(
+                "OVERLAP_TYPE_RESTATED",
+                tool,
+                path,
+                description,
+                keep_reason="",
+                detail=(
+                    "the whole description is the declared type; a reader recovers it from the "
+                    "schema and learns nothing else"
+                ),
+            )
+        )
+
+    members = [str(item) for item in spec.get("enum", []) or []]
+    lowered = description.casefold()
+    if members and all(member.casefold() in lowered for member in members):
+        residue = _residue(description, members)
+        semantic = residue >= ENUM_SEMANTIC_RESIDUE_MIN_CHARS
+        findings.append(
+            _finding(
+                "OVERLAP_ENUM_RESTATED",
+                tool,
+                path,
+                description,
+                keep_reason="member_semantics" if semantic else "",
+                detail=(
+                    f"names all {len(members)} enum members with {residue} characters of text "
+                    f"beyond them (floor {ENUM_SEMANTIC_RESIDUE_MIN_CHARS})"
+                ),
+            )
+        )
+
+    for bound in ("minimum", "maximum"):
+        if bound in spec and str(spec[bound]) in description:
+            findings.append(
+                _finding(
+                    "OVERLAP_BOUND_RESTATED",
+                    tool,
+                    path,
+                    description,
+                    keep_reason="bound_meaning" if _DIRECTION.search(description) else "",
+                    detail=f"repeats the declared {bound} {spec[bound]!r}",
+                )
+            )
+            break
+
+    if "default" in spec and "default" in lowered and str(spec["default"]).casefold() in lowered:
+        findings.append(
+            _finding(
+                "OVERLAP_DEFAULT_RESTATED",
+                tool,
+                path,
+                description,
+                keep_reason="default_direction" if _DIRECTION.search(description) else "",
+                detail=f"repeats the declared default {spec['default']!r}",
+            )
+        )
+
+    if name in required and re.search(r"\brequired\b", lowered):
+        findings.append(
+            _finding(
+                "OVERLAP_REQUIRED_RESTATED",
+                tool,
+                path,
+                description,
+                keep_reason="conditional_requirement" if _CONDITIONAL.search(description) else "",
+                detail="calls itself required for a property the schema already lists as required",
+            )
+        )
+    return findings
+
+
+def _walk(
+    tool: str,
+    properties: Mapping[str, Any],
+    required: Sequence[str],
+    prefix: str = "",
+) -> list[OverlapFinding]:
+    findings: list[OverlapFinding] = []
+    for name in sorted(properties):
+        spec = properties[name]
+        if not isinstance(spec, Mapping):
+            continue
+        findings.extend(_property_findings(tool, name, f"{prefix}{name}", spec, required))
+        nested = spec.get("properties")
+        if isinstance(nested, Mapping):
+            findings.extend(_walk(tool, nested, spec.get("required", []) or [], f"{prefix}{name}."))
+        items = spec.get("items")
+        if isinstance(items, Mapping) and isinstance(items.get("properties"), Mapping):
+            findings.extend(
+                _walk(tool, items["properties"], items.get("required", []) or [], f"{prefix}{name}[].")
+            )
+    return findings
+
+
+def schema_overlap_findings(
+    schemas: Sequence[Mapping[str, Any]] | None = None,
+) -> list[OverlapFinding]:
+    """Return every place a tool description restates its own schema."""
+    if schemas is None:
+        from ..plugin_bundle.omh.tools import builtin_tool_schemas
+
+        schemas = builtin_tool_schemas()
+    findings: list[OverlapFinding] = []
+    for schema in schemas:
+        tool = _text(schema.get("name"))
+        parameters = schema.get("parameters")
+        if not isinstance(parameters, Mapping):
+            continue
+        properties = parameters.get("properties")
+        if not isinstance(properties, Mapping):
+            continue
+        findings.extend(_walk(tool, properties, parameters.get("required", []) or []))
+    return sorted(findings, key=lambda finding: finding.id)
+
+
+def unreviewed_overlap_findings(
+    findings: Sequence[OverlapFinding] | None = None,
+) -> list[OverlapFinding]:
+    """Return findings nobody has classified yet — the gate's failure set."""
+    resolved = schema_overlap_findings() if findings is None else list(findings)
+    return [finding for finding in resolved if finding.id not in REVIEWED_OVERLAP_DECISIONS]
+
+
+def stale_overlap_decisions(
+    findings: Sequence[OverlapFinding] | None = None,
+) -> list[str]:
+    """Return reviewed decisions whose finding no longer exists.
+
+    A decision left behind after its description was rewritten is a claim about
+    text that is gone, so it goes when the overlap goes.
+    """
+    resolved = schema_overlap_findings() if findings is None else list(findings)
+    live = {finding.id for finding in resolved}
+    return sorted(set(REVIEWED_OVERLAP_DECISIONS) - live)
+
+
+def schema_overlap_payload() -> dict[str, object]:
+    findings = schema_overlap_findings()
+    unreviewed = unreviewed_overlap_findings(findings)
+    stale = stale_overlap_decisions(findings)
+    return {
+        "schema_version": SCHEMA_OVERLAP_SCHEMA_VERSION,
+        "description": (
+            "Deterministic overlap between omh tool descriptions and their own JSON schemas. "
+            "Every finding is a prune candidate or a reviewed keep; this probe never deletes "
+            "text and never runs a model."
+        ),
+        "ok": not unreviewed and not stale,
+        "rules": list(OVERLAP_RULE_IDS),
+        "keep_reasons": list(KEEP_REASONS),
+        "finding_count": len(findings),
+        "prune_candidate_count": sum(
+            1 for finding in findings if finding.verdict == VERDICT_PRUNE_CANDIDATE
+        ),
+        "keep_count": sum(1 for finding in findings if finding.verdict == VERDICT_KEEP),
+        "unreviewed": [finding.to_payload() for finding in unreviewed],
+        "stale_decisions": stale,
+        "findings": [finding.to_payload() for finding in findings],
+        "claim_boundary": (
+            "A prune candidate is a question for a reviewer, never an automatic delete. "
+            "`git blame` the line first: much of what restates a schema is incident scar tissue."
+        ),
+    }
+
+
+def format_schema_overlap_report(payload: Mapping[str, object]) -> str:
+    """Render the probe as a paste-ready review report."""
+    lines = [
+        f"omh tool prompt/schema overlap: {payload.get('finding_count', 0)} finding(s), "
+        f"{payload.get('prune_candidate_count', 0)} prune candidate(s), "
+        f"{payload.get('keep_count', 0)} reviewed keep(s)."
+    ]
+    for finding in payload.get("findings", []):  # type: ignore[union-attr]
+        verdict = str(finding["verdict"])
+        reason = f" ({finding['keep_reason']})" if finding["keep_reason"] else ""
+        lines.append(f"  [{finding['rule']}] {finding['tool']}.{finding['path']} -> {verdict}{reason}")
+        lines.append(f"    {finding['detail']}")
+        lines.append(f"    > {finding['excerpt']}")
+    unreviewed = list(payload.get("unreviewed", []))  # type: ignore[arg-type]
+    if unreviewed:
+        lines.append(
+            f"  {len(unreviewed)} finding(s) have no reviewed verdict. Add each id to "
+            "REVIEWED_OVERLAP_DECISIONS in src/quality/schema_overlap.py with either "
+            "'keep — <which bucket>' or 'prune candidate — <what git blame showed>':"
+        )
+        for finding in unreviewed:
+            lines.append(f"    {finding['id']}")
+    for stale in payload.get("stale_decisions", []):  # type: ignore[union-attr]
+        lines.append(f"  stale decision, its overlap is gone: {stale}")
+    lines.append(
+        "  Prune candidate is never an automatic delete. Keep defaults and their direction, "
+        "routing rules, exact output shape, worked anti-patterns, and type-invisible constraints."
+    )
+    return "\n".join(lines)
+
+
+__all__ = [
+    "ENUM_SEMANTIC_RESIDUE_MIN_CHARS",
+    "KEEP_REASONS",
+    "OVERLAP_RULE_IDS",
+    "REVIEWED_OVERLAP_DECISIONS",
+    "SCHEMA_OVERLAP_SCHEMA_VERSION",
+    "VERDICT_KEEP",
+    "VERDICT_PRUNE_CANDIDATE",
+    "OverlapFinding",
+    "format_schema_overlap_report",
+    "schema_overlap_findings",
+    "schema_overlap_payload",
+    "stale_overlap_decisions",
+    "unreviewed_overlap_findings",
+]

--- a/tests/test_schema_overlap.py
+++ b/tests/test_schema_overlap.py
@@ -29,13 +29,25 @@ _REGISTER = _REPO_ROOT / "src" / "plugin_bundle" / "omh" / "__init__.py"
 
 
 class ToolSurfaceCoverageTests(unittest.TestCase):
-    """The probe is only honest if it walks every registered tool."""
+    """The probe is only honest if it walks every registered tool.
+
+    Both checks below read committed repository sources, which is why every
+    read here passes `encoding="utf-8"` explicitly. `Path.read_text()` with no
+    encoding uses `locale.getencoding()` -- cp1252 on Windows -- and the tool
+    sources carry non-ASCII on purpose (`run_summary_tool.py` documents its
+    localized output in Korean), so the default would decode-error there and
+    nowhere else.
+    """
 
     def test_collector_covers_every_schema_defined_under_tools(self) -> None:
         declared = {
             match.group(1)
             for path in sorted(_TOOLS_DIR.glob("*.py"))
-            for match in re.finditer(r"^(OMH_[A-Z_]+_SCHEMA)\s*=\s*\{", path.read_text(), re.MULTILINE)
+            for match in re.finditer(
+                r"^(OMH_[A-Z_]+_SCHEMA)\s*=\s*\{",
+                path.read_text(encoding="utf-8"),
+                re.MULTILINE,
+            )
         }
         collected = {
             f"OMH_{str(schema['name']).removeprefix('omh_').upper()}_SCHEMA"
@@ -46,7 +58,12 @@ class ToolSurfaceCoverageTests(unittest.TestCase):
         self.assertEqual(len(builtin_tool_schemas()), len(declared), sorted(declared - collected))
 
     def test_collector_and_name_list_match_the_registered_tools(self) -> None:
-        registered = set(re.findall(r'ctx\.register_tool\(\s*"([a-z_]+)"', _REGISTER.read_text()))
+        registered = set(
+            re.findall(
+                r'ctx\.register_tool\(\s*"([a-z_]+)"',
+                _REGISTER.read_text(encoding="utf-8"),
+            )
+        )
         self.assertEqual(set(BUILTIN_TOOL_NAMES), registered)
         self.assertEqual(
             [str(schema["name"]) for schema in builtin_tool_schemas()],

--- a/tests/test_schema_overlap.py
+++ b/tests/test_schema_overlap.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.plugin_bundle.omh.tools import BUILTIN_TOOL_NAMES, builtin_tool_schemas  # noqa: E402
+from omh.quality.schema_overlap import (  # noqa: E402
+    ENUM_SEMANTIC_RESIDUE_MIN_CHARS,
+    KEEP_REASONS,
+    REVIEWED_OVERLAP_DECISIONS,
+    SCHEMA_OVERLAP_SCHEMA_VERSION,
+    VERDICT_KEEP,
+    VERDICT_PRUNE_CANDIDATE,
+    format_schema_overlap_report,
+    schema_overlap_findings,
+    schema_overlap_payload,
+    stale_overlap_decisions,
+    unreviewed_overlap_findings,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_TOOLS_DIR = _REPO_ROOT / "src" / "plugin_bundle" / "omh" / "tools"
+_REGISTER = _REPO_ROOT / "src" / "plugin_bundle" / "omh" / "__init__.py"
+
+
+class ToolSurfaceCoverageTests(unittest.TestCase):
+    """The probe is only honest if it walks every registered tool."""
+
+    def test_collector_covers_every_schema_defined_under_tools(self) -> None:
+        declared = {
+            match.group(1)
+            for path in sorted(_TOOLS_DIR.glob("*.py"))
+            for match in re.finditer(r"^(OMH_[A-Z_]+_SCHEMA)\s*=\s*\{", path.read_text(), re.MULTILINE)
+        }
+        collected = {
+            f"OMH_{str(schema['name']).removeprefix('omh_').upper()}_SCHEMA"
+            for schema in builtin_tool_schemas()
+        }
+        # Two names differ from the mechanical derivation; assert the count and
+        # the tool names instead of guessing at constant spelling.
+        self.assertEqual(len(builtin_tool_schemas()), len(declared), sorted(declared - collected))
+
+    def test_collector_and_name_list_match_the_registered_tools(self) -> None:
+        registered = set(re.findall(r'ctx\.register_tool\(\s*"([a-z_]+)"', _REGISTER.read_text()))
+        self.assertEqual(set(BUILTIN_TOOL_NAMES), registered)
+        self.assertEqual(
+            [str(schema["name"]) for schema in builtin_tool_schemas()],
+            sorted(BUILTIN_TOOL_NAMES),
+        )
+
+
+class SchemaOverlapProbeTests(unittest.TestCase):
+    def test_every_overlap_carries_a_reviewed_verdict(self) -> None:
+        # Given: the probe over the live tool surface.
+        payload = schema_overlap_payload()
+
+        # Then: nothing is unclassified and no decision outlives its finding.
+        self.assertEqual(
+            payload["unreviewed"],
+            [],
+            format_schema_overlap_report(payload),
+        )
+        self.assertEqual(payload["stale_decisions"], [], format_schema_overlap_report(payload))
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["schema_version"], SCHEMA_OVERLAP_SCHEMA_VERSION)
+
+    def test_reviewed_decisions_state_a_verdict_and_a_reason(self) -> None:
+        for finding_id, reason in sorted(REVIEWED_OVERLAP_DECISIONS.items()):
+            with self.subTest(finding=finding_id):
+                self.assertTrue(
+                    reason.startswith(("keep — ", "prune candidate — ")),
+                    f"{finding_id}: a decision names its verdict and why",
+                )
+                self.assertGreater(len(reason), 60, f"{finding_id}: a reason is not a label")
+
+    def test_probe_reports_candidates_and_never_deletes(self) -> None:
+        # The probe's whole output is a report; nothing it returns is a mutation
+        # and nothing in the payload authorises one.
+        payload = schema_overlap_payload()
+        self.assertIn("never an automatic delete", str(payload["claim_boundary"]))
+        self.assertIn("git blame", str(payload["claim_boundary"]))
+        self.assertEqual(
+            payload["finding_count"],
+            payload["prune_candidate_count"] + payload["keep_count"],
+        )
+        for finding in payload["findings"]:
+            with self.subTest(finding=finding["id"]):
+                self.assertIn(finding["verdict"], {VERDICT_KEEP, VERDICT_PRUNE_CANDIDATE})
+                if finding["verdict"] == VERDICT_KEEP:
+                    self.assertIn(finding["keep_reason"], KEEP_REASONS)
+                else:
+                    self.assertEqual(finding["keep_reason"], "")
+
+
+class OverlapRuleTests(unittest.TestCase):
+    """Each rule is exercised on a synthetic schema, both directions."""
+
+    def _findings(self, properties: dict, required: list[str] | None = None) -> dict[str, str]:
+        schema = {
+            "name": "demo_tool",
+            "description": "Demo.",
+            "parameters": {
+                "type": "object",
+                "properties": properties,
+                "required": required or [],
+            },
+        }
+        return {finding.rule: finding.verdict for finding in schema_overlap_findings([schema])}
+
+    def test_bare_type_restatement_is_a_prune_candidate(self) -> None:
+        self.assertEqual(
+            self._findings({"limit": {"type": "integer", "description": "An integer."}}),
+            {"OVERLAP_TYPE_RESTATED": VERDICT_PRUNE_CANDIDATE},
+        )
+
+    def test_a_description_that_says_what_the_type_is_for_is_not_a_finding(self) -> None:
+        self.assertEqual(
+            self._findings(
+                {"limit": {"type": "integer", "description": "How many route candidates to score."}}
+            ),
+            {},
+        )
+
+    def test_enum_listing_is_a_candidate_and_enum_semantics_are_a_keep(self) -> None:
+        listing = {"mode": {"type": "string", "enum": ["fast", "full"], "description": "fast or full."}}
+        self.assertEqual(
+            self._findings(listing), {"OVERLAP_ENUM_RESTATED": VERDICT_PRUNE_CANDIDATE}
+        )
+
+        semantics = {
+            "mode": {
+                "type": "string",
+                "enum": ["fast", "full"],
+                "description": (
+                    "fast scores only the explicit trigger table and returns within one turn; "
+                    "full scores the whole catalog and may ask a clarifying question first."
+                ),
+            }
+        }
+        self.assertEqual(self._findings(semantics), {"OVERLAP_ENUM_RESTATED": VERDICT_KEEP})
+
+    def test_the_enum_residue_floor_is_where_the_verdict_flips(self) -> None:
+        members = ["fast", "full"]
+        # Residue is what survives after the member names are struck out, so
+        # "or" and its separator already count: pad to one below the floor.
+        padding = "x" * (ENUM_SEMANTIC_RESIDUE_MIN_CHARS - 1 - len("or "))
+        below = {"mode": {"type": "string", "enum": members, "description": f"fast or full {padding}"}}
+        above = {"mode": {"type": "string", "enum": members, "description": f"fast or full {padding}y"}}
+        self.assertEqual(self._findings(below)["OVERLAP_ENUM_RESTATED"], VERDICT_PRUNE_CANDIDATE)
+        self.assertEqual(self._findings(above)["OVERLAP_ENUM_RESTATED"], VERDICT_KEEP)
+
+    def test_a_bare_clamp_restatement_is_a_candidate_and_bound_meaning_is_a_keep(self) -> None:
+        bare = {"depth": {"type": "integer", "minimum": 0, "description": "Nesting, at least 0."}}
+        self.assertEqual(
+            self._findings(bare), {"OVERLAP_BOUND_RESTATED": VERDICT_PRUNE_CANDIDATE}
+        )
+
+        meaningful = {
+            "depth": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Nesting level; 0 = top-level task.",
+            }
+        }
+        self.assertEqual(self._findings(meaningful), {"OVERLAP_BOUND_RESTATED": VERDICT_KEEP})
+
+    def test_a_bare_default_restatement_is_a_candidate_and_direction_is_a_keep(self) -> None:
+        bare = {
+            "source": {"type": "string", "default": "hermes", "description": "Default is hermes."}
+        }
+        self.assertEqual(
+            self._findings(bare), {"OVERLAP_DEFAULT_RESTATED": VERDICT_PRUNE_CANDIDATE}
+        )
+
+        # `gitignore: true` does not say "respects gitignore": the direction a
+        # default points is the thing the schema cannot carry.
+        direction = {
+            "gitignore": {
+                "type": "boolean",
+                "default": "true",
+                "description": "Defaults to the true setting, which means ignored paths are skipped.",
+            }
+        }
+        self.assertEqual(self._findings(direction), {"OVERLAP_DEFAULT_RESTATED": VERDICT_KEEP})
+
+    def test_unconditional_required_is_a_candidate_and_conditional_required_is_a_keep(self) -> None:
+        unconditional = {"role": {"type": "string", "description": "Role name. Required."}}
+        self.assertEqual(
+            self._findings(unconditional, ["role"]),
+            {"OVERLAP_REQUIRED_RESTATED": VERDICT_PRUNE_CANDIDATE},
+        )
+
+        conditional = {
+            "role": {"type": "string", "description": "Role name. Required only when action=read."}
+        }
+        self.assertEqual(
+            self._findings(conditional, ["role"]),
+            {"OVERLAP_REQUIRED_RESTATED": VERDICT_KEEP},
+        )
+
+
+class OverlapGateFailureTests(unittest.TestCase):
+    def test_an_unreviewed_finding_fails_with_paste_ready_instructions(self) -> None:
+        schema = {
+            "name": "unreviewed_tool",
+            "description": "Demo.",
+            "parameters": {
+                "type": "object",
+                "properties": {"limit": {"type": "integer", "description": "An integer."}},
+            },
+        }
+        findings = schema_overlap_findings([schema])
+        unreviewed = unreviewed_overlap_findings(findings)
+        self.assertEqual([finding.id for finding in unreviewed], ["unreviewed_tool.limit:OVERLAP_TYPE_RESTATED"])
+
+        report = format_schema_overlap_report(
+            {
+                "finding_count": len(findings),
+                "prune_candidate_count": len(findings),
+                "keep_count": 0,
+                "findings": [finding.to_payload() for finding in findings],
+                "unreviewed": [finding.to_payload() for finding in unreviewed],
+                "stale_decisions": [],
+                "claim_boundary": "",
+            }
+        )
+        self.assertIn("REVIEWED_OVERLAP_DECISIONS", report)
+        self.assertIn("src/quality/schema_overlap.py", report)
+        self.assertIn("unreviewed_tool.limit:OVERLAP_TYPE_RESTATED", report)
+
+    def test_a_decision_whose_overlap_is_gone_is_reported_stale(self) -> None:
+        self.assertEqual(stale_overlap_decisions([]), sorted(REVIEWED_OVERLAP_DECISIONS))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New `src/quality/schema_overlap.py`: a deterministic probe that finds text in an omh tool description already carried by its own JSON schema, and classifies each hit as a reviewed `keep` (with a named reason) or a `prune candidate`.
- New `builtin_tool_schemas()` / `BUILTIN_TOOL_NAMES` in `src/plugin_bundle/omh/tools/__init__.py`, so a check can walk the tool surface without a Hermes registration context.
- `docs/ADDING-A-SKILL.md` section 7: the bucketing table (what is a prune candidate, what is always a keep) and the three rules the measurement cannot apply.
- `tests/test_schema_overlap.py`: the gate plus both directions of all five rules.

### Why This Exists

- Every tool description is paid for in every context window that loads the toolset, and part of it is often reconstructible from `(name, schema, blank outline)` — parameter types, enum members, clamp ranges, defaults, `required`.
- The valuable half of that observation is the word "candidate". Much of what looks redundant is incident scar tissue: somebody wrote that sentence because a model got it wrong once, and the schema has not started saying it since. So the deliverable is a recorded verdict, not an edit.
- The gate is therefore not "no overlap" but "every overlap is classified". A new description that restates its schema gets a human decision instead of sliding in unread.

### User / Operator Impact

- No runtime behavior changes; no tool description was edited in this PR.
- Authors adding or rewording an omh tool now get a test failure naming the finding id and the two verdict forms to choose from.

### How It Works

- Five rules over each property spec: bare type restatement, enum listing, clamp restatement, default restatement, and unconditional `required`.
- A hit becomes a `keep` when the description carries what the schema cannot — per-member semantics, what a bound means, which way a default points, or a requirement conditional on another field. Otherwise it stays a `prune candidate`.
- The enum floor is measured rather than guessed: the two descriptions that teach what each member does carry 62 and 287 characters of text beyond the member names; the one that merely lists them carries 35. `ENUM_SEMANTIC_RESIDUE_MIN_CHARS = 40` sits between.
- `stale_overlap_decisions()` also fails a decision left behind after its description was rewritten, so the registry cannot accumulate claims about text that is gone.

### Files And Contracts Touched

- `src/quality/schema_overlap.py` (new) — `omh_schema_overlap/v1`.
- `src/plugin_bundle/omh/tools/__init__.py` — collector and name list.
- `docs/ADDING-A-SKILL.md` — new section 7.
- `tests/test_schema_overlap.py` (new).

Measured over all 14 registered tools: **4 findings, 3 reviewed keeps, 1 prune candidate**. That ratio is the expected shape — self-documenting flag-style tools prune heavily, DSL and capability tools barely, and omh's tools are the second kind. The one candidate (`omh_role.action`) is left in place with its reason recorded.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke ... release hermes-smoke ...`
- [ ] Relevant workflow-learning review queue smoke: no learning contract changed.
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli release drift` (No drift, 18 checks passed); `docs ulw-inventory --check`; `docs ulw-site --check`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run — no tool description, schema, or handler changed, so the plugin surface Hermes loads is byte-identical.

### Observed Evidence

- `PYTHONPATH=tests uv run python -m unittest tests.test_schema_overlap` -> Ran 14 tests, OK.
- Probe output over the live tool surface:
  ```
  omh tool prompt/schema overlap: 4 finding(s), 1 prune candidate(s), 3 reviewed keep(s).
    [OVERLAP_ENUM_RESTATED] omh_delegate_route.action -> keep (member_semantics)
    [OVERLAP_ENUM_RESTATED] omh_role.action -> prune_candidate
    [OVERLAP_ENUM_RESTATED] omh_todo.action -> keep (member_semantics)
    [OVERLAP_BOUND_RESTATED] omh_todo.items[].depth -> keep (bound_meaning)
  ```
- `PYTHONPATH=tests uv run python -m unittest discover -s tests` -> Ran 8359 tests, failures=21 errors=7. The identical 28 were measured on unmodified `origin/main` in this worktree before any edit; they are the known cross-harness `.claude`-path failures caused by running inside a linked worktree under `.claude/worktrees/`, unrelated to this change.
- `uv run python -m compileall -q src tests` -> clean. `ruff check src tests` -> All checks passed. `git diff --check` -> clean.
- Five `docs ... --check` byte gates and `release drift` -> all ok.

### Not Tested / Not Applicable

- `harness validate`, `release checklist`, `release hermes-smoke`, install smoke: no installer, harness manifest, or release-channel surface changed.
- The model-based recovery probe the upstream audit describes (does a model reconstruct this text from name + schema alone?): OMH makes no model calls, so cross-sample and cross-model recovery is out of scope by boundary, not by omission. The upstream caveat that a public repo may be training data — making recovery recitation rather than inference — is the reason that half is not worth faking locally.

## Risk

- Low. Nothing in the shipped plugin bundle changed except an additive collector function whose imports stay inside the function body, matching how `register()` already defers them.
- The gate can fail a future PR that adds a tool. That is the intent, and the failure message names the finding id and the two verdict forms.

## Compatibility / Rollout

- Additive. No tool description, schema, or handler changed.

## Release / Claims

- [x] Release-channel impact considered (`local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed

## Follow-Up

- `omh_role.action` is recorded as a prune candidate, not cut. Cutting it needs a `git blame` pass on the line first: it predates the role catalog split and may be scar tissue from a model calling `read` without a `role`.
