### PR TITLE
fix(release): the cut stages the site badge it rewrites

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -94,7 +94,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add pyproject.toml src/omh/version.py \
-            src/plugin_bundle/omh/plugin.yaml .release-channel
+            src/plugin_bundle/omh/plugin.yaml .release-channel \
+            site/index.html site/i18n.js
           git commit -s -m "chore(release): cut v$NEW_VERSION
 
           Constraint: npm/Bun, the GitHub wheel, and the Homebrew tap publish only from vX.Y.Z tags, so a release requires this version-bump commit on main

--- a/site/i18n.js
+++ b/site/i18n.js
@@ -24,10 +24,10 @@ window.OMH_I18N = {
 
     /* --------------------------------------------------------------- hero */
     "hero.badge": {
-      en: "For Hermes Agent · v2.0.0",
-      ko: "Hermes Agent 전용 · v2.0.0",
-      ja: "Hermes Agent のための · v2.0.0",
-      zh: "为 Hermes Agent 打造 · v2.0.0"
+      en: "For Hermes Agent · v2.0.1",
+      ko: "Hermes Agent 전용 · v2.0.1",
+      ja: "Hermes Agent のための · v2.0.1",
+      zh: "为 Hermes Agent 打造 · v2.0.1"
     },
     "hero.tagline": {
       en: 'Power intelligence and <em>agentic memory</em> for Hermes Agent.',

--- a/site/index.html
+++ b/site/index.html
@@ -88,7 +88,7 @@
           <img src="assets/omh-character-mask.png" alt="" width="768" height="768" fetchpriority="high">
         </figure>
 
-        <span class="pill pill--glass" data-reveal data-reveal-delay="40" data-i18n="hero.badge">For Hermes Agent · v2.0.0</span>
+        <span class="pill pill--glass" data-reveal data-reveal-delay="40" data-i18n="hero.badge">For Hermes Agent · v2.0.1</span>
 
         <h1 id="home-title" class="hero__title" data-reveal data-reveal-delay="90">
           <span class="chrome-word">Oh My Hermes</span>

--- a/tests/test_auto_release.py
+++ b/tests/test_auto_release.py
@@ -237,6 +237,10 @@ class AutoReleaseWorkflowTests(unittest.TestCase):
             "src/omh/version.py",
             "src/plugin_bundle/omh/plugin.yaml",
             ".release-channel",
+            # The bump tool rewrites the site badge too; a cut that leaves
+            # these unstaged ships a landing page one version behind.
+            "site/index.html",
+            "site/i18n.js",
         ):
             self.assertIn(staged, self.workflow)
 


### PR DESCRIPTION
## Capability

A release cut leaves the landing page badge on the version it just tagged.

## Motivation

The 2.0.1 cut ran `bump_version.py`, which rewrote the hero badge in `site/index.html` and the four locale strings in `site/i18n.js`, then committed only the four package surfaces. The site edits died on the runner, and main went red on `test_site_hero_badge_version_matches_the_package` (`['2.0.0'] != ['2.0.1']`).

## Implementation

- `.github/workflows/auto-release.yml`: the atomic commit step stages `site/index.html` and `site/i18n.js` alongside the package surfaces.
- `tests/test_auto_release.py`: the staged-path pin now includes both site files.
- `site/index.html`, `site/i18n.js`: badge moved to v2.0.1 by hand once, so main is green now; future cuts carry it automatically.

## Verification (observed)

```
PYTHONPATH=tests uv run python -m unittest tests/test_auto_release.py tests/test_release_smoke.py  → OK
git diff --check  → clean
```

## Risks

An actual Cut Release run with the new staging line has not been observed yet; the next cut is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZYwbzXpiWJpPUfEcKfRLY
