### PR TITLE
fix(site): the landing page's hero badge carries the released version

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -107,8 +107,9 @@ The release bump commit must move every current-version surface together.
 | --- | --- |
 | `pyproject.toml` `version` | wheel and package metadata |
 | `src/plugin_bundle/omh/plugin.yaml` `version` | the installed Hermes plugin manifest — `hermes plugins doctor` and the plugin listing report this value, so leaving it behind under-reports every install (issue #1079: it sat at 1.0.5 through the 1.0.6 and 1.0.7 releases) |
+| `site/index.html` and `site/i18n.js` `hero.badge` | the landing page's first visible version — the static markup plus all four locale strings (it sat at v1.0.6 through the 2.0.0 release) |
 
-`VersionSurfaceParityTests` in `tests/test_release_smoke.py` gates both: a bump
+`VersionSurfaceParityTests` in `tests/test_release_smoke.py` gates all three: a bump
 commit that misses one fails the suite instead of shipping the drift. Version
 strings quoted in README/docs prose and CLI help examples are illustrative and
 deliberately not parity-gated — update them in the bump commit, but a stale

--- a/site/i18n.js
+++ b/site/i18n.js
@@ -24,10 +24,10 @@ window.OMH_I18N = {
 
     /* --------------------------------------------------------------- hero */
     "hero.badge": {
-      en: "For Hermes Agent · v1.0.6",
-      ko: "Hermes Agent 전용 · v1.0.6",
-      ja: "Hermes Agent のための · v1.0.6",
-      zh: "为 Hermes Agent 打造 · v1.0.6"
+      en: "For Hermes Agent · v2.0.0",
+      ko: "Hermes Agent 전용 · v2.0.0",
+      ja: "Hermes Agent のための · v2.0.0",
+      zh: "为 Hermes Agent 打造 · v2.0.0"
     },
     "hero.tagline": {
       en: 'Power intelligence and <em>agentic memory</em> for Hermes Agent.',

--- a/site/index.html
+++ b/site/index.html
@@ -88,7 +88,7 @@
           <img src="assets/omh-character-mask.png" alt="" width="768" height="768" fetchpriority="high">
         </figure>
 
-        <span class="pill pill--glass" data-reveal data-reveal-delay="40" data-i18n="hero.badge">For Hermes Agent · v1.0.6</span>
+        <span class="pill pill--glass" data-reveal data-reveal-delay="40" data-i18n="hero.badge">For Hermes Agent · v2.0.0</span>
 
         <h1 id="home-title" class="hero__title" data-reveal data-reveal-delay="90">
           <span class="chrome-word">Oh My Hermes</span>

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from contextlib import ExitStack
 import json
+import re
 import sys
 import subprocess
 import unittest
@@ -1018,6 +1019,24 @@ class VersionSurfaceParityTests(unittest.TestCase):
             if line.startswith("version = ")
         ]
         self.assertEqual(versions, [package_version])
+
+    def test_site_hero_badge_version_matches_the_package(self) -> None:
+        # The landing page's hero badge is the first version a visitor sees.
+        # It sat at v1.0.6 through the 2.0.0 release because nothing gated it;
+        # the static markup and every i18n locale string must carry the
+        # current version, while historical "as of vX" prose stays free.
+        site = Path(__file__).resolve().parents[1] / "site"
+        index_badges = re.findall(
+            r'data-i18n="hero\.badge">[^<]*?· v(\d+\.\d+\.\d+)</span>',
+            (site / "index.html").read_text(encoding="utf-8"),
+        )
+        self.assertEqual(index_badges, [package_version])
+        i18n = (site / "i18n.js").read_text(encoding="utf-8")
+        block = re.search(r'"hero\.badge": \{(.*?)\}', i18n, re.DOTALL)
+        self.assertIsNotNone(block)
+        locale_versions = re.findall(r'(\w+): "[^"]*?· v(\d+\.\d+\.\d+)"', block.group(1))
+        self.assertEqual(sorted(locale for locale, _ in locale_versions), ["en", "ja", "ko", "zh"])
+        self.assertEqual({version for _, version in locale_versions}, {package_version})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Feature Report

### What Changed

- The landing page hero badge (`site/index.html` and the `hero.badge` block of `site/i18n.js`, all four locales) now reads `v2.0.0` instead of `v1.0.6`.
- `VersionSurfaceParityTests` in `tests/test_release_smoke.py` gains a third gate: the badge in the static markup and in every locale string must equal `omh.version.__version__`.
- `docs/RELEASE.md` Version Bump Surfaces table lists the site badge as a surface the bump commit must move.

### Why This Exists

- The badge is the first version string a visitor reads, and it has said `v1.0.6` through the 1.0.7 – 2.0.0 releases. The existing parity gates covered `pyproject.toml` and `plugin.yaml` only, and the site's ULW region check covers only the generated inventory block, so the drift had no gate.

### User / Operator Impact

- Visitors see the released version on the landing page in every language.
- A release bump that forgets the site badge fails the suite instead of shipping stale copy.

### How It Works

- The test reads the badge text out of `site/index.html` with a regex anchored on `data-i18n="hero.badge"`, and the four locale strings out of the `hero.badge` object in `site/i18n.js`. It requires exactly the `en`/`ja`/`ko`/`zh` locales and one version across all of them equal to the package version.
- The install-availability note ("package-manager installs are public as of v1.0.6") is a historical fact and is deliberately left alone, matching the RELEASE.md rule that prose examples are not parity-gated.

### Files And Contracts Touched

- `site/index.html`, `site/i18n.js`
- `tests/test_release_smoke.py` (`VersionSurfaceParityTests`)
- `docs/RELEASE.md`

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

Check only commands that completed successfully. Leave non-applicable checks
unchecked and explain why under **Not Tested / Not Applicable**.

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli docs ulw-site --check`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- `VersionSurfaceParityTests`: 3 tests ok.
- Negative run: with the `ja` locale string set back to `v1.0.6`, the new test fails with the drifted version in the assertion diff; restored, it passes.
- `docs ulw-site --check` ok; `tests.test_ulw_inventory` 12 ok; ruff clean; `git diff --check` clean.
- Full suite on the branch: 9,056 tests ok in 496.9 seconds. compileall, workflows/roles/capability-families `--check`, and ruff all pass.

### Not Tested / Not Applicable

- The site was not rendered in a browser; the change is two text strings with no markup or script change.
- Harness validate, release checklist, hermes-smoke, and the install smoke are not applicable: no catalog, release, or install surface changed.

## Risk

- Low. Two site strings, one test, one docs row. The regex is anchored on the existing `data-i18n="hero.badge"` attribute and the `hero.badge` object key; renaming either fails the test loudly rather than silently skipping.

## Compatibility / Rollout

- No runtime or install behaviour changes. The site is static and picks up the strings on the next deploy.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019b8yXELjdWBnnMTFsR7es2
