### PR TITLE
fix(skills): repoint the boundary-crossing refactor deference at refactor-plan

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -2622,7 +2622,7 @@ These surfaces are generated command references, not installed Hermes workflow s
   - The target is not UI code, or the smell is generic slop, duplication, or dead code outside a component tree; use `ai-slop-cleaner`.
   - The user wants new UI built or redesigned rather than restructured; use `frontend`.
   - The user wants findings and a verdict without changing the code; use `code-review`.
-  - The restructuring crosses module boundaries or changes architecture beyond the component tree; use `ralplan`.
+  - The restructuring crosses module boundaries or changes architecture beyond the component tree; use `refactor-plan` for the phased execution shape, or `ralplan` first when the direction itself is still contested.
 - Strong routing signals: `frontend-refactor`, `front-refactor`, `frontend refactor`, `refactor this component`, `refactor the component`, `refactor my component`, `component refactor`, `react refactor`, `refactor this hook`, `split this component`, `split the component`, `this component is too big`, `component is too large`, `state management review`, `state management`, `state colocation`, `too many useeffects`, `useeffect cleanup`, `clean up useeffect`, `prop drilling`, `컴포넌트 리팩터링`, `컴포넌트 리팩토링`, `컴포넌트 분리`, `컴포넌트가 너무 커`, `상태 관리 정리`, `상태 관리 리뷰`, `프론트 리팩터링`, `프론트엔드 리팩터링`, `useEffect 정리`
 - Good example:
   - Prompt: This dashboard component is 800 lines and has six useState booleans - refactor it without changing behavior.
@@ -4381,6 +4381,7 @@ These surfaces are generated command references, not installed Hermes workflow s
   - The request is still too ambiguous to name requirements, non-goals, or acceptance criteria; use `deep-interview` first.
   - The user asks for one full research-plan-implementation-review-PR cycle; use `ultrawork` (its `delivery_boundary` capability) and keep ralplan as the planning stage.
   - The change is a small local refactor or cleanup with no architectural or regression risk; use `ultrawork`, or `ai-slop-cleaner` when observable behavior must stay identical.
+  - The refactor's direction is already decided and what is missing is its execution shape - which files move in which phase, what verifies each phase, where each phase rolls back to; use `refactor-plan`.
   - The user wants a pure source lookup, citation check, or paper explanation with no implementation plan.
   - The unresolved work is repository terminology alignment or a project-language decision frontier; use `context` before planning.
 - Strong routing signals: `ralplan`, `$ralplan`, `consensus plan`, `reviewed plan`, `issue to PR`, `acceptance criteria`, `verification command`, `reviewable PR`, `risky planning`, `dangerous planning`, `unsafe change`, `refactor safety`, `PR로 만들`, `PR로 만들 수 있게`, `위험한 리팩터링`, `리팩터링 위험`, `리스크 있는 리팩터링`, `검증 command`, `리뷰 가능한 단위`, `코드베이스 조사`, `웹리서치 계획`, `대안 비교`, `리스크 검토`
@@ -4606,7 +4607,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 - Use when: Use when the goal is removing existing low-quality, duplicated, or AI-generated code and the observable behavior must not change; lock behavior with tests before and after the edits.
 - Do not use when:
   - The goal is new or changed behavior rather than removing existing code; a plain refactor, feature, or fix request belongs to `ultrawork`.
-  - The cleanup would change architecture, module boundaries, or carry regression risk that needs a reviewed plan first; use `ralplan`.
+  - The cleanup would change architecture or module boundaries and needs its execution shaped into phases first; use `refactor-plan`, or `ralplan` when the direction itself is still contested.
   - The user wants existing code judged rather than changed; use `code-review` for a bug-first review and `failure-signal-audit` for swallowed failures.
 - Strong routing signals: `ai-slop-cleaner`, `$ai-slop-cleaner`, `cleanup`, `deslop`, `refactor`, `risky`, `behavior-preserving refactor`, `risk analysis`, `refactor workflow`, `legacy refactor`, `리팩터링`, `리팩토링`, `위험 분석`, `변경 범위 제한`, `회귀 테스트`
 - Good example:

--- a/skills/omh-ai-slop-cleaner/SKILL.md
+++ b/skills/omh-ai-slop-cleaner/SKILL.md
@@ -21,7 +21,7 @@ This is a Hermes-native `ai-slop-cleaner` workflow skill.
 ## Do Not Use When
 
 - The goal is new or changed behavior rather than removing existing code; a plain refactor, feature, or fix request belongs to `ultrawork`.
-- The cleanup would change architecture, module boundaries, or carry regression risk that needs a reviewed plan first; use `ralplan`.
+- The cleanup would change architecture or module boundaries and needs its execution shaped into phases first; use `refactor-plan`, or `ralplan` when the direction itself is still contested.
 - The user wants existing code judged rather than changed; use `code-review` for a bug-first review and `failure-signal-audit` for swallowed failures.
 
 ## Examples

--- a/skills/omh-frontend-refactor/SKILL.md
+++ b/skills/omh-frontend-refactor/SKILL.md
@@ -23,7 +23,7 @@ This is a Hermes-native `frontend-refactor` workflow skill.
 - The target is not UI code, or the smell is generic slop, duplication, or dead code outside a component tree; use `ai-slop-cleaner`.
 - The user wants new UI built or redesigned rather than restructured; use `frontend`.
 - The user wants findings and a verdict without changing the code; use `code-review`.
-- The restructuring crosses module boundaries or changes architecture beyond the component tree; use `ralplan`.
+- The restructuring crosses module boundaries or changes architecture beyond the component tree; use `refactor-plan` for the phased execution shape, or `ralplan` first when the direction itself is still contested.
 
 ## Examples
 

--- a/skills/ulw-plan/SKILL.md
+++ b/skills/ulw-plan/SKILL.md
@@ -23,6 +23,7 @@ This is a Hermes-native `ralplan` workflow skill.
 - The request is still too ambiguous to name requirements, non-goals, or acceptance criteria; use `deep-interview` first.
 - The user asks for one full research-plan-implementation-review-PR cycle; use `ultrawork` (its `delivery_boundary` capability) and keep ralplan as the planning stage.
 - The change is a small local refactor or cleanup with no architectural or regression risk; use `ultrawork`, or `ai-slop-cleaner` when observable behavior must stay identical.
+- The refactor's direction is already decided and what is missing is its execution shape - which files move in which phase, what verifies each phase, where each phase rolls back to; use `refactor-plan`.
 - The user wants a pure source lookup, citation check, or paper explanation with no implementation plan.
 - The unresolved work is repository terminology alignment or a project-language decision frontier; use `context` before planning.
 

--- a/src/maintenance/release.py
+++ b/src/maintenance/release.py
@@ -585,7 +585,11 @@ STANDALONE_CAPABILITY_SKILL_ITEM_CHAR_LIMIT = 2200
 # it implies — served entries lead, nothing is removed, a CLI subscription
 # only seeds the Maestro lane — so Hermes explains the reordered chains it
 # will see instead of calling them drift; one sentence, warranted growth.
-FULL_PROFILE_SKILL_BODY_CHAR_LIMIT = 865700
+# 865700 -> 866062: the refactor-plan repointing lengthens two existing
+# boundary lines (frontend-refactor, ai-slop-cleaner) and adds one to
+# ralplan, so each side of the phase-planning boundary names the other;
+# three boundary sentences, not new prose; warranted growth.
+FULL_PROFILE_SKILL_BODY_CHAR_LIMIT = 866062
 FULL_PROFILE_SKILL_BODY_REVIEWED_EXCEPTION_CHARS = 0
 
 

--- a/src/skills/catalog_definitions.py
+++ b/src/skills/catalog_definitions.py
@@ -3310,7 +3310,7 @@ _DEFINITIONS = [
             "The target is not UI code, or the smell is generic slop, duplication, or dead code outside a component tree; use `ai-slop-cleaner`.",
             "The user wants new UI built or redesigned rather than restructured; use `frontend`.",
             "The user wants findings and a verdict without changing the code; use `code-review`.",
-            "The restructuring crosses module boundaries or changes architecture beyond the component tree; use `ralplan`.",
+            "The restructuring crosses module boundaries or changes architecture beyond the component tree; use `refactor-plan` for the phased execution shape, or `ralplan` first when the direction itself is still contested.",
         ),
         good_example=SkillExample(
             prompt="This dashboard component is 800 lines and has six useState booleans - refactor it without changing behavior.",
@@ -5415,6 +5415,7 @@ _DEFINITIONS = [
             "The request is still too ambiguous to name requirements, non-goals, or acceptance criteria; use `deep-interview` first.",
             "The user asks for one full research-plan-implementation-review-PR cycle; use `ultrawork` (its `delivery_boundary` capability) and keep ralplan as the planning stage.",
             "The change is a small local refactor or cleanup with no architectural or regression risk; use `ultrawork`, or `ai-slop-cleaner` when observable behavior must stay identical.",
+            "The refactor's direction is already decided and what is missing is its execution shape - which files move in which phase, what verifies each phase, where each phase rolls back to; use `refactor-plan`.",
             "The user wants a pure source lookup, citation check, or paper explanation with no implementation plan.",
             "The unresolved work is repository terminology alignment or a project-language decision frontier; use `context` before planning.",
         ),
@@ -5652,7 +5653,7 @@ _DEFINITIONS = [
         phase="cleanup",
         do_not_use_when=(
             "The goal is new or changed behavior rather than removing existing code; a plain refactor, feature, or fix request belongs to `ultrawork`.",
-            "The cleanup would change architecture, module boundaries, or carry regression risk that needs a reviewed plan first; use `ralplan`.",
+            "The cleanup would change architecture or module boundaries and needs its execution shaped into phases first; use `refactor-plan`, or `ralplan` when the direction itself is still contested.",
             "The user wants existing code judged rather than changed; use `code-review` for a bug-first review and `failure-signal-audit` for swallowed failures.",
         ),
         hermes_role="runtime-handoff-guidance",

--- a/tests/test_catalog_deference_policy.py
+++ b/tests/test_catalog_deference_policy.py
@@ -128,8 +128,14 @@ NON_SKILL_BACKTICKS = frozenset(
 # `code-review`, deletion-first cleanup to `ai-slop-cleaner`, phased execution
 # of a big fix to `refactor-plan`, and release risk to `production-audit`.
 # Four cases, four new pairs, one new deferring owner.
-EXPECTED_DEFERENCE_CASES = 183
-EXPECTED_DEFERENCE_PAIRS = 194
+# The `refactor-plan` repointing gives the phase planner the deference edges
+# its own boundaries already claimed: `frontend-refactor` and
+# `ai-slop-cleaner` hand a boundary-crossing restructure to it (keeping
+# `ralplan` for a contested direction), and `ralplan` hands back a decided
+# refactor that only needs its execution shape. One new case (ralplan's new
+# statement), three new pairs; the two rewritten statements already counted.
+EXPECTED_DEFERENCE_CASES = 184
+EXPECTED_DEFERENCE_PAIRS = 197
 EXPECTED_DEFERRING_OWNERS = 59
 
 # The ratchet. Recording a new inversion must be a visible edit to this number,

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -222,7 +222,12 @@ class EfficiencyContractTests(unittest.TestCase):
         # 850,000 -> 866,000: `inference-serving` took the full profile to
         # 854,431 bytes on the merged tree. The ceiling restores ~11k headroom;
         # the exact value is ratcheted in `FULL_PROFILE_SKILL_BODY_CHAR_LIMIT`.
-        self.assertLess(full["skill_body"]["bytes"], 866_000)
+        # 866,000 -> 878,000: `tech-debt-audit`, the decision-record rules, and
+        # the refactor-plan deference repointing together took the full profile
+        # to 866,062 bytes on the merged tree. The ceiling restores ~12k
+        # headroom; the exact value is ratcheted in
+        # `FULL_PROFILE_SKILL_BODY_CHAR_LIMIT`.
+        self.assertLess(full["skill_body"]["bytes"], 878_000)
         self.assertLess(full["repeated"]["share_percent"], 38.0)
 
         # References are progressive disclosure, counted outside the always-loaded body.


### PR DESCRIPTION
## Capability

Each side of the phase-planning boundary now names the other. A boundary-crossing restructure whose direction is already decided reaches `refactor-plan` (shipped in #1241) instead of bouncing back into consensus planning:

- **`frontend-refactor`** — a restructure that leaves the component tree goes to `refactor-plan` for the phased execution shape, with `ralplan` kept for a direction still contested.
- **`ai-slop-cleaner`** — cleanup that would change architecture or module boundaries goes to `refactor-plan` first, same contested-direction fallback.
- **`ralplan`** — new boundary handing back a decided refactor whose missing piece is which files move in which phase, what verifies each phase, and where each rolls back to.

The distinction the three lines carry: `ralplan` decides *whether and what*, `refactor-plan` decides *in what order and with what rollback*.

## Motivation

Named follow-up from the 2026-09-01 skill round (PRs #1238/#1239/#1241) and called out in #1241's own body. Both deference lines were authored before `refactor-plan` existed, so they sent a user whose direction was already settled into the workflow that re-settles direction — and `ralplan` named no way back out.

## Implementation (boundary level)

- Three `do_not_use_when` statements in `src/skills/catalog_definitions.py`; no routing weights, triggers, cards, or policies touched.
- Deference graph gate re-derives and re-routes every statement: **184 cases / 197 pairs / 59 owners** (one new case from ralplan's added statement; three new pairs — the two rewritten statements already counted). No new inversion recorded: `refactor-plan` is not outranked by any of the three declining owners.
- Regenerated surfaces: `omh-frontend-refactor`, `omh-ai-slop-cleaner`, `ulw-plan` SKILL.md and `docs/WORKFLOWS.md`.
- Two ratchets move because the merged tree had already grown into their headroom, not because these lines are large: `FULL_PROFILE_SKILL_BODY_CHAR_LIMIT` 865,700 → 866,062 (exact, with provenance) and the `test_efficiency` headroom ceiling 866,000 → 878,000 (restores ~12k, the established pattern).

## Verification (observed)

- Deference policy gate: pass (184/197/59, inversions still the recorded 4).
- All five docs byte gates pass; `omh release drift` 18/18.
- Full suite from this worktree: **8,633 tests OK**; `ruff check src tests` clean; `compileall` clean; `git diff --check` clean.

## Risks

- Low. The change is catalog prose the deference gate routes deterministically; the fallback to `ralplan` is preserved in both rewritten lines, so a contested direction cannot be captured by the phase planner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PAhXFdoD8RLx53aF7KjhrX
