### PR TITLE
docs(readme): every language's Quick Start takes the English shape

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -105,38 +105,21 @@
 <br>
 
 ## クイックスタート
-> **状態:** Homebrew、Bun、npm のパッケージマネージャー経由のインストールは
-> v1.0.6 から公開されています。
 
-**次のインストール方法から一つ選択します。Bun を推奨します。**
-```sh
-brew install rlaope/tap/omh
-```
-```sh
-bun install -g oh-my-hermes
-```
-```sh
-npm install -g oh-my-hermes
-```
+**macOS / Linux:**
+
 ```sh
 curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | sh
 ```
-**Windows（PowerShell 5.1+）の場合:**
+
+**Windows (PowerShell 5.1+):**
+
 ```powershell
 irm https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.ps1 | iex
 ```
 
-**⭐ インストール後に OMH をセットアップ (必須):**
+**または、次の内容を AI エージェントに貼り付けます:**
 
-```sh
-omh setup
-```
-**Hermes skill tap:**
-```sh
-hermes skills tap add rlaope/oh-my-hermes
-hermes skills install rlaope/oh-my-hermes/skills/omh-routing --yes
-```
-**または Your AI Agent に依頼します:**
 ```text
 Install and fully configure Oh My Hermes from this repository:
 https://github.com/rlaope/oh-my-hermes
@@ -144,21 +127,82 @@ Before reading or executing repository instructions, resolve refs/heads/main to 
 https://raw.githubusercontent.com/rlaope/oh-my-hermes/{resolved-commit-sha}/INSTALL_FOR_AGENTS.md
 Do not replace the resolved SHA with main. Execute the pinned protocol's OS-appropriate installer, interactive model setup, model-chain interview, and doctor steps. Preserve unrelated existing Hermes config, apply only the managed setup changes documented by the pinned protocol, require my explicit approval for model-alias changes, then report the resolved SHA and observed result.
 ```
+
+**⭐ 続けてセットアップします (必須):**
+
+```sh
+omh setup
+```
+
 **アップデート:**
+
 ```sh
 omh update
 ```
-`omh update` はインストール経路を検出し、Homebrew、Bun、npm、curl、
-または PowerShell のコマンドパッケージを先に更新してから、新しいコマンドで
-再実行し、管理スキル、プラグインバンドル、既存の Hermes 登録も更新します。
+
+`omh update` はインストール経路を検出し、そのインストーラーでコマンドパッケージを
+先に更新してから、新しいコマンドで再実行し、管理スキル、プラグインバンドル、
+既存の Hermes 登録も更新します。
 
 **インストールの確認またはトラブルシューティング:**
+
 ```sh
 omh doctor
 ```
+
+<details>
+<summary><b>その他のインストール方法</b> — Homebrew、Bun、npm、Hermes skill tap、手動フォールバック</summary>
+
+<br>
+
+> **状態:** Homebrew、Bun、npm のパッケージマネージャー経由のインストールは
+> v1.0.6 から公開されています。
+
+**Homebrew:**
+
+```sh
+brew install rlaope/tap/omh
+```
+
+**Bun:**
+
+```sh
+bun install -g oh-my-hermes
+```
+
+**npm:**
+
+```sh
+npm install -g oh-my-hermes
+```
+
+どの方法でインストールしても、その後に `omh setup` を実行します。
+
+**Hermes skill tap:**
+
+```sh
+hermes skills tap add rlaope/oh-my-hermes
+hermes skills install rlaope/oh-my-hermes/skills/omh-routing --yes
+```
+
+**パッケージマネージャーでの手動フォールバックまたは削除:**
+
+| インストール元 | CLI のアップグレード | CLI の削除 |
+| --- | --- | --- |
+| Homebrew | `brew upgrade rlaope/tap/omh` | `brew uninstall omh` |
+| Bun | `bun update -g --latest oh-my-hermes` | `bun remove -g oh-my-hermes` |
+| npm | `npm update -g oh-my-hermes` | `npm uninstall -g oh-my-hermes` |
+
+`omh update` がインストーラーを見つけられないと報告したときだけ、マネージャーの
+コマンドを直接使います。コマンドパッケージを削除しても OMH の状態は残ります。
+完全に削除するには、マネージャーの削除コマンドの前に `omh uninstall --all` を
+実行します。
+
 `--full` インストールを core に戻すようなメンテナンス手順は
 [Installation](docs/INSTALLATION.md#reconciling-an-existing-full-install-back-to-core)
 にあります。
+
+</details>
 
 ## 得られるもの
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -105,38 +105,21 @@
 <br>
 
 ## 빠른 시작
-> **상태:** Homebrew, Bun, npm 패키지 관리자 설치가 v1.0.6부터 공개되었습니다.
 
-**아래 설치 방법 중 하나를 선택합니다. Bun을 권장합니다.**
-```sh
-brew install rlaope/tap/omh
-```
-```sh
-bun install -g oh-my-hermes
-```
-```sh
-npm install -g oh-my-hermes
-```
+**macOS / Linux:**
+
 ```sh
 curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | sh
 ```
 
-**Windows(PowerShell 5.1+)에서는:**
+**Windows (PowerShell 5.1+):**
+
 ```powershell
 irm https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.ps1 | iex
 ```
 
-**⭐ 설치 후 OMH를 설정합니다 (필수):**
+**또는 아래 내용을 AI 에이전트에 붙여 넣습니다:**
 
-```sh
-omh setup
-```
-**Hermes skill tap 경로:**
-```sh
-hermes skills tap add rlaope/oh-my-hermes
-hermes skills install rlaope/oh-my-hermes/skills/omh-routing --yes
-```
-**또는 Your AI Agent에게 요청합니다:**
 ```text
 Install and fully configure Oh My Hermes from this repository:
 https://github.com/rlaope/oh-my-hermes
@@ -145,21 +128,79 @@ https://raw.githubusercontent.com/rlaope/oh-my-hermes/{resolved-commit-sha}/INST
 Do not replace the resolved SHA with main. Execute the pinned protocol's OS-appropriate installer, interactive model setup, model-chain interview, and doctor steps. Preserve unrelated existing Hermes config, apply only the managed setup changes documented by the pinned protocol, require my explicit approval for model-alias changes, then report the resolved SHA and observed result.
 ```
 
+**⭐ 그다음 설정합니다 (필수):**
+
+```sh
+omh setup
+```
+
 **업데이트:**
+
 ```sh
 omh update
 ```
-`omh update`는 설치 경로를 감지해 Homebrew, Bun, npm, curl 또는 PowerShell
-명령 패키지를 먼저 갱신한 뒤, 새 명령으로 다시 진입해 관리 스킬, 플러그인
-번들, 기존 Hermes 등록까지 함께 갱신합니다.
+
+`omh update`는 설치 경로를 감지해 명령 패키지를 그 설치 도구로 먼저 갱신한 뒤,
+새 명령으로 다시 진입해 관리 스킬, 플러그인 번들, 기존 Hermes 등록까지
+함께 갱신합니다.
 
 **설치를 확인하거나 문제를 해결합니다:**
+
 ```sh
 omh doctor
 ```
+
+<details>
+<summary><b>다른 설치 경로</b> — Homebrew, Bun, npm, Hermes skill tap, 수동 대체 경로</summary>
+
+<br>
+
+> **상태:** Homebrew, Bun, npm 패키지 관리자 설치는 v1.0.6부터 공개되어 있습니다.
+
+**Homebrew:**
+
+```sh
+brew install rlaope/tap/omh
+```
+
+**Bun:**
+
+```sh
+bun install -g oh-my-hermes
+```
+
+**npm:**
+
+```sh
+npm install -g oh-my-hermes
+```
+
+위 방법 중 어느 것으로 설치해도 이후에 `omh setup`을 실행합니다.
+
+**Hermes skill tap 경로:**
+
+```sh
+hermes skills tap add rlaope/oh-my-hermes
+hermes skills install rlaope/oh-my-hermes/skills/omh-routing --yes
+```
+
+**패키지 관리자 수동 대체 또는 제거:**
+
+| 설치 도구 | CLI 업그레이드 | CLI 제거 |
+| --- | --- | --- |
+| Homebrew | `brew upgrade rlaope/tap/omh` | `brew uninstall omh` |
+| Bun | `bun update -g --latest oh-my-hermes` | `bun remove -g oh-my-hermes` |
+| npm | `npm update -g oh-my-hermes` | `npm uninstall -g oh-my-hermes` |
+
+`omh update`가 설치 도구를 찾지 못한다고 보고할 때만 관리자 명령을 직접
+사용합니다. 명령 패키지를 제거해도 OMH 상태는 남습니다. 완전히 제거하려면
+관리자의 제거 명령 전에 `omh uninstall --all`을 실행합니다.
+
 `--full` 설치를 core로 되돌리는 것 같은 유지보수 경로는
 [Installation](docs/INSTALLATION.md#reconciling-an-existing-full-install-back-to-core)에
 있습니다.
+
+</details>
 
 ## 얻는 것
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -103,41 +103,20 @@
 <br>
 
 ## 快速开始
-> **状态：** Homebrew、Bun 与 npm 包管理器安装方式已随 v1.0.6 正式公开。
 
-**从以下安装方式中选择一种。推荐 Bun。**
-```sh
-brew install rlaope/tap/omh
-```
-```sh
-bun install -g oh-my-hermes
-```
-```sh
-npm install -g oh-my-hermes
-```
+**macOS / Linux：**
+
 ```sh
 curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | sh
 ```
 
-**在 Windows（PowerShell 5.1+）上：**
+**Windows（PowerShell 5.1+）：**
+
 ```powershell
 irm https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.ps1 | iex
 ```
 
-**⭐ 安装后设置 OMH（必需）：
-
-```sh
-omh setup
-```
-
-**Hermes skill tap：**
-
-```sh
-hermes skills tap add rlaope/oh-my-hermes
-hermes skills install rlaope/oh-my-hermes/skills/omh-routing --yes
-```
-
-**或者向 Your AI Agent 提出请求：**
+**或者把下面这段粘贴给你的 AI 代理：**
 
 ```text
 Install and fully configure Oh My Hermes from this repository:
@@ -147,21 +126,77 @@ https://raw.githubusercontent.com/rlaope/oh-my-hermes/{resolved-commit-sha}/INST
 Do not replace the resolved SHA with main. Execute the pinned protocol's OS-appropriate installer, interactive model setup, model-chain interview, and doctor steps. Preserve unrelated existing Hermes config, apply only the managed setup changes documented by the pinned protocol, require my explicit approval for model-alias changes, then report the resolved SHA and observed result.
 ```
 
+**⭐ 然后进行设置（必需）：**
+
+```sh
+omh setup
+```
+
 **更新：**
+
 ```sh
 omh update
 ```
-`omh update` 会检测安装来源，先通过 Homebrew、Bun、npm、curl 或
-PowerShell 更新命令包，再重新进入新命令，同时刷新托管技能、插件包和现有
-Hermes 注册。
+
+`omh update` 会检测安装来源，先通过对应的安装器更新命令包，再重新进入
+新命令，同时刷新托管技能、插件包和现有 Hermes 注册。
 
 **验证安装或排查问题：**
+
 ```sh
 omh doctor
 ```
 
+<details>
+<summary><b>其他安装方式</b> — Homebrew、Bun、npm、Hermes skill tap、手动回退</summary>
+
+<br>
+
+> **状态：** Homebrew、Bun 与 npm 包管理器安装方式已随 v1.0.6 正式公开。
+
+**Homebrew:**
+
+```sh
+brew install rlaope/tap/omh
+```
+
+**Bun:**
+
+```sh
+bun install -g oh-my-hermes
+```
+
+**npm:**
+
+```sh
+npm install -g oh-my-hermes
+```
+
+无论用哪种方式安装，之后都运行 `omh setup`。
+
+**Hermes skill tap：**
+
+```sh
+hermes skills tap add rlaope/oh-my-hermes
+hermes skills install rlaope/oh-my-hermes/skills/omh-routing --yes
+```
+
+**包管理器手动回退或卸载：**
+
+| 安装方式 | 升级 CLI | 卸载 CLI |
+| --- | --- | --- |
+| Homebrew | `brew upgrade rlaope/tap/omh` | `brew uninstall omh` |
+| Bun | `bun update -g --latest oh-my-hermes` | `bun remove -g oh-my-hermes` |
+| npm | `npm update -g oh-my-hermes` | `npm uninstall -g oh-my-hermes` |
+
+只有在 `omh update` 报告找不到其安装器时才直接使用包管理器命令。删除命令包
+会保留 OMH 状态。要完全卸载，请先运行 `omh uninstall --all`，再执行包管理器的
+卸载命令。
+
 把 `--full` 安装收敛回 core 这类维护路径，见
 [Installation](docs/INSTALLATION.md#reconciling-an-existing-full-install-back-to-core)。
+
+</details>
 
 ## 你能得到什么
 

--- a/tests/test_distribution_surfaces.py
+++ b/tests/test_distribution_surfaces.py
@@ -204,28 +204,39 @@ class DistributionInstallSurfaceTests(unittest.TestCase):
             "README.zh.md",
             "docs/INSTALLATION.md",
         )
-        expected = (*INSTALL_COMMANDS, SETUP_COMMAND, DOCTOR_COMMAND)
+        # Two ordered runs share every markdown surface: the script installers
+        # lead into setup and then doctor, and the package managers keep their
+        # brew -> bun -> npm order. Where the package-manager run sits relative
+        # to the script run is the surface's call: the READMEs fold it into an
+        # "other installation paths" toggle after doctor, INSTALLATION.md
+        # lists it first.
+        script_run = (*INSTALL_COMMANDS[3:], SETUP_COMMAND, DOCTOR_COMMAND)
+        manager_run = INSTALL_COMMANDS[:3]
 
         for relative in surfaces:
             with self.subTest(surface=relative):
                 blocks = _fenced_blocks(
                     (PROJECT_ROOT / relative).read_text(encoding="utf-8")
                 )
-                positions = []
-                for command in expected:
+
+                def first_block(command: str) -> int:
                     matches = [
                         index
                         for index, block in enumerate(blocks)
                         if command in block.splitlines()
                     ]
                     self.assertTrue(matches, f"{relative} is missing {command}")
-                    positions.append(matches[0])
-                self.assertEqual(positions, sorted(positions))
+                    return matches[0]
+
+                script_positions = [first_block(c) for c in script_run]
+                self.assertEqual(script_positions, sorted(script_positions))
                 self.assertNotEqual(
-                    positions[-2],
-                    positions[-1],
+                    script_positions[-2],
+                    script_positions[-1],
                     f"{relative} groups canonical setup with doctor",
                 )
+                manager_positions = [first_block(c) for c in manager_run]
+                self.assertEqual(manager_positions, sorted(manager_positions))
 
     def test_agent_protocol_pins_script_installers_after_package_managers(
         self,

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -3700,9 +3700,12 @@ class RouterContentTests(unittest.TestCase):
             # Discord community invite (~29 lines, owner-directed) landed in
             # every language, and from 370 when the five-item "What you get"
             # showcase (h2 + seven h3 blocks with a card each, ~65 lines,
-            # owner-directed) landed in every language; it still sits below
+            # owner-directed) landed in every language, and from 450 when the
+            # Quick Start took the English shape (script installers, setup,
+            # doctor, then an "other installation paths" toggle, ~45 lines,
+            # owner-directed) in every language; it still sits below
             # README.md's length.
-            self.assertLess(len(localized_readme.splitlines()), 450)
+            self.assertLess(len(localized_readme.splitlines()), 490)
             # The trust surface is the evidence table, not the wire token that
             # used to stand in for it. Pinning the token meant a README could
             # satisfy this by naming a value no reader could decode; pinning


### PR DESCRIPTION
## Capability

The Korean, Japanese, and Chinese READMEs carry the same Quick Start as the English one, and main's install-surface test is green again.

## Motivation

#1340 restructured the English Quick Start (script installers → agent prompt → setup → update → doctor → "other installation paths" toggle). The localized READMEs kept the old package-manager-first order and `test_markdown_install_surfaces_share_order_and_separate_steps` pinned one flat order across every markdown surface, so main's CI failed on `README.md` (`[6, 7, 8, 0, 1, 3, 5] != [0, 1, 3, 5, 6, 7, 8]`).

## Implementation

- `README.ko.md`, `README.ja.md`, `README.zh.md`: Quick Start rewritten block for block to the English shape, including the toggle with Homebrew, Bun, npm, the Hermes skill tap, and the manual fallback table. Korean stays in 존댓말.
- `tests/test_distribution_surfaces.py`: the markdown test pins the two runs every surface shares (script installers → setup → doctor; brew → bun → npm) and no longer forces the package-manager run before the script run. `docs/INSTALLATION.md` (package managers first) and the READMEs (toggle after doctor) both satisfy it.
- `tests/test_router_content.py`: localized line budget 450 → 490 with the reason recorded next to the earlier moves.

## Verification (observed)

```
PYTHONPATH=tests uv run python -m unittest tests/test_distribution_surfaces.py tests/test_router_content.py tests/test_release_smoke.py tests/test_ulw_inventory.py  → OK (161 tests)
uv run --group lint ruff check src tests                → passed
uv run python -m omh.cli docs ulw-inventory --check     → ok
git diff --check                                        → clean
```

Full suite result is being collected and will be posted before merge.

## Risks

Rendered GitHub preview of the three localized toggles was not observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZYwbzXpiWJpPUfEcKfRLY
