### PR TITLE
Point the language policy and the skill checklist at what the code does

### DIFF
--- a/docs/ADDING-A-SKILL.md
+++ b/docs/ADDING-A-SKILL.md
@@ -6,10 +6,12 @@ the file and structure to edit.
 
 ## 1. Define the skill (single registration point)
 
-- Add the `SkillDefinition` to `src/skills/catalog.py`.
+- Add the `SkillDefinition` to `src/skills/catalog_definitions.py`, which is
+  where the definitions moved when the catalog was split; `src/skills/catalog.py`
+  keeps the derivations that read them.
 - Set `capability_family` **only** when the skill's user-facing family differs
-  from its awareness-lane default (rare — 5 of 88 skills today). Leave it
-  empty otherwise; the lane default governs.
+  from its awareness-lane default, which is rare — a handful of skills set it.
+  Leave it empty otherwise; the lane default governs.
 - If the skill needs a recommendation policy, add its `_SKILL_POLICIES` entry
   in `src/routing/recommend.py`.
 - Author `triggers` in English only. Every other language reaches the skill

--- a/docs/DIRECTION.md
+++ b/docs/DIRECTION.md
@@ -139,12 +139,16 @@ OMH is not:
 ## Routing Language Policy
 
 OMH targets a global audience with English as the primary language. Its
-deterministic trigger tables, however, only ever grew in two scripts: of the
-catalog's routing triggers, Latin and Hangul hold effectively all of them,
-against single-digit Han and Kana entries and none at all in Devanagari,
-Arabic, or Cyrillic. `src/routing/localization.py` meanwhile renders chat copy
-in ko/ja/zh/hi. OMH therefore answers in four non-English languages while the
-router recognises two.
+deterministic trigger tables, however, grew unevenly: Latin dominates the
+catalog's routing triggers, Hangul is the next largest by a wide margin, the
+shipped `ja` and `zh` trigger packs put Han and Kana behind it, and Devanagari,
+Arabic, and Cyrillic have none at all. Chat copy is a separate surface --
+`src/wrapper/localized_copy.py` renders it, and `SUPPORTED_COPY_LOCALES` covers
+six non-English locales including Spanish, French, and German, which no trigger
+pack recognises. (`src/routing/localization.py` is input-side folding --
+normalization, tokens, and locale aliases -- and renders no copy at all.) OMH
+therefore answers in more languages than its router recognises, and that
+asymmetry is what the policy below is about.
 
 Per-language trigger tables are not the fix. Matching the Korean table for one
 more language means hundreds of hand-maintained entries, the work is unbounded
@@ -159,8 +163,9 @@ The policy:
   change, and a non-English routing miss is never fixed by adding tokens.
 - Input script is an explicit routing input, not an implicit accident.
   `src/routing/input_language.py` classifies it and states whether the trigger
-  tables carry that script, so a zero score on a Japanese or Hindi request reads
-  as missing coverage rather than missing intent.
+  tables carry that script, so a zero score on a Hindi or Arabic request reads
+  as missing coverage rather than missing intent. Japanese and Chinese left that
+  category when their packs shipped.
 - Non-English intent resolution belongs to model selection. Hermes already
   understands every language OMH would target; OMH supplies candidates,
   reasons, and evidence boundaries and lets the model choose.


### PR DESCRIPTION
Closes #1225

## What changed

Two documents that coding agents are told to read before working describe modules that moved and counts that drifted. Both were found while mapping the catalog for #1227, and both misdirect exactly the reader who is following instructions.

## `docs/DIRECTION.md` — the Routing Language Policy

The paragraph credited `src/routing/localization.py` with rendering chat copy in ko/ja/zh/hi. That module renders no copy: it is input-side folding — `prepare_routing_text`, `routing_tokens`, `LocaleAlias`, `unicodedata` normalization. Chat copy lives in `src/wrapper/localized_copy.py`, whose `SUPPORTED_COPY_LOCALES` is `("en", "ko", "ja", "zh", "es", "fr", "de")` — six non-English locales, and `hi` is not among them; it exists only as input aliases.

The same paragraph claimed Han and Kana held "single-digit" trigger counts and that the router recognised two scripts. Both stopped being true when the `ja` and `zh` trigger packs shipped: `trigger_backed_scripts()` now returns `('han', 'hangul', 'kana', 'latin')`.

Someone designing a localized output surface from that paragraph reaches for the wrong module, the wrong locale set, and the wrong picture of what the router already covers.

**The policy's argument is unchanged and is why the correction matters** — OMH still answers in more languages than it recognises (Spanish, French, and German have output copy and no trigger pack at all). The asymmetry is now stated from the surfaces that actually produce it. The input-script bullet now names Hindi and Arabic rather than Japanese, which left that category with its pack.

## `docs/ADDING-A-SKILL.md` — step 1 of the new-skill checklist

It sent the author to `src/skills/catalog.py`. Definitions moved to `src/skills/catalog_definitions.py` when the 10,834-line catalog was split at `363e766c`; `catalog.py` keeps the derivations that read them. An agent following the checklist edits a file that no longer holds what it is looking for.

The same file also restated a mutable count in prose — "rare — 5 of 88 skills today" — which CLAUDE.md's own Code Conventions rule says drifts. It has: the catalog now carries 114 builtin definitions and 110 installable skills. Replaced with a form that does not carry a number.

## Verification observed

- `PYTHONPATH=tests uv run python -m unittest tests.test_router_content tests.test_routing_language_policy` — 116 tests, OK
- `omh docs workflows --check`, `omh docs roles --check` — both ok
- `git diff --check`
- Every claim re-derived in a worktree (`SUPPORTED_COPY_LOCALES`, `trigger_backed_scripts()`, per-script trigger counts, the module's own function list) rather than read off the prose it replaces

## Risks

Prose only; neither file is generated and no gate reads them. `DIRECTION.md` is direction-governing, so the correction fixes the attribution without weakening the frozen-trigger-table policy the paragraph exists to justify.

## Follow-up

The next person to add a trigger pack has to revisit this paragraph again. The asymmetry it describes is measured, so it may be worth deriving the sentence rather than writing it.
