### PR TITLE
feat(fanout): bound review dispatches per goal attempt

### DIFF
--- a/src/coding/fanout.py
+++ b/src/coding/fanout.py
@@ -27,6 +27,7 @@ from .executor_capability_snapshots import (
     complete_executor_capability_snapshot,
     prepared_executor_capability_snapshot,
 )
+from .fanout_review_budget import normalized_review_role
 from .model_routing import MODEL_CATEGORIES, canonical_model_category, model_route_for_unit
 
 _UNIT_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
@@ -388,7 +389,11 @@ def _normalized_unit(unit: Mapping[str, object], index: int) -> dict[str, object
         "depends_on": sorted(set(depends_on)),
         "model": str(unit.get("model", "") or "").strip(),
         "reasoning_effort": str(unit.get("reasoning_effort", "") or "").strip(),
-        "role": str(unit.get("role", "") or "").strip(),
+        "role": (
+            "review"
+            if normalized_review_role(str(unit.get("role", "") or ""))
+            else str(unit.get("role", "") or "").strip()
+        ),
         # `category` accepts the OMO/ULW ulw-* aliases the resolver already
         # normalizes; validate_fanout_units rejects unknown vocabulary so a
         # typo fails the freeze instead of silently routing by role only.

--- a/src/coding/fanout.py
+++ b/src/coding/fanout.py
@@ -381,6 +381,8 @@ def _normalized_unit(unit: Mapping[str, object], index: int) -> dict[str, object
     file_scope = [str(path).strip() for path in unit.get("file_scope", []) or [] if str(path).strip()]
     depends_on = [str(dependency).strip() for dependency in unit.get("depends_on", []) or [] if str(dependency).strip()]
     owner = unit.get("owner")
+    raw_role = str(unit.get("role", "") or "").strip()
+    review_role = normalized_review_role(raw_role)
     return {
         "unit_id": str(unit.get("unit_id", "")).strip(),
         "title": " ".join(str(unit.get("title", "")).split()),
@@ -389,11 +391,8 @@ def _normalized_unit(unit: Mapping[str, object], index: int) -> dict[str, object
         "depends_on": sorted(set(depends_on)),
         "model": str(unit.get("model", "") or "").strip(),
         "reasoning_effort": str(unit.get("reasoning_effort", "") or "").strip(),
-        "role": (
-            "review"
-            if normalized_review_role(str(unit.get("role", "") or ""))
-            else str(unit.get("role", "") or "").strip()
-        ),
+        "role": "review" if review_role is not None else raw_role,
+        "review_role": review_role or "",
         # `category` accepts the OMO/ULW ulw-* aliases the resolver already
         # normalizes; validate_fanout_units rejects unknown vocabulary so a
         # typo fails the freeze instead of silently routing by role only.
@@ -514,6 +513,9 @@ def _contract_unit(
     }
     if model_route is not None:
         handoff["model_route"] = model_route
+    review_role = str(unit.get("review_role", "") or "")
+    if review_role:
+        handoff["review_role"] = review_role
     capability_snapshot = (capability_snapshots or {}).get(executor_target)
     if capability_snapshots is not None and executor_target != "choose":
         handoff["executor_capability_snapshot_policy"] = _FROZEN_CAPABILITY_SNAPSHOT_POLICY

--- a/src/coding/fanout_artifacts.py
+++ b/src/coding/fanout_artifacts.py
@@ -60,6 +60,11 @@ def fanout_run_journal_path(paths: OmhPaths, fanout_id: str) -> Path:
     return _managed_fanout_dir(paths, _validated_fanout_id(fanout_id)) / "run_journal.json"
 
 
+def fanout_review_dispatch_budget_path(paths: OmhPaths, fanout_id: str) -> Path:
+    """Validated durable review-dispatch budget path for one fanout goal."""
+    return _managed_fanout_dir(paths, _validated_fanout_id(fanout_id)) / "review_dispatch_budget.json"
+
+
 def fanout_contract_provenance_path(paths: OmhPaths, fanout_id: str) -> Path:
     return _managed_fanout_dir(
         paths,

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -89,6 +89,10 @@ from .fanout_journal import (
     resume_counts,
     write_fanout_run_journal,
 )
+from .fanout_review_budget import (
+    ReviewDispatchBudget,
+    normalized_review_role,
+)
 from .inflight import InflightMarkerError, clear_inflight_marker, write_inflight_marker
 from .parallelism_policy import FANOUT_MAX_DEPTH_DEFAULT, FANOUT_RUN_SPAWN_CEILING_DEFAULT
 from .fanout_retry import (
@@ -1232,6 +1236,9 @@ def dispatch_fanout(
     write_line: Callable[[str], None] | None = None,
     hermes_routing: Mapping[str, Any] | None = None,
     hermes_child: Callable[..., Mapping[str, Any]] | None = None,
+    goal_attempt_id: str = "attempt-1",
+    goal_attempt_progressed: bool = False,
+    review_dispatch_budget: int = 1,
 ) -> dict[str, Any]:
     # The spawn guard runs before every other check, including the two
     # boundary re-checks below: it is the only one whose whole job is that no
@@ -1288,6 +1295,13 @@ def dispatch_fanout(
     # Resolved up here rather than beside the summary write below: the dispatch
     # loop needs it to write per-unit in-flight markers while units are running.
     fanout_id = str(contract.get("fanout_id", "") or "")
+    review_budget = ReviewDispatchBudget(
+        paths=paths,
+        fanout_id=fanout_id,
+        attempt_id=goal_attempt_id,
+        limit=review_dispatch_budget,
+        progressed=goal_attempt_progressed,
+    )
     # Observed once per distinct owner, here at the dispatch boundary rather
     # than inside the prompt builder: `build_unit_prompt` stays a pure function
     # of its arguments, so a prompt built without discovery is byte-identical
@@ -1436,6 +1450,7 @@ def dispatch_fanout(
         "rng": rng,
         "sleep": sleep,
         "ignore_limit_signal": ignore_limit_signal,
+        "review_budget": review_budget,
     }
 
     def _dispatch_with_owner_gate(unit: Mapping[str, Any], **kwargs: Any) -> dict[str, Any]:
@@ -1624,6 +1639,14 @@ def dispatch_fanout(
         ),
         "base_sha": base_sha,
         "claim_boundary": f"{DISPATCH_CLAIM_BOUNDARY} {FANOUT_CLAIM_BOUNDARY}",
+    }
+    summary["review_dispatch_budget"] = {
+        "schema_version": "fanout_review_dispatch_budget/v1",
+        "attempt_id": review_budget.attempt_id,
+        "limit_per_role": review_budget.limit,
+        "progressed": review_budget.progressed,
+        "state_path": str(review_budget.path),
+        "claim_boundary": "Budget accounting is not review, verification, CI, or merge evidence.",
     }
     if concurrency_policy:
         # How the pool width was chosen (policy default vs flag, any clamp)
@@ -2494,6 +2517,7 @@ def _dispatch_unit(
     rng: Callable[[], float] = random.random,
     sleep: Callable[[float], None] = time.sleep,
     ignore_limit_signal: bool = False,
+    review_budget: ReviewDispatchBudget,
 ) -> dict[str, Any]:
     from .model_inventory import catalog_fingerprint_note
 
@@ -2665,6 +2689,35 @@ def _dispatch_unit(
                 else:
                     planned["skill_sequence_source"] = "none"
         return planned
+    review_role = normalized_review_role(_unit_role(unit))
+    if review_role is not None:
+        reservation = review_budget.reserve(review_role, unit_id)
+        if not reservation.granted:
+            reason_codes = {
+                "attempt_not_progressed": "review_dispatch_attempt_not_progressed",
+                "configuration_mismatch": "review_dispatch_budget_configuration_mismatch",
+                "exhausted": "review_dispatch_no_progress",
+            }
+            reason_code = reason_codes.get(reservation.status, "review_dispatch_no_progress")
+            reasons = {
+                "attempt_not_progressed": (
+                    "a new goal attempt was named without explicitly confirming concrete progress"
+                ),
+                "configuration_mismatch": (
+                    "the requested review dispatch budget differs from the durable attempt budget"
+                ),
+                "exhausted": "the normalized reviewer role has no dispatch allowance left in this goal attempt",
+            }
+            return {
+                "unit_id": unit_id,
+                "run_ref": run_ref,
+                "owner": owner,
+                "status": "review_dispatch_budget_exhausted",
+                "reason_code": reason_code,
+                "reason": reasons.get(reservation.status, "review dispatch made no progress"),
+                "review_dispatch_budget": reservation.as_dict(),
+                **_dispatch_status_ladder(),
+            }
     # Claimed here, after the dry-run return and BEFORE the worktree is
     # created: a run that has spent its whole spawn budget must not leave a
     # trail of empty worktrees for units it was never going to start.
@@ -3774,6 +3827,7 @@ def _dependency_failed(result: dict[str, Any] | None) -> bool:
         "unsupported_for_local_dispatch",
         "worktree_failed",
         "not_selected",
+        "review_dispatch_budget_exhausted",
         # A vetoed spawn never ran, so a dependent must block on it exactly as
         # it would on an unready executor -- admitting the dependent would run
         # it against work that does not exist.

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -449,6 +449,11 @@ class _SpawnLedger:
             self._claimed += 1
             return True
 
+    def release(self) -> None:
+        """Return a claim when a later admission reservation refuses the spawn."""
+        with self._lock:
+            self._claimed -= 1
+
     @property
     def claimed(self) -> int:
         with self._lock:
@@ -781,6 +786,9 @@ def unit_skill_lines(unit: Mapping[str, Any], discovery: Mapping[str, Any] | Non
 
 def _unit_role(unit: Mapping[str, Any]) -> str:
     handoff = unit.get("handoff", {}) if isinstance(unit.get("handoff"), Mapping) else {}
+    review_role = str(handoff.get("review_role", "") or "")
+    if review_role:
+        return review_role
     route = handoff.get("model_route") if isinstance(handoff.get("model_route"), Mapping) else {}
     return str(route.get("role", "") or "") if isinstance(route, Mapping) else ""
 
@@ -2689,10 +2697,30 @@ def _dispatch_unit(
                 else:
                     planned["skill_sequence_source"] = "none"
         return planned
+    # Claimed here, after the dry-run return and BEFORE either durable review
+    # accounting or worktree creation. A ceiling refusal therefore leaves both
+    # durable state and the filesystem untouched. If the review reservation
+    # refuses afterward, its claim is returned before that refusal is exposed.
+    spawn_claimed = spawn_ledger is not None and spawn_ledger.claim()
+    if spawn_ledger is not None and not spawn_claimed:
+        return {
+            "unit_id": unit_id,
+            "run_ref": run_ref,
+            "owner": owner,
+            "status": SPAWN_CEILING_STATUS,
+            **_dispatch_status_ladder(),
+            "reason": (
+                f"run spawn ceiling of {spawn_ledger.ceiling} reached before this unit started; "
+                "re-dispatch the remaining units, or raise `run_spawn_ceiling` in the setup "
+                "profile's parallelism block"
+            ),
+        }
     review_role = normalized_review_role(_unit_role(unit))
     if review_role is not None:
         reservation = review_budget.reserve(review_role, unit_id)
         if not reservation.granted:
+            if spawn_ledger is not None:
+                spawn_ledger.release()
             reason_codes = {
                 "attempt_not_progressed": "review_dispatch_attempt_not_progressed",
                 "configuration_mismatch": "review_dispatch_budget_configuration_mismatch",
@@ -2718,22 +2746,6 @@ def _dispatch_unit(
                 "review_dispatch_budget": reservation.as_dict(),
                 **_dispatch_status_ladder(),
             }
-    # Claimed here, after the dry-run return and BEFORE the worktree is
-    # created: a run that has spent its whole spawn budget must not leave a
-    # trail of empty worktrees for units it was never going to start.
-    if spawn_ledger is not None and not spawn_ledger.claim():
-        return {
-            "unit_id": unit_id,
-            "run_ref": run_ref,
-            "owner": owner,
-            "status": SPAWN_CEILING_STATUS,
-            **_dispatch_status_ladder(),
-            "reason": (
-                f"run spawn ceiling of {spawn_ledger.ceiling} reached before this unit started; "
-                "re-dispatch the remaining units, or raise `run_spawn_ceiling` in the setup "
-                "profile's parallelism block"
-            ),
-        }
     child_env = fanout_child_env(
         os.environ if base_env is None else base_env,
         depth=dispatch_depth,

--- a/src/coding/fanout_journal.py
+++ b/src/coding/fanout_journal.py
@@ -145,6 +145,7 @@ _NEVER_SPAWNED_STATUSES = frozenset(
         "interrupted",
         "model_choice_required",
         "spawn_ceiling_reached",
+        "review_dispatch_budget_exhausted",
         # A cooldown veto refuses the spawn before the worktree exists, so the
         # unit left nothing behind and a later resume — by which time the
         # window may have reset or the credential been repaired — re-attempts

--- a/src/coding/fanout_review_budget.py
+++ b/src/coding/fanout_review_budget.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Final
+from typing import Any, Final, Mapping
 
 from ..system.local_store import locked_json_update
 from ..system.paths import OmhPaths
@@ -16,20 +16,18 @@ REVIEW_DISPATCH_BUDGET_CLAIM_BOUNDARY: Final = (
     "one explicit goal attempt. It is not review, verification, CI, merge-readiness, or merge evidence."
 )
 
-_REVIEW_ROLE_ALIASES: Final = frozenset(
-    {
-        "review",
-        "reviewer",
-        "code-review",
-        "code-reviewer",
-        "manual-qa",
-        "qa",
-        "final-gate",
-        "review-gate",
-        "hybrid-review",
-        "hybrid-verification",
-    }
-)
+_REVIEW_ROLE_ALIASES: Final[Mapping[str, str]] = {
+    "review": "code-review",
+    "reviewer": "code-review",
+    "code-review": "code-review",
+    "code-reviewer": "code-review",
+    "hybrid-review": "code-review",
+    "manual-qa": "manual-qa",
+    "qa": "manual-qa",
+    "final-gate": "final-gate",
+    "review-gate": "final-gate",
+    "hybrid-verification": "final-gate",
+}
 
 
 class ReviewDispatchBudgetError(ValueError):
@@ -149,7 +147,7 @@ class ReviewDispatchBudget:
 
 def normalized_review_role(role: str) -> str | None:
     normalized = "-".join(str(role or "").strip().casefold().replace("_", "-").split())
-    return "reviewer" if normalized in _REVIEW_ROLE_ALIASES else None
+    return _REVIEW_ROLE_ALIASES.get(normalized)
 
 
 def _validate_state(state: dict[str, Any], fanout_id: str) -> None:

--- a/src/coding/fanout_review_budget.py
+++ b/src/coding/fanout_review_budget.py
@@ -1,0 +1,163 @@
+"""Durable attempt-scoped reservations for fanout review lanes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final
+
+from ..system.local_store import locked_json_update
+from ..system.paths import OmhPaths
+from .fanout_artifacts import fanout_review_dispatch_budget_path
+
+REVIEW_DISPATCH_BUDGET_SCHEMA_VERSION: Final = "fanout_review_dispatch_budget/v1"
+REVIEW_DISPATCH_BUDGET_CLAIM_BOUNDARY: Final = (
+    "A reservation records that an eligible, ready review lane consumed one dispatch allowance for "
+    "one explicit goal attempt. It is not review, verification, CI, merge-readiness, or merge evidence."
+)
+
+_REVIEW_ROLE_ALIASES: Final = frozenset(
+    {
+        "review",
+        "reviewer",
+        "code-review",
+        "code-reviewer",
+        "manual-qa",
+        "qa",
+        "final-gate",
+        "review-gate",
+        "hybrid-review",
+        "hybrid-verification",
+    }
+)
+
+
+class ReviewDispatchBudgetError(ValueError):
+    """The review dispatch budget configuration or stored state is invalid."""
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewDispatchReservation:
+    status: str
+    attempt_id: str
+    role: str
+    limit: int
+    reserved: int
+
+    @property
+    def granted(self) -> bool:
+        return self.status == "reserved"
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": REVIEW_DISPATCH_BUDGET_SCHEMA_VERSION,
+            "status": self.status,
+            "attempt_id": self.attempt_id,
+            "role": self.role,
+            "limit": self.limit,
+            "reserved": self.reserved,
+            "claim_boundary": REVIEW_DISPATCH_BUDGET_CLAIM_BOUNDARY,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewDispatchBudget:
+    paths: OmhPaths
+    fanout_id: str
+    attempt_id: str
+    limit: int
+    progressed: bool = False
+
+    def __post_init__(self) -> None:
+        attempt_id = self.attempt_id.strip()
+        if not attempt_id or len(attempt_id) > 128 or any(char in attempt_id for char in "\r\n"):
+            raise ReviewDispatchBudgetError(
+                "goal_attempt_id must be a non-empty single-line value of at most 128 characters"
+            )
+        if isinstance(self.limit, bool) or self.limit < 1:
+            raise ReviewDispatchBudgetError("review_dispatch_budget must be at least 1")
+        object.__setattr__(self, "attempt_id", attempt_id)
+
+    @property
+    def path(self) -> Path:
+        return fanout_review_dispatch_budget_path(self.paths, self.fanout_id)
+
+    def reserve(self, role: str, unit_id: str) -> ReviewDispatchReservation:
+        normalized_role = normalized_review_role(role)
+        if normalized_role is None:
+            raise ReviewDispatchBudgetError(f"role is not review-budgeted: {role!r}")
+        outcome: ReviewDispatchReservation | None = None
+
+        def _reserve(state: dict[str, Any]) -> dict[str, Any]:
+            nonlocal outcome
+            _validate_state(state, self.fanout_id)
+            if not state:
+                state.update(
+                    {
+                        "schema_version": REVIEW_DISPATCH_BUDGET_SCHEMA_VERSION,
+                        "fanout_id": self.fanout_id,
+                        "current_attempt_id": self.attempt_id,
+                        "attempts": {},
+                        "claim_boundary": REVIEW_DISPATCH_BUDGET_CLAIM_BOUNDARY,
+                    }
+                )
+            current_attempt = str(state["current_attempt_id"])
+            if current_attempt != self.attempt_id and not self.progressed:
+                current = state["attempts"].get(current_attempt, {})
+                role_state = current.get("roles", {}).get(normalized_role, {})
+                outcome = ReviewDispatchReservation(
+                    "attempt_not_progressed",
+                    self.attempt_id,
+                    normalized_role,
+                    int(current.get("limit", self.limit)),
+                    int(role_state.get("reserved", 0)),
+                )
+                return state
+            if current_attempt != self.attempt_id:
+                state["current_attempt_id"] = self.attempt_id
+            attempts = state["attempts"]
+            attempt = attempts.setdefault(
+                self.attempt_id,
+                {"limit": self.limit, "progressed": bool(self.progressed), "roles": {}},
+            )
+            stored_limit = int(attempt.get("limit", self.limit))
+            roles = attempt.setdefault("roles", {})
+            role_state = roles.setdefault(normalized_role, {"reserved": 0, "unit_ids": []})
+            reserved = int(role_state.get("reserved", 0))
+            if stored_limit != self.limit:
+                outcome = ReviewDispatchReservation(
+                    "configuration_mismatch", self.attempt_id, normalized_role, stored_limit, reserved
+                )
+                return state
+            if reserved >= stored_limit:
+                outcome = ReviewDispatchReservation(
+                    "exhausted", self.attempt_id, normalized_role, stored_limit, reserved
+                )
+                return state
+            role_state["reserved"] = reserved + 1
+            role_state.setdefault("unit_ids", []).append(unit_id)
+            outcome = ReviewDispatchReservation(
+                "reserved", self.attempt_id, normalized_role, stored_limit, reserved + 1
+            )
+            return state
+
+        locked_json_update(self.path, _reserve, default={}, private=True)
+        if outcome is None:
+            raise ReviewDispatchBudgetError("review dispatch reservation produced no outcome")
+        return outcome
+
+
+def normalized_review_role(role: str) -> str | None:
+    normalized = "-".join(str(role or "").strip().casefold().replace("_", "-").split())
+    return "reviewer" if normalized in _REVIEW_ROLE_ALIASES else None
+
+
+def _validate_state(state: dict[str, Any], fanout_id: str) -> None:
+    if not state:
+        return
+    if state.get("schema_version") != REVIEW_DISPATCH_BUDGET_SCHEMA_VERSION:
+        raise ReviewDispatchBudgetError("stored review dispatch budget schema is unsupported")
+    if state.get("fanout_id") != fanout_id:
+        raise ReviewDispatchBudgetError("stored review dispatch budget fanout_id does not match")
+    if not isinstance(state.get("attempts"), dict):
+        raise ReviewDispatchBudgetError("stored review dispatch budget attempts must be an object")

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -2075,6 +2075,9 @@ def cmd_coding_fanout_dispatch(args: argparse.Namespace) -> int:
             dry_run=bool(args.dry_run),
             run_verification=bool(args.run_verification),
             resume_journal=resume_journal,
+            goal_attempt_id=args.goal_attempt_id,
+            goal_attempt_progressed=bool(args.goal_attempt_progressed),
+            review_dispatch_budget=args.review_dispatch_budget,
             **recovery_kwargs,
         )
         _print_json(summary)
@@ -2110,6 +2113,9 @@ def cmd_coding_fanout_dispatch(args: argparse.Namespace) -> int:
             dry_run=bool(args.dry_run),
             run_verification=bool(args.run_verification),
             resume_journal=resume_journal,
+            goal_attempt_id=args.goal_attempt_id,
+            goal_attempt_progressed=bool(args.goal_attempt_progressed),
+            review_dispatch_budget=args.review_dispatch_budget,
             **recovery_kwargs,
         )
     except ValueError as exc:
@@ -2594,6 +2600,22 @@ def _add_coding_commands(sub) -> None:
         "--run-verification",
         action="store_true",
         help="Run each unit's contract verification_commands in its worktree after its sidecar validates.",
+    )
+    fanout_dispatch.add_argument(
+        "--goal-attempt-id",
+        default="attempt-1",
+        help="Stable identity for the current goal attempt (default: attempt-1).",
+    )
+    fanout_dispatch.add_argument(
+        "--goal-attempt-progressed",
+        action="store_true",
+        help="Allow a new attempt id to reset review allowances after concrete progress.",
+    )
+    fanout_dispatch.add_argument(
+        "--review-dispatch-budget",
+        type=int,
+        default=1,
+        help="Maximum eligible dispatches per normalized reviewer role and goal attempt.",
     )
     fanout_dispatch.add_argument(
         "--resume-journal",

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -628,6 +628,277 @@ class FanoutDispatchEngineTests(unittest.TestCase):
         contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, _UNITS))
         return paths, repo, sha, contract
 
+    def test_review_dispatch_budget_is_attempt_scoped(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            by_unit = {entry["unit_id"]: entry for entry in contract["units"]}
+            by_unit["core"]["handoff"]["model_route"] = {
+                "status": "routed",
+                "role": "code-review",
+                "selected_model": "",
+                "selected_reasoning_effort": "",
+            }
+            by_unit["docs"]["handoff"]["model_route"] = {
+                "status": "routed",
+                "role": "manual-qa",
+                "selected_model": "",
+                "selected_reasoning_effort": "",
+            }
+
+            first = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                concurrency=1,
+                only_units=["core", "docs"],
+                runner=_agent_runner(),
+                readiness=_ready,
+                goal_attempt_id="attempt-1",
+                review_dispatch_budget=1,
+            )
+            second_runner = _agent_runner()
+            second = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                concurrency=1,
+                only_units=["core", "docs"],
+                runner=second_runner,
+                readiness=_ready,
+                goal_attempt_id="attempt-1",
+                review_dispatch_budget=1,
+            )
+
+            first_statuses = [entry["status"] for entry in first["units"]]
+            second_by_unit = {entry["unit_id"]: entry for entry in second["units"]}
+            self.assertEqual(first_statuses.count("completed"), 1)
+            self.assertEqual(first_statuses.count("review_dispatch_budget_exhausted"), 1)
+            self.assertEqual(second_by_unit["docs"]["status"], "review_dispatch_budget_exhausted")
+            self.assertEqual(second_by_unit["docs"]["reason_code"], "review_dispatch_no_progress")
+            self.assertEqual(second_runner.spawned, [])
+
+    def test_review_dispatch_budget_reservation_is_atomic(self) -> None:
+        import threading as _threading
+
+        goal = "atomically reserve one review dispatch"
+        units = [
+            {
+                "unit_id": unit_id,
+                "title": unit_id,
+                "owner": "codex",
+                "file_scope": [f"review/{unit_id}/"],
+                "role": role,
+            }
+            for unit_id, role in (("review-a", "review-gate"), ("review-b", "final-gate"))
+        ]
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            repo, sha = _make_repo(root)
+            contract = write_fanout_contract(paths, build_fanout_contract(goal, units))
+            ready_barrier = _threading.Barrier(2)
+            runner = _agent_runner()
+
+            def both_ready(paths_, profile, **kwargs):
+                ready_barrier.wait(timeout=2)
+                return {"status": "ready", "profile": profile}
+
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=goal,
+                repo_root=repo,
+                base_sha=sha,
+                concurrency=2,
+                runner=runner,
+                readiness=both_ready,
+                goal_attempt_id="attempt-atomic",
+                review_dispatch_budget=1,
+            )
+
+            statuses = [entry["status"] for entry in summary["units"]]
+            self.assertEqual(statuses.count("completed"), 1)
+            self.assertEqual(statuses.count("review_dispatch_budget_exhausted"), 1)
+            self.assertEqual(len(runner.spawned), 1)
+
+    def test_review_dispatch_budget_normalizes_review_role_aliases(self) -> None:
+        goal = "normalize review lane aliases"
+        aliases = ("review", "code-review", "manual-qa", "final-gate")
+        units = [
+            {
+                "unit_id": f"lane-{index}",
+                "title": alias,
+                "owner": "codex",
+                "file_scope": [f"review/{index}/"],
+                "role": alias,
+            }
+            for index, alias in enumerate(aliases)
+        ]
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            repo, sha = _make_repo(root)
+            contract = write_fanout_contract(paths, build_fanout_contract(goal, units))
+
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=goal,
+                repo_root=repo,
+                base_sha=sha,
+                concurrency=1,
+                runner=_agent_runner(),
+                readiness=_ready,
+                goal_attempt_id="attempt-aliases",
+                review_dispatch_budget=1,
+            )
+
+            statuses = [entry["status"] for entry in summary["units"]]
+            self.assertEqual(statuses.count("completed"), 1)
+            self.assertEqual(statuses.count("review_dispatch_budget_exhausted"), 3)
+
+    def test_review_dispatch_budget_charges_only_after_readiness(self) -> None:
+        goal = "charge only review lanes that pass readiness"
+        units = [
+            {
+                "unit_id": "denied-review",
+                "title": "Denied review",
+                "owner": "codex",
+                "file_scope": ["review/denied/"],
+                "role": "review",
+            },
+            {
+                "unit_id": "ready-review",
+                "title": "Ready review",
+                "owner": "claude-code",
+                "file_scope": ["review/ready/"],
+                "role": "review",
+            },
+        ]
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            repo, sha = _make_repo(root)
+            contract = write_fanout_contract(paths, build_fanout_contract(goal, units))
+
+            def owner_readiness(paths_, profile, **kwargs):
+                return {"status": "missing" if profile == "codex" else "ready", "profile": profile}
+
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=goal,
+                repo_root=repo,
+                base_sha=sha,
+                concurrency=1,
+                runner=_agent_runner(),
+                readiness=owner_readiness,
+                goal_attempt_id="attempt-readiness",
+                review_dispatch_budget=1,
+            )
+
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            self.assertEqual(by_unit["denied-review"]["status"], "executor_not_ready")
+            self.assertEqual(by_unit["ready-review"]["status"], "completed")
+
+    def test_review_dispatch_budget_does_not_charge_non_review_lanes(self) -> None:
+        goal = "leave implementation lanes outside review accounting"
+        units = [
+            {
+                "unit_id": f"build-{index}",
+                "title": f"Build {index}",
+                "owner": "codex",
+                "file_scope": [f"src/{index}/"],
+                "role": "implementation",
+            }
+            for index in range(2)
+        ]
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            repo, sha = _make_repo(root)
+            contract = write_fanout_contract(paths, build_fanout_contract(goal, units))
+            runner = _agent_runner()
+
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=goal,
+                repo_root=repo,
+                base_sha=sha,
+                concurrency=2,
+                runner=runner,
+                readiness=_ready,
+                goal_attempt_id="attempt-build",
+                review_dispatch_budget=1,
+            )
+
+            self.assertTrue(all(entry["status"] == "completed" for entry in summary["units"]))
+            self.assertEqual(len(runner.spawned), 2)
+
+    def test_review_dispatch_budget_resets_only_for_progressed_new_attempt(self) -> None:
+        goal = "reset review budget only after progress"
+        units = [
+            {
+                "unit_id": f"review-{index}",
+                "title": f"Review {index}",
+                "owner": "codex",
+                "file_scope": [f"review/{index}/"],
+                "role": "review",
+            }
+            for index in range(2)
+        ]
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            repo, sha = _make_repo(root)
+            contract = write_fanout_contract(paths, build_fanout_contract(goal, units))
+            common = {
+                "goal_text": goal,
+                "repo_root": repo,
+                "base_sha": sha,
+                "concurrency": 1,
+                "readiness": _ready,
+                "review_dispatch_budget": 1,
+            }
+            dispatch_fanout(
+                paths,
+                contract,
+                runner=_agent_runner(),
+                goal_attempt_id="attempt-1",
+                **common,
+            )
+
+            denied_runner = _agent_runner()
+            denied = dispatch_fanout(
+                paths,
+                contract,
+                runner=denied_runner,
+                goal_attempt_id="attempt-2",
+                **common,
+            )
+            progressed_runner = _agent_runner()
+            progressed = dispatch_fanout(
+                paths,
+                contract,
+                runner=progressed_runner,
+                goal_attempt_id="attempt-2",
+                goal_attempt_progressed=True,
+                **common,
+            )
+
+            denied_by_unit = {entry["unit_id"]: entry for entry in denied["units"]}
+            progressed_by_unit = {entry["unit_id"]: entry for entry in progressed["units"]}
+            self.assertEqual(denied_by_unit["review-1"]["status"], "review_dispatch_budget_exhausted")
+            self.assertEqual(denied_by_unit["review-1"]["reason_code"], "review_dispatch_attempt_not_progressed")
+            self.assertEqual(denied_runner.spawned, [])
+            self.assertEqual(progressed_by_unit["review-1"]["status"], "completed")
+            self.assertEqual(len(progressed_runner.spawned), 1)
+
     def test_summary_discloses_how_the_pool_width_was_chosen(self) -> None:
         # The command layer resolves the parallelism policy and hands the
         # resolution in; the dispatch record must answer "why did only N run

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -640,7 +640,7 @@ class FanoutDispatchEngineTests(unittest.TestCase):
             }
             by_unit["docs"]["handoff"]["model_route"] = {
                 "status": "routed",
-                "role": "manual-qa",
+                "role": "code-reviewer",
                 "selected_model": "",
                 "selected_reasoning_effort": "",
             }
@@ -693,7 +693,7 @@ class FanoutDispatchEngineTests(unittest.TestCase):
                 "file_scope": [f"review/{unit_id}/"],
                 "role": role,
             }
-            for unit_id, role in (("review-a", "review-gate"), ("review-b", "final-gate"))
+            for unit_id, role in (("review-a", "code-review"), ("review-b", "code-reviewer"))
         ]
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -725,24 +725,41 @@ class FanoutDispatchEngineTests(unittest.TestCase):
             self.assertEqual(statuses.count("review_dispatch_budget_exhausted"), 1)
             self.assertEqual(len(runner.spawned), 1)
 
-    def test_review_dispatch_budget_normalizes_review_role_aliases(self) -> None:
-        goal = "normalize review lane aliases"
-        aliases = ("review", "code-review", "manual-qa", "final-gate")
+    def test_review_dispatch_budget_is_independent_per_normalized_role(self) -> None:
+        goal = "budget distinct review roles independently"
+        role_aliases = (
+            ("code-review", "CODE_REVIEWER"),
+            ("manual-qa", "MANUAL_QA"),
+            ("final-gate", "FINAL_GATE"),
+        )
         units = [
             {
-                "unit_id": f"lane-{index}",
+                "unit_id": f"lane-{role_index}-{alias_index}",
                 "title": alias,
                 "owner": "codex",
-                "file_scope": [f"review/{index}/"],
+                "file_scope": [f"review/{role_index}/{alias_index}/"],
                 "role": alias,
             }
-            for index, alias in enumerate(aliases)
+            for role_index, aliases in enumerate(role_aliases)
+            for alias_index, alias in enumerate(aliases)
         ]
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
             paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
             repo, sha = _make_repo(root)
-            contract = write_fanout_contract(paths, build_fanout_contract(goal, units))
+            contract = write_fanout_contract(
+                paths,
+                build_fanout_contract(
+                    goal,
+                    units,
+                    spawn_plan={
+                        "why_parallel": "Three independent review roles inspect disjoint evidence.",
+                        "why_not_single_unit": "One reviewer role cannot substitute for the other gates.",
+                        "independence": "Each role reads a separate review scope.",
+                        "expected_evidence_shape": "One result for each role and spelling alias.",
+                    },
+                ),
+            )
 
             summary = dispatch_fanout(
                 paths,
@@ -758,8 +775,59 @@ class FanoutDispatchEngineTests(unittest.TestCase):
             )
 
             statuses = [entry["status"] for entry in summary["units"]]
-            self.assertEqual(statuses.count("completed"), 1)
+            self.assertEqual(statuses.count("completed"), 3)
             self.assertEqual(statuses.count("review_dispatch_budget_exhausted"), 3)
+            exhausted_roles = {
+                entry["review_dispatch_budget"]["role"]
+                for entry in summary["units"]
+                if entry["status"] == "review_dispatch_budget_exhausted"
+            }
+            self.assertEqual(exhausted_roles, {"code-review", "manual-qa", "final-gate"})
+
+    def test_spawn_ceiling_denial_does_not_consume_durable_review_allowance(self) -> None:
+        goal = "preserve review allowance after spawn ceiling denial"
+        units = [
+            {
+                "unit_id": unit_id,
+                "title": unit_id,
+                "owner": "codex",
+                "file_scope": [f"review/{unit_id}/"],
+                "role": "code-review",
+            }
+            for unit_id in ("review-a", "review-b")
+        ]
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            repo, sha = _make_repo(root)
+            contract = write_fanout_contract(paths, build_fanout_contract(goal, units))
+            common = {
+                "goal_text": goal,
+                "repo_root": repo,
+                "base_sha": sha,
+                "concurrency": 1,
+                "readiness": _ready,
+                "goal_attempt_id": "attempt-ceiling",
+                "review_dispatch_budget": 2,
+                "spawn_ceiling": 1,
+            }
+
+            first = dispatch_fanout(paths, contract, runner=_agent_runner(), **common)
+            second_runner = _agent_runner()
+            second = dispatch_fanout(
+                paths,
+                contract,
+                only_units=["review-b"],
+                runner=second_runner,
+                **common,
+            )
+
+            first_by_unit = {entry["unit_id"]: entry for entry in first["units"]}
+            second_by_unit = {entry["unit_id"]: entry for entry in second["units"]}
+            self.assertEqual(first_by_unit["review-a"]["status"], "completed")
+            self.assertEqual(first_by_unit["review-b"]["status"], "spawn_ceiling_reached")
+            self.assertEqual(second_by_unit["review-b"]["status"], "completed")
+            self.assertEqual(len(second_runner.spawned), 1)
 
     def test_review_dispatch_budget_charges_only_after_readiness(self) -> None:
         goal = "charge only review lanes that pass readiness"


### PR DESCRIPTION
## Feature Report

### What Changed

- Added durable `fanout_review_dispatch_budget/v1` accounting keyed by fanout goal, explicit goal-attempt identity, and a semantic normalized reviewer role.
- Preserved separate per-attempt buckets for `code-review`, `manual-qa`, and `final-gate`; case, underscore, and legacy spelling aliases normalize only within their canonical bucket.
- Corrected admission ordering so a spawn-ceiling refusal never writes a durable review reservation, while a review-budget refusal returns its transient per-run spawn claim.
- Added `--goal-attempt-id`, `--goal-attempt-progressed`, and `--review-dispatch-budget` to the operator-invoked fanout dispatch surface.

### Why This Exists

Repeated fanout invocations could launch equivalent review lanes for an unchanged goal attempt without durable accounting. The first implementation introduced two acceptance defects: all review types shared one bucket, and a unit refused by the per-run spawn ceiling still consumed durable review allowance.

Closes #1252

### User / Operator Impact

Operators can cap eligible dispatches independently for each normalized review role and goal attempt. Capability, model-choice, cooldown, readiness, spawn-ceiling, and review-budget denials do not consume durable review allowance. A fresh allowance remains available only when a different attempt id is paired with explicit progressed state.

### How It Works

- Contract preparation retains a canonical `handoff.review_role` while keeping the established broad model-routing role unchanged.
- The dispatcher runs capability, model-choice, cooldown, executor-readiness, and dry-run gates first.
- Immediately before worktree creation, it claims the reversible per-run spawn slot. Ceiling refusal returns before durable accounting.
- A sidecar-locked JSON update atomically reserves the canonical review-role allowance. If that reservation refuses, the transient spawn claim is released.
- Durable attempt/reset behavior, atomic file reservation, retry handling, and resume-journal projections remain unchanged.

### Files And Contracts Touched

- `src/coding/fanout_review_budget.py`: semantic canonical role buckets and spelling aliases.
- `src/coding/fanout_dispatch.py`: coordinated spawn/review admission and canonical role consumption.
- `src/coding/fanout.py`: canonical review-role preservation in the handoff.
- `tests/test_fanout_dispatch.py`: exact two-run spawn-ceiling and per-role/alias regressions.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [x] Codex
- [x] Claude Code
- [ ] Hermes runtime or handoff
- [x] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli coding fanout dispatch --help`
- [x] Manual integration check: isolated real CLI two-run QA through local readiness, worktree, and subprocess boundaries.

### Observed Evidence

Clean RED was run with production files restored; `git status --short` showed only `M tests/test_fanout_dispatch.py`.

```text
PYTHONPATH=tests uv run python -m unittest tests.test_fanout_dispatch.FanoutDispatchEngineTests.test_spawn_ceiling_denial_does_not_consume_durable_review_allowance tests.test_fanout_dispatch.FanoutDispatchEngineTests.test_review_dispatch_budget_is_independent_per_normalized_role -v

AssertionError: 'review_dispatch_budget_exhausted' != 'completed'
AssertionError: 1 != 3
Ran 2 tests in 0.204s
FAILED (failures=2)
```

After GREEN:

- Seven focused budget tests passed.
- Dispatch/journal/retry suite: 194 tests passed.
- Full branch discovery: 8,608 tests passed.
- Real two-run CLI QA: first run `review-a=completed`, `review-b=spawn_ceiling_reached`; second run `review-b=completed`; durable code-review reservations `2`; one spawn claimed per run; overall `PASS`.
- Detached merge with current `origin/main@42bf052c`: 194 focused and 8,614 full tests passed, plus compileall, repository-wide Ruff, and diff check.
- Generated docs checks, CLI help, and LSP diagnostics on all changed files passed.

Delivery identity:

- Original commit: `1a684229116279ee6767f5109710dc5cbb82094f` (not amended).
- Signed follow-up: `0614bccba0abc15ec16279e8179ff3ed7bca7a1c`.
- Follow-up tree: `58c052406a033dbbe5d9e0cd9902979d37c39826`.
- Signature locally verified as a good SSH ED25519 Git signature for `piyrw9754@gmail.com`.
- Current-main validation merge tree: `cf0304ae564d1dbe1a54c3082cb310aa989900ae`.

### Not Tested / Not Applicable

- No external Codex, Claude Code, Hermes, provider, or network call was made. Real CLI QA used an isolated harmless local executable.
- Harness/release/install smokes are not applicable because this change affects only explicit fanout dispatch accounting and its existing CLI controls.
- No Hermes/TUI surface changed.

## Risk

Narrow to moderate. Admission ordering is on the shared live dispatch path, but changes are isolated to the existing spawn ledger and review-role budget seam. Same-role durable reservation remains file-locked and atomic; retry and resume behavior is unchanged and covered by the focused domain suite.

## Compatibility / Rollout

Existing contracts without `handoff.review_role` continue to use their frozen model-route role and normalize to the legacy code-review bucket. New contracts preserve semantic review roles. Non-review contracts and dry runs remain unchanged.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any live-provider gap

## Follow-Up

- None required for issue #1252.
