### PR TITLE
fix(hud): drop the context dash the header could never fill

### DIFF
--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -92,7 +92,18 @@ export default function register(sdk) {
       tokens: rows.some(row => Number.isFinite(row.tokens))
         ? `${tokenCountText(tokens)} tokens`
         : '',
-      ctx: Number.isFinite(ctx) ? `ctx ${ctx}%` : 'ctx --',
+      // `ctx N%` when a row reports a context reading, and NOTHING when none
+      // does. It used to render a permanent not-collected dash, which read
+      // as a broken
+      // feature rather than an absent number -- and it is absent on every
+      // session, not just some: `context_percentage` has a schema slot, a
+      // reader projection, and this render path, but no production writer
+      // anywhere in the tree (`grep -rn "context_percentage=" src/` outside
+      // tests finds none). Nor can one be derived from what OMH can reach:
+      // the host's usage table sums input tokens ACROSS calls, which is not
+      // the size of a context, and nothing records a model's window. The
+      // slot stays wired so a future writer lights it up; the dash goes.
+      ctx: Number.isFinite(ctx) ? `ctx ${ctx}%` : '',
     }
   }
 
@@ -198,7 +209,8 @@ export default function register(sdk) {
   // cache/ctx were honest but unresolvable for Hermes-native children — the
   // host never records a child's context percentage — and read as a fixable
   // problem ('서브에이전트 트리거는 다시 해야하나?'). Absence of a claim is
-  // just as honest, and the header's `ctx --` still marks the session gap.
+  // just as honest -- and the header follows the same rule now, rendering a
+  // context reading only when a row carries one.
   const observedPercent = (label, value) =>
     Number.isFinite(value) ? `${label} ${value}%` : ''
 
@@ -548,7 +560,7 @@ export default function register(sdk) {
         version ? h(Text, { color: t.color.muted }, ` v${version}`) : null,
         h(Text, { color: t.color.border }, SEPARATOR),
         h(Text, { color: active ? t.color.warn : t.color.ok }, hudStateLabel(active, agents)),
-        h(Text, { color: t.color.muted }, `${metrics.cost ? ` • ${metrics.cost}` : ''} • ${metrics.ctx}`),
+        h(Text, { color: t.color.muted }, `${metrics.cost ? ` • ${metrics.cost}` : ''}${metrics.ctx ? ` • ${metrics.ctx}` : ''}`),
         // Exact in-flight liveness, paired from pre_tool_call/post_tool_call
         // by tool_call_id: the only honest answer to "is something actually
         // running right now", as opposed to a lingering active todo item or

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -664,6 +664,16 @@ class TuiWidgetPackTests(unittest.TestCase):
         # permanent label for hermes-native children (the host never records
         # a child's context percentage) and read as a fixable problem.
         self.assertNotIn("uncollected", widget)
+        # The HEADER follows the same rule. `ctx --` was the last permanent
+        # not-collected label, and it was permanent on EVERY session, not
+        # some: `context_percentage` has a reader projection and this render
+        # path but no production writer anywhere, and none can be derived --
+        # the host's usage table sums input tokens across calls, which is not
+        # a context size, and nothing records a model's window. The slot
+        # stays wired for a future writer; the dash is gone.
+        self.assertNotIn("ctx --", widget)
+        self.assertIn("Number.isFinite(ctx) ? `ctx ${ctx}%` : ''", widget)
+        self.assertIn("${metrics.ctx ? ` • ${metrics.ctx}` : ''}", widget)
         self.assertIn("'MAIN'", widget)
         self.assertIn("maestro.rows", widget)
         self.assertIn("fallback:", widget)


### PR DESCRIPTION
## Capability

The header stops showing a permanent not-collected dash for the context reading. It renders `ctx N%` when a row carries one and nothing when none does — matching cost and tokens beside it.

## Motivation

The dash was not "absent on this session". It is absent on **every** session, and always will be with the data OMH can reach:

- **No writer.** `context_percentage` has a schema slot in `build_safe_progress_signal`, a projection in `runtime_reader`, and a render path in the widget — but `grep -rn "context_percentage=" src/ --include="*.py"` outside tests finds no production caller. Both row producers set cost, cache, tokens, and rate; neither sets this.
- **No derivation.** One cannot be built here either: the host's usage table sums input tokens *across calls*, which is a spend figure rather than the size of a context, and nothing in reach records a model's window to divide by.

So the dash announced a gap the reader cannot close, and read as a broken feature rather than an absent number — the same failure the row-level "uncollected" labels were removed for, which this very header line was written to survive.

## What this is not

**Not a feature deletion.** No plumbing is removed: the schema field, the reader projection, and the render path all stay. A future writer lights the segment up with no further change. This is a display honesty fix.

## Rejected

- **Deriving a percentage from summed input tokens** — a sum across calls is not a context size; dividing it by anything produces a number that climbs past 100% on a long session.
- **Shipping a context-window table to divide by** — the window is only half of what is missing. There is still no per-call context reading to divide, so the table would sit unused.

## Verification (observed)

- `tests/test_tui_widget_pack.py` — three locks: no dash reaches the render, the finite-guard renders a real reading, and the header omits the segment when empty.
- `tests/test_hermes_tui_preflight.py`; `node --check`; `ruff` clean; `compileall` clean; `git diff --check` clean.
- Full suite: **8,713 tests OK**.

## Risks

- The header is one segment shorter when no context is reported — which is every session today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)