### PR TITLE
fix(config): plugins.enabled items level with their key are read, and new items match the file's indent

### DIFF
--- a/src/install/config_adapter.py
+++ b/src/install/config_adapter.py
@@ -154,6 +154,15 @@ def plugin_enablement(config_text: str) -> dict[str, list[str]]:
             continue
         if not in_plugins or not stripped:
             continue
+        # A list item belongs to the key above it whether it sits under that
+        # key (`    - omh`, Hermes' own style) or level with it (`  - omh`,
+        # equally valid YAML). Checking the item shape before the key shape is
+        # what keeps a level item from being read as a new key and emptying
+        # the list (issue #1322).
+        if stripped.startswith("- "):
+            if current:
+                lists[current].append(stripped[2:].strip().strip("\"'"))
+            continue
         if line.startswith("  ") and not line.startswith("    "):
             key, _, rest = stripped.partition(":")
             key = key.strip()
@@ -163,10 +172,22 @@ def plugin_enablement(config_text: str) -> dict[str, list[str]]:
                 current = ""
                 continue
             current = key if key in lists else ""
-            continue
-        if current and stripped.startswith("- "):
-            lists[current].append(stripped[2:].strip().strip("\"'"))
     return lists
+
+
+def _plugin_list_item_indent(lines: list[str], plugins_index: int) -> str:
+    """The indent the file already uses for `plugins.*` list items.
+
+    Hermes writes `    - name`; a hand-edited file may use `  - name`. A new
+    item has to match whichever is there, or the list ends up with items at
+    two depths and YAML reads it as two different nodes.
+    """
+    for line in lines[plugins_index + 1:]:
+        if line.strip() and not line.startswith(" "):
+            break
+        if line.strip().startswith("- "):
+            return line[: len(line) - len(line.lstrip(" "))]
+    return "    "
 
 
 def configured_provider_ids(config_text: str) -> list[str]:
@@ -228,22 +249,25 @@ def ensure_plugin_enabled(config_text: str, name: str) -> ConfigChange:
         text = (config_text.rstrip() + f"\n\nplugins:\n  enabled:\n    - {name}\n").lstrip("\n")
         return ConfigChange(True, "appended plugins.enabled", text)
 
+    indent = _plugin_list_item_indent(lines, plugins_index)
     for idx in range(plugins_index + 1, len(lines)):
         line = lines[idx]
         if line.strip() and not line.startswith(" "):
             break
+        if line.strip().startswith("- "):
+            continue
         if line.startswith("  ") and not line.startswith("    "):
             key, _, rest = line.strip().partition(":")
             if key.strip() != "enabled":
                 continue
             inline = _parse_inline_list(rest.strip()) if rest.strip() else None
             if inline is not None:
-                lines[idx:idx + 1] = ["  enabled:", *[f"    - {value}" for value in [*inline, name]]]
+                lines[idx:idx + 1] = ["  enabled:", *[f"{indent}- {value}" for value in [*inline, name]]]
                 return ConfigChange(True, "expanded inline plugins.enabled", "\n".join(lines) + "\n")
-            lines.insert(idx + 1, f"    - {name}")
+            lines.insert(idx + 1, f"{indent}- {name}")
             return ConfigChange(True, "added plugin to plugins.enabled", "\n".join(lines) + "\n")
 
-    lines.insert(plugins_index + 1, f"    - {name}")
+    lines.insert(plugins_index + 1, f"{indent}- {name}")
     lines.insert(plugins_index + 1, "  enabled:")
     return ConfigChange(True, "inserted plugins.enabled", "\n".join(lines) + "\n")
 

--- a/tests/test_plugin_enablement_check.py
+++ b/tests/test_plugin_enablement_check.py
@@ -8,7 +8,7 @@ from _cli_harness import run_cli
 from _local_package import load_local_package
 
 load_local_package()
-from omh.config_adapter import plugin_enablement, plugin_is_enabled
+from omh.config_adapter import ensure_plugin_enabled, plugin_enablement, plugin_is_enabled
 from omh.maintenance.doctor import run_doctor
 from omh.paths import resolve_paths
 from omh.plugin_pack import PLUGIN_NAME
@@ -56,6 +56,63 @@ class PluginEnablementReaderTests(unittest.TestCase):
     def test_enablement_reports_both_lists(self) -> None:
         listed = plugin_enablement("plugins:\n  enabled:\n    - omh\n  disabled:\n    - browser\n")
         self.assertEqual(listed, {"enabled": ["omh"], "disabled": ["browser"]})
+
+
+    def test_level_indented_list_items_are_read(self) -> None:
+        # Issue #1322: `  - omh` (item level with its key) is valid YAML and
+        # what a hand-edited config used; the reader saw it as a key line and
+        # reported an empty list, so doctor blocked on a plugin that was on.
+        level = "plugins:\n  enabled:\n  - omh\n  - agentiker-plan-follow\n  disabled:\n  - github-prs\n"
+        self.assertEqual(plugin_enablement(level), {"enabled": ["omh", "agentiker-plan-follow"], "disabled": ["github-prs"]})
+        self.assertTrue(plugin_is_enabled(level, PLUGIN_NAME))
+
+    def test_level_indented_items_stay_with_their_own_key(self) -> None:
+        level = "plugins:\n  enabled:\n  - other\n  disabled:\n  - omh\n  entries:\n    omh:\n      allow_tool_override: false\n"
+        self.assertEqual(plugin_enablement(level), {"enabled": ["other"], "disabled": ["omh"]})
+        self.assertFalse(plugin_is_enabled(level, PLUGIN_NAME))
+
+    def test_items_under_an_untracked_key_are_ignored(self) -> None:
+        text = "plugins:\n  order:\n  - omh\n  enabled: []\n"
+        self.assertEqual(plugin_enablement(text), {"enabled": [], "disabled": []})
+
+
+class EnsurePluginEnabledMatchesTheFilesIndentTests(unittest.TestCase):
+    """A new list item takes the indent the file's plugin lists already use.
+
+    Writing `    - omh` into a file whose items sit at `  - ` puts items at
+    two depths under one key, which YAML reads as two nodes, not one list.
+    """
+
+    def test_level_style_file_gets_a_level_item(self) -> None:
+        text = "plugins:\n  enabled:\n  - other\n  disabled:\n  - github-prs\n"
+        change = ensure_plugin_enabled(text, PLUGIN_NAME)
+        self.assertEqual((change.changed, change.text), (True, "plugins:\n  enabled:\n  - omh\n  - other\n  disabled:\n  - github-prs\n"))
+        self.assertTrue(plugin_is_enabled(change.text, PLUGIN_NAME))
+
+    def test_nested_style_file_keeps_a_nested_item(self) -> None:
+        change = ensure_plugin_enabled(DISABLED_CONFIG, PLUGIN_NAME)
+        self.assertEqual((change.changed, change.text), (True, ENABLED_CONFIG))
+
+    def test_empty_enabled_follows_the_sibling_list(self) -> None:
+        text = "plugins:\n  enabled:\n  disabled:\n  - github-prs\n"
+        change = ensure_plugin_enabled(text, PLUGIN_NAME)
+        self.assertEqual(change.text, "plugins:\n  enabled:\n  - omh\n  disabled:\n  - github-prs\n")
+
+    def test_inline_expansion_follows_the_sibling_list(self) -> None:
+        text = "plugins:\n  enabled: [other]\n  disabled:\n  - github-prs\n"
+        change = ensure_plugin_enabled(text, PLUGIN_NAME)
+        self.assertEqual(change.text, "plugins:\n  enabled:\n  - other\n  - omh\n  disabled:\n  - github-prs\n")
+
+    def test_a_file_without_items_defaults_to_the_hermes_style(self) -> None:
+        change = ensure_plugin_enabled("plugins:\n  enabled: []\n", PLUGIN_NAME)
+        self.assertEqual(change.text, "plugins:\n  enabled:\n    - omh\n")
+        change = ensure_plugin_enabled("plugins:\n  entries: {}\n", PLUGIN_NAME)
+        self.assertEqual(change.text, "plugins:\n  enabled:\n    - omh\n  entries: {}\n")
+
+    def test_a_level_item_never_reads_as_already_enabled_for_another_key(self) -> None:
+        text = "plugins:\n  disabled:\n  - other\n"
+        change = ensure_plugin_enabled(text, PLUGIN_NAME)
+        self.assertEqual(change.text, "plugins:\n  enabled:\n  - omh\n  disabled:\n  - other\n")
 
 
 class DoctorPluginEnabledCheckTests(unittest.TestCase):


### PR DESCRIPTION
## Feature Report

### What Changed

- `plugin_enablement()` in `src/install/config_adapter.py` reads `plugins.enabled` / `plugins.disabled` list items at either depth: nested under the key (`    - omh`, Hermes' own style) or level with it (`  - omh`, equally valid YAML). It checks the `- ` item shape before the two-space key shape, so a level item is no longer read as a key that empties the list.
- `ensure_plugin_enabled()` writes a new item at the indent the file's plugin lists already use, via a small `_plugin_list_item_indent()` helper. It falls back to the four-space Hermes style only when the block has no list item to follow.
- `tests/test_plugin_enablement_check.py` gains three reader cases (the issue's exact config, level items staying with their own key, level items under an untracked key ignored) and a six-case writer class covering level, nested, empty-list, inline-expansion, no-items, and disabled-only files.

### Why This Exists

- Issue #1322: `omh doctor --json` reported `plugin_enabled_in_hermes` as blocking for a config whose `plugins.enabled` did list `omh`, because the items were written level with the key. The remediation it printed, `hermes plugins enable omh`, only cleared the check because Hermes rewrote the file in its nested style.
- The writer had the mirror assumption. Inserting `    - omh` into a level-style file puts items at two depths under one key, which a YAML parser rejects outright, so `omh setup` could leave a config Hermes cannot load.

### User / Operator Impact

- A hand-edited or tool-written config that uses level list items passes doctor when the plugin is enabled and gets a correct blocking verdict when it is not.
- `omh setup` on such a file inserts an item Hermes can parse, instead of producing mixed indentation.
- Nested-style files produce byte-identical output to before.

### How It Works

- The reader's loop inside the `plugins:` block now tests `stripped.startswith("- ")` first and appends to the currently tracked list key, or ignores the item when no tracked key is open. Only then does it treat a two-space line as a key. Inline lists (`enabled: [omh]`) are unchanged.
- The writer scans the `plugins:` block for the first `- ` line and reuses its leading whitespace for the new item, for the inline-expansion path, and for a freshly inserted `enabled:` list.
- The core stays dependency-free; this remains a line parser. PyYAML was used only as an out-of-tree oracle while writing the expected texts (see evidence).

### Files And Contracts Touched

- `src/install/config_adapter.py` (`plugin_enablement`, `_plugin_list_item_indent`, `ensure_plugin_enabled`)
- `tests/test_plugin_enablement_check.py`

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

Check only commands that completed successfully. Leave non-applicable checks
unchecked and explain why under **Not Tested / Not Applicable**.

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [ ] `uv run python -m omh.cli docs workflows --check`
- [ ] `uv run python -m omh.cli docs roles --check`
- [ ] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: PyYAML cross-check described below.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- `tests.test_plugin_enablement_check`: 23 tests ok. With `src/install/config_adapter.py` stashed back to `main`, the same file fails 6 (the three new reader cases and three of the writer cases), so the new cases pin the bug rather than the current behaviour.
- The issue's reproduction (`plugin_is_enabled` on the level-indented config) now returns `True`; the nested config still returns `True`.
- PyYAML cross-check (`uv run --with pyyaml`, not a repo dependency): for six input files (level, level with empty `enabled:`, level with inline `enabled:`, nested, no items, the issue's config) the text `ensure_plugin_enabled` writes is parsed by `yaml.safe_load` to exactly the lists `plugin_enablement` reads back, and every one contains `omh`. The pre-fix output shape for a level file (`    - omh` above `  - other`) raises `yaml.parser.ParserError`.
- `tests.test_tui_widget_pack` ok; ruff, compileall, and `git diff --check` clean.
- Full suite on the branch: 9,065 tests ok in 509.4 seconds.

### Not Tested / Not Applicable

- No live `hermes` was run against a config this code wrote; the YAML parser is the oracle for "Hermes can load it".
- Generated-artifact gates, harness validate, release checklist, and install smokes are not applicable: no catalog, docs, or install surface changed.

## Risk

- Low. Two functions, no new shapes accepted beyond the second list-item depth. A `- ` line inside the `plugins:` block under a key that is not `enabled`/`disabled` is ignored, as before.
- Comments inside the `plugins:` block are still not handled by this parser; that is pre-existing and out of the issue's scope.

## Compatibility / Rollout

- No install or config format change. Files in Hermes' nested style are read and written exactly as before.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- None.

Closes #1322

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019b8yXELjdWBnnMTFsR7es2
