### PR TITLE
Add adaptive provider-pressure admission to fanout dispatch

### DIFF
--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -135,13 +135,30 @@ Rules:
 
 ## Dispatch bridge semantics
 
-- **Concurrency is a profile tunable.** The dispatch pool width comes from
+- **Concurrency is fixed by default and adaptive only when requested.** The dispatch pool width comes from
   the setup profile's `parallelism` block — `default_concurrency` (5) sized
   against a `global_concurrency` ceiling (8), the same defaults OMO's task
   engine ships. A fresh `omh setup` writes the block into the profile so it
   is visible and editable; an explicit `--concurrency` flag still wins,
-  clamped to the ceiling, and the dispatch summary's `concurrency` block
-  records the requested and applied widths plus their source. `per_owner`
+  clamped to the ceiling. Without another flag, scheduling remains fixed-width.
+  `--adaptive-concurrency` makes that resolved concurrency the ceiling, starts
+  the admission window at 2 (capped by the ceiling), grows it by one after an
+  observed clean completion, and halves it with a floor of 1 after observed
+  provider-limit pressure. Pressure includes a final `limit_shaped` result or
+  a `transient_provider_limit` retry decision even when the retry recovered;
+  auth, timeout, missing-binary, crash, terminal test/code, and ordinary
+  transport failures do not reduce the window. Ready dependency-frontier units
+  are submitted only while they fit the current window; a reduction does not
+  cancel units already running.
+
+  The dispatch summary's `concurrency` block records the requested and applied
+  ceiling plus its source. Adaptive mode additionally emits a bounded,
+  metadata-only `adaptive_admission` (`fanout_admission/v1`) receipt with the
+  initial, ceiling, final, and minimum windows and unit-id/status-class
+  adjustments. It includes no raw output and is not provider quota,
+  verification, review, CI, or merge evidence. A dry run reports
+  `not_observed_dry_run`, zero observed completions and pressure, and no
+  adjustments; planned units are not successful execution. `per_owner`
   maps an executor owner (for example `codex: 2`) to its own lane width so
   one rate-limited provider is not hammered by the whole pool; owners not
   named there are governed by the global pool alone. A gated owner's units

--- a/src/coding/fanout_admission.py
+++ b/src/coding/fanout_admission.py
@@ -1,0 +1,24 @@
+"""Adaptive submission-window state for the explicit fanout bridge."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+class AdaptiveFanoutAdmission:
+    """Start conservatively and grow after clean observed completions."""
+
+    def __init__(self, *, ceiling: int) -> None:
+        self.ceiling = max(1, int(ceiling))
+        self.window = min(2, self.ceiling)
+
+    def available_slots(self, inflight: int) -> int:
+        return max(0, self.window - max(0, int(inflight)))
+
+    def observe(self, result: Mapping[str, Any]) -> None:
+        if (
+            result.get("status") == "completed"
+            and result.get("process_succeeded") is True
+            and result.get("exit_code") == 0
+        ):
+            self.window = min(self.ceiling, self.window + 1)

--- a/src/coding/fanout_admission.py
+++ b/src/coding/fanout_admission.py
@@ -4,21 +4,116 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
+FANOUT_ADMISSION_SCHEMA_VERSION = "fanout_admission/v1"
+FANOUT_ADMISSION_ADJUSTMENT_LIMIT = 32
+FANOUT_ADMISSION_CLAIM_BOUNDARY = (
+    "Adaptive admission records only how observed local unit process results changed this dispatch's "
+    "submission window. A provider-limit status class is not provider quota truth, and admission "
+    "decisions are not verification, review, CI, merge-readiness, or merge evidence."
+)
+
+_PROVIDER_LIMIT_FAILURE_KIND = "limit_shaped"
+_PROVIDER_LIMIT_RETRY_CLASS = "transient_provider_limit"
+
 
 class AdaptiveFanoutAdmission:
-    """Start conservatively and grow after clean observed completions."""
+    """Additive-increase, multiplicative-decrease admission state."""
 
     def __init__(self, *, ceiling: int) -> None:
         self.ceiling = max(1, int(ceiling))
-        self.window = min(2, self.ceiling)
+        self.initial_window = min(2, self.ceiling)
+        self.window = self.initial_window
+        self.minimum_window = self.initial_window
+        self._observed_completion_count = 0
+        self._observed_clean_completion_count = 0
+        self._observed_provider_pressure_count = 0
+        self._adjustment_count = 0
+        self._adjustments: list[dict[str, Any]] = []
 
     def available_slots(self, inflight: int) -> int:
         return max(0, self.window - max(0, int(inflight)))
 
-    def observe(self, result: Mapping[str, Any]) -> None:
-        if (
-            result.get("status") == "completed"
-            and result.get("process_succeeded") is True
-            and result.get("exit_code") == 0
-        ):
-            self.window = min(self.ceiling, self.window + 1)
+    def observe(self, unit_id: str, result: Mapping[str, Any]) -> None:
+        """Apply one observed unit-process result to the admission window."""
+        if not _is_observed_process_completion(result):
+            return
+        self._observed_completion_count += 1
+        before = self.window
+        if _has_provider_limit_pressure(result):
+            self._observed_provider_pressure_count += 1
+            self.window = max(1, before // 2)
+            status_class = "provider_limit_pressure"
+            action = "halve" if self.window < before else "hold_minimum"
+        elif _is_clean_completion(result):
+            self._observed_clean_completion_count += 1
+            self.window = min(self.ceiling, before + 1)
+            status_class = "clean_completion"
+            action = "increase" if self.window > before else "hold_ceiling"
+        else:
+            return
+        self.minimum_window = min(self.minimum_window, self.window)
+        self._adjustment_count += 1
+        if len(self._adjustments) < FANOUT_ADMISSION_ADJUSTMENT_LIMIT:
+            self._adjustments.append(
+                {
+                    "unit_id": str(unit_id),
+                    "status_class": status_class,
+                    "action": action,
+                    "window_before": before,
+                    "window_after": self.window,
+                }
+            )
+
+    def receipt(self) -> dict[str, Any]:
+        return {
+            "schema_version": FANOUT_ADMISSION_SCHEMA_VERSION,
+            "mode": "adaptive",
+            "requested": True,
+            "initial_window": self.initial_window,
+            "ceiling": self.ceiling,
+            "final_window": self.window,
+            "minimum_window": self.minimum_window,
+            "observation_status": (
+                "observed_local_process_results"
+                if self._observed_completion_count
+                else "no_observed_unit_results"
+            ),
+            "observed_completion_count": self._observed_completion_count,
+            "observed_clean_completion_count": self._observed_clean_completion_count,
+            "observed_provider_pressure_count": self._observed_provider_pressure_count,
+            "adjustment_count": self._adjustment_count,
+            "adjustments": list(self._adjustments),
+            "adjustments_omitted": max(
+                0, self._adjustment_count - len(self._adjustments)
+            ),
+            "claim_boundary": FANOUT_ADMISSION_CLAIM_BOUNDARY,
+        }
+
+
+def _is_observed_process_completion(result: Mapping[str, Any]) -> bool:
+    exit_code = result.get("exit_code")
+    return isinstance(exit_code, int) and not isinstance(exit_code, bool)
+
+
+def _is_clean_completion(result: Mapping[str, Any]) -> bool:
+    return (
+        result.get("status") == "completed"
+        and result.get("process_succeeded") is True
+        and result.get("exit_code") == 0
+    )
+
+
+def _has_provider_limit_pressure(result: Mapping[str, Any]) -> bool:
+    if result.get("failure_kind") == _PROVIDER_LIMIT_FAILURE_KIND:
+        return True
+    retry = result.get("retry")
+    if not isinstance(retry, Mapping):
+        return False
+    decisions = retry.get("decisions")
+    if not isinstance(decisions, (list, tuple)):
+        return False
+    return any(
+        isinstance(decision, Mapping)
+        and decision.get("failure_class") == _PROVIDER_LIMIT_RETRY_CLASS
+        for decision in decisions
+    )

--- a/src/coding/fanout_admission.py
+++ b/src/coding/fanout_admission.py
@@ -9,7 +9,8 @@ FANOUT_ADMISSION_ADJUSTMENT_LIMIT = 32
 FANOUT_ADMISSION_CLAIM_BOUNDARY = (
     "Adaptive admission records only how observed local unit process results changed this dispatch's "
     "submission window. A provider-limit status class is not provider quota truth, and admission "
-    "decisions are not verification, review, CI, merge-readiness, or merge evidence."
+    "decisions are not verification, review, CI, merge-readiness, or merge evidence. Dry-run plans "
+    "are not observed execution."
 )
 
 _PROVIDER_LIMIT_FAILURE_KIND = "limit_shaped"
@@ -19,11 +20,12 @@ _PROVIDER_LIMIT_RETRY_CLASS = "transient_provider_limit"
 class AdaptiveFanoutAdmission:
     """Additive-increase, multiplicative-decrease admission state."""
 
-    def __init__(self, *, ceiling: int) -> None:
+    def __init__(self, *, ceiling: int, dry_run: bool = False) -> None:
         self.ceiling = max(1, int(ceiling))
         self.initial_window = min(2, self.ceiling)
         self.window = self.initial_window
         self.minimum_window = self.initial_window
+        self.dry_run = bool(dry_run)
         self._observed_completion_count = 0
         self._observed_clean_completion_count = 0
         self._observed_provider_pressure_count = 0
@@ -35,7 +37,7 @@ class AdaptiveFanoutAdmission:
 
     def observe(self, unit_id: str, result: Mapping[str, Any]) -> None:
         """Apply one observed unit-process result to the admission window."""
-        if not _is_observed_process_completion(result):
+        if self.dry_run or not _is_observed_process_completion(result):
             return
         self._observed_completion_count += 1
         before = self.window
@@ -74,9 +76,13 @@ class AdaptiveFanoutAdmission:
             "final_window": self.window,
             "minimum_window": self.minimum_window,
             "observation_status": (
-                "observed_local_process_results"
-                if self._observed_completion_count
-                else "no_observed_unit_results"
+                "not_observed_dry_run"
+                if self.dry_run
+                else (
+                    "observed_local_process_results"
+                    if self._observed_completion_count
+                    else "no_observed_unit_results"
+                )
             ),
             "observed_completion_count": self._observed_completion_count,
             "observed_clean_completion_count": self._observed_clean_completion_count,

--- a/src/coding/fanout_admission.py
+++ b/src/coding/fanout_admission.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
+from ..system.metadata_safety import redact_metadata_text
+
 FANOUT_ADMISSION_SCHEMA_VERSION = "fanout_admission/v1"
 FANOUT_ADMISSION_ADJUSTMENT_LIMIT = 32
 FANOUT_ADMISSION_CLAIM_BOUNDARY = (
@@ -58,7 +60,7 @@ class AdaptiveFanoutAdmission:
         if len(self._adjustments) < FANOUT_ADMISSION_ADJUSTMENT_LIMIT:
             self._adjustments.append(
                 {
-                    "unit_id": str(unit_id),
+                    "unit_id": redact_metadata_text(str(unit_id), limit=64),
                     "status_class": status_class,
                     "action": action,
                     "window_before": before,

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -1563,7 +1563,7 @@ def dispatch_fanout(
                     result = future.result()
                     results[unit_id] = result
                     if admission is not None:
-                        admission.observe(result)
+                        admission.observe(unit_id, result)
                     pending.remove(unit_id)
             _admit_frontier()
         pool.shutdown(wait=True)
@@ -1677,6 +1677,8 @@ def dispatch_fanout(
         "state_path": str(review_budget.path),
         "claim_boundary": "Budget accounting is not review, verification, CI, or merge evidence.",
     }
+    if admission is not None:
+        summary["adaptive_admission"] = admission.receipt()
     if concurrency_policy:
         # How the pool width was chosen (policy default vs flag, any clamp)
         # so a dispatch record answers "why did only N run at once".

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -1582,7 +1582,10 @@ def dispatch_fanout(
             if unit_id in results:
                 continue
             try:
-                results[unit_id] = future.result(timeout=UNIT_TERMINATE_GRACE_SECONDS + 5)
+                result = future.result(timeout=UNIT_TERMINATE_GRACE_SECONDS + 5)
+                results[unit_id] = result
+                if admission is not None:
+                    admission.observe(unit_id, result)
             except (
                 FuturesCancelledError,
                 FuturesTimeoutError,

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -1418,7 +1418,7 @@ def dispatch_fanout(
 
     pending = [unit_id for unit_id in order if unit_id not in results]
     admission = (
-        AdaptiveFanoutAdmission(ceiling=concurrency)
+        AdaptiveFanoutAdmission(ceiling=concurrency, dry_run=dry_run)
         if adaptive_concurrency
         else None
     )

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -1262,7 +1262,7 @@ def dispatch_fanout(
             "fanout_recursion_depth", posture=resolve_security_posture(guard_env)
         )
         if depth_decision.tier != TIER_AUTO_ALLOWED:
-            return _depth_refusal_summary(
+            summary = _depth_refusal_summary(
                 contract,
                 dry_run=dry_run,
                 base_sha=base_sha,
@@ -1270,6 +1270,12 @@ def dispatch_fanout(
                 max_depth=effective_max_depth,
                 lineage=str(guard_env.get(FANOUT_LINEAGE_ENV_VAR, "") or ""),
             )
+            if adaptive_concurrency:
+                summary["adaptive_admission"] = AdaptiveFanoutAdmission(
+                    ceiling=concurrency,
+                    dry_run=dry_run,
+                ).receipt()
+            return summary
     spawn_ledger = _SpawnLedger(
         FANOUT_RUN_SPAWN_CEILING_DEFAULT if spawn_ceiling is None else spawn_ceiling
     )

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -72,6 +72,7 @@ from .executor_progress import (
     write_progress_binding,
 )
 from .executor_readiness import probe_executor_readiness
+from .fanout_admission import AdaptiveFanoutAdmission
 from .fanout_artifact_sharing import plan_and_link_shared_artifacts
 from .fanout_contracts import (
     FANOUT_CLAIM_BOUNDARY,
@@ -1210,6 +1211,7 @@ def dispatch_fanout(
     # Conservative library fallback only: the CLI resolves the pool width
     # from the setup profile's `parallelism` block (default 5, ceiling 8).
     concurrency: int = 2,
+    adaptive_concurrency: bool = False,
     timeout: int = 1800,
     only_units: Sequence[str] | None = None,
     dry_run: bool = False,
@@ -1415,6 +1417,11 @@ def dispatch_fanout(
             results[unit_id] = _skipped(unit, "not_selected")
 
     pending = [unit_id for unit_id in order if unit_id not in results]
+    admission = (
+        AdaptiveFanoutAdmission(ceiling=concurrency)
+        if adaptive_concurrency
+        else None
+    )
     # Per-owner lanes (OMO's per-provider limiter, reduced to what this
     # blocking pool can honor): only owners the policy names get a lane
     # semaphore — the global pool alone governs everyone else. The gate
@@ -1523,11 +1530,22 @@ def dispatch_fanout(
                 if any(_dependency_failed(results.get(dep)) for dep in units[unit_id].get("depends_on", [])):
                     results[unit_id] = _blocked(units[unit_id], results)
                     pending.remove(unit_id)
+            available_slots = (
+                admission.available_slots(
+                    sum(1 for unit_id in pending if unit_id in futures)
+                )
+                if admission is not None
+                else None
+            )
             for unit_id in list(pending):
+                if available_slots is not None and available_slots <= 0:
+                    break
                 if unit_id in futures:
                     continue
                 if all(_dependency_satisfied(results.get(dep)) for dep in units[unit_id].get("depends_on", [])):
                     _submit(unit_id)
+                    if available_slots is not None:
+                        available_slots -= 1
 
         _admit_frontier()
         while pending:
@@ -1542,7 +1560,10 @@ def dispatch_fanout(
             done, _ = futures_wait(inflight.values(), return_when=FIRST_COMPLETED)
             for unit_id, future in inflight.items():
                 if future in done:
-                    results[unit_id] = future.result()
+                    result = future.result()
+                    results[unit_id] = result
+                    if admission is not None:
+                        admission.observe(result)
                     pending.remove(unit_id)
             _admit_frontier()
         pool.shutdown(wait=True)

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -2065,6 +2065,7 @@ def cmd_coding_fanout_dispatch(args: argparse.Namespace) -> int:
             repo_root=repo_root,
             base_sha="",
             concurrency=concurrency["applied"],
+            adaptive_concurrency=bool(args.adaptive_concurrency),
             per_owner_lanes=parallelism["per_owner"],
             concurrency_policy=concurrency,
             max_depth=parallelism["max_depth"],
@@ -2103,6 +2104,7 @@ def cmd_coding_fanout_dispatch(args: argparse.Namespace) -> int:
             # this single resolve and the unit's own creation.
             source_ref=args.base_ref,
             concurrency=concurrency["applied"],
+            adaptive_concurrency=bool(args.adaptive_concurrency),
             per_owner_lanes=parallelism["per_owner"],
             concurrency_policy=concurrency,
             max_depth=parallelism["max_depth"],
@@ -2583,14 +2585,23 @@ def _add_coding_commands(sub) -> None:
     fanout_dispatch.add_argument("--base-ref", default="HEAD", help="Ref resolved once to a SHA all unit branches start from.")
     # Default None resolves through the setup profile's `parallelism` block
     # (default_concurrency 5, global_concurrency 8 unless edited); an
-    # explicit flag still wins, clamped to the global ceiling.
+    # explicit flag still wins, clamped to the global ceiling. Adaptive mode
+    # reads that same resolved width as its admission ceiling.
     fanout_dispatch.add_argument(
         "--concurrency",
         type=int,
         default=None,
         help=(
-            "Pool width override; defaults to the setup profile's "
-            "parallelism.default_concurrency and is clamped to global_concurrency."
+            "Pool width override; defaults to parallelism.default_concurrency, is clamped "
+            "to global_concurrency, and is the ceiling in adaptive mode."
+        ),
+    )
+    fanout_dispatch.add_argument(
+        "--adaptive-concurrency",
+        action="store_true",
+        help=(
+            "Use the --concurrency ceiling; start at 2 and grow after clean completions; "
+            "provider-limit pressure halves it, including recovered retries."
         ),
     )
     fanout_dispatch.add_argument("--timeout", type=int, default=1800, help="Per-unit subprocess timeout in seconds.")

--- a/tests/test_fanout_admission.py
+++ b/tests/test_fanout_admission.py
@@ -345,5 +345,66 @@ class FanoutRecoveredPressureIntegrationTests(unittest.TestCase):
         self.assertEqual(runner.attempts["b-pressure"], 2)
 
 
+class AdaptiveAdmissionDryRunTests(unittest.TestCase):
+    def test_dry_run_receipt_makes_no_observed_execution_or_pressure_claim(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            repo = root / "repo"
+            repo.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+            (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+            subprocess.run(["git", "add", "seed.txt"], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "init"],
+                cwd=repo,
+                check=True,
+            )
+            base_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            contract = write_fanout_contract(
+                paths,
+                build_fanout_contract(
+                    _GOAL,
+                    [
+                        {
+                            "unit_id": "dry-run",
+                            "title": "Dry run",
+                            "owner": "codex",
+                            "file_scope": ["src/dry-run/"],
+                        }
+                    ],
+                ),
+            )
+            runner = _ControlledRunner()
+
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=base_sha,
+                concurrency=4,
+                adaptive_concurrency=True,
+                dry_run=True,
+                runner=runner,
+                readiness=_ready,
+            )
+
+        receipt = summary["adaptive_admission"]
+        self.assertEqual(receipt["observation_status"], "not_observed_dry_run")
+        self.assertEqual(receipt["observed_completion_count"], 0)
+        self.assertEqual(receipt["observed_provider_pressure_count"], 0)
+        self.assertEqual(receipt["adjustments"], [])
+        self.assertEqual(receipt["final_window"], receipt["initial_window"])
+        self.assertEqual(runner.started, [])
+        self.assertIn("Dry-run plans are not observed execution", receipt["claim_boundary"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_fanout_admission.py
+++ b/tests/test_fanout_admission.py
@@ -7,6 +7,7 @@ import sys
 from tempfile import TemporaryDirectory
 import threading
 import unittest
+from unittest.mock import patch
 
 from omh.coding.fanout import build_fanout_contract
 from omh.coding.fanout_artifacts import write_fanout_contract
@@ -359,6 +360,75 @@ class FanoutRecoveredPressureIntegrationTests(unittest.TestCase):
         self.assertEqual(pressure["status_class"], "provider_limit_pressure")
         self.assertEqual((pressure["window_before"], pressure["window_after"]), (3, 1))
         self.assertEqual(runner.attempts["b-pressure"], 2)
+
+
+class FanoutInterruptedAdmissionTests(unittest.TestCase):
+    def test_interrupt_cleanup_observes_a_collected_clean_completion_once(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            repo = root / "repo"
+            repo.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+            (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+            subprocess.run(["git", "add", "seed.txt"], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "init"],
+                cwd=repo,
+                check=True,
+            )
+            base_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            contract = write_fanout_contract(
+                paths,
+                build_fanout_contract(
+                    _GOAL,
+                    [
+                        {
+                            "unit_id": "completed-during-interrupt",
+                            "title": "Completed during interrupt",
+                            "owner": "codex",
+                            "file_scope": ["src/completed-during-interrupt/"],
+                        }
+                    ],
+                ),
+            )
+
+            def interrupt_after_completion(futures, **_kwargs):
+                for future in futures:
+                    future.result(timeout=5)
+                raise KeyboardInterrupt
+
+            with patch(
+                "omh.coding.fanout_dispatch.futures_wait",
+                side_effect=interrupt_after_completion,
+            ):
+                summary = dispatch_fanout(
+                    paths,
+                    contract,
+                    goal_text=_GOAL,
+                    repo_root=repo,
+                    base_sha=base_sha,
+                    concurrency=1,
+                    adaptive_concurrency=True,
+                    runner=lambda argv, **kwargs: (
+                        subprocess.run(argv, **kwargs) if argv[0] == "git" else _FakeCompleted()
+                    ),
+                    readiness=_ready,
+                )
+
+        receipt = summary["adaptive_admission"]
+        self.assertTrue(summary["interrupted"])
+        self.assertEqual(summary["units"][0]["status"], "completed")
+        self.assertEqual(receipt["observation_status"], "observed_local_process_results")
+        self.assertEqual(receipt["observed_completion_count"], 1)
+        self.assertEqual(receipt["observed_clean_completion_count"], 1)
+        self.assertEqual(receipt["adjustment_count"], 1)
 
 
 class AdaptiveAdmissionDryRunTests(unittest.TestCase):

--- a/tests/test_fanout_admission.py
+++ b/tests/test_fanout_admission.py
@@ -136,6 +136,21 @@ class FanoutAdaptiveSchedulerTests(unittest.TestCase):
 
 
 class AdaptiveAdmissionReceiptTests(unittest.TestCase):
+    def test_receipt_redacts_a_secret_shaped_unit_identifier(self) -> None:
+        from omh.coding.fanout_admission import AdaptiveFanoutAdmission
+
+        sensitive_unit_id = "sk-reviewersentinel123456"
+        admission = AdaptiveFanoutAdmission(ceiling=2)
+        admission.observe(
+            sensitive_unit_id,
+            {"status": "completed", "exit_code": 0, "process_succeeded": True},
+        )
+
+        receipt = admission.receipt()
+
+        self.assertEqual(receipt["adjustments"][0]["unit_id"], "[redacted]")
+        self.assertNotIn(sensitive_unit_id, str(receipt))
+
     def test_receipt_bounds_provider_pressure_and_recovered_retry_adjustments(self) -> None:
         from omh.coding.fanout_admission import AdaptiveFanoutAdmission
 

--- a/tests/test_fanout_admission.py
+++ b/tests/test_fanout_admission.py
@@ -202,5 +202,148 @@ class AdaptiveAdmissionReceiptTests(unittest.TestCase):
         self.assertIn("not provider quota truth", receipt["claim_boundary"])
 
 
+class _RetryControlledRunner:
+    def __init__(self, pressure_unit: str) -> None:
+        self.pressure_unit = pressure_unit
+        self.attempts: dict[str, int] = {}
+        self.started: list[tuple[str, int]] = []
+        self._released: set[tuple[str, int]] = set()
+        self._release_future = False
+        self._condition = threading.Condition()
+
+    def __call__(self, argv, **kwargs):
+        if argv[0] == "git":
+            return subprocess.run(argv, **kwargs)
+        unit_id = Path(str(kwargs["cwd"])).name.rsplit("-fanout-", 1)[-1]
+        with self._condition:
+            attempt = self.attempts.get(unit_id, 0) + 1
+            self.attempts[unit_id] = attempt
+            key = (unit_id, attempt)
+            self.started.append(key)
+            self._condition.notify_all()
+            released = self._condition.wait_for(
+                lambda: self._release_future or key in self._released,
+                timeout=5,
+            )
+        if not released:
+            raise AssertionError(f"timed out waiting to release {key}")
+        if key == (self.pressure_unit, 1):
+            return _FakeLimitCompleted()
+        return _FakeCompleted()
+
+    def wait_for_distinct_units(self, count: int, timeout: float = 2.0) -> bool:
+        with self._condition:
+            return self._condition.wait_for(
+                lambda: len({unit_id for unit_id, _attempt in self.started}) >= count,
+                timeout=timeout,
+            )
+
+    def wait_for_attempt(self, unit_id: str, attempt: int, timeout: float = 2.0) -> bool:
+        with self._condition:
+            return self._condition.wait_for(
+                lambda: (unit_id, attempt) in self.started,
+                timeout=timeout,
+            )
+
+    def release(self, unit_id: str, attempt: int = 1) -> None:
+        with self._condition:
+            self._released.add((unit_id, attempt))
+            self._condition.notify_all()
+
+    def release_all(self) -> None:
+        with self._condition:
+            self._release_future = True
+            self._condition.notify_all()
+
+
+class _FakeLimitCompleted:
+    returncode = 1
+    stdout = "Error: You have hit your usage limit. Try again later."
+    stderr = ""
+
+
+class FanoutRecoveredPressureIntegrationTests(unittest.TestCase):
+    def test_recovered_limit_pressure_reduces_admission_before_the_next_queued_unit(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            repo = root / "repo"
+            repo.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+            (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+            subprocess.run(["git", "add", "seed.txt"], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "init"],
+                cwd=repo,
+                check=True,
+            )
+            base_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            unit_ids = ["a-clean", "b-pressure", "c-hold", "d-hold", "e-later", "f-later"]
+            units = [
+                {
+                    "unit_id": unit_id,
+                    "title": unit_id,
+                    "owner": "codex",
+                    "file_scope": [f"src/{unit_id}/"],
+                }
+                for unit_id in unit_ids
+            ]
+            contract = write_fanout_contract(
+                paths,
+                build_fanout_contract(
+                    _GOAL,
+                    units,
+                    spawn_plan={
+                        "why_parallel": "The six file scopes are independent.",
+                        "why_not_single_unit": "The admission boundary requires a queued frontier.",
+                        "independence": "No fixture unit depends on another.",
+                        "expected_evidence_shape": "One process result per unit plus one retry.",
+                    },
+                ),
+            )
+            runner = _RetryControlledRunner("b-pressure")
+
+            with ThreadPoolExecutor(max_workers=1) as caller:
+                future = caller.submit(
+                    dispatch_fanout,
+                    paths,
+                    contract,
+                    goal_text=_GOAL,
+                    repo_root=repo,
+                    base_sha=base_sha,
+                    concurrency=4,
+                    adaptive_concurrency=True,
+                    max_retries=1,
+                    rng=lambda: 0.0,
+                    sleep=lambda _seconds: None,
+                    runner=runner,
+                    readiness=_ready,
+                )
+                self.assertTrue(runner.wait_for_distinct_units(2))
+                runner.release("a-clean")
+                self.assertTrue(runner.wait_for_distinct_units(4))
+                runner.release("b-pressure")
+                self.assertTrue(runner.wait_for_attempt("b-pressure", 2))
+                runner.release("b-pressure", 2)
+                self.assertFalse(runner.wait_for_distinct_units(5, timeout=0.2))
+                runner.release_all()
+                summary = future.result(timeout=5)
+
+        pressure = next(
+            row
+            for row in summary["adaptive_admission"]["adjustments"]
+            if row["unit_id"] == "b-pressure"
+        )
+        self.assertEqual(pressure["status_class"], "provider_limit_pressure")
+        self.assertEqual((pressure["window_before"], pressure["window_after"]), (3, 1))
+        self.assertEqual(runner.attempts["b-pressure"], 2)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_fanout_admission.py
+++ b/tests/test_fanout_admission.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+import subprocess
+from tempfile import TemporaryDirectory
+import threading
+import unittest
+
+from omh.coding.fanout import build_fanout_contract
+from omh.coding.fanout_artifacts import write_fanout_contract
+from omh.coding.fanout_dispatch import dispatch_fanout
+from omh.system.paths import OmhPaths
+
+_GOAL = "admit a ready frontier through an adaptive window"
+
+
+class _FakeCompleted:
+    returncode = 0
+    stdout = "done"
+    stderr = ""
+
+
+class _ControlledRunner:
+    def __init__(self) -> None:
+        self.started: list[str] = []
+        self.active = 0
+        self.max_active = 0
+        self._released: set[str] = set()
+        self._release_future = False
+        self._condition = threading.Condition()
+
+    def __call__(self, argv, **kwargs):
+        if argv[0] == "git":
+            return subprocess.run(argv, **kwargs)
+        unit_id = Path(str(kwargs["cwd"])).name.rsplit("-fanout-", 1)[-1]
+        with self._condition:
+            self.started.append(unit_id)
+            self.active += 1
+            self.max_active = max(self.max_active, self.active)
+            self._condition.notify_all()
+            released = self._condition.wait_for(
+                lambda: self._release_future or unit_id in self._released,
+                timeout=5,
+            )
+            self.active -= 1
+            self._condition.notify_all()
+        if not released:
+            raise AssertionError(f"timed out waiting to release {unit_id}")
+        return _FakeCompleted()
+
+    def wait_for_started(self, count: int, timeout: float = 2.0) -> bool:
+        with self._condition:
+            return self._condition.wait_for(
+                lambda: len(set(self.started)) >= count,
+                timeout=timeout,
+            )
+
+    def release(self, unit_id: str) -> None:
+        with self._condition:
+            self._released.add(unit_id)
+            self._condition.notify_all()
+
+    def release_all(self) -> None:
+        with self._condition:
+            self._release_future = True
+            self._condition.notify_all()
+
+
+def _ready(paths, profile, **kwargs):
+    return {"status": "ready", "profile": profile}
+
+
+class FanoutAdaptiveSchedulerTests(unittest.TestCase):
+    def test_adaptive_scheduler_starts_at_two_then_grows_after_a_clean_completion(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            repo = root / "repo"
+            repo.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+            (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+            subprocess.run(["git", "add", "seed.txt"], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "init"],
+                cwd=repo,
+                check=True,
+            )
+            base_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            units = [
+                {
+                    "unit_id": f"unit-{index}",
+                    "title": f"Unit {index}",
+                    "owner": "codex",
+                    "file_scope": [f"src/unit-{index}/"],
+                }
+                for index in range(4)
+            ]
+            contract = write_fanout_contract(
+                paths,
+                build_fanout_contract(_GOAL, units),
+            )
+            runner = _ControlledRunner()
+
+            with ThreadPoolExecutor(max_workers=1) as caller:
+                future = caller.submit(
+                    dispatch_fanout,
+                    paths,
+                    contract,
+                    goal_text=_GOAL,
+                    repo_root=repo,
+                    base_sha=base_sha,
+                    concurrency=4,
+                    adaptive_concurrency=True,
+                    runner=runner,
+                    readiness=_ready,
+                )
+                if not runner.wait_for_started(2):
+                    future.result(timeout=0)
+                    self.fail("adaptive dispatch did not admit its initial window")
+                self.assertFalse(runner.wait_for_started(3, timeout=0.2))
+                runner.release(runner.started[0])
+                self.assertTrue(runner.wait_for_started(4))
+                runner.release_all()
+                summary = future.result(timeout=5)
+
+        self.assertEqual(runner.max_active, 3)
+        self.assertTrue(all(unit["status"] == "completed" for unit in summary["units"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fanout_admission.py
+++ b/tests/test_fanout_admission.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 import subprocess
+import sys
 from tempfile import TemporaryDirectory
 import threading
 import unittest
@@ -404,6 +405,49 @@ class AdaptiveAdmissionDryRunTests(unittest.TestCase):
         self.assertEqual(receipt["final_window"], receipt["initial_window"])
         self.assertEqual(runner.started, [])
         self.assertIn("Dry-run plans are not observed execution", receipt["claim_boundary"])
+
+
+class AdaptiveAdmissionCliTests(unittest.TestCase):
+    def test_dispatch_help_and_parser_expose_the_opt_in_ceiling_semantics(self) -> None:
+        from omh.commands.main import build_parser
+
+        help_result = subprocess.run(
+            [sys.executable, "-m", "omh.cli", "coding", "fanout", "dispatch", "--help"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(help_result.returncode, 0, help_result.stderr)
+        self.assertIn("--adaptive-concurrency", help_result.stdout)
+        self.assertIn("--concurrency ceiling", help_result.stdout)
+        self.assertIn("provider-limit pressure", help_result.stdout)
+        self.assertIn("recovered retries", help_result.stdout)
+        args = build_parser().parse_args(
+            [
+                "coding",
+                "fanout",
+                "dispatch",
+                "fanout-0123456789ab",
+                "--goal-file",
+                "goal.txt",
+                "--concurrency",
+                "6",
+                "--adaptive-concurrency",
+            ]
+        )
+        default_args = build_parser().parse_args(
+            [
+                "coding",
+                "fanout",
+                "dispatch",
+                "fanout-0123456789ab",
+                "--goal-file",
+                "goal.txt",
+            ]
+        )
+        self.assertTrue(args.adaptive_concurrency)
+        self.assertFalse(default_args.adaptive_concurrency)
 
 
 if __name__ == "__main__":

--- a/tests/test_fanout_admission.py
+++ b/tests/test_fanout_admission.py
@@ -134,5 +134,73 @@ class FanoutAdaptiveSchedulerTests(unittest.TestCase):
         self.assertTrue(all(unit["status"] == "completed" for unit in summary["units"]))
 
 
+class AdaptiveAdmissionReceiptTests(unittest.TestCase):
+    def test_receipt_bounds_provider_pressure_and_recovered_retry_adjustments(self) -> None:
+        from omh.coding.fanout_admission import AdaptiveFanoutAdmission
+
+        admission = AdaptiveFanoutAdmission(ceiling=4)
+        admission.observe(
+            "clean",
+            {"status": "completed", "exit_code": 0, "process_succeeded": True},
+        )
+        admission.observe(
+            "recovered-limit",
+            {
+                "status": "completed",
+                "exit_code": 0,
+                "process_succeeded": True,
+                "retry": {
+                    "decisions": [
+                        {"failure_class": "transient_provider_limit", "decision": "retrying"}
+                    ]
+                },
+            },
+        )
+        for index, failure_kind in enumerate(
+            ("auth_shaped", "timeout", "binary_missing", "crash")
+        ):
+            admission.observe(
+                f"other-{index}",
+                {"status": "failed", "exit_code": 1, "failure_kind": failure_kind},
+            )
+        admission.observe(
+            "transport",
+            {
+                "status": "failed",
+                "exit_code": 1,
+                "failure_kind": "crash",
+                "retry": {"decisions": [{"failure_class": "transient_transport"}]},
+            },
+        )
+        for index in range(40):
+            admission.observe(
+                f"clean-{index}",
+                {"status": "completed", "exit_code": 0, "process_succeeded": True},
+            )
+            admission.observe(
+                f"limit-{index}",
+                {"status": "failed", "exit_code": 1, "failure_kind": "limit_shaped"},
+            )
+
+        receipt = admission.receipt()
+
+        self.assertEqual(receipt["schema_version"], "fanout_admission/v1")
+        self.assertEqual(receipt["mode"], "adaptive")
+        self.assertTrue(receipt["requested"])
+        self.assertEqual(receipt["initial_window"], 2)
+        self.assertEqual(receipt["ceiling"], 4)
+        self.assertEqual(receipt["minimum_window"], 1)
+        self.assertEqual(receipt["observed_provider_pressure_count"], 41)
+        recovered = next(
+            row for row in receipt["adjustments"] if row["unit_id"] == "recovered-limit"
+        )
+        self.assertEqual(recovered["status_class"], "provider_limit_pressure")
+        self.assertEqual((recovered["window_before"], recovered["window_after"]), (3, 1))
+        self.assertLessEqual(len(receipt["adjustments"]), 32)
+        self.assertGreater(receipt["adjustments_omitted"], 0)
+        self.assertNotIn("raw_output", str(receipt))
+        self.assertIn("not provider quota truth", receipt["claim_boundary"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_fanout_admission.py
+++ b/tests/test_fanout_admission.py
@@ -431,6 +431,51 @@ class FanoutInterruptedAdmissionTests(unittest.TestCase):
         self.assertEqual(receipt["adjustment_count"], 1)
 
 
+class AdaptiveAdmissionRecursionRefusalTests(unittest.TestCase):
+    def test_adaptive_recursion_refusal_carries_an_unobserved_receipt(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            receipts = []
+
+            with patch(
+                "omh.coding.fanout_dispatch._owner_skill_discoveries",
+                side_effect=AssertionError("depth refusal must not run discovery"),
+            ):
+                for dry_run in (False, True):
+                    summary = dispatch_fanout(
+                        paths,
+                        {"fanout_id": "fanout-depth-refusal"},
+                        goal_text="must not be validated",
+                        repo_root=root / "missing-repo",
+                        base_sha="unobserved",
+                        concurrency=4,
+                        adaptive_concurrency=True,
+                        dry_run=dry_run,
+                        max_depth=1,
+                        env={"OMH_FANOUT_DEPTH": "1"},
+                        runner=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                            AssertionError("depth refusal must not spawn")
+                        ),
+                        readiness=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                            AssertionError("depth refusal must not probe readiness")
+                        ),
+                    )
+                    self.assertTrue(summary["refused"])
+                    self.assertEqual(summary["refusal_reason"], "fanout_depth_exceeded")
+                    receipts.append(summary.get("adaptive_admission"))
+
+        for receipt in receipts:
+            self.assertIsInstance(receipt, dict)
+            self.assertEqual(receipt["schema_version"], "fanout_admission/v1")
+            self.assertEqual(receipt["observed_completion_count"], 0)
+            self.assertEqual(receipt["adjustments"], [])
+        self.assertEqual(
+            [receipt["observation_status"] for receipt in receipts],
+            ["no_observed_unit_results", "not_observed_dry_run"],
+        )
+
+
 class AdaptiveAdmissionDryRunTests(unittest.TestCase):
     def test_dry_run_receipt_makes_no_observed_execution_or_pressure_claim(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Feature Report

### What Changed

- Added an opt-in adaptive admission window to the explicit local fanout dispatch bridge.
- Kept the existing fixed-width scheduler as the default.
- Added a bounded `fanout_admission/v1` receipt that records only local scheduling reactions to observed unit-process results.
- Kept interruption and recursion-depth refusal summaries evidence-honest, and redacted secret-shaped unit identifiers before they enter adjustment receipts.

### Why This Exists

A fixed submission width can keep admitting new work while one provider is already returning limit-shaped failures. The dispatcher already classifies those failures and retries replay-safe units, but it did not use that signal to reduce new admissions. This change lets an operator opt into a bounded AIMD-style window without changing existing fanout behavior for everyone else.

### User / Operator Impact

- Operators can pass `--adaptive-concurrency` to `omh coding fanout dispatch`.
- The resolved `--concurrency` value becomes the ceiling rather than a permanently full submission width.
- The window starts at two, increases after clean observed completions, and halves after provider-limit pressure, including a recovered retry.
- Already-running units are never cancelled by a downshift.

### How It Works

- `AdaptiveFanoutAdmission` owns the in-memory window and bounded adjustment receipt.
- The dependency-ready scheduler admits only the number of new units allowed by the current window.
- Completed unit results feed the controller after existing retry handling, so recovered provider-limit attempts still cause a downshift.
- Dry runs never update the window or claim observed execution.
- Interruption cleanup observes each collected process result exactly once; canceled or unavailable futures do not fabricate observations.
- An adaptive recursion-depth refusal still returns a zero-observation receipt without crossing the no-spawn guard.

### Files And Contracts Touched

- Fanout dispatcher scheduling and CLI wiring.
- New `fanout_admission/v1` metadata receipt.
- Fanout operator documentation.
- Unit, integration, interruption, recursion-refusal, dry-run, receipt-boundary, and CLI regression coverage.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

This is executor-neutral scheduler behavior in the explicit fanout bridge. The provider-pressure classification is derived from existing local unit results; OMH does not call a provider API.

## Validation

Check only commands that completed successfully. Leave non-applicable checks unchecked and explain why under **Not Tested / Not Applicable**.

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli release checklist --json`
- [x] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [x] `omh --help`
- [x] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli coding fanout dispatch --help`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not applicable; no Hermes chat/TUI surface changed.

### Observed Evidence

- `PYTHONPATH=tests uv run python -m unittest tests.test_fanout_admission -v` — 8 tests passed.
- `PYTHONPATH=tests uv run python -m unittest tests.test_fanout_dispatch tests.test_parallelism_policy tests.test_fanout_signal_safety -v` — 185 tests passed.
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` with the CI-pinned Bun 1.3.14 on `PATH` — 8,742 tests passed with one existing platform skip.
- Full Ruff over `src tests tools packaging`, compileall, all five generated-doc checks, harness validation, release checklist/smoke, isolated install/probe/installed-command smoke, cleanup, and diff hygiene passed on `728c27651d61e55db6af3da253b502a30558bdad`.
- `uv run python -m compileall -q src tests` — passed.
- Affected-file Ruff check — passed.
- CLI help smoke verified the opt-in flag and ceiling/pressure/recovered-retry language.
- Round-one correctness and trust-boundary reviews found three blocking receipt defects; each was fixed through an independent RED-to-GREEN cycle.
- Two independent round-two ratchet reviews on the final revision returned no findings, `ship`, and safety `PASS`.

### Not Tested / Not Applicable

- Live provider quota behavior: the receipt intentionally reacts to existing local result classification and does not claim provider quota truth.
- Live external executor dispatch: focused tests exercise the real dispatcher with controlled local runners; no provider workload was launched for this scheduler change.
- Manual Hermes chat/TUI behavior was not tested because this change only affects the explicit operator-invoked local fanout dispatch bridge.
- Workflow-learning review queue smoke was not applicable because no learning or routing contracts changed.

## Risk

- Adaptive mode can temporarily underutilize capacity after a limit-shaped result; recovery is bounded additive growth.
- Result classification remains the source of pressure signals. The receipt explicitly describes that signal as local scheduling evidence rather than provider quota truth.
- Static scheduling remains the default and preserves prior behavior.

## Compatibility / Rollout

- Opt-in only; existing commands without `--adaptive-concurrency` retain fixed-width behavior.
- No schema or dependency migration is required.
- No runtime dependency or network call was added.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Observe the bounded admission receipt in real operator workloads before changing any default concurrency policy.
- This PR does not implement provider quota discovery or a global cross-dispatch controller.
