### PR TITLE
feat(learning): calibrate the routing corpus against recorded decisions

### DIFF
--- a/docs/routing-quality.md
+++ b/docs/routing-quality.md
@@ -94,3 +94,62 @@ every language with a shipped `--language` / `OMH_LANG` **output**
 localization also ships a **trigger** pack, so input and output support cannot
 diverge. `tests/test_trigger_holdback_reachability.py` proves no hold-back
 entry, in any language, quietly removes nothing.
+
+## Calibrating the corpus against real recorded decisions
+
+`ROUTING_PRECISION_CASES` and `ROUTING_INTERVENTION_CASES` are hand-written.
+That is right for guarding regressions and useless for answering "does this
+corpus look like what the router actually sees?" Tuning a threshold against a
+corpus nobody has compared to real traffic is tuning against an assumption.
+
+`omh chat route --record` already writes the raw material: one
+`runtime/runs/<run-id>/routing.json` per recorded decision, carrying the
+`route_decision/v1` contract. `omh learning route-calibration` aggregates those
+files — no network, no model.
+
+```sh
+# Record decisions as you use the router. --record is per invocation.
+omh chat route --record "why is the build failing on main"
+
+# Read them back. --json for the full payload.
+omh learning route-calibration
+omh learning route-calibration --since "" --json   # every record, ignoring the window
+```
+
+**What it can and cannot tell you.** A routing record stores `message_sha256`
+and `message_length`, never the message. So the report calibrates *decision
+distributions* — which router stages fire, how often the router is confident,
+how thin its margins run — and never phrasings. A new corpus phrase still has
+to come from an operator's own message; these numbers say whether the corpus's
+shape is wrong, not which sentence to add.
+
+The procedure:
+
+1. **Record a working week's worth of real decisions.** One sample is noise.
+   Anything you would otherwise have typed into Hermes goes through
+   `omh chat route --record` instead.
+2. **Read parse coverage first, before any other number.** The report opens
+   with `parsed / routing records found`, and names every skipped record under
+   a reason (`no_routing_record`, `unreadable_json`, `unexpected_schema`,
+   `missing_recorded_at`, `recorded_before_since`). A format skew that silently
+   dropped a third of the records would bias everything below it, and nothing
+   else in the output would say so. An empty store reports coverage as
+   unmeasured, not as 0%.
+3. **Compare shape, not counts.** Corpus totals and recorded totals are not
+   commensurate. What is comparable: the router-stage mix, the confidence mix,
+   and the margin spread. A corpus whose cases are almost all `explicit` while
+   real decisions are mostly `recommendation` is tuned for a router path the
+   operator rarely takes.
+4. **Read the day-normalized median, not the flat one.** Recorded routing runs
+   carry no session id, so the recording day is the normalization unit and the
+   payload says so. `normalized_median` is the median of per-day medians, so an
+   afternoon of heavy recording cannot dominate. When the two disagree
+   sharply, the flat median is describing one day.
+5. **Mind the window.** `--since` defaults to the modification time of
+   `src/routing/chat.py`, so the default report covers only decisions made by
+   the current router. Widen it with an explicit `--since` when you want a
+   before/after across a router change, and say which window a reported number
+   came from.
+6. **Then change one thing.** Add the cases, move the threshold, or adjust the
+   triggers — and re-run both the corpus gates and this report, quoting the
+   window and the parse coverage alongside any number you report.

--- a/src/commands/learning.py
+++ b/src/commands/learning.py
@@ -5,6 +5,10 @@ import json
 
 from ..ingress import CHAT_SOURCES, extract_message_text
 from ..installer import OmhError
+from ..quality.routing_log_calibration import (
+    build_routing_log_calibration,
+    format_routing_log_calibration,
+)
 from ..routing.chat import CONFIDENCE_LEVELS
 from ..workflow_learning import (
     WorkflowLearningError,
@@ -56,7 +60,7 @@ from ..workflows.skill_draft import (
 )
 from ..local_store import utc_now
 from ..wrapper.contract import INTERACTION_MODES, build_chat_interaction_payload
-from .common import _chat_input_and_metadata, _explicit_source_metadata, _paths, _print_json
+from .common import _chat_input_and_metadata, _explicit_source_metadata, _paths, _print_json, _wants_json
 
 
 def cmd_learning_route_signal(args: argparse.Namespace) -> int:
@@ -467,6 +471,18 @@ def cmd_learning_metrics(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_learning_route_calibration(args: argparse.Namespace) -> int:
+    """Compare the hand-written routing corpus against locally recorded decisions."""
+    paths = _paths(args)
+    since = None if args.since is None else str(args.since)
+    payload = build_routing_log_calibration(paths.runtime_runs_dir, since=since)
+    if _wants_json(args):
+        _print_json(payload)
+    else:
+        print(format_routing_log_calibration(payload))
+    return 0
+
+
 SKILL_DRAFT_CLAIM_BOUNDARY_NOTE = (
     "A skill draft is review material stored under .omh/learning/skill-drafts/. OMH did not install a skill, "
     "write anything under skills/, register catalog data, run the workflow, pass review, run CI, or merge."
@@ -826,6 +842,25 @@ def _add_learning_commands(sub) -> None:
     )
     metrics.add_argument("--limit", type=int, default=None, help="Use only the newest N learning traces.")
     metrics.set_defaults(func=cmd_learning_metrics)
+
+    calibration = learning_sub.add_parser(
+        "route-calibration",
+        help=(
+            "Compare the hand-written routing corpus against locally recorded routing decisions "
+            "(no network, no model, no message text)."
+        ),
+    )
+    calibration.add_argument(
+        "--since",
+        default=None,
+        help=(
+            "ISO-8601 lower bound on the recorded timestamp. Defaults to the modification time of "
+            "src/routing/chat.py, so the report covers decisions made by the current router; pass "
+            "an empty string to read every record."
+        ),
+    )
+    calibration.add_argument("--json", action="store_true", help="Print the full machine-readable payload.")
+    calibration.set_defaults(func=cmd_learning_route_calibration)
 
     regression = learning_sub.add_parser("regression", help="Manage deterministic workflow regression cases.")
     regression_sub = regression.add_subparsers(dest="regression_command", required=True)

--- a/src/quality/routing_log_calibration.py
+++ b/src/quality/routing_log_calibration.py
@@ -1,0 +1,305 @@
+"""Calibrate the routing corpus against locally recorded routing decisions.
+
+`ROUTING_PRECISION_CASES` and `ROUTING_INTERVENTION_CASES` are hand-written.
+They are the right shape for guarding regressions, and no shape at all for
+answering "does this corpus look like what the router actually sees?" Tuning a
+threshold against a corpus nobody has compared to real traffic is tuning
+against an assumption.
+
+`omh chat route --record` already writes the raw material: one
+`runtime/runs/<run-id>/routing.json` per recorded decision, carrying the
+`route_decision/v1` contract — router stage, action, selected skill, confidence,
+score, threshold, and the top-two score margin. This module aggregates those
+files. No network, no model, no prompt text.
+
+**What this cannot tell you.** A routing record stores `message_sha256` and
+`message_length`, never the message. That is a deliberate privacy boundary, and
+it means this surface calibrates *decision distributions* — which stages fire,
+how often the router is confident, how thin its margins run — and never
+phrasings. A new corpus phrasing still has to come from an operator's own
+message; the numbers here say whether the corpus's *shape* is wrong, not which
+sentence to add.
+
+Two methodology rules, both copied deliberately:
+
+- **Print parse coverage.** Every report names how many run directories were
+  walked, how many carried a routing record, how many parsed, and why each
+  skipped file was skipped. A format skew that silently drops a third of the
+  corpus would otherwise bias every number below it, and nothing in the output
+  would say so.
+- **Normalize before taking a median.** A single heavy day of recording would
+  otherwise dominate a flat median. The report carries both: the flat median
+  over all decisions, and the median of per-day medians. OMH's routing runs
+  carry no session id, so the recording day is the normalization unit, and the
+  payload names it rather than implying a session.
+
+`--since` defaults to the modification time of the router source being studied
+(`src/routing/chat.py`), so the default report covers only decisions recorded
+after the router last changed. Comparing a corpus against decisions made by a
+router that no longer exists is the easiest way to calibrate against noise.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+ROUTING_LOG_CALIBRATION_SCHEMA_VERSION = "omh_routing_log_calibration/v1"
+
+# Every reason a routing record can leave the denominator, named. A skipped
+# file that is only counted is a file nobody can argue with.
+SKIP_REASONS = (
+    "no_routing_record",
+    "unreadable_json",
+    "not_an_object",
+    "unexpected_schema",
+    "missing_recorded_at",
+    "recorded_before_since",
+)
+
+# The router source whose modification time bounds the default window.
+ROUTER_SOURCE_RELATIVE_PATH = "src/routing/chat.py"
+
+CLAIM_BOUNDARY = (
+    "Routing log calibration reads locally recorded routing decisions only. Records carry "
+    "message_sha256 and message_length, never message text, so this compares decision "
+    "distributions and never phrasings. It is not live Hermes chat evidence, executor dispatch, "
+    "implementation, verification, review, CI, or merge evidence."
+)
+
+
+@dataclass(slots=True)
+class CalibrationCoverage:
+    """How much of the local record actually reached the numbers below."""
+
+    run_dirs_seen: int = 0
+    routing_records_found: int = 0
+    parsed: int = 0
+    skipped: Counter[str] = field(default_factory=Counter)
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "run_dirs_seen": self.run_dirs_seen,
+            "routing_records_found": self.routing_records_found,
+            "parsed": self.parsed,
+            "parse_coverage_percent": (
+                round(self.parsed * 100 / self.routing_records_found, 1)
+                if self.routing_records_found
+                else None
+            ),
+            "parse_coverage_numerator": "parsed routing records",
+            "parse_coverage_denominator": "routing records found on disk",
+            "skipped": {reason: self.skipped[reason] for reason in SKIP_REASONS if self.skipped[reason]},
+            "skipped_total": sum(self.skipped.values()),
+        }
+
+
+def router_source_mtime(repo_root: Path | None = None) -> str:
+    """Return the router source's mtime as an ISO-8601 UTC timestamp, or ''.
+
+    Defaulting the window to this is the point: a decision recorded by a router
+    that has since changed is evidence about a router that no longer exists.
+    """
+    from datetime import datetime, timezone
+
+    root = repo_root if repo_root is not None else Path(__file__).resolve().parents[2]
+    source = root / ROUTER_SOURCE_RELATIVE_PATH
+    try:
+        stamp = source.stat().st_mtime
+    except OSError:
+        return ""
+    return datetime.fromtimestamp(stamp, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _median(values: Sequence[float]) -> float | None:
+    ordered = sorted(values)
+    if not ordered:
+        return None
+    middle = len(ordered) // 2
+    if len(ordered) % 2:
+        return float(ordered[middle])
+    return round((ordered[middle - 1] + ordered[middle]) / 2, 2)
+
+
+def _recording_day(recorded_at: str) -> str:
+    return recorded_at[:10]
+
+
+def _read_routing_record(path: Path) -> tuple[Mapping[str, Any] | None, str]:
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None, "unreadable_json"
+    if not isinstance(parsed, dict):
+        return None, "not_an_object"
+    decision = parsed.get("route_decision")
+    if not isinstance(decision, dict) or not str(decision.get("schema_version", "")).startswith("route_decision/"):
+        return None, "unexpected_schema"
+    if not str(parsed.get("updated_at", "")):
+        return None, "missing_recorded_at"
+    return parsed, ""
+
+
+def collect_routing_records(
+    runs_dir: Path,
+    *,
+    since: str = "",
+) -> tuple[list[Mapping[str, Any]], CalibrationCoverage]:
+    """Read every recorded routing decision, counting what was skipped and why."""
+    coverage = CalibrationCoverage()
+    records: list[Mapping[str, Any]] = []
+    if not runs_dir.exists():
+        return records, coverage
+    for run_dir in sorted(path for path in runs_dir.glob("*") if path.is_dir()):
+        coverage.run_dirs_seen += 1
+        routing_path = run_dir / "routing.json"
+        if not routing_path.exists():
+            coverage.skipped["no_routing_record"] += 1
+            continue
+        coverage.routing_records_found += 1
+        record, reason = _read_routing_record(routing_path)
+        if record is None:
+            coverage.skipped[reason] += 1
+            continue
+        if since and str(record.get("updated_at", "")) < since:
+            coverage.skipped["recorded_before_since"] += 1
+            continue
+        coverage.parsed += 1
+        records.append(record)
+    return records, coverage
+
+
+def _corpus_shape() -> dict[str, object]:
+    from .routing_precision import ROUTING_INTERVENTION_CASES, ROUTING_PRECISION_CASES
+
+    return {
+        "precision_case_count": len(ROUTING_PRECISION_CASES),
+        "intervention_case_count": len(ROUTING_INTERVENTION_CASES),
+        "total_case_count": len(ROUTING_PRECISION_CASES) + len(ROUTING_INTERVENTION_CASES),
+        "note": (
+            "The corpus is hand-written and holds message text; recorded decisions hold none. "
+            "Compare the two on decision shape — stage mix, confidence mix, margin spread — "
+            "and source any new phrasing from an operator's own message."
+        ),
+    }
+
+
+def build_routing_log_calibration(
+    runs_dir: Path,
+    *,
+    since: str | None = None,
+    repo_root: Path | None = None,
+) -> dict[str, object]:
+    """Aggregate recorded routing decisions into a calibration report."""
+    if since is None:
+        resolved_since = router_source_mtime(repo_root)
+        since_basis = "router_source_mtime" if resolved_since else "none"
+    elif since:
+        resolved_since = since
+        since_basis = "explicit"
+    else:
+        resolved_since = ""
+        since_basis = "none"
+
+    records, coverage = collect_routing_records(runs_dir, since=resolved_since)
+    decisions = [record["route_decision"] for record in records]
+
+    margins = [
+        float(decision["margin"])
+        for decision in decisions
+        if isinstance(decision.get("margin"), (int, float)) and not isinstance(decision.get("margin"), bool)
+    ]
+    by_day: dict[str, list[float]] = {}
+    for record, decision in zip(records, decisions):
+        margin = decision.get("margin")
+        if isinstance(margin, (int, float)) and not isinstance(margin, bool):
+            by_day.setdefault(_recording_day(str(record.get("updated_at", ""))), []).append(float(margin))
+    per_day_medians = [value for value in (_median(day) for day in by_day.values()) if value is not None]
+
+    return {
+        "schema_version": ROUTING_LOG_CALIBRATION_SCHEMA_VERSION,
+        "since": {"value": resolved_since, "basis": since_basis, "source": ROUTER_SOURCE_RELATIVE_PATH},
+        "coverage": coverage.to_payload(),
+        "observed": {
+            "decision_count": len(decisions),
+            "router_stage": dict(sorted(Counter(str(item.get("router_stage", "")) for item in decisions).items())),
+            "action": dict(sorted(Counter(str(item.get("action", "")) for item in decisions).items())),
+            "confidence": dict(sorted(Counter(str(item.get("confidence", "")) for item in decisions).items())),
+            "selected_skill": dict(sorted(Counter(str(item.get("selected_skill", "")) for item in decisions).items())),
+            "source": dict(sorted(Counter(str(record.get("source", "")) for record in records).items())),
+        },
+        "margin": {
+            "reported_count": len(margins),
+            "reported_of_decisions": len(decisions),
+            "min": min(margins) if margins else None,
+            "max": max(margins) if margins else None,
+            "median": _median(margins),
+            "normalized_median": _median(per_day_medians),
+            "normalization_unit": "recording_day",
+            "normalization_note": (
+                "Recorded routing runs carry no session id, so the recording day is the "
+                "normalization unit. normalized_median is the median of per-day medians, so a "
+                "heavy day of recording cannot dominate."
+            ),
+            "day_count": len(by_day),
+        },
+        "corpus": _corpus_shape(),
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+
+
+def format_routing_log_calibration(payload: Mapping[str, object]) -> str:
+    coverage = payload.get("coverage", {})
+    observed = payload.get("observed", {})
+    margin = payload.get("margin", {})
+    corpus = payload.get("corpus", {})
+    since = payload.get("since", {})
+    assert isinstance(coverage, Mapping) and isinstance(observed, Mapping)
+    assert isinstance(margin, Mapping) and isinstance(corpus, Mapping) and isinstance(since, Mapping)
+
+    percent = coverage.get("parse_coverage_percent")
+    lines = [
+        "OMH routing log calibration",
+        f"Since: {since.get('value') or 'all records'} ({since.get('basis')}; {since.get('source')})",
+        (
+            f"Parse coverage: {coverage.get('parsed', 0)}/{coverage.get('routing_records_found', 0)} "
+            f"routing records parsed"
+            + (f" ({percent}%)" if percent is not None else " (no records found)")
+            + f"; {coverage.get('run_dirs_seen', 0)} run dir(s) walked"
+        ),
+    ]
+    skipped = coverage.get("skipped", {})
+    if isinstance(skipped, Mapping) and skipped:
+        lines.append("Skipped: " + ", ".join(f"{reason}={count}" for reason, count in skipped.items()))
+    lines.append(f"Decisions: {observed.get('decision_count', 0)}")
+    for label in ("router_stage", "action", "confidence"):
+        bucket = observed.get(label, {})
+        if isinstance(bucket, Mapping) and bucket:
+            lines.append(f"  {label}: " + ", ".join(f"{key}={value}" for key, value in bucket.items()))
+    lines.append(
+        f"Margin: median {margin.get('median')}, day-normalized median "
+        f"{margin.get('normalized_median')} over {margin.get('day_count', 0)} day(s); "
+        f"reported on {margin.get('reported_count', 0)}/{margin.get('reported_of_decisions', 0)} decisions"
+    )
+    lines.append(
+        f"Corpus: {corpus.get('precision_case_count', 0)} precision + "
+        f"{corpus.get('intervention_case_count', 0)} intervention case(s)"
+    )
+    lines.extend(["", f"Boundary: {payload.get('claim_boundary', '')}"])
+    return "\n".join(lines)
+
+
+__all__ = [
+    "CLAIM_BOUNDARY",
+    "ROUTER_SOURCE_RELATIVE_PATH",
+    "ROUTING_LOG_CALIBRATION_SCHEMA_VERSION",
+    "SKIP_REASONS",
+    "CalibrationCoverage",
+    "build_routing_log_calibration",
+    "collect_routing_records",
+    "format_routing_log_calibration",
+    "router_source_mtime",
+]

--- a/tests/test_routing_log_calibration.py
+++ b/tests/test_routing_log_calibration.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.quality.routing_log_calibration import (  # noqa: E402
+    ROUTING_LOG_CALIBRATION_SCHEMA_VERSION,
+    SKIP_REASONS,
+    build_routing_log_calibration,
+    collect_routing_records,
+    format_routing_log_calibration,
+    router_source_mtime,
+)
+
+
+def _record(run_id: str, *, updated_at: str, margin: int | None, stage: str, action: str) -> dict:
+    decision = {
+        "schema_version": "route_decision/v1",
+        "router_stage": stage,
+        "action": action,
+        "selected_skill": "code-review",
+        "selected_harness": "coding-handling",
+        "confidence": "high",
+    }
+    if margin is not None:
+        decision["margin"] = margin
+    return {
+        "schema_version": "omh_runtime/v1",
+        "updated_at": updated_at,
+        "source": "generic",
+        "route_decision": decision,
+        "message_sha256": "0" * 64,
+        "message_length": 24,
+        "run_id": run_id,
+    }
+
+
+def _write_runs(runs_dir: Path, records: dict[str, dict]) -> None:
+    for run_id, record in records.items():
+        run_dir = runs_dir / run_id
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "routing.json").write_text(json.dumps(record), encoding="utf-8")
+
+
+class ParseCoverageTests(unittest.TestCase):
+    """A format skew that silently drops records would bias everything below it."""
+
+    def test_every_skipped_record_is_counted_under_a_named_reason(self) -> None:
+        with TemporaryDirectory() as tmp:
+            runs = Path(tmp) / "runs"
+            _write_runs(
+                runs,
+                {
+                    "ok": _record("ok", updated_at="2026-08-30T01:00:00Z", margin=5, stage="recommendation", action="dispatch"),
+                },
+            )
+            # A run directory with no routing record at all.
+            (runs / "no-routing").mkdir(parents=True)
+            # A routing record that is not JSON.
+            (runs / "broken").mkdir(parents=True)
+            (runs / "broken" / "routing.json").write_text("{not json", encoding="utf-8")
+            # A routing record that parses but is not a routing record.
+            (runs / "wrong-shape").mkdir(parents=True)
+            (runs / "wrong-shape" / "routing.json").write_text(json.dumps({"hello": 1}), encoding="utf-8")
+            # A routing record with no recorded timestamp.
+            undated = _record("undated", updated_at="", margin=1, stage="fallback", action="fallback")
+            undated["updated_at"] = ""
+            (runs / "undated").mkdir(parents=True)
+            (runs / "undated" / "routing.json").write_text(json.dumps(undated), encoding="utf-8")
+
+            payload = build_routing_log_calibration(runs, since="")
+
+        coverage = payload["coverage"]
+        self.assertEqual(coverage["run_dirs_seen"], 5)
+        self.assertEqual(coverage["routing_records_found"], 4)
+        self.assertEqual(coverage["parsed"], 1)
+        self.assertEqual(coverage["parse_coverage_percent"], 25.0)
+        self.assertEqual(
+            coverage["skipped"],
+            {
+                "no_routing_record": 1,
+                "unreadable_json": 1,
+                "unexpected_schema": 1,
+                "missing_recorded_at": 1,
+            },
+        )
+        self.assertEqual(coverage["skipped_total"], 4)
+        for reason in coverage["skipped"]:
+            self.assertIn(reason, SKIP_REASONS)
+        # The named denominator travels with the percentage.
+        self.assertEqual(coverage["parse_coverage_denominator"], "routing records found on disk")
+
+    def test_an_empty_store_reports_unmeasured_coverage_not_zero_percent(self) -> None:
+        with TemporaryDirectory() as tmp:
+            payload = build_routing_log_calibration(Path(tmp) / "missing", since="")
+        self.assertIsNone(payload["coverage"]["parse_coverage_percent"])
+        self.assertEqual(payload["observed"]["decision_count"], 0)
+
+
+class NormalizedMedianTests(unittest.TestCase):
+    def test_a_heavy_day_cannot_dominate_the_normalized_median(self) -> None:
+        # Given: one day with many low margins and two days with one high each.
+        records = {}
+        for index in range(9):
+            records[f"heavy-{index}"] = _record(
+                f"heavy-{index}",
+                updated_at=f"2026-08-01T0{index}:00:00Z",
+                margin=1,
+                stage="recommendation",
+                action="dispatch",
+            )
+        records["quiet-a"] = _record("quiet-a", updated_at="2026-08-02T01:00:00Z", margin=40, stage="recommendation", action="dispatch")
+        records["quiet-b"] = _record("quiet-b", updated_at="2026-08-03T01:00:00Z", margin=50, stage="recommendation", action="dispatch")
+
+        with TemporaryDirectory() as tmp:
+            runs = Path(tmp) / "runs"
+            _write_runs(runs, records)
+            payload = build_routing_log_calibration(runs, since="")
+
+        margin = payload["margin"]
+        # The flat median is dragged to the heavy day's value.
+        self.assertEqual(margin["median"], 1.0)
+        # Per-day medians are 1, 40, 50 -> 40.
+        self.assertEqual(margin["normalized_median"], 40.0)
+        self.assertEqual(margin["day_count"], 3)
+        self.assertEqual(margin["normalization_unit"], "recording_day")
+        self.assertIn("no session id", str(margin["normalization_note"]))
+
+    def test_decisions_without_a_margin_are_excluded_from_the_margin_denominator(self) -> None:
+        with TemporaryDirectory() as tmp:
+            runs = Path(tmp) / "runs"
+            _write_runs(
+                runs,
+                {
+                    "with": _record("with", updated_at="2026-08-01T01:00:00Z", margin=7, stage="recommendation", action="dispatch"),
+                    "without": _record("without", updated_at="2026-08-01T02:00:00Z", margin=None, stage="fallback", action="fallback"),
+                },
+            )
+            payload = build_routing_log_calibration(runs, since="")
+
+        self.assertEqual(payload["margin"]["reported_count"], 1)
+        self.assertEqual(payload["margin"]["reported_of_decisions"], 2)
+
+
+class SinceWindowTests(unittest.TestCase):
+    def test_since_defaults_to_the_router_source_mtime(self) -> None:
+        # A decision made by a router that has since changed is evidence about a
+        # router that no longer exists.
+        default_since = router_source_mtime()
+        self.assertTrue(default_since.endswith("Z"), default_since)
+
+        with TemporaryDirectory() as tmp:
+            runs = Path(tmp) / "runs"
+            _write_runs(
+                runs,
+                {
+                    "old": _record("old", updated_at="2000-01-01T00:00:00Z", margin=3, stage="recommendation", action="dispatch"),
+                },
+            )
+            payload = build_routing_log_calibration(runs)
+
+        self.assertEqual(payload["since"]["basis"], "router_source_mtime")
+        self.assertEqual(payload["since"]["source"], "src/routing/chat.py")
+        self.assertEqual(payload["coverage"]["skipped"], {"recorded_before_since": 1})
+        self.assertEqual(payload["observed"]["decision_count"], 0)
+
+    def test_an_explicit_empty_since_reads_every_record(self) -> None:
+        with TemporaryDirectory() as tmp:
+            runs = Path(tmp) / "runs"
+            _write_runs(
+                runs,
+                {"old": _record("old", updated_at="2000-01-01T00:00:00Z", margin=3, stage="recommendation", action="dispatch")},
+            )
+            records, coverage = collect_routing_records(runs, since="")
+        self.assertEqual(len(records), 1)
+        self.assertEqual(coverage.parsed, 1)
+
+
+class BoundaryTests(unittest.TestCase):
+    def test_the_payload_states_that_message_text_is_never_recorded(self) -> None:
+        with TemporaryDirectory() as tmp:
+            payload = build_routing_log_calibration(Path(tmp), since="")
+        boundary = str(payload["claim_boundary"])
+        self.assertIn("never message text", boundary)
+        self.assertIn("decision distributions", boundary)
+        self.assertIn("never phrasings", boundary)
+        self.assertEqual(payload["schema_version"], ROUTING_LOG_CALIBRATION_SCHEMA_VERSION)
+        self.assertIn("operator's own message", str(payload["corpus"]["note"]))
+
+    def test_the_text_report_leads_with_parse_coverage(self) -> None:
+        with TemporaryDirectory() as tmp:
+            runs = Path(tmp) / "runs"
+            _write_runs(
+                runs,
+                {"ok": _record("ok", updated_at="2026-08-01T01:00:00Z", margin=4, stage="recommendation", action="dispatch")},
+            )
+            report = format_routing_log_calibration(build_routing_log_calibration(runs, since=""))
+        self.assertIn("Parse coverage: 1/1 routing records parsed (100.0%)", report)
+        self.assertIn("day-normalized median", report)
+
+
+class RouteCalibrationCliTests(unittest.TestCase):
+    def test_recorded_routes_reach_the_calibration_command(self) -> None:
+        with TemporaryDirectory() as tmp:
+            base = ["--omh-home", str(Path(tmp) / "omh"), "--hermes-home", str(Path(tmp) / "hermes")]
+            for message in ("code review this diff", "why is the build failing on main"):
+                status, _, stderr = run_cli([*base, "chat", "route", "--record", *message.split()])
+                self.assertEqual(status, 0, stderr)
+
+            status, stdout, stderr = run_cli([*base, "learning", "route-calibration", "--since", "", "--json"])
+            self.assertEqual(status, 0, stderr)
+            payload = json.loads(stdout)
+
+        self.assertEqual(payload["coverage"]["parsed"], 2)
+        self.assertEqual(payload["coverage"]["parse_coverage_percent"], 100.0)
+        self.assertEqual(payload["observed"]["decision_count"], 2)
+        self.assertGreaterEqual(payload["corpus"]["total_case_count"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New `omh learning route-calibration [--since] [--json]`: aggregates the routing decisions `omh chat route --record` already writes, so a corpus or threshold change can be argued against recorded decisions instead of an assumption.
- New `src/quality/routing_log_calibration.py`: the collector, the parse-coverage accounting, the day-normalized median, and a corpus-shape comparison.
- `docs/routing-quality.md`: a six-step calibration procedure, including what the record can and cannot answer.

### Why This Exists

- `ROUTING_PRECISION_CASES` and `ROUTING_INTERVENTION_CASES` are hand-written. That is right for guarding regressions and useless for answering "does this corpus look like what the router actually sees?"
- The raw material already existed and nothing read it back in aggregate: `runtime/runs/<run-id>/routing.json` carries the `route_decision/v1` contract — router stage, action, selected skill, confidence, top-two score margin. `omh learning metrics` aggregates learning *traces*, a different corpus with different fields.

### User / Operator Impact

- An operator can record real routing decisions as they work and then read the distribution back with one command, entirely offline.
- The default window covers only decisions made by the current router, so the default report is about the code in the tree rather than about a router that has since changed.

### How It Works

- Walks `runtime/runs/*/routing.json`, validating each against `route_decision/*` and a recorded timestamp.
- **Parse coverage is printed before any other number**: run directories walked, routing records found, records parsed, and every skipped record under a named reason (`no_routing_record`, `unreadable_json`, `not_an_object`, `unexpected_schema`, `missing_recorded_at`, `recorded_before_since`). An empty store reports coverage as unmeasured, never as `0%`.
- **The median is normalized before it is reported.** Recorded routing runs carry no session id, so the recording day is the normalization unit and the payload names it rather than implying a session. `normalized_median` is the median of per-day medians.
- `--since` defaults to the mtime of `src/routing/chat.py`. `--since ""` reads every record.

### Files And Contracts Touched

- `src/quality/routing_log_calibration.py` (new) — `omh_routing_log_calibration/v1`.
- `src/commands/learning.py` — new `route-calibration` subcommand.
- `docs/routing-quality.md` — new calibration section.
- `tests/test_routing_log_calibration.py` (new).

**Privacy boundary, stated in the payload and not only in the docs:** a routing record carries `message_sha256` and `message_length`, never the message. So this calibrates *decision distributions* and never phrasings. A new corpus phrase still has to come from an operator's own message; these numbers say whether the corpus's shape is wrong, not which sentence to add.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke ... release hermes-smoke ...`
- [ ] Relevant workflow-learning review queue smoke: no learning contract, trace shape, or review queue changed — this adds a read-only sibling command.
- [x] Relevant dry-run or smoke command: manual end-to-end, quoted below; `release drift` (No drift, 18 checks passed); `docs ulw-inventory --check`; `docs ulw-site --check`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run — this is a local CLI read over files OMH already writes; no plugin, TUI, or chat rendering surface changed.

### Observed Evidence

- Manual end-to-end against a scratch home: four `omh chat route --record` invocations, then `omh learning route-calibration --since ""`:
  ```
  OMH routing log calibration
  Since: all records (none; src/routing/chat.py)
  Parse coverage: 4/4 routing records parsed (100.0%); 4 run dir(s) walked
  Decisions: 4
    router_stage: fallback=1, guarded=1, recommendation=2
    action: dispatch=3, fallback=1
    confidence: high=3, low=1
  Margin: median 39.0, day-normalized median 39.0 over 1 day(s); reported on 3/4 decisions
  Corpus: 135 precision + 265 intervention case(s)
  ```
- `PYTHONPATH=tests uv run python -m unittest tests.test_routing_log_calibration` -> Ran 9 tests, OK. Covers each skip reason, the empty store, the heavy-day normalization (nine records of margin 1 drag the flat median to 1.0 while the normalized median stays at 40.0), the margin denominator, both `--since` bases, the stated boundary, and a CLI pass over two really recorded routes.
- `PYTHONPATH=tests uv run python -m unittest tests.test_cli tests.test_release_smoke tests.test_workflow_learning` -> Ran 392 tests, OK.
- `PYTHONPATH=tests uv run python -m unittest discover -s tests` -> Ran 8354 tests, failures=21 errors=7. The identical 28 were measured on unmodified `origin/main` in this worktree before any edit; they are the known cross-harness `.claude`-path failures caused by running inside a linked worktree under `.claude/worktrees/`, unrelated to this change.
- `uv run python -m compileall -q src tests` -> clean. `ruff check src tests` -> All checks passed. `git diff --check` -> clean.
- Five `docs ... --check` byte gates and `release drift` -> all ok.

### Not Tested / Not Applicable

- `harness validate`, `release checklist`, `release hermes-smoke`, install smoke: no installer, harness manifest, or release-channel surface changed.
- A real multi-week operator corpus: the fixtures cover the arithmetic and the coverage accounting; the procedure doc says one sample is noise for exactly the reason this cannot be tested in CI.
- Hermes-owned session artifacts (`state.db`, session JSONL) are deliberately not read; see Risk.

## Risk

- Low. The command is read-only: it opens files, never writes, and never mutates a run.
- The default `--since` makes an empty report the normal outcome on a machine that has not recorded anything since the router last changed. The report says so explicitly (`Since: <stamp> (router_source_mtime; src/routing/chat.py)`) rather than showing a bare zero.

## Compatibility / Rollout

- Purely additive: one new subcommand and one new module. No existing payload, record, or contract changed.

## Release / Claims

- [x] Release-channel impact considered (`local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data — the aggregated records carry hashes and lengths only, by design
- [x] Known manual Hermes checks are listed

## Follow-Up

- Reading Hermes session artifacts for a richer corpus was considered and rejected: that is Hermes-owned state outside OMH's boundary, and OMH already writes its own privacy-safe record of exactly the decisions this calibrates.
