### PR TITLE
feat(benchmarks): manifest-aware analysis for targeted family runs

### DIFF
--- a/benchmarks/live-model-tools/v1/analyze.py
+++ b/benchmarks/live-model-tools/v1/analyze.py
@@ -8,7 +8,7 @@ from common import load_object, write_json
 from statistics import analyze
 
 def main(argv=None):
- p=argparse.ArgumentParser(); p.add_argument("--baseline",type=Path,required=True); p.add_argument("--optimized",type=Path,required=True); p.add_argument("--bootstrap-repetitions",type=int,default=10000); p.add_argument("--seed",type=int,default=20260813); p.add_argument("--output",type=Path,required=True); a=p.parse_args(argv)
+ p=argparse.ArgumentParser(); p.add_argument("--baseline",type=Path,required=True); p.add_argument("--optimized",type=Path,required=True); p.add_argument("--bootstrap-repetitions",type=int,default=10000); p.add_argument("--seed",type=int,default=20260813); p.add_argument("--manifest",type=Path,default=BASE/"manifest.json"); p.add_argument("--output",type=Path,required=True); a=p.parse_args(argv)
  if a.bootstrap_repetitions<100: p.error("bootstrap repetitions must be at least 100")
- report=analyze(a.baseline,a.optimized,a.bootstrap_repetitions,a.seed,load_object(BASE/"manifest.json")); write_json(a.output,report); print(json.dumps(report,sort_keys=True,indent=2)); return 0
+ report=analyze(a.baseline,a.optimized,a.bootstrap_repetitions,a.seed,load_object(a.manifest)); write_json(a.output,report); print(json.dumps(report,sort_keys=True,indent=2)); return 0
 if __name__=="__main__": raise SystemExit(main())

--- a/benchmarks/live-model-tools/v1/tests/test_framework.py
+++ b/benchmarks/live-model-tools/v1/tests/test_framework.py
@@ -245,5 +245,152 @@ class OmhBenchmarkFrameworkTests(unittest.TestCase):
                 analyze(baseline, optimized, 10, 7, manifest)
 
 
+class OmhTargetedManifestAnalysisTests(unittest.TestCase):
+    """Issue #1056 step-0: targeted family manifests must flow end-to-end.
+
+    bench.py run accepts --manifest, but the analyze.py CLI used to reload the
+    canonical manifest directly, so a targeted manifest (for example, one live
+    solar family entry) could run but never pass the analysis coverage check.
+    These tests pin the CLI contract: --manifest selects the manifest used for
+    analysis coverage, defaults stay canonical, and mismatched manifests still
+    fail loudly.
+    """
+
+    def _run_cli(self, args):
+        return subprocess.run(
+            [sys.executable, str(BASE / "analyze.py"), *args],
+            capture_output=True,
+            text=True,
+        )
+
+    def _live_manifest(self):
+        manifest = json.loads((BASE / "manifest.json").read_text())
+        manifest["models"] = [m for m in manifest["models"] if m.get("live")][:1]
+        return manifest
+
+    def _evaluation_rows(self, manifest, condition):
+        import corpus
+
+        model = next(m for m in manifest["models"] if m.get("live"))
+        rows = []
+        for template, _task_class in corpus.TEMPLATES:
+            for seed in corpus.EVALUATION_SEEDS:
+                rows.append(
+                    {
+                        "schema_version": "omh_live_model_tool_run/v1",
+                        "created_at": "2026-08-13T00:00:00+00:00",
+                        "instance_id": f"E-{template}-{seed}",
+                        "split": "evaluation",
+                        "harness": "omh",
+                        "model": {"provider": model["provider"], "id": model["id"]},
+                        "task_digest": "a" * 64,
+                        "route": {},
+                        "observation": {
+                            "status": "completed",
+                            "tools": 1,
+                            "tokens": 1,
+                            "cost_usd": 0.0,
+                        },
+                        "grade": {"pass": True},
+                        "final_tree_digest": "b" * 64,
+                        "condition": condition,
+                    }
+                )
+        return rows
+
+    def _write_conditions(self, root_path, manifest):
+        """Write a baseline and an optimized run file for the manifest's live model.
+
+        Both rejection tests need a real optimized file too: passing the
+        baseline twice fails on "wrong condition" before the manifest check
+        is ever reached, which would let any non-zero exit pass for the
+        wrong reason.
+        """
+        paths = []
+        for condition in ("baseline", "optimized"):
+            output = root_path / f"{condition}.jsonl"
+            output.write_text(
+                "".join(json.dumps(row) + chr(10) for row in self._evaluation_rows(manifest, condition)),
+                encoding="utf-8",
+            )
+            paths.append(output)
+        return tuple(paths)
+
+    def test_targeted_manifest_cli_analyze_end_to_end(self) -> None:
+        manifest = self._live_manifest()
+        with TemporaryDirectory() as root:
+            root_path = Path(root)
+            manifest_path = root_path / "manifest.json"
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+            baseline, optimized = self._write_conditions(root_path, manifest)
+            result = self._run_cli(
+                [
+                    "--baseline", str(baseline),
+                    "--optimized", str(optimized),
+                    "--manifest", str(manifest_path),
+                    "--bootstrap-repetitions", "100",
+                    "--seed", "7",
+                    "--output", str(root_path / "report.json"),
+                ]
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            report = json.loads((root_path / "report.json").read_text())
+            model = next(m for m in manifest["models"] if m.get("live"))
+            label = f"{model['provider']}/{model['id']}"
+            self.assertIn(label, report["models"])
+            self.assertEqual(
+                report["models"][label]["n"],
+                len(self._evaluation_rows(manifest, "baseline")),
+            )
+
+    def test_targeted_manifest_cli_rejects_mismatched_manifest(self) -> None:
+        manifest = self._live_manifest()
+        excluded = manifest["models"][0]
+        # A populated matrix of a DIFFERENT live model, not an empty one:
+        # the run rows name `excluded`, the manifest under analysis does not.
+        other = json.loads((BASE / "manifest.json").read_text())
+        other["models"] = [
+            m
+            for m in other["models"]
+            if m.get("live") and (m["provider"], m["id"]) != (excluded["provider"], excluded["id"])
+        ][:1]
+        self.assertEqual(len(other["models"]), 1)
+        with TemporaryDirectory() as root:
+            root_path = Path(root)
+            other_path = root_path / "other.json"
+            other_path.write_text(json.dumps(other), encoding="utf-8")
+            baseline, optimized = self._write_conditions(root_path, manifest)
+            result = self._run_cli(
+                [
+                    "--baseline", str(baseline),
+                    "--optimized", str(optimized),
+                    "--manifest", str(other_path),
+                    "--bootstrap-repetitions", "100",
+                    "--output", str(root_path / "report.json"),
+                ]
+            )
+            self.assertNotEqual(result.returncode, 0)
+            # The analysis contract rejected it, not argparse.
+            self.assertIn("does not match the live manifest matrix", result.stderr)
+
+    def test_cli_analyze_defaults_to_canonical_manifest(self) -> None:
+        manifest = self._live_manifest()
+        with TemporaryDirectory() as root:
+            root_path = Path(root)
+            baseline, optimized = self._write_conditions(root_path, manifest)
+            result = self._run_cli(
+                [
+                    "--baseline", str(baseline),
+                    "--optimized", str(optimized),
+                    "--bootstrap-repetitions", "100",
+                    "--output", str(root_path / "report.json"),
+                ]
+            )
+            # One targeted live model against the canonical manifest violates
+            # the canonical matrix check: the old failure mode, still intact.
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("does not match the live manifest matrix", result.stderr)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- `benchmarks/live-model-tools/v1/analyze.py`: `--manifest <path>` (default: canonical `manifest.json`) forwarded to `statistics.analyze` (from #1305, credited via `Co-authored-by`).
- `benchmarks/live-model-tools/v1/tests/test_framework.py`: the end-to-end targeted-manifest test from #1305, plus review fixes — the mismatched-manifest test now builds a populated matrix of a *different* live model (the original filtered a one-model list down to zero), both rejection tests write a real optimized file and assert the coverage error text (`does not match the live manifest matrix`), a `_write_conditions` helper replaces the duplicated writers, and the EOF whitespace is fixed.

### Why This Exists

- Supersedes #1305. The CLI change is right and needed for the #1056 targeted-family path; the review findings (whitespace gate, DCO, tests passing for the wrong reason) are fixed here. While asserting on stderr it turned out both rejection tests were failing on `optimized file contains wrong condition` — they passed the baseline file twice — so they never reached the manifest check they were named for.

### User / Operator Impact

- Operators validating one family can analyse their targeted run with the same manifest they ran, end to end.

### How It Works

- Unchanged from #1305: `load_object(a.manifest)` instead of the hard-coded canonical path; coverage, digest-pairing, split, and instance checks are untouched.

### Files And Contracts Touched

- `benchmarks/live-model-tools/v1/analyze.py`, `benchmarks/live-model-tools/v1/tests/test_framework.py`

### Affected Surfaces

- [x] Not executor-specific

## Validation

- [x] `uv run python benchmarks/live-model-tools/v1/tests/test_framework.py` — 15/15
- [x] `git diff --check origin/main`
- [x] Ruff on the two touched files
- [ ] Full suite, byte gates, smoke commands — left to PR CI; nothing under `src/` changed.

### Observed Evidence

- 15/15; the two rejection tests now fail with the argparse-era CLI for the right reason and pass with the flag.

### Not Tested / Not Applicable

- Paid live runs (harness-only change).
- Note: `benchmarks/live-model-tools/v1/tests` is not in CI's discovery path (`unittest discover -s tests`); the 15 tests are enforced only when run by hand. Worth its own issue.

## Risk

- None at runtime; the default manifest is unchanged.

## Compatibility / Rollout

- Additive CLI flag.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- #1310 uses this path for the Astra paired run.

Supersedes #1305 (cc @GentechLabs — thank you; your change is carried here with `Co-authored-by`). Refs #1056.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019b8yXELjdWBnnMTFsR7es2
