### PR TITLE
fix(routing): the Codex Maestro defaults name the GPT generation the CLI serves

### DIFF
--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -25,7 +25,7 @@ goal to Hermes in chat; these commands are the backend surface.
    expensive for agent context.
    For user-facing briefings, `omh coding fanout brief <id>` renders one
    line per unit in merge-plan order — unit, owner, `(model effort)` label
-   (for example `(gpt-5-codex xhigh)`), status, elapsed seconds, token
+   (for example `(gpt-5.6-sol xhigh)`), status, elapsed seconds, token
    count, session ref, last observed summary — as plain text by default
    with `--json` for the `fanout_briefing/v1` payload. It joins the
    contract, the persisted dispatch summary, and a one-event journal tail;

--- a/src/coding/model_routing.py
+++ b/src/coding/model_routing.py
@@ -160,18 +160,18 @@ EXECUTOR_MODEL_OPTIONS: Final[dict[str, tuple[dict[str, object], ...]]] = {
             "reasoning_efforts": ("low", "medium", "high", "xhigh", "max"),
         },
         {
-            "model_id": "gpt-5-codex",
-            "label": "Codex frontier coding model",
+            "model_id": "gpt-5.6-sol",
+            "label": "GPT-5.6 Sol (frontier coding; the Codex CLI default)",
             "tier": "frontier",
             "recommended_roles": ("brain", "review", "design_visual"),
-            "reasoning_efforts": ("off", "minimal", "low", "medium", "high", "xhigh"),
+            "reasoning_efforts": ("low", "medium", "high", "xhigh"),
         },
         {
-            "model_id": "gpt-5",
-            "label": "General frontier model",
+            "model_id": "gpt-5.6-terra",
+            "label": "GPT-5.6 Terra (deep work tier)",
             "tier": "standard",
             "recommended_roles": ("implementation", "docs", "review", "research"),
-            "reasoning_efforts": ("off", "minimal", "low", "medium", "high", "xhigh"),
+            "reasoning_efforts": ("low", "medium", "high", "xhigh"),
         },
     ),
     "claude-code": (
@@ -326,28 +326,32 @@ def _CLAUDE_FRONTIER_CHAIN(effort: str) -> tuple[dict[str, str], ...]:
 
 
 BUILTIN_CATEGORY_MODELS: Final[dict[str, dict[str, tuple[dict[str, str], ...]]]] = {
-    # Codex: gpt-5-codex is the frontier CODING model, gpt-5 the general one.
-    # Every category that means "do the work well" therefore names the coding
-    # model, and the light categories name the general one. GPT-6 Astra heads
-    # the two full-depth categories (the slots the previous GPT frontier held)
-    # with gpt-5-codex as fall-through, mirroring the Hermes lane; the cost-tier
-    # categories keep their cheaper picks (Astra lists at 8x gpt-5.6-sol).
+    # Codex: the same GPT generation the Hermes lane ships. GPT-6 Astra heads
+    # the two full-depth categories with GPT-5.6 Sol as fall-through; `deep`
+    # is Terra over Sol, mirroring the Hermes lane; every lighter category
+    # names Sol, the Codex CLI's own default, at the effort the tier wants
+    # (Astra lists at 8x Sol, so it never heads a cost-tier slot). The
+    # previous table named the gpt-5 generation, which the CLI no longer
+    # serves on the owner machine (2026-09-05).
     "codex": {
         "ultrabrain": (
             {"model_id": "gpt-6-astra", "reasoning_effort": "xhigh"},
-            {"model_id": "gpt-5-codex", "reasoning_effort": "xhigh"},
+            {"model_id": "gpt-5.6-sol", "reasoning_effort": "xhigh"},
         ),
-        "deep": ({"model_id": "gpt-5-codex", "reasoning_effort": "high"},),
+        "deep": (
+            {"model_id": "gpt-5.6-terra", "reasoning_effort": "high"},
+            {"model_id": "gpt-5.6-sol", "reasoning_effort": "high"},
+        ),
         "architect": (
             {"model_id": "gpt-6-astra", "reasoning_effort": "xhigh"},
-            {"model_id": "gpt-5-codex", "reasoning_effort": "xhigh"},
+            {"model_id": "gpt-5.6-sol", "reasoning_effort": "xhigh"},
         ),
-        "unspecified-high": ({"model_id": "gpt-5-codex", "reasoning_effort": ""},),
-        "unspecified-low": ({"model_id": "gpt-5", "reasoning_effort": ""},),
-        "quick": ({"model_id": "gpt-5", "reasoning_effort": "low"},),
-        "writing": ({"model_id": "gpt-5", "reasoning_effort": ""},),
-        "visual-engineering": ({"model_id": "gpt-5-codex", "reasoning_effort": ""},),
-        "artistry": ({"model_id": "gpt-5", "reasoning_effort": ""},),
+        "unspecified-high": ({"model_id": "gpt-5.6-sol", "reasoning_effort": ""},),
+        "unspecified-low": ({"model_id": "gpt-5.6-sol", "reasoning_effort": ""},),
+        "quick": ({"model_id": "gpt-5.6-sol", "reasoning_effort": "low"},),
+        "writing": ({"model_id": "gpt-5.6-sol", "reasoning_effort": ""},),
+        "visual-engineering": ({"model_id": "gpt-5.6-sol", "reasoning_effort": ""},),
+        "artistry": ({"model_id": "gpt-5.6-sol", "reasoning_effort": ""},),
     },
     # Claude Code: every frontier category runs the owner-ordered Claude chain
     # (Fable 5.1 -> Mythos 5.1 -> Opus, 2026-09-02). Mythos 5.1 is Fable 5.1

--- a/src/coding/status_board.py
+++ b/src/coding/status_board.py
@@ -215,7 +215,7 @@ def _aligned_rows_only(payload: dict[str, Any]) -> str:
 
 
 def model_label_for(model: str, reasoning_effort: str) -> str:
-    """The `gpt-5-codex xhigh` label shape shared with `omh coding fanout brief`."""
+    """The `gpt-5.6-sol xhigh` label shape shared with `omh coding fanout brief`."""
     return " ".join(part for part in (str(model or ""), str(reasoning_effort or "")) if part) or _MODEL_DEFAULT_LABEL
 
 

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -1857,7 +1857,7 @@ def cmd_coding_fanout_brief(args: argparse.Namespace) -> int:
         selected_effort = model_route.get("selected_reasoning_effort", "")
         model_id = _bounded_fanout_brief_scalar(selected_model)
         effort = _bounded_fanout_brief_scalar(selected_effort)
-        # One human-readable label per subagent, e.g. "gpt-5-codex xhigh" —
+        # One human-readable label per subagent, e.g. "gpt-5.6-sol xhigh" —
         # what a briefing renders next to the unit without joining two fields.
         # The format is a stable part of fanout_briefing/v1 and is built by
         # the same `model_label_for` helper the status board uses, so the two
@@ -1984,7 +1984,7 @@ def _fanout_brief_unit_line(unit: dict) -> str:
         model_text += " [schema v1]"
     parts = [
         str(unit.get("unit_id", "")),
-        # Owner and model are ONE field visually: "codex (gpt-5-codex xhigh)".
+        # Owner and model are ONE field visually: "codex (gpt-5.6-sol xhigh)".
         # The status board's bullet renderer abandoned the standalone
         # "— (model)" field because a dash around a parenthetical doubled the
         # separator; the brief follows the same convention.

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -7643,7 +7643,7 @@ def _english_series(items: list[str]) -> str:
 
 def _status_executor_suffix(status_payload: dict[str, Any]) -> str:
     """`` (Codex)`` or, when the handoff carries a resolved model route,
-    `` (Codex — gpt-5-codex xhigh)`` — the status-board single-field label
+    `` (Codex — gpt-5.6-sol xhigh)`` — the status-board single-field label
     convention (`model_label_for`); empty when nothing is known."""
     display = " — ".join(
         part

--- a/src/wrapper/message_gate.py
+++ b/src/wrapper/message_gate.py
@@ -150,7 +150,7 @@ def build_message_gate(
     no executor reads ``unknown`` and raises ``message_gate_missing_model_label``;
     a resolved executor with no route reads ``codex (executor default)`` and
     raises ``message_gate_unresolved_model_route``; a resolved route reads
-    ``codex (gpt-5-codex xhigh)`` and raises nothing. Collapsing the middle
+    ``codex (gpt-5.6-sol xhigh)`` and raises nothing. Collapsing the middle
     state into the last one is what let the main delegate path ship a header
     that could not distinguish "OMH applied no override" from "OMH never
     resolved a route", with no warning either way.
@@ -275,7 +275,7 @@ def _prompt_block(composed_prompt: str, model_field: str) -> str:
 
 
 def _model_field(executor: str, model_label: str) -> str:
-    """``codex (gpt-5-codex xhigh)`` -- executor and model as ONE visual field.
+    """``codex (gpt-5.6-sol xhigh)`` -- executor and model as ONE visual field.
 
     The parenthetical is never emitted empty: ``DELEGATE_MODEL_LABEL_RULE``
     names that exact shape as forbidden. A known executor with no resolved route

--- a/tests/test_category_maestro.py
+++ b/tests/test_category_maestro.py
@@ -235,7 +235,7 @@ class CategoryMaestroResolverTests(unittest.TestCase):
         self.assertEqual(route["selected_reasoning_effort"], "high")
         self.assertEqual(route["provenance"], "role_chain_head")
         chain_models = [entry["model_id"] for entry in route["chain"]]
-        self.assertEqual(chain_models, ["gpt-5.6-sol", "gpt-5"])
+        self.assertEqual(chain_models, ["gpt-5.6-sol"])
 
     def test_depth_and_scale_chains_derive_from_the_merged_table(self) -> None:
         deep = resolve_model_route(
@@ -320,7 +320,7 @@ class CategoryMaestroFanoutTests(unittest.TestCase):
         route = contract["units"][0]["handoff"]["model_route"]
         self.assertEqual(route["selected_model"], "gpt-6-astra")
         self.assertEqual(
-            [entry["model_id"] for entry in route["chain"]], ["gpt-6-astra", "gpt-5-codex"]
+            [entry["model_id"] for entry in route["chain"]], ["gpt-6-astra", "gpt-5.6-sol"]
         )
         self.assertEqual(route["catalog_kind"], "built_in_defaults")
 

--- a/tests/test_coding_status_board.py
+++ b/tests/test_coding_status_board.py
@@ -122,7 +122,7 @@ class StatusBoardBuildTests(unittest.TestCase):
                         "unit_id": "core",
                         "run_ref": "run-core",
                         "owner": "codex",
-                        "model": "gpt-5-codex",
+                        "model": "gpt-5.6-sol",
                         "reasoning_effort": "xhigh",
                         "status": "completed",
                         "duration_seconds": 92.517,
@@ -136,7 +136,7 @@ class StatusBoardBuildTests(unittest.TestCase):
         self.assertEqual(payload["sources_used"], ["dispatch_summary"])
         self.assertEqual(unit["label"], "Core work")
         self.assertEqual(unit["status"], "completed")
-        self.assertEqual(unit["model_label"], "gpt-5-codex xhigh")
+        self.assertEqual(unit["model_label"], "gpt-5.6-sol xhigh")
         # The float duration is floored to a whole second; no float survives.
         self.assertEqual(unit["elapsed_seconds"], 92)
         self.assertIsInstance(unit["elapsed_seconds"], int)
@@ -367,7 +367,7 @@ class FormattingTests(unittest.TestCase):
         self.assertEqual(tokens_text_for(True), "unknown")
 
     def test_model_label_matches_fanout_brief_format(self) -> None:
-        self.assertEqual(model_label_for("gpt-5-codex", "xhigh"), "gpt-5-codex xhigh")
+        self.assertEqual(model_label_for("gpt-5.6-sol", "xhigh"), "gpt-5.6-sol xhigh")
         self.assertEqual(model_label_for("fable-5", ""), "fable-5")
         self.assertEqual(model_label_for("", ""), "executor default")
 
@@ -381,7 +381,7 @@ class FormattingTests(unittest.TestCase):
 
         table = (
             # (model, reasoning_effort, expected label)
-            ("gpt-5-codex", "xhigh", "gpt-5-codex xhigh"),
+            ("gpt-5.6-sol", "xhigh", "gpt-5.6-sol xhigh"),
             ("fable-5", "", "fable-5"),
             ("", "", "executor default"),
             # Provider-prefixed omo id from a local-inventory catalog
@@ -412,7 +412,7 @@ class MessengerProfileTests(unittest.TestCase):
                     {
                         "unit_id": "core",
                         "owner": "codex",
-                        "model": "gpt-5-codex",
+                        "model": "gpt-5.6-sol",
                         "reasoning_effort": "xhigh",
                         "status": "completed",
                         "duration_seconds": 2100,
@@ -459,7 +459,7 @@ class MessengerProfileTests(unittest.TestCase):
         # well produced "claude — (fable-5 high)", a doubled separator around a
         # parenthetical.
         self.assertIn("research — claude (fable-5 high) — Code · running — 35m — tokens unknown", bullets[0])
-        self.assertIn("feature work — codex (gpt-5-codex xhigh) — Code · reported done — 35m — 10,000,000 tokens", bullets[1])
+        self.assertIn("feature work — codex (gpt-5.6-sol xhigh) — Code · reported done — 35m — 10,000,000 tokens", bullets[1])
         for bullet in bullets:
             self.assertNotIn(" — (", bullet)
         self.assertIn("session sess-7", bullets[1])

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -3348,7 +3348,7 @@ class FanoutBriefCliTests(unittest.TestCase):
             by_unit = {entry["unit_id"]: entry for entry in brief["units"]}
             core = by_unit["core"]
             self.assertEqual(core["owner"], "codex")
-            self.assertEqual(core["model"], "gpt-5-codex")
+            self.assertEqual(core["model"], "gpt-5.6-terra")
             self.assertEqual(core["status"], "completed")
             self.assertEqual(core["session_ref"], "unknown")
             self.assertEqual(core["tokens_total"], "unknown")
@@ -3367,7 +3367,7 @@ class FanoutBriefCliTests(unittest.TestCase):
             root = Path(tmp)
             paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
             units = [
-                {"unit_id": "review", "title": "Review", "owner": "codex", "file_scope": ["src/r/"], "role": "review"},
+                {"unit_id": "core", "title": "Core", "owner": "codex", "file_scope": ["src/r/"], "role": "brain"},
                 {"unit_id": "docs", "title": "Docs", "owner": "codex", "file_scope": ["docs/"], "role": "docs"},
             ]
             contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, units))
@@ -3377,13 +3377,13 @@ class FanoutBriefCliTests(unittest.TestCase):
             self.assertEqual(status, 0, stderr)
             brief = json.loads(stdout)
             by_unit = {entry["unit_id"]: entry for entry in brief["units"]}
-            # Behavior change #3 (display consequence of the review-on-codex
-            # chain head): the model field is a concrete id, no longer
-            # executor_default, and the alternative is the second chain entry.
-            review = by_unit["review"]
-            self.assertEqual(review["model"], "gpt-5-codex")
-            self.assertEqual(review["model_label"], "gpt-5-codex")
-            self.assertEqual(review["model_alternative"], "gpt-5")
+            # Behavior change #3 (display consequence of the chain head): the
+            # model field is a concrete id, no longer executor_default, and the
+            # alternative is the second chain entry (brain = deep > standard).
+            core = by_unit["core"]
+            self.assertEqual(core["model"], "gpt-5.6-terra")
+            self.assertEqual(core["model_label"], "gpt-5.6-terra high")
+            self.assertEqual(core["model_alternative"], "gpt-5.6-sol")
             # Single-entry chain (docs on codex): no alternative, empty string.
             self.assertEqual(by_unit["docs"]["model_alternative"], "")
 
@@ -3394,9 +3394,9 @@ class FanoutBriefCliTests(unittest.TestCase):
             # Owner and model read as ONE field, matching the status board's
             # bullet convention; a standalone "— (model)" field doubled the
             # separator around a parenthetical.
-            self.assertIn("codex (gpt-5-codex, alt: gpt-5)", stdout)
+            self.assertIn("codex (gpt-5.6-terra high, alt: gpt-5.6-sol)", stdout)
             self.assertNotIn(" — (", stdout)
-            self.assertNotIn("(gpt-5, alt:", stdout)
+            self.assertNotIn("(gpt-5.6-sol, alt:", stdout)
 
     def test_brief_degrades_silently_for_v1_routes(self) -> None:
         # A persisted v1 route carries no chain[]: the alternative must be
@@ -3417,7 +3417,7 @@ class FanoutBriefCliTests(unittest.TestCase):
                     unit["handoff"]["model_route"] = {
                         "schema_version": "coding_model_route/v1",
                         "source": "role_catalog_default",
-                        "selected_model": "gpt-5-codex",
+                        "selected_model": "gpt-5.6-sol",
                         "selected_reasoning_effort": "high",
                     }
             contract_path.write_text(json.dumps(stored), encoding="utf-8")
@@ -3427,7 +3427,7 @@ class FanoutBriefCliTests(unittest.TestCase):
             self.assertEqual(status, 0, stderr)
             brief = json.loads(stdout)
             core = {entry["unit_id"]: entry for entry in brief["units"]}["core"]
-            self.assertEqual(core["model_label"], "gpt-5-codex high")
+            self.assertEqual(core["model_label"], "gpt-5.6-sol high")
             self.assertEqual(core["model_alternative"], "")
             self.assertEqual(core["route_schema_version"], "coding_model_route/v1")
 
@@ -3435,7 +3435,7 @@ class FanoutBriefCliTests(unittest.TestCase):
                 base + ["coding", "fanout", "brief", str(contract["fanout_id"])], output_json=False
             )
             self.assertEqual(status, 0, stderr)
-            self.assertIn("codex (gpt-5-codex high [schema v1])", stdout)
+            self.assertIn("codex (gpt-5.6-sol high [schema v1])", stdout)
             self.assertNotIn(" — (", stdout)
             self.assertNotIn("alt:", stdout.split("docs")[0].split("core")[-1])
 
@@ -3511,7 +3511,7 @@ class FanoutBriefTextCeilingTests(unittest.TestCase):
             {
                 "unit_id": f"unit-{index:02d}",
                 "owner": "codex",
-                "model_label": "gpt-5-codex xhigh",
+                "model_label": "gpt-5.6-sol xhigh",
                 "model_alternative": "",
                 "route_schema_version": "coding_model_route/v2",
                 "status": "completed",

--- a/tests/test_inflight_markers.py
+++ b/tests/test_inflight_markers.py
@@ -32,7 +32,7 @@ def _fields(**overrides: str) -> dict[str, str]:
     fields = {
         "owner": "codex",
         "owner_host": "local",
-        "model": "gpt-5-codex",
+        "model": "gpt-5.6-sol",
         "reasoning_effort": "medium",
         "run_ref": "run-core",
         "worktree": "/tmp/worktrees/core",
@@ -62,7 +62,7 @@ class WriteReadRoundTripTest(unittest.TestCase):
             self.assertEqual(marker["unit_id"], "core")
             self.assertEqual(marker["marker_status"], "present")
             self.assertEqual(marker["owner"], "codex")
-            self.assertEqual(marker["model"], "gpt-5-codex")
+            self.assertEqual(marker["model"], "gpt-5.6-sol")
             self.assertEqual(marker["reasoning_effort"], "medium")
             self.assertEqual(marker["run_ref"], "run-core")
             self.assertEqual(marker["worktree"], "/tmp/worktrees/core")

--- a/tests/test_message_gate.py
+++ b/tests/test_message_gate.py
@@ -59,7 +59,7 @@ def _routed_gate(**overrides: object) -> dict:
     fields: dict = {
         "skill": "ulw-work",
         "executor": "codex",
-        "model": "gpt-5-codex",
+        "model": "gpt-5.6-sol",
         "reasoning_effort": "xhigh",
         "status": "prepared_not_observed",
         "prompt_sha256": "533d406a486317830d49c302e798c242",
@@ -210,7 +210,7 @@ class PromptBlockTests(unittest.TestCase):
 
     def test_the_block_names_the_model_it_was_ordered_on(self) -> None:
         gate = _routed_gate(composed_prompt="You are Codex.")
-        self.assertIn("codex (gpt-5-codex xhigh)", gate["prompt_block"].split("\n")[0])
+        self.assertIn("codex (gpt-5.6-sol xhigh)", gate["prompt_block"].split("\n")[0])
 
 
 class PayloadShapeTests(unittest.TestCase):

--- a/tests/test_messenger_cross_channel.py
+++ b/tests/test_messenger_cross_channel.py
@@ -87,7 +87,7 @@ class StructuredGateTests(unittest.TestCase):
         gate = build_message_gate(
             skill="ulw-work",
             executor="codex",
-            model="gpt-5-codex",
+            model="gpt-5.6-sol",
             status="prepared_not_observed",
             prompt_sha256="abc123",
             composed_prompt="Refactor the parser.",

--- a/tests/test_messenger_platform_simulation.py
+++ b/tests/test_messenger_platform_simulation.py
@@ -170,7 +170,7 @@ def _long_brief_body() -> str:
             "\n".join(
                 (
                     f"### Unit unit-{index:02d}",
-                    f"**Owner**: codex (gpt-5-codex xhigh); **status**: running; see [session](https://example.test/s/{index}).",
+                    f"**Owner**: codex (gpt-5.6-sol xhigh); **status**: running; see [session](https://example.test/s/{index}).",
                     "",
                     "```log",
                     f"unit-{index:02d}  targeted tests passed  ({index * 7}s elapsed)",

--- a/tests/test_model_routing.py
+++ b/tests/test_model_routing.py
@@ -35,7 +35,7 @@ class ResearchRoleTests(unittest.TestCase):
         """Autorouting survey consensus: standard is the default; shallow is
         the declared saving, deep the declared escalation — never inferred."""
         codex = resolve_model_route("codex", role="research")
-        self.assertEqual(codex["selected_model"], "gpt-5")
+        self.assertEqual(codex["selected_model"], "gpt-5.6-sol")
         # Standard research carries no effort of its own now that chains derive
         # from categories: `research` reads unspecified-low/quick and neither
         # declares one. The old hand-written `medium` had no category behind it,
@@ -65,10 +65,10 @@ class ResearchRoleTests(unittest.TestCase):
 
     def test_standard_and_unknown_depths_keep_the_role_chain(self) -> None:
         standard = resolve_model_route("codex", role="research", requested_depth="standard")
-        self.assertEqual(standard["selected_model"], "gpt-5")
+        self.assertEqual(standard["selected_model"], "gpt-5.6-sol")
         self.assertEqual(standard["depth"], "standard")
         unknown = resolve_model_route("codex", role="research", requested_depth="bottomless")
-        self.assertEqual(unknown["selected_model"], "gpt-5")
+        self.assertEqual(unknown["selected_model"], "gpt-5.6-sol")
         outcomes = {entry["stage"]: entry["outcome"] for entry in unknown["attempted"]}
         self.assertEqual(outcomes["research_depth"], "unknown_depth")
 
@@ -356,15 +356,16 @@ class ModelRouteResolverTests(unittest.TestCase):
     def test_review_role_on_codex_routes_to_chain_head_with_named_alternative(self) -> None:
         # THE behavior change of this PR: review-on-codex previously resolved
         # choice_required with no selected model; it now routes to the chain
-        # head and carries the standard-tier alternative in chain[].
+        # head. Both review categories now head on the same served model, so
+        # the chain de-duplicates to the one entry the CLI can actually run.
         route = resolve_model_route("codex", role="review")
         self.assertEqual(route["status"], "routed")
         self.assertEqual(route["provenance"], "role_chain_head")
-        self.assertEqual(route["selected_model"], "gpt-5-codex")
+        self.assertEqual(route["selected_model"], "gpt-5.6-sol")
         chain_models = [entry["model_id"] for entry in route["chain"]]
-        self.assertEqual(chain_models, ["gpt-5-codex", "gpt-5"])
+        self.assertEqual(chain_models, ["gpt-5.6-sol"])
         selected_flags = [entry["selected"] for entry in route["chain"]]
-        self.assertEqual(selected_flags, [True, False])
+        self.assertEqual(selected_flags, [True])
 
     def test_brain_role_gets_high_effort_from_chain_entry(self) -> None:
         # brain's high default moved from _HIGH_EFFORT_ROLES into chain data;
@@ -485,7 +486,7 @@ class EffortLadderTests(unittest.TestCase):
         self.assertEqual(route["effort_change"]["kind"], "legacy_alias_normalized")
 
     def test_auto_passes_through_when_catalog_has_no_contract_for_it(self) -> None:
-        route = resolve_model_route("codex", requested_model="gpt-5-codex", requested_effort="auto")
+        route = resolve_model_route("codex", requested_model="gpt-5.6-sol", requested_effort="auto")
         self.assertEqual(route["selected_reasoning_effort"], "auto")
         self.assertEqual(route["effort_change"]["kind"], "automatic_passthrough")
 
@@ -503,7 +504,7 @@ class EffortLadderTests(unittest.TestCase):
         # THE second behavior change of this PR (the live-bug fix): `max` on a
         # codex catalog model previously passed through unsupported; it now
         # steps down the ladder to the strongest supported rung.
-        route = resolve_model_route("codex", requested_model="gpt-5-codex", requested_effort="max")
+        route = resolve_model_route("codex", requested_model="gpt-5.6-sol", requested_effort="max")
         self.assertEqual(route["selected_reasoning_effort"], "xhigh")
         change = route["effort_change"]
         self.assertEqual(change["kind"], "ladder_downgrade")
@@ -525,7 +526,7 @@ class EffortLadderTests(unittest.TestCase):
         # Never-edit guard (a): effort-shaped off-vocabulary values pass
         # through byte-identically so a newer CLI vocabulary is never blocked
         # by a stale catalog. Same never-edit rule as guard (b).
-        route = resolve_model_route("codex", requested_model="gpt-5-codex", requested_effort="turbo-9")
+        route = resolve_model_route("codex", requested_model="gpt-5.6-sol", requested_effort="turbo-9")
         self.assertEqual(route["selected_reasoning_effort"], "turbo-9")
         self.assertEqual(route["effort_change"]["kind"], "unknown_vocabulary_passthrough")
 
@@ -762,7 +763,7 @@ class DispatchArgvTests(unittest.TestCase):
         )
 
     def test_codex_model_and_effort_insert_before_prompt(self) -> None:
-        route = resolve_model_route("codex", requested_model="gpt-5-codex", requested_effort="xhigh")
+        route = resolve_model_route("codex", requested_model="gpt-5.6-sol", requested_effort="xhigh")
         argv = build_dispatch_argv("codex", "do the work", route)
         self.assertEqual(
             argv,
@@ -770,7 +771,7 @@ class DispatchArgvTests(unittest.TestCase):
                 "codex",
                 "exec",
                 "--model",
-                "gpt-5-codex",
+                "gpt-5.6-sol",
                 "--config",
                 "model_reasoning_effort=xhigh",
                 "do the work",
@@ -798,21 +799,21 @@ class DispatchArgvTests(unittest.TestCase):
     def test_behavior_change_review_on_codex_now_emits_model(self) -> None:
         # 5b(i) before/after: the old resolver returned choice_required with
         # no selected_model for review-on-codex, so dispatch emitted the bare
-        # template argv; the chain head now emits --model gpt-5-codex.
+        # template argv; the chain head now emits --model gpt-5.6-sol.
         old_shape_route = {"selected_model": "", "selected_reasoning_effort": ""}
         self.assertEqual(build_dispatch_argv("codex", "p", old_shape_route), ["codex", "exec", "p"])
         new_route = resolve_model_route("codex", role="review")
         self.assertEqual(
             build_dispatch_argv("codex", "p", new_route),
-            ["codex", "exec", "--model", "gpt-5-codex", "p"],
+            ["codex", "exec", "--model", "gpt-5.6-sol", "p"],
         )
 
     def test_behavior_change_effort_max_on_codex_catalog_model(self) -> None:
         # 5b(ii) before/after: `max` previously reached the CLI unsupported;
         # the ladder now emits the downgraded rung in the argv.
-        old_shape_route = {"selected_model": "gpt-5-codex", "selected_reasoning_effort": "max"}
+        old_shape_route = {"selected_model": "gpt-5.6-sol", "selected_reasoning_effort": "max"}
         self.assertIn("model_reasoning_effort=max", build_dispatch_argv("codex", "p", old_shape_route))
-        new_route = resolve_model_route("codex", requested_model="gpt-5-codex", requested_effort="max")
+        new_route = resolve_model_route("codex", requested_model="gpt-5.6-sol", requested_effort="max")
         self.assertIn("model_reasoning_effort=xhigh", build_dispatch_argv("codex", "p", new_route))
 
 
@@ -922,8 +923,8 @@ class ModelRouteCliTests(unittest.TestCase):
             self.assertEqual(status, 0, stderr)
             lines = [line for line in stdout.splitlines() if line.startswith("- ")]
             self.assertEqual(len(lines), len(MODEL_ROLES))
-            self.assertIn("gpt-5-codex*", stdout)
-            self.assertIn("gpt-5", stdout)
+            self.assertIn("gpt-5.6-terra high*", stdout)
+            self.assertIn("gpt-5.6-sol", stdout)
             self.assertNotIn("claude-code", stdout)
 
     def test_model_route_without_executor_or_explain_errors(self) -> None:

--- a/tests/test_owner_progress_normalization.py
+++ b/tests/test_owner_progress_normalization.py
@@ -1426,7 +1426,7 @@ class SilentLossTests(unittest.TestCase):
         signal = build_safe_progress_signal(
             executor_profile="codex",
             process_status="running",
-            routed_model="gpt-5-codex",
+            routed_model="gpt-5.6-sol",
             routed_reasoning_effort="xhigh",
             tokens_total=10,
             elapsed_seconds=5,

--- a/tests/test_provider_entitlements.py
+++ b/tests/test_provider_entitlements.py
@@ -479,11 +479,11 @@ class SetupInterviewTests(unittest.TestCase):
             _write(path, {"schema_version": "omh_dispatch_model_preferences/v1", "profiles": {"claude-code": "opus"}})
             self.assertEqual(setup_module._seed_claude_code_dispatch_head(paths)["status"], "already_present")
             self.assertEqual(json.loads(path.read_text(encoding="utf-8"))["profiles"], {"claude-code": "opus"})
-            _write(path, {"schema_version": "omh_dispatch_model_preferences/v1", "profiles": {"codex": "gpt-5-codex"}})
+            _write(path, {"schema_version": "omh_dispatch_model_preferences/v1", "profiles": {"codex": "gpt-5.6-sol"}})
             self.assertEqual(setup_module._seed_claude_code_dispatch_head(paths)["status"], "seeded")
             self.assertEqual(
                 json.loads(path.read_text(encoding="utf-8"))["profiles"],
-                {"claude-code": CLAUDE_FRONTIER_CHAIN_MODELS[0], "codex": "gpt-5-codex"},
+                {"claude-code": CLAUDE_FRONTIER_CHAIN_MODELS[0], "codex": "gpt-5.6-sol"},
             )
 
 

--- a/tests/test_status_board_auto_surface.py
+++ b/tests/test_status_board_auto_surface.py
@@ -103,7 +103,7 @@ def _fields(**overrides: str) -> dict[str, str]:
     fields = {
         "owner": "codex",
         "owner_host": "local",
-        "model": "gpt-5-codex",
+        "model": "gpt-5.6-sol",
         "reasoning_effort": "medium",
         "run_ref": "run-core",
         "worktree": "/tmp/worktrees/core",
@@ -136,14 +136,14 @@ class RunningWorkBoardReaderTests(unittest.TestCase):
             self.assertEqual({unit["unit_id"] for unit in board["units"]}, {"core", "docs"})
             for unit in board["units"]:
                 self.assertEqual(unit["status"], "running")
-                self.assertEqual(unit["model_label"], "gpt-5-codex medium")
+                self.assertEqual(unit["model_label"], "gpt-5.6-sol medium")
             self.assertEqual(board["sources"]["fanout_root"], "present")
             # The RENDERED row pins the `runtime (model effort) — status`
             # parenthesized shape, so drift in this plugin-bundle copy of the
             # renderer fails the suite, not just the JSON fields.
             text = render_running_work_block_text(board)
-            self.assertIn(f"- {_FANOUT_ID}/core: codex (gpt-5-codex medium) — Code · running", text)
-            self.assertIn(f"- {_FANOUT_ID}/docs: codex (gpt-5-codex medium) — Code · running", text)
+            self.assertIn(f"- {_FANOUT_ID}/core: codex (gpt-5.6-sol medium) — Code · running", text)
+            self.assertIn(f"- {_FANOUT_ID}/docs: codex (gpt-5.6-sol medium) — Code · running", text)
             self.assertNotIn(" — (", text)
 
     def test_more_units_than_the_limit_states_truncation(self) -> None:

--- a/tests/test_status_board_cli.py
+++ b/tests/test_status_board_cli.py
@@ -47,7 +47,7 @@ def _write_dispatched_unit(root: Path) -> None:
                         "unit_id": "core",
                         "run_ref": "run-core",
                         "owner": "codex",
-                        "model": "gpt-5-codex",
+                        "model": "gpt-5.6-sol",
                         "reasoning_effort": "xhigh",
                         "status": "completed",
                         "duration_seconds": 92,
@@ -85,7 +85,7 @@ class StatusBoardCliTests(unittest.TestCase):
             json.loads(stdout)
         # The board still shows the row, just as a column instead of JSON.
         self.assertIn("Core work", stdout)
-        self.assertIn("gpt-5-codex xhigh", stdout)
+        self.assertIn("gpt-5.6-sol xhigh", stdout)
         self.assertIn("12,345", stdout)
 
     def test_json_opt_in_emits_the_schema_versioned_payload(self) -> None:

--- a/tests/test_task_scale_routing.py
+++ b/tests/test_task_scale_routing.py
@@ -95,12 +95,13 @@ class TaskScaleVocabularyTests(unittest.TestCase):
 class TaskScaleResolutionTests(unittest.TestCase):
     def test_scale_moves_the_selected_model_on_codex(self) -> None:
         # Three distinct rungs: quick -> the default working model -> ultrabrain.
+        # The first two share the served Codex default and differ by effort.
         small = resolve_model_route("codex", role="implementation", requested_scale="small")
         standard = resolve_model_route("codex", role="implementation", requested_scale="standard")
         large = resolve_model_route("codex", role="implementation", requested_scale="large")
-        self.assertEqual(small["selected_model"], "gpt-5")
+        self.assertEqual(small["selected_model"], "gpt-5.6-sol")
         self.assertEqual(small["selected_reasoning_effort"], "low")
-        self.assertEqual(standard["selected_model"], "gpt-5-codex")
+        self.assertEqual(standard["selected_model"], "gpt-5.6-sol")
         self.assertEqual(standard["selected_reasoning_effort"], "")
         self.assertEqual(large["selected_model"], "gpt-6-astra")
         self.assertEqual(large["selected_reasoning_effort"], "xhigh")
@@ -130,7 +131,7 @@ class TaskScaleResolutionTests(unittest.TestCase):
     def test_an_unknown_scale_is_named_not_rejected(self) -> None:
         route = resolve_model_route("codex", role="implementation", requested_scale="enormous")
         self.assertEqual(route["status"], "routed")
-        self.assertEqual(route["selected_model"], "gpt-5-codex")
+        self.assertEqual(route["selected_model"], "gpt-5.6-sol")
         self.assertEqual(_scale_stage(route)["outcome"], "unknown_scale")
 
     def test_research_keeps_its_depth_dial_and_says_so(self) -> None:

--- a/tests/test_unit_telemetry.py
+++ b/tests/test_unit_telemetry.py
@@ -33,7 +33,7 @@ CODEX_TOKEN_COUNT_EVENT = {
 }
 CODEX_SESSION_CONFIGURED_EVENT = {
     "id": "0",
-    "msg": {"type": "session_configured", "session_id": "0199f0aa-1b2c-4d5e-8f90-abcdef123456", "model": "gpt-5-codex"},
+    "msg": {"type": "session_configured", "session_id": "0199f0aa-1b2c-4d5e-8f90-abcdef123456", "model": "gpt-5.6-sol"},
 }
 CLAUDE_RESULT_EVENT = {
     "type": "result",

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -4166,7 +4166,7 @@ class WrapperContractTests(unittest.TestCase):
                 "prepared": {
                     "executor_target": "codex",
                     "model_route": {
-                        "selected_model": "gpt-5-codex",
+                        "selected_model": "gpt-5.6-sol",
                         "selected_reasoning_effort": "xhigh",
                     },
                 },
@@ -4178,11 +4178,11 @@ class WrapperContractTests(unittest.TestCase):
 
         self.assertEqual(
             response["plain_headline"],
-            "The coding handoff (Codex — gpt-5-codex xhigh) was dispatched.",
+            "The coding handoff (Codex — gpt-5.6-sol xhigh) was dispatched.",
         )
         self.assertEqual(
             response["status_card"]["headline"],
-            "The coding handoff (Codex — gpt-5-codex xhigh) was dispatched.",
+            "The coding handoff (Codex — gpt-5.6-sol xhigh) was dispatched.",
         )
         # The status-board single-field convention: model and effort join with
         # a space, never nested parentheses.
@@ -4195,7 +4195,7 @@ class WrapperContractTests(unittest.TestCase):
                 "next_action": "dispatch_to_executor",
                 "prepared": {
                     "executor_target": "codex",
-                    "model_route": {"selected_model": "gpt-5-codex"},
+                    "model_route": {"selected_model": "gpt-5.6-sol"},
                 },
                 "execution": {"observed": False},
                 "verification": {"observed": False},
@@ -4203,7 +4203,7 @@ class WrapperContractTests(unittest.TestCase):
             }
         )
 
-        self.assertEqual(response["plain_headline"], "The coding handoff (Codex — gpt-5-codex) is ready.")
+        self.assertEqual(response["plain_headline"], "The coding handoff (Codex — gpt-5.6-sol) is ready.")
 
     def test_status_card_exposes_platform_neutral_progress_steps(self) -> None:
         card = build_status_card_from_status(


### PR DESCRIPTION
## Capability

The Maestro lane's built-in Codex chains name only models the Codex CLI serves today.

## Motivation

`BUILTIN_CATEGORY_MODELS["codex"]` still headed most categories on `gpt-5-codex` and closed chains on `gpt-5`. Every projection of that table (category-maestro show, fanout brief, dispatch argv, `model-route --explain`, and the README chains scene drawn from it) named a generation the CLI no longer offers.

## Implementation

- `src/coding/model_routing.py`: `EXECUTOR_MODEL_OPTIONS["codex"]` rows are `gpt-6-astra`, `gpt-5.6-sol` (frontier, the CLI default), `gpt-5.6-terra` (deep tier). Built-in chains: ultrabrain/architect → Astra xhigh > Sol xhigh; deep → Terra high > Sol high; unspecified-high, writing, visual-engineering, artistry → Sol; unspecified-low → Sol; quick → Sol low.
- Comments and docstrings in `message_gate.py`, `contract.py`, `status_board.py`, `commands/coding.py`, `docs/FANOUT.md` stop quoting the retired id.
- Tests: pinned chains, dispatch argv, effort-ladder downgrade cases, task-scale rungs, and fanout brief alternatives move to the served ids; the brief alt-chain fixture uses the `brain` role since review now de-duplicates to a single entry. Fixture literals renamed repo-wide.

## Verification (observed)

```
PYTHONPATH=tests uv run python -m unittest discover -s tests   → 9333 tests, 1 failure (site badge parity, pre-existing on main; fixed in the sibling PR)
uv run --group lint ruff check src tests                       → passed
uv run python -m compileall -q src tests                       → ok
omh docs workflows --check / roles --check                     → ok
git diff --check                                               → clean
```

## Risks

Operator `category-maestro` overrides keyed on the old ids still merge over the built-ins unchanged. A live `codex exec` dispatch with the new default id was not observed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZYwbzXpiWJpPUfEcKfRLY
