### PR TITLE
feat(benchmarks): manifest-aware analysis for targeted family runs

### DIFF
--- a/benchmarks/live-model-tools/v1/analyze.py
+++ b/benchmarks/live-model-tools/v1/analyze.py
@@ -8,7 +8,7 @@ from common import load_object, write_json
 from statistics import analyze
 
 def main(argv=None):
- p=argparse.ArgumentParser(); p.add_argument("--baseline",type=Path,required=True); p.add_argument("--optimized",type=Path,required=True); p.add_argument("--bootstrap-repetitions",type=int,default=10000); p.add_argument("--seed",type=int,default=20260813); p.add_argument("--output",type=Path,required=True); a=p.parse_args(argv)
+ p=argparse.ArgumentParser(); p.add_argument("--baseline",type=Path,required=True); p.add_argument("--optimized",type=Path,required=True); p.add_argument("--bootstrap-repetitions",type=int,default=10000); p.add_argument("--seed",type=int,default=20260813); p.add_argument("--manifest",type=Path,default=BASE/"manifest.json"); p.add_argument("--output",type=Path,required=True); a=p.parse_args(argv)
  if a.bootstrap_repetitions<100: p.error("bootstrap repetitions must be at least 100")
- report=analyze(a.baseline,a.optimized,a.bootstrap_repetitions,a.seed,load_object(BASE/"manifest.json")); write_json(a.output,report); print(json.dumps(report,sort_keys=True,indent=2)); return 0
+ report=analyze(a.baseline,a.optimized,a.bootstrap_repetitions,a.seed,load_object(a.manifest)); write_json(a.output,report); print(json.dumps(report,sort_keys=True,indent=2)); return 0
 if __name__=="__main__": raise SystemExit(main())

--- a/benchmarks/live-model-tools/v1/tests/test_framework.py
+++ b/benchmarks/live-model-tools/v1/tests/test_framework.py
@@ -245,5 +245,150 @@ class OmhBenchmarkFrameworkTests(unittest.TestCase):
                 analyze(baseline, optimized, 10, 7, manifest)
 
 
+class OmhTargetedManifestAnalysisTests(unittest.TestCase):
+    """Issue #1056 step-0: targeted family manifests must flow end-to-end.
+
+    bench.py run accepts --manifest, but the analyze.py CLI used to reload the
+    canonical manifest directly, so a targeted manifest (for example, one live
+    solar family entry) could run but never pass the analysis coverage check.
+    These tests pin the CLI contract: --manifest selects the manifest used for
+    analysis coverage, defaults stay canonical, and mismatched manifests still
+    fail loudly.
+    """
+
+    def _run_cli(self, args):
+        return subprocess.run(
+            [sys.executable, str(BASE / "analyze.py"), *args],
+            capture_output=True,
+            text=True,
+        )
+
+    def _live_manifest(self):
+        manifest = json.loads((BASE / "manifest.json").read_text())
+        manifest["models"] = [m for m in manifest["models"] if m.get("live")][:1]
+        return manifest
+
+    def _evaluation_rows(self, manifest, condition):
+        import corpus
+
+        model = next(m for m in manifest["models"] if m.get("live"))
+        rows = []
+        for template, _task_class in corpus.TEMPLATES:
+            for seed in corpus.EVALUATION_SEEDS:
+                rows.append(
+                    {
+                        "schema_version": "omh_live_model_tool_run/v1",
+                        "created_at": "2026-08-13T00:00:00+00:00",
+                        "instance_id": f"E-{template}-{seed}",
+                        "split": "evaluation",
+                        "harness": "omh",
+                        "model": {"provider": model["provider"], "id": model["id"]},
+                        "task_digest": "a" * 64,
+                        "route": {},
+                        "observation": {
+                            "status": "completed",
+                            "tools": 1,
+                            "tokens": 1,
+                            "cost_usd": 0.0,
+                        },
+                        "grade": {"pass": True},
+                        "final_tree_digest": "b" * 64,
+                        "condition": condition,
+                    }
+                )
+        return rows
+
+    def test_targeted_manifest_cli_analyze_end_to_end(self) -> None:
+        manifest = self._live_manifest()
+        with TemporaryDirectory() as root:
+            root_path = Path(root)
+            manifest_path = root_path / "manifest.json"
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+            baseline = root_path / "baseline.jsonl"
+            optimized = root_path / "optimized.jsonl"
+            for condition, output in (("baseline", baseline), ("optimized", optimized)):
+                rows = self._evaluation_rows(manifest, condition)
+                output.write_text(
+                    "".join(json.dumps(row) + chr(10) for row in rows),
+                    encoding="utf-8",
+                )
+            result = self._run_cli(
+                [
+                    "--baseline", str(baseline),
+                    "--optimized", str(optimized),
+                    "--manifest", str(manifest_path),
+                    "--bootstrap-repetitions", "100",
+                    "--seed", "7",
+                    "--output", str(root_path / "report.json"),
+                ]
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            report = json.loads((root_path / "report.json").read_text())
+            model = next(m for m in manifest["models"] if m.get("live"))
+            label = f"{model['provider']}/{model['id']}"
+            self.assertIn(label, report["models"])
+            self.assertEqual(
+                report["models"][label]["n"],
+                len(self._evaluation_rows(manifest, "baseline")),
+            )
+
+    def test_targeted_manifest_cli_rejects_mismatched_manifest(self) -> None:
+        manifest = self._live_manifest()
+        excluded = manifest["models"][0]
+        other = self._live_manifest()
+        other["models"] = [
+            m
+            for m in other["models"]
+            if (m["provider"], m["id"]) != (excluded["provider"], excluded["id"])
+        ]
+        with TemporaryDirectory() as root:
+            root_path = Path(root)
+            other_path = root_path / "other.json"
+            other_path.write_text(json.dumps(other), encoding="utf-8")
+            baseline = root_path / "baseline.jsonl"
+            baseline.write_text(
+                "".join(
+                    json.dumps(row) + chr(10)
+                    for row in self._evaluation_rows(manifest, "baseline")
+                ),
+                encoding="utf-8",
+            )
+            result = self._run_cli(
+                [
+                    "--baseline", str(baseline),
+                    "--optimized", str(baseline),
+                    "--manifest", str(other_path),
+                    "--bootstrap-repetitions", "100",
+                    "--output", str(root_path / "report.json"),
+                ]
+            )
+            self.assertNotEqual(result.returncode, 0)
+
+    def test_cli_analyze_defaults_to_canonical_manifest(self) -> None:
+        manifest = self._live_manifest()
+        with TemporaryDirectory() as root:
+            root_path = Path(root)
+            baseline = root_path / "baseline.jsonl"
+            baseline.write_text(
+                "".join(
+                    json.dumps(row) + chr(10)
+                    for row in self._evaluation_rows(manifest, "baseline")
+                ),
+                encoding="utf-8",
+            )
+            result = self._run_cli(
+                [
+                    "--baseline", str(baseline),
+                    "--optimized", str(baseline),
+                    "--bootstrap-repetitions", "100",
+                    "--output", str(root_path / "report.json"),
+                ]
+            )
+            # One targeted live model against the canonical manifest violates
+            # the canonical matrix check: the old failure mode, still intact.
+            self.assertNotEqual(result.returncode, 0)
+
+
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
## Feature Report

### What Changed

- `benchmarks/live-model-tools/v1/analyze.py` now accepts `--manifest <path>`, defaulting to the canonical `manifest.json`, and forwards the selected manifest object to `statistics.analyze(...)`.

### Why This Exists

- Issue #1056 defines a targeted-manifest path for family-calibration contributors (`bench.py run --manifest <targeted.json>`), but the analysis CLI reloaded the canonical manifest directly, so the analysis coverage check (`live manifest matrix`) could never pass for a targeted family run. The harness could run but not produce an auditable analysis report.

### User / Operator Impact

- Operators validating one family (the guide's path for mistral/llama/codestral/solar contributors) can now analyze their targeted run artifacts with the same manifest they ran, end to end, without touching the canonical manifest or its coverage contract.

### How It Works

- The CLI previously hard-coded `load_object(BASE / "manifest.json")`; it now resolves `--manifest` (default unchanged) and passes the parsed object to `statistics.analyze`, which was already manifest-relative. Coverage, digest-pairing, split, and instance checks are unchanged; a targeted manifest simply defines its own live matrix.

### Files And Contracts Touched

- `benchmarks/live-model-tools/v1/analyze.py` (CLI `--manifest` flag)
- `benchmarks/live-model-tools/v1/tests/test_framework.py` (new `OmhTargetedManifestAnalysisTests`)

### Affected Surfaces

- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` (8,867 tests, OK, 22 skips; benchmark suite 15/15)
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check` (177/177 skills, no stale)

Sabotage check: the new end-to-end test fails against the pre-change CLI (`unrecognized arguments: --manifest`) and passes with the fix.

**Not Tested / Not Applicable:** paid live model runs were intentionally not executed for this PR — it is harness-only (issue thread scope from the Aug 30 guide, step 0). Family calibration runs with observed evidence land in follow-up PRs per the one-family-per-PR guidance.

Refs #1056
