### PR TITLE
feat(surfaces): copy/export manifest for the current work artifacts

### DIFF
--- a/src/commands/chat.py
+++ b/src/commands/chat.py
@@ -31,6 +31,7 @@ from ..wrapper.executor_sessions import (
 )
 from ..wrapper.native_commands import NATIVE_COMMAND_SOURCES, build_native_command_surface
 from ..wrapper.route_hints import build_chat_route_hint_payload
+from ..wrapper.work_artifact_actions import build_work_artifact_copy_action
 from ..wrapper.sessions import (
     WrapperSessionError,
     build_wrapper_session_status,
@@ -764,6 +765,15 @@ def cmd_chat_session_status(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_chat_session_artifacts(args: argparse.Namespace) -> int:
+    try:
+        status = build_wrapper_session_status(_paths(args), args.session_id)
+    except FileNotFoundError as exc:
+        raise OmhError(f"wrapper session not found: {args.session_id}") from exc
+    _print_json(build_work_artifact_copy_action(status, artifact_id=args.artifact_id or ""))
+    return 0
+
+
 def cmd_chat_session_mission_control(args: argparse.Namespace) -> int:
     try:
         _print_json(build_mission_control(_paths(args), args.session_id))
@@ -1302,6 +1312,21 @@ def _add_chat_commands(sub) -> None:
     session_status = session_sub.add_parser("status")
     session_status.add_argument("session_id")
     session_status.set_defaults(func=cmd_chat_session_status)
+
+    session_artifacts = session_sub.add_parser(
+        "artifacts",
+        help=(
+            "List the copyable work artifacts for one session under stable ids, or print the exact text of "
+            "one with --artifact-id. Prepared metadata only; copying is not dispatch or evidence."
+        ),
+    )
+    session_artifacts.add_argument("session_id")
+    session_artifacts.add_argument(
+        "--artifact-id",
+        default="",
+        help="Return the exact text of one listed artifact instead of the id listing.",
+    )
+    session_artifacts.set_defaults(func=cmd_chat_session_artifacts)
 
     mission_control = session_sub.add_parser(
         "mission-control",

--- a/src/surfaces/work_artifact_copy.py
+++ b/src/surfaces/work_artifact_copy.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from typing import Any
+
+WORK_ARTIFACT_COPY_MANIFEST_SCHEMA_VERSION = "work_artifact_copy_manifest/v1"
+
+COPY_CLAIM_BOUNDARY = (
+    "Copying this artifact is not dispatch, execution, verification, review, CI, "
+    "merge-readiness, or merge evidence."
+)
+
+# The stable id set. Order and ids are the contract a caller lists against; an
+# entry stays listed with no text rather than disappearing when its source is
+# absent, so a picker never changes shape between two reads of the same work.
+_ARTIFACT_IDS = (
+    "handoff_prompt",
+    "acceptance_and_verification",
+    "status_brief",
+    "evidence_gaps",
+    "next_action",
+    "issue_pr_followup",
+)
+
+_ARTIFACT_LABELS = {
+    "handoff_prompt": "Handoff prompt",
+    "acceptance_and_verification": "Acceptance and verification",
+    "status_brief": "Status brief",
+    "evidence_gaps": "Evidence gaps and claim boundary",
+    "next_action": "Next action",
+    "issue_pr_followup": "Issue/PR follow-up",
+}
+
+_ARTIFACT_TYPES = {
+    "handoff_prompt": "prompt_text",
+    "acceptance_and_verification": "criteria_list",
+    "status_brief": "status_text",
+    "evidence_gaps": "gap_list",
+    "next_action": "action_text",
+    "issue_pr_followup": "followup_text",
+}
+
+
+def build_work_artifact_copy_manifest(
+    briefing: dict[str, Any],
+    *,
+    prompt_handoff: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """List the copyable blocks of one work item with stable ids and exact text.
+
+    Metadata-only projection of already-persisted wrapper artifacts: it reads a
+    ``coding_briefing/v1`` payload plus the session's prompt handoff and copies
+    their text verbatim. Nothing here composes new prose, and nothing here
+    upgrades a prepared artifact into observed evidence.
+    """
+
+    handoff = prompt_handoff if isinstance(prompt_handoff, dict) else {}
+    source_schema = str(briefing.get("schema_version", ""))
+    texts = {
+        "handoff_prompt": (str(handoff.get("prompt_template", "")), str(handoff.get("schema_version", ""))),
+        "acceptance_and_verification": (_acceptance_text(briefing), source_schema),
+        "status_brief": (_status_text(briefing), source_schema),
+        "evidence_gaps": (_evidence_gap_text(briefing), source_schema),
+        "next_action": (str(briefing.get("next_action", "")), source_schema),
+        "issue_pr_followup": (_followup_text(briefing), source_schema),
+    }
+    return {
+        "schema_version": WORK_ARTIFACT_COPY_MANIFEST_SCHEMA_VERSION,
+        "session_id": str(briefing.get("session_id", "")),
+        "run_id": str(briefing.get("run_id", "")),
+        "artifacts": [_entry(artifact_id, *texts[artifact_id]) for artifact_id in _ARTIFACT_IDS],
+        "claim_boundary": COPY_CLAIM_BOUNDARY,
+    }
+
+
+def select_work_artifact(manifest: dict[str, Any], artifact_id: str) -> dict[str, Any]:
+    """Return the exact text of one listed artifact, or an unavailable answer."""
+
+    for entry in _entries(manifest):
+        if str(entry.get("artifact_id", "")) != artifact_id:
+            continue
+        return {
+            "schema_version": WORK_ARTIFACT_COPY_MANIFEST_SCHEMA_VERSION,
+            "artifact_id": artifact_id,
+            "label": str(entry.get("label", "")),
+            "artifact_type": str(entry.get("artifact_type", "")),
+            "source_schema": str(entry.get("source_schema", "")),
+            "availability": str(entry.get("availability", "unavailable")),
+            "reason": str(entry.get("reason", "")),
+            "boundary": "prepared_not_observed",
+            "text": str(entry.get("text", "")),
+            "claim_boundary": COPY_CLAIM_BOUNDARY,
+        }
+    return {
+        "schema_version": WORK_ARTIFACT_COPY_MANIFEST_SCHEMA_VERSION,
+        "artifact_id": artifact_id,
+        "label": "",
+        "artifact_type": "",
+        "source_schema": "",
+        "availability": "unavailable",
+        "reason": "unknown_artifact_id",
+        "boundary": "prepared_not_observed",
+        "text": "",
+        "claim_boundary": COPY_CLAIM_BOUNDARY,
+    }
+
+
+def _entry(artifact_id: str, text: str, source_schema: str) -> dict[str, Any]:
+    available = bool(text)
+    return {
+        "artifact_id": artifact_id,
+        "label": _ARTIFACT_LABELS[artifact_id],
+        "artifact_type": _ARTIFACT_TYPES[artifact_id],
+        "source_schema": source_schema if available else "",
+        "availability": "available" if available else "unavailable",
+        "reason": "" if available else "source_not_recorded",
+        "boundary": "prepared_not_observed",
+        "text": text,
+    }
+
+
+def _acceptance_text(briefing: dict[str, Any]) -> str:
+    work_summary = _object(briefing.get("work_summary"))
+    acceptance = _string_list(work_summary.get("acceptance_criteria"))
+    verification = _string_list(work_summary.get("verification_expected"))
+    lines: list[str] = []
+    if acceptance:
+        lines.extend(["Acceptance criteria:", *(f"- {item}" for item in acceptance)])
+    if verification:
+        if lines:
+            lines.append("")
+        lines.extend(["Verification expected:", *(f"- {item}" for item in verification)])
+    return "\n".join(lines)
+
+
+def _status_text(briefing: dict[str, Any]) -> str:
+    return "\n".join(_string_list(briefing.get("user_facing_lines")))
+
+
+def _evidence_gap_text(briefing: dict[str, Any]) -> str:
+    gaps = _string_list(briefing.get("pending_gaps"))
+    if not gaps:
+        return ""
+    claim_boundary = str(briefing.get("claim_boundary", ""))
+    lines = ["Pending evidence gaps:", *(f"- {gap}" for gap in gaps)]
+    if claim_boundary:
+        lines.extend(["", claim_boundary])
+    return "\n".join(lines)
+
+
+def _followup_text(briefing: dict[str, Any]) -> str:
+    """The issue/PR block is optional: it exists only when a linked run does."""
+    run_id = str(briefing.get("run_id", ""))
+    if not run_id:
+        return ""
+    session_id = str(briefing.get("session_id", ""))
+    return "\n".join(
+        [
+            f"Run: {run_id}",
+            f"Session: {session_id}",
+            f"Next action: {briefing.get('next_action', '')}",
+        ]
+    )
+
+
+def _entries(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, list):
+        return []
+    return [entry for entry in artifacts if isinstance(entry, dict)]
+
+
+def _object(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if str(item)]

--- a/src/wrapper/work_artifact_actions.py
+++ b/src/wrapper/work_artifact_actions.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ..surfaces.work_artifact_copy import (
+    WORK_ARTIFACT_COPY_MANIFEST_SCHEMA_VERSION,
+    build_work_artifact_copy_manifest,
+    select_work_artifact,
+)
+
+LIST_ACTION = "list_work_artifacts"
+SELECT_ACTION = "select_work_artifact"
+
+
+def build_work_artifact_copy_action(
+    status_payload: dict[str, Any],
+    *,
+    artifact_id: str = "",
+) -> dict[str, Any]:
+    """List the current work item's copyable artifacts, or hand back exactly one.
+
+    Reads an already-built ``wrapper_session_result/v1`` payload; it performs no
+    session I/O, records nothing, and leaves ``next_action`` at ``show_status``
+    so copying a block never advances the session toward dispatch or evidence.
+    """
+
+    briefing = _object(status_payload.get("coding_briefing"))
+    manifest = build_work_artifact_copy_manifest(
+        briefing,
+        prompt_handoff=_object(status_payload.get("prompt_handoff")),
+    )
+    base = {
+        "schema_version": WORK_ARTIFACT_COPY_MANIFEST_SCHEMA_VERSION,
+        "session_id": str(status_payload.get("session_id", "")),
+        "next_action": "show_status",
+        "claim_boundary": str(manifest["claim_boundary"]),
+    }
+    if artifact_id:
+        return {**base, "action": SELECT_ACTION, "artifact": select_work_artifact(manifest, artifact_id)}
+    return {
+        **base,
+        "action": LIST_ACTION,
+        # The listing is an index: ids, labels, and availability only. Text
+        # comes back one selected block at a time, so a picker cannot spill
+        # every artifact into chat at once.
+        "artifacts": [_listed(entry) for entry in manifest["artifacts"]],
+    }
+
+
+def _listed(entry: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in entry.items() if key != "text"}
+
+
+def _object(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14361,5 +14361,118 @@ class RuntimeTodoCliTests(unittest.TestCase):
             self.assertFalse((Path(omh_home) / "runtime" / "todo.json").exists())
 
 
+class ChatSessionArtifactsCliTests(unittest.TestCase):
+    """The copy/export manifest has to be reachable from an operator command.
+
+    `work_artifact_copy_manifest/v1` and its wrapper action are only a contract
+    until something a person can run lists the stable ids and hands back one
+    exact block. `omh chat session artifacts` is that surface: the group that
+    already owns wrapper sessions.
+    """
+
+    def _base(self, root: Path) -> list[str]:
+        return ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+    def _prepared_session(self, base: list[str]) -> str:
+        message = "risky refactor with private-token-123"
+        status, stdout, stderr = run_cli(
+            base + ["chat", "session", "start", "--source", "discord", "--source-event-id", "m1", "--channel-ref", "c1", message]
+        )
+        self.assertEqual((status, stderr), (0, ""))
+        session_id = str(json.loads(stdout)["session"]["session_id"])
+        for argv in (
+            ["chat", "session", "accept-plan", session_id],
+            ["chat", "session", "select-executor", session_id, "claude-code"],
+            ["chat", "session", "prepare-handoff", session_id, message],
+        ):
+            status, _, stderr = run_cli(base + argv)
+            self.assertEqual((status, stderr), (0, ""))
+        return session_id
+
+    def test_artifacts_command_lists_stable_ids_without_body_text(self) -> None:
+        # Given a wrapper session with a prepared handoff.
+        with TemporaryDirectory() as tmp:
+            base = self._base(Path(tmp))
+            session_id = self._prepared_session(base)
+
+            # When an operator lists the session's copyable artifacts.
+            status, stdout, stderr = run_cli(base + ["chat", "session", "artifacts", session_id])
+
+            # Then the stable ids come back and no block body leaks into the listing.
+            self.assertEqual((status, stderr), (0, ""))
+            listing = json.loads(stdout)
+            self.assertEqual(listing["schema_version"], "work_artifact_copy_manifest/v1")
+            self.assertEqual(listing["action"], "list_work_artifacts")
+            self.assertEqual(
+                [str(entry["artifact_id"]) for entry in listing["artifacts"]],
+                [
+                    "handoff_prompt",
+                    "acceptance_and_verification",
+                    "status_brief",
+                    "evidence_gaps",
+                    "next_action",
+                    "issue_pr_followup",
+                ],
+            )
+            for entry in listing["artifacts"]:
+                self.assertNotIn("text", entry)
+
+    def test_artifacts_command_prints_one_exact_block_with_boundary(self) -> None:
+        # Given the same prepared session.
+        with TemporaryDirectory() as tmp:
+            base = self._base(Path(tmp))
+            session_id = self._prepared_session(base)
+
+            # When the operator selects one artifact id.
+            status, stdout, stderr = run_cli(
+                base + ["chat", "session", "artifacts", session_id, "--artifact-id", "status_brief"]
+            )
+
+            # Then exactly that block comes back, prepared-only, with its boundary.
+            self.assertEqual((status, stderr), (0, ""))
+            selection = json.loads(stdout)
+            self.assertEqual(selection["action"], "select_work_artifact")
+            self.assertEqual(selection["artifact"]["artifact_id"], "status_brief")
+            self.assertEqual(selection["artifact"]["availability"], "available")
+            self.assertEqual(selection["artifact"]["boundary"], "prepared_not_observed")
+            self.assertTrue(str(selection["artifact"]["text"]).strip())
+            self.assertIn("not dispatch, execution, verification", selection["artifact"]["claim_boundary"])
+            self.assertEqual(selection["next_action"], "show_status")
+            # The raw task message is never persisted, so it cannot be exported.
+            self.assertNotIn("private-token-123", stdout)
+
+    def test_artifacts_command_reports_unknown_id_as_unavailable(self) -> None:
+        # Given the same prepared session.
+        with TemporaryDirectory() as tmp:
+            base = self._base(Path(tmp))
+            session_id = self._prepared_session(base)
+
+            # When an id outside the stable set is selected.
+            status, stdout, stderr = run_cli(
+                base + ["chat", "session", "artifacts", session_id, "--artifact-id", "chat_transcript"]
+            )
+
+            # Then the command succeeds and reports unavailable instead of inventing text.
+            self.assertEqual((status, stderr), (0, ""))
+            selection = json.loads(stdout)
+            self.assertEqual(selection["artifact"]["availability"], "unavailable")
+            self.assertEqual(selection["artifact"]["reason"], "unknown_artifact_id")
+            self.assertEqual(selection["artifact"]["text"], "")
+
+    def test_artifacts_command_errors_when_no_such_session_exists(self) -> None:
+        # Given an OMH home with no wrapper session of that id.
+        with TemporaryDirectory() as tmp:
+            base = self._base(Path(tmp))
+
+            # When the operator asks for its artifacts.
+            status, stdout, stderr = run_cli(base + ["chat", "session", "artifacts", "ws-missing"])
+
+            # Then it fails as a not-found session rather than printing an empty manifest.
+            # OmhError is the repo's operator-error exit (2), per commands/main.py.
+            self.assertEqual(status, 2)
+            self.assertIn("wrapper session not found", stderr)
+            self.assertEqual(stdout, "")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_work_reporting.py
+++ b/tests/test_work_reporting.py
@@ -10,6 +10,12 @@ from _local_package import load_local_package
 load_local_package()
 from omh.external_effect_receipts import read_external_effect_receipts
 from omh.paths import resolve_paths
+from omh.surfaces.work_artifact_copy import (
+    WORK_ARTIFACT_COPY_MANIFEST_SCHEMA_VERSION,
+    build_work_artifact_copy_manifest,
+    select_work_artifact,
+)
+from omh.wrapper.briefing import build_coding_briefing
 from omh.work_reporting import (
     build_background_completion_report,
     build_markdown_export,
@@ -1018,6 +1024,109 @@ class WorkReportingTests(CheckRollupCitationHonestyMixin, unittest.TestCase):
         self.assertNotIn("[OMH Awareness]", rendered)
         self.assertNotIn("Native bridge status context", rendered)
         self.assertNotIn("Evidence boundary: prepared handoffs", rendered)
+
+
+class WorkArtifactCopyTests(unittest.TestCase):
+    """The copy/export manifest lists what exists and hands back only source text.
+
+    Selecting a block is a read: it must return the exact persisted text, keep
+    the prepared boundary attached, report a missing source as unavailable, and
+    never upgrade a prepared artifact into an observed claim.
+    """
+
+    PROMPT_TEMPLATE = "Implement the copy/export surface for {message}."
+
+    def _session(self) -> dict[str, object]:
+        return {
+            "session_id": "wsession-1245",
+            "thread_key": "discord:1245",
+            "source": "discord",
+            "status": "prompt_handoff_prepared",
+            "selected_executor_profile": "claude-code",
+            "plan": {"status": "accepted", "recommended_workflow": "ultrawork"},
+            "prompt_handoff": {
+                "schema_version": "coding_prompt_handoff/v1",
+                "selected_executor_profile": "claude-code",
+                "prompt_template": self.PROMPT_TEMPLATE,
+                "acceptance_criteria": ["Stable ids list", "Exact selected text"],
+                "verification": ["PYTHONPATH=tests uv run python -m unittest tests/test_work_reporting.py"],
+            },
+        }
+
+    def _briefing(self, **overrides: object) -> dict[str, object]:
+        briefing = build_coding_briefing(self._session())
+        briefing.update(overrides)
+        return briefing
+
+    def test_manifest_selects_exact_artifact_with_boundary(self) -> None:
+        # Given a prepared wrapper briefing carrying a prompt handoff.
+        briefing = self._briefing()
+
+        # When the manifest is built and the handoff prompt is selected by id.
+        manifest = build_work_artifact_copy_manifest(briefing, prompt_handoff=self._session()["prompt_handoff"])
+        selection = select_work_artifact(manifest, "handoff_prompt")
+
+        # Then the entry ids are stable and the selection is exact source text.
+        self.assertEqual(manifest["schema_version"], WORK_ARTIFACT_COPY_MANIFEST_SCHEMA_VERSION)
+        self.assertEqual(
+            [str(entry["artifact_id"]) for entry in manifest["artifacts"]],
+            [
+                "handoff_prompt",
+                "acceptance_and_verification",
+                "status_brief",
+                "evidence_gaps",
+                "next_action",
+                "issue_pr_followup",
+            ],
+        )
+        self.assertEqual(selection["availability"], "available")
+        self.assertEqual(selection["boundary"], "prepared_not_observed")
+        self.assertEqual(selection["text"], self.PROMPT_TEMPLATE)
+        self.assertEqual(
+            selection["claim_boundary"],
+            "Copying this artifact is not dispatch, execution, verification, review, CI, "
+            "merge-readiness, or merge evidence.",
+        )
+
+    def test_missing_source_is_unavailable_and_never_synthesized(self) -> None:
+        # Given a briefing with no prompt handoff and no recorded evidence gaps.
+        briefing = self._briefing(work_summary={}, pending_gaps=[])
+
+        # When the manifest is built.
+        manifest = build_work_artifact_copy_manifest(briefing)
+        prompt = select_work_artifact(manifest, "handoff_prompt")
+        gaps = select_work_artifact(manifest, "evidence_gaps")
+
+        # Then missing sources report unavailable with empty text.
+        self.assertEqual(prompt["availability"], "unavailable")
+        self.assertEqual(prompt["text"], "")
+        self.assertEqual(gaps["availability"], "unavailable")
+        self.assertEqual(gaps["text"], "")
+
+    def test_unknown_artifact_id_is_unavailable_not_an_error(self) -> None:
+        # Given a manifest built from a prepared briefing.
+        manifest = build_work_artifact_copy_manifest(self._briefing(), prompt_handoff=self._session()["prompt_handoff"])
+
+        # When an id outside the stable set is selected.
+        selection = select_work_artifact(manifest, "chat_transcript")
+
+        # Then the surface reports it unavailable rather than inventing content.
+        self.assertEqual(selection["availability"], "unavailable")
+        self.assertEqual(selection["reason"], "unknown_artifact_id")
+        self.assertEqual(selection["text"], "")
+
+    def test_copying_never_introduces_an_observed_claim(self) -> None:
+        # Given a prepared-only briefing whose evidence gaps are unobserved.
+        briefing = self._briefing()
+
+        # When every listed artifact is selected.
+        manifest = build_work_artifact_copy_manifest(briefing, prompt_handoff=self._session()["prompt_handoff"])
+        selections = [select_work_artifact(manifest, str(entry["artifact_id"])) for entry in manifest["artifacts"]]
+
+        # Then no selection claims observed evidence.
+        for selection in selections:
+            self.assertEqual(selection["boundary"], "prepared_not_observed")
+            self.assertNotIn("observed_evidence", selection)
 
 
 if __name__ == "__main__":

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -33,7 +33,9 @@ from omh.wrapper_contract import (
     messenger_rendering_contract,
     render_profile_for_source,
 )
+from omh.wrapper.briefing import build_coding_briefing
 from omh.wrapper.continuity import build_continuity_briefing
+from omh.wrapper.work_artifact_actions import build_work_artifact_copy_action
 from omh.wrapper.localized_copy import detect_copy_locale
 from omh.wrapper.native_commands import build_native_command_surface, render_native_command_response
 from omh.wrapper.route_hints import build_chat_route_hint_payload
@@ -4446,6 +4448,84 @@ class ContinuityBriefingProjectionTests(unittest.TestCase):
 
                 self.assertEqual(briefing["resume"]["status"], "blocked")
                 self.assertEqual(briefing["next_action"], "review_runtime_evidence")
+
+
+class WorkArtifactCopyActionTests(unittest.TestCase):
+    """The wrapper action lists or selects; it never dispatches or observes."""
+
+    PROMPT_TEMPLATE = "Implement the export surface for {message}."
+
+    def _status_payload(self) -> dict[str, object]:
+        session = {
+            "session_id": "wsession-copy",
+            "thread_key": "discord:copy",
+            "source": "discord",
+            "status": "prompt_handoff_prepared",
+            "selected_executor_profile": "claude-code",
+            "plan": {"status": "accepted", "recommended_workflow": "ultrawork"},
+            "prompt_handoff": {
+                "schema_version": "coding_prompt_handoff/v1",
+                "selected_executor_profile": "claude-code",
+                "prompt_template": self.PROMPT_TEMPLATE,
+                "acceptance_criteria": ["Stable ids"],
+                "verification": ["unittest tests/test_wrapper_contract.py"],
+            },
+        }
+        return {
+            "schema_version": "wrapper_session_result/v1",
+            "session_id": "wsession-copy",
+            "session_status": "prompt_handoff_prepared",
+            "prompt_handoff": session["prompt_handoff"],
+            "coding_briefing": build_coding_briefing(session),
+        }
+
+    def test_list_action_returns_stable_ids_without_artifact_text(self) -> None:
+        # Given a prepared wrapper session status payload.
+        status = self._status_payload()
+
+        # When the copy action lists the current work artifacts.
+        listing = build_work_artifact_copy_action(status)
+
+        # Then ids are stable, the prompt is available, and no body text leaks.
+        self.assertEqual(listing["action"], "list_work_artifacts")
+        self.assertEqual(
+            [str(entry["artifact_id"]) for entry in listing["artifacts"]],
+            [
+                "handoff_prompt",
+                "acceptance_and_verification",
+                "status_brief",
+                "evidence_gaps",
+                "next_action",
+                "issue_pr_followup",
+            ],
+        )
+        prompt_entry = next(entry for entry in listing["artifacts"] if entry["artifact_id"] == "handoff_prompt")
+        self.assertEqual(prompt_entry["availability"], "available")
+        self.assertNotIn("text", prompt_entry)
+
+    def test_select_action_returns_exact_source_text_with_boundary(self) -> None:
+        # Given the same prepared status payload.
+        status = self._status_payload()
+
+        # When one artifact id is selected.
+        selection = build_work_artifact_copy_action(status, artifact_id="handoff_prompt")
+
+        # Then the exact prepared text comes back with its boundary intact.
+        self.assertEqual(selection["action"], "select_work_artifact")
+        self.assertEqual(selection["artifact"]["text"], self.PROMPT_TEMPLATE)
+        self.assertEqual(selection["artifact"]["boundary"], "prepared_not_observed")
+        self.assertEqual(selection["next_action"], "show_status")
+
+    def test_action_on_a_session_without_a_briefing_reports_unavailable(self) -> None:
+        # Given a status payload with no coding briefing recorded.
+        status = {"schema_version": "wrapper_session_result/v1", "session_id": "wsession-empty"}
+
+        # When the copy action selects the handoff prompt.
+        selection = build_work_artifact_copy_action(status, artifact_id="handoff_prompt")
+
+        # Then it reports unavailable instead of synthesizing a prompt.
+        self.assertEqual(selection["artifact"]["availability"], "unavailable")
+        self.assertEqual(selection["artifact"]["text"], "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Feature Report

### What Changed

- New `work_artifact_copy_manifest/v1` projection (`src/surfaces/work_artifact_copy.py`) that enumerates the copyable blocks of one work item under stable ids, and returns the exact source text for a single selected id.
- New narrow wrapper action (`src/wrapper/work_artifact_actions.py`) that lists or selects those artifacts from an already-built `wrapper_session_result/v1` payload.
- New operator entry point `omh chat session artifacts <session-id> [--artifact-id ID]`, which is how a user actually reaches the surface.
- Focused reporting, contract, and CLI tests covering exact selection with boundary, unavailable sources, unknown ids, no-current-session, and the no-observed-claim guarantee.

### Why This Exists

- OMH already prepares every block a user needs to move work between Hermes chat, a coding owner, review, and issue/PR follow-up — but the copy path was scattered. Coding briefings render status lines, the prompt handoff renders inside a chat body, and `src/surfaces/evidence_copy.py` only produced a suffix-level not-evidence sentence.
- Nothing enumerated the copyable blocks for a work item, so a user had to hunt through chat output or read internal state to copy the exact block they wanted. Issue #1245 names that gap.

### User / Operator Impact

- An operator runs `omh chat session artifacts <session-id>` to list the current work item's copyable artifacts — stable ids with labels, artifact type, source schema, availability, and boundary — then `--artifact-id <id>` to print exactly one block, without dragging in unrelated chat history.
- A block whose source was never recorded is reported `unavailable` instead of being invented, so an empty status or evidence section reads as "OMH does not have this" rather than as a confident empty answer.

### How It Works

- The manifest is a read over artifacts OMH already persisted: a `coding_briefing/v1` payload plus the session's prompt handoff. It composes no new prose.
- Six stable ids in a fixed order: `handoff_prompt`, `acceptance_and_verification`, `status_brief`, `evidence_gaps`, `next_action`, `issue_pr_followup`.
- Selection returns the exact persisted text rather than a re-rendering. The prompt comes back as its stored `prompt_template` with the `{message}` placeholder intact, because OMH deliberately does not persist the raw task message — composing one would invent text the session never stored.
- An entry stays listed with no text when its source is absent, so the id set does not change shape between two reads of the same work. Missing source is `unavailable` / `source_not_recorded`; an id outside the set is `unavailable` / `unknown_artifact_id`.
- The wrapper action performs no session I/O and records nothing. The listing omits body text so a picker cannot spill every artifact into chat at once, and `next_action` stays `show_status` so copying never advances the session toward dispatch.
- Every selection carries `prepared_not_observed` plus a claim boundary stating the copy is not dispatch, execution, verification, review, CI, merge-readiness, or merge evidence.
- The CLI handler reuses `build_wrapper_session_status()` and the wrapper action; it adds no reader, no writer, and no state. An unknown artifact id exits 0 and reports `unavailable` (asking whether a block exists is a question, not an operator error); a missing session raises `OmhError` (exit 2, matching every sibling `chat session` subcommand).

### Files And Contracts Touched

- `src/surfaces/work_artifact_copy.py` (new) — `work_artifact_copy_manifest/v1`, `build_work_artifact_copy_manifest()`, `select_work_artifact()`.
- `src/wrapper/work_artifact_actions.py` (new) — `build_work_artifact_copy_action()` over `wrapper_session_result/v1`.
- `src/commands/chat.py` — `cmd_chat_session_artifacts()` plus its `artifacts` subparser under the existing `chat session` group.
- `tests/test_work_reporting.py`, `tests/test_wrapper_contract.py`, `tests/test_cli.py` — new `WorkArtifactCopyTests`, `WorkArtifactCopyActionTests`, and `ChatSessionArtifactsCliTests`.
- No existing schema, briefing, or handoff record was changed; both new modules only read.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [x] `omh chat session artifacts` exercised end to end against a real wrapper session
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: temporary manual driver against the real projection and wrapper action
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: the operator path is the CLI; no TUI rendering of the manifest is part of this change

### Observed Evidence

- Targeted: `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py tests/test_work_reporting.py tests/test_wrapper_contract.py` — 537 tests, OK.
- Full discovery: `PYTHONPATH=tests uv run python -m unittest discover -s tests` — 8612 tests, OK, on base `15e9b921`.
- Also observed: `compileall` clean; `ruff check src tests` clean; `git diff --check` clean; all five `docs … --check` byte gates OK.
- Red-first: both test classes were observed failing before the production modules existed (`NotImplementedError` from the skeletons), then passing after implementation.
- A temporary driver exercised the real projection and the real wrapper action and printed PASS for: stable id list, `handoff_prompt` returning the exact source text plus prepared boundary, missing status/evidence reported unavailable, and no asserted observed claim across all six blocks.
- A second temporary driver ran the **real `omh` CLI** against a **real wrapper session on disk** (start → accept-plan → select-executor → prepare-handoff) and printed PASS for all four operator scenarios: listing prints the six stable ids and no body text; `--artifact-id status_brief` prints the exact block with `prepared_not_observed` and its claim boundary; `--artifact-id chat_transcript` reports `unavailable` / `unknown_artifact_id` with empty text; and a missing session exits 2 with `wrapper session not found` and no stdout. The exported `handoff_prompt` was confirmed to be the stored `coding_prompt_handoff/v1` text verbatim, and the raw task message (`private-token-123`) appeared in no block.
- Both drivers were deleted afterward; neither is in any commit.

### Not Tested / Not Applicable

- `harness validate`, `release checklist`, `release hermes-smoke`, and the install smoke were not run: this change adds no catalog entry, no generated artifact, and no install-path behavior, so none of those gates cover it. The new subcommand is covered by `tests/test_cli.py` and the manual CLI driver.
- No Hermes chat-action surface invokes this yet; the CLI is the operator path in this change.
- No TUI rendering of the manifest.

## Risk

- Low. The modules are additive and read-only, with no existing caller changed and no persisted state written. The CLI change adds one subparser to an existing group and does not touch any sibling subcommand.
- The main design risk is naming: an artifact block may legitimately *name* an unobserved stage (`- merged` under a `Pending evidence gaps:` header). That is a gap listing, not a claim, and the boundary sentence travels with the block — but a future revision that adds an observed block must carry the observed evidence ref with it rather than relabeling a prepared artifact.

## Compatibility / Rollout

- No schema, config, or install change. Nothing to migrate and nothing to roll back beyond reverting the commit.
- The manifest is versioned `work_artifact_copy_manifest/v1`, so a later revision can extend the id set behind a version bump.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- A Hermes chat-action surface for the same manifest, so the blocks are selectable in chat and not only from the CLI.
- The `issue_pr_followup` block currently renders only when a linked run id exists; enriching it with actual issue/PR references depends on a source that records them.

Closes #1245

