### PR TITLE
fix(cost): a zero renders only with the provenance that earns it

### DIFF
--- a/src/coding/routing_observation.py
+++ b/src/coding/routing_observation.py
@@ -125,6 +125,10 @@ _PAYLOAD_FIELDS: Final[frozenset[str]] = frozenset(
         "provenance",
         "routing_provenance",
         *_METRIC_FIELDS,
+        # The provenance that says which of the three zeros a `cost_usd` of
+        # 0.0 is: billed nothing, not reported, or unpriceable.
+        "cost_status",
+        "cost_source",
         "current_action",
         "observed_at",
         "evaluation_binding",
@@ -227,6 +231,15 @@ def build_routing_observation(
         field: runtime_metrics[field] if runtime_metrics[field] is not None else child_metrics[field]
         for field in _METRIC_FIELDS
     }
+    # A cost of exactly zero means three different things -- billed nothing,
+    # not reported by the provider, or a model nothing can price -- and the
+    # figure alone cannot say which. Hermes' own usage record carries the
+    # answer in `cost_status`/`cost_source`; both travel with the number so a
+    # renderer can decline to state a zero it cannot vouch for.
+    cost_status = _first_safe(observed_session, ("cost_status",), field="cost_status") \
+        or _first_safe(child_usage, ("cost_status",), field="cost_status")
+    cost_source = _first_safe(observed_session, ("cost_source",), field="cost_source") \
+        or _first_safe(child_usage, ("cost_source",), field="cost_source")
     current_action = _first_safe(
         observed_session,
         ("current_action", "next_action"),
@@ -258,6 +271,8 @@ def build_routing_observation(
             field="selected_owner",
         )
         or _first_safe(route, ("executor_profile", "owner"), field="selected_owner"),
+        "cost_status": cost_status,
+        "cost_source": cost_source,
         "selected_provider": selected_provider,
         "selected_model": selected_model,
         "selected_reasoning": selected_reasoning,
@@ -417,7 +432,7 @@ def render_routing_status_rows(payload: Mapping[str, object]) -> tuple[str, ...]
         _metric("tools", payload.get("tools")),
         _metric("elapsed", payload.get("elapsed_seconds"), suffix="s"),
         _metric("tokens", payload.get("tokens")),
-        _metric("cost", payload.get("cost_usd"), prefix="$"),
+        _cost_metric(payload),
         _metric("rate", payload.get("rate_tokens_per_second"), suffix=" tok/s"),
     ]
     observed_metrics = [item for item in metrics if item]
@@ -684,3 +699,25 @@ def _metric(label: str, value: object, *, prefix: str = "", suffix: str = "") ->
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         return ""
     return f"{label} {prefix}{value}{suffix}"
+
+
+def _cost_metric(payload: Mapping[str, object]) -> str:
+    """Render a cost only when the figure is one the record can vouch for.
+
+    A positive number speaks for itself. A zero does not: the provider may
+    have billed nothing, may not have reported at all, or may serve a model
+    nothing can price, and all three arrive here as ``0.0``. Rendering the
+    bare ``cost $0.0`` for the last two states a billing fact the record does
+    not hold -- the failure an operator hit when a gateway route reported
+    nothing and the surface printed a confident zero. A zero renders only
+    alongside the provenance that earns it.
+    """
+    value = payload.get("cost_usd")
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return ""
+    if value > 0:
+        return _metric("cost", value, prefix="$")
+    provenance = payload.get("cost_status") or payload.get("cost_source")
+    if not isinstance(provenance, str) or not provenance.strip():
+        return ""
+    return f"cost ${value} ({provenance.strip()})"

--- a/src/commands/hermes_child_observations.py
+++ b/src/commands/hermes_child_observations.py
@@ -43,7 +43,17 @@ def result_payload(
     session.update(
         {
             key: usage[key]
-            for key in ("provider", "model", "total_tokens", "estimated_cost_usd")
+            # `cost_status`/`cost_source` travel with the cost they explain:
+            # without them a zero cannot be told apart from a provider that
+            # reported nothing, and the surface printed a confident $0.00.
+            for key in (
+                "provider",
+                "model",
+                "total_tokens",
+                "estimated_cost_usd",
+                "cost_status",
+                "cost_source",
+            )
             if key in usage
         }
     )

--- a/tests/test_routing_observation_surfaces.py
+++ b/tests/test_routing_observation_surfaces.py
@@ -142,22 +142,35 @@ class RoutingObservationSurfaceParityTests(unittest.TestCase):
             self.assertNotIn("tools 0", canonical_text)
             self.assertNotIn("cost $0", canonical_text)
 
-    def test_genuine_observed_zero_has_byte_parity_on_every_surface(self) -> None:
-        observation = build_routing_observation(
-            route=_route(),
-            session_observation=authenticate_executor_observation({
-                "status": "running",
-                "turn": 0,
-                "tools": 0,
-                "elapsed_seconds": 0.0,
-                "tokens": 0,
-                "cost_usd": 0.0,
-                "rate_tokens_per_second": 0.0,
-            }),
-        )
+    def test_a_zero_cost_renders_only_with_the_provenance_that_earns_it(self) -> None:
+        # A cost of exactly zero arrives from three different worlds -- the
+        # provider billed nothing, the provider reported nothing, or nothing
+        # can price the model -- and the number alone cannot say which. The
+        # figure renders only when the record carries the provenance; an
+        # unvouched zero is withheld rather than stated as a billing fact.
+        def _observation(**extra: object) -> dict[str, object]:
+            return build_routing_observation(
+                route=_route(),
+                session_observation=authenticate_executor_observation({
+                    "status": "running",
+                    "turn": 0,
+                    "tools": 0,
+                    "elapsed_seconds": 0.0,
+                    "tokens": 0,
+                    "cost_usd": 0.0,
+                    "rate_tokens_per_second": 0.0,
+                    **extra,
+                }),
+            )
+
+        unvouched = render_routing_code_block_text(_observation())
+        self.assertIn("METRICS turn 0  tools 0  elapsed 0.0s  tokens 0  rate 0.0 tok/s", unvouched)
+        self.assertNotIn("cost $", unvouched)
+
+        observation = _observation(cost_status="billed_zero")
         canonical_text = render_routing_code_block_text(observation)
         self.assertIn(
-            "METRICS turn 0  tools 0  elapsed 0.0s  tokens 0  cost $0.0  rate 0.0 tok/s",
+            "METRICS turn 0  tools 0  elapsed 0.0s  tokens 0  cost $0.0 (billed_zero)  rate 0.0 tok/s",
             canonical_text,
         )
         projection = routing_surface_projection(observation)


### PR DESCRIPTION
## Capability

A cost of zero now renders only when the record can vouch for it.

```
METRICS turn 0  tools 0  elapsed 0.0s  tokens 0  cost $0.0 (billed_zero)  rate 0.0 tok/s   ← vouched
METRICS turn 0  tools 0  elapsed 0.0s  tokens 0  rate 0.0 tok/s                            ← unvouched: withheld
```

## Motivation

Closes #1272. An operator ran Fable 5.1 through OpenGateway, the surface printed `$0.00`, and they correctly refused to believe it matched the gateway bill.

They were right. The figure on this lane is whatever the spawned child's `usage.json` happened to hold — a gateway route that never populated the field arrives as `0.0`, identical to a genuinely free run. The surface stated it as billing truth either way.

**The answer was already on disk and being discarded.** Hermes writes `cost_status` and `cost_source` beside the cost they explain. `_hermes_child_process` reads both into its bounded usage dict, and `result_payload` forwarded only `provider`, `model`, `total_tokens`, `estimated_cost_usd` — dropping exactly the two fields that separate a billed zero from an unreported one, before any renderer could see them.

## Implementation (boundary level)

- **Forward**: `cost_status`/`cost_source` travel with the cost through `result_payload` into the routing observation (joined from the session record or the child usage) and are admitted by `_PAYLOAD_FIELDS`.
- **Render**: `_cost_metric` replaces the bare `_metric` call. Positive cost renders as before; a zero renders only alongside its provenance; an unvouched zero renders nothing.
- **No new estimate, no price lookup.** This carries provenance the child already wrote and withholds a claim that was never earned. The three surfaces (CLI, status board, messenger) keep byte parity with each other.

The HUD widget already declined a zero for this reason (`row.cost_usd > 0`, *"a true zero with no approximation renders nothing"*). This brings the other surfaces to the same standard **without** losing the authenticated-zero case they were deliberately built to show.

## A note on the test that changed

`test_genuine_observed_zero_has_byte_parity_on_every_surface` asserted that a zero renders as `cost $0.0` — but its fixture was a bare `cost_usd: 0.0` with no provenance at all. The name claimed the zero was genuine; nothing in the fixture made it so. It is now split: the vouched zero keeps the parity assertion (with the provenance that earns it), and the unvouched zero is asserted beside it as the case this PR fixes.

## Verification (observed)

- `tests/test_routing_observation.py`, `tests/test_routing_observation_surfaces.py`, `tests/test_hermes_child_cli.py`: 41 tests OK.
- `ruff check src tests` clean; `compileall` clean; `git diff --check` clean.
- Full suite: **8,701 tests OK**.

## Risks

- The values Hermes puts in `cost_status` are its own vocabulary; the render passes the string through rather than interpreting it, so an unexpected value shows verbatim rather than being mapped or hidden.
- No live gateway dispatch was run from this worktree.

## Not in this PR

Two sibling defects from the same audit: #1273 (a recorded `$0.00` on the Hermes-native lane is treated as missing and overwritten by an approximation) and #1274 (token prices are hardcoded in source with no user override, against the repo's own config-vs-source rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
