### PR TITLE
feat(todo): the plan todo belongs to the session that declared it

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -108,13 +108,21 @@ active to stale to expired; they never prove results.
 _Avoid_: process handle, job
 
 **Plan todo**:
-The declared checklist at `$OMH_HOME/runtime/todo.json` that HUD surfaces
-render above the Hermes prompt input. Items are plan declarations; a done mark
-never upgrades into observed evidence. The artifact is global to the OMH home
-but the panel is scoped to the session that declared the plan: a record
-stamped with `session_ref` renders only for the live Hermes TUI session that
-owns it, an unstamped record is scoped by write time, and a host that cannot
-say which session is live keeps the age-only behavior.
+The declared checklist HUD surfaces render above the Hermes prompt input.
+Items are plan declarations; a done mark never upgrades into observed
+evidence. One record per declaring session: a plan stamped with `session_ref`
+lives at `$OMH_HOME/runtime/todos/<session key>.json` and renders only for
+the session that owns it — the TUI widget names its own session from the
+host's active-session file, the plugin tool and hooks from the session that
+invoked them — so a plan declared from Slack, Discord, or a second TUI is
+neither shown in nor overwritten by another session. An unstamped record
+(`omh runtime todo set` without `--session`) keeps the home-wide
+`$OMH_HOME/runtime/todo.json`, scoped by write time against the reading
+session's start; a reader with no live TUI row to date it against (a gateway
+session), or a host that cannot say which session is reading, keeps the
+age-only behavior. A widget reference that names no live TUI row and owns no
+record — a fresh session's transport id — reads as the most recently active
+live TUI would.
 _Avoid_: task list as evidence, TodoWrite (that is another product's tool name)
 
 ### Coding delegation

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -968,24 +968,44 @@ does not load TUI widget files, so this panel is a modern-TUI-only surface.
 merge evidence; an all-done list collapses to a single header line and a list
 untouched for 24 hours is hidden as stale.
 
-The panel is also scoped to the session that declared the plan. One OMH home
-holds one todo list, so without that scope an unfinished checklist from an
-earlier session — or one another live session is writing to the same OMH home
-right now — renders in every session, as state the reader never created. When
-Hermes declares a plan through `omh_todo` it stamps the record with its own
-session id, and the HUD projects the plan only for the live Hermes TUI session
-that owns it; a plan belonging to another session reads as stale and is not
-rendered. Records written without a session id — `omh runtime todo set`, or
-anything predating the field — are scoped by write time instead: a plan
-written before the live session started belongs to an earlier one.
+The panel belongs to the session that declared the plan. When Hermes
+declares a plan through `omh_todo`, the record is stored for that session
+(`$OMH_HOME/runtime/todos/<session key>.json`) and read back only for it: the
+modern TUI widget names its own session from the host's active-session file
+on every poll, and the plugin tools (`omh_todo`, `omh_hud`) and the pre-LLM
+reminder name the session Hermes dispatched them for — never one named in
+tool arguments, so a model cannot address another session's record. A plan declared from a Slack or Discord gateway session,
+or from a second TUI open at the same time, is its own record, so it neither
+renders in another session's panel nor overwrites that session's checklist.
+Per-session records are pruned on write once they pass the 24-hour stale
+bound; nothing else in that directory is touched. `omh runtime todo set|clear|show --session
+<id>` addresses one session's record from the command line.
 
-The scope only applies where the host can answer it. With no
-`$HERMES_HOME/state.db`, an unreadable one, or no live TUI session recorded in
-it, the projection keeps the age-only behavior above and shows the plan, since
-hiding a legitimately current checklist on missing evidence is the worse
-failure. Two TUI sessions live at once share one panel answer — the most
-recently active session owns it, and the other session's plan returns as soon
-as that session is used again.
+Records written without a session id — `omh runtime todo set` with no
+`--session`, or anything predating the field — are the home-wide
+`$OMH_HOME/runtime/todo.json`, scoped by write time instead: a plan written
+before the reading session started belongs to an earlier one and reads as
+stale. That fallback only applies where the host can answer it. With no
+`$HERMES_HOME/state.db`, an unreadable one, no live TUI session recorded in
+it, or a reading session it does not list as a TUI (a gateway session has no
+row to date the record against), the projection keeps the age-only behavior
+above and shows the plan, since hiding a legitimately current checklist on
+missing evidence is the worse failure. The widget's identity likewise needs
+a host that sets `HERMES_TUI_ACTIVE_SESSION_FILE` for the TUI process; on a
+Hermes that does not, the widget carries no identity and the panel answers
+for the most recently active live TUI session, as it did before.
+
+The widget's own identity has one known alias. After a resume or session
+switch the host's active-session file holds the durable session key; on a
+freshly created session it holds the gateway's transport id, which no record
+and no `state.db` row carries. The reader treats a widget reference that
+names no live TUI row and owns no record as that case and answers as an
+identity-less poll would — the most recently active live TUI session — so a
+fresh TUI still renders the plan it declares. Two TUIs both freshly created
+and not yet resumed therefore still share that answer — the pre-existing
+most-recently-active rule — until each is resumed or switched and the file
+carries its durable key; the plugin tools and the reminder are unaffected
+because Hermes dispatches them with the durable key.
 
 #### Status model: no-run, prepared-handoff, observed-run
 

--- a/src/commands/runtime.py
+++ b/src/commands/runtime.py
@@ -1249,8 +1249,9 @@ def cmd_runtime_todo_set(args: argparse.Namespace) -> int:
             return 1
     else:
         items = [{"text": text, "state": "pending"} for text in args.items]
+    session_ref = args.session_ref
     try:
-        record = build_todo_record(args.title, items, source="cli")
+        record = build_todo_record(args.title, items, source="cli", session_ref=session_ref)
         write_todo(paths.omh_home, record)
     except (TodoValidationError, TodoStoreError) as error:
         _print_json({"status": "invalid_todo", "error": str(error)})
@@ -1258,8 +1259,8 @@ def cmd_runtime_todo_set(args: argparse.Namespace) -> int:
     _print_json(
         {
             "status": "written",
-            "path": str(todo_path(paths.omh_home)),
-            "todo": build_hud_payload(paths)["todo"],
+            "path": str(todo_path(paths.omh_home, session_ref)),
+            "todo": build_hud_payload(paths, session_ref=session_ref)["todo"],
             "claim_boundary": TODO_CLAIM_BOUNDARY,
         }
     )
@@ -1268,17 +1269,23 @@ def cmd_runtime_todo_set(args: argparse.Namespace) -> int:
 
 def cmd_runtime_todo_clear(args: argparse.Namespace) -> int:
     paths = _paths(args)
+    session_ref = args.session_ref
     try:
-        cleared = clear_todo(paths.omh_home)
+        cleared = clear_todo(paths.omh_home, session_ref)
     except TodoStoreError as error:
         _print_json({"status": "invalid_todo", "error": str(error)})
         return 1
-    _print_json({"status": "cleared" if cleared else "already_absent", "path": str(todo_path(paths.omh_home))})
+    _print_json(
+        {
+            "status": "cleared" if cleared else "already_absent",
+            "path": str(todo_path(paths.omh_home, session_ref)),
+        }
+    )
     return 0
 
 
 def cmd_runtime_todo_show(args: argparse.Namespace) -> int:
-    payload = build_hud_payload(_paths(args))
+    payload = build_hud_payload(_paths(args), session_ref=args.session_ref)
     _print_json(
         {
             "status": "read",
@@ -1596,3 +1603,13 @@ def _add_runtime_commands(sub) -> None:
     todo_clear.set_defaults(func=cmd_runtime_todo_clear)
     todo_show = todo_sub.add_parser("show", help="Read the current todo projection exactly as HUD surfaces see it.")
     todo_show.set_defaults(func=cmd_runtime_todo_show)
+    for todo_command in (todo_set, todo_clear, todo_show):
+        todo_command.add_argument(
+            "--session",
+            dest="session_ref",
+            default="",
+            help=(
+                "Hermes session id the todo belongs to. Omit for the home-wide list; "
+                "show without it reads as the live TUI session would."
+            ),
+        )

--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process'
+import { readFileSync, statSync } from 'node:fs'
 
 export default function register(sdk) {
   const { Box, Text, defineWidgetApp, h, openWidget, updateWidget } = sdk
@@ -20,8 +21,35 @@ export default function register(sdk) {
     'import json,os,sys',
     "sys.path.insert(0, os.path.join(os.environ['HERMES_HOME'], 'plugins'))",
     'from omh.runtime_reader import read_omh_hud',
-    "print(json.dumps(read_omh_hud(os.environ.get('OMH_HOME'), os.environ.get('HERMES_HOME'), graph_preference=os.environ.get('OMH_SUBAGENT_GRAPH', 'auto'))))",
+    "print(json.dumps(read_omh_hud(os.environ.get('OMH_HOME'), os.environ.get('HERMES_HOME'), graph_preference=os.environ.get('OMH_SUBAGENT_GRAPH', 'auto'), tui_session_ref=os.environ.get('OMH_HUD_TUI_SESSION_REF', ''))))",
   ].join(';')
+  // This TUI's own session id. The host writes it to the file named by
+  // HERMES_TUI_ACTIVE_SESSION_FILE whenever it creates, resumes, or switches
+  // a session, and this widget runs inside that same TUI process, so the
+  // file is the one identity the poll can carry that no other TUI shares.
+  // The reader scopes the plan todo to it. After a resume or switch the
+  // file holds the durable session key; on a freshly created session it
+  // holds the gateway's transport id instead, which the reader detects
+  // (no live row, no record) and answers as an identity-less poll would.
+  // A missing, unreadable, or malformed value is passed as nothing rather
+  // than as a mutated string that would select the wrong record.
+  const ACTIVE_SESSION_FILE = process.env.HERMES_TUI_ACTIVE_SESSION_FILE || ''
+  const SESSION_REF_SHAPE = /^[\p{L}\p{N}_.:@-]{1,160}$/u
+  const ACTIVE_SESSION_FILE_MAX_BYTES = 4096
+  const activeSessionRef = () => {
+    if (!ACTIVE_SESSION_FILE) return ''
+    try {
+      // A regular, tiny file only: this runs on the TUI loop every poll, so
+      // a FIFO or a large file behind the env var must not stall it.
+      const info = statSync(ACTIVE_SESSION_FILE)
+      if (!info.isFile() || info.size > ACTIVE_SESSION_FILE_MAX_BYTES) return ''
+      const parsed = JSON.parse(readFileSync(ACTIVE_SESSION_FILE, 'utf8'))
+      const sessionId = typeof parsed?.session_id === 'string' ? parsed.session_id : ''
+      return SESSION_REF_SHAPE.test(sessionId) ? sessionId : ''
+    } catch {
+      return ''
+    }
+  }
 
   const sanitizeText = value => String(value ?? '')
     .replace(/[^\p{L}\p{N} .:/_·|+\[\]!\-]/gu, '')
@@ -125,12 +153,16 @@ export default function register(sdk) {
     return parts.join(' · ')
   }
   const readHud = () => new Promise(resolve => {
+    // Re-read per poll: /new and /resume move this TUI to another session
+    // without restarting the widget, and the todo must follow.
+    const sessionRef = activeSessionRef()
+    const env = sessionRef ? { ...READER_ENV, OMH_HUD_TUI_SESSION_REF: sessionRef } : READER_ENV
     execFile(
       __OMH_PYTHON_EXECUTABLE__,
       ['-I', '-c', READER],
       {
         encoding: 'utf8',
-        env: READER_ENV,
+        env,
         // Headroom over the payload's worst case (todo panel included) so an
         // oversized snapshot degrades to null instead of blanking the HUD.
         maxBuffer: 65536,

--- a/src/plugin_bundle/omh/hooks/llm_hooks.py
+++ b/src/plugin_bundle/omh/hooks/llm_hooks.py
@@ -191,7 +191,9 @@ def pre_llm_call(**kwargs) -> dict[str, object] | None:
     # carries the reconciliation line so a completion claim cannot part ways
     # with the HUD checklist unnoticed. Honors the caller's awareness opt-out.
     if include_awareness:
-        todo_reminder = open_todo_reminder(omh_home=str(kwargs.get("omh_home", "") or ""))
+        todo_reminder = open_todo_reminder(
+            omh_home=str(kwargs.get("omh_home", "") or ""), session_ref=session_id
+        )
         if todo_reminder:
             context_parts.append(todo_reminder)
 

--- a/src/plugin_bundle/omh/host_observation.py
+++ b/src/plugin_bundle/omh/host_observation.py
@@ -86,6 +86,19 @@ def observe_plugin_tool_call(tool_name: str, args: dict[str, Any], kwargs: dict[
     return _record_observation(metadata, event="tool_call", tool=tool_name, hook="")
 
 
+def host_session_id(kwargs: dict[str, Any]) -> str:
+    """The session the host dispatched this tool call for.
+
+    Hermes passes ``session_id`` as a keyword on every tool dispatch and no
+    ``host`` alongside it, while an observation record needs both, so a tool
+    that keeps per-session state must read the id here or it never learns
+    its session. Only the keyword counts: tool ``args`` are model-supplied,
+    and a per-session store must not let the model name another session's
+    record to read, replace, or clear.
+    """
+    return str(kwargs.get("session_id", "") or "").strip()
+
+
 def observe_plugin_hook_call(hook_name: str, kwargs: dict[str, Any]) -> dict[str, Any] | None:
     metadata = _observation_metadata({}, kwargs)
     return _record_observation(metadata, event="hook_call", tool="", hook=hook_name)

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -39,6 +39,7 @@ from .todo_store import (
     MAX_TODO_TITLE_CHARS,
     TODO_ITEM_STATES,
     TODO_SCHEMA_VERSION,
+    TODO_STALE_SECONDS,
     strip_control_characters,
     todo_path,
 )
@@ -46,7 +47,6 @@ from .todo_store import (
 STATUS_SCHEMA_VERSION = "omh_status/v1"
 HUD_SCHEMA_VERSION = "omh_hud/v1"
 HUD_PRESETS = {"minimal", "focused", "full"}
-TODO_STALE_SECONDS = 86400
 # How long a fully-done plan keeps rendering after its last update.
 ALL_DONE_TODO_LINGER_SECONDS = 15 * 60
 TODO_DISPLAY_ITEM_LIMIT = 3
@@ -752,7 +752,19 @@ def read_omh_hud(
     token_metadata: dict[str, Any] | None = None,
     package_version: str = "",
     graph_preference: str = "auto",
+    session_ref: str = "",
+    tui_session_ref: str = "",
 ) -> dict[str, Any]:
+    """The HUD payload for one reading session.
+
+    ``session_ref`` is the reader's own durable session id, as the host
+    dispatched it (plugin tool, hook, operator flag), and is trusted as-is.
+    ``tui_session_ref`` is what the host's active-session file reports for
+    the TUI a widget renders in; on a freshly created session that file
+    holds the gateway's transport id rather than the durable key, so a value
+    that neither names a live TUI row nor owns a record falls back to the
+    most recently active live TUI row instead of rendering nothing.
+    """
     safe_preset = preset if preset in HUD_PRESETS else "focused"
     home = _expand_path(omh_home) if omh_home else _default_omh_home()
     hermes = _expand_path(hermes_home) if hermes_home else _default_hermes_home()
@@ -780,10 +792,10 @@ def read_omh_hud(
         "runtime": _hud_runtime_summary(status_payload, latest_run),
         "achievements": _achievements_summary(hermes),
         "tokens": _token_summary(token_metadata or {}),
-        # Scoped to the live TUI session: one OMH home holds one plan todo, so
-        # without that scope a previous session's unfinished checklist renders
-        # in every new session.
-        "todo": _todo_summary(home, hermes),
+        # Scoped to the reading session: the widget names its own session
+        # (`session_ref`), and a caller that cannot falls back to the live
+        # TUI row, so one session's checklist never renders in another.
+        "todo": _todo_summary(home, hermes, session_ref, tui_session_ref),
         # Concurrent tool-call batches observed by the pre_tool_call hook;
         # the [OMH] status line brands a fresh batch as a parallel shot.
         "parallel_shot": tool_calls["parallel_shot"],
@@ -1687,12 +1699,19 @@ def _evidence_state(run: dict[str, Any]) -> str:
 
 
 def read_omh_todo(
-    omh_home: str | Path | None = None, hermes_home: str | Path | None = None
+    omh_home: str | Path | None = None,
+    hermes_home: str | Path | None = None,
+    session_ref: str = "",
 ) -> dict[str, Any]:
-    """Public todo projection for tools and hosts that only need the panel."""
+    """Public todo projection for tools and hosts that only need the panel.
+
+    ``session_ref`` names the session the caller is reading for -- the plugin
+    tool passes the host session that invoked it, the pre-LLM hook the
+    session whose turn is starting. Empty falls back to the live TUI row.
+    """
     home = _expand_path(omh_home) if omh_home else _default_omh_home()
     hermes = _expand_path(hermes_home) if hermes_home else _default_hermes_home()
-    return _todo_summary(home, hermes)
+    return _todo_summary(home, hermes, session_ref)
 
 
 def default_omh_home() -> Path:
@@ -1700,7 +1719,12 @@ def default_omh_home() -> Path:
     return _default_omh_home()
 
 
-def _todo_summary(home: Path, hermes: Path | None = None) -> dict[str, Any]:
+def _todo_summary(
+    home: Path,
+    hermes: Path | None = None,
+    session_ref: str = "",
+    tui_session_ref: str = "",
+) -> dict[str, Any]:
     empty = {
         "status": "absent",
         "title": "",
@@ -1712,7 +1736,19 @@ def _todo_summary(home: Path, hermes: Path | None = None) -> dict[str, Any]:
         "display_phase": "",
         "more_count": 0,
     }
-    record = _read_hud_json(todo_path(home), root=home)
+    session_id, session = _reading_session(hermes, session_ref or tui_session_ref)
+    record, own_record = _own_todo_record(home, session_id)
+    if not own_record and not session_ref and tui_session_ref and session is None:
+        # The widget's reference places no TUI: it is neither a live row nor
+        # the owner of a record, which is what a fresh session's transport id
+        # looks like. Read as a widget with no identity would, rather than
+        # hiding the plan this TUI is most likely looking at.
+        session_id, session = _reading_session(hermes, "")
+        record, own_record = _own_todo_record(home, session_id)
+    if not own_record:
+        # No per-session record: the home-wide file answers, gated below by
+        # the identity or write-time rule so another session's plan stays out.
+        record = _read_hud_json(todo_path(home), root=home)
     if record.get("schema_version") != TODO_SCHEMA_VERSION:
         return empty
     items: list[dict[str, Any]] = []
@@ -1771,7 +1807,9 @@ def _todo_summary(home: Path, hermes: Path | None = None) -> dict[str, Any]:
     if age is None or age > TODO_STALE_SECONDS:
         summary["status"] = "stale"
         return summary
-    if _todo_belongs_to_another_session(record, summary["updated_at"], hermes):
+    if not own_record and _todo_belongs_to_another_session(
+        record, summary["updated_at"], session_id, session
+    ):
         summary["status"] = "stale"
         return summary
     if counts["done"] == counts["total"]:
@@ -1820,47 +1858,73 @@ def _todo_summary(home: Path, hermes: Path | None = None) -> dict[str, Any]:
     return summary
 
 
-def _todo_belongs_to_another_session(
-    record: dict[str, Any], updated_at: str, hermes: Path | None
-) -> bool:
-    """Whether this plan was declared by a session other than the live one.
-
-    The plan todo is one artifact per OMH home, so nothing about the file
-    itself says which session declared it. Wall-clock age alone cannot answer
-    that: an INCOMPLETE plan written hours ago is inside every age bound and
-    so greeted every new session with a checklist it never created (a 4/7 plan
-    from one session observed rendering in a fresh one the next day).
-
-    The host's own ``state.db`` does say it. Scoped to the live TUI session
-    (`live_session.live_tui_session_rows`), a stamped record answers by
-    identity and an unstamped legacy or CLI record answers by write time --
-    a plan written before the current session started belongs to an earlier
-    one.
-
-    Unanswerable reads to False on purpose: no state.db, no live TUI row, an
-    unreadable one, or a row too old to describe anyone's session all keep the
-    age-only gates. A legitimately current plan must never be hidden on
-    missing evidence. The narrow known gap is two concurrently live TUI
-    sessions -- the widget poll carries no session identity, so the most
-    recently active row answers for both, and the other session's plan
-    returns as soon as that session is touched again.
-    """
-    if hermes is None:
-        return False
-    session = next(iter(live_tui_session_rows(str(hermes))), None)
-    if session is None:
-        return False
-    session_id = str(session.get("id") or "")
+def _own_todo_record(home: Path, session_id: str) -> tuple[dict[str, Any], bool]:
+    """The per-session record for ``session_id``, and whether it is one."""
     if not session_id:
-        return False
+        return {}, False
+    record = _read_hud_json(todo_path(home, session_id), root=home)
+    return record, record.get("schema_version") == TODO_SCHEMA_VERSION
+
+
+def _reading_session(
+    hermes: Path | None, session_ref: str
+) -> tuple[str, dict[str, Any] | None]:
+    """The session a todo read is for: its id, and its live TUI row if any.
+
+    An explicit ``session_ref`` is the reader's own identity -- the widget
+    reads it off the host's active-session file, the plugin tool and the
+    pre-LLM hook off the session that invoked them -- and is trusted as-is,
+    whether or not state.db lists it as a TUI session (a Slack or Discord
+    gateway session is a valid reader with no TUI row). Without one, the
+    most recently active live TUI row answers, as before, and a host that
+    cannot say returns no identity at all.
+    """
+    reference = strip_control_characters(session_ref)[:MAX_TODO_SESSION_REF_CHARS]
+    rows = live_tui_session_rows(str(hermes)) if hermes is not None else []
+    if reference:
+        return reference, next((row for row in rows if str(row.get("id") or "") == reference), None)
+    session = rows[0] if rows else None
+    if session is None:
+        return "", None
+    session_id = str(session.get("id") or "")
     activity = session.get("activity")
-    if not isinstance(activity, (int, float)) or (
+    if not session_id or not isinstance(activity, (int, float)) or (
         _utc_epoch_now() - float(activity) > LIVE_TUI_SESSION_FRESH_SECONDS
     ):
+        return "", None
+    return session_id, session
+
+
+def _todo_belongs_to_another_session(
+    record: dict[str, Any],
+    updated_at: str,
+    session_id: str,
+    session: dict[str, Any] | None,
+) -> bool:
+    """Whether a home-wide plan was declared by a session other than the reader.
+
+    The home-wide ``todo.json`` says nothing about who declared it, and
+    wall-clock age alone cannot answer: an INCOMPLETE plan written hours ago
+    is inside every age bound and so greeted every new session with a
+    checklist it never created (a 4/7 plan from one session observed
+    rendering in a fresh one the next day).
+
+    A stamped record answers by identity. An unstamped legacy or CLI record
+    answers by write time against the reader's own TUI row -- a plan written
+    before the session started belongs to an earlier one.
+
+    Unanswerable reads to False on purpose: no reader identity, or an
+    unstamped record with no row to date it against, keeps the age-only
+    gates. A legitimately current plan must never be hidden on missing
+    evidence.
+    """
+    if not session_id:
         return False
     reference = strip_control_characters(record.get("session_ref", ""))[:MAX_TODO_SESSION_REF_CHARS]
     if reference:
         return reference != session_id
+    if session is None:
+        return False
     started_at = session.get("started_at")
     written_at = _epoch_seconds(updated_at)
     if not isinstance(started_at, (int, float)) or written_at is None:

--- a/src/plugin_bundle/omh/todo_reconciliation.py
+++ b/src/plugin_bundle/omh/todo_reconciliation.py
@@ -25,9 +25,14 @@ TODO_RECONCILIATION_RULE = (
 )
 
 
-def open_todo_reminder(*, omh_home: str = "") -> str:
-    """One compact context line while an established plan has open items."""
-    todo = read_omh_todo(omh_home or None)
+def open_todo_reminder(*, omh_home: str = "", session_ref: str = "") -> str:
+    """One compact context line while an established plan has open items.
+
+    ``session_ref`` is the session whose turn is starting; its own plan is
+    the one a completion claim must reconcile against, never another
+    session's.
+    """
+    todo = read_omh_todo(omh_home or None, session_ref=session_ref)
     if todo.get("status") != "established":
         return ""
     counts = todo.get("counts") if isinstance(todo.get("counts"), dict) else {}

--- a/src/plugin_bundle/omh/todo_store.py
+++ b/src/plugin_bundle/omh/todo_store.py
@@ -1,28 +1,47 @@
 """Shared store for the HUD todo artifact.
 
-One todo list per OMH home, written to ``$OMH_HOME/runtime/todo.json``. The
-CLI (`omh runtime todo`) and the `omh_todo` plugin tool both write through this
-module so the schema has a single source of truth; `runtime_reader` projects
-the file into the HUD payload read-only.
+One todo list per declaring session. A record that knows the host session
+that declared it (``session_ref``) lives at
+``$OMH_HOME/runtime/todos/<session key>.json``; a record written without one
+-- `omh runtime todo set` with no ``--session``, or anything predating the
+field -- keeps the home-wide ``$OMH_HOME/runtime/todo.json``. The CLI and the
+`omh_todo` plugin tool both write through this module so the schema has a
+single source of truth; `runtime_reader` projects the records into the HUD
+payload read-only, choosing the file that belongs to the reading session.
 
-Because the artifact is global to the home and its writers are not, a record
-carries the session that declared it (``session_ref``) whenever the writer
-knows one. Nothing here enforces the scope -- the reader does, in
-``runtime_reader._todo_summary`` -- but without the stamp a plan from one
-session, or from a concurrent writer sharing the same home, is
-indistinguishable from the reader's own.
+The per-session layout is what keeps unrelated sessions apart: a plan
+declared from a Slack or Discord gateway session, or from a second live TUI,
+is its own file, so it neither overwrites nor renders inside another
+session's checklist. Writers sharing one home no longer race for one file.
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import os
+import re
 import secrets
+import stat
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 TODO_SCHEMA_VERSION = "omh_todo/v1"
 TODO_FILENAME = "todo.json"
+# Per-session records live one directory below the home-wide file, keyed by
+# the declaring session. The directory is bounded on every write: records
+# past the reader's own stale bound are removed, and so are temporary files a
+# crashed write left behind. Only files this module wrote are candidates --
+# a record's name has the key shape below -- so nothing else placed in the
+# directory is ever touched, and a fresh record is never evicted to make
+# room: one session declares one record, and the stale window is the bound.
+TODO_SESSION_DIRNAME = "todos"
+TODO_STALE_SECONDS = 86400
+_SESSION_RECORD_NAME = re.compile(r"(?:[A-Za-z0-9_-]{1,48}-)?[0-9a-f]{16}\.json")
+_TEMPORARY_NAME = re.compile(r"\..*\.tmp")
+# The largest record this module reads back itself (clear's stamp check);
+# the HUD reader applies the same cap to every metadata file.
+MAX_TODO_RECORD_BYTES = 262_144
 TODO_ITEM_STATES = ("pending", "active", "done")
 MAX_TODO_ITEMS = 20
 MAX_TODO_TEXT_CHARS = 200
@@ -127,20 +146,49 @@ def build_todo_record(
     return record
 
 
-def todo_path(omh_home: Path) -> Path:
-    return omh_home / "runtime" / TODO_FILENAME
+def todo_session_key(session_ref: object) -> str:
+    """The filename stem a session's todo record lives under.
+
+    Host session ids are filesystem-safe today (``20260831_153632_11fc69``),
+    but a gateway thread id may carry any character, so the key is a bounded
+    sanitized slug for legibility plus a short digest of the exact reference
+    for uniqueness. The reference is bounded to the host-observation session
+    limit before either is taken, the same bound the record's stamp has, so
+    the key and the stamp always describe the same string. Empty when the
+    reference is empty.
+    """
+    reference = strip_control_characters(session_ref)[:MAX_TODO_SESSION_REF_CHARS]
+    if not reference:
+        return ""
+    slug = re.sub(r"[^A-Za-z0-9_-]+", "_", reference).strip("_-")[:48]
+    digest = hashlib.sha256(reference.encode("utf-8")).hexdigest()[:16]
+    return f"{slug}-{digest}" if slug else digest
+
+
+def todo_path(omh_home: Path, session_ref: object = "") -> Path:
+    """Where the todo record for ``session_ref`` lives; the home-wide file when empty."""
+    key = todo_session_key(session_ref)
+    if not key:
+        return omh_home / "runtime" / TODO_FILENAME
+    return omh_home / "runtime" / TODO_SESSION_DIRNAME / f"{key}.json"
+
+
+def todo_session_dir(omh_home: Path) -> Path:
+    return omh_home / "runtime" / TODO_SESSION_DIRNAME
 
 
 def write_todo(omh_home: Path, record: dict[str, Any]) -> Path:
-    destination = todo_path(omh_home)
+    """Write ``record`` to the file its ``session_ref`` selects."""
+    session_ref = str(record.get("session_ref", "") or "")
+    destination = todo_path(omh_home, session_ref)
     _reject_symlink_ancestry(destination, root=omh_home)
     temporary = destination.with_name(f".{destination.name}.{os.getpid()}-{secrets.token_hex(8)}.tmp")
     try:
         destination.parent.mkdir(parents=True, exist_ok=True)
-        # Post-mkdir TOCTOU recheck; the ancestry walk above already rejected a
-        # pre-existing symlink at this path.
-        if destination.is_symlink():
-            raise TodoStoreError(f"refusing symlinked todo destination: {destination}")
+        # Post-mkdir TOCTOU recheck of the whole ancestry: the walk above ran
+        # before the session directory existed, so a link planted in between
+        # would otherwise be followed by the write.
+        _reject_symlink_ancestry(destination, root=omh_home)
         with temporary.open("x", encoding="utf-8") as handle:
             handle.write(json.dumps(record, sort_keys=True) + "\n")
         os.replace(temporary, destination)
@@ -149,11 +197,31 @@ def write_todo(omh_home: Path, record: dict[str, Any]) -> Path:
     finally:
         if temporary.exists() and not temporary.is_symlink():
             temporary.unlink()
+    if session_ref:
+        _prune_session_records(omh_home, keep=destination)
     return destination
 
 
-def clear_todo(omh_home: Path) -> bool:
-    destination = todo_path(omh_home)
+def clear_todo(omh_home: Path, session_ref: object = "") -> bool:
+    """Remove the todo record ``session_ref`` selects.
+
+    A session clearing its plan also removes the home-wide record when that
+    record is one the session renders: unstamped (an operator's
+    `omh runtime todo set`, which the reader shows to the live session), or
+    stamped by this very session (the layout that predates per-session
+    files). It never touches another session's stamped record, so a clear
+    always answers for what the caller was looking at and nothing else.
+    """
+    reference = strip_control_characters(session_ref)[:MAX_TODO_SESSION_REF_CHARS]
+    removed = _remove_todo_file(omh_home, todo_path(omh_home, reference))
+    if reference:
+        legacy = todo_path(omh_home)
+        if _stamped_session_ref(legacy) in {"", reference}:
+            removed = _remove_todo_file(omh_home, legacy) or removed
+    return removed
+
+
+def _remove_todo_file(omh_home: Path, destination: Path) -> bool:
     _reject_symlink_ancestry(destination, root=omh_home)
     if not destination.is_file() or destination.is_symlink():
         return False
@@ -162,6 +230,57 @@ def clear_todo(omh_home: Path) -> bool:
     except OSError as error:
         raise TodoStoreError(f"todo destination is not removable: {error}") from error
     return True
+
+
+def _stamped_session_ref(path: Path) -> str:
+    """The ``session_ref`` a record on disk carries, read without following links."""
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError:
+        return ""
+    try:
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode) or opened.st_size > MAX_TODO_RECORD_BYTES:
+            return ""
+        record = json.loads(os.read(descriptor, MAX_TODO_RECORD_BYTES).decode("utf-8"))
+    except (OSError, ValueError):
+        return ""
+    finally:
+        os.close(descriptor)
+    if not isinstance(record, dict):
+        return ""
+    return strip_control_characters(record.get("session_ref", ""))[:MAX_TODO_SESSION_REF_CHARS]
+
+
+def _prune_session_records(omh_home: Path, *, keep: Path) -> None:
+    """Drop per-session records the reader would already treat as stale.
+
+    Best effort: a prune failure never fails the write that triggered it.
+    Only regular files this module names -- session records and its own
+    temporary files -- directly inside the session directory are considered,
+    only once they are older than the stale bound, and the record just
+    written is always kept.
+    """
+    directory = todo_session_dir(omh_home)
+    now = datetime.now(timezone.utc).timestamp()
+    try:
+        entries = list(os.scandir(directory))
+    except OSError:
+        return
+    for entry in entries:
+        if entry.name == keep.name:
+            continue
+        if not (_SESSION_RECORD_NAME.fullmatch(entry.name) or _TEMPORARY_NAME.fullmatch(entry.name)):
+            continue
+        try:
+            if entry.is_symlink() or not entry.is_file(follow_symlinks=False):
+                continue
+            if now - entry.stat(follow_symlinks=False).st_mtime <= TODO_STALE_SECONDS:
+                continue
+            os.unlink(entry.path)
+        except OSError:
+            continue
 
 
 def _reject_symlink_ancestry(path: Path, *, root: Path) -> None:

--- a/src/plugin_bundle/omh/tools/hud_tool.py
+++ b/src/plugin_bundle/omh/tools/hud_tool.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from ..host_observation import OBSERVATION_SCHEMA, attach_public_observation, observe_plugin_tool_call
+from ..host_observation import (
+    OBSERVATION_SCHEMA,
+    attach_public_observation,
+    host_session_id,
+    observe_plugin_tool_call,
+)
 from ..runtime_reader import read_omh_hud
 
 OMH_HUD_SCHEMA = {
@@ -77,5 +82,6 @@ def omh_hud_handler(args: dict[str, Any], **kwargs) -> str:
         preset=str(args.get("preset", "focused") or "focused"),
         limit=args.get("limit") or 3,
         token_metadata=token_metadata,
+        session_ref=host_session_id(kwargs),
     )
     return json.dumps(attach_public_observation(payload, observation), sort_keys=True)

--- a/src/plugin_bundle/omh/tools/todo_tool.py
+++ b/src/plugin_bundle/omh/tools/todo_tool.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from ..host_observation import OBSERVATION_SCHEMA, attach_public_observation, observe_plugin_tool_call
+from ..host_observation import (
+    OBSERVATION_SCHEMA,
+    attach_public_observation,
+    host_session_id,
+    observe_plugin_tool_call,
+)
 from ..runtime_reader import default_omh_home, read_omh_todo
 from ..todo_store import (
     TODO_CLAIM_BOUNDARY,
@@ -18,7 +23,9 @@ OMH_TODO_SCHEMA = {
     "name": "omh_todo",
     "description": (
         "Declare, clear, or read the metadata-only plan todo list that OMH HUD surfaces render "
-        "above the Hermes prompt input. Initialize it BEFORE starting engine work (todo init): "
+        "above the Hermes prompt input. The list belongs to the session that declares it: "
+        "another TUI, Slack, or Discord session neither sees nor overwrites it. "
+        "Initialize it BEFORE starting engine work (todo init): "
         "declare numbered phases in delivery order (e.g. 'I. Bootstrap' through 'VI. Evidence "
         "and Cleanup') that cover the whole lifecycle — setup, one implement/verify/deliver "
         "task per work unit, independent review lanes, and an evidence-and-cleanup close — "
@@ -88,21 +95,13 @@ OMH_TODO_SCHEMA = {
 }
 
 
-def _observed_session_ref(observation: dict[str, Any] | None) -> str:
-    """The host session id this write belongs to, when the host supplied one.
-
-    Hermes passes its stable session/thread id as observation metadata on
-    every tool call, so a plan declared in chat can record which session
-    declared it. A host that supplies none leaves this empty and the record
-    stays unstamped, exactly like a CLI write.
-    """
-    if not isinstance(observation, dict):
-        return ""
-    return str(observation.get("session_id", "") or "")
-
-
 def omh_todo_handler(args: dict[str, Any], **kwargs) -> str:
     observation = observe_plugin_tool_call("omh_todo", args, kwargs)
+    # Hermes passes its stable session/thread id as a keyword on every tool
+    # call, so a plan declared in chat is stored for, and read back for, the
+    # session that declared it. A host that supplies none leaves this empty:
+    # the record is the home-wide one, exactly like a CLI write.
+    session_ref = host_session_id(kwargs)
     home_arg = str(args.get("omh_home", "") or "")
     action = str(args.get("action", ""))
     payload: dict[str, Any] = {
@@ -116,7 +115,7 @@ def omh_todo_handler(args: dict[str, Any], **kwargs) -> str:
     if action in {"set", "clear"} and home_arg:
         payload["status"] = "invalid_todo"
         payload["error"] = "omh_home override is read-only; set and clear use the configured OMH home"
-        payload["todo"] = read_omh_todo()
+        payload["todo"] = read_omh_todo(session_ref=session_ref)
         return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
     if action == "set":
         try:
@@ -124,7 +123,7 @@ def omh_todo_handler(args: dict[str, Any], **kwargs) -> str:
                 args.get("title", ""),
                 args.get("items"),
                 source="omh_todo",
-                session_ref=_observed_session_ref(observation),
+                session_ref=session_ref,
             )
             write_todo(default_omh_home(), record)
             payload["status"] = "written"
@@ -133,7 +132,9 @@ def omh_todo_handler(args: dict[str, Any], **kwargs) -> str:
             payload["error"] = str(error)
     elif action == "clear":
         try:
-            payload["status"] = "cleared" if clear_todo(default_omh_home()) else "already_absent"
+            payload["status"] = (
+                "cleared" if clear_todo(default_omh_home(), session_ref) else "already_absent"
+            )
         except TodoStoreError as error:
             payload["status"] = "invalid_todo"
             payload["error"] = str(error)
@@ -142,5 +143,5 @@ def omh_todo_handler(args: dict[str, Any], **kwargs) -> str:
     else:
         payload["status"] = "invalid_action"
         payload["error"] = "action must be set, clear, or show"
-    payload["todo"] = read_omh_todo(home_arg or None)
+    payload["todo"] = read_omh_todo(home_arg or None, session_ref=session_ref)
     return json.dumps(attach_public_observation(payload, observation), sort_keys=True)

--- a/src/surfaces/hud.py
+++ b/src/surfaces/hud.py
@@ -14,6 +14,7 @@ def build_hud_payload(
     limit: int = 3,
     token_metadata: dict[str, Any] | None = None,
     graph_preference: str = "auto",
+    session_ref: str = "",
 ) -> dict[str, Any]:
     return read_omh_hud(
         omh_home=paths.omh_home,
@@ -23,4 +24,5 @@ def build_hud_payload(
         token_metadata=token_metadata or {},
         package_version=__version__,
         graph_preference=graph_preference,
+        session_ref=session_ref,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14473,6 +14473,36 @@ class RuntimeTodoCliTests(unittest.TestCase):
             self.assertEqual(status, 0)
             self.assertEqual(json.loads(stdout)["todo"]["status"], "absent")
 
+    def test_runtime_todo_session_flag_addresses_one_session_record(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home = str(Path(tmp) / ".omh")
+            base = ["--omh-home", omh_home, "runtime", "todo"]
+            status, stdout, _ = run_cli(
+                base + ["set", "--session", "20260831_153632_11fc69", "--title", "Own", "--item", "first"]
+            )
+            self.assertEqual(status, 0)
+            written = json.loads(stdout)
+            self.assertEqual(written["todo"]["status"], "established")
+            self.assertEqual(
+                Path(written["path"]).resolve().parent,
+                (Path(omh_home) / "runtime" / "todos").resolve(),
+            )
+            self.assertFalse((Path(omh_home) / "runtime" / "todo.json").exists())
+
+            # Without a session (and no live TUI row to fall back to) the
+            # home-wide projection is empty: the record belongs to one session.
+            status, stdout, _ = run_cli(base + ["show"])
+            self.assertEqual(json.loads(stdout)["todo"]["status"], "absent")
+            status, stdout, _ = run_cli(base + ["show", "--session", "20260831_153632_11fc69"])
+            self.assertEqual(json.loads(stdout)["todo"]["title"], "Own")
+            status, stdout, _ = run_cli(base + ["show", "--session", "another-session"])
+            self.assertEqual(json.loads(stdout)["todo"]["status"], "absent")
+
+            status, stdout, _ = run_cli(base + ["clear", "--session", "another-session"])
+            self.assertEqual(json.loads(stdout)["status"], "already_absent")
+            status, stdout, _ = run_cli(base + ["clear", "--session", "20260831_153632_11fc69"])
+            self.assertEqual(json.loads(stdout)["status"], "cleared")
+
     def test_runtime_todo_set_supports_repeated_pending_items(self) -> None:
         with TemporaryDirectory() as tmp:
             omh_home = str(Path(tmp) / ".omh")

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -1508,23 +1508,8 @@ class TodoHudTests(unittest.TestCase):
             self.assertEqual(len(payload["display"]["todo_lines"]), 2)
 
 
-class TodoSessionScopeTests(unittest.TestCase):
-    """A plan belongs to the session that declared it, not to the OMH home.
-
-    The plan todo is ONE artifact per OMH home, and wall-clock age was its
-    only gate: a 24h staleness bound, plus a 15-minute linger that applies
-    only once every item is done. An INCOMPLETE plan written hours ago sat
-    inside both, so it projected `established` into every new Hermes session —
-    observed live, where a checklist declared in one session greeted a fresh
-    one the next day as state that session never created.
-
-    The host's own `state.db` knows which TUI session is live. A record
-    stamped with `session_ref` answers by identity; an unstamped legacy or CLI
-    record answers by write time. When state.db cannot answer — absent,
-    unreadable, no live TUI row, or a row too old to describe anyone's
-    session — the age-only gates stand, because hiding a legitimately current
-    plan on missing evidence is the worse failure.
-    """
+class _TodoSessionFixture:
+    """Shared fixture for the session-scope and session-isolation suites."""
 
     NOW = 1788158400.0
 
@@ -1600,6 +1585,25 @@ class TodoSessionScopeTests(unittest.TestCase):
         from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
 
         return read_omh_hud(self.omh_home, self.hermes_home)["todo"]
+
+
+class TodoSessionScopeTests(_TodoSessionFixture, unittest.TestCase):
+    """A plan belongs to the session that declared it, not to the OMH home.
+
+    The plan todo is ONE artifact per OMH home, and wall-clock age was its
+    only gate: a 24h staleness bound, plus a 15-minute linger that applies
+    only once every item is done. An INCOMPLETE plan written hours ago sat
+    inside both, so it projected `established` into every new Hermes session —
+    observed live, where a checklist declared in one session greeted a fresh
+    one the next day as state that session never created.
+
+    The host's own `state.db` knows which TUI session is live. A record
+    stamped with `session_ref` answers by identity; an unstamped legacy or CLI
+    record answers by write time. When state.db cannot answer — absent,
+    unreadable, no live TUI row, or a row too old to describe anyone's
+    session — the age-only gates stand, because hiding a legitimately current
+    plan on missing evidence is the worse failure.
+    """
 
     def test_an_incomplete_plan_from_a_previous_session_is_hidden(self) -> None:
         # The reported bug, in the shape it was observed: a checklist declared
@@ -1727,6 +1731,11 @@ class TodoSessionScopeTests(unittest.TestCase):
             self.assertEqual(open_todo_reminder(omh_home=str(self.omh_home)), "")
 
     def test_the_plugin_tool_stamps_the_host_session_that_declared_the_plan(self) -> None:
+        # Hermes dispatches every plugin tool as handler(args, session_id=...)
+        # with no host, so the session is read off that keyword. A session id
+        # inside the model-supplied observation argument is NOT the writer's
+        # identity: honoring it would let a model address another session's
+        # record.
         import os
 
         from omh.plugin_bundle.omh.tools.todo_tool import omh_todo_handler
@@ -1743,18 +1752,24 @@ class TodoSessionScopeTests(unittest.TestCase):
                         "items": [{"text": "Inspect routing fixtures", "state": "active"}],
                         "observation": {
                             "host": "hermes-agent",
-                            "session_id": "20260831_153632_11fc69",
+                            "session_id": "someone-else",
                         },
-                    }
+                    },
+                    session_id="20260831_153632_11fc69",
                 )
             )
 
         self.assertEqual(written["status"], "written")
+        from omh.plugin_bundle.omh.todo_store import todo_path
+
+        # A stamped record is that session's own file, not the home-wide one.
+        self.assertFalse((self.omh_home / "runtime" / "todo.json").exists())
         record = json.loads(
-            (self.omh_home / "runtime" / "todo.json").read_text(encoding="utf-8")
+            todo_path(self.omh_home, "20260831_153632_11fc69").read_text(encoding="utf-8")
         )
         self.assertEqual(record["session_ref"], "20260831_153632_11fc69")
         self.assertEqual(record["schema_version"], "omh_todo/v1")
+        self.assertFalse(todo_path(self.omh_home, "someone-else").exists())
 
     def test_an_unstamped_write_stays_byte_identical_to_the_pre_field_record(self) -> None:
         # session_ref is additive-optional inside omh_todo/v1: a writer that
@@ -1784,6 +1799,284 @@ class TodoSessionScopeTests(unittest.TestCase):
 
         self.assertEqual(len(record["session_ref"]), MAX_TODO_SESSION_REF_CHARS)
         self.assertTrue(record["session_ref"].startswith("s[2J9"))
+
+
+class TodoSessionIsolationTests(_TodoSessionFixture, unittest.TestCase):
+    """One plan per declaring session, read back only by that session.
+
+    The scope tests above keep the home-wide file honest. They could not fix
+    the sharper report: a plan declared from a Slack session, or from a
+    second TUI open at the same time, replaced the one file every session
+    shared, and the widget poll carried no identity to tell two live TUIs
+    apart. A stamped record is now its own file under `runtime/todos/`, the
+    widget names its own session, and every reader resolves its own plan.
+    """
+
+    TUI_A = "20260831_153632_11fc69"
+    TUI_B = "20260831_160102_9a1c22"
+    SLACK = "slack:C0123ABC:1725100000.000100"
+
+    def _declare(self, session_id: str, title: str, states=("done", "active", "pending")) -> dict:
+        import os
+
+        from omh.plugin_bundle.omh.tools.todo_tool import omh_todo_handler
+
+        with patch.dict(
+            os.environ,
+            {"OMH_HOME": str(self.omh_home), "HERMES_HOME": str(self.hermes_home)},
+        ):
+            return json.loads(
+                omh_todo_handler(
+                    {
+                        "action": "set",
+                        "title": title,
+                        "items": [
+                            {"text": f"{title} step {index}", "state": state}
+                            for index, state in enumerate(states)
+                        ],
+                    },
+                    session_id=session_id,
+                )
+            )
+
+    def _todo_for(self, session_ref: str) -> dict:
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+        return read_omh_hud(self.omh_home, self.hermes_home, session_ref=session_ref)["todo"]
+
+    def test_two_live_tuis_each_render_only_their_own_plan(self) -> None:
+        # Both TUIs are live; B was touched last, so B is the MRU row that
+        # used to answer for both. With the widget naming its own session,
+        # A reads A's plan and B reads B's, and neither write clobbered the
+        # other.
+        self._build_state_db(
+            [
+                (self.TUI_A, self._epoch(-600), self._epoch(-120)),
+                (self.TUI_B, self._epoch(-300), self._epoch(-5)),
+            ]
+        )
+        self.assertEqual(self._declare(self.TUI_A, "Alpha")["status"], "written")
+        self.assertEqual(self._declare(self.TUI_B, "Beta")["status"], "written")
+
+        alpha = self._todo_for(self.TUI_A)
+        beta = self._todo_for(self.TUI_B)
+
+        self.assertEqual((alpha["status"], alpha["title"]), ("established", "Alpha"))
+        self.assertEqual((beta["status"], beta["title"]), ("established", "Beta"))
+        # A poll that carries no identity still falls back to the MRU row.
+        self.assertEqual(self._todo()["title"], "Beta")
+
+    def test_a_slack_session_plan_neither_replaces_nor_reaches_the_tui(self) -> None:
+        # The reported bug: a gateway session (source != 'tui', so it never
+        # appears as a TUI row) declares a plan into the same OMH home. The
+        # TUI's own checklist must survive, and the Slack session must read
+        # its own plan back even though state.db lists no TUI row for it.
+        self._build_state_db([(self.TUI_A, self._epoch(-600), self._epoch(-5))])
+        self._declare(self.TUI_A, "Tui plan")
+        self._declare(self.SLACK, "Slack plan")
+
+        tui = self._todo_for(self.TUI_A)
+        slack = self._todo_for(self.SLACK)
+
+        self.assertEqual((tui["status"], tui["title"]), ("established", "Tui plan"))
+        self.assertEqual((slack["status"], slack["title"]), ("established", "Slack plan"))
+        self.assertEqual(self._todo()["title"], "Tui plan")
+        # A gateway session that declared nothing has nothing: its own
+        # identity never falls through to the TUI's plan.
+        self.assertEqual(self._todo_for("slack:C0123ABC:1725100000.000200")["status"], "absent")
+
+    def test_a_fresh_tui_whose_widget_carries_the_transport_id_still_renders(self) -> None:
+        # On session.create the host's active-session file holds the gateway
+        # transport id (uuid4 hex[:8]), not the durable session key the tool
+        # stamps with; only resume/switch write the key. A widget reference
+        # that is neither a live TUI row nor the owner of a record is that
+        # case, and reads as an identity-less poll would -- the MRU live row
+        # -- so the plan the fresh TUI just declared is not hidden.
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+        self._build_state_db([(self.TUI_A, self._epoch(-60), self._epoch(-5))])
+        self._declare(self.TUI_A, "Fresh")
+
+        as_widget = read_omh_hud(self.omh_home, self.hermes_home, tui_session_ref="3f9a1c2b")["todo"]
+        self.assertEqual((as_widget["status"], as_widget["title"]), ("established", "Fresh"))
+        # The durable key placed by the file after a resume reads directly.
+        as_resumed = read_omh_hud(self.omh_home, self.hermes_home, tui_session_ref=self.TUI_A)["todo"]
+        self.assertEqual(as_resumed["title"], "Fresh")
+        # The strict identity (tool, hook, operator flag) never falls through.
+        self.assertEqual(self._todo_for("3f9a1c2b")["status"], "absent")
+
+    def test_the_hud_tool_reads_the_todo_for_its_dispatching_session(self) -> None:
+        import os
+
+        from omh.plugin_bundle.omh.tools.hud_tool import omh_hud_handler
+
+        self._build_state_db([(self.TUI_A, self._epoch(-60), self._epoch(-5))])
+        self._declare(self.TUI_A, "Tui plan")
+        self._declare(self.SLACK, "Slack plan")
+        with patch.dict(
+            os.environ,
+            {"OMH_HOME": str(self.omh_home), "HERMES_HOME": str(self.hermes_home)},
+        ):
+            slack_view = json.loads(omh_hud_handler({}, session_id=self.SLACK))
+            tui_view = json.loads(omh_hud_handler({}, session_id=self.TUI_A))
+
+        self.assertEqual(slack_view["todo"]["title"], "Slack plan")
+        self.assertEqual(tui_view["todo"]["title"], "Tui plan")
+
+    def test_the_plugin_tool_reads_and_clears_its_own_session_only(self) -> None:
+        import os
+
+        from omh.plugin_bundle.omh.todo_store import todo_path
+        from omh.plugin_bundle.omh.tools.todo_tool import omh_todo_handler
+
+        self._declare(self.TUI_A, "Alpha")
+        self._declare(self.SLACK, "Slack plan")
+        with patch.dict(
+            os.environ,
+            {"OMH_HOME": str(self.omh_home), "HERMES_HOME": str(self.hermes_home)},
+        ):
+            shown = json.loads(omh_todo_handler({"action": "show"}, session_id=self.SLACK))
+            cleared = json.loads(omh_todo_handler({"action": "clear"}, session_id=self.SLACK))
+            again = json.loads(omh_todo_handler({"action": "clear"}, session_id=self.SLACK))
+
+        self.assertEqual(shown["todo"]["title"], "Slack plan")
+        self.assertEqual(cleared["status"], "cleared")
+        self.assertEqual(cleared["todo"]["status"], "absent")
+        self.assertEqual(again["status"], "already_absent")
+        self.assertFalse(todo_path(self.omh_home, self.SLACK).exists())
+        self.assertEqual(self._todo_for(self.TUI_A)["title"], "Alpha")
+
+    def test_a_session_clears_the_home_wide_record_it_stamped_before_the_upgrade(self) -> None:
+        # Pre-upgrade layout: a stamped record in the home-wide file. The
+        # session that owns it can still clear it; another session cannot.
+        from omh.plugin_bundle.omh.todo_store import clear_todo
+
+        self._write_todo(self._record(session_ref=self.TUI_A))
+
+        self.assertFalse(clear_todo(self.omh_home, self.TUI_B))
+        self.assertTrue((self.omh_home / "runtime" / "todo.json").exists())
+        self.assertTrue(clear_todo(self.omh_home, self.TUI_A))
+        self.assertFalse((self.omh_home / "runtime" / "todo.json").exists())
+
+    def test_a_session_clears_the_operator_record_it_is_looking_at(self) -> None:
+        # An unstamped `omh runtime todo set` record renders to the live
+        # session by write time, so that session's clear must remove it --
+        # otherwise the tool answers already_absent beside an established
+        # panel, and the operator's plan cannot be dismissed from chat.
+        import os
+
+        from omh.plugin_bundle.omh.tools.todo_tool import omh_todo_handler
+
+        self._build_state_db([(self.TUI_A, self._epoch(-600), self._epoch(-5))])
+        self._write_todo(self._record(title="Operator", source="cli", updated_at=self._stamp(-60)))
+        self.assertEqual(self._todo_for(self.TUI_A)["title"], "Operator")
+
+        with patch.dict(
+            os.environ,
+            {"OMH_HOME": str(self.omh_home), "HERMES_HOME": str(self.hermes_home)},
+        ):
+            cleared = json.loads(omh_todo_handler({"action": "clear"}, session_id=self.TUI_A))
+
+        self.assertEqual((cleared["status"], cleared["todo"]["status"]), ("cleared", "absent"))
+        self.assertFalse((self.omh_home / "runtime" / "todo.json").exists())
+
+    def test_an_own_record_wins_over_the_home_wide_file(self) -> None:
+        self._build_state_db([(self.TUI_A, self._epoch(-600), self._epoch(-5))])
+        self._write_todo(self._record(title="Operator", source="cli"))
+        self._declare(self.TUI_A, "Own")
+
+        self.assertEqual(self._todo_for(self.TUI_A)["title"], "Own")
+
+    def test_a_named_session_without_its_own_record_keeps_the_home_wide_gates(self) -> None:
+        # Explicit identity, no per-session file: the home-wide record is
+        # gated exactly as before -- by stamp, else by write time against
+        # the named session's own row.
+        self._build_state_db([(self.TUI_A, self._epoch(-300), self._epoch(-5))])
+
+        self._write_todo(self._record(session_ref=self.TUI_B))
+        self.assertEqual(self._todo_for(self.TUI_A)["status"], "stale")
+
+        self._write_todo(self._record(source="cli", updated_at=self._stamp(-3600)))
+        self.assertEqual(self._todo_for(self.TUI_A)["status"], "stale")
+
+        self._write_todo(self._record(source="cli", updated_at=self._stamp(-60)))
+        self.assertEqual(self._todo_for(self.TUI_A)["status"], "established")
+
+        # A reader state.db does not list (a gateway session) cannot date an
+        # unstamped record, so it keeps the age-only answer.
+        self.assertEqual(self._todo_for(self.SLACK)["status"], "established")
+
+    def test_session_keys_are_filesystem_safe_and_distinct(self) -> None:
+        from omh.plugin_bundle.omh.todo_store import todo_path, todo_session_key
+
+        plain = todo_session_key(self.TUI_A)
+        slack = todo_session_key(self.SLACK)
+        dotted = todo_session_key("../..:evil")
+
+        self.assertEqual(plain, todo_session_key(self.TUI_A))
+        self.assertTrue(plain.startswith(self.TUI_A))
+        self.assertNotEqual(plain, slack)
+        for key in (plain, slack, dotted):
+            self.assertRegex(key, r"^[A-Za-z0-9_-]+$")
+        self.assertEqual(todo_session_key(""), "")
+        self.assertEqual(todo_path(self.omh_home), self.omh_home / "runtime" / "todo.json")
+        self.assertEqual(
+            todo_path(self.omh_home, self.SLACK).parent, self.omh_home / "runtime" / "todos"
+        )
+
+    def test_per_session_records_are_pruned_only_when_stale_and_only_our_own(self) -> None:
+        # A stale record and a crash-left temporary file go; a fresh record
+        # from any number of other sessions stays (one session, one file --
+        # the stale window is the bound), and a file this module did not
+        # name is never touched even when it is old.
+        import os
+
+        from omh.plugin_bundle.omh.todo_store import (
+            TODO_STALE_SECONDS,
+            todo_path,
+            todo_session_dir,
+        )
+
+        self._declare("old-session", "Old")
+        old = todo_path(self.omh_home, "old-session")
+        directory = todo_session_dir(self.omh_home)
+        leftover = directory / ".todo.json.123-abcd.tmp"
+        leftover.write_text("{", encoding="utf-8")
+        foreign = directory / "operator-notes.json"
+        foreign.write_text("{}", encoding="utf-8")
+        stale_at = self._epoch(-(TODO_STALE_SECONDS + 60))
+        for path in (old, leftover, foreign):
+            os.utime(path, (stale_at, stale_at))
+        for index in range(40):
+            self._declare(f"session-{index}", f"Plan {index}")
+
+        survivors = sorted(path.name for path in directory.iterdir())
+        self.assertFalse(old.exists())
+        self.assertFalse(leftover.exists())
+        self.assertTrue(foreign.exists())
+        self.assertEqual(len(survivors), 41)
+        for index in range(40):
+            self.assertIn(todo_path(self.omh_home, f"session-{index}").name, survivors)
+
+    def test_a_symlinked_session_directory_is_refused_on_write_and_read(self) -> None:
+        from omh.plugin_bundle.omh.todo_store import (
+            TodoStoreError,
+            build_todo_record,
+            todo_session_dir,
+            write_todo,
+        )
+
+        outside = self.root / "outside"
+        outside.mkdir()
+        runtime_dir = self.omh_home / "runtime"
+        runtime_dir.mkdir(parents=True)
+        todo_session_dir(self.omh_home).symlink_to(outside, target_is_directory=True)
+        record = build_todo_record("Foundation", [{"text": "x"}], source="omh_todo", session_ref=self.TUI_A)
+
+        with self.assertRaises(TodoStoreError):
+            write_todo(self.omh_home, record)
+        (outside / (todo_session_dir(self.omh_home) / "x").name).write_text("{}", encoding="utf-8")
+        self.assertEqual(self._todo_for(self.TUI_A)["status"], "absent")
 
 
 class ActivityRowOrderTests(unittest.TestCase):

--- a/tests/test_todo_reconciliation.py
+++ b/tests/test_todo_reconciliation.py
@@ -25,12 +25,29 @@ class TodoReconciliationReminderTest(unittest.TestCase):
         self.addCleanup(self._tmp.cleanup)
         self.home = str(Path(self._tmp.name) / "omh")
 
-    def _write_plan(self, states):
+    def _write_plan(self, states, session_ref=""):
         items = [
             {"text": f"task {index}", "state": state, "phase": "Review"}
             for index, state in enumerate(states)
         ]
-        write_todo(Path(self.home), build_todo_record("plan", items, source="test"))
+        write_todo(
+            Path(self.home),
+            build_todo_record("plan", items, source="test", session_ref=session_ref),
+        )
+
+    def test_the_reminder_binds_to_the_turn_session_own_plan(self):
+        # A Slack session's open plan is not the TUI session's open work:
+        # each turn reconciles against the plan its own session declared.
+        self._write_plan(["done", "active", "pending"], session_ref="tui-session")
+        self._write_plan(["done", "done"], session_ref="slack-session")
+
+        self.assertIn(
+            "[OMH plan todo] 1/3 done",
+            open_todo_reminder(omh_home=self.home, session_ref="tui-session"),
+        )
+        self.assertEqual(open_todo_reminder(omh_home=self.home, session_ref="slack-session"), "")
+        payload = pre_llm_call(user_message="다 됐어?", omh_home=self.home, session_id="slack-session")
+        self.assertNotIn("[OMH plan todo]", str((payload or {}).get("context", "")))
 
     def test_an_open_plan_yields_one_compact_line(self):
         self._write_plan(["done", "active", "pending"])

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -241,6 +241,22 @@ class TuiWidgetPackTests(unittest.TestCase):
             self.assertEqual(unrelated.read_text(encoding="utf-8"), "personal\n")
             self.assertEqual(json.loads(stdout)["tui_widget"]["status"], "removed")
 
+    def test_widget_names_its_own_session_on_every_poll(self) -> None:
+        # Two live TUIs used to share one panel answer because the poll
+        # carried no identity. The host writes this TUI's session id to the
+        # file named by HERMES_TUI_ACTIVE_SESSION_FILE; the widget reads it
+        # per poll (the session moves on /new and /resume) and hands it to
+        # the reader as the todo scope, without widening the env allowlist.
+        widget = resources.files("omh.tui_widgets").joinpath("omh-status.mjs").read_text(encoding="utf-8")
+
+        self.assertIn("process.env.HERMES_TUI_ACTIVE_SESSION_FILE", widget)
+        self.assertIn("const sessionRef = activeSessionRef()", widget)
+        self.assertIn("{ ...READER_ENV, OMH_HUD_TUI_SESSION_REF: sessionRef }", widget)
+        self.assertIn("tui_session_ref=os.environ.get('OMH_HUD_TUI_SESSION_REF', '')", widget)
+        # A malformed value is dropped, never mutated into a different key.
+        self.assertIn("SESSION_REF_SHAPE.test(sessionId) ? sessionId : ''", widget)
+        self.assertNotIn("...process.env", widget)
+
     def test_widget_frames_the_composer_and_docks_the_plan_on_top(self) -> None:
         # Changed on purpose (this used to pin a single dock-bottom app and
         # forbid dock-top). The single bottom dock framed the OMH section


### PR DESCRIPTION
## Feature Report

### What Changed

- The OMH plan todo (the checklist HUD surfaces render above the Hermes prompt input) now belongs to the session that declared it. A record stamped with a session lives at `$OMH_HOME/runtime/todos/<session key>.json`; an unstamped operator record keeps the home-wide `runtime/todo.json`.
- The modern-TUI widget names its own session on every poll, read from the host's `HERMES_TUI_ACTIVE_SESSION_FILE`, and hands it to the reader as `tui_session_ref`.
- `omh_todo`, `omh_hud`, and the pre-LLM reconciliation reminder resolve the plan for the session Hermes dispatched them for. `omh runtime todo set|clear|show` gain `--session <id>`.
- Root-cause fix underneath: Hermes dispatches plugin tools as `handler(args, session_id=...)` with no `host`, and the observation record requires both, so the session stamp was never written from live Hermes. `host_session_id(kwargs)` reads the keyword directly, and only the keyword: a model-supplied `observation.session_id` can no longer name another session's record.

### Why This Exists

- Owner report: a plan todo declared from another session (a Slack gateway session, or a second TUI) showed up in unrelated TUIs. Two faults compounded: one file per OMH home meant any writer overwrote the plan every session shared, and the reader's identity was "the most recently active TUI row in state.db" because the widget poll carried no identity, so two live TUIs rendered whichever plan the last-touched one owned.

### User / Operator Impact

- A plan declared in one Hermes session renders only in that session. A Slack or Discord session's plan neither replaces nor appears inside a TUI's checklist, and two TUIs open at once each keep their own.
- Clearing from chat removes what that session was looking at: its own record, or an unstamped operator record the reader showed it. Another session's stamped record is never touched.
- Operators can address one session's record: `omh runtime todo show --session <id>`.

### How It Works

- `todo_store.py`: `todo_session_key()` (sanitized slug plus SHA-256 digest of the exact reference) selects the per-session path; `write_todo` derives the destination from the record's `session_ref`; `clear_todo(home, session_ref)` removes the session file and a home-wide record that is unstamped or stamped by that session; per-session records past the 24h stale bound and crash-left temp files are pruned on write, nothing else in the directory is touched.
- `runtime_reader.py`: `_todo_summary(home, hermes, session_ref, tui_session_ref)` reads the session's own record first; without one it falls back to the home-wide file gated by stamp or write time. A strict `session_ref` (tool, hook, CLI) is trusted as-is. A widget `tui_session_ref` that names no live TUI row and owns no record is the fresh-session case (Hermes writes the gateway transport id to the active-session file on `session.create`, the durable key only on resume/switch) and reads as an identity-less poll would.
- `omh-status.mjs`: reads the active-session file per poll (regular file, size-capped, shape-validated, rejected not mutated) and passes `OMH_HUD_TUI_SESSION_REF` to the reader subprocess env.

### Files And Contracts Touched

- `src/plugin_bundle/omh/todo_store.py`, `runtime_reader.py`, `host_observation.py`, `todo_reconciliation.py`, `hooks/llm_hooks.py`, `tools/todo_tool.py`, `tools/hud_tool.py`
- `src/omh/tui_widgets/omh-status.mjs`, `src/surfaces/hud.py`, `src/commands/runtime.py`
- `CONTEXT.md` (Plan todo entry), `docs/INSTALLATION.md`
- `omh_todo/v1` record schema unchanged; `session_ref` remains additive-optional. `read_omh_hud` and `read_omh_todo` gain keyword parameters only.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [x] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: the widget's exact READER snippet run with `python -I` against a temp OMH home holding two session records, once per `OMH_HUD_TUI_SESSION_REF`, each returning its own plan
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; needs `omh update` plus a TUI restart on the owner machine with two TUIs and a gateway session open

### Observed Evidence

- Full suite: 8882 tests, 1 failure. The one failure, `test_media_handoff_capabilities...binds_fresh_media_evidence`, fails identically on untouched `main` at the same base commit and is unrelated.
- New contracts in `tests/test_hud.py` (`TodoSessionIsolationTests`): two live TUIs each read their own plan; a Slack session's plan neither replaces nor reaches the TUI and a gateway session that declared nothing reads absent; a fresh TUI whose widget carries the transport id still renders; a model-supplied `observation.session_id` does not select the record; clear removes only the caller's own or the operator's unstamped record; prune is stale-only and never touches foreign files; a symlinked `todos/` directory is refused on write and read.
- `tests/test_todo_reconciliation.py`: the reminder binds to the turn session's own plan. `tests/test_tui_widget_pack.py`: widget carries its session per poll without widening the env allowlist. `tests/test_cli.py`: `--session` round trip.
- Three independent review passes (architecture, security, code quality) ran against the diff; their blocking findings (transport-id alias on fresh sessions, model-controlled session id, clear regression on operator records, prune deleting foreign files) are fixed in this PR with tests.

### Not Tested / Not Applicable

- `harness validate`, `release checklist`, `release hermes-smoke`: no harness, release, or install-manifest contract changed.
- Live modern-TUI observation with concurrent sessions: not run in this session; the widget→reader contract is proven by the READER-snippet smoke above, the two-live-TUI separation on a real host is `prepared_not_observed` until the owner machine runs `omh update` and restarts the TUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMPYLrccMB2j7QS1cXNed7
