### PR TITLE
fix(hud): scope the plan todo to the session that declared it

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -110,7 +110,11 @@ _Avoid_: process handle, job
 **Plan todo**:
 The declared checklist at `$OMH_HOME/runtime/todo.json` that HUD surfaces
 render above the Hermes prompt input. Items are plan declarations; a done mark
-never upgrades into observed evidence.
+never upgrades into observed evidence. The artifact is global to the OMH home
+but the panel is scoped to the session that declared the plan: a record
+stamped with `session_ref` renders only for the live Hermes TUI session that
+owns it, an unstamped record is scoped by write time, and a host that cannot
+say which session is live keeps the age-only behavior.
 _Avoid_: task list as evidence, TodoWrite (that is another product's tool name)
 
 ### Coding delegation

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -759,6 +759,25 @@ does not load TUI widget files, so this panel is a modern-TUI-only surface.
 merge evidence; an all-done list collapses to a single header line and a list
 untouched for 24 hours is hidden as stale.
 
+The panel is also scoped to the session that declared the plan. One OMH home
+holds one todo list, so without that scope an unfinished checklist from an
+earlier session — or one another live session is writing to the same OMH home
+right now — renders in every session, as state the reader never created. When
+Hermes declares a plan through `omh_todo` it stamps the record with its own
+session id, and the HUD projects the plan only for the live Hermes TUI session
+that owns it; a plan belonging to another session reads as stale and is not
+rendered. Records written without a session id — `omh runtime todo set`, or
+anything predating the field — are scoped by write time instead: a plan
+written before the live session started belongs to an earlier one.
+
+The scope only applies where the host can answer it. With no
+`$HERMES_HOME/state.db`, an unreadable one, or no live TUI session recorded in
+it, the projection keeps the age-only behavior above and shows the plan, since
+hiding a legitimately current checklist on missing evidence is the worse
+failure. Two TUI sessions live at once share one panel answer — the most
+recently active session owns it, and the other session's plan returns as soon
+as that session is used again.
+
 #### Status model: no-run, prepared-handoff, observed-run
 
 `omh setup` deliberately records a safety-first `choose` preference and asks

--- a/src/plugin_bundle/omh/approval_bypass.py
+++ b/src/plugin_bundle/omh/approval_bypass.py
@@ -30,6 +30,9 @@ from typing import Any
 # Reuse the awareness ledger's portable lock and atomic-write primitives so
 # there is exactly one file-locking implementation in the plugin.
 from .awareness_delivery import _awareness_delivery_lock, _write_delivery_record
+# One definition of "a live TUI session row", shared with the plan-todo
+# session scope so the two readers cannot drift apart on what they scope to.
+from .live_session import live_tui_session_rows
 
 APPROVAL_BYPASS_SCHEMA_VERSION = "omh_approval_bypass/v1"
 APPROVAL_BYPASS_FILE = "approval-bypass.json"
@@ -103,65 +106,22 @@ def _session_yolo_row(
     when no such row speaks (missing DB, older schema, no live TUI session,
     or a session the host has not stamped) so the caller can fall back.
     """
-    import json
-    import sqlite3
-    from urllib.parse import quote
-
     current = float(now if now is not None else time.time())
-    home = Path(hermes_home).expanduser() if hermes_home else Path.home() / ".hermes"
-    path = home / "state.db"
-    if not path.exists():
-        return None
-    try:
-        connection = sqlite3.connect(
-            f"file:{quote(str(path))}?mode=ro", uri=True, timeout=0.2
-        )
-    except sqlite3.Error:
-        return None
-    try:
-        cursor = connection.execute(
-            """
-            SELECT model_config, COALESCE(last_activity_at, started_at)
-            FROM sessions
-            WHERE source = 'tui'
-              AND ended_at IS NULL
-              AND COALESCE(archived, 0) = 0
-              AND COALESCE(hidden, 0) = 0
-              AND (
-                model_config IS NULL
-                OR NOT json_valid(model_config)
-                OR json_extract(model_config, '$._delegate_from') IS NULL
-              )
-            ORDER BY COALESCE(last_activity_at, started_at) DESC
-            LIMIT 32
-            """
-        )
-        for raw_config, activity in cursor.fetchall():
-            try:
-                config = json.loads(raw_config) if raw_config else {}
-            except (ValueError, TypeError):
-                continue
-            if not isinstance(config, dict) or config.get("_delegate_from"):
-                continue
-            if not isinstance(activity, (int, float)) or (
-                current - float(activity) > APPROVAL_BYPASS_FRESH_SECONDS
-            ):
-                # The freshest live TUI row is already too old to describe a
-                # session anyone is looking at; nothing below it is fresher.
-                return None
-            # A row without the key means the host never persisted a toggle
-            # for this session; only the hook ledger can speak for it.
-            if "yolo_mode" not in config:
-                return None
-            return bool(config.get("yolo_mode")), float(activity)
-        return None
-    except (sqlite3.Error, TypeError, ValueError):
-        return None
-    finally:
-        try:
-            connection.close()
-        except sqlite3.Error:
-            pass
+    for row in live_tui_session_rows(hermes_home):
+        activity = row["activity"]
+        config = row["model_config"]
+        if not isinstance(activity, (int, float)) or (
+            current - float(activity) > APPROVAL_BYPASS_FRESH_SECONDS
+        ):
+            # The freshest live TUI row is already too old to describe a
+            # session anyone is looking at; nothing below it is fresher.
+            return None
+        # A row without the key means the host never persisted a toggle
+        # for this session; only the hook ledger can speak for it.
+        if "yolo_mode" not in config:
+            return None
+        return bool(config.get("yolo_mode")), float(activity)
+    return None
 
 
 def _approvals_mode_off(hermes_home: str = "") -> bool:

--- a/src/plugin_bundle/omh/live_session.py
+++ b/src/plugin_bundle/omh/live_session.py
@@ -1,0 +1,100 @@
+"""The live Hermes TUI sessions a widget could plausibly be rendering for.
+
+``state.db`` is the host's own record of which sessions exist and which one
+the user is in front of. Two HUD readers need the same answer from it:
+
+* the effective-yolo projection (``approval_bypass``), which may only read a
+  ``/yolo`` flag off a session a widget is actually rendering, and
+* the plan-todo session scope (``runtime_reader._todo_summary``), which must
+  not project a previous session's checklist into a new one.
+
+Both scope the question identically -- ``source='tui'``, not ended, archived,
+or hidden, not a delegation child, ordered by the host's own MRU column
+(``last_activity_at``) -- so the scoping lives here once instead of as two
+copies of the same SQL.
+
+An empty result means the question is UNANSWERABLE here: no ``state.db``, an
+older schema, an unreadable file, or no live TUI session at all. It is never a
+negative answer, and every caller must fall back to what it would have done
+without this surface rather than acting on the silence.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+# A host restart leaves no live row behind, and nothing re-stamps a row after
+# the process that owned it is gone. Six hours bounds how long the freshest
+# surviving row may keep speaking for a session someone is looking at; it is
+# the same bound the approval-bypass ledger uses, for the same reason.
+LIVE_TUI_SESSION_FRESH_SECONDS = 6 * 3600.0
+_LIVE_TUI_SESSION_ROW_LIMIT = 32
+
+
+def live_tui_session_rows(hermes_home: str = "") -> list[dict[str, Any]]:
+    """Live TUI session rows, most recently active first.
+
+    Each row carries the host's own ``id``, the raw ``started_at`` and
+    ``activity`` stamps, and the parsed ``model_config`` dict. The stamps stay
+    raw on purpose: what an unusable timestamp means differs per caller, so
+    this reader does not decide it. Rows whose ``model_config`` is unparseable
+    or names a delegation parent are dropped, matching the host's own view of
+    which sessions a person is driving.
+    """
+    import json
+    import sqlite3
+    from urllib.parse import quote
+
+    home = Path(hermes_home).expanduser() if hermes_home else Path.home() / ".hermes"
+    path = home / "state.db"
+    if not path.exists():
+        return []
+    try:
+        connection = sqlite3.connect(
+            f"file:{quote(str(path))}?mode=ro", uri=True, timeout=0.2
+        )
+    except sqlite3.Error:
+        return []
+    rows: list[dict[str, Any]] = []
+    try:
+        cursor = connection.execute(
+            """
+            SELECT id, model_config, COALESCE(last_activity_at, started_at), started_at
+            FROM sessions
+            WHERE source = 'tui'
+              AND ended_at IS NULL
+              AND COALESCE(archived, 0) = 0
+              AND COALESCE(hidden, 0) = 0
+              AND (
+                model_config IS NULL
+                OR NOT json_valid(model_config)
+                OR json_extract(model_config, '$._delegate_from') IS NULL
+              )
+            ORDER BY COALESCE(last_activity_at, started_at) DESC
+            LIMIT ?
+            """,
+            (_LIVE_TUI_SESSION_ROW_LIMIT,),
+        )
+        for session_id, raw_config, activity, started_at in cursor.fetchall():
+            try:
+                config = json.loads(raw_config) if raw_config else {}
+            except (ValueError, TypeError):
+                continue
+            if not isinstance(config, dict) or config.get("_delegate_from"):
+                continue
+            rows.append(
+                {
+                    "id": str(session_id or ""),
+                    "model_config": config,
+                    "activity": activity,
+                    "started_at": started_at,
+                }
+            )
+    except (sqlite3.Error, TypeError, ValueError):
+        return []
+    finally:
+        try:
+            connection.close()
+        except sqlite3.Error:
+            pass
+    return rows

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -14,6 +14,7 @@ from typing import Any, Callable
 
 from .approval_bypass import effective_approval_bypass
 from .hermes_delegation import read_hermes_native_subagents
+from .live_session import LIVE_TUI_SESSION_FRESH_SECONDS, live_tui_session_rows
 from .subagent_graph import project_subagent_graph
 from .subagent_graph_contract import (
     GRAPH_CONTRACT_UNIT_LIMIT,
@@ -32,6 +33,7 @@ from .todo_store import (
     MAX_TODO_DEPTH,
     MAX_TODO_ITEMS,
     MAX_TODO_PHASE_CHARS,
+    MAX_TODO_SESSION_REF_CHARS,
     MAX_TODO_SOURCE_CHARS,
     MAX_TODO_TEXT_CHARS,
     MAX_TODO_TITLE_CHARS,
@@ -775,7 +777,10 @@ def read_omh_hud(
         "runtime": _hud_runtime_summary(status_payload, latest_run),
         "achievements": _achievements_summary(hermes),
         "tokens": _token_summary(token_metadata or {}),
-        "todo": _todo_summary(home),
+        # Scoped to the live TUI session: one OMH home holds one plan todo, so
+        # without that scope a previous session's unfinished checklist renders
+        # in every new session.
+        "todo": _todo_summary(home, hermes),
         # Concurrent tool-call batches observed by the pre_tool_call hook;
         # the [OMH] status line brands a fresh batch as a parallel shot.
         "parallel_shot": tool_calls["parallel_shot"],
@@ -1678,10 +1683,13 @@ def _evidence_state(run: dict[str, Any]) -> str:
     return str(run.get("observation_status", "unknown") or "unknown")
 
 
-def read_omh_todo(omh_home: str | Path | None = None) -> dict[str, Any]:
+def read_omh_todo(
+    omh_home: str | Path | None = None, hermes_home: str | Path | None = None
+) -> dict[str, Any]:
     """Public todo projection for tools and hosts that only need the panel."""
     home = _expand_path(omh_home) if omh_home else _default_omh_home()
-    return _todo_summary(home)
+    hermes = _expand_path(hermes_home) if hermes_home else _default_hermes_home()
+    return _todo_summary(home, hermes)
 
 
 def default_omh_home() -> Path:
@@ -1689,7 +1697,7 @@ def default_omh_home() -> Path:
     return _default_omh_home()
 
 
-def _todo_summary(home: Path) -> dict[str, Any]:
+def _todo_summary(home: Path, hermes: Path | None = None) -> dict[str, Any]:
     empty = {
         "status": "absent",
         "title": "",
@@ -1760,6 +1768,9 @@ def _todo_summary(home: Path) -> dict[str, Any]:
     if age is None or age > TODO_STALE_SECONDS:
         summary["status"] = "stale"
         return summary
+    if _todo_belongs_to_another_session(record, summary["updated_at"], hermes):
+        summary["status"] = "stale"
+        return summary
     if counts["done"] == counts["total"]:
         # A finished plan is a receipt, not ambient chrome. It lingers briefly
         # so the session that finished it sees the ✓, then leaves -- without
@@ -1804,6 +1815,54 @@ def _todo_summary(home: Path) -> dict[str, Any]:
     # honest; VOLATILE_KEYS carries it forward on the metrics repaint cadence.
     summary["updated_age_seconds"] = age
     return summary
+
+
+def _todo_belongs_to_another_session(
+    record: dict[str, Any], updated_at: str, hermes: Path | None
+) -> bool:
+    """Whether this plan was declared by a session other than the live one.
+
+    The plan todo is one artifact per OMH home, so nothing about the file
+    itself says which session declared it. Wall-clock age alone cannot answer
+    that: an INCOMPLETE plan written hours ago is inside every age bound and
+    so greeted every new session with a checklist it never created (a 4/7 plan
+    from one session observed rendering in a fresh one the next day).
+
+    The host's own ``state.db`` does say it. Scoped to the live TUI session
+    (`live_session.live_tui_session_rows`), a stamped record answers by
+    identity and an unstamped legacy or CLI record answers by write time --
+    a plan written before the current session started belongs to an earlier
+    one.
+
+    Unanswerable reads to False on purpose: no state.db, no live TUI row, an
+    unreadable one, or a row too old to describe anyone's session all keep the
+    age-only gates. A legitimately current plan must never be hidden on
+    missing evidence. The narrow known gap is two concurrently live TUI
+    sessions -- the widget poll carries no session identity, so the most
+    recently active row answers for both, and the other session's plan
+    returns as soon as that session is touched again.
+    """
+    if hermes is None:
+        return False
+    session = next(iter(live_tui_session_rows(str(hermes))), None)
+    if session is None:
+        return False
+    session_id = str(session.get("id") or "")
+    if not session_id:
+        return False
+    activity = session.get("activity")
+    if not isinstance(activity, (int, float)) or (
+        _utc_epoch_now() - float(activity) > LIVE_TUI_SESSION_FRESH_SECONDS
+    ):
+        return False
+    reference = strip_control_characters(record.get("session_ref", ""))[:MAX_TODO_SESSION_REF_CHARS]
+    if reference:
+        return reference != session_id
+    started_at = session.get("started_at")
+    written_at = _epoch_seconds(updated_at)
+    if not isinstance(started_at, (int, float)) or written_at is None:
+        return False
+    return written_at < float(started_at)
 
 
 def _collapse_todo_items(items: list[dict[str, str]]) -> list[dict[str, str]]:
@@ -2506,7 +2565,8 @@ def _has_raw_or_hidden_content(value: Any) -> bool:
     return False
 
 
-def _seconds_since(value: str) -> float | None:
+def _epoch_seconds(value: str) -> float | None:
+    """Parse an ISO-8601 stamp into POSIX seconds, comparable with state.db."""
     try:
         cleaned = value.strip()
         if cleaned.endswith("Z"):
@@ -2514,7 +2574,17 @@ def _seconds_since(value: str) -> float | None:
         parsed = datetime.fromisoformat(cleaned)
         if parsed.tzinfo is None:
             parsed = parsed.replace(tzinfo=timezone.utc)
-        now = datetime.now(timezone.utc)
-        return (now - parsed.astimezone(timezone.utc)).total_seconds()
+        return parsed.astimezone(timezone.utc).timestamp()
     except (TypeError, ValueError):
         return None
+
+
+def _utc_epoch_now() -> float:
+    return datetime.now(timezone.utc).timestamp()
+
+
+def _seconds_since(value: str) -> float | None:
+    parsed = _epoch_seconds(value)
+    if parsed is None:
+        return None
+    return _utc_epoch_now() - parsed

--- a/src/plugin_bundle/omh/todo_store.py
+++ b/src/plugin_bundle/omh/todo_store.py
@@ -4,6 +4,13 @@ One todo list per OMH home, written to ``$OMH_HOME/runtime/todo.json``. The
 CLI (`omh runtime todo`) and the `omh_todo` plugin tool both write through this
 module so the schema has a single source of truth; `runtime_reader` projects
 the file into the HUD payload read-only.
+
+Because the artifact is global to the home and its writers are not, a record
+carries the session that declared it (``session_ref``) whenever the writer
+knows one. Nothing here enforces the scope -- the reader does, in
+``runtime_reader._todo_summary`` -- but without the stamp a plan from one
+session, or from a concurrent writer sharing the same home, is
+indistinguishable from the reader's own.
 """
 from __future__ import annotations
 
@@ -21,6 +28,11 @@ MAX_TODO_ITEMS = 20
 MAX_TODO_TEXT_CHARS = 200
 MAX_TODO_TITLE_CHARS = 80
 MAX_TODO_SOURCE_CHARS = 80
+# Optional owning-session id, stamped when the writer knows which host session
+# declared the plan. Bounded to the host-observation session limit because it
+# is the same identifier. A record without it is a legacy or CLI write, and
+# readers scope it by write time instead of by identity.
+MAX_TODO_SESSION_REF_CHARS = 160
 # Optional phase label per item ("Internal Context", "Delivery", ...). A
 # phase-structured plan declared BEFORE engine work bounds the run: progress
 # is a checklist walked phase by phase, not an open-ended reasoning loop.
@@ -86,12 +98,23 @@ def validate_todo_items(items: object) -> list[dict[str, Any]]:
     return validated
 
 
-def build_todo_record(title: object, items: object, *, source: str) -> dict[str, Any]:
+def build_todo_record(
+    title: object, items: object, *, source: str, session_ref: object = ""
+) -> dict[str, Any]:
+    """Build the on-disk todo record.
+
+    ``session_ref`` names the host session that declared this plan, when the
+    writer knows it. It is additive-optional inside ``omh_todo/v1``: the key is
+    written only when non-empty, so a CLI write is byte-identical to what it
+    was before the field existed, and a reader that predates it still reads
+    every field it knew.
+    """
     safe_title = strip_control_characters(title)
     if len(safe_title) > MAX_TODO_TITLE_CHARS:
         raise TodoValidationError(f"todo title is capped at {MAX_TODO_TITLE_CHARS} characters")
     safe_source = strip_control_characters(source)[:MAX_TODO_SOURCE_CHARS]
-    return {
+    safe_session_ref = strip_control_characters(session_ref)[:MAX_TODO_SESSION_REF_CHARS]
+    record: dict[str, Any] = {
         "schema_version": TODO_SCHEMA_VERSION,
         "title": safe_title,
         "source": safe_source,
@@ -99,6 +122,9 @@ def build_todo_record(title: object, items: object, *, source: str) -> dict[str,
         "items": validate_todo_items(items),
         "claim_boundary": TODO_CLAIM_BOUNDARY,
     }
+    if safe_session_ref:
+        record["session_ref"] = safe_session_ref
+    return record
 
 
 def todo_path(omh_home: Path) -> Path:

--- a/src/plugin_bundle/omh/tools/todo_tool.py
+++ b/src/plugin_bundle/omh/tools/todo_tool.py
@@ -88,6 +88,19 @@ OMH_TODO_SCHEMA = {
 }
 
 
+def _observed_session_ref(observation: dict[str, Any] | None) -> str:
+    """The host session id this write belongs to, when the host supplied one.
+
+    Hermes passes its stable session/thread id as observation metadata on
+    every tool call, so a plan declared in chat can record which session
+    declared it. A host that supplies none leaves this empty and the record
+    stays unstamped, exactly like a CLI write.
+    """
+    if not isinstance(observation, dict):
+        return ""
+    return str(observation.get("session_id", "") or "")
+
+
 def omh_todo_handler(args: dict[str, Any], **kwargs) -> str:
     observation = observe_plugin_tool_call("omh_todo", args, kwargs)
     home_arg = str(args.get("omh_home", "") or "")
@@ -107,7 +120,12 @@ def omh_todo_handler(args: dict[str, Any], **kwargs) -> str:
         return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
     if action == "set":
         try:
-            record = build_todo_record(args.get("title", ""), args.get("items"), source="omh_todo")
+            record = build_todo_record(
+                args.get("title", ""),
+                args.get("items"),
+                source="omh_todo",
+                session_ref=_observed_session_ref(observation),
+            )
             write_todo(default_omh_home(), record)
             payload["status"] = "written"
         except (TodoValidationError, TodoStoreError) as error:

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -1508,6 +1508,284 @@ class TodoHudTests(unittest.TestCase):
             self.assertEqual(len(payload["display"]["todo_lines"]), 2)
 
 
+class TodoSessionScopeTests(unittest.TestCase):
+    """A plan belongs to the session that declared it, not to the OMH home.
+
+    The plan todo is ONE artifact per OMH home, and wall-clock age was its
+    only gate: a 24h staleness bound, plus a 15-minute linger that applies
+    only once every item is done. An INCOMPLETE plan written hours ago sat
+    inside both, so it projected `established` into every new Hermes session —
+    observed live, where a checklist declared in one session greeted a fresh
+    one the next day as state that session never created.
+
+    The host's own `state.db` knows which TUI session is live. A record
+    stamped with `session_ref` answers by identity; an unstamped legacy or CLI
+    record answers by write time. When state.db cannot answer — absent,
+    unreadable, no live TUI row, or a row too old to describe anyone's
+    session — the age-only gates stand, because hiding a legitimately current
+    plan on missing evidence is the worse failure.
+    """
+
+    NOW = 1788158400.0
+
+    def setUp(self) -> None:
+        self._tmp = TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+        self.omh_home = self.root / ".omh"
+        self.hermes_home = self.root / ".hermes"
+        self.hermes_home.mkdir(parents=True, exist_ok=True)
+
+    def _stamp(self, offset_seconds: float) -> str:
+        from datetime import datetime, timedelta, timezone
+
+        return (
+            (datetime.now(timezone.utc) + timedelta(seconds=offset_seconds))
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+
+    def _epoch(self, offset_seconds: float) -> float:
+        from datetime import datetime, timezone
+
+        return datetime.now(timezone.utc).timestamp() + offset_seconds
+
+    def _write_todo(self, record: dict) -> None:
+        runtime_dir = self.omh_home / "runtime"
+        runtime_dir.mkdir(parents=True, exist_ok=True)
+        (runtime_dir / "todo.json").write_text(json.dumps(record), encoding="utf-8")
+
+    def _record(self, **overrides: object) -> dict:
+        record = {
+            "schema_version": "omh_todo/v1",
+            "title": "Foundation",
+            "source": "omh_todo",
+            "updated_at": self._stamp(0),
+            "items": [
+                {"text": "Restore RED baseline", "state": "done"},
+                {"text": "Inspect routing fixtures", "state": "active"},
+                {"text": "Update count assertions", "state": "pending"},
+            ],
+        }
+        record.update(overrides)
+        return record
+
+    def _build_state_db(self, rows) -> None:
+        """rows: (id, started_at, activity, source='tui', ended_at=None)."""
+        import sqlite3
+
+        connection = sqlite3.connect(self.hermes_home / "state.db")
+        connection.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY, source TEXT, model_config TEXT,
+                started_at REAL NOT NULL, last_activity_at REAL, ended_at REAL,
+                archived INTEGER DEFAULT 0, hidden INTEGER DEFAULT 0
+            );
+            """
+        )
+        for row in rows:
+            session_id, started_at, activity = row[0], row[1], row[2]
+            source = row[3] if len(row) > 3 else "tui"
+            ended_at = row[4] if len(row) > 4 else None
+            connection.execute(
+                "INSERT INTO sessions (id, source, model_config, started_at,"
+                " last_activity_at, ended_at) VALUES (?, ?, ?, ?, ?, ?)",
+                (session_id, source, "{}", started_at, activity, ended_at),
+            )
+        connection.commit()
+        connection.close()
+
+    def _todo(self) -> dict:
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+        return read_omh_hud(self.omh_home, self.hermes_home)["todo"]
+
+    def test_an_incomplete_plan_from_a_previous_session_is_hidden(self) -> None:
+        # The reported bug, in the shape it was observed: a checklist declared
+        # in an earlier session, well inside the 24h staleness bound and not
+        # all done, rendering in a brand new session.
+        self._build_state_db([("20260831_153632_11fc69", self._epoch(-300), self._epoch(-60))])
+        self._write_todo(
+            self._record(updated_at=self._stamp(-7200), session_ref="20260829_192031_7f614e")
+        )
+
+        todo = self._todo()
+
+        self.assertEqual(todo["status"], "stale")
+        self.assertEqual(todo["display_items"], [])
+
+    def test_a_concurrently_live_foreign_writer_cannot_reach_this_tui(self) -> None:
+        # The sharper half of the same bug: the plan is not merely leftover.
+        # Another live session (a wrapper/bot lane running its own workflow)
+        # keeps writing the SAME global todo.json, so the checklist the owner
+        # cleared reappeared seconds later, progressed. Its write is NEWER
+        # than this TUI session's start, so no age or write-time rule can
+        # catch it -- only identity can. A wrapper session is not source
+        # 'tui', so it never becomes the reading-side identity either.
+        self._build_state_db(
+            [
+                ("20260831_153632_11fc69", self._epoch(-300), self._epoch(-60)),
+                ("bot-lane", self._epoch(-200), self._epoch(-5), "tool"),
+            ]
+        )
+        self._write_todo(
+            self._record(updated_at=self._stamp(-5), session_ref="bot-lane")
+        )
+
+        self.assertEqual(self._todo()["status"], "stale")
+
+    def test_a_plan_declared_by_the_live_session_still_renders(self) -> None:
+        self._build_state_db([("20260831_153632_11fc69", self._epoch(-300), self._epoch(-60))])
+        self._write_todo(
+            self._record(updated_at=self._stamp(-7200), session_ref="20260831_153632_11fc69")
+        )
+
+        todo = self._todo()
+
+        self.assertEqual(todo["status"], "established")
+        self.assertEqual(todo["counts"]["total"], 3)
+
+    def test_an_unstamped_plan_written_before_the_live_session_is_hidden(self) -> None:
+        # Legacy records and `omh runtime todo set` writes carry no
+        # session_ref. Write time still separates them: a plan that predates
+        # the session's own start cannot belong to it.
+        self._build_state_db([("20260831_153632_11fc69", self._epoch(-300), self._epoch(-60))])
+        self._write_todo(self._record(source="cli", updated_at=self._stamp(-3600)))
+
+        self.assertEqual(self._todo()["status"], "stale")
+
+    def test_an_unstamped_plan_written_inside_the_live_session_renders(self) -> None:
+        # A CLI-written plan is not foreign just because it lacks a stamp.
+        self._build_state_db([("20260831_153632_11fc69", self._epoch(-3600), self._epoch(-60))])
+        self._write_todo(self._record(source="cli", updated_at=self._stamp(-120)))
+
+        self.assertEqual(self._todo()["status"], "established")
+
+    def test_an_all_done_plan_still_lingers_inside_its_own_session(self) -> None:
+        # The finished-plan receipt is unchanged within the owning session:
+        # it lingers briefly, then goes absent on its own 15-minute window.
+        self._build_state_db([("20260831_153632_11fc69", self._epoch(-3600), self._epoch(-60))])
+        done_items = [{"text": "Ship", "state": "done"}]
+        self._write_todo(
+            self._record(
+                items=done_items,
+                updated_at=self._stamp(-60),
+                session_ref="20260831_153632_11fc69",
+            )
+        )
+        self.assertEqual(self._todo()["status"], "all_done")
+
+        self._write_todo(
+            self._record(
+                items=done_items,
+                updated_at=self._stamp(-1200),
+                session_ref="20260831_153632_11fc69",
+            )
+        )
+        self.assertEqual(self._todo()["status"], "absent")
+
+    def test_an_unanswerable_host_state_keeps_the_age_only_gates(self) -> None:
+        # No state.db, an unreadable one, a schema without the columns, no
+        # live TUI row at all, and a live row too old to describe anyone's
+        # session: every one of these is "the host cannot say", never "this
+        # plan is foreign". Today's behavior stands.
+        self._write_todo(self._record(session_ref="20260829_192031_7f614e"))
+        self.assertEqual(self._todo()["status"], "established")
+
+        db = self.hermes_home / "state.db"
+        db.write_bytes(b"not a sqlite database")
+        self.assertEqual(self._todo()["status"], "established")
+
+        db.unlink()
+        self._build_state_db(
+            [
+                ("cli-session", self._epoch(-300), self._epoch(-60), "cli"),
+                ("ended-tui", self._epoch(-300), self._epoch(-60), "tui", self._epoch(-30)),
+            ]
+        )
+        self.assertEqual(self._todo()["status"], "established")
+
+        db.unlink()
+        self._build_state_db([("stale-tui", self._epoch(-90000), self._epoch(-80000))])
+        self.assertEqual(self._todo()["status"], "established")
+
+    def test_a_foreign_plan_stops_nagging_the_reconciliation_reminder(self) -> None:
+        # `open_todo_reminder` binds completion claims to an OPEN plan. A
+        # previous session's plan is not this session's open work, so the
+        # per-turn reminder must stop with the panel.
+        import os
+
+        from omh.plugin_bundle.omh.todo_reconciliation import open_todo_reminder
+
+        self._build_state_db([("20260831_153632_11fc69", self._epoch(-300), self._epoch(-60))])
+        self._write_todo(
+            self._record(updated_at=self._stamp(-7200), session_ref="20260829_192031_7f614e")
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(self.hermes_home)}):
+            self.assertEqual(open_todo_reminder(omh_home=str(self.omh_home)), "")
+
+    def test_the_plugin_tool_stamps_the_host_session_that_declared_the_plan(self) -> None:
+        import os
+
+        from omh.plugin_bundle.omh.tools.todo_tool import omh_todo_handler
+
+        with patch.dict(
+            os.environ,
+            {"OMH_HOME": str(self.omh_home), "HERMES_HOME": str(self.hermes_home)},
+        ):
+            written = json.loads(
+                omh_todo_handler(
+                    {
+                        "action": "set",
+                        "title": "Foundation",
+                        "items": [{"text": "Inspect routing fixtures", "state": "active"}],
+                        "observation": {
+                            "host": "hermes-agent",
+                            "session_id": "20260831_153632_11fc69",
+                        },
+                    }
+                )
+            )
+
+        self.assertEqual(written["status"], "written")
+        record = json.loads(
+            (self.omh_home / "runtime" / "todo.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(record["session_ref"], "20260831_153632_11fc69")
+        self.assertEqual(record["schema_version"], "omh_todo/v1")
+
+    def test_an_unstamped_write_stays_byte_identical_to_the_pre_field_record(self) -> None:
+        # session_ref is additive-optional inside omh_todo/v1: a writer that
+        # knows no session emits exactly the keys it always did.
+        from omh.plugin_bundle.omh.todo_store import build_todo_record
+
+        record = build_todo_record("Foundation", [{"text": "x"}], source="cli")
+
+        self.assertNotIn("session_ref", record)
+        self.assertEqual(
+            sorted(record),
+            ["claim_boundary", "items", "schema_version", "source", "title", "updated_at"],
+        )
+
+    def test_a_session_ref_is_bounded_and_control_stripped_like_every_field(self) -> None:
+        from omh.plugin_bundle.omh.todo_store import (
+            MAX_TODO_SESSION_REF_CHARS,
+            build_todo_record,
+        )
+
+        record = build_todo_record(
+            "Foundation",
+            [{"text": "x"}],
+            source="omh_todo",
+            session_ref="s\x1b[2J" + "9" * (MAX_TODO_SESSION_REF_CHARS + 40),
+        )
+
+        self.assertEqual(len(record["session_ref"]), MAX_TODO_SESSION_REF_CHARS)
+        self.assertTrue(record["session_ref"].startswith("s[2J9"))
+
+
 class ActivityRowOrderTests(unittest.TestCase):
     """Merged activity rows: running first, settled newest-first, capped at 8.
 


### PR DESCRIPTION
## Feature Report

### What Changed

The HUD plan-todo panel is now scoped to the Hermes session that declared the
plan, instead of to the OMH home. A checklist written by one session no longer
renders in another one.

- Todo records carry an optional `session_ref` naming the host session that
  declared them. The `omh_todo` plugin tool stamps it automatically.
- The reader (`_todo_summary`) resolves the live Hermes TUI session from the
  host's own `state.db` and hides a plan that belongs to a different session.
- The live-TUI-session lookup that `approval_bypass` already performed for the
  same reason moves into one shared module, `live_session.py`.

### Why This Exists

The plan todo is **one artifact per OMH home** — `$OMH_HOME/runtime/todo.json`
— and until now wall-clock age was its only gate: hidden after 24 hours
(`TODO_STALE_SECONDS`), and lingering 15 minutes only once *every* item is
done (`ALL_DONE_TODO_LINGER_SECONDS`). An **incomplete** plan sits comfortably
inside both bounds, so nothing stopped it from projecting `established` into
every reader of that home. Nothing cleared it on a session boundary either;
`on_session_end` writes a checkpoint, and only an explicit `omh_todo
action=clear` removed the file.

Two distinct symptoms of the same defect were reported from the live machine:

1. **Leftover plan.** A 4/7 checklist declared in session `20260829_…`
   rendered unchanged in a brand-new session `20260831_153632_11fc69` the
   next day — state that session never created, sitting above its prompt.
2. **Concurrent foreign writer.** A wrapper/bot lane running its own workflow
   was writing the *same* global `todo.json` while the owner's TUI was open.
   The owner cleared the checklist to zero in their TUI and it reappeared
   moments later, progressed from 4/8 to 5/8.

The second case is why identity, not time, had to be the primary mechanism:
those foreign writes are *newer* than the reading session's start, so no
staleness or write-time rule can catch them.

### User / Operator Impact

A new Hermes TUI session opens with a clean composer. A plan declared in an
earlier session, or by another session writing the same OMH home right now, no
longer renders above the prompt. The plan the current session declared behaves
exactly as before, including the all-done receipt that lingers briefly and
then leaves.

Because `open_todo_reminder` keys off the same `established` status, the
per-turn reconciliation reminder also stops nagging about a plan this session
never declared.

### How It Works

**Write side.** `build_todo_record` takes an optional `session_ref`.
`omh_todo_handler` reads it from the host observation metadata Hermes already
supplies on every tool call (`observation.session_id` — the same id that
`plugin_host_observations.jsonl` embeds as `session=…` in its evidence refs).
CLI writes (`omh runtime todo set`) have no host session and stay unstamped.

**Read side.** `_todo_summary` gained a `hermes` argument and one new gate,
placed beside the existing staleness check:

- record **has** `session_ref` → render only if it equals the live TUI
  session's id;
- record has **no** `session_ref` (legacy or CLI) → treat it as foreign when
  its `updated_at` predates the live session's `started_at`;
- **unanswerable** → keep today's age-only behavior, always.

**Shared session lookup.** `live_session.live_tui_session_rows()` holds the
scoping that `approval_bypass._session_yolo_row` already used, verbatim:
`source='tui' AND ended_at IS NULL AND archived=0 AND hidden=0`, no delegation
children, ordered by the host's own `last_activity_at`, inside a 6h freshness
bound. `approval_bypass` now calls it instead of carrying its own copy of that
SQL; its 22 tests pass unchanged.

**Why a wrapper/bot lane cannot hijack the identity.** The reading side is the
MRU live *TUI* row. Checked against the live `state.db`: sessions there carry
`source` values `tui`, `cli`, `desktop`, and `tool`, and the currently-live set
is one `tui` row (the owner's terminal) plus two `source='tool'` rows. A bot or
wrapper lane is not `source='tui'`, so it is filtered out of the query and can
never answer for the terminal a widget is rendering — even while it is
actively writing the file.

**Why the fix is reader-side.** The widget deliberately does not gate the todo
panel on activity (`omh-status.mjs`, pinned by
`tests/test_tui_widget_pack.py`'s `assertNotIn("|| !payload.active", …)`).
Putting the scope in the reader keeps that pin intact and ships the fix through
`omh update` with the plugin bundle, with no widget change at all.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/plugin_bundle/omh/live_session.py` | **New.** `live_tui_session_rows()` + `LIVE_TUI_SESSION_FRESH_SECONDS`; the one definition of "a live TUI session row". |
| `src/plugin_bundle/omh/approval_bypass.py` | `_session_yolo_row` now consumes the shared reader; its duplicated SQL is removed, behavior identical. |
| `src/plugin_bundle/omh/todo_store.py` | `build_todo_record(..., session_ref="")`, `MAX_TODO_SESSION_REF_CHARS`, module docstring. |
| `src/plugin_bundle/omh/tools/todo_tool.py` | `_observed_session_ref()`; `action=set` stamps the host session id. |
| `src/plugin_bundle/omh/runtime_reader.py` | `_todo_belongs_to_another_session()`; `_todo_summary`/`read_omh_todo` take `hermes_home`; `_seconds_since` split into `_epoch_seconds` + `_utc_epoch_now`. |
| `tests/test_hud.py` | New `TodoSessionScopeTests` (11 cases). |
| `docs/INSTALLATION.md`, `CONTEXT.md` | Session scoping and the unanswerable fallback documented. |

**Schema version: `omh_todo/v1` is unchanged, deliberately.** `session_ref` is
additive-optional and the key is written only when non-empty, so an unstamped
write is byte-identical to what it produced before the field existed, and any
reader that predates the field still reads every field it knew. This matches
how the same schema absorbed the item-level `phase` and `depth` fields. A test
pins the unstamped key set so the claim cannot silently rot.

No install-manifest change is needed: `bundled_plugin_records()` enumerates the
bundle from package resources, so `live_session.py` is picked up automatically.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli release checklist --json`
- [x] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home … release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli docs ulw-inventory --check`, `… docs ulw-site --check`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- `PYTHONPATH=tests uv run python -m unittest discover -s tests` → **Ran 8480
  tests**, 28 failures, all of them in `test_cross_harness_adapters` /
  `test_cross_harness_adapter_security`. These are a **local worktree
  artifact, not a regression**: this branch was developed in a worktree under
  `.claude/worktrees/…`, and `read_roots_are_safe()` in
  `src/quality/cross_harness_adapter_sandbox.py` rejects any path containing
  `.claude` (it is in `_SENSITIVE_PARTS` alongside `.ssh`, `.aws`, `.hermes`,
  `.omh`), so every adapter request in those two files fails preflight with
  `unsafe_read_root`. Nothing in this change touches those modules. CI, which
  checks out to a normal path, is the authority here.
- `PYTHONPATH=tests uv run python -m unittest tests.test_hud` → **60 tests,
  OK** (49 before this change, 11 added).
- `PYTHONPATH=tests uv run python -m unittest tests.test_approval_bypass` →
  **22 tests, OK**, unchanged after the SQL extraction — the check that the
  refactor is behavior-preserving.
- `tests.test_broad_exception_policy` → OK. The new code adds only narrow
  `except (sqlite3.Error, TypeError, ValueError)` handlers, so no new
  classification entry was required.
- **RED baseline observed**, not assumed: with
  `_todo_belongs_to_another_session` monkeypatched to `return False` (the
  pre-change reader), 4 of the new tests fail —
  `…previous_session_is_hidden`, `…concurrently_live_foreign_writer…`,
  `…written_before_the_live_session_is_hidden`, and
  `…stops_nagging_the_reconciliation_reminder` — while every "must still
  render" test stays green, confirming the new tests pin the fix rather than
  the fixture.
- Byte gates: `docs workflows --check` (155/155 tap skills), `docs roles
  --check`, `docs capability-families --check`, `docs ulw-inventory --check`,
  `docs ulw-site --check` → all `ok: true`.
- `harness validate` → `ok: true` (75 harnesses, 114 skills).
  `release checklist --json` → `ok: true`. `release hermes-smoke` (plan mode) →
  renders with plan-only boundary. `compileall` → exit 0. `git diff --check` →
  clean.
- The two pinned existing behaviors are intact: `test_hud`'s 2020-timestamp
  staleness case and its all-done linger case both still pass, and the
  reader-side fix leaves `tests/test_tui_widget_pack.py`'s
  `assertNotIn("|| !payload.active", …)` non-gate pin untouched.
- `state.db` inspection on the live machine (read-only) confirmed the schema
  assumptions: `sessions.id` values (`20260831_153632_11fc69`) are exactly the
  ids the plugin observation metadata carries, and the live-session source
  distribution is as described under "How It Works".

### Not Tested / Not Applicable

- **A real two-session Hermes TUI handover was not observed.** Reproducing it
  requires two live TUI sessions and a running Hermes host; the regression
  tests simulate it against a constructed `state.db`, which is
  `prepared_not_observed` with respect to the real TUI. The verification that
  *is* observed is the RED baseline above plus the live `state.db` schema
  reads.
- `omh --help` and the installed-command / wheel / installer smokes were not
  run: they exercise the packaged console script and release-candidate
  packaging, neither of which this change touches. The release-checklist items
  requiring release authority are out of scope for a fix PR.
- No workflow-learning contract changed, so that queue smoke does not apply.

## Risk

- **Over-hiding is the risk that matters**, and every unanswerable path is
  wired to fail open: missing `state.db`, an unreadable one, an older schema
  without the columns, no live TUI row, or a live row older than 6h all keep
  the previous age-only behavior. Four of the new tests cover exactly those
  paths.
- **Two concurrently live TUI sessions share one answer.** The widget poll
  carries no session identity, so the MRU live TUI row answers for both; the
  non-MRU session's plan is hidden until that session is touched again, which
  re-stamps `last_activity_at` and restores it. Documented in
  `docs/INSTALLATION.md`.
- **The single-file clobber race is unchanged and remains a known residual.**
  A wrapper lane and a TUI session sharing one OMH home still write the same
  `todo.json`, so a clear-then-rewrite can still race at the file level. This
  PR removes the *user-visible* symptom (the foreign plan no longer renders in
  the owner's TUI even while the file churns underneath) without redesigning
  the artifact. Per-session todo files would fix it at the root but replace
  the artifact contract, every reader, and the CLI surface — deliberately not
  in this PR.
- One honest consequence of failing open: with a foreign **live** writer *and*
  an unanswerable host read, the foreign plan still shows. Stated in the docs
  rather than papered over.
- The `approval_bypass` extraction is the only refactor. It is covered by 22
  pre-existing tests that pass unchanged, and the raw timestamp handling was
  kept at the call site precisely so its "non-numeric activity → stop" branch
  stays byte-identical.

## Compatibility / Rollout

- Backward compatible in both directions. Existing unstamped `todo.json` files
  keep working under the write-time rule; a record written by this version is
  read correctly by an older reader, which simply ignores the extra key.
- Reaches a live machine through `omh update` plus a TUI restart, as the
  plugin bundle. No widget file changed, so no widget hash churn.
- No new dependency; `sqlite3` and `json` are imported lazily inside the
  reader, matching the surrounding style.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Per-session todo artifacts (or a writer-side compare-and-swap) to close the
  concurrent-writer clobber race at its root, rather than only its visible
  symptom.
- If the Modern TUI ever hands the widget its own session id, the reader could
  use that directly instead of the MRU-live-row heuristic, which would also
  close the two-concurrent-TUI-sessions gap.
