### PR TITLE
docs(readme): Homebrew, Bun, and npm go back into the other-paths toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,26 +113,6 @@
 
 ## Quick Start
 
-Choose one installation method, then run setup below.
-
-**Homebrew:**
-
-```sh
-brew install rlaope/tap/omh
-```
-
-**Bun:**
-
-```sh
-bun install -g oh-my-hermes
-```
-
-**npm:**
-
-```sh
-npm install -g oh-my-hermes
-```
-
 **macOS / Linux:**
 
 ```sh
@@ -179,9 +159,32 @@ omh doctor
 ```
 
 <details>
-<summary><b>Other installation paths</b> — Hermes skill tap, manual fallback</summary>
+<summary><b>Other installation paths</b> — Homebrew, Bun, npm, Hermes skill tap, manual fallback</summary>
 
 <br>
+
+> **Status:** Homebrew, Bun, and npm package-manager installs are public as of
+> v1.0.6.
+
+**Homebrew:**
+
+```sh
+brew install rlaope/tap/omh
+```
+
+**Bun:**
+
+```sh
+bun install -g oh-my-hermes
+```
+
+**npm:**
+
+```sh
+npm install -g oh-my-hermes
+```
+
+Run `omh setup` after any of these, same as above.
 
 **Hermes skill tap path:**
 


### PR DESCRIPTION
## Capability

The English README's Quick Start keeps Homebrew, Bun, and npm inside the "Other installation paths" toggle, as the owner asked.

## Motivation

Commit 8c81479c (merged via #1343) moved the three package-manager blocks back above `omh setup` to satisfy the flat install-order pin, which #1346 had already relaxed minutes earlier. The two fixes for the same CI red crossed, and the rendered README now shows Homebrew/Bun/npm outside the toggle.

## Implementation

- `README.md`: restored to its #1346 state (curl, irm, agent prompt, setup, update, doctor, then the toggle with Homebrew, Bun, npm, skill tap, manual fallback). Nothing else from 8c81479c is touched.

## Verification (observed)

```
PYTHONPATH=tests uv run python -m unittest tests/test_distribution_surfaces.py tests/test_router_content.py tests/test_release_smoke.py tests/test_ulw_inventory.py  → OK
uv run python -m omh.cli docs ulw-inventory --check  → ok
git diff --check  → clean
```

## Risks

None beyond the English README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZYwbzXpiWJpPUfEcKfRLY
