### PR TITLE
feat(memory): bind project-memory review decisions to the candidate revision they read

### DIFF
--- a/src/commands/memory.py
+++ b/src/commands/memory.py
@@ -29,6 +29,8 @@ from ..plugin_bundle.omh.metadata import MEMORY_PROVIDER_NAME
 from ..memory import (
     LifecycleCandidateError,
     RejectedDecisionRecallRequest,
+    StaleMemoryReviewError,
+    candidate_is_review_card_backed,
     apply_approved_memory_update_batch,
     apply_memory_attention_change,
     apply_memory_retirement,
@@ -132,15 +134,63 @@ def cmd_memory_review(args: argparse.Namespace) -> int:
     return 0
 
 
+def _review_revision_refusal(candidate_id: str, reason_code: str, detail: str) -> dict[str, object]:
+    """One refused review decision, shaped like every other memory control result."""
+    return {
+        "schema_version": "project_memory_review_refusal/v1",
+        "applied": False,
+        "candidate_id": candidate_id,
+        "reason_code": reason_code,
+        "detail": detail,
+        "next_action": (
+            "Re-read the card with `omh memory review --candidate "
+            f"{candidate_id}` and pass its review_revision with --candidate-revision."
+        ),
+        "claim_boundary": (
+            "A refused project-memory review changed no OMH-local candidate, record, or review decision, "
+            "and never touched Hermes global or internal memory."
+        ),
+    }
+
+
+def _missing_review_revision(paths, args: argparse.Namespace) -> dict[str, object] | None:
+    """Refuse an unproven decision on a candidate the review queue renders a card for.
+
+    Scoped to card-backed candidates on purpose. A v2 correction/restore
+    candidate never gets a card, so requiring a revision there would demand a
+    value no surface produces and break the one approve verb the operator has;
+    those keep their existing lifecycle guard. An unreadable or missing
+    candidate falls through to the workflow call, which owns that error.
+    """
+    if str(getattr(args, "candidate_revision", "") or ""):
+        return None
+    candidate, error = read_json_object_result(paths.memory_dir / "candidates" / f"{args.candidate_id}.json")
+    if candidate is None or error is not None or not candidate_is_review_card_backed(candidate):
+        return None
+    return _review_revision_refusal(
+        str(args.candidate_id),
+        "review_revision_required",
+        "An interactive review decision must name the review revision of the card it read.",
+    )
+
+
 def cmd_memory_approve(args: argparse.Namespace) -> int:
     paths = _paths(args)
+    refusal = _missing_review_revision(paths, args)
+    if refusal is not None:
+        _print_json(refusal)
+        return 1
     try:
         payload = approve_project_memory_candidate(
             paths,
             args.candidate_id,
             approved_by=args.approved_by,
             retention_class=args.retention_class,
+            expected_revision=args.candidate_revision,
         )
+    except StaleMemoryReviewError as exc:
+        _print_json(_review_revision_refusal(str(args.candidate_id), "stale_review", str(exc)))
+        return 1
     except LifecycleCandidateError:
         if args.retention_class is not None:
             raise OmhError(
@@ -168,13 +218,22 @@ def cmd_memory_approve(args: argparse.Namespace) -> int:
 
 
 def cmd_memory_reject(args: argparse.Namespace) -> int:
+    paths = _paths(args)
+    refusal = _missing_review_revision(paths, args)
+    if refusal is not None:
+        _print_json(refusal)
+        return 1
     try:
         payload = reject_project_memory_candidate(
-            _paths(args),
+            paths,
             args.candidate_id,
             rejected_by=args.rejected_by,
             reason=args.reason,
+            expected_revision=args.candidate_revision,
         )
+    except StaleMemoryReviewError as exc:
+        _print_json(_review_revision_refusal(str(args.candidate_id), "stale_review", str(exc)))
+        return 1
     except FileNotFoundError as exc:
         raise OmhError(f"memory candidate not found: {args.candidate_id}") from exc
     except (OSError, ValueError) as exc:

--- a/src/commands/memory_parser.py
+++ b/src/commands/memory_parser.py
@@ -9,6 +9,25 @@ from . import memory
 from .domain_intelligence_parser import add_domain_intelligence_commands
 
 
+def _add_candidate_revision_argument(parser: argparse.ArgumentParser, verb: str) -> None:
+    """Bind one review verb to the card revision its reviewer rendered.
+
+    Spelled and defaulted identically on both verbs so a wrapper submits the
+    same field either way. The default stays empty rather than absent: an
+    empty value means "no card was proven", which the command refuses, and a
+    caller that never rendered a card gets that refusal instead of a silent
+    decision on a payload it never read.
+    """
+    parser.add_argument(
+        "--candidate-revision",
+        default="",
+        help=(
+            f"Candidate revision from the `memory review` card being acted on; "
+            f"{verb} refuses when the stored candidate no longer matches it."
+        ),
+    )
+
+
 def add_memory_commands(sub: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     command = sub.add_parser("memory", help="Agent/operator-only OMH memory review, migration, lifecycle, and prepared-context controls.")
     memory_sub = command.add_subparsers(dest="memory_command", required=True)
@@ -65,6 +84,7 @@ def add_memory_commands(sub: argparse._SubParsersAction[argparse.ArgumentParser]
     approve = memory_sub.add_parser("approve", help="Approve a reviewed project-memory candidate.")
     approve.add_argument("candidate_id")
     approve.add_argument("--approved-by", default="operator")
+    _add_candidate_revision_argument(approve, "approve")
     approve.add_argument(
         "--retention-class",
         choices=("volatile", "standard", "durable"),
@@ -80,6 +100,7 @@ def add_memory_commands(sub: argparse._SubParsersAction[argparse.ArgumentParser]
     reject.add_argument("candidate_id")
     reject.add_argument("--rejected-by", default="operator")
     reject.add_argument("--reason", default="")
+    _add_candidate_revision_argument(reject, "reject")
     reject.set_defaults(func=memory.cmd_memory_reject)
 
     recall = memory_sub.add_parser("recall", help="Recall reviewed OMH project memory for a task as prepared context.")

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -929,23 +929,27 @@ def project_memory_review_revision(candidate: dict[str, Any]) -> str:
     repo-wide for the integer record revision on v2 lifecycle candidates and
     batch items. This is a content fingerprint of one rendered card, not a
     revision counter, and the two must not be read as the same field.
+
+    The projection is derived FROM the rendered card rather than re-listed
+    here. A hand-maintained field list is the bug this shape removes: it
+    already drifted once -- `time_sensitivity` (the warning that tells a
+    reviewer a fact has a hidden expiry, and what to do about it) was
+    displayed on every card while the fingerprint ignored it, so rewriting
+    that guidance under a candidate id left the revision frozen and a stale
+    card still passed the guard. Building from the card makes "displayed"
+    and "bound" the same set by construction, so a field added to the card
+    tomorrow is covered without anyone remembering this function.
     """
-    safety = candidate.get("safety", {}) if isinstance(candidate.get("safety"), dict) else {}
+    card = _project_memory_review_card_projection(candidate)
     content_ref = candidate.get("content_ref", {}) if isinstance(candidate.get("content_ref"), dict) else {}
     projection = {
-        "candidate_id": str(candidate.get("candidate_id", "")),
+        "card": card,
+        # Not displayed, but part of what approval will store, and the digest
+        # already stands in for raw content the card never shows.
         "schema_version": str(candidate.get("schema_version", "")),
         "status": str(candidate.get("status", "")),
-        "record_type": str(candidate.get("record_type", "")),
-        "summary": str(candidate.get("summary", "")),
-        "scope": _normalize_scope(candidate.get("scope", _scope("project", "default"))),
-        "tags": _string_list(candidate.get("tags", [])),
-        "created_at": str(candidate.get("created_at", "")),
         "source_ref": str(candidate.get("source_ref", "")),
         "retention_class": str(candidate.get("retention_class", "")),
-        "duplicate_of": str(candidate.get("duplicate_of", "")),
-        "safety_status": str(safety.get("status", "")),
-        "safety_review_reasons": _string_list(safety.get("review_reasons", [])),
         "content_sha256": str(content_ref.get("sha256", "")),
         "content_length": int(content_ref.get("length", 0) or 0),
     }
@@ -953,14 +957,18 @@ def project_memory_review_revision(candidate: dict[str, Any]) -> str:
     return "rev_" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:32]
 
 
-def build_project_memory_review_card(candidate: dict[str, Any]) -> dict[str, object]:
+def _project_memory_review_card_projection(candidate: dict[str, Any]) -> dict[str, object]:
+    """The candidate-derived half of a review card: everything a reviewer reads.
+
+    Static scaffolding -- schema version, the action list, the redaction and
+    claim-boundary labels, and `recommended_action`, which is a pure function
+    of the safety status already here -- is excluded on purpose: those cannot
+    differ between two cards for the same candidate, so binding them would
+    add noise to the fingerprint without adding any guarantee.
+    """
     safety = candidate.get("safety", {}) if isinstance(candidate.get("safety"), dict) else {}
-    safety_status = str(safety.get("status", "needs_review"))
-    recommended_action = "reject" if safety_status == "blocked" else "approve_or_reject"
     return {
-        "schema_version": PROJECT_MEMORY_REVIEW_CARD_SCHEMA_VERSION,
         "candidate_id": str(candidate.get("candidate_id", "")),
-        "review_revision": project_memory_review_revision(candidate),
         "record_type": str(candidate.get("record_type", "")),
         "summary": str(candidate.get("summary", "")),
         "scope": _normalize_scope(candidate.get("scope", _scope("project", "default"))),
@@ -973,6 +981,20 @@ def build_project_memory_review_card(candidate: dict[str, Any]) -> dict[str, obj
             else {}
         ),
         "safety": safety,
+    }
+
+
+def build_project_memory_review_card(candidate: dict[str, Any]) -> dict[str, object]:
+    # The displayed fields come from the same projection the revision hashes,
+    # so a card cannot show a candidate-derived value the fingerprint missed.
+    displayed = _project_memory_review_card_projection(candidate)
+    safety = displayed["safety"] if isinstance(displayed["safety"], dict) else {}
+    safety_status = str(safety.get("status", "needs_review"))
+    recommended_action = "reject" if safety_status == "blocked" else "approve_or_reject"
+    return {
+        "schema_version": PROJECT_MEMORY_REVIEW_CARD_SCHEMA_VERSION,
+        "review_revision": project_memory_review_revision(candidate),
+        **displayed,
         "recommended_action": recommended_action,
         "actions": [
             {"id": "approve_memory", "enabled": safety_status != "blocked"},
@@ -1036,41 +1058,47 @@ def approve_project_memory_candidate(
     retention_class: str | None = None,
     expected_revision: str = "",
 ) -> dict[str, object]:
-    candidate = _read_project_memory_candidate(paths, candidate_id)
-    if not candidate:
-        raise FileNotFoundError(candidate_id)
-    if expected_revision:
-        _require_review_revision(candidate, expected_revision)
-    # Fail closed on correction/restore candidates: their payload lives under
-    # "replacement", so the plain path would mint a record with an empty
-    # summary and revision 1 -- and that garbage record then blocks the real
-    # reapproval with newer_live_revision_conflict. The CLI catches this and
-    # routes to the lifecycle reapproval executor instead.
-    if str(candidate.get("schema_version", "")) == "project_memory_candidate/v2" or str(candidate.get("lifecycle", "") or ""):
-        raise LifecycleCandidateError(
-            f"candidate {candidate_id} is a lifecycle ({candidate.get('lifecycle', 'v2')}) candidate; "
-            "it must be reapproved through the lifecycle path, not plain approval"
-        )
-    safety = candidate.get("safety", {}) if isinstance(candidate.get("safety"), dict) else {}
-    if safety.get("status") == "blocked":
-        raise ValueError("blocked memory candidates must be rejected or recaptured without protected raw content")
-    approved_at = utc_now()
-    review_id = f"review_{candidate_id}"
-    admission_state = "approved_auto_safe" if approved_by == "auto-safe" else "approved_manual"
-    record = _record_from_candidate(
-        candidate,
-        approved_by=approved_by,
-        approved_at=approved_at,
-        review_id=review_id,
-        admission_state=admission_state,
-        retention_class=retention_class,
-        default_stale_after_days=_cadence_value(read_project_memory_policy(paths), "stale_after_days_default"),
-    )
-    review = _project_memory_review_record(record, review_id=review_id, reviewer=approved_by, decision=admission_state)
-    # The whole mutate sequence holds the store lock so a concurrent retirement
-    # cannot observe a half-written approval. Candidate writes go through the
-    # unlocked helper: the public wrapper acquires this same non-reentrant lock.
+    # Read, validate, and write under ONE hold of the store lock. Reading the
+    # candidate outside the lock made the guard advisory: a recapture landing
+    # between the revision check and the record write would be approved on the
+    # reviewer's behalf, with the stale check having already passed. The
+    # guarantee is "no write on a stale card", and only a read-check-write that
+    # cannot be interleaved can offer it. Everything derived from the candidate
+    # is derived in here too, so nothing is computed from a payload the write
+    # will not match. Candidate writes go through the unlocked helper: the
+    # public wrapper acquires this same non-reentrant lock.
     with file_lock(paths.memory_index_path, private=True):
+        candidate = _read_project_memory_candidate(paths, candidate_id)
+        if not candidate:
+            raise FileNotFoundError(candidate_id)
+        if expected_revision:
+            _require_review_revision(candidate, expected_revision)
+        # Fail closed on correction/restore candidates: their payload lives under
+        # "replacement", so the plain path would mint a record with an empty
+        # summary and revision 1 -- and that garbage record then blocks the real
+        # reapproval with newer_live_revision_conflict. The CLI catches this and
+        # routes to the lifecycle reapproval executor instead.
+        if str(candidate.get("schema_version", "")) == "project_memory_candidate/v2" or str(candidate.get("lifecycle", "") or ""):
+            raise LifecycleCandidateError(
+                f"candidate {candidate_id} is a lifecycle ({candidate.get('lifecycle', 'v2')}) candidate; "
+                "it must be reapproved through the lifecycle path, not plain approval"
+            )
+        safety = candidate.get("safety", {}) if isinstance(candidate.get("safety"), dict) else {}
+        if safety.get("status") == "blocked":
+            raise ValueError("blocked memory candidates must be rejected or recaptured without protected raw content")
+        approved_at = utc_now()
+        review_id = f"review_{candidate_id}"
+        admission_state = "approved_auto_safe" if approved_by == "auto-safe" else "approved_manual"
+        record = _record_from_candidate(
+            candidate,
+            approved_by=approved_by,
+            approved_at=approved_at,
+            review_id=review_id,
+            admission_state=admission_state,
+            retention_class=retention_class,
+            default_stale_after_days=_cadence_value(read_project_memory_policy(paths), "stale_after_days_default"),
+        )
+        review = _project_memory_review_record(record, review_id=review_id, reviewer=approved_by, decision=admission_state)
         _write_project_memory_record(paths, record)
         candidate = {
             **candidate,
@@ -1101,14 +1129,16 @@ def reject_project_memory_candidate(
     reason: str = "",
     expected_revision: str = "",
 ) -> dict[str, object]:
-    candidate = _read_project_memory_candidate(paths, candidate_id)
-    if not candidate:
-        raise FileNotFoundError(candidate_id)
-    if expected_revision:
-        _require_review_revision(candidate, expected_revision)
-    now = utc_now()
-    candidate = {**candidate, "status": "rejected", "reviewed_at": now, "reviewed_by": rejected_by, "rejection_reason": _redact(str(reason or ""))[:300]}
+    # Same single-hold read-check-write as approval: a rejection that races a
+    # recapture must refuse rather than reject text the reviewer never read.
     with file_lock(paths.memory_index_path, private=True):
+        candidate = _read_project_memory_candidate(paths, candidate_id)
+        if not candidate:
+            raise FileNotFoundError(candidate_id)
+        if expected_revision:
+            _require_review_revision(candidate, expected_revision)
+        now = utc_now()
+        candidate = {**candidate, "status": "rejected", "reviewed_at": now, "reviewed_by": rejected_by, "rejection_reason": _redact(str(reason or ""))[:300]}
         _write_project_memory_candidate_unlocked(paths, candidate)
         review = _write_project_memory_review_decision(
             paths,

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import re
 import unicodedata
@@ -863,7 +864,15 @@ def capture_project_memory_candidate(
     # review path even under auto-safe: derived content is a curation act,
     # not a captured observation.
     if bool(policy.get("auto_approve_safe")) and candidate.get("safety", {}).get("status") == "safe" and not duplicate_of and not force_review and not relative_phrase:
-        approved = approve_project_memory_candidate(paths, str(candidate["candidate_id"]), approved_by="auto-safe")
+        # Auto-safe binds to the candidate it just wrote: the revision comes
+        # from that object, so this path proves the same payload it approved
+        # rather than skipping the guard it asks reviewers to carry.
+        approved = approve_project_memory_candidate(
+            paths,
+            str(candidate["candidate_id"]),
+            approved_by="auto-safe",
+            expected_revision=project_memory_review_revision(candidate),
+        )
         record = approved.get("record", {}) if isinstance(approved.get("record"), dict) else {}
         candidate = approved.get("candidate", candidate) if isinstance(approved.get("candidate"), dict) else candidate
         auto_approved = True
@@ -904,6 +913,46 @@ def build_project_memory_review(
     }
 
 
+def project_memory_review_revision(candidate: dict[str, Any]) -> str:
+    """Fingerprint the candidate payload a review card displays.
+
+    A candidate id is a stable file name, not a version: a recapture, an
+    overwrite, or a supersession leaves the id resolvable while the payload
+    underneath it changed, so a card held open across that change could
+    approve text its reviewer never read. The revision is derived from the
+    displayed projection only -- summary, scope, tags, type, safety verdict,
+    status, creation time, and the content digest that already stands in for
+    the raw content -- so it moves exactly when what the reviewer saw moves,
+    and it stays metadata-only: no raw content ever reaches the digest.
+
+    Deliberately NOT named candidate_revision: that name is already taken
+    repo-wide for the integer record revision on v2 lifecycle candidates and
+    batch items. This is a content fingerprint of one rendered card, not a
+    revision counter, and the two must not be read as the same field.
+    """
+    safety = candidate.get("safety", {}) if isinstance(candidate.get("safety"), dict) else {}
+    content_ref = candidate.get("content_ref", {}) if isinstance(candidate.get("content_ref"), dict) else {}
+    projection = {
+        "candidate_id": str(candidate.get("candidate_id", "")),
+        "schema_version": str(candidate.get("schema_version", "")),
+        "status": str(candidate.get("status", "")),
+        "record_type": str(candidate.get("record_type", "")),
+        "summary": str(candidate.get("summary", "")),
+        "scope": _normalize_scope(candidate.get("scope", _scope("project", "default"))),
+        "tags": _string_list(candidate.get("tags", [])),
+        "created_at": str(candidate.get("created_at", "")),
+        "source_ref": str(candidate.get("source_ref", "")),
+        "retention_class": str(candidate.get("retention_class", "")),
+        "duplicate_of": str(candidate.get("duplicate_of", "")),
+        "safety_status": str(safety.get("status", "")),
+        "safety_review_reasons": _string_list(safety.get("review_reasons", [])),
+        "content_sha256": str(content_ref.get("sha256", "")),
+        "content_length": int(content_ref.get("length", 0) or 0),
+    }
+    canonical = json.dumps(projection, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return "rev_" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:32]
+
+
 def build_project_memory_review_card(candidate: dict[str, Any]) -> dict[str, object]:
     safety = candidate.get("safety", {}) if isinstance(candidate.get("safety"), dict) else {}
     safety_status = str(safety.get("status", "needs_review"))
@@ -911,6 +960,7 @@ def build_project_memory_review_card(candidate: dict[str, Any]) -> dict[str, obj
     return {
         "schema_version": PROJECT_MEMORY_REVIEW_CARD_SCHEMA_VERSION,
         "candidate_id": str(candidate.get("candidate_id", "")),
+        "review_revision": project_memory_review_revision(candidate),
         "record_type": str(candidate.get("record_type", "")),
         "summary": str(candidate.get("summary", "")),
         "scope": _normalize_scope(candidate.get("scope", _scope("project", "default"))),
@@ -941,16 +991,56 @@ class LifecycleCandidateError(ValueError):
     """A v2 lifecycle candidate reached the plain approval path."""
 
 
+class StaleMemoryReviewError(ValueError):
+    """A review decision named a candidate revision the store no longer holds."""
+
+
+def candidate_is_review_card_backed(candidate: dict[str, Any]) -> bool:
+    """True when `memory review` renders a card for this candidate.
+
+    Only card-backed candidates can carry a review revision, because the
+    revision IS the card's fingerprint. v2 lifecycle candidates (correction,
+    restore) are staged by the lifecycle path and approved by id without a
+    card ever being rendered, so demanding a revision for them would ask for
+    a value no surface produces.
+    """
+    return (
+        str(candidate.get("schema_version", "")) == PROJECT_MEMORY_CANDIDATE_SCHEMA_VERSION
+        and not str(candidate.get("lifecycle", "") or "")
+    )
+
+
+def _require_review_revision(candidate: dict[str, Any], expected_revision: str) -> None:
+    """Refuse a decision whose card no longer describes the stored candidate.
+
+    Called before any write, and only when the caller supplied a revision:
+    an omitted revision keeps the in-process API working for callers that
+    never rendered a card (auto-safe capture, lifecycle paths, wrappers that
+    predate the field). The CLI is where the revision is required, so an
+    interactive reviewer cannot approve unproven text.
+    """
+    actual = project_memory_review_revision(candidate)
+    if expected_revision != actual:
+        raise StaleMemoryReviewError(
+            f"stale_review: candidate {candidate.get('candidate_id', '')} is now revision {actual}, "
+            f"not the reviewed revision {expected_revision}; re-read the card with "
+            "`omh memory review --candidate <id>` and decide again on what it shows now"
+        )
+
+
 def approve_project_memory_candidate(
     paths: OmhPaths,
     candidate_id: str,
     *,
     approved_by: str = "operator",
     retention_class: str | None = None,
+    expected_revision: str = "",
 ) -> dict[str, object]:
     candidate = _read_project_memory_candidate(paths, candidate_id)
     if not candidate:
         raise FileNotFoundError(candidate_id)
+    if expected_revision:
+        _require_review_revision(candidate, expected_revision)
     # Fail closed on correction/restore candidates: their payload lives under
     # "replacement", so the plain path would mint a record with an empty
     # summary and revision 1 -- and that garbage record then blocks the real
@@ -1009,10 +1099,13 @@ def reject_project_memory_candidate(
     *,
     rejected_by: str = "operator",
     reason: str = "",
+    expected_revision: str = "",
 ) -> dict[str, object]:
     candidate = _read_project_memory_candidate(paths, candidate_id)
     if not candidate:
         raise FileNotFoundError(candidate_id)
+    if expected_revision:
+        _require_review_revision(candidate, expected_revision)
     now = utc_now()
     candidate = {**candidate, "status": "rejected", "reviewed_at": now, "reviewed_by": rejected_by, "rejection_reason": _redact(str(reason or ""))[:300]}
     with file_lock(paths.memory_index_path, private=True):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5227,7 +5227,21 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             self.assertEqual(review["cards"][0]["candidate_id"], candidate_id)
             self.assertIn("not execution", review["claim_boundary"])
 
-            status, stdout, stderr = run_cli(base + ["memory", "approve", candidate_id, "--approved-by", "user"])
+            # The interactive review verbs carry the revision of the card they
+            # acted on, so an approval cannot land on a payload the reviewer
+            # never saw.
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "memory",
+                    "approve",
+                    candidate_id,
+                    "--approved-by",
+                    "user",
+                    "--candidate-revision",
+                    review["cards"][0]["review_revision"],
+                ]
+            )
             self.assertEqual(stderr, "")
             self.assertEqual(status, 0)
             approved = json.loads(stdout)
@@ -5252,7 +5266,22 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             self.assertEqual(blocked["candidate"]["status"], "blocked_review_required")
             self.assertNotIn("token-secret", stdout)
 
-            status, stdout, stderr = run_cli(base + ["memory", "reject", blocked_id, "--reason", "unsafe raw content"])
+            status, stdout, stderr = run_cli(base + ["memory", "review", "--candidate", blocked_id])
+            self.assertEqual(status, 0)
+            blocked_revision = json.loads(stdout)["cards"][0]["review_revision"]
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "memory",
+                    "reject",
+                    blocked_id,
+                    "--reason",
+                    "unsafe raw content",
+                    "--candidate-revision",
+                    blocked_revision,
+                ]
+            )
             self.assertEqual(stderr, "")
             self.assertEqual(status, 0)
             rejected = json.loads(stdout)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import json
 import os
 import threading
+from contextlib import contextmanager
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
 import unittest
+from unittest.mock import patch
 
 from _local_package import load_local_package
 from _platform_support import requires_posix, requires_posix_permissions
@@ -1125,6 +1127,154 @@ class ProjectMemoryRevisionReviewTests(unittest.TestCase):
             self.assertTrue(captured["auto_approved"])
             self.assertEqual(captured["candidate"]["status"], "approved")
             self.assertEqual(captured["record"]["schema_version"], "project_memory_record/v2")
+
+    def test_replacement_between_check_and_write_cannot_slip_through(self) -> None:
+        # Given: a reviewer approving with the revision their card showed, and
+        # a concurrent recapture that replaces the payload under the same id.
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            captured = capture_project_memory_candidate(
+                paths, "Run the byte gates before every release", record_type="procedure"
+            )
+            candidate_id = str(captured["candidate"]["candidate_id"])
+            reviewed_revision = str(self._card(paths, candidate_id)["review_revision"])
+            candidate_path = paths.memory_dir / "candidates" / f"{candidate_id}.json"
+            replacement = {
+                **json.loads(candidate_path.read_text(encoding="utf-8")),
+                "summary": "Skip the byte gates when in a hurry",
+            }
+            # The recapture is a real mutator: it takes the store lock, as
+            # every mutating memory path does. It is released at the door of
+            # the approval's critical section and completes before the
+            # approval acquires the lock, so the payload is already replaced
+            # when the decision's protected section begins. A decision that
+            # validated its revision before that point is working from a read
+            # the store has since invalidated, and would approve text the
+            # reviewer never saw; a decision that reads and validates inside
+            # the lock sees the replacement and must refuse.
+            approval_reached_lock = threading.Event()
+            replacement_written = threading.Event()
+            failures: list[BaseException] = []
+
+            def replace_candidate() -> None:
+                try:
+                    self.assertTrue(approval_reached_lock.wait(timeout=10))
+                    with file_lock(paths.memory_index_path, private=True):
+                        candidate_path.write_text(json.dumps(replacement), encoding="utf-8")
+                except BaseException as error:  # surfaced in the main thread
+                    failures.append(error)
+                finally:
+                    replacement_written.set()
+
+            real_lock = memory_workflow.file_lock
+
+            @contextmanager
+            def lock_once_the_replacement_is_durable(lock_path, **kwargs):
+                approval_reached_lock.set()
+                self.assertTrue(replacement_written.wait(timeout=10))
+                with real_lock(lock_path, **kwargs) as held:
+                    yield held
+
+            writer = threading.Thread(target=replace_candidate)
+            writer.start()
+            try:
+                # When: the approval submits the revision its card showed.
+                with patch.object(
+                    memory_workflow, "file_lock", lock_once_the_replacement_is_durable
+                ):
+                    with self.assertRaises(StaleMemoryReviewError) as approving:
+                        approve_project_memory_candidate(
+                            paths, candidate_id, expected_revision=reviewed_revision
+                        )
+            finally:
+                approval_reached_lock.set()
+                writer.join(timeout=10)
+                self.assertFalse(writer.is_alive())
+                self.assertEqual(failures, [])
+
+            # Then: the decision is refused, and no record, review decision, or
+            # candidate mutation was written on the payload nobody reviewed.
+            self.assertIn("stale_review", str(approving.exception))
+            self.assertFalse((paths.memory_dir / "records").exists())
+            self.assertFalse((paths.memory_dir / "reviews").exists())
+            stored = json.loads(candidate_path.read_text(encoding="utf-8"))
+            self.assertEqual(stored["status"], "pending_review")
+            self.assertEqual(stored["summary"], replacement["summary"])
+
+    def test_displayed_time_sensitivity_change_moves_the_revision(self) -> None:
+        # Given: a candidate whose card displays a time-sensitivity warning --
+        # the reviewer reads `detail` and `next_action` to decide whether the
+        # relative-time phrase is acceptable, so both are decision inputs.
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            captured = capture_project_memory_candidate(paths, "The contract expires in 3 weeks")
+            candidate_id = str(captured["candidate"]["candidate_id"])
+            candidate_path = paths.memory_dir / "candidates" / f"{candidate_id}.json"
+            before_card = self._card(paths, candidate_id)
+            self.assertIn("time_sensitivity", before_card)
+
+            # When: only the displayed time-sensitivity guidance is rewritten
+            # under the same candidate id, leaving every other field alone.
+            stored = json.loads(candidate_path.read_text(encoding="utf-8"))
+            stored["time_sensitivity"] = {
+                **stored["time_sensitivity"],
+                "detail": "Superseded guidance: this deadline already passed and the fact now reads wrong.",
+                "next_action": "Reject this candidate; do not approve it as-is.",
+            }
+            candidate_path.write_text(json.dumps(stored), encoding="utf-8")
+            after_card = self._card(paths, candidate_id)
+
+            # Then: the card shows different guidance, so the revision that
+            # fingerprints it must have moved -- and the old card must be stale.
+            self.assertNotEqual(after_card["time_sensitivity"], before_card["time_sensitivity"])
+            self.assertNotEqual(after_card["review_revision"], before_card["review_revision"])
+            with self.assertRaises(StaleMemoryReviewError):
+                approve_project_memory_candidate(
+                    paths, candidate_id, expected_revision=str(before_card["review_revision"])
+                )
+
+    def test_every_displayed_candidate_field_is_bound_to_the_revision(self) -> None:
+        # Given: a rendered card and the exact set of fields it displays that
+        # come from the candidate. Static labels (schema, actions, boundary)
+        # are not candidate-derived, so they are not revision inputs.
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            captured = capture_project_memory_candidate(
+                paths, "The audit window closes in 2 days", record_type="procedure", tags=["audit"]
+            )
+            candidate = dict(captured["candidate"])
+            baseline_card = memory_workflow.build_project_memory_review_card(candidate)
+            baseline_revision = memory_workflow.project_memory_review_revision(candidate)
+            mutations: dict[str, dict] = {
+                "summary": {"summary": "The audit window never closes"},
+                "record_type": {"record_type": "constraint"},
+                "scope": {"scope": {"kind": "project", "ref": "other-project"}},
+                "tags": {"tags": ["unaudited"]},
+                "created_at": {"created_at": "2999-12-31T23:59:59Z"},
+                "duplicate_of": {"duplicate_of": "rec_previously_stored"},
+                "safety.status": {"safety": {**candidate["safety"], "status": "blocked"}},
+                "safety.extra": {"safety": {**candidate["safety"], "safe_to_auto_approve": True}},
+                "time_sensitivity.detail": {
+                    "time_sensitivity": {**candidate["time_sensitivity"], "detail": "different guidance"}
+                },
+                "time_sensitivity.next_action": {
+                    "time_sensitivity": {**candidate["time_sensitivity"], "next_action": "reject it"}
+                },
+            }
+
+            # When: each displayed field is mutated one at a time.
+            unbound = []
+            for name, patch in mutations.items():
+                mutated = {**candidate, **patch}
+                card_moved = memory_workflow.build_project_memory_review_card(mutated) != baseline_card
+                revision_moved = (
+                    memory_workflow.project_memory_review_revision(mutated) != baseline_revision
+                )
+                if card_moved and not revision_moved:
+                    unbound.append(name)
+
+            # Then: no field the card displays can change without the revision.
+            self.assertEqual(unbound, [])
 
     def test_revision_is_metadata_only_and_never_carries_sensitive_content(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -18,6 +18,7 @@ from omh.coding_lifecycle import start_codex_delegation_lifecycle
 from omh.plugin_bundle.omh import memory_governance
 from omh.workflows import memory as memory_workflow
 from omh.memory import (
+    StaleMemoryReviewError,
     apply_approved_memory_update_batch,
     apply_memory_update_batch,
     approve_project_memory_candidate,
@@ -1006,6 +1007,139 @@ class MemoryContractTests(unittest.TestCase):
             self.assertFalse(apply_result["applied"])
             self.assertFalse((paths.memory_dir / "scopes").exists())
             self.assertNotIn(staged["items"][0]["item_id"], {item["item_id"] for item in handoff["included_context"]})
+
+
+class ProjectMemoryRevisionReviewTests(unittest.TestCase):
+    """Review actions bind to the candidate revision the reviewer actually saw."""
+
+    @staticmethod
+    def _card(paths, candidate_id: str) -> dict:
+        review = build_project_memory_review(paths, candidate_id=candidate_id)
+        return review["cards"][0]
+
+    @staticmethod
+    def _store_bytes(paths) -> dict[str, bytes]:
+        """Every candidate, record, and review-decision file, byte for byte."""
+        return {
+            str(path.relative_to(paths.memory_dir)): path.read_bytes()
+            for name in ("candidates", "records", "reviews")
+            for path in sorted((paths.memory_dir / name).glob("*.json"))
+        }
+
+    def _recapture_same_candidate_id(self, paths, candidate_id: str, summary: str) -> dict:
+        """Overwrite one candidate id with a new payload, as a recapture does."""
+        superseded = capture_project_memory_candidate(paths, summary, record_type="procedure")["candidate"]
+        (paths.memory_dir / "candidates" / f"{superseded['candidate_id']}.json").unlink()
+        replacement = {**superseded, "candidate_id": candidate_id}
+        (paths.memory_dir / "candidates" / f"{candidate_id}.json").write_text(
+            json.dumps(replacement), encoding="utf-8"
+        )
+        return replacement
+
+    def test_stale_review_card_is_rejected_without_writes(self) -> None:
+        # Given: a reviewer holding a card for a candidate that was recaptured
+        # underneath them, so the id still resolves but the payload moved.
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            captured = capture_project_memory_candidate(
+                paths, "Run the byte gates before every release", record_type="procedure"
+            )
+            candidate_id = str(captured["candidate"]["candidate_id"])
+            stale_card = self._card(paths, candidate_id)
+            self._recapture_same_candidate_id(paths, candidate_id, "Skip the byte gates when in a hurry")
+            before = self._store_bytes(paths)
+
+            # When: the held card's revision is submitted with the approval.
+            with self.assertRaises(StaleMemoryReviewError) as approving:
+                approve_project_memory_candidate(
+                    paths, candidate_id, expected_revision=str(stale_card["review_revision"])
+                )
+
+            # Then: the review is refused as stale and nothing on disk moved.
+            self.assertIn("stale_review", str(approving.exception))
+            self.assertEqual(self._store_bytes(paths), before)
+            self.assertFalse((paths.memory_dir / "records").exists())
+
+    def test_matching_revision_approves_and_rejects(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            approving = capture_project_memory_candidate(paths, "Deploys go through staging first")["candidate"]
+            rejecting = capture_project_memory_candidate(paths, "Deploys skip staging on Fridays")["candidate"]
+
+            approved = approve_project_memory_candidate(
+                paths,
+                str(approving["candidate_id"]),
+                expected_revision=str(self._card(paths, str(approving["candidate_id"]))["review_revision"]),
+            )
+            rejected = reject_project_memory_candidate(
+                paths,
+                str(rejecting["candidate_id"]),
+                reason="contradicts the staging rule",
+                expected_revision=str(self._card(paths, str(rejecting["candidate_id"]))["review_revision"]),
+            )
+
+            self.assertEqual(approved["decision"], "approved_manual")
+            self.assertEqual(approved["candidate"]["status"], "approved")
+            self.assertTrue((paths.memory_dir / "records" / f"{approved['record']['record_id']}.json").exists())
+            self.assertEqual(rejected["decision"], "rejected")
+            self.assertEqual(rejected["candidate"]["status"], "rejected")
+
+    def test_recaptured_candidate_gets_a_new_revision_and_the_new_one_works(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            captured = capture_project_memory_candidate(
+                paths, "Run the byte gates before every release", record_type="procedure"
+            )
+            candidate_id = str(captured["candidate"]["candidate_id"])
+            first_revision = str(self._card(paths, candidate_id)["review_revision"])
+            self._recapture_same_candidate_id(paths, candidate_id, "Skip the byte gates when in a hurry")
+
+            second_revision = str(self._card(paths, candidate_id)["review_revision"])
+            approved = approve_project_memory_candidate(
+                paths, candidate_id, expected_revision=second_revision
+            )
+
+            self.assertNotEqual(first_revision, second_revision)
+            self.assertEqual(approved["record"]["summary"], "Skip the byte gates when in a hurry")
+
+    def test_omitted_revision_still_approves_for_non_interactive_callers(self) -> None:
+        # Migration safety: the in-process API keeps working without a revision;
+        # only the interactive CLI path requires one.
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            captured = capture_project_memory_candidate(paths, "Deploys go through staging first")
+
+            approved = approve_project_memory_candidate(paths, str(captured["candidate"]["candidate_id"]))
+
+            self.assertEqual(approved["decision"], "approved_manual")
+
+    def test_auto_safe_approval_binds_to_the_candidate_it_just_created(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, memory_mode="auto-safe")
+
+            captured = capture_project_memory_candidate(
+                paths, "Prefer docs workflow checks for generated workflow docs", record_type="procedure"
+            )
+
+            self.assertTrue(captured["auto_approved"])
+            self.assertEqual(captured["candidate"]["status"], "approved")
+            self.assertEqual(captured["record"]["schema_version"], "project_memory_record/v2")
+
+    def test_revision_is_metadata_only_and_never_carries_sensitive_content(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            captured = capture_project_memory_candidate(
+                paths,
+                "Deploy runbook lives in the ops repo",
+                content="password=hunter2-not-persisted",
+            )
+            candidate_id = str(captured["candidate"]["candidate_id"])
+
+            card = self._card(paths, candidate_id)
+
+            self.assertNotIn("hunter2-not-persisted", json.dumps(card))
+            self.assertRegex(str(card["review_revision"]), r"^rev_[0-9a-f]{32}$")
 
 
 class RetirementApplyTests(unittest.TestCase):

--- a/tests/test_parser_memory.py
+++ b/tests/test_parser_memory.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
 import unittest
 
+from _cli_harness import run_cli
 from _local_package import load_local_package
 
 load_local_package()
@@ -84,6 +88,85 @@ class MemoryParserTests(unittest.TestCase):
     def test_memory_lineage_defaults_to_three_hops(self) -> None:
         args = build_parser().parse_args(["memory", "lineage", "record-one"])
         self.assertEqual(args.depth, 3)
+
+    def test_memory_review_actions_accept_a_candidate_revision(self) -> None:
+        for argv in (
+            ["memory", "approve", "cand-one", "--candidate-revision", "rev_abc"],
+            ["memory", "reject", "cand-one", "--candidate-revision", "rev_abc"],
+        ):
+            with self.subTest(argv=argv):
+                self.assertEqual(build_parser().parse_args(argv).candidate_revision, "rev_abc")
+
+    def test_memory_review_actions_default_to_no_revision(self) -> None:
+        args = build_parser().parse_args(["memory", "approve", "cand-one"])
+        self.assertEqual(args.candidate_revision, "")
+
+
+class MemoryReviewRevisionCliTests(unittest.TestCase):
+    """The CLI review path refuses a stale or unproven card without writing."""
+
+    def _capture(self, tmp: Path) -> tuple[list[str], str]:
+        homes = ["--omh-home", str(tmp / ".omh"), "--hermes-home", str(tmp / ".hermes")]
+        status, stdout, _stderr = run_cli(
+            [*homes, "memory", "capture", "Deploys go through staging first"]
+        )
+        self.assertEqual(status, 0, stdout)
+        return homes, str(json.loads(stdout)["candidate"]["candidate_id"])
+
+    def _revision(self, homes: list[str], candidate_id: str) -> str:
+        status, stdout, _stderr = run_cli([*homes, "memory", "review", "--candidate", candidate_id])
+        self.assertEqual(status, 0, stdout)
+        return str(json.loads(stdout)["cards"][0]["review_revision"])
+
+    def test_approve_without_a_revision_refuses_and_writes_nothing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            homes, candidate_id = self._capture(root)
+
+            status, stdout, _stderr = run_cli([*homes, "memory", "approve", candidate_id])
+
+            payload = json.loads(stdout)
+            self.assertNotEqual(status, 0)
+            self.assertEqual(payload["reason_code"], "review_revision_required")
+            self.assertFalse(payload["applied"])
+            self.assertFalse((root / ".omh" / "memory" / "records").exists())
+
+    def test_approve_with_a_stale_revision_refuses_and_writes_nothing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            homes, candidate_id = self._capture(root)
+            self._revision(homes, candidate_id)
+
+            status, stdout, _stderr = run_cli(
+                [*homes, "memory", "approve", candidate_id, "--candidate-revision", "rev_" + "0" * 32]
+            )
+
+            payload = json.loads(stdout)
+            self.assertNotEqual(status, 0)
+            self.assertEqual(payload["reason_code"], "stale_review")
+            self.assertFalse(payload["applied"])
+            self.assertFalse((root / ".omh" / "memory" / "records").exists())
+
+    def test_approve_and_reject_with_the_displayed_revision_succeed(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            homes, candidate_id = self._capture(root)
+
+            status, stdout, _stderr = run_cli(
+                [*homes, "memory", "approve", candidate_id, "--candidate-revision", self._revision(homes, candidate_id)]
+            )
+            self.assertEqual(status, 0, stdout)
+            self.assertEqual(json.loads(stdout)["decision"], "approved_manual")
+
+            status, stdout, _stderr = run_cli([*homes, "memory", "capture", "Deploys skip staging on Fridays"])
+            self.assertEqual(status, 0, stdout)
+            second = str(json.loads(stdout)["candidate"]["candidate_id"])
+            status, stdout, _stderr = run_cli(
+                [*homes, "memory", "reject", second, "--candidate-revision", self._revision(homes, second)]
+            )
+
+            self.assertEqual(status, 0, stdout)
+            self.assertEqual(json.loads(stdout)["decision"], "rejected")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Feature Report

### What Changed

- Project-memory review cards now expose `review_revision`, a deterministic sha256 fingerprint of the exact candidate projection the card displays.
- `approve_project_memory_candidate()` and `reject_project_memory_candidate()` accept `expected_revision` and validate it **before any write**, raising the new `StaleMemoryReviewError`.
- `omh memory approve` and `omh memory reject` gained `--candidate-revision`. For card-backed candidates the flag is required; a missing or mismatched value returns a structured refusal with a nonzero exit and writes nothing.
- Auto-safe capture passes the revision of the candidate it just built, so the unattended path proves the same binding it asks reviewers to carry.

### Why This Exists

Closes #1247. A candidate id is a stable file name, not a version. Review actions were keyed by that id alone, so a review card held open across a recapture, overwrite, or supersession could approve whichever payload happened to occupy the id at decision time — text the reviewer never saw. The command path had no stale-card guard at all, which is a correctness hole in a review-first memory store whose entire value is that a human agreed to what got stored.

### User / Operator Impact

Before: `omh memory review` showed a card, and `omh memory approve <id>` later approved whatever lived at that id — silently, with exit 0, even if the payload had been replaced in between.

After: the reviewer passes back the `review_revision` the card showed. If the candidate moved underneath them, the command refuses with `reason_code: stale_review`, exits nonzero, leaves every candidate/record/review-decision file byte-identical, and tells them to re-read the card and decide again on what it shows now.

### How It Works

`project_memory_review_revision()` digests the displayed projection. The card and the fingerprint are built from **one shared projection** of the candidate-derived fields (`_project_memory_review_card_projection()`), so "displayed" and "bound" are the same set by construction rather than two hand-maintained lists that can drift. Static scaffolding — schema version, the action list, the redaction and claim-boundary labels, and `recommended_action` (a pure function of the safety status already bound) — is excluded on purpose: it cannot differ between two cards for the same candidate. It is metadata-only by construction: raw content never reaches the digest, only the sha256/length that the candidate already stored. The revision therefore moves exactly when what the reviewer saw moves.

The candidate is read, its revision validated, and the decision written under **one hold of the store lock**, so a concurrent replacement cannot land between the check and the write. Everything derived from the candidate is derived inside that same hold, so nothing is computed from a payload the write will not match. The CLI catches `StaleMemoryReviewError` and renders it through the same control-payload shape the other memory refusals use.

The requirement is scoped to card-backed v1 candidates via `candidate_is_review_card_backed()`. v2 correction/restore candidates are staged by the lifecycle path and approved by id without a card ever being rendered — demanding a revision there would ask for a value no surface produces and break the single approve verb the operator has. Those keep their existing lifecycle guard, which is the migration-safe path the issue asked for.

### Files And Contracts Touched

- `src/workflows/memory.py` — `project_memory_review_revision()`, `_project_memory_review_card_projection()` (shared by the card and the fingerprint), `candidate_is_review_card_backed()`, `StaleMemoryReviewError`, `_require_review_revision()`, the `review_revision` card field, the single-lock read-check-write in both decision paths, and the auto-safe binding.
- `src/commands/memory.py` — `--candidate-revision` plumbing, the `project_memory_review_refusal/v1` payload, and the scoped required-revision check.
- `src/commands/memory_parser.py` — `_add_candidate_revision_argument()` on both review verbs, spelled identically.
- `tests/test_memory.py`, `tests/test_parser_memory.py`, `tests/test_cli.py`.

Naming note: the new field is `review_revision`, **not** `candidate_revision`. The latter is already taken repo-wide for the integer record revision on v2 lifecycle candidates and batch items; a card fingerprint is not a revision counter, and collapsing the two names would make the guard unreadable at the call site. The CLI flag stays `--candidate-revision` because that is how an operator names it.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh ... release hermes-smoke --install-path setup ...`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed
- [x] Relevant dry-run or smoke command: temporary CLI driver, described below
- [ ] Manual Hermes/TUI check — no TUI surface renders these cards yet

### Observed Evidence

- Targeted: `PYTHONPATH=tests uv run python -m unittest tests/test_memory.py tests/test_parser_memory.py tests/test_memory_mnemosyne_port.py tests/test_memory_staleness.py` — 144 tests, OK.
- Broadened after the CLI contract changed: the same plus `tests/test_memory_attention_tiers.py tests/test_memory_reapproval_path.py` — 171 tests, OK.
- Full discovery on the rebased base: 8612 tests, OK.
- `docs ulw-inventory --check` and `docs ulw-site --check` also pass.
- A temporary driver (`.omo/qa/issue-1247-driver.py`, run against the real `omh memory` CLI, then deleted) printed PASS for: matching-revision approve and reject mutate as intended; a stale card returns `stale_review` with a nonzero exit; candidate/record/review-decision artifacts are byte-identical (sha256 per file, before vs after) across the refusal; no record is minted; the current revision then approves the payload actually on disk.
- Auto-safe binding verified directly through the module: `auto_approved: True`, candidate status `approved`, record schema `project_memory_record/v2`.

### Not Tested / Not Applicable

- `harness validate`, `release checklist`, `release hermes-smoke`, and the install smoke were not run: this change touches no harness contract, release manifest, or install path.
- No TUI or Hermes-chat surface renders project-memory review cards today, so the operator-facing refusal wording was verified only through CLI JSON output.

## Risk

The interactive approve/reject contract gained a required field for card-backed candidates, so any caller that scripted `omh memory approve <id>` with no revision now gets a nonzero `review_revision_required` refusal instead of a silent approval. That is the intended fix — such a call could not prove what it was approving — but it is a behavior change for existing scripts. Two pre-existing CLI tests were updated to carry the revision the `review` call already returns. The in-process Python API is unchanged for callers that omit the revision, so wrappers and lifecycle paths that never render a card keep working.

Pre-existing, not addressed here: `src/workflows/memory.py` is ~4470 pure LOC, far past the repo's readability ceiling. Splitting a shared memory module of that size is its own change and would swamp this review.

## Compatibility / Rollout

Local-only, metadata-only, no schema migration. Existing candidate files on disk need no rewrite — the revision is derived at read time, so a candidate written before this change gets a valid revision the first time a card renders it. The new refusal payload is `project_memory_review_refusal/v1`.

## Release / Claims

- [x] Release-channel impact considered (`local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed


## Follow-Up Correction (commit `75fd8e6c`)

Review of the first commit (`e096d095`) found two holes, each of which let through exactly the approval the guard exists to stop. Both are fixed in a second commit on this branch; `e096d095` was not amended.

**1. The fingerprint's input list was incomplete.** `time_sensitivity` — the warning that a summary carries a relative-time phrase, plus the guidance telling the reviewer to restate it with an absolute date or reject it — is rendered on every card that has it, but no part of it reached the hash. Rewriting that guidance under a candidate id left the revision byte-identical (`before=after=rev_2519a236c8860cd6d79b00e2bfd9b4da`), so a card showing the old advice still passed the check. An audit of every displayed field against the projection found the same class of gap in `safety`: the card displays the whole verdict dict while the projection cherry-picked two of its keys.

The fix removes the hand-maintained list rather than extending it — the list itself was the defect. Card and fingerprint now share one projection, so a field added to the card tomorrow is bound without anyone remembering to update the hash.

**2. The check was not atomic with the write.** The candidate was read and validated *outside* the store lock, and only the mutation ran inside it. A recapture landing in that window was approved on the reviewer's behalf with the stale check already passed — a check-then-write race that made the guard advisory. Approval and rejection now read, validate, and write under one hold of the existing lock. (The read had to move under the *existing* lock rather than take a second one: `file_lock` is non-reentrant, and a nested acquisition on the same index path would deadlock every approval.)

### Correction Evidence

Three new tests, each confirmed **RED against `e096d095`** and **GREEN after** — verified by reverting `src/workflows/memory.py` alone and re-running:

- `test_displayed_time_sensitivity_change_moves_the_revision` — mutates only the displayed `time_sensitivity` under the same candidate id; old code: `'rev_b8aed610…' == 'rev_b8aed610…'` (revision frozen), new code: revision moves and the old card is refused.
- `test_every_displayed_candidate_field_is_bound_to_the_revision` — mutates each displayed field in turn and asserts none can move the card without moving the revision; old code reported `['time_sensitivity.detail', 'time_sensitivity.next_action']` unbound.
- `test_replacement_between_check_and_write_cannot_slip_through` — deterministic, event-driven concurrent replacement using the real store lock with `threading.Event` handshakes and **no sleeps**; old code: `StaleMemoryReviewError not raised` (the approval committed on the replaced payload), new code: refuses, with no record, no review decision, and the candidate still `pending_review`.

Commands, all from the worktree at commit `75fd8e6c` (tree `e7588566`):

- Targeted memory/parser/staleness/mnemosyne/attention-tier/reapproval suites — **174 tests, OK**.
- `tests/test_cli.py` — **344 tests, OK**.
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — **8615 tests, OK**.
- `uv run python -m compileall -q` on both changed files — OK.
- `uv run ruff check` on both changed files — `All checks passed!`.
- `git diff --check` — clean.

Real CLI QA (not a module driver) against a fresh `OMH_HOME`, driving `python -m omh.cli`:

| Step | Result |
|---|---|
| Capture a time-sensitive summary, render the card | `review_revision=rev_d4052303fddf4cf13f27219b60565891` |
| Mutate **only** the displayed `time_sensitivity` under the same id, re-render | `review_revision=rev_f255f7a3ddc3e1ab89c56eaf4afc90e1` — moved |
| `memory approve <id> --candidate-revision <old>` | exit **1**, `reason_code=stale_review`, `applied=false` |
| `memory reject <id> --candidate-revision <old> --reason stale` | exit **1**, `reason_code=stale_review`, `applied=false` |
| Store after both refusals | byte-identical (sha256 per file); no `records/` or `reviews/` directory created |
| `memory approve <id> --candidate-revision <new>` | exit **0**, `decision=approved_manual`, record written |

The card's field set and values are unchanged by the correction — only key order shifted, and nothing in the repo consumes card key order. Revision strings change only for candidates whose previously-unbound fields are populated.

## Follow-Up

- When a TUI or chat review surface starts rendering these cards, it must submit `review_revision` back on the action; the guard is only as good as the surface that carries it.

Closes #1247

