### PR TITLE
feat(quality): budget the shared prompt for the smallest model in the fleet

### DIFF
--- a/MODEL_OPTI.md
+++ b/MODEL_OPTI.md
@@ -116,6 +116,57 @@ fifth generalizes that harness's priced-prefix composition constraint to
 every family, because every major serving stack is a byte-exact prefix
 cacher.
 
+### Writing for the smallest model in the fleet
+
+The per-family blocks below vary by family. The shared preamble does not: it
+is byte-identical across sibling prompts on purpose, so providers can cache
+the prefix. That makes it the one block that has to be written for the
+*smallest* model that will read it, not the largest. A frontier model
+tolerates a dense head; a weaker local CLI starts dropping rules once a
+prompt carries more than it can hold, and the rule it drops is not the one
+you would have picked. So every rule added to the shared head is paid for by
+displacing a rule already there — on exactly the lanes least able to afford
+it.
+
+`src/quality/small_model_prompt_budget.py` measures the two halves of that
+which a gate can actually check, and
+`tests/test_small_model_prompt_budget.py` enforces them:
+
+| Ceiling | Value | What it bounds |
+| --- | --- | --- |
+| `SHARED_PREAMBLE_MAX_BYTES` | 2770 | OMH-authored bytes of the executor-invariant head. `UNIT_PROMPT_MAX_BYTES` bounds the whole assembled prompt, which would let the shared head triple without tripping; the caller's goal line is excluded because its length is the operator's business. |
+| `SHARED_PREAMBLE_MAX_CONSTRAINTS` | 10 | Directive sentences in that head. |
+| `BLOCK_MAX_CONSTRAINTS` | 3 | Directive sentences in any single dispatched block, family calibrations included. |
+
+All three are the **measured current values**, not aspirations. The upstream
+doctrine puts a tiny pattern-completer's limit at roughly 3-5 constraints
+before rules start displacing each other; OMH's consumers are coding-agent
+CLIs rather than tiny models, so 5 is recorded as the target while the
+ceilings freeze the head where it is. Raising one is allowed and is a
+decision: say which existing rule the new one displaces, or move the rule
+into a unit-varying block where only the units that need it pay. The
+constraint count is a sentence-level proxy and is named as one — it counts
+the sentences a reader must hold as a rule, not the rules themselves.
+
+One further rule is mechanized: **no labelled contrast examples**. A block
+containing `Bad:` or `Wrong:` followed by a sample gets the sample copied
+rather than avoided by a weaker model, which is the opposite of the intent.
+State the wanted shape instead.
+
+Two rules are deliberately left to the author, because no regex can apply
+them:
+
+- **Positive framing, except where the negation is the payload.** Small
+  models drop the "not" and do the thing anyway, so prefer stating the
+  wanted behavior. But "do not re-verify once every criterion has passed" is
+  the entire anti-inertia rule; rewriting it positively would lose it. Judge
+  per rule, and keep the negation only when it *is* the rule.
+- **Delete rules the code already enforces deterministically.** OMH enforces
+  a great deal at freeze time — boundary overlap, dependency cycles, unit
+  schema, owner and model resolution — and a prompt rule restating one of
+  those spends headroom that a rule the code cannot enforce needs. Before
+  adding a rule, check whether a gate already makes it true.
+
 ### Techniques compared and already structural (DeepSeek Harness review)
 
 The same harness review surfaced techniques OMH already carries structurally,

--- a/src/quality/small_model_prompt_budget.py
+++ b/src/quality/small_model_prompt_budget.py
@@ -1,0 +1,278 @@
+"""Budget the prompt text every executor reads, including the weakest one.
+
+A fanout unit prompt is not dispatched to one model. It is dispatched to
+whatever local CLI the operator has: a frontier model on one lane and a kimi,
+glm, qwen, codestral, or solar variant on the next. The per-family calibration
+blocks already vary by family. The **shared preamble** does not -- it is the
+byte-identical head every sibling prompt carries, deliberately, so providers can
+cache the prefix.
+
+That makes the shared head the one block that must be written for the *smallest*
+model that will read it. A frontier model tolerates a dense head; a weaker one
+starts dropping rules once a prompt carries more of them than it can hold, and
+the rule it drops is not the one you would have picked. Every rule added to the
+shared head is therefore paid for by displacing a rule already there, on exactly
+the lanes least able to afford it.
+
+Two things are measured here, and only two, because only two are honest:
+
+- **A constraint ceiling on the shared head and on each block.** The upstream
+  doctrine puts a tiny pattern-completer's limit at roughly 3-5 constraints
+  before rules start displacing each other. OMH's consumers are coding-agent
+  CLIs rather than tiny models, so that figure is a target, not the threshold:
+  the ceilings below are the *measured* current values, which freezes the head
+  where it is. Growing it then requires saying which existing rule the new one
+  displaces, which is the decision the doctrine actually asks for. A byte
+  ceiling rides alongside, because `UNIT_PROMPT_MAX_BYTES` bounds the whole
+  assembled prompt and so lets the shared head triple without tripping.
+- **No labelled contrast examples.** A block containing `Bad:` or `Wrong:`
+  followed by a sample gets the sample copied rather than avoided by weaker
+  models, which is the opposite of the intent. There are none today; this keeps
+  it that way.
+
+Two rules from the same doctrine are deliberately NOT mechanized. "Positive
+framing only" would condemn text whose negations are the payload -- "do not
+re-verify" is the entire anti-inertia rule, and rewriting it positively would
+lose it. And "delete rules the code already enforces deterministically" needs a
+judgement about what the code enforces, which no regex has. Both belong in
+`MODEL_OPTI.md` as authoring rules, and they are there.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+SMALL_MODEL_PROMPT_BUDGET_SCHEMA_VERSION = "omh_small_model_prompt_budget/v1"
+
+# Measured ceilings, not aspirations. See the module docstring: these are the
+# current values, so the head is frozen where it is and growth is a decision.
+SHARED_PREAMBLE_MAX_BYTES = 2770
+SHARED_PREAMBLE_MAX_CONSTRAINTS = 10
+BLOCK_MAX_CONSTRAINTS = 3
+
+# The upstream figure for a tiny pattern-completer, kept as documentation of
+# where the target sits relative to the measured ceiling above.
+TINY_MODEL_CONSTRAINT_TARGET = 5
+
+# A labelled negative sample is copied, not avoided, by a weaker model.
+CONTRAST_EXAMPLE_MARKERS: tuple[str, ...] = (
+    "bad:",
+    "wrong:",
+    "incorrect:",
+    "anti-example:",
+    "counter-example:",
+    "don't do this",
+    "do not do this",
+)
+
+# A constraint is a sentence that tells the reader to do or not do something.
+# RFC 2119 modals plus the directive negations OMH's own prompt text uses.
+_CONSTRAINT_MARKER = re.compile(
+    r"\b(?:must|shall|should|may|never|always|only|required|forbidden|do not|don't|stop)\b",
+    re.IGNORECASE,
+)
+_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+|\s+--\s+")
+
+
+@dataclass(frozen=True, slots=True)
+class BlockBudget:
+    label: str
+    chars: int
+    constraints: int
+
+
+def constraint_count(text: str) -> int:
+    """Count sentences carrying a directive marker.
+
+    A proxy, and named as one: it counts the sentences a reader has to hold as
+    a rule, not the rules themselves. It is stable, arguable in the open, and
+    the same measure on both sides of a change, which is what a ratchet needs.
+    """
+    return sum(
+        1 for part in _SENTENCE_SPLIT.split(text) if part.strip() and _CONSTRAINT_MARKER.search(part)
+    )
+
+
+def contrast_example_markers(text: str) -> tuple[str, ...]:
+    """Return every labelled-negative-sample marker present in a block."""
+    lowered = text.casefold()
+    return tuple(marker for marker in CONTRAST_EXAMPLE_MARKERS if marker in lowered)
+
+
+def shared_preamble_blocks() -> list[BlockBudget]:
+    """Budget each OMH-authored block of the executor-invariant shared preamble.
+
+    The first line is the caller's goal text, whose length is the operator's
+    business rather than a budget OMH owns, so it is excluded.
+    """
+    from ..coding.unit_prompt_protocol import shared_unit_preamble_lines
+
+    return [
+        BlockBudget(f"shared[{index}]", len(line), constraint_count(line))
+        for index, line in enumerate(shared_unit_preamble_lines("goal"))
+        if index > 0
+    ]
+
+
+def dispatched_prompt_blocks() -> dict[str, str]:
+    """Every deterministic block of prompt text that reaches an executor.
+
+    Keyed by a stable label so a violation names the block an author edits.
+    The goal line is excluded: it is the caller's text, not OMH's.
+    """
+    from ..coding.unit_prompt_protocol import (
+        FAILURE_KIND_PROTOCOL,
+        GOAL_ECHO_PROTOCOL,
+        HIGH_EFFORT_CALIBRATIONS,
+        MAIN_AGENT_COMPOSITION_CALIBRATIONS,
+        PROMPT_CACHE_COMPOSITION_PROTOCOL,
+        REVIEW_ROLE_PROTOCOL,
+        UNIT_RESULT_RETURN_PROTOCOL,
+        VERIFICATION_STOP_PROTOCOL,
+    )
+
+    blocks = {
+        "GOAL_ECHO_PROTOCOL": GOAL_ECHO_PROTOCOL,
+        "VERIFICATION_STOP_PROTOCOL": VERIFICATION_STOP_PROTOCOL,
+        "FAILURE_KIND_PROTOCOL": FAILURE_KIND_PROTOCOL,
+        "UNIT_RESULT_RETURN_PROTOCOL": UNIT_RESULT_RETURN_PROTOCOL,
+        "PROMPT_CACHE_COMPOSITION_PROTOCOL": PROMPT_CACHE_COMPOSITION_PROTOCOL,
+        "REVIEW_ROLE_PROTOCOL": REVIEW_ROLE_PROTOCOL,
+    }
+    for family, text in HIGH_EFFORT_CALIBRATIONS.items():
+        blocks[f"HIGH_EFFORT_CALIBRATIONS[{family}]"] = text
+    for family, text in MAIN_AGENT_COMPOSITION_CALIBRATIONS.items():
+        blocks[f"MAIN_AGENT_COMPOSITION_CALIBRATIONS[{family}]"] = text
+    return blocks
+
+
+def small_model_prompt_violations() -> list[dict[str, object]]:
+    """Return every budget breach, each naming the block an author edits."""
+    found: list[dict[str, object]] = []
+    blocks = shared_preamble_blocks()
+    shared_bytes = sum(block.chars for block in blocks)
+    shared_constraints = sum(block.constraints for block in blocks)
+
+    if shared_bytes > SHARED_PREAMBLE_MAX_BYTES:
+        found.append(
+            {
+                "rule": "SHARED_PREAMBLE_BYTES",
+                "block": "shared_unit_preamble_lines()",
+                "measured": shared_bytes,
+                "ceiling": SHARED_PREAMBLE_MAX_BYTES,
+                "detail": (
+                    "the executor-invariant head every sibling prompt carries grew; every lane pays "
+                    "this, including the weakest local CLI in the fleet"
+                ),
+            }
+        )
+    if shared_constraints > SHARED_PREAMBLE_MAX_CONSTRAINTS:
+        found.append(
+            {
+                "rule": "SHARED_PREAMBLE_CONSTRAINTS",
+                "block": "shared_unit_preamble_lines()",
+                "measured": shared_constraints,
+                "ceiling": SHARED_PREAMBLE_MAX_CONSTRAINTS,
+                "detail": (
+                    "a rule added to the shared head displaces a rule already there on the lanes "
+                    "least able to afford it; say which one it displaces, or put it in a "
+                    "unit-varying block"
+                ),
+            }
+        )
+
+    for label, text in sorted(dispatched_prompt_blocks().items()):
+        constraints = constraint_count(text)
+        if constraints > BLOCK_MAX_CONSTRAINTS:
+            found.append(
+                {
+                    "rule": "BLOCK_CONSTRAINTS",
+                    "block": label,
+                    "measured": constraints,
+                    "ceiling": BLOCK_MAX_CONSTRAINTS,
+                    "detail": "one block asks a reader to hold too many rules at once; split it or cut one",
+                }
+            )
+        markers = contrast_example_markers(text)
+        if markers:
+            found.append(
+                {
+                    "rule": "CONTRAST_EXAMPLE",
+                    "block": label,
+                    "measured": ", ".join(markers),
+                    "ceiling": "none",
+                    "detail": (
+                        "a labelled negative sample gets copied rather than avoided by a weaker "
+                        "model; state the wanted shape instead"
+                    ),
+                }
+            )
+    return found
+
+
+def small_model_prompt_payload() -> dict[str, object]:
+    blocks = shared_preamble_blocks()
+    violations = small_model_prompt_violations()
+    dispatched = dispatched_prompt_blocks()
+    return {
+        "schema_version": SMALL_MODEL_PROMPT_BUDGET_SCHEMA_VERSION,
+        "description": (
+            "Budget for the prompt text every executor reads. The shared preamble is "
+            "executor-invariant, so it is written for the smallest model in the fleet, not the "
+            "largest. Constraint counts are a sentence-level proxy, not a count of rules."
+        ),
+        "ok": not violations,
+        "ceilings": {
+            "shared_preamble_max_bytes": SHARED_PREAMBLE_MAX_BYTES,
+            "shared_preamble_max_constraints": SHARED_PREAMBLE_MAX_CONSTRAINTS,
+            "block_max_constraints": BLOCK_MAX_CONSTRAINTS,
+            "tiny_model_constraint_target": TINY_MODEL_CONSTRAINT_TARGET,
+        },
+        "shared_preamble": {
+            "bytes": sum(block.chars for block in blocks),
+            "constraints": sum(block.constraints for block in blocks),
+            "blocks": [
+                {"label": block.label, "chars": block.chars, "constraints": block.constraints}
+                for block in blocks
+            ],
+        },
+        "dispatched_block_count": len(dispatched),
+        "violations": violations,
+    }
+
+
+def format_small_model_prompt_violations(violations: list[dict[str, object]]) -> str:
+    if not violations:
+        return ""
+    lines = [f"{len(violations)} shared-prompt budget violation(s):"]
+    for finding in violations:
+        lines.append(
+            f"  [{finding['rule']}] {finding['block']}: measured {finding['measured']}, "
+            f"ceiling {finding['ceiling']}"
+        )
+        lines.append(f"    {finding['detail']}")
+    lines.append(
+        "  Ceilings are the measured current values and live in "
+        "src/quality/small_model_prompt_budget.py; the authoring doctrine is the "
+        "'Writing for the smallest model in the fleet' section of MODEL_OPTI.md."
+    )
+    return "\n".join(lines)
+
+
+__all__ = [
+    "BLOCK_MAX_CONSTRAINTS",
+    "CONTRAST_EXAMPLE_MARKERS",
+    "SHARED_PREAMBLE_MAX_BYTES",
+    "SHARED_PREAMBLE_MAX_CONSTRAINTS",
+    "SMALL_MODEL_PROMPT_BUDGET_SCHEMA_VERSION",
+    "TINY_MODEL_CONSTRAINT_TARGET",
+    "BlockBudget",
+    "constraint_count",
+    "contrast_example_markers",
+    "dispatched_prompt_blocks",
+    "format_small_model_prompt_violations",
+    "shared_preamble_blocks",
+    "small_model_prompt_payload",
+    "small_model_prompt_violations",
+]

--- a/tests/test_small_model_prompt_budget.py
+++ b/tests/test_small_model_prompt_budget.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.coding.unit_prompt_protocol import (  # noqa: E402
+    HIGH_EFFORT_CALIBRATIONS,
+    MAIN_AGENT_COMPOSITION_CALIBRATIONS,
+    shared_unit_preamble_lines,
+)
+from omh.quality.small_model_prompt_budget import (  # noqa: E402
+    BLOCK_MAX_CONSTRAINTS,
+    CONTRAST_EXAMPLE_MARKERS,
+    SHARED_PREAMBLE_MAX_BYTES,
+    SHARED_PREAMBLE_MAX_CONSTRAINTS,
+    TINY_MODEL_CONSTRAINT_TARGET,
+    constraint_count,
+    contrast_example_markers,
+    dispatched_prompt_blocks,
+    format_small_model_prompt_violations,
+    shared_preamble_blocks,
+    small_model_prompt_payload,
+    small_model_prompt_violations,
+)
+
+_MODEL_OPTI = Path(__file__).resolve().parents[1] / "MODEL_OPTI.md"
+
+
+class SharedPromptBudgetTests(unittest.TestCase):
+    """The executor-invariant head is written for the weakest lane in the fleet."""
+
+    def test_the_shared_head_stays_inside_its_measured_budget(self) -> None:
+        violations = small_model_prompt_violations()
+        self.assertEqual(violations, [], format_small_model_prompt_violations(violations))
+
+    def test_the_measured_ceilings_are_the_current_values(self) -> None:
+        # A ratchet is only a ratchet while it sits on the measurement. If this
+        # fails low, re-measure and lower the ceiling; if it fails high, say
+        # which existing rule the new one displaces before raising it.
+        blocks = shared_preamble_blocks()
+        self.assertEqual(sum(block.chars for block in blocks), SHARED_PREAMBLE_MAX_BYTES)
+        self.assertEqual(sum(block.constraints for block in blocks), SHARED_PREAMBLE_MAX_CONSTRAINTS)
+        self.assertEqual(
+            max(constraint_count(text) for text in dispatched_prompt_blocks().values()),
+            BLOCK_MAX_CONSTRAINTS,
+        )
+
+    def test_the_goal_line_is_not_charged_to_omh_budget(self) -> None:
+        # The caller's goal text length is the operator's business.
+        short = shared_unit_preamble_lines("x")
+        long = shared_unit_preamble_lines("x" * 4000)
+        self.assertNotEqual(len(short[0]), len(long[0]))
+        self.assertEqual(
+            [block.label for block in shared_preamble_blocks()],
+            [f"shared[{index}]" for index in range(1, len(short))],
+        )
+
+    def test_every_family_calibration_is_inside_the_per_block_ceiling(self) -> None:
+        for family, text in sorted(HIGH_EFFORT_CALIBRATIONS.items()):
+            with self.subTest(family=family, table="executor"):
+                self.assertLessEqual(constraint_count(text), BLOCK_MAX_CONSTRAINTS)
+        for family, text in sorted(MAIN_AGENT_COMPOSITION_CALIBRATIONS.items()):
+            with self.subTest(family=family, table="composer"):
+                self.assertLessEqual(constraint_count(text), BLOCK_MAX_CONSTRAINTS)
+
+    def test_no_dispatched_block_carries_a_labelled_negative_sample(self) -> None:
+        # A weaker model copies a labelled "Bad:" sample rather than avoiding it.
+        for label, text in sorted(dispatched_prompt_blocks().items()):
+            with self.subTest(block=label):
+                self.assertEqual(contrast_example_markers(text), ())
+
+
+class BudgetMeasurementTests(unittest.TestCase):
+    def test_constraint_count_counts_directive_sentences(self) -> None:
+        # A directive is marked by an RFC 2119 modal or a directive negation.
+        # A bare imperative ("Run the tests.") is deliberately not counted:
+        # every prose verb would qualify, and the proxy would stop meaning
+        # anything.
+        self.assertEqual(constraint_count("You must run it. Never skip it."), 2)
+        self.assertEqual(constraint_count("Run it once, then stop. The suite is slow."), 1)
+        self.assertEqual(constraint_count("The suite is slow and the fixtures are large."), 0)
+
+    def test_contrast_markers_are_detected_case_insensitively(self) -> None:
+        self.assertEqual(contrast_example_markers("BAD: rm -rf /"), ("bad:",))
+        self.assertEqual(contrast_example_markers("Do not do this at home"), ("do not do this",))
+        self.assertEqual(contrast_example_markers("Nothing labelled here."), ())
+        for marker in CONTRAST_EXAMPLE_MARKERS:
+            with self.subTest(marker=marker):
+                self.assertEqual(contrast_example_markers(f"prefix {marker} sample"), (marker,))
+
+    def test_violations_name_the_block_an_author_edits(self) -> None:
+        message = format_small_model_prompt_violations(
+            [
+                {
+                    "rule": "BLOCK_CONSTRAINTS",
+                    "block": "HIGH_EFFORT_CALIBRATIONS[qwen]",
+                    "measured": 9,
+                    "ceiling": BLOCK_MAX_CONSTRAINTS,
+                    "detail": "too many rules",
+                }
+            ]
+        )
+        self.assertIn("HIGH_EFFORT_CALIBRATIONS[qwen]", message)
+        self.assertIn("src/quality/small_model_prompt_budget.py", message)
+        self.assertIn("MODEL_OPTI.md", message)
+
+    def test_payload_states_that_constraints_are_a_proxy(self) -> None:
+        payload = small_model_prompt_payload()
+        self.assertIn("proxy", str(payload["description"]))
+        self.assertEqual(
+            payload["ceilings"]["tiny_model_constraint_target"], TINY_MODEL_CONSTRAINT_TARGET
+        )
+        self.assertGreater(payload["dispatched_block_count"], len(HIGH_EFFORT_CALIBRATIONS))
+
+
+class SmallestModelDoctrineDocTests(unittest.TestCase):
+    """The two rules no regex can apply live in the doc, or nowhere."""
+
+    def test_model_opti_documents_the_budget_and_its_unmechanized_rules(self) -> None:
+        doc = _MODEL_OPTI.read_text(encoding="utf-8")
+        self.assertIn("Writing for the smallest model in the fleet", doc)
+        self.assertIn("SHARED_PREAMBLE_MAX_CONSTRAINTS", doc)
+        self.assertIn("src/quality/small_model_prompt_budget.py", doc)
+        # The two judgement rules, named so an author finds them.
+        self.assertIn("positive framing", doc.casefold())
+        self.assertIn("already enforces", doc.casefold())
+
+    def test_documented_ceilings_match_the_shipped_constants(self) -> None:
+        doc = _MODEL_OPTI.read_text(encoding="utf-8")
+        for name, value in (
+            ("SHARED_PREAMBLE_MAX_BYTES", SHARED_PREAMBLE_MAX_BYTES),
+            ("SHARED_PREAMBLE_MAX_CONSTRAINTS", SHARED_PREAMBLE_MAX_CONSTRAINTS),
+            ("BLOCK_MAX_CONSTRAINTS", BLOCK_MAX_CONSTRAINTS),
+        ):
+            with self.subTest(constant=name):
+                self.assertRegex(doc, rf"`{name}`[^\n]*\b{value}\b")
+        self.assertRegex(doc, rf"\b{TINY_MODEL_CONSTRAINT_TARGET}\b")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New `src/quality/small_model_prompt_budget.py`: three measured ceilings on the prompt text every executor reads, plus a scan for labelled contrast examples.
- `MODEL_OPTI.md`: a "Writing for the smallest model in the fleet" section beside the universal protocols it governs — the ceiling table, the contrast-example rule, and the two rules deliberately left to the author.
- `tests/test_small_model_prompt_budget.py`: the gate, per-family block ceilings across both calibration tables, and doc/constant parity.

No prompt text changed. This bounds what future prompt text may cost.

### Why This Exists

- A fanout unit prompt is not dispatched to one model. It goes to whatever local CLI the operator has: a frontier model on one lane, and a kimi, glm, qwen, codestral, or solar variant on the next.
- The per-family calibration blocks vary by family. The **shared preamble does not** — it is byte-identical across sibling prompts on purpose, so providers can cache the prefix. That makes it the one block that has to be written for the *smallest* model that will read it.
- A rule added to that head is paid for by displacing a rule already there, on exactly the lanes least able to afford it, and nothing bounded it: `UNIT_PROMPT_MAX_BYTES` bounds the whole assembled prompt, which would let the shared head triple without tripping.

### User / Operator Impact

- None at runtime. The effect is on authoring: a future PR that grows the shared head fails with a message naming the block, the measured value, and the ceiling.

### How It Works

| Ceiling | Value | Bounds |
| --- | --- | --- |
| `SHARED_PREAMBLE_MAX_BYTES` | 2770 | OMH-authored bytes of the executor-invariant head; the caller's goal line is excluded because its length is the operator's business. |
| `SHARED_PREAMBLE_MAX_CONSTRAINTS` | 10 | Directive sentences in that head. |
| `BLOCK_MAX_CONSTRAINTS` | 3 | Directive sentences in any single dispatched block, across all 32 including both family tables. |

All three are the **measured current values**, not aspirations, so the head is frozen where it is and growth becomes a decision. The upstream figure for a tiny pattern-completer is 3-5 constraints; that is recorded as the target (`TINY_MODEL_CONSTRAINT_TARGET`), not asserted as the threshold, because OMH's consumers are coding-agent CLIs rather than tiny models.

One further rule is mechanized: **no labelled contrast examples**. A block containing `Bad:` or `Wrong:` followed by a sample gets the sample copied rather than avoided by a weaker model. There are none today, and now there cannot be.

**Two rules are deliberately NOT mechanized**, and both the module and the doc say so:

- *Positive framing only* would condemn text whose negation is the payload. "Do not re-verify once every criterion has passed" is the entire anti-inertia rule; a gate demanding positive phrasing would either be exempted everywhere or would delete the rule while keeping the sentence.
- *Delete rules the code already enforces deterministically* needs a judgement about what the code enforces, which no regex has.

Claiming to check either would be worse than not checking it. Both are written into `MODEL_OPTI.md` as authoring rules instead.

### Files And Contracts Touched

- `src/quality/small_model_prompt_budget.py` (new) — `omh_small_model_prompt_budget/v1`.
- `MODEL_OPTI.md` — new section under Universal protocols.
- `tests/test_small_model_prompt_budget.py` (new).
- No change to `src/coding/unit_prompt_protocol.py`; the module reads it.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [x] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke ... release hermes-smoke ...`
- [ ] Relevant workflow-learning review queue smoke: no learning contract changed.
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli release drift` (No drift, 18 checks passed); `docs ulw-inventory --check`; `docs ulw-site --check`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run — no prompt text, contract, or runtime surface changed; this adds a measurement module and a test.

### Observed Evidence

- `PYTHONPATH=tests uv run python -m unittest tests.test_small_model_prompt_budget` -> Ran 11 tests, OK.
- Measured shared head on this base: 2770 OMH-authored bytes across 5 blocks, 10 directive sentences; max per-block constraint count 3 across 32 dispatched blocks; zero contrast-example markers.
- `PYTHONPATH=tests uv run python -m unittest discover -s tests` -> Ran 8356 tests, failures=21 errors=7. The identical 28 were measured on unmodified `origin/main` in this worktree before any edit; they are the known cross-harness `.claude`-path failures caused by running inside a linked worktree under `.claude/worktrees/`, unrelated to this change.
- `uv run python -m compileall -q src tests` -> clean. `ruff check src tests` -> All checks passed. `git diff --check` -> clean.
- Five `docs ... --check` byte gates and `release drift` -> all ok.

### Not Tested / Not Applicable

- `harness validate`, `release checklist`, `release hermes-smoke`, install smoke: no installer, harness manifest, or release-channel surface changed.
- Whether a weaker model actually follows the head better at these ceilings: OMH dispatches prompts and observes no executor runs, so that claim would be `prepared_not_observed`. The budget ratchets the surface; it does not claim an effect on any model's behavior.

## Risk

- Low, and deliberately noisy in one direction: the ceilings sit exactly on the measurement, so the next PR that adds a shared protocol block will fail here. That is the intent, and the failure message names the block, the measured value, the ceiling, and where the doctrine lives.
- The constraint count is a sentence-level proxy and is named as one in the payload, the module docstring, and the doc. It counts directive sentences (RFC 2119 modals and directive negations), not rules. A bare imperative is deliberately uncounted, because otherwise every prose verb would qualify and the proxy would stop meaning anything.

## Compatibility / Rollout

- Additive. No shipped prompt bytes moved, so no prompt cache is invalidated by this PR.

## Release / Claims

- [x] Release-channel impact considered (`local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed

## Follow-Up

- When a ceiling trips, the fix is normally a unit-varying block rather than a higher ceiling: moving a rule into `unit_protocol_lines()` charges it to the units that need it instead of to the whole fleet.
- Rewriting the shared preamble down toward the 3-5 constraint target was considered and rejected for now: it is a large diff to load-bearing dispatched text with no local way to measure whether it helped. Freezing the head is the reversible half of the same doctrine.
