### PR TITLE
fix(loop): an observed queue item says so, and an unresolved dispatch is reported

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2073,7 +2073,16 @@ attempt carries an empty `recorded_at`, since the legacy shape never stored a
 dispatch timestamp. `build_loop_queue_handoff` carries
 `active_dispatch_attempt_id` and `dispatch_attempt_count`, so the surface that
 names `observe_loop_queue` also hands over the id that action now requires.
-Other queue mutators retain status preconditions — `observe` requires
+Because recovery appends without retracting, an item can close with an attempt
+still `delivery_unknown` — a dispatch the executor may have run and nobody
+resolved — so the handoff, `omh loop queue list` and the cycle narration each
+report the open attempt ids, and the narration says plainly that the work may
+have run twice. Both observation paths move `dispatch_status` to
+`progress_observed`; leaving the generic one at `dispatched` made
+`_narration_next_message`, which reads `dispatch_status` before `status`, ask
+an operator to observe an item that had just been observed. A session that was
+never dispatched keeps its status, because no executor progress happened to
+claim. Other queue mutators retain status preconditions — `observe` requires
 `prepared_not_observed`, and `block` refuses an already-observed item. Wrapper
 sessions (`src/wrapper/sessions.py`) mutate in place — status transitions and a
 single `current_run_id` — instead of appending id-bearing items, so a repeat

--- a/src/workflows/goal_loop.py
+++ b/src/workflows/goal_loop.py
@@ -1506,6 +1506,12 @@ def list_loop_queue(paths: OmhPaths, loop_id: str, *, include_observed: bool = F
         "pending_queue_count": sum(1 for item in queue if item.get("status") == "prepared_not_observed"),
         "blocked_queue_count": sum(1 for item in queue if item.get("status") in {"blocked", "blocked_by_permission", "blocked_by_wait"}),
         "observed_queue_count": sum(1 for item in queue if item.get("status") == "observed" and item.get("observed") is True),
+        "unaccounted_dispatch_queue_count": sum(
+            1
+            for item in queue
+            if item.get("status") == "observed"
+            and _unresolved_dispatch_attempt_ids(_dict_value(item, "executor_session"))
+        ),
         "claim_boundary": _runtime_claim_boundary(),
     }
 
@@ -1548,6 +1554,7 @@ def build_loop_queue_handoff(paths: OmhPaths, loop_id: str, queue_id: str) -> di
         "connector_plan": item.get("connector_plan", _connector_plan("", "", str(item.get("planned_action", "")))),
         "active_dispatch_attempt_id": active_attempt_id,
         "dispatch_attempt_count": len(dispatch_attempts),
+        "unresolved_dispatch_attempt_ids": _unresolved_dispatch_attempt_ids(executor_session),
         "next_action": "observe_or_block_loop_queue",
         "actions": actions,
         "claim_boundary": _runtime_claim_boundary(),
@@ -2203,6 +2210,7 @@ def build_loop_cycle_narration(paths: OmhPaths, loop_id: str, queue_id: str = ""
         "executor_status": f"{executor_label} 상태: {executor_session.get('dispatch_status', 'not_dispatched')}",
         "progress_summary": progress_text,
         "verification_status": str(_dict_value(item, "verification_plan").get("expected_signal", "verification not planned yet")),
+        "unresolved_dispatch_attempts": _unresolved_dispatch_attempt_ids(executor_session),
         "next_message": _narration_next_message(status, executor_session),
         "not_evidence_yet": ["implementation", "review", "ci", "merge", "goal_completion"],
         "claim_boundary": _runtime_claim_boundary(),
@@ -2240,15 +2248,23 @@ def observe_loop_queue_item(
             executor_session,
             dispatch_attempt_id,
         )
+        updated_session = dict(executor_session)
         if observed_attempt_id:
-            item["executor_session"] = {
-                **executor_session,
-                "dispatch_attempts": _confirm_dispatch_attempt(
-                    executor_session,
-                    observed_attempt_id,
-                    aggregate_refs,
-                ),
-            }
+            updated_session["dispatch_attempts"] = _confirm_dispatch_attempt(
+                executor_session,
+                observed_attempt_id,
+                aggregate_refs,
+            )
+        if updated_session.get("dispatch_status") == "dispatched":
+            # observe_codex_loop_queue_item already does this. Leaving it at
+            # "dispatched" made the narration tell an operator to go observe
+            # progress for an item that had just been observed, because
+            # _narration_next_message reads dispatch_status before status.
+            # A prepared or never-requested session is untouched: no dispatch
+            # happened, so there is no executor progress to claim.
+            updated_session["dispatch_status"] = "progress_observed"
+        if updated_session != executor_session:
+            item["executor_session"] = updated_session
         item["status"] = "observed"
         item["observed"] = True
         item["observed_dispatch_attempt_id"] = observed_attempt_id
@@ -3417,6 +3433,21 @@ def _adopted_legacy_dispatch_attempt(
     }
 
 
+def _unresolved_dispatch_attempt_ids(executor_session: Mapping[str, Any]) -> list[str]:
+    """Attempts that were dispatched and never accounted for.
+
+    Recovery appends an attempt without retracting the one before it, so an
+    item can close with a dispatch nobody ever resolved -- the executor may
+    have run it twice. The record was already honest about that; nothing read
+    it back. These ids are what a reader needs to say so.
+    """
+    return [
+        str(entry.get("attempt_id", ""))
+        for entry in executor_session.get("dispatch_attempts", [])
+        if isinstance(entry, dict) and entry.get("delivery_outcome") == "delivery_unknown"
+    ]
+
+
 def _resolve_observed_dispatch_attempt(
     executor_session: Mapping[str, Any],
     requested_attempt_id: str,
@@ -3494,6 +3525,12 @@ def _superseded_outcomes(attempt: Mapping[str, Any]) -> list[dict[str, Any]]:
 
 def _narration_next_message(status: str, executor_session: dict[str, Any]) -> str:
     dispatch_status = str(executor_session.get("dispatch_status", ""))
+    unresolved = _unresolved_dispatch_attempt_ids(executor_session)
+    if status == "observed" and unresolved:
+        return (
+            f"이 항목은 관측됐지만 결과가 확인되지 않은 디스패치가 {len(unresolved)}건 남아 있어. "
+            "에이전트가 같은 작업을 두 번 실행했을 수 있으니, 다음 단계는 남은 시도의 전달 결과를 확인하는 거야."
+        )
     if status == "prepared_not_observed" and dispatch_status in {"", "not_requested", "prepared"}:
         return "아직 실행 증거는 없고, 다음 단계는 선택한 코딩 에이전트에 이 큐 항목을 넘기는 거야."
     if dispatch_status == "dispatched":
@@ -4201,6 +4238,7 @@ def _queue_item_summary(item: dict[str, Any]) -> dict[str, Any]:
         "dispatch_attempt_count": len(
             [entry for entry in _dict_value(item, "executor_session").get("dispatch_attempts", []) if isinstance(entry, dict)]
         ),
+        "unresolved_dispatch_attempt_ids": _unresolved_dispatch_attempt_ids(_dict_value(item, "executor_session")),
         "blocker_reason": str(item.get("blocker_reason", "")),
         "worktree_strategy": str(_dict_value(item, "worktree_plan").get("strategy", "")),
         "subagent_strategy": str(_dict_value(item, "subagent_plan").get("strategy", "")),

--- a/tests/test_loop_cycle.py
+++ b/tests/test_loop_cycle.py
@@ -1298,6 +1298,121 @@ class GoalLoopTests(unittest.TestCase):
         )
         self.assertEqual(validate_loop_cycle(observed), {"ok": True, "errors": []})
 
+    def test_loop_queue_observation_moves_dispatch_status_like_the_codex_path(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = create_loop_cycle(
+                paths,
+                goal_summary="Tell the operator what is actually next",
+                goal_reframe="A generic observation moves the executor session forward too.",
+                success_criteria=["The narration does not ask for an observation already made"],
+                permission_profile="execute_with_gates",
+                allowed_executors=["codex"],
+            )
+            ticked = tick_loop_runtime(paths, cycle["loop_id"])
+            queue_id = ticked["runtime"]["queue"][0]["queue_id"]
+            dispatch_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                executor="codex",
+                session_ref="codex-session-1",
+                evidence_refs=["wrapper:dispatch:1"],
+            )
+            observed = observe_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                evidence_refs=["wrapper:observed:1"],
+                summary="Wrapper observed the executor result.",
+            )
+            narration = build_loop_cycle_narration(paths, cycle["loop_id"], queue_id)
+
+        item = observed["runtime"]["queue"][0]
+        self.assertEqual(item["status"], "observed")
+        self.assertEqual(item["executor_session"]["dispatch_status"], "progress_observed")
+        self.assertIn("progress_observed", narration["executor_status"])
+        self.assertIn("검증", narration["next_message"])
+        self.assertEqual(validate_loop_cycle(observed), {"ok": True, "errors": []})
+
+    def test_loop_queue_observation_leaves_an_undispatched_session_alone(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = create_loop_cycle(
+                paths,
+                goal_summary="Never claim executor progress that did not happen",
+                goal_reframe="An item observed without a dispatch has no executor progress.",
+                success_criteria=["An undispatched session keeps its dispatch status"],
+                permission_profile="execute_with_gates",
+                allowed_executors=["codex"],
+            )
+            ticked = tick_loop_runtime(paths, cycle["loop_id"])
+            queue_id = ticked["runtime"]["queue"][0]["queue_id"]
+            observed = observe_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                evidence_refs=["wrapper:observed:1"],
+                summary="Operator observed the queue item without dispatching it.",
+            )
+
+        session = observed["runtime"]["queue"][0]["executor_session"]
+        self.assertEqual(session["dispatch_status"], "not_requested")
+        self.assertEqual(session["dispatch_attempts"], [])
+        self.assertEqual(validate_loop_cycle(observed), {"ok": True, "errors": []})
+
+    def test_loop_queue_surfaces_report_an_unaccounted_dispatch_attempt(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = create_loop_cycle(
+                paths,
+                goal_summary="Make a possible double execution readable",
+                goal_reframe="An item can close with a dispatch nobody resolved.",
+                success_criteria=["An unaccounted dispatch attempt is reported, not merely recorded"],
+                permission_profile="execute_with_gates",
+                allowed_executors=["codex"],
+            )
+            ticked = tick_loop_runtime(paths, cycle["loop_id"])
+            queue_id = ticked["runtime"]["queue"][0]["queue_id"]
+            first = dispatch_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                executor="codex",
+                session_ref="codex-session-1",
+                evidence_refs=["wrapper:dispatch:1"],
+            )
+            first_attempt_id = first["runtime"]["queue"][0]["executor_session"]["active_attempt_id"]
+            recover_loop_queue_item_dispatch(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                prior_attempt_id=first_attempt_id,
+                prior_outcome="delivery_unknown",
+                outcome_evidence_refs=["wrapper:ack-timeout:1"],
+                executor="codex",
+                session_ref="codex-session-2",
+                evidence_refs=["wrapper:dispatch:2"],
+            )
+            handoff = build_loop_queue_handoff(paths, cycle["loop_id"], queue_id)
+            observe_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                evidence_refs=["wrapper:observed:1"],
+                dispatch_attempt_id=first_attempt_id,
+            )
+            narration = build_loop_cycle_narration(paths, cycle["loop_id"], queue_id)
+            listed = list_loop_queue(paths, cycle["loop_id"], include_observed=True)
+
+        # Before the item is observed, both attempts are still open.
+        self.assertEqual(len(handoff["unresolved_dispatch_attempt_ids"]), 2)
+        # Observing attempt 1 resolves it and leaves the recovered attempt open.
+        self.assertEqual(len(narration["unresolved_dispatch_attempts"]), 1)
+        self.assertIn("두 번 실행", narration["next_message"])
+        self.assertEqual(listed["unaccounted_dispatch_queue_count"], 1)
+        self.assertEqual(len(listed["queue"][0]["unresolved_dispatch_attempt_ids"]), 1)
+
     def test_loop_queue_lifecycle_lists_handoffs_observes_and_blocks_items(self) -> None:
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")


### PR DESCRIPTION
## Feature Report

### What Changed

- `observe_loop_queue_item` moves `dispatch_status` to `progress_observed`, the way `observe_codex_loop_queue_item` already did. A session that was never dispatched keeps `not_requested` / `prepared`.
- `_unresolved_dispatch_attempt_ids` names the dispatch attempts still sitting at `delivery_unknown`, and three read surfaces report them: `build_loop_queue_handoff`, `omh loop queue list` (per item plus an `unaccounted_dispatch_queue_count` roll-up) and `build_loop_cycle_narration`.
- The narration's `next_message` says plainly that the agent may have run the same work twice when an observed item still carries an open attempt.

### Why This Exists

Both are the follow-ups #1299 listed and left open. Neither is a bad record — the persisted cycle was already right in both cases. Both are readers that did not read it back.

**An observed item kept telling the operator to go observe it.** `_narration_next_message` tests `dispatch_status` before `status`, so an item observed through the generic path — which left `dispatch_status` at `dispatched` while `observe_codex_loop_queue_item` moved it to `progress_observed` — fell into the `dispatched` branch and answered *"코딩 에이전트 세션은 기록됐고, 다음 단계는 진행 로그나 결과 evidence를 관측하는 거야."* `executor_status` read `dispatched` on an item whose `status` was `observed`.

**A dispatch nobody resolved was invisible.** Recovery appends an attempt without retracting the one before it, by design — that is what makes the history auditable. But an item can then close as `observed` while another attempt is still `delivery_unknown`, which is precisely the case where the executor may have run the work twice. The record has carried that since #1291, and no surface read it, so the one signal worth seeing was the one an operator could not see.

### User / Operator Impact

- `omh loop queue narrate` on an observed item now reports the item's real state and, when a dispatch is unaccounted for, says so instead of asking for an observation already made.
- `omh loop queue list` gains `unaccounted_dispatch_queue_count` and a per-item `unresolved_dispatch_attempt_ids`, so a possible double execution is visible in the roll-up rather than only inside `cycle.json`.
- `omh loop queue handoff` carries `unresolved_dispatch_attempt_ids` alongside the `active_dispatch_attempt_id` #1299 added, so the wrapper has the ids it needs to resolve them.

### How It Works

- The generic observe path builds its updated session, confirms the bound attempt as before, and moves `dispatch_status` only when it was `dispatched`. The guard is the point: moving it unconditionally would claim executor progress for an item nobody dispatched, which is the same class of false claim #1299's outcome ratchet exists to prevent.
- `_unresolved_dispatch_attempt_ids` is a pure read over `dispatch_attempts`. It is deliberately not a validation error and deliberately does not auto-resolve: an open attempt is a real state an operator has to persist and then answer, and inventing the answer is the failure being reported.

### Files And Contracts Touched

- `src/workflows/goal_loop.py` — the generic observe path, the new helper, and the handoff / queue-list / narration projections.
- `docs/ARCHITECTURE.md` — the *Materialized mutation ids* section states both rules.
- `tests/test_loop_cycle.py` — three regressions.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh … release hermes-smoke --install-path setup …`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: the reproduction below, run against `b4641e32` and again against this branch
- [ ] Manual Hermes/TUI check: not run — no installed artifact changes, so there is nothing to reflect with `omh update`

### Observed Evidence

```
Ran 8734 tests in 464.618s

OK
```

Also passing on this head: `ruff check src tests` → `All checks passed!`; `compileall -q src tests` (silent); `docs workflows --check` → `ok:true`, tap_skills 177/177; `docs roles`, `docs capability-families`, `docs ulw-inventory`, `docs ulw-site` → all `ok:true`; `git diff --check` clean.

One script reproduces both. Dispatch, recover once, observe binding attempt 1, then read the narration.

Against `b4641e32`:

```
item status:       observed
dispatch_status:   dispatched
attempt outcomes:  ['delivery_confirmed', 'delivery_unknown']
executor_status:   Codex 상태: dispatched
next_message:      코딩 에이전트 세션은 기록됐고, 다음 단계는 진행 로그나 결과 evidence를 관측하는 거야.
```

An observed item reporting `dispatched`, telling the operator to go observe it, with the second dispatch mentioned nowhere.

On this branch:

```
item status:       observed
dispatch_status:   progress_observed
attempt outcomes:  ['delivery_confirmed', 'delivery_unknown']
executor_status:   Codex 상태: progress_observed
next_message:      이 항목은 관측됐지만 결과가 확인되지 않은 디스패치가 1건 남아 있어.
                   에이전트가 같은 작업을 두 번 실행했을 수 있으니, 다음 단계는
                   남은 시도의 전달 결과를 확인하는 거야.
```

Pinned by `test_loop_queue_observation_moves_dispatch_status_like_the_codex_path`, `test_loop_queue_observation_leaves_an_undispatched_session_alone`, and `test_loop_queue_surfaces_report_an_unaccounted_dispatch_attempt`.

### Not Tested / Not Applicable

- No live executor delivery, and no wrapper driving dispatch → lost acknowledgement → recovery → observation against a real session. Everything here is record-level.
- `harness validate`, `release checklist`, `release hermes-smoke` and the install smoke were not run: no installable artifact, manifest, skill or release surface moves.
- No Hermes/TUI render of the narration. Nothing installed changes, so there is no `omh update` step to reflect this on a live machine.

## Risk

- The narration's `next_message` gains a branch that outranks the `dispatched` and `observed` ones. It only fires for an observed item with an open attempt, which previously produced the wrong message anyway.
- Three projections gain fields. Additive; no reader loses anything.
- `dispatch_status` now reaches `progress_observed` through a second path. Both the schema default set and `_validate_executor_dispatch_session` already accepted that value, so no stored shape changes.

## Compatibility / Rollout

- No migration and no stored-shape change. `dispatch_status: progress_observed` was already a value #1291's validator accepts.
- Records written before this keep validating; the new fields are computed at read time from `dispatch_attempts`, so a legacy session with no attempt history reports an empty list.

## Release / Claims

- [x] Release-channel impact considered (`local` — nothing installed changes)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Nothing outstanding from #1299's list; this closes both items it left.

Follows #1299 (`b4641e32`), which fixed #1291's three review findings and named these two as out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWzQjXUzVcFRLgFetK5DUu
