### PR TITLE
fix(loop): preserve executor dispatch identity across retries

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2049,16 +2049,23 @@ exits non-zero. That is the conservative direction; the alternative was a
 duplicate id the validator now rejects anyway. A distinct `mutation_id`
 applies normally.
 
-Surfaces that do **not** materialize the id need nothing extra, but the reason
-has to be checked rather than assumed. Loop cycles
-(`src/workflows/goal_loop.py`) mint `cycle_id` and `queue_id` from
-`_new_item_id()`, never from the `mutation_id`; their queue mutators are
-additionally guarded by status preconditions — `observe` and `dispatch` require
-`prepared_not_observed`, `block` refuses an already-observed item — so a
-replayed queue mutation is refused rather than applied twice. Wrapper sessions
-(`src/wrapper/sessions.py`) mutate in place — status transitions and a single
-`current_run_id` — instead of appending id-bearing items, so a repeat write is
-idempotent by shape.
+Surfaces that do **not** materialize the mutation id still need their own replay
+invariant. Loop cycles (`src/workflows/goal_loop.py`) mint `cycle_id` and
+`queue_id` from `_new_item_id()`, never from the `mutation_id`. Executor
+dispatch is the exception inside that record: it materializes a stable
+`loop_dispatch_attempt/v1` identity from the normalized dispatch metadata.
+Replaying the exact metadata is a no-op, divergent metadata is refused, and
+`omh loop queue recover-dispatch` is the only path that can append a new
+attempt. Recovery records the prior attempt as `delivery_failed` or
+`delivery_unknown` with evidence before appending; an observation names the
+attempt it confirms, and must do so explicitly once recovery has made the
+history ambiguous. The legacy single `executor_session` fields remain a mirror
+of the active attempt, and records written before attempt history remain
+readable. Other queue mutators retain status preconditions — `observe` requires
+`prepared_not_observed`, and `block` refuses an already-observed item. Wrapper
+sessions (`src/wrapper/sessions.py`) mutate in place — status transitions and a
+single `current_run_id` — instead of appending id-bearing items, so a repeat
+write is idempotent by shape.
 
 ### Bounded mutation ids
 

--- a/src/commands/loop.py
+++ b/src/commands/loop.py
@@ -4,6 +4,7 @@ import argparse
 
 from ..goal_loop import (
     LOOP_ACTIONS,
+    LOOP_DISPATCH_RECOVERY_OUTCOMES,
     LOOP_EXECUTOR_OPTION_IDS,
     LOOP_STICKY_RULE_DEFAULT_GAP,
     LOOP_STICKY_RULE_DEFAULT_MAX_REPEATS,
@@ -28,6 +29,7 @@ from ..goal_loop import (
     read_loop_cycle,
     record_loop_goal_driver_observation,
     record_loop_feedback,
+    recover_loop_queue_item_dispatch,
     run_loop_once_result,
     tick_loop_runtime,
     update_loop_permission,
@@ -309,6 +311,28 @@ def cmd_loop_queue_dispatch(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_loop_queue_recover_dispatch(args: argparse.Namespace) -> int:
+    try:
+        cycle = recover_loop_queue_item_dispatch(
+            _paths(args),
+            args.loop_id,
+            args.queue_id,
+            prior_attempt_id=args.prior_attempt_id,
+            prior_outcome=args.prior_outcome,
+            outcome_evidence_refs=args.outcome_evidence_ref or [],
+            outcome_summary=args.outcome_summary or "",
+            executor=args.executor,
+            session_ref=args.codex_session_ref or args.session_ref or "",
+            thread_ref=args.codex_thread_ref or args.thread_ref or "",
+            evidence_refs=args.evidence_ref or [],
+            summary=args.summary or "",
+        )
+        _print_json({"loop": cycle, "status_card": build_loop_status_card(_paths(args), args.loop_id)})
+    except (FileNotFoundError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    return 0
+
+
 def cmd_loop_queue_observe_codex(args: argparse.Namespace) -> int:
     try:
         log_text = ""
@@ -326,6 +350,7 @@ def cmd_loop_queue_observe_codex(args: argparse.Namespace) -> int:
             evidence_refs=args.evidence_ref or [],
             codex_log_ref=args.codex_log_ref or "",
             summary=args.summary or "",
+            dispatch_attempt_id=args.dispatch_attempt_id or "",
         )
         _print_json({"loop": cycle, "narration": build_loop_cycle_narration(_paths(args), args.loop_id, args.queue_id)})
     except (FileNotFoundError, OSError, ValueError) as exc:
@@ -352,6 +377,7 @@ def cmd_loop_queue_observe(args: argparse.Namespace) -> int:
             subagent_evidence_refs=args.subagent_evidence_ref or [],
             connector_evidence_refs=args.connector_evidence_ref or [],
             summary=args.summary or "",
+            dispatch_attempt_id=args.dispatch_attempt_id or "",
         )
         _print_json({"loop": cycle, "status_card": build_loop_status_card(_paths(args), args.loop_id)})
     except (FileNotFoundError, ValueError) as exc:
@@ -507,6 +533,26 @@ def _add_loop_commands(sub) -> None:
     queue_dispatch.add_argument("--summary", default="")
     queue_dispatch.set_defaults(func=cmd_loop_queue_dispatch)
 
+    queue_recover_dispatch = queue_sub.add_parser("recover-dispatch")
+    queue_recover_dispatch.add_argument("--loop", dest="loop_id", required=True)
+    queue_recover_dispatch.add_argument("--queue", dest="queue_id", required=True)
+    queue_recover_dispatch.add_argument("--prior-attempt-id", required=True)
+    queue_recover_dispatch.add_argument(
+        "--prior-outcome",
+        choices=LOOP_DISPATCH_RECOVERY_OUTCOMES,
+        required=True,
+    )
+    queue_recover_dispatch.add_argument("--outcome-evidence-ref", action="append", required=True)
+    queue_recover_dispatch.add_argument("--outcome-summary", default="")
+    queue_recover_dispatch.add_argument("--executor", choices=LOOP_EXECUTOR_OPTION_IDS, required=True)
+    queue_recover_dispatch.add_argument("--session-ref", default="")
+    queue_recover_dispatch.add_argument("--thread-ref", default="")
+    queue_recover_dispatch.add_argument("--codex-session-ref", default="")
+    queue_recover_dispatch.add_argument("--codex-thread-ref", default="")
+    queue_recover_dispatch.add_argument("--evidence-ref", action="append")
+    queue_recover_dispatch.add_argument("--summary", default="")
+    queue_recover_dispatch.set_defaults(func=cmd_loop_queue_recover_dispatch)
+
     queue_observe_codex = queue_sub.add_parser("observe-codex")
     queue_observe_codex.add_argument("--loop", dest="loop_id", required=True)
     queue_observe_codex.add_argument("--queue", dest="queue_id", required=True)
@@ -514,6 +560,7 @@ def _add_loop_commands(sub) -> None:
     queue_observe_codex.add_argument("--codex-log-text", default="")
     queue_observe_codex.add_argument("--codex-log-ref", default="")
     queue_observe_codex.add_argument("--evidence-ref", action="append", required=True)
+    queue_observe_codex.add_argument("--dispatch-attempt-id", default="")
     queue_observe_codex.add_argument("--summary", default="")
     queue_observe_codex.set_defaults(func=cmd_loop_queue_observe_codex)
 
@@ -529,6 +576,7 @@ def _add_loop_commands(sub) -> None:
     queue_observe.add_argument("--worktree-evidence-ref", action="append")
     queue_observe.add_argument("--subagent-evidence-ref", action="append")
     queue_observe.add_argument("--connector-evidence-ref", action="append")
+    queue_observe.add_argument("--dispatch-attempt-id", default="")
     queue_observe.add_argument("--summary", default="")
     queue_observe.set_defaults(func=cmd_loop_queue_observe)
 

--- a/src/workflows/goal_loop.py
+++ b/src/workflows/goal_loop.py
@@ -49,11 +49,13 @@ LOOP_SMALL_LOOP_GUIDANCE_SCHEMA = "loop_small_loop_guidance/v1"
 LOOP_RUN_ONCE_RESULT_SCHEMA = "loop_run_once_result/v1"
 EXECUTOR_LOOP_CAPABILITY_SCHEMA = "executor_loop_capability/v1"
 LOOP_CYCLE_NARRATION_SCHEMA = "loop_cycle_narration/v1"
+LOOP_DISPATCH_ATTEMPT_SCHEMA = "loop_dispatch_attempt/v1"
 LOOP_INVOCATION_SCHEMA = "loop_invocation/v1"
 LOOP_CONSTRAINT_ASSESSMENT_SCHEMA = "loop_constraint_assessment/v1"
 LOOP_STICKY_RULE_SCHEMA = "loop_sticky_rule/v1"
 LOOP_STICKY_RULE_ATTACHMENT_SCHEMA = "loop_sticky_rule_attachment/v1"
 LOOP_STOP_LADDER_SCHEMA = "loop_stop_ladder/v1"
+LOOP_DISPATCH_RECOVERY_OUTCOMES = ("delivery_failed", "delivery_unknown")
 
 # The ordered stop ladder evaluated before a tick advances. The tuple order IS
 # the ladder: assess_loop_stop_ladder walks it top to bottom, the first rung
@@ -1911,21 +1913,31 @@ def dispatch_loop_queue_item(
 ) -> dict[str, Any]:
     refs = _safe_list(evidence_refs or [], limit=320)
     capability = loop_executor_capability(executor)
+    dispatch = _dispatch_request(capability, session_ref, thread_ref, refs, summary)
 
-    def mutate(cycle: dict[str, Any]) -> dict[str, Any]:
+    def mutate(cycle: dict[str, Any]) -> dict[str, Any] | None:
         runtime, item = _queue_item_ref(cycle, queue_id)
         if item.get("status") != "prepared_not_observed":
             raise ValueError("only prepared_not_observed loop queue items can record executor dispatch")
+        existing = _dict_value(item, "executor_session")
+        if str(existing.get("dispatch_status", "")) in {"prepared", "dispatched"}:
+            if _executor_session_dispatch(existing) == dispatch:
+                return None
+            if existing.get("dispatch_status") == "dispatched":
+                raise ValueError(
+                    "loop queue item already has a different executor dispatch; use explicit recovery"
+                )
+        attempts = [entry for entry in existing.get("dispatch_attempts", []) if isinstance(entry, dict)]
+        attempt = (
+            _new_dispatch_attempt(queue_id, len(attempts) + 1, dispatch)
+            if dispatch["dispatch_status"] == "dispatched"
+            else None
+        )
         item["executor_session"] = {
             **_empty_executor_session(str(capability["executor"])),
-            "executor": capability["executor"],
-            "loop_mode": capability["loop_mode"],
-            "dispatch_owner": capability["dispatch_owner"],
-            "dispatch_status": "dispatched" if refs or session_ref.strip() or thread_ref.strip() else "prepared",
-            "session_ref": _safe_summary(session_ref, limit=220) if session_ref.strip() else "",
-            "thread_ref": _safe_summary(thread_ref, limit=220) if thread_ref.strip() else "",
-            "dispatch_evidence_refs": refs,
-            "summary": _safe_summary(summary, limit=320) if summary.strip() else "Executor dispatch metadata recorded for this loop queue item.",
+            **dispatch,
+            "active_attempt_id": str(attempt["attempt_id"]) if attempt else "",
+            "dispatch_attempts": [*attempts, *([attempt] if attempt else [])],
             "capability": capability,
         }
         runtime["last_queue_id"] = str(item["queue_id"])
@@ -1948,6 +1960,97 @@ def dispatch_loop_queue_item(
     )
 
 
+def recover_loop_queue_item_dispatch(
+    paths: OmhPaths,
+    loop_id: str,
+    queue_id: str,
+    *,
+    prior_attempt_id: str,
+    prior_outcome: str,
+    outcome_evidence_refs: Iterable[str],
+    executor: str,
+    session_ref: str = "",
+    thread_ref: str = "",
+    evidence_refs: Iterable[str] | None = None,
+    outcome_summary: str = "",
+    summary: str = "",
+    expected_revision: int | None = None,
+    mutation_id: str | None = None,
+) -> dict[str, Any]:
+    attempt_id = _safe_summary(prior_attempt_id, limit=120)
+    if not attempt_id:
+        raise ValueError("prior dispatch attempt id is required")
+    if prior_outcome not in LOOP_DISPATCH_RECOVERY_OUTCOMES:
+        raise ValueError(
+            f"prior dispatch outcome must be one of: {', '.join(LOOP_DISPATCH_RECOVERY_OUTCOMES)}"
+        )
+    outcome_refs = _safe_list(outcome_evidence_refs, limit=320)
+    if not outcome_refs:
+        raise ValueError("dispatch recovery requires prior outcome evidence")
+    capability = loop_executor_capability(executor)
+    dispatch_refs = _safe_list(evidence_refs or [], limit=320)
+    dispatch = _dispatch_request(capability, session_ref, thread_ref, dispatch_refs, summary)
+    if dispatch["dispatch_status"] != "dispatched":
+        raise ValueError("dispatch recovery requires new dispatch identity or evidence")
+
+    def mutate(cycle: dict[str, Any]) -> dict[str, Any]:
+        runtime, item = _queue_item_ref(cycle, queue_id)
+        if item.get("status") != "prepared_not_observed":
+            raise ValueError("only prepared_not_observed loop queue items can recover executor dispatch")
+        existing = _dict_value(item, "executor_session")
+        attempts = [dict(entry) for entry in existing.get("dispatch_attempts", []) if isinstance(entry, dict)]
+        if not attempts:
+            raise ValueError("legacy executor dispatch has no attempt identity; record its outcome before recovery")
+        if existing.get("active_attempt_id") != attempt_id or attempts[-1].get("attempt_id") != attempt_id:
+            raise ValueError("prior dispatch attempt must be the active attempt")
+        attempts[-1] = {
+            **attempts[-1],
+            "delivery_outcome": prior_outcome,
+            "outcome_evidence_refs": outcome_refs,
+            "outcome_summary": (
+                _safe_summary(outcome_summary, limit=320)
+                if outcome_summary.strip()
+                else "Prior dispatch outcome recorded before explicit recovery."
+            ),
+        }
+        next_attempt = _new_dispatch_attempt(queue_id, len(attempts) + 1, dispatch)
+        item["executor_session"] = {
+            **existing,
+            **dispatch,
+            "active_attempt_id": next_attempt["attempt_id"],
+            "dispatch_attempts": [*attempts, next_attempt],
+            "capability": capability,
+        }
+        runtime["last_queue_id"] = str(item["queue_id"])
+        runtime["last_queue_status"] = str(item["status"])
+        cycle["runtime"] = runtime
+        cycle["next_action"] = "observe_runtime_queue"
+        cycle["updated_at"] = utc_now()
+        return cycle
+
+    return _guarded_cycle_update(
+        paths,
+        loop_id,
+        mutate,
+        operation="recover_loop_queue_item_dispatch",
+        expected_revision=expected_revision,
+        mutation_id=mutation_id,
+        mutation_digest=_mutation_digest(
+            "recover_loop_queue_item_dispatch",
+            queue_id,
+            attempt_id,
+            prior_outcome,
+            outcome_refs,
+            outcome_summary,
+            executor,
+            session_ref,
+            thread_ref,
+            dispatch_refs,
+            summary,
+        ),
+    )
+
+
 def observe_codex_loop_queue_item(
     paths: OmhPaths,
     loop_id: str,
@@ -1957,6 +2060,7 @@ def observe_codex_loop_queue_item(
     evidence_refs: Iterable[str] | None = None,
     codex_log_ref: str = "",
     summary: str = "",
+    dispatch_attempt_id: str = "",
     expected_revision: int | None = None,
     mutation_id: str | None = None,
 ) -> dict[str, Any]:
@@ -1976,6 +2080,11 @@ def observe_codex_loop_queue_item(
         if item.get("status") != "prepared_not_observed":
             raise ValueError("only prepared_not_observed loop queue items can observe Codex progress")
         existing = _dict_value(item, "executor_session")
+        observed_attempt_id = _resolve_observed_dispatch_attempt(
+            existing,
+            dispatch_attempt_id,
+            expected_executor="codex",
+        )
         executor_session = {
             **_empty_executor_session("codex"),
             **existing,
@@ -1986,9 +2095,11 @@ def observe_codex_loop_queue_item(
             "progress_summary": progress,
             "summary": _safe_summary(summary, limit=320) if summary.strip() else str(progress.get("chat_summary", "")),
             "progress_evidence_refs": all_refs,
+            "dispatch_attempts": _confirm_dispatch_attempt(existing, observed_attempt_id, all_refs),
             "capability": loop_executor_capability("codex"),
         }
         item["executor_session"] = executor_session
+        item["observed_dispatch_attempt_id"] = observed_attempt_id
         item["status"] = "observed"
         item["observed"] = True
         observed_at = utc_now()
@@ -2040,7 +2151,9 @@ def observe_codex_loop_queue_item(
         operation="observe_codex_loop_queue_item",
         expected_revision=expected_revision,
         mutation_id=mutation_id,
-        mutation_digest=_mutation_digest("observe_codex_loop_queue_item", queue_id, all_refs, summary),
+        mutation_digest=_mutation_digest(
+            "observe_codex_loop_queue_item", queue_id, all_refs, summary, dispatch_attempt_id
+        ),
     )
 
 
@@ -2087,6 +2200,7 @@ def observe_loop_queue_item(
     subagent_evidence_refs: Iterable[str] | None = None,
     connector_evidence_refs: Iterable[str] | None = None,
     summary: str = "",
+    dispatch_attempt_id: str = "",
     expected_revision: int | None = None,
     mutation_id: str | None = None,
 ) -> dict[str, Any]:
@@ -2102,8 +2216,23 @@ def observe_loop_queue_item(
         runtime, item = _queue_item_ref(cycle, queue_id)
         if item.get("status") != "prepared_not_observed":
             raise ValueError("only prepared_not_observed loop queue items can be observed")
+        executor_session = _dict_value(item, "executor_session")
+        observed_attempt_id = _resolve_observed_dispatch_attempt(
+            executor_session,
+            dispatch_attempt_id,
+        )
+        if observed_attempt_id:
+            item["executor_session"] = {
+                **executor_session,
+                "dispatch_attempts": _confirm_dispatch_attempt(
+                    executor_session,
+                    observed_attempt_id,
+                    aggregate_refs,
+                ),
+            }
         item["status"] = "observed"
         item["observed"] = True
+        item["observed_dispatch_attempt_id"] = observed_attempt_id
         observed_at = utc_now()
         item["observed_at"] = observed_at
         item["observed_evidence_refs"] = aggregate_refs
@@ -2159,7 +2288,9 @@ def observe_loop_queue_item(
         operation="observe_loop_queue_item",
         expected_revision=expected_revision,
         mutation_id=mutation_id,
-        mutation_digest=_mutation_digest("observe_loop_queue_item", queue_id, aggregate_refs, summary),
+        mutation_digest=_mutation_digest(
+            "observe_loop_queue_item", queue_id, aggregate_refs, summary, dispatch_attempt_id
+        ),
     )
 
 
@@ -3177,6 +3308,8 @@ def _empty_executor_session(executor: str = "choose") -> dict[str, Any]:
         "session_ref": "",
         "thread_ref": "",
         "dispatch_evidence_refs": [],
+        "active_attempt_id": "",
+        "dispatch_attempts": [],
         "progress_evidence_refs": [],
         "progress_summary": {},
         "review_summary": {},
@@ -3184,6 +3317,114 @@ def _empty_executor_session(executor: str = "choose") -> dict[str, Any]:
         "capability": capability,
         "claim_boundary": capability["claim_boundary"],
     }
+
+
+def _dispatch_request(
+    capability: Mapping[str, Any],
+    session_ref: str,
+    thread_ref: str,
+    evidence_refs: Iterable[str],
+    summary: str,
+) -> dict[str, Any]:
+    refs = _safe_list(evidence_refs, limit=320)
+    return {
+        "executor": str(capability["executor"]),
+        "loop_mode": str(capability["loop_mode"]),
+        "dispatch_owner": str(capability["dispatch_owner"]),
+        "dispatch_status": "dispatched" if refs or session_ref.strip() or thread_ref.strip() else "prepared",
+        "session_ref": _safe_summary(session_ref, limit=220) if session_ref.strip() else "",
+        "thread_ref": _safe_summary(thread_ref, limit=220) if thread_ref.strip() else "",
+        "dispatch_evidence_refs": refs,
+        "summary": (
+            _safe_summary(summary, limit=320)
+            if summary.strip()
+            else "Executor dispatch metadata recorded for this loop queue item."
+        ),
+    }
+
+
+def _executor_session_dispatch(executor_session: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "executor": str(executor_session.get("executor", "")),
+        "loop_mode": str(executor_session.get("loop_mode", "")),
+        "dispatch_owner": str(executor_session.get("dispatch_owner", "")),
+        "dispatch_status": str(executor_session.get("dispatch_status", "")),
+        "session_ref": str(executor_session.get("session_ref", "")),
+        "thread_ref": str(executor_session.get("thread_ref", "")),
+        "dispatch_evidence_refs": _safe_list(
+            _string_list(executor_session.get("dispatch_evidence_refs", [])), limit=320
+        ),
+        "summary": str(executor_session.get("summary", "")),
+    }
+
+
+def _new_dispatch_attempt(
+    queue_id: str,
+    attempt_index: int,
+    dispatch: Mapping[str, Any],
+) -> dict[str, Any]:
+    identity = sha256_text(
+        json.dumps([queue_id, attempt_index, dict(dispatch)], sort_keys=True, separators=(",", ":"))
+    )[:16]
+    return {
+        "schema_version": LOOP_DISPATCH_ATTEMPT_SCHEMA,
+        "attempt_id": f"dispatch-{attempt_index}-{identity}",
+        "attempt_index": attempt_index,
+        **dict(dispatch),
+        "delivery_outcome": "delivery_unknown",
+        "outcome_evidence_refs": [],
+        "outcome_summary": "Dispatch was recorded without a confirmed delivery outcome.",
+        "recorded_at": utc_now(),
+    }
+
+
+def _resolve_observed_dispatch_attempt(
+    executor_session: Mapping[str, Any],
+    requested_attempt_id: str,
+    *,
+    expected_executor: str = "",
+) -> str:
+    attempts = [entry for entry in executor_session.get("dispatch_attempts", []) if isinstance(entry, dict)]
+    requested = _safe_summary(requested_attempt_id, limit=120) if requested_attempt_id.strip() else ""
+    if not attempts:
+        if requested:
+            raise ValueError("dispatch attempt id does not exist on this loop queue item")
+        return ""
+    if not requested:
+        if len(attempts) != 1:
+            raise ValueError("dispatch attempt id is required after explicit recovery")
+        requested = str(attempts[0].get("attempt_id", ""))
+    attempt = next((entry for entry in attempts if entry.get("attempt_id") == requested), None)
+    if attempt is None:
+        raise ValueError("dispatch attempt id does not exist on this loop queue item")
+    if expected_executor and attempt.get("executor") != expected_executor:
+        raise ValueError(f"dispatch attempt is not owned by {expected_executor}")
+    return requested
+
+
+def _confirm_dispatch_attempt(
+    executor_session: Mapping[str, Any],
+    attempt_id: str,
+    evidence_refs: Iterable[str],
+) -> list[dict[str, Any]]:
+    attempts = [dict(entry) for entry in executor_session.get("dispatch_attempts", []) if isinstance(entry, dict)]
+    if not attempt_id:
+        return attempts
+    refs = _safe_list(evidence_refs, limit=320)
+    for index, attempt in enumerate(attempts):
+        if attempt.get("attempt_id") != attempt_id:
+            continue
+        attempts[index] = {
+            **attempt,
+            "delivery_outcome": "delivery_confirmed",
+            "outcome_evidence_refs": _safe_list(
+                [*_string_list(attempt.get("outcome_evidence_refs", [])), *refs],
+                limit=320,
+            ),
+            "outcome_summary": "Executor progress or result was observed for this dispatch attempt.",
+        }
+        break
+    return attempts
 
 
 def _narration_next_message(status: str, executor_session: dict[str, Any]) -> str:
@@ -4122,6 +4363,9 @@ def _validate_runtime(runtime: object) -> list[str]:
         verification_plan = item.get("verification_plan")
         if verification_plan is not None:
             _validate_verification_plan(errors, index, verification_plan)
+        executor_session = item.get("executor_session")
+        if executor_session is not None:
+            _validate_executor_dispatch_session(errors, index, item, executor_session)
         if item.get("status") == "observed":
             if item.get("observed") is not True:
                 errors.append(f"runtime.queue[{index}].observed must be true when status is observed")
@@ -4153,6 +4397,98 @@ def _validate_runtime(runtime: object) -> list[str]:
                 if plan.get("strategy") != "none":
                     errors.append(f"runtime.queue[{index}].{key}.strategy must be none while blocked")
     return errors
+
+
+def _validate_executor_dispatch_session(
+    errors: list[str],
+    index: int,
+    queue_item: Mapping[str, Any],
+    value: object,
+) -> None:
+    prefix = f"runtime.queue[{index}].executor_session"
+    if not isinstance(value, dict):
+        errors.append(f"{prefix} must be an object")
+        return
+    if "dispatch_attempts" not in value:
+        return
+    attempts = value.get("dispatch_attempts")
+    if not isinstance(attempts, list):
+        errors.append(f"{prefix}.dispatch_attempts must be a list")
+        return
+    active_attempt_id = str(value.get("active_attempt_id", ""))
+    if not attempts:
+        if active_attempt_id:
+            errors.append(f"{prefix}.active_attempt_id must be empty without dispatch attempts")
+        if value.get("dispatch_status") == "dispatched":
+            errors.append(f"{prefix}.dispatch_attempts must record dispatched executor metadata")
+        return
+
+    seen_attempt_ids: set[str] = set()
+    attempts_by_id: dict[str, Mapping[str, Any]] = {}
+    for attempt_index, attempt in enumerate(attempts, start=1):
+        attempt_prefix = f"{prefix}.dispatch_attempts[{attempt_index - 1}]"
+        if not isinstance(attempt, dict):
+            errors.append(f"{attempt_prefix} must be an object")
+            continue
+        if attempt.get("schema_version") != LOOP_DISPATCH_ATTEMPT_SCHEMA:
+            errors.append(f"{attempt_prefix}.schema_version must be {LOOP_DISPATCH_ATTEMPT_SCHEMA}")
+        attempt_id = str(attempt.get("attempt_id", ""))
+        if not attempt_id:
+            errors.append(f"{attempt_prefix}.attempt_id is required")
+        elif attempt_id in seen_attempt_ids:
+            errors.append(f"{attempt_prefix}.attempt_id duplicates an earlier entry")
+        else:
+            seen_attempt_ids.add(attempt_id)
+            attempts_by_id[attempt_id] = attempt
+        if attempt.get("attempt_index") != attempt_index:
+            errors.append(f"{attempt_prefix}.attempt_index must preserve ordered attempt history")
+        if attempt.get("dispatch_status") != "dispatched":
+            errors.append(f"{attempt_prefix}.dispatch_status must be dispatched")
+        dispatch_refs = attempt.get("dispatch_evidence_refs")
+        if not isinstance(dispatch_refs, list) or not all(str(ref).strip() for ref in dispatch_refs):
+            errors.append(f"{attempt_prefix}.dispatch_evidence_refs must be a string list")
+        if not dispatch_refs and not str(attempt.get("session_ref", "")).strip() and not str(attempt.get("thread_ref", "")).strip():
+            errors.append(f"{attempt_prefix} must include dispatch identity or evidence")
+        outcome = attempt.get("delivery_outcome")
+        if outcome not in {"delivery_unknown", "delivery_confirmed", "delivery_failed"}:
+            errors.append(f"{attempt_prefix}.delivery_outcome is unsupported")
+        outcome_refs = attempt.get("outcome_evidence_refs")
+        if not isinstance(outcome_refs, list) or not all(str(ref).strip() for ref in outcome_refs):
+            errors.append(f"{attempt_prefix}.outcome_evidence_refs must be a string list")
+        elif outcome in {"delivery_confirmed", "delivery_failed"} and not outcome_refs:
+            errors.append(f"{attempt_prefix}.outcome_evidence_refs are required for a conclusive outcome")
+
+    active_attempt = attempts_by_id.get(active_attempt_id)
+    if active_attempt is None:
+        errors.append(f"{prefix}.active_attempt_id must identify a recorded dispatch attempt")
+        return
+    if attempts and active_attempt_id != str(attempts[-1].get("attempt_id", "")):
+        errors.append(f"{prefix}.active_attempt_id must identify the latest dispatch attempt")
+    if value.get("dispatch_status") not in {"dispatched", "progress_observed"}:
+        errors.append(f"{prefix}.dispatch_status must reflect recorded dispatch attempts")
+    for key in (
+        "executor",
+        "loop_mode",
+        "dispatch_owner",
+        "session_ref",
+        "thread_ref",
+        "dispatch_evidence_refs",
+    ):
+        if value.get(key) != active_attempt.get(key):
+            errors.append(f"{prefix}.{key} must match the active dispatch attempt")
+    observed_attempt_id = str(queue_item.get("observed_dispatch_attempt_id", ""))
+    if queue_item.get("status") == "observed":
+        observed_attempt = attempts_by_id.get(observed_attempt_id)
+        if observed_attempt is None:
+            errors.append(
+                f"runtime.queue[{index}].observed_dispatch_attempt_id must identify a recorded dispatch attempt"
+            )
+        elif observed_attempt.get("delivery_outcome") != "delivery_confirmed":
+            errors.append(
+                f"runtime.queue[{index}].observed_dispatch_attempt_id must identify a confirmed dispatch attempt"
+            )
+    elif observed_attempt_id:
+        errors.append(f"runtime.queue[{index}].observed_dispatch_attempt_id requires observed queue status")
 
 
 def _validate_verification_plan(errors: list[str], index: int, value: object) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8885,6 +8885,39 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             self.assertEqual(dispatched["loop"]["runtime"]["queue"][0]["status"], "prepared_not_observed")
             self.assertEqual(dispatched["loop"]["runtime"]["queue"][0]["executor_session"]["dispatch_status"], "dispatched")
             self.assertEqual(dispatched["loop"]["runtime"]["queue"][0]["executor_session"]["session_ref"], "codex-session-cli")
+            first_attempt_id = dispatched["loop"]["runtime"]["queue"][0]["executor_session"]["active_attempt_id"]
+
+            status, stdout, stderr = run_cli(
+                home
+                + [
+                    "loop",
+                    "queue",
+                    "recover-dispatch",
+                    "--loop",
+                    "loop-cli",
+                    "--queue",
+                    queue_id,
+                    "--prior-attempt-id",
+                    first_attempt_id,
+                    "--prior-outcome",
+                    "delivery_unknown",
+                    "--outcome-evidence-ref",
+                    "wrapper:ack-timeout:cli",
+                    "--executor",
+                    "codex",
+                    "--codex-session-ref",
+                    "codex-session-cli-2",
+                    "--evidence-ref",
+                    "wrapper:codex-dispatch:cli-2",
+                ]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            recovered = json.loads(stdout)
+            recovery_session = recovered["loop"]["runtime"]["queue"][0]["executor_session"]
+            self.assertEqual(len(recovery_session["dispatch_attempts"]), 2)
+            self.assertEqual(recovery_session["dispatch_attempts"][0]["delivery_outcome"], "delivery_unknown")
+            second_attempt_id = recovery_session["active_attempt_id"]
 
             status, stdout, stderr = run_cli(home + ["loop", "queue", "narrate", "--loop", "loop-cli", "--queue", queue_id])
             self.assertEqual(stderr, "")
@@ -8909,6 +8942,8 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
                     "codex-log:cli",
                     "--evidence-ref",
                     "codex-jsonl:cli",
+                    "--dispatch-attempt-id",
+                    second_attempt_id,
                     "--summary",
                     "Codex defined the issue and started implementation.",
                 ]
@@ -8918,6 +8953,10 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             codex_observed = json.loads(stdout)
             self.assertEqual(codex_observed["loop"]["runtime"]["queue"][0]["status"], "observed")
             self.assertEqual(codex_observed["loop"]["runtime"]["queue"][0]["executor_session"]["dispatch_status"], "progress_observed")
+            self.assertEqual(
+                codex_observed["loop"]["runtime"]["queue"][0]["observed_dispatch_attempt_id"],
+                second_attempt_id,
+            )
             self.assertEqual(codex_observed["narration"]["schema_version"], "loop_cycle_narration/v1")
 
             observed = codex_observed

--- a/tests/test_loop_cycle.py
+++ b/tests/test_loop_cycle.py
@@ -37,6 +37,7 @@ from omh.goal_loop import (
     observe_loop_queue_item,
     read_loop_cycle,
     record_loop_feedback,
+    recover_loop_queue_item_dispatch,
     run_loop_once_result,
     tick_loop_runtime,
     update_loop_permission,
@@ -771,6 +772,14 @@ class GoalLoopTests(unittest.TestCase):
         self.assertTrue(observed_item["observed"])
         self.assertEqual(observed_item["executor_session"]["dispatch_status"], "progress_observed")
         self.assertEqual(observed_item["executor_session"]["progress_summary"]["schema_version"], "codex_progress_summary/v1")
+        self.assertEqual(
+            observed_item["observed_dispatch_attempt_id"],
+            dispatched_item["executor_session"]["active_attempt_id"],
+        )
+        self.assertEqual(
+            observed_item["executor_session"]["dispatch_attempts"][0]["delivery_outcome"],
+            "delivery_confirmed",
+        )
         self.assertIn("codex-jsonl:1", observed_item["observed_evidence_refs"])
         self.assertEqual(narration["schema_version"], "loop_cycle_narration/v1")
         self.assertIn("이번 사이클", narration["headline"])
@@ -778,6 +787,309 @@ class GoalLoopTests(unittest.TestCase):
         self.assertIn("implementation", narration["not_evidence_yet"])
         self.assertIn("ci", narration["not_evidence_yet"])
         self.assertEqual(validate_loop_cycle(observed), {"ok": True, "errors": []})
+
+    def test_loop_queue_dispatch_exact_replay_is_a_no_op(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = create_loop_cycle(
+                paths,
+                goal_summary="Keep dispatch retries auditable",
+                goal_reframe="Record one stable executor dispatch identity.",
+                success_criteria=["Exact dispatch retries do not mutate the loop record"],
+                permission_profile="execute_with_gates",
+                allowed_executors=["codex"],
+            )
+            ticked = tick_loop_runtime(paths, cycle["loop_id"])
+            queue_id = ticked["runtime"]["queue"][0]["queue_id"]
+            first = dispatch_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                executor="codex",
+                session_ref="codex-session-1",
+                thread_ref="codex-thread-1",
+                evidence_refs=["wrapper:dispatch:1"],
+                summary="Codex dispatch recorded.",
+            )
+            replayed = dispatch_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                executor="codex",
+                session_ref="codex-session-1",
+                thread_ref="codex-thread-1",
+                evidence_refs=["wrapper:dispatch:1"],
+                summary="Codex dispatch recorded.",
+            )
+
+        self.assertEqual(replayed, first)
+        self.assertEqual(replayed["runtime"]["queue"][0]["executor_session"]["active_attempt_id"], replayed["runtime"]["queue"][0]["executor_session"]["dispatch_attempts"][0]["attempt_id"])
+
+    def test_loop_queue_dispatch_conflict_preserves_the_first_attempt(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = create_loop_cycle(
+                paths,
+                goal_summary="Keep dispatch retries auditable",
+                goal_reframe="Reject a conflicting executor dispatch identity.",
+                success_criteria=["Conflicting dispatch retries preserve the first attempt"],
+                permission_profile="execute_with_gates",
+                allowed_executors=["codex", "claude-code"],
+            )
+            ticked = tick_loop_runtime(paths, cycle["loop_id"])
+            queue_id = ticked["runtime"]["queue"][0]["queue_id"]
+            first = dispatch_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                executor="codex",
+                session_ref="codex-session-1",
+                thread_ref="codex-thread-1",
+                evidence_refs=["wrapper:dispatch:1"],
+                summary="First dispatch.",
+            )
+
+            with self.assertRaisesRegex(ValueError, "explicit recovery"):
+                dispatch_loop_queue_item(
+                    paths,
+                    cycle["loop_id"],
+                    queue_id,
+                    executor="claude-code",
+                    session_ref="claude-session-2",
+                    thread_ref="claude-thread-2",
+                    evidence_refs=["wrapper:dispatch:2"],
+                    summary="Conflicting dispatch.",
+                )
+
+            stored = read_loop_cycle(paths, cycle["loop_id"])
+
+        self.assertEqual(stored, first)
+        session = stored["runtime"]["queue"][0]["executor_session"]
+        self.assertEqual(session["executor"], "codex")
+        self.assertEqual(session["session_ref"], "codex-session-1")
+        self.assertEqual(session["thread_ref"], "codex-thread-1")
+        self.assertEqual(session["dispatch_evidence_refs"], ["wrapper:dispatch:1"])
+        self.assertEqual(len(session["dispatch_attempts"]), 1)
+
+    def test_loop_queue_dispatch_recovery_preserves_attempt_history(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = create_loop_cycle(
+                paths,
+                goal_summary="Recover failed executor dispatches",
+                goal_reframe="Create a new attempt without erasing the failed attempt.",
+                success_criteria=["Dispatch attempt history remains ordered"],
+                permission_profile="execute_with_gates",
+                allowed_executors=["codex"],
+            )
+            ticked = tick_loop_runtime(paths, cycle["loop_id"])
+            queue_id = ticked["runtime"]["queue"][0]["queue_id"]
+            first = dispatch_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                executor="codex",
+                session_ref="codex-session-1",
+                evidence_refs=["wrapper:dispatch:1"],
+            )
+            first_attempt_id = first["runtime"]["queue"][0]["executor_session"]["active_attempt_id"]
+            recovered = recover_loop_queue_item_dispatch(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                prior_attempt_id=first_attempt_id,
+                prior_outcome="delivery_failed",
+                outcome_evidence_refs=["wrapper:delivery-failed:1"],
+                outcome_summary="The executor rejected the dispatch.",
+                executor="codex",
+                session_ref="codex-session-2",
+                evidence_refs=["wrapper:dispatch:2"],
+            )
+
+        session = recovered["runtime"]["queue"][0]["executor_session"]
+        attempts = session["dispatch_attempts"]
+        self.assertEqual([attempt["attempt_index"] for attempt in attempts], [1, 2])
+        self.assertEqual(attempts[0]["attempt_id"], first_attempt_id)
+        self.assertEqual(attempts[0]["delivery_outcome"], "delivery_failed")
+        self.assertEqual(attempts[0]["outcome_evidence_refs"], ["wrapper:delivery-failed:1"])
+        self.assertEqual(attempts[1]["delivery_outcome"], "delivery_unknown")
+        self.assertEqual(session["active_attempt_id"], attempts[1]["attempt_id"])
+        self.assertEqual(session["session_ref"], "codex-session-2")
+
+    def test_loop_queue_dispatch_recovery_records_uncertain_prior_outcome(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = create_loop_cycle(
+                paths,
+                goal_summary="Recover an unacknowledged executor dispatch",
+                goal_reframe="Preserve the uncertain attempt before dispatching again.",
+                success_criteria=["Uncertain delivery remains distinguishable from failure"],
+                permission_profile="execute_with_gates",
+                allowed_executors=["codex"],
+            )
+            ticked = tick_loop_runtime(paths, cycle["loop_id"])
+            queue_id = ticked["runtime"]["queue"][0]["queue_id"]
+            first = dispatch_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                executor="codex",
+                session_ref="codex-session-1",
+                evidence_refs=["wrapper:dispatch:1"],
+            )
+            first_attempt_id = first["runtime"]["queue"][0]["executor_session"]["active_attempt_id"]
+            recovered = recover_loop_queue_item_dispatch(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                prior_attempt_id=first_attempt_id,
+                prior_outcome="delivery_unknown",
+                outcome_evidence_refs=["wrapper:ack-timeout:1"],
+                executor="codex",
+                session_ref="codex-session-2",
+                evidence_refs=["wrapper:dispatch:2"],
+            )
+
+        attempts = recovered["runtime"]["queue"][0]["executor_session"]["dispatch_attempts"]
+        self.assertEqual(attempts[0]["delivery_outcome"], "delivery_unknown")
+        self.assertEqual(attempts[1]["delivery_outcome"], "delivery_unknown")
+        self.assertNotEqual(attempts[0]["attempt_id"], attempts[1]["attempt_id"])
+
+    def test_loop_queue_observation_requires_attempt_binding_after_recovery(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = create_loop_cycle(
+                paths,
+                goal_summary="Bind executor observations to dispatch attempts",
+                goal_reframe="Identify which recovered dispatch produced observed progress.",
+                success_criteria=["Late observations cannot bind to the wrong dispatch attempt"],
+                permission_profile="execute_with_gates",
+                allowed_executors=["codex"],
+            )
+            ticked = tick_loop_runtime(paths, cycle["loop_id"])
+            queue_id = ticked["runtime"]["queue"][0]["queue_id"]
+            first = dispatch_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                executor="codex",
+                session_ref="codex-session-1",
+                evidence_refs=["wrapper:dispatch:1"],
+            )
+            first_attempt_id = first["runtime"]["queue"][0]["executor_session"]["active_attempt_id"]
+            recovered = recover_loop_queue_item_dispatch(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                prior_attempt_id=first_attempt_id,
+                prior_outcome="delivery_unknown",
+                outcome_evidence_refs=["wrapper:ack-timeout:1"],
+                executor="codex",
+                session_ref="codex-session-2",
+                evidence_refs=["wrapper:dispatch:2"],
+            )
+
+            with self.assertRaisesRegex(ValueError, "dispatch attempt id is required"):
+                observe_codex_loop_queue_item(
+                    paths,
+                    cycle["loop_id"],
+                    queue_id,
+                    codex_log_text='{"role":"assistant","content":"Work completed."}',
+                    evidence_refs=["codex-jsonl:1"],
+                )
+
+            observed = observe_codex_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                codex_log_text='{"role":"assistant","content":"Work completed."}',
+                evidence_refs=["codex-jsonl:1"],
+                dispatch_attempt_id=first_attempt_id,
+            )
+
+        item = observed["runtime"]["queue"][0]
+        self.assertEqual(item["observed_dispatch_attempt_id"], first_attempt_id)
+        attempts = item["executor_session"]["dispatch_attempts"]
+        self.assertEqual(attempts[0]["delivery_outcome"], "delivery_confirmed")
+        self.assertEqual(attempts[1]["delivery_outcome"], "delivery_unknown")
+        self.assertEqual(
+            recovered["runtime"]["queue"][0]["executor_session"]["active_attempt_id"],
+            attempts[1]["attempt_id"],
+        )
+
+    def test_loop_cycle_validation_rejects_ambiguous_dispatch_attempt_state(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = create_loop_cycle(
+                paths,
+                goal_summary="Validate executor dispatch identity",
+                goal_reframe="Reject persisted state that cannot identify its active dispatch.",
+                success_criteria=["Ambiguous dispatch state fails validation"],
+                permission_profile="execute_with_gates",
+                allowed_executors=["codex"],
+            )
+            ticked = tick_loop_runtime(paths, cycle["loop_id"])
+            queue_id = ticked["runtime"]["queue"][0]["queue_id"]
+            dispatched = dispatch_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                executor="codex",
+                session_ref="codex-session-1",
+                evidence_refs=["wrapper:dispatch:1"],
+            )
+            observed = observe_codex_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                codex_log_text='{"role":"assistant","content":"Work completed."}',
+                evidence_refs=["codex-jsonl:1"],
+            )
+
+        duplicate = copy.deepcopy(dispatched)
+        duplicate_session = duplicate["runtime"]["queue"][0]["executor_session"]
+        duplicate_session["dispatch_attempts"].append(copy.deepcopy(duplicate_session["dispatch_attempts"][0]))
+        duplicate_errors = validate_loop_cycle(duplicate)["errors"]
+
+        mismatched = copy.deepcopy(dispatched)
+        mismatched["runtime"]["queue"][0]["executor_session"]["session_ref"] = "other-session"
+        mismatch_errors = validate_loop_cycle(mismatched)["errors"]
+
+        unbound = copy.deepcopy(observed)
+        unbound["runtime"]["queue"][0]["observed_dispatch_attempt_id"] = ""
+        unbound_errors = validate_loop_cycle(unbound)["errors"]
+
+        self.assertTrue(any("attempt_id duplicates" in error for error in duplicate_errors))
+        self.assertTrue(any("must match the active dispatch attempt" in error for error in mismatch_errors))
+        self.assertTrue(any("must identify a recorded dispatch attempt" in error for error in unbound_errors))
+
+    def test_loop_cycle_validation_keeps_legacy_single_dispatch_records_readable(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = create_loop_cycle(
+                paths,
+                goal_summary="Read legacy executor dispatch state",
+                goal_reframe="Preserve compatibility with records written before attempt history.",
+                success_criteria=["Legacy records remain valid"],
+                permission_profile="execute_with_gates",
+                allowed_executors=["codex"],
+            )
+            ticked = tick_loop_runtime(paths, cycle["loop_id"])
+            queue_id = ticked["runtime"]["queue"][0]["queue_id"]
+            dispatched = dispatch_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                executor="codex",
+                session_ref="codex-session-1",
+                evidence_refs=["wrapper:dispatch:1"],
+            )
+
+        legacy = copy.deepcopy(dispatched)
+        session = legacy["runtime"]["queue"][0]["executor_session"]
+        session.pop("active_attempt_id")
+        session.pop("dispatch_attempts")
+        self.assertEqual(validate_loop_cycle(legacy), {"ok": True, "errors": []})
 
     def test_loop_queue_lifecycle_lists_handoffs_observes_and_blocks_items(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Capability

Loop queue dispatch now keeps one stable, auditable identity across retries.

An exact retry is a no-op. Conflicting executor, session, thread, evidence, or summary metadata is rejected instead of replacing the first dispatch. When delivery is uncertain or known to have failed, the explicit `recover-dispatch` path appends a new attempt while retaining the original evidence.

Closes #1277.

## Motivation

`dispatch_loop_queue_item` accepted repeated writes while a queue item remained `prepared_not_observed`. Each write replaced the entire `executor_session`, so a wrapper retry after a lost acknowledgement could erase the first executor session and make the persisted record unable to identify which dispatch owned the work. `validate_loop_cycle` still accepted that state.

## Implementation (boundary level)

- Persist ordered `loop_dispatch_attempt/v1` entries with stable attempt IDs and separate `delivery_unknown`, `delivery_failed`, and `delivery_confirmed` outcomes.
- Make identical dispatch writes idempotent and reject divergent writes with an actionable recovery error.
- Add `omh loop queue recover-dispatch` as the only path for a subsequent attempt; it records the prior outcome and evidence before appending.
- Bind observations to a recorded attempt and reject duplicate, mismatched, or ambiguous attempt state during loop validation.
- Continue accepting legacy single-dispatch records without a migration.

## Rejected

- **Reject every re-dispatch** — safe for overwrites, but leaves wrappers with no recovery path when acknowledgement is lost.
- **Keep replacing `executor_session`** — preserves the old API shape but destroys the evidence needed to distinguish a retry from a second execution.

## Verification (observed)

- 8 focused dispatch, recovery, observation-binding, validation, compatibility, and CLI regressions pass.
- Full suite: **8,726 tests OK**.
- `uv run --group lint ruff check src tests`, `uv run python -m compileall -q src tests`, and `git diff --check` pass.

## Risks

- Loop queue records now carry additive attempt-history fields; legacy records remain readable.
- No live executor delivery was run from this branch. Remote CI is pending.
