### PR TITLE
ci: the offline live-model-tools framework tests run on every shard-0 job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,12 @@ jobs:
           path: results/result-linux-${{ matrix.python-version }}-${{ matrix.shard }}.json
       # Non-test gates run once per python-version (shard 0) instead of once
       # per shard; sharding them would duplicate cost without new signal.
+      # The live-model-tools framework tests live outside tests/ with their own
+      # sys.path shim, so unittest discovery never sees them; every one is
+      # offline (the paid-live guard is one of them). Issue #1314.
+      - name: Benchmark framework tests (offline)
+        if: matrix.shard == 0
+        run: python benchmarks/live-model-tools/v1/tests/test_framework.py
       - name: Static analysis (ruff)
         if: matrix.python-version == '3.11' && matrix.shard == 0
         run: uv run --group lint ruff check src tests tools packaging
@@ -189,6 +195,9 @@ jobs:
         with:
           name: shard-result-windows-3.12-${{ matrix.shard }}
           path: results/result-windows-3.12-${{ matrix.shard }}.json
+      - name: Benchmark framework tests (offline)
+        if: matrix.shard == 0
+        run: python benchmarks/live-model-tools/v1/tests/test_framework.py
       - name: Compile package
         if: matrix.shard == 0
         run: python -m compileall src


### PR DESCRIPTION
## Feature Report

### What Changed

- `.github/workflows/ci.yml`: a `Benchmark framework tests (offline)` step runs `python benchmarks/live-model-tools/v1/tests/test_framework.py` on the shard-0 legs of `test` (Linux 3.11 and 3.12) and `test-windows`, right after the package install.

### Why This Exists

- Issue #1314: the file's 17 tests pin the benchmark analysis CLI (`--manifest`, `--baseline-condition`), the `family` arm, offline smoke, artifact safety, and the paid-live guard, but it lives outside `tests/` with its own `sys.path` shim, so discovery never sees it and CI never ran it. #1305's two rejection tests passed for the wrong reason until a reviewer ran the file by hand.

### User / Operator Impact

- A change that breaks the benchmark harness contract goes red in CI instead of at the next manual run.

### How It Works

- The file is runnable as `__main__`. It stays outside the shard plan because the planner's static inventory covers `tests/` only and never imports test modules; it is one serial run of about a second, gated like the other once-per-version steps with `matrix.shard == 0`.
- Every test is offline; `test_live_harness_is_blocked_without_explicit_flag` is what makes the file safe to run unattended.

### Files And Contracts Touched

- `.github/workflows/ci.yml`

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

Check only commands that completed successfully. Leave non-applicable checks
unchecked and explain why under **Not Tested / Not Applicable**.

- [ ] `uv run --group lint ruff check src tests`
- [ ] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [ ] `uv run python -m compileall -q src tests`
- [ ] `uv run python -m omh.cli docs workflows --check`
- [ ] `uv run python -m omh.cli docs roles --check`
- [ ] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `uv run python benchmarks/live-model-tools/v1/tests/test_framework.py`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- `uv run python benchmarks/live-model-tools/v1/tests/test_framework.py`: 17 tests ok, about 1 second, no network.
- `git diff --check` clean. No source or test file changed, so the suite and byte gates are unaffected; this PR's own CI run is the evidence for the new step on all three legs.

### Not Tested / Not Applicable

- The Windows leg was not run locally; this PR's CI is its first execution.
- Suite, ruff, compileall, byte gates, and smokes are not applicable to a workflow-only change beyond what CI itself runs.

## Risk

- Low. If the step fails on a platform, that platform's shard-0 job goes red and the aggregate follows; nothing else changes.

## Compatibility / Rollout

- No change to the shard plan, quarantine, or aggregate accounting; the step is additive.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- None.

Closes #1314

🤖 Generated with [Claude Code](https://claude.com/claude-code)
