### PR TITLE
fix: block token-shaped memory credentials

### DIFF
--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -9,6 +9,70 @@ from __future__ import annotations
 import re
 
 
+_BLOCKED_PATTERNS = (
+    re.compile(r"password\s*=", re.IGNORECASE),
+    re.compile(r"secret\s*=", re.IGNORECASE),
+    re.compile(r"token\s*=", re.IGNORECASE),
+    # Secret-token hyphen compounds (e.g. token-secret, secret-token,
+    # abc-secret-token). Keep this narrow so ordinary prose such as
+    # "token-based parsing" remains usable.
+    re.compile(
+        r"(?:password|passwd|secret|token|key)s?-(?:password|passwd|secret|token|key)s?",
+        re.IGNORECASE,
+    ),
+    re.compile(r"api[_-]key", re.IGNORECASE),
+    re.compile(r"auth[_-]header", re.IGNORECASE),
+    re.compile(r"Bearer\s+", re.IGNORECASE),
+    # High-confidence credential formats that carry no descriptive keyword.
+    re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b", re.IGNORECASE),
+    re.compile(r"\b(?:gh[oprs]|github_pat|glpat|npm|hf)[_-][A-Za-z0-9_-]{16,}\b", re.IGNORECASE),
+    re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{16,}\b", re.IGNORECASE),
+    re.compile(r"\bAIza[A-Za-z0-9_-]{20,}\b", re.IGNORECASE),
+    re.compile(r"\bxox[a-z]?-[A-Za-z0-9-]{16,}\b", re.IGNORECASE),
+    re.compile(r"\b[a-z][a-z0-9+.-]{1,31}://[^/\s:@]+:[^@\s/]+@", re.IGNORECASE),
+    re.compile(r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----", re.IGNORECASE),
+)
+
+_NEEDS_REVIEW_PATTERNS = (
+    re.compile(r"ignore\s+previous", re.IGNORECASE),
+    re.compile(r"reveal\s+the\s+system\s+prompt", re.IGNORECASE),
+    re.compile(r"disregard\s+instructions", re.IGNORECASE),
+    re.compile(r"this\s+is\s+temporary", re.IGNORECASE),
+    re.compile(r"workaround\s+while", re.IGNORECASE),
+    re.compile(r"(temporary|temp|hack|quick\s+fix)\s+", re.IGNORECASE),
+    # A credential-like value with an unknown prefix is not auto-safe. The
+    # character-class and uniqueness checks below avoid treating normal prose
+    # as an opaque value while keeping this gate deterministic.
+    re.compile(
+        r"\b(?:credential|access[_ -]?token|private[_ -]?key|secret|token|api[_ -]?key)\s*[:=]\s*\S{12,}",
+        re.IGNORECASE,
+    ),
+)
+_OPAQUE_TOKEN_PATTERN = re.compile(r"(?<![A-Za-z0-9])[A-Za-z0-9+/=_-]{32,}(?![A-Za-z0-9])")
+
+
+def _looks_like_opaque_token(content: str) -> bool:
+    """Recognize unknown long opaque values conservatively for review."""
+    for match in _OPAQUE_TOKEN_PATTERN.finditer(content):
+        token = match.group(0)
+        # Keep ordinary assignment labels and low-entropy hyphenated prose
+        # out of the opaque-value heuristic (for example sha256=aaaa... or
+        # human-definition-source-only-sentinel).
+        if "=" in token:
+            continue
+        character_classes = sum(
+            (
+                any(char.islower() for char in token),
+                any(char.isupper() for char in token),
+                any(char.isdigit() for char in token),
+                any(char in "+/=_-" for char in token),
+            )
+        )
+        if character_classes >= 3 or ("_-" not in token and len(set(token)) >= 12):
+            return True
+    return False
+
+
 def classify_memory_admission(content: str) -> dict[str, object]:
     """Classify memory content for safety admission.
     
@@ -20,39 +84,17 @@ def classify_memory_admission(content: str) -> dict[str, object]:
     if not isinstance(content, str):
         return {"status": "blocked"}
     
-    # Blocked patterns: explicit secrets/passwords, raw logs, transcripts, protected markers
-    blocked_patterns = [
-        r"password\s*=",
-        r"secret\s*=",
-        r"token\s*=",
-        # Secret-token hyphen compounds (e.g. token-secret, secret-token,
-        # abc-secret-token): two secret-class words joined by one hyphen.
-        # Narrow on purpose: no arbitrary hyphen chains, so ordinary prose
-        # like "token-based parsing" or "secret-management policy" never matches.
-        r"(?:password|passwd|secret|token|key)s?-(?:password|passwd|secret|token|key)s?",
-        r"api[_-]key",
-        r"auth[_-]header",
-        r"Bearer\s+",
-    ]
-    
-    for pattern in blocked_patterns:
-        if re.search(pattern, content, re.IGNORECASE):
+    for pattern in _BLOCKED_PATTERNS:
+        if pattern.search(content):
             return {"status": "blocked"}
-    
-    # Needs review patterns: prompt injection, temporary workarounds, credential hints
-    needs_review_patterns = [
-        r"ignore\s+previous",
-        r"reveal\s+the\s+system\s+prompt",
-        r"disregard\s+instructions",
-        r"this\s+is\s+temporary",
-        r"workaround\s+while",
-        r"(temporary|temp|hack|quick\s+fix)\s+",
-    ]
-    
-    for pattern in needs_review_patterns:
-        if re.search(pattern, content, re.IGNORECASE):
+
+    for pattern in _NEEDS_REVIEW_PATTERNS:
+        if pattern.search(content):
             return {"status": "needs_review"}
-    
+
+    if _looks_like_opaque_token(content):
+        return {"status": "needs_review"}
+
     return {"status": "safe"}
 
 

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -68,7 +68,7 @@ def _looks_like_opaque_token(content: str) -> bool:
                 any(char in "+/=_-" for char in token),
             )
         )
-        if character_classes >= 3 or ("_-" not in token and len(set(token)) >= 12):
+        if character_classes >= 3 or (not any(char in "_-" for char in token) and len(set(token)) >= 12):
             return True
     return False
 

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -25,7 +25,11 @@ _BLOCKED_PATTERNS = (
     re.compile(r"Bearer\s+", re.IGNORECASE),
     # High-confidence credential formats that carry no descriptive keyword.
     re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b", re.IGNORECASE),
-    re.compile(r"\b(?:gh[oprs]|github_pat|glpat|npm|hf)[_-][A-Za-z0-9_-]{16,}\b", re.IGNORECASE),
+    re.compile(r"\b(?:gh[oprsu]|github_pat|glpat|hf)[_-][A-Za-z0-9_-]{16,}\b", re.IGNORECASE),
+    # npm granular/access tokens use the npm_ prefix followed by an opaque
+    # payload. Keep ordinary package names such as npm-package-name out of
+    # the high-confidence credential rule.
+    re.compile(r"\bnpm_[A-Za-z0-9]{32,}\b", re.IGNORECASE),
     re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{16,}\b", re.IGNORECASE),
     re.compile(r"\bAIza[A-Za-z0-9_-]{20,}\b", re.IGNORECASE),
     re.compile(r"\bxox[a-z]?-[A-Za-z0-9-]{16,}\b", re.IGNORECASE),
@@ -49,16 +53,50 @@ _NEEDS_REVIEW_PATTERNS = (
     ),
 )
 _OPAQUE_TOKEN_PATTERN = re.compile(r"(?<![A-Za-z0-9])[A-Za-z0-9+/=_-]{32,}(?![A-Za-z0-9])")
+_DIGEST_ASSIGNMENT_PATTERN = re.compile(
+    r"(?:md5|sha1|sha224|sha256|sha384|sha512)=[0-9a-f]{32,128}",
+    re.IGNORECASE,
+)
+_HEX_DIGEST_PATTERN = re.compile(r"[0-9a-f]{40,64}", re.IGNORECASE)
+_UUID_PATTERN = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}",
+    re.IGNORECASE,
+)
+_WORDLIKE_IDENTIFIER_PATTERN = re.compile(r"[a-z]{2,}[A-Z][a-z]{2,}")
+_STRUCTURED_IDENTIFIER_PATTERN = re.compile(
+    r"^[a-z][a-z0-9]*(?:[-_](?:[a-z][a-z0-9]*|[0-9]+))+$"
+)
+_CREDENTIALISH_IDENTIFIER_PREFIXES = frozenset(
+    {"access", "api", "auth", "credential", "key", "private", "secret", "token"}
+)
+
+
+def _looks_like_structured_identifier(token: str) -> bool:
+    """Keep ordinary word/date/build identifiers out of opaque review."""
+    if not _STRUCTURED_IDENTIFIER_PATTERN.fullmatch(token):
+        return False
+    prefix = re.split(r"[-_]", token, maxsplit=1)[0]
+    return prefix not in _CREDENTIALISH_IDENTIFIER_PREFIXES
 
 
 def _looks_like_opaque_token(content: str) -> bool:
     """Recognize unknown long opaque values conservatively for review."""
     for match in _OPAQUE_TOKEN_PATTERN.finditer(content):
         token = match.group(0)
-        # Keep ordinary assignment labels and low-entropy hyphenated prose
-        # out of the opaque-value heuristic (for example sha256=aaaa... or
-        # human-definition-source-only-sentinel).
-        if "=" in token:
+        # Complete digest assignments and common non-secret identifiers are
+        # already safe metadata. Do not exempt every value containing "=";
+        # padded opaque values such as Base64-like credentials still need
+        # review.
+        if _DIGEST_ASSIGNMENT_PATTERN.fullmatch(token):
+            continue
+        if _HEX_DIGEST_PATTERN.fullmatch(token) or _UUID_PATTERN.fullmatch(token):
+            continue
+        if _looks_like_structured_identifier(token):
+            continue
+        # Long prose identifiers and CamelCase names are common in project,
+        # domain, and handoff metadata. They have no credential-like
+        # character mix, so do not let this shared classifier reject them.
+        if token.isalpha() and (token.islower() or token.isupper() or _WORDLIKE_IDENTIFIER_PATTERN.search(token)):
             continue
         character_classes = sum(
             (
@@ -99,34 +137,72 @@ def classify_memory_admission(content: str) -> dict[str, object]:
 
 
 def evaluate_renderable_strings(artifact: dict[str, object]) -> dict[str, object]:
-    """Evaluate all renderable string fields (summary, value, label).
+    """Evaluate every string that can reach a memory-facing surface.
     
     Returns worst-case result with status and reason_code.
     Fail-closed: any blocked field blocks, any needs_review fields need review.
     """
-    renderable_fields = ["summary", "value", "label"]
+    renderable_fields = [
+        "summary",
+        "value",
+        "label",
+        "key",
+        "source",
+        "source_ref",
+        "scope",
+        "derived_from",
+        "perspective",
+    ]
     
     worst_status = "safe"
     worst_field = None
     
     for field in renderable_fields:
-        content = artifact.get(field)
-        if not isinstance(content, str) or not content:
-            continue
-        
-        result = classify_memory_admission(content)
-        status = result.get("status", "safe")
-        
-        # Fail closed: blocked > needs_review > safe
-        if status == "blocked":
-            return {
-                "status": "blocked",
-                "field": field,
-                "reason_code": f"safety_blocked_in_{field}",
-            }
-        elif status == "needs_review" and worst_status != "blocked":
-            worst_status = "needs_review"
-            worst_field = field
+        values = artifact.get(field)
+        if isinstance(values, str):
+            values_to_check = ((field, values),)
+        elif field == "scope" and isinstance(values, dict):
+            values_to_check = ((field, str(values.get("ref", ""))),)
+        elif field == "perspective" and isinstance(values, dict):
+            values_to_check = tuple(
+                (field, str(values.get(key, ""))) for key in ("observer", "observed") if str(values.get(key, ""))
+            )
+        elif field == "derived_from" and isinstance(values, (list, tuple)):
+            values_to_check = tuple((field, str(value)) for value in values if str(value))
+        else:
+            values_to_check = ()
+
+        for checked_field, content in values_to_check:
+            if not content:
+                continue
+            result = classify_memory_admission(content)
+            status = result.get("status", "safe")
+
+            # Fail closed: blocked > needs_review > safe
+            if status == "blocked":
+                return {
+                    "status": "blocked",
+                    "field": checked_field,
+                    "reason_code": f"safety_blocked_in_{checked_field}",
+                }
+            elif status == "needs_review" and worst_status != "blocked":
+                worst_status = "needs_review"
+                worst_field = checked_field
+
+    tags = artifact.get("tags")
+    if isinstance(tags, (list, tuple)):
+        for content in (str(value) for value in tags if str(value)):
+            result = classify_memory_admission(content)
+            status = result.get("status", "safe")
+            if status == "blocked":
+                return {
+                    "status": "blocked",
+                    "field": "tags",
+                    "reason_code": "safety_blocked_in_tags",
+                }
+            if status == "needs_review" and worst_status != "blocked":
+                worst_status = "needs_review"
+                worst_field = "tags"
     
     if worst_status == "needs_review":
         return {

--- a/src/plugin_bundle/omh/memory_governance.py
+++ b/src/plugin_bundle/omh/memory_governance.py
@@ -44,7 +44,7 @@ PROJECT_MEMORY_REVIEW_RECORD_SCHEMA_VERSION = "project_memory_review_record/v2"
 
 # Governance policy and classifier versions
 MEMORY_GOVERNANCE_POLICY_VERSION = "governance/v2"
-MEMORY_CLASSIFIER_VERSION = "classifier/v2"
+MEMORY_CLASSIFIER_VERSION = "classifier/v3"
 
 # Retention classes
 RETENTION_CLASSES = frozenset({"volatile", "standard", "durable"})

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -3311,9 +3311,16 @@ def _build_project_memory_candidate(
 ) -> dict[str, object]:
     normalized_type = _normalize_record_type(record_type)
     scope = _scope_for_project_memory(scope_kind, scope_ref)
-    normalized_tags = _normalize_tags(tags)
+    raw_tags = _normalize_tags(tags, redact_sensitive=False)
+    normalized_tags = _normalize_tags(raw_tags)
     content_text = str(content or "")
-    safety = _project_memory_safety(summary, content_text, tags=normalized_tags)
+    safety = _project_memory_safety(
+        summary,
+        content_text,
+        tags=raw_tags,
+        source=str(source or "cli"),
+        source_ref=str(source_ref or ""),
+    )
     now = utc_now()
     if expires_at_value:
         # An absolute expiry carries no day count -- the date IS the policy.
@@ -3357,7 +3364,7 @@ def _build_project_memory_candidate(
         "summary": _redact(summary.strip())[:500],
         "scope": scope,
         "tags": normalized_tags,
-        "source": str(source or "cli"),
+        "source": _redact(str(source or "cli")),
         "source_ref": stored_source_ref,
         **({"source_evidence": source_evidence} if source_evidence else {}),
         "created_at": now,
@@ -3473,7 +3480,7 @@ def _record_from_candidate(
         "summary": _redact(str(candidate.get("summary", "")))[:500],
         "scope": scope,
         "tags": _normalize_tags(candidate.get("tags", [])),
-        "source": str(candidate.get("source", "cli")),
+        "source": _redact(str(candidate.get("source", "cli"))),
         "source_class": "omh_local",
         "source_ref": _redact(str(candidate.get("source_ref", "")))[:160],
         # The digest is carried over as observed at capture, never recomputed
@@ -4088,8 +4095,15 @@ def _source_evidence_state(record: dict[str, Any]) -> str:
     return "unchanged" if current == recorded else "changed"
 
 
-def _project_memory_safety(summary: str, content: str, *, tags: list[str]) -> dict[str, object]:
-    classification = classify_memory_admission("\n".join([summary, content, " ".join(tags)]))
+def _project_memory_safety(
+    summary: str,
+    content: str,
+    *,
+    tags: list[str],
+    source: str = "",
+    source_ref: str = "",
+) -> dict[str, object]:
+    classification = classify_memory_admission("\n".join([summary, content, " ".join(tags), source, source_ref]))
     status = str(classification.get("status", "blocked"))
     return {
         "schema_version": "project_memory_safety/v2",
@@ -4323,7 +4337,7 @@ def _scope_for_project_memory(kind: str, ref: str) -> dict[str, str]:
     return scope
 
 
-def _normalize_tags(values: Any) -> list[str]:
+def _normalize_tags(values: Any, *, redact_sensitive: bool = True) -> list[str]:
     if not isinstance(values, (list, tuple)):
         return []
     tags: list[str] = []
@@ -4332,6 +4346,8 @@ def _normalize_tags(values: Any) -> list[str]:
         tag = unicodedata.normalize("NFC", str(value)).strip().lower()
         if not tag or not _SAFE_TAG.match(tag):
             continue
+        if redact_sensitive and _looks_sensitive(tag):
+            tag = "[redacted]"
         if tag not in seen:
             tags.append(tag)
             seen.add(tag)
@@ -4891,7 +4907,9 @@ def _redact(value: str) -> str:
 
 def _looks_sensitive(value: str) -> bool:
     lowered = value.lower()
-    return any(marker in lowered for marker in ("secret", "token", "password", "private-key", "api_key", "apikey"))
+    if any(marker in lowered for marker in ("secret", "token", "password", "private-key", "api_key", "apikey")):
+        return True
+    return classify_memory_admission(value).get("status") == "blocked"
 
 
 def _validate_allowed_keys(value: dict[str, Any], allowed: set[str], errors: list[str], label: str) -> None:

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -1084,7 +1084,14 @@ def approve_project_memory_candidate(
                 "it must be reapproved through the lifecycle path, not plain approval"
             )
         safety = candidate.get("safety", {}) if isinstance(candidate.get("safety"), dict) else {}
-        if safety.get("status") == "blocked":
+        candidate_safety = _project_memory_safety(
+            str(candidate.get("summary", "")),
+            "",
+            tags=candidate.get("tags", []) if isinstance(candidate.get("tags"), list) else [],
+            source=str(candidate.get("source", "")),
+            source_ref=str(candidate.get("source_ref", "")),
+        )
+        if safety.get("status") == "blocked" or candidate_safety.get("status") == "blocked":
             raise ValueError("blocked memory candidates must be rejected or recaptured without protected raw content")
         approved_at = utc_now()
         review_id = f"review_{candidate_id}"
@@ -2531,7 +2538,10 @@ def _perspective_projection(value: Any) -> dict[str, str]:
     observed = str(perspective.get("observed", ""))
     if not observed:
         return {}
-    return {"observer": str(perspective.get("observer", "") or _DEFAULT_PERSPECTIVE_OBSERVER), "observed": observed}
+    return {
+        "observer": _redact(str(perspective.get("observer", "") or _DEFAULT_PERSPECTIVE_OBSERVER)),
+        "observed": _redact(observed),
+    }
 
 
 def _record_perspective_matches(record: dict[str, Any], *, observer: str | None, observed: str | None) -> bool:
@@ -3311,7 +3321,7 @@ def _build_project_memory_candidate(
 ) -> dict[str, object]:
     normalized_type = _normalize_record_type(record_type)
     scope = _scope_for_project_memory(scope_kind, scope_ref)
-    raw_tags = _normalize_tags(tags, redact_sensitive=False)
+    raw_tags = _normalize_tags(tags, redact_sensitive=False, preserve_case=True)
     normalized_tags = _normalize_tags(raw_tags)
     content_text = str(content or "")
     safety = _project_memory_safety(
@@ -3371,7 +3381,7 @@ def _build_project_memory_candidate(
         "ttl": ttl,
         "staleness": staleness,
         "retention_class": str(retention_class),
-        "derived_from": [str(ref) for ref in derived_from],
+        "derived_from": [_redact(str(ref))[:160] for ref in derived_from],
         **({"perspective": dict(perspective)} if perspective else {}),
         "content_ref": {
             "sha256": hashlib.sha256(content_text.encode("utf-8")).hexdigest() if content_text else "",
@@ -3487,7 +3497,7 @@ def _record_from_candidate(
         # here: approval must not silently re-bless a source that changed
         # while the candidate sat in the review queue.
         **({"source_evidence": evidence} if (evidence := _source_evidence_projection(candidate)) else {}),
-        "derived_from": _string_list(candidate.get("derived_from", [])),
+        "derived_from": _redacted_string_list(candidate.get("derived_from", [])),
         **(
             {"perspective": projection}
             if (projection := _perspective_projection(candidate.get("perspective")))
@@ -3639,12 +3649,12 @@ def _recall_item(
         "summary": _redact(str(record.get("summary", "")))[:500],
         "scope": _normalize_scope(record.get("scope", _scope("project", "default"))),
         "tags": _normalize_tags(record.get("tags", [])),
-        "source": str(record.get("source", "")),
+        "source": _redact(str(record.get("source", ""))),
         "approved_at": str(record.get("approved_at", "")),
         "staleness": staleness,
         "score": int(score),
         "attention_tier": attention_tier,
-        "derived_from": _string_list(record.get("derived_from", [])),
+        "derived_from": _redacted_string_list(record.get("derived_from", [])),
         "perspective": _perspective_projection(record.get("perspective")),
         **_recall_evidence_fields(evidence),
     }
@@ -4337,16 +4347,24 @@ def _scope_for_project_memory(kind: str, ref: str) -> dict[str, str]:
     return scope
 
 
-def _normalize_tags(values: Any, *, redact_sensitive: bool = True) -> list[str]:
+def _normalize_tags(
+    values: Any,
+    *,
+    redact_sensitive: bool = True,
+    preserve_case: bool = False,
+) -> list[str]:
     if not isinstance(values, (list, tuple)):
         return []
     tags: list[str] = []
     seen: set[str] = set()
     for value in values:
-        tag = unicodedata.normalize("NFC", str(value)).strip().lower()
+        original_tag = unicodedata.normalize("NFC", str(value)).strip()
+        tag = original_tag
+        if not preserve_case:
+            tag = tag.lower()
         if not tag or not _SAFE_TAG.match(tag):
             continue
-        if redact_sensitive and _looks_sensitive(tag):
+        if redact_sensitive and _looks_sensitive(original_tag):
             tag = "[redacted]"
         if tag not in seen:
             tags.append(tag)
@@ -4358,6 +4376,12 @@ def _string_list(value: Any) -> list[str]:
     if not isinstance(value, list):
         return []
     return [str(item) for item in value if str(item)]
+
+
+def _redacted_string_list(value: Any) -> list[str]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    return [_redact(str(item))[:160] for item in value if str(item)]
 
 
 def _read_project_memory_candidate(paths: OmhPaths, candidate_id: str) -> dict[str, Any] | None:
@@ -4909,7 +4933,7 @@ def _looks_sensitive(value: str) -> bool:
     lowered = value.lower()
     if any(marker in lowered for marker in ("secret", "token", "password", "private-key", "api_key", "apikey")):
         return True
-    return classify_memory_admission(value).get("status") == "blocked"
+    return classify_memory_admission(value).get("status") in {"blocked", "needs_review"}
 
 
 def _validate_allowed_keys(value: dict[str, Any], allowed: set[str], errors: list[str], label: str) -> None:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 
 from _local_package import load_local_package
 from _platform_support import requires_posix, requires_posix_permissions
+from _credential_fixtures import AWS_ACCESS_KEY_ID
 
 load_local_package()
 from omh.coding_delegation import build_coding_delegation_payload
@@ -131,6 +132,39 @@ class MemoryContractTests(unittest.TestCase):
             needs_review = capture_project_memory_candidate(paths, "PR #123 fixed this temporarily", record_type="lesson")
             self.assertEqual(needs_review["candidate"]["safety"]["status"], "safe")
             self.assertEqual(needs_review["candidate"]["safety"]["review_reasons"], [])
+
+    def test_project_memory_bare_credentials_are_blocked_and_redacted_before_review(self) -> None:
+        credentials = (
+            AWS_ACCESS_KEY_ID,
+            "gh" + "p_" + "a" * 36,
+            "sk" + "-" + "a" * 48,
+            "https://user:pass@example.com",
+            "-----BEGIN PRIVATE KEY-----",
+        )
+        for credential in credentials:
+            with self.subTest(credential_kind=credential[:4]), TemporaryDirectory() as tmp:
+                paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+                write_setup_profile(paths, memory_mode="auto-safe")
+
+                captured = capture_project_memory_candidate(
+                    paths,
+                    f"Observed {credential}",
+                    tags=[credential],
+                    source=credential,
+                    source_ref=credential,
+                )
+                candidate = captured["candidate"]
+                serialized = json.dumps(captured, sort_keys=True)
+                self.assertEqual(candidate["status"], "blocked_review_required")
+                self.assertFalse(captured["auto_approved"])
+                self.assertNotIn(credential, serialized)
+                self.assertNotIn(credential, json.dumps(build_project_memory_review(paths), sort_keys=True))
+
+                with self.assertRaises(ValueError):
+                    approve_project_memory_candidate(paths, candidate["candidate_id"])
+                rejected = reject_project_memory_candidate(paths, candidate["candidate_id"], reason=f"blocked {credential}")
+                self.assertNotIn(credential, json.dumps(rejected, sort_keys=True))
+                self.assertFalse((paths.memory_dir / "records").exists())
 
     def test_project_memory_auto_safe_policy_auto_approves_safe_candidates(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -137,6 +137,7 @@ class MemoryContractTests(unittest.TestCase):
         credentials = (
             AWS_ACCESS_KEY_ID,
             "gh" + "p_" + "a" * 36,
+            "gh" + "u_" + "a" * 36,
             "sk" + "-" + "a" * 48,
             "https://user:pass@example.com",
             "-----BEGIN PRIVATE KEY-----",
@@ -165,6 +166,51 @@ class MemoryContractTests(unittest.TestCase):
                 rejected = reject_project_memory_candidate(paths, candidate["candidate_id"], reason=f"blocked {credential}")
                 self.assertNotIn(credential, json.dumps(rejected, sort_keys=True))
                 self.assertFalse((paths.memory_dir / "records").exists())
+
+    def test_project_memory_classifies_original_tag_case_and_redacts_unknown_opaque_values(self) -> None:
+        opaque_tag = "AbC-" * 10
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            captured = capture_project_memory_candidate(
+                paths,
+                "A normal project note",
+                tags=[opaque_tag],
+            )
+            candidate = captured["candidate"]
+            self.assertEqual(candidate["safety"]["status"], "needs_review")
+            self.assertNotIn(opaque_tag, json.dumps(captured, sort_keys=True))
+            self.assertEqual(candidate["tags"], ["[redacted]"])
+
+    def test_project_memory_redacts_needs_review_values_before_candidate_and_review(self) -> None:
+        opaque_value = "Ab3_" * 12
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            captured = capture_project_memory_candidate(
+                paths,
+                f"Observed {opaque_value}",
+                source=opaque_value,
+                source_ref=opaque_value,
+            )
+            self.assertEqual(captured["candidate"]["safety"]["status"], "needs_review")
+            self.assertNotIn(opaque_value, json.dumps(captured, sort_keys=True))
+            self.assertNotIn(opaque_value, json.dumps(build_project_memory_review(paths), sort_keys=True))
+
+    def test_legacy_record_with_credential_in_source_is_excluded_from_recall(self) -> None:
+        credential = "ghu_" + "a" * 36
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            captured = capture_project_memory_candidate(paths, "Safe release note", tags=["release"])
+            approved = approve_project_memory_candidate(paths, captured["candidate"]["candidate_id"])
+            record = approved["record"]
+            record_path = paths.memory_dir / "records" / f"{record['record_id']}.json"
+            record["source"] = credential
+            record_path.write_text(json.dumps(record), encoding="utf-8")
+
+            recall = build_project_memory_recall_pack(paths, "release")
+            self.assertEqual(recall["included_records"], [])
+            excluded = next(item for item in recall["excluded_records"] if item["record_id"] == record["record_id"])
+            self.assertEqual(excluded["reason"], "safety_blocked_in_source")
+            self.assertNotIn(credential, json.dumps(recall, sort_keys=True))
 
     def test_project_memory_auto_safe_policy_auto_approves_safe_candidates(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_memory_governance_evaluation.py
+++ b/tests/test_memory_governance_evaluation.py
@@ -145,6 +145,22 @@ class SafetyAndEvaluationTests(unittest.TestCase):
             with self.subTest(content=content):
                 self.assertEqual(governance.classify_memory_admission(content)["status"], "safe")
         self.assertEqual(governance.classify_memory_admission("token-based auth uses rotating tokens")["status"], "safe")
+        self.assertEqual(governance.classify_memory_admission("npm-package-name-with-long-suffix")["status"], "safe")
+        self.assertEqual(governance.classify_memory_admission("ghu_" + "a" * 36)["status"], "blocked")
+        self.assertEqual(governance.classify_memory_admission("sha256=" + "a" * 64)["status"], "safe")
+        self.assertEqual(governance.classify_memory_admission("0f" * 20)["status"], "safe")
+        self.assertEqual(governance.classify_memory_admission("550e8400-e29b-41d4-a716-446655440000")["status"], "safe")
+        self.assertEqual(governance.classify_memory_admission("LongCamelCaseProjectIdentifierValue")["status"], "safe")
+        for identifier in (
+            "project-2026-09-05-abcdef1234567890",
+            "repo_20260905_build_123456789012345",
+        ):
+            with self.subTest(identifier=identifier):
+                self.assertEqual(governance.classify_memory_admission(identifier)["status"], "safe")
+        self.assertEqual(
+            governance.classify_memory_admission("token_20260905_build_123456789012345")["status"],
+            "needs_review",
+        )
 
     def test_bare_credential_shapes_are_blocked_and_unknown_opaque_values_need_review(self) -> None:
         aws = "AK" + "IA" + "A" * 16
@@ -173,6 +189,20 @@ class SafetyAndEvaluationTests(unittest.TestCase):
         unknown = "credential: " + "Ab3_" * 12
         self.assertEqual(governance.classify_memory_admission(unknown)["status"], "needs_review")
         self.assertEqual(governance.classify_memory_admission("Ab3_" * 12)["status"], "needs_review")
+        self.assertEqual(governance.classify_memory_admission("AbC-" * 10)["status"], "needs_review")
+
+    def test_replay_rescans_source_metadata_and_tags(self) -> None:
+        for field, value, reason in (
+            ("source", "ghu_" + "a" * 36, "safety_blocked_in_source"),
+            ("source_ref", "ghu_" + "a" * 36, "safety_blocked_in_source_ref"),
+            ("tags", ["AbC-" * 10], "safety_needs_review_in_tags"),
+        ):
+            with self.subTest(field=field):
+                artifact, review = _approved_artifact()
+                artifact[field] = value
+                result = _evaluate(artifact, review)
+                self.assertFalse(result["eligible"])
+                self.assertEqual(result["reason_code"], reason)
 
         for content in (
             "token-based parsing",

--- a/tests/test_memory_governance_evaluation.py
+++ b/tests/test_memory_governance_evaluation.py
@@ -146,6 +146,44 @@ class SafetyAndEvaluationTests(unittest.TestCase):
                 self.assertEqual(governance.classify_memory_admission(content)["status"], "safe")
         self.assertEqual(governance.classify_memory_admission("token-based auth uses rotating tokens")["status"], "safe")
 
+    def test_bare_credential_shapes_are_blocked_and_unknown_opaque_values_need_review(self) -> None:
+        aws = "AK" + "IA" + "A" * 16
+        github = "gh" + "p_" + "a" * 36
+        openai = "sk" + "-" + "a" * 48
+        for content in (
+            aws,
+            github,
+            openai,
+            "https://user:pass@example.com",
+            "-----BEGIN RSA PRIVATE KEY-----",
+        ):
+            with self.subTest(content_kind=content[:4]):
+                self.assertEqual(governance.classify_memory_admission(content)["status"], "blocked")
+
+        self.assertEqual(governance.classify_memory_admission(f"safe {aws} and {github}")["status"], "blocked")
+        self.assertEqual(governance.classify_memory_admission("akia" + "a" * 16)["status"], "blocked")
+        for content in (
+            "AK" + "IA" + "A" * 15,
+            "gh" + "p_" + "a" * 15,
+            "sk" + "-" + "a" * 15,
+        ):
+            with self.subTest(short_shape=content[:4]):
+                self.assertEqual(governance.classify_memory_admission(content)["status"], "safe")
+
+        unknown = "credential: " + "Ab3_" * 12
+        self.assertEqual(governance.classify_memory_admission(unknown)["status"], "needs_review")
+        self.assertEqual(governance.classify_memory_admission("Ab3_" * 12)["status"], "needs_review")
+
+        for content in (
+            "token-based parsing",
+            "secret-management policy",
+            "API key rotation",
+            "Store the API token rotation runbook",
+            "A normal release identifier has no credential shape.",
+        ):
+            with self.subTest(ordinary=content):
+                self.assertEqual(governance.classify_memory_admission(content)["status"], "safe")
+
     def test_scope_invalid_and_scope_mismatch_are_distinct_fail_closed_results(self) -> None:
         with self.assertRaises(ValueError):
             governance.canonical_memory_scope({"kind": "project", "ref": "default", "unexpected": "field"})


### PR DESCRIPTION
## Summary

Closes #1329 by making project-memory admission fail closed for recognized credentials and unknown opaque values, including metadata-only fields and legacy recall paths.

## Changes

- Block GitHub ghu_ user tokens and narrow npm token matching so ordinary package names remain usable.
- Keep padded opaque values in review unless they are complete digest assignments, and preserve original tag values for classification before normalization.
- Treat common SHA, UUID, CamelCase, and structured project/build identifiers as safe metadata instead of opaque credentials.
- Re-scan source, source_ref, tags, derived metadata, perspectives, and other renderable fields during replay and redact needs_review values before candidate, review, record, or recall serialization.
- Re-check candidate metadata at manual approval time so a legacy or edited blocked candidate cannot be persisted.

## Tests

- PYTHONPATH=tests python -m unittest tests.test_memory_governance_evaluation tests.test_memory_batches -v — 17 tests passed, 1 POSIX-only test skipped.
- PYTHONPATH=tests python -m unittest tests.test_memory -q — 58 tests ran; 2 POSIX-only tests skipped and 2 symlink setup cases could not run on this Windows host because SeCreateSymbolicLinkPrivilege is unavailable.
- ruff check and targeted py_compile passed.
- Project-terms regression reached the expected Windows symlink limitation; domain-context privacy is skipped on Windows because its store requires POSIX primitives.

## Compatibility / Known limitations

Existing records are not rewritten. Replay re-scans them and excludes unsafe records with a reason code. The change is limited to the shared safety classifier, memory serialization/replay boundaries, and regression tests.

## Issue

#1329