### PR TITLE
docs(sources): candidate rows carry their issues, and agentic-eval points at its real upstream

### DIFF
--- a/docs/SKILL-SOURCES.md
+++ b/docs/SKILL-SOURCES.md
@@ -43,6 +43,20 @@ Rules:
 
 | Proposed OMH unit | Upstream repo | Paths | License | Issue |
 | --- | --- | --- | --- | --- |
-| a11y rule IDs + auto-fixable partition | https://github.com/Effeilo/claude-code-frontend-skills | `front-a11y/*` | MIT | — |
-| CWV performance budgets | https://github.com/rohitg00/awesome-claude-code-toolkit | `skills/frontend-excellence/SKILL.md` | Apache-2.0 | — |
-| agentic-eval rubrics | https://github.com/kodustech/awesome-agent-skills | agentic-eval entry | check | — |
+| `accessibility-audit` rule IDs + auto-fixable partition | https://github.com/Effeilo/claude-code-frontend-skills | `front-a11y/front-a11y-rules.md` plus the per-syntax sub-files | MIT (see the detection note below) | [#1261](https://github.com/rlaope/oh-my-hermes/issues/1261) |
+| `frontend` Core Web Vitals thresholds + budget contract | https://github.com/rohitg00/awesome-claude-code-toolkit | `skills/frontend-excellence/SKILL.md` (CWV target table, `web-vitals` instrumentation) | Apache-2.0 | [#1262](https://github.com/rlaope/oh-my-hermes/issues/1262) |
+| `agent-evaluation` self-critique / evaluator-optimizer / judge stop rules | https://github.com/github/awesome-copilot | `skills/agentic-eval/SKILL.md` | MIT | [#1263](https://github.com/rlaope/oh-my-hermes/issues/1263) |
+
+Notes on these rows:
+
+- **The agentic-eval row was repointed.** It previously credited
+  `kodustech/awesome-agent-skills`, which publishes no license and is an
+  index, not a source: its agentic-eval entry links to
+  `github/awesome-copilot` `skills/agentic-eval`, already a registry upstream
+  (see the `refactor-plan` row). An index stays a discovery pointer; the row
+  names the repository the content actually lives in, because that is what
+  the tracker can diff.
+- **Effeilo's license detection is a false negative.** GitHub's license API
+  reports `other` for that repository because `LICENSE.md` opens with a logo
+  block above the MIT text. The license is MIT; a future tracker run that
+  reads the API field should not "correct" this row to unlicensed.


### PR DESCRIPTION
## Capability

The registry's candidate table becomes actionable: each of the three researched leads now carries the issue that owns it, is named as the skill it extends, and points at the repository the content actually lives in.

| Proposed unit | Upstream | Issue |
| --- | --- | --- |
| `accessibility-audit` rule IDs + auto-fixable partition | Effeilo/claude-code-frontend-skills (MIT) | #1261 |
| `frontend` Core Web Vitals thresholds + budget contract | rohitg00/awesome-claude-code-toolkit (Apache-2.0) | #1262 |
| `agent-evaluation` self-critique / evaluator-optimizer / judge stop rules | github/awesome-copilot (MIT) | #1263 |

## Motivation

Named follow-up from the 2026-09-01 skill round. The section header said "see the open issues" while every Issue cell held an em-dash, so the planned upstream-tracking cron had three rows it could not act on, and two rows carried wrong facts.

## Implementation (boundary level)

Documentation only — no generator owns `docs/SKILL-SOURCES.md`, and no skill, routing, or count surface moves. Two corrections are recorded as notes so a later tracker run cannot undo them:

- **agentic-eval repointed.** The row credited `kodustech/awesome-agent-skills`, which publishes **no license** and is an index rather than a source; its entry links to `github/awesome-copilot` `skills/agentic-eval` (MIT, HEAD `6a8fa297b0fe`) — already a registry upstream via the `refactor-plan` row. The row now names the repository the content lives in, because that is the only thing a tracker can diff. The index stays a discovery pointer.
- **Effeilo license false negative.** GitHub's license API answers `other` for that repository because `LICENSE.md` opens with a logo block above the MIT text. The license is MIT; the note keeps a later tracker run from "correcting" a true row into an unlicensed one off an API field.

Proposed units are also named as the skill they extend (matching how #1261–#1263 scope them) rather than as loose topics — each is a quality-bar plus reference extension of an existing skill, not a new catalog entry.

## Verification (observed)

- All five docs byte gates pass (`workflows`, `roles`, `capability-families`, `ulw-inventory`, `ulw-site`).
- `tests/test_router_content.py` (the docs-surface tests): 105 tests OK.
- `git diff --check` clean; table shape re-parsed (7-column shipped table, 5-column candidate table, three issue links resolved).

## Risks

- None to the product. The facts here were read from the GitHub API this session; if an upstream relicenses or moves the path, the tracker's first run against these rows is what surfaces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PAhXFdoD8RLx53aF7KjhrX
