### PR TITLE
fix(hud): the activity row's measured block sits beside its identity, and tells the truth

### DIFF
--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -79,13 +79,19 @@ export default function register(sdk) {
       // approximation renders nothing (a constant $0.000 read as broken).
       cost: cost > 0 ? `${approximate ? '~' : ''}$${cost.toFixed(3)}` : '',
       // Summed observed subagent tokens in the host gauge's own idiom
-      // (184.8k tokens). Zero renders nothing, same as cost: this is agent
-      // consumption, not the session gauge the host statusline already owns.
+      // (184.8k tokens). A summed zero still renders (`0 tokens`) whenever any
+      // row carried a figure: that zero is observed agent consumption, and
+      // hiding it left a header that read identically whether the agents did
+      // nothing or the reader knew nothing. Absence of every figure still
+      // renders nothing -- this is agent consumption, not the session gauge
+      // the host statusline already owns.
       // Like cost, the sum covers the rows the reader projects (live and
       // lingering bindings), so it is a live figure that can shrink as rows
       // age out or fall past the reader's cap — never a monotonic session
       // total, which the metadata-only projection has no state to carry.
-      tokens: tokens > 0 ? `${tokenCountText(tokens)} tokens` : '',
+      tokens: rows.some(row => Number.isFinite(row.tokens))
+        ? `${tokenCountText(tokens)} tokens`
+        : '',
       ctx: Number.isFinite(ctx) ? `ctx ${ctx}%` : 'ctx --',
     }
   }
@@ -158,18 +164,25 @@ export default function register(sdk) {
   const truncateCells = (value, limit) => truncateTextCells(safeText(value), limit)
 
   // The host's own gauge idiom (36.4k/272k) and Claude Code's token counter
-  // (184.8k, 2.1m): one decimal, trailing .0 trimmed, bare integers under a
-  // thousand. Subagent tokens are observed usage sums (input+output), so the
+  // (184.8k, 2.1m): one decimal ALWAYS kept above a thousand, bare integers
+  // under it. The trailing .0 used to be trimmed, which made a round count
+  // change width mid-wave (77k beside 77.4k) and cost the column its decimal
+  // alignment; the owner asked for `77.0k`. Subagent tokens are observed usage sums (input+output), so the
   // count stays exact even on subscription-billed hosts where only the COST
   // is a token-derived approximation — the owner asked for tokens '근사값으로
   // 라도' there, and the honest answer is better: the real count.
   const tokenCountText = value => {
-    if (!Number.isFinite(value) || value < 1) return ''
+    // A recorded zero renders as `0`, not as nothing. The reader only sends a
+    // number once the row is terminal or has reported usage, so zero here
+    // means the run consumed nothing -- which is exactly what a dispatch that
+    // died before its first API call did. Blanking it made a failed run look
+    // like an unmeasured one.
+    if (!Number.isFinite(value) || value < 0) return ''
     if (value < 1000) return `${Math.floor(value)}`
     // Unit break sits where one-decimal rounding lands, so 999,950 reads
     // 1m, never 1000k.
     const [amount, unit] = value < 999_950 ? [value / 1000, 'k'] : [value / 1_000_000, 'm']
-    return `${amount.toFixed(1).replace(/\.0$/, '')}${unit}`
+    return `${amount.toFixed(1)}${unit}`
   }
 
   const elapsedText = value => {
@@ -189,7 +202,7 @@ export default function register(sdk) {
   const observedPercent = (label, value) =>
     Number.isFinite(value) ? `${label} ${value}%` : ''
 
-  const activityLayout = (row, columns, main, extraSeconds, tokensColumn) => {
+  const activityLayout = (row, columns, main, extraSeconds, tokensColumn, routeColumn) => {
     const state = safeText(row.state) || 'running'
     const stateText = columns < 100 ? ({ running: 'run', blocked: 'block', failed: 'fail' })[state] || state : state
     const taskId = truncateCells(safeText(row.task_id) || safeText(row.role) || 'agent', 8).padEnd(8)
@@ -228,8 +241,13 @@ export default function register(sdk) {
     const tools = Number.isFinite(row.tool_count) ? `${row.tool_count} tools` : ''
     const turnTools = turn && tools ? `${turn} (${tools})` : turn || tools
     const tokenText = tokenCountText(row.tokens)
+    // The route/category is the row's identity, so it is a COLUMN, not one
+    // of the droppable middle segments: it sits immediately left of the
+    // state/elapsed/tokens block the owner asked to move beside it, padded
+    // to a constant width so the token figures still line up vertically
+    // from row to row.
+    const routeSegment = dispatchLane ? metricSegment('maestro', dispatchIdentity) : metricSegment(routeKind, route)
     const optional = [
-      dispatchLane ? metricSegment('maestro', dispatchIdentity) : metricSegment(routeKind, route),
       metricSegment('fallback', Number.isFinite(row.fallback_count) && row.fallback_count > 0 ? `fallback:${row.fallback_count}` : ''),
       metricSegment('cache', observedPercent('cache', row.cache_hit_percentage)),
       metricSegment('context', observedPercent('ctx', row.context_percentage)),
@@ -277,9 +295,18 @@ export default function register(sdk) {
     const prefix = `${taskId} `
     const separator = '  ·  '
     const budget = Math.max(24, columns - 4)
+    // The route column exists per LIST, exactly like the tokens column: a
+    // row without a route holds the grid with blank cells so the tail after
+    // it stays on the same screen column, and a wave with no routes at all
+    // spends none of the width.
+    const routeCap = Math.max(10, Math.min(30, Math.floor(columns * 0.24)))
+    const routeWidth = routeColumn ? cellWidth(separator) + routeCap : 0
+    const routeCell = routeColumn
+      ? `${separator}${padCells(truncateCells(routeSegment.text, routeCap), routeCap)}`
+      : ''
     const actionCap = Math.max(10, Math.min(48, Math.floor(columns * 0.4)))
-    const actionWidth = Math.max(8, Math.min(actionCap, budget - cellWidth(prefix) - tailWidth - 2))
-    const fixedWidth = cellWidth(prefix) + actionWidth + tailWidth
+    const actionWidth = Math.max(8, Math.min(actionCap, budget - cellWidth(prefix) - routeWidth - tailWidth - 2))
+    const fixedWidth = cellWidth(prefix) + actionWidth + routeWidth + tailWidth
     const segments = [...optional]
     while (segments.length) {
       const metadata = segments.map(item => item.text).join(separator)
@@ -287,11 +314,11 @@ export default function register(sdk) {
       segments.pop()
     }
     const metadata = segments.map(segment => segment.text).join(separator)
-    const used = fixedWidth + (metadata ? cellWidth(separator) + cellWidth(metadata) : 0)
     return {
       action: padCells(truncateCells(row.action, actionWidth), actionWidth),
       metadata,
-      pad: ' '.repeat(Math.max(0, budget - used)),
+      routeCell,
+      routeKind: routeSegment.kind,
       segments,
       tailRest,
       tailState,
@@ -299,8 +326,8 @@ export default function register(sdk) {
     }
   }
 
-  function ActivityRow({ columns, extraSeconds, frame, main, row, t, tokensColumn }) {
-    const layout = activityLayout(row, columns, main, extraSeconds, tokensColumn)
+  function ActivityRow({ columns, extraSeconds, frame, main, row, routeColumn, t, tokensColumn }) {
+    const layout = activityLayout(row, columns, main, extraSeconds, tokensColumn, routeColumn)
     const blocked = row.state === 'blocked' || row.state === 'failed'
     const done = row.state === 'done'
     const marker = blocked ? '▲' : done ? '✓' : SPINNER_FRAMES[frame % SPINNER_FRAMES.length]
@@ -311,6 +338,24 @@ export default function register(sdk) {
       h(Text, { color: blocked ? t.color.error : done ? t.color.ok : t.color.warn }, `${marker} `),
       h(Text, { color: t.color.muted }, `${layout.taskId} `),
       h(Text, { color: t.color.text }, layout.action),
+      // Identity, then the measured block, then the rest. The route column
+      // and the state/elapsed/tokens tail are fixed widths, so those figures
+      // line up vertically down the list; everything after them is variable
+      // and sheds from the right when the terminal narrows.
+      h(
+        Text,
+        {
+          color: layout.routeKind === 'route'
+            ? t.color.label
+            : layout.routeKind === 'route-fallback' || layout.routeKind === 'maestro'
+              ? t.color.warn
+              : t.color.muted,
+        },
+        layout.routeCell,
+      ),
+      h(Text, {}, '  '),
+      h(Text, { color: statusColor }, layout.tailState),
+      h(Text, { color: t.color.muted }, layout.tailRest),
       ...layout.segments.map((segment, index) =>
         h(
           Text,
@@ -332,12 +377,6 @@ export default function register(sdk) {
           `  ·  ${segment.text}`,
         )
       ),
-      // The fixed tail: state keeps its status color, the elapsed and
-      // tokens columns rest muted, and the pad in front right-anchors the
-      // whole block so every row's columns line up.
-      h(Text, {}, layout.pad),
-      h(Text, { color: statusColor }, layout.tailState),
-      h(Text, { color: t.color.muted }, layout.tailRest),
     )
   }
 
@@ -347,6 +386,10 @@ export default function register(sdk) {
     // the grid holds; a wave with no counts at all drops the column instead
     // of wasting sixteen blank cells on every row.
     const tokensColumn = [...mainRows, ...rows].some(row => tokenCountText(row.tokens))
+    // Same rule for the route/category column, which now carries the grid:
+    // it is what the fixed tail is anchored against, so every row reserves
+    // it as soon as one row has a route to show.
+    const routeColumn = [...mainRows, ...rows].some(row => safeText(row.category) || safeText(row.model) || safeText(row.dispatch_lane))
     return h(
       Box,
       { flexDirection: 'column', width: '100%' },
@@ -357,6 +400,7 @@ export default function register(sdk) {
           frame,
           key: `main-${index}`,
           main: true,
+          routeColumn,
           row,
           t,
           tokensColumn,
@@ -368,6 +412,7 @@ export default function register(sdk) {
           extraSeconds,
           frame,
           key: `${safeText(row.task_id)}-${index}`,
+          routeColumn,
           row,
           t,
           tokensColumn,

--- a/src/plugin_bundle/omh/hermes_delegation.py
+++ b/src/plugin_bundle/omh/hermes_delegation.py
@@ -1208,7 +1208,12 @@ def read_hermes_native_subagents(
             "provider": route_provider,
             "model": child["model"],
             "effort": child["effort"],
-            "tokens": tokens_total if tokens_total else None,
+            # A terminal row's zero is observed, not missing: the failure
+            # hint above is derived from this same absence, so sending `None`
+            # here made the HUD render `--` on a row the reader had just
+            # labelled failed for having no usage. Only a still-running child
+            # that has not reported yet is honestly unknown.
+            "tokens": tokens_total if tokens_total or row_state != "running" else None,
             "elapsed_seconds": max(0.0, elapsed_until - child["started_at"]),
             "observed_at": _iso_utc(last_activity),
             "category": mixture_category_for(

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -315,10 +315,14 @@ class TuiWidgetPackTests(unittest.TestCase):
             widget,
         )
         self.assertIn("const dispatchLane = safeText(row.dispatch_lane)", widget)
+        # The identity segment is now the row's own column rather than the
+        # first droppable metadata entry, so it is bound once and rendered
+        # between the title and the measured tail.
         self.assertIn(
-            "dispatchLane ? metricSegment('maestro', dispatchIdentity) : metricSegment(routeKind, route),",
+            "const routeSegment = dispatchLane ? metricSegment('maestro', dispatchIdentity) : metricSegment(routeKind, route)",
             widget,
         )
+        self.assertIn("layout.routeKind === 'route-fallback' || layout.routeKind === 'maestro'", widget)
         self.assertIn("|| segment.kind === 'maestro'", widget)
 
     def test_hud_liveness_signal_drives_the_status_line_todo_and_shot_badge(self) -> None:
@@ -515,22 +519,39 @@ class TuiWidgetPackTests(unittest.TestCase):
         # token counts render per row and summed on the header, one decimal
         # with trailing .0 trimmed. The row segment sits BEFORE cost so the
         # narrow-terminal drop order sheds the dollar figure first and keeps
-        # the token count; a zero renders nothing, exactly like cost.
+        # the token count; an unreadable value renders nothing.
         self.assertIn("const tokenCountText", widget)
-        self.assertIn(".toFixed(1).replace(/\\.0$/, '')", widget)
+        # One decimal is always kept above a thousand (`77.0k`, not `77k`):
+        # trimming it made a round count change width mid-wave and broke the
+        # column's decimal alignment.
+        self.assertIn("`${amount.toFixed(1)}${unit}`", widget)
+        self.assertNotIn(".replace(/\\.0$/, '')", widget)
         # The unit break sits where one-decimal rounding lands (999,950 reads
-        # 1m, never 1000k), sub-thousand counts render bare, and a fractional
-        # or zero value renders nothing rather than a broken-looking "0 tok".
+        # 1m, never 1000k) and sub-thousand counts render bare. A recorded
+        # zero now renders `0`: the reader sends a number only once the row is
+        # terminal or has reported, so zero means the run consumed nothing --
+        # the shape of a dispatch that died before its first API call, which
+        # the old blank made indistinguishable from an unmeasured row.
         self.assertIn("value < 999_950 ?", widget)
         self.assertIn("if (value < 1000) return", widget)
-        self.assertIn("|| value < 1) return ''", widget)
-        # Claude Code-style grid ('절대위치로 … 클로드코드처럼 정렬'): a
-        # fixed right-anchored tail `state · elapsed · N tokens`, each piece
-        # padded to constant cell widths so the columns line up vertically
-        # across rows; the token count anchors the right edge ('tokens로
-        # 해주고 맨 오른쪽에') and the metadata drop loop sheds rate, cost,
-        # and turn without ever touching the tail.
+        self.assertIn("|| value < 0) return ''", widget)
+        # Claude Code-style grid ('절대위치로 … 클로드코드처럼 정렬'): fixed
+        # columns first, variable metadata after. The owner moved the measured
+        # block beside the identity it belongs to ('category 바로옆에 두고
+        # 그뒤에 캐시히트나 턴'), so the order is title, route/category, then
+        # `state · elapsed · N tokens` -- each piece padded to a constant cell
+        # width so the token figures still line up vertically down the list --
+        # and only then cache, turn, cost, and rate, which the drop loop still
+        # sheds from the right without ever touching the tail.
         self.assertIn("` · ${tokenText.padStart(6)} tokens`", widget)
+        self.assertIn("const routeCap = Math.max(10, Math.min(30, Math.floor(columns * 0.24)))", widget)
+        # The route column reserves its width per LIST, exactly like tokens:
+        # otherwise a row without a category would slide its tail left and
+        # break the very alignment this ordering exists to keep.
+        self.assertIn(
+            "const routeColumn = [...mainRows, ...rows].some(row => safeText(row.category)",
+            widget,
+        )
         self.assertIn("h(Text, { color: statusColor }, layout.tailState)", widget)
         self.assertIn("h(Text, { color: t.color.muted }, layout.tailRest)", widget)
         # The tokens column exists per LIST: a row with no observed count
@@ -541,7 +562,16 @@ class TuiWidgetPackTests(unittest.TestCase):
             "const tokensColumn = [...mainRows, ...rows].some(row => tokenCountText(row.tokens))",
             widget,
         )
-        self.assertIn("tokens: tokens > 0 ? `${tokenCountText(tokens)} tokens` : ''", widget)
+        # The header renders a summed ZERO whenever any row carried a figure:
+        # a dispatch that died before its first API call really did consume
+        # nothing, and blanking that made a failed wave read exactly like an
+        # unmeasured one. Only a wave where no row reports at all still hides
+        # the segment.
+        self.assertIn(
+            "tokens: rows.some(row => Number.isFinite(row.tokens))",
+            widget,
+        )
+        self.assertIn("if (!Number.isFinite(value) || value < 0) return ''", widget)
         # The summed count anchors the header's right edge too, and the
         # header has no drop loop, so the segment hides below 100 columns
         # instead of pushing ctx and the yolo readout past truncate-end.
@@ -553,7 +583,10 @@ class TuiWidgetPackTests(unittest.TestCase):
         # the tail: the metadata column starts aligned and the tail block
         # keeps its right anchor even on narrow terminals.
         self.assertIn("Math.min(48, Math.floor(columns * 0.4))", widget)
-        self.assertIn("Math.min(actionCap, budget - cellWidth(prefix) - tailWidth - 2)", widget)
+        self.assertIn(
+            "Math.min(actionCap, budget - cellWidth(prefix) - routeWidth - tailWidth - 2)",
+            widget,
+        )
         # The plan panel's liveness cues are the ONE sanctioned animation:
         # a colour wave through the active item's characters plus a walking
         # ellipsis on the [Plan] header, both mounted only while an active


### PR DESCRIPTION
## Capability

The activity row's measured block now sits beside the identity it describes, and says what was actually observed.

```
▲ 9ef009 브라우저에서 실제 플레이 가능한…   ·  category:visual-engineering(c…  running · 7m 45s  · 110.3k tokens  ·  cache 42%  ·  turn 3  ·  ~$0.8412
▲ 0af265 코드베이스 UML 렌더 검수          ·  category:visual-engineering(c…  done    · 1m 26s  ·  32.8k tokens  ·  cache 18%  ·  turn 1
▲ b71c33 모델 라우팅 가드 초안             ·  category:architect(claude-opu…  failed  · 12s      ·      0 tokens  ·  turn 1
```

Four rules changed — three about truth, one about shape.

## Motivation

Reported from a live session: the OMH line read `4 agents · 1 running · 3 blocked · ctx --` with no tokens, cost, or cache. The dispatches had failed, so nothing was consumed — but the HUD rendered that identically to "the reader could not measure this."

The contradiction was inside one function. `read_hermes_native_subagents` labels such a row `failed` with the hint `no model usage observed`, then eleven lines later sent `tokens: None` for that same row, so the widget blanked it.

## What changed

- **Observed zero is a number.** A row carries its token count once it is terminal, zero included; only a still-running child that has not reported yet stays `None`. The widget renders a recorded `0`, and the header's summed segment renders whenever any row carried a figure.
- **The decimal stays.** `77.0k`, not `77k`. Trimming the trailing `.0` made a round count change width mid-wave (`77k` beside `77.4k`) and cost the column its decimal alignment.
- **Order follows meaning.** The row reads title → route/category → `state · elapsed · tokens` → cache, turn, cost, rate.
- **The grid survives the move.** Route/category becomes a fixed-width column reserved per list — the same rule the tokens column already used — so token figures still line up vertically instead of drifting with the category's length. A row with no route reserves blank cells rather than sliding its tail left.

## What deliberately did not change

- **Cost at zero stays hidden.** A subscription-billed host records no per-call cost; `$0.000` would claim zero spent when the truth is not-recorded. (A separate audit of cost tracking is running.)
- **`ctx --` stays.** Investigating turned up a distinct finding: `context_percentage` has a schema slot, a reader projection, and a render path — but **no production writer anywhere in the tree** (`grep -rn "context_percentage=" src/ --include="*.py"` outside tests returns nothing). It renders `--` on every session regardless of model or provider. Fixing it needs the model's context-window size, which none of the three usage lanes look up. Its own unit.

## Verification (observed)

- `tests/test_tui_widget_pack.py` + `tests/test_hermes_tui_preflight.py` + `tests/test_plugin_hermes_delegation.py`, with five golden substrings updated to the new rules, each carrying its reason.
- Row rendering simulated at 150 columns across running/done/failed rows to confirm the token column still right-aligns after the move.
- `node --check` on the widget; `ruff check src tests` clean; `compileall` clean; `git diff --check` clean.
- Full suite: **8,701 tests OK**.

## Risks

- The per-row token column now appears for waves whose rows all read zero — the intended visibility change.
- Category is truncated to a fixed cap (≤30 cells, 24% of width) where it used to run full length; the full value stays in the payload.
- Asserted as source text, not as a live TUI frame — confirming the rendered result needs a TUI restart on the owner's machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
