### PR TITLE
test(fanout): progress waits in the admission tests outlast a slow runner

### DIFF
--- a/tests/test_fanout_admission.py
+++ b/tests/test_fanout_admission.py
@@ -15,6 +15,15 @@ from omh.coding.fanout_dispatch import dispatch_fanout
 from omh.system.paths import OmhPaths
 
 _GOAL = "admit a ready frontier through an adaptive window"
+# Upper bound on every wait that expects dispatch to make progress. Each
+# unit's worktree is a real `git worktree add`, and the Windows CI runner has
+# been observed taking well over the previous 5s bound for a handful of them
+# (main run 33850199554: two different waits in this file timed out on two
+# attempts of the same commit, then passed on the third). A generous bound
+# costs nothing on a passing run -- every wait returns as soon as its
+# condition holds -- while a tight one turns runner speed into a failure.
+# Waits that assert NOTHING more starts keep their short, deliberate bound.
+_PROGRESS_WAIT_SECONDS = 60.0
 
 
 class _FakeCompleted:
@@ -43,7 +52,7 @@ class _ControlledRunner:
             self._condition.notify_all()
             released = self._condition.wait_for(
                 lambda: self._release_future or unit_id in self._released,
-                timeout=5,
+                timeout=_PROGRESS_WAIT_SECONDS,
             )
             self.active -= 1
             self._condition.notify_all()
@@ -51,7 +60,7 @@ class _ControlledRunner:
             raise AssertionError(f"timed out waiting to release {unit_id}")
         return _FakeCompleted()
 
-    def wait_for_started(self, count: int, timeout: float = 2.0) -> bool:
+    def wait_for_started(self, count: int, timeout: float = _PROGRESS_WAIT_SECONDS) -> bool:
         with self._condition:
             return self._condition.wait_for(
                 lambda: len(set(self.started)) >= count,
@@ -130,7 +139,7 @@ class FanoutAdaptiveSchedulerTests(unittest.TestCase):
                 runner.release(runner.started[0])
                 self.assertTrue(runner.wait_for_started(4))
                 runner.release_all()
-                summary = future.result(timeout=5)
+                summary = future.result(timeout=_PROGRESS_WAIT_SECONDS)
 
         self.assertEqual(runner.max_active, 3)
         self.assertTrue(all(unit["status"] == "completed" for unit in summary["units"]))
@@ -240,7 +249,7 @@ class _RetryControlledRunner:
             self._condition.notify_all()
             released = self._condition.wait_for(
                 lambda: self._release_future or key in self._released,
-                timeout=5,
+                timeout=_PROGRESS_WAIT_SECONDS,
             )
         if not released:
             raise AssertionError(f"timed out waiting to release {key}")
@@ -248,14 +257,14 @@ class _RetryControlledRunner:
             return _FakeLimitCompleted()
         return _FakeCompleted()
 
-    def wait_for_distinct_units(self, count: int, timeout: float = 2.0) -> bool:
+    def wait_for_distinct_units(self, count: int, timeout: float = _PROGRESS_WAIT_SECONDS) -> bool:
         with self._condition:
             return self._condition.wait_for(
                 lambda: len({unit_id for unit_id, _attempt in self.started}) >= count,
                 timeout=timeout,
             )
 
-    def wait_for_attempt(self, unit_id: str, attempt: int, timeout: float = 2.0) -> bool:
+    def wait_for_attempt(self, unit_id: str, attempt: int, timeout: float = _PROGRESS_WAIT_SECONDS) -> bool:
         with self._condition:
             return self._condition.wait_for(
                 lambda: (unit_id, attempt) in self.started,
@@ -350,7 +359,7 @@ class FanoutRecoveredPressureIntegrationTests(unittest.TestCase):
                 runner.release("b-pressure", 2)
                 self.assertFalse(runner.wait_for_distinct_units(5, timeout=0.2))
                 runner.release_all()
-                summary = future.result(timeout=5)
+                summary = future.result(timeout=_PROGRESS_WAIT_SECONDS)
 
         pressure = next(
             row
@@ -401,7 +410,7 @@ class FanoutInterruptedAdmissionTests(unittest.TestCase):
 
             def interrupt_after_completion(futures, **_kwargs):
                 for future in futures:
-                    future.result(timeout=5)
+                    future.result(timeout=_PROGRESS_WAIT_SECONDS)
                 raise KeyboardInterrupt
 
             with patch(


### PR DESCRIPTION
## Feature Report

### What Changed

- The fanout admission tests (`tests/test_fanout_admission.py`) bound every progress wait with one module constant, `_PROGRESS_WAIT_SECONDS = 60`, instead of hard-coded 2s and 5s limits. Negative waits that assert nothing more starts keep their 0.2s bound.

### Why This Exists

- main run 33850199554 (commit `7c99782c`) failed test-windows twice on two different waits in this file and passed on the third attempt with no code change. Each unit performs a real `git worktree add`, and the Windows runner's speed varies enough that a 5s bound turned runner load into a red main.

### User / Operator Impact

- A slow CI runner no longer fails the admission suite. Passing runs are not slower: every wait returns as soon as its condition holds.

### How It Works

- The controlled runners' release waits, the `wait_for_*` helper defaults, and the three `future.result(...)` calls use the constant. `future.result(timeout=0)` (surface-the-exception) and the two `assertFalse(..., timeout=0.2)` guards are unchanged.

### Files And Contracts Touched

- `tests/test_fanout_admission.py` only. No source or contract change.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [ ] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [ ] `uv run python -m omh.cli docs workflows --check`
- [ ] `uv run python -m omh.cli docs roles --check`
- [ ] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m unittest tests.test_fanout_admission`, 8 tests OK in under 2.5s
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not applicable, test-only change

### Observed Evidence

- Failure history: attempt 1 of run 33850199554 timed out in `test_adaptive_scheduler_starts_at_two_then_grows_after_a_clean_completion`, attempt 2 in `test_recovered_limit_pressure_reduces_admission_before_the_next_queued_unit`, attempt 3 passed. Windows suite durations for the same tree ranged from 909s to 1271s.
- The touched file's 8 tests pass locally; ruff, compileall, and `git diff --check` clean.

### Not Tested / Not Applicable

- Full suite, byte gates, harness, release: only a test file's wait bounds changed; no generated artifact, contract, or source path is affected. CI runs the full suite on this PR.
- A saturated Windows runner cannot be reproduced locally; the new bound is an upper limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMPYLrccMB2j7QS1cXNed7
