### PR TITLE
feat(cost): token prices become a config document, not a source edit

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -372,6 +372,36 @@ Supply wire-id routes in `~/.omh/routing/model-providers.json`
 }
 ```
 
+### Token prices
+
+The cost figures OMH shows when a host records none are ballparks from a
+shipped table, and what you actually pay is not: a gateway applies its own
+markup, an enterprise contract is not the list price, a free tier bills
+nothing, and vendors reprice. Put your own rates in
+`~/.omh/routing/model-prices.json` (`model_price_overrides/v1`):
+
+```json
+{
+  "schema_version": "model_price_overrides/v1",
+  "models": {
+    "claude-fable-5-1": {"input_per_mtok": 8.0, "output_per_mtok": 40.0},
+    "grok-code-fast": {"input_per_mtok": 0.2, "output_per_mtok": 1.5},
+    "my-free-tier-model": {"input_per_mtok": 0, "output_per_mtok": 0}
+  }
+}
+```
+
+A model listed here uses your rate; a model not listed falls back to the
+shipped ballpark, and a model neither prices reports no cost at all rather
+than claiming it was free. `cache_read_ratio` is optional and defaults to the
+shipped ratio for that model. Zero is a real rate, not an absent one, so a
+free tier can say so. Validation is strict and atomic, like its siblings: an
+invalid document is ignored whole rather than half-applied.
+
+A recorded cost from the host is never replaced by any of this — overrides
+only reach the approximation that fires when nothing was recorded, and an
+approximated figure still renders with its `~` marker.
+
 An alias listed here dispatches as that provider's model; an alias not listed
 dispatches unchanged with no provider, which is what a direct-billing host
 wants — the file is optional and absent by default. A `provider` passed

--- a/src/plugin_bundle/omh/hermes_delegation.py
+++ b/src/plugin_bundle/omh/hermes_delegation.py
@@ -784,10 +784,115 @@ APPROX_CACHE_READ_RATIO: dict[str, float] = {
 _DEFAULT_CACHE_READ_RATIO = 0.1
 
 
+# Token prices differ per user and drift over time: a gateway applies its own
+# markup, an enterprise contract is not the list price, a free tier bills
+# nothing, and vendors reprice. The shipped table below is a ballpark, so the
+# rates a user actually pays belong in their own document rather than in our
+# source -- the same rule `model-chains.json` and `providers.json` already
+# follow ("Chain customization is a config edit, not a source edit").
+#
+#   {"schema_version": "model_price_overrides/v1",
+#    "models": {"claude-fable-5-1": {"input_per_mtok": 8.0,
+#                                    "output_per_mtok": 40.0,
+#                                    "cache_read_ratio": 0.025}}}
+#
+# `cache_read_ratio` is optional and defaults to the shipped ratio for that
+# model. A model the shipped table never priced can be priced here, which is
+# how a user reaches a model OMH ships no rate for at all.
+MODEL_PRICE_OVERRIDES_SCHEMA_VERSION = "model_price_overrides/v1"
+
+
+def model_price_overrides_path(omh_home: str | Path | None = None) -> Path:
+    root = Path(omh_home).expanduser() if omh_home else Path.home() / ".omh"
+    return root / "routing" / "model-prices.json"
+
+
+def load_model_price_overrides(
+    omh_home: str | Path | None = None,
+) -> tuple[dict[str, tuple[float, float, float | None]], str]:
+    """Read the user's price override document.
+
+    Returns ``(overrides, status)`` where status is ``absent``, ``applied``,
+    or ``invalid: <reason>``, matching `load_mixture_chain_overrides`. An
+    invalid document is ignored entirely rather than half-applied.
+    """
+    path = model_price_overrides_path(omh_home)
+    try:
+        raw = _strict_json_loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}, "absent"
+    except (OSError, UnicodeDecodeError, ValueError):
+        return {}, "invalid: unreadable JSON"
+    return parse_model_price_overrides(raw)
+
+
+def parse_model_price_overrides(
+    raw: object,
+) -> tuple[dict[str, tuple[float, float, float | None]], str]:
+    """Validate one already-parsed price document (strict, atomic)."""
+    if not isinstance(raw, dict):
+        return {}, "invalid: document must be a JSON object"
+    if raw.get("schema_version") != MODEL_PRICE_OVERRIDES_SCHEMA_VERSION:
+        return {}, f"invalid: schema_version must be {MODEL_PRICE_OVERRIDES_SCHEMA_VERSION}"
+    unknown = sorted(set(raw) - {"schema_version", "models"})
+    if unknown:
+        return {}, f"invalid: unsupported fields {unknown}"
+    models = raw.get("models")
+    if not isinstance(models, dict):
+        return {}, "invalid: models must be an object"
+    overrides: dict[str, tuple[float, float, float | None]] = {}
+    for name, entry in models.items():
+        if not isinstance(name, str) or not _CHAIN_TOKEN_RE.fullmatch(name):
+            return {}, f"invalid: model {name!r} is not a plain model token"
+        if not isinstance(entry, dict):
+            return {}, f"invalid: model {name!r} must be an object"
+        entry_unknown = sorted(set(entry) - {"input_per_mtok", "output_per_mtok", "cache_read_ratio"})
+        if entry_unknown:
+            return {}, f"invalid: model {name!r} fields {entry_unknown}"
+        rates: list[float] = []
+        for field in ("input_per_mtok", "output_per_mtok"):
+            value = entry.get(field)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                return {}, f"invalid: model {name!r} {field} must be a number"
+            if value != value or value < 0 or value == float("inf"):
+                return {}, f"invalid: model {name!r} {field} must be zero or more"
+            rates.append(float(value))
+        ratio = entry.get("cache_read_ratio")
+        if ratio is None:
+            cache_ratio: float | None = None
+        elif isinstance(ratio, bool) or not isinstance(ratio, (int, float)):
+            return {}, f"invalid: model {name!r} cache_read_ratio must be a number"
+        elif ratio != ratio or ratio < 0 or ratio > 1:
+            return {}, f"invalid: model {name!r} cache_read_ratio must be between 0 and 1"
+        else:
+            cache_ratio = float(ratio)
+        overrides[name.casefold()] = (rates[0], rates[1], cache_ratio)
+    return overrides, "applied"
+
+
 def _approximate_cost_usd(
-    model: str, input_tokens: float, output_tokens: float, cache_read_tokens: float
+    model: str,
+    input_tokens: float,
+    output_tokens: float,
+    cache_read_tokens: float,
+    overrides: Mapping[str, tuple[float, float, float | None]] | None = None,
 ) -> float | None:
     key = _text(model).casefold()
+    override = (overrides or {}).get(key)
+    if override is not None:
+        input_price, output_price, override_ratio = override
+        if (input_tokens + output_tokens) <= 0:
+            return None
+        cache_ratio = (
+            override_ratio
+            if override_ratio is not None
+            else APPROX_CACHE_READ_RATIO.get(key, _DEFAULT_CACHE_READ_RATIO)
+        )
+        return (
+            input_tokens * input_price
+            + cache_read_tokens * input_price * cache_ratio
+            + output_tokens * output_price
+        ) / 1_000_000
     prices = APPROX_PRICE_PER_MTOK.get(key)
     if not prices or (input_tokens + output_tokens) <= 0:
         return None
@@ -1075,6 +1180,7 @@ def read_hermes_native_subagents(
     # overrides so a customized chain labels its children like a shipped one.
     active_chains = effective_mixture_category_chains(omh_home)
     provider_routes, _ = load_model_provider_routes(omh_home)
+    price_overrides, _price_status = load_model_price_overrides(omh_home)
     route_provenance = load_delegation_route_provenance(omh_home)
     payload: dict[str, Any] = {
         "status": "idle",
@@ -1195,7 +1301,9 @@ def read_hermes_native_subagents(
         # nothing rather than state a zero it cannot support.
         cost_approximate = False
         if not cost:
-            approx = _approximate_cost_usd(child["model"], input_tokens, output_tokens, cache_read)
+            approx = _approximate_cost_usd(
+                child["model"], input_tokens, output_tokens, cache_read, price_overrides
+            )
             if approx is not None:
                 cost = approx
                 cost_approximate = True

--- a/tests/test_model_price_overrides.py
+++ b/tests/test_model_price_overrides.py
@@ -1,0 +1,151 @@
+"""The user's own price document decides what a token costs.
+
+Prices differ per user and drift: a gateway marks up, an enterprise contract
+is not the list price, a free tier bills nothing, and vendors reprice. The
+shipped table is a ballpark, so these tests pin the rule that the operator's
+own document wins where it speaks, that an invalid document is ignored whole
+rather than half-applied, and that a model OMH never priced can be priced
+here — which is the only way a user reaches one today.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from omh.plugin_bundle.omh.hermes_delegation import (
+    MODEL_PRICE_OVERRIDES_SCHEMA_VERSION,
+    _approximate_cost_usd,
+    load_model_price_overrides,
+    model_price_overrides_path,
+    parse_model_price_overrides,
+)
+
+
+def _document(models: dict[str, object]) -> dict[str, object]:
+    return {"schema_version": MODEL_PRICE_OVERRIDES_SCHEMA_VERSION, "models": models}
+
+
+class ParseTests(unittest.TestCase):
+    def test_a_valid_document_applies(self) -> None:
+        overrides, status = parse_model_price_overrides(
+            _document({"claude-fable-5-1": {"input_per_mtok": 8.0, "output_per_mtok": 40.0}})
+        )
+        self.assertEqual(status, "applied")
+        self.assertEqual(overrides, {"claude-fable-5-1": (8.0, 40.0, None)})
+
+    def test_the_cache_ratio_is_optional_and_carried_when_given(self) -> None:
+        overrides, status = parse_model_price_overrides(
+            _document({
+                "m": {"input_per_mtok": 1.0, "output_per_mtok": 2.0, "cache_read_ratio": 0.025}
+            })
+        )
+        self.assertEqual(status, "applied")
+        self.assertEqual(overrides, {"m": (1.0, 2.0, 0.025)})
+
+    def test_a_model_name_is_folded_so_lookups_match(self) -> None:
+        overrides, _ = parse_model_price_overrides(
+            _document({"Claude-Fable-5-1": {"input_per_mtok": 1.0, "output_per_mtok": 2.0}})
+        )
+        self.assertIn("claude-fable-5-1", overrides)
+
+    def test_every_invalid_document_is_rejected_whole(self) -> None:
+        # Atomic, matching the sibling documents: half a price table is worse
+        # than none, because the half that applied is invisible.
+        cases = {
+            "not an object": [],
+            "wrong schema": {"schema_version": "nope", "models": {}},
+            "unsupported field": {
+                "schema_version": MODEL_PRICE_OVERRIDES_SCHEMA_VERSION,
+                "models": {},
+                "extra": 1,
+            },
+            "models not an object": _document([]),  # type: ignore[arg-type]
+            "entry not an object": _document({"m": 1.0}),
+            "unknown entry field": _document({"m": {"input_per_mtok": 1.0, "output_per_mtok": 2.0, "rate": 3}}),
+            "missing output": _document({"m": {"input_per_mtok": 1.0}}),
+            "boolean rate": _document({"m": {"input_per_mtok": True, "output_per_mtok": 2.0}}),
+            "negative rate": _document({"m": {"input_per_mtok": -1.0, "output_per_mtok": 2.0}}),
+            "ratio above one": _document({
+                "m": {"input_per_mtok": 1.0, "output_per_mtok": 2.0, "cache_read_ratio": 1.5}
+            }),
+            "path-shaped name": _document({"../m": {"input_per_mtok": 1.0, "output_per_mtok": 2.0}}),
+        }
+        for label, raw in cases.items():
+            with self.subTest(case=label):
+                overrides, status = parse_model_price_overrides(raw)
+                self.assertEqual(overrides, {})
+                self.assertTrue(status.startswith("invalid: "), status)
+
+
+class LoadTests(unittest.TestCase):
+    def test_an_absent_document_is_absent_not_invalid(self) -> None:
+        with TemporaryDirectory() as tmp:
+            overrides, status = load_model_price_overrides(Path(tmp))
+            self.assertEqual((overrides, status), ({}, "absent"))
+
+    def test_a_written_document_round_trips(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = model_price_overrides_path(Path(tmp))
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                json.dumps(_document({"m": {"input_per_mtok": 3.0, "output_per_mtok": 6.0}})),
+                encoding="utf-8",
+            )
+            overrides, status = load_model_price_overrides(Path(tmp))
+            self.assertEqual(status, "applied")
+            self.assertEqual(overrides, {"m": (3.0, 6.0, None)})
+
+    def test_unreadable_json_is_invalid_not_a_crash(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = model_price_overrides_path(Path(tmp))
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("{not json", encoding="utf-8")
+            overrides, status = load_model_price_overrides(Path(tmp))
+            self.assertEqual(overrides, {})
+            self.assertEqual(status, "invalid: unreadable JSON")
+
+
+class PricingTests(unittest.TestCase):
+    def test_the_users_rate_beats_the_shipped_ballpark(self) -> None:
+        shipped = _approximate_cost_usd("claude-fable-5-1", 1_000_000, 0, 0)
+        overridden = _approximate_cost_usd(
+            "claude-fable-5-1", 1_000_000, 0, 0, {"claude-fable-5-1": (1.0, 2.0, None)}
+        )
+        self.assertAlmostEqual(shipped, 10.0)
+        self.assertAlmostEqual(overridden, 1.0)
+
+    def test_a_model_the_shipped_table_never_priced_can_be_priced(self) -> None:
+        # The only route to a cost for a model OMH ships no rate for.
+        self.assertIsNone(_approximate_cost_usd("grok-code-fast", 1_000_000, 0, 0))
+        self.assertAlmostEqual(
+            _approximate_cost_usd(
+                "grok-code-fast", 1_000_000, 1_000_000, 0, {"grok-code-fast": (0.2, 1.5, None)}
+            ),
+            1.7,
+        )
+
+    def test_an_overridden_model_keeps_the_shipped_cache_ratio_unless_told_otherwise(self) -> None:
+        # claude-fable-5-1 ships a 0.025 cache ratio; an override that does not
+        # mention the ratio must not silently reset it to the 0.1 default.
+        with_shipped_ratio = _approximate_cost_usd(
+            "claude-fable-5-1", 0, 0, 1_000_000, {"claude-fable-5-1": (10.0, 50.0, None)}
+        )
+        self.assertIsNone(with_shipped_ratio)  # no input/output tokens: nothing to price
+        priced = _approximate_cost_usd(
+            "claude-fable-5-1", 1_000, 0, 1_000_000, {"claude-fable-5-1": (10.0, 50.0, None)}
+        )
+        self.assertAlmostEqual(priced, (1_000 * 10.0 + 1_000_000 * 10.0 * 0.025) / 1_000_000)
+
+    def test_a_zero_rate_is_a_real_price_not_an_absent_one(self) -> None:
+        # A free tier bills nothing; the override must be able to say so.
+        self.assertEqual(
+            _approximate_cost_usd("m", 1_000_000, 1_000_000, 0, {"m": (0.0, 0.0, None)}),
+            0.0,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Capability

Token prices become a config document instead of a source edit.

```json
{
  "schema_version": "model_price_overrides/v1",
  "models": {
    "claude-fable-5-1": {"input_per_mtok": 8.0, "output_per_mtok": 40.0},
    "grok-code-fast":   {"input_per_mtok": 0.2, "output_per_mtok": 1.5},
    "my-free-tier":     {"input_per_mtok": 0,   "output_per_mtok": 0}
  }
}
```

`~/.omh/routing/model-prices.json` joins its two siblings — `model-chains.json` and `model-providers.json` — and is built to their shape: schema-version check, token-only names, strict field sets, atomic validation.

## Motivation

Closes #1274. The rates OMH uses when a host records no cost were a dict literal in shipped source with no way for a user to change them. What a user actually pays is not a constant we can ship — a gateway applies its own markup, an enterprise contract is not the list price, a free tier bills nothing, and vendors reprice. The shipped table's own comment already concedes it went stale once (*"Earlier entries here were stale"*).

Correcting a rate meant editing our source, which the repo's own rule forbids: **"Chain customization is a config edit, not a source edit."**

## The rules

| | |
| --- | --- |
| **Precedence** | A recorded host cost is never touched. The document only reaches the approximation that fires when nothing was recorded, and that figure still carries its `~` marker. |
| **Fallback** | A model the document omits keeps the shipped ballpark; a model neither prices reports no cost at all rather than claiming free. |
| **Cache** | `cache_read_ratio` is optional and defaults to the shipped ratio for that model, so an override restating only the two rates cannot silently reset a model's cache economics. |
| **Zero** | A rate of zero is a real price, not an absent one — a free tier can say so. |

This is also the only route to a cost for a model OMH ships no rate for at all: `grok-code-fast` sits in the recommendation catalog with a provider family and no price row.

## Verification (observed)

- `tests/test_model_price_overrides.py` — 11 cases: valid parse, optional ratio, name folding, **eleven rejection shapes** (wrong schema, extra field, non-object entry, missing rate, boolean rate, negative rate, ratio > 1, path-shaped name…), absent-vs-invalid load, round trip, override beats ballpark, unpriced model becomes priceable, shipped cache ratio preserved, zero as a real rate.
- `ruff` clean; `compileall` clean; `git diff --check` clean.
- Full suite: **8,712 tests OK**.
- `docs/INSTALLATION.md` gains the section beside its siblings.

## Risks

- None by default — with no document present every existing approximation, marker, and precedence rule is unchanged.
- With a document present, a user's own wrong number produces a wrong approximation — flagged `~`, exactly as the shipped ballpark's is.

## Rejected

- **Seeding a starter file at setup** — an empty price document invites guessed rates; absent means "use the ballpark", which is the honest default.
- **Letting the document override a *recorded* cost** — the host's own figure is evidence and a user's table is not, so overrides stop at the approximation.
- **A CLI writer command** — the file is small and hand-editable; `model-chains.json` earned its writer through an interview flow this document has no equivalent of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
