### PR TITLE
feat(skins): `omh theme repair` for a skin the manifest can no longer prove

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -664,6 +664,9 @@ omh theme list               # plain listing, always (the scriptable surface)
 omh theme use crimson        # select one directly (also accepts omh-crimson)
 omh theme use crimson --dry-run
 omh theme status             # active skin, ownership, managed files on disk
+omh theme repair             # report unmanaged theme files; writes nothing
+omh theme repair sky         # adopt one back under OMH management
+omh theme repair --all --dry-run
 ```
 
 Bare `omh theme` opens a picker: up/down arrows (or `j`/`k`) move the cursor,
@@ -697,6 +700,65 @@ Rules worth knowing:
   hand-edited and stop updating it forever. Adopting our own bytes cannot
   destroy anything you wrote, because overwriting them is a no-op. A file
   matching neither proof stays `unmanaged`.
+
+#### Why a theme file can be `unmanaged`
+
+`omh theme status` reports each theme file as `managed`, `unmanaged`, or
+`missing`. `unmanaged` means OMH cannot prove it wrote that file, so it will
+never overwrite it — and therefore never update it either. Two very different
+situations end up there:
+
+1. **You edited it, or wrote your own.** Working as designed. The file is
+   yours, it keeps winning over every future release, and nothing needs fixing.
+2. **It is OMH's file, stranded.** The manifest record went stale at some point
+   *and* the shipped template has since changed, so the file now matches
+   neither ownership proof. It is ours in origin but indistinguishable on disk
+   from case 1 — and it is frozen on an old palette forever, because no later
+   release can reach a file OMH will not touch.
+
+Nothing on disk separates those two cases, which is why OMH cannot fix case 2
+on its own. `omh theme repair` resolves it by asking you:
+
+```sh
+omh theme repair                  # report only; safe and idempotent, writes nothing
+omh theme repair sky              # adopt sky: overwrite it with the shipped file and record it
+omh theme repair --all            # adopt every unmanaged theme file
+omh theme repair sky --dry-run    # show exactly what adopting would do, without doing it
+omh theme repair --json           # machine-readable payload (omh_theme_repair/v1)
+```
+
+The bare form and `--dry-run` never write. Both print, per file, the
+before/after `sha256` and the palette tokens that would change, so you see what
+you are accepting before anything is destructive:
+
+```text
+OMH theme repair
+  Skins directory: /Users/you/.hermes/skins
+Theme files
+  sky      omh.yaml          - unmanaged; NOT adopted (name it, or pass --all, to accept)
+      sha256 e99be0e84830b659 -> 122577bf7c5080e3
+      ui_label: #7FDBFF -> #9FE8FF
+  amber    omh-amber.yaml    - managed; untouched
+  crimson  omh-crimson.yaml  - managed; untouched
+  mono     omh-mono.yaml     - managed; untouched
+Next
+  Nothing was written. Accept with `omh theme repair <name>` or `omh theme repair --all`.
+```
+
+Naming a theme (or passing `--all`) IS the consent — there is no hash that can
+give it, which is why the command asks for a name instead. Rules:
+
+- **Nothing repairs automatically.** `omh setup`, `omh update`, and
+  `omh theme use` never call the repair path. A skin you wrote is never
+  silently overwritten.
+- **Already-`managed` files are untouched** and reported as such, whether or
+  not you named them.
+- **A `missing` file is installed when named**, matching what `omh setup` and
+  `omh update` already do for a theme file that is not there.
+- **Repair is reversible the usual way.** A repaired file is a managed file, so
+  `omh uninstall --all` takes it away exactly like an installed one.
+- **After a repair, updates flow again.** The file is recorded in the manifest,
+  so the next release's template change lands on it normally.
 
 ## Bot Profiles
 

--- a/src/commands/theme.py
+++ b/src/commands/theme.py
@@ -9,6 +9,11 @@ Running `omh theme use <name>` IS the explicit consent the managed-artifact
 rule asks for, which is why it takes the forcing `activate_omh_skin` path
 rather than the unset-only `ensure_omh_skin` default writer.
 
+`omh theme repair` follows the same consent rule for the other direction: it
+adopts a theme file OMH does not own, so the bare form only reports and a
+theme name (or `--all`) is the accept. Nothing else in the product may call
+the repair path.
+
 Plain text is the default and `--json` is the opt-in, matching every other
 polled surface in this package.
 """
@@ -30,6 +35,7 @@ from ..skin_pack import (
     install_skin,
     installed_skin_report,
     is_omh_skin_name,
+    repair_skins,
     theme_for_name,
     theme_for_skin_name,
     theme_names,
@@ -45,6 +51,7 @@ from .quickstart import _color, _use_color
 THEME_LIST_SCHEMA_VERSION = "omh_theme_list/v1"
 THEME_CHANGE_SCHEMA_VERSION = "omh_theme_change/v1"
 THEME_STATUS_SCHEMA_VERSION = "omh_theme_status/v1"
+THEME_REPAIR_SCHEMA_VERSION = "omh_theme_repair/v1"
 
 
 def _language(args: argparse.Namespace) -> str:
@@ -88,6 +95,12 @@ def _theme_report(args: argparse.Namespace) -> dict[str, object]:
         "config_path": str(paths.hermes_config_path),
         "skins_dir": str(paths.hermes_home / "skins"),
         "themes": [_theme_row(theme, active_skin, states) for theme in SKIN_THEMES],
+        # Named separately from the per-theme rows so the hint that makes
+        # `omh theme repair` findable has one thing to test, in both the text
+        # and the JSON surface.
+        "unmanaged_themes": [
+            theme.short_name for theme in SKIN_THEMES if states.get(theme.skin_name) == "unmanaged"
+        ],
     }
 
 
@@ -158,6 +171,55 @@ def cmd_theme_use(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_theme_repair(args: argparse.Namespace) -> int:
+    """Report unmanaged theme files, and adopt the ones explicitly named.
+
+    The invocation IS the consent. Nothing on disk distinguishes a theme file
+    OMH wrote from one a person wrote -- a manifest that went stale while the
+    template also moved on leaves ours looking exactly like theirs -- so the
+    bare form never writes and a name (or `--all`) is the accept.
+    """
+    language = _language(args)
+    paths = _paths(args)
+    requested = str(getattr(args, "name", "") or "")
+    every = bool(getattr(args, "all", False))
+    dry_run = bool(getattr(args, "dry_run", False))
+    if requested and every:
+        print("omh: pass a theme name or --all, not both.")
+        return 2
+    theme = theme_for_name(requested) if requested else None
+    if requested and theme is None:
+        print(
+            f"omh: unknown theme {requested!r}; valid names are {', '.join(theme_names())} "
+            "(or the full skin name, for example omh-amber)."
+        )
+        return 2
+    if every:
+        adopt = frozenset(candidate.filename for candidate in SKIN_THEMES)
+    elif theme is not None:
+        adopt = frozenset({theme.filename})
+    else:
+        adopt = frozenset()
+    result = repair_skins(paths.hermes_home, adopt=adopt, dry_run=dry_run)
+    payload = {
+        "schema_version": THEME_REPAIR_SCHEMA_VERSION,
+        "mode": "repair" if adopt else "report",
+        "requested": theme.short_name if theme is not None else "",
+        "all": every,
+        "dry_run": dry_run,
+        "status": result["status"],
+        "skins_dir": str(result["path"]),
+        "themes": result["skins"],
+        "restart_note": _restart_note(language),
+        "language": language,
+    }
+    if _wants_json(args):
+        _print_json(payload)
+    else:
+        _print_theme_repair(payload)
+    return 0
+
+
 def _apply_theme(args: argparse.Namespace, theme: SkinTheme, *, dry_run: bool) -> dict[str, object]:
     """The one selection path. `theme use` and the picker both land here.
 
@@ -204,6 +266,23 @@ def _active_line(payload: dict[str, object]) -> str:
     return f"  Active: {payload.get('active_skin', '')} - not an OMH theme; your own skin choice is kept."
 
 
+def _repair_hint(payload: dict[str, object]) -> str:
+    """The one line that makes `omh theme repair` findable, when it applies.
+
+    Printed only while something is actually unmanaged. An always-on hint would
+    train people to skip the Next block, and a hand-authored skin is a valid
+    end state rather than a fault to nag about.
+    """
+    names = payload.get("unmanaged_themes")
+    if not isinstance(names, list) or not names:
+        return ""
+    joined = ", ".join(str(name) for name in names)
+    return (
+        f"  Unmanaged: {joined} - OMH leaves these alone and never updates them. "
+        "Run `omh theme repair` to see what adopting them would change."
+    )
+
+
 def _print_theme_list(payload: dict[str, object]) -> None:
     use_color = _use_color()
     print(_color("OMH TUI themes", "1;36", use_color))
@@ -219,6 +298,9 @@ def _print_theme_list(payload: dict[str, object]) -> None:
     print(_active_line(payload))
     print(_color("Next", "1;32", use_color))
     print("  Switch with `omh theme use <name>`; the new look applies on the next Hermes start.")
+    hint = _repair_hint(payload)
+    if hint:
+        print(hint)
 
 
 def _print_theme_status(payload: dict[str, object]) -> None:
@@ -235,6 +317,9 @@ def _print_theme_status(payload: dict[str, object]) -> None:
                 print(f"  {str(entry.get('theme', '')):<8} {entry.get('filename', '')} - {entry.get('state', '')}")
     print(_color("Next", "1;32", use_color))
     print(f"  {payload.get('restart_note', '')}")
+    hint = _repair_hint(payload)
+    if hint:
+        print(hint)
 
 
 def _print_theme_change(payload: dict[str, object]) -> None:
@@ -252,6 +337,69 @@ def _print_theme_change(payload: dict[str, object]) -> None:
     print(_color("Next", "1;32", use_color))
     print(f"  {payload.get('restart_note', '')}")
     print(f"  Reverse: {payload.get('reverse_command', '')}")
+
+
+# What each repair status means in one human phrase. Kept out of the payload
+# on purpose: the JSON carries `state`/`status` for machines, and prose that
+# consumers might start parsing is prose that can never be reworded.
+_REPAIR_NOTES: dict[str, str] = {
+    "managed": "managed; untouched",
+    "unmanaged": "unmanaged; NOT adopted (name it, or pass --all, to accept)",
+    "missing": "missing; NOT installed (name it, or pass --all, to install)",
+    "would_repair": "unmanaged; WOULD be replaced with the shipped file",
+    "would_install": "missing; WOULD be installed",
+    "repaired": "repaired; replaced with the shipped file",
+    "installed": "installed",
+}
+_REPAIR_WRITTEN = ("repaired", "installed")
+
+
+def _print_theme_repair(payload: dict[str, object]) -> None:
+    """Show the before/after of every file BEFORE anything destructive lands.
+
+    Digest pair plus the palette tokens that move, per file. A person accepting
+    an overwrite of a file OMH cannot prove it wrote deserves to see exactly
+    what they are trading away first.
+    """
+    use_color = _use_color()
+    print(_color("OMH theme repair", "1;36", use_color))
+    print(f"  Skins directory: {payload.get('skins_dir', '')}")
+    print(_color("Theme files", "1;32", use_color))
+    written = 0
+    pending = 0
+    themes = payload.get("themes", [])
+    if isinstance(themes, list):
+        for entry in themes:
+            if not isinstance(entry, dict):
+                continue
+            status = str(entry.get("status", ""))
+            if status in _REPAIR_WRITTEN:
+                written += 1
+            elif status in ("unmanaged", "missing"):
+                pending += 1
+            note = _REPAIR_NOTES.get(status, status)
+            print(f"  {str(entry.get('theme', '')):<8} {str(entry.get('filename', '')):<17} - {note}")
+            if status == "managed":
+                continue
+            before = str(entry.get("before_sha256", "")) or "(absent)"
+            print(f"      sha256 {before[:16]} -> {str(entry.get('after_sha256', ''))[:16]}")
+            changes = entry.get("palette_changes")
+            if isinstance(changes, list):
+                for change in changes:
+                    if isinstance(change, dict):
+                        old = str(change.get("before", "")) or "(unset)"
+                        new = str(change.get("after", "")) or "(removed)"
+                        print(f"      {change.get('key', '')}: {old} -> {new}")
+    print(_color("Next", "1;32", use_color))
+    if payload.get("dry_run"):
+        print("  Dry run: nothing was written. Re-run without --dry-run to accept.")
+    elif written:
+        print(f"  Adopted {written} theme file(s); future updates now reach them.")
+        print(f"  {payload.get('restart_note', '')}")
+    elif pending:
+        print("  Nothing was written. Accept with `omh theme repair <name>` or `omh theme repair --all`.")
+    else:
+        print("  Every shipped theme file is managed; there is nothing to repair.")
 
 
 def _add_theme_commands(sub) -> None:
@@ -281,6 +429,25 @@ def _add_theme_commands(sub) -> None:
     )
     _add_shared_theme_arguments(theme_use, "Print the full machine-readable change payload.")
     theme_use.set_defaults(func=cmd_theme_use)
+
+    theme_repair = theme_sub.add_parser(
+        "repair",
+        help="Report theme files OMH does not own, and adopt the ones you name.",
+    )
+    theme_repair.add_argument(
+        "name",
+        nargs="?",
+        default="",
+        help=f"Theme to adopt ({', '.join(theme_names())}) or full skin name. Omit to only report.",
+    )
+    theme_repair.add_argument("--all", action="store_true", help="Adopt every unmanaged theme file.")
+    theme_repair.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what adopting would change without writing anything.",
+    )
+    _add_shared_theme_arguments(theme_repair, "Print the full machine-readable repair payload.")
+    theme_repair.set_defaults(func=cmd_theme_repair)
 
     theme_status = theme_sub.add_parser(
         "status",

--- a/src/omh/skin_pack.py
+++ b/src/omh/skin_pack.py
@@ -114,18 +114,20 @@ def skin_payload(name: str = SKIN_NAME) -> bytes:
     return resources.files("omh.skins").joinpath(theme.filename).read_text(encoding="utf-8").encode()
 
 
-def skin_colors(name: str = SKIN_NAME) -> dict[str, str]:
-    """The `colors:` block of one shipped theme, as token -> `#RRGGBB`.
+def colors_from_text(text: str) -> dict[str, str]:
+    """The `colors:` block of one skin document, as token -> `#RRGGBB`.
 
     A deliberately narrow reader rather than a YAML dependency: OMH ships with
     zero runtime dependencies, these documents are ours, and the block is a
     flat two-space mapping of quoted hex strings. The theme picker's preview is
-    the consumer -- it must paint with the palette a theme actually declares,
-    not a copy that drifts from the YAML.
+    one consumer -- it must paint with the palette a theme actually declares,
+    not a copy that drifts from the YAML. `omh theme repair` is the other: it
+    diffs an installed document against the shipped one to say, in palette
+    terms, what accepting the repair would change.
     """
     colors: dict[str, str] = {}
     inside = False
-    for line in skin_payload(name).decode("utf-8").splitlines():
+    for line in text.splitlines():
         if not line.strip() or line.lstrip().startswith("#"):
             continue
         if not line.startswith(" "):
@@ -138,6 +140,11 @@ def skin_colors(name: str = SKIN_NAME) -> dict[str, str]:
         if separator and value.startswith("#"):
             colors[key] = value
     return colors
+
+
+def skin_colors(name: str = SKIN_NAME) -> dict[str, str]:
+    """The palette of one shipped theme, read straight off its YAML."""
+    return colors_from_text(skin_payload(name).decode("utf-8"))
 
 
 def hex_to_rgb(value: str) -> tuple[int, int, int] | None:
@@ -380,6 +387,128 @@ def uninstall_skin(hermes_home: Path, *, dry_run: bool = False) -> dict[str, obj
     return {
         "status": _aggregate_status([entry["status"] for entry in entries], _UNINSTALL_STATUS_ORDER),
         "path": str(destination_dir),
+        "skins": entries,
+    }
+
+
+_REPAIR_STATUS_ORDER = (
+    "repaired",
+    "would_repair",
+    "installed",
+    "would_install",
+    "unmanaged",
+    "missing",
+    "managed",
+)
+
+
+def _palette_changes(before: bytes, after: bytes) -> list[dict[str, str]]:
+    """Which palette tokens differ between an installed document and ours.
+
+    The "what am I accepting?" line the repair command prints BEFORE it
+    overwrites anything. Palette-only on purpose: a colour token moving is the
+    part a person can actually see on screen, and a full text diff of a YAML we
+    ship would bury that single line under comment reflows.
+    """
+    try:
+        current = colors_from_text(before.decode("utf-8"))
+    except UnicodeDecodeError:
+        # A skin file that is not UTF-8 text is not one we can describe in
+        # palette terms; the digest pair still tells the honest story.
+        return []
+    shipped = colors_from_text(after.decode("utf-8"))
+    changes: list[dict[str, str]] = []
+    for key in sorted(set(current) | set(shipped)):
+        old = current.get(key, "")
+        new = shipped.get(key, "")
+        if old != new:
+            changes.append({"key": key, "before": old, "after": new})
+    return changes
+
+
+def repair_skins(
+    hermes_home: Path,
+    *,
+    adopt: frozenset[str] = frozenset(),
+    dry_run: bool = False,
+) -> dict[str, object]:
+    """Report, and on explicit consent adopt, theme files OMH does not own.
+
+    Closes the gap `_is_managed_file`'s self-heal cannot: a manifest that went
+    stale while the shipped template ALSO moved on. The installed file is then
+    ours in origin but matches neither ownership proof, so it reports
+    `unmanaged` and is frozen on its old palette forever -- no later release
+    can ever reach it. Observed exactly that way on the owner's machine, where
+    `omh.yaml` still held the pre-brightening `ui_label`.
+
+    No digest can separate that file from one a person wrote by hand, so the
+    repair is consent-based rather than automatic: `adopt` holds the theme
+    FILENAMES the caller explicitly named, and running the command with them IS
+    the consent. It is empty for the reporting form, which is why the bare
+    command writes nothing and is safe to run twice.
+
+    Never call this from `install_skin`, `omh update`, `omh setup`, or
+    `theme use`. Silently overwriting a skin someone wrote is the one outcome
+    the whole managed-artifact rule exists to prevent.
+    """
+    destination_dir = hermes_home / "skins"
+    manifest = destination_dir / MANIFEST_FILENAME
+    _reject_symlink_path(hermes_home)
+    _reject_symlink_path(destination_dir)
+    records = _read_manifest_records(manifest)
+    updated = dict(records)
+    entries: list[dict[str, object]] = []
+    wrote_any = False
+    for theme in SKIN_THEMES:
+        destination = destination_dir / theme.filename
+        _reject_symlink_path(destination)
+        if destination.exists() and not destination.is_file():
+            raise SkinInstallError(f"skin destination is not a regular file: {destination}")
+        payload = skin_payload(theme.skin_name)
+        present = destination.is_file()
+        current = destination.read_bytes() if present else b""
+        if not present:
+            state = "missing"
+        elif _is_managed_file(destination, records, payload):
+            state = "managed"
+        else:
+            state = "unmanaged"
+        consented = theme.filename in adopt
+        if state == "managed" or not consented:
+            # Reported, never written: `managed` needs nothing, and anything
+            # else without an explicit name is exactly the file we must not
+            # touch.
+            status = "managed" if state == "managed" else state
+        elif dry_run:
+            status = "would_repair" if state == "unmanaged" else "would_install"
+        else:
+            status = "repaired" if state == "unmanaged" else "installed"
+            destination_dir.mkdir(parents=True, exist_ok=True)
+            _reject_symlink_path(destination_dir)
+            _atomic_write_bytes(destination, payload)
+            updated[theme.filename] = _sha256(payload)
+            wrote_any = True
+        entries.append(
+            {
+                "skin": theme.skin_name,
+                "theme": theme.short_name,
+                "filename": theme.filename,
+                "path": str(destination),
+                "state": state,
+                "status": status,
+                "before_sha256": _sha256(current) if present else "",
+                "after_sha256": _sha256(payload),
+                "palette_changes": _palette_changes(current, payload) if present else [],
+            }
+        )
+    if not dry_run and wrote_any:
+        destination_dir.mkdir(parents=True, exist_ok=True)
+        _reject_symlink_path(manifest)
+        _atomic_write_bytes(manifest, _manifest_document(updated))
+    return {
+        "status": _aggregate_status([str(entry["status"]) for entry in entries], _REPAIR_STATUS_ORDER),
+        "path": str(destination_dir),
+        "dry_run": dry_run,
         "skins": entries,
     }
 

--- a/tests/test_skin_pack.py
+++ b/tests/test_skin_pack.py
@@ -18,6 +18,8 @@ from tempfile import TemporaryDirectory
 import unittest
 from unittest.mock import patch
 
+from _platform_support import requires_symlinks
+
 from omh.install.config_adapter import display_skin_selection, ensure_omh_skin
 from omh.skin_pack import (
     MANIFEST_FILENAME,
@@ -30,6 +32,7 @@ from omh.skin_pack import (
     install_skin,
     installed_skin_report,
     is_omh_skin_name,
+    repair_skins,
     skin_colors,
     skin_payload,
     theme_for_name,
@@ -443,6 +446,277 @@ class SkinInstallTests(unittest.TestCase):
             states = {entry["skin"]: entry["state"] for entry in installed_skin_report(home)}
             self.assertEqual(states["omh"], "managed")
             self.assertEqual(states["omh-mono"], "unmanaged")
+
+
+class SkinRepairTests(unittest.TestCase):
+    """`repair_skins` -- the consent-based way out of a permanently frozen skin.
+
+    `_is_managed_file`'s self-heal covers a stale manifest over an UNCHANGED
+    template. The gap this closes is the one seen on the owner's machine after
+    that fix shipped: the manifest went stale at some earlier point AND the
+    template has since moved on, so the installed file matches neither proof.
+    It is ours in origin, indistinguishable from a hand-written one on disk,
+    and frozen forever. Consent is therefore the only sound gate, and the
+    command invocation is the consent -- which is exactly why the no-argument
+    form must never write.
+    """
+
+    def _older_template(self, skin_name: str = SKIN_NAME) -> bytes:
+        """A believable previous release of one theme: same document, older palette.
+
+        Shaped after the observed drift, where the installed `omh.yaml` still
+        carried the pre-brightening `#7FDBFF` `ui_label` while the shipped
+        template had moved on to `#9FE8FF`. Derived from the current template
+        rather than pinned to literal bytes so it keeps meaning "one release
+        behind" as the palette keeps evolving.
+        """
+        payload = skin_payload(skin_name).replace(skin_colors(skin_name)["ui_label"].encode(), b"#7FDBFF")
+        self.assertNotEqual(payload, skin_payload(skin_name))
+        return payload
+
+    def _stranded_home(self, tmp: str) -> tuple[Path, bytes]:
+        """The exact live shape: an older-template file, no record naming it.
+
+        A v2 manifest that records the three other themes and not `omh.yaml`,
+        which is what `omh theme status` was reporting as `sky omh.yaml -
+        unmanaged` on the machine that motivated this.
+        """
+        home = Path(tmp).resolve()
+        install_skin(home)
+        skins = home / "skins"
+        stale = self._older_template()
+        (skins / SKIN_FILENAME).write_bytes(stale)
+        manifest = skins / MANIFEST_FILENAME
+        record = json.loads(manifest.read_text(encoding="utf-8"))
+        record["files"].pop(SKIN_FILENAME)
+        manifest.write_text(json.dumps(record, sort_keys=True), encoding="utf-8")
+        states = {entry["skin"]: entry["state"] for entry in installed_skin_report(home)}
+        self.assertEqual(states[SKIN_NAME], "unmanaged")
+        return home, stale
+
+    def test_repair_adopts_a_file_stranded_by_a_stale_record_and_a_moved_template(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home, stale = self._stranded_home(tmp)
+            result = repair_skins(home, adopt=frozenset({SKIN_FILENAME}))
+            entries = {entry["filename"]: entry for entry in result["skins"]}
+            self.assertEqual(result["status"], "repaired")
+            self.assertEqual(entries[SKIN_FILENAME]["state"], "unmanaged")
+            self.assertEqual(entries[SKIN_FILENAME]["status"], "repaired")
+            self.assertEqual(entries[SKIN_FILENAME]["before_sha256"], hashlib.sha256(stale).hexdigest())
+            self.assertEqual(
+                entries[SKIN_FILENAME]["after_sha256"],
+                hashlib.sha256(skin_payload()).hexdigest(),
+            )
+            self.assertEqual((home / "skins" / SKIN_FILENAME).read_bytes(), skin_payload())
+
+            manifest = json.loads((home / "skins" / MANIFEST_FILENAME).read_text(encoding="utf-8"))
+            self.assertEqual(manifest["schema_version"], "omh_skin_manifest/v2")
+            self.assertEqual(
+                manifest["files"][SKIN_FILENAME]["sha256"],
+                hashlib.sha256(skin_payload()).hexdigest(),
+            )
+            # The whole point: the machine is back on the update path.
+            states = {entry["skin"]: entry["state"] for entry in installed_skin_report(home)}
+            self.assertEqual(states[SKIN_NAME], "managed")
+
+    def test_a_repaired_machine_receives_the_next_release(self) -> None:
+        # Recording the file is not the win; the win is that the NEXT template
+        # change actually lands on it. Ship one and watch the bytes move.
+        with TemporaryDirectory() as tmp:
+            home, _ = self._stranded_home(tmp)
+            repair_skins(home, adopt=frozenset({SKIN_FILENAME}))
+
+            shipped = skin_payload
+            next_release = skin_payload(SKIN_NAME) + b"# a later release\n"
+
+            def _next_template(name: str = SKIN_NAME) -> bytes:
+                return next_release if name == SKIN_NAME else shipped(name)
+
+            with patch("omh.skin_pack.skin_payload", _next_template):
+                entries = {entry["filename"]: entry["status"] for entry in install_skin(home)["skins"]}
+            self.assertEqual(entries[SKIN_FILENAME], "installed")
+            self.assertEqual((home / "skins" / SKIN_FILENAME).read_bytes(), next_release)
+
+    def test_repair_names_the_palette_tokens_that_would_change(self) -> None:
+        # A person accepting an overwrite of a file we cannot prove we wrote
+        # gets to see what they are trading away first.
+        with TemporaryDirectory() as tmp:
+            home, _ = self._stranded_home(tmp)
+            entries = {entry["filename"]: entry for entry in repair_skins(home)["skins"]}
+            self.assertEqual(
+                entries[SKIN_FILENAME]["palette_changes"],
+                [{"key": "ui_label", "before": "#7FDBFF", "after": skin_colors()["ui_label"]}],
+            )
+
+    def test_the_bare_repair_reports_and_never_writes(self) -> None:
+        # The safety contract: with nothing named there is no consent, so the
+        # reporting form must be safe and idempotent to run.
+        with TemporaryDirectory() as tmp:
+            home, stale = self._stranded_home(tmp)
+            manifest = home / "skins" / MANIFEST_FILENAME
+            before_manifest = manifest.read_bytes()
+            result = repair_skins(home)
+            entries = {entry["filename"]: entry["status"] for entry in result["skins"]}
+            self.assertEqual(result["status"], "unmanaged")
+            self.assertEqual(entries[SKIN_FILENAME], "unmanaged")
+            self.assertEqual((home / "skins" / SKIN_FILENAME).read_bytes(), stale)
+            self.assertEqual(manifest.read_bytes(), before_manifest)
+            self.assertEqual(repair_skins(home)["status"], "unmanaged")
+            self.assertEqual((home / "skins" / SKIN_FILENAME).read_bytes(), stale)
+
+    def test_a_dry_run_shows_the_repair_without_performing_it(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home, stale = self._stranded_home(tmp)
+            manifest = home / "skins" / MANIFEST_FILENAME
+            before_manifest = manifest.read_bytes()
+            result = repair_skins(home, adopt=frozenset({SKIN_FILENAME}), dry_run=True)
+            entries = {entry["filename"]: entry for entry in result["skins"]}
+            self.assertEqual(result["status"], "would_repair")
+            self.assertEqual(entries[SKIN_FILENAME]["status"], "would_repair")
+            self.assertEqual(
+                entries[SKIN_FILENAME]["after_sha256"],
+                hashlib.sha256(skin_payload()).hexdigest(),
+            )
+            self.assertEqual((home / "skins" / SKIN_FILENAME).read_bytes(), stale)
+            self.assertEqual(manifest.read_bytes(), before_manifest)
+
+    def test_a_genuinely_user_authored_file_is_overwritten_only_when_named(self) -> None:
+        # The negative case that defines the consent contract. Nothing on disk
+        # separates this file from a stranded one of ours, so repair CAN take
+        # it -- but only because a person typed its name. Bare repair and
+        # --dry-run must both leave it exactly as written.
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp).resolve()
+            install_skin(home)
+            mine = skin_payload().replace(b"name: omh\n", b"name: omh\n# my own tweak\n")
+            destination = home / "skins" / SKIN_FILENAME
+            destination.write_bytes(mine)
+
+            self.assertEqual(
+                {entry["filename"]: entry["status"] for entry in repair_skins(home)["skins"]}[SKIN_FILENAME],
+                "unmanaged",
+            )
+            self.assertEqual(destination.read_bytes(), mine)
+
+            repair_skins(home, adopt=frozenset({SKIN_FILENAME}), dry_run=True)
+            self.assertEqual(destination.read_bytes(), mine)
+
+            adopted = repair_skins(home, adopt=frozenset({SKIN_FILENAME}))
+            entries = {entry["filename"]: entry["status"] for entry in adopted["skins"]}
+            self.assertEqual(entries[SKIN_FILENAME], "repaired")
+            self.assertEqual(destination.read_bytes(), skin_payload())
+
+    def test_repair_leaves_already_managed_files_untouched(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp).resolve()
+            install_skin(home)
+            manifest = home / "skins" / MANIFEST_FILENAME
+            before_manifest = manifest.read_bytes()
+            result = repair_skins(home, adopt=frozenset(theme.filename for theme in SKIN_THEMES))
+            self.assertEqual(result["status"], "managed")
+            self.assertEqual({entry["status"] for entry in result["skins"]}, {"managed"})
+            self.assertEqual(manifest.read_bytes(), before_manifest)
+
+    def test_repair_installs_a_missing_file_only_when_named(self) -> None:
+        # Consistent with `install_skin`, which installs a file that is not
+        # there; without a name it is reported and left alone.
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp).resolve()
+            install_skin(home)
+            destination = home / "skins" / "omh-mono.yaml"
+            destination.unlink()
+
+            entries = {entry["filename"]: entry["status"] for entry in repair_skins(home)["skins"]}
+            self.assertEqual(entries["omh-mono.yaml"], "missing")
+            self.assertFalse(destination.exists())
+
+            entries = {
+                entry["filename"]: entry["status"]
+                for entry in repair_skins(home, adopt=frozenset({"omh-mono.yaml"}))["skins"]
+            }
+            self.assertEqual(entries["omh-mono.yaml"], "installed")
+            self.assertEqual(destination.read_bytes(), skin_payload("omh-mono"))
+
+    def test_repair_all_adopts_every_file_that_needs_it_in_one_pass(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home, _ = self._stranded_home(tmp)
+            (home / "skins" / "omh-amber.yaml").write_text("name: omh-amber\n# mine\n", encoding="utf-8")
+            adopted = repair_skins(home, adopt=frozenset(theme.filename for theme in SKIN_THEMES))
+            entries = {entry["filename"]: entry["status"] for entry in adopted["skins"]}
+            self.assertEqual(entries[SKIN_FILENAME], "repaired")
+            self.assertEqual(entries["omh-amber.yaml"], "repaired")
+            self.assertEqual(entries["omh-mono.yaml"], "managed")
+            manifest = json.loads((home / "skins" / MANIFEST_FILENAME).read_text(encoding="utf-8"))
+            self.assertEqual(sorted(manifest["files"]), sorted(theme.filename for theme in SKIN_THEMES))
+
+    def test_repair_migrates_a_legacy_v1_manifest_forward(self) -> None:
+        # The v1 -> v2 migration is an invariant of every write path, not just
+        # `install_skin`: a machine old enough to be stranded is exactly the
+        # machine likeliest to still hold a v1 record.
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp).resolve()
+            skins = home / "skins"
+            skins.mkdir(parents=True)
+            stale = self._older_template()
+            (skins / SKIN_FILENAME).write_bytes(stale)
+            (skins / MANIFEST_FILENAME).write_text(
+                json.dumps(
+                    {
+                        "schema_version": "omh_skin_manifest/v1",
+                        "filename": SKIN_FILENAME,
+                        "sha256": "1420e408" + "0" * 56,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            adopted = repair_skins(home, adopt=frozenset({SKIN_FILENAME}))
+            entries = {entry["filename"]: entry["status"] for entry in adopted["skins"]}
+            self.assertEqual(entries[SKIN_FILENAME], "repaired")
+            manifest = json.loads((skins / MANIFEST_FILENAME).read_text(encoding="utf-8"))
+            self.assertEqual(manifest["schema_version"], "omh_skin_manifest/v2")
+            self.assertEqual(
+                manifest["files"][SKIN_FILENAME]["sha256"],
+                hashlib.sha256(skin_payload()).hexdigest(),
+            )
+
+    def test_uninstall_takes_back_a_repaired_file(self) -> None:
+        # Symmetry: a file repair adopted is a file uninstall must remove, or
+        # removal leaves an orphan behind on exactly the machines we just fixed.
+        with TemporaryDirectory() as tmp:
+            home, _ = self._stranded_home(tmp)
+            repair_skins(home, adopt=frozenset({SKIN_FILENAME}))
+            entries = {entry["filename"]: entry["status"] for entry in uninstall_skin(home)["skins"]}
+            self.assertEqual(entries[SKIN_FILENAME], "removed")
+            self.assertFalse((home / "skins" / SKIN_FILENAME).exists())
+
+    @requires_symlinks
+    def test_repair_refuses_a_symlinked_destination_and_parent(self) -> None:
+        # Repair is a write path, so it inherits the whole symlink invariant:
+        # naming a theme must never become a way to write through a link.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            home = root / ".hermes"
+            skins = home / "skins"
+            skins.mkdir(parents=True)
+            victim = root / "victim.yaml"
+            victim_bytes = b"do not overwrite\n"
+            victim.write_bytes(victim_bytes)
+            (skins / SKIN_FILENAME).symlink_to(victim)
+
+            with self.assertRaises(SkinInstallError):
+                repair_skins(home, adopt=frozenset({SKIN_FILENAME}))
+            with self.assertRaises(SkinInstallError):
+                repair_skins(home)
+            self.assertEqual(victim.read_bytes(), victim_bytes)
+
+            (skins / SKIN_FILENAME).unlink()
+            skins.rmdir()
+            external = root / "external-skins"
+            external.mkdir()
+            skins.symlink_to(external, target_is_directory=True)
+            with self.assertRaises(SkinInstallError):
+                repair_skins(home, adopt=frozenset({SKIN_FILENAME}))
+            self.assertEqual(list(external.iterdir()), [])
 
 
 class EnsureOmhSkinTests(unittest.TestCase):

--- a/tests/test_theme_command.py
+++ b/tests/test_theme_command.py
@@ -6,6 +6,11 @@ writes `display.skin` and installs the files it selects, that `--dry-run`
 writes nothing, that an invalid name fails loudly with the valid ones named,
 and that a foreign skin is reported as the user's own rather than overwritten
 behind their back.
+
+`repair` is the same contract read backwards: it is the only command that may
+overwrite a theme file OMH cannot prove it wrote, so the tests pin that the
+bare form never writes, that naming a theme is what makes it destructive, and
+that `status`/`list` point at it exactly when something is unmanaged.
 """
 
 from __future__ import annotations
@@ -18,7 +23,7 @@ import unittest
 from _cli_harness import run_cli
 
 from omh.install.config_adapter import display_skin_selection
-from omh.skin_pack import MANIFEST_FILENAME
+from omh.skin_pack import MANIFEST_FILENAME, SKIN_FILENAME, skin_colors, skin_payload
 
 
 class ThemeCommandTests(unittest.TestCase):
@@ -157,3 +162,181 @@ class ThemeCommandTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ThemeRepairCommandTests(unittest.TestCase):
+    """The repair surface: report by default, overwrite only when asked.
+
+    There is no digest that separates a theme file OMH wrote from one a person
+    wrote once the manifest has gone stale AND the template has moved on, so
+    the command invocation is the consent. Every test here is a statement about
+    where that line sits.
+    """
+
+    def _homes(self, tmp: str) -> list[str]:
+        root = Path(tmp)
+        (root / "hermes").mkdir()
+        (root / "omh").mkdir()
+        return ["--omh-home", str(root / "omh"), "--hermes-home", str(root / "hermes")]
+
+    def _strand_sky(self, tmp: str, homes: list[str]) -> bytes:
+        """Reproduce the live drift: an older-release `omh.yaml`, no record for it.
+
+        Exactly the state `omh theme status` reported as `sky omh.yaml -
+        unmanaged` on the owner's machine after `omh update` to merged main.
+        """
+        run_cli([*homes, "theme", "use", "sky"])
+        skins = Path(tmp) / "hermes" / "skins"
+        stale = skin_payload().replace(skin_colors()["ui_label"].encode(), b"#7FDBFF")
+        (skins / SKIN_FILENAME).write_bytes(stale)
+        manifest = skins / MANIFEST_FILENAME
+        record = json.loads(manifest.read_text(encoding="utf-8"))
+        record["files"].pop(SKIN_FILENAME)
+        manifest.write_text(json.dumps(record, sort_keys=True), encoding="utf-8")
+        return stale
+
+    def test_the_bare_repair_reports_the_change_and_writes_nothing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            homes = self._homes(tmp)
+            stale = self._strand_sky(tmp, homes)
+            status, out, _ = run_cli([*homes, "theme", "repair"], output_json=False)
+            self.assertEqual(status, 0)
+            self.assertIn("unmanaged; NOT adopted", out)
+            # The before/after a person needs in order to accept knowingly.
+            self.assertIn(f"ui_label: #7FDBFF -> {skin_colors()['ui_label']}", out)
+            self.assertIn("Nothing was written.", out)
+            self.assertIn("omh theme repair --all", out)
+            self.assertEqual((Path(tmp) / "hermes" / "skins" / SKIN_FILENAME).read_bytes(), stale)
+
+    def test_naming_a_theme_adopts_it_and_records_it(self) -> None:
+        with TemporaryDirectory() as tmp:
+            homes = self._homes(tmp)
+            self._strand_sky(tmp, homes)
+            status, out, _ = run_cli([*homes, "theme", "repair", "sky"], output_json=False)
+            self.assertEqual(status, 0)
+            self.assertIn("repaired; replaced with the shipped file", out)
+            skins = Path(tmp) / "hermes" / "skins"
+            self.assertEqual((skins / SKIN_FILENAME).read_bytes(), skin_payload())
+            manifest = json.loads((skins / MANIFEST_FILENAME).read_text(encoding="utf-8"))
+            self.assertIn(SKIN_FILENAME, manifest["files"])
+            # Idempotent afterwards: a repaired file is simply managed.
+            _, again, _ = run_cli([*homes, "theme", "repair"], output_json=False)
+            self.assertIn("there is nothing to repair", again)
+
+    def test_a_dry_run_shows_the_same_report_and_writes_nothing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            homes = self._homes(tmp)
+            stale = self._strand_sky(tmp, homes)
+            status, out, _ = run_cli([*homes, "theme", "repair", "sky", "--dry-run"], output_json=False)
+            self.assertEqual(status, 0)
+            self.assertIn("WOULD be replaced with the shipped file", out)
+            self.assertIn(f"ui_label: #7FDBFF -> {skin_colors()['ui_label']}", out)
+            self.assertIn("Dry run: nothing was written.", out)
+            self.assertEqual((Path(tmp) / "hermes" / "skins" / SKIN_FILENAME).read_bytes(), stale)
+
+    def test_all_adopts_every_unmanaged_file_at_once(self) -> None:
+        with TemporaryDirectory() as tmp:
+            homes = self._homes(tmp)
+            self._strand_sky(tmp, homes)
+            skins = Path(tmp) / "hermes" / "skins"
+            (skins / "omh-amber.yaml").write_text("name: omh-amber\n# mine\n", encoding="utf-8")
+            payload = json.loads(run_cli([*homes, "theme", "repair", "--all"])[1])
+            statuses = {entry["theme"]: entry["status"] for entry in payload["themes"]}
+            self.assertEqual(statuses["sky"], "repaired")
+            self.assertEqual(statuses["amber"], "repaired")
+            self.assertEqual(statuses["mono"], "managed")
+
+    def test_a_hand_written_skin_survives_the_no_argument_form(self) -> None:
+        # The negative control. A file a person actually authored looks exactly
+        # like a stranded one of ours, so the safety has to come from consent:
+        # reporting must never touch it, and `--dry-run` must not either.
+        with TemporaryDirectory() as tmp:
+            homes = self._homes(tmp)
+            run_cli([*homes, "theme", "use", "sky"])
+            destination = Path(tmp) / "hermes" / "skins" / SKIN_FILENAME
+            mine = b"name: omh\n# entirely my own skin\n"
+            destination.write_bytes(mine)
+
+            run_cli([*homes, "theme", "repair"], output_json=False)
+            self.assertEqual(destination.read_bytes(), mine)
+            run_cli([*homes, "theme", "repair", "sky", "--dry-run"], output_json=False)
+            self.assertEqual(destination.read_bytes(), mine)
+            run_cli([*homes, "theme", "list"], output_json=False)
+            self.assertEqual(destination.read_bytes(), mine)
+            run_cli([*homes, "theme", "status"], output_json=False)
+            self.assertEqual(destination.read_bytes(), mine)
+            # Selecting a theme must not repair either -- `use` installs, and
+            # installing has always left an unmanaged file alone.
+            run_cli([*homes, "theme", "use", "sky"])
+            self.assertEqual(destination.read_bytes(), mine)
+
+            # Only the explicit name takes it, and that is the whole contract.
+            run_cli([*homes, "theme", "repair", "sky"], output_json=False)
+            self.assertEqual(destination.read_bytes(), skin_payload())
+
+    def test_a_name_and_all_together_is_refused(self) -> None:
+        with TemporaryDirectory() as tmp:
+            status, out, _ = run_cli([*self._homes(tmp), "theme", "repair", "sky", "--all"], output_json=False)
+            self.assertEqual(status, 2)
+            self.assertIn("not both", out)
+
+    def test_an_unknown_theme_name_is_refused_with_the_valid_ones(self) -> None:
+        with TemporaryDirectory() as tmp:
+            status, out, _ = run_cli([*self._homes(tmp), "theme", "repair", "ultraviolet"], output_json=False)
+            self.assertEqual(status, 2)
+            self.assertIn("unknown theme", out)
+            self.assertIn("crimson", out)
+
+    def test_the_json_payload_carries_the_digests_and_the_palette_diff(self) -> None:
+        with TemporaryDirectory() as tmp:
+            homes = self._homes(tmp)
+            self._strand_sky(tmp, homes)
+            payload = json.loads(run_cli([*homes, "theme", "repair"])[1])
+            self.assertEqual(payload["schema_version"], "omh_theme_repair/v1")
+            self.assertEqual(payload["mode"], "report")
+            self.assertEqual(payload["status"], "unmanaged")
+            self.assertEqual(payload["requested"], "")
+            self.assertFalse(payload["all"])
+            self.assertFalse(payload["dry_run"])
+            self.assertEqual([entry["theme"] for entry in payload["themes"]], ["sky", "amber", "crimson", "mono"])
+            sky = payload["themes"][0]
+            self.assertEqual(
+                sorted(sky),
+                [
+                    "after_sha256",
+                    "before_sha256",
+                    "filename",
+                    "palette_changes",
+                    "path",
+                    "skin",
+                    "state",
+                    "status",
+                    "theme",
+                ],
+            )
+            self.assertEqual(sky["state"], "unmanaged")
+            self.assertEqual(sky["status"], "unmanaged")
+            self.assertNotEqual(sky["before_sha256"], sky["after_sha256"])
+            self.assertEqual(
+                sky["palette_changes"],
+                [{"key": "ui_label", "before": "#7FDBFF", "after": skin_colors()["ui_label"]}],
+            )
+
+    def test_status_and_list_point_at_repair_only_while_something_is_unmanaged(self) -> None:
+        # Discoverability is the other half of the fix: a frozen skin that
+        # nobody can find the cure for stays frozen. An always-on hint would
+        # be noise, so it appears exactly when it applies.
+        with TemporaryDirectory() as tmp:
+            homes = self._homes(tmp)
+            run_cli([*homes, "theme", "use", "sky"])
+            for surface in ("status", "list"):
+                _, out, _ = run_cli([*homes, "theme", surface], output_json=False)
+                self.assertNotIn("omh theme repair", out)
+                self.assertEqual(json.loads(run_cli([*homes, "theme", surface])[1])["unmanaged_themes"], [])
+
+            self._strand_sky(tmp, homes)
+            for surface in ("status", "list"):
+                _, out, _ = run_cli([*homes, "theme", surface], output_json=False)
+                self.assertIn("Unmanaged: sky", out)
+                self.assertIn("omh theme repair", out)
+                self.assertEqual(json.loads(run_cli([*homes, "theme", surface])[1])["unmanaged_themes"], ["sky"])


### PR DESCRIPTION
## Feature Report

### What Changed

- New user-invocable command `omh theme repair [<name>] [--all] [--dry-run] [--json]`. It reports every theme file OMH cannot prove it wrote, and — only when a theme is explicitly named, or `--all` is passed — overwrites that file with the shipped payload and records it in the skin manifest so future updates flow again.
- `omh theme status` and `omh theme list` now name `omh theme repair` in their `Next` block, and only while something is actually `unmanaged`. Both payloads gain an additive `unmanaged_themes` key.
- New `repair_skins()` in `src/omh/skin_pack.py`, plus `colors_from_text()` split out of `skin_colors()` so the repair report can read an **installed** document's palette rather than only a shipped one.
- Nothing repairs automatically. `omh update`, `omh setup`, and `omh theme use` do not call the repair path.

### Why This Exists

PR #1221 gave `_is_managed_file` a second ownership proof: a theme file is OMH's when its digest matches the manifest record **or** the currently shipped template. That heals a stale manifest sitting over an *unchanged* template.

The residual case — measured on the owner's machine right after #1221 merged, via `omh update` to merged main — is the one where **both** have moved:

- `~/.hermes/skins/omh.yaml` sha256 `e99be0e84830b65969772adcef802a439641d8c1df45d31d2576f3806d5924d3` (4733 bytes), byte-identical to the pre-#1221 shipped sky template.
- Current shipped template sha256 `122577bf7c5080e3632a9f4c26eae318d0fcdb853405580ae5365659b6e38309` (5119 bytes). The only substantive difference is the `ui_label` brightening `#7FDBFF` → `#9FE8FF` plus its explanatory comment.
- Manifest is `omh_skin_manifest/v2` with records for `omh-amber`/`omh-crimson`/`omh-mono` and **no record for `omh.yaml`**.

The file is OMH's in origin, matches neither ownership proof, and is therefore reported `sky omh.yaml - unmanaged`. Because OMH will never touch an unmanaged file, sky is frozen on the old palette **permanently** — on that machine and on any machine that hit the same drift. No future template change can ever reach it.

No hash closes that gap. Once the manifest has gone stale and the template has moved on, nothing on disk distinguishes such a file from one a person genuinely hand-wrote. So the fix cannot be another self-heal; it has to ask.

### User / Operator Impact

Before: a stranded theme file was a permanent dead end. `omh theme status` said `unmanaged`, and the only cure was to know the internals well enough to delete the file by hand and re-run setup.

After, the whole loop is one discoverable command:

```sh
omh theme repair                  # report only; writes nothing, safe and idempotent
omh theme repair sky              # adopt sky: overwrite with the shipped file, record it
omh theme repair --all            # adopt every unmanaged theme file
omh theme repair sky --dry-run    # show exactly what adopting would do, without doing it
omh theme repair --json           # machine-readable payload (omh_theme_repair/v1)
```

The bare form and `--dry-run` print, per file, the before/after `sha256` and the palette tokens that would change — so the user sees what they are accepting *before* anything destructive happens. On the observed machine that is a single line, `ui_label: #7FDBFF -> #9FE8FF`.

Observed output shape (report form, on a reconstruction of the live state):

```text
OMH theme repair
  Skins directory: /Users/you/.hermes/skins
Theme files
  sky      omh.yaml          - unmanaged; NOT adopted (name it, or pass --all, to accept)
      sha256 e99be0e84830b659 -> 122577bf7c5080e3
      ui_label: #7FDBFF -> #9FE8FF
  amber    omh-amber.yaml    - managed; untouched
  crimson  omh-crimson.yaml  - managed; untouched
  mono     omh-mono.yaml     - managed; untouched
Next
  Nothing was written. Accept with `omh theme repair <name>` or `omh theme repair --all`.
```

`--dry-run` prints the same block with `WOULD be replaced with the shipped file` and `Next: Dry run: nothing was written. Re-run without --dry-run to accept.` The accept prints `repaired; replaced with the shipped file` and `Next: Adopted 1 theme file(s); future updates now reach them.`

### How It Works

**The consent contract.** `repair_skins(hermes_home, *, adopt=frozenset(), dry_run=False)` takes the set of theme *filenames* the caller explicitly named. `adopt` is empty for the reporting form, which is precisely why bare `omh theme repair` never writes and is safe to run twice. The command invocation IS the consent, because no digest can supply it.

**Per-file statuses.** `managed` (untouched, reported as such), `unmanaged`/`missing` (reported only, no consent given), `would_repair`/`would_install` (dry run), `repaired`/`installed` (written and recorded). `missing` files are *installed* when named — consistent with `install_skin`, which already installs a theme file that is not there.

**Invariants preserved.** Symlink rejection runs over `hermes_home`, the skins directory, each destination, and the manifest — a name is never a way to write through a link. Writes go through the same `_atomic_write_bytes`. The v1 → v2 manifest migration flows through `_read_manifest_records`/`_manifest_document` exactly as the install path does. Uninstall symmetry holds: a repaired file is a managed file, so `omh uninstall --all` takes it back exactly like an installed one.

**Discoverability without automation.** `_repair_hint()` prints only while `unmanaged_themes` is non-empty. An always-on hint would train people to skip the `Next` block, and a hand-authored skin is a valid end state rather than a fault to nag about.

### Files And Contracts Touched

- `src/omh/skin_pack.py` — new `repair_skins()`, `_palette_changes()`, `_REPAIR_STATUS_ORDER`; `skin_colors()` split over new public `colors_from_text()`.
- `src/commands/theme.py` — new `cmd_theme_repair`, `_print_theme_repair`, `_repair_hint`, `_REPAIR_NOTES`; `repair` subparser; `unmanaged_themes` added to `_theme_report()`.
- `tests/test_skin_pack.py` — new `SkinRepairTests` (12 tests).
- `tests/test_theme_command.py` — new `ThemeRepairCommandTests` (9 tests).
- `docs/INSTALLATION.md` — TUI Themes section extended with the repair commands and a new "Why a theme file can be `unmanaged`" subsection separating the two situations that land there.

New payload schema `omh_theme_repair/v1`: `schema_version`, `mode` (`report`/`repair`), `requested`, `all`, `dry_run`, `status`, `skins_dir`, `themes[]`, `restart_note`, `language`. Each `themes[]` entry carries `skin`, `theme`, `filename`, `path`, `state`, `status`, `before_sha256`, `after_sha256`, `palette_changes[]`.

`omh_theme_list/v1` and `omh_theme_status/v1` gain `unmanaged_themes` additively; both schema versions are unchanged because no existing key moved.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run

Also run and passing (not on the template list): `uv run python -m omh.cli docs ulw-inventory --check`, `uv run python -m omh.cli docs ulw-site --check`.

### Observed Evidence

- **Full suite**: `Ran 8550 tests` — `FAILED (failures=21, errors=7)`. All 28 are the pre-existing `test_cross_harness_adapters` / `test_cross_harness_adapter_security` failures caused by running from a `.claude/worktrees/...` path (the sandbox rejects it as `unsafe_read_root`). Isolated separately: those two files alone produce `Ran 32 tests` → `failures=21, errors=7`, i.e. all 28, and `grep -c skin` over both files returns `0` — they touch no skin or theme surface. Zero failures anywhere else. CI is authoritative on this artifact.
- **Targeted**: `tests.test_skin_pack` → `Ran 48 tests ... OK` (12 new). `tests.test_theme_command` → `Ran 20 tests ... OK` (9 new).
- **Suite size, both arms measured rather than inferred**: with `tests/test_skin_pack.py` and `tests/test_theme_command.py` checked out at `origin/main` and everything else at this branch, discovery reports `Ran 8529 tests` → `FAILED (failures=21, errors=7)`. With this branch's test files restored: `Ran 8550 tests` → `FAILED (failures=21, errors=7)`. Same 28, identical in both arms; +21 tests, +0 failures.
- **Byte gates**: all five `docs {workflows,roles,capability-families,ulw-inventory,ulw-site} --check` returned `"ok":true`, exit 0 (tap-skills `checked:155 expected:155`, no missing/stale/extra).
- **Ruff**: `All checks passed!`. **compileall**: clean (only the two pre-existing `SyntaxWarning`s in `tests/test_menubar_app.py`). **`git diff --check`**: exit 0.
- **Manual CLI smoke** against a reconstruction of the live drift (older-template `omh.yaml` + a v2 manifest with its record removed): `theme status` reported `sky` unmanaged and printed the repair hint; bare `repair` reported the `ui_label` change and wrote nothing; `repair sky --dry-run` showed the same and wrote nothing; `repair sky` adopted the file; a second bare `repair` reported `Every shipped theme file is managed`; `theme status` then reported all four `managed` with no hint. Exit 0 throughout.
- The most load-bearing test is not that the record is written but that the *next release lands*: `test_a_repaired_machine_receives_the_next_release` patches in a changed template after a repair and asserts the bytes on disk actually move.

### Not Tested / Not Applicable

- `harness validate`, `release checklist`, `release hermes-smoke`, and the install-path smoke were not run: this change touches no harness contract, no release manifest, and no install path — only the theme command group and the skin-pack ownership predicate. No generated artifact family is derived from either.
- **The repair has not been run on the owner's live machine.** That remains `prepared_not_observed`; the owner will run it. Everything above is a faithful local reconstruction of the reported state, not the machine itself.
- No manual Hermes/TUI session was started. The command writes only files under `$HERMES_HOME/skins/`; whether Hermes then renders the brightened `ui_label` is the same next-start behavior #1221 already established.

## Risk

- **`--all` is genuinely destructive by design.** It overwrites every unmanaged theme file, including ones a person really did hand-write. That is the consent contract — there is no hash that separates the two cases — but it is why the bare form reports rather than writes, why the palette diff is printed before the accept, and why `--dry-run` exists. Mitigated further by `theme use` and `install_skin` still refusing to touch unmanaged files, so nothing reaches the repair path implicitly.
- Palette diffing uses the existing dependency-free `colors:` reader. A skin file that is not decodable UTF-8 yields an empty `palette_changes` rather than raising; the digest pair still tells the honest story.
- `unmanaged_themes` is additive in two existing payloads; no consumer key moved or changed meaning.

## Compatibility / Rollout

- Additive command and additive payload keys only. No existing behavior changes: the same files are managed, the same files are refused, `install_skin`/`uninstall_skin`/`theme use` are untouched.
- Reaches machines the usual way, through `omh update`. Running `omh theme repair` afterwards is then a deliberate, one-time operator action per stranded file.
- Rolls back cleanly: reverting removes a command nothing else calls.

## Release / Claims

- [x] Release-channel impact considered (`stable`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including the live-machine gap

## Follow-Up

- The owner runs `omh theme repair` (or `omh theme repair sky`) on the affected machine after this merges and `omh update` runs, converting the live-machine claim from `prepared_not_observed` to observed.
- If more machines turn out to be stranded than expected, the next question worth asking is whether `omh doctor` should *report* (never fix) unmanaged theme files, so the condition surfaces without anyone having to run `theme status`.
