### PR TITLE
test(adapters): the non-timeout scenarios get the 5-second budget the crash-descendant test already uses

### DIFF
--- a/tests/test_cross_harness_adapters.py
+++ b/tests/test_cross_harness_adapters.py
@@ -91,6 +91,22 @@ def _passthrough_backend(argv: tuple[str, ...], *_args: Path | str | bool | tupl
     return argv
 
 
+def _scenario_diagnostics(outcome: runner.AdapterRunReceipt, elapsed: float) -> str:
+    # When a scenario is misclassified the interesting facts are how long the
+    # child lived and what the host does with a dying process (issue #1321:
+    # `crash` read as `process_timeout` on Linux shards); put them in the
+    # assertion message so a red run explains itself.
+    core_pattern = Path("/proc/sys/kernel/core_pattern")
+    pattern = core_pattern.read_text(encoding="utf-8").strip() if core_pattern.exists() else "n/a"
+    rep = outcome.repetitions[0] if outcome.repetitions else None
+    return (
+        f"elapsed={elapsed:.2f}s core_pattern={pattern!r} "
+        f"status={getattr(rep, 'process_status', None)} exit={getattr(rep, 'exit_code', None)} "
+        f"group_terminated={getattr(rep, 'process_group_terminated', None)} "
+        f"stdout_bytes={getattr(rep, 'stdout_bytes', None)} stderr_bytes={getattr(rep, 'stderr_bytes', None)}"
+    )
+
+
 class _RunnerMixin(unittest.TestCase):
     def _run_fake_adapter(self, request: AdapterRequest, spec: ExecutionSpec, output: runner.OutputContract) -> runner.AdapterRunReceipt:
         with patch("src.quality.cross_harness_adapters._backend_available", return_value=True), patch("src.quality.cross_harness_adapters._sandbox_command", _passthrough_backend), patch("src.quality.cross_harness_adapters._preflight", return_value=(True, "test-backend")):
@@ -264,8 +280,16 @@ class FailClosedAdapterRunnerTests(_RunnerMixin):
         }
         for scenario, reason in expected.items():
             with self.subTest(scenario=scenario):
-                outcome = self._run(scenario)
-                self.assertEqual(outcome.reason_code, reason)
+                # Only `timeout` has to finish inside the 2-second default; it
+                # is the one scenario the deadline is the point of. The others
+                # exit on their own, and `crash` in particular was read as
+                # `process_timeout` on Linux CI shards under that budget on
+                # five of seven runs (issue #1321), the same tightness the
+                # crash-descendant test had already hit. They get the 5s
+                # budget that test uses.
+                started = time.monotonic()
+                outcome = self._run(scenario, timeout_seconds=2 if scenario == "timeout" else 5)
+                self.assertEqual(outcome.reason_code, reason, msg=_scenario_diagnostics(outcome, time.monotonic() - started))
                 self.assertNotEqual(outcome.status, "observed_success")
                 if scenario == "timeout":
                     self.assertEqual((outcome.repetitions[0].process_group_terminated, outcome.repetitions[0].inventory[0].path), (True, "work/descendant-heartbeat"))


### PR DESCRIPTION
## Feature Report

### What Changed

- `tests/test_cross_harness_adapters.py`: in `test_timeout_crash_wrong_stale_and_misleading_zero_fail`, only the `timeout` scenario keeps the 2-second budget. The five scenarios that exit on their own (`crash`, `wrong-artifact`, `stale-artifact`, `preseed-stale`, `misleading-zero`) run with the 5-second budget the `crash-descendant` test already uses.
- The assertion message for those subtests now carries elapsed time, the host's `core_pattern`, and the observed process status, so a future red on this test explains itself without a diagnostic commit.
- The fixture and the runner are untouched.

### Why This Exists

- Issue #1321: the `crash` subtest failed as `'process_timeout' != 'process_crash'` on five of seven Linux shard runs in the last day, including a rerun of a single job on a fresh VM, which rules out the sibling-shard load explanation the issue opened with.
- Two diagnostic revisions of this branch each failed on the same shard and reported the child still alive when the 2-second deadline fired (`elapsed=2.07s status=timeout exit=None`, no bytes on either stream) on a host whose `core_pattern` is a pipe to systemd-coredump. Neither `RLIMIT_CORE=0` before `os.abort()` nor dying by SIGKILL changed that, so the dying signal is not the whole story.
- The same test's `crash-descendant` twin aborts the same way under `timeout_seconds=5` and never failed in those runs. That is the direct evidence the wider budget is enough.

### User / Operator Impact

- CI shards that carry the adapter runner tests stop going red on a child that the runner never got to observe, so `aggregate` stops needing reruns for this test.

### How It Works

- `self._run(scenario, timeout_seconds=2 if scenario == "timeout" else 5)`. The `timeout` scenario is the one the deadline is the point of, and it keeps the tight bound with its existing process-group and heartbeat assertions.
- `_scenario_diagnostics()` reads `/proc/sys/kernel/core_pattern` when present and formats the first repetition's status, exit code, group termination, and stream byte counts into the assertion message.

### Files And Contracts Touched

- `tests/test_cross_harness_adapters.py`

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

Check only commands that completed successfully. Leave non-applicable checks
unchecked and explain why under **Not Tested / Not Applicable**.

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [ ] `uv run python -m omh.cli docs workflows --check`
- [ ] `uv run python -m omh.cli docs roles --check`
- [ ] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m unittest tests.test_cross_harness_adapters -v`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- Diagnostic runs on earlier revisions of this branch: run 33893104849 (`RLIMIT_CORE=0` + `os.abort()`) and run 33894040613 (SIGKILL) each failed `test (3.12, 1)` on the `crash` subtest with `elapsed=2.07s core_pattern='|/usr/lib/systemd/systemd-coredump ...' status=timeout exit=None stderr_bytes=0`.
- Run 33894959976 (SIGKILL + stderr breadcrumbs) passed that shard on both attempts; its attempt-1 failure was an unrelated Windows junction timeout in `test_staged_self_update`.
- `crash-descendant` (`timeout_seconds=5`, same `os.abort()`) passed on every one of those runs.
- `tests.test_cross_harness_adapters`: 14 tests ok on macOS with this revision.
- Full local suite: 9,065 tests ok on an earlier revision of this branch that changed the same test file and the fixture; this revision reverts the fixture and touches only the test.
- Ruff, compileall, and `git diff --check` clean.

### Not Tested / Not Applicable

- The Linux shard with this exact revision is only exercised by this PR's CI run. Local runs are macOS, where the test has never failed.
- Generated-artifact gates, harness validate, release checklist, and install smokes are not applicable: one test file changed, nothing under `src/`.

## Risk

- Low. One test method and one message helper. The `timeout` scenario's own assertions are unchanged, so a runner that stops honouring the deadline still fails.

## Compatibility / Rollout

- No product change.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- None.

Closes #1321

🤖 Generated with [Claude Code](https://claude.com/claude-code)

