### PR TITLE
feat(coding): classify, repair, and interview dispatch failures

### DIFF
--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -638,6 +638,100 @@ Rules:
   work that cannot resolve an executor becomes an explicit user choice, not
   retained Hermes implementation).
 
+## Failure recovery
+
+A spawned agent CLI that dies because the provider quota is spent or the stored
+credential is rejected is recoverable, and the two are not recoverable the same
+way. This section is what dispatch does about that. It applies identically to
+`omh coding fanout dispatch` and to the `omh coding run` single-run entry, which
+funnel into the same engine.
+
+- **`failure_kind` is a closed enum on every failed unit envelope**:
+  `auth_shaped`, `limit_shaped`, `timeout`, `binary_missing`, or `crash` as the
+  fallback. Precedence is fixed and deterministic. The dispatcher's own
+  synthetic exit codes classify first — 127 is `binary_missing`, 124 is
+  `timeout` — because they are observations of the process rather than text the
+  provider wrote. Text then classifies as `auth_shaped` **before**
+  `limit_shaped`: the two pattern sets overlap in practice (a 401 body routinely
+  also mentions a rate limit for unauthenticated callers), and an invalid
+  credential must be repaired before any attempt can succeed while a limit
+  clears on its own — filing an overlapping failure into the wait-it-out lane
+  would put it where waiting can never clear it. The auth patterns are
+  multi-word and anchored to credential context for the same reason the limit
+  patterns are: a bare `401`, `token`, or `auth` matches ordinary CLI narration.
+  Only the boolean and the matched label are ever persisted, never the matched
+  text. The existing `limit_shaped` / `limit_pattern` fields are unchanged.
+- **Auth-failure signals persist per owner**, in
+  `~/.omh/runtime/executor-auth-failure-signals.json`
+  (`executor_auth_failure_signals/v1`), a sibling of the limit signals rather
+  than another key inside them — the limit record's own field is
+  `last_limit_shaped_at`, and writing a credential rejection under that name
+  would make every reader report a quota problem that never happened. Records
+  gain read-time `age_seconds` and a `stale` marker, and the owner's next exit-0
+  clears them, exactly like limit signals. These are **not** the presence
+  markers in `executor_auth_signals`: a marker is absent for every legitimate
+  API-key install and never vetoes anything.
+- **Repair cards** ride every `auth_shaped` and `limit_shaped` unit entry
+  (`dispatch_failure_repair_card/v1`). An auth card names re-authentication then
+  re-dispatch, with the owner's own login command where this repo has verified
+  one and a neutral "re-authenticate the `<owner>` CLI" instruction where it has
+  not — no CLI is the implied default. A limit card names the wait and the
+  remaining cooldown window.
+- **A fresh observed signal is a spawn cooldown.** At spawn time, an owner
+  carrying a non-stale auth or limit signal does not spawn: the unit finishes as
+  `executor_auth_invalid` or `executor_limit_cooldown`, before the readiness
+  probe and before its worktree exists, so nothing is left behind. This is the
+  one place an observed signal becomes a veto rather than a ranking hint, and it
+  does not contradict the advisory-marker principle: the input is a runtime
+  failure omh observed from a real spawn of that owner, not the absence of a
+  local login file. A record whose observation time cannot be read never vetoes
+  — it cannot be *shown* to be inside the window. `--ignore-limit-signal`
+  overrides both and re-observes the provider's answer directly. A vetoed unit
+  blocks its dependents and journals as `not_attempted`, so a later resume
+  re-attempts it.
+- **The recovery interview offers three actions, and never picks one.** After
+  the run, each unit that failed as `auth_shaped` or `limit_shaped` gets a
+  numbered choice: **[1] retarget** to another coding owner, ranked from
+  `executor_choice_context` with the failed owner excluded; **[2] Hermes
+  subagent**, re-running the unit through the `omh coding hermes-child dispatch`
+  boundary, which carries separate auth and a separate quota; **[3] wait**,
+  marking the unit for retry later. An option this environment cannot carry out
+  is still listed, with `available: false` and the reason. Every decision —
+  including "none" — is recorded in the summary's `failure_recovery` block
+  (`fanout_failure_recovery/v1`). **No coding owner is ever switched without an
+  explicit choice recorded there.**
+  - **Retarget** re-dispatches under a derived unit id
+    (`<unit-id>-retarget-<owner>`), which gives it its own worktree and branch.
+    The failed unit's worktree is neither reused nor deleted — this engine
+    refuses a pre-existing worktree path and never removes an operator's
+    directory. The frozen model route is dropped rather than carried across: a
+    model id belongs to the CLI it was resolved for. Retargeting to the owner
+    that just failed is refused.
+  - **Hermes** runs the unit in its OWN worktree or not at all; pointing the
+    child at the dispatch repo root would let a recovery attempt edit the main
+    checkout. Selecting it is the explicit dispatch consent the Hermes child
+    boundary requires — equivalent to `--confirm-dispatch` — and it is recorded
+    as such. The lane is offered only when `--hermes-model`,
+    `--hermes-provider`, and `--hermes-reasoning` are supplied.
+  - **Wait** marks the unit `awaiting_retry` in the run journal with its
+    failure kind. The next `--resume-journal` run re-dispatches exactly those
+    units under the `rerun_awaiting_retry` action; units whose success was
+    observed stay skipped, and a deferred unit that is replay-unsafe is still
+    held with its side effect named — deferring is a reason to re-attempt, never
+    a licence to rebuild a worktree over work a failure left behind.
+- **`--on-failure=report|retarget:<owner>|hermes|wait`** is the non-interactive
+  degradation. `report` is the default and today's behavior: the notice, the
+  repair card, and the options are printed to stderr and nothing changes. The
+  interview runs only when the mode is `report`, `--no-interactive` was not
+  passed, and stdin is a real terminal — a named mode is the operator answering
+  on the command line, and a pipe or a CI job never blocks on a prompt nobody
+  can see. The prompt-reading seam is injected, so the interview is exercised
+  without a terminal anywhere in the test suite.
+- **Not evidence.** A recovery decision records what was chosen and what the
+  attempt observed. Choosing an action is not a claim it succeeded, and a
+  retargeted or Hermes-lane unit that exits 0 is no more verified than any other
+  unit that exits 0.
+
 ## Installed-skill discovery
 
 Before building unit prompts, dispatch probes fixed executor-specific

--- a/src/coding/dispatch_failure_recovery.py
+++ b/src/coding/dispatch_failure_recovery.py
@@ -1,0 +1,722 @@
+"""Classify a failed dispatch, say how to repair it, and offer the operator a choice.
+
+A spawned agent CLI that dies because the provider quota is spent or the stored
+credential is invalid used to reach the operator as `status: failed` plus a
+bounded output tail. Both are recoverable and neither is recoverable the same
+way: a limit clears on its own and a credential does not, so the two need
+different words, different repair steps, and — because switching a coding owner
+behind the operator's back is exactly what `AGENTS.md` forbids — an explicit
+choice rather than an automatic fallback.
+
+Three pieces live here.
+
+1. **`failure_kind`**, a closed enum every failed unit envelope carries. The two
+   synthetic exit codes the dispatcher assigns itself (127 for a binary missing
+   from PATH, 124 for a unit that burned its timeout) classify first, because
+   they are the dispatcher's own observation of the process rather than text the
+   provider wrote. Then `auth_shaped`, then `limit_shaped`, then `crash` as the
+   fallback.
+
+   Auth is checked before limit deliberately, and the two pattern sets are not
+   disjoint in practice: a 401 body routinely also mentions a rate limit for
+   unauthenticated callers. An invalid credential is a state the operator must
+   repair before ANY attempt can succeed; a limit is a state that clears on its
+   own. Classifying an overlapping failure as `limit_shaped` would file it into
+   the wait-it-out lane, where waiting can never clear it. Classifying it as
+   `auth_shaped` costs the operator one re-auth check that the limit lane would
+   have skipped, which is the cheaper of the two mistakes.
+
+2. **Observed auth-failure signals**, persisted per owner beside the limit
+   signals and cleared by the same rule (the next exit-0 for that owner). These
+   are deliberately NOT the presence markers in `executor_auth_signals`: a marker
+   is absent for every legitimate API-key install and never vetoes anything. A
+   signal here is an observed runtime failure of a real spawn, which is why it
+   is allowed to become a spawn cooldown while a marker never is.
+
+3. **The recovery choice.** Three named actions — retarget to another owner,
+   re-run through the Hermes subagent lane, or wait and retry later — and the
+   `--on-failure` degradation for every non-interactive caller. Nothing here
+   picks one on the operator's behalf; the default mode prints the card and the
+   options and changes nothing.
+
+Nothing in this module spawns anything. It classifies, it persists metadata, and
+it renders choices. Acting on a choice is the dispatcher's job.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping, Sequence
+
+from ..executors import executor_label
+from ..system.local_store import locked_json_update, read_json_object_result, utc_now
+from ..system.paths import OmhPaths
+from .executor_auth_signals import LIMIT_SIGNAL_STALE_AFTER_SECONDS, signal_age_seconds
+
+# The closed enum. Every failed unit envelope carries exactly one of these.
+FAILURE_KIND_AUTH_SHAPED = "auth_shaped"
+FAILURE_KIND_LIMIT_SHAPED = "limit_shaped"
+FAILURE_KIND_TIMEOUT = "timeout"
+FAILURE_KIND_BINARY_MISSING = "binary_missing"
+FAILURE_KIND_CRASH = "crash"
+
+FAILURE_KINDS: tuple[str, ...] = (
+    FAILURE_KIND_AUTH_SHAPED,
+    FAILURE_KIND_LIMIT_SHAPED,
+    FAILURE_KIND_TIMEOUT,
+    FAILURE_KIND_BINARY_MISSING,
+    FAILURE_KIND_CRASH,
+)
+
+# The two kinds a recovery choice is offered for: both describe the provider
+# refusing to serve this owner right now, which another owner or a later attempt
+# can answer. A crash, a timeout, or a missing binary is not that.
+RECOVERABLE_FAILURE_KINDS: frozenset[str] = frozenset(
+    {FAILURE_KIND_AUTH_SHAPED, FAILURE_KIND_LIMIT_SHAPED}
+)
+
+FAILURE_KIND_PRECEDENCE = (
+    "binary_missing (synthetic exit 127) and timeout (synthetic exit 124) are the dispatcher's own "
+    "observations of the process and classify before any text match. Text then classifies as "
+    "auth_shaped before limit_shaped: an invalid credential must be repaired before any attempt can "
+    "succeed, while a limit clears on its own, so an overlapping message belongs in the lane that "
+    "waiting cannot clear. Everything else is crash."
+)
+
+# Deterministic auth-shape patterns, matched case-insensitively over the
+# in-memory stdout/stderr tails of a FAILED spawn only. Multi-word and anchored
+# to credential context for the same reason `_LIMIT_SHAPED_PATTERNS` is: a bare
+# "401" matches a version string or a count, and a bare "token" or "auth"
+# matches half of every agent CLI's ordinary narration. Only the boolean and the
+# matched label are ever persisted — never the matched text.
+_AUTH_SHAPED_PATTERNS: tuple[tuple[str, str], ...] = (
+    ("invalid_api_key", "invalid api key"),
+    ("invalid_api_key", "api key not found"),
+    ("invalid_api_key", "incorrect api key"),
+    ("token_expired", "token expired"),
+    ("token_expired", "token has expired"),
+    ("not_logged_in", "not logged in"),
+    ("not_logged_in", "please run /login"),
+    ("not_logged_in", "please log in"),
+    ("authentication_failed", "authentication failed"),
+    ("authentication_failed", "credentials are invalid"),
+    ("authentication_failed", "invalid credentials"),
+    ("http_401", "status 401"),
+    ("http_401", "error 401"),
+    ("http_401", "http 401"),
+    ("http_401", "401 unauthorized"),
+    ("oauth_revoked", "oauth token revoked"),
+    ("oauth_revoked", "refresh token is invalid"),
+)
+
+
+def auth_shaped_label(output_tail: str, stderr_tail: str) -> str:
+    """The auth shape a failed spawn's tails match, or an empty string."""
+    haystack = f"{output_tail}\n{stderr_tail}".casefold()
+    for label, pattern in _AUTH_SHAPED_PATTERNS:
+        if pattern in haystack:
+            return label
+    return ""
+
+
+def classify_failure_kind(*, exit_code: int, limit_label: str = "", auth_label: str = "") -> str:
+    """The closed-enum kind of one observed unit failure. See FAILURE_KIND_PRECEDENCE."""
+    if exit_code == 0:
+        return ""
+    if exit_code == 127:
+        return FAILURE_KIND_BINARY_MISSING
+    if exit_code == 124:
+        return FAILURE_KIND_TIMEOUT
+    if auth_label:
+        return FAILURE_KIND_AUTH_SHAPED
+    if limit_label:
+        return FAILURE_KIND_LIMIT_SHAPED
+    return FAILURE_KIND_CRASH
+
+
+EXECUTOR_AUTH_FAILURE_SIGNALS_SCHEMA_VERSION = "executor_auth_failure_signals/v1"
+EXECUTOR_AUTH_FAILURE_SIGNALS_CLAIM_BOUNDARY = (
+    "An auth-failure signal records that one observed local dispatch failure matched a "
+    "credential-rejection shape. It is not provider login truth, not an entitlement statement, and "
+    "no secret value is ever read into omh state."
+)
+
+# Deliberately the same window the limit signals use, imported rather than
+# restated so the two cadences cannot drift. It is NOT a claim that a rejected
+# credential heals in six hours — it is how long the veto below holds before the
+# next dispatch is allowed to re-observe the answer for itself. A signal that
+# never went stale would be a permanent block, because the exit-0 that clears it
+# can only come from a spawn the veto is refusing.
+AUTH_FAILURE_SIGNAL_STALE_AFTER_SECONDS = LIMIT_SIGNAL_STALE_AFTER_SECONDS
+
+
+def record_auth_failure_signal(
+    paths: OmhPaths,
+    owner: str,
+    *,
+    run_ref: str,
+    unit_id: str,
+    pattern_label: str,
+) -> None:
+    """Persist the last observed auth-shaped dispatch failure for one owner."""
+
+    def _update(state: dict[str, Any]) -> dict[str, Any]:
+        state["schema_version"] = EXECUTOR_AUTH_FAILURE_SIGNALS_SCHEMA_VERSION
+        profiles = state.setdefault("profiles", {})
+        profiles[owner] = {
+            "last_auth_shaped_at": utc_now(),
+            "run_ref": run_ref,
+            "unit_id": unit_id,
+            "pattern_label": pattern_label,
+        }
+        state["claim_boundary"] = EXECUTOR_AUTH_FAILURE_SIGNALS_CLAIM_BOUNDARY
+        return state
+
+    try:
+        locked_json_update(paths.executor_auth_failure_signals_path, _update, private=True)
+    except (OSError, TimeoutError):
+        # Same rule the limit signal holds: an advisory that cannot be written
+        # must never abort the dispatch it describes.
+        pass
+
+
+def clear_auth_failure_signal(paths: OmhPaths, owner: str) -> None:
+    """Drop one owner's auth-failure signal; a later exit-0 is fresher evidence."""
+    if not paths.executor_auth_failure_signals_path.exists():
+        return
+
+    def _update(state: dict[str, Any]) -> dict[str, Any]:
+        profiles = state.get("profiles")
+        if isinstance(profiles, dict):
+            profiles.pop(owner, None)
+        return state
+
+    try:
+        locked_json_update(paths.executor_auth_failure_signals_path, _update, private=True)
+    except (OSError, TimeoutError):
+        pass
+
+
+def last_auth_failure_signal(paths: OmhPaths, owner: str) -> dict[str, Any]:
+    """The last observed auth-shaped failure for one owner, with read-time age.
+
+    `age_seconds` and `stale` are computed on read for the same reason the limit
+    signal computes them there: a stored observation must never be mistaken for
+    current provider state.
+    """
+    state, error = read_json_object_result(paths.executor_auth_failure_signals_path)
+    if error or not isinstance(state, dict):
+        return {}
+    profiles = state.get("profiles")
+    if not isinstance(profiles, dict):
+        return {}
+    entry = profiles.get(str(owner or "").strip().casefold())
+    if not isinstance(entry, dict):
+        return {}
+    payload = {str(key): value for key, value in entry.items()}
+    age = signal_age_seconds(str(payload.get("last_auth_shaped_at", "") or ""))
+    if age is not None:
+        payload["age_seconds"] = age
+        payload["stale"] = age > AUTH_FAILURE_SIGNAL_STALE_AFTER_SECONDS
+    return payload
+
+
+COOLDOWN_STATUS_LIMIT = "executor_limit_cooldown"
+COOLDOWN_STATUS_AUTH = "executor_auth_invalid"
+
+COOLDOWN_CLAIM_BOUNDARY = (
+    "A spawn cooldown refuses one spawn because THIS machine observed that owner's own CLI fail "
+    "that way inside the staleness window. It is an observed-failure veto, never a marker-absence "
+    "veto, and it is not provider truth: `--ignore-limit-signal` re-observes the answer directly."
+)
+
+# The one place an observed signal becomes a veto rather than a ranking hint.
+# This does not contradict the advisory-marker principle in
+# `executor_auth_signals`: that principle forbids pre-blocking on the ABSENCE of
+# a local login file, which every API-key install legitimately shows. This veto
+# fires only on a runtime failure omh itself observed from a real spawn of that
+# owner, inside the staleness window, and the operator overrides it with
+# `--ignore-limit-signal`.
+_AUTH_REPAIR_COMMANDS: dict[str, str] = {
+    "claude-code": "claude   # then run /login inside the session",
+    "codex": "codex login",
+}
+
+
+def auth_repair_command(owner: str) -> str:
+    """The command that re-authenticates one owner's CLI, or a neutral instruction.
+
+    Executor-specific values inside an executor-neutral surface: an owner whose
+    login command this repo has not verified gets the neutral sentence rather
+    than a guessed command, so no CLI reads as the assumed default.
+    """
+    return _AUTH_REPAIR_COMMANDS.get(owner, f"re-authenticate the {owner} CLI, then re-run this dispatch")
+
+
+DISPATCH_REPAIR_CARD_SCHEMA_VERSION = "dispatch_failure_repair_card/v1"
+_MAX_CARD_TEXT = 300
+
+
+def build_repair_card(
+    *,
+    owner: str,
+    failure_kind: str,
+    detail: str = "",
+    remaining_seconds: int | None = None,
+) -> dict[str, Any]:
+    """The deterministic repair card for one recoverable dispatch failure.
+
+    Two kinds, two repair steps, one shape: a reader branches on `failure_kind`
+    and `reason_code`, never on the prose.
+    """
+    card: dict[str, Any] = {
+        "schema_version": DISPATCH_REPAIR_CARD_SCHEMA_VERSION,
+        "status": "prepared_not_observed",
+        "owner": owner,
+        "label": executor_label(owner) if owner else "",
+        "failure_kind": failure_kind,
+        "reason_code": failure_kind,
+        "detail": str(detail)[:_MAX_CARD_TEXT],
+        "claim_boundary": COOLDOWN_CLAIM_BOUNDARY,
+    }
+    if failure_kind == FAILURE_KIND_AUTH_SHAPED:
+        card["repair_steps"] = [
+            {
+                "id": "reauthenticate_owner",
+                "action": f"Re-authenticate the {owner} CLI on this machine; omh never reads or stores the credential.",
+                "command": auth_repair_command(owner),
+            },
+            {
+                "id": "redispatch_after_repair",
+                "action": (
+                    "Re-run the dispatch for this unit once the CLI answers as authenticated. "
+                    "The observed signal is re-checked, not trusted, on the next attempt."
+                ),
+                "command": "omh coding fanout dispatch <fanout-id> --unit <unit-id> --goal-file <file>",
+            },
+        ]
+    else:
+        wait_note = (
+            "Wait for the provider window to reset."
+            if remaining_seconds is None
+            else f"Wait for the provider window to reset (cooldown re-checks in about {remaining_seconds}s)."
+        )
+        card["repair_steps"] = [
+            {
+                "id": "wait_for_provider_window",
+                "action": wait_note,
+                "command": "omh coding executor-readiness --json",
+            },
+            {
+                "id": "redispatch_or_retarget",
+                "action": (
+                    "Re-run the dispatch for this unit, or choose another coding owner explicitly. "
+                    "omh never switches owners on its own."
+                ),
+                "command": "omh coding fanout dispatch <fanout-id> --unit <unit-id> --goal-file <file>",
+            },
+        ]
+    if remaining_seconds is not None:
+        card["cooldown_remaining_seconds"] = int(remaining_seconds)
+    return card
+
+
+def spawn_cooldown(paths: OmhPaths, owner: str) -> dict[str, Any] | None:
+    """The veto for one owner with a fresh observed auth or limit signal, or None.
+
+    Auth is checked first for the same reason `classify_failure_kind` checks it
+    first: waiting out a credential rejection never clears it.
+
+    `stale is False` rather than a falsy check: `stale` exists only when the
+    record's observation time could be read, so a record whose age is unknown
+    cannot be SHOWN to be inside the window and never vetoes a spawn. It still
+    ranks the owner down in the choose-executor context, which is the weaker
+    claim an unaged observation supports.
+    """
+    auth = last_auth_failure_signal(paths, owner)
+    if auth.get("stale") is False:
+        return _cooldown(
+            owner=owner,
+            status=COOLDOWN_STATUS_AUTH,
+            failure_kind=FAILURE_KIND_AUTH_SHAPED,
+            signal=auth,
+            stale_after=AUTH_FAILURE_SIGNAL_STALE_AFTER_SECONDS,
+            observed_key="last_auth_shaped_at",
+        )
+    from .executor_auth_signals import last_limit_signal_for_profile
+
+    limit = last_limit_signal_for_profile(paths, owner)
+    if limit.get("stale") is False:
+        return _cooldown(
+            owner=owner,
+            status=COOLDOWN_STATUS_LIMIT,
+            failure_kind=FAILURE_KIND_LIMIT_SHAPED,
+            signal=limit,
+            stale_after=LIMIT_SIGNAL_STALE_AFTER_SECONDS,
+            observed_key="last_limit_shaped_at",
+        )
+    return None
+
+
+def _cooldown(
+    *,
+    owner: str,
+    status: str,
+    failure_kind: str,
+    signal: Mapping[str, Any],
+    stale_after: int,
+    observed_key: str,
+) -> dict[str, Any]:
+    age = signal.get("age_seconds")
+    remaining = None
+    if isinstance(age, int) and not isinstance(age, bool):
+        remaining = max(0, int(stale_after) - age)
+    detail = (
+        f"this machine observed {owner} fail as {failure_kind} "
+        f"({signal.get('pattern_label') or 'unlabelled'}) at {signal.get(observed_key) or 'an unrecorded time'}"
+    )
+    return {
+        "status": status,
+        "failure_kind": failure_kind,
+        "pattern_label": str(signal.get("pattern_label", "")),
+        "observed_at": str(signal.get(observed_key, "")),
+        "cooldown_remaining_seconds": remaining,
+        "reason": (
+            f"{detail}; the spawn is refused inside the staleness window. "
+            "Pass --ignore-limit-signal to spawn anyway and re-observe the answer directly."
+        ),
+        "repair_card": build_repair_card(
+            owner=owner,
+            failure_kind=failure_kind,
+            detail=detail,
+            remaining_seconds=remaining,
+        ),
+        "claim_boundary": COOLDOWN_CLAIM_BOUNDARY,
+    }
+
+
+ON_FAILURE_REPORT = "report"
+ON_FAILURE_HERMES = "hermes"
+ON_FAILURE_WAIT = "wait"
+ON_FAILURE_RETARGET_PREFIX = "retarget:"
+
+ON_FAILURE_MODES: tuple[str, ...] = (
+    ON_FAILURE_REPORT,
+    f"{ON_FAILURE_RETARGET_PREFIX}<owner>",
+    ON_FAILURE_HERMES,
+    ON_FAILURE_WAIT,
+)
+
+CHOICE_RETARGET = "retarget"
+CHOICE_HERMES = "hermes"
+CHOICE_WAIT = "wait"
+CHOICE_REPORT = "report"
+
+FAILURE_RECOVERY_SCHEMA_VERSION = "fanout_failure_recovery/v1"
+FAILURE_RECOVERY_CLAIM_BOUNDARY = (
+    "A failure-recovery record states which recovery action the operator explicitly chose for a "
+    "failed unit and what that action observed. Choosing one is not a claim that it succeeded, and "
+    "omh never switches a coding owner without an explicit choice recorded here."
+)
+
+
+class OnFailureModeError(ValueError):
+    """`--on-failure` was given a value outside the closed mode set."""
+
+
+def parse_on_failure(value: str, *, known_owners: Sequence[str] = ()) -> tuple[str, str]:
+    """Split `--on-failure` into (mode, target_owner). Empty reads as `report`.
+
+    `retarget:<owner>` is the only form carrying a value, and the owner is
+    validated against `known_owners` when the caller supplies a roster, so a
+    typo fails at parse time rather than as a mid-run refusal.
+    """
+    raw = str(value or "").strip()
+    if not raw:
+        return ON_FAILURE_REPORT, ""
+    if raw in {ON_FAILURE_REPORT, ON_FAILURE_HERMES, ON_FAILURE_WAIT}:
+        return raw, ""
+    if raw.startswith(ON_FAILURE_RETARGET_PREFIX):
+        owner = raw[len(ON_FAILURE_RETARGET_PREFIX) :].strip()
+        if not owner:
+            raise OnFailureModeError("--on-failure=retarget: requires an owner, for example retarget:codex")
+        if known_owners and owner not in known_owners:
+            raise OnFailureModeError(
+                f"unknown retarget owner {owner!r}; choose one of: {', '.join(known_owners)}"
+            )
+        return CHOICE_RETARGET, owner
+    raise OnFailureModeError(
+        f"unsupported --on-failure value {raw!r}; choose one of: {', '.join(ON_FAILURE_MODES)}"
+    )
+
+
+def recovery_candidates(units: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """The failed units a recovery choice is offered for, in summary order."""
+    return [
+        {
+            "unit_id": str(entry.get("unit_id", "")),
+            "owner": str(entry.get("owner", "")),
+            "failure_kind": str(entry.get("failure_kind", "")),
+            "status": str(entry.get("status", "")),
+        }
+        for entry in units
+        if isinstance(entry, Mapping)
+        and str(entry.get("failure_kind", "")) in RECOVERABLE_FAILURE_KINDS
+        and not entry.get("process_succeeded")
+    ]
+
+
+def retarget_candidates(
+    choice_context: Mapping[str, Any] | None,
+    *,
+    exclude_owner: str,
+) -> list[dict[str, Any]]:
+    """Ranked retarget owners from the choose-executor context, minus the failed one.
+
+    The context ranks; it never vetoes, so every candidate it lists other than
+    the owner that just failed stays offerable and carries its own readiness and
+    signal state for the operator to read.
+    """
+    candidates = (choice_context or {}).get("candidates")
+    if not isinstance(candidates, Sequence):
+        return []
+    rows: list[dict[str, Any]] = []
+    for candidate in candidates:
+        if not isinstance(candidate, Mapping):
+            continue
+        profile = str(candidate.get("profile", ""))
+        if not profile or profile == exclude_owner:
+            continue
+        rows.append(
+            {
+                "profile": profile,
+                "label": str(candidate.get("label", "")),
+                "readiness_status": str(candidate.get("readiness_status", "")),
+                "auth_marker": str(
+                    (candidate.get("auth_signal") or {}).get("login_marker", "")
+                    if isinstance(candidate.get("auth_signal"), Mapping)
+                    else ""
+                ),
+            }
+        )
+    return rows
+
+
+def recovery_options(
+    *,
+    candidate: Mapping[str, Any],
+    retargets: Sequence[Mapping[str, Any]],
+    hermes_available: bool,
+) -> list[dict[str, Any]]:
+    """The numbered choices offered for one failed unit, in a fixed order.
+
+    An option that this environment cannot carry out is still listed, with
+    `available: false` and the reason, rather than silently dropped: an operator
+    who was told there were three ways out should be told which one is closed
+    and why.
+    """
+    options: list[dict[str, Any]] = [
+        {
+            "key": "1",
+            "choice": CHOICE_RETARGET,
+            "title": "Retarget this unit to another coding owner and re-dispatch it now.",
+            "available": bool(retargets),
+            "unavailable_reason": "" if retargets else "no other locally-installed coding owner is offered",
+            "candidates": [dict(row) for row in retargets],
+        },
+        {
+            "key": "2",
+            "choice": CHOICE_HERMES,
+            "title": "Re-run this unit through the Hermes subagent lane (separate auth and quota).",
+            "available": bool(hermes_available),
+            "unavailable_reason": (
+                ""
+                if hermes_available
+                else "supply --hermes-model, --hermes-provider, and --hermes-reasoning to offer this lane"
+            ),
+            "consent_note": (
+                "Choosing this is the explicit dispatch consent the Hermes child boundary requires; "
+                "it is recorded as such."
+            ),
+        },
+        {
+            "key": "3",
+            "choice": CHOICE_WAIT,
+            "title": "Wait: mark the unit for retry later and stop this run.",
+            "available": True,
+            "unavailable_reason": "",
+        },
+    ]
+    return options
+
+
+_PROMPT_ATTEMPTS = 3
+
+
+def prompt_recovery_choice(
+    *,
+    candidate: Mapping[str, Any],
+    options: Sequence[Mapping[str, Any]],
+    read_line: Callable[[str], str],
+    write_line: Callable[[str], None],
+) -> dict[str, Any]:
+    """Ask the operator which recovery action to take for one failed unit.
+
+    The reading seam is injected on purpose: the interview is exercised without
+    a tty anywhere in the test suite. An empty answer, an unavailable option, or
+    a value outside the set re-asks; exhausting the attempts (or an input stream
+    that ended) falls back to `report`, which changes nothing.
+    """
+    unit_id = str(candidate.get("unit_id", ""))
+    owner = str(candidate.get("owner", ""))
+    kind = str(candidate.get("failure_kind", ""))
+    write_line(f"Unit {unit_id} failed on {owner} as {kind}. Choose a recovery action:")
+    for option in options:
+        suffix = "" if option.get("available") else f"  (unavailable: {option.get('unavailable_reason')})"
+        write_line(f"  [{option.get('key')}] {option.get('title')}{suffix}")
+        for row in option.get("candidates", []) or []:
+            if isinstance(row, Mapping):
+                write_line(
+                    f"        - {row.get('profile')} (readiness {row.get('readiness_status')}, "
+                    f"login marker {row.get('auth_marker')})"
+                )
+    by_key = {str(option.get("key")): option for option in options}
+    for _attempt in range(_PROMPT_ATTEMPTS):
+        try:
+            answer = read_line(f"Recovery choice for {unit_id} [1/2/3]: ").strip()
+        except (EOFError, OSError):
+            break
+        option = by_key.get(answer)
+        if option is None:
+            write_line("Answer 1, 2, or 3.")
+            continue
+        if not option.get("available"):
+            write_line(f"Option {answer} is unavailable: {option.get('unavailable_reason')}")
+            continue
+        if option.get("choice") != CHOICE_RETARGET:
+            return {"choice": str(option["choice"]), "target_owner": ""}
+        target = _prompt_retarget_owner(
+            unit_id=unit_id,
+            rows=[row for row in option.get("candidates", []) or [] if isinstance(row, Mapping)],
+            read_line=read_line,
+            write_line=write_line,
+        )
+        if target:
+            return {"choice": CHOICE_RETARGET, "target_owner": target}
+    write_line(f"No recovery action chosen for {unit_id}; reporting it unchanged.")
+    return {"choice": CHOICE_REPORT, "target_owner": ""}
+
+
+def _prompt_retarget_owner(
+    *,
+    unit_id: str,
+    rows: Sequence[Mapping[str, Any]],
+    read_line: Callable[[str], str],
+    write_line: Callable[[str], None],
+) -> str:
+    if len(rows) == 1:
+        return str(rows[0].get("profile", ""))
+    names = [str(row.get("profile", "")) for row in rows if row.get("profile")]
+    for _attempt in range(_PROMPT_ATTEMPTS):
+        write_line(f"Retarget owners for {unit_id}: {', '.join(names)}")
+        try:
+            answer = read_line(f"Owner for {unit_id}: ").strip()
+        except (EOFError, OSError):
+            return ""
+        if answer in names:
+            return answer
+        write_line(f"Choose one of: {', '.join(names)}")
+    return ""
+
+
+HERMES_LANE_CONSENT = (
+    "The operator selected the Hermes subagent lane for this unit in the dispatch recovery "
+    "interview. That selection is the explicit dispatch confirmation the Hermes child boundary "
+    "requires, equivalent to --confirm-dispatch, and it is recorded here as such."
+)
+HERMES_ROUTING_KEYS: tuple[str, ...] = ("model", "provider", "reasoning")
+
+
+def hermes_routing_available(routing: Mapping[str, Any] | None) -> bool:
+    """Whether the caller supplied the three routing aliases the child lane needs."""
+    if not isinstance(routing, Mapping):
+        return False
+    return all(str(routing.get(key, "") or "").strip() for key in HERMES_ROUTING_KEYS)
+
+
+def dispatch_unit_via_hermes_child(
+    *,
+    prompt: str,
+    routing: Mapping[str, Any],
+    parent_run_id: str,
+    run_id: str,
+    cwd: Any,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    """Run one recovery unit through the sanctioned Hermes child boundary.
+
+    `confirmed=True` is not a bypass: the operator's interview selection (or an
+    explicit `--on-failure=hermes`) is the same explicit act `--confirm-dispatch`
+    carries on the command line, and `HERMES_LANE_CONSENT` is what the journal
+    records it as. Every other part of the boundary — the depth-one limit, the
+    stdin-only prompt, the isolated child home, the sealed observation — is the
+    child module's own and is untouched here.
+    """
+    from .hermes_child_dispatch import (
+        HermesChildDispatchError,
+        HermesChildRequest,
+        dispatch_hermes_child,
+    )
+
+    try:
+        result = dispatch_hermes_child(
+            HermesChildRequest(
+                prompt=prompt,
+                model=str(routing.get("model", "")),
+                provider=str(routing.get("provider", "")),
+                reasoning=str(routing.get("reasoning", "")),
+                parent_run_id=parent_run_id,
+                run_id=run_id,
+                timeout_seconds=float(timeout_seconds),
+                cwd=cwd,
+            ),
+            dispatch_policy="ask_before_dispatch",
+            confirmed=True,
+        )
+    except (HermesChildDispatchError, ValueError, OSError) as exc:
+        return {"status": "hermes_child_refused", "reason": str(exc)[:_MAX_CARD_TEXT]}
+    return {
+        "status": str(result.status),
+        "exit_code": result.exit_code,
+        "run_id": str(result.run_id),
+        "model": str(result.model),
+        "usage": {
+            key: value
+            for key, value in (result.usage or {}).items()
+            if value is None or isinstance(value, (str, int, float, bool))
+        },
+    }
+
+
+def recovery_decision(
+    *,
+    candidate: Mapping[str, Any],
+    choice: str,
+    target_owner: str = "",
+    consent: str = "",
+    reason: str = "",
+) -> dict[str, Any]:
+    """One recorded recovery decision, before any action is carried out."""
+    decision: dict[str, Any] = {
+        "unit_id": str(candidate.get("unit_id", "")),
+        "owner": str(candidate.get("owner", "")),
+        "failure_kind": str(candidate.get("failure_kind", "")),
+        "choice": choice,
+        "decided_at": utc_now(),
+    }
+    if target_owner:
+        decision["target_owner"] = target_owner
+    if consent:
+        decision["consent"] = consent
+    if reason:
+        decision["reason"] = reason
+    return decision

--- a/src/coding/executor_auth_signals.py
+++ b/src/coding/executor_auth_signals.py
@@ -109,6 +109,16 @@ def last_limit_signal_for_profile(paths: OmhPaths, profile: str) -> dict[str, ob
     return payload
 
 
+def signal_age_seconds(observed_at: str) -> int | None:
+    """Age in whole seconds of one recorded observation timestamp, or None.
+
+    Public because the auth-failure signals in `dispatch_failure_recovery` age
+    their records by the same rule; a second copy of this arithmetic is how two
+    staleness answers start disagreeing.
+    """
+    return _age_seconds(observed_at)
+
+
 def _age_seconds(observed_at: str) -> int | None:
     if not observed_at:
         return None

--- a/src/coding/executor_readiness.py
+++ b/src/coding/executor_readiness.py
@@ -327,11 +327,19 @@ def _with_advisory_signals(paths: OmhPaths, profile: str, result: dict[str, obje
     Login and limit markers change whenever the user logs in/out or a dispatch
     hits a provider limit, so they are recomputed on every call and never
     persisted with the cached probe (which would freeze them at first use).
+
+    `last_auth_failure_signal` is the third, and the only one of the three that
+    can currently refuse a spawn (see `dispatch_failure_recovery.spawn_cooldown`).
+    It is surfaced here because an operator whose unit came back
+    `executor_auth_invalid` should be able to read WHY from the readiness
+    surface, rather than only from the dispatch summary that refused them.
     """
+    from .dispatch_failure_recovery import last_auth_failure_signal
     from .executor_auth_signals import auth_signal_for_profile, last_limit_signal_for_profile
 
     result["auth_signal"] = auth_signal_for_profile(profile)
     result["last_limit_signal"] = last_limit_signal_for_profile(paths, profile)
+    result["last_auth_failure_signal"] = last_auth_failure_signal(paths, profile)
     return result
 
 
@@ -647,6 +655,7 @@ def _write_state(paths: OmhPaths, state: dict[str, Any], profile: str, result: d
     # login/limit state at first probe (see _with_advisory_signals).
     stored.pop("auth_signal", None)
     stored.pop("last_limit_signal", None)
+    stored.pop("last_auth_failure_signal", None)
     # The binding is what makes `updated_at` readable later: without it a
     # stored decision can only be aged, never checked against the machine it
     # described. It carries no timestamp of its own, deliberately -- it is

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -29,6 +29,35 @@ from ..system.paths import OmhPaths
 from ._hermes_child_process import terminate_process_group
 from .action_gate import recheck_safety_profile_revision
 from .coding_contracts import STRUCTURAL_SEARCH_GUIDANCE
+from .dispatch_failure_recovery import (
+    HERMES_LANE_CONSENT,
+    dispatch_unit_via_hermes_child,
+    hermes_routing_available,
+    CHOICE_HERMES,
+    CHOICE_REPORT,
+    CHOICE_RETARGET,
+    CHOICE_WAIT,
+    COOLDOWN_STATUS_AUTH,
+    COOLDOWN_STATUS_LIMIT,
+    ON_FAILURE_HERMES,
+    ON_FAILURE_REPORT,
+    ON_FAILURE_WAIT,
+    FAILURE_KIND_AUTH_SHAPED,
+    FAILURE_KIND_LIMIT_SHAPED,
+    FAILURE_RECOVERY_CLAIM_BOUNDARY,
+    FAILURE_RECOVERY_SCHEMA_VERSION,
+    auth_shaped_label,
+    build_repair_card,
+    classify_failure_kind,
+    clear_auth_failure_signal,
+    prompt_recovery_choice,
+    record_auth_failure_signal,
+    recovery_candidates,
+    recovery_decision,
+    recovery_options,
+    retarget_candidates,
+    spawn_cooldown,
+)
 from .executor_capability_snapshots import (
     complete_executor_capability_snapshot,
     validate_executor_capability_snapshot,
@@ -1190,6 +1219,19 @@ def dispatch_fanout(
     max_retries: int = FANOUT_MAX_RETRIES,
     rng: Callable[[], float] = random.random,
     sleep: Callable[[float], None] = time.sleep,
+    # Failure-recovery inputs. `on_failure` is the closed degradation mode
+    # (`report` changes nothing, which is the pre-recovery behavior); the
+    # interview only ever runs when the caller states BOTH that this session is
+    # interactive and how to read a line, so nothing here can block on a
+    # terminal that is not there.
+    ignore_limit_signal: bool = False,
+    on_failure: str = ON_FAILURE_REPORT,
+    retarget_owner: str = "",
+    interactive: bool = False,
+    read_line: Callable[[str], str] | None = None,
+    write_line: Callable[[str], None] | None = None,
+    hermes_routing: Mapping[str, Any] | None = None,
+    hermes_child: Callable[..., Mapping[str, Any]] | None = None,
 ) -> dict[str, Any]:
     # The spawn guard runs before every other check, including the two
     # boundary re-checks below: it is the only one whose whole job is that no
@@ -1369,6 +1411,32 @@ def dispatch_fanout(
     # only for runners carrying the real-runner `accepts_on_spawn` seam, so
     # injected test runners and dry runs never wait.
     spawn_stagger = _SpawnStagger(CACHE_WARM_SPAWN_STAGGER_SECONDS)
+    # Every per-unit argument except the unit and its capability precheck.
+    # Named once so the post-run recovery pass re-dispatches a retargeted unit
+    # through exactly the arguments the pool used, rather than a second
+    # hand-maintained copy of them that would drift on the next new parameter.
+    unit_dispatch_kwargs: dict[str, Any] = {
+        "goal_text": goal_text,
+        "repo_root": repo_root,
+        "base_sha": base_sha,
+        "source_ref": source_ref,
+        "timeout": timeout,
+        "dry_run": dry_run,
+        "run_verification": run_verification,
+        "runner": runner,
+        "readiness": readiness,
+        "current_catalog_digest": current_catalog_digest,
+        "fanout_id": fanout_id,
+        "discoveries": discoveries,
+        "spawn_stagger": spawn_stagger,
+        "spawn_ledger": spawn_ledger,
+        "dispatch_depth": current_depth,
+        "base_env": guard_env,
+        "max_retries": max_retries,
+        "rng": rng,
+        "sleep": sleep,
+        "ignore_limit_signal": ignore_limit_signal,
+    }
 
     def _dispatch_with_owner_gate(unit: Mapping[str, Any], **kwargs: Any) -> dict[str, Any]:
         # A worker that reaches its turn after the interrupt — queued in the
@@ -1416,26 +1484,8 @@ def dispatch_fanout(
             futures[unit_id] = pool.submit(
                 _dispatch_with_owner_gate,
                 units[unit_id],
-                goal_text=goal_text,
-                repo_root=repo_root,
-                base_sha=base_sha,
-                source_ref=source_ref,
-                timeout=timeout,
-                dry_run=dry_run,
-                run_verification=run_verification,
-                runner=runner,
-                readiness=readiness,
-                current_catalog_digest=current_catalog_digest,
-                fanout_id=fanout_id,
-                discoveries=discoveries,
+                **unit_dispatch_kwargs,
                 capability_precheck=capability_prechecks[unit_id],
-                spawn_stagger=spawn_stagger,
-                spawn_ledger=spawn_ledger,
-                dispatch_depth=current_depth,
-                base_env=guard_env,
-                max_retries=max_retries,
-                rng=rng,
-                sleep=sleep,
             )
 
         def _admit_frontier() -> None:
@@ -1521,6 +1571,30 @@ def dispatch_fanout(
         if installed_term:
             signal.signal(signal.SIGTERM, previous_term)
 
+    # Recovery runs on the collected results and before the summary is built, so
+    # a retarget attempt's own outcome and a `wait` mark are both in hand when
+    # the run journal is projected. An interrupted batch is skipped entirely:
+    # the operator already asked for it to stop.
+    failure_recovery = (
+        None
+        if (dry_run or interrupted_by is not None)
+        else _run_failure_recovery(
+            paths,
+            results=results,
+            order=order,
+            units=units,
+            repo_root=repo_root,
+            timeout=timeout,
+            mode=on_failure,
+            retarget_owner=retarget_owner,
+            interactive=interactive,
+            read_line=read_line,
+            write_line=write_line,
+            hermes_routing=hermes_routing,
+            hermes_child=hermes_child,
+            unit_dispatch_kwargs=unit_dispatch_kwargs,
+        )
+    )
     summary_units = [results[unit_id] for unit_id in order]
     for entry in summary_units:
         decision = resume_decisions.get(str(entry.get("unit_id", "")))
@@ -1565,6 +1639,8 @@ def dispatch_fanout(
         "spawns_claimed": spawn_ledger.claimed,
         "claim_boundary": FANOUT_SPAWN_GUARD_CLAIM_BOUNDARY,
     }
+    if failure_recovery is not None:
+        summary["failure_recovery"] = failure_recovery
     if resume_plan is not None:
         summary["resume"] = {**resume_plan, "counts": resume_counts(resume_plan["decisions"])}
     if interrupted_by is not None:
@@ -1609,6 +1685,296 @@ def dispatch_fanout(
         # operator is at the keyboard reading it.
         raise interrupted_by
     return summary
+
+
+def _silent_write_line(_line: str) -> None:
+    """Default narration sink: a library call prints nothing.
+
+    The decisions and their options ride the summary, so a programmatic caller
+    already has everything the narration would have said. The CLI passes a real
+    writer (stderr, so a piped JSON stdout stays clean).
+    """
+    return None
+
+
+def _run_failure_recovery(
+    paths: OmhPaths,
+    *,
+    results: dict[str, dict[str, Any]],
+    order: Sequence[str],
+    units: Mapping[str, Mapping[str, Any]],
+    repo_root: Path,
+    timeout: int,
+    mode: str,
+    retarget_owner: str,
+    interactive: bool,
+    read_line: Callable[[str], str] | None,
+    write_line: Callable[[str], None] | None,
+    hermes_routing: Mapping[str, Any] | None,
+    hermes_child: Callable[..., Mapping[str, Any]] | None,
+    unit_dispatch_kwargs: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    """Offer, record, and carry out one recovery action per recoverable failure.
+
+    Returns None when nothing failed recoverably, so a clean run's summary is
+    byte-identical to what it was before this lane existed. Every decision is
+    recorded whether or not it changed anything: `report` is a decision too, and
+    an operator who was shown three options and picked none should be able to
+    see that in the record.
+
+    The one invariant this function exists to hold: no coding owner is ever
+    switched without an explicit choice — an interview answer, or an explicit
+    `--on-failure=retarget:<owner>` on the command line.
+    """
+    candidates = recovery_candidates([results[unit_id] for unit_id in order if unit_id in results])
+    if not candidates:
+        return None
+    emit = write_line if write_line is not None else _silent_write_line
+    hermes_available = hermes_routing_available(hermes_routing)
+    context: dict[str, Any] | None = None
+
+    def _choice_context() -> Mapping[str, Any]:
+        nonlocal context
+        if context is None:
+            from .executor_readiness import executor_choice_context
+
+            try:
+                context = dict(executor_choice_context(paths))
+            except (OSError, ValueError):
+                # Ranking context is advisory. Losing it costs the operator the
+                # readiness column on the retarget list, never the choice.
+                context = {"candidates": []}
+        return context
+
+    decisions: list[dict[str, Any]] = []
+    for candidate in candidates:
+        unit_id = str(candidate["unit_id"])
+        entry = results[unit_id]
+        retargets = retarget_candidates(_choice_context(), exclude_owner=str(candidate["owner"]))
+        options = recovery_options(
+            candidate=candidate, retargets=retargets, hermes_available=hermes_available
+        )
+        chosen = _chosen_recovery(
+            candidate=candidate,
+            options=options,
+            mode=mode,
+            retarget_owner=retarget_owner,
+            interactive=interactive,
+            read_line=read_line,
+            emit=emit,
+        )
+        decision = recovery_decision(
+            candidate=candidate,
+            choice=str(chosen["choice"]),
+            target_owner=str(chosen.get("target_owner", "")),
+            consent=HERMES_LANE_CONSENT if chosen["choice"] == CHOICE_HERMES else "",
+            reason=str(chosen.get("reason", "")),
+        )
+        decision["options"] = options
+        if entry.get("repair_card") is not None:
+            decision["repair_card"] = entry["repair_card"]
+        if decision["choice"] == CHOICE_RETARGET:
+            decision["attempt"] = _retarget_dispatch(
+                paths,
+                unit=units[unit_id],
+                new_owner=str(decision["target_owner"]),
+                failed_owner=str(candidate["owner"]),
+                unit_dispatch_kwargs=unit_dispatch_kwargs,
+            )
+        elif decision["choice"] == CHOICE_HERMES:
+            decision["attempt"] = _hermes_recovery_dispatch(
+                unit=units[unit_id],
+                goal_text=str(unit_dispatch_kwargs["goal_text"]),
+                repo_root=repo_root,
+                timeout=timeout,
+                routing=hermes_routing or {},
+                hermes_child=hermes_child,
+            )
+        elif decision["choice"] == CHOICE_WAIT:
+            # No re-dispatch: the mark on the unit is the whole action, and the
+            # run journal turns it into the next resume's selection.
+            entry["awaiting_retry"] = True
+        entry["recovery_choice"] = {
+            "choice": decision["choice"],
+            "failure_kind": str(candidate["failure_kind"]),
+            **({"target_owner": decision["target_owner"]} if decision.get("target_owner") else {}),
+        }
+        decisions.append(decision)
+    return {
+        "schema_version": FAILURE_RECOVERY_SCHEMA_VERSION,
+        "mode": mode,
+        "interactive": bool(interactive and read_line is not None),
+        "decisions": decisions,
+        "awaiting_retry_units": [
+            str(decision["unit_id"]) for decision in decisions if decision["choice"] == CHOICE_WAIT
+        ],
+        "claim_boundary": FAILURE_RECOVERY_CLAIM_BOUNDARY,
+    }
+
+
+def _chosen_recovery(
+    *,
+    candidate: Mapping[str, Any],
+    options: Sequence[Mapping[str, Any]],
+    mode: str,
+    retarget_owner: str,
+    interactive: bool,
+    read_line: Callable[[str], str] | None,
+    emit: Callable[[str], None],
+) -> dict[str, Any]:
+    """Resolve one unit's recovery choice from the mode, or by asking.
+
+    A named mode is obeyed without a prompt even on a terminal: the operator
+    already answered on the command line. `report` prompts only when the caller
+    stated the session is interactive AND supplied a reader — which is how a
+    non-tty invocation can never block.
+    """
+    by_choice = {str(option.get("choice")): option for option in options}
+    if mode == CHOICE_RETARGET:
+        if retarget_owner == str(candidate.get("owner", "")):
+            return {
+                "choice": CHOICE_REPORT,
+                "reason": f"--on-failure named {retarget_owner}, the owner that just failed",
+            }
+        return {"choice": CHOICE_RETARGET, "target_owner": retarget_owner}
+    if mode == ON_FAILURE_HERMES:
+        option = by_choice.get(CHOICE_HERMES, {})
+        if not option.get("available"):
+            return {"choice": CHOICE_REPORT, "reason": str(option.get("unavailable_reason", ""))}
+        return {"choice": CHOICE_HERMES}
+    if mode == ON_FAILURE_WAIT:
+        return {"choice": CHOICE_WAIT}
+    if interactive and read_line is not None:
+        return prompt_recovery_choice(
+            candidate=candidate, options=options, read_line=read_line, write_line=emit
+        )
+    _report_recovery_options(candidate=candidate, options=options, emit=emit)
+    return {"choice": CHOICE_REPORT, "reason": "no recovery action was requested"}
+
+
+def _report_recovery_options(
+    *,
+    candidate: Mapping[str, Any],
+    options: Sequence[Mapping[str, Any]],
+    emit: Callable[[str], None],
+) -> None:
+    emit(
+        f"Unit {candidate.get('unit_id')} failed on {candidate.get('owner')} as "
+        f"{candidate.get('failure_kind')}. Recovery options (none taken; pass --on-failure to choose):"
+    )
+    for option in options:
+        suffix = "" if option.get("available") else f"  (unavailable: {option.get('unavailable_reason')})"
+        emit(f"  [{option.get('key')}] {option.get('title')}{suffix}")
+
+
+def _retarget_dispatch(
+    paths: OmhPaths,
+    *,
+    unit: Mapping[str, Any],
+    new_owner: str,
+    failed_owner: str,
+    unit_dispatch_kwargs: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Re-dispatch one failed unit under an explicitly chosen different owner.
+
+    The attempt runs as a DERIVED unit id, which is what gives it its own
+    worktree and branch. Reusing the failed unit's worktree would mean either
+    building on state a refused spawn left behind or deleting an operator's
+    directory, and this engine does neither — `worktree_creator` refuses a
+    pre-existing path for exactly that reason.
+
+    The frozen model route is dropped rather than carried across: a model id
+    belongs to the CLI it was resolved for, and handing codex's route to claude
+    substitutes a value the contract never froze for this owner. The retarget
+    falls through to the new owner's own dispatch-model preference, or its CLI
+    default, both of which are recorded.
+    """
+    from .executor_capability_snapshots import (
+        ExecutorCapabilitySnapshotError,
+        resolved_executor_capability_snapshot,
+    )
+
+    unit_id = str(unit.get("unit_id", ""))
+    retarget_id = f"{unit_id}-retarget-{new_owner}"
+    try:
+        snapshot = resolved_executor_capability_snapshot(
+            new_owner, paths.executor_capability_snapshots_dir
+        )
+    except (ExecutorCapabilitySnapshotError, ValueError) as exc:
+        return {
+            "unit_id": retarget_id,
+            "owner": new_owner,
+            "status": "capability_snapshot_invalid",
+            "reason": str(exc),
+        }
+    handoff = dict(unit.get("handoff") or {})
+    handoff["executor_target"] = new_owner
+    handoff["executor_capability_snapshot"] = snapshot
+    handoff["executor_capability_snapshot_policy"] = "frozen_required"
+    handoff.pop("model_route", None)
+    retargeted = {
+        **dict(unit),
+        "unit_id": retarget_id,
+        "run_ref": f"{unit.get('run_ref', unit_id)}-retarget-{new_owner}",
+        "owner": new_owner,
+        "branch_suggestion": f"agent/{retarget_id}",
+        "handoff": handoff,
+        "depends_on": [],
+    }
+    result = _dispatch_unit(
+        paths,
+        retargeted,
+        **{**dict(unit_dispatch_kwargs), "ignore_limit_signal": False},
+        capability_precheck=(new_owner, snapshot, []),
+    )
+    result["retargeted_from"] = {"unit_id": unit_id, "owner": failed_owner}
+    return result
+
+
+def _hermes_recovery_dispatch(
+    *,
+    unit: Mapping[str, Any],
+    goal_text: str,
+    repo_root: Path,
+    timeout: int,
+    routing: Mapping[str, Any],
+    hermes_child: Callable[..., Mapping[str, Any]] | None,
+) -> dict[str, Any]:
+    """Re-run one failed unit through the Hermes subagent lane, in its worktree.
+
+    The child runs in the unit's OWN worktree or not at all: pointing it at the
+    dispatch repo root would let a recovery attempt edit the operator's main
+    checkout, which no unit of a fanout is ever allowed to do.
+    """
+    unit_id = str(unit.get("unit_id", ""))
+    worktree = _worktree_path(repo_root, unit_id)
+    if not worktree.is_dir():
+        return {
+            "unit_id": unit_id,
+            "owner": "hermes",
+            "status": "hermes_child_refused",
+            "reason": (
+                f"unit worktree {worktree} does not exist; the Hermes lane never runs against the "
+                "dispatch repo root"
+            ),
+        }
+    dispatcher = hermes_child if hermes_child is not None else dispatch_unit_via_hermes_child
+    run_ref = str(unit.get("run_ref", unit_id))
+    attempt = dispatcher(
+        prompt=build_unit_prompt(unit, goal_text),
+        routing=routing,
+        parent_run_id=run_ref,
+        run_id=f"{run_ref}-hermes-recovery",
+        cwd=worktree,
+        timeout_seconds=float(timeout),
+    )
+    return {
+        "unit_id": unit_id,
+        "owner": "hermes",
+        "worktree_path": str(worktree),
+        "consent": HERMES_LANE_CONSENT,
+        **dict(attempt),
+    }
 
 
 def _depth_refusal_summary(
@@ -2127,6 +2493,7 @@ def _dispatch_unit(
     max_retries: int = FANOUT_MAX_RETRIES,
     rng: Callable[[], float] = random.random,
     sleep: Callable[[float], None] = time.sleep,
+    ignore_limit_signal: bool = False,
 ) -> dict[str, Any]:
     from .model_inventory import catalog_fingerprint_note
 
@@ -2174,6 +2541,31 @@ def _dispatch_unit(
             **_dispatch_status_ladder(),
             "fallback": "use the unit handoff as a prepared prompt for this owner",
         }
+    # The one place an observed signal vetoes a spawn instead of ranking one.
+    # It is checked before the readiness probe because the cheapest refusal is
+    # the one that runs no subprocess at all, and it never fires on a dry run,
+    # which spawns nothing to begin with. See COOLDOWN_CLAIM_BOUNDARY for why
+    # this does not contradict the advisory-marker principle: the input is a
+    # runtime failure omh observed from a real spawn of this owner, not the
+    # absence of a local login file.
+    if not dry_run and not ignore_limit_signal:
+        cooldown = spawn_cooldown(paths, owner)
+        if cooldown is not None:
+            return {
+                "unit_id": unit_id,
+                "run_ref": run_ref,
+                "owner": owner,
+                "status": str(cooldown["status"]),
+                "failure_kind": str(cooldown["failure_kind"]),
+                **_dispatch_status_ladder(),
+                "reason": str(cooldown["reason"]),
+                "cooldown": {
+                    key: value
+                    for key, value in cooldown.items()
+                    if key in {"pattern_label", "observed_at", "cooldown_remaining_seconds", "claim_boundary"}
+                },
+                "repair_card": cooldown["repair_card"],
+            }
     probe = readiness(paths, owner)
     if str(probe.get("status", "")) != "ready":
         # The pre-handoff recheck (#837) can turn a once-ready owner into
@@ -2562,13 +2954,29 @@ def _dispatch_unit(
     finished_at = utc_now()
     duration_seconds = round(time.monotonic() - started_clock, 3)
     limit_label = _limit_shaped_label(output_tail, stderr_tail) if exit_code != 0 else ""
-    if limit_label:
+    auth_label = auth_shaped_label(output_tail, stderr_tail) if exit_code != 0 else ""
+    # One closed-enum answer per failed unit, derived once so the envelope, the
+    # persisted signal, and the recovery interview cannot disagree about what
+    # kind of failure this was.
+    failure_kind = classify_failure_kind(
+        exit_code=exit_code, limit_label=limit_label, auth_label=auth_label
+    )
+    # Auth takes the persisted signal when both shapes match, for the same
+    # reason it takes the enum: a credential rejection filed as a limit would be
+    # waited out forever. `limit_shaped` stays on the envelope either way, so no
+    # existing consumer of that flag loses its answer.
+    if failure_kind == FAILURE_KIND_AUTH_SHAPED:
+        record_auth_failure_signal(
+            paths, owner, run_ref=run_ref, unit_id=unit_id, pattern_label=auth_label
+        )
+    elif limit_label:
         _record_limit_signal(paths, owner, run_ref=run_ref, unit_id=unit_id, pattern_label=limit_label)
     elif exit_code == 0:
         # A successful dispatch to this executor is the freshest evidence the
-        # provider is serving it again; a stale limit signal must not keep
-        # down-ranking the executor forever.
+        # provider is serving it again; a stale limit or auth signal must not
+        # keep down-ranking (or vetoing) the executor forever.
         _clear_limit_signal(paths, owner)
+        clear_auth_failure_signal(paths, owner)
     status = "observed" if exit_code == 0 else "failed"
     # A second cap over an already-bounded tail. It goes through the shared
     # contract too, so the journal line says which of the two it is: the whole
@@ -2595,7 +3003,9 @@ def _dispatch_unit(
     journal_notice = truncation_notice(journal_truncation, compact=True)
     if journal_notice:
         summary = f"{summary} {journal_notice}"
-    if limit_label:
+    if failure_kind == FAILURE_KIND_AUTH_SHAPED:
+        summary = f"auth-shaped failure ({auth_label}); {summary}"
+    elif limit_label:
         summary = f"limit-shaped failure ({limit_label}); {summary}"
     # The compact notice above says "continuation=evidence_refs"; these are the
     # refs it means. Uncapped by the journal, so the pointer arrives whole.
@@ -2693,6 +3103,20 @@ def _dispatch_unit(
     if limit_label:
         result["limit_shaped"] = True
         result["limit_pattern"] = limit_label
+    if failure_kind:
+        # Every failed envelope carries exactly one closed-enum kind, including
+        # `crash` -- the fallback exists so a reader never has to infer "no kind
+        # recorded" from an absent key.
+        result["failure_kind"] = failure_kind
+    if failure_kind == FAILURE_KIND_AUTH_SHAPED:
+        result["auth_shaped"] = True
+        result["auth_pattern"] = auth_label
+    if failure_kind in {FAILURE_KIND_AUTH_SHAPED, FAILURE_KIND_LIMIT_SHAPED}:
+        result["repair_card"] = build_repair_card(
+            owner=owner,
+            failure_kind=failure_kind,
+            detail=f"unit {unit_id} exited {exit_code} on {owner} with a {failure_kind} output shape",
+        )
     if retry_decisions:
         # Only when something actually failed once: a unit that succeeded on
         # its first attempt carries no retry key at all, so the presence of
@@ -3350,6 +3774,11 @@ def _dependency_failed(result: dict[str, Any] | None) -> bool:
         "unsupported_for_local_dispatch",
         "worktree_failed",
         "not_selected",
+        # A vetoed spawn never ran, so a dependent must block on it exactly as
+        # it would on an unready executor -- admitting the dependent would run
+        # it against work that does not exist.
+        COOLDOWN_STATUS_AUTH,
+        COOLDOWN_STATUS_LIMIT,
     } and not result.get("process_succeeded")
 
 

--- a/src/coding/fanout_journal.py
+++ b/src/coding/fanout_journal.py
@@ -109,12 +109,23 @@ RESUME_HOLD_SUCCEEDED = "hold_succeeded"
 RESUME_HOLD_REPLAY_UNSAFE = "hold_replay_unsafe"
 RESUME_HOLD_BLOCKED_DEPENDENCY = "hold_blocked_dependency"
 RESUME_HOLD_DECLINED = "hold_declined_conclusive"
+# The operator chose "wait" for this unit in the dispatch recovery interview:
+# its provider refused to serve the owner, and the answer was to come back
+# later rather than retarget or switch lanes. It is a rerun action with its own
+# name so the resume record says the unit is being re-attempted because someone
+# asked for exactly that, not because a failure happened to be replay-safe.
+RESUME_RERUN_AWAITING_RETRY = "rerun_awaiting_retry"
 
 RESUME_HOLD_ACTIONS = frozenset(
     {RESUME_HOLD_SUCCEEDED, RESUME_HOLD_REPLAY_UNSAFE, RESUME_HOLD_BLOCKED_DEPENDENCY, RESUME_HOLD_DECLINED}
 )
 RESUME_RERUN_ACTIONS = frozenset(
-    {RESUME_RERUN_FAILED, RESUME_RERUN_NOT_ATTEMPTED, RESUME_UNSKIP_DEPENDENT}
+    {
+        RESUME_RERUN_FAILED,
+        RESUME_RERUN_NOT_ATTEMPTED,
+        RESUME_UNSKIP_DEPENDENT,
+        RESUME_RERUN_AWAITING_RETRY,
+    }
 )
 
 # Reason codes for an unreadable journal, in OMH's `reason_code` idiom so a
@@ -134,6 +145,12 @@ _NEVER_SPAWNED_STATUSES = frozenset(
         "interrupted",
         "model_choice_required",
         "spawn_ceiling_reached",
+        # A cooldown veto refuses the spawn before the worktree exists, so the
+        # unit left nothing behind and a later resume — by which time the
+        # window may have reset or the credential been repaired — re-attempts
+        # it like any other unit that never ran.
+        "executor_limit_cooldown",
+        "executor_auth_invalid",
     }
 )
 _SUCCEEDED_STATUSES = frozenset({"completed", "already_completed", "dry_run_planned"})
@@ -189,6 +206,17 @@ def journal_unit_entry(entry: Mapping[str, Any]) -> dict[str, Any]:
     exit_code = entry.get("exit_code")
     if isinstance(exit_code, int) and not isinstance(exit_code, bool):
         row["exit_code"] = exit_code
+    # Optional rather than part of `_JOURNAL_UNIT_KEYS`: a journal written
+    # before the recovery lane existed is still readable, and a unit nobody
+    # chose to defer carries no marker at all.
+    kind = str(entry.get("failure_kind", ""))
+    if kind:
+        row["failure_kind"] = kind
+    if entry.get("awaiting_retry"):
+        row["awaiting_retry"] = True
+        choice = entry.get("recovery_choice")
+        if isinstance(choice, Mapping):
+            row["awaiting_retry_kind"] = str(choice.get("failure_kind", ""))
     return row
 
 
@@ -371,6 +399,23 @@ def _unit_resume_decision(
                 "held because "
                 + ", ".join(unresolved)
                 + " is not being re-dispatched, so this unit would only block again"
+            ),
+            row=row,
+        )
+    if row.get("awaiting_retry"):
+        # Reached only after replay-safety and the blocker check have both
+        # passed: "wait for the provider window" is a reason to re-attempt a
+        # unit, never a licence to rebuild a worktree over work a failure left
+        # behind. A deferred unit that IS replay-unsafe is held above, with the
+        # side effect named, exactly like any other.
+        return _decision(
+            unit_id,
+            prior_state=prior_state,
+            action=RESUME_RERUN_AWAITING_RETRY,
+            reason=(
+                "the operator deferred this unit in the dispatch recovery interview after a "
+                f"{row.get('awaiting_retry_kind') or row.get('failure_kind') or 'recoverable'} failure; "
+                "this resume is the retry that was asked for"
             ),
             row=row,
         )

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -1946,6 +1946,53 @@ def _record_fanout_board_emission(paths, watched_runs: list[str], payload: dict,
         )
 
 
+def _failure_recovery_kwargs(args: argparse.Namespace) -> dict:
+    """Resolve the failure-recovery inputs the dispatch engine takes.
+
+    The interview runs only when `--on-failure` is left at `report` AND stdin is
+    a real terminal AND `--no-interactive` was not passed: a named mode is the
+    operator answering on the command line, and a pipe or a CI job must never
+    block on a prompt that nobody can see.
+    """
+    from ..coding.dispatch_failure_recovery import (
+        ON_FAILURE_REPORT,
+        OnFailureModeError,
+        parse_on_failure,
+    )
+    from ..executors import EXECUTOR_PROFILES
+
+    try:
+        mode, target_owner = parse_on_failure(
+            getattr(args, "on_failure", "") or "", known_owners=EXECUTOR_PROFILES
+        )
+    except OnFailureModeError as exc:
+        raise OmhError(str(exc)) from exc
+    interactive = (
+        mode == ON_FAILURE_REPORT
+        and not getattr(args, "no_interactive", False)
+        and sys.stdin.isatty()
+    )
+    routing = {
+        "model": getattr(args, "hermes_model", "") or "",
+        "provider": getattr(args, "hermes_provider", "") or "",
+        "reasoning": getattr(args, "hermes_reasoning", "") or "",
+    }
+    return {
+        "ignore_limit_signal": bool(getattr(args, "ignore_limit_signal", False)),
+        "on_failure": mode,
+        "retarget_owner": target_owner,
+        "interactive": interactive,
+        "read_line": input if interactive else None,
+        # stderr, so a caller piping the dispatch JSON reads a clean document.
+        "write_line": _write_stderr_line,
+        "hermes_routing": routing,
+    }
+
+
+def _write_stderr_line(line: str) -> None:
+    print(line, file=sys.stderr)
+
+
 def _fanout_dispatch_exit_code(summary: dict) -> int:
     """130 for a cut-short batch, 1 for a refusal, 0 otherwise.
 
@@ -1972,6 +2019,7 @@ def cmd_coding_fanout_dispatch(args: argparse.Namespace) -> int:
     from ..coding.parallelism_policy import read_parallelism_policy, resolve_fanout_concurrency
 
     paths = _paths(args)
+    recovery_kwargs = _failure_recovery_kwargs(args)
     try:
         parallelism = read_parallelism_policy(paths)
     except ValueError as exc:
@@ -2027,6 +2075,7 @@ def cmd_coding_fanout_dispatch(args: argparse.Namespace) -> int:
             dry_run=bool(args.dry_run),
             run_verification=bool(args.run_verification),
             resume_journal=resume_journal,
+            **recovery_kwargs,
         )
         _print_json(summary)
         return _fanout_dispatch_exit_code(summary)
@@ -2061,6 +2110,7 @@ def cmd_coding_fanout_dispatch(args: argparse.Namespace) -> int:
             dry_run=bool(args.dry_run),
             run_verification=bool(args.run_verification),
             resume_journal=resume_journal,
+            **recovery_kwargs,
         )
     except ValueError as exc:
         raise OmhError(str(exc)) from exc
@@ -2194,6 +2244,7 @@ def cmd_coding_run(args: argparse.Namespace) -> int:
             timeout=args.timeout,
             dry_run=bool(args.dry_run),
             run_verification=bool(args.run_verification),
+            **_failure_recovery_kwargs(args),
         )
     except ValueError as exc:
         raise OmhError(str(exc)) from exc
@@ -2445,6 +2496,40 @@ def cmd_coding_commit_plan(args: argparse.Namespace) -> int:
     return 0
 
 
+def _add_failure_recovery_arguments(parser) -> None:
+    """The failure-recovery flags shared by `fanout dispatch` and `coding run`.
+
+    Both surfaces funnel into the same `dispatch_fanout`, so a recovery option
+    that exists on one and not the other would be a difference in the CLI only.
+    """
+    parser.add_argument(
+        "--on-failure",
+        default="report",
+        metavar="report|retarget:<owner>|hermes|wait",
+        help=(
+            "What to do with units that failed as auth_shaped or limit_shaped. 'report' (default) "
+            "prints the repair card and the options and changes nothing, or runs the interactive "
+            "interview when stdin is a terminal. A named mode is applied without prompting."
+        ),
+    )
+    parser.add_argument(
+        "--no-interactive",
+        action="store_true",
+        help="Never prompt, even on a terminal; --on-failure alone decides.",
+    )
+    parser.add_argument(
+        "--ignore-limit-signal",
+        action="store_true",
+        help=(
+            "Spawn even when this machine observed a fresh limit-shaped or auth-shaped failure for "
+            "the unit's owner, re-observing the provider's answer directly."
+        ),
+    )
+    parser.add_argument("--hermes-model", default="", help="Hermes model alias for the Hermes-subagent recovery lane.")
+    parser.add_argument("--hermes-provider", default="", help="Hermes provider alias for the Hermes-subagent recovery lane.")
+    parser.add_argument("--hermes-reasoning", default="", help="Hermes reasoning alias for the Hermes-subagent recovery lane.")
+
+
 def _add_coding_commands(sub) -> None:
     coding = sub.add_parser("coding", help="Prepare executor-neutral or tracked coding handoff artifacts.")
     coding_sub = coding.add_subparsers(dest="coding_command", required=True)
@@ -2519,6 +2604,7 @@ def _add_coding_commands(sub) -> None:
             "re-run a unit that already succeeded."
         ),
     )
+    _add_failure_recovery_arguments(fanout_dispatch)
     fanout_dispatch.set_defaults(func=cmd_coding_fanout_dispatch)
 
     fanout_migrate = fanout_sub.add_parser(
@@ -2626,6 +2712,7 @@ def _add_coding_commands(sub) -> None:
             "category-maestro table when one is configured. --model still wins."
         ),
     )
+    _add_failure_recovery_arguments(run_cmd)
     run_cmd.set_defaults(func=cmd_coding_run)
 
     model_route = coding_sub.add_parser(

--- a/src/system/paths.py
+++ b/src/system/paths.py
@@ -310,6 +310,15 @@ class OmhPaths:
         return self.runtime_dir / "executor-limit-signals.json"
 
     @property
+    def executor_auth_failure_signals_path(self) -> Path:
+        # A sibling of the limit signals rather than another key inside them:
+        # the limit record's own field is `last_limit_shaped_at`, and writing an
+        # observed credential rejection under that name would make every reader
+        # of `last_limit_signal_for_profile` report a quota problem that never
+        # happened.
+        return self.runtime_dir / "executor-auth-failure-signals.json"
+
+    @property
     def executor_capability_snapshots_dir(self) -> Path:
         return self.omh_home / "coding" / "executor-capability-snapshots"
 

--- a/tests/test_dispatch_failure_recovery.py
+++ b/tests/test_dispatch_failure_recovery.py
@@ -1,0 +1,864 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+from tempfile import TemporaryDirectory
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from _cli_harness import run_cli  # noqa: E402
+
+from omh.coding.dispatch_failure_recovery import (  # noqa: E402
+    CHOICE_HERMES,
+    CHOICE_REPORT,
+    CHOICE_RETARGET,
+    CHOICE_WAIT,
+    COOLDOWN_STATUS_AUTH,
+    COOLDOWN_STATUS_LIMIT,
+    EXECUTOR_AUTH_FAILURE_SIGNALS_SCHEMA_VERSION,
+    FAILURE_KIND_AUTH_SHAPED,
+    FAILURE_KIND_BINARY_MISSING,
+    FAILURE_KIND_CRASH,
+    FAILURE_KIND_LIMIT_SHAPED,
+    FAILURE_KIND_TIMEOUT,
+    FAILURE_KINDS,
+    OnFailureModeError,
+    auth_repair_command,
+    auth_shaped_label,
+    build_repair_card,
+    classify_failure_kind,
+    clear_auth_failure_signal,
+    last_auth_failure_signal,
+    parse_on_failure,
+    prompt_recovery_choice,
+    record_auth_failure_signal,
+    recovery_candidates,
+    recovery_options,
+    retarget_candidates,
+    spawn_cooldown,
+)
+from omh.coding.fanout import build_fanout_contract  # noqa: E402
+from omh.coding.fanout_artifacts import write_fanout_contract  # noqa: E402
+from omh.coding.fanout_dispatch import dispatch_fanout  # noqa: E402
+from omh.coding.fanout_journal import (  # noqa: E402
+    RESUME_RERUN_AWAITING_RETRY,
+    build_fanout_run_journal,
+    plan_fanout_resume,
+)
+from omh.system.local_store import atomic_write_json, utc_now  # noqa: E402
+from omh.system.paths import OmhPaths  # noqa: E402
+
+_GOAL = "split the sample feature across agents"
+_UNITS = [
+    {"unit_id": "core", "title": "Core work", "owner": "codex", "file_scope": ["src/core/"]},
+]
+_CLI_UNITS = _UNITS + [
+    {"unit_id": "docs", "title": "Docs work", "owner": "claude-code", "file_scope": ["docs/"]},
+]
+
+
+def _git(repo: Path, *argv: str) -> None:
+    subprocess.run(["git", *argv], cwd=str(repo), check=True, capture_output=True, text=True)
+
+
+def _make_repo(root: Path) -> tuple[Path, str]:
+    repo = root / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+    _git(repo, "add", "seed.txt")
+    _git(repo, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "init")
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=str(repo), capture_output=True, text=True, check=True
+    ).stdout.strip()
+    return repo, sha
+
+
+class _FakeCompleted:
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _ready(paths, profile, **kwargs):
+    return {"status": "ready", "profile": profile}
+
+
+def _runner(outputs: dict[str, _FakeCompleted]):
+    """Route git to the real subprocess; answer each agent CLI from `outputs`."""
+    spawned: list[list[str]] = []
+
+    def runner(argv, **kwargs):
+        if argv[0] == "git":
+            return subprocess.run(argv, **kwargs)
+        spawned.append(list(argv))
+        return outputs.get(argv[0], _FakeCompleted(0, "done"))
+
+    runner.spawned = spawned
+    return runner
+
+
+class FailureKindClassificationTests(unittest.TestCase):
+    def test_closed_enum_covers_every_classifier_answer(self) -> None:
+        answers = {
+            classify_failure_kind(exit_code=127),
+            classify_failure_kind(exit_code=124),
+            classify_failure_kind(exit_code=1, auth_label="http_401"),
+            classify_failure_kind(exit_code=1, limit_label="rate_limit"),
+            classify_failure_kind(exit_code=1),
+        }
+        self.assertEqual(answers, set(FAILURE_KINDS))
+
+    def test_synthetic_exit_codes_map_before_any_text_match(self) -> None:
+        # 127 and 124 are the dispatcher's own observations of the process, so
+        # they win even when the tail also carries a provider-shaped message.
+        self.assertEqual(
+            classify_failure_kind(exit_code=127, limit_label="rate_limit", auth_label="http_401"),
+            FAILURE_KIND_BINARY_MISSING,
+        )
+        self.assertEqual(
+            classify_failure_kind(exit_code=124, limit_label="rate_limit", auth_label="http_401"),
+            FAILURE_KIND_TIMEOUT,
+        )
+
+    def test_auth_wins_over_limit_when_both_shapes_match(self) -> None:
+        # The documented precedence: a credential rejection filed as a limit
+        # would go into the wait-it-out lane, which can never clear it.
+        self.assertEqual(
+            classify_failure_kind(exit_code=1, limit_label="rate_limit", auth_label="http_401"),
+            FAILURE_KIND_AUTH_SHAPED,
+        )
+
+    def test_unclassified_nonzero_exit_is_crash(self) -> None:
+        self.assertEqual(classify_failure_kind(exit_code=2), FAILURE_KIND_CRASH)
+        self.assertEqual(classify_failure_kind(exit_code=0), "")
+
+    def test_auth_shaped_phrases_are_recognized(self) -> None:
+        for text, expected in (
+            ("Error: Invalid API key provided", "invalid_api_key"),
+            ("your token has expired, please log in again", "token_expired"),
+            ("You are not logged in. Please run /login.", "not_logged_in"),
+            ("request failed with status 401", "http_401"),
+            ("401 Unauthorized", "http_401"),
+            ("authentication failed for this account", "authentication_failed"),
+            ("the oauth token revoked by the workspace admin", "oauth_revoked"),
+        ):
+            with self.subTest(text=text):
+                self.assertEqual(auth_shaped_label(text, ""), expected)
+
+    def test_unrelated_author_and_401_text_is_not_auth_shaped(self) -> None:
+        # The negative controls that keep the patterns multi-word: a bare
+        # "auth", "author", or "401" appears constantly in ordinary CLI output.
+        for text in (
+            "git shortlog: author list for the release notes",
+            "unauthorized_reviewers.md mentioned in output",
+            "processed value 401 items in the batch",
+            "AUTHORS file updated",
+            "token budget exceeded for this context window",
+            "authorization header forwarded to the proxy",
+        ):
+            with self.subTest(text=text):
+                self.assertEqual(auth_shaped_label(text, ""), "")
+                self.assertEqual(auth_shaped_label("", text), "")
+
+    def test_auth_shape_is_matched_case_insensitively_across_both_tails(self) -> None:
+        self.assertEqual(auth_shaped_label("", "FATAL: INVALID API KEY"), "invalid_api_key")
+
+
+class AuthFailureSignalTests(unittest.TestCase):
+    def _paths(self, tmp: str) -> OmhPaths:
+        root = Path(tmp)
+        return OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+
+    def test_signal_persists_per_owner_and_reads_back_with_age(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = self._paths(tmp)
+            record_auth_failure_signal(
+                paths, "codex", run_ref="run-1", unit_id="core", pattern_label="http_401"
+            )
+            stored = json.loads(paths.executor_auth_failure_signals_path.read_text(encoding="utf-8"))
+            self.assertEqual(stored["schema_version"], EXECUTOR_AUTH_FAILURE_SIGNALS_SCHEMA_VERSION)
+            self.assertEqual(stored["profiles"]["codex"]["pattern_label"], "http_401")
+            signal = last_auth_failure_signal(paths, "codex")
+            self.assertFalse(signal["stale"])
+            self.assertIsInstance(signal["age_seconds"], int)
+            self.assertEqual(last_auth_failure_signal(paths, "claude-code"), {})
+
+    def test_clear_removes_only_the_named_owner(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = self._paths(tmp)
+            record_auth_failure_signal(paths, "codex", run_ref="r", unit_id="u", pattern_label="a")
+            record_auth_failure_signal(
+                paths, "claude-code", run_ref="r", unit_id="u", pattern_label="b"
+            )
+            clear_auth_failure_signal(paths, "codex")
+            self.assertEqual(last_auth_failure_signal(paths, "codex"), {})
+            self.assertEqual(last_auth_failure_signal(paths, "claude-code")["pattern_label"], "b")
+
+    def test_missing_file_reads_as_no_signal_and_clear_is_a_noop(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = self._paths(tmp)
+            self.assertEqual(last_auth_failure_signal(paths, "codex"), {})
+            clear_auth_failure_signal(paths, "codex")
+            self.assertFalse(paths.executor_auth_failure_signals_path.exists())
+
+    def test_stale_signal_does_not_cool_down_and_fresh_one_does(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = self._paths(tmp)
+            record_auth_failure_signal(
+                paths, "codex", run_ref="r", unit_id="u", pattern_label="http_401"
+            )
+            cooldown = spawn_cooldown(paths, "codex")
+            self.assertIsNotNone(cooldown)
+            self.assertEqual(cooldown["status"], COOLDOWN_STATUS_AUTH)
+            self.assertEqual(cooldown["failure_kind"], FAILURE_KIND_AUTH_SHAPED)
+            atomic_write_json(
+                paths.executor_auth_failure_signals_path,
+                {
+                    "schema_version": EXECUTOR_AUTH_FAILURE_SIGNALS_SCHEMA_VERSION,
+                    "profiles": {
+                        "codex": {"last_auth_shaped_at": "2020-01-01T00:00:00Z", "pattern_label": "x"}
+                    },
+                },
+                private=True,
+            )
+            self.assertIsNone(spawn_cooldown(paths, "codex"))
+
+    def test_unaged_record_never_vetoes_a_spawn(self) -> None:
+        # A record whose observation time cannot be read cannot be shown to be
+        # inside the window, so it ranks but never refuses.
+        with TemporaryDirectory() as tmp:
+            paths = self._paths(tmp)
+            atomic_write_json(
+                paths.executor_limit_signals_path,
+                {"schema_version": "executor_limit_signals/v1", "profiles": {"codex": {"pattern_label": "x"}}},
+                private=True,
+            )
+            self.assertIsNone(spawn_cooldown(paths, "codex"))
+
+    def test_limit_cooldown_is_reported_when_no_auth_signal_exists(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = self._paths(tmp)
+            atomic_write_json(
+                paths.executor_limit_signals_path,
+                {
+                    "schema_version": "executor_limit_signals/v1",
+                    "profiles": {"codex": {"last_limit_shaped_at": utc_now(), "pattern_label": "rate_limit"}},
+                },
+                private=True,
+            )
+            cooldown = spawn_cooldown(paths, "codex")
+            self.assertEqual(cooldown["status"], COOLDOWN_STATUS_LIMIT)
+            self.assertEqual(cooldown["failure_kind"], FAILURE_KIND_LIMIT_SHAPED)
+            self.assertIsInstance(cooldown["cooldown_remaining_seconds"], int)
+
+
+class ReadinessSurfaceTests(unittest.TestCase):
+    def test_readiness_reports_the_auth_failure_signal_without_persisting_it(self) -> None:
+        # The operator whose unit came back `executor_auth_invalid` reads the
+        # reason here; advisory markers are recomputed per call, never frozen
+        # into the observed-once probe cache.
+        from omh.coding.executor_readiness import probe_executor_readiness
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            record_auth_failure_signal(
+                paths, "codex", run_ref="r", unit_id="core", pattern_label="http_401"
+            )
+            result = probe_executor_readiness(paths, "codex", dry_run=True)
+            self.assertEqual(result["last_auth_failure_signal"]["pattern_label"], "http_401")
+            probe_executor_readiness(paths, "codex")
+            stored = json.loads(paths.executor_readiness_path.read_text(encoding="utf-8"))
+            self.assertNotIn("last_auth_failure_signal", stored["profiles"]["codex"])
+
+
+class RepairCardTests(unittest.TestCase):
+    def test_known_owners_get_their_own_login_command(self) -> None:
+        self.assertIn("/login", auth_repair_command("claude-code"))
+        self.assertEqual(auth_repair_command("codex"), "codex login")
+
+    def test_unknown_owner_gets_a_neutral_instruction(self) -> None:
+        # Executor-neutral: no CLI is the implied default for an owner this
+        # repo has not verified a login command for.
+        command = auth_repair_command("omo-runtime")
+        self.assertIn("omo-runtime", command)
+        self.assertNotIn("codex login", command)
+        self.assertNotIn("claude", command)
+
+    def test_auth_card_names_reauth_then_redispatch(self) -> None:
+        card = build_repair_card(owner="codex", failure_kind=FAILURE_KIND_AUTH_SHAPED, detail="d")
+        self.assertEqual(card["reason_code"], FAILURE_KIND_AUTH_SHAPED)
+        self.assertEqual(
+            [step["id"] for step in card["repair_steps"]],
+            ["reauthenticate_owner", "redispatch_after_repair"],
+        )
+
+    def test_limit_card_names_the_wait_and_carries_the_remaining_window(self) -> None:
+        card = build_repair_card(
+            owner="codex", failure_kind=FAILURE_KIND_LIMIT_SHAPED, detail="d", remaining_seconds=90
+        )
+        self.assertEqual(card["cooldown_remaining_seconds"], 90)
+        self.assertIn("90s", card["repair_steps"][0]["action"])
+
+
+class OnFailureModeTests(unittest.TestCase):
+    def test_named_modes_parse_without_a_target(self) -> None:
+        self.assertEqual(parse_on_failure(""), ("report", ""))
+        self.assertEqual(parse_on_failure("report"), ("report", ""))
+        self.assertEqual(parse_on_failure("hermes"), ("hermes", ""))
+        self.assertEqual(parse_on_failure("wait"), ("wait", ""))
+
+    def test_retarget_carries_its_owner_and_validates_it(self) -> None:
+        self.assertEqual(
+            parse_on_failure("retarget:claude-code", known_owners=("codex", "claude-code")),
+            (CHOICE_RETARGET, "claude-code"),
+        )
+        with self.assertRaises(OnFailureModeError):
+            parse_on_failure("retarget:", known_owners=("codex",))
+        with self.assertRaises(OnFailureModeError):
+            parse_on_failure("retarget:nope", known_owners=("codex",))
+
+    def test_unknown_mode_is_refused_by_name(self) -> None:
+        with self.assertRaises(OnFailureModeError) as caught:
+            parse_on_failure("switch")
+        self.assertIn("switch", str(caught.exception))
+
+
+class RecoveryOptionTests(unittest.TestCase):
+    def test_only_auth_and_limit_failures_are_candidates(self) -> None:
+        units = [
+            {"unit_id": "a", "owner": "codex", "failure_kind": FAILURE_KIND_AUTH_SHAPED},
+            {"unit_id": "b", "owner": "codex", "failure_kind": FAILURE_KIND_LIMIT_SHAPED},
+            {"unit_id": "c", "owner": "codex", "failure_kind": FAILURE_KIND_CRASH},
+            {"unit_id": "d", "owner": "codex", "failure_kind": FAILURE_KIND_TIMEOUT},
+            {"unit_id": "e", "owner": "codex", "failure_kind": FAILURE_KIND_BINARY_MISSING},
+            {"unit_id": "f", "owner": "codex"},
+        ]
+        self.assertEqual([row["unit_id"] for row in recovery_candidates(units)], ["a", "b"])
+
+    def test_the_failed_owner_is_never_offered_as_a_retarget(self) -> None:
+        context = {
+            "candidates": [
+                {"profile": "codex", "label": "Codex", "readiness_status": "ready"},
+                {"profile": "claude-code", "label": "Claude Code", "readiness_status": "ready"},
+            ]
+        }
+        rows = retarget_candidates(context, exclude_owner="codex")
+        self.assertEqual([row["profile"] for row in rows], ["claude-code"])
+
+    def test_unavailable_options_are_listed_with_their_reason(self) -> None:
+        options = recovery_options(
+            candidate={"unit_id": "a", "owner": "codex", "failure_kind": FAILURE_KIND_AUTH_SHAPED},
+            retargets=[],
+            hermes_available=False,
+        )
+        self.assertEqual([option["choice"] for option in options], [CHOICE_RETARGET, CHOICE_HERMES, CHOICE_WAIT])
+        self.assertFalse(options[0]["available"])
+        self.assertIn("no other locally-installed coding owner", options[0]["unavailable_reason"])
+        self.assertFalse(options[1]["available"])
+        self.assertIn("--hermes-model", options[1]["unavailable_reason"])
+        self.assertTrue(options[2]["available"])
+
+
+class RecoveryInterviewPromptTests(unittest.TestCase):
+    """The prompt seam is injected, so no test ever needs a real terminal."""
+
+    def _ask(self, answers: list[str], *, retargets, hermes_available=True):
+        written: list[str] = []
+        candidate = {"unit_id": "core", "owner": "codex", "failure_kind": FAILURE_KIND_LIMIT_SHAPED}
+        options = recovery_options(
+            candidate=candidate, retargets=retargets, hermes_available=hermes_available
+        )
+        queue = list(answers)
+
+        def read_line(_prompt: str) -> str:
+            if not queue:
+                raise EOFError
+            return queue.pop(0)
+
+        chosen = prompt_recovery_choice(
+            candidate=candidate,
+            options=options,
+            read_line=read_line,
+            write_line=written.append,
+        )
+        return chosen, written
+
+    def test_choice_one_with_a_single_candidate_selects_that_owner(self) -> None:
+        chosen, written = self._ask(["1"], retargets=[{"profile": "claude-code"}])
+        self.assertEqual(chosen, {"choice": CHOICE_RETARGET, "target_owner": "claude-code"})
+        self.assertTrue(any("core failed on codex" in line for line in written))
+
+    def test_choice_one_with_several_candidates_asks_which_owner(self) -> None:
+        chosen, _ = self._ask(
+            ["1", "omo-runtime"],
+            retargets=[{"profile": "claude-code"}, {"profile": "omo-runtime"}],
+        )
+        self.assertEqual(chosen, {"choice": CHOICE_RETARGET, "target_owner": "omo-runtime"})
+
+    def test_choice_two_selects_the_hermes_lane(self) -> None:
+        chosen, _ = self._ask(["2"], retargets=[{"profile": "claude-code"}])
+        self.assertEqual(chosen["choice"], CHOICE_HERMES)
+
+    def test_choice_three_selects_wait(self) -> None:
+        chosen, _ = self._ask(["3"], retargets=[])
+        self.assertEqual(chosen["choice"], CHOICE_WAIT)
+
+    def test_an_unavailable_option_is_refused_and_re_asked(self) -> None:
+        chosen, written = self._ask(["2", "3"], retargets=[], hermes_available=False)
+        self.assertEqual(chosen["choice"], CHOICE_WAIT)
+        self.assertTrue(any("Option 2 is unavailable" in line for line in written))
+
+    def test_a_closed_input_stream_falls_back_to_report(self) -> None:
+        chosen, written = self._ask([], retargets=[])
+        self.assertEqual(chosen["choice"], CHOICE_REPORT)
+        self.assertTrue(any("No recovery action chosen" in line for line in written))
+
+    def test_junk_answers_are_re_asked_then_give_up_as_report(self) -> None:
+        chosen, written = self._ask(["x", "9", "  "], retargets=[])
+        self.assertEqual(chosen["choice"], CHOICE_REPORT)
+        self.assertEqual(sum(1 for line in written if line == "Answer 1, 2, or 3."), 3)
+
+
+_AUTH_FAILURE_TEXT = "Error: invalid API key. Run `codex login` and try again."
+_LIMIT_FAILURE_TEXT = "Error: you have hit your usage limit. Try again later."
+
+
+class DispatchFailureRecoveryEngineTests(unittest.TestCase):
+    def _setup(self, tmp: str, units=None):
+        root = Path(tmp)
+        paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+        repo, sha = _make_repo(root)
+        contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, list(units or _UNITS)))
+        return paths, repo, sha, contract
+
+    def _dispatch(self, paths, repo, sha, contract, runner, **kwargs):
+        return dispatch_fanout(
+            paths,
+            contract,
+            goal_text=_GOAL,
+            repo_root=repo,
+            base_sha=sha,
+            runner=runner,
+            readiness=_ready,
+            **kwargs,
+        )
+
+    def test_auth_shaped_failure_classifies_persists_and_carries_a_repair_card(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            summary = self._dispatch(
+                paths, repo, sha, contract, _runner({"codex": _FakeCompleted(1, _AUTH_FAILURE_TEXT)})
+            )
+            core = summary["units"][0]
+            self.assertEqual(core["failure_kind"], FAILURE_KIND_AUTH_SHAPED)
+            self.assertTrue(core["auth_shaped"])
+            self.assertEqual(core["auth_pattern"], "invalid_api_key")
+            self.assertEqual(core["repair_card"]["repair_steps"][0]["command"], "codex login")
+            self.assertEqual(last_auth_failure_signal(paths, "codex")["pattern_label"], "invalid_api_key")
+            # Auth takes the persisted signal; no limit record is fabricated.
+            self.assertFalse(paths.executor_limit_signals_path.exists())
+
+    def test_limit_shaped_failure_keeps_its_existing_flags_and_gains_a_kind(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            summary = self._dispatch(
+                paths, repo, sha, contract, _runner({"codex": _FakeCompleted(1, _LIMIT_FAILURE_TEXT)})
+            )
+            core = summary["units"][0]
+            self.assertEqual(core["failure_kind"], FAILURE_KIND_LIMIT_SHAPED)
+            self.assertTrue(core["limit_shaped"])
+            self.assertNotIn("auth_shaped", core)
+            self.assertEqual(last_auth_failure_signal(paths, "codex"), {})
+
+    def test_a_missing_binary_and_a_timeout_map_to_their_synthetic_kinds(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+
+            def missing(argv, **kwargs):
+                if argv[0] == "git":
+                    return subprocess.run(argv, **kwargs)
+                raise FileNotFoundError(argv[0])
+
+            summary = self._dispatch(paths, repo, sha, contract, missing)
+            self.assertEqual(summary["units"][0]["failure_kind"], FAILURE_KIND_BINARY_MISSING)
+
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+
+            def slow(argv, **kwargs):
+                if argv[0] == "git":
+                    return subprocess.run(argv, **kwargs)
+                raise subprocess.TimeoutExpired(argv, 1)
+
+            summary = self._dispatch(paths, repo, sha, contract, slow, sleep=lambda _s: None)
+            self.assertEqual(summary["units"][0]["failure_kind"], FAILURE_KIND_TIMEOUT)
+
+    def test_a_later_success_clears_the_auth_signal(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            record_auth_failure_signal(
+                paths, "codex", run_ref="r", unit_id="core", pattern_label="http_401"
+            )
+            self._dispatch(
+                paths,
+                repo,
+                sha,
+                contract,
+                _runner({}),
+                ignore_limit_signal=True,
+            )
+            self.assertEqual(last_auth_failure_signal(paths, "codex"), {})
+
+    def test_a_fresh_auth_signal_vetoes_the_spawn_with_a_repair_card(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            record_auth_failure_signal(
+                paths, "codex", run_ref="r", unit_id="core", pattern_label="http_401"
+            )
+            runner = _runner({})
+            summary = self._dispatch(paths, repo, sha, contract, runner)
+            core = summary["units"][0]
+            self.assertEqual(core["status"], COOLDOWN_STATUS_AUTH)
+            self.assertEqual(core["failure_kind"], FAILURE_KIND_AUTH_SHAPED)
+            self.assertIn("--ignore-limit-signal", core["reason"])
+            self.assertEqual(core["repair_card"]["reason_code"], FAILURE_KIND_AUTH_SHAPED)
+            self.assertEqual(runner.spawned, [])
+            # Nothing was created for a unit that never started.
+            self.assertFalse((repo.parent / f"{repo.name}-fanout-core").exists())
+
+    def test_a_fresh_limit_signal_vetoes_the_spawn(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            atomic_write_json(
+                paths.executor_limit_signals_path,
+                {
+                    "schema_version": "executor_limit_signals/v1",
+                    "profiles": {"codex": {"last_limit_shaped_at": utc_now(), "pattern_label": "rate_limit"}},
+                },
+                private=True,
+            )
+            runner = _runner({})
+            summary = self._dispatch(paths, repo, sha, contract, runner)
+            self.assertEqual(summary["units"][0]["status"], COOLDOWN_STATUS_LIMIT)
+            self.assertEqual(runner.spawned, [])
+
+    def test_ignore_limit_signal_overrides_both_cooldowns(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            record_auth_failure_signal(
+                paths, "codex", run_ref="r", unit_id="core", pattern_label="http_401"
+            )
+            runner = _runner({})
+            summary = self._dispatch(paths, repo, sha, contract, runner, ignore_limit_signal=True)
+            self.assertEqual(summary["units"][0]["status"], "completed")
+            self.assertEqual(len(runner.spawned), 1)
+
+    def test_a_cooldown_veto_blocks_dependents_and_resumes_as_never_attempted(self) -> None:
+        units = [
+            {"unit_id": "core", "title": "Core", "owner": "codex", "file_scope": ["src/core/"]},
+            {
+                "unit_id": "docs",
+                "title": "Docs",
+                "owner": "codex",
+                "file_scope": ["docs/"],
+                "depends_on": ["core"],
+            },
+        ]
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp, units=units)
+            record_auth_failure_signal(
+                paths, "codex", run_ref="r", unit_id="core", pattern_label="http_401"
+            )
+            summary = self._dispatch(paths, repo, sha, contract, _runner({}))
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            self.assertEqual(by_unit["core"]["status"], COOLDOWN_STATUS_AUTH)
+            self.assertEqual(by_unit["docs"]["status"], "blocked_by_dependency")
+            journal = build_fanout_run_journal(summary)
+            rows = {row["unit_id"]: row for row in journal["units"]}
+            self.assertEqual(rows["core"]["terminal_state"], "not_attempted")
+            plan = plan_fanout_resume(
+                journal, order=["core", "docs"], depends_on={"core": [], "docs": ["core"]}
+            )
+            self.assertEqual(plan["selected_units"], ["core", "docs"])
+
+
+class DispatchRecoveryChoiceTests(unittest.TestCase):
+    def _setup(self, tmp: str):
+        root = Path(tmp)
+        paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+        repo, sha = _make_repo(root)
+        contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, list(_UNITS)))
+        return paths, repo, sha, contract
+
+    def _dispatch(self, paths, repo, sha, contract, **kwargs):
+        return dispatch_fanout(
+            paths,
+            contract,
+            goal_text=_GOAL,
+            repo_root=repo,
+            base_sha=sha,
+            runner=_runner({"codex": _FakeCompleted(1, _LIMIT_FAILURE_TEXT)}),
+            readiness=_ready,
+            **kwargs,
+        )
+
+    def test_report_mode_records_the_options_and_changes_nothing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            lines: list[str] = []
+            summary = self._dispatch(paths, repo, sha, contract, write_line=lines.append)
+            recovery = summary["failure_recovery"]
+            self.assertEqual(recovery["mode"], "report")
+            self.assertFalse(recovery["interactive"])
+            decision = recovery["decisions"][0]
+            self.assertEqual(decision["choice"], CHOICE_REPORT)
+            self.assertEqual(decision["failure_kind"], FAILURE_KIND_LIMIT_SHAPED)
+            self.assertEqual(len(decision["options"]), 3)
+            self.assertIn("repair_card", decision)
+            self.assertTrue(any("Recovery options (none taken" in line for line in lines))
+            self.assertNotIn("awaiting_retry", summary["units"][0])
+
+    def test_a_clean_run_carries_no_failure_recovery_block(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                runner=_runner({}),
+                readiness=_ready,
+            )
+            self.assertNotIn("failure_recovery", summary)
+
+    def test_wait_marks_the_unit_and_the_next_resume_reruns_exactly_it(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            summary = self._dispatch(paths, repo, sha, contract, on_failure="wait")
+            self.assertEqual(summary["failure_recovery"]["awaiting_retry_units"], ["core"])
+            core = summary["units"][0]
+            self.assertTrue(core["awaiting_retry"])
+            self.assertEqual(core["recovery_choice"]["choice"], CHOICE_WAIT)
+            journal = build_fanout_run_journal(summary)
+            row = journal["units"][0]
+            self.assertTrue(row["awaiting_retry"])
+            self.assertEqual(row["awaiting_retry_kind"], FAILURE_KIND_LIMIT_SHAPED)
+            self.assertEqual(row["failure_class"], "transient_provider_limit")
+            plan = plan_fanout_resume(journal, order=["core"], depends_on={"core": []})
+            self.assertEqual(plan["selected_units"], ["core"])
+            self.assertEqual(plan["decisions"][0]["action"], RESUME_RERUN_AWAITING_RETRY)
+
+    def test_an_observed_success_is_still_skipped_by_the_resume(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                runner=_runner({}),
+                readiness=_ready,
+            )
+            journal = build_fanout_run_journal(summary)
+            plan = plan_fanout_resume(journal, order=["core"], depends_on={"core": []})
+            self.assertEqual(plan["selected_units"], [])
+            self.assertEqual(plan["held_units"], ["core"])
+
+    def test_retarget_redispatches_under_the_chosen_owner_with_provenance(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            summary = self._dispatch(
+                paths, repo, sha, contract, on_failure=CHOICE_RETARGET, retarget_owner="claude-code"
+            )
+            decision = summary["failure_recovery"]["decisions"][0]
+            self.assertEqual(decision["choice"], CHOICE_RETARGET)
+            self.assertEqual(decision["target_owner"], "claude-code")
+            attempt = decision["attempt"]
+            self.assertEqual(attempt["owner"], "claude-code")
+            self.assertEqual(attempt["unit_id"], "core-retarget-claude-code")
+            self.assertEqual(attempt["status"], "completed")
+            self.assertEqual(attempt["retargeted_from"], {"unit_id": "core", "owner": "codex"})
+            # Its own worktree, so the failed unit's directory is never reused
+            # and never deleted.
+            self.assertTrue((repo.parent / f"{repo.name}-fanout-core-retarget-claude-code").is_dir())
+            self.assertTrue((repo.parent / f"{repo.name}-fanout-core").is_dir())
+
+    def test_retargeting_to_the_owner_that_just_failed_is_refused(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            summary = self._dispatch(
+                paths, repo, sha, contract, on_failure=CHOICE_RETARGET, retarget_owner="codex"
+            )
+            decision = summary["failure_recovery"]["decisions"][0]
+            self.assertEqual(decision["choice"], CHOICE_REPORT)
+            self.assertIn("the owner that just failed", decision["reason"])
+            self.assertNotIn("attempt", decision)
+
+    def test_hermes_choice_dispatches_through_the_injected_lane_with_consent(self) -> None:
+        calls: list[dict] = []
+
+        def stub_hermes(**kwargs):
+            calls.append(kwargs)
+            return {"status": "completed", "exit_code": 0, "run_id": kwargs["run_id"]}
+
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            summary = self._dispatch(
+                paths,
+                repo,
+                sha,
+                contract,
+                on_failure="hermes",
+                hermes_routing={"model": "m", "provider": "p", "reasoning": "high"},
+                hermes_child=stub_hermes,
+            )
+            decision = summary["failure_recovery"]["decisions"][0]
+            self.assertEqual(decision["choice"], CHOICE_HERMES)
+            self.assertIn("--confirm-dispatch", decision["consent"])
+            self.assertEqual(decision["attempt"]["status"], "completed")
+            self.assertEqual(decision["attempt"]["owner"], "hermes")
+            self.assertEqual(len(calls), 1)
+            # The child runs in the unit's own worktree, never the repo root.
+            self.assertEqual(Path(calls[0]["cwd"]).name, f"{repo.name}-fanout-core")
+            self.assertEqual(calls[0]["routing"]["model"], "m")
+            self.assertIn("Work unit:", calls[0]["prompt"])
+
+    def test_hermes_choice_without_routing_degrades_to_report(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            summary = self._dispatch(paths, repo, sha, contract, on_failure="hermes")
+            decision = summary["failure_recovery"]["decisions"][0]
+            self.assertEqual(decision["choice"], CHOICE_REPORT)
+            self.assertIn("--hermes-model", decision["reason"])
+
+    def test_the_interview_answer_drives_the_action(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            answers = iter(["3"])
+            summary = self._dispatch(
+                paths,
+                repo,
+                sha,
+                contract,
+                interactive=True,
+                read_line=lambda _prompt: next(answers),
+                write_line=lambda _line: None,
+            )
+            recovery = summary["failure_recovery"]
+            self.assertTrue(recovery["interactive"])
+            self.assertEqual(recovery["decisions"][0]["choice"], CHOICE_WAIT)
+            self.assertTrue(summary["units"][0]["awaiting_retry"])
+
+    def test_a_dry_run_neither_cools_down_nor_interviews(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            record_auth_failure_signal(
+                paths, "codex", run_ref="r", unit_id="core", pattern_label="http_401"
+            )
+            summary = self._dispatch(paths, repo, sha, contract, dry_run=True)
+            self.assertEqual(summary["units"][0]["status"], "dry_run_planned")
+            self.assertNotIn("failure_recovery", summary)
+
+
+class FailureRecoveryCliTests(unittest.TestCase):
+    def _prepared(self, tmp: str) -> tuple[list[str], Path, Path, str]:
+        root = Path(tmp)
+        base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+        repo, _sha = _make_repo(root)
+        goal_file = root / "goal.txt"
+        goal_file.write_text(_GOAL, encoding="utf-8")
+        units_file = root / "units.json"
+        # Two units: a one-unit split is redirected to `omh coding run`, which
+        # is a different (single-run) entry into the same engine.
+        units_file.write_text(json.dumps(_CLI_UNITS), encoding="utf-8")
+        status, stdout, stderr = run_cli(
+            base
+            + [
+                "coding",
+                "fanout",
+                "prepare",
+                "--goal",
+                *_GOAL.split(),
+                "--units",
+                str(units_file),
+                "--record",
+            ]
+        )
+        self.assertEqual(status, 0, stderr)
+        return base, repo, goal_file, json.loads(stdout)["fanout_id"]
+
+    def test_an_unknown_on_failure_value_is_refused_before_anything_runs(self) -> None:
+        with TemporaryDirectory() as tmp:
+            base, repo, goal_file, fanout_id = self._prepared(tmp)
+            status, _stdout, stderr = run_cli(
+                base
+                + [
+                    "coding",
+                    "fanout",
+                    "dispatch",
+                    fanout_id,
+                    "--goal-file",
+                    str(goal_file),
+                    "--repo-root",
+                    str(repo),
+                    "--on-failure",
+                    "switch-owner",
+                ]
+            )
+            self.assertEqual(status, 2)
+            self.assertIn("switch-owner", stderr)
+
+    def test_an_unknown_retarget_owner_is_refused_by_name(self) -> None:
+        with TemporaryDirectory() as tmp:
+            base, repo, goal_file, fanout_id = self._prepared(tmp)
+            status, _stdout, stderr = run_cli(
+                base
+                + [
+                    "coding",
+                    "fanout",
+                    "dispatch",
+                    fanout_id,
+                    "--goal-file",
+                    str(goal_file),
+                    "--repo-root",
+                    str(repo),
+                    "--on-failure",
+                    "retarget:not-an-owner",
+                ]
+            )
+            self.assertEqual(status, 2)
+            self.assertIn("not-an-owner", stderr)
+
+    def test_a_non_tty_dispatch_never_prompts_and_reports_the_options(self) -> None:
+        with TemporaryDirectory() as tmp:
+            base, repo, goal_file, fanout_id = self._prepared(tmp)
+            status, stdout, _stderr = run_cli(
+                base
+                + [
+                    "coding",
+                    "fanout",
+                    "dispatch",
+                    fanout_id,
+                    "--goal-file",
+                    str(goal_file),
+                    "--repo-root",
+                    str(repo),
+                    "--dry-run",
+                ]
+            )
+            self.assertEqual(status, 0, stdout)
+            summary = json.loads(stdout)
+            self.assertNotIn("failure_recovery", summary)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- Failed fanout/maestro dispatch units now carry a closed `failure_kind` enum
  (`auth_shaped` | `limit_shaped` | `timeout` | `binary_missing` | `crash`),
  a repair card for the two recoverable kinds, and — for those two — an
  explicit three-way recovery choice that `omh` never answers on the
  operator's behalf.
- New per-owner observed **auth-failure signals** (`executor_auth_failure_signals/v1`,
  `~/.omh/runtime/executor-auth-failure-signals.json`), cleared by the owner's
  next exit-0 exactly like limit signals.
- New **spawn cooldown**: an owner with a fresh observed auth or limit signal
  does not spawn; the unit finishes as `executor_auth_invalid` /
  `executor_limit_cooldown` before its worktree exists.
  `--ignore-limit-signal` overrides both.
- New **recovery interview** (TTY) and `--on-failure=report|retarget:<owner>|hermes|wait`
  for every non-interactive caller, on both `omh coding fanout dispatch` and
  `omh coding run`.
- New run-journal state: a `wait` choice marks the unit `awaiting_retry`, and
  the next `--resume-journal` run re-dispatches exactly those units under the
  new `rerun_awaiting_retry` resume action.

### Why This Exists

When a spawned external agent CLI (`claude`, `codex`, an omo host CLI) died
because the provider quota was exhausted or the stored credential was
rejected, the operator got `status: failed`, an exit code, and a 2000-char
output tail. Nothing said which of the two it was, nothing said what to do
about it, and — critically — nothing offered a way forward that did not
involve re-reading the tail by hand and re-running the command.

The two failures are not the same problem. A limit clears on its own; a
credential does not. Filing an auth rejection into the "wait it out" lane
puts it where waiting can never clear it, and the two output shapes overlap
in practice (a 401 body routinely also mentions a rate limit for
unauthenticated callers), so the distinction had to be a decided precedence
rather than an accident of pattern ordering.

The other half of the gap is a product-direction constraint, not a UX one:
`AGENTS.md` forbids making any CLI the implied default coding owner. The
obvious "fix" — silently falling back to another owner when one is rate
limited — is exactly what OMH must not do. So the answer had to be an
explicit choice with a recorded decision, not an automatic fallback.

### User / Operator Impact

After this change an operator whose dispatch hit a quota wall or a bad
credential can:

- read **which** of the two happened, from `failure_kind` on the unit
  envelope, without parsing an output tail;
- read **what to do about it** from the unit's `dispatch_failure_repair_card/v1`
  — for auth, the owner's own login command where this repo has verified one
  (`codex login`; `claude` then `/login`) and a neutral
  "re-authenticate the `<owner>` CLI" instruction where it has not;
- pick a way forward at the prompt: **[1]** retarget to another ranked owner
  and re-dispatch now, **[2]** re-run through the Hermes subagent lane
  (separate auth, separate quota), or **[3]** wait, deferring the unit to the
  next resume;
- get the same three actions non-interactively via `--on-failure`, including
  from a script or CI, where nothing ever prompts;
- stop wasting a spawn on an owner this machine just watched fail — the
  cooldown refuses it before the readiness probe, with the remaining window
  stated;
- see the reason from the readiness surface too: `omh coding executor-readiness`
  now reports `last_auth_failure_signal` alongside the existing markers.

What they still cannot do, by design, is have an owner switched for them.

### How It Works

New module `src/coding/dispatch_failure_recovery.py` holds classification,
signal persistence, repair cards, and the choice rendering. It spawns
nothing; acting on a choice is the dispatcher's job.

**Classification precedence (deterministic, documented, tested).** The two
synthetic exit codes the dispatcher assigns itself classify first — 127 is
`binary_missing`, 124 is `timeout` — because they are observations of the
process rather than text the provider wrote. Text then classifies as
`auth_shaped` **before** `limit_shaped`, on the reasoning above: an invalid
credential must be repaired before any attempt can succeed, so an overlapping
message belongs in the lane that waiting cannot clear. Misclassifying an
overlap as auth costs one re-auth check; misclassifying it as limit costs an
unbounded wait. Everything else is `crash`. `_AUTH_SHAPED_PATTERNS` is
multi-word and credential-anchored for the same reason `_LIMIT_SHAPED_PATTERNS`
is, and only the boolean and the matched label are ever persisted — never the
matched text.

**Signal storage.** A sibling file rather than an additive field on
`executor_limit_signals/v1`: that record's own field is `last_limit_shaped_at`,
and writing a credential rejection under that name would make every reader of
`last_limit_signal_for_profile` report a quota problem that never happened.
Neither schema version is bumped; both keep their shape.

**The cooldown is the one place an observed signal vetoes a spawn** instead of
ranking one. This does not contradict the advisory-marker principle stated in
`executor_auth_signals`: that principle forbids pre-blocking on the *absence*
of a local login file, which every API-key install legitimately shows. The
cooldown's input is a runtime failure omh itself observed from a real spawn of
that owner, inside the staleness window, overridable with
`--ignore-limit-signal`. A record whose observation time cannot be read never
vetoes — it cannot be *shown* to be inside the window, so it ranks but does not
refuse. The reasoning is stated in a comment at the call site and in
`COOLDOWN_CLAIM_BOUNDARY`.

**Retarget** re-dispatches under a derived unit id (`<unit-id>-retarget-<owner>`),
which gives it its own worktree and branch. The failed unit's directory is
neither reused nor deleted — `worktree_creator` already refuses a pre-existing
path, and this engine has never removed an operator's directory. The frozen
model route is dropped rather than carried across, because a model id belongs
to the CLI it was resolved for. A fresh capability snapshot is resolved for the
new owner. Retargeting to the owner that just failed is refused.

**Hermes** runs the unit in its own worktree or not at all; pointing the child
at the dispatch repo root would let a recovery attempt edit the main checkout.
It goes through `dispatch_hermes_child`, so the depth-one limit, stdin-only
prompt, isolated child home, spawn preflight (#1206) and sealed observation are
all the child module's own and untouched. Selecting the lane IS the explicit
dispatch consent that boundary requires — equivalent to `--confirm-dispatch` —
and is recorded as `HERMES_LANE_CONSENT`.

**Wait** sets `awaiting_retry` on the journal row with its failure kind. The
resume rule checks it *after* replay-safety and the blocker check, so a
deferred unit that is replay-unsafe is still held with its side effect named:
deferring is a reason to re-attempt, never a licence to rebuild a worktree over
work a failure left behind. Observed-success units stay skipped.

**Interactivity.** The interview runs only when the mode is `report`,
`--no-interactive` was not passed, and stdin is a real terminal. A named
`--on-failure` mode is the operator answering on the command line and is
applied without prompting. The prompt-reading seam is injected, so all three
choices are exercised in tests with no terminal anywhere.

`omh coding run` funnels into the same `dispatch_fanout`, so both lanes get
this from one implementation and one set of flags.

### Files And Contracts Touched

| File | What |
| --- | --- |
| `src/coding/dispatch_failure_recovery.py` (new) | `failure_kind` enum + precedence, `_AUTH_SHAPED_PATTERNS`, `executor_auth_failure_signals/v1` record/clear/read, `spawn_cooldown`, `dispatch_failure_repair_card/v1`, `--on-failure` parsing, choice rendering and the injected-seam prompt, Hermes-lane adapter |
| `src/coding/fanout_dispatch.py` | cooldown veto before the readiness probe; `failure_kind` / `auth_shaped` / `auth_pattern` / `repair_card` on the envelope; auth-signal record and clear; post-run `_run_failure_recovery` producing `fanout_failure_recovery/v1`; retarget and Hermes re-dispatch; new `dispatch_fanout` parameters; cooldown statuses added to `_dependency_failed` |
| `src/coding/fanout_journal.py` | optional `failure_kind` / `awaiting_retry` / `awaiting_retry_kind` row fields (deliberately outside `_JOURNAL_UNIT_KEYS`, so older journals stay readable); `RESUME_RERUN_AWAITING_RETRY`; cooldown statuses added to `_NEVER_SPAWNED_STATUSES` |
| `src/coding/executor_auth_signals.py` | public `signal_age_seconds`, so the two staleness answers cannot drift apart |
| `src/coding/executor_readiness.py` | `last_auth_failure_signal` surfaced as an advisory, recomputed per call and never persisted into the observed-once cache |
| `src/system/paths.py` | `executor_auth_failure_signals_path` |
| `src/commands/coding.py` | `--on-failure`, `--no-interactive`, `--ignore-limit-signal`, `--hermes-model/-provider/-reasoning` on both `fanout dispatch` and `coding run`; TTY resolution; stderr narration so piped JSON stdout stays clean |
| `docs/FANOUT.md` | new **Failure recovery** section (boundary level) |
| `tests/test_dispatch_failure_recovery.py` (new) | 52 tests |

No generated artifact, skill catalog, or routing corpus was touched; all five
`--check` byte gates were still run.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [x] Codex
- [x] Claude Code
- [x] Hermes runtime or handoff
- [x] Generic executor
- [ ] Not executor-specific

Executor-neutral by construction: owner-specific values (the login command)
live inside a neutral card shape, and an owner without a verified login
command gets a neutral instruction rather than a guessed one.

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli release checklist --json`
- [x] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [x] `omh --help`
- [ ] `omh ... release hermes-smoke --install-path setup --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed
- [x] Relevant dry-run or smoke command: `omh coding fanout dispatch --help`
      renders every new flag; a CLI dry-run dispatch produces no
      `failure_recovery` block (nothing spawned, nothing to recover).
- [ ] Manual Hermes/TUI check

Also run (not on the template, required by `CLAUDE.md`):

- [x] `uv run python -m omh.cli docs ulw-inventory --check`
- [x] `uv run python -m omh.cli docs ulw-site --check`

### Observed Evidence

- Full suite: `PYTHONPATH=tests uv run python -m unittest discover -s tests` —
  **8455 tests**, up from 8403 on `origin/main` (52 new). The only failures are
  the 28 known `.claude`-path-worktree `unsafe_read_root` failures in
  `test_cross_harness_adapters` / `test_cross_harness_adapter_security`
  (21 failures + 7 errors). Verified as a pre-existing local artifact by
  `git stash`-ing the entire change and re-running those two files on the
  unmodified tree: **identical 21 failures + 7 errors**. CI is authoritative
  for those.
- New coverage (52 tests in `tests/test_dispatch_failure_recovery.py`):
  - classification: the closed enum is exactly the classifier's answer set;
    127/124 map ahead of any text match; auth wins over limit when both match;
    unclassified non-zero is `crash`; seven positive auth phrases; **six
    negative controls** (`author list`, `unauthorized_reviewers.md mentioned in
    output`, `value 401 items`, `AUTHORS file updated`, `token budget
    exceeded`, `authorization header forwarded`) across both tails;
    case-insensitivity;
  - signals: persist per owner with read-time age; clear removes only the named
    owner; missing file reads as no signal; stale record does not cool down;
    unaged record never vetoes;
  - cooldown: fresh auth signal vetoes with a repair card and **zero spawns and
    no worktree created**; fresh limit signal vetoes; `--ignore-limit-signal`
    overrides both and the unit completes; a vetoed unit blocks its dependents
    and resumes as `not_attempted`;
  - repair cards: per-owner login commands; the neutral instruction for an
    unverified owner names neither `codex login` nor `claude`;
  - `--on-failure` parsing incl. `retarget:<owner>` validation and refusals;
  - interview, through an injected reader: choice 1 with one candidate and with
    several (owner sub-prompt), choice 2, choice 3, an unavailable option
    re-asked, a closed stream falling back to `report`, junk answers re-asked
    three times then `report`;
  - engine: auth failure classifies/persists/carries a card and fabricates no
    limit record; limit failure keeps its existing `limit_shaped` flags; a
    later success clears the auth signal; a clean run carries no
    `failure_recovery` block at all; report mode records the options and
    changes nothing; `wait` marks the unit and the resume re-runs exactly it
    while an observed success stays held; retarget lands on its own worktree
    with `retargeted_from` provenance and the original worktree untouched;
    retarget to the failed owner refused; Hermes choice dispatches through the
    injected stub, in the unit's worktree, with consent recorded; Hermes
    without routing degrades to `report`; a dry run neither cools down nor
    interviews;
  - CLI: unknown `--on-failure` and unknown retarget owner refused by name
    before anything runs; a non-tty dispatch never prompts;
  - readiness: the auth-failure signal is reported and is **not** persisted
    into the observed-once probe cache.
- `tests/test_broad_exception_policy.py` passes: the two new `except (OSError,
  TimeoutError)` sites mirror the existing limit-signal ones and are narrow,
  not broad, so no new policy verdict was needed.

### Not Tested / Not Applicable

- **No live dispatch against a real exhausted quota or a real invalid
  credential.** Every classification test drives synthetic output tails. The
  patterns are written from the shapes the CLIs are documented/observed to
  print; a live confirmation would need a deliberately broken credential and a
  genuinely spent quota.
- **The Hermes recovery lane is exercised through the injected seam only**,
  never against a running `hermes --oneshot`. `dispatch_unit_via_hermes_child`
  itself (the `HermesChildRequest` construction and the call into
  `dispatch_hermes_child`) is `prepared_not_observed`.
- `release hermes-smoke --install-path setup --include-command-smoke` and the
  manual Hermes/TUI check were not run: this change adds no installed artifact,
  no widget, no skill, and no plugin surface.
- Workflow-learning queue smoke: no learning contract changed.

## Risk

- **Behavior change for an existing flow.** A machine that already carries a
  fresh limit signal for an owner will now see that owner's units refused
  rather than spawned. That is the intent, but it is a change to what a
  re-run does. `--ignore-limit-signal` is the escape hatch, the refusal names
  it in its own `reason` string, and a signal with no readable timestamp
  (including hand-written or pre-existing records) never vetoes at all.
- **Pattern overreach.** A new false positive on the auth patterns would
  cool down an owner that is fine. Mitigated by multi-word anchoring, six
  negative controls, the 6-hour staleness ceiling, and the override flag —
  and the failure mode is one wasted re-run, not lost work.
- **Retarget leaves a second worktree behind** (`<repo>-fanout-<unit>-retarget-<owner>`)
  next to the failed unit's. That is deliberate: the alternative is deleting an
  operator's directory. Both are the operator's to clean up, as every fanout
  worktree already is.
- The recovery pass is skipped entirely for dry runs and interrupted batches,
  so neither grows a new failure mode.

## Compatibility / Rollout

- Additive on every persisted contract. `executor_limit_signals/v1` and
  `fanout_run_journal/v1` keep their schema versions and their shapes; the new
  journal fields are optional and deliberately outside `_JOURNAL_UNIT_KEYS`, so
  a journal written before this change still reads and still resumes.
- `dispatch_fanout`'s new parameters all default to today's behavior;
  `--on-failure` defaults to `report`, which prints and changes nothing.
- The new signals file is created on first observed auth failure; nothing
  needs migrating and nothing needs to exist beforehand.
- No `omh setup` / `omh update` change is required.

## Release / Claims

- [x] Release-channel impact considered (`local` — no installed artifact changes)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data — only the matched pattern *label* is persisted, never the matched text
- [x] Known manual Hermes checks are listed, including the live Hermes-lane gap

## Follow-Up

- A live confirmation pass for the Hermes recovery lane against a real
  `hermes --oneshot`, which would upgrade that path from
  `prepared_not_observed` to observed.
- If the auth patterns prove too narrow or too broad against real CLI output,
  the corpus is one tuple and its negative controls sit beside it.
