### PR TITLE
test(media): stamp the primary-handoff fixture at test time

### DIFF
--- a/tests/test_media_handoff_capabilities.py
+++ b/tests/test_media_handoff_capabilities.py
@@ -6,6 +6,7 @@ from tempfile import TemporaryDirectory
 import unittest
 
 from omh.coding.coding_delegation import build_coding_delegation_payload
+from omh.local_store import utc_now
 from omh.coding.executor_capability_snapshots import (
     build_executor_capability_snapshot,
     complete_executor_capability_snapshot,
@@ -59,6 +60,10 @@ def _primary_handoff_decision(
     transformation: dict[str, str] | None = None,
     recommendation: dict[str, object] | None = None,
 ) -> dict[str, object]:
+    # The delegation payload judges freshness against the real clock (it has
+    # no `now` seam), so the fixture must be stamped at test time: a fixed
+    # date crossed the 24-hour evidence horizon the day after it was written.
+    stamp = utc_now()
     with TemporaryDirectory() as temporary:
         directory = Path(temporary)
         snapshot = build_executor_capability_snapshot(
@@ -68,10 +73,10 @@ def _primary_handoff_decision(
                     "status": "host_observed",
                     "scope": scope or _ROUTE,
                     "evidence_ref": "operator:primary-handoff-fixture",
-                    "observed_at": "2026-09-03T00:00:00Z",
+                    "observed_at": stamp,
                 }
             },
-            recorded_at="2026-09-03T00:00:00Z",
+            recorded_at=stamp,
         )
         write_executor_capability_snapshot(
             executor_capability_snapshot_path(directory, "codex"),


### PR DESCRIPTION
## Feature Report

### What Changed

- `tests/test_media_handoff_capabilities.py`: the `_primary_handoff_decision` fixture stamps `observed_at` / `recorded_at` with `utc_now()` at test time instead of the fixed `2026-09-03T00:00:00Z`.

### Why This Exists

- `test_primary_handoff_binds_fresh_media_evidence_to_its_selected_route` fails on `main` (b10851e5) since 2026-09-04: `build_coding_delegation_payload` judges media-evidence freshness against the real clock (no `now` seam), and the fixed stamp crossed the 24-hour `CAPABILITY_EVIDENCE_STALE_AFTER_SECONDS` horizon the day after #1301 merged. Every PR's CI is red on it until this lands.

### User / Operator Impact

- None at runtime; test-only.

### How It Works

- The fixture is what asserts "fresh", so it is stamped fresh. The decision-level tests in the same module keep their explicit `now="2026-09-03T01:00:00Z"` and remain deterministic.

### Files And Contracts Touched

- `tests/test_media_handoff_capabilities.py`

### Affected Surfaces

- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests` (module)
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_media_handoff_capabilities.py` — 7/7
- [x] `git diff --check`
- [ ] Full suite, byte gates, smoke commands — not run locally; one test module changed, PR CI runs the full suite.

### Observed Evidence

- Before: the named test fails on `origin/main` with `'modality_unknown' != 'dispatch'`. After: 7/7 pass.

### Not Tested / Not Applicable

- No runtime surface changed.

## Risk

- None beyond the test; a seam in production code was deliberately not added.

## Compatibility / Rollout

- n/a

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- #1307 rebases onto this once merged so its CI can go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019b8yXELjdWBnnMTFsR7es2
