### PR TITLE
feat(models): measure the gpt-6-astra override against the block it replaced, and revise it on the number

### DIFF
--- a/MODEL_OPTI.md
+++ b/MODEL_OPTI.md
@@ -277,13 +277,15 @@ pairing so a benchmark claim can never mix in other prompt changes.
   (re-deriving settled facts, re-verifying for reassurance) is not what the
   guide describes for Astra, which is why the override exists.
 - **What OMH injects (subagent):** the user's instructions outrank skill or
-  guideline text and the numbered criteria are the complete task — carry
-  them to completion instead of pausing for sign-off on authorized work; ask
-  one focused question only when a missing input would materially change
-  the result, otherwise state the assumption and proceed; size tests to the
-  change — a reversible, low-impact edit that mirrors its implementation
-  needs no new test, and a green check is re-run only when its inputs
-  changed. Two constraint sentences; under the per-block ceiling.
+  guideline text and the numbered criteria are the complete task — nothing
+  outside them is owed; ask one focused question only when a missing input
+  would materially change the result, otherwise state the assumption and
+  proceed; size tests to the change — a reversible, low-impact edit that
+  mirrors its implementation needs no new test, and a green check is re-run
+  only when its inputs changed. Two constraint sentences; under the
+  per-block ceiling. The first sentence originally read "carry them to
+  completion instead of pausing for sign-off on work the boundary already
+  authorizes"; the 2026-09-05 measurement below is why it no longer does.
 - **What OMH injects (composer):** write the user's intent into each unit
   prompt above any skill text; delegate every unit that is independent of
   the work you keep (an undelegated independent unit is chosen latency);
@@ -317,16 +319,34 @@ pairing so a benchmark claim can never mix in other prompt changes.
   input at the default tenth). The $12.5/M cache-write rate and the 2x
   input / 1.5x output multiplier above 272K input tokens have no column in
   that table and are documented in the contract instead of flattened.
+- **Measured (2026-09-05, subagent block):** four arms on
+  `benchmarks/live-model-tools/v1`, evaluation split (30 instances, corpus
+  digest `c4ea899a…`), `hermes_current_session` path, `openai-codex` /
+  `gpt-6-astra` at `xhigh`, omh 2.0.0, Hermes 0.21.0, arm order
+  optimized → family → baseline → revised. Every arm passed 18 / 30 with
+  identical per-template results, so pass rate decided nothing. Tokens did:
+  the original override cost 1,675,942 against the inherited `gpt` block's
+  1,513,367 (+5,419 per instance, bootstrap CI95 [+1,444, +10,150], more in
+  26 / 30) and against no calibration at all (1,550,904). Hermes' own
+  session rows put it at 310 tool calls / 206 API turns versus 286 / 194 for
+  the family block, with the excess concentrated in `BUGFIX` and
+  `DIAGNOSTICS` — the model kept working on tasks it was not going to pass.
+  The "carry them to completion instead of pausing" clause was the one
+  sentence with that reading, and the block above is the revision that
+  replaces it: 1,532,241 tokens (−4,790 per instance against the original,
+  CI95 [−9,336, −1,075]; +629 against the family block, CI95 [−1,109,
+  +2,445], indistinguishable), 294 tool calls, 192 API turns, still 18 / 30.
+  Per §8 that is the "revise" outcome: the Astra-specific counters
+  (assumption over question, test sizing) stay, the clause that made the
+  model over-work is gone, and the override now costs what the block it
+  replaced costs. Full tables in the benchmark README. Not measured: the
+  composer block (no fanout in this harness), clarification and delegation
+  counts (the corpus never provokes them; #1327 is the follow-up), and any
+  claim beyond this corpus.
 - **Source:** official (the OpenAI model reference, latest-model guide,
   reasoning guide, async tool calling and steering guides, monitorability
-  evaluation, and system card, read 2026-09-04). Not yet measured: the
-  named follow-up is a same-corpus, same-effort, counterbalanced paired run
-  of the inherited `gpt` calibration against this override on
-  `benchmarks/live-model-tools/v1` (targeted manifest, one GPT family
-  entry), recording criteria pass, wall time, token usage, tool-call,
-  clarification, delegation, and verification counts, and reopened
-  criteria; a variant that measures worse than the inherited block is
-  revised or removed in the change that reports the number.
+  evaluation, and system card, read 2026-09-04), plus the 2026-09-05
+  measurement above for the first sentence's wording.
 
 ### `claude` (Fable 5.1, Mythos 5.1, Fable 5, Opus 5, Sonnet, Haiku)
 

--- a/benchmarks/live-model-tools/v1/README.md
+++ b/benchmarks/live-model-tools/v1/README.md
@@ -173,3 +173,71 @@ workspace-pinned `TERMINAL_CWD`, and tool byproducts (`.venv`, `.pytest_cache`,
 
 Results describe this pinned corpus, OMH version, Hermes version, model IDs,
 and conditions only. They do not establish universal model superiority.
+
+### 2026-09-05 `gpt-6-astra` four-arm evaluation (issue #1310)
+
+The first exact-model override (`MODEL_HIGH_EFFORT_CALIBRATIONS["gpt-6-astra"]`,
+#1307) measured against the block it replaced. Same pinned evaluation corpus
+(30 instances, digest `c4ea899a8e727fcc531776e56306ff0e83d129e2248fe4362614b3d186fa7b33`),
+`hermes_current_session` path, `openai-codex` / `gpt-6-astra` at `xhigh`,
+omh 2.0.0, Hermes Agent 0.21.0, targeted manifest with that one live entry.
+Arms ran sequentially in the order optimized → family → baseline → revised
+(not counterbalanced within an arm; the harness runs one condition per
+invocation). Only validator passes count as success.
+
+| Arm | What the prompt carries | Passed | Total tokens | Mean tokens | Tool calls | API turns |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| baseline | bare contract, no calibration | 18 / 30 | 1,550,904 | 51,697 | 310 | 203 |
+| family | inherited `HIGH_EFFORT_CALIBRATIONS["gpt"]` | 18 / 30 | 1,513,367 | 50,446 | 286 | 194 |
+| optimized | original `gpt-6-astra` override (#1307 wording) | 18 / 30 | 1,675,942 | 55,865 | 310 | 206 |
+| revised | `gpt-6-astra` override as shipped after this run | 18 / 30 | 1,532,241 | 51,075 | 294 | 192 |
+
+Tool calls and API turns are not harness metrics on this path (the usage
+file carries neither); they were read afterwards from the Hermes `sessions`
+table for the sessions each arm created, joined by run order, and are
+reported as out-of-harness observations.
+
+Per template (passes out of 3 / tokens over the 3 seeds):
+
+| Template (class) | baseline | family | optimized | revised |
+| --- | ---: | ---: | ---: | ---: |
+| RENAME (edit) | 3 / 159,187 | 3 / 159,894 | 3 / 163,757 | 3 / 163,468 |
+| BUGFIX (edit) | 3 / 228,497 | 3 / 189,869 | 3 / 233,835 | 3 / 205,791 |
+| PRECEDENCE (read) | 0 / 106,910 | 0 / 109,283 | 0 / 109,617 | 0 / 109,779 |
+| CALLFLOW (read) | 0 / 161,874 | 0 / 174,767 | 0 / 165,916 | 0 / 163,897 |
+| REFERENCES (search) | 3 / 160,587 | 3 / 156,328 | 3 / 154,761 | 3 / 161,001 |
+| PREDICATE (search) | 3 / 133,311 | 3 / 119,482 | 3 / 120,176 | 3 / 119,834 |
+| DEFINITION (lsp) | 0 / 156,716 | 0 / 149,832 | 0 / 172,126 | 0 / 148,439 |
+| DIAGNOSTICS (lsp) | 0 / 233,511 | 0 / 227,993 | 0 / 322,645 | 0 / 227,300 |
+| SCALE (routing) | 3 / 116,522 | 3 / 124,772 | 3 / 128,995 | 3 / 128,785 |
+| EXPLICIT (routing) | 3 / 93,789 | 3 / 101,147 | 3 / 104,114 | 3 / 103,947 |
+
+Paired token deltas per instance (10,000-sample bootstrap, seed 20260813):
+
+| Pair (b − a) | Mean Δ tokens | CI95 | b > a |
+| --- | ---: | ---: | ---: |
+| family − baseline | −1,251 | [−3,763, +1,300] | 15 / 30 |
+| optimized − baseline | +4,168 | [−324, +9,100] | 23 / 30 |
+| optimized − family | +5,419 | [+1,444, +10,150] | 26 / 30 |
+| revised − family | +629 | [−1,109, +2,445] | 24 / 30 |
+| revised − optimized | −4,790 | [−9,336, −1,075] | 7 / 30 |
+
+Pass rate tied across every arm (McNemar p = 1.0 for both `analyze.py`
+pairs), so the decision rests on cost. The original override spent more than
+the block it replaced, with the excess in `BUGFIX` and `DIAGNOSTICS`: the
+model kept working on instances it did not pass. Its first sentence ("carry
+them to completion instead of pausing for sign-off") was the one clause with
+that reading; the revised block replaces it with "nothing outside them is
+owed", keeps the assumption-over-question and test-sizing sentences, and
+lands within the family block's cost. That is the wording now in
+`unit_prompt_protocol.py`; the `optimized` row is the wording it replaced.
+
+The read and lsp classes scored 0 in every arm, as they did for every model
+in the 2026-08-14 run; that is a property of those templates against the
+current validators, not of the calibration. The traits the Astra override was
+written for (clarifying questions, delegation, test breadth) are never
+provoked by this corpus; #1327 tracks the templates and counters that would
+measure them.
+
+Results describe this pinned corpus, OMH version, Hermes version, model IDs,
+and conditions only. They do not establish universal model superiority.

--- a/benchmarks/live-model-tools/v1/README.md
+++ b/benchmarks/live-model-tools/v1/README.md
@@ -77,7 +77,11 @@ writes a metadata-only record with a redacted failure classification and receipt
 raw stdout, stderr, prompts, credentials, and config remain unpersisted.
 
 Run baseline and optimized matrices separately so every condition uses the same
-pinned instances:
+pinned instances. A third condition, `family`, sends the block the model would
+inherit from its family with any exact-model override skipped; it exists so an
+override (for example `gpt-6-astra` over the `gpt` block) is measured against
+what it replaced and not only against no calibration. Pair it with `analyze.py
+--baseline-condition family` so the override is the `optimized` side:
 
 ```bash
 python benchmarks/live-model-tools/v1/bench.py run \

--- a/benchmarks/live-model-tools/v1/analyze.py
+++ b/benchmarks/live-model-tools/v1/analyze.py
@@ -8,7 +8,7 @@ from common import load_object, write_json
 from statistics import analyze
 
 def main(argv=None):
- p=argparse.ArgumentParser(); p.add_argument("--baseline",type=Path,required=True); p.add_argument("--optimized",type=Path,required=True); p.add_argument("--bootstrap-repetitions",type=int,default=10000); p.add_argument("--seed",type=int,default=20260813); p.add_argument("--manifest",type=Path,default=BASE/"manifest.json"); p.add_argument("--output",type=Path,required=True); a=p.parse_args(argv)
+ p=argparse.ArgumentParser(); p.add_argument("--baseline",type=Path,required=True); p.add_argument("--optimized",type=Path,required=True); p.add_argument("--bootstrap-repetitions",type=int,default=10000); p.add_argument("--seed",type=int,default=20260813); p.add_argument("--manifest",type=Path,default=BASE/"manifest.json"); p.add_argument("--output",type=Path,required=True); p.add_argument("--baseline-condition",choices=("baseline","optimized","family"),default="baseline"); p.add_argument("--optimized-condition",choices=("baseline","optimized","family"),default="optimized"); a=p.parse_args(argv)
  if a.bootstrap_repetitions<100: p.error("bootstrap repetitions must be at least 100")
- report=analyze(a.baseline,a.optimized,a.bootstrap_repetitions,a.seed,load_object(a.manifest)); write_json(a.output,report); print(json.dumps(report,sort_keys=True,indent=2)); return 0
+ report=analyze(a.baseline,a.optimized,a.bootstrap_repetitions,a.seed,load_object(a.manifest),baseline_condition=a.baseline_condition,optimized_condition=a.optimized_condition); write_json(a.output,report); print(json.dumps(report,sort_keys=True,indent=2)); return 0
 if __name__=="__main__": raise SystemExit(main())

--- a/benchmarks/live-model-tools/v1/bench.py
+++ b/benchmarks/live-model-tools/v1/bench.py
@@ -33,7 +33,7 @@ def main(argv: list[str] | None = None) -> int:
         command.add_argument("--harness", choices=("fake", "omh", "hermes_current_session"), default="fake")
         command.add_argument("--manifest", type=Path, default=BASE / "manifest.json")
         command.add_argument("--model", action="append")
-        command.add_argument("--condition", choices=("baseline", "optimized"), default="baseline")
+        command.add_argument("--condition", choices=("baseline", "optimized", "family"), default="baseline")
         command.add_argument("--split", choices=("development", "evaluation"), default="development")
         command.add_argument("--output", type=Path)
         command.add_argument("--omh-executable", default="omh")

--- a/benchmarks/live-model-tools/v1/lib/omh_live.py
+++ b/benchmarks/live-model-tools/v1/lib/omh_live.py
@@ -176,6 +176,24 @@ def prompt_pair(task: str, route: Mapping[str, Any]) -> tuple[str, str]:
     return common, optimized
 
 
+def prompt_for_condition(task: str, route: Mapping[str, Any], condition: str) -> str:
+    """The prompt one benchmark condition sends; every condition shares one task.
+
+    `baseline` is the bare contract, `optimized` adds the calibration the
+    route resolves (an exact-model override when one exists), and `family`
+    adds the block the model would inherit from its family with the override
+    skipped. `family` exists so an exact-model override can be measured
+    against what it replaced, not only against no calibration at all.
+    """
+    baseline, optimized = prompt_pair(task, route)
+    if condition == "optimized":
+        return optimized
+    if condition == "family":
+        calibration = calibration_for_route(route, family_only=True)
+        return baseline if not calibration else f"{calibration}\n\n{baseline}"
+    return baseline
+
+
 def task_digest(prompt: str) -> str:
     try:
         task = prompt.split(_TASK_START, 1)[1].split(_TASK_END, 1)[0]
@@ -229,8 +247,7 @@ def run_trial(
     if route_completed.returncode:
         raise RuntimeError(f"OMH model route failed with exit {route_completed.returncode}")
     route = json.loads(route_completed.stdout)
-    baseline, optimized = prompt_pair(task, route)
-    prompt = optimized if condition == "optimized" else baseline
+    prompt = prompt_for_condition(task, route, condition)
     completed = subprocess.run(
         _platform_argv(dispatch_argv(
             omh_executable,
@@ -335,8 +352,7 @@ def run_current_session_trial(
             kind="route_protocol",
             classification="adapter_protocol_error",
         )
-    baseline, optimized = prompt_pair(task, route)
-    prompt = optimized if condition == "optimized" else baseline
+    prompt = prompt_for_condition(task, route, condition)
     with TemporaryDirectory(prefix="omh-current-session-usage-") as usage_root:
         usage_file = Path(usage_root) / "usage.json"
         try:

--- a/benchmarks/live-model-tools/v1/lib/runner.py
+++ b/benchmarks/live-model-tools/v1/lib/runner.py
@@ -71,8 +71,8 @@ def execute_one(
     hermes_executable: str = "hermes",
     current_session_provider: str | None = None,
 ) -> dict[str, Any]:
-    if condition not in {"baseline", "optimized"}:
-        raise ValueError("condition must be baseline or optimized")
+    if condition not in {"baseline", "optimized", "family"}:
+        raise ValueError("condition must be baseline, optimized, or family")
     with TemporaryDirectory(prefix="omh-bench-") as root_text:
         root = Path(root_text)
         workspace = root / "workspace"

--- a/benchmarks/live-model-tools/v1/lib/statistics.py
+++ b/benchmarks/live-model-tools/v1/lib/statistics.py
@@ -91,9 +91,16 @@ def analyze(
     repetitions: int,
     seed: int,
     manifest: dict[str, Any],
+    *,
+    baseline_condition: str = "baseline",
+    optimized_condition: str = "optimized",
 ) -> dict[str, Any]:
-    baseline = _indexed(read_jsonl(baseline_path), "baseline")
-    optimized = _indexed(read_jsonl(optimized_path), "optimized")
+    # The two files are compared positionally; the condition each must carry
+    # is a parameter so an exact-model override (`optimized`) can be paired
+    # against the family block it replaced (`family`) as well as against the
+    # bare contract (`baseline`).
+    baseline = _indexed(read_jsonl(baseline_path), baseline_condition)
+    optimized = _indexed(read_jsonl(optimized_path), optimized_condition)
     if set(baseline) != set(optimized):
         raise ValueError("baseline and optimized coverage differ")
     for key in baseline:
@@ -156,6 +163,7 @@ def analyze(
     return {
         "schema_version": "omh_live_model_tool_analysis/v1",
         "analysis_seed": seed,
+        "conditions": {"baseline": baseline_condition, "optimized": optimized_condition},
         "models": models,
         "holm": holm(pvalues),
         "claim_boundary": manifest["claim_boundary"],

--- a/benchmarks/live-model-tools/v1/schemas/run-record.schema.json
+++ b/benchmarks/live-model-tools/v1/schemas/run-record.schema.json
@@ -21,7 +21,7 @@
     "created_at": {"type": "string"},
     "instance_id": {"type": "string"},
     "split": {"enum": ["development", "evaluation"]},
-    "condition": {"enum": ["baseline", "optimized"]},
+    "condition": {"enum": ["baseline", "optimized", "family"]},
     "harness": {"enum": ["fake", "omh"]},
     "model": {"type": ["object", "null"]},
     "task_digest": {"$ref": "#/$defs/digest"},

--- a/benchmarks/live-model-tools/v1/tests/test_framework.py
+++ b/benchmarks/live-model-tools/v1/tests/test_framework.py
@@ -163,6 +163,38 @@ class OmhBenchmarkFrameworkTests(unittest.TestCase):
             self.assertTrue(audited["ok"])
             self.assertFalse(audited["claim_permitted"])
 
+    def test_analysis_pairs_the_family_arm_against_the_override(self) -> None:
+        manifest = json.loads((BASE / "manifest.json").read_text())
+        with TemporaryDirectory() as root:
+            root_path = Path(root)
+            family = root_path / "family.jsonl"
+            optimized = root_path / "optimized.jsonl"
+            for condition, output in (("family", family), ("optimized", optimized)):
+                record = execute_one(BASE, manifest, "development", "D-RENAME", "edit", 7919, condition, output)
+                self.assertEqual(record["condition"], condition)
+            result = analyze(family, optimized, 100, 7, manifest, baseline_condition="family")
+            self.assertEqual(result["conditions"], {"baseline": "family", "optimized": "optimized"})
+            self.assertEqual(result["models"]["offline/fake-model"]["n"], 1)
+            with self.assertRaisesRegex(ValueError, "baseline file contains wrong condition"):
+                analyze(family, optimized, 100, 7, manifest)
+            default = analyze(optimized, optimized, 100, 7, manifest, baseline_condition="optimized")
+            self.assertEqual(default["conditions"], {"baseline": "optimized", "optimized": "optimized"})
+
+    def test_bench_cli_schedules_the_family_condition_offline(self) -> None:
+        with TemporaryDirectory() as root:
+            output = Path(root) / "family-runs.jsonl"
+            completed = subprocess.run(
+                [sys.executable, str(BASE / "bench.py"), "run", "--condition", "family", "--output", str(output)],
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            receipt = json.loads(completed.stdout)
+            self.assertEqual((receipt["condition"], receipt["scheduled"], receipt["paid_calls_launched"]), ("family", 10, 0))
+            conditions = {json.loads(line)["condition"] for line in output.read_text().splitlines()}
+            self.assertEqual(conditions, {"family"})
+
     def test_analysis_rejects_unscheduled_model_claim_matrix(self) -> None:
         manifest = json.loads((BASE / "manifest.json").read_text())
         with TemporaryDirectory() as root:

--- a/docs/MODEL-ONBOARDING.md
+++ b/docs/MODEL-ONBOARDING.md
@@ -155,6 +155,15 @@ pair (old generation vs new, same task corpus, same effort) as the follow-up
 when no served route exists yet. A calibration that measures worse than
 baseline is revised or removed in the same change that reports the number.
 
+An exact-model override has a second pair: `family` vs `optimized` on
+`benchmarks/live-model-tools/v1` (`bench.py run --condition family`, then
+`analyze.py --baseline-condition family`). The family arm sends the block the
+model would inherit if the override did not exist, so the override is judged
+against what it replaced, not only against no calibration. Pass rate alone
+is the wrong yardstick on that corpus (every arm tends to tie); read the
+paired token delta and, where the host records them, tool-call and turn
+counts, because a counter for an "over-doing" trait shows up there first.
+
 ## 9. Report
 
 PR body per the repo template: capability, motivation, boundary-level

--- a/src/coding/unit_prompt_protocol.py
+++ b/src/coding/unit_prompt_protocol.py
@@ -447,20 +447,26 @@ def completion_criteria_for_unit(unit: Mapping[str, Any]) -> list[str]:
     return criteria
 
 
-def calibration_for_route(model_route: Mapping[str, Any] | None) -> str:
+def calibration_for_route(model_route: Mapping[str, Any] | None, *, family_only: bool = False) -> str:
     """Return the high-effort calibration block for a routed unit, or ''.
 
     Selected only when the route's effective reasoning effort is in the high
     tier; an exact-model override on the recorded `selected_model` wins, then
     family comes from the already-recorded `model_family` (falling back to
     generic for unknown/blank families).
+
+    `family_only=True` skips the exact-model override and returns the block
+    the model would inherit from its family. That is the measurement arm
+    `docs/MODEL-ONBOARDING.md` §8 asks for when an override ships: the
+    override is kept only if it measures at least as well as the inherited
+    block on the same corpus. Production callers never pass it.
     """
     if not isinstance(model_route, Mapping):
         return ""
     effort = str(model_route.get("selected_reasoning_effort", "") or "").casefold()
     if effort not in HIGH_EFFORT_TIER:
         return ""
-    override = MODEL_HIGH_EFFORT_CALIBRATIONS.get(
+    override = None if family_only else MODEL_HIGH_EFFORT_CALIBRATIONS.get(
         contract_model_id(str(model_route.get("selected_model", "") or ""))
     )
     if override:

--- a/src/coding/unit_prompt_protocol.py
+++ b/src/coding/unit_prompt_protocol.py
@@ -340,11 +340,10 @@ MODEL_HIGH_EFFORT_CALIBRATIONS: Final[dict[str, str]] = {
     # are not restated. No monitoring language, no chain-of-thought requests.
     "gpt-6-astra": (
         "High-effort calibration: the user's instructions outrank any skill or guideline text, and "
-        "the numbered criteria are the complete task — carry them to completion instead of pausing "
-        "for sign-off on work the boundary already authorizes. Ask one focused question only when a "
-        "missing input would materially change the result; otherwise state the assumption and "
-        "proceed. Size tests to the change: a reversible, low-impact edit that mirrors its "
-        "implementation needs no new test, and a green check is re-run only when its inputs changed."
+        "the numbered criteria are the complete task — nothing outside them is owed. Ask one focused "
+        "question only when a missing input would materially change the result; otherwise state the "
+        "assumption and proceed. Size tests to the change: a reversible, low-impact edit that mirrors "
+        "its implementation needs no new test, and a green check is re-run only when its inputs changed."
     ),
 }
 MODEL_COMPOSITION_CALIBRATIONS: Final[dict[str, str]] = {

--- a/tests/test_model_contracts.py
+++ b/tests/test_model_contracts.py
@@ -181,6 +181,11 @@ class VersionAwareCalibrationTests(unittest.TestCase):
         self.assertEqual(calibration_for_route(astra), MODEL_HIGH_EFFORT_CALIBRATIONS["gpt-6-astra"])
         self.assertEqual(calibration_for_route(sol), HIGH_EFFORT_CALIBRATIONS["gpt"])
         self.assertNotEqual(calibration_for_route(astra), calibration_for_route(sol))
+        # The measurement arm: the block Astra would inherit if the override
+        # were removed, which is exactly Sol's block.
+        self.assertEqual(calibration_for_route(astra, family_only=True), HIGH_EFFORT_CALIBRATIONS["gpt"])
+        self.assertEqual(calibration_for_route(astra, family_only=True), calibration_for_route(sol))
+        self.assertEqual(calibration_for_route({**astra, "selected_reasoning_effort": "low"}, family_only=True), "")
         self.assertEqual(
             composition_calibration_for_model("gpt-6-astra"), MODEL_COMPOSITION_CALIBRATIONS["gpt-6-astra"]
         )

--- a/tests/test_omh_live_model_benchmark.py
+++ b/tests/test_omh_live_model_benchmark.py
@@ -13,7 +13,7 @@ from _local_package import load_local_package
 
 load_local_package()
 
-from omh.coding.unit_prompt_protocol import HIGH_EFFORT_CALIBRATIONS  # noqa: E402
+from omh.coding.unit_prompt_protocol import HIGH_EFFORT_CALIBRATIONS, MODEL_HIGH_EFFORT_CALIBRATIONS  # noqa: E402
 
 
 BASE = Path(__file__).resolve().parents[1] / "benchmarks" / "live-model-tools" / "v1"
@@ -183,6 +183,27 @@ class OmhLiveAdapterTests(unittest.TestCase):
         self.assertIn("Verify the file exists and parses as JSON", baseline)
         self.assertIn(HIGH_EFFORT_CALIBRATIONS["deepseek"], optimized)
         self.assertEqual(module.task_digest(baseline), module.task_digest(optimized))
+
+    def test_family_condition_sends_the_inherited_block_without_the_override(self) -> None:
+        module = _load_omh_live()
+        task = "Read TARGET.txt and return its exact contents."
+        route = {
+            "selected_model": "gpt-6-astra",
+            "selected_reasoning_effort": "xhigh",
+            "model_family": "gpt",
+        }
+        override = MODEL_HIGH_EFFORT_CALIBRATIONS["gpt-6-astra"]
+        family = HIGH_EFFORT_CALIBRATIONS["gpt"]
+        prompts = {name: module.prompt_for_condition(task, route, name) for name in ("baseline", "optimized", "family")}
+        self.assertNotIn(override, prompts["baseline"])
+        self.assertNotIn(family, prompts["baseline"])
+        self.assertIn(override, prompts["optimized"])
+        self.assertNotIn(family, prompts["optimized"])
+        self.assertIn(family, prompts["family"])
+        self.assertNotIn(override, prompts["family"])
+        self.assertEqual(prompts["family"].split("\n\n", 1)[1], prompts["baseline"])
+        self.assertEqual({module.task_digest(prompt) for prompt in prompts.values()}, {module.task_digest(prompts["baseline"])})
+        self.assertEqual(module.prompt_for_condition(task, route, "unknown-condition"), prompts["baseline"])
 
     def test_snapshot_and_changed_paths_use_canonical_posix_keys(self) -> None:
         with TemporaryDirectory() as root_text:


### PR DESCRIPTION
## Feature Report

### What Changed

- **Benchmark:** `benchmarks/live-model-tools/v1` gains a third condition, `family`, which sends the block a model would inherit from its family with any exact-model override skipped (`calibration_for_route(route, family_only=True)`), and `analyze.py --baseline-condition / --optimized-condition` so that arm can be paired against `optimized`. The run-record schema admits the value; the analysis report names the pairing in a new `conditions` field. `prompt_pair` is unchanged and still pinned.
- **Measurement:** four live arms of `gpt-6-astra` on the pinned evaluation corpus: `baseline` (no calibration), `family` (inherited `gpt` block), `optimized` (the #1307 override), and the same override with one clause revised. Results in `MODEL_OPTI.md` (`gpt-6-astra` → Measured) and the benchmark README.
- **Calibration:** `MODEL_HIGH_EFFORT_CALIBRATIONS["gpt-6-astra"]` first sentence now ends "nothing outside them is owed" instead of "carry them to completion instead of pausing for sign-off on work the boundary already authorizes". The assumption-over-question and test-sizing sentences are unchanged.
- **Docs:** `docs/MODEL-ONBOARDING.md` §8 names the family arm as the second pair an exact-model override owes and says to read cost before pass rate on this corpus.

### Why This Exists

- #1310: the Astra override shipped in #1307 was documented but unmeasured because no served route existed. The route is now served (`openai-codex` / `gpt-6-astra`, cost status `included`), so §8's "measure, then revise or remove in the same change" applies.
- The harness could compare an override with no calibration, but not with the family block it replaced, which is the comparison the issue asks for.

### User / Operator Impact

- Astra subagent units keep the two Astra-specific counters and stop paying for the clause that made the model keep working on tasks it would not pass: −4,790 tokens per instance against the #1307 wording on this corpus, now indistinguishable from the family block's cost, same pass rate.
- Any future exact-model override can be measured against its family block with two flags instead of a harness change.

### How It Works

- `prompt_for_condition(task, route, condition)` in `lib/omh_live.py` selects baseline / optimized / family over one shared task text; the task digest is identical across all three.
- `statistics.analyze(..., baseline_condition=, optimized_condition=)` indexes each file by the condition it must carry; error text and the `conditions` field name the pairing.
- The arms were run with a targeted manifest (one live entry, `gpt-6-astra` at `xhigh`, the effort its chain placement uses) through `bench.py run --harness hermes_current_session --split evaluation`, 30 paid calls per arm; artifacts stay out of git per the benchmark `.gitignore`, the README carries the tables.

### Files And Contracts Touched

- `src/coding/unit_prompt_protocol.py` (`calibration_for_route` keyword, Astra override wording)
- `benchmarks/live-model-tools/v1/{bench.py,analyze.py,lib/omh_live.py,lib/statistics.py,lib/runner.py,schemas/run-record.schema.json,README.md,tests/test_framework.py}`
- `tests/test_omh_live_model_benchmark.py`, `tests/test_model_contracts.py`
- `MODEL_OPTI.md`, `docs/MODEL-ONBOARDING.md`

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [x] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

Check only commands that completed successfully. Leave non-applicable checks
unchecked and explain why under **Not Tested / Not Applicable**.

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `bench.py smoke` ×2 (baseline, optimized) before the arms; `bench.py run --condition family` offline in the framework tests; `docs ulw-inventory --check`, `docs ulw-site --check`.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

| Arm | Passed | Total tokens | Mean | Tool calls | API turns |
| --- | ---: | ---: | ---: | ---: | ---: |
| baseline | 18 / 30 | 1,550,904 | 51,697 | 310 | 203 |
| family | 18 / 30 | 1,513,367 | 50,446 | 286 | 194 |
| optimized (#1307 wording) | 18 / 30 | 1,675,942 | 55,865 | 310 | 206 |
| revised (this PR's wording) | 18 / 30 | 1,532,241 | 51,075 | 294 | 192 |

- Per-template pass counts identical across arms; McNemar p = 1.0 for both `analyze.py` pairs (`baseline`↔`optimized`, `family`↔`optimized`).
- Paired token deltas (bootstrap CI95): optimized − family +5,419 [+1,444, +10,150], more in 26/30; revised − optimized −4,790 [−9,336, −1,075]; revised − family +629 [−1,109, +2,445]. The original override's excess sits in `BUGFIX` (+44k over family) and `DIAGNOSTICS` (+95k, both arms 0/3).
- Tool-call and API-turn counts were read after the run from the Hermes `sessions` table for each arm's sessions, joined by run order; they are labeled out-of-harness in the README.
- Arm order optimized → family → baseline → revised, ~25 min per arm, 120 paid calls, every call `completed`, no failure receipts, `cost_status` `included`.
- Framework tests 17 ok (family arm scheduled offline; family-vs-optimized pairing accepted, default pairing on a family file rejected). `tests.test_unit_prompt_protocol`, `test_model_contracts`, `test_omh_live_model_benchmark`, `test_small_model_prompt_budget`: 76 ok. Ruff, compileall, five byte gates, `git diff --check` clean.
- Full suite on the branch: Ran 9057 tests in 480.053s, OK.

### Not Tested / Not Applicable

- The composer block (`MODEL_COMPOSITION_CALIBRATIONS["gpt-6-astra"]`) is unmeasured: this harness has no fanout, so delegation never happens. It keeps its documented-only status in `MODEL_OPTI.md`.
- Clarification, delegation, and test-breadth counts the issue lists are not produced by this corpus (nothing in it provokes them); #1327 is the follow-up that adds trait-provoking templates and counters.
- The isolated `omh` child harness path was not used; the `hermes_current_session` path is what the owner machine can authenticate.
- Arms were not counterbalanced within an arm (the harness runs one condition per invocation); the order is recorded.
- Harness validate, release checklist, and install smokes are not applicable: no catalog, release, or install surface changed.

## Risk

- Low for code: one calibration string and a keyword-only parameter no production caller passes. The wording change is reported, not assumed, and a re-run can reproduce it with the commands in the README.
- The benchmark conclusion is bounded by the corpus: 30 instances, ties on pass rate, cost as the deciding signal. The docs say so.

## Compatibility / Rollout

- `bench.py` and `analyze.py` defaults are unchanged; existing baseline/optimized runs and analyses behave as before. Records with `condition: family` are new and the schema admits them.
- Astra units get the revised block on the next `omh update`; Sol/Terra/Luna prompts are byte-identical to before.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- #1327: trait-provoking templates and overreach counters so a calibration sentence can earn its place on the behaviour it targets.
- Whether `deep` (GPT-5.6 Terra) should move to Astra stays an owner decision, unchanged by this measurement.

Closes #1310

🤖 Generated with [Claude Code](https://claude.com/claude-code)
