### PR TITLE
feat(hud): the subagent row's metric run reads in three tones and one order

### DIFF
--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -204,7 +204,14 @@ export default function register(sdk) {
     return `${Math.floor(seconds / 3600)}h ${String(Math.floor(seconds / 60) % 60).padStart(2, '0')}m`
   }
 
-  const metricSegment = (kind, text) => ({ kind, text })
+  // `drop` is shed priority, not screen position. The metadata now reads in
+  // the order the figures explain each other -- rate beside the token count
+  // it is derived from, then cache, then turn -- while a narrowing terminal
+  // still sheds the least valuable figure first (rate, then cost, then
+  // turn), exactly as it did when position and priority were the same list.
+  // Two orders, because the figure that reads first is not the figure that
+  // should go first.
+  const metricSegment = (kind, text, drop = 0) => ({ drop, kind, text })
   // Only observed values render. The old permanent not-collected labels on
   // cache/ctx were honest but unresolvable for Hermes-native children — the
   // host never records a child's context percentage — and read as a fixable
@@ -260,10 +267,15 @@ export default function register(sdk) {
     // from row to row.
     const routeSegment = dispatchLane ? metricSegment('maestro', dispatchIdentity) : metricSegment(routeKind, route)
     const optional = [
-      metricSegment('fallback', Number.isFinite(row.fallback_count) && row.fallback_count > 0 ? `fallback:${row.fallback_count}` : ''),
-      metricSegment('cache', observedPercent('cache', row.cache_hit_percentage)),
-      metricSegment('context', observedPercent('ctx', row.context_percentage)),
-      metricSegment('turn', turnTools),
+      metricSegment('fallback', Number.isFinite(row.fallback_count) && row.fallback_count > 0 ? `fallback:${row.fallback_count}` : '', 1),
+      // Rate reads immediately after the tail's token count ('tokens, tok/s,
+      // cache, turns 순으로'): one number is the other's derivative, so the
+      // pair belongs together on the line. Its drop rank keeps it the first
+      // figure a narrow terminal sheds all the same.
+      metricSegment('rate', Number.isFinite(row.tokens_per_second) ? `${Math.round(row.tokens_per_second)} tok/s` : '', 6),
+      metricSegment('cache', observedPercent('cache', row.cache_hit_percentage), 2),
+      metricSegment('context', observedPercent('ctx', row.context_percentage), 3),
+      metricSegment('turn', turnTools, 4),
       // A subscription-billed host records no per-call cost, so the reader
       // supplies a token-derived approximation flagged cost_approximate —
       // rendered with a `~` so it never reads as billing truth. A true zero
@@ -274,8 +286,8 @@ export default function register(sdk) {
         Number.isFinite(row.cost_usd) && row.cost_usd > 0
           ? `${row.cost_approximate ? '~' : ''}$${row.cost_usd.toFixed(4)}`
           : '',
+        5,
       ),
-      metricSegment('rate', Number.isFinite(row.tokens_per_second) ? `${Math.round(row.tokens_per_second)} tok/s` : ''),
     ].filter(segment => segment.text)
     const running = !row.state || row.state === 'running'
     // A running row's elapsed ticks in real time: the snapshot's value plus
@@ -303,7 +315,10 @@ export default function register(sdk) {
       ? ` · ${tokenText.padStart(6)} tokens`
       : ' '.repeat(tokensWidth)
     const tailState = padCells(stateText, stateWidth)
-    const tailRest = ` · ${padCells(elapsedText(elapsed) || '0s', 7)}${tokensColumn ? tokensPiece : ''}`
+    // Elapsed and the token count are one fixed-width tail but two colours,
+    // so they render as two pieces: same cells as before, split at the dot.
+    const tailRest = ` · ${padCells(elapsedText(elapsed) || '0s', 7)}`
+    const tailTokens = tokensColumn ? tokensPiece : ''
     const prefix = `${taskId} `
     const separator = '  ·  '
     const budget = Math.max(24, columns - 4)
@@ -323,7 +338,11 @@ export default function register(sdk) {
     while (segments.length) {
       const metadata = segments.map(item => item.text).join(separator)
       if (fixedWidth + cellWidth(separator) + cellWidth(metadata) + 2 <= budget) break
-      segments.pop()
+      let shed = 0
+      for (let index = 1; index < segments.length; index += 1) {
+        if (segments[index].drop > segments[shed].drop) shed = index
+      }
+      segments.splice(shed, 1)
     }
     const metadata = segments.map(segment => segment.text).join(separator)
     return {
@@ -334,6 +353,7 @@ export default function register(sdk) {
       segments,
       tailRest,
       tailState,
+      tailTokens,
       taskId: main ? 'MAIN'.padEnd(8) : taskId,
     }
   }
@@ -368,6 +388,14 @@ export default function register(sdk) {
       h(Text, {}, '  '),
       h(Text, { color: statusColor }, layout.tailState),
       h(Text, { color: t.color.muted }, layout.tailRest),
+      // The token count is the one figure on the row that is a plain
+      // quantity, so it reads in `statusFg` -- the tone the host's own status
+      // line spends on its token gauge -- instead of the muted tint every
+      // other metric shares ('tokens는 약간 회색'). The palette derives that
+      // tone as a literal grey (grayOf) and a skin may retune it to its own
+      // status-bar text, so it stays neutral against the muted run either
+      // way. Still a theme token, never a literal.
+      h(Text, { color: t.color.statusFg }, layout.tailTokens),
       ...layout.segments.map((segment, index) =>
         h(
           Text,
@@ -382,6 +410,13 @@ export default function register(sdk) {
                 // something other than the plain Hermes-native default,
                 // here the Maestro lane's own spawned CLI.
                 || segment.kind === 'maestro'
+                // Cache hit rate is the figure the owner reads first on a
+                // long run, and asked for in yellow. `warn` is the palette's
+                // only amber, so the cache figure shares a colour with the
+                // route warnings above -- it is told apart by its `cache`
+                // label and by sitting in the metric run, not the route
+                // column. No literal enters this file for it.
+                || segment.kind === 'cache'
                 ? t.color.warn
                 : t.color.muted,
             key: `${segment.kind}-${index}`,

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -541,8 +541,8 @@ class TuiWidgetPackTests(unittest.TestCase):
         # 그뒤에 캐시히트나 턴'), so the order is title, route/category, then
         # `state · elapsed · N tokens` -- each piece padded to a constant cell
         # width so the token figures still line up vertically down the list --
-        # and only then cache, turn, cost, and rate, which the drop loop still
-        # sheds from the right without ever touching the tail.
+        # and only then rate, cache, turn and cost, which the drop loop still
+        # sheds by rank without ever touching the tail.
         self.assertIn("` · ${tokenText.padStart(6)} tokens`", widget)
         self.assertIn("const routeCap = Math.max(10, Math.min(30, Math.floor(columns * 0.24)))", widget)
         # The route column reserves its width per LIST, exactly like tokens:
@@ -553,7 +553,34 @@ class TuiWidgetPackTests(unittest.TestCase):
             widget,
         )
         self.assertIn("h(Text, { color: statusColor }, layout.tailState)", widget)
+        # The tail is one fixed-width block but two colours: elapsed keeps the
+        # muted tint every metric shares, and the token count -- the row's one
+        # plain quantity -- reads in `statusFg`, the tone the host status line
+        # spends on its own token gauge ('tokens는 약간 회색'). A theme token
+        # either way; no literal colour enters this widget.
         self.assertIn("h(Text, { color: t.color.muted }, layout.tailRest)", widget)
+        self.assertIn("h(Text, { color: t.color.statusFg }, layout.tailTokens)", widget)
+        self.assertIn("const tailTokens = tokensColumn ? tokensPiece : ''", widget)
+        # Rate reads beside the token count it is derived from ('tokens,
+        # tok/s, cache, turns 순으로'), so the metric run is ordered rate,
+        # cache, ctx, turn, cost on screen.
+        self.assertLess(widget.index("metricSegment('rate'"), widget.index("metricSegment('cache'"))
+        self.assertLess(widget.index("metricSegment('cache'"), widget.index("metricSegment('turn'"))
+        self.assertLess(widget.index("metricSegment('turn'"), widget.index("        'cost',"))
+        # Screen position stopped being shed priority when rate moved left, so
+        # each segment carries a `drop` rank and the loop sheds the highest --
+        # rate first, then cost, then turn -- exactly the order the tail's
+        # comment has always promised. Popping the last segment would now shed
+        # cost before rate and drop the cheapest figure last.
+        self.assertIn("const metricSegment = (kind, text, drop = 0) => ({ drop, kind, text })", widget)
+        self.assertIn("if (segments[index].drop > segments[shed].drop) shed = index", widget)
+        self.assertIn("segments.splice(shed, 1)", widget)
+        self.assertNotIn("segments.pop()", widget)
+        # Cache hit rate renders in the palette's amber ('cache는 노란색'),
+        # which it shares with the route/dispatch warnings; turn and rate stay
+        # muted, so the run reads grey count, muted rate, amber cache, muted
+        # turn.
+        self.assertIn("|| segment.kind === 'cache'\n                ? t.color.warn", widget)
         # The tokens column exists per LIST: a row with no observed count
         # holds the grid with blank cells, and a wave with no counts at all
         # drops the column instead of wasting the width.


### PR DESCRIPTION
## Feature Report

### What Changed

- The metric run trailing every subagent/MAIN row in the OMH status widget now
  renders in three tones instead of one: the token count in `statusFg`, the
  cache hit rate in `warn` (the palette's amber), and turn / tok-s / cost in
  the muted tint they already had.
- The run's reading order changed to `tokens · tok/s · cache · turn` (cost
  after turn when a row carries one). `tok/s` moved from the far right to sit
  beside the token count.
- Screen position stopped being shed priority. Each metric segment carries a
  `drop` rank and the narrow-terminal loop sheds the highest rank, so the
  documented `rate → cost → turn` drop order survives the reorder.

### Why This Exists

- Every figure after the row's route column rendered in one muted tone, so a
  wave of rows read as an undifferentiated grey run — finding the cache rate
  or the token count meant reading labels rather than colours. The owner asked
  for the token count in grey and the cache figure in yellow, with turn and
  tok/s left alone, and for tok/s to sit next to the count it derives from.
- The naive fix (reorder the array) would have silently inverted the drop
  order: with rate first in the list, the pop-the-last loop would have shed
  `turn` before `tok/s` on a narrow dock — the opposite of what the tail's own
  comment promises and of what is worth keeping on a cramped screen.

### User / Operator Impact

- On a live wave, the row's rightmost figures are now scannable by colour: a
  neutral grey token count anchoring the right edge, an amber cache rate, and
  muted supporting figures. Total and speed read as a pair.
- Nothing changes about which rows render, when they render, or what they
  claim. Display only.

### How It Works

- `metricSegment(kind, text, drop)` gained a shed rank; `optional` is now in
  screen order (`fallback`, `rate`, `cache`, `ctx`, `turn`, `cost`) with ranks
  that reproduce the old shed sequence (`rate` 6 → `cost` 5 → `turn` 4 →
  `ctx` 3 → `cache` 2 → `fallback` 1). The width loop picks the highest
  remaining rank and splices it out instead of popping the tail.
- The fixed-width tail split into `tailRest` (elapsed, muted) and `tailTokens`
  (the token count, `statusFg`) so the two halves can carry different colours.
  Cell widths, padding, and the per-list tokens/route column rules are
  untouched, so the vertical grid still lines up.
- `cache` joins `route-fallback` / `maestro` on the `warn` branch of the
  segment colour ladder. Colours still resolve only through the active theme —
  no literal hex enters the widget, which is a standing rule in that file.
  `warn` is the palette's only amber, so the cache figure shares a colour with
  the route warnings; it is told apart by its `cache` label and by sitting in
  the metric run rather than the route column.

### Files And Contracts Touched

- `src/omh/tui_widgets/omh-status.mjs` — the managed Modern-TUI widget.
- `tests/test_tui_widget_pack.py` — source-shape assertions for the tail split,
  the two new tones, the screen order, and the rank-based shed loop (plus an
  explicit `assertNotIn("segments.pop()")` so the drop order cannot silently
  revert to position order).
- No reader, schema, payload field, catalog entry, or generated artifact moves.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli release checklist --json`
- [x] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [x] `omh --help`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed
- [x] Relevant dry-run or smoke command: stub-SDK render of the widget at five
      terminal widths (see Observed Evidence)
- [ ] Manual Hermes/TUI check — not run; see Not Tested

### Observed Evidence

- `PYTHONPATH=tests uv run python -m unittest discover -s tests`: **8720 tests,
  OK** (459.6s).
- `uv run --group lint ruff check src tests`: All checks passed.
- Byte gates green: `docs workflows|roles|capability-families|ulw-inventory|
  ulw-site --check`, plus `compileall`, `node --check` on the widget, and
  `git diff --check`.
- Behaviour observed by importing the widget's `register()` against a stub SDK
  (Box/Text/h captured, function components resolved) and rendering one MAIN
  row plus two subagent rows at cols 220 / 190 / 175 / 165 / 155:
  - cols 220 — `running · 12m 22s · GREY[970.5k tokens] · MUTED[22 tok/s] ·
    WARN[cache 97.3%] · MUTED[turn 186] · MUTED[$0.4213]`
  - cols 175 — `tok/s` shed first, `$0.4213` still present
  - cols 165 — cost shed next
  - cols 155 — `turn` shed next, cache and the token count still standing
  i.e. the rate → cost → turn drop order is preserved while the line reads in
  the new order.

### Not Tested / Not Applicable

- Manual Hermes Modern-TUI render: not run. The widget is a managed artifact,
  so the new tones only appear on a machine after `omh update` plus a TUI
  restart; the stub-SDK render above is the observed proof of the colour and
  order, not a live screenshot.
- Workflow-learning review queue smoke: no learning contract changed.
- Live `omh release hermes-smoke --live`: not run; no runtime/native claim
  changed here.

## Risk

- Low, display-only. The one behavioural subtlety is the shed loop: it now
  removes by rank rather than by position. The rank table reproduces the
  previous sequence exactly, and the test asserts both the rank comparison and
  the absence of `segments.pop()`.
- `warn` now carries two meanings on a row (route/dispatch warning, and the
  cache figure). Accepted deliberately: the palette has no second amber, and
  the two live in different columns with different labels.

## Compatibility / Rollout

- No config, schema, or payload change; older payloads render exactly as
  before with the new tones. Reaches a machine through `omh update` plus a TUI
  restart, never by hand-copying the widget into `~/.hermes/tui-widgets/`.

## Release / Claims

- [x] Release-channel impact considered (`local`; ships with the next widget
      refresh)
- [x] Runtime/native capability claims are backed by evidence or marked as not
      observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as
      execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events,
      transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including the `omh release
      hermes-smoke --live` gap

## Follow-Up

- If the amber double-duty reads badly on a live wave, the next step is a
  dedicated skin key for metric emphasis rather than a literal in the widget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1FBdSEPoAmCnHsq5LXqkr
