### PR TITLE
fix(hud): the row identity keeps its parentheses

### DIFF
--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -51,8 +51,12 @@ export default function register(sdk) {
     }
   }
 
+  // Parentheses are in the allowlist because the row identity is SHAPED by
+  // them: `category:architect(anthropic/claude...)`, `(codex/maestro ...)`,
+  // and `turn 3 (12 tools)` all lost their brackets here and rendered as
+  // one run-on token (`architectanthropic/c...`, the owner's report).
   const sanitizeText = value => String(value ?? '')
-    .replace(/[^\p{L}\p{N} .:/_·|+\[\]!\-]/gu, '')
+    .replace(/[^\p{L}\p{N} .:/_·|+()\[\]!\-]/gu, '')
   const safeText = value => sanitizeText(value).slice(0, 96)
 
   // Text, not chrome. The owner's direction after living with the bordered

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -310,6 +310,11 @@ class TuiWidgetPackTests(unittest.TestCase):
         self.assertIn("const truncateTextCells =", widget)
         self.assertIn("const sanitizeText =", widget)
         self.assertIn("sanitizeText(value).slice(0, 4096)", widget)
+        # The route identity is shaped by parentheses -- `category:architect(
+        # anthropic/claude...)`, `(codex/maestro ...)`, `turn 3 (12 tools)` --
+        # so the allowlist keeps them; stripping them rendered the category
+        # and model as one run-on token (`architectanthropic/c...`).
+        self.assertIn("/[^\\p{L}\\p{N} .:/_·|+()\\[\\]!\\-]/gu", widget)
         self.assertNotIn("safeText(value, 4096)", widget)
         self.assertIn("'blocked_by_dependency'", widget)
         self.assertIn("'dry_run_planned'", widget)


### PR DESCRIPTION
## Feature Report

### What Changed

- The TUI widget's text sanitizer (`sanitizeText` in `src/omh/tui_widgets/omh-status.mjs`) now keeps `(` and `)`. The subagent row identity `category:architect(anthropic/claude...)`, the Maestro lane identity `(codex/maestro ...)`, and `turn 3 (12 tools)` render with their brackets.

### Why This Exists

- Owner report with screenshot: activity rows read `category:architectanthropic/c...`, the lane name fused to the model. The allowlist predates the parenthesized identity shape, so the brackets were stripped one render step after the string was built.

### User / Operator Impact

- Subagent rows show the lane and the model as two readable parts again, and the turn/tool count keeps its grouping.

### How It Works

- One character-class change in the sanitizer regex. Every other unlisted character, including escapes and control characters, is still dropped. `tests/test_tui_widget_pack.py` pins the exact allowlist.

### Files And Contracts Touched

- `src/omh/tui_widgets/omh-status.mjs`, `tests/test_tui_widget_pack.py`. No payload or schema change; the widget is a managed artifact refreshed by `omh update`.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [ ] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [ ] `uv run python -m omh.cli docs workflows --check`
- [ ] `uv run python -m omh.cli docs roles --check`
- [ ] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: node evaluation of the sanitizer on `category:architect(anthropic/claude-fable-5-1:high)`, `(codex/maestro gpt-5.6)`, `turn 3 (12 tools)`, and a string carrying an ANSI escape; brackets survive, the escape is dropped
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: needs `omh update` plus TUI restart on the owner machine

### Observed Evidence

- `node --check` on the widget, `tests/test_tui_widget_pack.py` green, ruff and `git diff --check` clean. Full suite runs in CI.

### Not Tested / Not Applicable

- Byte gates, harness, release checks: no catalog, generated artifact, or release surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMPYLrccMB2j7QS1cXNed7
