### PR TITLE
docs(readme): demo grid under the terminal section, and a current What OMH Adds

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,29 +2,6 @@
   <img src="assets/oh-my-hermes-wordmark.png" alt="OH-MY-HERMES" width="100%" style="display:block;max-width:none;height:auto">
 </p>
 
-<table align="center">
-  <tr>
-    <td width="50%" align="center">
-      <img src="assets/hermes-desktop.gif" alt="Hermes Desktop running an OMH workflow" width="380" height="266"><br>
-      <sub><b>Hermes デスクトップ、oh-my-hermes とともに。</b><br>ワークフローを選ぶと、作る前に確認します。</sub>
-    </td>
-    <td width="50%" align="center">
-      <img src="assets/hermes-cli.gif" alt="Hermes CLI running an OMH workflow" width="380" height="266"><br>
-      <sub><b>Hermes CLI、oh-my-hermes とともに。</b><br>使っているターミナルで同じワークフローを。</sub>
-    </td>
-  </tr>
-  <tr>
-    <td width="50%" align="center">
-      <img src="assets/hermes-messenger.gif" alt="Hermes messenger app running an OMH workflow" width="380" height="266"><br>
-      <sub><b>Hermes メッセンジャーアプリ、oh-my-hermes とともに。</b><br>スレッドで依頼すると同じスレッドに返ります。</sub>
-    </td>
-    <td width="50%" align="center">
-      <img src="assets/omh-setup.gif" alt="omh setup installing the OMH workflows" width="380" height="266"><br>
-      <sub><b><code>omh setup</code>、コマンド一つで。</b><br>ワークフローをインストールし、Hermes に接続します。</sub>
-    </td>
-  </tr>
-</table>
-
 # oh-my-hermes
 
 <p align="center">
@@ -313,6 +290,29 @@ OMH ワークフローの実行中にターミナルが表示するもの:
   (`todo init`)、プロンプト上のチェックリストとして描画されます: アクティブ
   項目は常に一つ、各 phase ヘッダー下にインデントされた task、サブタスクの
   ネスト、7 行を超えると折りたたみ。
+
+<table align="center">
+  <tr>
+    <td width="50%" align="center">
+      <img src="assets/hermes-desktop.gif" alt="Hermes Desktop running an OMH workflow" width="380" height="266"><br>
+      <sub><b>Hermes デスクトップ、oh-my-hermes とともに。</b><br>ワークフローを選ぶと、作る前に確認します。</sub>
+    </td>
+    <td width="50%" align="center">
+      <img src="assets/hermes-cli.gif" alt="Hermes CLI running an OMH workflow" width="380" height="266"><br>
+      <sub><b>Hermes CLI、oh-my-hermes とともに。</b><br>使っているターミナルで同じワークフローを。</sub>
+    </td>
+  </tr>
+  <tr>
+    <td width="50%" align="center">
+      <img src="assets/hermes-messenger.gif" alt="Hermes messenger app running an OMH workflow" width="380" height="266"><br>
+      <sub><b>Hermes メッセンジャーアプリ、oh-my-hermes とともに。</b><br>スレッドで依頼すると同じスレッドに返ります。</sub>
+    </td>
+    <td width="50%" align="center">
+      <img src="assets/omh-setup.gif" alt="omh setup installing the OMH workflows" width="380" height="266"><br>
+      <sub><b><code>omh setup</code>、コマンド一つで。</b><br>ワークフローをインストールし、Hermes に接続します。</sub>
+    </td>
+  </tr>
+</table>
 
 <br>
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -405,29 +405,30 @@ Do not replace the resolved SHA with main. Execute the pinned protocol's OS-appr
 
 ## OMH が追加するもの
 
-OMH は、モデル選択とコーディングの所有者を別の判断として扱い、準備を実行として
-報告しません。人が理解しやすい capability family は引き続き入口であり、精密な
-制御・runtime 境界・証拠ルールは wrapper や operator が必要なときに確認
-できます。完全な catalog、trigger、harness、証拠ルールは
-[Workflow Reference](docs/WORKFLOWS.md) にあります。
+Hermes Agent はすでにループを回しています。OMH はそのループに何を入れるかを
+決めます。どの lane にどのモデルと推論強度を与えるか、コード変更の owner は
+誰か、どのスキルを適用するか、何を完了とみなすかです。どこでも二つの
+ルールが守られます。モデル選択とコーディングの所有権は別々の決定であり、
+準備されたものを実行済みとして報告することは決してありません。生成
+カタログ、trigger、証拠ルールは [Workflow Reference](docs/WORKFLOWS.md)
+にあります。
 
 **ハイライト**
 
 | インテリジェンス | OMH が追加するもの |
 | --- | --- |
-| 🧭 **Mixture-of-models ルーティング** | 委譲される lane ごとにカテゴリ(モデル + 推論強度)を dispatch 単位で適用し、provider がモデルを拒否したら編集可能な fallback chain に沿って前進します — 仕事をしなかった子は正直に `failed` と表示されます。 |
-| 🖥️ **ネイティブ TUI サーフェス** | OMH HUD(カテゴリ・ターン・コスト・キャッシュ付きのライブ delegation 行)、プロンプト上の phase todo チェックリスト、`parallel shot ×N` 表示、full-row diff バンド、管理されたスキン — すべて Hermes の隣にインストールされ、Hermes 本体にはパッチしません。 |
-| 📋 **Phase 構造のプラン** | `todo init` がエンジン作業の前に phase と task を宣言し、実行を開かれた推論ループではなく有界のチェックリストにします。 |
-| ⚡ **観測可能な並列作業** | 独立した作業を所有権の分かれた fanout unit に分割し、進行状況と verification gate を観測します。 |
-| 🎼 **Maestro handoff** | 隠れた executor にならず、準備を実行として扱わずに、明示的な coding owner と runtime profile への handoff を準備します。 |
-| 🧠 **コンテキストインテリジェンス** | 隠れた記憶を捏造したり選択済み route を密かに変えたりせず、レビュー済み repository context をコンパクトに投影します。 |
-| 📚 **JIT learning** | 現在の blocker に最も価値のある学習対象を選び、学習済みと主張せずに、情報源に基づく即時適用可能なガイダンスを準備します。 |
-| 🔍 **証拠に基づく delivery** | coding・review・CI・merge 全体で、準備された意図、観測された runtime 活動、検証済み結果を分離します。 |
-| 🔎 **構造的コード検索** | 実測に基づく `ast-grep` プレイブック — 28 言語の構造クエリ、body-capture の禁止、grep フォールバック — を executor がコードを検索する場面に注入します。OMH はバイナリの存在だけを検知し、自分では実行しません。 |
-| 🗄️ **プロジェクトメモリシステム** | Hermes がロードできる決定的なファイルベース memory provider、レビュー型プロジェクトメモリコマンド(inspect・pack・domain capture)、consolidation スケジューリング brief、メモリレビュー用スキル — Hermes の不透明な内部メモリは読みも書きもしません。 |
-| 🛠️ **コーディングハーネス & ガードレール** | executor readiness probe、準備済み handoff に付く capability snapshot と owner-fit レポート、`execute_code` 結果への code-mode discipline、ルール違反の tool call をルール本文で遮断するユーザー作成 toolcall rules。 |
-| ♾️ **ウルトラワークフローエンジン** | 所有権を分離した並列デリバリーレーン、ledger と実際の完了 gate で回る計測ループ、エンジン実行前に意図を明確化する decision-frontier インタビュー — エンジンの一覧は下のウルトラスキル節にあります。 |
-| 📦 **決定的なスキルカタログ** | 120 個超のインストール可能な workflow スキル、バイト単位で検証される生成カタログ、否定ケースを含む routing precision コーパス、一文字のドリフトでも CI を失敗させる drift gate。 |
+| 🧭 **Mixture-of-models ルーティング** | 委譲される lane ごとに、dispatch 時点でカテゴリ（モデル + 推論強度）が付きます。provider がモデルを拒否すれば chain を下り、仕事をしなかった子は緑の行ではなく `failed` と表示されます。 |
+| 🎛️ **モデル系列ごとのキャリブレーション** | GPT-6 Astra、GPT-5.6、Claude 5.1、GLM 5.3、Kimi、Gemini、Qwen、DeepSeek など、系列と世代ごとにプロンプティングを調整し、ベンチマークのペアが効果を示す間だけ維持します。 |
+| 🗂️ **自分で所有するカテゴリ** | executor ごとに 9 つの標準カテゴリ、`omh model-chains set` による並べ替え、マシンごとに chain を並べ替える entitlement インタビュー、実行前にリクエストがどこへルーティングされるかを示すライブビュー。 |
+| 🖥️ **ネイティブ TUI サーフェス** | OMH HUD（カテゴリ・ターン・コスト・キャッシュ付きのライブ行）、プロンプト上の phase todo、`parallel shot ×N`、full-row diff バンド、管理されたスキン。Hermes の隣にインストールされ、Hermes にパッチは当てません。 |
+| ⚡ **観測できる並列作業** | 独立した作業を、ファイル所有権が重ならない fanout unit に分割し、provider 負荷に応じた admission control、型付きの結果 sidecar、返ってきた結果を読む verification gate を付けます。 |
+| 🎼 **Maestro handoff** | Codex、Claude Code、その他の CLI のための明示的な第二 lane。readiness probe、capability snapshot、owner-fit レポート、実行ごとのモデルと強度の指定。opt-in であり、既定の経路ではありません。 |
+| 💸 **価格付きコストテレメトリ** | すべての HUD 行と run summary にトークン数とドル金額を表示します。出典を明記した料金表で計算し、計算できない run は `$0` ではなく `unknown` と読めます。 |
+| 🧠 **長期プロジェクトメモリ** | Hermes が読み込むファイルベースの memory provider、admission と retention のポリシー、レビュアーが承認する書き込み、freshness と budget を持つ recall pack。Hermes 自身のメモリには触れません。 |
+| 🔎 **構造的コード検索** | 計測に基づく `ast-grep` プレイブック（28 言語、grep フォールバック）と、リポジトリ全体のアーキテクチャ図を描く `omh codegraph uml` を、executor がコードを読む地点に注入します。 |
+| 🛡️ **自分で書くガードレール** | ルールを外れた tool call を自分のルール文で遮断する toolcall rules、stub やスキップされたテストを証拠と認めない completion-integrity gate、危険な操作のための approval tier。 |
+| ♾️ **ウルトラワークフローエンジン** | 並列デリバリー lane、ledger と実際の完了 gate で回る計測ループ、エンジン実行前の decision-frontier インタビュー。一覧は上のウルトラスキルにあります。 |
+| 📦 **決定的なカタログ** | 一つのソースから生成される 100 以上のインストール可能なスキル、ネガティブケースを含む routing precision コーパス、1 バイトのずれで CI が失敗する drift gate。 |
 
 ## 主張より証拠
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -2,29 +2,6 @@
   <img src="assets/oh-my-hermes-wordmark.png" alt="OH-MY-HERMES" width="100%" style="display:block;max-width:none;height:auto">
 </p>
 
-<table align="center">
-  <tr>
-    <td width="50%" align="center">
-      <img src="assets/hermes-desktop.gif" alt="Hermes Desktop running an OMH workflow" width="380" height="266"><br>
-      <sub><b>Hermes 데스크톱, oh-my-hermes와 함께.</b><br>워크플로를 고르면, 만들기 전에 먼저 확인합니다.</sub>
-    </td>
-    <td width="50%" align="center">
-      <img src="assets/hermes-cli.gif" alt="Hermes CLI running an OMH workflow" width="380" height="266"><br>
-      <sub><b>Hermes CLI, oh-my-hermes와 함께.</b><br>쓰던 터미널에서 같은 워크플로를.</sub>
-    </td>
-  </tr>
-  <tr>
-    <td width="50%" align="center">
-      <img src="assets/hermes-messenger.gif" alt="Hermes messenger app running an OMH workflow" width="380" height="266"><br>
-      <sub><b>Hermes 메신저 앱, oh-my-hermes와 함께.</b><br>스레드에서 요청하면 같은 스레드로 답합니다.</sub>
-    </td>
-    <td width="50%" align="center">
-      <img src="assets/omh-setup.gif" alt="omh setup installing the OMH workflows" width="380" height="266"><br>
-      <sub><b><code>omh setup</code>, 명령 하나로.</b><br>워크플로를 설치하고 Hermes에 연결합니다.</sub>
-    </td>
-  </tr>
-</table>
-
 # oh-my-hermes
 
 <p align="center">
@@ -307,6 +284,29 @@ OMH 워크플로가 도는 동안 터미널이 보여주는 것:
 - **Phase-structured TODO** — 작업은 시작 전에 phase와 task로 선언되고
   (`todo init`), 프롬프트 위 체크리스트로 렌더됩니다: 활성 항목 하나,
   모든 phase 헤더 아래 들여쓴 task, 서브태스크 중첩, 7행 초과 시 접기.
+
+<table align="center">
+  <tr>
+    <td width="50%" align="center">
+      <img src="assets/hermes-desktop.gif" alt="Hermes Desktop running an OMH workflow" width="380" height="266"><br>
+      <sub><b>Hermes 데스크톱, oh-my-hermes와 함께.</b><br>워크플로를 고르면, 만들기 전에 먼저 확인합니다.</sub>
+    </td>
+    <td width="50%" align="center">
+      <img src="assets/hermes-cli.gif" alt="Hermes CLI running an OMH workflow" width="380" height="266"><br>
+      <sub><b>Hermes CLI, oh-my-hermes와 함께.</b><br>쓰던 터미널에서 같은 워크플로를.</sub>
+    </td>
+  </tr>
+  <tr>
+    <td width="50%" align="center">
+      <img src="assets/hermes-messenger.gif" alt="Hermes messenger app running an OMH workflow" width="380" height="266"><br>
+      <sub><b>Hermes 메신저 앱, oh-my-hermes와 함께.</b><br>스레드에서 요청하면 같은 스레드로 답합니다.</sub>
+    </td>
+    <td width="50%" align="center">
+      <img src="assets/omh-setup.gif" alt="omh setup installing the OMH workflows" width="380" height="266"><br>
+      <sub><b><code>omh setup</code>, 명령 하나로.</b><br>워크플로를 설치하고 Hermes에 연결합니다.</sub>
+    </td>
+  </tr>
+</table>
 
 <br>
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -399,29 +399,29 @@ Do not replace the resolved SHA with main. Execute the pinned protocol's OS-appr
 
 ## OMH가 더하는 것
 
-OMH는 모델 선택과 코딩 소유권을 서로 다른 결정으로 다루며, 준비를 실행으로
-보고하지 않습니다. 사람이 이해하기 쉬운 기능군은 계속 첫 진입점으로 남고,
-정밀한 제어·runtime 경계·증거 규칙은 wrapper나 operator가 필요할 때 확인할 수
-있습니다. 전체 목록과 trigger, harness, 증거 규칙은
+Hermes Agent는 이미 루프를 돌립니다. OMH는 그 루프에 무엇을 넣을지 정합니다.
+어느 lane에 어떤 모델과 추론 강도를 줄지, 코드 변경의 owner는 누구인지,
+어떤 스킬이 적용되는지, 무엇을 완료로 볼지입니다. 어디서나 두 규칙이
+지켜집니다. 모델 선택과 코딩 소유권은 별개의 결정이고, 준비된 것은 절대
+실행된 것으로 보고하지 않습니다. 생성 카탈로그와 trigger, 증거 규칙은
 [Workflow Reference](docs/WORKFLOWS.md)에 있습니다.
 
 **하이라이트**
 
 | 인텔리전스 | OMH가 더하는 것 |
 | --- | --- |
-| 🧭 **Mixture-of-models 라우팅** | 위임되는 lane마다 카테고리(모델 + 추론 강도)를 dispatch 단위로 적용하고, provider가 모델을 거부하면 편집 가능한 fallback chain을 따라 전진합니다 — 일을 하지 않은 자식은 정직하게 `failed`로 표시됩니다. |
-| 🖥️ **네이티브 TUI 표면** | OMH HUD(카테고리·턴·비용·캐시가 붙은 실시간 delegation 행), 프롬프트 위 phase todo 체크리스트, `parallel shot ×N` 표시, full-row diff 밴드, 관리형 스킨 — 모두 Hermes 옆에 설치되며 Hermes를 패치하지 않습니다. |
-| 📋 **Phase 구조 플랜** | `todo init`이 엔진 작업 전에 phase와 task를 선언해, 실행이 열린 추론 루프가 아니라 유한한 체크리스트를 걷게 합니다. |
-| ⚡ **관측 가능한 병렬 작업** | 독립적인 작업을 소유권이 분리된 fanout unit으로 나누고, 진행 상황과 verification gate를 관측합니다. |
-| 🎼 **Maestro handoff** | 숨은 executor가 되거나 준비를 실행으로 취급하지 않으면서 명시적인 코딩 owner와 runtime profile을 위한 handoff를 준비합니다. |
-| 🧠 **컨텍스트 인텔리전스** | 숨은 기억을 지어내거나 선택된 route를 몰래 바꾸지 않고, 검토된 저장소 컨텍스트를 간결하게 투영합니다. |
-| 📚 **JIT 학습** | 현재 blocker에 가장 가치 있는 학습 목표를 고르고, 이미 학습했다고 주장하지 않으면서 출처 기반의 즉시 적용 가능한 지침을 준비합니다. |
-| 🔍 **증거 기반 전달** | 코딩·review·CI·merge 전반에서 준비된 의도, 관측된 runtime 활동, 검증된 결과를 분리합니다. |
-| 🔎 **구조적 코드 검색** | 측정 기반 `ast-grep` 플레이북 — 28개 언어 구조 쿼리, body-capture 금지, grep 폴백 — 을 executor가 코드를 검색하는 지점에 주입합니다. OMH는 바이너리 존재만 감지하며 직접 실행하지 않습니다. |
-| 🗄️ **프로젝트 메모리 시스템** | Hermes가 로드할 수 있는 결정적 파일 기반 memory provider, 검토형 프로젝트 메모리 명령(inspect·pack·domain capture), consolidation 스케줄링 brief, 메모리 리뷰 스킬 — Hermes의 불투명한 내부 메모리는 읽지도 고치지도 않습니다. |
-| 🛠️ **코딩 하네스 & 가드레일** | executor readiness probe, 준비된 handoff에 붙는 capability snapshot과 owner-fit 리포트, `execute_code` 결과에 붙는 code-mode discipline, 규칙을 어긴 tool call을 규칙 텍스트로 차단하는 사용자 작성 toolcall rules. |
-| ♾️ **울트라 워크플로 엔진** | 소유권이 분리된 병렬 전달 레인, ledger와 실제 완료 gate로 도는 측정 루프, 엔진 실행 전에 의도를 명확히 하는 decision-frontier 인터뷰 — 엔진 목록은 아래 울트라 스킬 섹션에 있습니다. |
-| 📦 **결정적 스킬 카탈로그** | 120개 이상의 설치형 workflow 스킬, byte 단위로 검증되는 생성 카탈로그, 부정 케이스를 포함한 routing precision 코퍼스, 한 글자 드리프트에도 CI가 실패하는 drift gate. |
+| 🧭 **Mixture-of-models 라우팅** | 위임되는 lane마다 dispatch 시점에 카테고리(모델 + 추론 강도)가 붙습니다. provider가 모델을 거부하면 chain을 따라 내려가고, 일을 하지 않은 자식은 초록 행이 아니라 `failed`로 표시됩니다. |
+| 🎛️ **모델 계열별 캘리브레이션** | GPT-6 Astra, GPT-5.6, Claude 5.1, GLM 5.3, Kimi, Gemini, Qwen, DeepSeek 등 계열과 세대별로 프롬프팅을 튜닝하고, 벤치마크 쌍이 효과를 보여줄 때만 유지합니다. |
+| 🗂️ **직접 소유하는 카테고리** | executor마다 9개의 기본 카테고리, `omh model-chains set`으로 순서 변경, 머신별로 chain을 재정렬하는 entitlement 인터뷰, 실행 전에 요청이 어디로 라우팅될지 보여주는 실시간 뷰를 제공합니다. |
+| 🖥️ **네이티브 TUI 표면** | OMH HUD(카테고리·턴·비용·캐시가 붙은 실시간 행), 프롬프트 위 phase todo, `parallel shot ×N`, full-row diff 밴드, 관리형 스킨을 Hermes 옆에 설치하며 Hermes를 패치하지 않습니다. |
+| ⚡ **관측 가능한 병렬 작업** | 독립적인 작업을 파일 소유권이 겹치지 않는 fanout unit으로 나누고, provider 부하에 따른 admission control, 타입이 있는 결과 sidecar, 돌아온 결과를 읽는 verification gate를 붙입니다. |
+| 🎼 **Maestro handoff** | Codex, Claude Code 등 다른 CLI를 위한 명시적 두 번째 lane입니다. readiness probe, capability snapshot, owner-fit 리포트, 실행별 모델·강도 지정을 제공하며 opt-in이고 기본 경로가 아닙니다. |
+| 💸 **가격이 붙은 비용 텔레메트리** | 모든 HUD 행과 run summary에 토큰 수와 달러 금액을 표시합니다. 출처를 밝힌 요금표로 계산하고, 계산할 수 없는 run은 `$0`이 아니라 `unknown`으로 읽힙니다. |
+| 🧠 **장기 프로젝트 메모리** | Hermes가 로드하는 파일 기반 memory provider, admission·retention 정책, 리뷰어가 승인하는 쓰기, freshness와 budget이 있는 recall pack을 제공합니다. Hermes 자체 메모리는 건드리지 않습니다. |
+| 🔎 **구조적 코드 검색** | 측정 기반 `ast-grep` 플레이북(28개 언어, grep 폴백)과 저장소 전체 아키텍처 그림을 그리는 `omh codegraph uml`을 executor가 코드를 읽는 지점에 주입합니다. |
+| 🛡️ **직접 쓰는 가드레일** | 규칙을 어긴 tool call을 사용자의 규칙 텍스트로 차단하는 toolcall rules, stub과 skip된 테스트를 증거로 인정하지 않는 completion-integrity gate, 위험한 작업을 위한 approval tier를 제공합니다. |
+| ♾️ **울트라 워크플로 엔진** | 병렬 전달 lane, ledger와 실제 완료 gate로 도는 측정 루프, 엔진 실행 전의 decision-frontier 인터뷰를 제공합니다. 목록은 위 울트라 스킬 섹션에 있습니다. |
+| 📦 **결정적 카탈로그** | 하나의 소스에서 생성되는 100개 이상의 설치형 스킬, 부정 케이스를 포함한 routing precision 코퍼스, 한 바이트만 어긋나도 CI가 실패하는 drift gate를 제공합니다. |
 
 ## 주장보다 증거
 

--- a/README.md
+++ b/README.md
@@ -517,30 +517,29 @@ rest. Full catalog: [Workflow Reference](docs/WORKFLOWS.md).
 
 ## What OMH Adds
 
-OMH treats model choice and coding ownership as separate decisions, and it
-never reports preparation as execution. Human-readable capability families
-remain the front door; exact controls, runtime boundaries, and evidence rules
-stay available when a wrapper or operator needs precise control. The full
-generated catalog, triggers, harnesses, and evidence rules live in
-[Workflow Reference](docs/WORKFLOWS.md).
+Hermes Agent already runs the loop. OMH decides what goes into it: which
+model and effort each lane gets, who owns the code change, which skills
+apply, and what counts as done. Two rules hold everywhere — model choice
+and coding ownership are separate decisions, and nothing prepared is ever
+reported as executed. The generated catalog, triggers, and evidence rules
+live in [Workflow Reference](docs/WORKFLOWS.md).
 
 **Highlights**
 
 | Intelligence | What OMH adds |
 | --- | --- |
-| 🧭 **Mixture-of-models routing** | Routes each delegated lane onto a category (model + reasoning effort) applied per dispatch, with editable fallback chains that advance when a provider rejects a model — and honest `failed` rows when a child did no work. |
-| 🖥️ **Native TUI surface** | The OMH HUD (live delegation rows with category, turn, cost, cache), the phase todo checklist above the prompt, `parallel shot ×N` branding, full-row diff bands, and four managed skins (sky, amber, crimson, mono) you switch from an arrow-key picker with `omh theme` — all installed next to Hermes, never patching it. |
-| 📋 **Phase-structured plans** | `todo init` declares phases and tasks before engine work so runs walk a bounded checklist instead of an open-ended reasoning loop. |
-| ⚡ **Observed parallel work** | Splits independent work into explicit fanout units with isolated ownership, progress observation, and verification gates. |
-| 🎼 **Maestro handoffs** | Prepares handoffs to explicit coding owners and runtime profiles without becoming a hidden executor or treating preparation as execution. |
-| 🧠 **Context intelligence** | Projects compact, reviewed repository context without inventing hidden memory or silently changing the selected route. |
-| 📚 **Just-in-time learning** | Selects the highest-value learning target for the current blocker and prepares source-backed, application-first guidance without claiming learning already happened. |
-| 🔍 **Evidence-bound delivery** | Separates prepared intent, observed runtime activity, and verified outcomes across coding, review, CI, and merge work. |
-| 🔎 **Structural code search** | A measured `ast-grep` playbook — structural queries across 28 languages, body-capture bans, grep fallback — injected where executors search code; OMH detects the binary and never runs it. |
-| 🗄️ **Project memory system** | A deterministic file-backed memory provider Hermes can load, reviewed project-memory commands (inspect, pack, domain capture), consolidation-scheduling briefs, and memory review skills — never reading or patching Hermes' opaque internal memory. |
-| 🛠️ **Coding harnesses & guardrails** | Executor readiness probes, capability snapshots and owner-fit reports on prepared handoffs, code-mode discipline on `execute_code` results, and user-authored toolcall rules that block an off-script tool call with your rule text. |
-| ♾️ **Ultra workflow engines** | Parallel delivery lanes with disjoint ownership, measured goal loops with ledgers and real completion gates, and decision-frontier interviews that clarify intent before any engine runs — the ULW engines are listed in Ultra-Skills below. |
-| 📦 **A deterministic skill catalog** | 120+ installable workflow skills with a byte-exact generated catalog, routing precision corpora (negative controls included), and drift gates that fail CI on one-character divergence. |
+| 🧭 **Mixture-of-models routing** | Every delegated lane lands on a category (model + reasoning effort) at dispatch time. Chains fall through when a provider rejects a model, and a child that did no work shows `failed`, never a green row. |
+| 🎛️ **Per-family calibration** | Prompting is tuned per model family and generation — GPT-6 Astra, GPT-5.6, Claude 5.1, GLM 5.3, Kimi, Gemini, Qwen, DeepSeek and more — and each tune is kept only while the benchmark pair says it helps. |
+| 🗂️ **Categories you own** | Nine shipped categories per executor, with `omh model-chains set` to reorder, an entitlement interview that reorders chains per machine, and a live view of what a request would route to before it runs. |
+| 🖥️ **Native TUI surface** | The OMH HUD (live rows with category, turns, cost, cache), the phase todo above the prompt, `parallel shot ×N`, full-row diff bands, and managed skins — installed beside Hermes, never patching it. |
+| ⚡ **Observed parallel work** | Independent work splits into fanout units with disjoint file ownership, admission control under provider pressure, typed result sidecars, and verification gates that read what came back. |
+| 🎼 **Maestro handoffs** | An explicit second lane for Codex, Claude Code, or another CLI: readiness probes, capability snapshots, owner-fit reports, and per-run model and effort — opt-in, and never the default path. |
+| 💸 **Priced cost telemetry** | Token counts and dollar figures on every HUD row and run summary, priced from a rate table that cites its source; an unpriceable run reads `unknown`, never `$0`. |
+| 🧠 **Long-term project memory** | A file-backed memory provider Hermes loads, admission and retention policies, reviewer-gated writes, and recall packs with freshness and budget — Hermes' own memory stays untouched. |
+| 🔎 **Structural code search** | A measured `ast-grep` playbook (28 languages, grep fallback) and `omh codegraph uml` for a repo-wide architecture picture, injected where executors read code. |
+| 🛡️ **Guardrails you write** | Toolcall rules that block an off-script call with your own rule text, a completion-integrity gate that refuses stubs and skipped tests as evidence, and an approval tier for risky actions. |
+| ♾️ **Ultra workflow engines** | Parallel delivery lanes, measured goal loops with ledgers and real completion gates, and decision-frontier interviews before any engine runs — listed in Ultra-Skills above. |
+| 📦 **A deterministic catalog** | A hundred-plus installable skills generated from one source, routing precision corpora with negative controls, and drift gates that fail CI on a single divergent byte. |
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -2,29 +2,6 @@
   <img src="assets/oh-my-hermes-wordmark.png" alt="OH-MY-HERMES" width="100%" style="display:block;max-width:none;height:auto">
 </p>
 
-<table align="center">
-  <tr>
-    <td width="50%" align="center">
-      <img src="assets/hermes-desktop.gif" alt="Hermes Desktop running an OMH workflow" width="380" height="266"><br>
-      <sub><b>Hermes Desktop, with oh-my-hermes.</b><br>Pick a workflow; Hermes clarifies before it builds.</sub>
-    </td>
-    <td width="50%" align="center">
-      <img src="assets/hermes-cli.gif" alt="Hermes CLI running an OMH workflow" width="380" height="266"><br>
-      <sub><b>Hermes CLI, with oh-my-hermes.</b><br>The same workflows, in your terminal.</sub>
-    </td>
-  </tr>
-  <tr>
-    <td width="50%" align="center">
-      <img src="assets/hermes-messenger.gif" alt="Hermes messenger app running an OMH workflow" width="380" height="266"><br>
-      <sub><b>Hermes messenger app, with oh-my-hermes.</b><br>Ask in a thread; the run reports back there.</sub>
-    </td>
-    <td width="50%" align="center">
-      <img src="assets/omh-setup.gif" alt="omh setup installing the OMH workflows" width="380" height="266"><br>
-      <sub><b><code>omh setup</code>, one command.</b><br>Installs the workflows and connects them to Hermes.</sub>
-    </td>
-  </tr>
-</table>
-
 # oh-my-hermes
 
 <p align="center">
@@ -376,6 +353,29 @@ What the terminal shows while OMH workflows run:
   with tasks (`todo init`), rendered as the checklist above the prompt: one
   active item, tasks indented beneath every phase header, subtask nesting,
   and fold lines once the plan grows past eight rows.
+
+<table align="center">
+  <tr>
+    <td width="50%" align="center">
+      <img src="assets/hermes-desktop.gif" alt="Hermes Desktop running an OMH workflow" width="380" height="266"><br>
+      <sub><b>Hermes Desktop, with oh-my-hermes.</b><br>Pick a workflow; Hermes clarifies before it builds.</sub>
+    </td>
+    <td width="50%" align="center">
+      <img src="assets/hermes-cli.gif" alt="Hermes CLI running an OMH workflow" width="380" height="266"><br>
+      <sub><b>Hermes CLI, with oh-my-hermes.</b><br>The same workflows, in your terminal.</sub>
+    </td>
+  </tr>
+  <tr>
+    <td width="50%" align="center">
+      <img src="assets/hermes-messenger.gif" alt="Hermes messenger app running an OMH workflow" width="380" height="266"><br>
+      <sub><b>Hermes messenger app, with oh-my-hermes.</b><br>Ask in a thread; the run reports back there.</sub>
+    </td>
+    <td width="50%" align="center">
+      <img src="assets/omh-setup.gif" alt="omh setup installing the OMH workflows" width="380" height="266"><br>
+      <sub><b><code>omh setup</code>, one command.</b><br>Installs the workflows and connects them to Hermes.</sub>
+    </td>
+  </tr>
+</table>
 
 <br>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -2,29 +2,6 @@
   <img src="assets/oh-my-hermes-wordmark.png" alt="OH-MY-HERMES" width="100%" style="display:block;max-width:none;height:auto">
 </p>
 
-<table align="center">
-  <tr>
-    <td width="50%" align="center">
-      <img src="assets/hermes-desktop.gif" alt="Hermes Desktop running an OMH workflow" width="380" height="266"><br>
-      <sub><b>Hermes 桌面端，搭配 oh-my-hermes。</b><br>选一个工作流，它会先确认再构建。</sub>
-    </td>
-    <td width="50%" align="center">
-      <img src="assets/hermes-cli.gif" alt="Hermes CLI running an OMH workflow" width="380" height="266"><br>
-      <sub><b>Hermes CLI，搭配 oh-my-hermes。</b><br>在你已在用的终端里运行同样的工作流。</sub>
-    </td>
-  </tr>
-  <tr>
-    <td width="50%" align="center">
-      <img src="assets/hermes-messenger.gif" alt="Hermes messenger app running an OMH workflow" width="380" height="266"><br>
-      <sub><b>Hermes 消息应用，搭配 oh-my-hermes。</b><br>在话题里提出请求，结果回到同一个话题。</sub>
-    </td>
-    <td width="50%" align="center">
-      <img src="assets/omh-setup.gif" alt="omh setup installing the OMH workflows" width="380" height="266"><br>
-      <sub><b><code>omh setup</code>，一条命令。</b><br>安装工作流并连接到 Hermes。</sub>
-    </td>
-  </tr>
-</table>
-
 # oh-my-hermes
 
 <p align="center">
@@ -302,6 +279,29 @@ OMH 工作流运行时,终端会展示:
 - **Phase-structured TODO** — 工作在开始前以 phase 和 task 声明
   (`todo init`),渲染为提示符上方的清单:单一活动项、每个 phase 标题下
   缩进的任务、子任务嵌套、超过七行后折叠。
+
+<table align="center">
+  <tr>
+    <td width="50%" align="center">
+      <img src="assets/hermes-desktop.gif" alt="Hermes Desktop running an OMH workflow" width="380" height="266"><br>
+      <sub><b>Hermes 桌面端，搭配 oh-my-hermes。</b><br>选一个工作流，它会先确认再构建。</sub>
+    </td>
+    <td width="50%" align="center">
+      <img src="assets/hermes-cli.gif" alt="Hermes CLI running an OMH workflow" width="380" height="266"><br>
+      <sub><b>Hermes CLI，搭配 oh-my-hermes。</b><br>在你已在用的终端里运行同样的工作流。</sub>
+    </td>
+  </tr>
+  <tr>
+    <td width="50%" align="center">
+      <img src="assets/hermes-messenger.gif" alt="Hermes messenger app running an OMH workflow" width="380" height="266"><br>
+      <sub><b>Hermes 消息应用，搭配 oh-my-hermes。</b><br>在话题里提出请求，结果回到同一个话题。</sub>
+    </td>
+    <td width="50%" align="center">
+      <img src="assets/omh-setup.gif" alt="omh setup installing the OMH workflows" width="380" height="266"><br>
+      <sub><b><code>omh setup</code>，一条命令。</b><br>安装工作流并连接到 Hermes。</sub>
+    </td>
+  </tr>
+</table>
 
 <br>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -394,28 +394,27 @@ Do not replace the resolved SHA with main. Execute the pinned protocol's OS-appr
 
 ## OMH 提供什么
 
-OMH 把模型选择和编码所有权作为两个独立决策，并且绝不把准备报告为执行。
-容易理解的能力族仍然是入口；精确控制、runtime 边界和证据规则会在 wrapper
-或 operator 需要时保持可查。完整 catalog、trigger、harness 和证据规则位于
-[Workflow Reference](docs/WORKFLOWS.md)。
+Hermes Agent 已经在跑循环。OMH 决定往循环里放什么：每条 lane 用哪个模型和
+推理强度、代码变更由谁负责、应用哪些技能、什么算完成。两条规则处处成立：
+模型选择与编码归属是两个独立决定，准备好的东西绝不当作已执行来报告。生成的
+目录、trigger 与证据规则见 [Workflow Reference](docs/WORKFLOWS.md)。
 
 **亮点**
 
-| 智能层 | OMH 提供什么 |
+| 智能 | OMH 提供什么 |
 | --- | --- |
-| 🧭 **Mixture-of-models 路由** | 每条委派 lane 按类别(模型 + 推理强度)在每次 dispatch 时应用,provider 拒绝某个模型时沿可编辑的 fallback chain 前进 — 没有做任何工作的子代理会诚实地标记为 `failed`。 |
-| 🖥️ **原生 TUI 表面** | OMH HUD(带类别、轮次、成本、缓存的实时 delegation 行)、提示符上方的 phase todo 清单、`parallel shot ×N` 标注、整行 diff 色带、受管理的皮肤 — 全部安装在 Hermes 旁边,绝不修改 Hermes 本体。 |
-| 📋 **Phase 结构化计划** | `todo init` 在引擎工作开始前声明 phase 和 task,让运行沿有界清单推进,而不是陷入开放式推理循环。 |
-| ⚡ **可观测的并行工作** | 把独立工作拆成所有权隔离的 fanout unit,并观测进度和 verification gate。 |
-| 🎼 **Maestro handoff** | 在不成为隐藏 executor、也不把准备当作执行的前提下,为明确的 coding owner 和 runtime profile 准备 handoff。 |
-| 🧠 **上下文智能** | 在不虚构隐藏记忆、也不暗中改变已选 route 的前提下,投影紧凑且经过审查的仓库上下文。 |
-| 📚 **JIT learning** | 为当前 blocker 选择最有价值的学习目标,并在不声称已经学会的前提下准备有来源、可立即应用的指导。 |
-| 🔍 **证据约束的交付** | 在 coding、review、CI 和 merge 全程分开已准备意图、已观测 runtime 活动与已验证结果。 |
-| 🔎 **结构化代码搜索** | 基于实测的 `ast-grep` 手册 — 覆盖 28 种语言的结构查询、禁止 body-capture、grep 回退 — 注入到 executor 搜索代码的场景。OMH 只检测二进制是否存在,从不亲自执行。 |
-| 🗄️ **项目记忆系统** | Hermes 可加载的确定性文件型 memory provider、可审查的项目记忆命令(inspect、pack、domain capture)、consolidation 调度 brief 以及记忆审查技能 — 从不读取或修改 Hermes 不透明的内部记忆。 |
-| 🛠️ **编码 harness 与护栏** | executor readiness 探测、附在已准备 handoff 上的 capability snapshot 与 owner-fit 报告、作用于 `execute_code` 结果的 code-mode discipline,以及用规则文本拦截越界 tool call 的用户自定义 toolcall rules。 |
-| ♾️ **Ultra 工作流引擎** | 所有权彼此隔离的并行交付 lane、带 ledger 和真实完成 gate 的计量循环,以及在任何引擎运行前先澄清意图的 decision-frontier 访谈 — 引擎列表见下方 Ultra 技能一节。 |
-| 📦 **确定性技能目录** | 120+ 可安装的 workflow 技能、逐字节校验的生成目录、包含负向用例的 routing precision 语料,以及一字符漂移即令 CI 失败的 drift gate。 |
+| 🧭 **Mixture-of-models 路由** | 每条委派 lane 在 dispatch 时落到一个类别（模型 + 推理强度）。provider 拒绝模型时沿 chain 下落，没做事的子任务显示 `failed`，而不是一行绿色。 |
+| 🎛️ **按模型家族校准** | 按家族和代次调校提示词：GPT-6 Astra、GPT-5.6、Claude 5.1、GLM 5.3、Kimi、Gemini、Qwen、DeepSeek 等，只在基准对照证明有效时才保留。 |
+| 🗂️ **你自己掌控的类别** | 每个 executor 九个内置类别，`omh model-chains set` 调整顺序，按机器重排 chain 的 entitlement 访谈，以及运行前就能看到请求会路由到哪里的实时视图。 |
+| 🖥️ **原生 TUI 界面** | OMH HUD（带类别、轮次、成本、缓存的实时行）、提示符上方的 phase todo、`parallel shot ×N`、整行 diff 色带与托管皮肤，安装在 Hermes 旁边，绝不打补丁。 |
+| ⚡ **可观测的并行工作** | 把独立工作拆成文件归属互不重叠的 fanout unit，带 provider 压力下的 admission control、有类型的结果 sidecar，以及读取返回结果的 verification gate。 |
+| 🎼 **Maestro 交接** | 为 Codex、Claude Code 或其他 CLI 准备的显式第二 lane：readiness 探测、capability 快照、owner-fit 报告、按次指定模型与强度。需要主动开启，从不是默认路径。 |
+| 💸 **带价格的成本遥测** | 每一行 HUD 和 run summary 都显示 token 数与美元金额，按注明来源的价目表计算；无法计价的 run 显示 `unknown`，而不是 `$0`。 |
+| 🧠 **长期项目记忆** | Hermes 可加载的文件型 memory provider、admission 与 retention 策略、审阅者把关的写入、带新鲜度与预算的 recall pack。Hermes 自身的记忆不被触碰。 |
+| 🔎 **结构化代码搜索** | 经测量的 `ast-grep` 手册（28 种语言，grep 回退）和绘制整个仓库架构图的 `omh codegraph uml`，注入到 executor 读代码的位置。 |
+| 🛡️ **你自己写的护栏** | 用你的规则文本拦截越界 tool call 的 toolcall rules、拒绝把 stub 和跳过的测试当证据的 completion-integrity gate，以及高风险操作的 approval tier。 |
+| ♾️ **Ultra 工作流引擎** | 并行交付 lane、带 ledger 与真实完成 gate 的度量循环、引擎运行前的 decision-frontier 访谈。列表见上方 Ultra 技能。 |
+| 📦 **确定性目录** | 由同一来源生成的一百多个可安装技能、含负例的 routing precision 语料，以及一个字节偏差就让 CI 失败的 drift gate。 |
 
 ## 证据先于声明
 


### PR DESCRIPTION
## Capability

The README leads with the wordmark and title, the four-scene demo grid sits with the terminal captures, and the "What OMH Adds" table names what ships today.

## Motivation

Owner asked for the demo grid (Desktop, CLI, messenger, `omh setup`) to move under "The OH-MY-HERMES terminal", and for the "What OMH Adds" section to read current and cleaner.

## Implementation

- **Demo grid** (`README.md` + ko/ja/zh): moved from above the h1 to the end of the terminal section, no copy changes.
- **What OMH Adds** (`README.md` + ko/ja/zh): new intro (what OMH decides on top of the Hermes loop, and the two rules that hold everywhere) and twelve rows, each naming one merged capability: routing, per-family calibration, owned categories, the TUI, observed fanout, the opt-in Maestro lane, priced cost telemetry, long-term memory, structural search plus `omh codegraph uml`, user-written guardrails, ULW engines, and the deterministic catalog. The calibration row names only families with a composition block in `unit_prompt_protocol.py`. The pinned table header and routing row label are unchanged.

## Verification (observed)

```
PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py tests/test_distribution_surfaces.py tests/test_release_smoke.py tests/test_ulw_inventory.py  → OK
uv run python -m omh.cli docs ulw-inventory --check  → ok
git diff --check  → clean
```

## Risks

Rendered GitHub preview not observed. Localized line counts stay under the budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZYwbzXpiWJpPUfEcKfRLY
