### PR TITLE
ulw-research asks who the output is for, and writes the human a real briefing

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -753,6 +753,9 @@ These surfaces are generated command references, not installed Hermes workflow s
   - Why: Local repo orientation needs no external evidence gathering or claim verification.
 - Quality bar:
   - Ask for the research question, source boundaries, freshness, jurisdiction, and version assumptions before retrieval.
+  - Ask who the output is for before retrieval and never infer it: a human reader gets a briefing document, a coding agent gets the dense handoff of findings, exact symbols, and file paths. The answer changes what the run records, not only how it is written up.
+  - On the human branch ask the output format (markdown, a print-ready page, or both) and the output language before writing, then hold the document to `references/briefing-format.md` - noun-phrase titles carrying a role label from its closed vocabulary, cause before effect, terms defined at first use, figures drawn in code blocks, and the fixed chapter-and-appendix structure.
+  - Keep the coding-agent branch dense: findings, exact symbols, file paths, and the plan-feed block, with no narrative framing and no briefing structure.
   - Use official or primary sources first when current or external facts matter, then add source diversity when the topic is contested.
   - Revise the search plan when new evidence exposes a gap or contradiction instead of stopping at the first pass.
   - Gate contested claims: require at least two independent source domains, one counter-search for disconfirming evidence, and a primary source, or move the claim to the unresolved annex.
@@ -777,8 +780,12 @@ These surfaces are generated command references, not installed Hermes workflow s
   - If the evidence stays thin or contested, lower the stated confidence and keep the unresolved claims in the annex rather than flattening them.
   - If leads keep expanding past the declared budget, stop, record open leads in the dossier, and ask whether to extend the budget.
   - If enough evidence already exists and the real request is planning, hand off to ralplan with the recorded dossier.
+  - If the audience answer arrives after retrieval started, keep the evidence and re-render rather than re-running: the dossier feeds both branches.
 - Required inputs:
   - research question
+  - output audience - a human reader or a coding agent - asked before retrieval and never inferred
+  - output format when the reader is human - markdown, a print-ready page, or both
+  - output language when the reader is human - declared, never inferred from the request
   - target user/task if usability matters
   - usability/quality dimension if applicable
   - source boundaries
@@ -795,6 +802,7 @@ These surfaces are generated command references, not installed Hermes workflow s
   - confidence and residual uncertainty
   - product_evidence_loop/v1
   - deep_research_dossier/v1
+  - research_briefing/v1 with its markdown and print-ready page when the reader is human
 - Artifact expectations:
   - research notes with source URLs, retrieval dates, source-quality notes, and per-reference mechanism, tradeoff, license, and pinned-ref notes when the wrapper captures them
 - Safety rules:
@@ -810,6 +818,7 @@ These surfaces are generated command references, not installed Hermes workflow s
   - State retrieval limits, dates, and missing-source gaps for unstable facts.
   - product_evidence_loop/v1 is prepared-only opaque references, not observed evidence or execution.
   - deep_research_dossier/v1 is prepared decision context, not observed evidence, execution, review, CI, or merge evidence.
+  - research_briefing/v1 is prepared decision context; a rendered page is a page, and calling it a PDF needs observed file evidence.
 
 ### web-research
 

--- a/skills/ulw-research/SKILL.md
+++ b/skills/ulw-research/SKILL.md
@@ -56,6 +56,7 @@ Bad example:
 - If the evidence stays thin or contested, lower the stated confidence and keep the unresolved claims in the annex rather than flattening them.
 - If leads keep expanding past the declared budget, stop, record open leads in the dossier, and ask whether to extend the budget.
 - If enough evidence already exists and the real request is planning, hand off to ralplan with the recorded dossier.
+- If the audience answer arrives after retrieval started, keep the evidence and re-render rather than re-running: the dossier feeds both branches.
 
 ## Workflow Lane
 
@@ -80,6 +81,9 @@ Reasoning demand: `standard`
 Quality bar:
 
 - Ask for the research question, source boundaries, freshness, jurisdiction, and version assumptions before retrieval.
+- Ask who the output is for before retrieval and never infer it: a human reader gets a briefing document, a coding agent gets the dense handoff of findings, exact symbols, and file paths. The answer changes what the run records, not only how it is written up.
+- On the human branch ask the output format (markdown, a print-ready page, or both) and the output language before writing, then hold the document to `references/briefing-format.md` - noun-phrase titles carrying a role label from its closed vocabulary, cause before effect, terms defined at first use, figures drawn in code blocks, and the fixed chapter-and-appendix structure.
+- Keep the coding-agent branch dense: findings, exact symbols, file paths, and the plan-feed block, with no narrative framing and no briefing structure.
 - Use official or primary sources first when current or external facts matter, then add source diversity when the topic is contested.
 - Revise the search plan when new evidence exposes a gap or contradiction instead of stopping at the first pass.
 - Gate contested claims: require at least two independent source domains, one counter-search for disconfirming evidence, and a primary source, or move the claim to the unresolved annex.
@@ -103,6 +107,9 @@ Run as a Hermes-side research lane when web or repository access is available; H
 Required inputs:
 
 - research question
+- output audience - a human reader or a coding agent - asked before retrieval and never inferred
+- output format when the reader is human - markdown, a print-ready page, or both
+- output language when the reader is human - declared, never inferred from the request
 - target user/task if usability matters
 - usability/quality dimension if applicable
 - source boundaries
@@ -121,6 +128,7 @@ Expected outputs:
 - confidence and residual uncertainty
 - product_evidence_loop/v1
 - deep_research_dossier/v1
+- research_briefing/v1 with its markdown and print-ready page when the reader is human
 
 Artifact expectations:
 
@@ -140,6 +148,7 @@ Safety rules:
 - State retrieval limits, dates, and missing-source gaps for unstable facts.
 - product_evidence_loop/v1 is prepared-only opaque references, not observed evidence or execution.
 - deep_research_dossier/v1 is prepared decision context, not observed evidence, execution, review, CI, or merge evidence.
+- research_briefing/v1 is prepared decision context; a rendered page is a page, and calling it a PDF needs observed file evidence.
 
 ## Runtime Evidence
 

--- a/skills/ulw-research/references/briefing-format.md
+++ b/skills/ulw-research/references/briefing-format.md
@@ -1,0 +1,83 @@
+# Briefing Document Format
+
+The rules below govern the briefing the research engine writes when the reader is a person. They do not govern the coding-agent handoff, which stays dense findings, exact symbols, and file paths with no narrative. Ask which one is wanted before retrieval starts, because the answer changes what the run records, not only how it is written up.
+
+These rules are authored in English and applied to a document written in any language. A rule about sentence order or title shape is not an English rule; it survives translation. The clause-level examples below are English so the shape is legible, and each names the property being tested rather than the words.
+
+## Titles
+
+**Compress a title to a noun phrase.** Name the subject; do not state a sentence about it.
+
+- WRONG: `Load rises as input grows` -> RIGHT: `Load growth under rising input`
+- WRONG: `Each expert gets different traffic` -> RIGHT: `Expert load imbalance`
+- WRONG: `Deployment is simple` -> RIGHT: `What a GQA deployment has to decide`
+
+**Use the established term.** Write the term the field uses rather than a paraphrase of it. When the document body is not in English, put the English term in parentheses at first use.
+
+**Prefix a role label.** The shape is `Role - noun phrase`. Without the label a reader cannot tell whether the section states a problem, an advantage, or an observation. The vocabulary is closed: Concept, Problem, Option, Solution, Reversal, Case, Guideline, Constraint, Pitfall, Limit, Cost, Deployment, Check.
+
+**A cost title names both sides.** Say what was spent and what it bought.
+
+- WRONG: `Cost - precise retrieval and reproducibility are given up`
+- RIGHT: `Cost - retrieval precision weakens in proportion to the KV cache removed`
+
+**Five title shapes are banned.**
+
+- Numeric scaffolding: `(1) problem / (2) mechanism / (3) numbers`
+- Evaluation only: `Deployment is simple`
+- Counting only: `Three options`
+- Repetition: the same title used for four different sections
+- Metaphor: `Copying something compressed is wasted work`
+
+## Sentences
+
+- **Order.** Cause before effect, premise before verdict, observation before reading. Do not state the conclusion first and attach its support afterward.
+- **Endings.** Ban the shapes that announce their own rhetorical role: `that is the cost`, `the point is that`, `the reason is`. Rewrite `the reason it works is here` as `it works because ...`.
+- **Deixis.** Do not point across sentences with `here` or `this`. Name the thing.
+- **Emphasis.** Do not bold a conclusion and then supply its evidence underneath. Emphasis marks a term, not a verdict.
+- **Enumeration.** Ban `A is X. B is Y. C is Z.` Carry the previous paragraph's conclusion into the next paragraph's opening.
+- **Length.** Inside one list, keep the items the same size.
+
+Four sentence forms are banned outright: the question-and-answer frame (`the question X answered was`), the rhetorical question (`so what happens?`), intensifiers (`dramatically`, `overwhelmingly`, `decisively`), and methodology exposure - the document never mentions its own method, its review, or the feedback that shaped it.
+
+## Content
+
+- Open on the problem, with numbers, and establish the premises before anything else.
+- Define a term where it first appears, expanding the acronym there. A definition that exists only in the appendix is not a definition.
+- Ground every number in a premise the reader has already been given, so the figure is derived rather than asserted.
+- Explain every setting and parameter, not one selected example. The order is: what it decides, then the options, then why this value.
+- Derive a setting from the preceding calculation. Do not list settings as items.
+- Open each chapter with one paragraph defining its subject and a figure contrasting it with the neighbouring idea.
+- Let the limit that closes a chapter become the problem that opens the next.
+- When the assessment turns from favourable to unfavourable, write the transition paragraph: state what has been solved so far and what has not been examined yet.
+- Keep back-references minimal, and never forward-reference.
+
+## Form
+
+- **Figures.** Draw flow, structure, calculation, and scale contrasts in code blocks.
+- **Lists.** Bullets for parameter explanations. A table only when several subjects are compared on the same axes.
+- **Block quotes.** Analogies and warnings only. Body explanation never goes in a quote.
+- **Subheads.** What should be a subhead is written as a subhead, not as a sentence in running text.
+- **Code.** Runnable form, attached to every case the document discusses.
+
+## Structure
+
+Learning objectives (what the reader can do once the document is closed) -> assumed knowledge, what is built from scratch, and what is out of scope -> contents -> body as part, chapter, section -> Appendix A: glossary -> Appendix B: misconceptions and traps -> Appendix C: sources.
+
+## Exercises
+
+Run exercises as a hypothetical scenario, and build failure into it: a session that succeeds on the first attempt teaches nothing. Logs and output follow the real format of the tool being shown, with the values marked as simulated.
+
+## Currency
+
+Confirm the current state by retrieval rather than recall. Separate durable principles from time-dependent figures, and give every time-dependent figure its as-of date and how it was confirmed. Separate vendor claims from independent measurement, and present the unfavourable data alongside the favourable.
+
+## Language
+
+The output language is declared by the requester and never inferred from the language of the request. Body prose, role labels, chapter headings, and appendix captions follow the declared language together -- a Korean briefing under English section captions is a half-translated document. Identifiers, schema ids, file paths, command names, and code stay as written. When the declaration is absent, the document is English.
+
+OMH holds no translation table for the scaffolding, because one would have to be maintained for every language the engine can write in. Supply the labels with the payload instead: `role_labels` maps a role to its label in the document's language, `captions` does the same for the section headings, and anything left unnamed falls back to English. Translating the body while leaving the captions unset is the failure this field exists to prevent.
+
+## Evidence boundary
+
+A briefing is prepared decision context. It is not execution, review, CI, merge-readiness, or merge evidence, and neither is any figure inside it. A rendered page is a page: calling it a PDF requires observed file evidence, and the format handoff is `handoff_prepared` until then.

--- a/src/commands/hermes.py
+++ b/src/commands/hermes.py
@@ -15,6 +15,11 @@ from ..hermes_planning import (
 )
 from ..hermes_readiness import build_hermes_agent_readiness
 from ..workflows.hermes_retained_context import build_hermes_retained_context
+from ..workflows.research_briefing import (
+    render_research_briefing_markdown,
+    render_research_briefing_page,
+    research_briefing_errors,
+)
 from ..workflows.plan_variants import (
     PLAN_VARIANT_DELTA_DIMENSIONS,
     build_plan_variant,
@@ -222,6 +227,53 @@ def cmd_hermes_retained_context(args: argparse.Namespace) -> int:
     return 0
 
 
+
+def _write_briefing_document(path: str, document: str) -> str:
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    # newline="" so the artifact is byte-identical on Windows; a rendered
+    # document that differs by platform cannot be compared or regenerated.
+    with target.open("w", encoding="utf-8", newline="") as handle:
+        handle.write(document)
+    return str(target)
+
+
+def cmd_hermes_briefing(args: argparse.Namespace) -> int:
+    """Render a research_briefing/v1 payload as Markdown, a page, or both."""
+    try:
+        raw = sys.stdin.read() if args.input == "-" else Path(args.input).read_text(encoding="utf-8")
+        payload = json.loads(raw)
+    except (OSError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    issues = research_briefing_errors(payload)
+    if issues:
+        raise OmhError("; ".join(issues[:5]))
+    written: dict[str, str] = {}
+    try:
+        if args.markdown:
+            written["markdown"] = _write_briefing_document(
+                args.markdown, render_research_briefing_markdown(payload)
+            )
+        if args.page:
+            written["page"] = _write_briefing_document(args.page, render_research_briefing_page(payload))
+    except (OSError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(
+        {
+            "schema_version": payload["schema_version"],
+            "audience": payload["audience"],
+            "output_formats": payload["output_formats"],
+            "language": payload["language"],
+            "written": written,
+            # Writing the file is observed; a PDF is not, and OMH never opens
+            # the page it wrote.
+            "export": {name: ("rendered_observed" if name in written else "prepared") for name in payload["export"]},
+            "pdf": "handoff_prepared: print the page, or hand the format to a generation owner",
+            "claim_boundary": payload["claim_boundary"],
+        }
+    )
+    return 0
+
 def _add_hermes_commands(sub) -> None:
     hermes = sub.add_parser("hermes", help="Build Hermes-facing plan and readiness scaffolds for natural-language work.")
     hermes_sub = hermes.add_subparsers(dest="hermes_command", required=True)
@@ -237,6 +289,15 @@ def _add_hermes_commands(sub) -> None:
         help="Inspect Hermes and OMH retained-context channels for memory, learning, loop, and wiki readiness.",
     )
     retained_context.set_defaults(func=cmd_hermes_retained_context)
+
+    briefing = hermes_sub.add_parser(
+        "briefing",
+        help="Render a research_briefing/v1 payload as Markdown and a print-ready page.",
+    )
+    briefing.add_argument("--input", required=True, help="Path to a research_briefing/v1 JSON payload, or '-' for stdin.")
+    briefing.add_argument("--markdown", default="", help="Write the Markdown briefing to this path.")
+    briefing.add_argument("--page", default="", help="Write the self-contained print-ready HTML page to this path.")
+    briefing.set_defaults(func=cmd_hermes_briefing)
 
     plan = hermes_sub.add_parser("plan")
     plan.add_argument("message", nargs="*", help="Task description to turn into a Hermes-facing planning scaffold.")

--- a/src/maintenance/release.py
+++ b/src/maintenance/release.py
@@ -133,7 +133,13 @@ ROLE_CONTEXT_CHAR_LIMIT = 2600
 # paying the engine's declared depth budget and reference-implementation
 # study. One section for one new workflow, not per-section padding;
 # the engine's own section shrank by the triggers that left it.
-FULL_CAPABILITY_SKILL_SECTION_CHAR_LIMIT = 356826
+# 356826 -> 357345: `research` gained the audience branch -- three required
+# inputs (audience, format, language), the briefing artifact in its outputs,
+# and the three quality-bar rules that make Hermes ask before retrieval
+# rather than after. The document standard itself is a reference file, so it
+# costs progressive disclosure rather than the always-loaded body; what is
+# counted here is the asking, not the standard.
+FULL_CAPABILITY_SKILL_SECTION_CHAR_LIMIT = 357345
 FULL_CAPABILITY_SKILL_ITEM_CHAR_LIMIT = 9000
 # 100000 -> 102070: the same three domain workflows each add one standalone
 # capability row, again measured on the merged tree; warranted growth for three
@@ -481,7 +487,13 @@ STANDALONE_CAPABILITY_SKILL_ITEM_CHAR_LIMIT = 2200
 # became two once the lookup half of it stopped belonging to the engine.
 # The split is what removed a deference inversion the policy test had been
 # carrying; 106 chars is the sentence that did it.
-FULL_PROFILE_SKILL_BODY_CHAR_LIMIT = 815057
+# 815057 -> 816478: `research` gained the audience branch -- three required
+# inputs (audience, format, language), the briefing artifact in its outputs,
+# and the three quality-bar rules that make Hermes ask before retrieval
+# rather than after. The document standard itself is a reference file, so it
+# costs progressive disclosure rather than the always-loaded body; what is
+# counted here is the asking, not the standard.
+FULL_PROFILE_SKILL_BODY_CHAR_LIMIT = 816478
 FULL_PROFILE_SKILL_BODY_REVIEWED_EXCEPTION_CHARS = 0
 
 

--- a/src/skills/catalog_definitions.py
+++ b/src/skills/catalog_definitions.py
@@ -1160,6 +1160,9 @@ _DEFINITIONS = [
         handoff_policy="Run as a Hermes-side research lane when web or repository access is available; Hermes and its delegated readers study sources, distill evidence or the dossier before any planning or coding handoff, and never treat research as implementation.",
         required_inputs=(
             "research question",
+            "output audience - a human reader or a coding agent - asked before retrieval and never inferred",
+            "output format when the reader is human - markdown, a print-ready page, or both",
+            "output language when the reader is human - declared, never inferred from the request",
             "target user/task if usability matters",
             "usability/quality dimension if applicable",
             "source boundaries",
@@ -1177,6 +1180,7 @@ _DEFINITIONS = [
             "confidence and residual uncertainty",
             "product_evidence_loop/v1",
             "deep_research_dossier/v1",
+            "research_briefing/v1 with its markdown and print-ready page when the reader is human",
         ),
         artifact_expectations=("research notes with source URLs, retrieval dates, source-quality notes, and per-reference mechanism, tradeoff, license, and pinned-ref notes when the wrapper captures them",),
         safety_rules=(
@@ -1192,10 +1196,14 @@ _DEFINITIONS = [
             "State retrieval limits, dates, and missing-source gaps for unstable facts.",
             "product_evidence_loop/v1 is prepared-only opaque references, not observed evidence or execution.",
             "deep_research_dossier/v1 is prepared decision context, not observed evidence, execution, review, CI, or merge evidence.",
+            "research_briefing/v1 is prepared decision context; a rendered page is a page, and calling it a PDF needs observed file evidence.",
         ),
         quality_tier="source-gated",
         quality_bar=(
             "Ask for the research question, source boundaries, freshness, jurisdiction, and version assumptions before retrieval.",
+            "Ask who the output is for before retrieval and never infer it: a human reader gets a briefing document, a coding agent gets the dense handoff of findings, exact symbols, and file paths. The answer changes what the run records, not only how it is written up.",
+            "On the human branch ask the output format (markdown, a print-ready page, or both) and the output language before writing, then hold the document to `references/briefing-format.md` - noun-phrase titles carrying a role label from its closed vocabulary, cause before effect, terms defined at first use, figures drawn in code blocks, and the fixed chapter-and-appendix structure.",
+            "Keep the coding-agent branch dense: findings, exact symbols, file paths, and the plan-feed block, with no narrative framing and no briefing structure.",
             "Use official or primary sources first when current or external facts matter, then add source diversity when the topic is contested.",
             "Revise the search plan when new evidence exposes a gap or contradiction instead of stopping at the first pass.",
             "Gate contested claims: require at least two independent source domains, one counter-search for disconfirming evidence, and a primary source, or move the claim to the unresolved annex.",
@@ -1239,6 +1247,7 @@ _DEFINITIONS = [
             "If the evidence stays thin or contested, lower the stated confidence and keep the unresolved claims in the annex rather than flattening them.",
             "If leads keep expanding past the declared budget, stop, record open leads in the dossier, and ask whether to extend the budget.",
             "If enough evidence already exists and the real request is planning, hand off to ralplan with the recorded dossier.",
+            "If the audience answer arrives after retrieval started, keep the evidence and re-render rather than re-running: the dossier feeds both branches.",
         ),
     ),
     SkillDefinition(

--- a/src/skills/packaging.py
+++ b/src/skills/packaging.py
@@ -25,6 +25,7 @@ from .render import (
     maestro_reference_templates,
     memory_new_skill,
     memory_sync_skill,
+    research_reference_templates,
     router_reference_templates,
     router_skill,
     structural_search_skill,
@@ -63,6 +64,7 @@ def builtin_skill_reference_templates() -> list[SkillReferenceTemplate]:
             for definition in workflow_reference_definitions()
             if definition.procedure_steps
         ],
+        *research_reference_templates(),
         *design_reference_templates(),
         *domain_engineering_reference_templates(),
     ]

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -3788,6 +3788,107 @@ demonstrated the defect no longer does.
 """
 
 
+def research_reference_templates() -> list[SkillReferenceTemplate]:
+    return list(_research_reference_templates_cached())
+
+
+@lru_cache(maxsize=1)
+def _research_reference_templates_cached() -> tuple[SkillReferenceTemplate, ...]:
+    return (
+        SkillReferenceTemplate(
+            "research",
+            "references/briefing-format.md",
+            _research_briefing_format_reference(),
+        ),
+    )
+
+
+def _research_briefing_format_reference() -> str:
+    return """# Briefing Document Format
+
+The rules below govern the briefing the research engine writes when the reader is a person. They do not govern the coding-agent handoff, which stays dense findings, exact symbols, and file paths with no narrative. Ask which one is wanted before retrieval starts, because the answer changes what the run records, not only how it is written up.
+
+These rules are authored in English and applied to a document written in any language. A rule about sentence order or title shape is not an English rule; it survives translation. The clause-level examples below are English so the shape is legible, and each names the property being tested rather than the words.
+
+## Titles
+
+**Compress a title to a noun phrase.** Name the subject; do not state a sentence about it.
+
+- WRONG: `Load rises as input grows` -> RIGHT: `Load growth under rising input`
+- WRONG: `Each expert gets different traffic` -> RIGHT: `Expert load imbalance`
+- WRONG: `Deployment is simple` -> RIGHT: `What a GQA deployment has to decide`
+
+**Use the established term.** Write the term the field uses rather than a paraphrase of it. When the document body is not in English, put the English term in parentheses at first use.
+
+**Prefix a role label.** The shape is `Role - noun phrase`. Without the label a reader cannot tell whether the section states a problem, an advantage, or an observation. The vocabulary is closed: Concept, Problem, Option, Solution, Reversal, Case, Guideline, Constraint, Pitfall, Limit, Cost, Deployment, Check.
+
+**A cost title names both sides.** Say what was spent and what it bought.
+
+- WRONG: `Cost - precise retrieval and reproducibility are given up`
+- RIGHT: `Cost - retrieval precision weakens in proportion to the KV cache removed`
+
+**Five title shapes are banned.**
+
+- Numeric scaffolding: `(1) problem / (2) mechanism / (3) numbers`
+- Evaluation only: `Deployment is simple`
+- Counting only: `Three options`
+- Repetition: the same title used for four different sections
+- Metaphor: `Copying something compressed is wasted work`
+
+## Sentences
+
+- **Order.** Cause before effect, premise before verdict, observation before reading. Do not state the conclusion first and attach its support afterward.
+- **Endings.** Ban the shapes that announce their own rhetorical role: `that is the cost`, `the point is that`, `the reason is`. Rewrite `the reason it works is here` as `it works because ...`.
+- **Deixis.** Do not point across sentences with `here` or `this`. Name the thing.
+- **Emphasis.** Do not bold a conclusion and then supply its evidence underneath. Emphasis marks a term, not a verdict.
+- **Enumeration.** Ban `A is X. B is Y. C is Z.` Carry the previous paragraph's conclusion into the next paragraph's opening.
+- **Length.** Inside one list, keep the items the same size.
+
+Four sentence forms are banned outright: the question-and-answer frame (`the question X answered was`), the rhetorical question (`so what happens?`), intensifiers (`dramatically`, `overwhelmingly`, `decisively`), and methodology exposure - the document never mentions its own method, its review, or the feedback that shaped it.
+
+## Content
+
+- Open on the problem, with numbers, and establish the premises before anything else.
+- Define a term where it first appears, expanding the acronym there. A definition that exists only in the appendix is not a definition.
+- Ground every number in a premise the reader has already been given, so the figure is derived rather than asserted.
+- Explain every setting and parameter, not one selected example. The order is: what it decides, then the options, then why this value.
+- Derive a setting from the preceding calculation. Do not list settings as items.
+- Open each chapter with one paragraph defining its subject and a figure contrasting it with the neighbouring idea.
+- Let the limit that closes a chapter become the problem that opens the next.
+- When the assessment turns from favourable to unfavourable, write the transition paragraph: state what has been solved so far and what has not been examined yet.
+- Keep back-references minimal, and never forward-reference.
+
+## Form
+
+- **Figures.** Draw flow, structure, calculation, and scale contrasts in code blocks.
+- **Lists.** Bullets for parameter explanations. A table only when several subjects are compared on the same axes.
+- **Block quotes.** Analogies and warnings only. Body explanation never goes in a quote.
+- **Subheads.** What should be a subhead is written as a subhead, not as a sentence in running text.
+- **Code.** Runnable form, attached to every case the document discusses.
+
+## Structure
+
+Learning objectives (what the reader can do once the document is closed) -> assumed knowledge, what is built from scratch, and what is out of scope -> contents -> body as part, chapter, section -> Appendix A: glossary -> Appendix B: misconceptions and traps -> Appendix C: sources.
+
+## Exercises
+
+Run exercises as a hypothetical scenario, and build failure into it: a session that succeeds on the first attempt teaches nothing. Logs and output follow the real format of the tool being shown, with the values marked as simulated.
+
+## Currency
+
+Confirm the current state by retrieval rather than recall. Separate durable principles from time-dependent figures, and give every time-dependent figure its as-of date and how it was confirmed. Separate vendor claims from independent measurement, and present the unfavourable data alongside the favourable.
+
+## Language
+
+The output language is declared by the requester and never inferred from the language of the request. Body prose, role labels, chapter headings, and appendix captions follow the declared language together -- a Korean briefing under English section captions is a half-translated document. Identifiers, schema ids, file paths, command names, and code stay as written. When the declaration is absent, the document is English.
+
+OMH holds no translation table for the scaffolding, because one would have to be maintained for every language the engine can write in. Supply the labels with the payload instead: `role_labels` maps a role to its label in the document's language, `captions` does the same for the section headings, and anything left unnamed falls back to English. Translating the body while leaving the captions unset is the failure this field exists to prevent.
+
+## Evidence boundary
+
+A briefing is prepared decision context. It is not execution, review, CI, merge-readiness, or merge evidence, and neither is any figure inside it. A rendered page is a page: calling it a PDF requires observed file evidence, and the format handoff is `handoff_prepared` until then.
+"""
+
 def design_reference_templates() -> list[SkillReferenceTemplate]:
     return list(_design_reference_templates_cached())
 

--- a/src/workflows/research_briefing.py
+++ b/src/workflows/research_briefing.py
@@ -1,0 +1,537 @@
+"""Deterministic projection of a research run into a reader-facing briefing.
+
+The engine's other outputs are written for a machine consumer. This one is
+written for a person, so the shape it must hold is a writing standard rather
+than a data contract: noun-phrase titles carrying a role label, figures drawn
+as code blocks, every time-dependent figure carrying its as-of date. The rules
+live in `skills/ulw-research/references/briefing-format.md`; the ones a
+function can decide are checked here, because a prose rule no surface
+validates is a hope.
+
+Nothing in this module reaches the network, spawns a process, or opens a file
+viewer. `render_research_briefing_page` returns one self-contained HTML
+document with its own print rules; turning that into a PDF is the reader's
+print dialog or an explicit generation handoff, never a claim OMH makes.
+"""
+
+from __future__ import annotations
+
+from html import escape
+from typing import Any
+
+RESEARCH_BRIEFING_SCHEMA_VERSION = "research_briefing/v1"
+
+#: The interview answer that decides which document the run produces.
+BRIEFING_AUDIENCES = ("human_briefing", "coding_agent_handoff")
+
+#: Asked only on the human branch. `page` is a print-ready HTML document.
+BRIEFING_OUTPUT_FORMATS = ("markdown", "page", "both")
+
+#: Closed vocabulary. Without a role label a reader cannot tell whether a
+#: section states a problem, an advantage, or an observation.
+BRIEFING_ROLE_LABELS = (
+    "concept",
+    "problem",
+    "option",
+    "solution",
+    "reversal",
+    "case",
+    "guideline",
+    "constraint",
+    "pitfall",
+    "limit",
+    "cost",
+    "deployment",
+    "check",
+)
+
+#: Scaffolding captions the document renders around the author's own prose.
+#: The document body may be written in any language, and a Korean briefing with
+#: English section captions is a half-translated document. OMH does not own a
+#: translation table -- it would have to be maintained for every language the
+#: engine can write in -- so the caller supplies the labels it wants and the
+#: renderer falls back to English for anything it does not name.
+BRIEFING_CAPTION_KEYS = (
+    "question",
+    "as_of",
+    "learning_objectives",
+    "assumed_knowledge",
+    "out_of_scope",
+    "figures",
+    "figure_value",
+    "figure_basis",
+    "figure_as_of",
+    "glossary",
+    "traps",
+    "sources",
+)
+
+_DEFAULT_CAPTIONS = {
+    "question": "Question",
+    "as_of": "As of",
+    "learning_objectives": "What you can do after reading",
+    "assumed_knowledge": "Assumed knowledge",
+    "out_of_scope": "Out of scope",
+    "figures": "Figures",
+    "figure_value": "Value",
+    "figure_basis": "Basis",
+    "figure_as_of": "As of",
+    "glossary": "Appendix A: glossary",
+    "traps": "Appendix B: misconceptions and traps",
+    "sources": "Appendix C: sources",
+}
+
+#: A figure is measured, assumed, or derived; the axis is separate from the
+#: source class below, and neither one settles completion.
+BRIEFING_FIGURE_BASES = ("measured", "assumed", "derived")
+
+#: Upstream official guidance is the strongest class and still not evidence
+#: that anything was done.
+BRIEFING_SOURCE_CLASSES = ("upstream_official", "practitioner", "unattributed")
+
+#: Connectives whose deletion leaves the claim intact, plus the intensifiers
+#: the format bans outright.
+_BANNED_PROSE = (
+    "dramatically",
+    "overwhelmingly",
+    "decisively",
+    "game-changing",
+    "revolutionary",
+)
+
+BRIEFING_CLAIM_BOUNDARY = (
+    "A research briefing is prepared decision context. It is not execution, review, CI, "
+    "merge-readiness, or merge evidence, and a rendered page is not a rendered PDF without "
+    "observed file evidence."
+)
+
+_EXPORT_STATUSES = ("prepared", "handoff_prepared", "rendered_observed")
+
+
+def _rows(value: Any) -> list[Any]:
+    return list(value) if isinstance(value, list | tuple) else []
+
+
+def _text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def research_briefing_errors(value: Any) -> list[str]:
+    """Return every contract and format violation, most structural first."""
+    issues: list[str] = []
+    if not isinstance(value, dict):
+        return ["research briefing must be a mapping"]
+    if value.get("schema_version") != RESEARCH_BRIEFING_SCHEMA_VERSION:
+        issues.append(f"schema_version must be {RESEARCH_BRIEFING_SCHEMA_VERSION}")
+
+    audience = _text(value.get("audience"))
+    if audience not in BRIEFING_AUDIENCES:
+        issues.append(f"audience must be one of {', '.join(BRIEFING_AUDIENCES)}")
+    formats = [_text(item) for item in _rows(value.get("output_formats"))]
+    if audience == "human_briefing":
+        if not formats:
+            issues.append("human_briefing must declare at least one output format")
+        for item in formats:
+            if item not in BRIEFING_OUTPUT_FORMATS:
+                issues.append(f"unknown output format {item!r}")
+    elif formats:
+        issues.append("coding_agent_handoff takes no output format; the format question is human-only")
+
+    if not _text(value.get("language")):
+        issues.append("language must be declared explicitly; it is never inferred from the request")
+    if not _text(value.get("question")):
+        issues.append("question is required")
+    if not _text(value.get("as_of")):
+        issues.append("as_of is required so time-dependent figures carry their date")
+
+    issues.extend(_section_errors(_rows(value.get("sections"))))
+    issues.extend(_figure_errors(_rows(value.get("figures"))))
+    issues.extend(_source_errors(_rows(value.get("sources"))))
+
+    issues.extend(_label_errors(value.get("role_labels"), BRIEFING_ROLE_LABELS, "role_labels"))
+    issues.extend(_label_errors(value.get("captions"), BRIEFING_CAPTION_KEYS, "captions"))
+
+    export = value.get("export")
+    if not isinstance(export, dict):
+        issues.append("export must be a mapping of format to status")
+    else:
+        for key, status in export.items():
+            if _text(status) not in _EXPORT_STATUSES:
+                issues.append(f"export status for {key!r} must be one of {', '.join(_EXPORT_STATUSES)}")
+    if _text(value.get("claim_boundary")) != BRIEFING_CLAIM_BOUNDARY:
+        issues.append("claim_boundary must be the exact briefing boundary sentence")
+    return issues
+
+
+def _label_errors(value: Any, allowed: tuple[str, ...], where: str) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, dict):
+        return [f"{where} must be a mapping"]
+    issues: list[str] = []
+    for key, label in value.items():
+        if key not in allowed:
+            issues.append(f"{where}: {key!r} is not one of {', '.join(allowed)}")
+        if not _text(label):
+            issues.append(f"{where}: {key!r} has an empty label")
+    return issues
+
+
+def _section_errors(sections: list[Any]) -> list[str]:
+    issues: list[str] = []
+    if not sections:
+        return ["at least one section is required"]
+    seen: set[str] = set()
+    for index, section in enumerate(sections):
+        where = f"section {index}"
+        if not isinstance(section, dict):
+            issues.append(f"{where} must be a mapping")
+            continue
+        role = _text(section.get("role"))
+        if role not in BRIEFING_ROLE_LABELS:
+            issues.append(f"{where}: role must be one of {', '.join(BRIEFING_ROLE_LABELS)}")
+        title = _text(section.get("title"))
+        issues.extend(f"{where}: {problem}" for problem in _title_errors(title))
+        key = title.casefold()
+        if key and key in seen:
+            issues.append(f"{where}: title {title!r} repeats an earlier section title")
+        seen.add(key)
+        paragraphs = [_text(item) for item in _rows(section.get("paragraphs"))]
+        if not paragraphs:
+            issues.append(f"{where}: at least one paragraph is required")
+        for paragraph in paragraphs:
+            issues.extend(f"{where}: {problem}" for problem in _prose_errors(paragraph))
+    return issues
+
+
+def _title_errors(title: str) -> list[str]:
+    """Check the title rules a function can decide."""
+    issues: list[str] = []
+    if not title:
+        return ["title is required"]
+    if title.endswith((".", "!")):
+        issues.append(f"title {title!r} is a sentence; compress it to a noun phrase")
+    if title.endswith("?"):
+        issues.append(f"title {title!r} is a question; name the subject instead")
+    if title[0].isdigit() or title[0] in "①②③④⑤⑥⑦⑧⑨":
+        issues.append(f"title {title!r} opens with numeric scaffolding")
+    return issues
+
+
+def _prose_errors(paragraph: str) -> list[str]:
+    issues: list[str] = []
+    folded = paragraph.casefold()
+    for banned in _BANNED_PROSE:
+        if banned in folded:
+            issues.append(f"paragraph uses the banned intensifier {banned!r}")
+    if paragraph.endswith("?"):
+        issues.append("paragraph ends on a rhetorical question")
+    return issues
+
+
+def _figure_errors(figures: list[Any]) -> list[str]:
+    issues: list[str] = []
+    for index, figure in enumerate(figures):
+        where = f"figure {index}"
+        if not isinstance(figure, dict):
+            issues.append(f"{where} must be a mapping")
+            continue
+        if not _text(figure.get("label")):
+            issues.append(f"{where}: label is required")
+        if _text(figure.get("basis")) not in BRIEFING_FIGURE_BASES:
+            issues.append(f"{where}: basis must be one of {', '.join(BRIEFING_FIGURE_BASES)}")
+        if not _text(figure.get("value")):
+            issues.append(f"{where}: value is required")
+        if _text(figure.get("basis")) == "measured" and not _text(figure.get("as_of")):
+            issues.append(f"{where}: a measured figure carries the date it was measured")
+    return issues
+
+
+def _source_errors(sources: list[Any]) -> list[str]:
+    issues: list[str] = []
+    for index, source in enumerate(sources):
+        where = f"source {index}"
+        if not isinstance(source, dict):
+            issues.append(f"{where} must be a mapping")
+            continue
+        if not _text(source.get("title")):
+            issues.append(f"{where}: title is required")
+        if _text(source.get("source_class")) not in BRIEFING_SOURCE_CLASSES:
+            issues.append(f"{where}: source_class must be one of {', '.join(BRIEFING_SOURCE_CLASSES)}")
+        if not _text(source.get("retrieved_on")):
+            issues.append(f"{where}: retrieved_on is required for a cited source")
+    return issues
+
+
+def build_research_briefing(
+    *,
+    audience: str,
+    question: str,
+    as_of: str,
+    language: str = "en",
+    output_formats: tuple[str, ...] = (),
+    title: str = "",
+    learning_objectives: tuple[str, ...] = (),
+    assumed_knowledge: tuple[str, ...] = (),
+    out_of_scope: tuple[str, ...] = (),
+    sections: tuple[dict[str, Any], ...] = (),
+    figures: tuple[dict[str, Any], ...] = (),
+    glossary: tuple[dict[str, str], ...] = (),
+    traps: tuple[str, ...] = (),
+    sources: tuple[dict[str, str], ...] = (),
+    role_labels: dict[str, str] | None = None,
+    captions: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Assemble the payload and validate it before returning."""
+    payload: dict[str, Any] = {
+        "schema_version": RESEARCH_BRIEFING_SCHEMA_VERSION,
+        "audience": audience,
+        "output_formats": list(output_formats),
+        "language": language,
+        "title": title or question,
+        "question": question,
+        "as_of": as_of,
+        "learning_objectives": list(learning_objectives),
+        "assumed_knowledge": list(assumed_knowledge),
+        "out_of_scope": list(out_of_scope),
+        "sections": [dict(section) for section in sections],
+        "figures": [dict(figure) for figure in figures],
+        "glossary": [dict(entry) for entry in glossary],
+        "traps": list(traps),
+        "sources": [dict(source) for source in sources],
+        "role_labels": dict(role_labels or {}),
+        "captions": dict(captions or {}),
+        # Preparing a document is never rendering one, so every declared
+        # format starts at `prepared` and only observed file evidence moves it.
+        "export": {name: "prepared" for name in output_formats},
+        "claim_boundary": BRIEFING_CLAIM_BOUNDARY,
+    }
+    issues = research_briefing_errors(payload)
+    if issues:
+        raise ValueError(issues[0])
+    return payload
+
+
+def _role_label(value: Any, role: str) -> str:
+    labels = value.get("role_labels")
+    if isinstance(labels, dict) and _text(labels.get(role)):
+        return _text(labels[role])
+    return role.capitalize()
+
+
+def _caption(value: Any, key: str) -> str:
+    captions = value.get("captions")
+    if isinstance(captions, dict) and _text(captions.get(key)):
+        return _text(captions[key])
+    return _DEFAULT_CAPTIONS[key]
+
+
+def _section_heading(value: Any, section: dict[str, Any]) -> str:
+    return f"{_role_label(value, str(section['role']))} - {section['title']}"
+
+
+def render_research_briefing_markdown(value: Any) -> str:
+    """Render the briefing as Markdown in the structure the format requires."""
+    issues = research_briefing_errors(value)
+    if issues:
+        raise ValueError(issues[0])
+    lines: list[str] = [f"# {value['title']}", ""]
+    lines.append(f"{_caption(value, 'question')}: {value['question']}")
+    lines.append(f"{_caption(value, 'as_of')}: {value['as_of']}")
+    lines.append("")
+    for key in ("learning_objectives", "assumed_knowledge", "out_of_scope"):
+        rows = _rows(value.get(key))
+        if rows:
+            lines.extend([f"## {_caption(value, key)}", ""])
+            lines.extend(f"- {item}" for item in rows)
+            lines.append("")
+    for section in _rows(value.get("sections")):
+        lines.extend([f"## {_section_heading(value, section)}", ""])
+        for paragraph in _rows(section.get("paragraphs")):
+            lines.extend([str(paragraph), ""])
+        figure = _text(section.get("figure"))
+        if figure:
+            lines.extend(["```", figure, "```", ""])
+    figures = _rows(value.get("figures"))
+    if figures:
+        lines.extend([f"## {_caption(value, 'figures')}", ""])
+        for figure in figures:
+            stamp = f", {figure['as_of']}" if _text(figure.get("as_of")) else ""
+            lines.append(f"- {figure['label']}: {figure['value']} ({figure['basis']}{stamp})")
+        lines.append("")
+    glossary = _rows(value.get("glossary"))
+    if glossary:
+        lines.extend([f"## {_caption(value, 'glossary')}", ""])
+        lines.extend(f"- {entry['term']}: {entry['definition']}" for entry in glossary)
+        lines.append("")
+    traps = _rows(value.get("traps"))
+    if traps:
+        lines.extend([f"## {_caption(value, 'traps')}", ""])
+        lines.extend(f"- {item}" for item in traps)
+        lines.append("")
+    sources = _rows(value.get("sources"))
+    if sources:
+        lines.extend([f"## {_caption(value, 'sources')}", ""])
+        for source in sources:
+            location = f" - {source['url']}" if _text(source.get("url")) else ""
+            lines.append(
+                f"- {source['title']}{location} ({source['source_class']}, retrieved {source['retrieved_on']})"
+            )
+        lines.append("")
+    lines.extend([f"> {value['claim_boundary']}", ""])
+    return "\n".join(lines)
+
+
+def _page_list(heading: str, rows: list[Any]) -> str:
+    """Render one captioned list, or nothing when the list is empty."""
+    if not rows:
+        return ""
+    items = "".join(f"<li>{escape(str(item))}</li>" for item in rows)
+    return f"<section><h2>{escape(heading)}</h2><ul>{items}</ul></section>"
+
+
+def _page_section(value: Any, section: dict[str, Any]) -> str:
+    paragraphs = "".join(f"<p>{escape(str(item))}</p>" for item in _rows(section.get("paragraphs")))
+    figure = _text(section.get("figure"))
+    drawing = f"<pre>{escape(figure)}</pre>" if figure else ""
+    return (
+        f"<section class=\"sec\"><h2>{escape(_section_heading(value, section))}</h2>{paragraphs}{drawing}</section>"
+    )
+
+
+def render_research_briefing_page(value: Any) -> str:
+    """One self-contained, print-ready HTML document. No external request.
+
+    Every font is a stack of faces the reader already has, because a `<link>`
+    to a web font would fetch at open time -- the shape the repo's network
+    invariant exists to prevent. `@page` and the print block are what make the
+    reader's own print dialog produce a sane PDF.
+    """
+    issues = research_briefing_errors(value)
+    if issues:
+        raise ValueError(issues[0])
+    sections = "".join(_page_section(value, section) for section in _rows(value.get("sections")))
+    figures = _rows(value.get("figures"))
+    figure_rows = "".join(
+        "<tr><td>{label}</td><td>{amount}</td><td>{basis}</td><td>{stamp}</td></tr>".format(
+            label=escape(str(figure.get("label", ""))),
+            amount=escape(str(figure.get("value", ""))),
+            basis=escape(str(figure.get("basis", ""))),
+            stamp=escape(str(figure.get("as_of", "") or "-")),
+        )
+        for figure in figures
+    )
+    figure_block = (
+        f"<section><h2>{escape(_caption(value, 'figures'))}</h2><table><thead><tr>"
+        f"<th>{escape(_caption(value, 'figures'))}</th>"
+        f"<th>{escape(_caption(value, 'figure_value'))}</th>"
+        f"<th>{escape(_caption(value, 'figure_basis'))}</th>"
+        f"<th>{escape(_caption(value, 'figure_as_of'))}</th>"
+        f"</tr></thead><tbody>{figure_rows}</tbody></table></section>"
+        if figures
+        else ""
+    )
+    glossary = _rows(value.get("glossary"))
+    glossary_block = (
+        f"<section><h2>{escape(_caption(value, 'glossary'))}</h2><dl>"
+        + "".join(
+            f"<dt>{escape(str(entry.get('term', '')))}</dt>"
+            f"<dd>{escape(str(entry.get('definition', '')))}</dd>"
+            for entry in glossary
+        )
+        + "</dl></section>"
+        if glossary
+        else ""
+    )
+    sources = _rows(value.get("sources"))
+    source_block = (
+        f"<section><h2>{escape(_caption(value, 'sources'))}</h2><ol>"
+        + "".join(
+            "<li>{title}<span class=\"muted\"> &middot; {cls} &middot; retrieved {stamp}</span></li>".format(
+                title=escape(str(source.get("title", ""))),
+                cls=escape(str(source.get("source_class", ""))),
+                stamp=escape(str(source.get("retrieved_on", ""))),
+            )
+            for source in sources
+        )
+        + "</ol></section>"
+        if sources
+        else ""
+    )
+    return f"""<!DOCTYPE html>
+<html lang="{escape(str(value['language']))}">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{escape(str(value['title']))}</title>
+<style>
+  :root {{
+    --page: #fdfdfc; --ink: #1a1a16; --muted: #6c6c62; --hair: #e2e2da; --rule: #c8c8bd;
+  }}
+  @media (prefers-color-scheme: dark) {{
+    :root {{ --page: #131312; --ink: #f0f0ea; --muted: #9a9a90; --hair: #2d2d29; --rule: #43433d; }}
+  }}
+  * {{ box-sizing: border-box; }}
+  body {{
+    margin: 0; padding: 3rem 1.5rem 5rem; background: var(--page); color: var(--ink);
+    font-family: 'Iowan Old Style', 'Palatino Linotype', Palatino, Georgia, 'Nanum Myeongjo', serif;
+    font-size: 16px; line-height: 1.65;
+  }}
+  .wrap {{ max-width: 46rem; margin: 0 auto; }}
+  h1 {{ font-size: 1.75rem; line-height: 1.25; margin: 0 0 .75rem; letter-spacing: -.015em; }}
+  h2 {{
+    font-size: 1rem; margin: 2.5rem 0 .75rem; letter-spacing: .01em;
+    padding-bottom: .35rem; border-bottom: 1px solid var(--rule);
+  }}
+  p {{ margin: 0 0 .9rem; }}
+  .meta {{ color: var(--muted); font-size: .8125rem; margin: 0 0 .2rem; }}
+  .lede {{ border-bottom: 2px solid var(--rule); padding-bottom: 1.25rem; margin-bottom: .5rem; }}
+  ul, ol {{ margin: 0 0 .9rem; padding-left: 1.2rem; }}
+  li {{ margin: 0 0 .3rem; }}
+  dt {{ font-weight: 600; }}
+  dd {{ margin: 0 0 .55rem; padding-left: 0; color: var(--muted); }}
+  pre {{
+    font-family: ui-monospace, SFMono-Regular, Menlo, 'Cascadia Mono', monospace;
+    font-size: .8125rem; line-height: 1.5; background: transparent; color: var(--ink);
+    border: 1px solid var(--hair); border-radius: 6px; padding: .85rem 1rem;
+    overflow-x: auto; margin: 0 0 1.1rem;
+  }}
+  table {{ width: 100%; border-collapse: collapse; font-size: .875rem; margin: 0 0 1.1rem; }}
+  th, td {{ text-align: left; padding: .4rem .5rem; border-bottom: 1px solid var(--hair); }}
+  th {{ font-weight: 600; color: var(--muted); font-size: .75rem;
+        text-transform: uppercase; letter-spacing: .07em; }}
+  .muted {{ color: var(--muted); }}
+  .boundary {{
+    margin-top: 3rem; padding: .85rem 1rem; border-left: 3px solid var(--rule);
+    color: var(--muted); font-size: .875rem;
+  }}
+  @page {{ size: A4; margin: 20mm 18mm; }}
+  @media print {{
+    :root {{ --page: #ffffff; --ink: #101010; --muted: #55554e; --hair: #d8d8d0; --rule: #b4b4a8; }}
+    body {{ padding: 0; font-size: 10.5pt; }}
+    .wrap {{ max-width: none; }}
+    h2 {{ break-after: avoid; }}
+    .sec, pre, table, li {{ break-inside: avoid; }}
+  }}
+</style>
+</head>
+<body>
+<div class="wrap">
+<header class="lede">
+<h1>{escape(str(value['title']))}</h1>
+<p class="meta">{escape(_caption(value, 'question'))}: {escape(str(value['question']))}</p>
+<p class="meta">{escape(_caption(value, 'as_of'))} {escape(str(value['as_of']))}</p>
+</header>
+{_page_list(_caption(value, "learning_objectives"), _rows(value.get("learning_objectives")))}
+{_page_list(_caption(value, "assumed_knowledge"), _rows(value.get("assumed_knowledge")))}
+{_page_list(_caption(value, "out_of_scope"), _rows(value.get("out_of_scope")))}
+{sections}
+{figure_block}
+{glossary_block}
+{_page_list(_caption(value, "traps"), _rows(value.get("traps")))}
+{source_block}
+<p class="boundary">{escape(str(value['claim_boundary']))}</p>
+</div>
+</body>
+</html>
+"""

--- a/tests/test_research_briefing.py
+++ b/tests/test_research_briefing.py
@@ -1,0 +1,274 @@
+"""`research_briefing/v1` -- the reader-facing half of the research engine.
+
+The engine's other outputs answer to a machine, so nothing in the repo used to
+decide whether a document was written well. These tests pin the half of the
+briefing format a function can decide: a title that is a sentence, a role label
+outside the closed vocabulary, a repeated title, an intensifier, a measured
+figure with no date, and a source with no class are all rejected at build time
+rather than noticed by a reader.
+
+The page renderer is pinned on the two properties that make it safe to hand to
+someone: it fetches nothing when opened, and it carries its own print rules so
+the reader's print dialog is what produces a PDF. OMH never claims it produced
+one.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from omh.skills.catalog import builtin_definitions
+from omh.skills.packaging import builtin_skill_reference_templates
+from omh.workflows.research_briefing import (
+    BRIEFING_CLAIM_BOUNDARY,
+    BRIEFING_ROLE_LABELS,
+    RESEARCH_BRIEFING_SCHEMA_VERSION,
+    build_research_briefing,
+    render_research_briefing_markdown,
+    render_research_briefing_page,
+    research_briefing_errors,
+)
+
+
+def _sections() -> tuple[dict[str, object], ...]:
+    return (
+        {
+            "role": "problem",
+            "title": "Load growth under rising input",
+            "paragraphs": (
+                "Context length rose from 8k to 128k across one year, so the per-request "
+                "key-value cache now dominates serving memory.",
+            ),
+            "figure": "req 8k   |####\nreq 128k |################################",
+        },
+        {
+            "role": "cost",
+            "title": "Retrieval precision weakens in proportion to the KV cache removed",
+            "paragraphs": (
+                "Grouped-query attention shares key and value heads, so it removes cache in "
+                "proportion to the group size and weakens exact-match retrieval by the same factor.",
+            ),
+        },
+    )
+
+
+def _briefing(**overrides: object) -> dict[str, object]:
+    kwargs: dict[str, object] = {
+        "audience": "human_briefing",
+        "question": "Which attention cache layout should the serving stack adopt?",
+        "as_of": "2026-09-01",
+        "output_formats": ("markdown", "page"),
+        "title": "KV cache layout choice for the serving stack",
+        "learning_objectives": ("Choose between MHA, GQA, and MLA for a fixed memory budget.",),
+        "assumed_knowledge": ("Transformer attention at the level of query, key, and value tensors.",),
+        "out_of_scope": ("Training-time memory behaviour.",),
+        "sections": _sections(),
+        "figures": (
+            {
+                "label": "KV cache per request at 128k",
+                "value": "40 GB",
+                "basis": "derived",
+                "as_of": "2026-09-01",
+            },
+        ),
+        "glossary": (
+            {"term": "GQA", "definition": "Grouped-query attention: query heads share one key/value head per group."},
+        ),
+        "traps": ("Treating a cache reduction as a quality-neutral change.",),
+        "sources": (
+            {
+                "title": "GQA paper",
+                "url": "https://arxiv.org/abs/2305.13245",
+                "source_class": "upstream_official",
+                "retrieved_on": "2026-09-01",
+            },
+        ),
+    }
+    kwargs.update(overrides)
+    return build_research_briefing(**kwargs)  # type: ignore[arg-type]
+
+
+class ResearchBriefingContractTests(unittest.TestCase):
+    def test_build_returns_a_validated_payload_with_prepared_exports(self) -> None:
+        payload = _briefing()
+        self.assertEqual(payload["schema_version"], RESEARCH_BRIEFING_SCHEMA_VERSION)
+        self.assertEqual(research_briefing_errors(payload), [])
+        self.assertEqual(payload["claim_boundary"], BRIEFING_CLAIM_BOUNDARY)
+        # Preparing a document is never rendering one.
+        self.assertEqual(payload["export"], {"markdown": "prepared", "page": "prepared"})
+
+    def test_audience_and_format_are_declared_not_inferred(self) -> None:
+        with self.assertRaises(ValueError):
+            _briefing(audience="whatever")
+        with self.assertRaises(ValueError):
+            _briefing(language="")
+        # The format question belongs to the human branch alone.
+        with self.assertRaises(ValueError):
+            _briefing(audience="coding_agent_handoff")
+        agent = _briefing(audience="coding_agent_handoff", output_formats=())
+        self.assertEqual(agent["output_formats"], [])
+
+    def test_title_rules_a_function_can_decide_are_enforced(self) -> None:
+        cases = (
+            ("Load rises as input grows.", "sentence"),
+            ("Is the cache the problem?", "question"),
+            ("3 options", "numeric scaffolding"),
+        )
+        for title, _why in cases:
+            with self.subTest(title=title):
+                with self.assertRaises(ValueError):
+                    _briefing(sections=({"role": "problem", "title": title, "paragraphs": ("Body.",)},))
+
+    def test_role_label_comes_from_the_closed_vocabulary(self) -> None:
+        with self.assertRaises(ValueError):
+            _briefing(sections=({"role": "summary", "title": "A real title", "paragraphs": ("Body.",)},))
+        for role in BRIEFING_ROLE_LABELS:
+            with self.subTest(role=role):
+                payload = _briefing(
+                    sections=({"role": role, "title": f"Title for {role}", "paragraphs": ("Body.",)},)
+                )
+                self.assertEqual(research_briefing_errors(payload), [])
+
+    def test_repeated_titles_and_banned_prose_are_rejected(self) -> None:
+        repeated = (
+            {"role": "problem", "title": "Remaining problems", "paragraphs": ("One.",)},
+            {"role": "limit", "title": "Remaining problems", "paragraphs": ("Two.",)},
+        )
+        with self.assertRaises(ValueError):
+            _briefing(sections=repeated)
+        with self.assertRaises(ValueError):
+            _briefing(
+                sections=(
+                    {"role": "solution", "title": "A real title", "paragraphs": ("This is dramatically better.",)},
+                )
+            )
+        with self.assertRaises(ValueError):
+            _briefing(
+                sections=({"role": "solution", "title": "A real title", "paragraphs": ("So what happens?",)},)
+            )
+
+    def test_figures_and_sources_carry_their_basis_and_class(self) -> None:
+        with self.assertRaises(ValueError):
+            _briefing(figures=({"label": "x", "value": "1", "basis": "guessed"},))
+        # A measured figure without a date cannot be checked later.
+        with self.assertRaises(ValueError):
+            _briefing(figures=({"label": "x", "value": "1", "basis": "measured"},))
+        with self.assertRaises(ValueError):
+            _briefing(sources=({"title": "x", "source_class": "blog", "retrieved_on": "2026-09-01"},))
+        with self.assertRaises(ValueError):
+            _briefing(sources=({"title": "x", "source_class": "practitioner"},))
+
+
+class ResearchBriefingRenderTests(unittest.TestCase):
+    def test_markdown_follows_the_required_structure(self) -> None:
+        markdown = render_research_briefing_markdown(_briefing())
+        self.assertTrue(markdown.startswith("# KV cache layout choice for the serving stack"))
+        for heading in (
+            "## What you can do after reading",
+            "## Assumed knowledge",
+            "## Out of scope",
+            "## Problem - Load growth under rising input",
+            "## Cost - Retrieval precision weakens in proportion to the KV cache removed",
+            "## Appendix A: glossary",
+            "## Appendix B: misconceptions and traps",
+            "## Appendix C: sources",
+        ):
+            self.assertIn(heading, markdown)
+        # The figure is drawn, not described.
+        self.assertIn("```", markdown)
+        self.assertIn(BRIEFING_CLAIM_BOUNDARY, markdown)
+        # Appendices come after the body.
+        self.assertLess(markdown.index("## Problem -"), markdown.index("## Appendix A"))
+
+    def test_page_is_self_contained_and_print_ready(self) -> None:
+        page = render_research_briefing_page(_briefing())
+        self.assertIn("<!DOCTYPE html>", page)
+        self.assertIn("@page", page)
+        self.assertIn("@media print", page)
+        # Nothing may fetch when the page is opened.
+        for forbidden in ("<link", "<script", "@import", "src=", "//fonts."):
+            self.assertNotIn(forbidden, page, forbidden)
+        self.assertIn(BRIEFING_CLAIM_BOUNDARY, page)
+
+    def test_page_escapes_supplied_text_and_renders_deterministically(self) -> None:
+        payload = _briefing(
+            sections=(
+                {
+                    "role": "pitfall",
+                    "title": "Markup in a supplied title",
+                    "paragraphs": ("A body mentioning <script>alert(1)</script> and A & B.",),
+                },
+            )
+        )
+        page = render_research_briefing_page(payload)
+        self.assertNotIn("<script>alert(1)</script>", page)
+        self.assertIn("&lt;script&gt;", page)
+        self.assertIn("A &amp; B", page)
+        self.assertEqual(page, render_research_briefing_page(payload))
+
+
+class ResearchBriefingLanguageTests(unittest.TestCase):
+    def test_scaffolding_labels_travel_with_the_payload(self) -> None:
+        payload = _briefing(
+            language="ko",
+            title="서빙 스택의 KV 캐시 레이아웃 선택",
+            sections=(
+                {
+                    "role": "problem",
+                    "title": "입력 증가로 인한 부하 증가",
+                    "paragraphs": ("컨텍스트 길이가 8k에서 128k로 늘면서 요청당 KV 캐시가 서빙 메모리를 지배하게 됐다.",),
+                },
+            ),
+            figures=(),
+            role_labels={"problem": "문제"},
+            captions={"question": "질문", "as_of": "기준 시점", "glossary": "부록 A 개념 사전"},
+        )
+        markdown = render_research_briefing_markdown(payload)
+        self.assertIn("## 문제 - 입력 증가로 인한 부하 증가", markdown)
+        self.assertIn("질문:", markdown)
+        self.assertIn("기준 시점:", markdown)
+        self.assertIn("## 부록 A 개념 사전", markdown)
+        # Anything left unnamed falls back to English rather than failing.
+        self.assertIn("## Appendix C: sources", markdown)
+        page = render_research_briefing_page(payload)
+        self.assertIn('lang="ko"', page)
+        self.assertIn("문제 - 입력 증가로 인한 부하 증가", page)
+
+    def test_unknown_label_keys_are_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            _briefing(role_labels={"summary": "요약"})
+        with self.assertRaises(ValueError):
+            _briefing(captions={"epilogue": "맺음말"})
+        with self.assertRaises(ValueError):
+            _briefing(captions={"glossary": "   "})
+
+
+class ResearchSkillBranchTests(unittest.TestCase):
+    def test_the_research_skill_asks_the_audience_before_retrieval(self) -> None:
+        definition = next(item for item in builtin_definitions() if item.name == "research")
+        inputs = " ".join(definition.required_inputs)
+        self.assertIn("output audience", inputs)
+        self.assertIn("output format", inputs)
+        self.assertIn("output language", inputs)
+        bar = " ".join(definition.quality_bar)
+        self.assertIn("Ask who the output is for before retrieval", bar)
+        self.assertIn("references/briefing-format.md", bar)
+        self.assertIn(RESEARCH_BRIEFING_SCHEMA_VERSION, " ".join(definition.expected_outputs))
+        self.assertIn(RESEARCH_BRIEFING_SCHEMA_VERSION, " ".join(definition.safety_rules))
+
+    def test_the_briefing_format_reference_ships_with_the_skill(self) -> None:
+        templates = {
+            template.relative_path: template
+            for template in builtin_skill_reference_templates()
+            if template.skill_name == "research"
+        }
+        self.assertIn("references/briefing-format.md", templates)
+        content = templates["references/briefing-format.md"].content
+        # The closed role vocabulary must be discoverable from the reference.
+        for role in BRIEFING_ROLE_LABELS:
+            self.assertIn(role.capitalize(), content, role)
+        self.assertIn("never inferred", content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1224
Stacked on #1227 — review that first; this branch contains its commits.

## What changed

`ulw-research` now asks **who the output is for** before retrieval starts, and on the human branch produces a briefing document that conforms to a written standard, as Markdown, as a print-ready page, or both, in a declared language.

## Why now

Every one of the engine's nine `expected_outputs` was written for a machine consumer — a plan-feed block for `ralplan`, a verified-claims ledger, `product_evidence_loop/v1`, `deep_research_dossier/v1`. When the person who asked for the research wanted to *read* the result, or send it to someone who was not in the chat, the engine had nothing to give them but raw notes.

The gap was repo-wide. Nothing in `src/`, `skills/`, `docs/`, `AGENTS.md`, `CLAUDE.md`, or `CONTEXT.md` stated a document-writing standard: no title rule, no sentence-order rule, no banned-phrasing list, no chapter or appendix structure. The only quality standards that existed were visual (`taste-foundations.md`, `design-critique-rubric.md`) or process-shaped (`content-operator`'s `audience_tone_style/v1`, where the style guide is a slot the user fills, never a rule set OMH supplies).

And the two audiences want opposite documents. A coding agent reading a reverse-engineering study wants dense findings, exact symbols, and file paths. A person wants the problem stated before its answer, terms defined where they first appear, and every number traceable to a premise. Producing one and handing it to the other wastes the run.

## What a user can do now

Ask for research without saying who it is for, and the skill asks. Say "for me to read" and it asks the format. Say "for the coding agent" and it does not — it produces the handoff it always did. On the human branch the document follows a fixed standard and can be printed to a PDF that does not look like a terminal dump.

## Implementation at the boundary

**The asking is a `quality_bar` rule, not an `ExpertQuestion`.** This is the one design decision worth reviewing carefully. `research` is direct-dispatched (`_DIRECT_WORKFLOW_SKILLS`, `src/wrapper/contract.py:570`), and the only runtime path that surfaces a catalog question is gated to unresolved clarify/fallback routes with `selected_skill == "oh-my-hermes"` and `explicit is False` (`src/routing/domain_context_eligibility.py:36-70`). A catalog question declared on this skill would render into documentation and **never be asked**. The body is what Hermes reads, so the body is where the question goes — the same mechanism the skill's existing "ask for source boundaries, freshness, jurisdiction, and version assumptions before retrieval" rule already uses.

**The standard is a reference file.** `skills/ulw-research/references/briefing-format.md` (6.1 KB): noun-phrase titles carrying a role label from a closed 13-value vocabulary, cause before effect, banned sentence shapes and intensifiers, terms defined at first use, figures drawn in code blocks, and the learning-objectives → body → three-appendix structure. Reference files are progressive disclosure and sit outside the always-loaded body, which is what makes a full standard affordable against a zero-headroom ratchet. Rules authored in English; they govern a document written in any language.

**`research_briefing/v1` is the half a function can decide** — because `src/wrapper/message_gate.py:15` is right that "a prose rule that no surface validates is a hope". `build_research_briefing` rejects:

- a title that is a sentence (`Load rises as input grows.`) or a question
- a title opening on numeric scaffolding (`3 options`, `① problem`)
- a repeated title
- a role outside the closed vocabulary
- a banned intensifier (`dramatically`, `overwhelmingly`, `decisively`)
- a paragraph ending on a rhetorical question
- a `measured` figure with no as-of date
- a source with no `source_class` or no retrieval date
- a format declared on the coding-agent branch (the format question is human-only)

**Two renderers.** Markdown, and one self-contained print-ready HTML page: `@page` size and margins, a `@media print` block, inlined font stacks, hairline rules, restrained palette, light/dark tokens. It contains no `<link>`, no `<script>`, and no `src=` — opening it fetches nothing, which is the shape the repo's network invariant exists to prevent. All interpolation goes through `html.escape`; the writer uses `newline=""` so the artifact is byte-identical on Windows.

**PDF stays honest.** No dependency was added and no binary is spawned; owner decision 2026-09-01 chose the print-CSS page plus a generation handoff over both. `omh hermes briefing --input … --markdown … --page …` reports `rendered_observed` only for files it actually wrote and `handoff_prepared` for the PDF. OMH never opens the page it produced — `webbrowser` and `os.startfile` are statically barred by the handoff-safety invariants.

**Scaffolding labels travel with the payload.** A Korean briefing under English section captions is a half-translated document, but a translation table would have to be maintained for every language the engine can write in. `role_labels` and `captions` are supplied by the caller; anything unnamed falls back to English:

```
## 문제 - 입력 증가로 인한 부하 증가
```

## Verification observed

- 13 new tests in `tests/test_research_briefing.py` — validator rejections, both renderers, HTML escaping and determinism, the localized scaffolding, unknown label keys, and the skill contract itself
- `PYTHONPATH=tests unittest` for `test_efficiency`, `test_router_content`, `test_catalog_deference_policy`, `test_chat_router`, `test_skill_density`, `test_duplicate_content_suppression`, `test_hermes_ux_quality`, `test_capabilities`, `test_wrapper_contract`, `test_routing_precision`
- Five `docs … --check` byte gates ok; tap skills 157/157
- `omh release drift` — No drift, 18 checks
- `ruff`, `compileall`, `git diff --check`
- End-to-end: `omh hermes briefing` writing a Korean Markdown + page pair, verified `lang="ko"`, `@page` present, zero external references

## Risks and follow-ups

- The research skill body grows by the asking rules; one release ratchet moves (`FULL_PROFILE_SKILL_BODY_CHAR_LIMIT`, comment names what it bought).
- The new module and CLI subcommand are additive — nothing else calls them yet, so this ships the contract and the renderer ahead of a wrapper that consumes them.
- `deep_research_dossier/v1` is still prose-only with no builder or validator, which `docs/CONTRACT_SUNSET_CANDIDATES.md` already names a defect class. This PR adds the shape a dossier should eventually follow rather than fixing it.
- Live Hermes performing the audience interview in chat is `not_tested`; no observed PDF produced from the rendered page.
