### PR TITLE
feat(routing): refuse a dispatch that would inherit a provider which cannot serve it

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -402,6 +402,15 @@ A recorded cost from the host is never replaced by any of this — overrides
 only reach the approximation that fires when nothing was recorded, and an
 approximated figure still renders with its `~` marker.
 
+A dispatch that inherits its provider is checked before the route is written:
+if the session's own provider cannot serve the model being pinned — the
+catalog records which provider families serve each model — the route is
+refused, naming the inherited provider and which of your recorded providers
+could serve it instead. The check only refuses what is known wrong. An
+unrecorded provider, a model the catalog never described, and a multi-vendor
+relay (which serves every family) all leave the answer unknown, and unknown
+dispatches unchanged.
+
 An alias listed here dispatches as that provider's model; an alias not listed
 dispatches unchanged with no provider, which is what a direct-billing host
 wants — the file is optional and absent by default. A `provider` passed

--- a/src/plugin_bundle/omh/delegation_routing.py
+++ b/src/plugin_bundle/omh/delegation_routing.py
@@ -36,6 +36,8 @@ ROUTABLE_KEYS = ("model", "reasoning_effort", "provider")
 
 _VALUE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$")
 _SECTION_RE = re.compile(r"^delegation:\s*(#.*)?$")
+_MODEL_SECTION_RE = re.compile(r"^model:\s*(#.*)?$")
+_MODEL_PROVIDER_RE = re.compile(r"^\s+provider\s*:")
 def _managed_key_re(key: str, indent: int) -> re.Pattern[str]:
     return re.compile(rf"^ {{{indent}}}{re.escape(key)}\s*:")
 
@@ -83,6 +85,43 @@ def _read_delegation_route_text(text: str) -> dict[str, str]:
                 else:
                     values.pop(key, None)
     return values
+
+
+def read_session_provider(hermes_home: str | Path | None = None) -> str:
+    """The provider this session runs on, from config.yaml's own `model:` block.
+
+    A child dispatched with no `delegation.provider` inherits this value, so
+    it is the provider that will actually serve the run. Read by the same
+    text scan as the delegation keys, and empty whenever the file, the block,
+    or the key is missing -- an unknown provider must never be treated as a
+    wrong one.
+    """
+    config_path = _config_path(hermes_home)
+    text, _, error = _read_config_snapshot(config_path)
+    if error:
+        return ""
+    return _read_session_provider_text(text)
+
+
+def _read_session_provider_text(text: str) -> str:
+    lines = text.splitlines()
+    in_model = False
+    provider = ""
+    for line in lines:
+        if _MODEL_SECTION_RE.match(line):
+            in_model = True
+            continue
+        if in_model and _top_level_key(line) is not None:
+            in_model = False
+        if not in_model:
+            continue
+        if _MODEL_PROVIDER_RE.match(line):
+            _, _, raw = line.partition(":")
+            value = _yaml_string_token(raw)
+            # Last occurrence wins, mirroring YAML, and a bare empty value
+            # unsets an earlier one exactly as it does for delegation keys.
+            provider = value or ""
+    return provider
 
 
 def write_delegation_route(

--- a/src/plugin_bundle/omh/hermes_delegation.py
+++ b/src/plugin_bundle/omh/hermes_delegation.py
@@ -389,6 +389,74 @@ def alias_is_served(
     return bool(kinds & set(families))
 
 
+def provider_family_for(provider_id: str, entitlements: Mapping[str, Any] | None) -> str:
+    """The family a provider id belongs to, or "" when nothing records it.
+
+    The operator's own document decides first, because a provider id is
+    theirs to name -- `og`, `work-gateway`, anything. A id that is itself a
+    catalog family name (`anthropic`, `openai-codex`) resolves without a
+    document, which is what an install with no entitlements recorded has.
+    """
+    key = str(provider_id or "").strip()
+    if not key:
+        return ""
+    providers = (entitlements or {}).get("providers", {})
+    if isinstance(providers, Mapping):
+        recorded = providers.get(key)
+        if isinstance(recorded, str) and recorded:
+            return recorded
+    return key if key in PROVIDER_FAMILY_VOCABULARY else ""
+
+
+def provider_serves_alias(
+    alias: str,
+    provider_id: str,
+    entitlements: Mapping[str, Any] | None = None,
+) -> bool | None:
+    """Whether ONE named provider can serve ``alias``. None means unknown.
+
+    Distinct from `alias_is_served`, which asks whether ANY confirmed
+    provider could. That question cannot catch the failure this one exists
+    for: a dispatch that inherits its provider goes to whatever the session
+    runs on, and a multi-vendor account elsewhere in the document does not
+    make the inherited one able to serve the model.
+
+    Unknown -- not False -- whenever the provider has no recorded family, the
+    catalog never described the alias, or the family is multi-vendor and so
+    serves everything. Nothing is refused on a guess.
+    """
+    family = provider_family_for(provider_id, entitlements)
+    if not family or family in MULTI_VENDOR_PROVIDER_KINDS:
+        return None
+    families = HERMES_MIXTURE_ALIAS_PROVIDER_FAMILIES.get(str(alias or "").strip().casefold())
+    if families is None:
+        return None
+    return family in families
+
+
+def providers_serving_alias(
+    alias: str,
+    entitlements: Mapping[str, Any] | None,
+) -> tuple[str, ...]:
+    """The operator's own provider ids that could serve ``alias``.
+
+    The direction half of the guard: refusing a dispatch is only useful
+    beside the answer, and the answer can only come from what the operator
+    recorded holding.
+    """
+    providers = (entitlements or {}).get("providers", {})
+    if not isinstance(providers, Mapping):
+        return ()
+    families = HERMES_MIXTURE_ALIAS_PROVIDER_FAMILIES.get(str(alias or "").strip().casefold())
+    candidates = []
+    for provider_id, kind in providers.items():
+        if not isinstance(provider_id, str) or not isinstance(kind, str):
+            continue
+        if kind in MULTI_VENDOR_PROVIDER_KINDS or (families and kind in families):
+            candidates.append(provider_id)
+    return tuple(sorted(candidates))
+
+
 def entitlement_shaped_chain(
     chain: tuple[tuple[str, str], ...],
     entitlements: Mapping[str, Any],

--- a/src/plugin_bundle/omh/tools/delegate_route_tool.py
+++ b/src/plugin_bundle/omh/tools/delegate_route_tool.py
@@ -4,13 +4,20 @@ import json
 import time
 from typing import Any
 
-from ..delegation_routing import read_delegation_route, write_delegation_route
+from ..delegation_routing import (
+    read_delegation_route,
+    read_session_provider,
+    write_delegation_route,
+)
 from ..hermes_delegation import (
     HERMES_MIXTURE_CATEGORY_CHAINS,
     append_delegation_route_provenance,
     chain_alias_for,
     load_mixture_chain_overrides,
     load_model_provider_routes,
+    load_provider_entitlements,
+    provider_serves_alias,
+    providers_serving_alias,
     mixture_chain_overrides_path,
     model_provider_routes_path,
     resolve_provider_model,
@@ -419,6 +426,36 @@ def omh_delegate_route_handler(args: dict[str, Any], **kwargs) -> str:
         wire_model = model
     else:
         wire_model, provider = resolve_provider_model(alias, routes=provider_routes)
+    if not provider:
+        # With no provider the child inherits the session's own, and nothing
+        # checked that it can serve the model being pinned. Observed live: a
+        # Fable alias inherited an `openai-codex` session and every dispatch
+        # returned HTTP 400, twice, before the operator worked out the model
+        # needed a different provider and hunted down its wire id by hand.
+        # Refuse only what is known wrong -- an unrecorded provider, an alias
+        # the catalog never described, or a multi-vendor account all answer
+        # "unknown" and dispatch unchanged -- and refuse it beside the answer.
+        entitlements, _ = load_provider_entitlements(omh_home)
+        session_provider = read_session_provider(hermes_home)
+        if provider_serves_alias(alias, session_provider, entitlements) is False:
+            candidates = providers_serving_alias(alias, entitlements)
+            remedy = (
+                f"pin one of your providers that can: {', '.join(candidates)}"
+                if candidates
+                else "record which provider serves it in routing/model-providers.json"
+            )
+            payload = {
+                "status": "error",
+                "error": (
+                    f"{alias} would inherit this session's provider {session_provider!r}, "
+                    f"which does not serve it. Pass an explicit provider with its wire model, "
+                    f"or {remedy}."
+                ),
+                "alias": alias,
+                "inherited_provider": session_provider,
+                "providers_serving_alias": list(candidates),
+            }
+            return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
     if "/" in wire_model and not provider:
         payload = {
             "status": "error",

--- a/tests/test_provider_inheritance_guard.py
+++ b/tests/test_provider_inheritance_guard.py
@@ -1,0 +1,124 @@
+"""A dispatch may not inherit a provider that cannot serve the model it pins.
+
+Observed live: a Fable alias was pinned with no provider, inherited an
+`openai-codex` session, and every dispatch returned HTTP 400. It happened
+twice before the operator worked out that the model needed a different
+provider and hunted its wire id down by hand. Nothing in OMH had checked the
+one thing it could check -- that the provider about to serve the run is one
+the catalog says can serve that model -- even though the alias and the
+provider are both in scope at the moment the route is written.
+
+These tests pin the guard and, just as importantly, its silence: it refuses
+only what is known wrong, and says who could serve the model instead.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from omh.plugin_bundle.omh.tools.delegate_route_tool import omh_delegate_route_handler
+
+
+class ProviderInheritanceGuardTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.home = Path(self._tmp.name)
+        self.config = self.home / "config.yaml"
+        self.omh_home = self.home / ".omh"
+
+    def _session_on(self, provider: str) -> None:
+        self.config.write_text(f"model:\n  provider: {provider}\n", encoding="utf-8")
+
+    def _entitlements(self, providers: dict[str, str]) -> None:
+        path = self.omh_home / "routing" / "providers.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({
+                "schema_version": "provider_entitlements/v1",
+                "providers": providers,
+                "subscription_clis": [],
+            }),
+            encoding="utf-8",
+        )
+
+    def _call(self, **args) -> dict:
+        return json.loads(
+            omh_delegate_route_handler(
+                {"hermes_home": str(self.home), "omh_home": str(self.omh_home), **args}
+            )
+        )
+
+    def test_the_incident_is_refused_with_the_provider_that_could_serve_it(self) -> None:
+        self._session_on("openai-codex")
+        self._entitlements({"og": "gateway", "openai-codex": "openai-codex"})
+        result = self._call(action="set", model="claude-fable-5-1", reasoning_effort="high")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("openai-codex", result["error"])
+        self.assertIn("does not serve it", result["error"])
+        self.assertEqual(result["inherited_provider"], "openai-codex")
+        # The refusal is only half the help; the answer is the other half.
+        self.assertEqual(result["providers_serving_alias"], ["og"])
+        self.assertIn("og", result["error"])
+        # Nothing was written: a refused route must not leave a half-route.
+        self.assertNotIn("delegation:", self.config.read_text(encoding="utf-8"))
+
+    def test_it_still_catches_the_incident_with_no_entitlements_recorded(self) -> None:
+        # The provider id is itself a catalog family name, so the check holds
+        # on an install that never ran the entitlement interview -- which is
+        # the install the incident happened on.
+        self._session_on("openai-codex")
+        result = self._call(action="set", model="claude-fable-5-1")
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["providers_serving_alias"], [])
+        self.assertIn("routing/model-providers.json", result["error"])
+
+    def test_an_explicit_provider_is_never_second_guessed(self) -> None:
+        self._session_on("openai-codex")
+        result = self._call(
+            action="set",
+            model="anthropic/claude-fable-5-1",
+            provider="og",
+            reasoning_effort="high",
+        )
+        self.assertEqual(result["status"], "routed")
+
+    def test_a_provider_that_serves_the_alias_dispatches(self) -> None:
+        self._session_on("anthropic")
+        result = self._call(action="set", model="claude-fable-5-1")
+        self.assertEqual(result["status"], "routed")
+
+    def test_silence_on_every_unknown(self) -> None:
+        # Nothing is refused on a guess. Each of these leaves the answer
+        # genuinely unknown, and an unknown provider must never be treated as
+        # a wrong one.
+        cases = {
+            "no session provider recorded": ("", "claude-fable-5-1", {}),
+            "a model the catalog never described": ("openai-codex", "some-local-model", {}),
+            "a provider id nothing records": ("my-own-thing", "claude-fable-5-1", {}),
+        }
+        for label, (session_provider, model, providers) in cases.items():
+            with self.subTest(case=label):
+                self.config.write_text(
+                    f"model:\n  provider: {session_provider}\n" if session_provider else "model:\n",
+                    encoding="utf-8",
+                )
+                if providers:
+                    self._entitlements(providers)
+                result = self._call(action="set", model=model)
+                self.assertEqual(result["status"], "routed", result)
+
+    def test_a_multi_vendor_session_provider_is_left_alone(self) -> None:
+        # A relay serves models of every family, so inheriting one is not a
+        # known-wrong dispatch even when the alias names other families.
+        self._session_on("og")
+        self._entitlements({"og": "gateway"})
+        result = self._call(action="set", model="claude-fable-5-1")
+        self.assertEqual(result["status"], "routed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Capability

A route that would inherit a provider unable to serve the model it pins is now refused at write time, beside the answer:

```
claude-fable-5-1 would inherit this session's provider 'openai-codex', which does not
serve it. Pass an explicit provider with its wire model, or pin one of your providers
that can: og.
```

## Motivation

Observed live: a Fable alias was pinned with no provider, inherited an `openai-codex` session, and every dispatch returned HTTP 400 — **twice** — before the operator worked out that the model needed a different provider and hunted its wire id down by hand. The alias and the provider it will inherit are both in scope at the moment the route is written, so the check costs one lookup.

## Implementation (boundary level)

| | |
| --- | --- |
| **read** | `read_session_provider` scans config.yaml's own `model:` block for the provider a child inherits, by the same text scan the delegation keys already use. Missing file, block, or key all return `""`. |
| **judge** | `provider_serves_alias` asks whether **one** named provider can serve the alias. |
| **direct** | `providers_serving_alias` names the operator's own providers that could, so the refusal is not a dead end. |

**Why not `alias_is_served`** — it was the obvious reach and it answers a different question: whether *any* confirmed provider could serve the alias. That is `True` whenever a multi-vendor account is recorded anywhere in the document, which is exactly the state the incident was in. A relay recorded elsewhere does not make the *inherited* provider able to serve the model.

**Provider-neutral by construction.** Every input is the operator's own config and their own recorded entitlements. No provider is named in source, and a relay is never demoted for being one.

**It refuses only what is known wrong.** An unrecorded provider, an alias the catalog never described, and a multi-vendor relay all answer *unknown*, and unknown dispatches unchanged — the same fail-open discipline `alias_is_served` documents. It also holds on an install that never ran the entitlement interview, because a provider id that is itself a catalog family name resolves without a document — and that is the install the incident happened on.

## Verification (observed)

- `tests/test_provider_inheritance_guard.py` — 6 cases: the incident with entitlements and without, an explicit provider left untouched, a serving provider dispatching, three silent-unknown shapes, and a multi-vendor session.
- The reader was run against the owner machine's real `config.yaml` and returned its actual provider (`openai-codex` — the value the incident inherited).
- `tests/test_delegate_route_tool.py`, `tests/test_provider_entitlements.py`, `tests/test_plugin_hermes_delegation.py`; `ruff` clean; `compileall` clean; `git diff --check` clean.
- Full suite: **8,719 tests OK**.

## Risks

- A route that used to be written and then fail at dispatch is now refused at write time. A false refusal would need a provider whose family the catalog records **and** an alias whose family list is wrong — both editorial data this repo owns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
