### PR TITLE
fix(loop): a dispatch outcome only tightens, and a legacy record still recovers

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2049,16 +2049,23 @@ exits non-zero. That is the conservative direction; the alternative was a
 duplicate id the validator now rejects anyway. A distinct `mutation_id`
 applies normally.
 
-Surfaces that do **not** materialize the id need nothing extra, but the reason
-has to be checked rather than assumed. Loop cycles
-(`src/workflows/goal_loop.py`) mint `cycle_id` and `queue_id` from
-`_new_item_id()`, never from the `mutation_id`; their queue mutators are
-additionally guarded by status preconditions — `observe` and `dispatch` require
-`prepared_not_observed`, `block` refuses an already-observed item — so a
-replayed queue mutation is refused rather than applied twice. Wrapper sessions
-(`src/wrapper/sessions.py`) mutate in place — status transitions and a single
-`current_run_id` — instead of appending id-bearing items, so a repeat write is
-idempotent by shape.
+Surfaces that do **not** materialize the mutation id still need their own replay
+invariant. Loop cycles (`src/workflows/goal_loop.py`) mint `cycle_id` and
+`queue_id` from `_new_item_id()`, never from the `mutation_id`. Executor
+dispatch is the exception inside that record: it materializes a stable
+`loop_dispatch_attempt/v1` identity from the normalized dispatch metadata.
+Replaying the exact metadata is a no-op, divergent metadata is refused, and
+`omh loop queue recover-dispatch` is the only path that can append a new
+attempt. Recovery records the prior attempt as `delivery_failed` or
+`delivery_unknown` with evidence before appending; an observation names the
+attempt it confirms, and must do so explicitly once recovery has made the
+history ambiguous. The legacy single `executor_session` fields remain a mirror
+of the active attempt, and records written before attempt history remain
+readable. Other queue mutators retain status preconditions — `observe` requires
+`prepared_not_observed`, and `block` refuses an already-observed item. Wrapper
+sessions (`src/wrapper/sessions.py`) mutate in place — status transitions and a
+single `current_run_id` — instead of appending id-bearing items, so a repeat
+write is idempotent by shape.
 
 ### Bounded mutation ids
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2059,9 +2059,21 @@ Replaying the exact metadata is a no-op, divergent metadata is refused, and
 attempt. Recovery records the prior attempt as `delivery_failed` or
 `delivery_unknown` with evidence before appending; an observation names the
 attempt it confirms, and must do so explicitly once recovery has made the
-history ambiguous. The legacy single `executor_session` fields remain a mirror
-of the active attempt, and records written before attempt history remain
-readable. Other queue mutators retain status preconditions — `observe` requires
+history ambiguous. Outcomes only ever tighten: an observation that confirms an
+attempt moves the superseded claim, with its own evidence and summary, into
+that attempt's `outcome_history` rather than merging the two ref lists — an
+acknowledgement timeout must not end up cited as evidence that the dispatch
+arrived — and `delivery_failed` is final, so a later observation is refused
+instead of reversing it. The legacy single `executor_session` fields remain a
+mirror of the active attempt. Records written before attempt history stay
+readable, and recovery adopts such a session as attempt 1 rather than refusing
+it, because dispatch already refuses their divergent retry and refusing here
+too would leave an in-flight legacy item with no way forward; the adopted
+attempt carries an empty `recorded_at`, since the legacy shape never stored a
+dispatch timestamp. `build_loop_queue_handoff` carries
+`active_dispatch_attempt_id` and `dispatch_attempt_count`, so the surface that
+names `observe_loop_queue` also hands over the id that action now requires.
+Other queue mutators retain status preconditions — `observe` requires
 `prepared_not_observed`, and `block` refuses an already-observed item. Wrapper
 sessions (`src/wrapper/sessions.py`) mutate in place — status transitions and a
 single `current_run_id` — instead of appending id-bearing items, so a repeat

--- a/src/commands/loop.py
+++ b/src/commands/loop.py
@@ -4,6 +4,7 @@ import argparse
 
 from ..goal_loop import (
     LOOP_ACTIONS,
+    LOOP_DISPATCH_RECOVERY_OUTCOMES,
     LOOP_EXECUTOR_OPTION_IDS,
     LOOP_STICKY_RULE_DEFAULT_GAP,
     LOOP_STICKY_RULE_DEFAULT_MAX_REPEATS,
@@ -28,6 +29,7 @@ from ..goal_loop import (
     read_loop_cycle,
     record_loop_goal_driver_observation,
     record_loop_feedback,
+    recover_loop_queue_item_dispatch,
     run_loop_once_result,
     tick_loop_runtime,
     update_loop_permission,
@@ -309,6 +311,28 @@ def cmd_loop_queue_dispatch(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_loop_queue_recover_dispatch(args: argparse.Namespace) -> int:
+    try:
+        cycle = recover_loop_queue_item_dispatch(
+            _paths(args),
+            args.loop_id,
+            args.queue_id,
+            prior_attempt_id=args.prior_attempt_id,
+            prior_outcome=args.prior_outcome,
+            outcome_evidence_refs=args.outcome_evidence_ref or [],
+            outcome_summary=args.outcome_summary or "",
+            executor=args.executor,
+            session_ref=args.codex_session_ref or args.session_ref or "",
+            thread_ref=args.codex_thread_ref or args.thread_ref or "",
+            evidence_refs=args.evidence_ref or [],
+            summary=args.summary or "",
+        )
+        _print_json({"loop": cycle, "status_card": build_loop_status_card(_paths(args), args.loop_id)})
+    except (FileNotFoundError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    return 0
+
+
 def cmd_loop_queue_observe_codex(args: argparse.Namespace) -> int:
     try:
         log_text = ""
@@ -326,6 +350,7 @@ def cmd_loop_queue_observe_codex(args: argparse.Namespace) -> int:
             evidence_refs=args.evidence_ref or [],
             codex_log_ref=args.codex_log_ref or "",
             summary=args.summary or "",
+            dispatch_attempt_id=args.dispatch_attempt_id or "",
         )
         _print_json({"loop": cycle, "narration": build_loop_cycle_narration(_paths(args), args.loop_id, args.queue_id)})
     except (FileNotFoundError, OSError, ValueError) as exc:
@@ -352,6 +377,7 @@ def cmd_loop_queue_observe(args: argparse.Namespace) -> int:
             subagent_evidence_refs=args.subagent_evidence_ref or [],
             connector_evidence_refs=args.connector_evidence_ref or [],
             summary=args.summary or "",
+            dispatch_attempt_id=args.dispatch_attempt_id or "",
         )
         _print_json({"loop": cycle, "status_card": build_loop_status_card(_paths(args), args.loop_id)})
     except (FileNotFoundError, ValueError) as exc:
@@ -507,6 +533,26 @@ def _add_loop_commands(sub) -> None:
     queue_dispatch.add_argument("--summary", default="")
     queue_dispatch.set_defaults(func=cmd_loop_queue_dispatch)
 
+    queue_recover_dispatch = queue_sub.add_parser("recover-dispatch")
+    queue_recover_dispatch.add_argument("--loop", dest="loop_id", required=True)
+    queue_recover_dispatch.add_argument("--queue", dest="queue_id", required=True)
+    queue_recover_dispatch.add_argument("--prior-attempt-id", required=True)
+    queue_recover_dispatch.add_argument(
+        "--prior-outcome",
+        choices=LOOP_DISPATCH_RECOVERY_OUTCOMES,
+        required=True,
+    )
+    queue_recover_dispatch.add_argument("--outcome-evidence-ref", action="append", required=True)
+    queue_recover_dispatch.add_argument("--outcome-summary", default="")
+    queue_recover_dispatch.add_argument("--executor", choices=LOOP_EXECUTOR_OPTION_IDS, required=True)
+    queue_recover_dispatch.add_argument("--session-ref", default="")
+    queue_recover_dispatch.add_argument("--thread-ref", default="")
+    queue_recover_dispatch.add_argument("--codex-session-ref", default="")
+    queue_recover_dispatch.add_argument("--codex-thread-ref", default="")
+    queue_recover_dispatch.add_argument("--evidence-ref", action="append")
+    queue_recover_dispatch.add_argument("--summary", default="")
+    queue_recover_dispatch.set_defaults(func=cmd_loop_queue_recover_dispatch)
+
     queue_observe_codex = queue_sub.add_parser("observe-codex")
     queue_observe_codex.add_argument("--loop", dest="loop_id", required=True)
     queue_observe_codex.add_argument("--queue", dest="queue_id", required=True)
@@ -514,6 +560,7 @@ def _add_loop_commands(sub) -> None:
     queue_observe_codex.add_argument("--codex-log-text", default="")
     queue_observe_codex.add_argument("--codex-log-ref", default="")
     queue_observe_codex.add_argument("--evidence-ref", action="append", required=True)
+    queue_observe_codex.add_argument("--dispatch-attempt-id", default="")
     queue_observe_codex.add_argument("--summary", default="")
     queue_observe_codex.set_defaults(func=cmd_loop_queue_observe_codex)
 
@@ -529,6 +576,7 @@ def _add_loop_commands(sub) -> None:
     queue_observe.add_argument("--worktree-evidence-ref", action="append")
     queue_observe.add_argument("--subagent-evidence-ref", action="append")
     queue_observe.add_argument("--connector-evidence-ref", action="append")
+    queue_observe.add_argument("--dispatch-attempt-id", default="")
     queue_observe.add_argument("--summary", default="")
     queue_observe.set_defaults(func=cmd_loop_queue_observe)
 

--- a/src/commands/loop.py
+++ b/src/commands/loop.py
@@ -317,7 +317,7 @@ def cmd_loop_queue_recover_dispatch(args: argparse.Namespace) -> int:
             _paths(args),
             args.loop_id,
             args.queue_id,
-            prior_attempt_id=args.prior_attempt_id,
+            prior_attempt_id=args.prior_attempt_id or "",
             prior_outcome=args.prior_outcome,
             outcome_evidence_refs=args.outcome_evidence_ref or [],
             outcome_summary=args.outcome_summary or "",
@@ -536,7 +536,7 @@ def _add_loop_commands(sub) -> None:
     queue_recover_dispatch = queue_sub.add_parser("recover-dispatch")
     queue_recover_dispatch.add_argument("--loop", dest="loop_id", required=True)
     queue_recover_dispatch.add_argument("--queue", dest="queue_id", required=True)
-    queue_recover_dispatch.add_argument("--prior-attempt-id", required=True)
+    queue_recover_dispatch.add_argument("--prior-attempt-id", default="")
     queue_recover_dispatch.add_argument(
         "--prior-outcome",
         choices=LOOP_DISPATCH_RECOVERY_OUTCOMES,

--- a/src/workflows/goal_loop.py
+++ b/src/workflows/goal_loop.py
@@ -49,11 +49,13 @@ LOOP_SMALL_LOOP_GUIDANCE_SCHEMA = "loop_small_loop_guidance/v1"
 LOOP_RUN_ONCE_RESULT_SCHEMA = "loop_run_once_result/v1"
 EXECUTOR_LOOP_CAPABILITY_SCHEMA = "executor_loop_capability/v1"
 LOOP_CYCLE_NARRATION_SCHEMA = "loop_cycle_narration/v1"
+LOOP_DISPATCH_ATTEMPT_SCHEMA = "loop_dispatch_attempt/v1"
 LOOP_INVOCATION_SCHEMA = "loop_invocation/v1"
 LOOP_CONSTRAINT_ASSESSMENT_SCHEMA = "loop_constraint_assessment/v1"
 LOOP_STICKY_RULE_SCHEMA = "loop_sticky_rule/v1"
 LOOP_STICKY_RULE_ATTACHMENT_SCHEMA = "loop_sticky_rule_attachment/v1"
 LOOP_STOP_LADDER_SCHEMA = "loop_stop_ladder/v1"
+LOOP_DISPATCH_RECOVERY_OUTCOMES = ("delivery_failed", "delivery_unknown")
 
 # The ordered stop ladder evaluated before a tick advances. The tuple order IS
 # the ladder: assess_loop_stop_ladder walks it top to bottom, the first rung
@@ -1911,21 +1913,31 @@ def dispatch_loop_queue_item(
 ) -> dict[str, Any]:
     refs = _safe_list(evidence_refs or [], limit=320)
     capability = loop_executor_capability(executor)
+    dispatch = _dispatch_request(capability, session_ref, thread_ref, refs, summary)
 
-    def mutate(cycle: dict[str, Any]) -> dict[str, Any]:
+    def mutate(cycle: dict[str, Any]) -> dict[str, Any] | None:
         runtime, item = _queue_item_ref(cycle, queue_id)
         if item.get("status") != "prepared_not_observed":
             raise ValueError("only prepared_not_observed loop queue items can record executor dispatch")
+        existing = _dict_value(item, "executor_session")
+        if str(existing.get("dispatch_status", "")) in {"prepared", "dispatched"}:
+            if _executor_session_dispatch(existing) == dispatch:
+                return None
+            if existing.get("dispatch_status") == "dispatched":
+                raise ValueError(
+                    "loop queue item already has a different executor dispatch; use explicit recovery"
+                )
+        attempts = [entry for entry in existing.get("dispatch_attempts", []) if isinstance(entry, dict)]
+        attempt = (
+            _new_dispatch_attempt(queue_id, len(attempts) + 1, dispatch)
+            if dispatch["dispatch_status"] == "dispatched"
+            else None
+        )
         item["executor_session"] = {
             **_empty_executor_session(str(capability["executor"])),
-            "executor": capability["executor"],
-            "loop_mode": capability["loop_mode"],
-            "dispatch_owner": capability["dispatch_owner"],
-            "dispatch_status": "dispatched" if refs or session_ref.strip() or thread_ref.strip() else "prepared",
-            "session_ref": _safe_summary(session_ref, limit=220) if session_ref.strip() else "",
-            "thread_ref": _safe_summary(thread_ref, limit=220) if thread_ref.strip() else "",
-            "dispatch_evidence_refs": refs,
-            "summary": _safe_summary(summary, limit=320) if summary.strip() else "Executor dispatch metadata recorded for this loop queue item.",
+            **dispatch,
+            "active_attempt_id": str(attempt["attempt_id"]) if attempt else "",
+            "dispatch_attempts": [*attempts, *([attempt] if attempt else [])],
             "capability": capability,
         }
         runtime["last_queue_id"] = str(item["queue_id"])
@@ -1948,6 +1960,97 @@ def dispatch_loop_queue_item(
     )
 
 
+def recover_loop_queue_item_dispatch(
+    paths: OmhPaths,
+    loop_id: str,
+    queue_id: str,
+    *,
+    prior_attempt_id: str,
+    prior_outcome: str,
+    outcome_evidence_refs: Iterable[str],
+    executor: str,
+    session_ref: str = "",
+    thread_ref: str = "",
+    evidence_refs: Iterable[str] | None = None,
+    outcome_summary: str = "",
+    summary: str = "",
+    expected_revision: int | None = None,
+    mutation_id: str | None = None,
+) -> dict[str, Any]:
+    attempt_id = _safe_summary(prior_attempt_id, limit=120)
+    if not attempt_id:
+        raise ValueError("prior dispatch attempt id is required")
+    if prior_outcome not in LOOP_DISPATCH_RECOVERY_OUTCOMES:
+        raise ValueError(
+            f"prior dispatch outcome must be one of: {', '.join(LOOP_DISPATCH_RECOVERY_OUTCOMES)}"
+        )
+    outcome_refs = _safe_list(outcome_evidence_refs, limit=320)
+    if not outcome_refs:
+        raise ValueError("dispatch recovery requires prior outcome evidence")
+    capability = loop_executor_capability(executor)
+    dispatch_refs = _safe_list(evidence_refs or [], limit=320)
+    dispatch = _dispatch_request(capability, session_ref, thread_ref, dispatch_refs, summary)
+    if dispatch["dispatch_status"] != "dispatched":
+        raise ValueError("dispatch recovery requires new dispatch identity or evidence")
+
+    def mutate(cycle: dict[str, Any]) -> dict[str, Any]:
+        runtime, item = _queue_item_ref(cycle, queue_id)
+        if item.get("status") != "prepared_not_observed":
+            raise ValueError("only prepared_not_observed loop queue items can recover executor dispatch")
+        existing = _dict_value(item, "executor_session")
+        attempts = [dict(entry) for entry in existing.get("dispatch_attempts", []) if isinstance(entry, dict)]
+        if not attempts:
+            raise ValueError("legacy executor dispatch has no attempt identity; record its outcome before recovery")
+        if existing.get("active_attempt_id") != attempt_id or attempts[-1].get("attempt_id") != attempt_id:
+            raise ValueError("prior dispatch attempt must be the active attempt")
+        attempts[-1] = {
+            **attempts[-1],
+            "delivery_outcome": prior_outcome,
+            "outcome_evidence_refs": outcome_refs,
+            "outcome_summary": (
+                _safe_summary(outcome_summary, limit=320)
+                if outcome_summary.strip()
+                else "Prior dispatch outcome recorded before explicit recovery."
+            ),
+        }
+        next_attempt = _new_dispatch_attempt(queue_id, len(attempts) + 1, dispatch)
+        item["executor_session"] = {
+            **existing,
+            **dispatch,
+            "active_attempt_id": next_attempt["attempt_id"],
+            "dispatch_attempts": [*attempts, next_attempt],
+            "capability": capability,
+        }
+        runtime["last_queue_id"] = str(item["queue_id"])
+        runtime["last_queue_status"] = str(item["status"])
+        cycle["runtime"] = runtime
+        cycle["next_action"] = "observe_runtime_queue"
+        cycle["updated_at"] = utc_now()
+        return cycle
+
+    return _guarded_cycle_update(
+        paths,
+        loop_id,
+        mutate,
+        operation="recover_loop_queue_item_dispatch",
+        expected_revision=expected_revision,
+        mutation_id=mutation_id,
+        mutation_digest=_mutation_digest(
+            "recover_loop_queue_item_dispatch",
+            queue_id,
+            attempt_id,
+            prior_outcome,
+            outcome_refs,
+            outcome_summary,
+            executor,
+            session_ref,
+            thread_ref,
+            dispatch_refs,
+            summary,
+        ),
+    )
+
+
 def observe_codex_loop_queue_item(
     paths: OmhPaths,
     loop_id: str,
@@ -1957,6 +2060,7 @@ def observe_codex_loop_queue_item(
     evidence_refs: Iterable[str] | None = None,
     codex_log_ref: str = "",
     summary: str = "",
+    dispatch_attempt_id: str = "",
     expected_revision: int | None = None,
     mutation_id: str | None = None,
 ) -> dict[str, Any]:
@@ -1976,6 +2080,11 @@ def observe_codex_loop_queue_item(
         if item.get("status") != "prepared_not_observed":
             raise ValueError("only prepared_not_observed loop queue items can observe Codex progress")
         existing = _dict_value(item, "executor_session")
+        observed_attempt_id = _resolve_observed_dispatch_attempt(
+            existing,
+            dispatch_attempt_id,
+            expected_executor="codex",
+        )
         executor_session = {
             **_empty_executor_session("codex"),
             **existing,
@@ -1986,9 +2095,11 @@ def observe_codex_loop_queue_item(
             "progress_summary": progress,
             "summary": _safe_summary(summary, limit=320) if summary.strip() else str(progress.get("chat_summary", "")),
             "progress_evidence_refs": all_refs,
+            "dispatch_attempts": _confirm_dispatch_attempt(existing, observed_attempt_id, all_refs),
             "capability": loop_executor_capability("codex"),
         }
         item["executor_session"] = executor_session
+        item["observed_dispatch_attempt_id"] = observed_attempt_id
         item["status"] = "observed"
         item["observed"] = True
         observed_at = utc_now()
@@ -2040,7 +2151,9 @@ def observe_codex_loop_queue_item(
         operation="observe_codex_loop_queue_item",
         expected_revision=expected_revision,
         mutation_id=mutation_id,
-        mutation_digest=_mutation_digest("observe_codex_loop_queue_item", queue_id, all_refs, summary),
+        mutation_digest=_mutation_digest(
+            "observe_codex_loop_queue_item", queue_id, all_refs, summary, dispatch_attempt_id
+        ),
     )
 
 
@@ -2087,6 +2200,7 @@ def observe_loop_queue_item(
     subagent_evidence_refs: Iterable[str] | None = None,
     connector_evidence_refs: Iterable[str] | None = None,
     summary: str = "",
+    dispatch_attempt_id: str = "",
     expected_revision: int | None = None,
     mutation_id: str | None = None,
 ) -> dict[str, Any]:
@@ -2102,8 +2216,23 @@ def observe_loop_queue_item(
         runtime, item = _queue_item_ref(cycle, queue_id)
         if item.get("status") != "prepared_not_observed":
             raise ValueError("only prepared_not_observed loop queue items can be observed")
+        executor_session = _dict_value(item, "executor_session")
+        observed_attempt_id = _resolve_observed_dispatch_attempt(
+            executor_session,
+            dispatch_attempt_id,
+        )
+        if observed_attempt_id:
+            item["executor_session"] = {
+                **executor_session,
+                "dispatch_attempts": _confirm_dispatch_attempt(
+                    executor_session,
+                    observed_attempt_id,
+                    aggregate_refs,
+                ),
+            }
         item["status"] = "observed"
         item["observed"] = True
+        item["observed_dispatch_attempt_id"] = observed_attempt_id
         observed_at = utc_now()
         item["observed_at"] = observed_at
         item["observed_evidence_refs"] = aggregate_refs
@@ -2159,7 +2288,9 @@ def observe_loop_queue_item(
         operation="observe_loop_queue_item",
         expected_revision=expected_revision,
         mutation_id=mutation_id,
-        mutation_digest=_mutation_digest("observe_loop_queue_item", queue_id, aggregate_refs, summary),
+        mutation_digest=_mutation_digest(
+            "observe_loop_queue_item", queue_id, aggregate_refs, summary, dispatch_attempt_id
+        ),
     )
 
 
@@ -3177,6 +3308,8 @@ def _empty_executor_session(executor: str = "choose") -> dict[str, Any]:
         "session_ref": "",
         "thread_ref": "",
         "dispatch_evidence_refs": [],
+        "active_attempt_id": "",
+        "dispatch_attempts": [],
         "progress_evidence_refs": [],
         "progress_summary": {},
         "review_summary": {},
@@ -3184,6 +3317,114 @@ def _empty_executor_session(executor: str = "choose") -> dict[str, Any]:
         "capability": capability,
         "claim_boundary": capability["claim_boundary"],
     }
+
+
+def _dispatch_request(
+    capability: Mapping[str, Any],
+    session_ref: str,
+    thread_ref: str,
+    evidence_refs: Iterable[str],
+    summary: str,
+) -> dict[str, Any]:
+    refs = _safe_list(evidence_refs, limit=320)
+    return {
+        "executor": str(capability["executor"]),
+        "loop_mode": str(capability["loop_mode"]),
+        "dispatch_owner": str(capability["dispatch_owner"]),
+        "dispatch_status": "dispatched" if refs or session_ref.strip() or thread_ref.strip() else "prepared",
+        "session_ref": _safe_summary(session_ref, limit=220) if session_ref.strip() else "",
+        "thread_ref": _safe_summary(thread_ref, limit=220) if thread_ref.strip() else "",
+        "dispatch_evidence_refs": refs,
+        "summary": (
+            _safe_summary(summary, limit=320)
+            if summary.strip()
+            else "Executor dispatch metadata recorded for this loop queue item."
+        ),
+    }
+
+
+def _executor_session_dispatch(executor_session: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "executor": str(executor_session.get("executor", "")),
+        "loop_mode": str(executor_session.get("loop_mode", "")),
+        "dispatch_owner": str(executor_session.get("dispatch_owner", "")),
+        "dispatch_status": str(executor_session.get("dispatch_status", "")),
+        "session_ref": str(executor_session.get("session_ref", "")),
+        "thread_ref": str(executor_session.get("thread_ref", "")),
+        "dispatch_evidence_refs": _safe_list(
+            _string_list(executor_session.get("dispatch_evidence_refs", [])), limit=320
+        ),
+        "summary": str(executor_session.get("summary", "")),
+    }
+
+
+def _new_dispatch_attempt(
+    queue_id: str,
+    attempt_index: int,
+    dispatch: Mapping[str, Any],
+) -> dict[str, Any]:
+    identity = sha256_text(
+        json.dumps([queue_id, attempt_index, dict(dispatch)], sort_keys=True, separators=(",", ":"))
+    )[:16]
+    return {
+        "schema_version": LOOP_DISPATCH_ATTEMPT_SCHEMA,
+        "attempt_id": f"dispatch-{attempt_index}-{identity}",
+        "attempt_index": attempt_index,
+        **dict(dispatch),
+        "delivery_outcome": "delivery_unknown",
+        "outcome_evidence_refs": [],
+        "outcome_summary": "Dispatch was recorded without a confirmed delivery outcome.",
+        "recorded_at": utc_now(),
+    }
+
+
+def _resolve_observed_dispatch_attempt(
+    executor_session: Mapping[str, Any],
+    requested_attempt_id: str,
+    *,
+    expected_executor: str = "",
+) -> str:
+    attempts = [entry for entry in executor_session.get("dispatch_attempts", []) if isinstance(entry, dict)]
+    requested = _safe_summary(requested_attempt_id, limit=120) if requested_attempt_id.strip() else ""
+    if not attempts:
+        if requested:
+            raise ValueError("dispatch attempt id does not exist on this loop queue item")
+        return ""
+    if not requested:
+        if len(attempts) != 1:
+            raise ValueError("dispatch attempt id is required after explicit recovery")
+        requested = str(attempts[0].get("attempt_id", ""))
+    attempt = next((entry for entry in attempts if entry.get("attempt_id") == requested), None)
+    if attempt is None:
+        raise ValueError("dispatch attempt id does not exist on this loop queue item")
+    if expected_executor and attempt.get("executor") != expected_executor:
+        raise ValueError(f"dispatch attempt is not owned by {expected_executor}")
+    return requested
+
+
+def _confirm_dispatch_attempt(
+    executor_session: Mapping[str, Any],
+    attempt_id: str,
+    evidence_refs: Iterable[str],
+) -> list[dict[str, Any]]:
+    attempts = [dict(entry) for entry in executor_session.get("dispatch_attempts", []) if isinstance(entry, dict)]
+    if not attempt_id:
+        return attempts
+    refs = _safe_list(evidence_refs, limit=320)
+    for index, attempt in enumerate(attempts):
+        if attempt.get("attempt_id") != attempt_id:
+            continue
+        attempts[index] = {
+            **attempt,
+            "delivery_outcome": "delivery_confirmed",
+            "outcome_evidence_refs": _safe_list(
+                [*_string_list(attempt.get("outcome_evidence_refs", [])), *refs],
+                limit=320,
+            ),
+            "outcome_summary": "Executor progress or result was observed for this dispatch attempt.",
+        }
+        break
+    return attempts
 
 
 def _narration_next_message(status: str, executor_session: dict[str, Any]) -> str:
@@ -4122,6 +4363,9 @@ def _validate_runtime(runtime: object) -> list[str]:
         verification_plan = item.get("verification_plan")
         if verification_plan is not None:
             _validate_verification_plan(errors, index, verification_plan)
+        executor_session = item.get("executor_session")
+        if executor_session is not None:
+            _validate_executor_dispatch_session(errors, index, item, executor_session)
         if item.get("status") == "observed":
             if item.get("observed") is not True:
                 errors.append(f"runtime.queue[{index}].observed must be true when status is observed")
@@ -4153,6 +4397,98 @@ def _validate_runtime(runtime: object) -> list[str]:
                 if plan.get("strategy") != "none":
                     errors.append(f"runtime.queue[{index}].{key}.strategy must be none while blocked")
     return errors
+
+
+def _validate_executor_dispatch_session(
+    errors: list[str],
+    index: int,
+    queue_item: Mapping[str, Any],
+    value: object,
+) -> None:
+    prefix = f"runtime.queue[{index}].executor_session"
+    if not isinstance(value, dict):
+        errors.append(f"{prefix} must be an object")
+        return
+    if "dispatch_attempts" not in value:
+        return
+    attempts = value.get("dispatch_attempts")
+    if not isinstance(attempts, list):
+        errors.append(f"{prefix}.dispatch_attempts must be a list")
+        return
+    active_attempt_id = str(value.get("active_attempt_id", ""))
+    if not attempts:
+        if active_attempt_id:
+            errors.append(f"{prefix}.active_attempt_id must be empty without dispatch attempts")
+        if value.get("dispatch_status") == "dispatched":
+            errors.append(f"{prefix}.dispatch_attempts must record dispatched executor metadata")
+        return
+
+    seen_attempt_ids: set[str] = set()
+    attempts_by_id: dict[str, Mapping[str, Any]] = {}
+    for attempt_index, attempt in enumerate(attempts, start=1):
+        attempt_prefix = f"{prefix}.dispatch_attempts[{attempt_index - 1}]"
+        if not isinstance(attempt, dict):
+            errors.append(f"{attempt_prefix} must be an object")
+            continue
+        if attempt.get("schema_version") != LOOP_DISPATCH_ATTEMPT_SCHEMA:
+            errors.append(f"{attempt_prefix}.schema_version must be {LOOP_DISPATCH_ATTEMPT_SCHEMA}")
+        attempt_id = str(attempt.get("attempt_id", ""))
+        if not attempt_id:
+            errors.append(f"{attempt_prefix}.attempt_id is required")
+        elif attempt_id in seen_attempt_ids:
+            errors.append(f"{attempt_prefix}.attempt_id duplicates an earlier entry")
+        else:
+            seen_attempt_ids.add(attempt_id)
+            attempts_by_id[attempt_id] = attempt
+        if attempt.get("attempt_index") != attempt_index:
+            errors.append(f"{attempt_prefix}.attempt_index must preserve ordered attempt history")
+        if attempt.get("dispatch_status") != "dispatched":
+            errors.append(f"{attempt_prefix}.dispatch_status must be dispatched")
+        dispatch_refs = attempt.get("dispatch_evidence_refs")
+        if not isinstance(dispatch_refs, list) or not all(str(ref).strip() for ref in dispatch_refs):
+            errors.append(f"{attempt_prefix}.dispatch_evidence_refs must be a string list")
+        if not dispatch_refs and not str(attempt.get("session_ref", "")).strip() and not str(attempt.get("thread_ref", "")).strip():
+            errors.append(f"{attempt_prefix} must include dispatch identity or evidence")
+        outcome = attempt.get("delivery_outcome")
+        if outcome not in {"delivery_unknown", "delivery_confirmed", "delivery_failed"}:
+            errors.append(f"{attempt_prefix}.delivery_outcome is unsupported")
+        outcome_refs = attempt.get("outcome_evidence_refs")
+        if not isinstance(outcome_refs, list) or not all(str(ref).strip() for ref in outcome_refs):
+            errors.append(f"{attempt_prefix}.outcome_evidence_refs must be a string list")
+        elif outcome in {"delivery_confirmed", "delivery_failed"} and not outcome_refs:
+            errors.append(f"{attempt_prefix}.outcome_evidence_refs are required for a conclusive outcome")
+
+    active_attempt = attempts_by_id.get(active_attempt_id)
+    if active_attempt is None:
+        errors.append(f"{prefix}.active_attempt_id must identify a recorded dispatch attempt")
+        return
+    if attempts and active_attempt_id != str(attempts[-1].get("attempt_id", "")):
+        errors.append(f"{prefix}.active_attempt_id must identify the latest dispatch attempt")
+    if value.get("dispatch_status") not in {"dispatched", "progress_observed"}:
+        errors.append(f"{prefix}.dispatch_status must reflect recorded dispatch attempts")
+    for key in (
+        "executor",
+        "loop_mode",
+        "dispatch_owner",
+        "session_ref",
+        "thread_ref",
+        "dispatch_evidence_refs",
+    ):
+        if value.get(key) != active_attempt.get(key):
+            errors.append(f"{prefix}.{key} must match the active dispatch attempt")
+    observed_attempt_id = str(queue_item.get("observed_dispatch_attempt_id", ""))
+    if queue_item.get("status") == "observed":
+        observed_attempt = attempts_by_id.get(observed_attempt_id)
+        if observed_attempt is None:
+            errors.append(
+                f"runtime.queue[{index}].observed_dispatch_attempt_id must identify a recorded dispatch attempt"
+            )
+        elif observed_attempt.get("delivery_outcome") != "delivery_confirmed":
+            errors.append(
+                f"runtime.queue[{index}].observed_dispatch_attempt_id must identify a confirmed dispatch attempt"
+            )
+    elif observed_attempt_id:
+        errors.append(f"runtime.queue[{index}].observed_dispatch_attempt_id requires observed queue status")
 
 
 def _validate_verification_plan(errors: list[str], index: int, value: object) -> None:

--- a/src/workflows/goal_loop.py
+++ b/src/workflows/goal_loop.py
@@ -1527,6 +1527,14 @@ def build_loop_queue_handoff(paths: OmhPaths, loop_id: str, queue_id: str) -> di
     if item.get("status") != "prepared_not_observed":
         raise ValueError("only prepared_not_observed loop queue items can render a handoff")
     text = _queue_handoff_text(cycle, item)
+    executor_session = _dict_value(item, "executor_session")
+    active_attempt_id = str(executor_session.get("active_attempt_id", ""))
+    dispatch_attempts = [entry for entry in executor_session.get("dispatch_attempts", []) if isinstance(entry, dict)]
+    actions = ["observe_loop_queue", "block_loop_queue", "show_loop_status"]
+    if dispatch_attempts:
+        # observe_loop_queue needs the attempt id once recovery has made the
+        # history ambiguous, so the surface that names the action carries it.
+        actions.insert(1, "recover_loop_queue_dispatch")
     return {
         "schema_version": LOOP_QUEUE_HANDOFF_SCHEMA,
         "loop_id": cycle["loop_id"],
@@ -1538,8 +1546,10 @@ def build_loop_queue_handoff(paths: OmhPaths, loop_id: str, queue_id: str) -> di
         "worktree_plan": item.get("worktree_plan", _empty_worktree_plan()),
         "subagent_plan": item.get("subagent_plan", _empty_subagent_plan()),
         "connector_plan": item.get("connector_plan", _connector_plan("", "", str(item.get("planned_action", "")))),
+        "active_dispatch_attempt_id": active_attempt_id,
+        "dispatch_attempt_count": len(dispatch_attempts),
         "next_action": "observe_or_block_loop_queue",
-        "actions": ["observe_loop_queue", "block_loop_queue", "show_loop_status"],
+        "actions": actions,
         "claim_boundary": _runtime_claim_boundary(),
     }
 
@@ -1927,9 +1937,12 @@ def dispatch_loop_queue_item(
                 raise ValueError(
                     "loop queue item already has a different executor dispatch; use explicit recovery"
                 )
-        attempts = [entry for entry in existing.get("dispatch_attempts", []) if isinstance(entry, dict)]
+        # Nothing to carry forward: an attempt is only ever appended once the
+        # status is dispatched, an equal dispatch returned above, a divergent one
+        # raised, and progress_observed implies an observed item the precondition
+        # already rejected. So this is always the first attempt.
         attempt = (
-            _new_dispatch_attempt(queue_id, len(attempts) + 1, dispatch)
+            _new_dispatch_attempt(queue_id, 1, dispatch)
             if dispatch["dispatch_status"] == "dispatched"
             else None
         )
@@ -1937,7 +1950,7 @@ def dispatch_loop_queue_item(
             **_empty_executor_session(str(capability["executor"])),
             **dispatch,
             "active_attempt_id": str(attempt["attempt_id"]) if attempt else "",
-            "dispatch_attempts": [*attempts, *([attempt] if attempt else [])],
+            "dispatch_attempts": [attempt] if attempt else [],
             "capability": capability,
         }
         runtime["last_queue_id"] = str(item["queue_id"])
@@ -1965,10 +1978,10 @@ def recover_loop_queue_item_dispatch(
     loop_id: str,
     queue_id: str,
     *,
-    prior_attempt_id: str,
     prior_outcome: str,
     outcome_evidence_refs: Iterable[str],
     executor: str,
+    prior_attempt_id: str = "",
     session_ref: str = "",
     thread_ref: str = "",
     evidence_refs: Iterable[str] | None = None,
@@ -1977,9 +1990,7 @@ def recover_loop_queue_item_dispatch(
     expected_revision: int | None = None,
     mutation_id: str | None = None,
 ) -> dict[str, Any]:
-    attempt_id = _safe_summary(prior_attempt_id, limit=120)
-    if not attempt_id:
-        raise ValueError("prior dispatch attempt id is required")
+    attempt_id = _safe_summary(prior_attempt_id, limit=120) if prior_attempt_id.strip() else ""
     if prior_outcome not in LOOP_DISPATCH_RECOVERY_OUTCOMES:
         raise ValueError(
             f"prior dispatch outcome must be one of: {', '.join(LOOP_DISPATCH_RECOVERY_OUTCOMES)}"
@@ -1999,10 +2010,15 @@ def recover_loop_queue_item_dispatch(
             raise ValueError("only prepared_not_observed loop queue items can recover executor dispatch")
         existing = _dict_value(item, "executor_session")
         attempts = [dict(entry) for entry in existing.get("dispatch_attempts", []) if isinstance(entry, dict)]
-        if not attempts:
-            raise ValueError("legacy executor dispatch has no attempt identity; record its outcome before recovery")
-        if existing.get("active_attempt_id") != attempt_id or attempts[-1].get("attempt_id") != attempt_id:
-            raise ValueError("prior dispatch attempt must be the active attempt")
+        if attempts:
+            if not attempt_id:
+                raise ValueError("prior dispatch attempt id is required")
+            if existing.get("active_attempt_id") != attempt_id or attempts[-1].get("attempt_id") != attempt_id:
+                raise ValueError("prior dispatch attempt must be the active attempt")
+        else:
+            attempts = [_adopted_legacy_dispatch_attempt(queue_id, existing)]
+            if attempt_id and attempts[-1]["attempt_id"] != attempt_id:
+                raise ValueError("prior dispatch attempt must be the active attempt")
         attempts[-1] = {
             **attempts[-1],
             "delivery_outcome": prior_outcome,
@@ -2014,6 +2030,9 @@ def recover_loop_queue_item_dispatch(
             ),
         }
         next_attempt = _new_dispatch_attempt(queue_id, len(attempts) + 1, dispatch)
+        # Unlike the first dispatch, recovery spreads **existing: the item keeps
+        # whatever progress the earlier attempt already recorded, and only the
+        # dispatch identity is replaced.
         item["executor_session"] = {
             **existing,
             **dispatch,
@@ -3378,6 +3397,26 @@ def _new_dispatch_attempt(
     }
 
 
+def _adopted_legacy_dispatch_attempt(
+    queue_id: str,
+    executor_session: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Attempt 1 for a record written before dispatch attempt history existed.
+
+    Refusing recovery on such a record leaves it with no way forward at all -
+    dispatch already refuses a divergent retry - so the legacy executor_session
+    is adopted as the attempt it always was. recorded_at is empty because the
+    legacy shape never stored a dispatch timestamp, and inventing one here
+    would be a claim the record cannot support.
+    """
+    if str(executor_session.get("dispatch_status", "")) != "dispatched":
+        raise ValueError("loop queue item has no recorded executor dispatch to recover")
+    return {
+        **_new_dispatch_attempt(queue_id, 1, _executor_session_dispatch(executor_session)),
+        "recorded_at": "",
+    }
+
+
 def _resolve_observed_dispatch_attempt(
     executor_session: Mapping[str, Any],
     requested_attempt_id: str,
@@ -3399,6 +3438,10 @@ def _resolve_observed_dispatch_attempt(
         raise ValueError("dispatch attempt id does not exist on this loop queue item")
     if expected_executor and attempt.get("executor") != expected_executor:
         raise ValueError(f"dispatch attempt is not owned by {expected_executor}")
+    if attempt.get("delivery_outcome") == "delivery_failed":
+        raise ValueError(
+            "dispatch attempt was recorded as delivery_failed; a later observation cannot confirm it"
+        )
     return requested
 
 
@@ -3417,14 +3460,36 @@ def _confirm_dispatch_attempt(
         attempts[index] = {
             **attempt,
             "delivery_outcome": "delivery_confirmed",
-            "outcome_evidence_refs": _safe_list(
-                [*_string_list(attempt.get("outcome_evidence_refs", [])), *refs],
-                limit=320,
-            ),
+            "outcome_evidence_refs": refs,
             "outcome_summary": "Executor progress or result was observed for this dispatch attempt.",
+            "outcome_history": _superseded_outcomes(attempt),
         }
         break
     return attempts
+
+
+def _superseded_outcomes(attempt: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Prior delivery claims, kept as their own entries rather than merged.
+
+    An attempt recorded as delivery_unknown carries the evidence for that
+    uncertainty - an acknowledgement timeout, say. Concatenating those refs
+    onto the confirmation would make the timeout read as evidence that the
+    dispatch arrived, so the superseded claim keeps its own outcome, refs and
+    summary here and outcome_evidence_refs holds only the current outcome.
+    """
+    history = [dict(entry) for entry in attempt.get("outcome_history", []) if isinstance(entry, dict)]
+    prior_refs = _safe_list(_string_list(attempt.get("outcome_evidence_refs", [])), limit=320)
+    if not prior_refs:
+        return history
+    return [
+        *history,
+        {
+            "delivery_outcome": str(attempt.get("delivery_outcome", "")),
+            "outcome_evidence_refs": prior_refs,
+            "outcome_summary": str(attempt.get("outcome_summary", "")),
+            "superseded_at": utc_now(),
+        },
+    ]
 
 
 def _narration_next_message(status: str, executor_session: dict[str, Any]) -> str:
@@ -4132,6 +4197,10 @@ def _queue_item_summary(item: dict[str, Any]) -> dict[str, Any]:
         "reason": str(item.get("reason", "")),
         "observed": bool(item.get("observed", False)),
         "observed_evidence_refs": _string_list(item.get("observed_evidence_refs", [])),
+        "active_dispatch_attempt_id": str(_dict_value(item, "executor_session").get("active_attempt_id", "")),
+        "dispatch_attempt_count": len(
+            [entry for entry in _dict_value(item, "executor_session").get("dispatch_attempts", []) if isinstance(entry, dict)]
+        ),
         "blocker_reason": str(item.get("blocker_reason", "")),
         "worktree_strategy": str(_dict_value(item, "worktree_plan").get("strategy", "")),
         "subagent_strategy": str(_dict_value(item, "subagent_plan").get("strategy", "")),
@@ -4457,6 +4526,17 @@ def _validate_executor_dispatch_session(
             errors.append(f"{attempt_prefix}.outcome_evidence_refs must be a string list")
         elif outcome in {"delivery_confirmed", "delivery_failed"} and not outcome_refs:
             errors.append(f"{attempt_prefix}.outcome_evidence_refs are required for a conclusive outcome")
+        if "outcome_history" in attempt:
+            history = attempt.get("outcome_history")
+            if not isinstance(history, list) or not all(isinstance(entry, dict) for entry in history):
+                errors.append(f"{attempt_prefix}.outcome_history must be a list of superseded outcomes")
+            elif any(
+                entry.get("delivery_outcome") not in {"delivery_unknown", "delivery_confirmed", "delivery_failed"}
+                for entry in history
+            ):
+                errors.append(f"{attempt_prefix}.outcome_history records an unsupported delivery outcome")
+            elif any(entry.get("delivery_outcome") == "delivery_failed" for entry in history):
+                errors.append(f"{attempt_prefix}.outcome_history cannot supersede a recorded delivery failure")
 
     active_attempt = attempts_by_id.get(active_attempt_id)
     if active_attempt is None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8885,6 +8885,39 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             self.assertEqual(dispatched["loop"]["runtime"]["queue"][0]["status"], "prepared_not_observed")
             self.assertEqual(dispatched["loop"]["runtime"]["queue"][0]["executor_session"]["dispatch_status"], "dispatched")
             self.assertEqual(dispatched["loop"]["runtime"]["queue"][0]["executor_session"]["session_ref"], "codex-session-cli")
+            first_attempt_id = dispatched["loop"]["runtime"]["queue"][0]["executor_session"]["active_attempt_id"]
+
+            status, stdout, stderr = run_cli(
+                home
+                + [
+                    "loop",
+                    "queue",
+                    "recover-dispatch",
+                    "--loop",
+                    "loop-cli",
+                    "--queue",
+                    queue_id,
+                    "--prior-attempt-id",
+                    first_attempt_id,
+                    "--prior-outcome",
+                    "delivery_unknown",
+                    "--outcome-evidence-ref",
+                    "wrapper:ack-timeout:cli",
+                    "--executor",
+                    "codex",
+                    "--codex-session-ref",
+                    "codex-session-cli-2",
+                    "--evidence-ref",
+                    "wrapper:codex-dispatch:cli-2",
+                ]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            recovered = json.loads(stdout)
+            recovery_session = recovered["loop"]["runtime"]["queue"][0]["executor_session"]
+            self.assertEqual(len(recovery_session["dispatch_attempts"]), 2)
+            self.assertEqual(recovery_session["dispatch_attempts"][0]["delivery_outcome"], "delivery_unknown")
+            second_attempt_id = recovery_session["active_attempt_id"]
 
             status, stdout, stderr = run_cli(home + ["loop", "queue", "narrate", "--loop", "loop-cli", "--queue", queue_id])
             self.assertEqual(stderr, "")
@@ -8909,6 +8942,8 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
                     "codex-log:cli",
                     "--evidence-ref",
                     "codex-jsonl:cli",
+                    "--dispatch-attempt-id",
+                    second_attempt_id,
                     "--summary",
                     "Codex defined the issue and started implementation.",
                 ]
@@ -8918,6 +8953,10 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             codex_observed = json.loads(stdout)
             self.assertEqual(codex_observed["loop"]["runtime"]["queue"][0]["status"], "observed")
             self.assertEqual(codex_observed["loop"]["runtime"]["queue"][0]["executor_session"]["dispatch_status"], "progress_observed")
+            self.assertEqual(
+                codex_observed["loop"]["runtime"]["queue"][0]["observed_dispatch_attempt_id"],
+                second_attempt_id,
+            )
             self.assertEqual(codex_observed["narration"]["schema_version"], "loop_cycle_narration/v1")
 
             observed = codex_observed

--- a/tests/test_loop_cycle.py
+++ b/tests/test_loop_cycle.py
@@ -37,6 +37,7 @@ from omh.goal_loop import (
     observe_loop_queue_item,
     read_loop_cycle,
     record_loop_feedback,
+    recover_loop_queue_item_dispatch,
     run_loop_once_result,
     tick_loop_runtime,
     update_loop_permission,
@@ -771,6 +772,14 @@ class GoalLoopTests(unittest.TestCase):
         self.assertTrue(observed_item["observed"])
         self.assertEqual(observed_item["executor_session"]["dispatch_status"], "progress_observed")
         self.assertEqual(observed_item["executor_session"]["progress_summary"]["schema_version"], "codex_progress_summary/v1")
+        self.assertEqual(
+            observed_item["observed_dispatch_attempt_id"],
+            dispatched_item["executor_session"]["active_attempt_id"],
+        )
+        self.assertEqual(
+            observed_item["executor_session"]["dispatch_attempts"][0]["delivery_outcome"],
+            "delivery_confirmed",
+        )
         self.assertIn("codex-jsonl:1", observed_item["observed_evidence_refs"])
         self.assertEqual(narration["schema_version"], "loop_cycle_narration/v1")
         self.assertIn("이번 사이클", narration["headline"])
@@ -778,6 +787,309 @@ class GoalLoopTests(unittest.TestCase):
         self.assertIn("implementation", narration["not_evidence_yet"])
         self.assertIn("ci", narration["not_evidence_yet"])
         self.assertEqual(validate_loop_cycle(observed), {"ok": True, "errors": []})
+
+    def test_loop_queue_dispatch_exact_replay_is_a_no_op(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = create_loop_cycle(
+                paths,
+                goal_summary="Keep dispatch retries auditable",
+                goal_reframe="Record one stable executor dispatch identity.",
+                success_criteria=["Exact dispatch retries do not mutate the loop record"],
+                permission_profile="execute_with_gates",
+                allowed_executors=["codex"],
+            )
+            ticked = tick_loop_runtime(paths, cycle["loop_id"])
+            queue_id = ticked["runtime"]["queue"][0]["queue_id"]
+            first = dispatch_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                executor="codex",
+                session_ref="codex-session-1",
+                thread_ref="codex-thread-1",
+                evidence_refs=["wrapper:dispatch:1"],
+                summary="Codex dispatch recorded.",
+            )
+            replayed = dispatch_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                executor="codex",
+                session_ref="codex-session-1",
+                thread_ref="codex-thread-1",
+                evidence_refs=["wrapper:dispatch:1"],
+                summary="Codex dispatch recorded.",
+            )
+
+        self.assertEqual(replayed, first)
+        self.assertEqual(replayed["runtime"]["queue"][0]["executor_session"]["active_attempt_id"], replayed["runtime"]["queue"][0]["executor_session"]["dispatch_attempts"][0]["attempt_id"])
+
+    def test_loop_queue_dispatch_conflict_preserves_the_first_attempt(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = create_loop_cycle(
+                paths,
+                goal_summary="Keep dispatch retries auditable",
+                goal_reframe="Reject a conflicting executor dispatch identity.",
+                success_criteria=["Conflicting dispatch retries preserve the first attempt"],
+                permission_profile="execute_with_gates",
+                allowed_executors=["codex", "claude-code"],
+            )
+            ticked = tick_loop_runtime(paths, cycle["loop_id"])
+            queue_id = ticked["runtime"]["queue"][0]["queue_id"]
+            first = dispatch_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                executor="codex",
+                session_ref="codex-session-1",
+                thread_ref="codex-thread-1",
+                evidence_refs=["wrapper:dispatch:1"],
+                summary="First dispatch.",
+            )
+
+            with self.assertRaisesRegex(ValueError, "explicit recovery"):
+                dispatch_loop_queue_item(
+                    paths,
+                    cycle["loop_id"],
+                    queue_id,
+                    executor="claude-code",
+                    session_ref="claude-session-2",
+                    thread_ref="claude-thread-2",
+                    evidence_refs=["wrapper:dispatch:2"],
+                    summary="Conflicting dispatch.",
+                )
+
+            stored = read_loop_cycle(paths, cycle["loop_id"])
+
+        self.assertEqual(stored, first)
+        session = stored["runtime"]["queue"][0]["executor_session"]
+        self.assertEqual(session["executor"], "codex")
+        self.assertEqual(session["session_ref"], "codex-session-1")
+        self.assertEqual(session["thread_ref"], "codex-thread-1")
+        self.assertEqual(session["dispatch_evidence_refs"], ["wrapper:dispatch:1"])
+        self.assertEqual(len(session["dispatch_attempts"]), 1)
+
+    def test_loop_queue_dispatch_recovery_preserves_attempt_history(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = create_loop_cycle(
+                paths,
+                goal_summary="Recover failed executor dispatches",
+                goal_reframe="Create a new attempt without erasing the failed attempt.",
+                success_criteria=["Dispatch attempt history remains ordered"],
+                permission_profile="execute_with_gates",
+                allowed_executors=["codex"],
+            )
+            ticked = tick_loop_runtime(paths, cycle["loop_id"])
+            queue_id = ticked["runtime"]["queue"][0]["queue_id"]
+            first = dispatch_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                executor="codex",
+                session_ref="codex-session-1",
+                evidence_refs=["wrapper:dispatch:1"],
+            )
+            first_attempt_id = first["runtime"]["queue"][0]["executor_session"]["active_attempt_id"]
+            recovered = recover_loop_queue_item_dispatch(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                prior_attempt_id=first_attempt_id,
+                prior_outcome="delivery_failed",
+                outcome_evidence_refs=["wrapper:delivery-failed:1"],
+                outcome_summary="The executor rejected the dispatch.",
+                executor="codex",
+                session_ref="codex-session-2",
+                evidence_refs=["wrapper:dispatch:2"],
+            )
+
+        session = recovered["runtime"]["queue"][0]["executor_session"]
+        attempts = session["dispatch_attempts"]
+        self.assertEqual([attempt["attempt_index"] for attempt in attempts], [1, 2])
+        self.assertEqual(attempts[0]["attempt_id"], first_attempt_id)
+        self.assertEqual(attempts[0]["delivery_outcome"], "delivery_failed")
+        self.assertEqual(attempts[0]["outcome_evidence_refs"], ["wrapper:delivery-failed:1"])
+        self.assertEqual(attempts[1]["delivery_outcome"], "delivery_unknown")
+        self.assertEqual(session["active_attempt_id"], attempts[1]["attempt_id"])
+        self.assertEqual(session["session_ref"], "codex-session-2")
+
+    def test_loop_queue_dispatch_recovery_records_uncertain_prior_outcome(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = create_loop_cycle(
+                paths,
+                goal_summary="Recover an unacknowledged executor dispatch",
+                goal_reframe="Preserve the uncertain attempt before dispatching again.",
+                success_criteria=["Uncertain delivery remains distinguishable from failure"],
+                permission_profile="execute_with_gates",
+                allowed_executors=["codex"],
+            )
+            ticked = tick_loop_runtime(paths, cycle["loop_id"])
+            queue_id = ticked["runtime"]["queue"][0]["queue_id"]
+            first = dispatch_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                executor="codex",
+                session_ref="codex-session-1",
+                evidence_refs=["wrapper:dispatch:1"],
+            )
+            first_attempt_id = first["runtime"]["queue"][0]["executor_session"]["active_attempt_id"]
+            recovered = recover_loop_queue_item_dispatch(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                prior_attempt_id=first_attempt_id,
+                prior_outcome="delivery_unknown",
+                outcome_evidence_refs=["wrapper:ack-timeout:1"],
+                executor="codex",
+                session_ref="codex-session-2",
+                evidence_refs=["wrapper:dispatch:2"],
+            )
+
+        attempts = recovered["runtime"]["queue"][0]["executor_session"]["dispatch_attempts"]
+        self.assertEqual(attempts[0]["delivery_outcome"], "delivery_unknown")
+        self.assertEqual(attempts[1]["delivery_outcome"], "delivery_unknown")
+        self.assertNotEqual(attempts[0]["attempt_id"], attempts[1]["attempt_id"])
+
+    def test_loop_queue_observation_requires_attempt_binding_after_recovery(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = create_loop_cycle(
+                paths,
+                goal_summary="Bind executor observations to dispatch attempts",
+                goal_reframe="Identify which recovered dispatch produced observed progress.",
+                success_criteria=["Late observations cannot bind to the wrong dispatch attempt"],
+                permission_profile="execute_with_gates",
+                allowed_executors=["codex"],
+            )
+            ticked = tick_loop_runtime(paths, cycle["loop_id"])
+            queue_id = ticked["runtime"]["queue"][0]["queue_id"]
+            first = dispatch_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                executor="codex",
+                session_ref="codex-session-1",
+                evidence_refs=["wrapper:dispatch:1"],
+            )
+            first_attempt_id = first["runtime"]["queue"][0]["executor_session"]["active_attempt_id"]
+            recovered = recover_loop_queue_item_dispatch(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                prior_attempt_id=first_attempt_id,
+                prior_outcome="delivery_unknown",
+                outcome_evidence_refs=["wrapper:ack-timeout:1"],
+                executor="codex",
+                session_ref="codex-session-2",
+                evidence_refs=["wrapper:dispatch:2"],
+            )
+
+            with self.assertRaisesRegex(ValueError, "dispatch attempt id is required"):
+                observe_codex_loop_queue_item(
+                    paths,
+                    cycle["loop_id"],
+                    queue_id,
+                    codex_log_text='{"role":"assistant","content":"Work completed."}',
+                    evidence_refs=["codex-jsonl:1"],
+                )
+
+            observed = observe_codex_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                codex_log_text='{"role":"assistant","content":"Work completed."}',
+                evidence_refs=["codex-jsonl:1"],
+                dispatch_attempt_id=first_attempt_id,
+            )
+
+        item = observed["runtime"]["queue"][0]
+        self.assertEqual(item["observed_dispatch_attempt_id"], first_attempt_id)
+        attempts = item["executor_session"]["dispatch_attempts"]
+        self.assertEqual(attempts[0]["delivery_outcome"], "delivery_confirmed")
+        self.assertEqual(attempts[1]["delivery_outcome"], "delivery_unknown")
+        self.assertEqual(
+            recovered["runtime"]["queue"][0]["executor_session"]["active_attempt_id"],
+            attempts[1]["attempt_id"],
+        )
+
+    def test_loop_cycle_validation_rejects_ambiguous_dispatch_attempt_state(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = create_loop_cycle(
+                paths,
+                goal_summary="Validate executor dispatch identity",
+                goal_reframe="Reject persisted state that cannot identify its active dispatch.",
+                success_criteria=["Ambiguous dispatch state fails validation"],
+                permission_profile="execute_with_gates",
+                allowed_executors=["codex"],
+            )
+            ticked = tick_loop_runtime(paths, cycle["loop_id"])
+            queue_id = ticked["runtime"]["queue"][0]["queue_id"]
+            dispatched = dispatch_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                executor="codex",
+                session_ref="codex-session-1",
+                evidence_refs=["wrapper:dispatch:1"],
+            )
+            observed = observe_codex_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                codex_log_text='{"role":"assistant","content":"Work completed."}',
+                evidence_refs=["codex-jsonl:1"],
+            )
+
+        duplicate = copy.deepcopy(dispatched)
+        duplicate_session = duplicate["runtime"]["queue"][0]["executor_session"]
+        duplicate_session["dispatch_attempts"].append(copy.deepcopy(duplicate_session["dispatch_attempts"][0]))
+        duplicate_errors = validate_loop_cycle(duplicate)["errors"]
+
+        mismatched = copy.deepcopy(dispatched)
+        mismatched["runtime"]["queue"][0]["executor_session"]["session_ref"] = "other-session"
+        mismatch_errors = validate_loop_cycle(mismatched)["errors"]
+
+        unbound = copy.deepcopy(observed)
+        unbound["runtime"]["queue"][0]["observed_dispatch_attempt_id"] = ""
+        unbound_errors = validate_loop_cycle(unbound)["errors"]
+
+        self.assertTrue(any("attempt_id duplicates" in error for error in duplicate_errors))
+        self.assertTrue(any("must match the active dispatch attempt" in error for error in mismatch_errors))
+        self.assertTrue(any("must identify a recorded dispatch attempt" in error for error in unbound_errors))
+
+    def test_loop_cycle_validation_keeps_legacy_single_dispatch_records_readable(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = create_loop_cycle(
+                paths,
+                goal_summary="Read legacy executor dispatch state",
+                goal_reframe="Preserve compatibility with records written before attempt history.",
+                success_criteria=["Legacy records remain valid"],
+                permission_profile="execute_with_gates",
+                allowed_executors=["codex"],
+            )
+            ticked = tick_loop_runtime(paths, cycle["loop_id"])
+            queue_id = ticked["runtime"]["queue"][0]["queue_id"]
+            dispatched = dispatch_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                executor="codex",
+                session_ref="codex-session-1",
+                evidence_refs=["wrapper:dispatch:1"],
+            )
+
+        legacy = copy.deepcopy(dispatched)
+        session = legacy["runtime"]["queue"][0]["executor_session"]
+        session.pop("active_attempt_id")
+        session.pop("dispatch_attempts")
+        self.assertEqual(validate_loop_cycle(legacy), {"ok": True, "errors": []})
 
     def test_loop_queue_lifecycle_lists_handoffs_observes_and_blocks_items(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_loop_cycle.py
+++ b/tests/test_loop_cycle.py
@@ -1091,6 +1091,213 @@ class GoalLoopTests(unittest.TestCase):
         session.pop("dispatch_attempts")
         self.assertEqual(validate_loop_cycle(legacy), {"ok": True, "errors": []})
 
+    def test_loop_queue_observation_cannot_confirm_a_failed_dispatch_attempt(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = create_loop_cycle(
+                paths,
+                goal_summary="Keep a recorded delivery failure final",
+                goal_reframe="Refuse to confirm an attempt the operator recorded as failed.",
+                success_criteria=["A recorded delivery failure is not reversible by a later observation"],
+                permission_profile="execute_with_gates",
+                allowed_executors=["codex"],
+            )
+            ticked = tick_loop_runtime(paths, cycle["loop_id"])
+            queue_id = ticked["runtime"]["queue"][0]["queue_id"]
+            first = dispatch_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                executor="codex",
+                session_ref="codex-session-1",
+                evidence_refs=["wrapper:dispatch:1"],
+            )
+            first_attempt_id = first["runtime"]["queue"][0]["executor_session"]["active_attempt_id"]
+            recover_loop_queue_item_dispatch(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                prior_attempt_id=first_attempt_id,
+                prior_outcome="delivery_failed",
+                outcome_evidence_refs=["wrapper:delivery-failed:1"],
+                outcome_summary="The executor rejected the dispatch.",
+                executor="codex",
+                session_ref="codex-session-2",
+                evidence_refs=["wrapper:dispatch:2"],
+            )
+
+            with self.assertRaisesRegex(ValueError, "recorded as delivery_failed"):
+                observe_codex_loop_queue_item(
+                    paths,
+                    cycle["loop_id"],
+                    queue_id,
+                    codex_log_text='{"role":"assistant","content":"Work completed."}',
+                    evidence_refs=["codex-jsonl:1"],
+                    dispatch_attempt_id=first_attempt_id,
+                )
+
+            stored = read_loop_cycle(paths, cycle["loop_id"])
+
+        attempt = stored["runtime"]["queue"][0]["executor_session"]["dispatch_attempts"][0]
+        self.assertEqual(attempt["delivery_outcome"], "delivery_failed")
+        self.assertEqual(attempt["outcome_evidence_refs"], ["wrapper:delivery-failed:1"])
+        self.assertEqual(stored["runtime"]["queue"][0]["status"], "prepared_not_observed")
+
+    def test_loop_queue_observation_supersedes_rather_than_absorbs_prior_outcome_evidence(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = create_loop_cycle(
+                paths,
+                goal_summary="Keep delivery evidence attributable",
+                goal_reframe="An uncertainty claim must not read as confirmation evidence.",
+                success_criteria=["A superseded delivery claim keeps its own evidence"],
+                permission_profile="execute_with_gates",
+                allowed_executors=["codex"],
+            )
+            ticked = tick_loop_runtime(paths, cycle["loop_id"])
+            queue_id = ticked["runtime"]["queue"][0]["queue_id"]
+            first = dispatch_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                executor="codex",
+                session_ref="codex-session-1",
+                evidence_refs=["wrapper:dispatch:1"],
+            )
+            first_attempt_id = first["runtime"]["queue"][0]["executor_session"]["active_attempt_id"]
+            recover_loop_queue_item_dispatch(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                prior_attempt_id=first_attempt_id,
+                prior_outcome="delivery_unknown",
+                outcome_evidence_refs=["wrapper:ack-timeout:1"],
+                outcome_summary="No acknowledgement arrived within the wrapper timeout.",
+                executor="codex",
+                session_ref="codex-session-2",
+                evidence_refs=["wrapper:dispatch:2"],
+            )
+            observed = observe_codex_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                codex_log_text='{"role":"assistant","content":"Work completed."}',
+                evidence_refs=["codex-jsonl:1"],
+                dispatch_attempt_id=first_attempt_id,
+            )
+
+        attempt = observed["runtime"]["queue"][0]["executor_session"]["dispatch_attempts"][0]
+        self.assertEqual(attempt["delivery_outcome"], "delivery_confirmed")
+        self.assertEqual(attempt["outcome_evidence_refs"], ["codex-jsonl:1"])
+        self.assertEqual(
+            [entry["delivery_outcome"] for entry in attempt["outcome_history"]],
+            ["delivery_unknown"],
+        )
+        self.assertEqual(attempt["outcome_history"][0]["outcome_evidence_refs"], ["wrapper:ack-timeout:1"])
+        self.assertEqual(validate_loop_cycle(observed), {"ok": True, "errors": []})
+
+    def test_loop_queue_dispatch_recovery_adopts_a_legacy_dispatch_record(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = create_loop_cycle(
+                paths,
+                goal_summary="Recover a record written before attempt history",
+                goal_reframe="Adopt the legacy executor session as the attempt it always was.",
+                success_criteria=["A legacy in-flight dispatch is still recoverable"],
+                permission_profile="execute_with_gates",
+                allowed_executors=["codex"],
+            )
+            ticked = tick_loop_runtime(paths, cycle["loop_id"])
+            queue_id = ticked["runtime"]["queue"][0]["queue_id"]
+            dispatch_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                executor="codex",
+                session_ref="codex-session-1",
+                evidence_refs=["wrapper:dispatch:1"],
+            )
+
+            # Downgrade the persisted record to the pre-attempt-history shape.
+            path = loop_cycle_path(paths, cycle["loop_id"])
+            record = json.loads(path.read_text())
+            legacy_session = record["runtime"]["queue"][0]["executor_session"]
+            legacy_session.pop("active_attempt_id")
+            legacy_session.pop("dispatch_attempts")
+            path.write_text(json.dumps(record))
+
+            recovered = recover_loop_queue_item_dispatch(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                prior_outcome="delivery_unknown",
+                outcome_evidence_refs=["wrapper:ack-timeout:1"],
+                executor="codex",
+                session_ref="codex-session-2",
+                evidence_refs=["wrapper:dispatch:2"],
+            )
+
+        session = recovered["runtime"]["queue"][0]["executor_session"]
+        attempts = session["dispatch_attempts"]
+        self.assertEqual([attempt["attempt_index"] for attempt in attempts], [1, 2])
+        self.assertEqual(attempts[0]["session_ref"], "codex-session-1")
+        self.assertEqual(attempts[0]["dispatch_evidence_refs"], ["wrapper:dispatch:1"])
+        self.assertEqual(attempts[0]["delivery_outcome"], "delivery_unknown")
+        self.assertEqual(attempts[0]["outcome_evidence_refs"], ["wrapper:ack-timeout:1"])
+        self.assertEqual(attempts[0]["recorded_at"], "")
+        self.assertEqual(session["active_attempt_id"], attempts[1]["attempt_id"])
+        self.assertEqual(validate_loop_cycle(recovered), {"ok": True, "errors": []})
+
+    def test_loop_queue_handoff_carries_the_dispatch_attempt_id_after_recovery(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = create_loop_cycle(
+                paths,
+                goal_summary="Hand the wrapper the identifier observe now needs",
+                goal_reframe="The surface that names an action carries what the action requires.",
+                success_criteria=["The queue handoff stays runnable after a recovery"],
+                permission_profile="execute_with_gates",
+                allowed_executors=["codex"],
+            )
+            ticked = tick_loop_runtime(paths, cycle["loop_id"])
+            queue_id = ticked["runtime"]["queue"][0]["queue_id"]
+            first = dispatch_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                executor="codex",
+                session_ref="codex-session-1",
+                evidence_refs=["wrapper:dispatch:1"],
+            )
+            first_attempt_id = first["runtime"]["queue"][0]["executor_session"]["active_attempt_id"]
+            recover_loop_queue_item_dispatch(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                prior_attempt_id=first_attempt_id,
+                prior_outcome="delivery_unknown",
+                outcome_evidence_refs=["wrapper:ack-timeout:1"],
+                executor="codex",
+                session_ref="codex-session-2",
+                evidence_refs=["wrapper:dispatch:2"],
+            )
+            handoff = build_loop_queue_handoff(paths, cycle["loop_id"], queue_id)
+            observed = observe_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                evidence_refs=["wrapper:observed:1"],
+                dispatch_attempt_id=handoff["active_dispatch_attempt_id"],
+            )
+
+        self.assertIn("recover_loop_queue_dispatch", handoff["actions"])
+        self.assertEqual(handoff["dispatch_attempt_count"], 2)
+        self.assertEqual(
+            observed["runtime"]["queue"][0]["observed_dispatch_attempt_id"],
+            handoff["active_dispatch_attempt_id"],
+        )
+        self.assertEqual(validate_loop_cycle(observed), {"ok": True, "errors": []})
+
     def test_loop_queue_lifecycle_lists_handoffs_observes_and_blocks_items(self) -> None:
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")


### PR DESCRIPTION
## Feature Report

### What Changed

- Carries #1291 (`vumrra`, dispatch attempt history) unchanged and fixes the three states its review found reachable-but-unleavable.
- A recorded `delivery_failed` is terminal: a later observation is refused instead of flipping the attempt to `delivery_confirmed`.
- Confirming an uncertain attempt moves the superseded claim — outcome, refs, summary — into that attempt's `outcome_history` instead of merging the two ref lists.
- `omh loop queue recover-dispatch` adopts a legacy single-dispatch `executor_session` as attempt 1, so `--prior-attempt-id` is optional in that case.
- `build_loop_queue_handoff` and `_queue_item_summary` carry `active_dispatch_attempt_id` and `dispatch_attempt_count`; the handoff names `recover_loop_queue_dispatch` once attempts exist.

### Why This Exists

#1291 is the right design and its happy paths are well covered. Reviewing it at `6ddb72a5` ([review](https://github.com/rlaope/oh-my-hermes/pull/1291#pullrequestreview-5098827349)) turned up three states the new code can reach and then cannot leave, or can leave with a record that misstates its own evidence. All three were reproduced against that head before the fix and re-run after.

**A recorded delivery failure was reversible, and its evidence was recycled as confirmation.** `_confirm_dispatch_attempt` matched on `attempt_id` alone and overwrote `delivery_outcome`, then concatenated the observation's refs onto the attempt's existing `outcome_evidence_refs`. An attempt the operator had recorded as `delivery_failed`, with evidence, flipped to `delivery_confirmed` while still citing `wrapper:delivery-failed:...` under a confirmation summary. `validate_loop_cycle` accepted it.

**A cycle written before #1291 could no longer be re-dispatched at all.** Dispatch refused a divergent retry with *"use explicit recovery"*, and recovery refused because a legacy record has no attempt identity — telling the caller to *"record its outcome before recovery"*, which no command or API performs. That is exactly the population #1277 is about: in-flight items already on disk. Before #1291 such an item could be re-dispatched; after it, it could only be observed or blocked.

**The handoff named an action the wrapper could no longer run.** After a recovery the item stays `prepared_not_observed`, so `build_loop_queue_handoff` still rendered and still listed `observe_loop_queue` — which now requires an attempt id that neither the handoff payload nor `_queue_item_summary` carried. Following the documented next step was a hard error.

### User / Operator Impact

- An operator who records a delivery failure keeps it. Nothing downstream can quietly turn that into a confirmation, and the failure's evidence never appears under a confirmation summary.
- A loop that was already in flight when this ships can still recover. `omh loop queue recover-dispatch --loop … --queue … --prior-outcome delivery_unknown --outcome-evidence-ref … --executor … --session-ref …` works on a legacy record without a `--prior-attempt-id`, because there is no id to give.
- A wrapper reading `omh loop queue handoff` gets `active_dispatch_attempt_id` and can pass it straight to `observe --dispatch-attempt-id`, and sees `recover_loop_queue_dispatch` in `actions` once the item has attempts.

### How It Works

- `_resolve_observed_dispatch_attempt` refuses to bind an observation to an attempt whose `delivery_outcome` is `delivery_failed`. It is the binding decision, so the refusal happens before any mutation.
- `_superseded_outcomes` builds the displaced claim's entry — `delivery_outcome`, `outcome_evidence_refs`, `outcome_summary`, `superseded_at` — and `_confirm_dispatch_attempt` sets `outcome_evidence_refs` to the observation's refs only. `_validate_executor_dispatch_session` validates the history shape and refuses one that supersedes a failure.
- `_adopted_legacy_dispatch_attempt` builds attempt 1 from `_executor_session_dispatch(existing)`, which is the same normalization dispatch already uses, and requires the legacy session's `dispatch_status` to be `dispatched`. Its `recorded_at` is empty: the legacy shape never stored a dispatch timestamp and inventing one would be a claim the record cannot support.
- The unreachable attempt carry-forward in `dispatch_loop_queue_item` is gone. An entry is only appended once the status is `dispatched`, an equal dispatch returns early, a divergent one raises, and `progress_observed` implies an observed item the precondition already rejects — so that path is always the first attempt.

### Files And Contracts Touched

- `src/workflows/goal_loop.py` — outcome ratchet, superseded-outcome history and its validation, legacy attempt adoption, handoff and queue-summary projections.
- `src/commands/loop.py` — `recover-dispatch --prior-attempt-id` becomes optional.
- `docs/ARCHITECTURE.md` — the *Materialized mutation ids* section now states the ratchet, the legacy adoption and its empty `recorded_at`, and what the handoff carries.
- `tests/test_loop_cycle.py` — four regressions.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke …`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: the three reproductions below, run against `6ddb72a5` and again against this branch
- [ ] Manual Hermes/TUI check: not run — no loop cycle surface renders in the TUI on this branch, and nothing here changes an installed artifact

### Observed Evidence

Full suite on the rebased tree:

```
Ran 8731 tests in 447.405s

OK
```

Also run on this head and passing: `ruff check src tests` → `All checks passed!`; `compileall -q src tests` (silent); `docs workflows --check` → `ok:true`, tap_skills 177/177; `docs roles --check`, `docs capability-families --check`, `docs ulw-inventory --check`, `docs ulw-site --check` → all `ok:true`; `git diff --check` clean.

The three defects, each reproduced against `6ddb72a5` before the fix and re-run here:

**Failure reversal.** Before: the attempt read `delivery_confirmed` with `['codex-jsonl:1', 'wrapper:delivery-failed:executor-rejected-the-dispatch']` under *"Executor progress or result was observed"*, and `validate_loop_cycle` returned `{'ok': True, 'errors': []}`. Now: `ValueError: dispatch attempt was recorded as delivery_failed; a later observation cannot confirm it`, and the stored attempt keeps `delivery_failed` with its own ref. Pinned by `test_loop_queue_observation_cannot_confirm_a_failed_dispatch_attempt`.

**Superseded uncertainty.** A `delivery_unknown` attempt confirmed by a later observation now reads:

```
outcome:                 delivery_confirmed
outcome_evidence_refs:   ['codex-jsonl:1']
outcome_history:         [{'delivery_outcome': 'delivery_unknown',
                           'outcome_evidence_refs': ['wrapper:ack-timeout:1'],
                           'outcome_summary': 'No acknowledgement arrived within the wrapper timeout.',
                           'superseded_at': '…'}]
```

Pinned by `test_loop_queue_observation_supersedes_rather_than_absorbs_prior_outcome_evidence`.

**Legacy dead end.** Reproduced by writing a record back to `loop_cycle_path(...)` with `active_attempt_id` and `dispatch_attempts` popped — the same downgrade #1291's own compatibility test performs. Before: `re-dispatch → ValueError: … use explicit recovery` then `recover → ValueError: legacy executor dispatch has no attempt identity …`. Now:

```
legacy validates: True
attempt indexes: [1, 2]
adopted attempt session_ref: codex-session-1 | recorded_at: ''
validates: {'ok': True, 'errors': []}
```

Pinned by `test_loop_queue_dispatch_recovery_adopts_a_legacy_dispatch_record`.

**Handoff round trip.** Before: `actions` was `['observe_loop_queue', 'block_loop_queue', 'show_loop_status']` with no attempt id anywhere in the payload, and following it raised `ValueError: dispatch attempt id is required after explicit recovery`. Now the handoff carries `active_dispatch_attempt_id` and `dispatch_attempt_count: 2`, lists `recover_loop_queue_dispatch`, and passing its id straight into `observe` binds and validates. Pinned by `test_loop_queue_handoff_carries_the_dispatch_attempt_id_after_recovery`.

### Not Tested / Not Applicable

- No live executor delivery, and no wrapper driving dispatch → lost acknowledgement → recovery → observation end to end against a real Codex or Claude Code session. Everything here is record-level.
- `harness validate`, `release checklist`, `release hermes-smoke`, and the install smoke were not run: no installable artifact, manifest, skill, or release surface moves in this diff.
- No manual Hermes/TUI check. Reflecting this on a live machine would go through `omh update` plus a TUI restart, and nothing here changes an installed artifact.

## Risk

- `outcome_evidence_refs` on a confirmed attempt now holds only the observation's refs. A consumer wanting the full outcome trail must also read `outcome_history`. No consumer does today — the field arrived in #1291 and has not shipped — but that is the one shape change a reader could notice.
- Legacy adoption mints an attempt id from the legacy metadata at recovery time. Two adoptions of the same legacy record would derive the same id, which is the intended behaviour, but it means the id is a function of the dispatch metadata rather than of when recovery happened.
- Refusing to confirm a `delivery_failed` attempt is a new way for `observe` to fail. It only fires on an attempt an operator explicitly recorded as failed, which previously would have been silently overwritten.

## Compatibility / Rollout

- No migration. Records written before #1291 stay readable, and are now recoverable rather than wedged.
- Records written by #1291 itself stay valid: `outcome_history` is additive and validated only when present.
- `--prior-attempt-id` loosening from required to optional is backward compatible; every existing invocation keeps working.

## Release / Claims

- [x] Release-channel impact considered (`local` — nothing installed changes)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- `observe_loop_queue_item` leaves `dispatch_status` at `dispatched` where `observe_codex_loop_queue_item` moves it to `progress_observed`. Pre-existing, out of scope here, worth reconciling.
- An attempt that is never observed and never recovered stays `delivery_unknown` forever once the item is observed through a different attempt. That is honest, but a report surface that counts unresolved attempts would make a double-execution visible rather than merely recorded.

Supersedes #1291 — same author commit, carried unchanged, with the review fixes on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWzQjXUzVcFRLgFetK5DUu
