### PR TITLE
feat(skills): code-review gains a spec-conformance axis and a named smell baseline

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -4412,10 +4412,15 @@ These surfaces are generated command references, not installed Hermes workflow s
   - Say clearly when no actionable issue is found and name remaining test gaps.
   - Report each finding with `priority` (`P0`-`P3`), `confidence`, `evidence`, `path`, and `line_range`, then close with one verdict of `ship` or `no_ship` plus its own `confidence`; a finding without a path and line range is an open question, not a finding.
   - `REVIEW.md` in the reviewed repository defines what blocks: map its blocking definitions onto `P0`/`P1` and let a `no_ship` verdict follow from that file rather than from reviewer preference. When the repository has no such file, say which blocking definition was used instead.
+  - Review on two axes and report them side by side, never re-ranked against each other: the correctness/risk axis judges the code as it is, and the spec axis judges the diff against the dispatch's Claim and Requirements pointer. A clean diff that does not do what was asked is a spec-axis finding; when no Claim or spec pointer was supplied, report the spec axis as `not_assessed` with that reason instead of staying silent.
+  - Judge maintainability findings against the named baseline in `omh-code-review/references/smell-baseline.md`: a baseline smell is a judgement call to argue from evidence, never an automatic finding, and the reviewed repository's own standards override the baseline wherever they conflict.
+  - Close with two lists beside the verdict: what was checked and found clean, and what could not be assessed with the reason. An absent finding is evidence only when the closing says the surface was actually checked.
 - Completion checklist:
   - Findings come first and are ranked by severity before summary or praise.
   - Every finding cites file, diff, command output, artifact, or expected behavior evidence.
+  - Both axes appear in the report: correctness/risk findings, and a spec-axis verdict naming its Claim source or the `not_assessed` reason.
   - No-issue reviews still name residual risk, missing tests, and independent review evidence if unavailable.
+  - The closing carries the checked-and-clean list and the could-not-assess list, each naming its surfaces.
   - Fix implementation, architecture follow-up, and CI/merge claims stay separate from the review result.
 - Recovery notes:
   - If no diff, file set, PR, or artifact is available, inspect the requested target or ask one target question before reviewing.
@@ -4423,14 +4428,18 @@ These surfaces are generated command references, not installed Hermes workflow s
   - If independent review evidence is unavailable, say so directly instead of implying a second reviewer passed it.
   - To dispatch a reviewer rather than write the findings yourself, load `omh-code-review/references/review-dispatch.md`; it carries the base-SHA rule and the implementer status contract.
   - When findings arrive for work you own, load `omh-code-review/references/review-response.md` before changing anything.
+  - For maintainability judgement calls, load `omh-code-review/references/smell-baseline.md`; it names the twelve baseline smells with their fixes and the repo-standards-override rule.
 - Required inputs:
   - diff or files
   - expected behavior
   - test evidence
+  - the dispatch Claim and Requirements pointer (issue, plan, or spec section) when intent is reviewable
 - Expected outputs:
-  - ranked findings
+  - ranked findings per axis
+  - spec-axis verdict or a named not-assessed reason
   - open questions
   - test gaps
+  - checked-and-clean and could-not-assess lists
 - Artifact expectations:
   - critic run record when review evidence is captured
 - Safety rules:

--- a/skills/omh-code-review/SKILL.md
+++ b/skills/omh-code-review/SKILL.md
@@ -42,7 +42,9 @@ Bad example:
 
 - Findings come first and are ranked by severity before summary or praise.
 - Every finding cites file, diff, command output, artifact, or expected behavior evidence.
+- Both axes appear in the report: correctness/risk findings, and a spec-axis verdict naming its Claim source or the `not_assessed` reason.
 - No-issue reviews still name residual risk, missing tests, and independent review evidence if unavailable.
+- The closing carries the checked-and-clean list and the could-not-assess list, each naming its surfaces.
 - Fix implementation, architecture follow-up, and CI/merge claims stay separate from the review result.
 
 ## Recovery Notes
@@ -52,6 +54,7 @@ Bad example:
 - If independent review evidence is unavailable, say so directly instead of implying a second reviewer passed it.
 - To dispatch a reviewer rather than write the findings yourself, load `omh-code-review/references/review-dispatch.md`; it carries the base-SHA rule and the implementer status contract.
 - When findings arrive for work you own, load `omh-code-review/references/review-response.md` before changing anything.
+- For maintainability judgement calls, load `omh-code-review/references/smell-baseline.md`; it names the twelve baseline smells with their fixes and the repo-standards-override rule.
 
 ## Workflow Lane
 
@@ -81,6 +84,9 @@ Quality bar:
 - Say clearly when no actionable issue is found and name remaining test gaps.
 - Report each finding with `priority` (`P0`-`P3`), `confidence`, `evidence`, `path`, and `line_range`, then close with one verdict of `ship` or `no_ship` plus its own `confidence`; a finding without a path and line range is an open question, not a finding.
 - `REVIEW.md` in the reviewed repository defines what blocks: map its blocking definitions onto `P0`/`P1` and let a `no_ship` verdict follow from that file rather than from reviewer preference. When the repository has no such file, say which blocking definition was used instead.
+- Review on two axes and report them side by side, never re-ranked against each other: the correctness/risk axis judges the code as it is, and the spec axis judges the diff against the dispatch's Claim and Requirements pointer. A clean diff that does not do what was asked is a spec-axis finding; when no Claim or spec pointer was supplied, report the spec axis as `not_assessed` with that reason instead of staying silent.
+- Judge maintainability findings against the named baseline in `omh-code-review/references/smell-baseline.md`: a baseline smell is a judgement call to argue from evidence, never an automatic finding, and the reviewed repository's own standards override the baseline wherever they conflict.
+- Close with two lists beside the verdict: what was checked and found clean, and what could not be assessed with the reason. An absent finding is evidence only when the closing says the surface was actually checked.
 
 Handoff policy:
 
@@ -91,12 +97,15 @@ Required inputs:
 - diff or files
 - expected behavior
 - test evidence
+- the dispatch Claim and Requirements pointer (issue, plan, or spec section) when intent is reviewable
 
 Expected outputs:
 
-- ranked findings
+- ranked findings per axis
+- spec-axis verdict or a named not-assessed reason
 - open questions
 - test gaps
+- checked-and-clean and could-not-assess lists
 
 Artifact expectations:
 

--- a/skills/omh-code-review/references/smell-baseline.md
+++ b/skills/omh-code-review/references/smell-baseline.md
@@ -1,0 +1,43 @@
+# Smell Baseline
+
+The named baseline for maintainability findings. A smell here is a judgement
+call to argue from evidence in the diff, never an automatic finding - and the
+reviewed repository's own documented standards override this baseline wherever
+they conflict. Cite the smell name in the finding so the author can look up the
+same definition. Adapted from the classic Fowler/Beck catalog.
+
+## The twelve baseline smells
+
+| Smell | What it is | The usual fix |
+| --- | --- | --- |
+| Mysterious name | A name that forces the reader to open the body to learn what it does. | Rename to what it does or returns; a long clear name beats a short opaque one. |
+| Duplicated code | The same decision encoded in two places, so one edit needs two. | Extract the shared decision to one owner; leave lookalikes that encode different decisions alone. |
+| Feature envy | A function that reads or writes another module's data more than its own. | Move the function to the data it envies, or move the data to the function. |
+| Data clumps | The same group of values travelling together through signatures. | Introduce the object the clump is trying to be. |
+| Primitive obsession | Domain concepts passed as bare strings/ints so nothing checks them. | Wrap the concept in a type that validates at the boundary. |
+| Repeated switches | The same type/kind dispatch re-implemented at several sites. | Centralize the dispatch (polymorphism, a table, one router) so a new case is one edit. |
+| Shotgun surgery | One conceptual change that requires edits scattered across many files. | Move the pieces of the concept into one place before the next change. |
+| Divergent change | One module edited for many unrelated reasons. | Split the module along its change reasons. |
+| Speculative generality | Hooks, parameters, or layers serving only an imagined future caller. | Delete until a real second caller exists. |
+| Message chains | `a.b().c().d()` walks a structure the caller should not know. | Hand the caller what it actually needs, or hide the walk behind the owner. |
+| Middle man | A layer that only forwards to another layer. | Collapse it; talk to the real owner. |
+| Refused bequest | A subtype that stubs, ignores, or overrides most of what it inherits. | Replace the inheritance with composition or split the interface. |
+
+## How to report one
+
+- Name the smell, cite the evidence (`path`, `line_range`, and what shows it),
+  and say what the fix would be - as a finding, usually `P2`/`P3` unless the
+  smell hides a correctness risk.
+- One instance is a question; a pattern is a finding. Prefer the site where the
+  next change will hurt.
+- Do not report a baseline smell the repository's standards explicitly accept;
+  cite the standard instead and move on.
+- New code matching surrounding style beats abstract purity: a smell the whole
+  file already commits to belongs in a follow-up scope question, not a blocking
+  finding on this diff.
+
+## Boundary
+
+A smell finding is a maintainability judgement over the diff, not execution,
+verification, CI, or merge evidence, and never blocks on its own unless the
+reviewed repository's standards say it does.

--- a/src/maintenance/release.py
+++ b/src/maintenance/release.py
@@ -142,7 +142,10 @@ ROLE_CONTEXT_CHAR_LIMIT = 2600
 # 357345 -> 358092: ai-slop-cleaner's capability section grew its taxonomy,
 # ordered-pass, detection, and closing-report rules; instruction lines on one
 # existing skill, not padding; warranted growth.
-FULL_CAPABILITY_SKILL_SECTION_CHAR_LIMIT = 358092
+# 358092 -> 358305: the code-review capability section grew its two-axis
+# (correctness/spec) and checked-and-clean closing rules; instruction lines on
+# one existing skill, not padding; warranted growth.
+FULL_CAPABILITY_SKILL_SECTION_CHAR_LIMIT = 358305
 FULL_CAPABILITY_SKILL_ITEM_CHAR_LIMIT = 9000
 # 100000 -> 102070: the same three domain workflows each add one standalone
 # capability row, again measured on the merged tree; warranted growth for three
@@ -500,7 +503,11 @@ STANDALONE_CAPABILITY_SKILL_ITEM_CHAR_LIMIT = 2200
 # the fixed pass order, the detection-first rule, the scope boundary, and the
 # four-part closing report; the taxonomy and command tables live in the new
 # on-demand cleanup-passes reference outside this count; warranted growth.
-FULL_PROFILE_SKILL_BODY_CHAR_LIMIT = 817601
+# 817601 -> 819169: code-review gained the spec-conformance axis, the
+# smell-baseline pointer, and the checked-and-clean / could-not-assess closing
+# contract; the twelve-smell table itself lives in an on-demand reference
+# outside this body count; warranted growth.
+FULL_PROFILE_SKILL_BODY_CHAR_LIMIT = 819169
 FULL_PROFILE_SKILL_BODY_REVIEWED_EXCEPTION_CHARS = 0
 
 

--- a/src/skills/catalog_definitions.py
+++ b/src/skills/catalog_definitions.py
@@ -5356,8 +5356,19 @@ _DEFINITIONS = [
         phase="critique",
         hermes_role="hybrid-review",
         handoff_policy="Hermes may frame and summarize review evidence; fixes or code mutations found during review should be delegated to the selected coding executor.",
-        required_inputs=("diff or files", "expected behavior", "test evidence"),
-        expected_outputs=("ranked findings", "open questions", "test gaps"),
+        required_inputs=(
+            "diff or files",
+            "expected behavior",
+            "test evidence",
+            "the dispatch Claim and Requirements pointer (issue, plan, or spec section) when intent is reviewable",
+        ),
+        expected_outputs=(
+            "ranked findings per axis",
+            "spec-axis verdict or a named not-assessed reason",
+            "open questions",
+            "test gaps",
+            "checked-and-clean and could-not-assess lists",
+        ),
         artifact_expectations=("critic run record when review evidence is captured",),
         safety_rules=(
             "Findings come before summaries.",
@@ -5372,6 +5383,9 @@ _DEFINITIONS = [
             "Say clearly when no actionable issue is found and name remaining test gaps.",
             "Report each finding with `priority` (`P0`-`P3`), `confidence`, `evidence`, `path`, and `line_range`, then close with one verdict of `ship` or `no_ship` plus its own `confidence`; a finding without a path and line range is an open question, not a finding.",
             "`REVIEW.md` in the reviewed repository defines what blocks: map its blocking definitions onto `P0`/`P1` and let a `no_ship` verdict follow from that file rather than from reviewer preference. When the repository has no such file, say which blocking definition was used instead.",
+            "Review on two axes and report them side by side, never re-ranked against each other: the correctness/risk axis judges the code as it is, and the spec axis judges the diff against the dispatch's Claim and Requirements pointer. A clean diff that does not do what was asked is a spec-axis finding; when no Claim or spec pointer was supplied, report the spec axis as `not_assessed` with that reason instead of staying silent.",
+            "Judge maintainability findings against the named baseline in `omh-code-review/references/smell-baseline.md`: a baseline smell is a judgement call to argue from evidence, never an automatic finding, and the reviewed repository's own standards override the baseline wherever they conflict.",
+            "Close with two lists beside the verdict: what was checked and found clean, and what could not be assessed with the reason. An absent finding is evidence only when the closing says the surface was actually checked.",
         ),
         why_this_exists="`code-review` exists to make review bug-first and evidence-grounded: findings must cite concrete files, diffs, commands, or artifacts before any summary or fix proposal.",
         do_not_use_when=(
@@ -5392,7 +5406,9 @@ _DEFINITIONS = [
         final_checklist=(
             "Findings come first and are ranked by severity before summary or praise.",
             "Every finding cites file, diff, command output, artifact, or expected behavior evidence.",
+            "Both axes appear in the report: correctness/risk findings, and a spec-axis verdict naming its Claim source or the `not_assessed` reason.",
             "No-issue reviews still name residual risk, missing tests, and independent review evidence if unavailable.",
+            "The closing carries the checked-and-clean list and the could-not-assess list, each naming its surfaces.",
             "Fix implementation, architecture follow-up, and CI/merge claims stay separate from the review result.",
         ),
         recovery_notes=(
@@ -5401,6 +5417,7 @@ _DEFINITIONS = [
             "If independent review evidence is unavailable, say so directly instead of implying a second reviewer passed it.",
             "To dispatch a reviewer rather than write the findings yourself, load `omh-code-review/references/review-dispatch.md`; it carries the base-SHA rule and the implementer status contract.",
             "When findings arrive for work you own, load `omh-code-review/references/review-response.md` before changing anything.",
+            "For maintainability judgement calls, load `omh-code-review/references/smell-baseline.md`; it names the twelve baseline smells with their fixes and the repo-standards-override rule.",
         ),
     ),
     SkillDefinition(

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -3645,7 +3645,55 @@ def _code_review_reference_templates_cached() -> tuple[SkillReferenceTemplate, .
     return (
         SkillReferenceTemplate("code-review", "references/review-dispatch.md", _review_dispatch_reference()),
         SkillReferenceTemplate("code-review", "references/review-response.md", _review_response_reference()),
+        SkillReferenceTemplate("code-review", "references/smell-baseline.md", _review_smell_baseline_reference()),
     )
+
+
+def _review_smell_baseline_reference() -> str:
+    return """# Smell Baseline
+
+The named baseline for maintainability findings. A smell here is a judgement
+call to argue from evidence in the diff, never an automatic finding - and the
+reviewed repository's own documented standards override this baseline wherever
+they conflict. Cite the smell name in the finding so the author can look up the
+same definition. Adapted from the classic Fowler/Beck catalog.
+
+## The twelve baseline smells
+
+| Smell | What it is | The usual fix |
+| --- | --- | --- |
+| Mysterious name | A name that forces the reader to open the body to learn what it does. | Rename to what it does or returns; a long clear name beats a short opaque one. |
+| Duplicated code | The same decision encoded in two places, so one edit needs two. | Extract the shared decision to one owner; leave lookalikes that encode different decisions alone. |
+| Feature envy | A function that reads or writes another module's data more than its own. | Move the function to the data it envies, or move the data to the function. |
+| Data clumps | The same group of values travelling together through signatures. | Introduce the object the clump is trying to be. |
+| Primitive obsession | Domain concepts passed as bare strings/ints so nothing checks them. | Wrap the concept in a type that validates at the boundary. |
+| Repeated switches | The same type/kind dispatch re-implemented at several sites. | Centralize the dispatch (polymorphism, a table, one router) so a new case is one edit. |
+| Shotgun surgery | One conceptual change that requires edits scattered across many files. | Move the pieces of the concept into one place before the next change. |
+| Divergent change | One module edited for many unrelated reasons. | Split the module along its change reasons. |
+| Speculative generality | Hooks, parameters, or layers serving only an imagined future caller. | Delete until a real second caller exists. |
+| Message chains | `a.b().c().d()` walks a structure the caller should not know. | Hand the caller what it actually needs, or hide the walk behind the owner. |
+| Middle man | A layer that only forwards to another layer. | Collapse it; talk to the real owner. |
+| Refused bequest | A subtype that stubs, ignores, or overrides most of what it inherits. | Replace the inheritance with composition or split the interface. |
+
+## How to report one
+
+- Name the smell, cite the evidence (`path`, `line_range`, and what shows it),
+  and say what the fix would be - as a finding, usually `P2`/`P3` unless the
+  smell hides a correctness risk.
+- One instance is a question; a pattern is a finding. Prefer the site where the
+  next change will hurt.
+- Do not report a baseline smell the repository's standards explicitly accept;
+  cite the standard instead and move on.
+- New code matching surrounding style beats abstract purity: a smell the whole
+  file already commits to belongs in a follow-up scope question, not a blocking
+  finding on this diff.
+
+## Boundary
+
+A smell finding is a maintainability judgement over the diff, not execution,
+verification, CI, or merge evidence, and never blocks on its own unless the
+reviewed repository's standards say it does.
+"""
 
 
 def _review_dispatch_reference() -> str:

--- a/tests/test_code_review_references.py
+++ b/tests/test_code_review_references.py
@@ -24,7 +24,14 @@ class CodeReviewReferenceTests(unittest.TestCase):
 
     def test_both_references_ship_under_the_code_review_skill(self) -> None:
         paths = {template.relative_path for template in code_review_reference_templates()}
-        self.assertEqual(paths, {"references/review-dispatch.md", "references/review-response.md"})
+        self.assertEqual(
+            paths,
+            {
+                "references/review-dispatch.md",
+                "references/review-response.md",
+                "references/smell-baseline.md",
+            },
+        )
         for template in code_review_reference_templates():
             self.assertEqual(template.skill_name, "code-review")
 
@@ -34,6 +41,7 @@ class CodeReviewReferenceTests(unittest.TestCase):
         packaged = {(t.skill_name, t.relative_path) for t in builtin_skill_reference_templates()}
         self.assertIn(("code-review", "references/review-dispatch.md"), packaged)
         self.assertIn(("code-review", "references/review-response.md"), packaged)
+        self.assertIn(("code-review", "references/smell-baseline.md"), packaged)
 
     def test_the_base_sha_rule_states_the_defect_not_just_the_preference(self) -> None:
         content = self._content("references/review-dispatch.md")
@@ -52,12 +60,50 @@ class CodeReviewReferenceTests(unittest.TestCase):
     def test_attempted_is_not_addressed_survives(self) -> None:
         self.assertIn('"Attempted" is not "addressed."', self._content("references/review-dispatch.md"))
 
+    def test_the_smell_baseline_names_all_twelve_and_stays_a_judgement_call(self) -> None:
+        content = self._content("references/smell-baseline.md")
+        for smell in (
+            "Mysterious name",
+            "Duplicated code",
+            "Feature envy",
+            "Data clumps",
+            "Primitive obsession",
+            "Repeated switches",
+            "Shotgun surgery",
+            "Divergent change",
+            "Speculative generality",
+            "Message chains",
+            "Middle man",
+            "Refused bequest",
+        ):
+            with self.subTest(smell=smell):
+                self.assertIn(smell, content)
+        # The two rules that keep the baseline from becoming a linter: repo
+        # standards override it, and a smell is argued, never auto-reported.
+        self.assertIn("override this baseline", content)
+        self.assertIn("never an automatic finding", content)
+
+    def test_the_spec_axis_is_locked_into_the_skill_body(self) -> None:
+        from omh.skills.catalog import builtin_definitions
+
+        definition = next(d for d in builtin_definitions() if d.name == "code-review")
+        joined = "\n".join(definition.quality_bar)
+        self.assertIn("never re-ranked against each other", joined)
+        self.assertIn("`not_assessed`", joined)
+        checklist = "\n".join(definition.final_checklist)
+        self.assertIn("spec-axis verdict", checklist)
+        self.assertIn("could-not-assess list", checklist)
+
     def test_the_clarification_gate_is_all_or_nothing(self) -> None:
         content = self._content("references/review-response.md")
         self.assertIn("before implementing any of them", content)
 
     def test_both_references_end_at_a_boundary(self) -> None:
-        for relative_path in ("references/review-dispatch.md", "references/review-response.md"):
+        for relative_path in (
+            "references/review-dispatch.md",
+            "references/review-response.md",
+            "references/smell-baseline.md",
+        ):
             with self.subTest(relative_path=relative_path):
                 self.assertIn("## Boundary", self._content(relative_path))
 


### PR DESCRIPTION
## Feature Report

### What Changed

The `code-review` skill now reviews on **two axes reported side by side** — correctness/risk (unchanged) and **spec conformance** (does the diff do what the dispatch's Claim and Requirements pointer asked) — and judges maintainability findings against a **named twelve-smell baseline** shipped as a new on-demand reference (`skills/omh-code-review/references/smell-baseline.md`). The review's close now lists what was checked and found clean and what could not be assessed.

### Why This Exists

The audit of OMH's code-improvement skills (issue #1232) found two holes: a review could pass a diff that didn't do what was asked (the dispatch reference makes the *requester* carry a Claim, but no checklist item ever made the *reviewer* check the diff against it — required inputs had no issue or spec at all), and with no named smell catalog anywhere in the tree, maintainability findings depended on improvised vocabulary.

### User / Operator Impact

- A dispatched review now returns a spec-axis verdict: a clean diff that does not implement the request is a finding; a dispatch with no Claim gets an explicit `not_assessed` line instead of silence.
- Quality findings cite a stable smell name (mysterious name, duplicated code, feature envy, data clumps, primitive obsession, repeated switches, shotgun surgery, divergent change, speculative generality, message chains, middle man, refused bequest) with what-it-is / usual-fix, so author and reviewer share definitions.
- "No findings" is now evidence: the closing names the surfaces actually checked and the ones that couldn't be.

### How It Works

- Catalog: quality-bar, checklist, inputs, and outputs lines on the existing `code-review` definition. Axes are never re-ranked against each other (a P3 style nit can't bury "does not do what was asked").
- The baseline stays a judgement call, not a linter: repo standards override it; one instance is a question, a pattern is a finding; a smell the whole file already commits to is a follow-up scope question, not a blocker. Both rules are locked by test.
- New reference registered in `code_review_reference_templates()` and the packaged set; ends at a claim boundary like its two siblings.

### Files And Contracts Touched

`src/skills/catalog_definitions.py`, `src/skills/render.py`, regenerated `skills/omh-code-review/` (SKILL.md + new reference) and `docs/WORKFLOWS.md`, `tests/test_code_review_references.py` (path set + twelve-smell/override/judgement-call/spec-axis locks), two body budgets in `src/maintenance/release.py` with provenance comments. **No routing changes** — triggers, policy, cards, and all count contracts are untouched.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` (8,574 tests, OK)
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate` — not run in this worktree; no harness contracts touched
- [ ] `uv run python -m omh.cli release checklist --json` — superseded by `release drift` below
- [ ] `uv run python -m omh.cli release hermes-smoke` — no install-path changes
- [x] `git diff --check`
- [x] Relevant dry-run or smoke command: `omh release drift` → No drift, 18 checks passed; ulw-inventory/ulw-site checks green
- [ ] Manual Hermes/TUI check — deterministic catalog/generated-content change only

### Observed Evidence

- `tests/test_code_review_references.py`: 9 tests OK, including the new locks (all twelve smells present, "override this baseline", "never an automatic finding", spec-axis `not_assessed` and closing-list lines in the catalog body).
- Full suite OK from this worktree after the change; all five docs byte gates green; drift 18/18.

### Not Tested / Not Applicable

- No live Hermes review run — the change is catalog text plus one generated reference behind byte-exact gates.

### Risks / Follow-ups

- Reviews dispatched without a Claim now visibly report `not_assessed` on the spec axis — one line longer by design.
- Sibling issues from the same audit: #1233 (ai-slop-cleaner passes), #1234 (refactor-plan), #1235 (tech-debt ledger), #1236 (ADR lifecycle).

Closes #1232

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WNZ54eMrn7EDJFry8nPd68