### PR TITLE
feat: add user-configurable model price overrides

### DIFF
--- a/MODEL_OPTI.md
+++ b/MODEL_OPTI.md
@@ -573,12 +573,14 @@ gate requires a completed paired run on the intended execution surface.
 - **Cost approximation** — `APPROX_PRICE_PER_MTOK` in
   `src/plugin_bundle/omh/hermes_delegation.py` supplies `~$` estimates only
   when the host recorded no cost; models absent from the table show no
-  approximation (never a fabricated number). Cache reads are priced at a
-  tenth of input unless `APPROX_CACHE_READ_RATIO` names the model: Claude
-  Fable 5.1 lists $10 / $50 per MTok with cache reads at $0.25 (0.025x) and
-  cache writes at $12.50 (5-minute TTL) / $20 (1-hour TTL); Opus 5 reads at
-  the tenth. Mythos 5.1 carries the Fable figure because its cache-read rate
-  was open at launch — approximate, like every number in the table.
+  approximation (never a fabricated number). Overrides live in
+  `~/.omh/routing/model-prices.json` (`model_price_overrides/v1`). Cache reads
+  are priced at a tenth of input unless `APPROX_CACHE_READ_RATIO` names the
+  model: Claude Fable 5.1 lists $10 / $50 per MTok with cache reads at $0.25
+  (0.025x) and cache writes at $12.50 (5-minute TTL) / $20 (1-hour TTL); Opus 5
+  reads at the tenth. Mythos 5.1 carries the Fable figure because its
+  cache-read rate was open at launch — approximate, like every number in the
+  table.
 - **`max_tokens` is a failure signal, not a stop** — a unit whose final turn
   ended on `stop_reason: max_tokens` is a failed attempt: the output was cut
   mid-thought and nothing after the cut was verified. It is never a done

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -389,6 +389,36 @@ configured mapping for labeling and mark the provider source as
 `model_provider_routes`; that configured metadata is not provider execution
 or credential evidence.
 
+### Customizing token prices for cost approximation
+
+When hosts record no per-call cost (such as subscription-billed plans), OMH
+derives an approximate cost from observed tokens using a shipped fallback
+ballpark table. Users and operators who use custom gateways with markups,
+enterprise committed-use discounts, promotional rates, or free tiers ($0.00)
+can override these prices without modifying source code.
+
+Supply overrides in `~/.omh/routing/model-prices.json`
+(`model_price_overrides/v1`), a sibling of the chain and provider documents:
+
+```json
+{
+  "schema_version": "model_price_overrides/v1",
+  "prices": {
+    "glm-5.2": {"input": 0.6, "output": 2.2},
+    "free-tier-model": {"input": 0.0, "output": 0.0}
+  }
+}
+```
+
+Prices are expressed in USD per million tokens (`input` and `output`). Values
+must be non-negative finite numbers (0.0 is explicitly accepted for free tiers
+and subscriptions). A model listed here supersedes the shipped ballpark table;
+unlisted models continue to use the shipped fallback. When cost is derived from
+a user override, the HUD activity row marks the derivation with both
+`cost_approximate: true` and `cost_override: true`. Validation matches the
+sibling documents: strict, atomic, and token-only, with an invalid file ignored
+whole rather than partially applied.
+
 The X/Grok row is a static, editable affinity for work explicitly declaring X
 platform data. It is not a measured capability, performance, or availability
 claim, never removes another candidate, and never overrides an explicit user

--- a/docs/MODEL-ONBOARDING.md
+++ b/docs/MODEL-ONBOARDING.md
@@ -99,7 +99,9 @@ Files that move together (grep the old id to find every site):
 `APPROX_PRICE_PER_MTOK` takes the vendor's first-party list price with the
 source and month in a comment. A model or tier without a documented price
 gets no entry; absence renders no estimate. Check the existing family rows
-while you are there — the Claude 5 rows were stale until the 5.1 pass.
+while you are there — the Claude 5 rows were stale until the 5.1 pass. Users
+can override or supply prices via `~/.omh/routing/model-prices.json`
+(`model_price_overrides/v1`).
 
 ## 6. Machine placement stays provider-neutral
 

--- a/src/plugin_bundle/omh/hermes_delegation.py
+++ b/src/plugin_bundle/omh/hermes_delegation.py
@@ -25,6 +25,7 @@ mixture routing is visible as such instead of masquerading as a routed one.
 from __future__ import annotations
 
 import json
+import math
 import os
 import re
 import sqlite3
@@ -742,6 +743,7 @@ def _strict_json_loads(text: str) -> object:
 # and rendered with a `~`. Cache reads are charged at a tenth of input unless
 # APPROX_CACHE_READ_RATIO names the model.
 APPROX_PRICE_PER_MTOK: dict[str, tuple[float, float]] = {
+    # OpenAI list prices (openai.com/api/pricing, 2026-08):
     "gpt-5.6-sol": (1.25, 10.0),
     "gpt-5.6-terra": (1.25, 10.0),
     "gpt-5.6-luna": (0.25, 2.0),
@@ -754,21 +756,30 @@ APPROX_PRICE_PER_MTOK: dict[str, tuple[float, float]] = {
     "claude-mythos-5-1": (10.0, 50.0),
     "claude-sonnet-5": (2.0, 10.0),
     "claude-haiku-4-5": (1.0, 5.0),
+    # Moonshot AI list price (platform.moonshot.cn pricing, 2026-08):
     "kimi-k3": (0.6, 2.5),
+    # Zhipu AI list price (docs.z.ai pricing, 2026-08):
     "glm-5.2": (0.6, 2.2),
     # Z.ai list price for the 5.3 generation (docs.z.ai pricing, 2026-08).
     # 5.3 always reasons and bills the reasoning inside output tokens, so the
     # output side dominates real spend; still an approximation, not billing.
     "glm-5.3": (1.4, 4.4),
     "glm-5.3-flash": (0.15, 0.5),
+    # DeepSeek list price (api-docs.deepseek.com pricing, 2026-08):
     "deepseek-v3.2": (0.28, 0.42),
+    # Zhipu AI speed-tier ballpark (docs.z.ai pricing, 2026-08):
     "glm-5.2-ultrafast": (0.3, 1.2),
     # Speed-tier ballpark mirrors the glm pattern (roughly half the base
     # model's list price); editable approximation, not billing evidence.
     "kimi-k3-ultrafast": (0.3, 1.25),
+    # Google AI Studio list price (ai.google.dev/pricing, 2026-08):
     "gemini-3.1-pro": (1.25, 10.0),
+    # Alibaba Cloud Model Studio list price (alibabacloud.com pricing, 2026-08):
     "qwen3-coder": (0.4, 1.6),
+    # Upstage list price (upstage.ai pricing, 2026-08):
     "solar-pro2": (0.15, 0.60),
+    # xAI list price (docs.x.ai pricing, 2026-08):
+    "grok-code-fast": (0.2, 1.5),
 }
 
 
@@ -783,15 +794,121 @@ APPROX_CACHE_READ_RATIO: dict[str, float] = {
 }
 _DEFAULT_CACHE_READ_RATIO = 0.1
 
+# User-editable price overrides. Allows operators and users to correct or
+# customize token list prices (gateways with markups, enterprise rates, free tiers)
+# without editing shipped source code.
+MODEL_PRICE_OVERRIDES_SCHEMA_VERSION = "model_price_overrides/v1"
+
+
+def model_price_overrides_path(omh_home: str | Path | None = None) -> Path:
+    root = Path(omh_home).expanduser() if omh_home else Path.home() / ".omh"
+    return root / "routing" / "model-prices.json"
+
+
+def load_model_price_overrides(
+    omh_home: str | Path | None = None,
+) -> tuple[dict[str, tuple[float, float]], str]:
+    """Read the user's price override document.
+
+    Returns ``(overrides, status)`` where status is ``absent``, ``applied``,
+    or ``invalid: <reason>``, matching ``load_mixture_chain_overrides``.
+    """
+    path = model_price_overrides_path(omh_home)
+    try:
+        raw = _strict_json_loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}, "absent"
+    except (OSError, UnicodeDecodeError, ValueError):
+        return {}, "invalid: unreadable JSON"
+    return parse_model_price_overrides(raw)
+
+
+def parse_model_price_overrides(
+    raw: object,
+) -> tuple[dict[str, tuple[float, float]], str]:
+    """Validate one already-parsed price override document."""
+    if not isinstance(raw, dict):
+        return {}, "invalid: document must be a JSON object"
+    if raw.get("schema_version") != MODEL_PRICE_OVERRIDES_SCHEMA_VERSION:
+        return {}, f"invalid: schema_version must be {MODEL_PRICE_OVERRIDES_SCHEMA_VERSION}"
+    prices = raw.get("prices")
+    if not isinstance(prices, dict):
+        return {}, "invalid: prices must be an object"
+    unknown = sorted(set(raw) - {"schema_version", "prices"})
+    if unknown:
+        return {}, f"invalid: unsupported fields {unknown}"
+    overrides: dict[str, tuple[float, float]] = {}
+    for alias, entry in prices.items():
+        if not isinstance(alias, str) or not _CHAIN_TOKEN_RE.fullmatch(alias):
+            return {}, f"invalid: alias {alias!r} is not a token"
+        if not isinstance(entry, dict):
+            return {}, f"invalid: alias {alias!r} must map to an object"
+        unknown_keys = sorted(set(entry) - {"input", "output"})
+        if unknown_keys:
+            return {}, f"invalid: alias {alias!r} entry fields {unknown_keys}"
+        if "input" not in entry:
+            return {}, f"invalid: alias {alias!r} missing input price"
+        if "output" not in entry:
+            return {}, f"invalid: alias {alias!r} missing output price"
+        input_raw = entry["input"]
+        output_raw = entry["output"]
+        if isinstance(input_raw, bool) or not isinstance(input_raw, (int, float)):
+            return {}, f"invalid: alias {alias!r} names a non-numeric input price"
+        if isinstance(output_raw, bool) or not isinstance(output_raw, (int, float)):
+            return {}, f"invalid: alias {alias!r} names a non-numeric output price"
+        input_price = float(input_raw)
+        output_price = float(output_raw)
+        if not math.isfinite(input_price) or input_price < 0.0:
+            return {}, f"invalid: alias {alias!r} names an invalid input price"
+        if not math.isfinite(output_price) or output_price < 0.0:
+            return {}, f"invalid: alias {alias!r} names an invalid output price"
+        overrides[alias.casefold()] = (input_price, output_price)
+    return overrides, "applied"
+
+
+def effective_model_prices(
+    omh_home: str | Path | None = None,
+) -> dict[str, tuple[float, float]]:
+    """Shipped ballpark prices with the user's per-model overrides applied."""
+    overrides, _ = load_model_price_overrides(omh_home)
+    if not overrides:
+        return dict(APPROX_PRICE_PER_MTOK)
+    effective = dict(APPROX_PRICE_PER_MTOK)
+    effective.update(overrides)
+    return effective
+
+
+def resolve_model_price(
+    model: str,
+    price_overrides: Mapping[str, tuple[float, float]] | None = None,
+) -> tuple[tuple[float, float] | None, bool]:
+    """Look up price per Mtok for a model alias: (prices, is_override).
+
+    Returns ((input_price, output_price), True) if found in user overrides,
+    ((input_price, output_price), False) if found in shipped fallback,
+    or (None, False) if unknown.
+    """
+    key = _text(model).casefold()
+    if price_overrides and key in price_overrides:
+        return price_overrides[key], True
+    if key in APPROX_PRICE_PER_MTOK:
+        return APPROX_PRICE_PER_MTOK[key], False
+    return None, False
+
 
 def _approximate_cost_usd(
-    model: str, input_tokens: float, output_tokens: float, cache_read_tokens: float
+    model: str,
+    input_tokens: float,
+    output_tokens: float,
+    cache_read_tokens: float,
+    *,
+    prices: tuple[float, float] | None = None,
 ) -> float | None:
     key = _text(model).casefold()
-    prices = APPROX_PRICE_PER_MTOK.get(key)
-    if not prices or (input_tokens + output_tokens) <= 0:
+    effective_prices = prices if prices is not None else APPROX_PRICE_PER_MTOK.get(key)
+    if not effective_prices or (input_tokens + output_tokens) <= 0:
         return None
-    input_price, output_price = prices
+    input_price, output_price = effective_prices
     cache_ratio = APPROX_CACHE_READ_RATIO.get(key, _DEFAULT_CACHE_READ_RATIO)
     return (
         input_tokens * input_price
@@ -1076,6 +1193,7 @@ def read_hermes_native_subagents(
     active_chains = effective_mixture_category_chains(omh_home)
     provider_routes, _ = load_model_provider_routes(omh_home)
     route_provenance = load_delegation_route_provenance(omh_home)
+    price_overrides, _ = load_model_price_overrides(omh_home)
     payload: dict[str, Any] = {
         "status": "idle",
         "rows": [],
@@ -1183,11 +1301,25 @@ def read_hermes_native_subagents(
         # for an approximation there rather than a blank. Token-derived, and
         # flagged approximate so the widget can render it as `~$…`.
         cost_approximate = False
+        cost_override = False
         if not cost:
-            approx = _approximate_cost_usd(child["model"], input_tokens, output_tokens, cache_read)
-            if approx is not None:
-                cost = approx
-                cost_approximate = True
+            resolved_prices, is_override = resolve_model_price(
+                child["model"],
+                price_overrides=price_overrides,
+            )
+            if resolved_prices is not None:
+                approx = _approximate_cost_usd(
+                    child["model"],
+                    input_tokens,
+                    output_tokens,
+                    cache_read,
+                    prices=resolved_prices,
+                )
+                if approx is not None:
+                    cost = approx
+                    cost_approximate = True
+                    if is_override:
+                        cost_override = True
 
         parent_model = state.get("parent_models", {}).get(child["parent_id"], "")
         route_alias, route_provider = configured_route_for_wire(
@@ -1262,6 +1394,8 @@ def read_hermes_native_subagents(
             row["cost_usd"] = cost
             if cost_approximate:
                 row["cost_approximate"] = True
+            if cost_override:
+                row["cost_override"] = True
         if tokens_per_second is not None:
             row["tokens_per_second"] = tokens_per_second
         if cache_hit is not None:

--- a/tests/test_plugin_hermes_delegation.py
+++ b/tests/test_plugin_hermes_delegation.py
@@ -16,19 +16,26 @@ import unittest
 from pathlib import Path
 
 from omh.plugin_bundle.omh.hermes_delegation import (
+    APPROX_PRICE_PER_MTOK,
     COMPLETED_LINGER_SECONDS,
     DELEGATION_ROUTE_PROVENANCE_SCHEMA_VERSION,
     HERMES_MIXTURE_CATEGORY_CHAINS,
     MIXTURE_CHAIN_OVERRIDES_SCHEMA_VERSION,
+    MODEL_PRICE_OVERRIDES_SCHEMA_VERSION,
     RECENT_ACTIVITY_SECONDS,
     append_delegation_route_provenance,
     effective_mixture_category_chains,
+    effective_model_prices,
     load_delegation_route_provenance,
     load_mixture_chain_overrides,
+    load_model_price_overrides,
     mixture_category_for,
     mixture_chain_overrides_path,
+    model_price_overrides_path,
+    parse_model_price_overrides,
     parse_model_provider_routes,
     read_hermes_native_subagents,
+    resolve_model_price,
 )
 
 NOW = 1_800_000_000.0
@@ -233,6 +240,13 @@ def _write_overrides(omh_home: Path, document: object) -> Path:
     return path
 
 
+def _write_price_overrides(omh_home: Path, document: object) -> Path:
+    path = model_price_overrides_path(omh_home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(document), encoding="utf-8")
+    return path
+
+
 class ClaudeFableTierContractTest(unittest.TestCase):
     def test_every_hermes_lane_claude_row_declares_an_effort(self):
         # Hermes defaults an unset effort to medium, not the API default high,
@@ -361,6 +375,234 @@ class MixtureChainOverridesTest(unittest.TestCase):
         # Attribution order is the canonical category order; a reordered dict
         # would silently change which chain claims a shared model.
         self.assertEqual(tuple(HERMES_MIXTURE_CATEGORY_CHAINS), MODEL_CATEGORIES)
+
+
+class ModelPriceOverridesTest(unittest.TestCase):
+    """~/.omh/routing/model-prices.json is the user's price override surface:
+    it replaces prices for only the models it names, accepts 0.0 as a valid
+    free-tier/subscription rate, and an invalid document is ignored whole
+    rather than half-applied."""
+
+    def test_an_absent_document_yields_shipped_defaults(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            overrides, status = load_model_price_overrides(tmp)
+            self.assertEqual((overrides, status), ({}, "absent"))
+            self.assertEqual(len(effective_model_prices(tmp)), len(APPROX_PRICE_PER_MTOK))
+            self.assertEqual(
+                resolve_model_price("gpt-5.6-sol"),
+                ((1.25, 10.0), False),
+            )
+            self.assertEqual(
+                resolve_model_price("grok-code-fast"),
+                ((0.2, 1.5), False),
+            )
+            self.assertEqual(resolve_model_price("unknown-model"), (None, False))
+
+    def test_a_seeded_empty_document_applies_and_keeps_defaults(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_price_overrides(Path(tmp), {
+                "schema_version": MODEL_PRICE_OVERRIDES_SCHEMA_VERSION,
+                "prices": {},
+            })
+            overrides, status = load_model_price_overrides(tmp)
+            self.assertEqual((overrides, status), ({}, "applied"))
+            self.assertEqual(effective_model_prices(tmp), dict(APPROX_PRICE_PER_MTOK))
+
+    def test_overriding_a_shipped_model_supersedes_fallback(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_price_overrides(Path(tmp), {
+                "schema_version": MODEL_PRICE_OVERRIDES_SCHEMA_VERSION,
+                "prices": {
+                    "gpt-5.6-sol": {"input": 2.0, "output": 12.0},
+                },
+            })
+            overrides, status = load_model_price_overrides(tmp)
+            self.assertEqual(status, "applied")
+            effective = effective_model_prices(tmp)
+            self.assertEqual(effective["gpt-5.6-sol"], (2.0, 12.0))
+            self.assertEqual(effective["claude-opus-5"], (5.0, 25.0))
+            self.assertEqual(
+                resolve_model_price("gpt-5.6-sol", overrides),
+                ((2.0, 12.0), True),
+            )
+            self.assertEqual(
+                resolve_model_price("claude-opus-5", overrides),
+                ((5.0, 25.0), False),
+            )
+
+    def test_adding_a_custom_model_price(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_price_overrides(Path(tmp), {
+                "schema_version": MODEL_PRICE_OVERRIDES_SCHEMA_VERSION,
+                "prices": {
+                    "custom-gateway-model": {"input": 0.5, "output": 1.5},
+                },
+            })
+            overrides, status = load_model_price_overrides(tmp)
+            self.assertEqual(status, "applied")
+            self.assertEqual(
+                resolve_model_price("custom-gateway-model", overrides),
+                ((0.5, 1.5), True),
+            )
+            self.assertEqual(
+                effective_model_prices(tmp)["custom-gateway-model"],
+                (0.5, 1.5),
+            )
+
+    def test_zero_input_and_output_prices_are_valid(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_price_overrides(Path(tmp), {
+                "schema_version": MODEL_PRICE_OVERRIDES_SCHEMA_VERSION,
+                "prices": {
+                    "free-promo-model": {"input": 0.0, "output": 0.0},
+                },
+            })
+            overrides, status = load_model_price_overrides(tmp)
+            self.assertEqual(status, "applied")
+            self.assertEqual(overrides["free-promo-model"], (0.0, 0.0))
+            self.assertEqual(
+                resolve_model_price("free-promo-model", overrides),
+                ((0.0, 0.0), True),
+            )
+
+    def test_boolean_price_values_are_rejected(self):
+        cases = {
+            "boolean input": {
+                "schema_version": MODEL_PRICE_OVERRIDES_SCHEMA_VERSION,
+                "prices": {"bad-model": {"input": True, "output": 1.0}},
+            },
+            "boolean output": {
+                "schema_version": MODEL_PRICE_OVERRIDES_SCHEMA_VERSION,
+                "prices": {"bad-model": {"input": 1.0, "output": False}},
+            },
+        }
+        for label, document in cases.items():
+            with self.subTest(case=label):
+                overrides, status = parse_model_price_overrides(document)
+                self.assertEqual(overrides, {})
+                self.assertTrue(status.startswith("invalid:"), status)
+                self.assertIn("non-numeric", status)
+
+    def test_negative_price_values_are_rejected(self):
+        cases = {
+            "negative input": {
+                "schema_version": MODEL_PRICE_OVERRIDES_SCHEMA_VERSION,
+                "prices": {"bad-model": {"input": -0.5, "output": 1.0}},
+            },
+            "negative output": {
+                "schema_version": MODEL_PRICE_OVERRIDES_SCHEMA_VERSION,
+                "prices": {"bad-model": {"input": 1.0, "output": -0.01}},
+            },
+        }
+        for label, document in cases.items():
+            with self.subTest(case=label):
+                overrides, status = parse_model_price_overrides(document)
+                self.assertEqual(overrides, {})
+                self.assertTrue(status.startswith("invalid:"), status)
+                self.assertIn("names an invalid", status)
+
+    def test_non_finite_price_values_are_rejected(self):
+        cases = {
+            "nan input": {
+                "schema_version": MODEL_PRICE_OVERRIDES_SCHEMA_VERSION,
+                "prices": {"bad-model": {"input": float("nan"), "output": 1.0}},
+            },
+            "inf output": {
+                "schema_version": MODEL_PRICE_OVERRIDES_SCHEMA_VERSION,
+                "prices": {"bad-model": {"input": 1.0, "output": float("inf")}},
+            },
+            "negative inf input": {
+                "schema_version": MODEL_PRICE_OVERRIDES_SCHEMA_VERSION,
+                "prices": {"bad-model": {"input": float("-inf"), "output": 1.0}},
+            },
+        }
+        for label, document in cases.items():
+            with self.subTest(case=label):
+                overrides, status = parse_model_price_overrides(document)
+                self.assertEqual(overrides, {})
+                self.assertTrue(status.startswith("invalid:"), status)
+                self.assertIn("names an invalid", status)
+
+    def test_unknown_fields_are_rejected(self):
+        cases = {
+            "top-level models container": {
+                "schema_version": MODEL_PRICE_OVERRIDES_SCHEMA_VERSION,
+                "prices": {},
+                "models": {},
+            },
+            "top-level extra field": {
+                "schema_version": MODEL_PRICE_OVERRIDES_SCHEMA_VERSION,
+                "prices": {},
+                "extra": 1,
+            },
+            "entry extra field": {
+                "schema_version": MODEL_PRICE_OVERRIDES_SCHEMA_VERSION,
+                "prices": {"m": {"input": 1.0, "output": 2.0, "cache": 0.1}},
+            },
+            "alternative key input_per_mtok": {
+                "schema_version": MODEL_PRICE_OVERRIDES_SCHEMA_VERSION,
+                "prices": {"m": {"input_per_mtok": 1.0, "output": 2.0}},
+            },
+        }
+        for label, document in cases.items():
+            with self.subTest(case=label):
+                overrides, status = parse_model_price_overrides(document)
+                self.assertEqual(overrides, {})
+                self.assertTrue(status.startswith("invalid:"), status)
+
+    def test_invalid_schema_version_is_rejected(self):
+        overrides, status = parse_model_price_overrides({
+            "schema_version": "model_prices/v1",
+            "prices": {},
+        })
+        self.assertEqual(overrides, {})
+        self.assertEqual(
+            status,
+            f"invalid: schema_version must be {MODEL_PRICE_OVERRIDES_SCHEMA_VERSION}",
+        )
+
+    def test_non_token_model_names_are_rejected(self):
+        cases = {
+            "space in name": "model name with spaces",
+            "newline in name": "model\nname",
+            "empty string": "",
+        }
+        for label, bad_name in cases.items():
+            with self.subTest(case=label):
+                overrides, status = parse_model_price_overrides({
+                    "schema_version": MODEL_PRICE_OVERRIDES_SCHEMA_VERSION,
+                    "prices": {bad_name: {"input": 1.0, "output": 2.0}},
+                })
+                self.assertEqual(overrides, {})
+                self.assertTrue(status.startswith("invalid:"), status)
+                self.assertIn("is not a token", status)
+
+    def test_duplicate_json_keys_are_rejected_as_unreadable_json(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = model_price_overrides_path(tmp)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                '{"schema_version": "model_price_overrides/v1", "prices": {}, "prices": {}}',
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                load_model_price_overrides(tmp),
+                ({}, "invalid: unreadable JSON"),
+            )
+
+    def test_partially_invalid_document_is_rejected_atomically(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_price_overrides(Path(tmp), {
+                "schema_version": MODEL_PRICE_OVERRIDES_SCHEMA_VERSION,
+                "prices": {
+                    "valid-model": {"input": 1.0, "output": 2.0},
+                    "bad-model": {"input": "not-a-number", "output": 2.0},
+                },
+            })
+            overrides, status = load_model_price_overrides(tmp)
+            self.assertEqual(overrides, {})
+            self.assertTrue(status.startswith("invalid:"), status)
+            self.assertNotIn("valid-model", overrides)
 
 
 class HermesNativeSubagentReaderTest(unittest.TestCase):
@@ -508,6 +750,237 @@ class HermesNativeSubagentReaderTest(unittest.TestCase):
         self.assertAlmostEqual(
             row["cost_usd"],
             (20_000 * 0.15 + 10_000 * 0.015 + 5_000 * 0.60) / 1_000_000,
+        )
+
+    def test_user_price_override_applies_at_runtime_with_cost_approximate_and_cost_override(self):
+        _write_price_overrides(
+            self.home / ".omh",
+            {
+                "schema_version": MODEL_PRICE_OVERRIDES_SCHEMA_VERSION,
+                "prices": {
+                    "gpt-5.6-sol": {"input": 2.50, "output": 20.0},
+                },
+            },
+        )
+        _build_state_db(
+            self.home,
+            [
+                {
+                    "id": "20260818_100100_override",
+                    "model": "gpt-5.6-sol",
+                    "effort": "high",
+                    "started_at": NOW - 60,
+                    "usage": {
+                        "input_tokens": 20_000,
+                        "output_tokens": 5_000,
+                        "cache_read_tokens": 10_000,
+                        "first_seen": NOW - 50,
+                        "last_seen": NOW - 5,
+                    },
+                }
+            ],
+        )
+        _write_manifest(
+            self.home,
+            "deleg_override",
+            ["override lane"],
+            started=NOW - 65,
+            log_mtime=NOW - 5,
+        )
+        payload = read_hermes_native_subagents(self.home, now=NOW, omh_home=self.home / ".omh")
+        row = payload["rows"][0]
+        self.assertEqual(row["model"], "gpt-5.6-sol")
+        self.assertTrue(row["cost_approximate"])
+        self.assertTrue(row["cost_override"])
+        # Overridden rates: $2.50/M input, $20.0/M output; cache reads @ tenth ($0.25/M).
+        # 20k * 2.50 + 10k * 0.25 + 5k * 20.0 = 50 + 2.5 + 100 = 152.5 / 1000 = $0.1525.
+        self.assertAlmostEqual(
+            row["cost_usd"],
+            (20_000 * 2.50 + 10_000 * 0.25 + 5_000 * 20.0) / 1_000_000,
+        )
+
+    def test_shipped_price_approximation_does_not_set_cost_override(self):
+        _write_price_overrides(
+            self.home / ".omh",
+            {
+                "schema_version": MODEL_PRICE_OVERRIDES_SCHEMA_VERSION,
+                "prices": {
+                    "gpt-5.6-sol": {"input": 2.50, "output": 20.0},
+                },
+            },
+        )
+        _build_state_db(
+            self.home,
+            [
+                {
+                    "id": "20260818_100100_shipped",
+                    "model": "claude-opus-5",
+                    "effort": "high",
+                    "started_at": NOW - 60,
+                    "usage": {
+                        "input_tokens": 10_000,
+                        "output_tokens": 4_000,
+                        "cache_read_tokens": 30_000,
+                        "first_seen": NOW - 50,
+                        "last_seen": NOW - 5,
+                    },
+                }
+            ],
+        )
+        _write_manifest(
+            self.home,
+            "deleg_shipped",
+            ["shipped lane"],
+            started=NOW - 65,
+            log_mtime=NOW - 5,
+        )
+        payload = read_hermes_native_subagents(self.home, now=NOW, omh_home=self.home / ".omh")
+        row = payload["rows"][0]
+        self.assertEqual(row["model"], "claude-opus-5")
+        self.assertTrue(row["cost_approximate"])
+        self.assertNotIn("cost_override", row)
+        # Claude Opus 5 shipped price: $5.0/M input, $25.0/M output, tenth cache read ($0.50/M).
+        self.assertAlmostEqual(
+            row["cost_usd"],
+            (10_000 * 5.0 + 30_000 * 0.50 + 4_000 * 25.0) / 1_000_000,
+        )
+
+    def test_grok_code_fast_shipped_price_approximation(self):
+        _build_state_db(
+            self.home,
+            [
+                {
+                    "id": "20260818_100100_grok01",
+                    "model": "grok-code-fast",
+                    "effort": "low",
+                    "started_at": NOW - 300,
+                    "usage": {
+                        "api_calls": 5,
+                        "input_tokens": 20_000,
+                        "output_tokens": 5_000,
+                        "cache_read_tokens": 10_000,
+                        "first_seen": NOW - 290,
+                        "last_seen": NOW - 10,
+                    },
+                }
+            ],
+        )
+        _write_manifest(
+            self.home,
+            "deleg_grok",
+            ["grok lane"],
+            started=NOW - 305,
+            log_mtime=NOW - 5,
+        )
+        payload = read_hermes_native_subagents(self.home, now=NOW, omh_home=self.home / ".omh")
+        self.assertEqual(payload["status"], "observed")
+        self.assertEqual(payload["running"], 1)
+        row = payload["rows"][0]
+        self.assertEqual(row["model"], "grok-code-fast")
+        self.assertTrue(row["cost_approximate"])
+        self.assertNotIn("cost_override", row)
+        # Grok Code Fast shipped list price: $0.20/M input, $1.50/M output; cache reads @ tenth ($0.02/M).
+        # 20k input @ $0.20/M + 10k cache reads @ $0.02/M + 5k output @ $1.50/M.
+        self.assertAlmostEqual(
+            row["cost_usd"],
+            (20_000 * 0.20 + 10_000 * 0.02 + 5_000 * 1.50) / 1_000_000,
+        )
+
+    def test_zero_price_override_applies_at_runtime_with_cost_approximate_and_cost_override(self):
+        _write_price_overrides(
+            self.home / ".omh",
+            {
+                "schema_version": MODEL_PRICE_OVERRIDES_SCHEMA_VERSION,
+                "prices": {
+                    "free-tier-model": {"input": 0.0, "output": 0.0},
+                    "gpt-5.6-sol": {"input": 2.50, "output": 20.0},
+                },
+            },
+        )
+        overrides, status = load_model_price_overrides(self.home / ".omh")
+        self.assertEqual(status, "applied")
+        self.assertEqual(overrides["free-tier-model"], (0.0, 0.0))
+        self.assertEqual(overrides["gpt-5.6-sol"], (2.50, 20.0))
+
+        _build_state_db(
+            self.home,
+            [
+                {
+                    "id": "20260818_100100_free",
+                    "model": "free-tier-model",
+                    "effort": "low",
+                    "started_at": NOW - 60,
+                    "usage": {
+                        "input_tokens": 15_000,
+                        "output_tokens": 3_000,
+                        "cache_read_tokens": 5_000,
+                        "first_seen": NOW - 50,
+                        "last_seen": NOW - 5,
+                    },
+                },
+                {
+                    "id": "20260818_100100_nonzero",
+                    "model": "gpt-5.6-sol",
+                    "effort": "high",
+                    "started_at": NOW - 70,
+                    "usage": {
+                        "input_tokens": 20_000,
+                        "output_tokens": 5_000,
+                        "cache_read_tokens": 10_000,
+                        "first_seen": NOW - 60,
+                        "last_seen": NOW - 10,
+                    },
+                },
+                {
+                    "id": "20260818_100100_shipped",
+                    "model": "claude-opus-5",
+                    "effort": "high",
+                    "started_at": NOW - 80,
+                    "usage": {
+                        "input_tokens": 10_000,
+                        "output_tokens": 4_000,
+                        "cache_read_tokens": 30_000,
+                        "first_seen": NOW - 70,
+                        "last_seen": NOW - 15,
+                    },
+                },
+            ],
+        )
+        _write_manifest(
+            self.home,
+            "deleg_multi",
+            ["free lane", "nonzero lane", "shipped lane"],
+            started=NOW - 85,
+            log_mtime=NOW - 5,
+        )
+        payload = read_hermes_native_subagents(self.home, now=NOW, omh_home=self.home / ".omh")
+        rows_by_model = {row["model"]: row for row in payload["rows"]}
+
+        # 1. Zero-cost override row:
+        free_row = rows_by_model["free-tier-model"]
+        self.assertIn("cost_usd", free_row)
+        self.assertEqual(free_row["cost_usd"], 0.0)
+        self.assertTrue(free_row["cost_approximate"])
+        self.assertTrue(free_row["cost_override"])
+        self.assertIsNotNone(free_row["cost_usd"])
+        self.assertIs(type(free_row["cost_usd"]), float)
+
+        # 2. Non-zero override row:
+        nonzero_row = rows_by_model["gpt-5.6-sol"]
+        self.assertTrue(nonzero_row["cost_approximate"])
+        self.assertTrue(nonzero_row["cost_override"])
+        self.assertAlmostEqual(
+            nonzero_row["cost_usd"],
+            (20_000 * 2.50 + 10_000 * 0.25 + 5_000 * 20.0) / 1_000_000,
+        )
+
+        # 3. Shipped fallback row (un-overridden):
+        shipped_row = rows_by_model["claude-opus-5"]
+        self.assertTrue(shipped_row["cost_approximate"])
+        self.assertNotIn("cost_override", shipped_row)
+        self.assertAlmostEqual(
+            shipped_row["cost_usd"],
+            (10_000 * 5.0 + 30_000 * 0.50 + 4_000 * 25.0) / 1_000_000,
         )
 
     def test_an_observed_host_cost_is_never_replaced_by_the_approximation(self):


### PR DESCRIPTION
## Summary

Fixes #1274.

Adds a validated, user-configurable model price override document at `~/.omh/routing/model-prices.json` using the `model_price_overrides/v1` schema. The shipped `APPROX_PRICE_PER_MTOK` table remains the fallback, while explicit user prices take precedence for approximate cost calculations.

Also adds the missing `grok-code-fast` shipped price and provenance comments for the shipped pricing table.

## Changes

- Add `model_price_overrides/v1` parsing and loading under `~/.omh/routing/model-prices.json`
- Follow the existing strict sibling routing-document contract with duplicate-key rejection and atomic validation
- Validate model tokens and non-negative finite numeric prices, while allowing `0.0` for free tiers/subscriptions
- Resolve user overrides before shipped approximate prices without changing existing cache-read ratio behavior
- Mark override-derived approximate costs with `cost_approximate: true` and `cost_override: true`
- Add `grok-code-fast` pricing from xAI's documented list price and add provenance comments to shipped prices
- Update installation/model onboarding documentation and model optimization notes

## Validation

- `tests/test_plugin_hermes_delegation.py`: 61 tests passed
- `tests/test_model_chains_command.py`: 9 tests passed
- `tests/test_model_recommendations.py`: 26 tests passed
- `tests/test_model_routing.py`: 80 tests passed
- `tests/test_provider_entitlements.py`: 26 tests passed
- `uv run python -m compileall -q src tests`: passed
- `uv run --group lint ruff check src tests`: passed
- `git diff --check`: passed
- Documentation projection checks (`workflows`, `roles`, `capability-families`, `ulw-inventory`, `ulw-site`): passed

The full repository unittest discovery was also exercised locally; unrelated Windows-specific failures were investigated separately. The directly affected and dependent suites are green.

## Design / Compatibility

- When the override document is absent, existing shipped-price behavior is unchanged.
- Invalid override documents are rejected atomically rather than partially applied.
- `0.0` remains a valid price and is not treated as missing.
- Existing observed host cost remains distinct from token-derived approximate cost.

## Files changed

- `src/plugin_bundle/omh/hermes_delegation.py`
- `tests/test_plugin_hermes_delegation.py`
- `docs/INSTALLATION.md`
- `docs/MODEL-ONBOARDING.md`
- `MODEL_OPTI.md`