### PR TITLE
fix(cost): an unpriceable unrecorded cost is unknown, not free

### DIFF
--- a/src/plugin_bundle/omh/hermes_delegation.py
+++ b/src/plugin_bundle/omh/hermes_delegation.py
@@ -1182,12 +1182,25 @@ def read_hermes_native_subagents(
         # Subscription-billed hosts record no per-call cost; the owner asked
         # for an approximation there rather than a blank. Token-derived, and
         # flagged approximate so the widget can render it as `~$…`.
+        #
+        # `session_model_usage` declares both cost columns NOT NULL DEFAULT 0,
+        # so a host that billed zero and a host that recorded nothing reach
+        # this line as the same 0.0 -- the distinction is destroyed before OMH
+        # can read it, which is why the approximation fires on a falsy cost at
+        # all. What must NOT happen is the third case: no recorded cost AND no
+        # price for the model (`_approximate_cost_usd` returns None for an
+        # unpriced model, and for a run with no tokens). That left `cost` at
+        # 0.0 with no approximate flag, so the row claimed the run was free.
+        # An unknown cost is unknown: send None and let the surface say
+        # nothing rather than state a zero it cannot support.
         cost_approximate = False
         if not cost:
             approx = _approximate_cost_usd(child["model"], input_tokens, output_tokens, cache_read)
             if approx is not None:
                 cost = approx
                 cost_approximate = True
+            else:
+                cost = None
 
         parent_model = state.get("parent_models", {}).get(child["parent_id"], "")
         route_alias, route_provider = configured_route_for_wire(

--- a/tests/test_plugin_hermes_delegation.py
+++ b/tests/test_plugin_hermes_delegation.py
@@ -510,6 +510,47 @@ class HermesNativeSubagentReaderTest(unittest.TestCase):
             (20_000 * 0.15 + 10_000 * 0.015 + 5_000 * 0.60) / 1_000_000,
         )
 
+    def test_an_unpriceable_unrecorded_cost_is_unknown_rather_than_free(self):
+        # grok-code-fast ships in the catalog with a provider family but no
+        # price row, so nothing can derive a figure for it. The host recorded
+        # no cost either (the columns are NOT NULL DEFAULT 0, so "billed
+        # nothing" and "recorded nothing" arrive identically as 0.0). The row
+        # must then carry NO cost at all: a bare 0.0 with no approximate flag
+        # renders exactly like a genuinely free run, which is the claim OMH
+        # cannot support.
+        _build_state_db(
+            self.home,
+            [
+                {
+                    "id": "20260818_100200_grok001",
+                    "model": "grok-code-fast",
+                    "effort": "medium",
+                    "started_at": NOW - 300,
+                    "usage": {
+                        "api_calls": 3,
+                        "input_tokens": 12_000,
+                        "output_tokens": 3_000,
+                        "cache_read_tokens": 0,
+                        "first_seen": NOW - 290,
+                        "last_seen": NOW - 10,
+                    },
+                }
+            ],
+        )
+        _write_manifest(
+            self.home,
+            "deleg_grok",
+            ["grok lane"],
+            started=NOW - 305,
+            log_mtime=NOW - 5,
+        )
+        payload = read_hermes_native_subagents(self.home, now=NOW, omh_home=self.home / ".omh")
+        row = payload["rows"][0]
+        self.assertEqual(row["model"], "grok-code-fast")
+        self.assertEqual(row["tokens"], 15_000)
+        self.assertNotIn("cost_usd", row)
+        self.assertNotIn("cost_approximate", row)
+
     def test_an_observed_host_cost_is_never_replaced_by_the_approximation(self):
         _build_state_db(
             self.home,


### PR DESCRIPTION
## Capability

A cost that cannot be known is now reported as unknown rather than as free.

A row whose host recorded no cost **and** whose model has no price entry kept `cost_usd: 0.0` with no `cost_approximate` flag — rendering identically to a run that genuinely cost nothing. `grok-code-fast` ships in the recommendation catalog with a full provider-family entry and **no price row**, so every run on it reported itself as free, permanently.

## Motivation

Closes #1273, from the cost-tracking audit.

## A correction to the issue's premise

Worth stating plainly, because it changes what the fix can honestly be: `session_model_usage` declares both cost columns **`NOT NULL DEFAULT 0`**. A host that billed zero and a host that recorded nothing therefore reach OMH as the *same* `0.0` — the distinction is destroyed in Hermes' own table before OMH can read it, and `SUM(actual_cost_usd)` can never come back NULL.

So the truthiness check I originally flagged is **not** the defect. Approximating on a falsy cost is correct for the case OMH can actually observe (real tokens, no recorded cost = a subscription host), and it is already flagged `~`.

The third case is the one that was lying, and it is fixable:

```python
cost = actual or estimated              # 0.0 for an unrecorded host
if not cost:
    approx = _approximate_cost_usd(...) # None for an unpriced model
    ...                                 # cost stayed 0.0, unflagged
```

Now, when nothing can be priced, the cost becomes `None` and the row carries no `cost_usd` at all.

Recovering "billed zero vs recorded nothing" would require Hermes to stop collapsing them in its own schema — outside this repo, and worth raising there rather than pretending OMH can infer it.

## Verification (observed)

- New test: a `grok-code-fast` row carries neither `cost_usd` nor `cost_approximate`, asserted beside the existing recorded-cost and approximated-cost cases so all three branches are pinned.
- `tests/test_plugin_hermes_delegation.py`, `tests/test_hud.py`; `ruff` clean; `compileall` clean; `git diff --check` clean.
- Full suite: **8,702 tests OK**.

## Risks

- A row that previously showed `$0.0000` for an unpriced model now shows no cost segment. That is the intended correction.

## Rejected

- **Adding a `grok-code-fast` price row instead** — that hides this class of bug behind one more table entry; the next unpriced model would claim free again. The row belongs in the price work (#1274).
- **Inferring billed-zero from `api_call_count`** — a call count proves calls happened, not what they cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
